### PR TITLE
C++: clean up the --host arg

### DIFF
--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -352,7 +352,7 @@ The `lemonade-router` executable is a pure HTTP server without any command-based
 
 # Available options:
 #   --port PORT              Port number (default: 8000)
-#   --host HOST              Bind address (default: 0.0.0.0)
+#   --host HOST              Bind address (default: 127.0.0.1)
 #   --ctx-size SIZE          Context size (default: 4096)
 #   --log-level LEVEL        Log level: critical, error, warning, info, debug, trace
 #   --llamacpp BACKEND       LlamaCpp backend: vulkan, rocm, metal
@@ -399,7 +399,7 @@ The `lemonade-server-beta` executable is the command-line interface for terminal
 
 **Available Options:**
 - `--port PORT` - Server port (default: 8000)
-- `--host HOST` - Server host (default: localhost)
+- `--host HOST` - Server host (default: 127.0.0.1)
 - `--ctx-size SIZE` - Context size (default: 4096)
 - `--log-level LEVEL` - Logging verbosity: info, debug (default: info)
 - `--log-file PATH` - Custom log file location

--- a/src/cpp/include/lemon/cli_parser.h
+++ b/src/cpp/include/lemon/cli_parser.h
@@ -7,7 +7,7 @@ namespace lemon {
 
 struct ServerConfig {
     int port = 8000;
-    std::string host = "0.0.0.0";
+    std::string host = "127.0.0.1";
     std::string log_level = "info";
     bool tray = false;  // Tray is handled by lemonade-server-beta, not lemonade-router
     std::string llamacpp_backend = "vulkan";

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -16,7 +16,7 @@ namespace lemon {
 class Server {
 public:
     Server(int port = 8000, 
-           const std::string& host = "localhost",
+           const std::string& host = "127.0.0.1",
            const std::string& log_level = "info",
            int ctx_size = 4096,
            bool tray = false,

--- a/src/cpp/include/lemon_tray/server_manager.h
+++ b/src/cpp/include/lemon_tray/server_manager.h
@@ -49,7 +49,8 @@ public:
         const std::string& llamacpp_backend = "vulkan",
         bool show_console = false,
         bool is_ephemeral = false,
-        const std::string& llamacpp_args = ""
+        const std::string& llamacpp_args = "",
+        const std::string& host = "127.0.0.1"
     );
     
     bool stop_server();
@@ -101,6 +102,7 @@ private:
     std::string log_level_;
     std::string llamacpp_backend_;
     std::string llamacpp_args_;
+    std::string host_;
     int port_;
     int ctx_size_;
     bool show_console_;

--- a/src/cpp/include/lemon_tray/tray_app.h
+++ b/src/cpp/include/lemon_tray/tray_app.h
@@ -26,7 +26,7 @@ struct AppConfig {
 #endif
     bool show_help = false;
     bool show_version = false;
-    std::string host = "localhost";
+    std::string host = "127.0.0.1";
     std::string llamacpp_backend = "vulkan";  // Default to vulkan
     std::string llamacpp_args = "";  // Custom arguments for llama-server
     

--- a/src/cpp/server/cli_parser.cpp
+++ b/src/cpp/server/cli_parser.cpp
@@ -14,7 +14,7 @@ CLIParser::CLIParser()
         ->default_val(8000);
     
     app_.add_option("--host", config_.host, "Address to bind for connections")
-        ->default_val("0.0.0.0");
+        ->default_val("127.0.0.1");
     
     app_.add_option("--log-level", config_.log_level, "Log level for the server")
         ->check(CLI::IsMember({"critical", "error", "warning", "info", "debug", "trace"}))

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -352,9 +352,7 @@ void Server::setup_cors() {
 }
 
 void Server::run() {
-    // Display user-friendly address
-    std::string display_host = (host_ == "0.0.0.0") ? "localhost" : host_;
-    std::cout << "[Server] Starting on " << display_host << ":" << port_ << std::endl;
+    std::cout << "[Server] Starting on " << host_ << ":" << port_ << std::endl;
     
     // Add request logging for ALL requests
     http_server_->set_logger([](const httplib::Request& req, const httplib::Response& res) {

--- a/src/cpp/tray/tray_app.cpp
+++ b/src/cpp/tray/tray_app.cpp
@@ -534,6 +534,8 @@ void TrayApp::parse_arguments(int argc, char* argv[]) {
                 config_.log_level = argv[++i];
             } else if (arg == "--port" && i + 1 < argc) {
                 config_.port = std::stoi(argv[++i]);
+            } else if (arg == "--host" && i + 1 < argc) {
+                config_.host = argv[++i];
             } else if (arg == "--ctx-size" && i + 1 < argc) {
                 config_.ctx_size = std::stoi(argv[++i]);
             } else if (arg == "--llamacpp" && i + 1 < argc) {
@@ -588,7 +590,7 @@ void TrayApp::print_usage(bool show_serve_options) {
     if (show_serve_options) {
         std::cout << "Serve Options:\n";
         std::cout << "  --port PORT              Server port (default: 8000)\n";
-        std::cout << "  --host HOST              Server host (default: localhost)\n";
+        std::cout << "  --host HOST              Server host (default: 127.0.0.1)\n";
         std::cout << "  --ctx-size SIZE          Context size (default: 4096)\n";
         std::cout << "  --llamacpp BACKEND       LlamaCpp backend: vulkan, rocm, metal (default: vulkan)\n";
         std::cout << "  --llamacpp-args ARGS     Custom arguments for llama-server\n";
@@ -750,7 +752,8 @@ bool TrayApp::start_ephemeral_server(int port) {
         config_.llamacpp_backend,  // Pass llamacpp backend to ServerManager
         false,  // show_console
         true,   // is_ephemeral (suppress startup message)
-        config_.llamacpp_args  // Pass custom llamacpp args
+        config_.llamacpp_args,  // Pass custom llamacpp args
+        config_.host  // Pass host to ServerManager
     );
     
     if (!success) {
@@ -996,7 +999,7 @@ int TrayApp::execute_run_command() {
         std::cout << "Model loaded successfully!" << std::endl;
         
         // Open browser to chat interface
-        std::string url = "http://localhost:" + std::to_string(config_.port) + "/?model=" + model_name + "#llm-chat";
+        std::string url = "http://" + config_.host + ":" + std::to_string(config_.port) + "/?model=" + model_name + "#llm-chat";
         std::cout << "Opening browser: " << url << std::endl;
         open_url(url);
     } else {
@@ -1389,7 +1392,8 @@ bool TrayApp::start_server() {
         config_.llamacpp_backend,  // Pass llamacpp backend to ServerManager
         true,               // Always show console output for serve command
         false,              // is_ephemeral = false (persistent server, show startup message with URL)
-        config_.llamacpp_args  // Pass custom llamacpp args
+        config_.llamacpp_args,  // Pass custom llamacpp args
+        config_.host        // Pass host to ServerManager
     );
     
     // Start log tail thread to show logs in console
@@ -1683,11 +1687,11 @@ void TrayApp::on_open_documentation() {
 }
 
 void TrayApp::on_open_llm_chat() {
-    open_url("http://localhost:" + std::to_string(config_.port) + "/#llm-chat");
+    open_url("http://" + config_.host + ":" + std::to_string(config_.port) + "/#llm-chat");
 }
 
 void TrayApp::on_open_model_manager() {
-    open_url("http://localhost:" + std::to_string(config_.port) + "/#model-management");
+    open_url("http://" + config_.host + ":" + std::to_string(config_.port) + "/#model-management");
 }
 
 void TrayApp::on_upgrade() {

--- a/src/ryzenai-server/src/server.cpp
+++ b/src/ryzenai-server/src/server.cpp
@@ -944,17 +944,15 @@ void RyzenAIServer::handleChatCompletions(const httplib::Request& req, httplib::
 void RyzenAIServer::run() {
     running_ = true;
     
-    std::string display_host = (args_.host == "0.0.0.0") ? "localhost" : args_.host;
-    
     std::cout << "\n";
     std::cout << "===============================================================\n";
-    std::cout << "  Server running at: http://" << display_host << ":" << args_.port << "\n";
+    std::cout << "  Server running at: http://" << args_.host << ":" << args_.port << "\n";
     std::cout << "===============================================================\n";
     std::cout << "\n";
     std::cout << "Available endpoints:\n";
-    std::cout << "  GET  http://" << display_host << ":" << args_.port << "/health\n";
-    std::cout << "  POST http://" << display_host << ":" << args_.port << "/v1/completions\n";
-    std::cout << "  POST http://" << display_host << ":" << args_.port << "/v1/chat/completions\n";
+    std::cout << "  GET  http://" << args_.host << ":" << args_.port << "/health\n";
+    std::cout << "  POST http://" << args_.host << ":" << args_.port << "/v1/completions\n";
+    std::cout << "  POST http://" << args_.host << ":" << args_.port << "/v1/chat/completions\n";
     std::cout << "\n";
     std::cout << "Press Ctrl+C to stop the server\n";
     std::cout << "===============================================================\n\n";


### PR DESCRIPTION
Closes #550 

`--host` default is 127.0.0.1 now

confirmed that launching with default settings does not make lemonade available over the network

also confirmed that settings `--host 0.0.0.0` still _does_ make lemonade available over the network