### PR TITLE
Add Kwaipilot KAT-Dev model to server_models.json

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -317,6 +317,13 @@
         "labels": ["coding","tool-calling","hot"],
         "size": 43.7
     },
+    "Kwaipilot_KAT-Dev-GGUF": {
+        "checkpoint": "bartowski/Kwaipilot_KAT-Dev-GGUF:Kwaipilot_KAT-Dev-Q6_K_L.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": ["coding"],
+        "size": 26.9
+    },
     "Nemotron-3-Nano-30B-A3B-GGUF": {
         "checkpoint": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF:Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
         "recipe": "llamacpp",


### PR DESCRIPTION
Added bartowski/Kwaipilot_KAT-Dev-GGUF with Q6_K_L quantization (26.9GB). This is a 33B parameter coding model optimized for development tasks.


Change-type: feat
Changelog-entry: Add Kwaipilot KAT-Dev-GGUF coding model