### PR TITLE
Refactor WrappedServer out of LlamaServer

### DIFF
--- a/src/lemonade/tools/server/llamacpp.py
+++ b/src/lemonade/tools/server/llamacpp.py
@@ -1,143 +1,27 @@
 import os
 import logging
-import time
 import subprocess
 import re
 import threading
 import platform
 
-import requests
-from tabulate import tabulate
 from dotenv import load_dotenv
-from fastapi import HTTPException, status
-from fastapi.responses import StreamingResponse
-
-from openai import OpenAI
 
 from lemonade_server.pydantic_models import (
-    ChatCompletionRequest,
-    CompletionRequest,
     PullConfig,
-    EmbeddingsRequest,
-    RerankingRequest,
 )
-from lemonade_server.model_manager import ModelManager
-from lemonade.tools.server.utils.port import find_free_port
 from lemonade.tools.llamacpp.utils import (
     get_llama_server_exe_path,
     install_llamacpp,
     download_gguf,
 )
+from lemonade.tools.server.wrapped_server import WrappedServerTelemetry, WrappedServer
 
 
-def llamacpp_address(port: int) -> str:
-    """
-    Generate the base URL for the llamacpp server.
-
-    Args:
-        port: The port number the llamacpp server is running on
-
-    Returns:
-        The base URL for the llamacpp server
-    """
-    return f"http://127.0.0.1:{port}/v1"
-
-
-def _separate_openai_params(request_dict: dict, endpoint_type: str = "chat") -> dict:
-    """
-    Separate standard OpenAI parameters from custom llama.cpp parameters.
-
-    Args:
-        request_dict: Dictionary of all request parameters
-        endpoint_type: Type of endpoint ("chat" or "completion")
-
-    Returns:
-        Dictionary with parameters properly separated for OpenAI client
-    """
-    openai_client_params = {}
-    extra_params = {}
-
-    # Common OpenAI parameters for both endpoint types
-    common_params = {
-        "model",
-        "frequency_penalty",
-        "logit_bias",
-        "logprobs",
-        "max_tokens",
-        "n",
-        "presence_penalty",
-        "seed",
-        "stop",
-        "stream",
-        "temperature",
-        "top_p",
-        "user",
-    }
-
-    # Standard OpenAI parameters by endpoint type
-    if endpoint_type == "chat":
-        chat_specific_params = {
-            "messages",
-            "top_logprobs",
-            "response_format",
-            "service_tier",
-            "stream_options",
-            "tools",
-            "tool_choice",
-            "parallel_tool_calls",
-        }
-        openai_params = common_params | chat_specific_params
-    else:  # completion
-        completion_specific_params = {
-            "prompt",
-            "best_of",
-            "echo",
-            "suffix",
-        }
-        openai_params = common_params | completion_specific_params
-
-    for key, value in request_dict.items():
-        if key in openai_params:
-            openai_client_params[key] = value
-        else:
-            extra_params[key] = value
-
-    # If there are custom parameters, use extra_body to pass them through
-    if extra_params:
-        openai_client_params["extra_body"] = extra_params
-
-    return openai_client_params
-
-
-class LlamaTelemetry:
+class LlamaTelemetry(WrappedServerTelemetry):
     """
     Manages telemetry data collection and display for llama server.
     """
-
-    def __init__(self):
-        self.input_tokens = None
-        self.output_tokens = None
-        self.time_to_first_token = None
-        self.tokens_per_second = None
-        self.prompt_eval_time = None
-        self.eval_time = None
-        self.port = None
-
-    def choose_port(self):
-        """
-        Users probably don't care what port we start llama-server on, so let's
-        search for an empty port
-        """
-
-        self.port = find_free_port()
-
-        if self.port is None:
-            msg = "Failed to find an empty port to start llama-server on"
-            logging.error(msg)
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=msg,
-            )
 
     def parse_telemetry_line(self, line: str):
         """
@@ -186,468 +70,187 @@ class LlamaTelemetry:
             self.tokens_per_second = tokens_per_second
             return
 
-    def get_telemetry_data(self):
-        return {
-            "input_tokens": self.input_tokens,
-            "output_tokens": self.output_tokens,
-            "time_to_first_token": self.time_to_first_token,
-            "tokens_per_second": self.tokens_per_second,
-            "decode_token_times": None,
-        }
 
-    def show_telemetry(self):
-        # Check if debug logging is enabled
-        if not logging.getLogger().isEnabledFor(logging.DEBUG):
-            return
+class LlamaServer(WrappedServer):
+    def __init__(self, backend: str):
+        self.telemetry = LlamaTelemetry()
+        self.backend = backend
+        super().__init__(server_name="llama-server", telemetry=self.telemetry)
 
-        # Prepare telemetry data (transposed format)
-        telemetry = [
-            ["Input tokens", self.input_tokens],
-            ["Output tokens", self.output_tokens],
-            ["TTFT (s)", f"{self.time_to_first_token:.2f}"],
-            ["TPS", f"{self.tokens_per_second:.2f}"],
+    def install_server(self, backend=None):
+        """
+        Install the wrapped server
+        """
+        install_llamacpp(self.backend)
+
+    def download_model(
+        self, config_checkpoint, config_mmproj=None, do_not_upgrade=False
+    ) -> dict:
+        """
+        Download a model for the wrapper server
+        """
+        download_gguf(
+            config_checkpoint=config_checkpoint,
+            config_mmproj=config_mmproj,
+            do_not_upgrade=do_not_upgrade,
+        )
+
+    def _launch_device_backend_subprocess(
+        self,
+        snapshot_files: dict,
+        use_gpu: bool,
+        ctx_size: int,
+        supports_embeddings: bool = False,
+        supports_reranking: bool = False,
+    ) -> subprocess.Popen:
+        """
+        Launch llama server subprocess with appropriate configuration.
+
+        Args:
+            snapshot_files: Dictionary of model files to load
+            use_gpu: Whether to use GPU acceleration
+            telemetry: Telemetry object for tracking performance metrics
+            backend: Backend to use (e.g., 'vulkan', 'rocm')
+            supports_embeddings: Whether the model supports embeddings
+            supports_reranking: Whether the model supports reranking
+
+        Returns:
+            Subprocess handle for the llama server
+        """
+
+        # Get the current executable path (handles both Windows and Ubuntu structures)
+        exe_path = get_llama_server_exe_path(self.backend)
+
+        # Build the base command
+        base_command = [
+            exe_path,
+            "-m",
+            snapshot_files["variant"],
+            "--ctx-size",
+            str(ctx_size),
         ]
 
-        table = tabulate(
-            telemetry, headers=["Metric", "Value"], tablefmt="fancy_grid"
-        ).split("\n")
+        # Lock random seed for deterministic behavior in CI
+        if os.environ.get("LEMONADE_CI_MODE"):
+            base_command.extend(["--seed", "42"])
 
-        # Show telemetry in debug while complying with uvicorn's log indentation
-        logging.debug("\n          ".join(table))
+        if "mmproj" in snapshot_files:
+            base_command.extend(["--mmproj", snapshot_files["mmproj"]])
+            if not use_gpu:
+                base_command.extend(["--no-mmproj-offload"])
 
+        # Find a port, and save it in the telemetry object for future reference
+        # by other functions
+        self.choose_port()
 
-def _log_subprocess_output(
-    process: subprocess.Popen, prefix: str, telemetry: LlamaTelemetry
-):
-    """
-    Read subprocess output line by line, log to debug, and parse telemetry
-    """
+        # Add port and jinja to enable tool use
+        base_command.extend(["--port", str(self.port), "--jinja"])
 
-    if process.stdout:
-        try:
-            for line in iter(process.stdout.readline, ""):
-                if line:
-                    line_stripped = line.strip()
-                    logging.debug("%s: %s", prefix, line_stripped)
-
-                    telemetry.parse_telemetry_line(line_stripped)
-
-                if process.poll() is not None:
-                    break
-        except UnicodeDecodeError as e:
-            logging.debug("Unicode decode error reading subprocess output: %s", str(e))
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logging.error("Unexpected error reading subprocess output: %s", str(e))
-
-
-def _wait_for_load(llama_server_process: subprocess.Popen, port: int):
-    status_code = None
-    while not llama_server_process.poll() and status_code != 200:
-        health_url = f"http://localhost:{port}/health"
-        try:
-            health_response = requests.get(health_url)
-        except requests.exceptions.ConnectionError:
-            logging.debug("Not able to connect to llama-server yet, will retry")
-        else:
-            status_code = health_response.status_code
-            logging.debug(
-                "Testing llama-server readiness (will retry until ready), "
-                f"result: {health_response.json()}"
+        # Disable jinja for gpt-oss-120b on Vulkan
+        if (
+            self.backend == "vulkan"
+            and "gpt-oss-120b" in snapshot_files["variant"].lower()
+        ):
+            base_command.remove("--jinja")
+            logging.warning(
+                "Jinja is disabled for gpt-oss-120b on Vulkan due to a llama.cpp bug "
+                "(see https://github.com/ggml-org/llama.cpp/issues/15274). "
+                "The model cannot use tools. If needed, use the ROCm backend instead."
             )
-        time.sleep(1)
 
+        # Use legacy reasoning formatting, since not all apps support the new
+        # reasoning_content field
+        base_command.extend(["--reasoning-format", "none"])
 
-def _launch_llama_subprocess(
-    snapshot_files: dict,
-    use_gpu: bool,
-    telemetry: LlamaTelemetry,
-    backend: str,
-    ctx_size: int,
-    supports_embeddings: bool = False,
-    supports_reranking: bool = False,
-) -> subprocess.Popen:
-    """
-    Launch llama server subprocess with appropriate configuration.
+        # Add embeddings support if the model supports it
+        if supports_embeddings:
+            base_command.append("--embeddings")
 
