### PR TITLE
Update CMake minimum version to use <min>...<max> syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.10...3.28)
 
 # Use static runtime library on Windows to avoid DLL dependencies
 if(MSVC)


### PR DESCRIPTION
Replace deprecated VERSION syntax with 3.10...3.28 to specify that the project requires at least CMake 3.10 and has been updated to work with policies introduced by CMake 3.28 or earlier.