### PR TITLE
Windows launcher: support env vars for lemonade-server options

### DIFF
--- a/docs/server/server_integration.md
+++ b/docs/server/server_integration.md
@@ -115,6 +115,12 @@ You can also prevent the server from showing a system tray icon by using the `--
 lemonade-server serve --no-tray
 ```
 
+On Windows installations created with the Lemonade installer, the server can also read
+its host, port, log level, Llama.cpp backend, and context size from environment
+variables. Set `LEMONADE_HOST`, `LEMONADE_PORT`, `LEMONADE_LOG_LEVEL`,
+`LEMONADE_LLAMACPP`, or `LEMONADE_CTX_SIZE` before launching `lemonade-server` to
+override the default settings without editing the startup script.
+
 You can also run the server as a background process using a subprocess or any preferred method.
 
 To stop the server, you may use the `lemonade-server stop` command, or simply terminate the process you created by keeping track of its PID. Please do not run the `lemonade-server stop` command if your application has not started the server, as the server may be used by other applications.

--- a/installer/lemonade_server.vbs
+++ b/installer/lemonade_server.vbs
@@ -1,4 +1,4 @@
-' This script detects wheter we are in headless mode and launches lemonade-server
+' This script detects whether we are in headless mode and launches lemonade-server
 ' either in headless mode or with a system tray icon.
 
 Set wshShell = CreateObject("WScript.Shell")
@@ -8,6 +8,35 @@ scriptDir = fso.GetParentFolderName(WScript.ScriptFullName)
 
 ' Declare headless variable
 Dim HEADLESS
+
+' Build argument list from optional environment variables
+Dim args, host, port, logLevel, llamaBackend, ctxSize
+args = " serve"
+
+host = wshShell.ExpandEnvironmentStrings("%LEMONADE_HOST%")
+If host <> "%LEMONADE_HOST%" And host <> "" Then
+    args = args & " --host """ & host & """"
+End If
+
+port = wshShell.ExpandEnvironmentStrings("%LEMONADE_PORT%")
+If port <> "%LEMONADE_PORT%" And port <> "" Then
+    args = args & " --port " & port
+End If
+
+logLevel = wshShell.ExpandEnvironmentStrings("%LEMONADE_LOG_LEVEL%")
+If logLevel <> "%LEMONADE_LOG_LEVEL%" And logLevel <> "" Then
+    args = args & " --log-level """ & logLevel & """"
+End If
+
+llamaBackend = wshShell.ExpandEnvironmentStrings("%LEMONADE_LLAMACPP%")
+If llamaBackend <> "%LEMONADE_LLAMACPP%" And llamaBackend <> "" Then
+    args = args & " --llamacpp """ & llamaBackend & """"
+End If
+
+ctxSize = wshShell.ExpandEnvironmentStrings("%LEMONADE_CTX_SIZE%")
+If ctxSize <> "%LEMONADE_CTX_SIZE%" And ctxSize <> "" Then
+    args = args & " --ctx-size " & ctxSize
+End If
 
 ' Simple GUI detection: check if system tray is available
 On Error Resume Next
@@ -35,15 +64,15 @@ End If
 
 If HEADLESS = True Then
     ' Headless mode: open a terminal and run the server without the tray
-    wshShell.Run """" & scriptDir & "\lemonade-server.bat"" serve --no-tray", 1, True
+    wshShell.Run """" & scriptDir & "\lemonade-server.bat""" & args & " --no-tray", 1, True
 Else
     ' Check if we're in CI mode via environment variable
     ciMode = wshShell.ExpandEnvironmentStrings("%LEMONADE_CI_MODE%")
     If ciMode <> "%LEMONADE_CI_MODE%" And (LCase(ciMode) = "true" Or LCase(ciMode) = "1") Then
         ' CI mode: run without tray even in GUI environment
-        wshShell.Run """" & scriptDir & "\lemonade-server.bat"" serve --no-tray", 1, True
+        wshShell.Run """" & scriptDir & "\lemonade-server.bat""" & args & " --no-tray", 1, True
     Else
         ' GUI mode: Run the server on a hidden window with the tray
-        wshShell.Run """" & scriptDir & "\lemonade-server.bat"" serve", 0, False
+        wshShell.Run """" & scriptDir & "\lemonade-server.bat""" & args, 0, False
     End If
 End If


### PR DESCRIPTION
Add env var parsing in installer/lemonade_server.vbs: LEMONADE_HOST, LEMONADE_PORT, LEMONADE_LOG_LEVEL, LEMONADE_LLAMACPP, LEMONADE_CTX_SIZE. Build command-line args accordingly. Fix comment typo ('whether').

Update docs/server/server_integration.md to document Windows env-based configuration.

Rationale: allows configuration without editing installed scripts; good for CI and enterprise deployments; fully backwards compatible when variables are unset.