### PR TITLE
Fix Lemonade Server URL reference

### DIFF
--- a/src/lemonade_install/install.py
+++ b/src/lemonade_install/install.py
@@ -177,7 +177,7 @@ def _get_ryzenai_version_info(device=None):
             f"{e}\n Please install lemonade-sdk with "
             "one of the oga extras, for example:\n"
             "pip install lemonade-sdk[dev,oga-cpu]\n"
-            "See https://lemonade_server.ai/install_options.html for details"
+            "See https://lemonade-server.ai/install_options.html for details"
         ) from e
 
 


### PR DESCRIPTION
## Summary
- correct Lemonade Server link

## Testing
- `pytest test/model_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af43b00e4c832b9510c4da4b13aa8e