### PR TITLE
Replace hybrid model with device-agnostic model in spec

### DIFF
--- a/docs/server/server_spec.md
+++ b/docs/server/server_spec.md
@@ -145,7 +145,7 @@ Chat Completions API. You provide a list of messages and receive a completion. T
       -Method POST `
       -Headers @{ "Content-Type" = "application/json" } `
       -Body '{
-        "model": "Llama-3.2-1B-Instruct-Hybrid",
+        "model": "Qwen3-0.6B-GGUF",
         "messages": [
           {
             "role": "user",
@@ -161,7 +161,7 @@ Chat Completions API. You provide a list of messages and receive a completion. T
     curl -X POST http://localhost:8000/api/v1/chat/completions \
       -H "Content-Type: application/json" \
       -d '{
-            "model": "Llama-3.2-1B-Instruct-Hybrid",
+            "model": "Qwen3-0.6B-GGUF",
             "messages": [
               {"role": "user", "content": "What is the population of Paris?"}
             ],
@@ -178,7 +178,7 @@ Chat Completions API. You provide a list of messages and receive a completion. T
       "id": "0",
       "object": "chat.completion",
       "created": 1742927481,
-      "model": "Llama-3.2-1B-Instruct-Hybrid",
+      "model": "Qwen3-0.6B-GGUF",
       "choices": [{
         "index": 0,
         "message": {
@@ -197,7 +197,7 @@ Chat Completions API. You provide a list of messages and receive a completion. T
       "id": "0",
       "object": "chat.completion.chunk",
       "created": 1742927481,
-      "model": "Llama-3.2-1B-Instruct-Hybrid",
+      "model": "Qwen3-0.6B-GGUF",
       "choices": [{
         "index": 0,
         "delta": {
@@ -238,7 +238,7 @@ Text Completions API. You provide a prompt and receive a completion. This API wi
       -Method POST `
       -Headers @{ "Content-Type" = "application/json" } `
       -Body '{
-        "model": "Llama-3.2-1B-Instruct-Hybrid",
+        "model": "Qwen3-0.6B-GGUF",
         "prompt": "What is the population of Paris?",
         "stream": false
       }'
@@ -250,7 +250,7 @@ Text Completions API. You provide a prompt and receive a completion. This API wi
     curl -X POST http://localhost:8000/api/v1/completions \
       -H "Content-Type: application/json" \
       -d '{
-            "model": "Llama-3.2-1B-Instruct-Hybrid",
+            "model": "Qwen3-0.6B-GGUF",
             "prompt": "What is the population of Paris?",
             "stream": false
           }'
@@ -265,7 +265,7 @@ The following format is used for both streaming and non-streaming responses:
   "id": "0",
   "object": "text_completion",
   "created": 1742927481,
-  "model": "Llama-3.2-1B-Instruct-Hybrid",
+  "model": "Qwen3-0.6B-GGUF",
   "choices": [{
     "index": 0,
     "text": "Paris has a population of approximately 2.2 million people in the city proper.",
@@ -700,7 +700,7 @@ If the model is not found, the endpoint returns a 404 error:
 ```json
 {
   "error": {
-    "message": "Model Llama-3.2-1B-Instruct-Hybrid has not been found",
+    "message": "Model Qwen3-0.6B-GGUF has not been found",
     "type": "not_found"
   }
 }
@@ -954,7 +954,7 @@ Unload a specific model:
 ```bash
 curl -X POST http://localhost:8000/api/v1/unload \
   -H "Content-Type: application/json" \
-  -d '{"model_name": "Llama-3.2-1B-Instruct-Hybrid"}'
+  -d '{"model_name": "Qwen3-0.6B-GGUF"}'
 ```
 
 Unload all models:
@@ -979,7 +979,7 @@ Error response (model not found):
 ```json
 {
   "status": "error",
-  "message": "Model not found: Llama-3.2-1B-Instruct-Hybrid"
+  "message": "Model not found: Qwen3-0.6B-GGUF"
 }
 ```
 


### PR DESCRIPTION
Most server spec example requests used a -Hybrid model, which only works on some systems. This PR changes most example requests to use a device-agnostic model for better compatibility.