### PR TITLE
FLM Version Update to v0.9.33

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -18,7 +18,7 @@
   },
   "ryzenai-server": "v1.7.0",
   "flm": {
-    "version": "v0.9.31",
+    "version": "v0.9.33",
     "min_npu_driver": "32.0.203.304"
   },
   "kokoro": {

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1141,7 +1141,7 @@
         "suggested": true,
         "size": 1.75
     },
-    "Qwen3-1.7b-FLM": {
+    "Qwen3-1.7B-FLM": {
         "checkpoint": "qwen3:1.7b",
         "recipe": "flm",
         "suggested": true,


### PR DESCRIPTION
- Updated FLM to `v0.9.33`.

- Added two new FLM models:
  - `Qwen2.5-3B-Instruct-FLM`
  - `Qwen2.5-VL-3B-Instruct-FLM` (vision)

- Renamed FLM models for naming consistency:
  - `Qwen3-4B-VL-FLM` → `Qwen3-VL-4B-Instruct-FLM`
  - `Qwen3-0.6b-FLM` → `Qwen3-0.6B-FLM`
  - `Qwen3-1.7b-FLM` → `Qwen3-1.7B-FLM`