### PR TITLE
Fix Windows Unicode cache paths for downloads

### DIFF
--- a/src/cpp/include/lemon/utils/path_utils.h
+++ b/src/cpp/include/lemon/utils/path_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <string>
 
 namespace lemon {
@@ -33,6 +34,21 @@ std::string find_flm_executable();
  * @return true if validation succeeds, false otherwise.
  */
 bool run_flm_validate(const std::string& flm_path, std::string& error_message);
+
+/**
+ * Get an environment variable as UTF-8 text.
+ */
+std::string get_environment_variable_utf8(const std::string& name);
+
+/**
+ * Convert a UTF-8 path string to a std::filesystem::path.
+ */
+std::filesystem::path path_from_utf8(const std::string& path);
+
+/**
+ * Convert a std::filesystem::path to a UTF-8 string.
+ */
+std::string path_to_utf8(const std::filesystem::path& path);
 
 /**
  * Get the cache directory

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -223,28 +223,28 @@ std::string ModelManager::get_recipe_options_file() {
 
 std::string ModelManager::get_hf_cache_dir() const {
     // Check HF_HUB_CACHE first (highest priority)
-    const char* hf_hub_cache_env = std::getenv("HF_HUB_CACHE");
-    if (hf_hub_cache_env) {
-        return std::string(hf_hub_cache_env);
+    std::string hf_hub_cache_env = get_environment_variable_utf8("HF_HUB_CACHE");
+    if (!hf_hub_cache_env.empty()) {
+        return hf_hub_cache_env;
     }
 
     // Check HF_HOME second (append /hub)
-    const char* hf_home_env = std::getenv("HF_HOME");
-    if (hf_home_env) {
-        return std::string(hf_home_env) + "/hub";
+    std::string hf_home_env = get_environment_variable_utf8("HF_HOME");
+    if (!hf_home_env.empty()) {
+        return hf_home_env + "/hub";
     }
 
     // Default platform-specific paths
 #ifdef _WIN32
-    const char* userprofile = std::getenv("USERPROFILE");
-    if (userprofile) {
-        return std::string(userprofile) + "\\.cache\\huggingface\\hub";
+    std::string userprofile = get_environment_variable_utf8("USERPROFILE");
+    if (!userprofile.empty()) {
+        return userprofile + "\\.cache\\huggingface\\hub";
     }
     return "C:\\.cache\\huggingface\\hub";
 #else
-    const char* home = std::getenv("HOME");
-    if (home) {
-        return std::string(home) + "/.cache/huggingface/hub";
+    std::string home = get_environment_variable_utf8("HOME");
+    if (!home.empty()) {
+        return home + "/.cache/huggingface/hub";
     }
     return "/tmp/.cache/huggingface/hub";
 #endif
@@ -448,13 +448,14 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
     }
 
     std::string model_cache_path = hf_cache + "/" + cache_dir_name;
+    fs::path model_cache_path_fs = path_from_utf8(model_cache_path);
 
     // For RyzenAI LLM models, look for genai_config.json directory
     if (info.recipe == "ryzenai-llm") {
-        if (fs::exists(model_cache_path)) {
-            for (const auto& entry : fs::recursive_directory_iterator(model_cache_path)) {
+        if (fs::exists(model_cache_path_fs)) {
+            for (const auto& entry : fs::recursive_directory_iterator(model_cache_path_fs)) {
                 if (entry.is_regular_file() && entry.path().filename() == "genai_config.json") {
-                    return entry.path().parent_path().string();
+                    return path_to_utf8(entry.path().parent_path());
                 }
             }
         }
@@ -463,10 +464,10 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
 
     // For kokoro models, look for index.json directory
     if (info.recipe == "kokoro") {
-        if (fs::exists(model_cache_path)) {
-            for (const auto& entry : fs::recursive_directory_iterator(model_cache_path)) {
+        if (fs::exists(model_cache_path_fs)) {
+            for (const auto& entry : fs::recursive_directory_iterator(model_cache_path_fs)) {
                 if (entry.is_regular_file() && entry.path().filename() == "index.json") {
-                    return entry.path().string();
+                    return path_to_utf8(entry.path());
                 }
             }
         }
@@ -477,17 +478,17 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
     // For whispercpp, find the .bin model file
     if (info.recipe == "whispercpp" && variant.empty()) {
         // No variant specified - use fallback logic to find any .bin file
-        if (!fs::exists(model_cache_path)) {
+        if (!fs::exists(model_cache_path_fs)) {
             return model_cache_path;  // Return directory path even if not found
         }
 
         // Collect all .bin files
         std::vector<std::string> all_bin_files;
-        for (const auto& entry : fs::recursive_directory_iterator(model_cache_path)) {
+        for (const auto& entry : fs::recursive_directory_iterator(model_cache_path_fs)) {
             if (entry.is_regular_file()) {
                 std::string filename = entry.path().filename().string();
                 if (filename.find(".bin") != std::string::npos) {
-                    all_bin_files.push_back(entry.path().string());
+                    all_bin_files.push_back(path_to_utf8(entry.path()));
                 }
             }
         }
@@ -505,20 +506,20 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
 
     // For llamacpp, find the GGUF file with advanced sharded model support
     if (info.recipe == "llamacpp" && type == "main") {
-        if (!fs::exists(model_cache_path)) {
+        if (!fs::exists(model_cache_path_fs)) {
             return model_cache_path;  // Return directory path even if not found
         }
 
         // Collect all GGUF files (exclude mmproj files)
         std::vector<std::string> all_gguf_files;
-        for (const auto& entry : fs::recursive_directory_iterator(model_cache_path)) {
+        for (const auto& entry : fs::recursive_directory_iterator(model_cache_path_fs)) {
             if (entry.is_regular_file()) {
                 std::string filename = entry.path().filename().string();
                 std::string filename_lower = filename;
                 std::transform(filename_lower.begin(), filename_lower.end(), filename_lower.begin(), ::tolower);
 
                 if (filename.find(".gguf") != std::string::npos && filename_lower.find("mmproj") == std::string::npos) {
-                    all_gguf_files.push_back(entry.path().string());
+                    all_gguf_files.push_back(path_to_utf8(entry.path()));
                 }
             }
         }
@@ -543,7 +544,7 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
         // Case 2: Exact filename match (variant ends with .gguf)
         if (variant.find(".gguf") != std::string::npos) {
             for (const auto& filepath : all_gguf_files) {
-                std::string filename = fs::path(filepath).filename().string();
+                std::string filename = path_from_utf8(filepath).filename().string();
                 if (filename == variant) {
                     return filepath;
                 }
@@ -558,7 +559,7 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
 
         std::vector<std::string> matching_files;
         for (const auto& filepath : all_gguf_files) {
-            std::string filename = fs::path(filepath).filename().string();
+            std::string filename = path_from_utf8(filepath).filename().string();
             std::string filename_lower = filename;
             std::transform(filename_lower.begin(), filename_lower.end(), filename_lower.begin(), ::tolower);
 
@@ -577,7 +578,8 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
 
         for (const auto& filepath : all_gguf_files) {
             // Get relative path from model cache path
-            std::string relative_path = filepath.substr(model_cache_path.length());
+            std::string relative_path = path_to_utf8(
+                path_from_utf8(filepath).lexically_relative(model_cache_path_fs));
             std::string relative_lower = relative_path;
             std::transform(relative_lower.begin(), relative_lower.end(), relative_lower.begin(), ::tolower);
 
@@ -593,18 +595,17 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
     // Everything else
     if (!variant.empty()) {
         // Try to find the exact variant in snapshots subdirectories
-        if (fs::exists(model_cache_path)) {
-            for (const auto& entry : fs::recursive_directory_iterator(model_cache_path)) {
+        if (fs::exists(model_cache_path_fs)) {
+            for (const auto& entry : fs::recursive_directory_iterator(model_cache_path_fs)) {
                 if (entry.is_regular_file()) {
                     std::string filename = entry.path().filename().string();
                     if (filename == variant) {
-                        return entry.path().string();
+                        return path_to_utf8(entry.path());
                     }
                 } else if (entry.is_directory()) {
-                    // variant could be a path
-                    std::string variant_path = (entry.path() / variant).string();
+                    fs::path variant_path = entry.path() / path_from_utf8(variant);
                     if (fs::exists(variant_path)) {
-                        return variant_path;
+                        return path_to_utf8(variant_path);
                     }
                 }
             }
@@ -1822,9 +1823,10 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
 
     // Get Hugging Face cache directory
     std::string hf_cache = get_hf_cache_dir();
+    fs::path hf_cache_path = path_from_utf8(hf_cache);
 
     // Create cache directory structure
-    fs::create_directories(hf_cache);
+    fs::create_directories(hf_cache_path);
 
     std::string cache_dir_name = "models--";
     for (char c : main_repo_id) {
@@ -1835,7 +1837,7 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
         }
     }
 
-    std::string model_cache_path = hf_cache + "/" + cache_dir_name;
+    fs::path model_cache_path = hf_cache_path / cache_dir_name;
     fs::create_directories(model_cache_path);
 
     // Get HF token if available
@@ -1881,13 +1883,13 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
     }
 
     // Create snapshot directory using commit hash
-    std::string snapshot_path = model_cache_path + "/snapshots/" + commit_hash;
+    fs::path snapshot_path = model_cache_path / "snapshots" / commit_hash;
     fs::create_directories(snapshot_path);
 
     // Create refs/main file pointing to this commit (matching huggingface_hub behavior)
-    std::string refs_dir = model_cache_path + "/refs";
+    fs::path refs_dir = model_cache_path / "refs";
     fs::create_directories(refs_dir);
-    std::string refs_main_path = refs_dir + "/main";
+    fs::path refs_main_path = refs_dir / "main";
     std::ofstream refs_file(refs_main_path);
     if (refs_file.is_open()) {
         refs_file << commit_hash;
@@ -1980,7 +1982,7 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
 
     // Create download manifest to track incomplete downloads
     // This allows us to detect partially downloaded models
-    std::string manifest_path = snapshot_path + "/.download_manifest.json";
+    std::string manifest_path = path_to_utf8(snapshot_path / ".download_manifest.json");
 
     // Fetch file sizes from the tree API (the models API doesn't include sizes)
     std::map<std::string, size_t> file_sizes;
@@ -2011,7 +2013,7 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
     json manifest;
     manifest["repo_id"] = main_repo_id;
     manifest["commit_hash"] = commit_hash;
-    manifest["download_path"] = snapshot_path;
+    manifest["download_path"] = path_to_utf8(snapshot_path);
     manifest["files_count"] = total_files;
     manifest["files"] = json::array();
     for (auto const& [repo_id, files] : files_to_download) {
@@ -2050,7 +2052,7 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
     }
 
     std::cout << "[ModelManager] ✓ All files downloaded and validated successfully!" << std::endl;
-    std::cout << "[ModelManager DEBUG] Download location: " << snapshot_path << std::endl;
+    std::cout << "[ModelManager DEBUG] Download location: " << path_to_utf8(snapshot_path) << std::endl;
 }
 
 void ModelManager::download_from_flm(const std::string& checkpoint,
@@ -2369,14 +2371,14 @@ void ModelManager::delete_model(const std::string& model_name) {
 
     // Find the models--* directory from resolved_path
     // resolved_path could be a file or directory, we need to find the models-- ancestor
-    fs::path path_obj(info.resolved_path());
+    fs::path path_obj(path_from_utf8(info.resolved_path()));
     std::string model_cache_path;
 
     // Walk up the directory tree to find models--* directory
     while (!path_obj.empty() && path_obj.has_filename()) {
         std::string dirname = path_obj.filename().string();
         if (dirname.find("models--") == 0) {
-            model_cache_path = path_obj.string();
+            model_cache_path = path_to_utf8(path_obj);
             break;
         }
         path_obj = path_obj.parent_path();
@@ -2388,9 +2390,10 @@ void ModelManager::delete_model(const std::string& model_name) {
 
     std::cout << "[ModelManager] Cache path: " << model_cache_path << std::endl;
 
-    if (fs::exists(model_cache_path)) {
+    fs::path model_cache_path_fs = path_from_utf8(model_cache_path);
+    if (fs::exists(model_cache_path_fs)) {
         std::cout << "[ModelManager] Removing directory..." << std::endl;
-        fs::remove_all(model_cache_path);
+        fs::remove_all(model_cache_path_fs);
         std::cout << "[ModelManager] ✓ Deleted model files: " << model_name << std::endl;
     } else {
         std::cout << "[ModelManager] Warning: Model cache directory not found (may already be deleted)" << std::endl;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2704,13 +2704,16 @@ void Server::resolve_and_register_local_model(
 
     // Build checkpoint for registration - store as relative path from HF cache
     std::string checkpoint_to_register;
+    std::filesystem::path hf_cache_path = utils::path_from_utf8(hf_cache);
     if (!resolved_checkpoint.empty()) {
-        std::filesystem::path rel = std::filesystem::relative(resolved_checkpoint, hf_cache);
-        checkpoint_to_register = rel.string();
+        std::filesystem::path rel = std::filesystem::relative(
+            utils::path_from_utf8(resolved_checkpoint), hf_cache_path);
+        checkpoint_to_register = utils::path_to_utf8(rel);
     } else {
         // Fallback - use dest_path relative to hf_cache
-        std::filesystem::path rel = std::filesystem::relative(dest_path, hf_cache);
-        checkpoint_to_register = rel.string();
+        std::filesystem::path rel = std::filesystem::relative(
+            utils::path_from_utf8(dest_path), hf_cache_path);
+        checkpoint_to_register = utils::path_to_utf8(rel);
     }
 
     std::cout << "[Server] Registering model with checkpoint: " << checkpoint_to_register << std::endl;

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -1,4 +1,5 @@
 #include <lemon/utils/http_client.h>
+#include <lemon/utils/path_utils.h>
 #include <curl/curl.h>
 #include <sstream>
 #include <stdexcept>
@@ -308,7 +309,13 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
     }
 
     const char* mode = (resume_from > 0) ? "ab" : "wb";
+    fs::path output_path_fs = path_from_utf8(output_path);
+#ifdef _WIN32
+    std::wstring wide_mode = (resume_from > 0) ? L"ab" : L"wb";
+    FILE* fp = _wfopen(output_path_fs.c_str(), wide_mode.c_str());
+#else
     FILE* fp = fopen(output_path.c_str(), mode);
+#endif
     if (!fp) {
         result.error_message = "Failed to open file for writing: " + output_path;
         curl_easy_cleanup(curl);
@@ -402,8 +409,8 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
         }
 
         size_t current_file_size = 0;
-        if (fs::exists(output_path)) {
-            current_file_size = fs::file_size(output_path);
+        if (fs::exists(output_path_fs)) {
+            current_file_size = fs::file_size(output_path_fs);
         }
         result.can_resume = retryable && (current_file_size > 0);
 
@@ -502,9 +509,11 @@ DownloadResult HttpClient::download_file(const std::string& url,
 
     // Use .partial extension for in-progress downloads
     std::string partial_path = output_path + ".partial";
+    fs::path output_path_fs = path_from_utf8(output_path);
+    fs::path partial_path_fs = path_from_utf8(partial_path);
 
     // Check if final file already exists and is complete
-    if (fs::exists(output_path) && !fs::exists(partial_path)) {
+    if (fs::exists(output_path_fs) && !fs::exists(partial_path_fs)) {
         // Final file exists with no partial - consider it complete
         final_result.success = true;
         final_result.bytes_downloaded = 0;
@@ -514,8 +523,8 @@ DownloadResult HttpClient::download_file(const std::string& url,
 
     // Check for existing partial file to resume
     size_t resume_offset = 0;
-    if (options.resume_partial && fs::exists(partial_path)) {
-        resume_offset = fs::file_size(partial_path);
+    if (options.resume_partial && fs::exists(partial_path_fs)) {
+        resume_offset = fs::file_size(partial_path_fs);
         if (resume_offset > 0) {
             std::cout << "\n[Download] Found partial file ("
                       << std::fixed << std::setprecision(1)
@@ -533,8 +542,8 @@ DownloadResult HttpClient::download_file(const std::string& url,
             // Exponential backoff (parentheses avoid Windows min/max macro)
             retry_delay_ms = (std::min)(retry_delay_ms * 2, options.max_retry_delay_ms);
 
-            if (options.resume_partial && fs::exists(partial_path)) {
-                size_t new_offset = fs::file_size(partial_path);
+            if (options.resume_partial && fs::exists(partial_path_fs)) {
+                size_t new_offset = fs::file_size(partial_path_fs);
                 if (new_offset > resume_offset) {
                     resume_offset = new_offset;
                     std::cout << "[Download] Resuming from "
@@ -570,12 +579,12 @@ DownloadResult HttpClient::download_file(const std::string& url,
         if (final_result.success) {
             // Download complete - rename .partial to final path
             std::error_code ec;
-            fs::rename(partial_path, output_path, ec);
+            fs::rename(partial_path_fs, output_path_fs, ec);
             if (ec) {
                 // Rename failed - try copy and delete
-                fs::copy_file(partial_path, output_path, fs::copy_options::overwrite_existing, ec);
+                fs::copy_file(partial_path_fs, output_path_fs, fs::copy_options::overwrite_existing, ec);
                 if (!ec) {
-                    fs::remove(partial_path, ec);
+                    fs::remove(partial_path_fs, ec);
                 }
             }
             if (ec) {
@@ -589,9 +598,9 @@ DownloadResult HttpClient::download_file(const std::string& url,
             std::cerr << "\n[Download] Error (attempt " << (attempt + 1) << "): "
                       << final_result.error_message << std::endl;
 
-            if (fs::exists(partial_path)) {
+            if (fs::exists(partial_path_fs)) {
                 std::cerr << "[Download] Removing incomplete file for fresh retry..." << std::endl;
-                fs::remove(partial_path);
+                fs::remove(partial_path_fs);
             }
             resume_offset = 0;
         } else if (final_result.can_resume) {
@@ -606,8 +615,8 @@ DownloadResult HttpClient::download_file(const std::string& url,
     oss << "Download failed after " << (options.max_retries + 1) << " attempts.\n";
     oss << "Last error: " << final_result.error_message;
 
-    if (fs::exists(partial_path)) {
-        size_t partial_size = fs::file_size(partial_path);
+    if (fs::exists(partial_path_fs)) {
+        size_t partial_size = fs::file_size(partial_path_fs);
         if (partial_size > 0) {
             oss << "\n\nPartial file preserved: " << partial_path;
             oss << "\nPartial size: " << std::fixed << std::setprecision(1)

--- a/src/cpp/server/utils/json_utils.cpp
+++ b/src/cpp/server/utils/json_utils.cpp
@@ -1,4 +1,5 @@
 #include <lemon/utils/json_utils.h>
+#include <lemon/utils/path_utils.h>
 #include <fstream>
 #include <stdexcept>
 #include <vector>
@@ -7,7 +8,7 @@ namespace lemon {
 namespace utils {
 
 json JsonUtils::load_from_file(const std::string& file_path) {
-    std::ifstream file(file_path);
+    std::ifstream file(path_from_utf8(file_path));
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open file: " + file_path);
     }
@@ -23,7 +24,7 @@ json JsonUtils::load_from_file(const std::string& file_path) {
 }
 
 void JsonUtils::save_to_file(const json& j, const std::string& file_path) {
-    std::ofstream file(file_path);
+    std::ofstream file(path_from_utf8(file_path));
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open file for writing: " + file_path);
     }

--- a/src/cpp/server/utils/path_utils.cpp
+++ b/src/cpp/server/utils/path_utils.cpp
@@ -22,6 +22,70 @@ namespace fs = std::filesystem;
 
 namespace lemon::utils {
 
+#ifdef _WIN32
+static std::wstring utf8_to_wstring(const std::string& str) {
+    if (str.empty()) return std::wstring();
+
+    int size_needed = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
+    if (size_needed <= 0) {
+        return std::wstring();
+    }
+
+    std::wstring result(size_needed, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &result[0], size_needed);
+    result.resize(size_needed - 1);
+    return result;
+}
+
+static std::string wstring_to_utf8(const std::wstring& wstr) {
+    if (wstr.empty()) return std::string();
+
+    int size_needed = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    if (size_needed <= 0) {
+        return std::string();
+    }
+
+    std::string result(size_needed, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, &result[0], size_needed, nullptr, nullptr);
+    result.resize(size_needed - 1);
+    return result;
+}
+#endif
+
+std::string get_environment_variable_utf8(const std::string& name) {
+#ifdef _WIN32
+    std::wstring wide_name = utf8_to_wstring(name);
+    DWORD size_needed = GetEnvironmentVariableW(wide_name.c_str(), nullptr, 0);
+    if (size_needed == 0) {
+        return "";
+    }
+
+    std::wstring value(size_needed, L'\0');
+    GetEnvironmentVariableW(wide_name.c_str(), &value[0], size_needed);
+    value.resize(size_needed - 1);
+    return wstring_to_utf8(value);
+#else
+    const char* value = std::getenv(name.c_str());
+    return value ? std::string(value) : "";
+#endif
+}
+
+fs::path path_from_utf8(const std::string& path) {
+#ifdef _WIN32
+    return fs::u8path(path);
+#else
+    return fs::path(path);
+#endif
+}
+
+std::string path_to_utf8(const fs::path& path) {
+#ifdef _WIN32
+    return wstring_to_utf8(path.wstring());
+#else
+    return path.string();
+#endif
+}
+
 std::string get_executable_dir() {
 #ifdef _WIN32
     char buffer[MAX_PATH];
@@ -141,33 +205,35 @@ std::string find_flm_executable() {
 }
 
 std::string get_cache_dir() {
-    const char* cache_dir_env = std::getenv("LEMONADE_CACHE_DIR");
-    if (cache_dir_env) {
-        std::string cache_dir = std::string(cache_dir_env);
+    std::string cache_dir_env = get_environment_variable_utf8("LEMONADE_CACHE_DIR");
+    if (!cache_dir_env.empty()) {
+        std::string cache_dir = cache_dir_env;
 #ifdef __APPLE__
         // Ensure directory exists on macOS
-        if (!fs::exists(cache_dir)) {
-            fs::create_directories(cache_dir);
+        fs::path cache_path = path_from_utf8(cache_dir);
+        if (!fs::exists(cache_path)) {
+            fs::create_directories(cache_path);
         }
 #endif
         return cache_dir;
     }
 
 #ifdef _WIN32
-    const char* userprofile = std::getenv("USERPROFILE");
-    if (userprofile) {
-        return std::string(userprofile) + "\\.cache\\lemonade";
+    std::string userprofile = get_environment_variable_utf8("USERPROFILE");
+    if (!userprofile.empty()) {
+        return userprofile + "\\.cache\\lemonade";
     }
 #elif defined(__APPLE__)
     // Check if we are running as root (UID 0)
     if (geteuid() != 0) {
         // --- NORMAL USER MODE ---
-        const char* home = std::getenv("HOME");
-        if (home) {
-            std::string cache_dir = std::string(home) + "/.cache/lemonade";
+        std::string home = get_environment_variable_utf8("HOME");
+        if (!home.empty()) {
+            std::string cache_dir = home + "/.cache/lemonade";
             // Ensure directory exists
-            if (!fs::exists(cache_dir)) {
-                fs::create_directories(cache_dir);
+            fs::path cache_path = path_from_utf8(cache_dir);
+            if (!fs::exists(cache_path)) {
+                fs::create_directories(cache_path);
             }
             return cache_dir;
         }
@@ -176,8 +242,9 @@ std::string get_cache_dir() {
         if (pw) {
             std::string cache_dir = std::string(pw->pw_dir) + "/.cache/lemonade";
             // Ensure directory exists
-            if (!fs::exists(cache_dir)) {
-                fs::create_directories(cache_dir);
+            fs::path cache_path = path_from_utf8(cache_dir);
+            if (!fs::exists(cache_path)) {
+                fs::create_directories(cache_path);
             }
             return cache_dir;
         }
@@ -188,16 +255,17 @@ std::string get_cache_dir() {
     // /Users/Shared is okay, but /Library/Application Support is the standard macOS system path.
     std::string cache_dir = "/Library/Application Support/lemonade/.cache";
     // Ensure directory exists
-    if (!fs::exists(cache_dir)) {
-        fs::create_directories(cache_dir);
+    fs::path cache_path = path_from_utf8(cache_dir);
+    if (!fs::exists(cache_path)) {
+        fs::create_directories(cache_path);
     }
     return cache_dir;
 
 #else
     // Linux and other Unix systems
-    const char* home = std::getenv("HOME");
-    if (home) {
-        return std::string(home) + "/.cache/lemonade";
+    std::string home = get_environment_variable_utf8("HOME");
+    if (!home.empty()) {
+        return home + "/.cache/lemonade";
     }
     #endif
 
@@ -210,8 +278,9 @@ std::string get_downloaded_bin_dir() {
     std::string bin_dir = get_cache_dir() + "/bin";
 
     // Ensure directory exists
-    if (!fs::exists(bin_dir)) {
-        fs::create_directories(bin_dir);
+    fs::path bin_path = path_from_utf8(bin_dir);
+    if (!fs::exists(bin_path)) {
+        fs::create_directories(bin_path);
     }
 
     return bin_dir;


### PR DESCRIPTION
  ## Summary

  Fixes #1153.

  Model downloads on Windows could fail when the user’s home directory contained non-ASCII characters. The Hugging Face cache path and
  download targets were being handled through narrow string/file APIs, which could corrupt the path and cause downloads to fail silently.

  ## Changes

  - add UTF-8/native path conversion helpers in the shared path utilities
  - read Windows environment variables (`HF_HUB_CACHE`, `HF_HOME`, `USERPROFILE`) through Unicode-safe APIs
  - make Hugging Face cache path handling use `std::filesystem::path` instead of relying on lossy narrow strings
  - make JSON file reads/writes use filesystem paths
  - make downloader output file creation use `_wfopen` on Windows for Unicode-safe file paths
  - update local import / relative path handling to use the same UTF-8/native path conversions

  ## Root Cause

  The Windows download flow mixed UTF-8 text with narrow CRT/file APIs and narrow environment variable reads. When the home path
  contained characters outside the active code page, the Hugging Face cache path could be mangled (for example `Böckh` becoming `B�ckh`),
  which then broke directory creation and file writes.

  ## Behavior Before

  - cache paths could be logged with corrupted characters
  - `pull` for non-FLM models could fail under home directories with special characters
  - failures could appear silent because the path corruption happened before or during file creation/writes

  ## Behavior After

  - Windows cache paths are handled with Unicode-safe APIs and native filesystem paths
  - Hugging Face downloads can use cache locations under home directories with special characters
  - the same Unicode-safe handling is applied across cache path lookup, directory creation, manifest writes, and download file writes

  ## Testing

  - built `lemonade-router` successfully:
    - `cmake --build --preset default --target lemonade-router`

  ## Notes

  - this fixes the underlying path handling instead of only adding a warning
  - `HF_HOME` and `HF_HUB_CACHE` remain valid workarounds/overrides, but should no longer be required just because the Windows home path
  contains special characters