### PR TITLE
Add model size metadata (GB) to server_models and UI Model Manager

### DIFF
--- a/src/lemonade/tools/server/static/js/models.js
+++ b/src/lemonade/tools/server/static/js/models.js
@@ -529,16 +529,22 @@ async function deleteModel(modelId) {
 
 // Create model name with labels
 function createModelNameWithLabels(modelId, serverModels) {
+    const modelData = serverModels[modelId];
     const container = document.createElement('div');
     container.className = 'model-labels-container';
     
     // Model name
     const nameSpan = document.createElement('span');
-    nameSpan.textContent = modelId;
+
+    // Append size if available
+    let displayName = modelId;
+    if (modelData && typeof modelData.size === 'number') {
+        displayName += ` (${modelData.size} GB)`;
+    }
+    nameSpan.textContent = displayName;
     container.appendChild(nameSpan);
     
     // Labels
-    const modelData = serverModels[modelId];
     if (modelData && modelData.labels && Array.isArray(modelData.labels)) {
         modelData.labels.forEach(label => {
             const labelLower = label.toLowerCase();

--- a/src/lemonade_server/server_models.json
+++ b/src/lemonade_server/server_models.json
@@ -2,345 +2,407 @@
     "Qwen2.5-0.5B-Instruct-CPU": {
         "checkpoint": "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx",
         "recipe": "oga-cpu",
-        "suggested": true
+        "suggested": true,
+        "size": 0.77
     },
     "Llama-3.2-1B-Instruct-CPU": {
         "checkpoint": "amd/Llama-3.2-1B-Instruct-awq-uint4-float16-cpu-onnx",
         "recipe": "oga-cpu",
-        "suggested": false
+        "suggested": false,
+        "size": 1.64
     },
     "Llama-3.2-3B-Instruct-CPU": {
         "checkpoint": "amd/Llama-3.2-3B-Instruct-awq-uint4-float16-cpu-onnx",
         "recipe": "oga-cpu",
-        "suggested": false
+        "suggested": false,
+        "size": 3.15
     },
     "Phi-3-Mini-Instruct-CPU": {
         "checkpoint": "amd/Phi-3-mini-4k-instruct_int4_float16_onnx_cpu",
         "recipe": "oga-cpu",
-        "suggested": true
+        "suggested": true,
+        "size": 2.23
     },
     "Qwen-1.5-7B-Chat-CPU": {
         "checkpoint": "amd/Qwen1.5-7B-Chat_uint4_asym_g128_float16_onnx_cpu",
         "recipe": "oga-cpu",
-        "suggested": true
+        "suggested": true,
+        "size": 5.89
     },
     "DeepSeek-R1-Distill-Llama-8B-CPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-awq-asym-uint4-g128-lmhead-onnx-cpu",
         "recipe": "oga-cpu",
         "suggested": true,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 5.78
     },
     "DeepSeek-R1-Distill-Qwen-7B-CPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-awq-asym-uint4-g128-lmhead-onnx-cpu",
         "recipe": "oga-cpu",
         "suggested": true,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 5.78
     },
     "Llama-3.2-1B-Instruct-Hybrid": {
         "checkpoint": "amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": true
+        "suggested": true,
+        "size": 1.75
     },
     "Llama-3.2-3B-Instruct-Hybrid": {
         "checkpoint": "amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": true
+        "suggested": true,
+        "size": 3.97
     },
     "Phi-3-Mini-Instruct-Hybrid": {
         "checkpoint": "amd/Phi-3-mini-4k-instruct-awq-g128-int4-asym-fp16-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": true
+        "suggested": true,
+        "size": 3.89
     },
     "Phi-3.5-Mini-Instruct-Hybrid": {
         "checkpoint": "amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-fp16-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": false
+        "suggested": false,
+        "size": 3.92
     },
     "Qwen-1.5-7B-Chat-Hybrid": {
         "checkpoint": "amd/Qwen1.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": true
+        "suggested": true,
+        "size": 8.22
     },
     "Qwen-2.5-7B-Instruct-Hybrid": {
         "checkpoint": "amd/Qwen2.5-7B-Instruct-awq-uint4-asym-g128-lmhead-g32-fp16-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": true
+        "suggested": true,
+        "size": 8.42
     },
     "Qwen-2.5-3B-Instruct-Hybrid": {
         "checkpoint": "amd/Qwen2.5-3B-Instruct-awq-uint4-asym-g128-lmhead-g32-fp16-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": true
+        "suggested": true,
+        "size": 3.84
     },
     "Qwen-2.5-1.5B-Instruct-Hybrid": {
         "checkpoint": "amd/Qwen2.5-1.5B-Instruct-awq-uint4-asym-g128-lmhead-g32-fp16-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": true
+        "suggested": true,
+        "size": 2.08
     },
     "DeepSeek-R1-Distill-Llama-8B-Hybrid": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-awq-asym-uint4-g128-lmhead-onnx-hybrid",
         "recipe": "oga-hybrid",
         "suggested": true,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 8.45
     },
     "DeepSeek-R1-Distill-Qwen-7B-Hybrid": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-7B-awq-asym-uint4-g128-lmhead-onnx-hybrid",
         "recipe": "oga-hybrid",
         "max_prompt_length": 2000,
         "suggested": false,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 8.84
     },
     "Mistral-7B-v0.3-Instruct-Hybrid": {
         "checkpoint": "amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-fp16-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": true
+        "suggested": true,
+        "size": 7.31
     },
     "Llama-3.1-8B-Instruct-Hybrid": {
         "checkpoint": "amd/Llama-3.1-8B-Instruct-awq-asym-uint4-g128-lmhead-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": true
+        "suggested": true,
+        "size": 8.47
     },
     "Llama-xLAM-2-8b-fc-r-Hybrid": {
         "checkpoint": "amd/Llama-xLAM-2-8b-fc-r-awq-g128-int4-asym-bfp16-onnx-hybrid",
         "recipe": "oga-hybrid",
-        "suggested": true
+        "suggested": true,
+        "size": 8.47
     },
     "Qwen-2.5-7B-Instruct-NPU": {
         "checkpoint": "amd/Qwen2.5-7B-Instruct-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": true
+        "suggested": true,
+        "size": 10.14
     },
     "Qwen-2.5-1.5B-Instruct-NPU": {
         "checkpoint": "amd/Qwen2.5-1.5B-Instruct-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": true
+        "suggested": true,
+        "size": 2.89
     },
     "DeepSeek-R1-Distill-Llama-8B-NPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": true
+        "suggested": true,
+        "size": 10.63
     },
     "DeepSeek-R1-Distill-Qwen-7B-NPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-7B-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": false
