### PR TITLE
Upgrade to Ryzen AI SW 1.7

### DIFF
--- a/docs/server/lemonade-server-cli.md
+++ b/docs/server/lemonade-server-cli.md
@@ -123,7 +123,7 @@ lemonade-server pull <model_name> [options]
 | Option | Description | Required |
 |--------|-------------|----------|
 | `--checkpoint CHECKPOINT` | Hugging Face checkpoint in the format `org/model:variant`. For GGUF models, the variant (after the colon) is required. Examples: `unsloth/Qwen3-8B-GGUF:Q4_0`, `amd/Qwen3-4B-awq-quant-onnx-hybrid` | For custom models |
-| `--recipe RECIPE` | Inference recipe to use. Options: `llamacpp`, `flm`, `oga-cpu`, `oga-hybrid`, `oga-npu` | For custom models |
+| `--recipe RECIPE` | Inference recipe to use. Options: `llamacpp`, `flm`, `ryzenai-llm` | For custom models |
 | `--reasoning` | Mark the model as a reasoning model (e.g., DeepSeek-R1). Adds the 'reasoning' label to model metadata. | No |
 | `--vision` | Mark the model as a vision/multimodal model. Adds the 'vision' label to model metadata. | No |
 | `--embedding` | Mark the model as an embedding model. Adds the 'embeddings' label to model metadata. For use with the `/api/v1/embeddings` endpoint. | No |
