### PR TITLE
Fix llama-server warning messages

### DIFF
--- a/src/lemonade/tools/server/llamacpp.py
+++ b/src/lemonade/tools/server/llamacpp.py
@@ -145,9 +145,7 @@ def _log_subprocess_output(
                 break
 
 
-def _wait_for_load(
-    llama_server_process: subprocess.Popen, port: int
-):
+def _wait_for_load(llama_server_process: subprocess.Popen, port: int):
     status_code = None
     while not llama_server_process.poll() and status_code != 200:
         health_url = f"http://localhost:{port}/health"
@@ -256,8 +254,10 @@ def server_load(model_config: dict, model_reference: str, telemetry: LlamaTeleme
 
     # If loading on GPU failed, try loading on CPU
     if llama_server_process.poll():
-        logging.warning(f"Loading {model_reference} on GPU didn't work, re-attempting on CPU")
-        
+        logging.warning(
+            f"Loading {model_reference} on GPU didn't work, re-attempting on CPU"
+        )
+
         llama_server_process = _launch_llama_subprocess(
             snapshot_files, use_gpu=False, telemetry=telemetry
         )

--- a/src/lemonade/tools/server/llamacpp.py
+++ b/src/lemonade/tools/server/llamacpp.py
@@ -146,7 +146,7 @@ def _log_subprocess_output(
 
 
 def _wait_for_load(
-    llama_server_process: subprocess.Popen, port: int, fail_message: str
+    llama_server_process: subprocess.Popen, port: int
 ):
     status_code = None
     while not llama_server_process.poll() and status_code != 200:
@@ -154,7 +154,7 @@ def _wait_for_load(
         try:
             health_response = requests.get(health_url)
         except requests.exceptions.ConnectionError:
-            logging.warning(fail_message)
+            logging.debug("Not able to connect to llama-server yet, will retry")
         else:
             status_code = health_response.status_code
             logging.debug(
@@ -252,11 +252,12 @@ def server_load(model_config: dict, model_reference: str, telemetry: LlamaTeleme
     _wait_for_load(
         llama_server_process,
         telemetry.port,
-        f"Loading {model_reference} on GPU didn't work, re-attempting on CPU",
     )
 
     # If loading on GPU failed, try loading on CPU
     if llama_server_process.poll():
+        logging.warning(f"Loading {model_reference} on GPU didn't work, re-attempting on CPU")
+        
         llama_server_process = _launch_llama_subprocess(
             snapshot_files, use_gpu=False, telemetry=telemetry
         )
@@ -265,7 +266,6 @@ def server_load(model_config: dict, model_reference: str, telemetry: LlamaTeleme
         _wait_for_load(
             llama_server_process,
             telemetry.port,
-            f"Loading {model_reference} on CPU didn't work",
         )
 
     if llama_server_process.poll():


### PR DESCRIPTION
We were raising a scary warning that Vulkan GPU loading failed, when in fact the server just wasn't ready to respond to an http request yet, and everything was fine.

This PR changes the logic so that the warning only fires if the process actually fails to load, and in the not-ready-for-http-case we show a gentle logging.debug() message.