### PR TITLE
Fix 334 installer text

### DIFF
--- a/installer/Installer.nsi
+++ b/installer/Installer.nsi
@@ -344,7 +344,7 @@ LangString MUI_BUTTONTEXT_FINISH "${LANG_ENGLISH}" "Finish"
 LangString MUI_TEXT_LICENSE_TITLE ${LANG_ENGLISH} "AMD License Agreement"
 LangString MUI_TEXT_LICENSE_SUBTITLE ${LANG_ENGLISH} "Please review the license terms before installing AMD Ryzen AI SW with NPU and Hybrid Support."
 LangString DESC_SEC01 ${LANG_ENGLISH} "The minimum set of dependencies for a lemonade server that runs LLMs on CPU (includes Python)."
-LangString DESC_HybridSec ${LANG_ENGLISH} "Support LLMs on Ryzen AI with NPU/Hybrid. Ryzen AI 300-series only."
+LangString DESC_HybridSec ${LANG_ENGLISH} "Add support for running LLMs on Ryzen AI with NPU/Hybrid. Ryzen AI 300-series only."
 LangString DESC_ModelsSec ${LANG_ENGLISH} "Default model for Lemonade Server"
 LangString DESC_Qwen05Sec ${LANG_ENGLISH} "Qwen2.5-0.5B-Instruct-CPU model (ONNX format). This lightweight model helps you quickly get started with Lemonade Server."
 


### PR DESCRIPTION
### What I changed 
- Shortened the DESC_HybridSec string in `Installer.nsi` so the full text fits in the installer UI.

### Why 
- The original string was too long and was getting cut off in the installer.
- As the maintainer noted in issue #334, this was confusing for users since they couldn’t see the full requirement details. 

### How I tested 
- Rebuilt the installer locally using NSIS. 
- Ran the generated `.exe` and confirmed the shortened text now displays fully in the "Choose Components" screen. 
- Attached screenshot of the fixed installer below. 

### Notes 
- This is my first contribution to Lemonade SDK, and first open source contribution overall. 
- Thank you for labeling this as a `good first issue` and making it easier to get started. 


<img width="618" height="480" alt="Screenshot 2025-09-18 210142" src="https://github.com/user-attachments/assets/c0422f32-596c-47c2-895f-90c873772e8c" />
