### PR TITLE
Move OGA API examples to pre-built OGA model, and remove hf token from test

### DIFF
--- a/.github/workflows/test_lemonade_oga_cpu.yml
+++ b/.github/workflows/test_lemonade_oga_cpu.yml
@@ -44,8 +44,6 @@ jobs:
           pylint src/lemonade --rcfile .pylintrc --disable E0401
       - name: Run lemonade tests
         shell: bash -el {0}
-        env:
-          HF_TOKEN: "${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}" # Required by OGA model_builder in OGA 0.4.0 but not future versions
         run: |
           # Test CLI
           lemonade -i amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx oga-load --device cpu --dtype int4 llm-prompt -p "tell me a story" --max-new-tokens 5

--- a/examples/api_oga_cpu.py
+++ b/examples/api_oga_cpu.py
@@ -10,7 +10,9 @@ https://github.com/lemonade-sdk/lemonade/blob/main/docs/README.md#installation
 
 from lemonade.api import from_pretrained
 
-model, tokenizer = from_pretrained("Qwen/Qwen2.5-0.5B-Instruct", recipe="oga-cpu")
+model, tokenizer = from_pretrained(
+    "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx", recipe="oga-cpu"
+)
 
 input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
 response = model.generate(input_ids, max_new_tokens=30)

--- a/examples/api_oga_cpu_streaming.py
+++ b/examples/api_oga_cpu_streaming.py
@@ -15,7 +15,9 @@ from threading import Thread
 from lemonade.api import from_pretrained
 from lemonade.tools.oga.utils import OrtGenaiStreamer
 
-model, tokenizer = from_pretrained("Qwen/Qwen2.5-0.5B-Instruct", recipe="oga-cpu")
+model, tokenizer = from_pretrained(
+    "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx", recipe="oga-cpu"
+)
 
 input_ids = tokenizer("This is my prompt", return_tensors="pt").input_ids
 


### PR DESCRIPTION
This change unblocks external contribs from passing tests, and allows the OGA test to be "required" again

It does have the side effect that OGA model_builder is no longer tested during that check, but I don't think that was the intention in the first place.