### PR TITLE
Fix graceful shutdown to prevent systemd timeout on service stop

### DIFF
--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -15,16 +15,19 @@ static Server* g_server_instance = nullptr;
 // Signal handler for Ctrl+C and SIGTERM
 void signal_handler(int signal) {
     if (signal == SIGINT || signal == SIGTERM) {
-        std::cout << "\n[Server] Shutdown signal received, exiting..." << std::endl;
+        std::cout << "\n[Server] Shutdown signal received, stopping gracefully..." << std::endl;
         std::cout.flush();
-        
-        // Don't call server->stop() from signal handler - it can block/deadlock
-        // Just set the flag and exit immediately. The OS will clean up resources.
+
+        // Set shutdown flag
         g_shutdown_requested = true;
-        
-        // Use _exit() for async-signal-safe immediate termination
-        // The OS will handle cleanup of file descriptors, memory, and child processes
-        _exit(0);
+
+        // Call stop() to gracefully shutdown HTTP server and child processes
+        // This is safe for httplib's stop() which just sets a flag
+        if (g_server_instance) {
+            g_server_instance->stop();
+        }
+
+        // The main function will clean up and exit normally
     }
 }
 


### PR DESCRIPTION
## Summary
This PR fixes graceful shutdown of child processes to prevent systemd timeout errors when stopping the lemonade launched as a service.

## Problem
When stopping the lemonade service via systemd, the server would call `_exit(0)` in the signal handler, which:
- Exits immediately without cleaning up child processes
- Leaves orphaned llama-server and whisper-server processes running
- Causes systemd "State 'final-sigterm' timed out. Killing" errors

## Solution
Replace `_exit(0)` with proper `server->stop()` call in the signal handler to:
- Cleanly terminate child processes (llama-server, whisper-server)
- Use ProcessManager's existing SIGTERM handling (5s timeout with SIGKILL fallback)
- Exit gracefully within the shutdown timeout period

## Changes
- Replace `_exit(0)` with `server->stop()` in signal handler
- Leverage existing ProcessManager termination logic
- Ensure all child processes are properly cleaned up

## Test plan
- Start lemonade.service with systemd
- Stop the service and verify no timeout errors in systemd logs
- Verify no orphaned child processes remain after shutdown
- Confirm all processes terminate within the shutdown timeout period