### PR TITLE
Add background beacon listener for automatic server port discovery

### DIFF
--- a/src/app/src/renderer/LogsWindow.tsx
+++ b/src/app/src/renderer/LogsWindow.tsx
@@ -127,7 +127,7 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
           setConnectionStatus('error');
           eventSource.close();
 
-          // Attempt to reconnect after 5 seconds
+          // Reconnect after 5 seconds
           reconnectTimeoutRef.current = setTimeout(() => {
             console.log('Attempting to reconnect to log stream...');
             connectToLogStream();
@@ -137,7 +137,6 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
         console.error('Failed to connect to log stream:', error);
         setConnectionStatus('error');
 
-        // Attempt to reconnect after 5 seconds
         reconnectTimeoutRef.current = setTimeout(() => {
           connectToLogStream();
         }, 5000);

--- a/src/app/src/renderer/components/panels/TranscriptionPanel.tsx
+++ b/src/app/src/renderer/components/panels/TranscriptionPanel.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { useModels } from '../../hooks/useModels';
 import { Modality } from '../../hooks/useInferenceState';
 import { ModelsData } from '../../utils/modelData';
-import { serverFetch, getServerBaseUrl } from '../../utils/serverConfig';
+import { serverFetch } from '../../utils/serverConfig';
 import { useAudioCapture } from '../../hooks/useAudioCapture';
 import { TranscriptionWebSocket } from '../../utils/websocketClient';
 import { MicrophoneIcon } from '../Icons';
@@ -91,8 +91,7 @@ const TranscriptionPanel: React.FC<TranscriptionPanelProps> = ({
     if (!ready) return;
 
     try {
-      const serverUrl = getServerBaseUrl();
-      wsClientRef.current = await TranscriptionWebSocket.connect(serverUrl, selectedModel, {
+      wsClientRef.current = await TranscriptionWebSocket.connect(selectedModel, {
         onTranscription: handleLiveTranscription,
         onSpeechEvent: handleSpeechEvent,
         onError: (err) => setLiveError(err),

--- a/src/app/src/renderer/utils/websocketClient.ts
+++ b/src/app/src/renderer/utils/websocketClient.ts
@@ -2,6 +2,7 @@
  * WebSocket client for realtime transcription.
  * Uses a raw WebSocket with OpenAI Realtime API message format.
  */
+import { serverFetch } from './serverConfig';
 
 export interface TranscriptionCallbacks {
   /** Called with transcription text. isFinal=false for interim results that replace previous interim. */
@@ -98,15 +99,13 @@ export class TranscriptionWebSocket {
    * Fetches the WebSocket port from /health endpoint.
    */
   static async connect(
-    serverUrl: string,
     model: string,
     callbacks: TranscriptionCallbacks,
   ): Promise<TranscriptionWebSocket> {
-    // Fetch WebSocket port from /health endpoint
-    const healthUrl = `${serverUrl}/api/v1/health`;
-    console.log('[WebSocket] Fetching WebSocket port from:', healthUrl);
+    // Fetch WebSocket port from /health endpoint using serverFetch for auto port discovery
+    console.log('[WebSocket] Fetching WebSocket port from server');
 
-    const response = await fetch(healthUrl);
+    const response = await serverFetch('/health');
     if (!response.ok) {
       throw new Error(`Failed to fetch health: ${response.status}`);
     }


### PR DESCRIPTION
- Add continuous UDP beacon listener in main process that detects server port changes and broadcasts updates to the renderer
- Fix LogsWindow SSE reconnection to avoid race conditions between discovery callbacks and useEffect re-runs
- Route websocketClient health check through serverFetch for automatic port discovery on failure
- Clean up TranscriptionPanel to use serverFetch instead of raw fetch