### PR TITLE
Update styles.css so tooltips will show correctly

### DIFF
--- a/src/lemonade/tools/server/static/styles.css
+++ b/src/lemonade/tools/server/static/styles.css
@@ -1836,7 +1836,7 @@ body::before {
   background: #fff;
   border-radius: 8px;
   border: 1px solid #e0e0e0;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .model-browser-sidebar {
@@ -1974,7 +1974,7 @@ body::before {
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .model-browser-header {


### PR DESCRIPTION
Tooltips previously obscured by other page elements. They now display correctly to inform users.

Changed CSS style for .model-browser-container and .model-browser-main from hidden to visible. I didn't notice any negative impacts on the display of any page elements.

before:

<img width="1057" height="412" alt="image" src="https://github.com/user-attachments/assets/6414868d-5338-45ae-9021-8eff5ffe6a69" />
<img width="1189" height="406" alt="image" src="https://github.com/user-attachments/assets/a2ad18e9-ae9d-41db-ac45-8f0a03080377" />

after:

<img width="971" height="362" alt="image" src="https://github.com/user-attachments/assets/edef2174-94e0-4a11-b578-e2585809d210" />
<img width="1046" height="398" alt="image" src="https://github.com/user-attachments/assets/b293c194-3672-4b0e-b361-98d37002595a" />

Hope this helps!