### PR TITLE
Add Electron desktop app and update installer

### DIFF
--- a/.github/workflows/server_installer_windows_latest.yml
+++ b/.github/workflows/server_installer_windows_latest.yml
@@ -14,6 +14,17 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build Electron application
+        shell: bash
+        run: |
+          cd electron
+          npm install
+          npm run build
 
       - name: Install NSIS
         shell: PowerShell
@@ -75,7 +86,7 @@ jobs:
           Write-Host "ls of install directory to make sure the server is there"
           ls "$HOME\AppData\Local\lemonade_server"
 
-          $shortcutPath = "$HOME\AppData\Local\lemonade_server\lemonade-server.lnk"
+          $shortcutPath = "$HOME\AppData\Local\lemonade_server\lemonade.lnk"
           $fullCommand = Get-ShortcutTarget -shortcutPath $shortcutPath
 
           Write-Host "Server shortcut full command: $fullCommand"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+electron/node_modules/
+electron/dist/

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,40 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+const { spawn } = require('child_process');
+
+let serverProcess;
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    webPreferences: {
+      nodeIntegration: false
+    }
+  });
+  win.loadURL('http://localhost:8000/');
+}
+
+function startServer() {
+  const installDir = path.dirname(app.getPath('exe'));
+  const script = path.join(installDir, 'bin', 'lemonade-server.bat');
+  serverProcess = spawn(script, ['serve', '--no-tray'], {
+    cwd: installDir,
+    shell: true,
+    detached: false
+  });
+}
+
+app.whenReady().then(() => {
+  startServer();
+  setTimeout(createWindow, 5000);
+});
+
+app.on('window-all-closed', () => {
+  if (serverProcess) {
+    serverProcess.kill();
+  }
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "lemonade-desktop",
+  "version": "0.1.0",
+  "description": "Electron wrapper for Lemonade server web app",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "build": "electron-builder --win --dir"
+  },
+  "build": {
+    "productName": "Lemonade",
+    "directories": {
+      "output": "dist"
+    }
+  },
+  "devDependencies": {
+    "electron": "^30.0.8",
+    "electron-builder": "^24.13.1"
+  }
+}

--- a/installer/Installer.nsi
+++ b/installer/Installer.nsi
@@ -130,12 +130,15 @@ SectionIn RO ; Read only, always installed
     # Pack lemonade repo into the installer
     # Exclude hidden files (like .git, .gitignore) and the installation folder itself
     File /r /x nsis.exe /x installer /x .* /x *.pyc /x docs /x examples /x utilities ..\*.* lemonade-server.bat add_to_path.py lemonade_notification.vbs lemonade_server.vbs
+    File /r ..\electron\dist\win-unpacked\*.*
 
     # Create bin directory and move lemonade-server.bat there
     CreateDirectory "$INSTDIR\bin"
     Rename "$INSTDIR\lemonade-server.bat" "$INSTDIR\bin\lemonade-server.bat"
     Rename "$INSTDIR\lemonade_notification.vbs" "$INSTDIR\bin\lemonade_notification.vbs"
     Rename "$INSTDIR\lemonade_server.vbs" "$INSTDIR\bin\lemonade_server.vbs"
+    IfFileExists "$INSTDIR\Lemonade.exe" 0 +2
+      Rename "$INSTDIR\Lemonade.exe" "$INSTDIR\lemonade.exe"
 
     DetailPrint "- Packaged repo"
 
@@ -201,7 +204,7 @@ SectionIn RO ; Read only, always installed
 
       DetailPrint "*** INSTALLATION COMPLETED ***"
       # Create a shortcut inside $INSTDIR
-      CreateShortcut "$INSTDIR\lemonade-server.lnk" "$INSTDIR\bin\lemonade_server.vbs" "" "$INSTDIR\src\lemonade\tools\server\static\favicon.ico"
+      CreateShortcut "$INSTDIR\lemonade.lnk" "$INSTDIR\lemonade.exe" "" "$INSTDIR\src\lemonade\tools\server\static\favicon.ico"
 
       ; Add bin folder to user PATH
       DetailPrint "- Adding bin directory to user PATH..."
@@ -298,19 +301,19 @@ SubSectionEnd
 
 Section "-Add Desktop Shortcut" ShortcutSec  
   ${If} $NO_DESKTOP_SHORTCUT != "true"
-    CreateShortcut "$DESKTOP\lemonade-server.lnk" "$INSTDIR\bin\lemonade_server.vbs" "" "$INSTDIR\src\lemonade\tools\server\static\favicon.ico"
+    CreateShortcut "$DESKTOP\lemonade.lnk" "$INSTDIR\lemonade.exe" "" "$INSTDIR\src\lemonade\tools\server\static\favicon.ico"
   ${EndIf}
 SectionEnd
 
 Function RunServer
-  ExecShell "open" "$INSTDIR\LEMONADE-SERVER.lnk"
+  ExecShell "open" "$INSTDIR\lemonade.lnk"
 FunctionEnd
 
 Function AddToStartup
   ; Delete existing shortcut if it exists
-  Delete "$SMSTARTUP\lemonade-server.lnk"
+  Delete "$SMSTARTUP\lemonade.lnk"
   ; Create shortcut in the startup folder
-  CreateShortcut "$SMSTARTUP\lemonade-server.lnk" "$INSTDIR\bin\lemonade_server.vbs" "" "$INSTDIR\src\lemonade\tools\server\static\favicon.ico"
+  CreateShortcut "$SMSTARTUP\lemonade.lnk" "$INSTDIR\lemonade.exe" "" "$INSTDIR\src\lemonade\tools\server\static\favicon.ico"
 FunctionEnd
 
 ; Define constants for better readability


### PR DESCRIPTION
## Summary
- package Lemonade web UI in an Electron desktop wrapper that starts the server automatically
- include Electron build in NSIS installer and create desktop/startup shortcuts to the new app
- update Windows installer workflow to build the Electron app and adjust shortcut path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f5908d62c832ba6607822061aa657