### PR TITLE
Improve the UX when FLM updates invalidate models

### DIFF
--- a/src/cpp/include/lemon/backends/fastflowlm_server.h
+++ b/src/cpp/include/lemon/backends/fastflowlm_server.h
@@ -61,8 +61,8 @@ private:
     std::string get_npu_driver_version();      // Get current NPU driver version via WMI
     bool check_npu_driver_version();           // Check if NPU driver meets minimum requirements
     
-    // Installation
-    void install_flm_if_needed();  // Install FLM if not present or version is too old
+    // Installation - returns true if FLM was upgraded (may invalidate existing models)
+    bool install_flm_if_needed();
     bool download_flm_installer(const std::string& output_path);
     void run_flm_installer(const std::string& installer_path, bool silent);
     
@@ -73,6 +73,9 @@ private:
     // Cache for installed version (to avoid repeated calls to flm --version)
     mutable std::string cached_installed_version_;
     void invalidate_version_cache();  // Call after installation to force re-check
+    
+    // Track whether FLM was upgraded during install() - used to detect model invalidation
+    bool flm_was_upgraded_ = false;
     
     bool is_loaded_ = false;
 };

--- a/src/cpp/include/lemon/error_types.h
+++ b/src/cpp/include/lemon/error_types.h
@@ -11,6 +11,7 @@ using json = nlohmann::json;
 // Error types as constants
 namespace ErrorType {
     constexpr const char* MODEL_NOT_LOADED = "model_not_loaded";
+    constexpr const char* MODEL_INVALIDATED = "model_invalidated";
     constexpr const char* BACKEND_ERROR = "backend_error";
     constexpr const char* NETWORK_ERROR = "network_error";
     constexpr const char* INVALID_REQUEST = "invalid_request";
@@ -93,6 +94,15 @@ public:
     UnsupportedOperationException(const std::string& operation, const std::string& backend = "")
         : LemonException(operation + " not supported" + (backend.empty() ? "" : " by " + backend), 
                         ErrorType::UNSUPPORTED_OPERATION) {}
+};
+
+class ModelInvalidatedException : public LemonException {
+public:
+    ModelInvalidatedException(const std::string& model_name, const std::string& reason = "")
+        : LemonException("Model '" + model_name + "' was invalidated" + 
+                        (reason.empty() ? "" : ": " + reason) +
+                        ". Please download the model again.", 
+                        ErrorType::MODEL_INVALIDATED) {}
 };
 
 // Helper class for consistent error responses


### PR DESCRIPTION
Closes #794 

<img width="1765" height="996" alt="image" src="https://github.com/user-attachments/assets/2c462f59-96ae-4c71-afc0-e7720ec0bb1f" />

New features:
1. Server: Check for model invalidations when upgrading FLM (model changes from available to unavailable when calling `flm list`)
2. App: When trying to load an invalidated model, first download it with the download manager (see screenshot above), then load it.