### PR TITLE
Improve server error handling in web UI

### DIFF
--- a/src/lemonade/tools/server/static/styles.css
+++ b/src/lemonade/tools/server/static/styles.css
@@ -1378,3 +1378,20 @@ body::before {
   from { opacity: 0; transform: translateY(-5px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
+/* Error banner styles */
+.error-banner {
+  position: fixed;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #dc3545;
+  color: #fff;
+  padding: 0.6em 1.2em;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  z-index: 10000;
+  font-weight: 600;
+  display: none;
+  animation: fadeIn 0.2s ease;
+}

--- a/src/lemonade/tools/server/static/webapp.html
+++ b/src/lemonade/tools/server/static/webapp.html
@@ -24,6 +24,7 @@
             <a href="https://lemonade-server.ai/news/" target="_blank">News</a>
         </div>
     </nav>
+    <div id="error-banner" class="error-banner" style="display:none;"></div>
     <main class="main">
         <div class="tab-container"> 
             <div class="tabs"> 
@@ -213,6 +214,35 @@
         }
     }
 
+    // Display an error message in the banner
+    function showErrorBanner(msg) {
+        const banner = document.getElementById('error-banner');
+        if (!banner) return;
+        banner.textContent = msg;
+        banner.style.display = 'block';
+        clearTimeout(banner._hideTimer);
+        banner._hideTimer = setTimeout(() => { banner.style.display = 'none'; }, 5000);
+    }
+
+    // Helper fetch wrappers that surface server error details
+    async function httpRequest(url, options = {}) {
+        const resp = await fetch(url, options);
+        if (!resp.ok) {
+            let detail = resp.statusText;
+            try {
+                const data = await resp.json();
+                if (data && data.detail) detail = data.detail;
+            } catch (_) {}
+            throw new Error(detail);
+        }
+        return resp;
+    }
+
+    async function httpJson(url, options = {}) {
+        const resp = await httpRequest(url, options);
+        return await resp.json();
+    }
+
     // Tab switching logic 
     function showTab(tab, updateHash = true) { 
         document.getElementById('tab-chat').classList.remove('active'); 
@@ -314,8 +344,7 @@
     // Populate model dropdown from /api/v1/models endpoint
     async function loadModels() {
         try {
-            const resp = await fetch(getServerBaseUrl() + '/api/v1/models');
-            const data = await resp.json();
+            const data = await httpJson(getServerBaseUrl() + '/api/v1/models');
             const select = document.getElementById('model-select');
             select.innerHTML = '';
             if (!data.data || !Array.isArray(data.data)) {
@@ -383,6 +412,7 @@
             const select = document.getElementById('model-select');
             select.innerHTML = `<option>Error loading models: ${e.message}</option>`;
             console.error('Error loading models:', e);
+            showErrorBanner(`Error loading models: ${e.message}`);
         }
     }
     loadModels();
@@ -428,12 +458,13 @@
         // Get installed models from /api/v1/models
         let installed = [];
         try {
-            const resp = await fetch(getServerBaseUrl() + '/api/v1/models');
-            const data = await resp.json();
+            const data = await httpJson(getServerBaseUrl() + '/api/v1/models');
             if (data.data && Array.isArray(data.data)) {
                 installed = data.data.map(m => m.id || m.name || m);
             }
-        } catch (e) {}
+        } catch (e) {
+            showErrorBanner(`Error loading models: ${e.message}`);
+        }
         // All models from server_models.json (window.SERVER_MODELS)
         const allModels = window.SERVER_MODELS || {};
         // Filter suggested models not installed
@@ -466,21 +497,17 @@
                 btn.textContent = 'Deleting...';
                 btn.style.backgroundColor = '#888';
                 try {
-                    const response = await fetch(getServerBaseUrl() + '/api/v1/delete', {
+                    await httpRequest(getServerBaseUrl() + '/api/v1/delete', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ model_name: mid })
                     });
-                    if (!response.ok) {
-                        const errorData = await response.json();
-                        throw new Error(errorData.detail || 'Failed to delete model');
-                    }
                     await refreshModelMgmtUI();
                     await loadModels(); // update chat dropdown too
                 } catch (e) {
                     btn.textContent = 'Error';
                     btn.disabled = false;
-                    alert(`Failed to delete model: ${e.message}`);
+                    showErrorBanner(`Failed to delete model: ${e.message}`);
                 }
             };
             tdBtn.appendChild(btn);
@@ -510,7 +537,7 @@
                 btn.textContent = 'Installing...';
                 btn.classList.add('installing-btn');
                 try {
-                    await fetch(getServerBaseUrl() + '/api/v1/pull', {
+                    await httpRequest(getServerBaseUrl() + '/api/v1/pull', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ model_name: mid })
@@ -519,6 +546,7 @@
                     await loadModels(); // update chat dropdown too
                 } catch (e) {
                     btn.textContent = 'Error';
+                    showErrorBanner(`Failed to install model: ${e.message}`);
                 }
             };
             tdBtn.appendChild(btn);
@@ -657,7 +685,7 @@
         const llmBubble = appendMessage('llm', '...');
         try {
             // Use the correct endpoint for chat completions
-            const resp = await fetch(getServerBaseUrl() + '/api/v1/chat/completions', {
+            const resp = await httpRequest(getServerBaseUrl() + '/api/v1/chat/completions', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -703,6 +731,7 @@
             messages.push({ role: 'assistant', content: llmText });
         } catch (e) {
             llmBubble.textContent = '[Error: ' + e.message + ']';
+            showErrorBanner(`Chat error: ${e.message}`);
         }
         sendBtn.disabled = false;
     }
@@ -735,14 +764,11 @@
         btn.disabled = true;
         btn.textContent = 'Installing...';
         try {
-          const resp = await fetch(getServerBaseUrl() + '/api/v1/pull', {
+          await httpRequest(getServerBaseUrl() + '/api/v1/pull', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)
           });
-          if (!resp.ok) {
-            const err = await resp.json().catch(() => ({}));
-            throw new Error(err.detail || 'Failed to register model.');          }
           registerStatus.textContent = 'Model installed!';
           registerStatus.style.color = '#27ae60';
           registerStatus.className = 'register-status success';
@@ -753,6 +779,7 @@
           registerStatus.textContent = e.message + ' See the Lemonade Server log for details.';
           registerStatus.style.color = '#dc3545';
           registerStatus.className = 'register-status error';
+          showErrorBanner(`Model install failed: ${e.message}`);
         }
         btn.disabled = false;
         btn.textContent = 'Install';


### PR DESCRIPTION
## Summary
- show HTTP error details in a banner on the web interface
- add helper fetch wrappers and display functions
- style the new error banner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810b9e29b4832bbc9b8308c661be57