### PR TITLE
Docker always tag latest

### DIFF
--- a/.github/workflows/build-and-push-container.yml
+++ b/.github/workflows/build-and-push-container.yml
@@ -61,12 +61,4 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
             ${{ github.event_name == 'push' && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}
-
-      - name: Tag image as latest (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch' && inputs.add_latest
-        run: |
-          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
-          docker tag \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ github.event_name == 'workflow_dispatch' && inputs.add_latest && format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) || '' }}


### PR DESCRIPTION
Changed docker release workflow so that any v* tag trigger gets marked also as "latest".

resolves #898 