### PR TITLE
block default Enter behavior

### DIFF
--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -288,6 +288,7 @@ function handleChatInputKeydown(e) {
         e.preventDefault();
         clearAttachments();
     } else if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
         // Check if we have a loaded model
         if (currentLoadedModel && modelSelect.value !== '' && !modelSelect.disabled) {
             sendMessage();


### PR DESCRIPTION
Simple fix to block default Enter key behavior on chatInput.value when sending a message