### PR TITLE
Remove GAIA UI recommendation from Open WebUI documentation

### DIFF
--- a/docs/server/apps/open-webui.md
+++ b/docs/server/apps/open-webui.md
@@ -15,10 +15,6 @@ This guide walks through how to connect Lemonade Server to Open WebUI and highli
 <iframe width="560" height="315" src="https://www.youtube.com/embed/yZs-Yzl736E?si=BFfxJYSqfu0wBMEP" 
 title="YouTube video player" frameborder="0" allowfullscreen></iframe>
 
-## Consider Using GAIA
-
-The team maintains a fork of Open WebUI called GAIA that provides automatic Lemonade integration and a simple Windows installer. You can try it out at <https://github.com/amd/gaia>. If you choose GAIA, you can skip the installation and configuration sections below and go straight to [Using Open WebUI with Lemonade](#using-open-webui-with-lemonade).
-
 ## Installing Open WebUI
 
 1. We recommend installing Open WebUI into a dedicated conda environment using the following commands. To download conda, see [Miniforge](https://conda-forge.org/download/).


### PR DESCRIPTION
Removed section recommending GAIA fork of Open WebUI. @kovtcharov says the current iteration is EoL.