### PR TITLE
Add basic API key support to the webapp

### DIFF
--- a/src/app/src/renderer/utils/serverConfig.ts
+++ b/src/app/src/renderer/utils/serverConfig.ts
@@ -40,7 +40,7 @@ class ServerConfig {
         }
 
         if (this.apiKey != apiKey) {
-           this.setUpdatedAPIKey(apiKey); 
+           this.setUpdatedAPIKey(apiKey);
         }
       });
     }
@@ -48,6 +48,11 @@ class ServerConfig {
 
   private async initialize(): Promise<void> {
     try {
+      // Get API Key if available
+      if (typeof window !== 'undefined'&& window.api?.getServerAPIKey) {
+        this.apiKey = await window.api.getServerAPIKey();
+      }
+
       // In web app mode, use the current origin as the server base URL
       if (typeof window !== 'undefined' && window.api?.isWebApp) {
         const origin = window.location?.origin;
@@ -63,14 +68,9 @@ class ServerConfig {
       // Check if an explicit base URL was configured (--base-url or env var)
       if (typeof window !== 'undefined' && window.api?.getServerBaseUrl && window.api?.getServerAPIKey) {
         const baseUrl = await window.api.getServerBaseUrl();
-        const apiKey = await window.api.getServerAPIKey();
         if (baseUrl) {
           console.log('Using explicit server base URL:', baseUrl);
           this.explicitBaseUrl = baseUrl;
-        }
-
-        if (apiKey) {
-          this.apiKey = apiKey;
         }
 
         this.initialized = true;
@@ -263,7 +263,7 @@ class ServerConfig {
   private notifyUrlListeners() {
     const url = this.getServerBaseUrl();
     const apiKey = this.getAPIKey();
-    
+
     this.urlListeners.forEach((listener) => {
       try {
         listener(url, apiKey);
@@ -283,13 +283,13 @@ class ServerConfig {
       : `${this.getApiBaseUrl()}${endpoint.startsWith('/') ? endpoint : `/${endpoint}`}`;
 
     const options = { ...opts };
-  
+
     if(this.apiKey != null && this.apiKey != '') {
       options.headers = {
         ...options.headers,
         Authorization: `Bearer ${this.apiKey}`,
       }
-    }  
+    }
 
     try {
       const response = await fetch(fullUrl, options);


### PR DESCRIPTION
currently the webapp and API key features are mutually exclusive. This PR fixes this in two ways:

1. The server only applies API authentication to requests under `/api/` so that static files will always be available
2. The API key is read and used also when not running as Electron app

Shortcoming: you will have to refresh the page after entering the API key for the setting to apply. I guess whatever events are used in the electron app are not propagating in the webapp. I am not a web dev and didn't want to make too many changes. Better support can be added later.

Testing:
1. Run `LEMONADE_API_KEY=test build/lemonade-server serve`
2. Open `http://localhost:8000` in the browser
3. Open settings, enter `test` as API key and save.
4. Refresh the page