### PR TITLE
Patching max_tokens in llamacpp to openai server max_completion_tokens

### DIFF
--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -641,11 +641,25 @@ void LlamaCppServer::unload() {
 }
 
 json LlamaCppServer::chat_completion(const json& request) {
-    return forward_request("/v1/chat/completions", request);
+    // OpenAI API compatibility: Transform max_completion_tokens to max_tokens
+    // OpenAI deprecated max_tokens in favor of max_completion_tokens (Sep 2024)
+    // but llama.cpp only supports the older max_tokens parameter
+    json modified_request = request;
+    if (modified_request.contains("max_completion_tokens") && !modified_request.contains("max_tokens")) {
+        modified_request["max_tokens"] = modified_request["max_completion_tokens"];
+    }
+    return forward_request("/v1/chat/completions", modified_request);
 }
 
 json LlamaCppServer::completion(const json& request) {
-    return forward_request("/v1/completions", request);
+    // OpenAI API compatibility: Transform max_completion_tokens to max_tokens
+    // OpenAI deprecated max_tokens in favor of max_completion_tokens (Sep 2024)
+    // but llama.cpp only supports the older max_tokens parameter
+    json modified_request = request;
+    if (modified_request.contains("max_completion_tokens") && !modified_request.contains("max_tokens")) {
+        modified_request["max_tokens"] = modified_request["max_completion_tokens"];
+    }
+    return forward_request("/v1/completions", modified_request);
 }
 
 json LlamaCppServer::embeddings(const json& request) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1200,14 +1200,6 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
         std::string request_body = req.body;
         bool request_modified = false;
 
-        // OpenAI API compatibility: Transform max_completion_tokens to max_tokens
-        // OpenAI deprecated max_tokens in favor of max_completion_tokens (Sep 2024)
-        // but llama.cpp backends only support the older max_tokens parameter
-        if (request_json.contains("max_completion_tokens") && !request_json.contains("max_tokens")) {
-            request_json["max_tokens"] = request_json["max_completion_tokens"];
-            request_modified = true;
-        }
-
         // Handle enable_thinking=false by prepending /no_think to last user message
         if (request_json.contains("enable_thinking") &&
             request_json["enable_thinking"].is_boolean() &&
@@ -1427,20 +1419,6 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
 
         // Use original request body - each backend handles model name transformation internally
         std::string request_body = req.body;
-        bool request_modified = false;
-
-        // OpenAI API compatibility: Transform max_completion_tokens to max_tokens
-        // OpenAI deprecated max_tokens in favor of max_completion_tokens (Sep 2024)
-        // but llama.cpp backends only support the older max_tokens parameter
-        if (request_json.contains("max_completion_tokens") && !request_json.contains("max_tokens")) {
-            request_json["max_tokens"] = request_json["max_completion_tokens"];
-            request_modified = true;
-        }
-
-        // If we modified the request, serialize it back to string
-        if (request_modified) {
-            request_body = request_json.dump();
-        }
 
         if (is_streaming) {
             try {


### PR DESCRIPTION
Adds automatic translation of max_completion_tokens to max_tokens in the llama.cpp backend to support the modern OpenAI API standard (Sep 2024+). OpenAI deprecated max_tokens in favor of max_completion_tokens, but llama.cpp only supports the older parameter, causing requests to ignore token limits and generate indefinitely. The transformation is applied only in LlamaCppServer methods, allowing other backends to handle max_completion_tokens natively if they support it.