### PR TITLE
FIxed simple non-assigned boolean variable using else statement.

### DIFF
--- a/src/lemonade_server/cli.py
+++ b/src/lemonade_server/cli.py
@@ -615,7 +615,6 @@ def main():
         args.no_tray = True
     else:
         args.no_tray = False
-    
     if args.version:
         version()
     elif args.command == "serve":


### PR DESCRIPTION
Condition for "args.no_tray = True" needs an else condition to make sure the value of the attribute is not Nonetype.