### PR TITLE
Restore default port and host values in ServerManager

### DIFF
--- a/src/cpp/tray/server_manager.cpp
+++ b/src/cpp/tray/server_manager.cpp
@@ -50,6 +50,8 @@ namespace lemon_tray {
 
 ServerManager::ServerManager()
     : server_pid_(0)
+    , port_(8000)
+    , host_("localhost")
     , show_console_(false)
     , is_ephemeral_(false)
     , server_started_(false)


### PR DESCRIPTION
Fixes #923 

@bitgamma this fixes an important Windows-only bug (see issue linked above). Any reason this change is not a good fix, and the bug should be solved a different way?