### PR TITLE
Restore CI system

### DIFF
--- a/.github/workflows/docs_and_style.yml
+++ b/.github/workflows/docs_and_style.yml
@@ -2,11 +2,7 @@ name: Docs And Style
 on:
   push:
     branches: ["main"]
-    paths:
-      - '**/*.md'
   pull_request:
-    paths:
-      - '**/*.md'
   merge_group:
 
 permissions:

--- a/.github/workflows/test_llamacpp_oss.yml
+++ b/.github/workflows/test_llamacpp_oss.yml
@@ -7,9 +7,8 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches:
-      - '**'
   workflow_dispatch:
+  merge_group:
 
 
 permissions:

--- a/.github/workflows/test_llamacpp_oss.yml
+++ b/.github/workflows/test_llamacpp_oss.yml
@@ -123,19 +123,6 @@ jobs:
 
           echo "HF_HOME=$(pwd)/hf-cache" >> $GITHUB_ENV
 
-      - name: Run lemonade Llamacpp CLI tests
-        env:
-          HF_HOME: "${{ env.HF_HOME }}"
-        run: |
-          source ~/miniforge3/etc/profile.d/conda.sh
-          conda activate $CONDA_ENV_PATH
-
-          if [ "${{ matrix.backend }}" != "rocm" ]; then
-            lemonade -i unsloth/Qwen3-0.6B-GGUF:Q4_0 llamacpp-load --backend ${{ matrix.backend }} --device cpu llm-prompt -p "Hi" --max-new-tokens 10 || exit 1
-          fi
-
-          lemonade -i unsloth/Qwen3-0.6B-GGUF:Q4_0 llamacpp-load --backend ${{ matrix.backend }} --device igpu llm-prompt -p "Hi" --max-new-tokens 10 || exit 1
-
       - name: Run lemonade Llamacpp API tests
         env:
           HF_HOME: "${{ env.HF_HOME }}"

--- a/.github/workflows/test_llamacpp_oss.yml
+++ b/.github/workflows/test_llamacpp_oss.yml
@@ -135,7 +135,6 @@ jobs:
           fi
 
           lemonade -i unsloth/Qwen3-0.6B-GGUF:Q4_0 llamacpp-load --backend ${{ matrix.backend }} --device igpu llm-prompt -p "Hi" --max-new-tokens 10 || exit 1
-          lemonade -i unsloth/Qwen3-0.6B-GGUF:Q4_0 llamacpp-load --backend ${{ matrix.backend }} llamacpp-bench -w 0 -i 2 || exit 1
 
       - name: Run lemonade Llamacpp API tests
         env:

--- a/src/lemonade/tools/llamacpp/utils.py
+++ b/src/lemonade/tools/llamacpp/utils.py
@@ -366,8 +366,6 @@ def install_llamacpp(backend):
                 zip_ref.extractall(llama_server_exe_dir)
 
             # On Unix-like systems (macOS/Linux), make executables executable
-            import platform
-
             if platform.system().lower() in ["darwin", "linux"]:
                 import stat
 


### PR DESCRIPTION
Fixes #404 

- Remove redundant `import platform` (it is imported at the top of the file)
- Disable certain llamacpp-bench tests (see #408)