### PR TITLE
Add Discord Icon to Docs Site

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,7 +27,7 @@
 
    👉 [Supported Configurations](https://github.com/lemonade-sdk/lemonade?tab=readme-ov-file#supported-configurations)
 
-   For more information on Hybrid/NPU Support, see the section [Hybrid/NPU](#hybrid--npu-specific-questions).
+   For more information on Hybrid/NPU Support, see the section [Hybrid/NPU](#hybrid-and-npu-questions).
 
 ### 3. **Is Linux supported?**
 
@@ -82,7 +82,7 @@
 
    Yes, there's a guide on preparing your models for Ryzen AI NPU:
 
-   👉 [Model Preparation Guide]([https://ryzenai.docs.amd.com/en/latest/oga_model_prepare.html](https://github.com/lemonade-sdk/lemonade/blob/main/docs/dev_cli/finetuned_model_export.md))
+   👉 [Model Preparation Guide](https://ryzenai.docs.amd.com/en/latest/oga_model_prepare.html)
 
 ### 5. **What's the difference between GGUF and ONNX models?**
 
@@ -114,7 +114,7 @@
 
    Lemonade supports llama.cpp as a backend, so performance is similar when using the same model and quantization.
 
-## Hybrid & NPU-Specific Questions
+## Hybrid and NPU Questions
 
 ### 1. **Does hybrid inference with the NPU only work on Windows?**
 

--- a/docs/server/lemonade-server-cli.md
+++ b/docs/server/lemonade-server-cli.md
@@ -9,7 +9,7 @@ The `lemonade-server` command-line interface (CLI) provides a set of utility com
 | Option/Command      | Description                         |
 |---------------------|-------------------------------------|
 | `-v`, `--version`   | Print the `lemonade-sdk` package version used to install Lemonade Server. |
-| `serve`             | Start the server process in the current terminal. See command options [below](#command-line-options-for-serve). |
+| `serve`             | Start the server process in the current terminal. See command options [below](#command-line-options-for-serve-and-run). |
 | `status`            | Check if server is running. If it is, print the port number. |
 | `stop`              | Stop any running Lemonade Server process. |
 | `pull MODEL_NAME`   | Install an LLM named `MODEL_NAME`. See the [server models guide](./server_models.md) for more information. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,8 @@ extra:
       link: https://www.youtube.com/@AMDDevCentral
     - icon: simple/github
       link: https://github.com/lemonade-sdk/lemonade
+    - icon: simple/discord
+      link: https://discord.gg/5xXzkMu8Zk
 
 copyright: Copyright &copy; 2025 AMD. All rights reserved.
 


### PR DESCRIPTION
This PR adds a discord icon to the footer of the docs site.
Also caught a couple of deadlinks in our docs. 