### PR TITLE
Adds LEMONADE_API_KEY in secrets file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1095,6 +1095,12 @@ if(UNIX AND NOT APPLE)
     endif()
     install(FILES ${CMAKE_SOURCE_DIR}/data/lemonade.conf
         DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/lemonade
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ
+    )
+
+    install(FILES ${CMAKE_SOURCE_DIR}/data/secrets.conf
+        DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/lemonade
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE
     )
 
     # Create symlinks for KaTeX fonts if they exist on the system

--- a/data/lemonade-server.service.in
+++ b/data/lemonade-server.service.in
@@ -8,6 +8,7 @@ User=lemonade
 Group=lemonade
 WorkingDirectory=@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/lemonade
 EnvironmentFile=@CMAKE_INSTALL_FULL_SYSCONFDIR@/lemonade/lemonade.conf
+EnvironmentFile=@CMAKE_INSTALL_FULL_SYSCONFDIR@/lemonade/secrets.conf
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/lemonade-server serve
 Restart=on-failure
 RestartSec=5s

--- a/data/secrets.conf
+++ b/data/secrets.conf
@@ -1,0 +1,1 @@
+#LEMONADE_API_KEY=

--- a/docs/server/server_integration.md
+++ b/docs/server/server_integration.md
@@ -237,7 +237,13 @@ The Lemonade Server systemd service is configured to read settings from `/etc/le
 sudo nano /etc/lemonade/lemonade.conf
 ```
 
-After making changes to the configuration file, restart the service for changes to take effect:
+Secrets, like the LEMONADE_API_KEY secret, are defined in `/etc/lemonade/secrets.conf` 
+
+```bash
+sudo nano /etc/lemonade/secrets.conf
+```
+
+After making changes to the configuration files, restart the service for changes to take effect:
 
 ```bash
 sudo systemctl restart lemonade-server


### PR DESCRIPTION
Added secrets to align with AUR package. If you think it's too much I can forget about it :) 

The file should probably have 660 permissions while lemonade.conf should probably have 644 permissions. But I'm not sure where we set this.