### PR TITLE
Added a missing --device support for llamacpp

### DIFF
--- a/src/lemonade/tools/llamacpp/utils.py
+++ b/src/lemonade/tools/llamacpp/utils.py
@@ -1067,6 +1067,8 @@ class LlamaCppAdapter(ModelAdapter):
             "-ub",
             1,
         ]
+        ngl_value = "99" if self.device == "igpu" else "0"
+        cmd = cmd + ["-ngl", ngl_value]
         cmd = [str(m) for m in cmd]
 
         # save llama-bench command


### PR DESCRIPTION
The command ```lemonade -i <model-path> llamacpp-load --device cpu llamacpp-bench --iterations 10 --prompts 64``` is targeting the iGPU even though the CPU is specified. 
**Fix**: Add the ngl_value linked to --device in the cmd variable.