### PR TITLE
Enable users to override the `HIP_VISIBLE_DEVICES` environment variable

### DIFF
--- a/src/lemonade/tools/server/llamacpp.py
+++ b/src/lemonade/tools/server/llamacpp.py
@@ -197,7 +197,7 @@ class LlamaServer(WrappedServer):
         exe_dir = os.path.dirname(exe_path)
         env_file_path = os.path.join(exe_dir, ".env")
         if os.path.exists(env_file_path):
-            load_dotenv(env_file_path, override=True)
+            load_dotenv(env_file_path, override=False)
             env.update(os.environ)
             logging.debug(f"Loaded environment variables from {env_file_path}")
 


### PR DESCRIPTION
# Description

This PR enables users to override the HIP_VISIBLE_DEVICES environment variable, which is currently the only env var being saved in the .env file.

## Pros

More user control

## Cons

Harder to reproduce future bugs, as some people now may set their own variables.
