### PR TITLE
Fix `lemonade-server run` on Linux ('OutputDuplicator' is not defined)

### DIFF
--- a/src/lemonade_server/cli.py
+++ b/src/lemonade_server/cli.py
@@ -260,6 +260,7 @@ def run(
     model_name: str,
     port: int = None,
     log_level: str = None,
+    tray: bool = False,
     llamacpp_backend: str = None,
     ctx_size: int = None,
 ):
@@ -276,7 +277,7 @@ def run(
         port, server_thread = serve(
             port=port,
             log_level=log_level,
-            tray=True,
+            tray=tray,
             use_thread=True,
             llamacpp_backend=llamacpp_backend,
             ctx_size=ctx_size,
@@ -604,6 +605,7 @@ def main():
             args.model,
             port=args.port,
             log_level=args.log_level,
+            tray=not args.no_tray,
             llamacpp_backend=args.llamacpp,
             ctx_size=args.ctx_size,
         )


### PR DESCRIPTION
# Description

This PR fixes a bug where running `lemonade-server run` would cause the error message shonw below.

```
Starting Lemonade Server...
Exception in thread Thread-1 (run):
Traceback (most recent call last):
  File "/usr/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/lemon/lib/python3.10/site-packages/lemonade/tools/server/serve.py", line 380, in run
    self._setup_server_common(
  File "/lemon/lib/python3.10/site-packages/lemonade/tools/server/serve.py", line 352, in _setup_server_common
    sys.stdout = OutputDuplicator(log_file, sys.stdout)
NameError: name 'OutputDuplicator' is not defined
```