### PR TITLE
Test real deb install on github hosted runners

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -548,9 +548,12 @@ jobs:
           echo "Installing .deb package: $DEB_FILE"
           sudo dpkg -i "$DEB_FILE"
 
-          # Verify installation
+          # Verify binaries installed
           lemonade-server --version
           lemonade-router --version
+
+          # Verify the systemd service started automatically
+          sudo systemctl status lemonade-server
 
       - name: Set environment (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
This PR changes the Ubuntu CLI and endpoints tests to use real package and service installation.