### PR TITLE
Lock transformers version for cpu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     extras_require={
         "llm": [
             "torch>=2.0.0",
-            "transformers",
+            "transformers==4.52.1",
             "accelerate",
             "py-cpuinfo",
             "sentencepiece",


### PR DESCRIPTION
A recent update to the transformers package appears to break lemonade for CPU. This hotfix locks it to the previous working version.