### PR TITLE
Fix duplicate server exit messaging

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -861,6 +861,8 @@ void Server::run() {
 
     std::string ipv4 = resolve_host_to_ip(AF_INET, host_);
     std::string ipv6 = resolve_host_to_ip(AF_INET6, host_);
+    std::atomic<bool> listener_started(false);
+    std::atomic<bool> listener_start_failed(false);
 
     running_ = true;
 
@@ -878,17 +880,29 @@ void Server::run() {
     if (!ipv4.empty()) {
         // setup ipv4 thread
         setup_http_logger(*http_server_);
-        http_v4_thread_ = std::thread([this, ipv4]() {
-            http_server_->bind_to_port(ipv4, port_);
-            http_server_->listen_after_bind();
+        http_v4_thread_ = std::thread([this, ipv4, &listener_started, &listener_start_failed]() {
+            if (http_server_->bind_to_port(ipv4, port_) <= 0) {
+                listener_start_failed = true;
+                return;
+            }
+            listener_started = true;
+            if (!http_server_->listen_after_bind()) {
+                listener_start_failed = true;
+            }
         });
     }
     if (!ipv6.empty()) {
         // setup ipv6 thread
         setup_http_logger(*http_server_v6_);
-        http_v6_thread_ = std::thread([this, ipv6]() {
-            http_server_v6_->bind_to_port(ipv6, port_);
-            http_server_v6_->listen_after_bind();
+        http_v6_thread_ = std::thread([this, ipv6, &listener_started, &listener_start_failed]() {
+            if (http_server_v6_->bind_to_port(ipv6, port_) <= 0) {
+                listener_start_failed = true;
+                return;
+            }
+            listener_started = true;
+            if (!http_server_v6_->listen_after_bind()) {
+                listener_start_failed = true;
+            }
         });
     }
 
@@ -918,6 +932,12 @@ void Server::run() {
         http_v4_thread_.join();
     if(http_v6_thread_.joinable())
         http_v6_thread_.join();
+
+    if (!listener_started && listener_start_failed) {
+        std::cerr << "[Server] Another Lemonade router/server instance is already running on "
+                  << host_ << ":" << port_ << ". Duplicate instance now exiting." << std::endl;
+        stop();
+    }
 }
 
 void Server::stop() {

--- a/test/server_cli.py
+++ b/test/server_cli.py
@@ -561,7 +561,60 @@ class EphemeralCLITests(CLITestBase):
             except subprocess.TimeoutExpired:
                 server_process.kill()
 
-    def test_005_status_when_stopped(self):
+    def test_005_duplicate_serve_reports_existing_server(self):
+        """Test duplicate serve prints an explicit already-running message."""
+        self.assertFalse(is_server_running(), "Server should not be running initially")
+
+        first_cmd = [_config["server_binary"], "serve"]
+        second_cmd = [_config["server_binary"], "serve"]
+        if os.name == "nt" or os.getenv("LEMONADE_CI_MODE"):
+            first_cmd.append("--no-tray")
+            second_cmd.append("--no-tray")
+
+        first_process = subprocess.Popen(
+            first_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        try:
+            self.assertTrue(
+                wait_for_server_start(timeout=60),
+                "First server should start within 60 seconds",
+            )
+
+            duplicate_result = subprocess.run(
+                second_cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                encoding="utf-8",
+                errors="replace",
+            )
+
+            duplicate_output = duplicate_result.stdout + duplicate_result.stderr
+            duplicate_output_lower = duplicate_output.lower()
+
+            self.assertNotEqual(
+                duplicate_result.returncode,
+                0,
+                f"Duplicate serve should fail: {duplicate_output}",
+            )
+            self.assertTrue(
+                "already running" in duplicate_output_lower
+                or "duplicate instance now exiting" in duplicate_output_lower,
+                f"Duplicate serve should explain why it exited: {duplicate_output}",
+            )
+        finally:
+            stop_server()
+            first_process.terminate()
+            try:
+                first_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                first_process.kill()
+
+    def test_006_status_when_stopped(self):
         """Test status command when server is not running."""
         self.assertFalse(is_server_running(), "Server should not be running")
 
@@ -576,7 +629,7 @@ class EphemeralCLITests(CLITestBase):
             f"Status should indicate server is not running: {result.stdout}",
         )
 
-    def test_006_recipes_no_server(self):
+    def test_007_recipes_no_server(self):
         """Test recipes command works without server running."""
         self.assertFalse(is_server_running(), "Server should not be running")
 
@@ -605,7 +658,7 @@ class EphemeralCLITests(CLITestBase):
 
         print("[OK] Recipes command works without server running")
 
-    def test_007_status_reports_http_port_not_websocket(self):
+    def test_008_status_reports_http_port_not_websocket(self):
         """Test that status reports the HTTP port, not the WebSocket port.
 
         Regression test: the router listens on both an HTTP port and a
@@ -682,7 +735,7 @@ class EphemeralCLITests(CLITestBase):
             except subprocess.TimeoutExpired:
                 server_process.kill()
 
-    def test_008_recipes_install_no_server(self):
+    def test_009_recipes_install_no_server(self):
         """Test recipes --install works when no server is running (starts ephemeral server)."""
         import sys
 


### PR DESCRIPTION
  ## Summary

  Fixes #1223.

  When a second Lemonade server/router instance starts while one is already
  running, it could initialize, fail to bind, and exit without any explicit
  duplicate-instance message. This change restores a clear message in that path.

  ## Changes

  - detect listener bind/start failure in `Server::run()`
  - print an explicit duplicate-instance exit message when no listener can start
  - keep the normal cleanup/shutdown path unchanged
  - add a CLI regression test covering duplicate `serve` startup

  ## Behavior Before

  A second server process could print normal startup logs, then shut down with
  cleanup messages only, without explaining that another instance was already
  - ran targeted regression test:
    - `EphemeralCLITests.test_005_duplicate_serve_reports_existing_server`

  ## Notes

  - the fix is in the runtime startup path, not just the early single-instance CLI check
  - this covers the case where startup reaches bind/listen and fails because the port is already occupied by the existing instance