### PR TITLE
Feat/UI stop button

### DIFF
--- a/src/lemonade/tools/server/serve.py
+++ b/src/lemonade/tools/server/serve.py
@@ -521,7 +521,9 @@ class Server:
 
         return lc
 
-    async def completions(self, completion_request: CompletionRequest, request: Request):
+    async def completions(
+        self, completion_request: CompletionRequest, request: Request
+    ):
         """
         Stream completion responses using HTTP chunked transfer encoding.
         """
@@ -581,7 +583,9 @@ class Server:
                             break
 
                         choice = CompletionChoice(
-                            text=("<think>" + token if reasoning_first_token else token),
+                            text=(
+                                "<think>" + token if reasoning_first_token else token
+                            ),
                             index=0,
                             finish_reason="stop",
                             logprobs=None,
@@ -597,7 +601,9 @@ class Server:
 
                         # Format as SSE
                         reasoning_first_token = False
-                        yield f"data: {completion.model_dump_json()}\n\n".encode("utf-8")
+                        yield f"data: {completion.model_dump_json()}\n\n".encode(
+                            "utf-8"
+                        )
 
                     # Send the [DONE] marker only if still connected
                     if not await request.is_disconnected():
@@ -663,7 +669,9 @@ class Server:
                 created=int(time.time()),
             )
 
-    async def chat_completions(self, chat_completion_request: ChatCompletionRequest, request: Request):
+    async def chat_completions(
+        self, chat_completion_request: ChatCompletionRequest, request: Request
+    ):
         """
         Stream chat completion responses using HTTP chunked transfer encoding.
         """
@@ -770,7 +778,9 @@ class Server:
                                         index=0,
                                         id="-",
                                         function=ChoiceDeltaToolCallFunction(
-                                            arguments=json.dumps(tool_call["arguments"]),
+                                            arguments=json.dumps(
+                                                tool_call["arguments"]
+                                            ),
                                             name=tool_call["name"],
                                         ),
                                         type="function",
@@ -1047,7 +1057,9 @@ class Server:
                         # Create an event
                         delta_event = ResponseTextDeltaEvent(
                             content_index=0,
-                            delta=("<think>" + token if reasoning_first_token else token),
+                            delta=(
+                                "<think>" + token if reasoning_first_token else token
+                            ),
                             item_id="0 ",
                             output_index=0,
                             type="response.output_text.delta",
@@ -1057,7 +1069,9 @@ class Server:
 
                         # Format as SSE
                         reasoning_first_token = False
-                        yield f"data: {delta_event.model_dump_json()}\n\n".encode("utf-8")
+                        yield f"data: {delta_event.model_dump_json()}\n\n".encode(
+                            "utf-8"
+                        )
 
                     # Send the completed event (only if still connected)
                     if not await request.is_disconnected():
@@ -1089,7 +1103,9 @@ class Server:
                             type="response.completed",
                             sequence_number=0,
                         )
-                        yield f"data: {completed_event.model_dump_json()}\n\n".encode("utf-8")
+                        yield f"data: {completed_event.model_dump_json()}\n\n".encode(
+                            "utf-8"
+                        )
 
                         # Send the [DONE] marker
                         yield b"data: [DONE]\n\n"

--- a/src/lemonade/tools/server/serve.py
+++ b/src/lemonade/tools/server/serve.py
@@ -521,7 +521,7 @@ class Server:
 
         return lc
 
-    async def completions(self, completion_request: CompletionRequest):
+    async def completions(self, completion_request: CompletionRequest, request: Request):
         """
         Stream completion responses using HTTP chunked transfer encoding.
         """
@@ -573,29 +573,39 @@ class Server:
                 # This is necessary because the variable is modified
                 # in the inner function
                 nonlocal reasoning_first_token
+                try:
+                    async for token in self._generate_tokens(**generation_args):
+                        # Handle client disconnect: stop generation and exit
+                        if await request.is_disconnected():
+                            self.stop_event.set()
+                            break
 
-                async for token in self._generate_tokens(**generation_args):
-                    choice = CompletionChoice(
-                        text=("<think>" + token if reasoning_first_token else token),
-                        index=0,
-                        finish_reason="stop",
-                        logprobs=None,
-                    )
+                        choice = CompletionChoice(
+                            text=("<think>" + token if reasoning_first_token else token),
+                            index=0,
+                            finish_reason="stop",
+                            logprobs=None,
+                        )
 
-                    completion = Completion(
-                        id="0",
-                        choices=[choice],
-                        model=self.llm_loaded.checkpoint,
-                        object="text_completion",
-                        created=int(time.time()),
-                    )
+                        completion = Completion(
+                            id="0",
+                            choices=[choice],
+                            model=self.llm_loaded.checkpoint,
+                            object="text_completion",
+                            created=int(time.time()),
+                        )
 
