### PR TITLE
Infinite timeout for inference requests

### DIFF
--- a/src/cpp/include/lemon/streaming_proxy.h
+++ b/src/cpp/include/lemon/streaming_proxy.h
@@ -37,7 +37,8 @@ public:
         const std::string& backend_url,
         const std::string& request_body,
         httplib::DataSink& sink,
-        std::function<void(const TelemetryData&)> on_complete = nullptr
+        std::function<void(const TelemetryData&)> on_complete = nullptr,
+        long timeout_seconds = 300
     );
     
 private:

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -29,13 +29,15 @@ public:
     // Simple POST request
     static HttpResponse post(const std::string& url,
                             const std::string& body,
-                            const std::map<std::string, std::string>& headers = {});
+                            const std::map<std::string, std::string>& headers = {},
+                            long timeout_seconds = 300);
     
     // Streaming POST request (calls callback for each chunk as it arrives)
     static HttpResponse post_stream(const std::string& url,
                                    const std::string& body,
                                    StreamCallback stream_callback,
-                                   const std::map<std::string, std::string>& headers = {});
+                                   const std::map<std::string, std::string>& headers = {},
+                                   long timeout_seconds = 300);
     
     // Download file to disk
     static bool download_file(const std::string& url,

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -49,6 +49,9 @@ public:
         : server_name_(server_name), port_(0), process_handle_({nullptr, 0}), log_level_(log_level), model_manager_(model_manager) {}
     
     virtual ~WrappedServer() = default;
+
+    // Timeout for inference requests (0 = infinite)
+    static constexpr long INFERENCE_TIMEOUT_SECONDS = 0;
     
     // Set log level
     void set_log_level(const std::string& log_level) { log_level_ = log_level; }
@@ -113,7 +116,7 @@ protected:
     virtual bool wait_for_ready();
     
     // Common method to forward requests to the wrapped server (non-streaming)
-    json forward_request(const std::string& endpoint, const json& request);
+    json forward_request(const std::string& endpoint, const json& request, long timeout_seconds = INFERENCE_TIMEOUT_SECONDS);
     
     // Validate that the process is running (platform-agnostic check)
     bool is_process_running() const;

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -9,7 +9,8 @@ void StreamingProxy::forward_sse_stream(
     const std::string& backend_url,
     const std::string& request_body,
     httplib::DataSink& sink,
-    std::function<void(const TelemetryData&)> on_complete) {
+    std::function<void(const TelemetryData&)> on_complete,
+    long timeout_seconds) {
     
     std::string telemetry_buffer;
     bool stream_error = false;
@@ -35,7 +36,9 @@ void StreamingProxy::forward_sse_stream(
             }
             
             return true; // Continue streaming
-        }
+        },
+        {}, // Empty headers map
+        timeout_seconds
     );
     
     if (result.status_code != 200) {

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -87,7 +87,8 @@ HttpResponse HttpClient::get(const std::string& url,
 
 HttpResponse HttpClient::post(const std::string& url,
                               const std::string& body,
-                              const std::map<std::string, std::string>& headers) {
+                              const std::map<std::string, std::string>& headers,
+                              long timeout_seconds) {
     CURL* curl = curl_easy_init();
     if (!curl) {
         throw std::runtime_error("Failed to initialize CURL");
@@ -100,7 +101,7 @@ HttpResponse HttpClient::post(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
     
     // Add custom headers
@@ -166,7 +167,8 @@ static size_t stream_write_callback(char* ptr, size_t size, size_t nmemb, void* 
 HttpResponse HttpClient::post_stream(const std::string& url,
                                      const std::string& body,
                                      StreamCallback stream_callback,
-                                     const std::map<std::string, std::string>& headers) {
+                                     const std::map<std::string, std::string>& headers,
+                                     long timeout_seconds) {
     CURL* curl = curl_easy_init();
     if (!curl) {
         throw std::runtime_error("Failed to initialize CURL");
@@ -183,7 +185,7 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, stream_write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &callback_data);
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 300L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
     
     // Add custom headers

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -68,7 +68,7 @@ bool WrappedServer::is_process_running() const {
 #endif
 }
 
-json WrappedServer::forward_request(const std::string& endpoint, const json& request) {
+json WrappedServer::forward_request(const std::string& endpoint, const json& request, long timeout_seconds) {
     if (!is_process_running()) {
         return ErrorResponse::from_exception(ModelNotLoadedException(server_name_));
     }
@@ -77,7 +77,7 @@ json WrappedServer::forward_request(const std::string& endpoint, const json& req
     std::map<std::string, std::string> headers = {{"Content-Type", "application/json"}};
     
     try {
-        auto response = utils::HttpClient::post(url, request.dump(), headers);
+        auto response = utils::HttpClient::post(url, request.dump(), headers, timeout_seconds);
         
         if (response.status_code == 200) {
             return json::parse(response.body);
@@ -118,6 +118,7 @@ void WrappedServer::forward_streaming_request(const std::string& endpoint,
     
     try {
         // Use StreamingProxy to forward the SSE stream with telemetry callback
+        // Use INFERENCE_TIMEOUT_SECONDS (0 = infinite) as chat completions can take a long time
         StreamingProxy::forward_sse_stream(url, request_body, sink, 
             [this](const StreamingProxy::TelemetryData& telemetry) {
                 // Save telemetry to member variable
@@ -126,7 +127,9 @@ void WrappedServer::forward_streaming_request(const std::string& endpoint,
                 telemetry_.time_to_first_token = telemetry.time_to_first_token;
                 telemetry_.tokens_per_second = telemetry.tokens_per_second;
                 // Note: decode_token_times is not available from streaming proxy
-            });
+            },
+            INFERENCE_TIMEOUT_SECONDS
+        );
     } catch (const std::exception& e) {
         // Log the error but don't crash the server
         std::cerr << "[WrappedServer ERROR] Streaming request failed: " << e.what() << std::endl;


### PR DESCRIPTION
Fixes #572 

Turns out we had a 300 second timeout for inference requests. This PR change it to infinite, and also introduces a new centralized constant `INFERENCE_TIMEOUT_SECONDS` in case anyone wants to change this value later.

fyi @kovtcharov that this bug exists in the 9.0.3 release