### PR TITLE
Fix code block formatting in NPU Linux documentation

### DIFF
--- a/docs/flm_npu_linux.html
+++ b/docs/flm_npu_linux.html
@@ -283,8 +283,8 @@
         </div>
         <p>Add these lines at the end:</p>
         <div class="code-block">
-          <code>*    soft    memlock    unlimited
-       * hard    memlock    unlimited</code>
+          <pre><code>*    soft    memlock    unlimited
+*    hard    memlock    unlimited</code></pre>
         </div>
         <p>Then <strong>log out and log back in</strong> for changes to take effect.</p>
       </div>


### PR DESCRIPTION
The "lines at the end" should show as 2 separate lines in the code block.

old:
<img width="932" height="315" alt="image" src="https://github.com/user-attachments/assets/971e22a6-fee6-4f5c-b913-c3d8fdbc168d" />

new:
<img width="957" height="307" alt="image" src="https://github.com/user-attachments/assets/32a91103-fe03-4feb-b3be-ef43ebcee540" />
