### PR TITLE
Sync ROCm and Vulkan versions

### DIFF
--- a/src/lemonade/tools/llamacpp/utils.py
+++ b/src/lemonade/tools/llamacpp/utils.py
@@ -14,8 +14,8 @@ from lemonade.common.system_info import get_system_info
 
 from dotenv import set_key, load_dotenv
 
-LLAMA_VERSION_VULKAN = "b6392"
-LLAMA_VERSION_ROCM = "b1021"
+LLAMA_VERSION_VULKAN = "b6431"
+LLAMA_VERSION_ROCM = "b1057"
 
 
 def identify_rocm_arch_from_name(device_name: str) -> str | None:


### PR DESCRIPTION
# Description

This PR updates `LLAMA_VERSION_VULKAN` to b6431 and `LLAMA_VERSION_ROCM` to `b1057`. Both of those correspond to Llama.cpp Commit Hash `4f63c`.