+        "suggested": false,
+        "size": 10.3
     },
     "DeepSeek-R1-Distill-Qwen-1.5B-NPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-1.5B-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": false
+        "suggested": false,
+        "size": 3.02
     },
     "Llama-3.2-3B-Instruct-NPU": {
         "checkpoint": "amd/Llama-3.2-3B-Instruct-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": false
+        "suggested": false,
+        "size": 2.46
     },
     "Llama-3.2-1B-Instruct-NPU": {
         "checkpoint": "amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": false
+        "suggested": false,
+        "size": 1.18
     },
     "Mistral-7B-v0.3-Instruct-NPU": {
         "checkpoint": "amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": true
+        "suggested": true,
+        "size": 11.75
     },
     "Phi-3.5-Mini-Instruct-NPU": {
         "checkpoint": "amd/Phi-3.5-mini-instruct-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": true
+        "suggested": true,
+        "size": 4.18
     },
     "ChatGLM-3-6b-Instruct-NPU": {
         "checkpoint": "amd/chatglm3-6b-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": false
+        "suggested": false,
+        "size": 3.53
     },
     "AMD-OLMo-1B-Instruct-NPU": {
         "checkpoint": "amd/AMD-OLMo-1B-SFT-DPO-awq-g128-int4-asym-bf16-onnx-ryzen-strix",
         "recipe": "oga-npu",
-        "suggested": false
+        "suggested": false,
+        "size": 2.56
     },
     "Llama-3.2-1B-Instruct-DirectML": {
         "checkpoint": "amd/Llama-3.2-1B-Instruct-dml-int4-awq-block-128-directml",
         "recipe": "oga-igpu",
-        "suggested": false
+        "suggested": false,
+        "size": 2.81
     },
     "Llama-3.2-3B-Instruct-DirectML": {
         "checkpoint": "amd/Llama-3.2-3B-Instruct-dml-int4-awq-block-128-directml",
         "recipe": "oga-igpu",
-        "suggested": false
+        "suggested": false,
+        "size": 6.75
     },
     "Phi-3.5-Mini-Instruct-DirectML": {
         "checkpoint": "amd/phi3.5-mini-instruct-int4-awq-block-128-directml",
         "recipe": "oga-igpu",
-        "suggested": false
+        "suggested": false,
+        "size": 2.14
     },
     "Qwen-1.5-7B-Chat-DirectML": {
         "checkpoint": "amd/Qwen1.5-7B-Chat-dml-int4-awq-block-128-directml",
         "recipe": "oga-igpu",
-        "suggested": false
+        "suggested": false,
+        "size": 3.73
     },
     "Mistral-7B-v0.1-Instruct-DirectML": {
         "checkpoint": "amd/Mistral-7B-Instruct-v0.1-awq-g128-int4-onnx-directml",
         "recipe": "oga-igpu",
-        "suggested": false
+        "suggested": false,
+        "size": 3.67
     },
     "Llama-3-8B-Instruct-DirectML": {
         "checkpoint": "amd/llama3-8b-instruct-awq-g128-int4-onnx-directml",
         "recipe": "oga-igpu",
-        "suggested": false
+        "suggested": false,
+        "size": 4.61
     },
     "Qwen3-0.6B-GGUF": {
         "checkpoint": "unsloth/Qwen3-0.6B-GGUF:Q4_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 0.38
     },
     "Qwen3-1.7B-GGUF": {
         "checkpoint": "unsloth/Qwen3-1.7B-GGUF:Q4_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 1.06
     },
     "Qwen3-4B-GGUF": {
         "checkpoint": "unsloth/Qwen3-4B-GGUF:Q4_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 2.38
     },
     "Qwen3-8B-GGUF": {
         "checkpoint": "unsloth/Qwen3-8B-GGUF:Q4_1",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 5.25
     },
     "DeepSeek-Qwen3-8B-GGUF": {
         "checkpoint": "unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF:Q4_1",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 5.25
     },
     "Qwen3-14B-GGUF": {
         "checkpoint": "unsloth/Qwen3-14B-GGUF:Q4_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 8.54
     },
     "Qwen3-4B-Instruct-2507-GGUF": {
         "checkpoint": "unsloth/Qwen3-4B-Instruct-2507-GGUF:Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot"]
