### PR TITLE
Prevent a rare Windows model load bug

### DIFF
--- a/src/cpp/server/backends/fastflowlm_server.cpp
+++ b/src/cpp/server/backends/fastflowlm_server.cpp
@@ -201,6 +201,7 @@ void FastFlowLMServer::load(const std::string& model_name,
     bool ready = wait_for_ready();
     if (!ready) {
         utils::ProcessManager::stop_process(process_handle_);
+        process_handle_ = {nullptr, 0};  // Reset to prevent double-stop on destructor
         throw std::runtime_error("flm-server failed to start");
     }
 

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -624,6 +624,7 @@ void LlamaCppServer::load(const std::string& model_name,
     // Wait for server to be ready
     if (!wait_for_ready()) {
         ProcessManager::stop_process(process_handle_);
+        process_handle_ = {nullptr, 0};  // Reset to prevent double-stop on destructor
         throw std::runtime_error("llama-server failed to start");
     }
 

--- a/src/cpp/server/backends/ryzenaiserver.cpp
+++ b/src/cpp/server/backends/ryzenaiserver.cpp
@@ -378,6 +378,8 @@ void RyzenAIServer::load(const std::string& model_name,
 
     // Wait for server to be ready
     if (!wait_for_ready()) {
+        utils::ProcessManager::stop_process(process_handle_);
+        process_handle_ = {nullptr, 0};  // Reset to prevent double-stop on destructor
         throw std::runtime_error("RyzenAI-Server failed to start (check logs for details)");
     }
 

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -25,8 +25,8 @@ bool WrappedServer::wait_for_ready() {
 
     std::cout << "Waiting for " + server_name_ + " to be ready..." << std::endl;
 
-    // Wait up to 5 minutes (large models can take time to load)
-    const int max_attempts = 3000; // 5 minutes at 100ms intervals
+    // Wait up to 10 minutes (large models can take time to load)
+    const int max_attempts = 6000; // 10 minutes at 100ms intervals
 
     for (int i = 0; i < max_attempts; i++) {
         // Check if process is still running


### PR DESCRIPTION
Fix Windows handle reuse bug where the retry path's llama-server process was killed by the failed attempt's destructor, causing "model loaded" to report success while the backend was actually dead. Also increased model load timeout from 5 to 10 minutes for large models.