### PR TITLE
Fix image generation request timeout

### DIFF
--- a/src/app/src/renderer/recipes/recipeOptionsConfig.ts
+++ b/src/app/src/renderer/recipes/recipeOptionsConfig.ts
@@ -213,7 +213,6 @@ export const OPTION_DEFINITIONS: Record<string, OptionDef> = {
     label: 'Height',
     description: 'Image height in pixels',
   },
-
   // Common option - save settings
   saveOptions: {
     type: 'boolean',

--- a/src/cpp/include/lemon/backends/fastflowlm_server.h
+++ b/src/cpp/include/lemon/backends/fastflowlm_server.h
@@ -59,7 +59,7 @@ public:
                                    const std::string& request_body,
                                    httplib::DataSink& sink,
                                    bool sse = true,
-                                   long timeout_seconds = 0) override;
+                                   long timeout_seconds = -1) override;
 
 private:
     // Static helpers for install logic (no instance state needed)

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -72,19 +72,19 @@ public:
     static HttpResponse post(const std::string& url,
                             const std::string& body,
                             const std::map<std::string, std::string>& headers = {},
-                            long timeout_seconds = 300);
+                            long timeout_seconds = -1);
 
     // Multipart form data POST request
     static HttpResponse post_multipart(const std::string& url,
                                        const std::vector<MultipartField>& fields,
-                                       long timeout_seconds = 300);
+                                       long timeout_seconds = -1);
 
     // Streaming POST request (calls callback for each chunk as it arrives)
     static HttpResponse post_stream(const std::string& url,
                                    const std::string& body,
                                    StreamCallback stream_callback,
                                    const std::map<std::string, std::string>& headers = {},
-                                   long timeout_seconds = 300);
+                                   long timeout_seconds = -1);
 
     // Download file to disk with automatic retry and resume support
     static DownloadResult download_file(const std::string& url,

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -132,7 +132,7 @@ public:
                                            const std::string& request_body,
                                            httplib::DataSink& sink,
                                            bool sse = true,
-                                           long timeout_seconds = 0);
+                                           long timeout_seconds = -1);
 
     // Get the server address
     std::string get_address() const {
@@ -164,12 +164,12 @@ protected:
     virtual bool wait_for_ready(const std::string& endpoint, long timeout_seconds = 600, long poll_interval_ms = 100);
 
     // Common method to forward requests to the wrapped server (non-streaming)
-    json forward_request(const std::string& endpoint, const json& request, long timeout_seconds = 0);
+    json forward_request(const std::string& endpoint, const json& request, long timeout_seconds = -1);
 
     // Forward multipart form data to the wrapped server
     json forward_multipart_request(const std::string& endpoint,
                                    const std::vector<utils::MultipartField>& fields,
-                                   long timeout_seconds = 0);
+                                   long timeout_seconds = -1);
 
     // Validate that the process is running (platform-agnostic check)
     bool is_process_running() const;

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -7,8 +7,11 @@
 #include "lemon/error_types.h"
 #include "lemon/system_info.h"
 #include <httplib.h>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <filesystem>
+#include <stdexcept>
 #include <lemon/utils/aixlog.hpp>
 
 namespace fs = std::filesystem;