-                    # Format as SSE
-                    reasoning_first_token = False
-                    yield f"data: {completion.model_dump_json()}\n\n".encode("utf-8")
+                        # Format as SSE
+                        reasoning_first_token = False
+                        yield f"data: {completion.model_dump_json()}\n\n".encode("utf-8")
 
-                # Send the [DONE] marker
-                yield b"data: [DONE]\n\n"
+                    # Send the [DONE] marker only if still connected
+                    if not await request.is_disconnected():
+                        yield b"data: [DONE]\n\n"
+                except asyncio.CancelledError:
+                    # Propagate cancellation to the generator loop
+                    self.stop_event.set()
+                    return
 
             return StreamingResponse(
                 generate(),
@@ -653,7 +663,7 @@ class Server:
                 created=int(time.time()),
             )
 
-    async def chat_completions(self, chat_completion_request: ChatCompletionRequest):
+    async def chat_completions(self, chat_completion_request: ChatCompletionRequest, request: Request):
         """
         Stream chat completion responses using HTTP chunked transfer encoding.
         """
@@ -731,69 +741,78 @@ class Server:
 
                 # Keep track of the full response for tool call extraction
                 full_response = ""
+                try:
+                    async for token in self._generate_tokens(**generation_args):
+                        # Handle client disconnect: stop generation and exit
+                        if await request.is_disconnected():
+                            self.stop_event.set()
+                            break
 
-                async for token in self._generate_tokens(**generation_args):
-                    # Continuously look for tool calls embedded into the generated text
-                    openai_tool_calls = None
-                    if chat_completion_request.tools:
+                        # Continuously look for tool calls embedded into the generated text
+                        openai_tool_calls = None
+                        if chat_completion_request.tools:
 
-                        # Append the token to the full response
-                        full_response += token
+                            # Append the token to the full response
+                            full_response += token
 
