### PR TITLE
Expand Model Manager models by default if only one recipe is available

### DIFF
--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -178,6 +178,17 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isVisible, width = 280 }) =
     };
   }, [fetchDownloadedModels, fetchCurrentLoadedModel, loadModels]);
 
+  // Auto-expand the single category if only one is available
+  useEffect(() => {
+    const groupedModels = organizationMode === 'recipe' ? groupModelsByRecipe() : groupModelsByCategory();
+    const categories = Object.keys(groupedModels);
+    
+    // If only one category exists and it's not already expanded, expand it
+    if (categories.length === 1 && !expandedCategories.has(categories[0])) {
+      setExpandedCategories(new Set([categories[0]]));
+    }
+  }, [models, organizationMode, showDownloadedOnly, searchQuery]);
+
   const getFilteredModels = () => {
     let filtered = models;
     


### PR DESCRIPTION
This PR expands Model Manager models by default if only one recipe is available
<img width="1197" height="793" alt="image" src="https://github.com/user-attachments/assets/19d824ca-9c6f-4e30-bb7b-1e4009c2c020" />