@@ -16,6 +19,32 @@ using namespace lemon::utils;
 
 namespace lemon {
 namespace backends {
+namespace {
+
+constexpr const char* kImageRequestTimeoutEnv = "LEMONADE_IMAGE_REQUEST_TIMEOUT";
+
+long get_image_request_timeout_seconds() {
+    const char* raw_value = std::getenv(kImageRequestTimeoutEnv);
+    if (raw_value == nullptr || raw_value[0] == '\0') {
+        return -1;
+    }
+
+    try {
+        size_t parsed_chars = 0;
+        long timeout_seconds = std::stol(raw_value, &parsed_chars);
+        if (parsed_chars != std::strlen(raw_value) || timeout_seconds < 0) {
+            throw std::invalid_argument("invalid timeout");
+        }
+        return timeout_seconds;
+    } catch (const std::exception&) {
+        LOG(WARNING, "SDServer") << "Ignoring invalid " << kImageRequestTimeoutEnv
+                                 << "=" << raw_value
+                                 << "; using global timeout instead" << std::endl;
+        return -1;
+    }
+}
+
+} // namespace
 
 InstallParams SDServer::get_install_params(const std::string& backend, const std::string& version) {
     InstallParams params;
@@ -252,8 +281,7 @@ json SDServer::image_generations(const json& request) {
     LOG(DEBUG, "SDServer") << "Forwarding request to sd-server: "
                   << sd_request.dump(2) << std::endl;
 
-    // Use base class forward_request with 10 minute timeout for image generation
-    return forward_request("/v1/images/generations", sd_request, 600);
+    return forward_request("/v1/images/generations", sd_request, get_image_request_timeout_seconds());
 }
 
 json SDServer::image_edits(const json& request) {
@@ -307,7 +335,7 @@ json SDServer::image_edits(const json& request) {
                   << " size=" << request.value("size", "")
                   << std::endl;
 
-    return forward_multipart_request("/v1/images/edits", fields, 600);
+    return forward_multipart_request("/v1/images/edits", fields, get_image_request_timeout_seconds());
 }
 
 json SDServer::image_variations(const json& request) {
@@ -335,7 +363,7 @@ json SDServer::image_variations(const json& request) {
                   << " size=" << request.value("size", "")
                   << std::endl;
 
-    return forward_multipart_request("/v1/images/edits", fields, 600);
+    return forward_multipart_request("/v1/images/edits", fields, get_image_request_timeout_seconds());
 }
 
 } // namespace backends

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -120,8 +120,8 @@ HttpResponse HttpClient::post(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_);
+    // Negative values use the global default; 0 disables the timeout.
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds >= 0 ? timeout_seconds : default_timeout_seconds_);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     // Add custom headers
@@ -182,8 +182,8 @@ HttpResponse HttpClient::post_multipart(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_);
+    // Negative values use the global default; 0 disables the timeout.
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds >= 0 ? timeout_seconds : default_timeout_seconds_);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     CURLcode res = curl_easy_perform(curl);
@@ -258,8 +258,8 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, stream_write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &callback_data);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_);
+    // Negative values use the global default; 0 disables the timeout.
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds >= 0 ? timeout_seconds : default_timeout_seconds_);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     // Add custom headers

--- a/test/server_cli.py
+++ b/test/server_cli.py
@@ -515,6 +515,23 @@ class EphemeralCLITests(CLITestBase):
             f"Serve help should document LEMONADE_WHISPERCPP_ARGS: {output}",
         )
 
+    def test_001_help_uses_global_timeout_not_image_timeout_no_server(self):
+        """Test help output exposes the global timeout and not the removed image-specific CLI flag."""
+        self.assertFalse(is_server_running(), "Server should not be running")
+        result = self.assertCommandSucceeds(["serve", "--help"])
+        output = result.stdout + result.stderr
+
+        self.assertIn(
+            "--global-timeout",
+            output,
+            f"Serve help should document --global-timeout: {output}",
+        )
+        self.assertNotIn(
+            "--image-request-timeout",
+            output,
+            f"Serve help should not document --image-request-timeout: {output}",
+        )
+
     def test_002_list_ephemeral(self):
         """Test list command starts ephemeral server if needed."""
         self.assertFalse(is_server_running(), "Server should not be running initially")


### PR DESCRIPTION
  ## Summary

  Fixes #1222.

  Image generation requests for `sd-cpp` could time out after 10 minutes even while the backend was still actively generating the image.
  This change removes the hardcoded timeout behavior and adds a configurable server-side setting for image request timeouts.

  ## Changes

  - replace the hardcoded 600 second Stable Diffusion request timeout
  - add a new server config option:
    - CLI: `--image-request-timeout <seconds>`
    - env var: `LEMONADE_IMAGE_REQUEST_TIMEOUT=<seconds>`
  - default `image_request_timeout` to `0` meaning no overall timeout
  - apply the setting consistently to:
    - image generations
    - image edits
    - image variations
  - update the frontend recipe-options mirror so config metadata stays in sync with the server

  ## Behavior Before

  Stable Diffusion requests used a fixed 10 minute timeout in the backend forwarding layer. Long-running image generation jobs could fail
  with a network timeout even though `sd-server` was still processing the request.

  ## Behavior After

  Stable Diffusion image requests now use a configurable timeout, with the default set to no overall timeout.

  Examples:

  ```bash
  lemonade-server serve --image-request-timeout 1800

  LEMONADE_IMAGE_REQUEST_TIMEOUT=1800 lemonade-server serve

  0 disables the timeout entirely.

  ## Testing

  - built lemonade-router successfully:
      - cmake --build --preset default --target lemonade-router

  ## Notes

  - this setting is implemented in the existing server config / recipe options path
  - the fix is server-side, so it applies to CLI, web app, and other clients using the same server