### PR TITLE
feat: Add support for using NPU on linux.

### DIFF
--- a/src/lemonade/tools/oga/load.py
+++ b/src/lemonade/tools/oga/load.py
@@ -341,7 +341,17 @@ class OgaLoad(FirstTool):
         """
 
         # For RyzenAI 1.6.0, check NPU driver version for NPU and hybrid devices
-        if device in ["npu", "hybrid"]:
+        if device not in ["npu", "hybrid"]:
+            return
+
+        if not sys.platform.startswith("win"):
+            printing.log_info(
+                f"[OGA] Skipping Windows-only NPU dependency checks "
+                f"for device={device} on platform={sys.platform}."
+            )
+            return
+
+        else:
             required_driver_version = REQUIRED_NPU_DRIVER_VERSION
 
             current_driver_version = _get_npu_driver_version()


### PR DESCRIPTION
Only works with RyzenSW 1.6.1 and NPU models from
https://huggingface.co/collections/amd/ryzenai-15-llm-npu-models since RyzenSW 1.6.1's onnxruntime driver doesn't support the change in the genai_config model yet.

# Description of the changes

Remove the windows specific checks (credit @wc2333)
Fix the **windows**-ity in the `genai_config.json` configuration file so it can load on linux unattended.

# Example usage

1. Install xrt for linux (use your preferred method)
2. Install RyzenAI SW version 1.6.1 from AMD's site (not github, the open source version is lacking) 
3. Create the python3.10 environment from the extracted archive above
4. Pull this branch in another folder (don't create a new virtual environment for lemonade, use the one from RyzenAI SW 1.6.1) 
5. Run `pip install setuptools`
6. Run `python setup.py build`
7. Run `python setup.py install` 
8. Download a model (for example: `lemonade-server-dev pull user.Mistral-7B-Instruct-v0.3-NPU --checkpoint amd/Mistral-7B-Instruct-v0.3-awq-g128-int4-asym-bf16-onnx-ryzen-strix --recipe oga-npu`)
9. Run the pulled model (for example: `lemonade-server-dev run user.Mistral-7B-Instruct-v0.3-NPU`)

You can use any model from the huggingface page above: they all work.
The performance isn't that great, since none of the hybrid model works however.
