### PR TITLE
Add qwen-coder-next to the models list

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -310,6 +310,13 @@
         "labels": ["coding","tool-calling","hot"],
         "size": 18.6
     },
+    "Qwen3-Coder-Next-GGUF": {
+        "checkpoint": "unsloth/Qwen3-Coder-Next-GGUF:Qwen3-Coder-Next-MXFP4_MOE.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": ["coding","tool-calling","hot"],
+        "size": 43.7
+    },
     "Nemotron-3-Nano-30B-A3B-GGUF": {
         "checkpoint": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF:Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
         "recipe": "llamacpp",


### PR DESCRIPTION
Closes #1019 

Works on the current llamacpp version on `main`!

Demo: https://www.reddit.com/r/LocalLLaMA/comments/1qv65ed/got_qwencodernext_running_on_rocm_on_my_strix_halo/