### PR TITLE
Fix perf report bug on single iteration for bench tool

### DIFF
--- a/src/lemonade/tools/report/table.py
+++ b/src/lemonade/tools/report/table.py
@@ -591,7 +591,7 @@ class LemonadePerfTable(Table):
                     _wrap("Total Generated Tokens", 9),
                     Keys.RESPONSE_TOKENS,
                     "d",
-                    stat_fn=sum,
+                    stat_fn=lambda x: sum(_to_list(x)),
                 ),
                 SimpleStat(
                     _wrap("Memory Used (GB)", 8), Keys.MAX_MEMORY_USED_GBYTE, ".3f"


### PR DESCRIPTION
This addresses issue #314 .

To observe the issue, first run:
```
lemonade -i amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid oga-load --device hybrid --dtype int4 oga-bench -w 0 -i 1
```
and then run this before and after the fix:
```
lemonade report --perf --no-save --lean
```