### PR TITLE
Switch to PEP 517 build backend to silence pip deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=68",
+  "wheel"
+]
+build-backend = "setuptools.build_meta"
+
+


### PR DESCRIPTION
# Description

This pr adds a `pyproject.toml` with `setuptools.build_meta` to use the standardized PEP 517 build interface. As a result, this eliminates pip’s legacy setup.py `bdist_wheel` deprecation warning.