### PR TITLE
Added ability to build rpm packages for Fedora users

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -510,5 +510,7 @@ if(UNIX AND NOT APPLE)
         endif()
     endif()
     
+    # RPM specific variables defined within
+    include(${CMAKE_CURRENT_SOURCE_DIR}/CPackRPM.cmake)
     include(CPack)
 endif()

--- a/src/cpp/CPackRPM.cmake
+++ b/src/cpp/CPackRPM.cmake
@@ -1,0 +1,21 @@
+# Optional CPack RPM configuration for lemonade-server
+# Include this file before include(CPack) in CMakeLists.txt
+
+# Only set these when RPM packaging is requested or when on RPM-friendly host.
+# We do not force CPACK_GENERATOR here; the caller can run `cpack -G RPM`.
+set(CPACK_RPM_PACKAGE_LICENSE "Apache-2.0")
+set(CPACK_RPM_PACKAGE_GROUP "Applications/System")
+set(CPACK_RPM_PACKAGE_URL "https://github.com/lemonade-sdk/lemonade")
+
+# RPM runtime requirements (package names on Fedora/RHEL)
+# Adjust for target distro if needed.
+set(CPACK_RPM_PACKAGE_REQUIRES "libcurl, openssl, zlib")
+
+# Architecture and file name
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
+set(CPACK_PACKAGE_FILE_NAME "lemonade-server-minimal-${CPACK_PACKAGE_VERSION}.${CPACK_RPM_PACKAGE_ARCHITECTURE}")
+
+# Provide script hooks (optional)
+set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_CURRENT_SOURCE_DIR}/postinst")
+
+# End of RPM config.

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -30,6 +30,17 @@ sudo apt install build-essential cmake libcurl4-openssl-dev libssl-dev pkg-confi
 # This avoids LGPL dependencies and provides a cleaner server-only experience
 ```
 
+**Linux (Fedora):**
+```bash
+sudo dnf install @development-tools cmake libcurl-devel openssl-devel
+
+# If you then want to package the binaries into .rpm
+sudo dnf install rpm-build rpmdevtools
+
+# Note: Tray application is disabled on Linux (headless mode only)
+# This avoids LGPL dependencies and provides a cleaner server-only experience
+```
+
 **macOS:**
 ```bash
 # Install Xcode command line tools
@@ -220,6 +231,39 @@ lemonade-server serve --no-tray
 # Or just:
 lemonade-server serve
 ```
+
+### Linux .rpm Package (Fedora, RHEL etc)
+
+Very similar to the Debian instructions above with minor changes
+
+**Building:**
+
+```bash
+cd src/cpp/build
+cpack -G RPM
+```
+
+**Package Output:**
+
+Creates `lemonade-server-minimal-<VERSION>.x86_64.rpm` (e.g., `lemonade-server-minimal-9.1.2.x86_64.rpm`) and 
+resources are installed as per DEB version above
+
+**Installation:**
+
+```bash
+# Replace <VERSION> with the actual version (e.g., 9.0.0)
+sudo dnf install ./lemonade-server-minimal-<VERSION>.x86_64.rpm
+```
+
+**Uninstallation:**
+
+```bash
+sudo dnf remove lemonade-server-minimal
+```
+
+**Post-Installation:**
+
+Same as .deb above
 
 ### Developer IDE & IDE Build Steps
 


### PR DESCRIPTION
Updated the readme and the .cmake to easily allow the creation of rpm packages for Fedora users. 

This is done just by 
```
cd src/cpp/build
cpack -G RPM
```