### PR TITLE
Simplify and fix the web ui

### DIFF
--- a/src/lemonade/tools/server/static/js/chat.js
+++ b/src/lemonade/tools/server/static/js/chat.js
@@ -162,17 +162,22 @@ async function handleModelSelectChange() {
             	loadingOption.hidden = true;
             	select.appendChild(loadingOption);
             }
+            // Gray out send button during loading
+            updateAttachmentButtonState();
         },
         onLoadingEnd: (modelId, success) => {
             // Reset the default option text
             const defaultOption = modelSelect.querySelector('option[value=""]');
             if (defaultOption) defaultOption.textContent = 'Click to select a model ▼';
+            // Update button state after loading completes
+            updateAttachmentButtonState();
 		},
         onSuccess: () => {
             updateAttachmentButtonState();
         },
         onError: () => {
             updateModelSelectValue();
+            updateAttachmentButtonState();
         }
     });
 }

--- a/src/lemonade/tools/server/static/js/shared.js
+++ b/src/lemonade/tools/server/static/js/shared.js
@@ -224,7 +224,7 @@ async function loadModelStandardized(modelId, options = {}) {
         
         // Update chat dropdown and send button to show loading state
         const modelSelect = document.getElementById('model-select');
-        const sendBtn = document.getElementById('send-btn');
+        const sendBtn = document.getElementById('toggle-btn');
         if (modelSelect && sendBtn) {
             // Ensure the model exists in the dropdown options
             let modelOption = modelSelect.querySelector(`option[value="${modelId}"]`);
@@ -338,7 +338,7 @@ async function loadModelStandardized(modelId, options = {}) {
         
         // Reset chat controls on error
         const modelSelect = document.getElementById('model-select');
-        const sendBtn = document.getElementById('send-btn');
+        const sendBtn = document.getElementById('toggle-btn');
         if (modelSelect && sendBtn) {
             modelSelect.disabled = false;
             sendBtn.disabled = false;


### PR DESCRIPTION
1. Remove the concept of a "default model", which was sometimes overriding the user's loaded model
2. Fix bugs related to the Send button being available when no model is loaded