### PR TITLE
fix a typo that breaks external binary lookup

### DIFF
--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -139,8 +139,7 @@ namespace lemon::backends {
             return "";
         }
 
-        std::string backend_bin = std::string(backend_bin);
-
+        std::string backend_bin = std::string(backend_bin_env);
         return fs::exists(backend_bin) ? backend_bin : "";
     }
 


### PR DESCRIPTION
Fixed a typo that breaks the `LEMONADE_RECIPE_BACKEND_BIN` lookup