### PR TITLE
Make some llamacpp-server args optional defaults

### DIFF
--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -98,7 +98,7 @@ static void push_overridable_arg(std::vector<std::string>& args,
     }
 }
 
-// Helper to add a flag-value overridable pair (e.g., --port 8000, -m model.gguf)
+// Helper to add a flag-value overridable pair (e.g., --keep 16)
 static void push_overridable_arg(std::vector<std::string>& args,
                     const std::string& custom_args,
                     const std::string& key,


### PR DESCRIPTION
This PR makes some of the arguments set by lemonade when launching llama-server optional defaults. It works like this: if no custom `llamacpp_args` are present, apply the default flags otherwise skip all default flags completely. The affected flags are

`--context-shift`
`--keep`
`--reasoning-format`

the rationale for this is that those arguments are not strictly needed and power users might want to customize them, so making them strictly reserved seems too restrictive. These flags are also not mentioned as being reserved anywhere in the documentation.

Also by introducing the concept of optional defaults, it is easier to balance user-friendliness without sacrificing flexibility for power users.