+        "labels": ["hot"],
+        "size": 2.5
     },
     "Qwen3-30B-A3B-GGUF": {
         "checkpoint": "unsloth/Qwen3-30B-A3B-GGUF:Q4_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"]
+        "labels": ["reasoning"],
+        "size": 17.4
     },
     "Qwen3-30B-A3B-Instruct-2507-GGUF": {
         "checkpoint": "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF:Qwen3-30B-A3B-Instruct-2507-Q4_0.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot"]
+        "labels": ["hot"],
+        "size": 17.4
     },
     "Qwen3-Coder-30B-A3B-Instruct-GGUF": {
         "checkpoint": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["coding","tool-calling"]
+        "labels": ["coding","tool-calling"],
+        "size": 18.6
     },
     "Gemma-3-4b-it-GGUF": {
         "checkpoint": "ggml-org/gemma-3-4b-it-GGUF:Q4_K_M",
         "mmproj": "mmproj-model-f16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot","vision"]
+        "labels": ["hot","vision"],
+        "size": 3.61
     },
     "Qwen2.5-VL-7B-Instruct-GGUF": {
         "checkpoint": "ggml-org/Qwen2.5-VL-7B-Instruct-GGUF:Q4_K_M",
         "mmproj": "mmproj-Qwen2.5-VL-7B-Instruct-f16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["vision"]
+        "labels": ["vision"],
+        "size": 4.68
     },
     "Llama-4-Scout-17B-16E-Instruct-GGUF": {
         "checkpoint": "unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF:Q4_K_S",
         "mmproj": "mmproj-F16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["vision"]
+        "labels": ["vision"],
+        "size": 61.5
     },
     "Cogito-v2-llama-109B-MoE-GGUF": {
         "checkpoint": "unsloth/cogito-v2-preview-llama-109B-MoE-GGUF:Q4_K_M",
         "mmproj": "mmproj-F16.gguf",
         "recipe": "llamacpp",
         "suggested": false,
-        "labels": ["vision"]
+        "labels": ["vision"],
+        "size": 65.3
     },
     "nomic-embed-text-v1-GGUF": {
         "checkpoint": "nomic-ai/nomic-embed-text-v1-GGUF:Q4_K_S",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["embeddings"]
+        "labels": ["embeddings"],
+        "size": 0.0781
     },
     "nomic-embed-text-v2-moe-GGUF": {
         "checkpoint": "nomic-ai/nomic-embed-text-v2-moe-GGUF:Q8_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["embeddings"]
+        "labels": ["embeddings"],
+        "size": 0.51
     },
     "bge-reranker-v2-m3-GGUF": {
         "checkpoint": "pqnet/bge-reranker-v2-m3-Q8_0-GGUF",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reranking"]
+        "labels": ["reranking"],
+        "size": 0.53
     },
     "jina-reranker-v1-tiny-en-GGUF": {
         "checkpoint": "mradermacher/jina-reranker-v1-tiny-en-GGUF:Q8_0",
         "recipe": "llamacpp",
         "suggested": false,
-        "labels": ["reranking"]
+        "labels": ["reranking"],
+        "size": 0.03
     },
     "Devstral-Small-2507-GGUF":{
         "checkpoint": "mistralai/Devstral-Small-2507_gguf:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["coding","tool-calling"]
+        "labels": ["coding","tool-calling"],
+        "size": 14.3
     },
     "Qwen2.5-Coder-32B-Instruct-GGUF": {
         "checkpoint": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": true,  
-        "labels": ["coding"]
+        "labels": ["coding"],
+        "size": 19.85
     },
     "gpt-oss-120b-GGUF": {
         "checkpoint": "unsloth/gpt-oss-120b-GGUF:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": false,
-        "labels": ["reasoning", "tool-calling"]
+        "labels": ["reasoning", "tool-calling"],
+        "size": 62.7
     },
     "gpt-oss-20b-GGUF": {
         "checkpoint": "unsloth/gpt-oss-20b-GGUF:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": false,
-        "labels": ["reasoning", "tool-calling"]
+        "labels": ["reasoning", "tool-calling"],
+        "size": 11.6
     },
     "gpt-oss-120b-mxfp-GGUF": {
         "checkpoint": "ggml-org/gpt-oss-120b-GGUF:*",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot", "reasoning", "tool-calling"]
+        "labels": ["hot", "reasoning", "tool-calling"],
+        "size": 63.3
     },
     "gpt-oss-20b-mxfp4-GGUF": {
         "checkpoint": "ggml-org/gpt-oss-20b-GGUF",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot", "reasoning", "tool-calling"]
+        "labels": ["hot", "reasoning", "tool-calling"],
+        "size": 19.48
     },
     "GLM-4.5-Air-UD-Q4K-XL-GGUF": {
         "checkpoint": "unsloth/GLM-4.5-Air-GGUF:UD-Q4_K_XL",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning","hot"]
+        "labels": ["reasoning","hot"],
+        "size": 73.1
     }
 }


### PR DESCRIPTION
### Summary
This PR adds the model size (in GB) to `server_models.json` so users can better understand storage usage when downloading models from the UI Model Manager. The UI has been updated to display the size (when available) alongside the model name.

### Changes
- `src/lemonade_server/server_models.json`
  - Added "size" property (in GB) to each model entry.
- `src/lemonade/tools/server/static/js/models.js`
  - Moved `modelData `constant higher in the function for reuse.
  - Updated logic to append size (in parentheses) to the model display name if available.

### Notes
- If size metadata is missing, the UI gracefully ignores it and shows only the model name.

issue https://github.com/lemonade-sdk/lemonade/issues/385
Fixes: #385 