### PR TITLE
Add image generation docs openwebui

### DIFF
--- a/docs/server/apps/open-webui.md
+++ b/docs/server/apps/open-webui.md
@@ -199,7 +199,7 @@ This mode uses tool calling for image generation and is recommended for high-qua
 
 1. Configure your model for native tool calling:
     1. Go to Admin > Settings > Models and choose your model.
-    2. Go to `Advanced Parameters` and toggle `Standard` to `Native`.
+    2. Go to `Advanced Parameters` and toggle `Function Calling` to `Native`.
     
     > Note: Open WebUI recommends using native mode only for high-quality models. See [Tool Calling Modes](https://docs.openwebui.com/features/plugin/tools/#tool-calling-modes-default-vs-native) for more information. (try out >30B models like GPT-OSS-120B, GLM-4.7-Flash or Qwen-3-Next-80B-A3B)
 


### PR DESCRIPTION
Hi,
i added bit of documentation for image generation in open webui.
I have skipped adding images, since that would involve adding them to the assets repository.

But if you need:

<img width="960" height="457" alt="grafik" src="https://github.com/user-attachments/assets/6412eb6d-0bfa-424a-9e2e-22e3bfae5339" />
<img width="1207" height="124" alt="Image-Gen" src="https://github.com/user-attachments/assets/be2a58ac-3813-4424-8c7b-1bffea1536c4" />
<img width="713" height="314" alt="Native-Image-Gen" src="https://github.com/user-attachments/assets/b7ed9ef8-b1c4-49c1-ad2f-baabb9075914" />
<img width="751" height="170" alt="Image-Gen-Chat" src="https://github.com/user-attachments/assets/2aca9d4b-d796-4fe9-be21-e7da5690b8df" />

