### PR TITLE
Fix incorrect skipping of PID file and instance locks

### DIFF
--- a/src/cpp/include/lemon/single_instance.h
+++ b/src/cpp/include/lemon/single_instance.h
@@ -39,13 +39,6 @@ public:
 
         return false;
 #else
-        // Skip lock file when running under systemd, unless explicitly disabled
-        const char* journal_stream = std::getenv("JOURNAL_STREAM");
-        const char* disable_journal = std::getenv("LEMONADE_DISABLE_SYSTEMD_JOURNAL");
-        if (journal_stream && !disable_journal) {
-            return false;  // Systemd ensures single instance
-        }
-
         std::string lock_file = "/tmp/lemonade_" + app_name + ".lock";
         int fd = open(lock_file.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0666);
 

--- a/src/cpp/tray/server_manager.cpp
+++ b/src/cpp/tray/server_manager.cpp
@@ -777,14 +777,6 @@ bool ServerManager::terminate_router_tree() {
 }
 
 void ServerManager::write_pid_file() {
-    // Skip PID file when running under systemd, unless explicitly disabled
-    // LEMONADE_DISABLE_SYSTEMD_JOURNAL can be set in CI to force PID file creation
-    const char* journal_stream = std::getenv("JOURNAL_STREAM");
-    const char* disable_journal = std::getenv("LEMONADE_DISABLE_SYSTEMD_JOURNAL");
-    if (journal_stream && !disable_journal) {
-        return;  // Systemd tracks PID itself
-    }
-
     std::string pid_file_path = "/tmp/lemonade-router.pid";
     DEBUG_LOG(this, "write_pid_file() called - PID: " << server_pid_ << ", Port: " << port_);
 
@@ -801,13 +793,6 @@ void ServerManager::write_pid_file() {
 }
 
 void ServerManager::remove_pid_file() {
-    // Skip PID file when running under systemd, unless explicitly disabled
-    const char* journal_stream = std::getenv("JOURNAL_STREAM");
-    const char* disable_journal = std::getenv("LEMONADE_DISABLE_SYSTEMD_JOURNAL");
-    if (journal_stream && !disable_journal) {
-        return;
-    }
-
     std::string pid_file_path = "/tmp/lemonade-router.pid";
     if (remove(pid_file_path.c_str()) == 0) {
         DEBUG_LOG(this, "Removed PID file: " << pid_file_path);


### PR DESCRIPTION
JOURNAL_STREAM is inherited by all processes in a systemd login session, not just actual systemd service processes. Guards in write_pid_file(), remove_pid_file(), and SingleInstance::IsAnotherInstanceRunning() were using this env var to detect a systemd service context, but this caused those mechanisms to be bypassed whenever lemonade was started from a terminal on a modern systemd-based Linux system.

Consequences:
- `lemonade-server status` always reported "Server is not running" even when the server was running (PID file was never written)
- Multiple instances of lemonade-router, lemonade-server, or lemonade-tray could run simultaneously (lock file was never created or checked)

get_server_info() already handles the true systemd service case via is_any_systemd_service_active() before falling through to the PID file, so writing the PID file and lock files unconditionally is safe.