-                        tool_calls, _ = extract_tool_calls(
-                            full_response,
-                            tool_call_pattern,
+                            tool_calls, _ = extract_tool_calls(
+                                full_response,
+                                tool_call_pattern,
+                            )
+
+                            # If there are tool calls, reset the full response for the next tool call
+                            if tool_calls:
+                                openai_tool_calls = []
+                                full_response = ""
+                            for tool_call in tool_calls:
+                                openai_tool_calls.append(
+                                    ChoiceDeltaToolCall(
+                                        index=0,
+                                        id="-",
+                                        function=ChoiceDeltaToolCallFunction(
+                                            arguments=json.dumps(tool_call["arguments"]),
+                                            name=tool_call["name"],
+                                        ),
+                                        type="function",
+                                    )
+                                )
+
+                        # Create a ChatCompletionChunk
+                        chunk = ChatCompletionChunk.model_construct(
+                            id="0",
+                            object="chat.completion.chunk",
+                            created=int(time.time()),
+                            model=self.llm_loaded.checkpoint,
+                            choices=[
+                                Choice.model_construct(
+                                    index=0,
+                                    delta=ChoiceDelta(
+                                        content=(
+                                            "<think>" + token
+                                            if reasoning_first_token
+                                            else token
+                                        ),
+                                        function_call=None,
+                                        role="assistant",
+                                        tool_calls=openai_tool_calls,
+                                        refusal=None,
+                                    ),
+                                    finish_reason=None,
+                                    logprobs=None,
+                                )
+                            ],
                         )
 
-                        # If there are tool calls, reset the full response for the next tool call
-                        if tool_calls:
-                            openai_tool_calls = []
-                            full_response = ""
-                        for tool_call in tool_calls:
-                            openai_tool_calls.append(
-                                ChoiceDeltaToolCall(
-                                    index=0,
-                                    id="-",
-                                    function=ChoiceDeltaToolCallFunction(
-                                        arguments=json.dumps(tool_call["arguments"]),
-                                        name=tool_call["name"],
-                                    ),
-                                    type="function",
-                                )
-                            )
+                        # Format as SSE
+                        reasoning_first_token = False
+                        yield f"data: {chunk.model_dump_json()}\n\n".encode("utf-8")
 
-                    # Create a ChatCompletionChunk
-                    chunk = ChatCompletionChunk.model_construct(
-                        id="0",
-                        object="chat.completion.chunk",
-                        created=int(time.time()),
-                        model=self.llm_loaded.checkpoint,
-                        choices=[
-                            Choice.model_construct(
-                                index=0,
-                                delta=ChoiceDelta(
-                                    content=(
-                                        "<think>" + token
-                                        if reasoning_first_token
-                                        else token
-                                    ),
-                                    function_call=None,
-                                    role="assistant",
-                                    tool_calls=openai_tool_calls,
-                                    refusal=None,
-                                ),
-                                finish_reason=None,
-                                logprobs=None,
-                            )
-                        ],
-                    )
-
-                    # Format as SSE
-                    reasoning_first_token = False
-                    yield f"data: {chunk.model_dump_json()}\n\n".encode("utf-8")
-
-                # Send the [DONE] marker
-                yield b"data: [DONE]\n\n"
+                    # Send the [DONE] marker only if still connected
+                    if not await request.is_disconnected():
+                        yield b"data: [DONE]\n\n"
+                except asyncio.CancelledError:
+                    self.stop_event.set()
+                    return
 
             return StreamingResponse(
                 generate(),
@@ -952,7 +971,7 @@ class Server:
             formatted_messages.append(f"{role_marker}\n{content} <|end|>")
         return "\n".join(formatted_messages) + "\n<|assistant|>"
 
-    async def responses(self, responses_request: ResponsesRequest):
+    async def responses(self, responses_request: ResponsesRequest, request: Request):
         """
         Stream responses using HTTP chunked transfer encoding.
         """
@@ -1018,56 +1037,65 @@ class Server:
 
                 full_response = "<think>" if reasoning_first_token else ""
 
-                async for token in self._generate_tokens(**generation_args):
+                try:
+                    async for token in self._generate_tokens(**generation_args):
+                        # Handle client disconnect: stop generation and exit
+                        if await request.is_disconnected():
+                            self.stop_event.set()
+                            break
 
-                    # Create an event
-                    delta_event = ResponseTextDeltaEvent(
-                        content_index=0,
-                        delta=("<think>" + token if reasoning_first_token else token),
-                        item_id="0 ",
-                        output_index=0,
-                        type="response.output_text.delta",
-                        sequence_number=0,
-                    )
-                    full_response += token
-
-                    # Format as SSE
-                    reasoning_first_token = False
-                    yield f"data: {delta_event.model_dump_json()}\n\n".encode("utf-8")
-
-                # Send the completed event
-                response_output_message = ResponseOutputMessage(
-                    id="0",
-                    content=[
-                        ResponseOutputText(
-                            annotations=[],
-                            text=full_response,
-                            type="output_text",
+                        # Create an event
+                        delta_event = ResponseTextDeltaEvent(
+                            content_index=0,
+                            delta=("<think>" + token if reasoning_first_token else token),
+                            item_id="0 ",
+                            output_index=0,
+                            type="response.output_text.delta",
+                            sequence_number=0,
                         )
-                    ],
-                    role="assistant",
-                    status="completed",
-                    type="message",
-                )
-                response = Response(
-                    id="0",
-                    model=self.llm_loaded.checkpoint,
-                    created_at=int(time.time()),
-                    object="response",
-                    output=[response_output_message],
-                    parallel_tool_calls=True,
-                    tool_choice="auto",
-                    tools=[],
-                )
-                completed_event = ResponseCompletedEvent(
-                    response=response,
-                    type="response.completed",
-                    sequence_number=0,
-                )
-                yield f"data: {completed_event.model_dump_json()}\n\n".encode("utf-8")
+                        full_response += token
 
-                # Send the [DONE] marker
-                yield b"data: [DONE]\n\n"
+                        # Format as SSE
+                        reasoning_first_token = False
+                        yield f"data: {delta_event.model_dump_json()}\n\n".encode("utf-8")
+
+                    # Send the completed event (only if still connected)
+                    if not await request.is_disconnected():
+                        response_output_message = ResponseOutputMessage(
+                            id="0",
+                            content=[
+                                ResponseOutputText(
+                                    annotations=[],
+                                    text=full_response,
+                                    type="output_text",
+                                )
+                            ],
+                            role="assistant",
+                            status="completed",
+                            type="message",
+                        )
+                        response = Response(
+                            id="0",
+                            model=self.llm_loaded.checkpoint,
+                            created_at=int(time.time()),
+                            object="response",
+                            output=[response_output_message],
+                            parallel_tool_calls=True,
+                            tool_choice="auto",
+                            tools=[],
+                        )
+                        completed_event = ResponseCompletedEvent(
+                            response=response,
+                            type="response.completed",
+                            sequence_number=0,
+                        )
+                        yield f"data: {completed_event.model_dump_json()}\n\n".encode("utf-8")
+
+                        # Send the [DONE] marker
+                        yield b"data: [DONE]\n\n"
+                except asyncio.CancelledError:
+                    self.stop_event.set()
+                    return
 
             return StreamingResponse(
                 generate(),

--- a/src/lemonade/tools/server/serve.py
+++ b/src/lemonade/tools/server/serve.py
@@ -768,7 +768,7 @@ class Server:
                                 tool_call_pattern,
                             )
 
-                            # If there are tool calls, reset the full response for the next tool call
+                            # If there are tool calls, reset the full response for the next call
                             if tool_calls:
                                 openai_tool_calls = []
                                 full_response = ""

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -141,11 +141,11 @@ function updateAttachmentButtonState() {
 
     // Update send button state based on model loading
     if (modelSelect.disabled) {
-        sendBtn.disabled = true;
-        sendBtn.textContent = 'Loading...';
+        toggleBtn.disabled = true;
+        toggleBtn.textContent = 'Loading...';
     } else {
-        sendBtn.disabled = false;
-        sendBtn.textContent = 'Send';
+        toggleBtn.disabled = false;
+        toggleBtn.textContent = 'Start';
     }
     
     if (!currentLoadedModel) {

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -623,7 +623,7 @@ function abortCurrentRequest() {
         abortController = null;
         if (toggleBtn) {
             toggleBtn.disabled = false;
-            toggleBtn.textContent = 'Start';
+            toggleBtn.textContent = 'Send';
         }
         isStreaming = false;
         console.log('Streaming request aborted by user.');

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -612,7 +612,14 @@ function displaySystemMessage() {
 
 function abortCurrentRequest() {
     if (abortController) {
+        // Abort the in-flight fetch stream immediately
         abortController.abort();
+
+        // Also signal the server to halt generation promptly (helps slow CPU backends)
+        try {
+            // Fire-and-forget; no await to avoid blocking UI
+            fetch(getServerBaseUrl() + '/api/v1/halt', { method: 'GET', keepalive: true }).catch(() => {});
+        } catch (_) {}
         abortController = null;
         if (toggleBtn) {
             toggleBtn.disabled = false;

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -1063,6 +1063,5 @@ async function sendMessage(existingTextIfAny) {
     if (sendBtn) sendBtn.disabled = false;
     if (stopBtn) stopBtn.disabled = true;
     abortController = null;
-    // Force a final render to trigger stop animation if needed
     updateMessageContent(llmBubble, llmText, true);
 }

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -15,19 +15,18 @@ const THINKING_FRAMES = THINKING_USE_LEMON
     : ['Thinking.','Thinking..','Thinking...'];
 
 // Get DOM elements
-let chatHistory, chatInput, sendBtn, attachmentBtn, fileAttachment, attachmentsPreviewContainer, attachmentsPreviewRow, modelSelect, stopBtn;
+let chatHistory, chatInput, attachmentBtn, fileAttachment, attachmentsPreviewContainer, attachmentsPreviewRow, modelSelect, toggleBtn;
 
 // Initialize chat functionality when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
     chatHistory = document.getElementById('chat-history');
     chatInput = document.getElementById('chat-input');
-    sendBtn = document.getElementById('send-btn');
+    toggleBtn = document.getElementById('toggle-btn');
     attachmentBtn = document.getElementById('attachment-btn');
     fileAttachment = document.getElementById('file-attachment');
     attachmentsPreviewContainer = document.getElementById('attachments-preview-container');
     attachmentsPreviewRow = document.getElementById('attachments-preview-row');
     modelSelect = document.getElementById('model-select');
-    stopBtn = document.getElementById('stop-btn');
 
     // Set up event listeners
     setupChatEventListeners();
@@ -44,10 +43,26 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function setupChatEventListeners() {
-    // Send button click
-    sendBtn.onclick = sendMessage;
-    // Stop button click – abort in‑flight request
-    if (stopBtn) stopBtn.onclick = abortCurrentRequest;
+    // Toggle button click – start or stop streaming
+    toggleBtn.onclick = function () {
+        if (abortController) {
+            abortCurrentRequest();
+        } else {
+            sendMessage();
+        }
+    };
+```
+
+src\lemonade\tools\server\static\js\chat.js
+```javascript
+<<<<<<< SEARCH
+    if (modelSelect.disabled) {
+        sendBtn.disabled = true;
+        sendBtn.textContent = 'Loading...';
+    } else {
+        sendBtn.disabled = false;
+        sendBtn.textContent = 'Send';
+    }
 
     // Attachment button click
     attachmentBtn.onclick = () => {
@@ -618,8 +633,10 @@ function abortCurrentRequest() {
     if (abortController) {
         abortController.abort();
         abortController = null;
-        if (sendBtn) sendBtn.disabled = false;
-        if (stopBtn) stopBtn.disabled = true;
+        if (toggleBtn) {
+            toggleBtn.disabled = false;
+            toggleBtn.textContent = 'Start';
+        }
         console.log('Streaming request aborted by user.');
     }
 }
@@ -775,9 +792,11 @@ async function sendMessage(existingTextIfAny) {
 
     // Prepare abort controller for this request
     abortController = new AbortController();
-    // UI state: disable Send, enable Stop
-    if (sendBtn) sendBtn.disabled = true;
-    if (stopBtn) stopBtn.disabled = false;
+    // UI state: set button to Stop
+    if (toggleBtn) {
+        toggleBtn.disabled = false;
+        toggleBtn.textContent = 'Stop';
+    }
     if (!text && attachedFiles.length === 0) return;
 
     // Remove system message when user starts chatting
@@ -877,7 +896,7 @@ async function sendMessage(existingTextIfAny) {
     updateInputPlaceholder(); // Reset placeholder
     updateAttachmentPreviewVisibility(); // Hide preview container
     updateAttachmentPreviews(); // Clear previews
-    sendBtn.disabled = true;
+    toggleBtn.disabled = true;
 
     // Streaming OpenAI completions (placeholder, adapt as needed)
     let llmText = '';
@@ -1040,8 +1059,10 @@ async function sendMessage(existingTextIfAny) {
     }
     }
     // Reset UI state after streaming finishes
-    if (sendBtn) sendBtn.disabled = false;
-    if (stopBtn) stopBtn.disabled = true;
+    if (toggleBtn) {
+        toggleBtn.disabled = false;
+        toggleBtn.textContent = 'Start';
+    }
     abortController = null;
     updateMessageContent(llmBubble, llmText, true);
 }

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -53,6 +53,26 @@ function setupChatEventListeners() {
             sendMessage();
         }
     };
+
+    // Send on Enter, clear attachments on Escape
+    if (chatInput) {
+        chatInput.addEventListener('keydown', handleChatInputKeydown);
+        chatInput.addEventListener('paste', handleChatInputPaste);
+    }
+
+    // Open file picker and handle image selection
+    if (attachmentBtn && fileAttachment) {
+        attachmentBtn.addEventListener('click', function () {
+            // Let the selection handler validate vision capability, etc.
+            fileAttachment.click();
+        });
+        fileAttachment.addEventListener('change', handleFileSelection);
+    }
+
+    // React to model selection changes
+    if (modelSelect) {
+        modelSelect.addEventListener('change', handleModelSelectChange);
+    }
 }
 
 // Initialize model dropdown with available models

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -226,7 +226,7 @@ async function autoLoadDefaultModelAndSend() {
         // Custom UI updates for auto-loading
         onLoadingStart: () => { if (toggleBtn) { toggleBtn.textContent = 'Loading model...'; } },
         // Reset send button text
-        onLoadingEnd: () => { if (toggleBtn) { toggleBtn.textContent = 'Start'; } },
+        onLoadingEnd: () => { if (toggleBtn) { toggleBtn.textContent = 'Send'; } },
         // Send the message after successful load
         onSuccess: () => { sendMessage(messageToSend); },
         onError: (error) => {

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -624,27 +624,6 @@ function abortCurrentRequest() {
     }
 }
 
-function toggleThinkTokens(header) {
-    const container = header.parentElement;
-    const content = container.querySelector('.think-tokens-content');
-    const chevron = header.querySelector('.think-tokens-chevron');
-    const bubble = header.closest('.chat-bubble');
-
-    const nowCollapsed = !container.classList.contains('collapsed'); // current (before toggle) expanded?
-    if (nowCollapsed) {
-        // Collapse
-        content.style.display = 'none';
-        chevron.textContent = '▶';
-        container.classList.add('collapsed');
-        if (bubble) bubble.dataset.thinkExpanded = 'false';
-    } else {
-        // Expand
-        content.style.display = 'block';
-        chevron.textContent = '▼';
-        container.classList.remove('collapsed');
-        if (bubble) bubble.dataset.thinkExpanded = 'true';
-    }
-}
 
 // ---------- Reasoning Parsing (Harmony + <think>) ----------
 

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -51,6 +51,7 @@ function setupChatEventListeners() {
             sendMessage();
         }
     };
+}
 
 // Initialize model dropdown with available models
 function initializeModelDropdown() {

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -51,53 +51,6 @@ function setupChatEventListeners() {
             sendMessage();
         }
     };
-```
-
-src\lemonade\tools\server\static\js\chat.js
-```javascript
-<<<<<<< SEARCH
-    if (modelSelect.disabled) {
-        sendBtn.disabled = true;
-        sendBtn.textContent = 'Loading...';
-    } else {
-        sendBtn.disabled = false;
-        sendBtn.textContent = 'Send';
-    }
-
-    // Attachment button click
-    attachmentBtn.onclick = () => {
-        if (!currentLoadedModel) {
-            alert('Please load a model first before attaching images.');
-            return;
-        }
-        if (!isVisionModel(currentLoadedModel)) {
-            alert(`The current model "${currentLoadedModel}" does not support image inputs. Please load a model with "Vision" capabilities to attach images.`);
-            return;
-        }
-        fileAttachment.click();
-    };
-
-    // File input change
-    fileAttachment.addEventListener('change', handleFileSelection);
-
-    // Chat input events
-    chatInput.addEventListener('keydown', handleChatInputKeydown);
-    chatInput.addEventListener('paste', handleChatInputPaste);
-
-    // Model select change
-    modelSelect.addEventListener('change', handleModelSelectChange);
-
-    // Send button click
-    sendBtn.addEventListener('click', function() {
-        // Check if we have a loaded model
-        if (currentLoadedModel && modelSelect.value !== '' && !modelSelect.disabled) {
-            sendMessage();
-        } else if (!currentLoadedModel) {
-            // Auto-load default model and send
-            autoLoadDefaultModelAndSend();
-        }
-    });
-}
 
 // Initialize model dropdown with available models
 function initializeModelDropdown() {

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -1038,6 +1038,7 @@ async function sendMessage(existingTextIfAny) {
             showErrorBanner(`Chat error: ${detail}`);
         }
     }
+    }
     // Reset UI state after streaming finishes
     if (sendBtn) sendBtn.disabled = false;
     if (stopBtn) stopBtn.disabled = true;

--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -790,7 +790,7 @@ async function sendMessage(existingTextIfAny) {
         // Nothing to send; revert button state and clear abort handle
         abortController = null;
         if (toggleBtn) {
-            toggleBtn.textContent = 'Start';
+            toggleBtn.textContent = 'Send';
         }
         return;
     }

--- a/src/lemonade/tools/server/static/styles.css
+++ b/src/lemonade/tools/server/static/styles.css
@@ -414,18 +414,38 @@ button:disabled {
   border: 1px solid #e0e0e0;
   border-radius: 8px;
   background: #fff;
-  resize: both;
-  overflow: auto;
+  /* Use a semi-fixed chat 'window' height so streaming content never expands the page.
+     The chat-history area inside will scroll. The CSS variable allows easy tuning. */
+  --chat-height: 520px;
+  /* Allow vertical resizing by the user while keeping horizontal size fixed.
+     Constrain the resize with min/max heights so it stays usable and doesn't overflow the viewport. */
+  resize: vertical;
+  height: var(--chat-height);
+  min-height: 240px;
+  max-height: calc(100vh - 120px);
+  overflow: hidden; /* hide overflow at container level; chat-history will scroll */
+}
+
+/* Responsive fallback: if the viewport height is small, cap the chat window to fit */
+@media (max-height: 700px) {
+  .chat-container {
+    height: calc(100vh - 180px); /* leave space for navbar/footer */
+  }
 }
 
 .chat-history {
-  flex: 1;
+  /* Make chat history take remaining space in the chat container and scroll when content
+     exceeds this space. This prevents streaming text from expanding the overall layout. */
+  flex: 1 1 auto;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   padding: 1em;
   border-bottom: 1px solid #e0e0e0;
   display: flex;
   flex-direction: column;
   gap: 0.5em;
+  /* Optional visual hint for scrollable content */
+  scrollbar-width: thin;
 }
 
 .chat-message {

--- a/src/lemonade/tools/server/static/webapp.html
+++ b/src/lemonade/tools/server/static/webapp.html
@@ -54,8 +54,7 @@
                         </div>
                         <input type="file" id="file-attachment" style="display: none;" multiple accept="image/*">
                         <button id="attachment-btn" title="Attach files">&#x1F4CE;</button>
-                        <button id="send-btn">Send</button> 
-                        <button id="stop-btn" disabled title="Stop">Stop</button>
+                        <button id="toggle-btn" title="Start">Start</button>
                     </div>
                     <div class="attachments-preview-container" id="attachments-preview-container">
                         <div class="attachments-preview-row" id="attachments-preview-row"></div>

--- a/src/lemonade/tools/server/static/webapp.html
+++ b/src/lemonade/tools/server/static/webapp.html
@@ -48,7 +48,7 @@
 			</div>
             <div class="tab-content active" id="content-chat">
                 <div class="chat-container">
-                    <div class="chat-history" id="chat-history" style="max-height: 500px; overflow-y: auto;"></div>
+                    <div class="chat-history" id="chat-history" style="overflow-y: auto;"></div>
                     <div class="chat-input-row">
                         <div class="input-with-indicator">
                             <textarea id="chat-input" placeholder="Type your message..." rows="1"></textarea> 

--- a/src/lemonade/tools/server/static/webapp.html
+++ b/src/lemonade/tools/server/static/webapp.html
@@ -250,4 +250,3 @@
     <script src="/static/js/chat.js"></script>
 </body>
 </html>
-</html>

--- a/src/lemonade/tools/server/static/webapp.html
+++ b/src/lemonade/tools/server/static/webapp.html
@@ -47,7 +47,7 @@
 			</div>
             <div class="tab-content active" id="content-chat">
                 <div class="chat-container">
-                    <div class="chat-history" id="chat-history"></div>
+                    <div class="chat-history" id="chat-history" style="max-height: 500px; overflow-y: auto;"></div>
                     <div class="chat-input-row">
                         <div class="input-with-indicator">
                             <textarea id="chat-input" placeholder="Type your message..." rows="1"></textarea> 

--- a/src/lemonade/tools/server/static/webapp.html
+++ b/src/lemonade/tools/server/static/webapp.html
@@ -55,6 +55,7 @@
                         <input type="file" id="file-attachment" style="display: none;" multiple accept="image/*">
                         <button id="attachment-btn" title="Attach files">&#x1F4CE;</button>
                         <button id="send-btn">Send</button> 
+                        <button id="stop-btn" disabled title="Stop">Stop</button>
                     </div>
                     <div class="attachments-preview-container" id="attachments-preview-container">
                         <div class="attachments-preview-row" id="attachments-preview-row"></div>

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -329,7 +329,9 @@ class WrappedServer(ABC):
                 ) as response:
                     try:
                         for line in response.iter_lines():
-                            if not line:
+                            # Preserve SSE event boundaries: blank line separates events
+                            if line == b"" or line == "":
+                                yield "\n"
                                 continue
                             if isinstance(line, bytes):
                                 try:
@@ -421,7 +423,9 @@ class WrappedServer(ABC):
                 ) as response:
                     try:
                         for line in response.iter_lines():
-                            if not line:
+                            # Preserve SSE event boundaries: blank line separates events
+                            if line == b"" or line == "":
+                                yield "\n"
                                 continue
                             if isinstance(line, bytes):
                                 try:

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -336,9 +336,8 @@ class WrappedServer(ABC):
                             if isinstance(line, bytes):
                                 try:
                                     line = line.decode("utf-8", errors="ignore")
-                                except (
-                                    Exception
-                                ):  # pylint: disable=broad-exception-caught
+                                except (UnicodeDecodeError, LookupError):
+                                    # Skip lines that fail decoding due to encoding issues
                                     continue
                             # Forward SSE lines as-is
                             if not line.endswith("\n"):
@@ -432,9 +431,8 @@ class WrappedServer(ABC):
                             if isinstance(line, bytes):
                                 try:
                                     line = line.decode("utf-8", errors="ignore")
-                                except (
-                                    Exception
-                                ):  # pylint: disable=broad-exception-caught
+                                except (UnicodeDecodeError, LookupError):
+                                    # Skip lines that fail decoding due to encoding issues
                                     continue
                             # Forward SSE lines as-is
                             if not line.endswith("\n"):

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -318,18 +318,41 @@ class WrappedServer(ABC):
         if chat_completion_request.stream:
 
             def event_stream():
-                try:
-                    # Enable streaming
+                # Ensure streaming is enabled in params
+                stream_params = dict(openai_client_params)
+                stream_params["stream"] = True
+
+                # Use streaming context so we can explicitly close on cancellation
+                with client.chat.completions.with_streaming_response.create(
                     # pylint: disable=missing-kwoa
-                    for chunk in client.chat.completions.create(**openai_client_params):
-                        yield f"data: {chunk.model_dump_json()}\n\n"
-                    yield "data: [DONE]\n\n"
+                    **stream_params,
+                ) as response:
+                    try:
+                        for line in response.iter_lines():
+                            if not line:
+                                continue
+                            if isinstance(line, bytes):
+                                try:
+                                    line = line.decode("utf-8", errors="ignore")
+                                except Exception:  # pylint: disable=broad-exception-caught
+                                    continue
+                            # Forward SSE lines as-is
+                            if not line.endswith("\n"):
+                                line += "\n"
+                            yield line
 
-                    # Show telemetry after completion
-                    self.telemetry.show_telemetry()
+                        # Show telemetry after completion
+                        self.telemetry.show_telemetry()
 
-                except Exception as e:  # pylint: disable=broad-exception-caught
-                    yield f'data: {{"error": "{str(e)}"}}\n\n'
+                    except GeneratorExit:
+                        # Client disconnected/cancelled; close upstream stream and stop
+                        try:
+                            response.close()
+                        except Exception:  # pylint: disable=broad-exception-caught
+                            pass
+                        raise
+                    except Exception as e:  # pylint: disable=broad-exception-caught
+                        yield f'data: {{"error": "{str(e)}"}}\n\n'
 
             return StreamingResponse(
                 event_stream(),
@@ -387,18 +410,41 @@ class WrappedServer(ABC):
         if completion_request.stream:
 
             def event_stream():
-                try:
-                    # Enable streaming
+                # Ensure streaming is enabled in params
+                stream_params = dict(openai_client_params)
+                stream_params["stream"] = True
+
+                # Use streaming context so we can explicitly close on cancellation
+                with client.completions.with_streaming_response.create(
                     # pylint: disable=missing-kwoa
-                    for chunk in client.completions.create(**openai_client_params):
-                        yield f"data: {chunk.model_dump_json()}\n\n"
-                    yield "data: [DONE]\n\n"
+                    **stream_params,
+                ) as response:
+                    try:
+                        for line in response.iter_lines():
+                            if not line:
+                                continue
+                            if isinstance(line, bytes):
+                                try:
+                                    line = line.decode("utf-8", errors="ignore")
+                                except Exception:  # pylint: disable=broad-exception-caught
+                                    continue
+                            # Forward SSE lines as-is
+                            if not line.endswith("\n"):
+                                line += "\n"
+                            yield line
 
-                    # Show telemetry after completion
-                    self.telemetry.show_telemetry()
+                        # Show telemetry after completion
+                        self.telemetry.show_telemetry()
 
-                except Exception as e:  # pylint: disable=broad-exception-caught
-                    yield f'data: {{"error": "{str(e)}"}}\n\n'
+                    except GeneratorExit:
+                        # Client disconnected/cancelled; close upstream stream and stop
+                        try:
+                            response.close()
+                        except Exception:  # pylint: disable=broad-exception-caught
+                            pass
+                        raise
+                    except Exception as e:  # pylint: disable=broad-exception-caught
+                        yield f'data: {{"error": "{str(e)}"}}\n\n'
 
             return StreamingResponse(
                 event_stream(),

--- a/src/lemonade/tools/server/wrapped_server.py
+++ b/src/lemonade/tools/server/wrapped_server.py
@@ -336,7 +336,9 @@ class WrappedServer(ABC):
                             if isinstance(line, bytes):
                                 try:
                                     line = line.decode("utf-8", errors="ignore")
-                                except Exception:  # pylint: disable=broad-exception-caught
+                                except (
+                                    Exception
+                                ):  # pylint: disable=broad-exception-caught
                                     continue
                             # Forward SSE lines as-is
                             if not line.endswith("\n"):
@@ -430,7 +432,9 @@ class WrappedServer(ABC):
                             if isinstance(line, bytes):
                                 try:
                                     line = line.decode("utf-8", errors="ignore")
-                                except Exception:  # pylint: disable=broad-exception-caught
+                                except (
+                                    Exception
+                                ):  # pylint: disable=broad-exception-caught
                                     continue
                             # Forward SSE lines as-is
                             if not line.endswith("\n"):


### PR DESCRIPTION
Adds a Stop button and AbortController integration to cancel streaming chat responses, plus a set of defensive fixes and UX improvements to make streaming more reliable and friendlier.

# What changed (high level)
- Add Stop button to the chat UI and wire it to an AbortController to cancel in-flight streaming requests.
- Update UI state handling (enable/disable Send/Stop) and add null guards to avoid DOM-related TypeErrors.
- Handle user-initiated aborts gracefully (preserve existing bubble text; reset UI).
- Auto-scroll improvements: manual-scroll detection (pin/unpin), threshold, and requestAnimationFrame-based scrolling.
- Make response bubbles auto-grow instead of internal scrolling.
Minor housekeeping: ignore local aider files in .gitignore.
# Files touched
- src/lemonade/tools/server/static/js/chat.js — main logic: AbortController, stop button wiring, null checks, auto-scroll, bubble sizing, Enter handling, error handling.
- src/lemonade/tools/server/static/webapp.html — add stop-btn to UI.
- .gitignore — add .aider* ignore.

Fixes #371 #123 