### PR TITLE
Add stx-test back in for new ci runners

### DIFF
--- a/.github/workflows/test_ryzenai.yml
+++ b/.github/workflows/test_ryzenai.yml
@@ -28,6 +28,7 @@ on:
         - 'rai300_400'
         - 'stx'
         - 'stx-halo'
+        - 'stx-test'
 
 permissions:
   contents: read


### PR DESCRIPTION
The stx-test was removed from our workflow. Adding it back so we can test new CI runners before adding to the pool. 