### PR TITLE
Fix backwards compatibility bug in model_manager.py

### DIFF
--- a/src/lemonade_server/model_manager.py
+++ b/src/lemonade_server/model_manager.py
@@ -43,7 +43,7 @@ class ModelManager:
                 if "reasoning" in model_info:
                     model_info["labels"] = (
                         ["reasoning"]
-                        if not model_info["labels"]
+                        if not model_info.get("labels", None)
                         else model_info["labels"] + ["reasoning"]
                     )
                     del model_info["reasoning"]


### PR DESCRIPTION
Addresses #108 

The `if not model_info["labels"]` doesn't seem right @danielholanda. That is only testing whether labels is None, but doesn't account for labels not existing at all.

Do we need it to be  `if not model_info.get("labels",None) and model_info["labels"]`, or is what I did ok?