### PR TITLE
llamacpp errors should be visible to users

### DIFF
--- a/src/lemonade/tools/server/llamacpp.py
+++ b/src/lemonade/tools/server/llamacpp.py
@@ -28,6 +28,9 @@ class LlamaTelemetry(WrappedServerTelemetry):
         Parse telemetry data from llama server output lines.
         """
 
+        if "error" in line.lower():
+            logging.error(line)
+
         # Parse Vulkan device detection
         vulkan_match = re.search(r"ggml_vulkan: Found (\d+) Vulkan devices?:", line)
         if vulkan_match:

--- a/src/lemonade/tools/server/llamacpp.py
+++ b/src/lemonade/tools/server/llamacpp.py
@@ -6,6 +6,7 @@ import threading
 import platform
 
 from dotenv import load_dotenv
+from fastapi import HTTPException, status
 
 from lemonade_server.pydantic_models import (
     PullConfig,
@@ -28,7 +29,18 @@ class LlamaTelemetry(WrappedServerTelemetry):
         Parse telemetry data from llama server output lines.
         """
 
-        if "error" in line.lower():
+        if "vk::PhysicalDevice::createDevice: ErrorExtensionNotPresent" in line:
+            msg = (
+                "Your AMD GPU driver version is not compatible with this software.\n"
+                "Please update and try again: "
+                "https://www.amd.com/en/support/download/drivers.html"
+            )
+            logging.error(msg)
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=msg,
+            )
+        elif "error" in line.lower():
             logging.error(line)
 
         # Parse Vulkan device detection

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -217,6 +217,7 @@ async function autoLoadDefaultModelAndSend() {
         },
         onError: (error, failedModelId) => {
             console.error('Error auto-loading default model:', error);
+            showErrorBanner('Failed to load model: ' + error.message);
         }
     });
 }

--- a/src/lemonade/tools/server/static/js/models.js
+++ b/src/lemonade/tools/server/static/js/models.js
@@ -417,6 +417,7 @@ async function loadModel(modelId) {
         },
         onError: (error, failedModelId) => {
             console.error(`Failed to load model ${failedModelId}:`, error);
+            showErrorBanner('Failed to load model: ' + error.message);
         }
     });
 }

--- a/src/lemonade/tools/server/static/js/shared.js
+++ b/src/lemonade/tools/server/static/js/shared.js
@@ -54,6 +54,14 @@ function renderMarkdown(text) {
 
 // Display an error message in the banner
 function showErrorBanner(msg) {
+    // If DOM isn't ready, wait for it
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => {
+            showErrorBanner(msg);
+        });
+        return;
+    }
+    
     const banner = document.getElementById('error-banner');
     if (!banner) return;
     const msgEl = document.getElementById('error-banner-msg');
@@ -303,12 +311,12 @@ async function loadModelStandardized(modelId, options = {}) {
             onLoadingEnd(modelId, false);
         }
         
-        // Call error callback or show default error
+        // Call error callback and always show default error banner as fallback
         if (onError) {
             onError(error, modelId);
-        } else {
-            showErrorBanner('Failed to load model: ' + error.message);
         }
+        // Always show error banner to ensure user sees the error
+        showErrorBanner('Failed to load model: ' + error.message);
         
         return false;
     }

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -81,6 +81,7 @@ class WrappedServer(ABC):
         self.process: subprocess.Popen = None
         self.server_name: str = server_name
         self.telemetry: WrappedServerTelemetry = telemetry
+        self.log_thread_exception = None
 
     def choose_port(self):
         """
@@ -182,6 +183,8 @@ class WrappedServer(ABC):
         """
 
         if self.process.stdout:
+            from fastapi import HTTPException, status
+
             try:
                 for line in iter(self.process.stdout.readline, ""):
                     if line:
@@ -192,6 +195,8 @@ class WrappedServer(ABC):
 
                     if self.process.poll() is not None:
                         break
+            except HTTPException as e:
+                self.log_thread_exception = e
             except UnicodeDecodeError as e:
                 logging.debug(
                     "Unicode decode error reading subprocess output: %s", str(e)
@@ -216,6 +221,12 @@ class WrappedServer(ABC):
                     f"result: {health_response.json()}"
                 )
             time.sleep(1)
+
+        if self.log_thread_exception:
+            # Check if the
+            e = self.log_thread_exception
+            self.log_thread_exception = None
+            raise e
 
     @abstractmethod
     def _launch_server_subprocess(

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -221,7 +221,6 @@ class WrappedServer(ABC):
             time.sleep(1)
 
         if self.log_thread_exception:
-            # Check if the
             e = self.log_thread_exception
             self.log_thread_exception = None
             raise e

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -183,8 +183,6 @@ class WrappedServer(ABC):
         """
 
         if self.process.stdout:
-            from fastapi import HTTPException, status
-
             try:
                 for line in iter(self.process.stdout.readline, ""):
                     if line:


### PR DESCRIPTION
Closes #75 

We have been hiding some errors under the llamacpp debug logs, when they would be really useful to users in debugging.

Additionally, the vkDestroyFence error is common, so this PR adds special handling for that.

Finally, we had some bugs with respect to showing errors in the webapp. This PR fixes those.

## Before:

No feedback whatsoever! Silent failure.

<img width="960" height="262" alt="image" src="https://github.com/user-attachments/assets/30ef46e6-b54b-4ede-b240-7eee16b9a096" />

## After (this specific error):

"vkDestroyFence" raises a specific httpexception that gets elevated to the webapp.

<img width="1241" height="956" alt="image" src="https://github.com/user-attachments/assets/49a6085a-813e-4381-8d2a-2c791bb54ed5" />

<img width="832" height="357" alt="image" src="https://github.com/user-attachments/assets/588bfb3b-5789-4416-a3ad-5efba625894a" />


## After (generic error):

Anything from the llamacpp log with the word "error" will get elevated to "logging.error"

<img width="1125" height="539" alt="image" src="https://github.com/user-attachments/assets/50a33b15-d799-427c-a3d9-4776c2ab247c" />
