### PR TITLE
Web UI Server Log Feature (#179)

### DIFF
--- a/src/lemonade/tools/server/static/logs.html
+++ b/src/lemonade/tools/server/static/logs.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Lemonade Server Logs</title>
+    <style>
+        body {
+            font-family: monospace;
+            background: #1e1e1e;
+            color: #d4d4d4;
+            margin: 0;
+            padding: 0;
+        }
+        #log-container {
+            padding: 10px;
+            height: 100vh;
+            overflow-y: auto;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+<body>
+    <div id="log-container"></div>
+
+    <script>
+        function stripAnsi(str) {
+            return str.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
+        }
+        const logContainer = document.getElementById("log-container");
+        const ws = new WebSocket(`ws://${location.host}/api/v1/logs/ws`);
+
+        ws.onmessage = (event) => {
+            const line = document.createElement("div");
+            line.textContent = stripAnsi(event.data);
+            logContainer.appendChild(line);
+            logContainer.scrollTop = logContainer.scrollHeight; // auto scroll
+        };
+
+        ws.onclose = () => {
+            const msg = document.createElement("div");
+            msg.textContent = "[Disconnected from log stream]";
+            msg.style.color = "red";
+            logContainer.appendChild(msg);
+        };
+    </script>
+</body>
+</html>

--- a/src/lemonade/tools/server/static/styles.css
+++ b/src/lemonade/tools/server/static/styles.css
@@ -2296,3 +2296,44 @@ button:disabled {
     0 3px 10px rgba(0, 0, 0, 0.1),
     inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
+
+
+/* Dropdown styling */
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropbtn {
+    background-color: transparent;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #ffe76c;
+    border-radius: 8px; /* rounded corners */
+    min-width: 140px;
+    box-shadow: 0px 8px 16px rgba(0,0,0,0.2);
+    z-index: 1000;
+    overflow: hidden; /* keep rounded edges clean */
+}
+
+.dropdown-content a {
+    color: black;
+    font-size: 12px;   /* smaller font */
+    padding: 8px 12px;
+    text-decoration: none;
+    display: block;
+}
+
+.dropdown-content a:hover {
+    background-color: #f6c146;
+}
+
+.dropdown:hover .dropdown-content {
+    display: block;
+}

--- a/src/lemonade/tools/server/static/webapp.html
+++ b/src/lemonade/tools/server/static/webapp.html
@@ -15,8 +15,19 @@
 <body>
     <nav class="navbar" id="navbar">
         <div class="navbar-brand">
-            <span class="brand-title"><a href="https://lemonade-server.ai">🍋 Lemonade Server</a></span>
-        </div>
+            <span class="brand-title">
+                <a href="https://lemonade-server.ai">🍋 Lemonade Server</a>
+            </span>
+            <!-- Dropdown -->
+            <div class="dropdown" style="display:inline-block; margin-left: 10px;">
+                <button class="dropbtn" aria-label="Logs" style="font-size:16px; background:none; border:none; cursor:pointer;">
+                    🍃
+                </button>
+                <div class="dropdown-content">
+                    <a href="/static/logs.html" target="_blank">View Logs</a>
+                </div>
+            </div>
+        </div>  
         <div class="navbar-links">
             <a href="https://github.com/lemonade-sdk/lemonade" target="_blank">GitHub</a>
             <a href="https://lemonade-server.ai/docs/" target="_blank">Docs</a>


### PR DESCRIPTION
### Description
This PR implements log streaming feature described in #179  
It opens the logs in a separate window so the user can view them on the side.
I used web sockets to simply stream the logs from file, it can be replaced with a simple get endpoint as well if needed.

### Changes
- Added WebSocket endpoint and streamer function (src/lemonade/tools/server/serve.py)
- Added a utilities dropdown next to Brand in navbar to view logs (src/lemonade/tools/server/static/webapp.html)
- Added style for the new utility dropw down (src/lemonade/tools/server/static/styles.css)
- Added a new template for log viewing (src/lemonade/tools/server/static/logs.html)

Closes #179 
