### PR TITLE
fix recipe options creation for newly added models

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -824,6 +824,7 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
     info.model_name = model_name;
     info.checkpoint = JsonUtils::get_or_default<std::string>(*model_json, "checkpoint", "");
     info.recipe = JsonUtils::get_or_default<std::string>(*model_json, "recipe", "");
+    info.recipe_options = RecipeOptions(info.recipe, JsonUtils::get_or_default(recipe_options_, model_name, json::object()));
     info.suggested = JsonUtils::get_or_default<bool>(*model_json, "suggested", is_user_model);
     info.mmproj = JsonUtils::get_or_default<std::string>(*model_json, "mmproj", "");
     info.source = JsonUtils::get_or_default<std::string>(*model_json, "source", "");


### PR DESCRIPTION
Fixes the following issue:

if adding a new model through GUI or pull command and running it immediately the default options will be applied, regardless of command line switches or existing recipe options. This fixes it