### PR TITLE
Add error handling for conda commands in workflow

### DIFF
--- a/.github/workflows/test_ryzenai.yml
+++ b/.github/workflows/test_ryzenai.yml
@@ -68,7 +68,9 @@ jobs:
           
           $ErrorActionPreference = "Stop"
           conda create -p .\lemon-ryzenai-ci python=3.10 -y
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           conda init
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           
       - name: Install dependencies
         shell: PowerShell


### PR DESCRIPTION
Raise an error if env creation fails, so problems like #440 wont be as ambiguous to debug.