### PR TITLE
C++: log streaming to web app

### DIFF
--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -56,6 +56,7 @@ private:
     void handle_system_info(const httplib::Request& req, httplib::Response& res);
     void handle_log_level(const httplib::Request& req, httplib::Response& res);
     void handle_shutdown(const httplib::Request& req, httplib::Response& res);
+    void handle_logs_stream(const httplib::Request& req, httplib::Response& res);
     
     // Helper function for auto-loading models (eliminates code duplication and race conditions)
     void auto_load_model_if_needed(const std::string& model_name);
@@ -66,6 +67,7 @@ private:
     int ctx_size_;
     bool tray_;
     std::string llamacpp_backend_;
+    std::string log_file_path_;
     
     std::unique_ptr<httplib::Server> http_server_;
     std::unique_ptr<Router> router_;

--- a/src/lemonade/tools/server/static/logs.html
+++ b/src/lemonade/tools/server/static/logs.html
@@ -23,35 +23,169 @@
     <div id="log-container"></div>
 
 <script>
+    /**
+     * LogStreamer - Backwards-compatible log streaming client
+     * Supports both WebSocket (Python server) and SSE (C++ server)
+     * Tries WebSocket first, falls back to SSE if unavailable
+     */
+    class LogStreamer {
+        constructor(baseUrl, onMessage, onError = null) {
+            this.baseUrl = baseUrl;
+            this.onMessage = onMessage;
+            this.onError = onError;
+            this.connection = null;
+            this.type = null; // 'websocket' or 'sse'
+        }
+        
+        async connect() {
+            // Try WebSocket first (Python server)
+            try {
+                await this.connectWebSocket();
+                console.log('[LogStreamer] Connected via WebSocket');
+                return;
+            } catch (wsError) {
+                console.log('[LogStreamer] WebSocket failed, trying SSE...', wsError);
+            }
+            
+            // Fallback to SSE (C++ server)
+            try {
+                this.connectSSE();
+                console.log('[LogStreamer] Connected via SSE');
+            } catch (sseError) {
+                console.error('[LogStreamer] Both WebSocket and SSE failed', sseError);
+                if (this.onError) {
+                    this.onError(new Error('Unable to connect to log stream'));
+                }
+            }
+        }
+        
+        connectWebSocket() {
+            return new Promise((resolve, reject) => {
+                const wsUrl = this.baseUrl
+                    .replace('http://', 'ws://')
+                    .replace('https://', 'wss://') + '/api/v1/logs/ws';
+                
+                const ws = new WebSocket(wsUrl);
+                let connectionTimeout = setTimeout(() => {
+                    reject(new Error('WebSocket connection timeout'));
+                    ws.close();
+                }, 3000); // 3 second timeout
+                
+                ws.onopen = () => {
+                    clearTimeout(connectionTimeout);
+                    this.connection = ws;
+                    this.type = 'websocket';
+                    resolve();
+                };
+                
+                ws.onmessage = (event) => {
+                    this.onMessage(event.data);
+                };
+                
+                ws.onerror = (error) => {
+                    clearTimeout(connectionTimeout);
+                    if (this.onError && this.connection) {
+                        this.onError(error);
+                    }
+                    reject(error);
+                };
+                
+                ws.onclose = () => {
+                    if (this.type === 'websocket') {
+                        console.log('[LogStreamer] WebSocket closed');
+                        if (this.onError) {
+                            this.onError(new Error('WebSocket connection closed'));
+                        }
+                    }
+                };
+            });
+        }
+        
+        connectSSE() {
+            const sseUrl = this.baseUrl + '/api/v1/logs/stream';
+            const eventSource = new EventSource(sseUrl);
+            
+            eventSource.onopen = () => {
+                this.connection = eventSource;
+                this.type = 'sse';
+            };
+            
+            eventSource.onmessage = (event) => {
+                this.onMessage(event.data);
+            };
+            
+            eventSource.onerror = (error) => {
+                console.error('[LogStreamer] SSE error:', error);
+                if (this.onError) {
+                    this.onError(error);
+                }
+            };
+        }
+        
+        disconnect() {
+            if (!this.connection) return;
+            
+            if (this.type === 'websocket') {
+                this.connection.close();
+            } else if (this.type === 'sse') {
+                this.connection.close();
+            }
+            
+            this.connection = null;
+            this.type = null;
+        }
+        
+        getConnectionType() {
+            return this.type;
+        }
+    }
+
+    // Utility functions
     function stripAnsi(str) {
         return str.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '');
     }
-
-    const logContainer = document.getElementById("log-container");
-    const ws = new WebSocket(`ws://${location.host}/api/v1/logs/ws`);
 
     function isNearBottom() {
         const threshold = 50; // px from bottom
         return logContainer.scrollTop + logContainer.clientHeight >= logContainer.scrollHeight - threshold;
     }
 
-    ws.onmessage = (event) => {
-        const line = document.createElement("div");
-        line.textContent = stripAnsi(event.data);
-        logContainer.appendChild(line);
+    // Initialize log streaming
+    const logContainer = document.getElementById("log-container");
+    const baseUrl = `${location.protocol}//${location.host}`;
+    
+    const logStreamer = new LogStreamer(
+        baseUrl,
+        (logLine) => {
+            // Handle incoming log line
+            const line = document.createElement("div");
+            line.textContent = stripAnsi(logLine);
+            logContainer.appendChild(line);
 
-        // Only autoscroll if the user is already at (or near) the bottom
-        if (isNearBottom()) {
-            logContainer.scrollTop = logContainer.scrollHeight;
+            // Only autoscroll if the user is already at (or near) the bottom
+            if (isNearBottom()) {
+                logContainer.scrollTop = logContainer.scrollHeight;
+            }
+        },
+        (error) => {
+            // Handle error
+            const msg = document.createElement("div");
+            msg.textContent = `[Connection error: ${error.message}]`;
+            msg.style.color = "red";
+            logContainer.appendChild(msg);
         }
-    };
-
-    ws.onclose = () => {
-        const msg = document.createElement("div");
-        msg.textContent = "[Disconnected from log stream]";
-        msg.style.color = "red";
-        logContainer.appendChild(msg);
-    };
+    );
+    
+    // Connect to log stream
+    logStreamer.connect();
+    
+    // Show connection type in console
+    setTimeout(() => {
+        const type = logStreamer.getConnectionType();
+        if (type) {
+            console.log(`[LogViewer] Connected via ${type === 'websocket' ? 'WebSocket' : 'Server-Sent Events'}`);
+        }
+    }, 100);
 </script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds SSE-based server log streaming and updates the logs UI to auto-fallback from WebSocket to SSE.
> 
> - **Backend (C++ server)**:
>   - **SSE log stream**: New `GET /api/v1/logs/stream` streaming handler `handle_logs_stream` that tails `lemonade-server.log` and sends SSE with heartbeats.
>   - **Log file detection**: Auto-detects log file path (`/tmp/lemonade-server.log` or Windows temp) via new `log_file_path_`.
>   - **Health**: `handle_health` now advertises `log_streaming` support (`sse: true`, `websocket: false`).
> - **Frontend (web UI)**:
>   - **logs.html**: Adds `LogStreamer` that tries WebSocket at `/api/v1/logs/ws` first, then falls back to SSE at `/api/v1/logs/stream`; shows errors and preserves auto-scroll.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f5c96e5a080dacf9252b6bb911d98c997addb78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->