@@ -190,7 +190,7 @@ To connect the app to a server running on a different machine:
    lemonade-app
    ```
 
-The app automatically discovers and connects to a local server unless an endpoint is explicitly configured in the UI. 
+The app automatically discovers and connects to a local server unless an endpoint is explicitly configured in the UI.
 
 ## Next Steps
 

--- a/docs/server/server_spec.md
+++ b/docs/server/server_spec.md
@@ -747,7 +747,7 @@ curl http://localhost:8000/api/v1/models?show_all=true
   - `object` - Type of object, always `"model"`
   - `owned_by` - Owner of the model, always `"lemonade"`
   - `checkpoint` - Full checkpoint identifier on Hugging Face
-  - `recipe` - Backend/device recipe used to load the model (e.g., `"oga-cpu"`, `"oga-hybrid"`, `"llamacpp"`, `"flm"`)
+  - `recipe` - Backend/device recipe used to load the model (e.g., `"ryzenai-llm"`, `"llamacpp"`, `"flm"`)
   - `size` - Model size in GB (omitted for models without size information)
   - `downloaded` - Boolean indicating if the model is downloaded and available locally
   - `suggested` - Boolean indicating if the model is recommended for general use
@@ -962,7 +962,7 @@ Explicitly load a registered model into memory. This is useful to ensure that th
 |-----------|----------|------------|-------------|
 | `model_name` | Yes | All | [Lemonade Server model name](./server_models.md) to load. |
 | `save_options` | No | All | Boolean. If true, saves recipe options to `recipe_options.json`. Any previously stored value for `model_name` is replaced. |
-| `ctx_size` | No | llamacpp, flm, oga-* | Context size for the model. Overrides the default value. |
+| `ctx_size` | No | llamacpp, flm, ryzenai-llm | Context size for the model. Overrides the default value. |
 | `llamacpp_backend` | No | llamacpp | LlamaCpp backend to use (`vulkan`, `rocm`, `metal` or `cpu`). |
 | `llamacpp_args` | No | llamacpp | Custom arguments to pass to llama-server. The following are NOT allowed: `-m`, `--port`, `--ctx-size`, `-ngl`. |
 | `whispercpp_backend` | No | whispercpp | WhisperCpp backend to use (`npu` or `cpu`). Default is `npu` if supported. |
@@ -1151,7 +1151,7 @@ curl http://localhost:8000/api/v1/health
       "last_use": 1732123456.789,
       "type": "llm",
       "device": "gpu npu",
-      "recipe": "oga-hybrid",
+      "recipe": "ryzenai-llm",
       "recipe_options": {
         "ctx_size": 4096
       },
@@ -1191,7 +1191,7 @@ curl http://localhost:8000/api/v1/health
   - `type` - Model type: `"llm"`, `"embedding"`, or `"reranking"`
   - `device` - Space-separated device list: `"cpu"`, `"gpu"`, `"npu"`, or combinations like `"gpu npu"`
   - `backend_url` - URL of the backend server process handling this model (useful for debugging)
-  - `recipe`: - Backend/device recipe used to load the model (e.g., `"oga-cpu"`, `"oga-hybrid"`, `"llamacpp"`, `"flm"`)
+  - `recipe`: - Backend/device recipe used to load the model (e.g., `"ryzenai-llm"`, `"llamacpp"`, `"flm"`)
   - `recipe_options`: - Options used to load the model (e.g., `"ctx_size"`, `"llamacpp_backend"`, `"llamacpp_args"`)
 - `max_models` - Maximum number of models that can be loaded simultaneously (set via `--max-loaded-models`):
   - `llm` - Maximum LLM/chat models
@@ -1328,28 +1328,10 @@ curl "http://localhost:8000/api/v1/system-info"
         }
       }
     },
-    "oga-npu": {
+    "ryzenai-llm": {
       "backends": {
         "default": {
           "devices": ["npu"],
-          "supported": true,
-          "available": true
-        }
-      }
-    },
-    "oga-hybrid": {
-      "backends": {
-        "default": {
-          "devices": ["npu"],
-          "supported": true,
-          "available": true
-        }
-      }
-    },
-    "oga-cpu": {
-      "backends": {
-        "default": {
-          "devices": ["cpu"],
           "supported": true,
           "available": true
         }

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -233,10 +233,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isVisible, width = 280 }) =
 
   const getRecipeLabel = (recipe: string): string => {
     const labels: { [key: string]: string } = {
-      'oga-cpu': 'CPU',
-      'oga-hybrid': 'Hybrid',
-      'oga-npu': 'NPU',
-      'oga-igpu': 'iGPU',
+      'ryzenai-llm': 'RyzenAI',
       'llamacpp': 'GGUF',
       'flm': 'FLM',
       'whispercpp': 'Whisper.cpp'
@@ -278,9 +275,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isVisible, width = 280 }) =
       const recipeLabels: { [key: string]: string } = {
         'flm': 'FastFlowLM NPU',
         'llamacpp': 'Llama.cpp GPU',
-        'oga-cpu': 'ONNX Runtime CPU',
-        'oga-hybrid': 'ONNX Runtime Hybrid',
-        'oga-npu': 'ONNX Runtime NPU',
+        'ryzenai-llm': 'Ryzen AI LLM',
         'whispercpp': 'Whisper.cpp',
         'sd-cpp': 'StableDiffusion.cpp'
       };
@@ -1013,9 +1008,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isVisible, width = 280 }) =
                 <option value="">Select a recipe...</option>
                 <option value="llamacpp">Llama.cpp GPU</option>
                 <option value="flm">FastFlowLM NPU</option>
-                <option value="oga-cpu">ONNX Runtime CPU</option>
-                <option value="oga-hybrid">ONNX Runtime Hybrid</option>
-                <option value="oga-npu">ONNX Runtime NPU</option>
+                <option value="ryzenai-llm">Ryzen AI LLM</option>
               </select>
             </div>
 

--- a/src/app/src/renderer/hooks/useSystem.tsx
+++ b/src/app/src/renderer/hooks/useSystem.tsx
@@ -10,7 +10,7 @@ interface SystemContextValue {
 
 // Programmatic structure: recipe -> list of supported backends
 export interface SupportedRecipes {
-  [recipeName: string]: string[]; // e.g., { llamacpp: ['vulkan', 'rocm', 'cpu'], 'oga-hybrid': ['default'] }
+  [recipeName: string]: string[]; // e.g., { llamacpp: ['vulkan', 'rocm', 'cpu'], 'ryzenai-llm': ['default'] }
 }
 
 const SystemContext = createContext<SystemContextValue | null>(null);

--- a/src/app/src/renderer/recipes/recipeOptions.ts
+++ b/src/app/src/renderer/recipes/recipeOptions.ts
@@ -15,18 +15,18 @@ export {
   LlamaOptions,
   WhisperOptions,
   FlmOptions,
-  OgaOptions,
-  OgaRecipe,
+  RyzenAIOptions,
+  RyzenAIRecipe,
   StableDiffusionOptions,
 
   // Union type
   RecipeOptions,
 
   // Constants
-  OGA_RECIPES,
+  RYZENAI_RECIPES,
 
   // Utilities
-  isOgaRecipe,
+  isRyzenAIRecipe,
   getOptionsForRecipe,
   getOptionDefinition,
   clampOptionValue,

--- a/src/app/src/renderer/recipes/recipeOptionsConfig.ts
+++ b/src/app/src/renderer/recipes/recipeOptionsConfig.ts
@@ -51,10 +51,10 @@ export interface FlmOptions {
   saveOptions: BooleanOption;
 }
 
-export type OgaRecipe = 'oga-cpu' | 'oga-npu' | 'oga-hybrid';
+export type RyzenAIRecipe = 'ryzenai-llm';
 
-export interface OgaOptions {
-  recipe: OgaRecipe;
+export interface RyzenAIOptions {
+  recipe: RyzenAIRecipe;
   ctxSize: NumericOption;
   saveOptions: BooleanOption;
 }
@@ -69,19 +69,19 @@ export interface StableDiffusionOptions {
 }
 
 // Union type of all recipe options
-export type RecipeOptions = LlamaOptions | WhisperOptions | FlmOptions | OgaOptions | StableDiffusionOptions;
+export type RecipeOptions = LlamaOptions | WhisperOptions | FlmOptions | RyzenAIOptions | StableDiffusionOptions;
 
 // =============================================================================
 // Recipe Constants
 // =============================================================================
 
-export const OGA_RECIPES: OgaRecipe[] = ['oga-cpu', 'oga-npu', 'oga-hybrid'];
+export const RYZENAI_RECIPES: RyzenAIRecipe[] = ['ryzenai-llm'];
 
 /**
- * Checks if a recipe name is an OGA recipe
+ * Checks if a recipe name is a RyzenAI recipe
  */
-export function isOgaRecipe(recipe: string): boolean {
-  return OGA_RECIPES.includes(recipe as OgaRecipe);
+export function isRyzenAIRecipe(recipe: string): boolean {
+  return RYZENAI_RECIPES.includes(recipe as RyzenAIRecipe);
 }
 
 // =============================================================================
@@ -123,7 +123,7 @@ export type OptionDef = NumericOptionDef | StringOptionDef | BooleanOptionDef;
 // =============================================================================
 
 export const OPTION_DEFINITIONS: Record<string, OptionDef> = {
-  // LLM context size option (shared by llamacpp, flm, oga-*)
+  // LLM context size option (shared by llamacpp, flm, ryzenai-llm)
   ctxSize: {
     type: 'numeric',
     default: 4096,
@@ -211,7 +211,7 @@ export const OPTION_DEFINITIONS: Record<string, OptionDef> = {
 // Recipe Configuration - Maps recipes to their available options
 // =============================================================================
 
-export type RecipeName = 'llamacpp' | 'whispercpp' | 'flm' | 'oga-cpu' | 'oga-npu' | 'oga-hybrid' | 'sd-cpp';
+export type RecipeName = 'llamacpp' | 'whispercpp' | 'flm' | 'ryzenai-llm' | 'sd-cpp';
 
 /**
  * Maps recipe names to the option keys they support.
@@ -221,9 +221,7 @@ export const RECIPE_OPTIONS_MAP: Record<RecipeName, string[]> = {
   'llamacpp': ['ctxSize', 'llamacppBackend', 'llamacppArgs', 'saveOptions'],
   'whispercpp': ['whispercppBackend', 'saveOptions'],
   'flm': ['ctxSize', 'saveOptions'],
-  'oga-cpu': ['ctxSize', 'saveOptions'],
-  'oga-npu': ['ctxSize', 'saveOptions'],
-  'oga-hybrid': ['ctxSize', 'saveOptions'],
+  'ryzenai-llm': ['ctxSize', 'saveOptions'],
   'sd-cpp': ['steps', 'cfgScale', 'width', 'height', 'saveOptions'],
 };
 

--- a/src/cpp/Multi-Model-Spec.md
+++ b/src/cpp/Multi-Model-Spec.md
@@ -47,8 +47,7 @@ This "nuclear" policy simplifies implementation while remaining effective in pra
 ### NPU Exclusivity
 
 Only one model can occupy the NPU at a time. The following recipes use the NPU:
-- `oga-hybrid`
-- `oga-npu`
+- `ryzenai-llm`
 - `flm`
 
 When loading a WrappedServer with an NPU recipe, any existing NPU-using WrappedServer is evicted regardless of type or `--max-loaded-models` settings.
@@ -59,9 +58,7 @@ When loading a WrappedServer with an NPU recipe, any existing NPU-using WrappedS
 | Recipe | Device(s) |
 |--------|-----------|
 | `llamacpp` | gpu |
-| `oga-hybrid` | gpu, npu |
-| `oga-npu` | npu |
-| `oga-cpu` | cpu |
+| `ryzenai-llm` | npu |
 | `flm` | npu |
 
 ModelInfo and WrappedServer include a bitmask enum field for tracking target devices, enabling checks like `if (model.device & Device::NPU)`.

--- a/src/cpp/include/lemon/backends/ryzenaiserver.h
+++ b/src/cpp/include/lemon/backends/ryzenaiserver.h
@@ -31,9 +31,6 @@ public:
              const RecipeOptions& options,
              bool do_not_upgrade = false) override;
 
-    // RyzenAI-specific: set execution mode before loading
-    void set_execution_mode(const std::string& mode) { execution_mode_ = mode; }
-
     // RyzenAI-specific: set model path before loading
     void set_model_path(const std::string& path) { model_path_ = path; }
 
@@ -47,15 +44,10 @@ public:
 private:
     std::string model_name_;
     std::string model_path_;
-    std::string execution_mode_; // "auto", "npu", or "hybrid"
     bool is_loaded_;
 
     // Helper to download and install ryzenai-server
     static void download_and_install(const std::string& version);
-
-    // Helper to determine best execution mode based on model
-    std::string determine_execution_mode(const std::string& model_path,
-                                        const std::string& backend);
 };
 
 } // namespace lemon

--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -14,7 +14,7 @@ enum class ModelType {
 };
 
 // Device type flags for tracking hardware usage
-// Uses bitmask pattern for models that use multiple devices (e.g., oga-hybrid)
+// Uses bitmask pattern for models that use multiple devices
 enum DeviceType : uint32_t {
     DEVICE_NONE = 0,
     DEVICE_CPU  = 1 << 0,  // 0x01
@@ -89,12 +89,8 @@ inline ModelType get_model_type_from_labels(const std::vector<std::string>& labe
 inline DeviceType get_device_type_from_recipe(const std::string& recipe) {
     if (recipe == "llamacpp") {
         return DEVICE_GPU;
-    } else if (recipe == "oga-hybrid") {
-        return DEVICE_GPU | DEVICE_NPU;
-    } else if (recipe == "oga-npu") {
+    } else if (recipe == "ryzenai-llm") {
         return DEVICE_NPU;
-    } else if (recipe == "oga-cpu") {
-        return DEVICE_CPU;
     } else if (recipe == "flm") {
         return DEVICE_NPU;
     } else if (recipe == "whispercpp") {

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -15,7 +15,7 @@
   "sd-cpp": {
     "cpu": "master-471-7010bb4"
   },
-  "ryzenai-server": "v1.0.2",
+  "ryzenai-server": "v1.7.0",
   "flm": {
     "version": "v0.9.31",
     "min_npu_driver": "32.0.203.304"

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1,245 +1,544 @@
 {
     "Qwen2.5-0.5B-Instruct-CPU": {
         "checkpoint": "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx",
-        "recipe": "oga-cpu",
+        "recipe": "ryzenai-llm",
         "suggested": true,
         "size": 0.77
     },
     "Llama-3.2-1B-Instruct-CPU": {
         "checkpoint": "amd/Llama-3.2-1B-Instruct-awq-uint4-float16-cpu-onnx",
-        "recipe": "oga-cpu",
+        "recipe": "ryzenai-llm",
         "suggested": false,
         "size": 1.64
     },
     "Llama-3.2-3B-Instruct-CPU": {
         "checkpoint": "amd/Llama-3.2-3B-Instruct-awq-uint4-float16-cpu-onnx",
-        "recipe": "oga-cpu",
+        "recipe": "ryzenai-llm",
         "suggested": false,
         "size": 3.15
     },
     "Phi-3-Mini-Instruct-CPU": {
         "checkpoint": "amd/Phi-3-mini-4k-instruct_int4_float16_onnx_cpu",
-        "recipe": "oga-cpu",
+        "recipe": "ryzenai-llm",
         "suggested": true,
         "size": 2.23
     },
     "Qwen-1.5-7B-Chat-CPU": {
         "checkpoint": "amd/Qwen1.5-7B-Chat_uint4_asym_g128_float16_onnx_cpu",
-        "recipe": "oga-cpu",
+        "recipe": "ryzenai-llm",
         "suggested": true,
         "size": 5.89
     },
     "DeepSeek-R1-Distill-Llama-8B-CPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-awq-asym-uint4-g128-lmhead-onnx-cpu",
-        "recipe": "oga-cpu",
+        "recipe": "ryzenai-llm",
         "suggested": true,
         "labels": ["reasoning"],
         "size": 5.78
     },
     "DeepSeek-R1-Distill-Qwen-7B-CPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-awq-asym-uint4-g128-lmhead-onnx-cpu",
-        "recipe": "oga-cpu",
+        "recipe": "ryzenai-llm",
         "suggested": true,
         "labels": ["reasoning"],
         "size": 5.78
     },
-    "Llama-3.2-1B-Instruct-Hybrid": {
-        "checkpoint": "amd/Llama-3.2-1B-Instruct-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
+    "AMD-OLMo-1B-SFT-DPO-Hybrid": {
+        "checkpoint": "amd/AMD-OLMo-1B-SFT-DPO-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 1.89
+        "size": 1.38
     },
-    "Llama-3.2-3B-Instruct-Hybrid": {
-        "checkpoint": "amd/Llama-3.2-3B-Instruct-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
+    "CodeLlama-7b-Instruct-hf-Hybrid": {
+        "checkpoint": "amd/CodeLlama-7b-Instruct-hf-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 4.28
-    },
-    "Phi-3-Mini-Instruct-Hybrid": {
-        "checkpoint": "amd/Phi-3-mini-4k-instruct-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
-        "suggested": true,
-        "size": 4.18
-    },
-    "Phi-3.5-Mini-Instruct-Hybrid": {
-        "checkpoint": "amd/Phi-3.5-mini-instruct-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
-        "suggested": false,
-        "size": 4.21
-    },
-    "Qwen-1.5-7B-Chat-Hybrid": {
-        "checkpoint": "amd/Qwen1.5-7B-Chat-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
-        "suggested": true,
-        "size": 8.83
-    },
-    "Qwen-2.5-7B-Instruct-Hybrid": {
-        "checkpoint": "amd/Qwen2.5-7B-Instruct-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
-        "suggested": true,
-        "size": 8.65
-    },
-    "Qwen-2.5-3B-Instruct-Hybrid": {
-        "checkpoint": "amd/Qwen2.5-3B-Instruct-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
-        "suggested": true,
-        "size": 3.97
-    },
-    "Qwen-2.5-1.5B-Instruct-Hybrid": {
-    "checkpoint": "amd/Qwen-2.5-1.5B-Instruct-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
-        "suggested": true,
-        "size": 2.16
+        "size": 6.74,
+        "labels": [
+            "coding"
+        ]
     },
     "DeepSeek-R1-Distill-Llama-8B-Hybrid": {
-        "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
+        "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "labels": ["reasoning"],
-        "size": 9.09
+        "size": 8.47,
+        "labels": [
+            "reasoning"
+        ]
+    },
+    "DeepSeek-R1-Distill-Qwen-1.5B-Hybrid": {
+        "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-1.5B-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 2.04,
+        "labels": [
+            "reasoning"
+        ]
     },
     "DeepSeek-R1-Distill-Qwen-7B-Hybrid": {
-        "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-7B-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
-        "max_prompt_length": 2000,
-        "suggested": false,
-        "labels": ["reasoning"],
-        "size": 8.67
-    },
-    "Mistral-7B-v0.3-Instruct-Hybrid": {
-        "checkpoint": "amd/Mistral-7B-Instruct-v0.3-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
+        "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-7B-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 7.85
+        "size": 8.08,
+        "labels": [
+            "reasoning"
+        ]
     },
-    "Llama-3.1-8B-Instruct-Hybrid": {
-        "checkpoint": "amd/Meta-Llama-3.1-8B-Instruct-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
+    "Llama-2-7b-chat-hf-Hybrid": {
+        "checkpoint": "amd/Llama-2-7b-chat-hf-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 9.09
+        "size": 6.8
+    },
+    "Llama-2-7b-hf-Hybrid": {
+        "checkpoint": "amd/Llama-2-7b-hf-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 6.8
+    },
+    "Llama-3.1-8B-Hybrid": {
+        "checkpoint": "amd/Llama-3.1-8B-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.47
+    },
+    "Llama-3.2-1B-Hybrid": {
+        "checkpoint": "amd/Llama-3.2-1B-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 1.76
+    },
+    "Llama-3.2-1B-Instruct-Hybrid": {
+        "checkpoint": "amd/Llama-3.2-1B-Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 1.76
+    },
+    "Llama-3.2-3B-Hybrid": {
+        "checkpoint": "amd/Llama-3.2-3B-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 3.98
+    },
+    "Llama-3.2-3B-Instruct-Hybrid": {
+        "checkpoint": "amd/Llama-3.2-3B-Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 3.98
+    },
+    "Meta-Llama-3-8B-Hybrid": {
+        "checkpoint": "amd/Meta-Llama-3-8B-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.44
+    },
+    "Meta-Llama-3.1-8B-Instruct-Hybrid": {
+        "checkpoint": "amd/Meta-Llama-3.1-8B-Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.47
+    },
+    "Mistral-7B-Instruct-v0.1-Hybrid": {
+        "checkpoint": "amd/Mistral-7B-Instruct-v0.1-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 7.3
+    },
+    "Mistral-7B-Instruct-v0.2-Hybrid": {
+        "checkpoint": "amd/Mistral-7B-Instruct-v0.2-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 7.3
+    },
+    "Mistral-7B-Instruct-v0.3-Hybrid": {
+        "checkpoint": "amd/Mistral-7B-Instruct-v0.3-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 7.31
+    },
+    "Mistral-7B-v0.3-Hybrid": {
+        "checkpoint": "amd/Mistral-7B-v0.3-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 7.31
+    },
+    "Phi-3-mini-128k-instruct-Hybrid": {
+        "checkpoint": "amd/Phi-3-mini-128k-instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 3.92
+    },
+    "Phi-3-mini-4k-instruct-Hybrid": {
+        "checkpoint": "amd/Phi-3-mini-4k-instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 3.9
+    },
+    "Phi-3.5-mini-instruct-Hybrid": {
+        "checkpoint": "amd/Phi-3.5-mini-instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 3.92
+    },
+    "Phi-4-mini-instruct-Hybrid": {
+        "checkpoint": "amd/Phi-4-mini-instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 5.1
+    },
+    "Phi-4-mini-reasoning-Hybrid": {
+        "checkpoint": "amd/Phi-4-mini-reasoning-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 5.1,
+        "labels": [
+            "reasoning"
+        ]
+    },
+    "Qwen-2.5-1.5B-Instruct-Hybrid": {
+        "checkpoint": "amd/Qwen-2.5_1.5B_Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 2.02
+    },
+    "Qwen1.5-7B-Chat-Hybrid": {
+        "checkpoint": "amd/Qwen1.5-7B-Chat-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.23
+    },
+    "Qwen2-1.5B-Hybrid": {
+        "checkpoint": "amd/Qwen2-1.5B-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 2.04
+    },
+    "Qwen2-7B-Hybrid": {
+        "checkpoint": "amd/Qwen2-7B-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.08
+    },
+    "Qwen2.5-0.5B-Instruct-Hybrid": {
+        "checkpoint": "amd/Qwen2.5-0.5B-Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 0.77
+    },
+    "Qwen2.5-14B-instruct-Hybrid": {
+        "checkpoint": "amd/Qwen2.5-14B-instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 15.31
+    },
+    "Qwen2.5-3B-Instruct-Hybrid": {
+        "checkpoint": "amd/Qwen2.5_3B_Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 3.7
+    },
+    "Qwen2.5-7B-Instruct-Hybrid": {
+        "checkpoint": "amd/Qwen2.5-7B-Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.06
+    },
+    "Qwen2.5-Coder-0.5B-Instruct-Hybrid": {
+        "checkpoint": "amd/Qwen2.5-Coder-0.5B-Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 0.77,
+        "labels": [
+            "coding"
+        ]
+    },
+    "Qwen2.5-Coder-1.5B-Instruct-Hybrid": {
+        "checkpoint": "amd/Qwen2.5-Coder-1.5B-Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 2.02,
+        "labels": [
+            "coding"
+        ]
+    },
+    "Qwen2.5-Coder-7B-Instruct-Hybrid": {
+        "checkpoint": "amd/Qwen2.5-Coder-7B-Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.06,
+        "labels": [
+            "coding"
+        ]
     },
     "Qwen3-1.7B-Hybrid": {
-        "checkpoint": "amd/Qwen3-1.7B-awq-quant-onnx-hybrid",
-        "recipe": "oga-hybrid",
+        "checkpoint": "amd/Qwen3-1.7B-awq-quant-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "labels": ["reasoning"],
-        "size": 2.55
+        "size": 2.38,
+        "labels": [
+            "reasoning"
+        ]
     },
-    "Phi-4-Mini-Instruct-Hybrid": {
-        "checkpoint": "amd/Phi-4-mini-instruct-onnx-ryzenai-hybrid",
-        "recipe": "oga-hybrid",
+    "Qwen3-14B-Hybrid": {
+        "checkpoint": "amd/Qwen3-14B-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 5.46
+        "size": 15.31,
+        "labels": [
+            "reasoning"
+        ]
     },
     "Qwen3-4B-Hybrid": {
-        "checkpoint": "amd/Qwen3-4B-awq-quant-onnx-hybrid",
-        "recipe": "oga-hybrid",
+        "checkpoint": "amd/Qwen3-4B-awq-quant-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "labels": ["reasoning"],
-        "size": 5.17
+        "size": 4.82,
+        "labels": [
+            "reasoning"
+        ]
     },
     "Qwen3-8B-Hybrid": {
-        "checkpoint": "amd/Qwen3-8B-awq-quant-onnx-hybrid",
-        "recipe": "oga-hybrid",
+        "checkpoint": "amd/Qwen3-8B-awq-quant-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "labels": ["reasoning"],
-        "size": 9.42
+        "size": 8.77,
+        "labels": [
+            "reasoning"
+        ]
     },
-    "Qwen-2.5-7B-Instruct-NPU": {
-        "checkpoint": "amd/Qwen2.5-7B-Instruct-onnx-ryzenai-npu",
-        "recipe": "oga-npu",
+    "SmolLM-135M-Instruct-Hybrid": {
+        "checkpoint": "amd/SmolLM-135M-Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.82
+        "size": 0.22
     },
-    "Qwen-2.5-3B-Instruct-NPU": {
-        "checkpoint": "amd/Qwen2.5-3B-Instruct-onnx-ryzenai-npu",
-        "recipe": "oga-npu",
+    "SmolLM2-135M-Instruct-Hybrid": {
+        "checkpoint": "amd/SmolLM2-135M-Instruct-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 4.09
+        "size": 0.22
+    },
+    "chatglm3-6b-Hybrid": {
+        "checkpoint": "amd/chatglm3-6b-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 6.43
+    },
+    "gemma-2-2b-Hybrid": {
+        "checkpoint": "amd/gemma-2-2b-onnx-ryzenai-1.7-hybrid",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 3.76
+    },
+    "CodeLlama-7b-Instruct-hf-NPU": {
+        "checkpoint": "amd/CodeLlama-7b-Instruct-hf-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 7.03,
+        "labels": [
+            "coding"
+        ]
     },
     "DeepSeek-R1-Distill-Llama-8B-NPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-onnx-ryzenai-npu",
-        "recipe": "oga-npu",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 9.30
-    },
-    "DeepSeek-R1-Distill-Qwen-7B-NPU": {
-        "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-7B-onnx-ryzenai-npu",
-        "recipe": "oga-npu",
-        "suggested": false,
-        "size": 8.87
+        "size": 8.66,
+        "labels": [
+            "reasoning"
+        ]
     },
     "DeepSeek-R1-Distill-Qwen-1.5B-NPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-1.5B-onnx-ryzenai-npu",
-        "recipe": "oga-npu",
-        "suggested": false,
-        "size": 2.30
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 2.14,
+        "labels": [
+            "reasoning"
+        ]
+    },
+    "DeepSeek-R1-Distill-Qwen-7B-NPU": {
+        "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-7B-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.26,
+        "labels": [
+            "reasoning"
+        ]
+    },
+    "Gemma-3-4b-it-mm-NPU": {
+        "checkpoint": "amd/Gemma-3-4b-it-mm-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 6.22,
+        "labels": [
+            "vision"
+        ]
+    },
+    "Llama-2-7b-chat-hf-NPU": {
+        "checkpoint": "amd/Llama-2-7b-chat-hf-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 6.95
+    },
+    "Llama-2-7b-hf-NPU": {
+        "checkpoint": "amd/Llama-2-7b-hf-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 6.95
+    },
+    "Llama-3.1-8B-NPU": {
+        "checkpoint": "amd/Llama-3.1-8B-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.66
     },
     "Llama-3.2-1B-Instruct-NPU": {
         "checkpoint": "amd/Llama-3.2-1B-Instruct-onnx-ryzenai-npu",
-        "recipe": "oga-npu",
-        "suggested": false,
-        "size": 1.96
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 1.82
     },
-    "Mistral-7B-v0.3-Instruct-NPU": {
+    "Llama-3.2-1B-NPU": {
+        "checkpoint": "amd/Llama-3.2-1B-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 1.82
+    },
+    "Meta-Llama-3-8B-NPU": {
+        "checkpoint": "amd/Meta-Llama-3-8B-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.6
+    },
+    "Meta-Llama-3.1-8B-Instruct-NPU": {
+        "checkpoint": "amd/Meta-Llama-3.1-8B-Instruct-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.66
+    },
+    "Mistral-7B-Instruct-v0.1-NPU": {
+        "checkpoint": "amd/Mistral-7B-Instruct-v0.1-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 7.46
+    },
+    "Mistral-7B-Instruct-v0.2-NPU": {
+        "checkpoint": "amd/Mistral-7B-Instruct-v0.2-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 7.46
+    },
+    "Mistral-7B-Instruct-v0.3-NPU": {
         "checkpoint": "amd/Mistral-7B-Instruct-v0.3-onnx-ryzenai-npu",
-        "recipe": "oga-npu",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.09
+        "size": 7.54
     },
-    "Phi-3.5-Mini-Instruct-NPU": {
+    "Mistral-7B-v0.3-NPU": {
+        "checkpoint": "amd/Mistral-7B-v0.3-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 7.54
+    },
+    "Phi-3-mini-128k-instruct-NPU": {
+        "checkpoint": "amd/Phi-3-mini-128k-instruct-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 4.05
+    },
+    "Phi-3-mini-4k-instruct-NPU": {
+        "checkpoint": "amd/Phi-3-mini-4k-instruct-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 4.0
+    },
+    "Phi-3.5-mini-instruct-NPU": {
         "checkpoint": "amd/Phi-3.5-mini-instruct-onnx-ryzenai-npu",
-        "recipe": "oga-npu",
+        "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 4.35
+        "size": 4.05
     },
-    "ChatGLM-3-6b-Instruct-NPU": {
-        "checkpoint": "amd/chatglm3-6b-onnx-ryzenai-npu",
-        "recipe": "oga-npu",
-        "suggested": false,
-        "size": 7.03
+    "Phi-4-mini-instruct-NPU": {
+        "checkpoint": "amd/Phi-4-mini-instruct-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 5.21
     },
-    "Llama-3.2-1B-Instruct-DirectML": {
-        "checkpoint": "amd/Llama-3.2-1B-Instruct-dml-int4-awq-block-128-directml",
-        "recipe": "oga-igpu",
-        "suggested": false,
-        "size": 2.81
+    "Qwen-2.5-1.5B-Instruct-NPU": {
+        "checkpoint": "amd/Qwen-2.5_1.5B_Instruct-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 2.1
     },
-    "Llama-3.2-3B-Instruct-DirectML": {
-        "checkpoint": "amd/Llama-3.2-3B-Instruct-dml-int4-awq-block-128-directml",
-        "recipe": "oga-igpu",
-        "suggested": false,
-        "size": 6.75
+    "Qwen1.5-7B-Chat-NPU": {
+        "checkpoint": "amd/Qwen1.5-7B-Chat-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.4
     },
-    "Phi-3.5-Mini-Instruct-DirectML": {
-        "checkpoint": "amd/phi3.5-mini-instruct-int4-awq-block-128-directml",
-        "recipe": "oga-igpu",
-        "suggested": false,
+    "Qwen2-1.5B-NPU": {
+        "checkpoint": "amd/Qwen2-1.5B-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
         "size": 2.14
     },
-    "Qwen-1.5-7B-Chat-DirectML": {
-        "checkpoint": "amd/Qwen1.5-7B-Chat-dml-int4-awq-block-128-directml",
-        "recipe": "oga-igpu",
-        "suggested": false,
-        "size": 3.73
+    "Qwen2-7B-NPU": {
+        "checkpoint": "amd/Qwen2-7B-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.27
     },
-    "Mistral-7B-v0.1-Instruct-DirectML": {
-        "checkpoint": "amd/Mistral-7B-Instruct-v0.1-awq-g128-int4-onnx-directml",
-        "recipe": "oga-igpu",
-        "suggested": false,
-        "size": 3.67
+    "Qwen2.5-3B-Instruct-NPU": {
+        "checkpoint": "amd/Qwen2.5-3B-Instruct-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 3.81
     },
-    "Llama-3-8B-Instruct-DirectML": {
-        "checkpoint": "amd/llama3-8b-instruct-awq-g128-int4-onnx-directml",
-        "recipe": "oga-igpu",
-        "suggested": false,
-        "size": 4.61
+    "Qwen2.5-7B-Instruct-NPU": {
+        "checkpoint": "amd/Qwen2.5-7B-Instruct-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.22
+    },
+    "Qwen2.5-Coder-1.5B-Instruct-NPU": {
+        "checkpoint": "amd/Qwen2.5-Coder-1.5B-Instruct-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 2.1,
+        "labels": [
+            "coding"
+        ]
+    },
+    "Qwen2.5-Coder-7B-Instruct-NPU": {
+        "checkpoint": "amd/Qwen2.5-Coder-7B-Instruct-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 8.22,
+        "labels": [
+            "coding"
+        ]
+    },
+    "chatglm3-6b-NPU": {
+        "checkpoint": "amd/chatglm3-6b-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 6.55
+    },
+    "gpt-oss-20b-NPU": {
+        "checkpoint": "amd/gpt-oss-20b-onnx-ryzenai-npu",
+        "recipe": "ryzenai-llm",
+        "suggested": true,
+        "size": 12.49
     },
     "Qwen3-0.6B-GGUF": {
         "checkpoint": "unsloth/Qwen3-0.6B-GGUF:Q4_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 0.38
     },
     "Tiny-Test-Model-GGUF": {
@@ -252,49 +551,63 @@
         "checkpoint": "unsloth/Qwen3-1.7B-GGUF:Q4_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 1.06
     },
     "Qwen3-4B-GGUF": {
         "checkpoint": "unsloth/Qwen3-4B-GGUF:Q4_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 2.38
     },
     "Qwen3-8B-GGUF": {
         "checkpoint": "unsloth/Qwen3-8B-GGUF:Q4_1",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 5.25
     },
     "DeepSeek-Qwen3-8B-GGUF": {
         "checkpoint": "unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF:Q4_1",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 5.25
     },
     "Qwen3-14B-GGUF": {
         "checkpoint": "unsloth/Qwen3-14B-GGUF:Q4_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 8.54
     },
     "Qwen3-4B-Instruct-2507-GGUF": {
         "checkpoint": "unsloth/Qwen3-4B-Instruct-2507-GGUF:Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot"],
+        "labels": [
+            "hot"
+        ],
         "size": 2.5
     },
     "Qwen3-30B-A3B-GGUF": {
         "checkpoint": "unsloth/Qwen3-30B-A3B-GGUF:Q4_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 17.4
     },
     "Qwen3-30B-A3B-Instruct-2507-GGUF": {
@@ -307,21 +620,31 @@
         "checkpoint": "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["coding","tool-calling","hot"],
+        "labels": [
+            "coding",
+            "tool-calling",
+            "hot"
+        ],
         "size": 18.6
     },
     "Qwen3-Coder-Next-GGUF": {
         "checkpoint": "unsloth/Qwen3-Coder-Next-GGUF:Qwen3-Coder-Next-MXFP4_MOE.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["coding","tool-calling","hot"],
+        "labels": [
+            "coding",
+            "tool-calling",
+            "hot"
+        ],
         "size": 43.7
     },
     "Nemotron-3-Nano-30B-A3B-GGUF": {
         "checkpoint": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF:Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot"],
+        "labels": [
+            "hot"
+        ],
         "size": 22.8
     },
     "Gemma-3-4b-it-GGUF": {
@@ -329,7 +652,10 @@
         "mmproj": "mmproj-model-f16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot","vision"],
+        "labels": [
+            "hot",
+            "vision"
+        ],
         "size": 3.61
     },
     "Phi-4-mini-instruct-GGUF": {
@@ -379,7 +705,9 @@
         "mmproj": "Ministral-3-3B-Instruct-2512-BF16-mmproj.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["vision"],
+        "labels": [
+            "vision"
+        ],
         "size": 2.85
     },
     "Qwen2.5-VL-7B-Instruct-GGUF": {
@@ -387,7 +715,9 @@
         "mmproj": "mmproj-Qwen2.5-VL-7B-Instruct-f16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["vision"],
+        "labels": [
+            "vision"
+        ],
         "size": 4.68
     },
     "Qwen3-VL-4B-Instruct-GGUF": {
@@ -395,7 +725,9 @@
         "mmproj": "mmproj-Qwen3VL-4B-Instruct-F16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["vision"],
+        "labels": [
+            "vision"
+        ],
         "size": 3.33
     },
     "Qwen3-VL-8B-Instruct-GGUF": {
@@ -403,14 +735,18 @@
         "mmproj": "mmproj-Qwen3VL-8B-Instruct-F16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["vision"],
+        "labels": [
+            "vision"
+        ],
         "size": 6.19
     },
     "Qwen3-Next-80B-A3B-Instruct-GGUF": {
         "checkpoint": "unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF:Qwen3-Next-80B-A3B-Instruct-UD-Q4_K_XL.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot"],
+        "labels": [
+            "hot"
+        ],
         "size": 45.1
     },
     "Llama-4-Scout-17B-16E-Instruct-GGUF": {
@@ -418,7 +754,9 @@
         "mmproj": "mmproj-F16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["vision"],
+        "labels": [
+            "vision"
+        ],
         "size": 61.5
     },
     "Cogito-v2-llama-109B-MoE-GGUF": {
@@ -426,126 +764,169 @@
         "mmproj": "mmproj-F16.gguf",
         "recipe": "llamacpp",
         "suggested": false,
-        "labels": ["vision"],
+        "labels": [
+            "vision"
+        ],
         "size": 65.3
     },
     "nomic-embed-text-v1-GGUF": {
         "checkpoint": "nomic-ai/nomic-embed-text-v1-GGUF:Q4_K_S",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["embeddings"],
+        "labels": [
+            "embeddings"
+        ],
         "size": 0.0781
     },
     "nomic-embed-text-v2-moe-GGUF": {
         "checkpoint": "nomic-ai/nomic-embed-text-v2-moe-GGUF:Q8_0",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["embeddings"],
+        "labels": [
+            "embeddings"
+        ],
         "size": 0.51
     },
     "Qwen3-Embedding-0.6B-GGUF": {
         "checkpoint": "Qwen/Qwen3-Embedding-0.6B-GGUF:Qwen3-Embedding-0.6B-Q8_0.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["embeddings"],
+        "labels": [
+            "embeddings"
+        ],
         "size": 0.64
     },
     "Qwen3-Embedding-4B-GGUF": {
         "checkpoint": "Qwen/Qwen3-Embedding-4B-GGUF:Qwen3-Embedding-4B-Q8_0.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["embeddings"],
+        "labels": [
+            "embeddings"
+        ],
         "size": 4.28
     },
     "Qwen3-Embedding-8B-GGUF": {
         "checkpoint": "Qwen/Qwen3-Embedding-8B-GGUF:Qwen3-Embedding-8B-Q8_0.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["embeddings"],
+        "labels": [
+            "embeddings"
+        ],
         "size": 8.05
     },
     "bge-reranker-v2-m3-GGUF": {
         "checkpoint": "pqnet/bge-reranker-v2-m3-Q8_0-GGUF",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reranking"],
+        "labels": [
+            "reranking"
+        ],
         "size": 0.53
     },
     "jina-reranker-v1-tiny-en-GGUF": {
         "checkpoint": "mradermacher/jina-reranker-v1-tiny-en-GGUF:Q8_0",
         "recipe": "llamacpp",
         "suggested": false,
-        "labels": ["reranking"],
+        "labels": [
+            "reranking"
+        ],
         "size": 0.03
     },
-    "Devstral-Small-2507-GGUF":{
+    "Devstral-Small-2507-GGUF": {
         "checkpoint": "mistralai/Devstral-Small-2507_gguf:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["coding","tool-calling"],
+        "labels": [
+            "coding",
+            "tool-calling"
+        ],
         "size": 14.3
     },
     "Qwen2.5-Coder-32B-Instruct-GGUF": {
         "checkpoint": "Qwen/Qwen2.5-Coder-32B-Instruct-GGUF:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["coding"],
+        "labels": [
+            "coding"
+        ],
         "size": 19.85
     },
     "gpt-oss-120b-GGUF": {
         "checkpoint": "unsloth/gpt-oss-120b-GGUF:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": false,
-        "labels": ["reasoning", "tool-calling"],
+        "labels": [
+            "reasoning",
+            "tool-calling"
+        ],
         "size": 62.7
     },
     "gpt-oss-20b-GGUF": {
         "checkpoint": "unsloth/gpt-oss-20b-GGUF:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": false,
-        "labels": ["reasoning", "tool-calling"],
+        "labels": [
+            "reasoning",
+            "tool-calling"
+        ],
         "size": 11.6
     },
     "gpt-oss-120b-mxfp-GGUF": {
         "checkpoint": "ggml-org/gpt-oss-120b-GGUF:*",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot", "reasoning", "tool-calling"],
+        "labels": [
+            "hot",
+            "reasoning",
+            "tool-calling"
+        ],
         "size": 63.3
     },
     "gpt-oss-20b-mxfp4-GGUF": {
         "checkpoint": "ggml-org/gpt-oss-20b-GGUF",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot", "reasoning", "tool-calling"],
+        "labels": [
+            "hot",
+            "reasoning",
+            "tool-calling"
+        ],
         "size": 12.1
     },
     "GLM-4.5-Air-UD-Q4K-XL-GGUF": {
         "checkpoint": "unsloth/GLM-4.5-Air-GGUF:UD-Q4_K_XL",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 73.1
     },
     "GLM-4.7-Flash-GGUF": {
         "checkpoint": "unsloth/GLM-4.7-Flash-GGUF:GLM-4.7-Flash-UD-Q4_K_XL.gguf",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["hot"],
+        "labels": [
+            "hot"
+        ],
         "size": 17.6
     },
     "Playable1-GGUF": {
         "checkpoint": "playable/Playable1-GGUF:Playable1-q4_k_m.gguf",
         "recipe": "llamacpp",
         "suggested": false,
-        "labels": ["coding"],
+        "labels": [
+            "coding"
+        ],
         "size": 4.68
     },
     "granite-4.0-h-tiny-GGUF": {
         "checkpoint": "unsloth/granite-4.0-h-tiny-GGUF:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": true,
-        "labels": ["tool-calling"],
+        "labels": [
+            "tool-calling"
+        ],
         "size": 4.25
     },
     "LFM2-8B-A1B-GGUF": {
@@ -558,7 +939,9 @@
         "checkpoint": "gpt-oss:20b",
         "recipe": "flm",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 13.4
     },
     "Gemma3-1b-it-FLM": {
@@ -571,21 +954,29 @@
         "checkpoint": "gemma3:4b",
         "recipe": "flm",
         "suggested": true,
-        "labels": ["hot","vision"],
+        "labels": [
+            "hot",
+            "vision"
+        ],
         "size": 5.26
     },
     "Qwen3-4B-VL-FLM": {
         "checkpoint": "qwen3vl-it:4b",
         "recipe": "flm",
         "suggested": true,
-        "labels": ["hot","vision"],
+        "labels": [
+            "hot",
+            "vision"
+        ],
         "size": 3.85
     },
     "Qwen3-0.6b-FLM": {
         "checkpoint": "qwen3:0.6b",
         "recipe": "flm",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 0.66
     },
     "Qwen3-4B-Instruct-2507-FLM": {
@@ -598,7 +989,9 @@
         "checkpoint": "qwen3:8b",
         "recipe": "flm",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 5.57
     },
     "Llama-3.1-8B-FLM": {
@@ -641,7 +1034,10 @@
         "checkpoint": "ggerganov/whisper.cpp:ggml-tiny.bin",
         "recipe": "whispercpp",
         "suggested": true,
-        "labels": ["audio", "transcription"],
+        "labels": [
+            "audio",
+            "transcription"
+        ],
         "size": 0.075,
         "npu_cache_repo": "amd/whisper-tiny-onnx-npu",
         "npu_cache_filename": "ggml-tiny-encoder-vitisai.rai"
@@ -650,7 +1046,10 @@
         "checkpoint": "ggerganov/whisper.cpp:ggml-base.bin",
         "recipe": "whispercpp",
         "suggested": true,
-        "labels": ["audio", "transcription"],
+        "labels": [
+            "audio",
+            "transcription"
+        ],
         "size": 0.142,
         "npu_cache_repo": "amd/whisper-base-onnx-npu",
         "npu_cache_filename": "ggml-base-encoder-vitisai.rai"
@@ -659,7 +1058,10 @@
         "checkpoint": "ggerganov/whisper.cpp:ggml-small.bin",
         "recipe": "whispercpp",
         "suggested": true,
-        "labels": ["audio", "transcription"],
+        "labels": [
+            "audio",
+            "transcription"
+        ],
         "size": 0.466,
         "npu_cache_repo": "amd/whisper-small-onnx-npu",
         "npu_cache_filename": "ggml-small-encoder-vitisai.rai"
@@ -668,7 +1070,10 @@
         "checkpoint": "ggerganov/whisper.cpp:ggml-medium.bin",
         "recipe": "whispercpp",
         "suggested": true,
-        "labels": ["audio", "transcription"],
+        "labels": [
+            "audio",
+            "transcription"
+        ],
         "size": 1.42,
         "npu_cache_repo": "amd/whisper-medium-onnx-npu",
         "npu_cache_filename": "ggml-medium-encoder-vitisai.rai"
@@ -677,7 +1082,10 @@
         "checkpoint": "ggerganov/whisper.cpp:ggml-large-v3.bin",
         "recipe": "whispercpp",
         "suggested": true,
-        "labels": ["audio", "transcription"],
+        "labels": [
+            "audio",
+            "transcription"
+        ],
         "size": 2.87,
         "npu_cache_repo": "amd/whisper-large-v3-onnx-npu",
         "npu_cache_filename": "ggml-large-v3-encoder-vitisai.rai"
@@ -686,7 +1094,11 @@
         "checkpoint": "ggerganov/whisper.cpp:ggml-large-v3-turbo.bin",
         "recipe": "whispercpp",
         "suggested": true,
-        "labels": ["audio", "transcription", "hot"],
+        "labels": [
+            "audio",
+            "transcription",
+            "hot"
+        ],
         "size": 1.55,
         "npu_cache_repo": "amd/whisper-large-turbo-onnx-npu",
         "npu_cache_filename": "ggml-large-v3-turbo-encoder-vitisai.rai"
@@ -695,14 +1107,18 @@
         "checkpoint": "deepseek-r1:8b",
         "recipe": "flm",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 5.36
     },
     "DeepSeek-R1-0528-Qwen3-8B-FLM": {
         "checkpoint": "deepseek-r1-0528:8b",
         "recipe": "flm",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 5.57
     },
     "LFM2-2.6B-FLM": {
@@ -715,21 +1131,27 @@
         "checkpoint": "qwen3:1.7b",
         "recipe": "flm",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 1.59
     },
     "LFM2.5-1.2B-Thinking-FLM": {
         "checkpoint": "lfm2.5-tk:1.2b",
         "recipe": "flm",
         "suggested": true,
-        "labels": ["reasoning"],
+        "labels": [
+            "reasoning"
+        ],
         "size": 0.96
     },
     "SD-Turbo": {
         "checkpoint": "stabilityai/sd-turbo:sd_turbo.safetensors",
         "recipe": "sd-cpp",
         "suggested": true,
-        "labels": ["image"],
+        "labels": [
+            "image"
+        ],
         "size": 5.2,
         "image_defaults": {
             "steps": 4,
@@ -742,7 +1164,9 @@
         "checkpoint": "stabilityai/sdxl-turbo:sd_xl_turbo_1.0_fp16.safetensors",
         "recipe": "sd-cpp",
         "suggested": true,
-        "labels": ["image"],
+        "labels": [
+            "image"
+        ],
         "size": 6.9,
         "image_defaults": {
             "steps": 4,
@@ -755,7 +1179,9 @@
         "checkpoint": "stable-diffusion-v1-5/stable-diffusion-v1-5:v1-5-pruned.safetensors",
         "recipe": "sd-cpp",
         "suggested": true,
-        "labels": ["image"],
+        "labels": [
+            "image"
+        ],
         "size": 4.3,
         "image_defaults": {
             "steps": 20,
@@ -768,7 +1194,9 @@
         "checkpoint": "stabilityai/stable-diffusion-xl-base-1.0:sd_xl_base_1.0.safetensors",
         "recipe": "sd-cpp",
         "suggested": true,
-        "labels": ["image"],
+        "labels": [
+            "image"
+        ],
         "size": 6.9,
         "image_defaults": {
             "steps": 20,
@@ -781,7 +1209,10 @@
         "checkpoint": "mikkoph/kokoro-onnx",
         "recipe": "kokoro",
         "suggested": false,
-        "labels": ["audio", "speech"],
+        "labels": [
+            "audio",
+            "speech"
+        ],
         "size": 0.34
     }
 }

--- a/src/cpp/server/backends/ryzenaiserver.cpp
+++ b/src/cpp/server/backends/ryzenaiserver.cpp
@@ -67,7 +67,6 @@ static std::string get_install_directory() {
 RyzenAIServer::RyzenAIServer(const std::string& model_name, bool debug, ModelManager* model_manager)
     : WrappedServer("RyzenAI-Server", debug ? "debug" : "info", model_manager),
       model_name_(model_name),
-      execution_mode_("auto"),
       is_loaded_(false) {
 }
 
@@ -285,21 +284,6 @@ std::string RyzenAIServer::download_model(const std::string& checkpoint,
     return checkpoint;
 }
 
-std::string RyzenAIServer::determine_execution_mode(const std::string& model_path,
-                                                   const std::string& backend) {
-    // Map backend to execution mode
-    if (backend == "npu" || backend == "oga-npu") {
-        return "npu";
-    } else if (backend == "hybrid" || backend == "oga-hybrid") {
-        return "hybrid";
-    } else if (backend == "cpu" || backend == "oga-cpu") {
-        return "cpu";
-    } else {
-        // "auto" will let ryzenai-server decide
-        return "auto";
-    }
-}
-
 void RyzenAIServer::load(const std::string& model_name,
                         const ModelInfo& model_info,
                         const RecipeOptions& options,
@@ -330,13 +314,7 @@ void RyzenAIServer::load(const std::string& model_name,
 
     model_name_ = model_name;
 
-    // execution_mode_ should have been set via set_execution_mode() before calling load()
-    if (execution_mode_.empty()) {
-        execution_mode_ = "auto";
-    }
-
     std::cout << "[RyzenAI-Server] Model path: " << model_path_ << std::endl;
-    std::cout << "[RyzenAI-Server] Execution mode: " << execution_mode_ << std::endl;
 
     // Find available port
     port_ = choose_port();
@@ -345,7 +323,6 @@ void RyzenAIServer::load(const std::string& model_name,
     std::vector<std::string> args = {
         "-m", model_path_,
         "--port", std::to_string(port_),
-        "--mode", execution_mode_,
         "--ctx-size", std::to_string(ctx_size)
     };
 

--- a/src/cpp/server/cli_parser.cpp
+++ b/src/cpp/server/cli_parser.cpp
@@ -120,7 +120,7 @@ CLIParser::CLIParser()
         ->type_name("CHECKPOINT");
     pull->add_option("--recipe", tray_config_.recipe, "Inference recipe to use. Required when using a local path.")
         ->type_name("RECIPE")
-        ->check(CLI::IsMember({"llamacpp", "flm", "oga-cpu", "oga-hybrid", "oga-npu", "ryzenai", "whispercpp"}));
+        ->check(CLI::IsMember({"llamacpp", "flm", "ryzenai-llm", "whispercpp"}));
     pull->add_flag("--reasoning", tray_config_.is_reasoning, "Mark model as a reasoning model (e.g., DeepSeek-R1). Adds 'reasoning' label to model metadata.");
     pull->add_flag("--vision", tray_config_.is_vision, "Mark model as a vision model (multimodal). Adds 'vision' label to model metadata.");
     pull->add_flag("--embedding", tray_config_.is_embedding, "Mark model as an embedding model. Adds 'embeddings' label to model metadata. For use with /api/v1/embeddings endpoint.");

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -84,7 +84,7 @@ static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
         return {"ctx_size", "llamacpp_backend", "llamacpp_args"};
     } else if (recipe == "whispercpp") {
         return {"whispercpp_backend"};
-    } else if (recipe == "oga-npu" || recipe == "oga-hybrid" || recipe == "oga-cpu" || recipe == "ryzenai" || recipe == "flm") {
+    } else if (recipe == "ryzenai-llm" || recipe == "flm") {
         return {"ctx_size"};
     } else if (recipe == "sd-cpp") {
         return {"steps", "cfg_scale", "width", "height"};

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -165,28 +165,15 @@ std::unique_ptr<WrappedServer> Router::create_backend_server(const ModelInfo& mo
     } else if (model_info.recipe == "flm") {
         std::cout << "[Router] Creating FastFlowLM backend" << std::endl;
         new_server = std::make_unique<backends::FastFlowLMServer>(log_level_, model_manager_);
-    } else if (model_info.recipe == "oga-npu" || model_info.recipe == "oga-hybrid" ||
-               model_info.recipe == "oga-cpu" || model_info.recipe == "ryzenai") {
-        std::cout << "[Router] Creating RyzenAI-Server backend: " << model_info.recipe << std::endl;
+    } else if (model_info.recipe == "ryzenai-llm") {
+        std::cout << "[Router] Creating RyzenAI-Server backend" << std::endl;
 
         std::string model_path = model_info.resolved_path;
         std::cout << "[Router] Using model path: " << model_path << std::endl;
 
-        std::string backend_mode = model_info.recipe;
-        if (model_info.recipe == "oga-npu") {
-            backend_mode = "npu";
-        } else if (model_info.recipe == "oga-hybrid") {
-            backend_mode = "hybrid";
-        } else if (model_info.recipe == "oga-cpu") {
-            backend_mode = "cpu";
-        } else {
-            backend_mode = "auto";
-        }
-
         auto* ryzenai_server = new RyzenAIServer(model_info.model_name,
                                                   log_level_ == "debug", model_manager_);
         ryzenai_server->set_model_path(model_path);
-        ryzenai_server->set_execution_mode(backend_mode);
         new_server.reset(ryzenai_server);
     } else {
         std::cout << "[Router] Creating LlamaCpp backend" << std::endl;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2360,7 +2360,7 @@ void Server::handle_params(const httplib::Request& req, httplib::Response& res) 
 // Parameters:
 //   - dest_path: Directory where model files are located (already copied/uploaded)
 //   - model_name: Model name with "user." prefix
-//   - recipe: Inference recipe (llamacpp, oga-*, whispercpp)
+//   - recipe: Inference recipe (llamacpp, ryzenai-llm, whispercpp)
 //   - variant: Optional variant hint for GGUF file selection
 //   - mmproj: Optional mmproj filename hint
 //   - reasoning, vision, embedding, reranking, image: Model labels
@@ -2381,8 +2381,8 @@ void Server::resolve_and_register_local_model(
     std::string resolved_checkpoint;
     std::string resolved_mmproj;
 
-    // For OGA models, find genai_config.json
-    if (recipe.find("oga-") == 0) {
+    // For RyzenAI LLM models, find genai_config.json
+    if (recipe == "ryzenai-llm") {
         for (const auto& entry : std::filesystem::recursive_directory_iterator(dest_path)) {
             if (entry.is_regular_file() && entry.path().filename() == "genai_config.json") {
                 resolved_checkpoint = entry.path().parent_path().string();

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -124,14 +124,8 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
         {"npu", {"XDNA2"}},
     }},
 
-    // OGA recipes - Windows NPU (XDNA2)
-    {"oga-npu", "default", {"windows"}, {
-        {"npu", {"XDNA2"}},
-    }},
-    {"oga-hybrid", "default", {"windows"}, {
-        {"npu", {"XDNA2"}},
-    }},
-    {"oga-cpu", "default", {"windows"}, {
+    // RyzenAI LLM - Windows NPU (XDNA2)
+    {"ryzenai-llm", "default", {"windows"}, {
         {"npu", {"XDNA2"}},
     }},
 };
@@ -317,7 +311,7 @@ static bool is_recipe_installed(const std::string& recipe, const std::string& ba
         #endif
         return false;
     }
-    if (recipe.find("oga") == 0) {  // oga-npu, oga-hybrid, oga-cpu
+    if (recipe == "ryzenai-llm") {
         return SystemInfo::is_ryzenai_serve_available();
     }
     return false;
@@ -340,7 +334,7 @@ static std::string get_recipe_version(const std::string& recipe, const std::stri
     if (recipe == "flm") {
         return SystemInfo::get_flm_version();
     }
-    if (recipe.find("oga") == 0) {  // oga-npu, oga-hybrid, oga-cpu
+    if (recipe == "ryzenai-llm") {
         return SystemInfo::get_oga_version();
     }
     return "";

--- a/src/cpp/tray/tray_app.cpp
+++ b/src/cpp/tray/tray_app.cpp
@@ -1222,7 +1222,7 @@ int TrayApp::execute_pull_command() {
         // Recipe is required for local imports
         if (tray_config_.recipe.empty()) {
             std::cerr << "Error: --recipe is required when importing from a local path" << std::endl;
-            std::cerr << "Options: llamacpp, oga-cpu, oga-hybrid, oga-npu, whispercpp" << std::endl;
+            std::cerr << "Options: llamacpp, ryzenai-llm, whispercpp" << std::endl;
             return 1;
         }
 

--- a/test/server_cli.py
+++ b/test/server_cli.py
@@ -317,9 +317,7 @@ class PersistentServerCLITests(CLITestBase):
             "whispercpp",
             "sd-cpp",
             "flm",
-            "oga-npu",
-            "oga-hybrid",
-            "oga-cpu",
+            "ryzenai-llm",
         ]
         for recipe in known_recipes:
             self.assertTrue(
@@ -482,9 +480,7 @@ class EphemeralCLITests(CLITestBase):
             "whispercpp",
             "sd-cpp",
             "flm",
-            "oga-npu",
-            "oga-hybrid",
-            "oga-cpu",
+            "ryzenai-llm",
         ]
         for recipe in known_recipes:
             self.assertTrue(

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -676,9 +676,7 @@ class EndpointTests(ServerTestBase):
             "whispercpp",
             "sd-cpp",
             "flm",
-            "oga-npu",
-            "oga-hybrid",
-            "oga-cpu",
+            "ryzenai-llm",
         ]
         for recipe in known_recipes:
             self.assertIn(recipe, recipes, f"Missing recipe: {recipe}")

--- a/test/server_system_info.py
+++ b/test/server_system_info.py
@@ -144,13 +144,11 @@ MOCK_HARDWARE_CONFIGS = {
             "whispercpp": ["npu"],  # npu backend requires XDNA2 NPU
             # NPU recipes unsupported: CPU is "Ryzen 9 7950X" (no "Ryzen AI" -> no XDNA2)
             "flm": ["default"],
-            "oga-npu": ["default"],
-            "oga-hybrid": ["default"],
-            "oga-cpu": ["default"],
+            "ryzenai-llm": ["default"],
         },
     },
     # Windows x86_64 with AMD iGPU (Strix Point - ROCm-capable) and NPU
-    # Tests: ROCm iGPU support, NPU recipes (flm, oga-*)
+    # Tests: ROCm iGPU support, NPU recipes (flm, ryzenai-llm)
     "windows_x86_with_rocm_igpu": {
         "requires_os": "windows",
         "requires_arch": "x86_64",
@@ -188,9 +186,7 @@ MOCK_HARDWARE_CONFIGS = {
             "whispercpp": ["npu", "cpu"],  # npu supported on XDNA2, cpu on x86_64
             "sd-cpp": ["cpu"],
             "flm": ["default"],
-            "oga-npu": ["default"],
-            "oga-hybrid": ["default"],
-            "oga-cpu": ["default"],
+            "ryzenai-llm": ["default"],
         },
         "expected_unsupported": {
             "llamacpp": ["metal"],
@@ -238,9 +234,7 @@ MOCK_HARDWARE_CONFIGS = {
             "whispercpp": ["npu"],  # npu backend requires XDNA2 NPU
             # NPU recipes unsupported: CPU is "Intel Core i9-13900K" (no Ryzen AI)
             "flm": ["default"],
-            "oga-npu": ["default"],
-            "oga-hybrid": ["default"],
-            "oga-cpu": ["default"],
+            "ryzenai-llm": ["default"],
         },
     },
     # Windows x86_64 with AMD iGPU but NOT ROCm-capable (older GPU)
@@ -283,9 +277,7 @@ MOCK_HARDWARE_CONFIGS = {
             "whispercpp": ["npu"],  # npu backend requires XDNA2 NPU
             # NPU recipes unsupported: CPU is "Ryzen 7 6800U" (no Ryzen AI)
             "flm": ["default"],
-            "oga-npu": ["default"],
-            "oga-hybrid": ["default"],
-            "oga-cpu": ["default"],
+            "ryzenai-llm": ["default"],
         },
     },
     # macOS ARM64 (Apple Silicon) - ONLY RUN ON MACOS
@@ -317,9 +309,7 @@ MOCK_HARDWARE_CONFIGS = {
             "whispercpp": ["npu", "cpu"],  # whispercpp is Windows-only
             "sd-cpp": ["cpu"],
             "flm": ["default"],
-            "oga-npu": ["default"],
-            "oga-hybrid": ["default"],
-            "oga-cpu": ["default"],
+            "ryzenai-llm": ["default"],
         },
     },
     # Linux x86_64 with no AMD GPU - ONLY RUN ON LINUX
@@ -351,9 +341,7 @@ MOCK_HARDWARE_CONFIGS = {
             "llamacpp": ["metal", "rocm"],
             "whispercpp": ["npu", "cpu"],  # whispercpp is Windows-only
             "flm": ["default"],
-            "oga-npu": ["default"],
-            "oga-hybrid": ["default"],
-            "oga-cpu": ["default"],
+            "ryzenai-llm": ["default"],
         },
     },
     # Linux x86_64 with AMD RDNA3 dGPU (ROCm-capable) - ONLY RUN ON LINUX
@@ -392,9 +380,7 @@ MOCK_HARDWARE_CONFIGS = {
             "llamacpp": ["metal"],
             "whispercpp": ["npu", "cpu"],  # whispercpp is Windows-only
             "flm": ["default"],  # Windows NPU only
-            "oga-npu": ["default"],
-            "oga-hybrid": ["default"],
-            "oga-cpu": ["default"],
+            "ryzenai-llm": ["default"],
         },
     },
     # Linux x86_64 with AMD GPU that doesn't support ROCm (RDNA2) - ONLY RUN ON LINUX
@@ -433,9 +419,7 @@ MOCK_HARDWARE_CONFIGS = {
             "llamacpp": ["metal", "rocm"],  # rocm not supported on RDNA2
             "whispercpp": ["npu", "cpu"],  # whispercpp is Windows-only
             "flm": ["default"],
-            "oga-npu": ["default"],
-            "oga-hybrid": ["default"],
-            "oga-cpu": ["default"],
+            "ryzenai-llm": ["default"],
         },
     },
 }

--- a/test/utils/capabilities.py
+++ b/test/utils/capabilities.py
@@ -71,12 +71,12 @@ WRAPPED_SERVER_CAPABILITIES = {
             "multi_model": True,
             "stop_parameter": True,
             "echo_parameter": False,
-            "generation_parameters": True,
+            "generation_parameters": False,
         },
         "test_models": {
             "llm_cpu": "Qwen2.5-0.5B-Instruct-CPU",
             "llm_hybrid": "Qwen-2.5-1.5B-Instruct-Hybrid",
-            "llm_npu": "Qwen-2.5-3B-Instruct-NPU",
+            "llm_npu": "Qwen2.5-3B-Instruct-NPU",
         },
     },
     "flm": {


### PR DESCRIPTION
Closes #1055

Complete overhaul of Ryzen AI SW support:
- `ryzenai-server` version upgraded to `1.7.0`: https://github.com/lemonade-sdk/ryzenai-server/releases/tag/v1.7.0
- All `oga-*` recipes have been replaced by a monolithic `ryzenai-llm` recipe (npu vs. hybrid vs. cpu is auto-detected)
- *All* previous `oga-hybrid` and `oga-npu` models in server_models.json are invalidated and no longer supported
    - The `oga-cpu` models are still there, the recipe is just changed to `ryzenai-llm`
    - Most LoC changes in this PR are from this.
    - **We suggest going to your Hugging Face cache dir and removing all AMD NPU and Hybrid models prior to installing.** 
- *Every* Ryzen AI 1.7 model from the [NPU](https://huggingface.co/collections/amd/ryzen-ai-17-npu-llm) and [Hybrid](https://huggingface.co/collections/amd/ryzen-ai-17-hybrid-llm) collections has been added to `server_models.json` and marked as `suggested: true` (70 models total). 
