### PR TITLE
Sdcpp vulkan integration

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -443,6 +443,11 @@ jobs:
             test_type: sd
             backend: rocm
             runner: [stx-halo, Windows]
+          # Stable Diffusion (Vulkan)
+          - name: stable-diffusion (vulkan)
+            test_type: sd
+            backend: vulkan
+            runner: [rai300_400, Windows]
           # Text to speech
           - name: text-to-speech
             test_type: tts
@@ -550,6 +555,11 @@ jobs:
           - name: stable-diffusion (cpu)
             test_type: sd
             backend: ""
+            runner: [rai300_400, Linux]
+          # Stable Diffusion (Vulkan)
+          - name: stable-diffusion (vulkan)
+            test_type: sd
+            backend: vulkan
             runner: [rai300_400, Linux]
           # Text to speech
           - name: text-to-speech

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -556,11 +556,6 @@ jobs:
             test_type: sd
             backend: ""
             runner: [rai300_400, Linux]
-          # Stable Diffusion (Vulkan)
-          - name: stable-diffusion (vulkan)
-            test_type: sd
-            backend: vulkan
-            runner: [rai300_400, Linux]
           # Text to speech
           - name: text-to-speech
             test_type: tts

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -14,7 +14,8 @@
   },
   "sd-cpp": {
     "cpu": "master-471-7010bb4",
-    "rocm": "master-487-43e829f"
+    "rocm": "master-487-43e829f",
+    "vulkan": "master-487-43e829f"
   },
   "ryzenai-server": "v1.7.0",
   "flm": {

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -68,6 +68,18 @@ void SDServer::install(const std::string& backend) {
         throw std::runtime_error("ROCm sd.cpp only supported on Windows and Linux");
 #endif
         std::cout << "[SDServer] Using ROCm GPU backend" << std::endl;
+    } else if (backend_ == "vulkan") {
+        // Vulkan backend for cross-platform GPU support
+#ifdef _WIN32
+        filename = "sd-" + short_version + "-bin-win-vulkan-x64.zip";
+#elif defined(__linux__)
+        filename = "sd-" + short_version + "-bin-linux-vulkan-x64.zip";
+#elif defined(__APPLE__)
+        filename = "sd-" + short_version + "-bin-macos-vulkan-arm64.zip";
+#else
+        throw std::runtime_error("Vulkan sd.cpp platform not supported");
+#endif
+        std::cout << "[SDServer] Using Vulkan GPU backend" << std::endl;
     } else {
         // CPU build (default)
 #ifdef _WIN32

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -72,14 +72,10 @@ void SDServer::install(const std::string& backend) {
         // Vulkan backend for cross-platform GPU support
 #ifdef _WIN32
         filename = "sd-" + short_version + "-bin-win-vulkan-x64.zip";
-#elif defined(__linux__)
-        filename = "sd-" + short_version + "-bin-linux-vulkan-x64.zip";
-#elif defined(__APPLE__)
-        filename = "sd-" + short_version + "-bin-macos-vulkan-arm64.zip";
-#else
-        throw std::runtime_error("Vulkan sd.cpp platform not supported");
-#endif
         std::cout << "[SDServer] Using Vulkan GPU backend" << std::endl;
+#else
+        throw std::runtime_error("Vulkan sd.cpp backend is only supported on Windows");
+#endif
     } else {
         // CPU build (default)
 #ifdef _WIN32

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -49,9 +49,9 @@ static const json CLI_OPTIONS = {
     {"--sdcpp", {
         {"option_name", "sd-cpp_backend"},
         {"type_name", "BACKEND"},
-        {"allowed_values", {"cpu", "rocm"}},
+        {"allowed_values", {"cpu", "rocm", "vulkan"}},
         {"envname", "LEMONADE_SDCPP"},
-        {"help", "SD.cpp backend to use (cpu for CPU, rocm for AMD GPU)"}
+        {"help", "SD.cpp backend to use (cpu for CPU, rocm for AMD GPU, vulkan for cross-platform GPU)"}
     }},
     // ASR options
     {"--whispercpp", {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -120,6 +120,13 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
         {"amd_dgpu", {"gfx110X", "gfx120X"}},
     }},
 
+    // stable-diffusion.cpp - Vulkan backend (cross-platform GPU)
+    {"sd-cpp", "vulkan", {"windows", "linux"}, {
+        {"cpu", {"x86_64"}},
+        {"amd_igpu", {}},
+        {"amd_dgpu", {}},
+    }},
+
     // stable-diffusion.cpp - CPU backend (Windows/Linux x86_64)
     {"sd-cpp", "cpu", {"windows", "linux"}, {
         {"cpu", {"x86_64"}},

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -121,10 +121,12 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
     }},
 
     // stable-diffusion.cpp - Vulkan backend (cross-platform GPU)
-    {"sd-cpp", "vulkan", {"windows", "linux"}, {
+    {"sd-cpp", "vulkan", {"windows"}, {
         {"cpu", {"x86_64"}},
         {"amd_igpu", {}},
         {"amd_dgpu", {}},
+        {"nvidia_dgpu", {}},
+        {"intel_igpu", {}},
     }},
 
     // stable-diffusion.cpp - CPU backend (Windows/Linux x86_64)

--- a/test/server_system_info.py
+++ b/test/server_system_info.py
@@ -137,7 +137,7 @@ MOCK_HARDWARE_CONFIGS = {
         "expected_supported": {
             "llamacpp": ["vulkan", "rocm", "cpu"],
             "whispercpp": ["cpu"],  # cpu backend available on x86_64
-            "sd-cpp": ["cpu", "rocm"],
+            "sd-cpp": ["cpu", "rocm", "vulkan"],
         },
         "expected_unsupported": {
             "llamacpp": ["metal"],
@@ -184,7 +184,7 @@ MOCK_HARDWARE_CONFIGS = {
         "expected_supported": {
             "llamacpp": ["vulkan", "rocm", "cpu"],
             "whispercpp": ["npu", "cpu"],  # npu supported on XDNA2, cpu on x86_64
-            "sd-cpp": ["cpu", "rocm"],
+            "sd-cpp": ["cpu", "rocm", "vulkan"],
             "flm": ["default"],
             "ryzenai-llm": ["default"],
         },
@@ -227,7 +227,7 @@ MOCK_HARDWARE_CONFIGS = {
         "expected_supported": {
             "llamacpp": ["vulkan", "cpu"],
             "whispercpp": ["cpu"],  # cpu backend available on x86_64
-            "sd-cpp": ["cpu"],
+            "sd-cpp": ["cpu", "vulkan"],
         },
         "expected_unsupported": {
             "llamacpp": ["metal", "rocm"],
@@ -271,7 +271,7 @@ MOCK_HARDWARE_CONFIGS = {
         "expected_supported": {
             "llamacpp": ["vulkan", "cpu"],
             "whispercpp": ["cpu"],  # cpu backend available on x86_64
-            "sd-cpp": ["cpu"],
+            "sd-cpp": ["cpu", "vulkan"],
         },
         "expected_unsupported": {
             "llamacpp": ["metal", "rocm"],  # rocm not supported on RDNA2
@@ -337,7 +337,7 @@ MOCK_HARDWARE_CONFIGS = {
         },
         "expected_supported": {
             "llamacpp": ["vulkan", "cpu"],
-            "sd-cpp": ["cpu"],
+            "sd-cpp": ["cpu", "vulkan"],
         },
         "expected_unsupported": {
             "llamacpp": ["metal", "rocm"],
@@ -377,7 +377,7 @@ MOCK_HARDWARE_CONFIGS = {
         },
         "expected_supported": {
             "llamacpp": ["vulkan", "rocm", "cpu"],
-            "sd-cpp": ["cpu", "rocm"],
+            "sd-cpp": ["cpu", "rocm", "vulkan"],
         },
         "expected_unsupported": {
             "llamacpp": ["metal"],
@@ -416,7 +416,7 @@ MOCK_HARDWARE_CONFIGS = {
         },
         "expected_supported": {
             "llamacpp": ["vulkan", "cpu"],
-            "sd-cpp": ["cpu"],
+            "sd-cpp": ["cpu", "vulkan"],
         },
         "expected_unsupported": {
             "llamacpp": ["metal", "rocm"],  # rocm not supported on RDNA2

--- a/test/server_system_info.py
+++ b/test/server_system_info.py
@@ -337,12 +337,12 @@ MOCK_HARDWARE_CONFIGS = {
         },
         "expected_supported": {
             "llamacpp": ["vulkan", "cpu"],
-            "sd-cpp": ["cpu", "vulkan"],
+            "sd-cpp": ["cpu"],
         },
         "expected_unsupported": {
             "llamacpp": ["metal", "rocm"],
             "whispercpp": ["npu", "cpu"],  # whispercpp is Windows-only
-            "sd-cpp": ["rocm"],
+            "sd-cpp": ["rocm","vulkan"],
             "flm": ["default"],
             "ryzenai-llm": ["default"],
         },
@@ -377,13 +377,14 @@ MOCK_HARDWARE_CONFIGS = {
         },
         "expected_supported": {
             "llamacpp": ["vulkan", "rocm", "cpu"],
-            "sd-cpp": ["cpu", "rocm", "vulkan"],
+            "sd-cpp": ["cpu", "rocm"],
         },
         "expected_unsupported": {
             "llamacpp": ["metal"],
             "whispercpp": ["npu", "cpu"],  # whispercpp is Windows-only
             "flm": ["default"],  # Windows NPU only
             "ryzenai-llm": ["default"],
+            "sd-cpp": ["vulkan"]
         },
     },
     # Linux x86_64 with AMD GPU that doesn't support ROCm (RDNA2) - ONLY RUN ON LINUX
@@ -416,12 +417,12 @@ MOCK_HARDWARE_CONFIGS = {
         },
         "expected_supported": {
             "llamacpp": ["vulkan", "cpu"],
-            "sd-cpp": ["cpu", "vulkan"],
+            "sd-cpp": ["cpu"],
         },
         "expected_unsupported": {
             "llamacpp": ["metal", "rocm"],  # rocm not supported on RDNA2
             "whispercpp": ["npu", "cpu"],  # whispercpp is Windows-only
-            "sd-cpp": ["rocm"],
+            "sd-cpp": ["rocm","vulkan"],
             "flm": ["default"],
             "ryzenai-llm": ["default"],
         },


### PR DESCRIPTION
Add Vulkan support to sd-cpp.

Vulkan seems to have more robust for SOTA models and may offer different performance compared with ROCm