### PR TITLE
Adjust behavior of `lemonade-server` with no arguments

### DIFF
--- a/docs/dev-getting-started.md
+++ b/docs/dev-getting-started.md
@@ -124,7 +124,7 @@ The tray app looks for `Lemonade.exe` in the same directory as the executable (d
 **Linux:**
 - Linux builds are headless-only (no tray application) by default
 - This avoids LGPL dependencies (GTK3, libappindicator3, libnotify)
-- Run server using: `lemonade-server serve` (headless mode is automatic)
+- Run server using: `lemonade-server` (headless mode is automatic)
 - Fully functional for server operations and model management
 - Uses permissively licensed dependencies only (MIT, Apache 2.0, BSD, curl license)
 - Clean .deb package with only runtime files (no development headers)

--- a/docs/server/lemonade-server-cli.md
+++ b/docs/server/lemonade-server-cli.md
@@ -16,6 +16,7 @@ The `lemonade-server` command-line interface (CLI) provides a set of utility com
 
 | Option/Command      | Description                         |
 |---------------------|-------------------------------------|
+| *(no command)*      | Start the server process (equivalent to `serve`). See command options [below](#options-for-serve-and-run). |
 | `-v`, `--version`   | Print the `lemonade-sdk` package version used to install Lemonade Server. |
 | `serve`             | Start the server process in the current terminal. See command options [below](#options-for-serve-and-run). |
 | `status`            | Check if server is running. If it is, print the port number. |
@@ -29,6 +30,9 @@ The `lemonade-server` command-line interface (CLI) provides a set of utility com
 Examples:
 
 ```bash
+# Start server with default settings (same as 'serve')
+lemonade-server
+
 # Start server with custom settings
 lemonade-server serve --port 8080 --log-level debug --llamacpp vulkan
 
@@ -38,9 +42,10 @@ lemonade-server run Qwen3-0.6B-GGUF --port 8080 --log-level debug --llamacpp roc
 
 ## Options for serve and run
 
-When using the `serve` command, you can configure the server with these additional options. The `run` command supports the same options but also requires a `MODEL_NAME` parameter:
+When using the `serve` command (or when running `lemonade-server` with no command), you can configure the server with these additional options. The `run` command supports the same options but also requires a `MODEL_NAME` parameter:
 
 ```bash
+lemonade-server [options]
 lemonade-server serve [options]
 lemonade-server run MODEL_NAME [options]
 ```

--- a/src/cpp/server/cli_parser.cpp
+++ b/src/cpp/server/cli_parser.cpp
@@ -87,7 +87,7 @@ CLIParser::CLIParser()
     app_.set_version_flag("-v,--version", (APP_NAME " version " LEMON_VERSION_STRING));
 
 #ifdef LEMONADE_TRAY
-    app_.require_subcommand(1);
+    app_.require_subcommand(0, 1);  // 0 or 1 subcommand required, making it optional
     app_.set_help_all_flag("--help-all", "Print help for all commands");
 
     // Serve
@@ -161,7 +161,13 @@ int CLIParser::parse(int argc, char** argv) {
             }
         }
 #ifdef LEMONADE_TRAY
-        tray_config_.command = app_.get_subcommands().at(0)->get_name();
+        // Default to "serve" command if no subcommand is provided
+        auto subcommands = app_.get_subcommands();
+        if (subcommands.empty()) {
+            tray_config_.command = "serve";
+        } else {
+            tray_config_.command = subcommands.at(0)->get_name();
+        }
 #endif
         should_continue_ = true;
         exit_code_ = 0;


### PR DESCRIPTION
The most common way to run lemonade-server would be with no arguments. Especially with moving more options to be in the UI at runtime.

If no argument are passed assume the user meant the `serve` command.