### PR TITLE
Change location where defaults are defined

### DIFF
--- a/docs/server/README.md
+++ b/docs/server/README.md
@@ -4,11 +4,6 @@
 
 Lemonade Server is available as a standalone tool with a [one-click Windows GUI installer](https://github.com/lemonade-sdk/lemonade/releases/latest/download/Lemonade_Server_Installer.exe).
 
-No matter how the server is launched, you can configure its host, port, log
-level, Llama.cpp backend, and context size by setting the environment variables
-`LEMONADE_HOST`, `LEMONADE_PORT`, `LEMONADE_LOG_LEVEL`, `LEMONADE_LLAMACPP`, and
-`LEMONADE_CTX_SIZE`.
-
 Once you've installed, we recommend checking out these resources:
 
 | Documentation | Description |

--- a/docs/server/server_integration.md
+++ b/docs/server/server_integration.md
@@ -115,12 +115,6 @@ You can also prevent the server from showing a system tray icon by using the `--
 lemonade-server serve --no-tray
 ```
 
-Regardless of how Lemonade Server is installed or launched, it can read its host,
-port, log level, Llama.cpp backend, and context size from environment variables.
-Set `LEMONADE_HOST`, `LEMONADE_PORT`, `LEMONADE_LOG_LEVEL`, `LEMONADE_LLAMACPP`,
-or `LEMONADE_CTX_SIZE` before launching `lemonade-server` by any method to
-override the default settings without editing the startup script.
-
 You can also run the server as a background process using a subprocess or any preferred method.
 
 To stop the server, you may use the `lemonade-server stop` command, or simply terminate the process you created by keeping track of its PID. Please do not run the `lemonade-server stop` command if your application has not started the server, as the server may be used by other applications.

--- a/src/lemonade/tools/server/serve.py
+++ b/src/lemonade/tools/server/serve.py
@@ -56,6 +56,11 @@ from lemonade.tools.server.utils.port import lifespan
 from lemonade_server.model_manager import ModelManager
 from lemonade_server.pydantic_models import (
     DEFAULT_MAX_NEW_TOKENS,
+    DEFAULT_PORT,
+    DEFAULT_HOST,
+    DEFAULT_LOG_LEVEL,
+    DEFAULT_LLAMACPP_BACKEND,
+    DEFAULT_CTX_SIZE,
     LoadConfig,
     CompletionRequest,
     ChatCompletionRequest,
@@ -70,14 +75,6 @@ from lemonade_server.pydantic_models import (
 if platform.system() == "Windows":
     # pylint: disable=ungrouped-imports
     from lemonade.tools.server.tray import LemonadeTray, OutputDuplicator
-
-
-DEFAULT_PORT = int(os.getenv("LEMONADE_PORT", "8000"))
-DEFAULT_HOST = os.getenv("LEMONADE_HOST", "localhost")
-DEFAULT_LOG_LEVEL = os.getenv("LEMONADE_LOG_LEVEL", "info")
-DEFAULT_LLAMACPP_BACKEND = os.getenv("LEMONADE_LLAMACPP", "vulkan")
-DEFAULT_CTX_SIZE = int(os.getenv("LEMONADE_CTX_SIZE", "4096"))
-
 
 class ServerModel(Model):
     """

--- a/src/lemonade/tools/server/serve.py
+++ b/src/lemonade/tools/server/serve.py
@@ -54,7 +54,6 @@ from lemonade.tools.server.utils.port import lifespan
 
 from lemonade_server.model_manager import ModelManager
 from lemonade_server.pydantic_models import (
-    DEFAULT_MAX_NEW_TOKENS,
     DEFAULT_PORT,
     DEFAULT_HOST,
     DEFAULT_LOG_LEVEL,
@@ -69,6 +68,10 @@ from lemonade_server.pydantic_models import (
     PullConfig,
     DeleteConfig,
 )
+
+# Set to a high number to allow for interesting experiences in real apps
+# Tests should use the max_new_tokens argument to set a lower value
+DEFAULT_MAX_NEW_TOKENS = 1500
 
 # Only import tray on Windows
 if platform.system() == "Windows":

--- a/src/lemonade/tools/server/serve.py
+++ b/src/lemonade/tools/server/serve.py
@@ -11,7 +11,6 @@ from typing import Optional, Union
 import json
 import subprocess
 from pathlib import Path
-import os
 
 from fastapi import FastAPI, HTTPException, status, Request
 from fastapi.responses import StreamingResponse
@@ -75,6 +74,7 @@ from lemonade_server.pydantic_models import (
 if platform.system() == "Windows":
     # pylint: disable=ungrouped-imports
     from lemonade.tools.server.tray import LemonadeTray, OutputDuplicator
+
 
 class ServerModel(Model):
     """

--- a/src/lemonade_server/cli.py
+++ b/src/lemonade_server/cli.py
@@ -4,7 +4,13 @@ import os
 from typing import Tuple, Optional
 import psutil
 from typing import List
-
+from lemonade_server.pydantic_models import (
+    DEFAULT_PORT,
+    DEFAULT_HOST,
+    DEFAULT_LOG_LEVEL,
+    DEFAULT_LLAMACPP_BACKEND,
+    DEFAULT_CTX_SIZE,
+)
 
 # Error codes for different CLI scenarios
 class ExitCodes:
@@ -60,14 +66,8 @@ def serve(
 
     # Otherwise, start the server
     print("Starting Lemonade Server...")
-    from lemonade.tools.server.serve import (
-        Server,
-        DEFAULT_PORT,
-        DEFAULT_HOST,
-        DEFAULT_LOG_LEVEL,
-        DEFAULT_LLAMACPP_BACKEND,
-        DEFAULT_CTX_SIZE,
-    )
+    from lemonade.tools.server.serve import Server
+
 
     port = port if port is not None else DEFAULT_PORT
     host = host if host is not None else DEFAULT_HOST
@@ -75,8 +75,6 @@ def serve(
     llamacpp_backend = (
         llamacpp_backend if llamacpp_backend is not None else DEFAULT_LLAMACPP_BACKEND
     )
-
-    # Use ctx_size if provided, otherwise use default
     ctx_size = ctx_size if ctx_size is not None else DEFAULT_CTX_SIZE
 
     # Start the server
@@ -473,13 +471,6 @@ def developer_entrypoint():
 
 def _add_server_arguments(parser):
     """Add common server arguments to a parser"""
-    from lemonade.tools.server.serve import (
-        DEFAULT_PORT,
-        DEFAULT_HOST,
-        DEFAULT_LOG_LEVEL,
-        DEFAULT_LLAMACPP_BACKEND,
-        DEFAULT_CTX_SIZE,
-    )
 
     parser.add_argument(
         "--port",

--- a/src/lemonade_server/cli.py
+++ b/src/lemonade_server/cli.py
@@ -12,6 +12,7 @@ from lemonade_server.pydantic_models import (
     DEFAULT_CTX_SIZE,
 )
 
+
 # Error codes for different CLI scenarios
 class ExitCodes:
     SUCCESS = 0
@@ -67,7 +68,6 @@ def serve(
     # Otherwise, start the server
     print("Starting Lemonade Server...")
     from lemonade.tools.server.serve import Server
-
 
     port = port if port is not None else DEFAULT_PORT
     host = host if host is not None else DEFAULT_HOST

--- a/src/lemonade_server/pydantic_models.py
+++ b/src/lemonade_server/pydantic_models.py
@@ -3,7 +3,6 @@ from typing import Optional, Union, List
 
 from pydantic import BaseModel
 
-DEFAULT_MAX_NEW_TOKENS = int(os.getenv("LEMONADE_MAX_NEW_TOKENS", "1500"))
 DEFAULT_PORT = int(os.getenv("LEMONADE_PORT", "8000"))
 DEFAULT_HOST = os.getenv("LEMONADE_HOST", "localhost")
 DEFAULT_LOG_LEVEL = os.getenv("LEMONADE_LOG_LEVEL", "info")

--- a/src/lemonade_server/pydantic_models.py
+++ b/src/lemonade_server/pydantic_models.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, Union, List
 
 from pydantic import BaseModel
@@ -8,6 +9,7 @@ DEFAULT_HOST = os.getenv("LEMONADE_HOST", "localhost")
 DEFAULT_LOG_LEVEL = os.getenv("LEMONADE_LOG_LEVEL", "info")
 DEFAULT_LLAMACPP_BACKEND = os.getenv("LEMONADE_LLAMACPP", "vulkan")
 DEFAULT_CTX_SIZE = int(os.getenv("LEMONADE_CTX_SIZE", "4096"))
+
 
 class LoadConfig(BaseModel):
     """

--- a/src/lemonade_server/pydantic_models.py
+++ b/src/lemonade_server/pydantic_models.py
@@ -2,10 +2,12 @@ from typing import Optional, Union, List
 
 from pydantic import BaseModel
 
-# Set to a high number to allow for interesting experiences in real apps
-# Tests should use the max_new_tokens argument to set a lower value
-DEFAULT_MAX_NEW_TOKENS = 1500
-
+DEFAULT_MAX_NEW_TOKENS = int(os.getenv("LEMONADE_MAX_NEW_TOKENS", "1500"))
+DEFAULT_PORT = int(os.getenv("LEMONADE_PORT", "8000"))
+DEFAULT_HOST = os.getenv("LEMONADE_HOST", "localhost")
+DEFAULT_LOG_LEVEL = os.getenv("LEMONADE_LOG_LEVEL", "info")
+DEFAULT_LLAMACPP_BACKEND = os.getenv("LEMONADE_LLAMACPP", "vulkan")
+DEFAULT_CTX_SIZE = int(os.getenv("LEMONADE_CTX_SIZE", "4096"))
 
 class LoadConfig(BaseModel):
     """


### PR DESCRIPTION
# Description

This PR changes the location where the default values for the server are defined, ensuring we can use `lemonade-server` without having to load from `lemonade`.