### PR TITLE
Add support to prefer ROCm as preference for llamacpp

### DIFF
--- a/docs/server/lemonade-server-cli.md
+++ b/docs/server/lemonade-server-cli.md
@@ -51,7 +51,7 @@ lemonade-server run MODEL_NAME [options]
 | `--host [host]`                | Specify the host address for where to listen connections | `localhost` |
 | `--log-level [level]`          | Set the logging level               | info |
 | `--no-tray`                    | Start server without the tray app (headless mode) | False |
-| `--llamacpp [vulkan\|rocm\cpu]`    | Default LlamaCpp backend to use when loading models. Can be overridden per-model via the `/api/v1/load` endpoint. | vulkan |
+| `--llamacpp [auto\|vulkan\|rocm\|metal\|cpu]`    | Default LlamaCpp backend to use when loading models. When set to `auto`, the system automatically detects available hardware and uses ROCm for AMD devices or Vulkan as a fallback. Can be overridden per-model via the `/api/v1/load` endpoint. | auto |
 | `--ctx-size [size]`            | Default context size for models. For llamacpp recipes, this sets the `--ctx-size` parameter for the llama server. For other recipes, prompts exceeding this size will be truncated. Can be overridden per-model via the `/api/v1/load` endpoint. | 4096 |
 | `--llamacpp-args [args]`       | Default custom arguments to pass to llama-server. Must not conflict with arguments managed by Lemonade (e.g., `-m`, `--port`, `--ctx-size`, `-ngl`). Can be overridden per-model via the `/api/v1/load` endpoint. Example: `--llamacpp-args "--flash-attn on --no-mmap"` | "" |
 | `--extra-models-dir [path]`    | Experimental feature. Secondary directory to scan for LLM GGUF model files. Audio, embedding, reranking, and non-GGUF files are not supported, yet. | None |

--- a/src/cpp/include/lemon/backends/llamacpp_server.h
+++ b/src/cpp/include/lemon/backends/llamacpp_server.h
@@ -41,6 +41,7 @@ private:
     std::string get_llama_server_path(const std::string& backend);
     std::string find_executable_in_install_dir(const std::string& install_dir);
     std::string find_external_llama_server(const std::string& backend);
+    std::string resolve_auto_backend();
 };
 
 } // namespace backends

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -7,7 +7,7 @@ using json = nlohmann::json;
 
 static const json DEFAULTS = {
     {"ctx_size", 4096},
-    {"llamacpp_backend", "vulkan"},
+    {"llamacpp_backend", "auto"},
     {"llamacpp_args", ""},
     // Image generation defaults (for sd-cpp recipe)
     {"steps", 20},
@@ -26,7 +26,7 @@ static const json CLI_OPTIONS = {
     {"--llamacpp", {
         {"option_name", "llamacpp_backend"},
         {"type_name", "BACKEND"},
-        {"allowed_values", {"vulkan", "rocm", "metal", "cpu"}},
+        {"allowed_values", {"auto", "vulkan", "rocm", "metal", "cpu"}},
         {"envname", "LEMONADE_LLAMACPP"},
         {"help", "LlamaCpp backend to use"}
     }},


### PR DESCRIPTION
Add a new "auto" mode.  In this mode:
1. Detect the GFX ISA.
2. Try to download a ROCm binary for that ISA
3. If the error code is 404, fall back to vulkan