### PR TITLE
Enable `wmi` on python embeddable distribution

### DIFF
--- a/installer/Installer.nsi
+++ b/installer/Installer.nsi
@@ -150,6 +150,9 @@ SectionIn RO ; Read only, always installed
     FileSeek $2 0 END
     FileWrite $2 "$\r$\nLib$\r$\n"
     FileWrite $2 "$\r$\nLib\site-packages$\r$\n"
+    FileWrite $2 "$\r$\nLib\site-packages\win32$\r$\n"
+    FileWrite $2 "$\r$\nLib\site-packages\win32\lib$\r$\n"
+    FileWrite $2 "$\r$\nLib\site-packages\Pythonwin$\r$\n"
     FileClose $2
 
     DetailPrint "-------------------------"


### PR DESCRIPTION
Closes https://github.com/lemonade-sdk/lemonade/issues/118

# Description

This PR enables our installer (which uses Python 3.10 embeddable package) to access `wmi`.

This enables the use of `rocm` using the command `lemonade-server serve --llamacpp rocm`.