### PR TITLE
Fix linux multi-user permissions problem

### DIFF
--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -433,6 +433,13 @@ void LlamaCppServer::install(const std::string& backend) {
 #ifndef _WIN32
         // Make executable on Linux/macOS
         chmod(exe_path.c_str(), 0755);
+        
+        // Make entire install directory world-writable for multi-user access
+        // The /usr/local/share/lemonade-server/llama/ directory is shared between users
+        chmod(install_dir.c_str(), 0777);
+        for (const auto& entry : fs::recursive_directory_iterator(install_dir)) {
+            chmod(entry.path().c_str(), 0777);
+        }
 #endif
         
         // Delete ZIP file

--- a/src/cpp/tray/server_manager.cpp
+++ b/src/cpp/tray/server_manager.cpp
@@ -569,7 +569,8 @@ bool ServerManager::spawn_process() {
     if (pid == 0) {
         // Child process - redirect stdout/stderr to log file if specified, or /dev/null if not
         if (!log_file_.empty()) {
-            int log_fd = open(log_file_.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+            // Use 0666 permissions for multi-user access (umask will restrict as needed)
+            int log_fd = open(log_file_.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
             if (log_fd >= 0) {
                 dup2(log_fd, STDOUT_FILENO);
                 dup2(log_fd, STDERR_FILENO);


### PR DESCRIPTION
Closes #799 

Linux installations are already multi-user, but we were setting restrictive permissions on runtime-created files that caused errors. This PR sets better permissions.