### PR TITLE
Add hot models: qwen3-coder and cogito

### DIFF
--- a/docs/generate_server_models_md.py
+++ b/docs/generate_server_models_md.py
@@ -62,13 +62,18 @@ lemonade-server pull Qwen2.5-0.5B-Instruct-CPU
 > If you are using Lemonade Server from a Python environment, use the `lemonade-server-dev pull` command instead.
 """
 
-# Separate models into Hybrid, CPU, and GGUF
+# Separate models into Hot, Hybrid, CPU, and GGUF
+hot_models = []
 hybrid_models = []
 npu_models = []
 cpu_models = []
 gguf_models = []
 for model_name, details in models.items():
     if details.get("suggested", False):
+        # Check for hot models first (these can appear in multiple sections)
+        if "labels" in details and "hot" in details["labels"]:
+            hot_models.append((model_name, details))
+        
         if model_name.endswith("-Hybrid"):
             hybrid_models.append((model_name, details))
         elif model_name.endswith("-NPU"):
@@ -112,7 +117,8 @@ def model_section_md(title, models):
     return section
 
 
-# Add models sections using the helper function
+# Add models sections using the helper function - Hot models first!
+markdown_content += model_section_md("🔥 Hot Models", hot_models)
 markdown_content += model_section_md("GGUF", gguf_models)
 markdown_content += model_section_md("Hybrid", hybrid_models)
 markdown_content += model_section_md("NPU", npu_models)

--- a/docs/server/server_models.md
+++ b/docs/server/server_models.md
@@ -17,6 +17,61 @@ Lemonade Server offers a model management GUI to help you see which models are a
 
 ## Supported Models
 
+### 🔥 Hot Models
+
+<details>
+<summary>Qwen3-30B-A3B-Instruct-2507-GGUF</summary>
+
+```bash
+lemonade-server pull Qwen3-30B-A3B-Instruct-2507-GGUF
+```
+
+<table>
+<tr><th>Key</th><th>Value</th></tr>
+<tr><td>Checkpoint</td><td><a href="https://huggingface.co/unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF">unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF</a></td></tr>
+<tr><td>GGUF Variant</td><td>Qwen3-30B-A3B-Instruct-2507-Q4_0.gguf</td></tr>
+<tr><td>Recipe</td><td>llamacpp</td></tr>
+<tr><td>Labels</td><td>hot</td></tr>
+</table>
+
+</details>
+
+<details>
+<summary>Qwen3-Coder-30B-A3B-Instruct-GGUF</summary>
+
+```bash
+lemonade-server pull Qwen3-Coder-30B-A3B-Instruct-GGUF
+```
+
+<table>
+<tr><th>Key</th><th>Value</th></tr>
+<tr><td>Checkpoint</td><td><a href="https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF">unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF</a></td></tr>
+<tr><td>GGUF Variant</td><td>Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf</td></tr>
+<tr><td>Recipe</td><td>llamacpp</td></tr>
+<tr><td>Labels</td><td>coding, hot</td></tr>
+</table>
+
+</details>
+
+<details>
+<summary>Cogito-v2-llama-109B-MoE-GGUF</summary>
+
+```bash
+lemonade-server pull Cogito-v2-llama-109B-MoE-GGUF
+```
+
+<table>
+<tr><th>Key</th><th>Value</th></tr>
+<tr><td>Checkpoint</td><td><a href="https://huggingface.co/unsloth/cogito-v2-preview-llama-109B-MoE-GGUF">unsloth/cogito-v2-preview-llama-109B-MoE-GGUF</a></td></tr>
+<tr><td>GGUF Variant</td><td>Q4_K_M</td></tr>
+<tr><td>Mmproj</td><td>mmproj-F16.gguf</td></tr>
+<tr><td>Recipe</td><td>llamacpp</td></tr>
+<tr><td>Labels</td><td>vision, hot</td></tr>
+</table>
+
+</details>
+
+
 ### GGUF
 
 <details>
@@ -150,7 +205,24 @@ lemonade-server pull Qwen3-30B-A3B-Instruct-2507-GGUF
 <tr><td>Checkpoint</td><td><a href="https://huggingface.co/unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF">unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF</a></td></tr>
 <tr><td>GGUF Variant</td><td>Qwen3-30B-A3B-Instruct-2507-Q4_0.gguf</td></tr>
 <tr><td>Recipe</td><td>llamacpp</td></tr>
-<tr><td>Labels</td><td>coding</td></tr>
+<tr><td>Labels</td><td>hot</td></tr>
+</table>
+
+</details>
+
+<details>
+<summary>Qwen3-Coder-30B-A3B-Instruct-GGUF</summary>
+
+```bash
+lemonade-server pull Qwen3-Coder-30B-A3B-Instruct-GGUF
+```
+
+<table>
+<tr><th>Key</th><th>Value</th></tr>
+<tr><td>Checkpoint</td><td><a href="https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF">unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF</a></td></tr>
+<tr><td>GGUF Variant</td><td>Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf</td></tr>
+<tr><td>Recipe</td><td>llamacpp</td></tr>
+<tr><td>Labels</td><td>coding, hot</td></tr>
 </table>
 
 </details>
@@ -205,6 +277,24 @@ lemonade-server pull Llama-4-Scout-17B-16E-Instruct-GGUF
 <tr><td>Mmproj</td><td>mmproj-F16.gguf</td></tr>
 <tr><td>Recipe</td><td>llamacpp</td></tr>
 <tr><td>Labels</td><td>vision</td></tr>
+</table>
+
+</details>
+
+<details>
+<summary>Cogito-v2-llama-109B-MoE-GGUF</summary>
+
+```bash
+lemonade-server pull Cogito-v2-llama-109B-MoE-GGUF
+```
+
+<table>
+<tr><th>Key</th><th>Value</th></tr>
+<tr><td>Checkpoint</td><td><a href="https://huggingface.co/unsloth/cogito-v2-preview-llama-109B-MoE-GGUF">unsloth/cogito-v2-preview-llama-109B-MoE-GGUF</a></td></tr>
+<tr><td>GGUF Variant</td><td>Q4_K_M</td></tr>
+<tr><td>Mmproj</td><td>mmproj-F16.gguf</td></tr>
+<tr><td>Recipe</td><td>llamacpp</td></tr>
+<tr><td>Labels</td><td>vision, hot</td></tr>
 </table>
 
 </details>

--- a/src/lemonade/tools/server/static/webapp.html
+++ b/src/lemonade/tools/server/static/webapp.html
@@ -485,6 +485,59 @@
         return container;
     }
 
+    // Helper function to render a model table section
+    function renderModelTable(tbody, models, allModels, emptyMessage) {
+        tbody.innerHTML = '';
+        if (models.length === 0) {
+            const tr = document.createElement('tr');
+            const td = document.createElement('td');
+            td.colSpan = 2;
+            td.textContent = emptyMessage;
+            td.style.textAlign = 'center';
+            td.style.fontStyle = 'italic';
+            td.style.color = '#666';
+            td.style.padding = '1em';
+            tr.appendChild(td);
+            tbody.appendChild(tr);
+        } else {
+            models.forEach(mid => {
+                const tr = document.createElement('tr');
+                const tdName = document.createElement('td');
+                
+                tdName.appendChild(createModelNameWithLabels(mid, allModels));
+                tdName.style.paddingRight = '1em';
+                tdName.style.verticalAlign = 'middle';
+                const tdBtn = document.createElement('td');
+                tdBtn.style.width = '1%';
+                tdBtn.style.verticalAlign = 'middle';
+                const btn = document.createElement('button');
+                btn.textContent = '+';
+                btn.title = 'Install model';
+                btn.onclick = async function() {
+                    btn.disabled = true;
+                    btn.textContent = 'Installing...';
+                    btn.classList.add('installing-btn');
+                    try {
+                        await httpRequest(getServerBaseUrl() + '/api/v1/pull', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ model_name: mid })
+                        });
+                        await refreshModelMgmtUI();
+                        await loadModels(); // update chat dropdown too
+                    } catch (e) {
+                        btn.textContent = 'Error';
+                        showErrorBanner(`Failed to install model: ${e.message}`);
+                    }
+                };
+                tdBtn.appendChild(btn);
+                tr.appendChild(tdName);
+                tr.appendChild(tdBtn);
+                tbody.appendChild(tr);
+            });
+        }
+    }
+
     // Model Management Tab Logic
     async function refreshModelMgmtUI() {
         // Get installed models from /api/v1/models
@@ -564,83 +617,12 @@
             installedTbody.appendChild(tr);
         });
         
-        // Render hot models as a table
+        // Render hot models and suggested models using the helper function
         const hotTbody = document.getElementById('hot-models-tbody');
-        hotTbody.innerHTML = '';
-        hotModels.forEach(mid => {
-            const tr = document.createElement('tr');
-            const tdName = document.createElement('td');
-            
-            tdName.appendChild(createModelNameWithLabels(mid, allModels));
-            tdName.style.paddingRight = '1em';
-            tdName.style.verticalAlign = 'middle';
-            const tdBtn = document.createElement('td');
-            tdBtn.style.width = '1%';
-            tdBtn.style.verticalAlign = 'middle';
-            const btn = document.createElement('button');
-            btn.textContent = '+';
-            btn.title = 'Install model';
-            btn.onclick = async function() {
-                btn.disabled = true;
-                btn.textContent = 'Installing...';
-                btn.classList.add('installing-btn');
-                try {
-                    await httpRequest(getServerBaseUrl() + '/api/v1/pull', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ model_name: mid })
-                    });
-                    await refreshModelMgmtUI();
-                    await loadModels(); // update chat dropdown too
-                } catch (e) {
-                    btn.textContent = 'Error';
-                    showErrorBanner(`Failed to install model: ${e.message}`);
-                }
-            };
-            tdBtn.appendChild(btn);
-            tr.appendChild(tdName);
-            tr.appendChild(tdBtn);
-            hotTbody.appendChild(tr);
-        });
-        
-        // Render regular suggested models as a table
         const suggestedTbody = document.getElementById('suggested-models-tbody');
-        suggestedTbody.innerHTML = '';
-        regularSuggested.forEach(mid => {
-            const tr = document.createElement('tr');
-            const tdName = document.createElement('td');
-            
-            tdName.appendChild(createModelNameWithLabels(mid, allModels));
-            tdName.style.paddingRight = '1em';
-            tdName.style.verticalAlign = 'middle';
-            const tdBtn = document.createElement('td');
-            tdBtn.style.width = '1%';
-            tdBtn.style.verticalAlign = 'middle';
-            const btn = document.createElement('button');
-            btn.textContent = '+';
-            btn.title = 'Install model';
-            btn.onclick = async function() {
-                btn.disabled = true;
-                btn.textContent = 'Installing...';
-                btn.classList.add('installing-btn');
-                try {
-                    await httpRequest(getServerBaseUrl() + '/api/v1/pull', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ model_name: mid })
-                    });
-                    await refreshModelMgmtUI();
-                    await loadModels(); // update chat dropdown too
-                } catch (e) {
-                    btn.textContent = 'Error';
-                    showErrorBanner(`Failed to install model: ${e.message}`);
-                }
-            };
-            tdBtn.appendChild(btn);
-            tr.appendChild(tdName);
-            tr.appendChild(tdBtn);
-            suggestedTbody.appendChild(tr);
-        });
+        
+        renderModelTable(hotTbody, hotModels, allModels, "Nice, you've already installed all these models!");
+        renderModelTable(suggestedTbody, regularSuggested, allModels, "Nice, you've already installed all these models!");
     }
     // Initial load
     refreshModelMgmtUI();

--- a/src/lemonade/tools/server/static/webapp.html
+++ b/src/lemonade/tools/server/static/webapp.html
@@ -145,7 +145,12 @@
                         </table>
                     </div>
                     <div class="model-mgmt-pane">
-                        <h3>Suggested Models</h3>
+                        <h3>🔥 Hot Models</h3>
+                        <table class="model-table" id="hot-models-table">
+                            <tbody id="hot-models-tbody"></tbody>
+                        </table>
+                        
+                        <h3 style="margin-top: 2em;">Suggested Models</h3>
                         <table class="model-table" id="suggested-models-table">
                             <tbody id="suggested-models-tbody"></tbody>
                         </table>
@@ -451,8 +456,14 @@
         const modelData = allModels[modelId];
         if (modelData && modelData.labels && Array.isArray(modelData.labels)) {
             modelData.labels.forEach(label => {
-                const labelSpan = document.createElement('span');
                 const labelLower = label.toLowerCase();
+                
+                // Skip "hot" labels since they have their own section
+                if (labelLower === 'hot') {
+                    return;
+                }
+                
+                const labelSpan = document.createElement('span');
                 let labelClass = 'other';
                 if (labelLower === 'vision') {
                     labelClass = 'vision';
@@ -488,10 +499,25 @@
         }
         // All models from server_models.json (window.SERVER_MODELS)
         const allModels = window.SERVER_MODELS || {};
-        // Filter suggested models not installed
-        const suggested = Object.keys(allModels).filter(
-            k => allModels[k].suggested && !installed.includes(k)
-        );
+        
+        // Separate hot models and regular suggested models not installed
+        const hotModels = [];
+        const regularSuggested = [];
+        
+        Object.keys(allModels).forEach(k => {
+            if (allModels[k].suggested && !installed.includes(k)) {
+                const modelData = allModels[k];
+                const hasHotLabel = modelData.labels && modelData.labels.some(label => 
+                    label.toLowerCase() === 'hot'
+                );
+                
+                if (hasHotLabel) {
+                    hotModels.push(k);
+                } else {
+                    regularSuggested.push(k);
+                }
+            }
+        });
         // Render installed models as a table (two columns, second is invisible)
         const installedTbody = document.getElementById('installed-models-tbody');
         installedTbody.innerHTML = '';
@@ -537,10 +563,50 @@
             tr.appendChild(tdBtn);
             installedTbody.appendChild(tr);
         });
-        // Render suggested models as a table
+        
+        // Render hot models as a table
+        const hotTbody = document.getElementById('hot-models-tbody');
+        hotTbody.innerHTML = '';
+        hotModels.forEach(mid => {
+            const tr = document.createElement('tr');
+            const tdName = document.createElement('td');
+            
+            tdName.appendChild(createModelNameWithLabels(mid, allModels));
+            tdName.style.paddingRight = '1em';
+            tdName.style.verticalAlign = 'middle';
+            const tdBtn = document.createElement('td');
+            tdBtn.style.width = '1%';
+            tdBtn.style.verticalAlign = 'middle';
+            const btn = document.createElement('button');
+            btn.textContent = '+';
+            btn.title = 'Install model';
+            btn.onclick = async function() {
+                btn.disabled = true;
+                btn.textContent = 'Installing...';
+                btn.classList.add('installing-btn');
+                try {
+                    await httpRequest(getServerBaseUrl() + '/api/v1/pull', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ model_name: mid })
+                    });
+                    await refreshModelMgmtUI();
+                    await loadModels(); // update chat dropdown too
+                } catch (e) {
+                    btn.textContent = 'Error';
+                    showErrorBanner(`Failed to install model: ${e.message}`);
+                }
+            };
+            tdBtn.appendChild(btn);
+            tr.appendChild(tdName);
+            tr.appendChild(tdBtn);
+            hotTbody.appendChild(tr);
+        });
+        
+        // Render regular suggested models as a table
         const suggestedTbody = document.getElementById('suggested-models-tbody');
         suggestedTbody.innerHTML = '';
-        suggested.forEach(mid => {
+        regularSuggested.forEach(mid => {
             const tr = document.createElement('tr');
             const tdName = document.createElement('td');
             

--- a/src/lemonade_server/server_models.json
+++ b/src/lemonade_server/server_models.json
@@ -190,7 +190,13 @@
         "checkpoint": "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Qwen3-30B-A3B-Instruct-2507-Q4_0.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["coding"]
+        "labels": ["hot"]
+    },
+    "Qwen3-Coder-30B-A3B-Instruct-GGUF": {
+        "checkpoint": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": ["coding","hot"]
     },
     "Gemma-3-4b-it-GGUF": {
         "checkpoint": "ggml-org/gemma-3-4b-it-GGUF:Q4_K_M",
@@ -212,6 +218,13 @@
         "recipe": "llamacpp",
         "suggested": true,
         "labels": ["vision"]
+    },
+    "Cogito-v2-llama-109B-MoE-GGUF": {
+        "checkpoint": "unsloth/cogito-v2-preview-llama-109B-MoE-GGUF:Q4_K_M",
+        "mmproj": "mmproj-F16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": ["vision","hot"]
     },
     "nomic-embed-text-v1-GGUF": {
         "checkpoint": "nomic-ai/nomic-embed-text-v1-GGUF:Q4_K_S",


### PR DESCRIPTION
Closes #110 

Adds `Qwen3-Coder-30B-A3B-Instruct-GGUF` and `Cogito-v2-llama-109B-MoE-GGUF` to the server.

Also introduces the concept of a "hot" model. Hot models are displayed at the top of the models doc and Model Manager. We'll curate these over time, probably only 3-5 models should ever be marked as "hot" at once.

## Demo

Model Manager:

<img width="1026" height="748" alt="image" src="https://github.com/user-attachments/assets/f8ea0689-d8ef-4d60-b250-5961ea1b450b" />

Model manager, if you already have all the models:

<img width="1025" height="513" alt="image" src="https://github.com/user-attachments/assets/fc974dfe-34b3-449c-a67f-628ed6b6ffb6" />

Docs:

<img width="1164" height="825" alt="image" src="https://github.com/user-attachments/assets/1dfbcd5b-9e6e-4de1-a059-7aff168b6064" />