-    Args:
-        snapshot_files: Dictionary of model files to load
-        use_gpu: Whether to use GPU acceleration
-        telemetry: Telemetry object for tracking performance metrics
-        backend: Backend to use (e.g., 'vulkan', 'rocm')
-        supports_embeddings: Whether the model supports embeddings
-        supports_reranking: Whether the model supports reranking
+        # Add reranking support if the model supports it
+        if supports_reranking:
+            base_command.append("--reranking")
 
-    Returns:
-        Subprocess handle for the llama server
-    """
+        # Configure GPU layers: 99 for GPU, 0 for CPU-only
+        ngl_value = "99" if use_gpu else "0"
+        command = base_command + ["-ngl", ngl_value]
 
-    # Get the current executable path (handles both Windows and Ubuntu structures)
-    exe_path = get_llama_server_exe_path(backend)
+        # Set up environment with library path for Linux
+        env = os.environ.copy()
 
-    # Build the base command
-    base_command = [
-        exe_path,
-        "-m",
-        snapshot_files["variant"],
-        "--ctx-size",
-        str(ctx_size),
-    ]
+        # Load environment variables from .env file in the executable directory
+        exe_dir = os.path.dirname(exe_path)
+        env_file_path = os.path.join(exe_dir, ".env")
+        if os.path.exists(env_file_path):
+            load_dotenv(env_file_path, override=True)
+            env.update(os.environ)
+            logging.debug(f"Loaded environment variables from {env_file_path}")
 
-    # Lock random seed for deterministic behavior in CI
-    if os.environ.get("LEMONADE_CI_MODE"):
-        base_command.extend(["--seed", "42"])
+        if platform.system().lower() == "linux":
+            lib_dir = os.path.dirname(exe_path)  # Same directory as the executable
+            current_ld_path = env.get("LD_LIBRARY_PATH", "")
+            if current_ld_path:
+                env["LD_LIBRARY_PATH"] = f"{lib_dir}:{current_ld_path}"
+            else:
+                env["LD_LIBRARY_PATH"] = lib_dir
+            logging.debug(f"Set LD_LIBRARY_PATH to {env['LD_LIBRARY_PATH']}")
 
-    if "mmproj" in snapshot_files:
-        base_command.extend(["--mmproj", snapshot_files["mmproj"]])
-        if not use_gpu:
-            base_command.extend(["--no-mmproj-offload"])
-
-    # Find a port, and save it in the telemetry object for future reference
-    # by other functions
-    telemetry.choose_port()
-
-    # Add port and jinja to enable tool use
-    base_command.extend(["--port", str(telemetry.port), "--jinja"])
-
-    # Disable jinja for gpt-oss-120b on Vulkan
-    if backend == "vulkan" and "gpt-oss-120b" in snapshot_files["variant"].lower():
-        base_command.remove("--jinja")
-        logging.warning(
-            "Jinja is disabled for gpt-oss-120b on Vulkan due to a llama.cpp bug "
-            "(see https://github.com/ggml-org/llama.cpp/issues/15274). "
-            "The model cannot use tools. If needed, use the ROCm backend instead."
+        # Start subprocess with output capture
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+            env=env,
         )
 
-    # Use legacy reasoning formatting, since not all apps support the new
-    # reasoning_content field
-    base_command.extend(["--reasoning-format", "none"])
+        # Start background thread to log subprocess output
+        device_type = "GPU" if use_gpu else "CPU"
+        threading.Thread(
+            target=self._log_subprocess_output,
+            args=(process, f"LLAMA SERVER {device_type}", self.telemetry),
+            daemon=True,
+        ).start()
 
-    # Add embeddings support if the model supports it
-    if supports_embeddings:
-        base_command.append("--embeddings")
+        return process
 
-    # Add reranking support if the model supports it
-    if supports_reranking:
-        base_command.append("--reranking")
+    def _launch_server_subprocess(
+        self,
+        model_config: PullConfig,
+        snapshot_files: dict,
+        ctx_size: int,
+        supports_embeddings: bool = False,
+        supports_reranking: bool = False,
+    ):
 
-    # Configure GPU layers: 99 for GPU, 0 for CPU-only
-    ngl_value = "99" if use_gpu else "0"
-    command = base_command + ["-ngl", ngl_value]
-
-    # Set up environment with library path for Linux
-    env = os.environ.copy()
-
-    # Load environment variables from .env file in the executable directory
-    exe_dir = os.path.dirname(exe_path)
-    env_file_path = os.path.join(exe_dir, ".env")
-    if os.path.exists(env_file_path):
-        load_dotenv(env_file_path, override=True)
-        env.update(os.environ)
-        logging.debug(f"Loaded environment variables from {env_file_path}")
-
-    if platform.system().lower() == "linux":
-        lib_dir = os.path.dirname(exe_path)  # Same directory as the executable
-        current_ld_path = env.get("LD_LIBRARY_PATH", "")
-        if current_ld_path:
-            env["LD_LIBRARY_PATH"] = f"{lib_dir}:{current_ld_path}"
-        else:
-            env["LD_LIBRARY_PATH"] = lib_dir
-        logging.debug(f"Set LD_LIBRARY_PATH to {env['LD_LIBRARY_PATH']}")
-
-    # Start subprocess with output capture
-    process = subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        bufsize=1,
-        env=env,
-    )
-
-    # Start background thread to log subprocess output
-    device_type = "GPU" if use_gpu else "CPU"
-    threading.Thread(
-        target=_log_subprocess_output,
-        args=(process, f"LLAMA SERVER {device_type}", telemetry),
-        daemon=True,
-    ).start()
-
-    return process
-
-
-def server_load(
-    model_config: PullConfig,
-    telemetry: LlamaTelemetry,
-    backend: str,
-    ctx_size: int,
-    do_not_upgrade: bool = False,
-):
-    # Install and/or update llama.cpp if needed
-    try:
-        install_llamacpp(backend)
-    except NotImplementedError as e:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
-        )
-
-    # Download the gguf to the hugging face cache
-    snapshot_files = download_gguf(
-        model_config.checkpoint, model_config.mmproj, do_not_upgrade=do_not_upgrade
-    )
-    logging.debug(f"GGUF file paths: {snapshot_files}")
-
-    # Check if model supports embeddings
-    supported_models = ModelManager().supported_models
-    model_info = supported_models.get(model_config.model_name, {})
-    supports_embeddings = "embeddings" in model_info.get("labels", [])
-    supports_reranking = "reranking" in model_info.get("labels", [])
-
-    # Attempt loading on GPU first
-    llama_server_process = _launch_llama_subprocess(
-        snapshot_files,
-        use_gpu=True,
-        telemetry=telemetry,
-        backend=backend,
-        ctx_size=ctx_size,
-        supports_embeddings=supports_embeddings,
-        supports_reranking=supports_reranking,
-    )
-
-    # Check the /health endpoint until GPU server is ready
-    _wait_for_load(
-        llama_server_process,
-        telemetry.port,
-    )
-
-    # If loading on GPU failed, try loading on CPU
-    if llama_server_process.poll():
-        logging.warning(
-            f"Loading {model_config.model_name} on GPU didn't work, re-attempting on CPU"
-        )
-
-        if os.environ.get("LEMONADE_LLAMACPP_NO_FALLBACK"):
-            # Used for testing, when the test should fail if GPU didn't work
-            raise Exception("llamacpp GPU loading failed")
-
-        llama_server_process = _launch_llama_subprocess(
+        # Attempt loading on GPU first
+        self.process = self._launch_device_backend_subprocess(
             snapshot_files,
-            use_gpu=False,
-            telemetry=telemetry,
-            backend=backend,
+            use_gpu=True,
             ctx_size=ctx_size,
             supports_embeddings=supports_embeddings,
             supports_reranking=supports_reranking,
         )
 
-        # Check the /health endpoint until CPU server is ready
-        _wait_for_load(
-            llama_server_process,
-            telemetry.port,
-        )
+        # Check the /health endpoint until GPU server is ready
+        self._wait_for_load()
 
-    if llama_server_process.poll():
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Failed to load {model_config.model_name} with llama.cpp",
-        )
-
-    return llama_server_process
-
-
-def chat_completion(
-    chat_completion_request: ChatCompletionRequest, telemetry: LlamaTelemetry
-):
-    base_url = llamacpp_address(telemetry.port)
-    client = OpenAI(
-        base_url=base_url,
-        api_key="lemonade",
-    )
-
-    # Convert Pydantic model to dict and remove unset/null values
-    request_dict = chat_completion_request.model_dump(
-        exclude_unset=True, exclude_none=True
-    )
-
-    # Separate standard OpenAI parameters from custom llama.cpp parameters
-    openai_client_params = _separate_openai_params(request_dict, "chat")
-
-    # Check if streaming is requested
-    if chat_completion_request.stream:
-
-        def event_stream():
-            try:
-                # Enable streaming
-                # pylint: disable=missing-kwoa
-                for chunk in client.chat.completions.create(**openai_client_params):
-                    yield f"data: {chunk.model_dump_json()}\n\n"
-                yield "data: [DONE]\n\n"
-
-                # Show telemetry after completion
-                telemetry.show_telemetry()
-
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                yield f'data: {{"error": "{str(e)}"}}\n\n'
-
-        return StreamingResponse(
-            event_stream(),
-            media_type="text/event-stream",
-            headers={
-                "Cache-Control": "no-cache",
-                "Connection": "keep-alive",
-            },
-        )
-    else:
-        # Non-streaming response
-        try:
-            # Disable streaming for non-streaming requests
-            # pylint: disable=missing-kwoa
-            response = client.chat.completions.create(**openai_client_params)
-
-            # Show telemetry after completion
-            telemetry.show_telemetry()
-
-            return response
-
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logging.error("Error during chat completion: %s", str(e))
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Chat completion error: {str(e)}",
+        # If loading on GPU failed, try loading on CPU
+        if self.process.poll():
+            logging.warning(
+                f"Loading {model_config.model_name} on GPU didn't work, re-attempting on CPU"
             )
 
+            if os.environ.get("LEMONADE_LLAMACPP_NO_FALLBACK"):
+                # Used for testing, when the test should fail if GPU didn't work
+                raise Exception("llamacpp GPU loading failed")
 
-def completion(completion_request: CompletionRequest, telemetry: LlamaTelemetry):
-    """
-    Handle text completions using the llamacpp server.
-
-    Args:
-        completion_request: The completion request containing prompt and parameters
-        telemetry: Telemetry object containing the server port
-
-    Returns:
-        Completion response from the llamacpp server
-    """
-    base_url = llamacpp_address(telemetry.port)
-    client = OpenAI(
-        base_url=base_url,
-        api_key="lemonade",
-    )
-
-    # Convert Pydantic model to dict and remove unset/null values
-    request_dict = completion_request.model_dump(exclude_unset=True, exclude_none=True)
-
-    # Separate standard OpenAI parameters from custom llama.cpp parameters
-    openai_client_params = _separate_openai_params(request_dict, "completion")
-
-    # Check if streaming is requested
-    if completion_request.stream:
-
-        def event_stream():
-            try:
-                # Enable streaming
-                # pylint: disable=missing-kwoa
-                for chunk in client.completions.create(**openai_client_params):
-                    yield f"data: {chunk.model_dump_json()}\n\n"
-                yield "data: [DONE]\n\n"
-
-                # Show telemetry after completion
-                telemetry.show_telemetry()
-
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                yield f'data: {{"error": "{str(e)}"}}\n\n'
-
-        return StreamingResponse(
-            event_stream(),
-            media_type="text/event-stream",
-            headers={
-                "Cache-Control": "no-cache",
-                "Connection": "keep-alive",
-            },
-        )
-    else:
-        # Non-streaming response
-        try:
-            # Disable streaming for non-streaming requests
-            # pylint: disable=missing-kwoa
-            response = client.completions.create(**openai_client_params)
-
-            # Show telemetry after completion
-            telemetry.show_telemetry()
-
-            return response
-
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logging.error("Error during completion: %s", str(e))
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Completion error: {str(e)}",
+            self.process = self._launch_device_backend_subprocess(
+                snapshot_files,
+                use_gpu=False,
+                ctx_size=ctx_size,
+                supports_embeddings=supports_embeddings,
+                supports_reranking=supports_reranking,
             )
-
-
-def embeddings(embeddings_request: EmbeddingsRequest, telemetry: LlamaTelemetry):
-    """
-    Generate embeddings using the llamacpp server.
-
-    Args:
-        embeddings_request: The embeddings request containing input text/tokens
-        telemetry: Telemetry object containing the server port
-
-    Returns:
-        Embeddings response from the llamacpp server
-    """
-    base_url = llamacpp_address(telemetry.port)
-    client = OpenAI(
-        base_url=base_url,
-        api_key="lemonade",
-    )
-
-    # Convert Pydantic model to dict and remove unset/null values
-    request_dict = embeddings_request.model_dump(exclude_unset=True, exclude_none=True)
-
-    try:
-        # Call the embeddings endpoint
-        response = client.embeddings.create(**request_dict)
-        return response
-
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Embeddings error: {str(e)}",
-        )
-
-
-def reranking(reranking_request: RerankingRequest, telemetry: LlamaTelemetry):
-    """
-    Rerank documents based on their relevance to a query using the llamacpp server.
-
-    Args:
-        reranking_request: The reranking request containing query and documents
-        telemetry: Telemetry object containing the server port
-
-    Returns:
-        Reranking response from the llamacpp server containing ranked documents and scores
-    """
-    base_url = llamacpp_address(telemetry.port)
-
-    try:
-        # Convert Pydantic model to dict and exclude unset/null values
-        request_dict = reranking_request.model_dump(
-            exclude_unset=True, exclude_none=True
-        )
-
-        # Call the reranking endpoint directly since it's not supported by the OpenAI API
-        response = requests.post(
-            f"{base_url}/rerank",
-            json=request_dict,
-        )
-        response.raise_for_status()
-        return response.json()
-
-    except Exception as e:
-        logging.error("Error during reranking: %s", str(e))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Reranking error: {str(e)}",
-        ) from e

--- a/src/lemonade/tools/server/llamacpp.py
+++ b/src/lemonade/tools/server/llamacpp.py
@@ -89,7 +89,7 @@ class LlamaServer(WrappedServer):
         """
         Download a model for the wrapper server
         """
-        download_gguf(
+        return download_gguf(
             config_checkpoint=config_checkpoint,
             config_mmproj=config_mmproj,
             do_not_upgrade=do_not_upgrade,
@@ -195,7 +195,7 @@ class LlamaServer(WrappedServer):
             logging.debug(f"Set LD_LIBRARY_PATH to {env['LD_LIBRARY_PATH']}")
 
         # Start subprocess with output capture
-        process = subprocess.Popen(
+        self.process = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -210,11 +210,9 @@ class LlamaServer(WrappedServer):
         device_type = "GPU" if use_gpu else "CPU"
         threading.Thread(
             target=self._log_subprocess_output,
-            args=(process, f"LLAMA SERVER {device_type}", self.telemetry),
+            args=(f"LLAMA SERVER {device_type}",),
             daemon=True,
         ).start()
-
-        return process
 
     def _launch_server_subprocess(
         self,
@@ -226,7 +224,7 @@ class LlamaServer(WrappedServer):
     ):
 
         # Attempt loading on GPU first
-        self.process = self._launch_device_backend_subprocess(
+        self._launch_device_backend_subprocess(
             snapshot_files,
             use_gpu=True,
             ctx_size=ctx_size,
@@ -247,7 +245,7 @@ class LlamaServer(WrappedServer):
                 # Used for testing, when the test should fail if GPU didn't work
                 raise Exception("llamacpp GPU loading failed")
 
-            self.process = self._launch_device_backend_subprocess(
+            self._launch_device_backend_subprocess(
                 snapshot_files,
                 use_gpu=False,
                 ctx_size=ctx_size,

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -226,7 +226,7 @@ class WrappedServer(ABC):
         ctx_size: int,
         supports_embeddings: bool = False,
         supports_reranking: bool = False,
-    ) -> subprocess.Popen:
+    ):
         """
         Launch wrapped server subprocess with appropriate configuration.
 
