### PR TITLE
Preserve chat message width when editing

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1993,7 +1993,6 @@ footer {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    width: 100%;
 }
 
 .edit-image-preview-container {
@@ -2006,7 +2005,6 @@ footer {
     display: flex;
     align-items: flex-end;
     gap: 8px;
-    width: 100%;
 }
 
 .edit-message-controls {
@@ -2016,7 +2014,6 @@ footer {
 }
 
 .edit-message-input {
-    flex: 1;
     background: transparent;
     border: none;
     padding: 0;
@@ -2027,6 +2024,9 @@ footer {
     min-height: 20px;
     line-height: 1.5;
     overflow: hidden;
+    min-width: 100px;
+    width: auto;
+    field-sizing: content;
 }
 
 .edit-message-input:focus {


### PR DESCRIPTION
# Description
When editing a user message, the input was jumping to full width (very narrow) instead of staying about the same size as the original message. This made editing big messages very annoying.

Now the text area sizes itself based on content.

## Before
<img width="1187" height="756" alt="image" src="https://github.com/user-attachments/assets/7723c5c6-175e-4a42-ab88-d76e6f014d33" />

## After
<img width="1190" height="764" alt="image" src="https://github.com/user-attachments/assets/c26bc7f5-fe87-4ec9-8e4e-d1000a415264" />

