### PR TITLE
Fix Electron app port discovery always being skipped

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -552,7 +552,7 @@ ipcMain.handle('get-version', async () => {
 });
 
 ipcMain.handle('discover-server-port', async () => {
-  let baseURL = getBaseURLFromConfig();
+  let baseURL = await getBaseURLFromConfig();
   if (baseURL) {
     console.log('Port discovery skipped - using explicit server URL:', baseURL);
     ensureTrayRunning();


### PR DESCRIPTION
## Summary
- `getBaseURLFromConfig()` is `async` but was called without `await` on line 555 of `main.js`
- The unawaited Promise was always truthy, so port discovery was unconditionally skipped and the handler returned `null`
- The renderer interpreted `null` as "explicit URL configured" and stayed on the default port 8000, never discovering the actual server port
- **One-character fix**: add the missing `await`


Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)