@@ -234,9 +234,6 @@ class WrappedServer(ABC):
             snapshot_files: Dictionary of model files to load
             supports_embeddings: Whether the model supports embeddings
             supports_reranking: Whether the model supports reranking
-
-        Returns:
-            Subprocess handle for the wrapped server
         """
 
     @abstractmethod

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -1,0 +1,489 @@
+import logging
+import time
+import subprocess
+from abc import ABC, abstractmethod
+
+import requests
+from tabulate import tabulate
+from fastapi import HTTPException, status
+from fastapi.responses import StreamingResponse
+
+from openai import OpenAI
+
+from lemonade_server.pydantic_models import (
+    ChatCompletionRequest,
+    CompletionRequest,
+    PullConfig,
+    EmbeddingsRequest,
+    RerankingRequest,
+)
+from lemonade_server.model_manager import ModelManager
+from lemonade.tools.server.utils.port import find_free_port
+
+
+class WrappedServerTelemetry(ABC):
+    """
+    Manages telemetry data collection and display for wrapped server.
+    """
+
+    def __init__(self):
+        self.input_tokens = None
+        self.output_tokens = None
+        self.time_to_first_token = None
+        self.tokens_per_second = None
+        self.prompt_eval_time = None
+        self.eval_time = None
+
+    @abstractmethod
+    def parse_telemetry_line(self, line: str):
+        """
+        Parse telemetry data from wrapped server output lines.
+        """
+
+    def get_telemetry_data(self):
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "time_to_first_token": self.time_to_first_token,
+            "tokens_per_second": self.tokens_per_second,
+            "decode_token_times": None,
+        }
+
+    def show_telemetry(self):
+        # Check if debug logging is enabled
+        if not logging.getLogger().isEnabledFor(logging.DEBUG):
+            return
+
+        # Prepare telemetry data (transposed format)
+        telemetry = [
+            ["Input tokens", self.input_tokens],
+            ["Output tokens", self.output_tokens],
+            ["TTFT (s)", f"{self.time_to_first_token:.2f}"],
+            ["TPS", f"{self.tokens_per_second:.2f}"],
+        ]
+
+        table = tabulate(
+            telemetry, headers=["Metric", "Value"], tablefmt="fancy_grid"
+        ).split("\n")
+
+        # Show telemetry in debug while complying with uvicorn's log indentation
+        logging.debug("\n          ".join(table))
+
+
+class WrappedServer(ABC):
+    """
+    Abstract base class that defines the interface for Lemonade to "wrap" a server
+    like llama-server.
+    """
+
+    def __init__(self, server_name: str, telemetry: WrappedServerTelemetry):
+        self.port: int = None
+        self.process: subprocess.Popen = None
+        self.server_name: str = server_name
+        self.telemetry: WrappedServerTelemetry = telemetry
+
+    def choose_port(self):
+        """
+        Users probably don't care what port we start the wrapped server on, so let's
+        search for an empty port
+        """
+
+        self.port = find_free_port()
+
+        if self.port is None:
+            msg = f"Failed to find an empty port to start {self.server_name} on"
+            logging.error(msg)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=msg,
+            )
+
+    @property
+    def address(self) -> str:
+        """
+        Generate the base URL for the server.
+
+        Returns:
+            The base URL for the wrapped server
+        """
+        return f"http://127.0.0.1:{self.port}/v1"
+
+    def _separate_openai_params(
+        self,
+        request_dict: dict,
+        endpoint_type: str = "chat",
+    ) -> dict:
+        """
+        Separate standard OpenAI parameters from custom wrapped server parameters.
+
+        Args:
+            request_dict: Dictionary of all request parameters
+            endpoint_type: Type of endpoint ("chat" or "completion")
+
+        Returns:
+            Dictionary with parameters properly separated for OpenAI client
+        """
+        openai_client_params = {}
+        extra_params = {}
+
+        # Common OpenAI parameters for both endpoint types
+        common_params = {
+            "model",
+            "frequency_penalty",
+            "logit_bias",
+            "logprobs",
+            "max_tokens",
+            "n",
+            "presence_penalty",
+            "seed",
+            "stop",
+            "stream",
+            "temperature",
+            "top_p",
+            "user",
+        }
+
+        # Standard OpenAI parameters by endpoint type
+        if endpoint_type == "chat":
+            chat_specific_params = {
+                "messages",
+                "top_logprobs",
+                "response_format",
+                "service_tier",
+                "stream_options",
+                "tools",
+                "tool_choice",
+                "parallel_tool_calls",
+            }
+            openai_params = common_params | chat_specific_params
+        else:  # completion
+            completion_specific_params = {
+                "prompt",
+                "best_of",
+                "echo",
+                "suffix",
+            }
+            openai_params = common_params | completion_specific_params
+
+        for key, value in request_dict.items():
+            if key in openai_params:
+                openai_client_params[key] = value
+            else:
+                extra_params[key] = value
+
+        # If there are custom parameters, use extra_body to pass them through
+        if extra_params:
+            openai_client_params["extra_body"] = extra_params
+
+        return openai_client_params
+
+    def _log_subprocess_output(self, prefix: str):
+        """
+        Read subprocess output line by line, log to debug, and parse telemetry
+        """
+
+        if self.process.stdout:
+            try:
+                for line in iter(self.process.stdout.readline, ""):
+                    if line:
+                        line_stripped = line.strip()
+                        logging.debug("%s: %s", prefix, line_stripped)
+
+                        self.telemetry.parse_telemetry_line(line_stripped)
+
+                    if self.process.poll() is not None:
+                        break
+            except UnicodeDecodeError as e:
+                logging.debug(
+                    "Unicode decode error reading subprocess output: %s", str(e)
+                )
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                logging.error("Unexpected error reading subprocess output: %s", str(e))
+
+    def _wait_for_load(self):
+        status_code = None
+        while not self.process.poll() and status_code != 200:
+            health_url = f"http://localhost:{self.telemetry.port}/health"
+            try:
+                health_response = requests.get(health_url)
+            except requests.exceptions.ConnectionError:
+                logging.debug(
+                    f"Not able to connect to {self.server_name} yet, will retry"
+                )
+            else:
+                status_code = health_response.status_code
+                logging.debug(
+                    f"Testing {self.server_name} readiness (will retry until ready), "
+                    f"result: {health_response.json()}"
+                )
+            time.sleep(1)
+
+    @abstractmethod
+    def _launch_server_subprocess(
+        self,
+        model_config: PullConfig,
+        snapshot_files: dict,
+        ctx_size: int,
+        supports_embeddings: bool = False,
+        supports_reranking: bool = False,
+    ) -> subprocess.Popen:
+        """
+        Launch wrapped server subprocess with appropriate configuration.
+
+        Args:
+            snapshot_files: Dictionary of model files to load
+            supports_embeddings: Whether the model supports embeddings
+            supports_reranking: Whether the model supports reranking
+
+        Returns:
+            Subprocess handle for the wrapped server
+        """
+
+    @abstractmethod
+    def install_server(self, backend=None):
+        """
+        Install the wrapped server
+        """
+
+    @abstractmethod
+    def download_model(
+        self, config_checkpoint, config_mmproj=None, do_not_upgrade=False
+    ) -> dict:
+        """
+        Download a model for the wrapper server
+        """
+
+    def load(
+        self,
+        model_config: PullConfig,
+        ctx_size: int,
+        do_not_upgrade: bool = False,
+    ):
+        # Install and/or update the wrapped server if needed
+        try:
+            self.install_server()
+        except NotImplementedError as e:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+            )
+
+        # Download the model to the hugging face cache
+        snapshot_files = self.download_model(
+            model_config.checkpoint, model_config.mmproj, do_not_upgrade=do_not_upgrade
+        )
+        logging.debug(f"Model file paths: {snapshot_files}")
+
+        # Check if model supports embeddings
+        supported_models = ModelManager().supported_models
+        model_info = supported_models.get(model_config.model_name, {})
+        supports_embeddings = "embeddings" in model_info.get("labels", [])
+        supports_reranking = "reranking" in model_info.get("labels", [])
+
+        self.process = self._launch_server_subprocess(
+            model_config=model_config,
+            snapshot_files=snapshot_files,
+            ctx_size=ctx_size,
+            supports_embeddings=supports_embeddings,
+            supports_reranking=supports_reranking,
+        )
+
+        # Check the /health endpoint until server is ready
+        self._wait_for_load()
+
+        if self.process.poll():
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Failed to load {model_config.model_name} with {self.server_name}",
+            )
+
+    def chat_completion(self, chat_completion_request: ChatCompletionRequest):
+        client = OpenAI(
+            base_url=self.address,
+            api_key="lemonade",
+        )
+
+        # Convert Pydantic model to dict and remove unset/null values
+        request_dict = chat_completion_request.model_dump(
+            exclude_unset=True, exclude_none=True
+        )
+
+        # Separate standard OpenAI parameters from custom llama.cpp parameters
+        openai_client_params = self._separate_openai_params(request_dict, "chat")
+
+        # Check if streaming is requested
+        if chat_completion_request.stream:
+
+            def event_stream():
+                try:
+                    # Enable streaming
+                    # pylint: disable=missing-kwoa
+                    for chunk in client.chat.completions.create(**openai_client_params):
+                        yield f"data: {chunk.model_dump_json()}\n\n"
+                    yield "data: [DONE]\n\n"
+
+                    # Show telemetry after completion
+                    self.telemetry.show_telemetry()
+
+                except Exception as e:  # pylint: disable=broad-exception-caught
+                    yield f'data: {{"error": "{str(e)}"}}\n\n'
+
+            return StreamingResponse(
+                event_stream(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                },
+            )
+        else:
+            # Non-streaming response
+            try:
+                # Disable streaming for non-streaming requests
+                # pylint: disable=missing-kwoa
+                response = client.chat.completions.create(**openai_client_params)
+
+                # Show telemetry after completion
+                self.telemetry.show_telemetry()
+
+                return response
+
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                logging.error("Error during chat completion: %s", str(e))
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"Chat completion error: {str(e)}",
+                )
+
+    def completion(self, completion_request: CompletionRequest):
+        """
+        Handle text completions using the wrapped server.
+
+        Args:
+            completion_request: The completion request containing prompt and parameters
+            telemetry: Telemetry object containing the server port
+
+        Returns:
+            Completion response from the wrapped server
+        """
+
+        client = OpenAI(
+            base_url=self.address,
+            api_key="lemonade",
+        )
+
+        # Convert Pydantic model to dict and remove unset/null values
+        request_dict = completion_request.model_dump(
+            exclude_unset=True, exclude_none=True
+        )
+
+        # Separate standard OpenAI parameters from custom llama.cpp parameters
+        openai_client_params = self._separate_openai_params(request_dict, "completion")
+
+        # Check if streaming is requested
+        if completion_request.stream:
+
+            def event_stream():
+                try:
+                    # Enable streaming
+                    # pylint: disable=missing-kwoa
+                    for chunk in client.completions.create(**openai_client_params):
+                        yield f"data: {chunk.model_dump_json()}\n\n"
+                    yield "data: [DONE]\n\n"
+
+                    # Show telemetry after completion
+                    self.telemetry.show_telemetry()
+
+                except Exception as e:  # pylint: disable=broad-exception-caught
+                    yield f'data: {{"error": "{str(e)}"}}\n\n'
+
+            return StreamingResponse(
+                event_stream(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                },
+            )
+        else:
+            # Non-streaming response
+            try:
+                # Disable streaming for non-streaming requests
+                # pylint: disable=missing-kwoa
+                response = client.completions.create(**openai_client_params)
+
+                # Show telemetry after completion
+                self.telemetry.show_telemetry()
+
+                return response
+
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                logging.error("Error during completion: %s", str(e))
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"Completion error: {str(e)}",
+                )
+
+    def embeddings(self, embeddings_request: EmbeddingsRequest):
+        """
+        Generate embeddings using the wrapped server.
+
+        Args:
+            embeddings_request: The embeddings request containing input text/tokens
+            telemetry: Telemetry object containing the server port
+
+        Returns:
+            Embeddings response from the wrapped server
+        """
+        client = OpenAI(
+            base_url=self.address,
+            api_key="lemonade",
+        )
+
+        # Convert Pydantic model to dict and remove unset/null values
+        request_dict = embeddings_request.model_dump(
+            exclude_unset=True, exclude_none=True
+        )
+
+        try:
+            # Call the embeddings endpoint
+            response = client.embeddings.create(**request_dict)
+            return response
+
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Embeddings error: {str(e)}",
+            )
+
+    def reranking(self, reranking_request: RerankingRequest):
+        """
+        Rerank documents based on their relevance to a query using the wrapped server.
+
+        Args:
+            reranking_request: The reranking request containing query and documents
+            telemetry: Telemetry object containing the server port
+
+        Returns:
+            Reranking response from the wrapped server containing ranked documents and scores
+        """
+
+        try:
+            # Convert Pydantic model to dict and exclude unset/null values
+            request_dict = reranking_request.model_dump(
+                exclude_unset=True, exclude_none=True
+            )
+
+            # Call the reranking endpoint directly since it's not supported by the OpenAI API
+            response = requests.post(
+                f"{self.address}/rerank",
+                json=request_dict,
+            )
+            response.raise_for_status()
+            return response.json()
+
+        except Exception as e:
+            logging.error("Error during reranking: %s", str(e))
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Reranking error: {str(e)}",
+            ) from e

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -98,7 +98,6 @@ class WrappedServer(ABC):
                 detail=msg,
             )
 
-    @property
     def address(self) -> str:
         """
         Generate the base URL for the server.
