### PR TITLE
Fix /v1/* endpoints returning HTML instead of JSON for OpenAI compati…

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -108,8 +108,11 @@ Server::~Server() {
 
 void Server::log_request(const httplib::Request& req) {
     if (req.path != "/api/v0/health" && req.path != "/api/v1/health" &&
+        req.path != "/v0/health" && req.path != "/v1/health" &&
         req.path != "/api/v0/system-stats" && req.path != "/api/v1/system-stats" &&
+        req.path != "/v0/system-stats" && req.path != "/v1/system-stats" &&
         req.path != "/api/v0/stats" && req.path != "/api/v1/stats" &&
+        req.path != "/v0/stats" && req.path != "/v1/stats" &&
         req.path != "/live") {
         std::cout << "[Server PRE-ROUTE] " << req.method << " " << req.path << std::endl;
         std::cout.flush();
@@ -810,9 +813,12 @@ void Server::setup_http_logger(httplib::Server &web_server) {
     // Add request logging for ALL requests (except health checks and stats endpoints)
     web_server.set_logger([](const httplib::Request& req, const httplib::Response& res) {
         // Skip logging health checks and stats endpoints to reduce log noise
-        if (req.path != "/api/v0/health" && req.path != "/api/v1/health" && req.path != "/live" &&
+        if (req.path != "/api/v0/health" && req.path != "/api/v1/health" &&
+            req.path != "/v0/health" && req.path != "/v1/health" && req.path != "/live" &&
             req.path != "/api/v0/system-stats" && req.path != "/api/v1/system-stats" &&
-            req.path != "/api/v0/stats" && req.path != "/api/v1/stats") {
+            req.path != "/v0/system-stats" && req.path != "/v1/system-stats" &&
+            req.path != "/api/v0/stats" && req.path != "/api/v1/stats" &&
+            req.path != "/v0/stats" && req.path != "/v1/stats") {
             std::cout << "[Server] " << req.method << " " << req.path << " - " << res.status << std::endl;
         }
     });


### PR DESCRIPTION
…bility

Problem:
- Clients accessing /v1/models (OpenAI-compatible path) were receiving HTML instead of JSON, causing "Response body is not valid JSON" errors
- Routes were only registered with /api/ prefix (/api/v1/models)
- SPA fallback regex was catching /v1/* paths and serving web app HTML

Solution:
- Register all API routes with both /api/v1/* and /v1/* patterns for full OpenAI API compatibility
- Update SPA fallback regex to exclude /v0 and /v1 paths from catching
- Fix trailing comma in model_info_to_json for strict JSON compliance

Now both /api/v1/models and /v1/models return proper JSON responses.