### PR TITLE
Respect LEMONADE_DISABLE_MODEL_FILTERING in model pull/download

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1609,8 +1609,9 @@ void ModelManager::download_model(const std::string& model_name,
     }
 
     // Check if this recipe is supported on the current system
+    bool disable_filtering = parse_TF_env_var("LEMONADE_DISABLE_MODEL_FILTERING");
     std::string unsupported_reason = SystemInfo::check_recipe_supported(actual_recipe);
-    if (!unsupported_reason.empty()) {
+    if (!unsupported_reason.empty() && !disable_filtering) {
         throw std::runtime_error(
             "Model '" + model_name + "' cannot be used on this system (recipe: " + actual_recipe + "): " +
             unsupported_reason


### PR DESCRIPTION
The env var was only checked in filter_models_by_backend() (model listing) but not in download_model(), so users who set the env var could see a model in the list but still get "cannot be used on this system" when pulling it.