### PR TITLE
Add KwaiCoder-23B-A4B-v1 model to server_models.json

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -317,6 +317,13 @@
         "labels": ["coding","tool-calling","hot"],
         "size": 43.7
     },
+    "KwaiCoder-23B-A4B-v1-GGUF": {
+        "checkpoint": "mradermacher/KwaiCoder-23B-A4B-v1-GGUF:KwaiCoder-23B-A4B-v1.Q8_0.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": ["coding"],
+        "size": 24.5
+    },
     "Nemotron-3-Nano-30B-A3B-GGUF": {
         "checkpoint": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF:Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
         "recipe": "llamacpp",


### PR DESCRIPTION
This model is **Mixtral Architecture based.
I was having some slight issues with generation or equipment while running. Must futher eval model generation quality and prompt template usage.**

Added mradermacher/KwaiCoder-23B-A4B-v1-GGUF with Q8_0 quantization (24.5GB). This is a 23B parameter coding model with A4B architecture for high-quality code generation.


Change-type: feat
Changelog-entry: Add KwaiCoder-23B-A4B-v1-GGUF coding model


