### PR TITLE
Add a limited mobile view for the web-app

### DIFF
--- a/src/app/src/renderer/App.tsx
+++ b/src/app/src/renderer/App.tsx
@@ -257,6 +257,18 @@ const App: React.FC = () => {
           onToggleLogs={() => setIsLogsVisible(!isLogsVisible)}
           isDownloadManagerVisible={isDownloadManagerVisible}
           onToggleDownloadManager={() => setIsDownloadManagerVisible(!isDownloadManagerVisible)}
+          onSelectMobilePanel={(panel) => {
+            if (panel === 'model-manager') {
+              setIsModelManagerVisible(true);
+              setIsChatVisible(false);
+            }
+            if (panel === 'chat') {
+              setIsChatVisible(true);
+              setIsModelManagerVisible(false);
+            }
+            setIsCenterPanelVisible(false);
+            setIsLogsVisible(false);
+          }}
         />
         <DownloadManager
           isVisible={isDownloadManagerVisible}

--- a/src/app/src/renderer/TitleBar.tsx
+++ b/src/app/src/renderer/TitleBar.tsx
@@ -16,6 +16,7 @@ interface TitleBarProps {
   onToggleLogs: () => void;
   isDownloadManagerVisible: boolean;
   onToggleDownloadManager: () => void;
+  onSelectMobilePanel: (panel: 'model-manager' | 'chat') => void;
 }
 
 const TitleBar: React.FC<TitleBarProps> = ({
@@ -28,7 +29,8 @@ const TitleBar: React.FC<TitleBarProps> = ({
   isLogsVisible,
   onToggleLogs,
   isDownloadManagerVisible,
-  onToggleDownloadManager
+  onToggleDownloadManager,
+  onSelectMobilePanel
 }) => {
   const [activeMenu, setActiveMenu] = useState<MenuType>(null);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -44,6 +46,19 @@ const TitleBar: React.FC<TitleBarProps> = ({
 
   // Detect if running as web app vs Electron using explicit flag
   const isWebApp = window.api?.isWebApp === true;
+
+  // Detect mobile viewport
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 768);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -144,57 +159,78 @@ const TitleBar: React.FC<TitleBarProps> = ({
               </span>
               {activeMenu === 'view' && (
                 <div className="menu-dropdown">
-                  <div className="menu-option" onClick={() => { onToggleModelManager(); setActiveMenu(null); }}>
-                    <span>{isModelManagerVisible ? '✓ ' : ''}Model Manager</span>
-                    <span className="menu-shortcut">Ctrl+Shift+M</span>
-                  </div>
-                  <div className="menu-option" onClick={() => { onToggleCenterPanel(); setActiveMenu(null); }}>
-                    <span>{isCenterPanelVisible ? '✓ ' : ''}Center Panel</span>
-                    <span className="menu-shortcut">Ctrl+Shift+P</span>
-                  </div>
-                  <div className="menu-option" onClick={() => { onToggleChat(); setActiveMenu(null); }}>
-                    <span>{isChatVisible ? '✓ ' : ''}Chat Window</span>
-                    <span className="menu-shortcut">Ctrl+Shift+H</span>
-                  </div>
-                  <div className="menu-option" onClick={() => { onToggleLogs(); setActiveMenu(null); }}>
-                    <span>{isLogsVisible ? '✓ ' : ''}Logs</span>
-                    <span className="menu-shortcut">Ctrl+Shift+L</span>
-                  </div>
-                  <div className="menu-separator"></div>
-                  <div className="menu-option" onClick={() => handleZoom('in')}>
-                    <span>Zoom In</span>
-                    <span className="menu-shortcut">{zoomInShortcutLabel}</span>
-                  </div>
-                  <div className="menu-option" onClick={() => handleZoom('out')}>
-                    <span>Zoom Out</span>
-                    <span className="menu-shortcut">{zoomOutShortcutLabel}</span>
-                  </div>
+                  {isMobile ? (
+                    <>
+                      <div className="menu-option" onClick={() => {
+                        onSelectMobilePanel('model-manager');
+                        setActiveMenu(null);
+                      }}>
+                        <span>{isModelManagerVisible ? '✓ ' : ''}Model Manager</span>
+                      </div>
+                      <div className="menu-option" onClick={() => {
+                        onSelectMobilePanel('chat');
+                        setActiveMenu(null);
+                      }}>
+                        <span>{isChatVisible ? '✓ ' : ''}Chat</span>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="menu-option" onClick={() => { onToggleModelManager(); setActiveMenu(null); }}>
+                        <span>{isModelManagerVisible ? '✓ ' : ''}Model Manager</span>
+                        <span className="menu-shortcut">Ctrl+Shift+M</span>
+                      </div>
+                      <div className="menu-option" onClick={() => { onToggleCenterPanel(); setActiveMenu(null); }}>
+                        <span>{isCenterPanelVisible ? '✓ ' : ''}Center Panel</span>
+                        <span className="menu-shortcut">Ctrl+Shift+P</span>
+                      </div>
+                      <div className="menu-option" onClick={() => { onToggleChat(); setActiveMenu(null); }}>
+                        <span>{isChatVisible ? '✓ ' : ''}Chat Window</span>
+                        <span className="menu-shortcut">Ctrl+Shift+H</span>
+                      </div>
+                      <div className="menu-option" onClick={() => { onToggleLogs(); setActiveMenu(null); }}>
+                        <span>{isLogsVisible ? '✓ ' : ''}Logs</span>
+                        <span className="menu-shortcut">Ctrl+Shift+L</span>
+                      </div>
+                      <div className="menu-separator"></div>
+                      <div className="menu-option" onClick={() => handleZoom('in')}>
+                        <span>Zoom In</span>
+                        <span className="menu-shortcut">{zoomInShortcutLabel}</span>
+                      </div>
+                      <div className="menu-option" onClick={() => handleZoom('out')}>
+                        <span>Zoom Out</span>
+                        <span className="menu-shortcut">{zoomOutShortcutLabel}</span>
+                      </div>
+                    </>
+                  )}
                 </div>
               )}
             </div>
 
-            <div className="menu-item-wrapper">
-              <span
-                className={`menu-item ${activeMenu === 'help' ? 'active' : ''}`}
-                onClick={() => handleMenuClick('help')}
-              >
-                Help
-              </span>
-              {activeMenu === 'help' && (
-                <div className="menu-dropdown">
-                  <div className="menu-option" onClick={() => { window.api.openExternal('https://lemonade-server.ai/docs/'); setActiveMenu(null); }}>
-                    Documentation
+            {!isMobile && (
+              <div className="menu-item-wrapper">
+                <span
+                  className={`menu-item ${activeMenu === 'help' ? 'active' : ''}`}
+                  onClick={() => handleMenuClick('help')}
+                >
+                  Help
+                </span>
+                {activeMenu === 'help' && (
+                  <div className="menu-dropdown">
+                    <div className="menu-option" onClick={() => { window.api.openExternal('https://lemonade-server.ai/docs/'); setActiveMenu(null); }}>
+                      Documentation
+                    </div>
+                    <div className="menu-option" onClick={() => { window.api.openExternal('https://github.com/lemonade-sdk/lemonade/releases'); setActiveMenu(null); }}>
+                      Release Notes
+                    </div>
+                    <div className="menu-separator"></div>
+                    <div className="menu-option" onClick={() => { setIsAboutOpen(prev => !prev); setActiveMenu(null); }}>
+                      About
+                    </div>
                   </div>
-                  <div className="menu-option" onClick={() => { window.api.openExternal('https://github.com/lemonade-sdk/lemonade/releases'); setActiveMenu(null); }}>
-                    Release Notes
-                  </div>
-                  <div className="menu-separator"></div>
-                  <div className="menu-option" onClick={() => { setIsAboutOpen(prev => !prev); setActiveMenu(null); }}>
-                    About
-                  </div>
-                </div>
-              )}
-            </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
         <div className="title-bar-center">

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -4582,3 +4582,245 @@ footer {
     color: #888;
     font-variant-numeric: tabular-nums;
 }
+
+/* ===================================================================
+   MOBILE RESPONSIVE STYLES
+   ===================================================================
+*/
+
+@media (max-width: 768px) {
+    /* Show title bar on mobile but style it as a mobile header */
+    .title-bar {
+        display: flex;
+        height: 50px;
+        padding: 8px 16px;
+        gap: 12px;
+        align-items: center;
+        justify-content: flex-start;
+        position: sticky;
+        top: 0;
+        z-index: 1000;
+        background: #000000;
+    }
+
+    /* Hide logo on mobile */
+    .title-bar-logo {
+        display: none;
+    }
+
+    /* Menu items container */
+    .menu-items {
+        display: flex;
+        gap: 0;
+        align-items: center;
+    }
+
+    /* Show only first menu item (View) as hamburger */
+    .menu-item-wrapper {
+        display: none;
+    }
+
+    .menu-item-wrapper:first-child {
+        display: block;
+        flex: 1;
+    }
+
+    /* Style View menu as hamburger on mobile */
+    .menu-item-wrapper:first-child .menu-item {
+        padding: 8px 12px;
+        font-size: 1.5rem;
+        font-weight: bold;
+        color: #ffffff;
+        cursor: pointer;
+        user-select: none;
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+    }
+
+    /* Show hamburger symbol before "View" text */
+    .menu-item-wrapper:first-child .menu-item::before {
+        content: "☰ ";
+        margin-right: 8px;
+        font-size: 1.8rem;
+    }
+
+    /* Center and title sections - hide on mobile */
+    .title-bar-center,
+    .title-bar-right {
+        display: none;
+    }
+
+    /* Hide status bar on mobile */
+    .status-bar {
+        display: none;
+    }
+
+    /* Recalculate app layout height without title bar - use flex instead */
+    .app-layout {
+        height: calc(100vh - 50px);
+        flex: 1 1 auto;
+        width: 100%;
+        flex-direction: column;
+        min-height: 0;
+    }
+
+    /* Panels - sized for mobile, visibility handled by rendering */
+    .model-manager {
+        width: 100% !important;
+        max-width: 100% !important;
+        min-width: 0 !important;
+        height: 100%;
+        border-right: none;
+        flex: 1 1 auto;
+    }
+
+    .main-content-container {
+        width: 100%;
+        height: 100%;
+        flex: 1 1 auto;
+    }
+
+    /* Chat window - full width on mobile */
+    .chat-window {
+        width: 100%;
+        flex: 1 1 auto !important;
+        border-left: none;
+        min-width: auto;
+    }
+
+    /* Logs window - mobile sizing */
+    .logs-window {
+        width: 100%;
+        height: 100%;
+        flex: 1 1 auto;
+    }
+
+    /* Adjust touch target sizes */
+    .btn {
+        min-height: 44px;
+        min-width: 44px;
+    }
+
+    .form-input,
+    .form-select {
+        min-height: 40px;
+    }
+
+    /* Status indicator - allow text wrapping */
+    .status-indicator {
+        flex-wrap: wrap;
+        gap: 4px;
+        align-items: flex-start;
+    }
+
+    .status-dot {
+        flex-shrink: 0;
+    }
+
+    /* Font sizing for mobile */
+    .chat-message {
+        font-size: 0.9rem;
+    }
+
+    .card p {
+        font-size: 0.9rem;
+    }
+
+    /* Chat adjustments */
+    .chat-header h3 {
+        font-size: 0.75rem;
+    }
+
+    .chat-messages {
+        padding: 12px;
+        gap: 10px;
+    }
+
+    .chat-message {
+        max-width: 95%;
+        font-size: 0.85rem;
+    }
+
+    .user-message {
+        padding: 8px 12px;
+    }
+
+    .chat-input-wrapper {
+        padding: 8px 8px 6px 10px;
+    }
+
+    .chat-input {
+        min-height: 20px;
+        font-size: 0.85rem;
+    }
+
+    .chat-send-button,
+    .chat-stop-button,
+    .image-upload-button {
+        width: 36px;
+        height: 36px;
+        min-width: 36px;
+        min-height: 36px;
+    }
+
+    /* Model manager adjustments */
+    .model-manager-content {
+        font-size: 0.75rem;
+    }
+
+    .model-item {
+        padding: 3px 8px;
+        min-height: 20px;
+    }
+
+    /* Logs adjustments */
+    .logs-content {
+        padding: 12px;
+        font-size: 0.7rem;
+    }
+
+    /* Resizable dividers - hide on mobile */
+    .resizable-divider {
+        display: none;
+    }
+
+    /* Mobile menu dropdown styling */
+    .menu-dropdown {
+        top: 100%;
+        left: 0;
+        width: 200px;
+    }
+
+    .menu-option {
+        padding: 12px 16px;
+        font-size: 0.9rem;
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+    }
+}
+
+@media (max-width: 480px) {
+    /* Extra small screen adjustments */
+    .btn {
+        padding: 8px 12px;
+        font-size: 0.85rem;
+    }
+
+    .card {
+        padding: 10px 12px;
+    }
+
+    header h1 {
+        font-size: 1.2rem;
+    }
+
+    .chat-send-button,
+    .image-upload-button {
+        width: 32px;
+        height: 32px;
+        min-width: 32px;
+        min-height: 32px;
+    }
+}


### PR DESCRIPTION
Rather than showing all panels, it just shows a panel for model manager and for chat.

Also the status bar is disabled.  Here are some screenshots of what it looks like (using Chrome devtools to emulate a mobile device)

<img width="488" height="1070" alt="Screenshot_20260203_234416" src="https://github.com/user-attachments/assets/856db13a-2033-4c89-a0b8-c351ab7757fd" />
<img width="488" height="1070" alt="Screenshot_20260203_234354" src="https://github.com/user-attachments/assets/7266b15c-b4d9-41d4-bbcb-9d64d10dac26" />
