### PR TITLE
Remove some unneeded messages from window.api emulation

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -476,8 +476,6 @@ window.api = {
         }
         return 'Unknown';
     },
-    pauseDownload: () => {},
-    cancelDownload: () => {},
     restartApp: () => window.location.reload(),
     getSystemStats: async () => {
         try {


### PR DESCRIPTION
I noticed these aren't actually used.