### PR TITLE
Add --convert flag when launching whisper-server

### DIFF
--- a/src/cpp/server/backends/whisper_server.cpp
+++ b/src/cpp/server/backends/whisper_server.cpp
@@ -403,7 +403,8 @@ void WhisperServer::load(const std::string& model_name,
     // Note: Don't include exe_path here - ProcessManager::start_process already handles it
     std::vector<std::string> args = {
         "-m", model_path_,
-        "--port", std::to_string(port_)
+        "--port", std::to_string(port_),
+        "--convert"
     };
 
     // Note: whisper-server doesn't support --debug flag


### PR DESCRIPTION
## Summary
This PR adds the `--convert` flag when launching whisper-server to fix crashes in binaries compiled with ffmpeg support.

## Problem
When whisper-server binaries are compiled with ffmpeg support, they crash because whisper.cpp takes the content of the file instead of the filename (different behaviour than with the default miniaudio integrated in whisper).

## Solution
Add the `--convert` flag when launching whisper-server. This flag has been tested and is safe for:
- Binaries built with ffmpeg support (fixes the crash)
- Binaries using only the default built-in miniaudio library (no side effects)

## Test plan
- Test with whisper-server binary compiled with ffmpeg support (with standards wav/mp3 and with m4a)
- Test with whisper-server binary using miniaudio only
- Verify transcription works correctly in both cases