### PR TITLE
Gracefully handle no FLM on linux

### DIFF
--- a/src/lemonade/tools/flm/utils.py
+++ b/src/lemonade/tools/flm/utils.py
@@ -240,7 +240,12 @@ def get_flm_installed_models() -> List[str]:
 
         return installed_checkpoints
 
-    except (subprocess.CalledProcessError, FileNotFoundError, AttributeError, NotADirectoryError):
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        AttributeError,
+        NotADirectoryError,
+    ):
         # FLM not installed, not available, or output parsing failed
         return []
 


### PR DESCRIPTION
Seems like some Linux distros raise a `NotADirectoryError` on our FLM model check, which we were not expecting.

See https://github.com/lemonade-sdk/infinity-arcade/issues/59 for context.