### PR TITLE
add GLM 4.5 AIR to server_models.json

### DIFF
--- a/src/lemonade_server/server_models.json
+++ b/src/lemonade_server/server_models.json
@@ -318,5 +318,11 @@
         "recipe": "llamacpp",
         "suggested": true,
         "labels": ["hot", "reasoning"]
+    },
+    "GLM-4.5-Air-UD-Q4K-XL-GGUF": {
+        "checkpoint": "unsloth/GLM-4.5-Air-GGUF:UD-Q4_K_XL",
+        "recipe": "llamacpp",
+        "suggested": false,
+        "labels": ["reasoning"]
     }
 }

--- a/src/lemonade_server/server_models.json
+++ b/src/lemonade_server/server_models.json
@@ -322,7 +322,7 @@
     "GLM-4.5-Air-UD-Q4K-XL-GGUF": {
         "checkpoint": "unsloth/GLM-4.5-Air-GGUF:UD-Q4_K_XL",
         "recipe": "llamacpp",
-        "suggested": false,
-        "labels": ["reasoning"]
+        "suggested": true,
+        "labels": ["reasoning","hot"]
     }
 }


### PR DESCRIPTION
**unsloth/GLM-4.5-Air-GGUF:UD-Q4_K_XL**

<img width="1680" height="940" alt="Screenshot 2025-08-13 at 10 38 10 AM" src="https://github.com/user-attachments/assets/cac8d27c-d52f-4819-84e0-1ee3b67ccbef" />

_did not set "suggested" flag_

**Rationale for choosing GLM-4.5-Air-UD-Q4_K_XL**
	•	Fits comfortably in 96 GB VRAM. Weights are ~73 GB, leaving headroom for KV cache, longer context, and small batching without spilling to system RAM.
	•	Strong quality/size trade-off.
	•	UD = Unsloth Dynamic 2.0 quantization; better accuracy retention than older 4-bit schemes.
	•	Q4_K = proven 4-bit K-quant family for llama.cpp.
	•	XL = mixed precision on sensitive matrices; quality bump over plain Q4_K at similar size.
	•	MoE-friendly. GLM-4.5-Air activates ~12B params per token, so keeping VRAM margin for KV cache is important; this variant preserves that margin.
	•	Alternatives considered.
	•	UD-Q5_K_XL (~83–84 GB): works but reduces VRAM headroom.
	•	Q6_K / Q8_0: exceed 96 GB and will spill.
	•	IQ4_NL (~62 GB): smaller but larger quality hit versus UD-XL.
	•	Maintainer. unsloth GGUFs have correct chat-template metadata and load cleanly in Lemonade’s llama.cpp backend with no prompt hacks.