### PR TITLE
Reload loaded models if calling /load explicitly

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1644,22 +1644,6 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
         auto request_json = nlohmann::json::parse(req.body);
         model_name = request_json["model_name"];
         
-        // Check if model is already loaded (early return optimization)
-        std::string loaded_model = router_->get_loaded_model();
-        if (loaded_model == model_name) {
-            std::cout << "[Server] Model already loaded: " << model_name << std::endl;
-            auto info = model_manager_->get_model_info(model_name);
-            nlohmann::json response = {
-                {"status", "success"},
-                {"model_name", model_name},
-                {"checkpoint", info.checkpoint},
-                {"recipe", info.recipe},
-                {"message", "Model already loaded"}
-            };
-            res.set_content(response.dump(), "application/json");
-            return;
-        }
-        
         // Get model info
         if (!model_manager_->model_exists(model_name)) {
             std::cerr << "[Server ERROR] Model not found: " << model_name << std::endl;
@@ -1675,7 +1659,12 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
         RecipeOptions options = RecipeOptions(info.recipe, request_json);
         bool save_options = request_json.value("save_options", false);
         
-        std::cout << "[Server] Loading model: " << model_name;
+        if (router_->is_model_loaded(model_name)) {
+            router_->unload_model(model_name);
+            std::cout << "[Server] Reloading model: " << model_name;
+        } else {
+            std::cout << "[Server] Loading model: " << model_name;
+        }
         std::cout << " " << options.to_log_string(false);
         std::cout << std::endl;
 


### PR DESCRIPTION
Closes #897 

I choose the approach to explicitly unload the model if it is already loaded so that it doesn't take a second slot (if for example max llm model are set to 2). It also keeps the change contained to the `handle_load` function.

Testing note: until #874 is merged, to reload the model with different parameters use cURL, not the CLI