### PR TITLE
Windows - fix some issues with buildscripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,9 +532,9 @@ if(NODE_EXECUTABLE AND NPM_EXECUTABLE)
         COMMAND ${CMAKE_COMMAND} -E make_directory "${ELECTRON_BUILD_SOURCE_DIR}"
         COMMAND ${CMAKE_COMMAND} -E copy_directory "${ELECTRON_APP_SOURCE_DIR}" "${ELECTRON_BUILD_SOURCE_DIR}"
         COMMAND ${CMAKE_COMMAND} -E echo "Installing npm dependencies (clean install)..."
-        COMMAND ${CMAKE_COMMAND} -E chdir "${ELECTRON_BUILD_SOURCE_DIR}" cmd /c ${NPM_EXECUTABLE} ci
+        COMMAND ${CMAKE_COMMAND} -E chdir "${ELECTRON_BUILD_SOURCE_DIR}" ${NPM_EXECUTABLE} ci
         COMMAND ${CMAKE_COMMAND} -E echo "Building Electron app for current platform..."
-        COMMAND ${CMAKE_COMMAND} -E chdir "${ELECTRON_BUILD_SOURCE_DIR}" cmd /c ${NPM_EXECUTABLE} run ${ELECTRON_BUILD_TARGET} -- --config.directories.output=${ELECTRON_APP_BUILD_DIR}
+        COMMAND ${CMAKE_COMMAND} -E chdir "${ELECTRON_BUILD_SOURCE_DIR}" ${NPM_EXECUTABLE} run ${ELECTRON_BUILD_TARGET} -- --config.directories.output=${ELECTRON_APP_BUILD_DIR}
         COMMENT "Building Electron app with npm"
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
         VERBATIM


### PR DESCRIPTION
### Assumptions:
- windows system with VS 2022
- using powershell prompt for VS 2022
- node for windows installed and in path
- python for windows installed and in path

### Issue 1: Powershell setup script during `pre-commit` installation: 
by default pip or pip3 are not in path nor aliased. Recommended usage is using py. 
See https://packaging.python.org/en/latest/tutorials/installing-packages/#use-pip-for-installing

~~### Issue 2: Cmake command chdir seems to fail with scripts:
Even if `find_program(NPM_EXECUTABLE npm)` is actually finding the path to `npm`, the `chdir` command still fails to invoke it.
I suspect that this is because `npm` is actually a script and not an exe. Calling it with `cmd` did fix the situation.~~
This was breaking the CI build

CC @jeremyfowers 