### PR TITLE
Fix major testing issues in server.py

### DIFF
--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -162,6 +162,7 @@ def ensure_model_is_cached():
         print(f"Failed to download model: {e}")
         return False
 
+
 class ServerTestingBase(unittest.IsolatedAsyncioTestCase):
     """Base class containing only shared setup/cleanup functionality, no test methods."""
 
@@ -250,7 +251,6 @@ class ServerTestingBase(unittest.IsolatedAsyncioTestCase):
             )
 
 
-
 def run_server_tests_with_class(test_class, description="SERVER TESTS", offline=None):
     """Utility function to run server tests with a given test class."""
     # If offline parameter is not provided, use argparse to get it
@@ -273,7 +273,9 @@ def run_server_tests_with_class(test_class, description="SERVER TESTS", offline=
 
         # Run the tests in offline mode
         with simulate_offline_mode():
-            result = unittest.TextTestRunner().run(test_suite)
+            result = unittest.TextTestRunner(
+                verbosity=2, buffer=False, failfast=True
+            ).run(test_suite)
 
         # Set exit code based on test results
         sys.exit(0 if result.wasSuccessful() else 1)
@@ -282,7 +284,11 @@ def run_server_tests_with_class(test_class, description="SERVER TESTS", offline=
         # Create a new test suite for the specific class
         test_loader = unittest.TestLoader()
         test_suite = test_loader.loadTestsFromTestCase(test_class)
-        unittest.TextTestRunner().run(test_suite)
+        # Use verbosity=2 to show test names, buffer=False to see output in real-time,
+        # and failfast=True to stop on first failure and show the error immediately
+        unittest.TextTestRunner(verbosity=2, buffer=False, failfast=True).run(
+            test_suite
+        )
 
 
 # This file was originally licensed under Apache 2.0. It has been modified.


### PR DESCRIPTION
`python test/server.py` was not working on local windows PCs because it would hang forever soon after starting.

It was also rather hard to tell what was going on.

This PR makes the following improvements:

1. Fixes the hang! Turns out the problem was spamming v0/system-info followed by v1/system-info in test_000.
    - Fixed this by using HEAD requests instead of GET requests in test_000. HEAD doesn't actually run the endpoint, it just checks that it is registered. This is much more appropriate for a test called "test_000_endpoints_available"
    - Made sure this still detects endpoint registration by commenting on the pull endpoint in serve.py and confirming that the test failed.
2. Added a timeout of all the `requests.get()` calls so that we don't have hanging tests anymore.
3. Changed the test settings in test/server_base.py:
    - Now "fails fast", so as you as you fail a test it will exit and give you the stack trace. That makes it massively easier to figure out what failed.
    - Increased print verbosity and removed buffering so that we can get all the info needed to debug. For example, the name of the test now prints right before the log output for that test.