### PR TITLE
Add workflows to test and monitor our runners

### DIFF
--- a/.github/workflows/monitor_selfhosted_runners.yml
+++ b/.github/workflows/monitor_selfhosted_runners.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: "0 1 * * 1"   # every Monday at 1AM UTC
   workflow_dispatch:
-  push:
-    branches: 
-      - vgodsoe/ci-runner-heartbeat  # Temporary: remove before merging
-    paths:
-      - '.github/workflows/monitor_selfhosted_runners.yml'
 
 permissions:
   actions: read  # Required to read artifacts

--- a/.github/workflows/runner_heartbeat.yml
+++ b/.github/workflows/runner_heartbeat.yml
@@ -1,16 +1,9 @@
 name: Runner Heartbeat
 
-# Change to trigger push.
-
 on:
   schedule:
     - cron: "0 1 * * 0"    # every Sunday at 1AM UTC
   workflow_dispatch:
-  push:
-    branches: 
-      - vgodsoe/ci-runner-heartbeat  # Temporary: remove before merging
-    paths:
-      - '.github/workflows/runner_heartbeat.yml'
 
 permissions:
   actions: write  # Required to upload artifacts


### PR DESCRIPTION
Our self-hosted runners are removed after 14 days of inactivity. This PR adds 2 workflows: 
1) Pulses each self-hosted runner to make sure it's alive. Generates an artifact if it is. This is scheduled to run on Sunday's at 1AM.
2) Pulls the artifacts and checks if any is missing. If one is missing, a message is created to notify the Lemonade team that a runner is down and needs maintenance. This runs Monday at 1AM so reports are ready for review.