### PR TITLE
Show `--help` output if no arguments to `lemonade-server`

### DIFF
--- a/src/cpp/server/cli_parser.cpp
+++ b/src/cpp/server/cli_parser.cpp
@@ -148,6 +148,12 @@ CLIParser::CLIParser()
 
 int CLIParser::parse(int argc, char** argv) {
     try {
+#ifdef LEMONADE_TRAY
+        // Show help if no arguments provided
+        if (argc == 1) {
+            throw CLI::CallForHelp();
+        }
+#endif
         app_.parse(argc, argv);
 
         // Process --max-loaded-models values


### PR DESCRIPTION
Closes: https://github.com/lemonade-sdk/lemonade/issues/1016