### PR TITLE
Fix: Remove redundant callback from webui

### DIFF
--- a/src/lemonade/tools/server/static/js/models.js
+++ b/src/lemonade/tools/server/static/js/models.js
@@ -635,8 +635,6 @@ document.addEventListener('DOMContentLoaded', async function() {
         unloadBtn.onclick = unloadModel;
     }
     
-    // Note: Model selection change listener is handled in chat.js to avoid duplicate load requests
-    
     // Initial fetch of model data - this will populate installedModels
     await updateModelStatusIndicator();
     


### PR DESCRIPTION
This bug could cause two load requests to get sent from a single click.