### PR TITLE
Set the FLM server host name

### DIFF
--- a/src/cpp/server/backends/fastflowlm_server.cpp
+++ b/src/cpp/server/backends/fastflowlm_server.cpp
@@ -140,11 +140,13 @@ void FastFlowLMServer::load(const std::string& model_name,
     std::string flm_path = get_flm_path();
     
     // Construct flm serve command
+    // Bind to localhost only for security
     std::vector<std::string> args = {
         "serve",
         model_info.checkpoint,
         "--ctx-len", std::to_string(ctx_size),
-        "--port", std::to_string(port_)
+        "--port", std::to_string(port_),
+        "--host", "127.0.0.1"
     };
     
     std::cout << "[FastFlowLM] Starting flm-server..." << std::endl;

--- a/src/cpp/server/utils/process_manager.cpp
+++ b/src/cpp/server/utils/process_manager.cpp
@@ -476,59 +476,25 @@ int ProcessManager::find_free_port(int start_port) {
 #endif
     
     for (int port = start_port; port < start_port + 1000; port++) {
-        // Test BOTH 127.0.0.1 and 0.0.0.0 - different servers bind to different addresses
-        // llama-server binds to 127.0.0.1, while FLM binds to 0.0.0.0
-        // We need to detect both cases to avoid port conflicts
-        
-        bool port_free = true;
-        
-        // Test 1: Try binding to 127.0.0.1 (catches llama-server and any loopback bind)
-        {
-            int sock = socket(AF_INET, SOCK_STREAM, 0);
-            if (sock < 0) {
-                continue;
-            }
-            
-            sockaddr_in addr;
-            addr.sin_family = AF_INET;
-            addr.sin_port = htons(port);
-            addr.sin_addr.s_addr = inet_addr("127.0.0.1");
-            
-            int result = bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
-#ifdef _WIN32
-            closesocket(sock);
-#else
-            close(sock);
-#endif
-            if (result != 0) {
-                port_free = false;
-            }
+        // Test if port is free by attempting to bind to localhost
+        int sock = socket(AF_INET, SOCK_STREAM, 0);
+        if (sock < 0) {
+            continue;
         }
         
-        // Test 2: Try binding to 0.0.0.0 (catches FLM and any wildcard bind)
-        if (port_free) {
-            int sock = socket(AF_INET, SOCK_STREAM, 0);
-            if (sock < 0) {
-                continue;
-            }
-            
-            sockaddr_in addr;
-            addr.sin_family = AF_INET;
-            addr.sin_port = htons(port);
-            addr.sin_addr.s_addr = INADDR_ANY;
-            
-            int result = bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
-#ifdef _WIN32
-            closesocket(sock);
-#else
-            close(sock);
-#endif
-            if (result != 0) {
-                port_free = false;
-            }
-        }
+        sockaddr_in addr;
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(port);
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1");
         
-        if (port_free) {
+        int result = bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+#ifdef _WIN32
+        closesocket(sock);
+#else
+        close(sock);
+#endif
+        
+        if (result == 0) {
 #ifdef _WIN32
             WSACleanup();
 #endif


### PR DESCRIPTION
FLM v0.9.22 just added a `--host` flag, which helps to simplify lemonade code.