### PR TITLE
Improve HIP ID detection mechanism

### DIFF
--- a/src/lemonade/tools/llamacpp/utils.py
+++ b/src/lemonade/tools/llamacpp/utils.py
@@ -873,6 +873,7 @@ def get_hip_devices():
             )
             continue
 
+        # Extract device name from HIP device properties
         device_name = ctypes.string_at(prop, 256).decode("utf-8").rstrip("\x00")
         devices.append([i, device_name])
 

--- a/src/lemonade/tools/llamacpp/utils.py
+++ b/src/lemonade/tools/llamacpp/utils.py
@@ -101,7 +101,7 @@ def identify_hip_id() -> str:
     if len(rocm_devices) == 0:
         rocm_devices = [hip_devices[-1]]
         logging.warning(
-            "No ROCm devices found when identifying HIP ID\n"
+            "No ROCm devices found when identifying HIP ID. "
             f"Falling back to the following device: {rocm_devices[0]}"
         )
     elif len(rocm_devices) > 1:

--- a/src/lemonade/tools/llamacpp/utils.py
+++ b/src/lemonade/tools/llamacpp/utils.py
@@ -785,24 +785,24 @@ def get_hip_devices(hip_path):
     import ctypes
     import sys
     import os
+    import glob
     from ctypes import c_int, POINTER
     from ctypes.util import find_library
 
     # Load HIP library
-    hip_library = "amdhip64_7.dll" if sys.platform.startswith('win') else "libamdhip64.so"
-    path = os.path.join(hip_path, hip_library)
-    if not path:
-        raise RuntimeError(f"Could not find HIP runtime library: {hip_library}")
-    
+    hip_library_pattern = "amdhip64*.dll" if sys.platform.startswith('win') else "libamdhip64*.so"
+    search_pattern = os.path.join(hip_path, hip_library_pattern)
+    matching_files = glob.glob(search_pattern)
+    if not matching_files:
+        raise RuntimeError(f"Could not find HIP runtime library matching pattern: {hip_library_pattern}")
     try:
-        libhip = ctypes.CDLL(path)
+        libhip = ctypes.CDLL(matching_files[0])
     except OSError:
         raise RuntimeError(f"Could not load HIP runtime library from {path}")
     
     # Setup function signatures
     hipError_t = c_int
     hipDeviceProp_t = ctypes.c_char * 1024
-    
     libhip.hipGetDeviceCount.restype = hipError_t
     libhip.hipGetDeviceCount.argtypes = [POINTER(c_int)]
     libhip.hipGetDeviceProperties.restype = hipError_t

--- a/src/lemonade/tools/llamacpp/utils.py
+++ b/src/lemonade/tools/llamacpp/utils.py
@@ -101,8 +101,8 @@ def identify_hip_id() -> str:
     if len(rocm_devices) == 0:
         rocm_devices = [hip_devices[-1]]
         logging.warning(
-            "No ROCm devices found when identifying HIP ID"
-            "Falling back to the following device: {rocm_devices[0]}"
+            "No ROCm devices found when identifying HIP ID\n"
+            f"Falling back to the following device: {rocm_devices[0]}"
         )
     elif len(rocm_devices) > 1:
         logging.warning(

--- a/src/lemonade/tools/llamacpp/utils.py
+++ b/src/lemonade/tools/llamacpp/utils.py
@@ -844,7 +844,7 @@ def get_hip_devices():
 
     # Setup function signatures
     hipError_t = c_int
-    hipDeviceProp_t = ctypes.c_char * 1024
+    hipDeviceProp_t = ctypes.c_char * 2048
     libhip.hipGetDeviceCount.restype = hipError_t
     libhip.hipGetDeviceCount.argtypes = [POINTER(c_int)]
     libhip.hipGetDeviceProperties.restype = hipError_t

--- a/test/server_llamacpp.py
+++ b/test/server_llamacpp.py
@@ -58,6 +58,17 @@ class LlamaCppTesting(ServerTestingBase):
         print("\n=== Cleaning up GGUF/LlamaCPP test ===")
         super().cleanup_lemonade(server_subprocess)
 
+    def test_000_get_hip_devices_returns_zero(self):
+        """ROCm-only: get_hip_devices should report zero devices in CI."""
+        if self.llamacpp_backend != "rocm":
+            return
+        
+        from lemonade.tools.llamacpp.utils import get_hip_devices
+
+        expected_devices = [[0, "AMD Radeon Graphics"]] if sys.platform.startswith("win") else [[0, "AMD Radeon Graphics"]]
+        devices = get_hip_devices()
+        assert devices == expected_devices, f"Expected {expected_devices} devices, got {devices}"
+        
     # Endpoint: /api/v1/chat/completions
     def test_001_test_llamacpp_chat_completion_streaming(self):
         client = OpenAI(

--- a/test/server_llamacpp.py
+++ b/test/server_llamacpp.py
@@ -20,6 +20,7 @@ If you get the `ImportError: cannot import name 'TypeIs' from 'typing_extensions
     2. pip install openai
 """
 
+import sys
 import asyncio
 import requests
 import numpy as np


### PR DESCRIPTION
# Description

This PR improves HIP ID detection by directly querying HIP for device IDs, which are then used to set HIP_VISIBLE_DEVICES.

## Understanding ROCm device identification

ROCm requires the device to be identified in two separate stages:

* **Stage 1**: Before downloading binaries
  * Goal: identify the device family, which in turn allows us to select which binary to download.
  * At this stage, we do not assume that ROCm or HIP are available on the system
  
* **Stage 2**: After downloading the binaries
  * Goal: identify which value to set for HIP_VISIBLE_DEVICES
  * Since we have now have the downloaded binaries, we query HIP directly
  * After getting the list of HIP devices available, we filter those to only keep the devices we support on ROCm

## Fallbacks

On Linux, HIP identifies the STX Halo's iGPU (AMD Radeon(TM) 8060S Graphics) simply as "AMD Radeon Graphics". In cases where we can detect HIP devices but cannot filter them by name, we fall back to using the detected device and issue a warning, rather than causing a crash.

## Frequency in which HIP ID is updated

We currently only detect HIP devices once, during installation. This is intentional to avoid any added delays when loading a model. Users that wish to change our selection may change the `.env` file located at `<ENV_PATH>\rocm\llama_server\`.

## Testing

To test this PR, please create a new environment, install Lemonade, and run `lemonade-server-dev serve --llamacpp rocm --log-level debug`. You should see something along the following lines as part of your logs once you run your first GGUF model:

```
DEBUG:    HIP devices found: [[0, 'AMD Radeon(TM) 8060S Graphics']]
DEBUG:    ROCm devices found: [[0, 'AMD Radeon(TM) 8060S Graphics']]
DEBUG:    Selected ROCm device: [0, 'AMD Radeon(TM) 8060S Graphics']
```


