### PR TITLE
Add support for NPU detection on Linux

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -19,7 +19,8 @@
   "ryzenai-server": "v1.7.0",
   "flm": {
     "version": "v0.9.33",
-    "min_npu_driver": "32.0.203.304"
+    "min_npu_driver": "32.0.203.304",
+    "min_kernel_version": "7.0"
   },
   "kokoro": {
     "cpu": "b14"


### PR DESCRIPTION
The baseline detection will be based upon kernel version, and based upon stability measurements has been decided that will run on Linux 7.0 or later.

This doesn't actually glue any `flm` launching code and it certainly doesn't mark `flm` as supported on Linux, but baby steps.