### PR TITLE
fix: Don't attempt to preserve ownership when extracting backends

### DIFF
--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -88,13 +88,13 @@ namespace lemon::backends {
             return false;
         }
         // Command structure is identical to Linux for modern Windows tar
-        command = "tar -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1";
+        command = "tar -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
 #elif defined(__APPLE__)
-        command = "tar -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1";
+        command = "tar -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
 
 #else
         // Linux (uses GNU tar by default)
-        command = "tar -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1";
+        command = "tar -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
 #endif
         result = system(command.c_str());
         if (result != 0) {


### PR DESCRIPTION
This fixes errors such as:

Jan 29 18:28:52 monster lemonade-server.service[84101]: tar: libggml-vulkan.so: Cannot change ownership to uid 1001, gid 1001: Operation not permitted
Jan 29 18:28:52 monster lemonade-server.service[84101]: tar: Exiting with failure status due to previous errors