@@ -295,7 +294,7 @@ class WrappedServer(ABC):
 
     def chat_completion(self, chat_completion_request: ChatCompletionRequest):
         client = OpenAI(
-            base_url=self.address,
+            base_url=self.address(),
             api_key="lemonade",
         )
 
@@ -364,7 +363,7 @@ class WrappedServer(ABC):
         """
 
         client = OpenAI(
-            base_url=self.address,
+            base_url=self.address(),
             api_key="lemonade",
         )
 
@@ -432,7 +431,7 @@ class WrappedServer(ABC):
             Embeddings response from the wrapped server
         """
         client = OpenAI(
-            base_url=self.address,
+            base_url=self.address(),
             api_key="lemonade",
         )
 
@@ -472,7 +471,7 @@ class WrappedServer(ABC):
 
             # Call the reranking endpoint directly since it's not supported by the OpenAI API
             response = requests.post(
-                f"{self.address}/rerank",
+                f"{self.address()}/rerank",
                 json=request_dict,
             )
             response.raise_for_status()

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -203,7 +203,7 @@ class WrappedServer(ABC):
     def _wait_for_load(self):
         status_code = None
         while not self.process.poll() and status_code != 200:
-            health_url = f"http://localhost:{self.telemetry.port}/health"
+            health_url = f"http://localhost:{self.port}/health"
             try:
                 health_response = requests.get(health_url)
             except requests.exceptions.ConnectionError:
