### PR TITLE
Fix inference engine import

### DIFF
--- a/src/lemonade/common/inference_engines.py
+++ b/src/lemonade/common/inference_engines.py
@@ -6,7 +6,6 @@ import platform
 import subprocess
 from abc import ABC, abstractmethod
 from typing import Dict, Optional
-import transformers
 
 
 class InferenceEngineDetector:
@@ -368,6 +367,7 @@ class TransformersDetector(BaseEngineDetector):
 
         try:
             import torch
+            import transformers
 
             if device_type == "cpu":
                 result = {


### PR DESCRIPTION
## Summary
- keep import for transformers lazy inside detection logic
- revert lazy CLI wrapper to keep scope minimal

------
https://chatgpt.com/codex/tasks/task_e_68810b4267dc832bafc1f57b2bf66ea6