### PR TITLE
Make sure we don't throw an error when there are no mkdocs changes

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -47,5 +47,9 @@ jobs:
           shell: bash -el {0}
           run: |
             git add .
-            git commit -am "Update website for: ${MAIN_COMMIT_HASH}"
+            if git diff --staged --quiet; then
+              echo "No changes to commit, skipping commit step"
+            else
+              git commit -m "Update website for: ${MAIN_COMMIT_HASH}"
+            fi
             git push


### PR DESCRIPTION
Closes #103 

To avoid problems like this: https://github.com/lemonade-sdk/lemonade/actions/runs/16655261400/job/47138518473

when there is no change to mkdocs.