### PR TITLE
Change pip install from '[llm]' to '[dev]'

### DIFF
--- a/.github/workflows/test_llamacpp_oss.yml
+++ b/.github/workflows/test_llamacpp_oss.yml
@@ -54,7 +54,7 @@ jobs:
           conda activate $CONDA_ENV_PATH
           python -m pip install --upgrade pip
           conda install -y pylint
-          pip install -e .[llm] --extra-index-url https://pypi.amd.com/simple
+          pip install -e .[dev]
           pip check
 
           echo "HF_HOME=$(pwd)/hf-cache" >> $GITHUB_ENV
@@ -114,7 +114,7 @@ jobs:
           conda activate $CONDA_ENV_PATH
           python -m pip install --upgrade pip
           conda install -y pylint
-          pip install -e .[llm]
+          pip install -e .[dev]
           pip check
 
           echo "HF_HOME=$(pwd)/hf-cache" >> $GITHUB_ENV


### PR DESCRIPTION
Cleaning up some deprecated install commands in llamacpp testing.