### PR TITLE
Document LEMONADE_MAX_LOADED_MODELS environment variable

### DIFF
--- a/docs/server/lemonade-server-cli.md
+++ b/docs/server/lemonade-server-cli.md
@@ -72,6 +72,7 @@ These settings can also be provided via environment variables that Lemonade Serv
 | `LEMONADE_CTX_SIZE`                | Default context size for models                                                                                                                         |
 | `LEMONADE_LLAMACPP_ARGS`           | Custom arguments to pass to llama-server                                                                                                                |
 | `LEMONADE_EXTRA_MODELS_DIR`        | Secondary directory to scan for GGUF model files                                                                                                        |
+| `LEMONADE_MAX_LOADED_MODELS`       | Maximum number of models to keep loaded per type slot (LLMs, audio, image, etc.). Use `-1` for unlimited, or a positive integer. Default: `1`           |
 | `LEMONADE_DISABLE_MODEL_FILTERING` | Set to `1` to disable hardware-based model filtering (e.g., RAM amount, NPU availability) and show all models regardless of system capabilities         |
 | `LEMONADE_ENABLE_DGPU_GTT`         | Set to `1` to include GTT for hardware-based model filtering |
 


### PR DESCRIPTION
Closes #919

## Summary
Added documentation for the `LEMONADE_MAX_LOADED_MODELS` environment variable in the Lemonade Server CLI configuration guide.

## Changes
- Added new environment variable entry to the configuration table documenting `LEMONADE_MAX_LOADED_MODELS`
- Documented the variable's purpose: controlling the maximum number of models to keep loaded per type slot (LLMs, audio, image, etc.)
- Clarified usage options: `-1` for unlimited models, positive integers for specific limits, with a default value of `1`

## Details
This documentation addition helps users understand how to configure model loading behavior in Lemonade Server, allowing them to optimize memory usage and model management based on their system capabilities and use case requirements.

https://claude.ai/code/session_01VhyZxheJ1DaY5TRTFimDkp