### PR TITLE
Fix up the models endpoint code and spec

### DIFF
--- a/docs/server/server_spec.md
+++ b/docs/server/server_spec.md
@@ -533,7 +533,7 @@ For a full list of event types, see the [API reference for streaming](https://pl
 
 ### `GET /api/v1/models` <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
 
-Returns a list of key models available on the server in an OpenAI-compatible format. We also expanded each model object with the `checkpoint` and `recipe` fields, which may be used to load a model using the `load` endpoint.
+Returns a list of models available on the server in an OpenAI-compatible format. Each model object includes extended fields like `checkpoint`, `recipe`, `size`, `downloaded`, and `labels`.
 
 By default, only models available locally (downloaded) are shown, matching OpenAI API behavior.
 
@@ -541,7 +541,7 @@ By default, only models available locally (downloaded) are shown, matching OpenA
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `show_all` | No | If set to `true`, returns all models from the catalog with additional fields (`name`, `downloaded`, `labels`). Used by the CLI `list` command. Defaults to `false`. |
+| `show_all` | No | If set to `true`, returns all models from the catalog including those not yet downloaded. Defaults to `false`. |
 
 #### Example request
 
@@ -549,77 +549,63 @@ By default, only models available locally (downloaded) are shown, matching OpenA
 # Show only downloaded models (OpenAI-compatible)
 curl http://localhost:8000/api/v1/models
 
-# Show all models with download status (CLI usage)
+# Show all models including not-yet-downloaded (extended usage)
 curl http://localhost:8000/api/v1/models?show_all=true
 ```
 
 #### Response format
 
-Default response (only downloaded models):
-
 ```json
 {
   "object": "list",
   "data": [
     {
-      "id": "Qwen2.5-0.5B-Instruct-CPU",
+      "id": "Qwen3-0.6B-GGUF",
       "created": 1744173590,
       "object": "model",
       "owned_by": "lemonade",
-      "checkpoint": "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx",
-      "recipe": "oga-cpu",
-      "size": 0.77
-    },
-    {
-      "id": "Llama-3.2-1B-Instruct-Hybrid",
-      "created": 1744173590,
-      "object": "model",
-      "owned_by": "lemonade",
-      "checkpoint": "amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid",
-      "recipe": "oga-hybrid",
-      "size": 1.89
-    }
-  ]
-}
-```
-
-With `show_all=true` (includes all models with additional fields):
-
-```json
-{
-  "object": "list",
-  "data": [
-    {
-      "id": "Qwen2.5-0.5B-Instruct-CPU",
-      "object": "model",
-      "created": 1744173590,
-      "owned_by": "lemonade",
-      "name": "Qwen2.5-0.5B-Instruct-CPU",
-      "checkpoint": "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx",
-      "recipe": "oga-cpu",
-      "size": 0.77,
+      "checkpoint": "unsloth/Qwen3-0.6B-GGUF:Q4_0",
+      "recipe": "llamacpp",
+      "size": 0.38,
       "downloaded": true,
-      "labels": ["hot", "cpu"]
+      "suggested": true,
+      "labels": ["reasoning"]
     },
     {
-      "id": "Llama-3.2-1B-Instruct-Hybrid",
-      "object": "model",
+      "id": "Gemma-3-4b-it-GGUF",
       "created": 1744173590,
+      "object": "model",
       "owned_by": "lemonade",
-      "name": "Llama-3.2-1B-Instruct-Hybrid",
-      "checkpoint": "amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid",
-      "recipe": "oga-hybrid",
-      "size": 1.89,
-      "downloaded": false,
-      "labels": ["hot", "hybrid"]
+      "checkpoint": "ggml-org/gemma-3-4b-it-GGUF:Q4_K_M",
+      "recipe": "llamacpp",
+      "size": 3.61,
+      "downloaded": true,
+      "suggested": true,
+      "labels": ["hot", "vision"]
     }
   ]
 }
 ```
+
+**Field Descriptions:**
+
+- `object` - Type of response object, always `"list"`
+- `data` - Array of model objects with the following fields:
+  - `id` - Model identifier (used for loading and inference requests)
+  - `created` - Unix timestamp of when the model entry was created
+  - `object` - Type of object, always `"model"`
+  - `owned_by` - Owner of the model, always `"lemonade"`
+  - `checkpoint` - Full checkpoint identifier on Hugging Face
+  - `recipe` - Backend/device recipe used to load the model (e.g., `"oga-cpu"`, `"oga-hybrid"`, `"llamacpp"`, `"flm"`)
+  - `size` - Model size in GB (omitted for models without size information)
+  - `downloaded` - Boolean indicating if the model is downloaded and available locally
+  - `suggested` - Boolean indicating if the model is recommended for general use
+  - `labels` - Array of tags describing the model (e.g., `"hot"`, `"reasoning"`, `"vision"`, `"embeddings"`, `"reranking"`, `"coding"`, `"tool-calling"`)
+
 
 ### `GET /api/v1/models/{model_id}` <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
 
-Retrieve a specific model by its ID in an OpenAI-compatible format. Returns detailed information about a single model including the `checkpoint` and `recipe` fields.
+Retrieve a specific model by its ID. Returns the same model object format as the list endpoint above.
 
 #### Parameters
 
@@ -630,32 +616,27 @@ Retrieve a specific model by its ID in an OpenAI-compatible format. Returns deta
 #### Example request
 
 ```bash
-curl http://localhost:8000/api/v1/models/Llama-3.2-1B-Instruct-Hybrid
+curl http://localhost:8000/api/v1/models/Qwen3-0.6B-GGUF
 ```
 
 #### Response format
 
+Returns a single model object with the same fields as described in the [models list endpoint](#get-apiv1models) above.
+
 ```json
 {
-  "id": "Llama-3.2-1B-Instruct-Hybrid",
+  "id": "Qwen3-0.6B-GGUF",
   "created": 1744173590,
   "object": "model",
   "owned_by": "lemonade",
-  "checkpoint": "amd/Llama-3.2-1B-Instruct-awq-g128-int4-asym-fp16-onnx-hybrid",
-  "recipe": "oga-hybrid",
-  "size": 1.89
+  "checkpoint": "unsloth/Qwen3-0.6B-GGUF:Q4_0",
+  "recipe": "llamacpp",
+  "size": 0.38,
+  "downloaded": true,
+  "suggested": true,
+  "labels": ["reasoning"]
 }
 ```
-
-**Field Descriptions:**
-
-- `id` - Model identifier
-- `created` - Unix timestamp of when the model entry was created
-- `object` - Type of object, always `"model"`
-- `owned_by` - Owner of the model, always `"lemonade"`
-- `checkpoint` - Full checkpoint identifier on Hugging Face
-- `recipe` - Backend/device recipe used to load the model (e.g., `"oga-cpu"`, `"oga-hybrid"`, `"llamacpp"`, `"flm"`)
-- `size` - Model size in GB (may be `null` for models without size information)
 
 #### Error responses
 

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -66,6 +66,9 @@ private:
     // Helper function for auto-loading models (eliminates code duplication and race conditions)
     void auto_load_model_if_needed(const std::string& model_name);
     
+    // Helper function to convert ModelInfo to JSON (used by models endpoints)
+    nlohmann::json model_info_to_json(const std::string& model_id, const ModelInfo& info);
+    
     int port_;
     std::string host_;
     std::string log_level_;


### PR DESCRIPTION
Updates the models endpoint with:
- Spec now shows and defines all return fields (some were missing)
- `suggested` is now returned
- `show_all=true` no longer has different return fields than `show_all=false`. The only difference is whether `downloaded=false` models appear or not.
- Changed example models to some that have `labels`
- Simplified `/api/v1/models/{model_id}` definition in code and spec because it matches `/api/v1/models` now
- Removed `name` response field from `show_all=true` because it was completely redundant with the `id` field