### PR TITLE
Download llamacpp/whisper binaries to cache on linux

### DIFF
--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -134,7 +134,6 @@ private:
     json load_optional_json(const std::string& path);
     void save_user_models(const json& user_models);
     
-    std::string get_cache_dir();
     std::string get_user_models_file();
     std::string get_recipe_options_file();
     

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -167,7 +167,6 @@ public:
     
 private:
     std::string cache_file_path_;
-    std::string get_cache_dir() const;
     std::string get_lemonade_version() const;
     bool is_ci_mode() const;
     

--- a/src/cpp/include/lemon/utils/path_utils.h
+++ b/src/cpp/include/lemon/utils/path_utils.h
@@ -26,6 +26,21 @@ std::string get_resource_path(const std::string& relative_path);
  */
 std::string find_flm_executable();
 
+/**
+ * Get the cache directory
+ */
+std::string get_cache_dir();
+
+/**
+ * Get the directory where backend executables will be downloaded
+ */
+std::string get_downloaded_bin_dir();
+
+#ifndef _WIN32
+/** on Linux we changed the download location, the old location is used for cleanup only */
+std::string get_deprecated_downloaded_bin_dir();
+#endif
+
 } // namespace utils
 } // namespace lemon
 

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -216,45 +216,11 @@ static std::string identify_rocm_arch() {
     return "gfx110X";  // Default architecture
 }
 
-// Helper to get the directory where llama binaries should be installed
-// Policy: Next to the executable for both dev builds and installed binaries
-static std::string get_llama_base_dir() {
-#ifdef _WIN32
-    char exe_path[MAX_PATH];
-    GetModuleFileNameA(NULL, exe_path, MAX_PATH);
-    fs::path exe_dir = fs::path(exe_path).parent_path();
-    return exe_dir.string();
-#else
-    // Get the actual executable location
-    char exe_path[1024];
-    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
-    if (len != -1) {
-        exe_path[len] = '\0';
-        fs::path exe_dir = fs::path(exe_path).parent_path();
-        
-        // If we're in /usr/local/bin, use /usr/local/share/lemonade-server instead
-        if (exe_dir == "/usr/local/bin" || exe_dir == "/usr/bin") {
-            if (fs::exists("/usr/local/share/lemonade-server")) {
-                return "/usr/local/share/lemonade-server";
-            }
-            if (fs::exists("/usr/share/lemonade-server")) {
-                return "/usr/share/lemonade-server";
-            }
-        }
-        
-        // Otherwise (dev builds), use the exe directory
-        return exe_dir.string();
-    }
-    return ".";
-#endif
-}
-
 // Helper to get the install directory for llama-server binaries
 // Policy: Put in llama/{backend}/ next to the executable
 static std::string get_install_directory(const std::string& backend) {
-    return (fs::path(get_llama_base_dir()) / "llama" / backend).string();
+    return (fs::path(get_downloaded_bin_dir()) / "llama" / backend).string();
 }
-
 
 // Helper to extract ZIP files (Windows/Linux built-in tools)
 static bool extract_zip(const std::string& zip_path, const std::string& dest_dir) {

--- a/src/cpp/server/backends/whisper_server.cpp
+++ b/src/cpp/server/backends/whisper_server.cpp
@@ -50,39 +50,9 @@ static std::string get_whisper_version() {
     }
 }
 
-// Helper to get the base directory for whisper binaries
-static std::string get_whisper_base_dir() {
-#ifdef _WIN32
-    char exe_path[MAX_PATH];
-    GetModuleFileNameA(NULL, exe_path, MAX_PATH);
-    fs::path exe_dir = fs::path(exe_path).parent_path();
-    return exe_dir.string();
-#else
-    char exe_path[1024];
-    ssize_t len = readlink("/proc/self/exe", exe_path, sizeof(exe_path) - 1);
-    if (len != -1) {
-        exe_path[len] = '\0';
-        fs::path exe_dir = fs::path(exe_path).parent_path();
-
-        // If we're in /usr/local/bin, use /usr/local/share/lemonade-server
-        if (exe_dir == "/usr/local/bin" || exe_dir == "/usr/bin") {
-            if (fs::exists("/usr/local/share/lemonade-server")) {
-                return "/usr/local/share/lemonade-server";
-            }
-            if (fs::exists("/usr/share/lemonade-server")) {
-                return "/usr/share/lemonade-server";
-            }
-        }
-
-        return exe_dir.string();
-    }
-    return ".";
-#endif
-}
-
 // Helper to get the install directory for whisper-server
 static std::string get_whisper_install_dir() {
-    return (fs::path(get_whisper_base_dir()) / "whisper").string();
+    return (fs::path(get_downloaded_bin_dir()) / "whisper").string();
 }
 
 // Helper to extract ZIP files

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -208,29 +208,6 @@ ModelManager::ModelManager() {
     recipe_options_ = load_optional_json(get_recipe_options_file());
 }
 
-std::string ModelManager::get_cache_dir() {
-    // Check environment variable first
-    const char* cache_env = std::getenv("LEMONADE_CACHE_DIR");
-    if (cache_env) {
-        return std::string(cache_env);
-    }
-    
-    // Default to ~/.cache/lemonade (matching Python implementation)
-#ifdef _WIN32
-    const char* userprofile = std::getenv("USERPROFILE");
-    if (userprofile) {
-        return std::string(userprofile) + "\\.cache\\lemonade";
-    }
-    return "C:\\.cache\\lemonade";
-#else
-    const char* home = std::getenv("HOME");
-    if (home) {
-        return std::string(home) + "/.cache/lemonade";
-    }
-    return "/tmp/.cache/lemonade";
-#endif
-}
-
 std::string ModelManager::get_user_models_file() {
     return get_cache_dir() + "/user_models.json";
 }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1,5 +1,6 @@
 #include "lemon/system_info.h"
 #include "lemon/version.h"
+#include "lemon/utils/path_utils.h"
 #include <filesystem>
 #include <fstream>
 #include <sstream>
@@ -20,6 +21,7 @@
 namespace lemon {
 
 namespace fs = std::filesystem;
+using namespace lemon::utils;
 
 // AMD discrete GPU keywords
 const std::vector<std::string> AMD_DISCRETE_GPU_KEYWORDS = {
@@ -1702,27 +1704,6 @@ NPUInfo MacOSSystemInfo::get_npu_device() {
 
 SystemInfoCache::SystemInfoCache() {
     cache_file_path_ = get_cache_dir() + "/hardware_info.json";
-}
-
-std::string SystemInfoCache::get_cache_dir() const {
-    const char* cache_dir_env = std::getenv("LEMONADE_CACHE_DIR");
-    if (cache_dir_env) {
-        return std::string(cache_dir_env);
-    }
-    
-    #ifdef _WIN32
-    const char* userprofile = std::getenv("USERPROFILE");
-    if (userprofile) {
-        return std::string(userprofile) + "\\.cache\\lemonade";
-    }
-    #else
-    const char* home = std::getenv("HOME");
-    if (home) {
-        return std::string(home) + "/.cache/lemonade";
-    }
-    #endif
-    
-    return ".cache/lemonade";
 }
 
 std::string SystemInfoCache::get_lemonade_version() const {


### PR DESCRIPTION
Closes #799  

changes the download destination of external binaries on Linux to (cache + "/bin"). I also took the occasion to remove some code duplication in path searching/building

@jeremyfowers I didn't implement cleanup of old binaries yet, but I wonder if this is better handled through a documentation note - nothing happens if they remain in place and I am always a little nervous at deleting stuff on the user's system. Let me know what you think