### PR TITLE
Fix app download progress bugs with 0B files

### DIFF
--- a/src/app/src/renderer/DownloadManager.tsx
+++ b/src/app/src/renderer/DownloadManager.tsx
@@ -97,6 +97,10 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
     if (speed === 0) return '--';
     
     const remainingBytes = download.bytesTotal - download.bytesDownloaded;
+    
+    // Handle edge case where bytesDownloaded > bytesTotal (incomplete byte tracking)
+    if (remainingBytes <= 0) return '--';
+    
     const remainingSeconds = remainingBytes / speed;
     
     if (remainingSeconds < 60) {


### PR DESCRIPTION
Fixes a bug reported by @ZaneNi that could produce crazy download status like this in the app

<img width="603" height="387" alt="Attached_image" src="https://github.com/user-attachments/assets/22cc9872-1a5a-4958-b312-d48c1d2c7a75" />

## What you really need to know

The download manager is janky for multi-file downloads because the server doesn't report total size or total progress. The app kinda guesses and looks weird. Opened https://github.com/lemonade-sdk/lemonade/issues/744 to address this for real.


## Fix Details

Bug Analysis
Root Cause: In downloadTracker.ts, when tracking cumulative bytes across multiple files during FLM downloads:
const previousFileSize = cumulative.fileSizes.get(download.fileIndex) || download.bytesTotal;
When small FLM files download instantly (no byte progress events), fileSizes.get(download.fileIndex) returns undefined. The fallback download.bytesTotal was the cumulative total of all files, not the individual file's size. This caused exponential growth:
File	Expected to add	Actually added (bug)
9 → 10	~0 MB (tiny file)	3,625 MB (cumulative)
10 → 11	~0 MB	~7,250 MB
11 → 12	~0 MB	~14,500 MB
Result: Downloaded bytes inflated to 14+ GB while Total stayed ~3.5 GB → 400%
Fixes Applied
downloadTracker.ts line 92: Changed fallback from download.bytesTotal (cumulative) to 0
downloadTracker.ts line 116: Added cap so percentage never exceeds 100%
downloadTracker.ts lines 119-121: Cap displayed bytesDownloaded to not exceed bytesTotal
DownloadManager.tsx lines 99-101: Added protection for negative remaining bytes in ETA calculation (now shows "--")