### PR TITLE
Return a 422 when responses API is sent to llamacpp server

### DIFF
--- a/src/lemonade/tools/server/serve.py
+++ b/src/lemonade/tools/server/serve.py
@@ -966,6 +966,12 @@ class Server:
         # Load the model if it's different from the currently loaded one
         await self.load_llm(lc)
 
+        if self.llm_loaded.recipe == "llamacpp":
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Responses API not supported for recipe: {self.llm_loaded.recipe}",
+            )
+
         # Convert chat messages to text using the model's chat template
         if isinstance(responses_request.input, str):
             text = responses_request.input


### PR DESCRIPTION
We have a similar error message on reranking, embedding, etc. for unsupported API calls, but we didn't have one on Reponses.