### PR TITLE
Use an image for the lemonade logo on the web ui

### DIFF
--- a/src/lemonade/tools/server/static/styles.css
+++ b/src/lemonade/tools/server/static/styles.css
@@ -99,6 +99,15 @@ body::before {
 .brand-title a {
   color: inherit;
   text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.brand-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  vertical-align: middle;
 }
 
 .navbar-links {
@@ -1512,6 +1521,11 @@ button:disabled {
     font-size: 1.3rem;
   }
   
+  .brand-icon {
+    width: 1.3rem;
+    height: 1.3rem;
+  }
+  
   .navbar-links {
     gap: 1.5rem;
     font-size: 1rem;
@@ -1525,6 +1539,11 @@ button:disabled {
   
   .brand-title {
     font-size: 1.2rem;
+  }
+  
+  .brand-icon {
+    width: 1.2rem;
+    height: 1.2rem;
   }
   
   .navbar-links {

--- a/src/lemonade/tools/server/static/webapp.html
+++ b/src/lemonade/tools/server/static/webapp.html
@@ -15,7 +15,7 @@
 <body>
     <nav class="navbar" id="navbar">
         <div class="navbar-brand">
-            <span class="brand-title"><a href="https://lemonade-server.ai">🍋 Lemonade Server</a></span>
+            <span class="brand-title"><a href="https://lemonade-server.ai"><img src="/static/favicon.ico" alt="🍋" class="brand-icon"> Lemonade Server</a></span>
         </div>
         <div class="navbar-links">
             <a href="https://github.com/lemonade-sdk/lemonade" target="_blank">GitHub</a>


### PR DESCRIPTION
Closes #393 

Proof on macOS:

<img width="1174" height="642" alt="image" src="https://github.com/user-attachments/assets/4b7a9e44-c217-4832-819a-0afa498a38b2" />


Before and after

<img width="405" height="282" alt="image" src="https://github.com/user-attachments/assets/8ed29de1-ea48-4c0a-8260-6472d58982c4" />

<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/d24a130c-e4e4-44b7-a622-495fcfde058d" />

Proof it's an image now:

<img width="470" height="569" alt="image" src="https://github.com/user-attachments/assets/119c6cba-5591-4da6-8250-37d6453fefb2" />
