### PR TITLE
Update supported OS for gfx120X to include Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Lemonade supports the following configurations, while also making it easy to swi
     </tr>
     <tr>
       <td><b>gfx120X</b> (RDNA4)</td>
-      <td>Windows only</td>
+      <td>Windows, Ubuntu</td>
       <td>Radeon AI PRO R9700, RX 9070 XT/GRE/9070, RX 9060 XT</td>
     </tr>
     <tr>


### PR DESCRIPTION
This was debugged a while ago, just updating the doc