### PR TITLE
Update lemonade server `LimitMEMLOCK` value

### DIFF
--- a/data/lemonade-server.service.in
+++ b/data/lemonade-server.service.in
@@ -13,6 +13,7 @@ ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/lemonade-server serve
 Restart=on-failure
 RestartSec=5s
 KillSignal=SIGINT
+LimitMEMLOCK=infinity
 
 # Security hardening
 PrivateTmp=yes


### PR DESCRIPTION
This effectively changes the `ulimit -l` value used for lemonade server and all child processes.

Due to how memory is allocated by some engines (like `flm`) for model use it's important that the maximum size that may be locked into memory is not limited.