@@ -279,7 +279,7 @@ class WrappedServer(ABC):
         supports_embeddings = "embeddings" in model_info.get("labels", [])
         supports_reranking = "reranking" in model_info.get("labels", [])
 
-        self.process = self._launch_server_subprocess(
+        self._launch_server_subprocess(
             model_config=model_config,
             snapshot_files=snapshot_files,
             ctx_size=ctx_size,

--- a/test/server_llamacpp.py
+++ b/test/server_llamacpp.py
@@ -82,225 +82,225 @@ class LlamaCppTesting(ServerTestingBase):
         ), f"Expected {expected_devices} devices, got {devices}"
 
     # Endpoint: /api/v1/chat/completions
-    # def test_001_test_llamacpp_chat_completion_streaming(self):
-    #     client = OpenAI(
-    #         base_url=self.base_url,
-    #         api_key="lemonade",  # required, but unused
-    #     )
+    def test_001_test_llamacpp_chat_completion_streaming(self):
+        client = OpenAI(
+            base_url=self.base_url,
+            api_key="lemonade",  # required, but unused
+        )
 
-    #     stream = client.chat.completions.create(
-    #         model="Qwen3-0.6B-GGUF",
-    #         messages=self.messages,
-    #         stream=True,
-    #         max_completion_tokens=10,
-    #     )
+        stream = client.chat.completions.create(
+            model="Qwen3-0.6B-GGUF",
+            messages=self.messages,
+            stream=True,
+            max_completion_tokens=10,
+        )
 
-    #     complete_response = ""
-    #     chunk_count = 0
-    #     for chunk in stream:
-    #         if chunk.choices[0].delta.content is not None:
-    #             complete_response += chunk.choices[0].delta.content
-    #             print(chunk.choices[0].delta.content, end="")
-    #             chunk_count += 1
+        complete_response = ""
+        chunk_count = 0
+        for chunk in stream:
+            if chunk.choices[0].delta.content is not None:
+                complete_response += chunk.choices[0].delta.content
+                print(chunk.choices[0].delta.content, end="")
+                chunk_count += 1
 
-    #     assert chunk_count > 5
-    #     assert len(complete_response) > 5
+        assert chunk_count > 5
+        assert len(complete_response) > 5
 
-    # # Endpoint: /api/v1/chat/completions
-    # def test_002_test_llamacpp_chat_completion_non_streaming(self):
-    #     client = OpenAI(
-    #         base_url=self.base_url,
-    #         api_key="lemonade",  # required, but unused
-    #     )
+    # Endpoint: /api/v1/chat/completions
+    def test_002_test_llamacpp_chat_completion_non_streaming(self):
+        client = OpenAI(
+            base_url=self.base_url,
+            api_key="lemonade",  # required, but unused
+        )
 
-    #     response = client.chat.completions.create(
-    #         model="Qwen3-0.6B-GGUF",
-    #         messages=self.messages,
-    #         stream=False,
-    #         max_completion_tokens=10,
-    #     )
+        response = client.chat.completions.create(
+            model="Qwen3-0.6B-GGUF",
+            messages=self.messages,
+            stream=False,
+            max_completion_tokens=10,
+        )
 
-    #     assert response.choices[0].message.content is not None
-    #     assert len(response.choices[0].message.content) > 5
-    #     print(response.choices[0].message.content)
+        assert response.choices[0].message.content is not None
+        assert len(response.choices[0].message.content) > 5
+        print(response.choices[0].message.content)
 
-    # # Endpoint: /api/v1/embeddings
-    # def test_003_test_embeddings_with_gguf(self):
-    #     client = OpenAI(
-    #         base_url=self.base_url,
-    #         api_key="lemonade",  # required, but unused
-    #     )
-    #     model_id = "nomic-embed-text-v2-moe-GGUF"
+    # Endpoint: /api/v1/embeddings
+    def test_003_test_embeddings_with_gguf(self):
+        client = OpenAI(
+            base_url=self.base_url,
+            api_key="lemonade",  # required, but unused
+        )
+        model_id = "nomic-embed-text-v2-moe-GGUF"
 
-    #     # Test 1: Single string
-    #     response = client.embeddings.create(
-    #         input="Hello, how are you today?",
-    #         model=model_id,
-    #         encoding_format="float",
-    #     )
-    #     assert response.data is not None
-    #     assert len(response.data) == 1
-    #     assert response.data[0].embedding is not None
-    #     assert len(response.data[0].embedding) > 0
-    #     print(f"Single string embedding dimension: {len(response.data[0].embedding)}")
+        # Test 1: Single string
+        response = client.embeddings.create(
+            input="Hello, how are you today?",
+            model=model_id,
+            encoding_format="float",
+        )
+        assert response.data is not None
+        assert len(response.data) == 1
+        assert response.data[0].embedding is not None
+        assert len(response.data[0].embedding) > 0
+        print(f"Single string embedding dimension: {len(response.data[0].embedding)}")
 
-    #     # Test 2: Array of strings
-    #     response = client.embeddings.create(
-    #         input=["Hello world", "How are you?", "This is a test"],
-    #         model=model_id,
-    #         encoding_format="float",
-    #     )
-    #     assert response.data is not None
-    #     assert len(response.data) == 3
-    #     for i, embedding in enumerate(response.data):
-    #         assert embedding.embedding is not None
-    #         assert len(embedding.embedding) > 0
-    #         print(f"Array embedding {i+1} dimension: {len(embedding.embedding)}")
+        # Test 2: Array of strings
+        response = client.embeddings.create(
+            input=["Hello world", "How are you?", "This is a test"],
+            model=model_id,
+            encoding_format="float",
+        )
+        assert response.data is not None
+        assert len(response.data) == 3
+        for i, embedding in enumerate(response.data):
+            assert embedding.embedding is not None
+            assert len(embedding.embedding) > 0
+            print(f"Array embedding {i+1} dimension: {len(embedding.embedding)}")
 
-    #     # Test 3: Base64 encoding format
-    #     response = client.embeddings.create(
-    #         input="Test base64 encoding",
-    #         model=model_id,
-    #         encoding_format="base64",
-    #     )
-    #     assert response.data is not None
-    #     assert len(response.data) == 1
-    #     assert response.data[0].embedding is not None
-    #     assert len(response.data[0].embedding) > 0
-    #     print(f"Base64 embedding length: {len(response.data[0].embedding)}")
+        # Test 3: Base64 encoding format
+        response = client.embeddings.create(
+            input="Test base64 encoding",
+            model=model_id,
+            encoding_format="base64",
+        )
+        assert response.data is not None
+        assert len(response.data) == 1
+        assert response.data[0].embedding is not None
+        assert len(response.data[0].embedding) > 0
+        print(f"Base64 embedding length: {len(response.data[0].embedding)}")
 
-    #     # Test 4: Token IDs (if supported by model)
-    #     response = client.embeddings.create(
-    #         input=[15496, 11, 1268, 527, 499, 3432, 30],
-    #         model=model_id,
-    #         encoding_format="float",
-    #     )
-    #     assert response.data is not None
-    #     assert len(response.data) == 1
-    #     print(f"Token embedding dimension: {len(response.data[0].embedding)}")
+        # Test 4: Token IDs (if supported by model)
+        response = client.embeddings.create(
+            input=[15496, 11, 1268, 527, 499, 3432, 30],
+            model=model_id,
+            encoding_format="float",
+        )
+        assert response.data is not None
+        assert len(response.data) == 1
+        print(f"Token embedding dimension: {len(response.data[0].embedding)}")
 
-    #     # Test 5: Mixed input types (if supported by model)
-    #     response = client.embeddings.create(
-    #         input=[15496, "hello", 527, "world"],
-    #         model=model_id,
-    #         encoding_format="float",
-    #     )
-    #     assert response.data is not None
-    #     print(f"Mixed input embedding dimension: {len(response.data[0].embedding)}")
+        # Test 5: Mixed input types (if supported by model)
+        response = client.embeddings.create(
+            input=[15496, "hello", 527, "world"],
+            model=model_id,
+            encoding_format="float",
+        )
+        assert response.data is not None
+        print(f"Mixed input embedding dimension: {len(response.data[0].embedding)}")
 
-    #     # Test 6: Semantic similarity comparison
-    #     texts = [
-    #         "The cat sat on the mat",
-    #         "A feline rested on the carpet",
-    #         "Dogs are loyal animals",
-    #         "Python is a programming language",
-    #     ]
-    #     response = client.embeddings.create(
-    #         input=texts,
-    #         model=model_id,
-    #         encoding_format="float",
-    #     )
-    #     assert response.data is not None
-    #     assert len(response.data) == 4
+        # Test 6: Semantic similarity comparison
+        texts = [
+            "The cat sat on the mat",
+            "A feline rested on the carpet",
+            "Dogs are loyal animals",
+            "Python is a programming language",
+        ]
+        response = client.embeddings.create(
+            input=texts,
+            model=model_id,
+            encoding_format="float",
+        )
+        assert response.data is not None
+        assert len(response.data) == 4
 
-    #     def cosine_similarity(a, b):
-    #         return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
+        def cosine_similarity(a, b):
+            return np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
 
-    #     emb1 = np.array(response.data[0].embedding)
-    #     emb2 = np.array(response.data[1].embedding)
-    #     emb3 = np.array(response.data[2].embedding)
+        emb1 = np.array(response.data[0].embedding)
+        emb2 = np.array(response.data[1].embedding)
+        emb3 = np.array(response.data[2].embedding)
 
-    #     sim_12 = cosine_similarity(emb1, emb2)
-    #     sim_13 = cosine_similarity(emb1, emb3)
+        sim_12 = cosine_similarity(emb1, emb2)
+        sim_13 = cosine_similarity(emb1, emb3)
 
-    #     print(f"Similarity cat/mat vs feline/carpet: {sim_12:.4f}")
-    #     print(f"Similarity cat/mat vs dogs: {sim_13:.4f}")
-    #     assert (
-    #         sim_12 > sim_13
-    #     ), f"Semantic similarity test failed: {sim_12:.4f} <= {sim_13:.4f}"
+        print(f"Similarity cat/mat vs feline/carpet: {sim_12:.4f}")
+        print(f"Similarity cat/mat vs dogs: {sim_13:.4f}")
+        assert (
+            sim_12 > sim_13
+        ), f"Semantic similarity test failed: {sim_12:.4f} <= {sim_13:.4f}"
 
-    # # Endpoint: /api/v1/reranking
-    # def test_004_test_reranking_with_gguf(self):
-    #     query = "A man is eating pasta."
-    #     documents = [
-    #         "A man is eating food.",  # index 0
-    #         "The girl is carrying a baby.",  # index 1
-    #         "A man is riding a horse.",  # index 2
-    #         "A young girl is playing violin.",  # index 3
-    #         "A man is eating a piece of bread.",  # index 4
-    #         "A man is eating noodles.",  # index 5
-    #     ]
+    # Endpoint: /api/v1/reranking
+    def test_004_test_reranking_with_gguf(self):
+        query = "A man is eating pasta."
+        documents = [
+            "A man is eating food.",  # index 0
+            "The girl is carrying a baby.",  # index 1
+            "A man is riding a horse.",  # index 2
+            "A young girl is playing violin.",  # index 3
+            "A man is eating a piece of bread.",  # index 4
+            "A man is eating noodles.",  # index 5
+        ]
 
-    #     # Make the reranking request
-    #     payload = {
-    #         "query": query,
-    #         "documents": documents,
-    #         "model": "jina-reranker-v1-tiny-en-GGUF",
-    #     }
-    #     response = requests.post(f"{self.base_url}/reranking", json=payload)
-    #     response.raise_for_status()
-    #     result = response.json()
+        # Make the reranking request
+        payload = {
+            "query": query,
+            "documents": documents,
+            "model": "jina-reranker-v1-tiny-en-GGUF",
+        }
+        response = requests.post(f"{self.base_url}/reranking", json=payload)
+        response.raise_for_status()
+        result = response.json()
 
-    #     # Sort results by score
-    #     results = result.get("results", [])
-    #     results.sort(key=lambda x: x.get("relevance_score", 0), reverse=True)
+        # Sort results by score
+        results = result.get("results", [])
+        results.sort(key=lambda x: x.get("relevance_score", 0), reverse=True)
 
-    #     # Get the indices of the top 3 ranked documents
-    #     top_3_indices = [r["index"] for r in results[:3]]
+        # Get the indices of the top 3 ranked documents
+        top_3_indices = [r["index"] for r in results[:3]]
 
-    #     # The food-related documents should be in top 3 (indices 0, 4, and 5)
-    #     expected_top_3 = {0, 4, 5}
-    #     actual_top_3 = set(top_3_indices)
+        # The food-related documents should be in top 3 (indices 0, 4, and 5)
+        expected_top_3 = {0, 4, 5}
+        actual_top_3 = set(top_3_indices)
 
-    #     assert (
-    #         actual_top_3 == expected_top_3
-    #     ), f"Expected food-related documents (indices {expected_top_3}) to be in top 3, but got {actual_top_3}"
+        assert (
+            actual_top_3 == expected_top_3
+        ), f"Expected food-related documents (indices {expected_top_3}) to be in top 3, but got {actual_top_3}"
 
-    # def test_005_test_llamacpp_completions_non_streaming(self):
-    #     """Test completion endpoint specifically with llamacpp model (non-streaming)"""
-    #     client = OpenAI(
-    #         base_url=self.base_url,
-    #         api_key="lemonade",  # required, but unused
-    #     )
+    def test_005_test_llamacpp_completions_non_streaming(self):
+        """Test completion endpoint specifically with llamacpp model (non-streaming)"""
+        client = OpenAI(
+            base_url=self.base_url,
+            api_key="lemonade",  # required, but unused
+        )
 
-    #     completion = client.completions.create(
-    #         model="Qwen3-0.6B-GGUF",  # This will use llamacpp recipe
-    #         prompt="Hello, how are you?",
-    #         stream=False,
-    #         max_tokens=20,
-    #     )
+        completion = client.completions.create(
+            model="Qwen3-0.6B-GGUF",  # This will use llamacpp recipe
+            prompt="Hello, how are you?",
+            stream=False,
+            max_tokens=20,
+        )
 
-    #     # Basic validation (same as existing completion tests)
-    #     assert len(completion.choices[0].text) > 5
-    #     assert completion.usage.prompt_tokens > 0
-    #     assert completion.usage.completion_tokens > 0
+        # Basic validation (same as existing completion tests)
+        assert len(completion.choices[0].text) > 5
+        assert completion.usage.prompt_tokens > 0
+        assert completion.usage.completion_tokens > 0
 
-    #     print(f"LlamaCPP completion: {completion.choices[0].text}")
+        print(f"LlamaCPP completion: {completion.choices[0].text}")
 
-    # def test_006_test_llamacpp_completions_streaming(self):
-    #     """Test streaming completion endpoint specifically with llamacpp model"""
-    #     client = OpenAI(
-    #         base_url=self.base_url,
-    #         api_key="lemonade",  # required, but unused
-    #     )
+    def test_006_test_llamacpp_completions_streaming(self):
+        """Test streaming completion endpoint specifically with llamacpp model"""
+        client = OpenAI(
+            base_url=self.base_url,
+            api_key="lemonade",  # required, but unused
+        )
 
-    #     stream = client.completions.create(
-    #         model="Qwen3-0.6B-GGUF",  # This will use llamacpp recipe
-    #         prompt="def hello_world():",
-    #         stream=True,
-    #         max_tokens=20,
-    #     )
+        stream = client.completions.create(
+            model="Qwen3-0.6B-GGUF",  # This will use llamacpp recipe
+            prompt="def hello_world():",
+            stream=True,
+            max_tokens=20,
+        )
 
-    #     complete_response = ""
-    #     chunk_count = 0
-    #     for chunk in stream:
-    #         if chunk.choices[0].text is not None:
-    #             complete_response += chunk.choices[0].text
-    #             print(chunk.choices[0].text, end="")
-    #             chunk_count += 1
+        complete_response = ""
+        chunk_count = 0
+        for chunk in stream:
+            if chunk.choices[0].text is not None:
+                complete_response += chunk.choices[0].text
+                print(chunk.choices[0].text, end="")
+                chunk_count += 1
 
-    #     assert chunk_count > 5
-    #     assert len(complete_response) > 5
+        assert chunk_count > 5
+        assert len(complete_response) > 5
 
     def test_007_test_generation_parameters_with_llamacpp(self):
         """Test generation parameters across all endpoints with llamacpp models"""


### PR DESCRIPTION
<img width="1006" height="653" alt="image" src="https://github.com/user-attachments/assets/e9341c87-55ad-4b8e-aec7-6846fdddbe6d" />

This PR paves the way for Lemonade to wrap additional types of servers.

The major change is that `server/llamacpp.py`
- used to be 1) largely functional, and 2) pass this `LlamaTelemetry` class around to all functions
- is now 1) object oriented, 2) much cleaner, 3) based on an `ABC` called `WrappedServer`

The `WrappedServer` actually took most of the code (almost 500 LoC) with only minor changes, since they turned out to be generic to any kind wrapped server. For example, the completions/chat/responses/embedding/rerank code was all generic.

Now `LlamaServer` is only responsible for a few llama-specific things like:
- Parsing llama-server.exe output logs
- Downloading a GGUF
- Downloading and installing llama-server.exe
- Launching llama-server.exe