### PR TITLE
Fix journald detection using sd_pid_get_unit() instead of JOURNAL_STREAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,9 +691,13 @@ elseif(UNIX)
     if(PkgConfig_FOUND)
         pkg_check_modules(SYSTEMD QUIET libsystemd)
         if(SYSTEMD_FOUND)
+            set(LEMONADE_SYSTEMD_UNIT_NAME "lemonade-server.service" CACHE STRING
+                "Systemd unit name to match for journald log mode (overridable at runtime via LEMONADE_SYSTEMD_UNIT env var)")
             target_include_directories(${EXECUTABLE_NAME} PRIVATE ${SYSTEMD_INCLUDE_DIRS})
             target_link_libraries(${EXECUTABLE_NAME} PRIVATE ${SYSTEMD_LIBRARIES})
-            target_compile_definitions(${EXECUTABLE_NAME} PRIVATE HAVE_SYSTEMD)
+            target_compile_definitions(${EXECUTABLE_NAME} PRIVATE
+                HAVE_SYSTEMD
+                LEMONADE_SYSTEMD_UNIT_NAME="${LEMONADE_SYSTEMD_UNIT_NAME}")
         endif()
     endif()
 endif()

--- a/src/cpp/tray/CMakeLists.txt
+++ b/src/cpp/tray/CMakeLists.txt
@@ -234,9 +234,15 @@ if(UNIX AND NOT APPLE)
     if(PKG_CONFIG_FOUND)
         pkg_check_modules(SYSTEMD QUIET libsystemd)
         if(SYSTEMD_FOUND)
+            if(NOT DEFINED LEMONADE_SYSTEMD_UNIT_NAME)
+                set(LEMONADE_SYSTEMD_UNIT_NAME "lemonade-server.service" CACHE STRING
+                    "Systemd unit name to match for journald log mode (overridable at runtime via LEMONADE_SYSTEMD_UNIT env var)")
+            endif()
             target_include_directories(lemonade-server PRIVATE ${SYSTEMD_INCLUDE_DIRS})
             target_link_libraries(lemonade-server PRIVATE ${SYSTEMD_LIBRARIES})
-            target_compile_definitions(lemonade-server PRIVATE HAVE_SYSTEMD)
+            target_compile_definitions(lemonade-server PRIVATE
+                HAVE_SYSTEMD
+                LEMONADE_SYSTEMD_UNIT_NAME="${LEMONADE_SYSTEMD_UNIT_NAME}")
         endif()
     endif()
 endif()

--- a/src/cpp/tray/tray_app.cpp
+++ b/src/cpp/tray/tray_app.cpp
@@ -40,6 +40,7 @@
 #ifdef HAVE_SYSTEMD
 #include <systemd/sd-bus.h>
 #include <systemd/sd-daemon.h>
+#include <systemd/sd-login.h>
 #endif
 #endif
 
@@ -2220,17 +2221,35 @@ bool TrayApp::start_server() {
             log_file_ = "lemonade-server.log";
         }
         #else
-        // Use systemd journal if JOURNAL_STREAM is set, unless explicitly disabled
-        // LEMONADE_DISABLE_SYSTEMD_JOURNAL can be set in CI to force file logging
-        const char* journal_stream = std::getenv("JOURNAL_STREAM");
+        // Use systemd journal only when actually running as lemonade-server.service.
+        // sd_pid_get_unit() reads the process's cgroup assignment (not environment variables),
+        // so it cannot give false positives from inherited env vars like JOURNAL_STREAM or
+        // INVOCATION_ID, both of which are inherited by all child processes in a systemd session.
+        // LEMONADE_DISABLE_SYSTEMD_JOURNAL overrides this for testing/CI.
+        #ifdef HAVE_SYSTEMD
+        const char* service_name_env = std::getenv("LEMONADE_SYSTEMD_UNIT");
+        const char* service_name = service_name_env ? service_name_env : LEMONADE_SYSTEMD_UNIT_NAME;
+        char* unit_name = nullptr;
         const char* disable_journal = std::getenv("LEMONADE_DISABLE_SYSTEMD_JOURNAL");
-        if (journal_stream && !disable_journal) {
-            log_file_ = "-";  // Special value: don't redirect stdout/stderr
-            DEBUG_LOG(this, "Detected systemd environment - logging will go to journal");
+        if (!disable_journal && sd_pid_get_unit(0, &unit_name) >= 0) {
+            bool is_service = (strcmp(unit_name, service_name) == 0);
+            free(unit_name);
+            if (is_service) {
+                log_file_ = "-";  // Special value: don't redirect stdout/stderr
+                DEBUG_LOG(this, "Detected systemd environment - logging will go to journal");
+            } else {
+                log_file_ = "/tmp/lemonade-server.log";
+                DEBUG_LOG(this, "Using default log file: " << log_file_);
+            }
         } else {
+            if (unit_name) free(unit_name);
             log_file_ = "/tmp/lemonade-server.log";
             DEBUG_LOG(this, "Using default log file: " << log_file_);
         }
+        #else
+        log_file_ = "/tmp/lemonade-server.log";
+        DEBUG_LOG(this, "Using default log file: " << log_file_);
+        #endif
         #endif
     }
 


### PR DESCRIPTION
JOURNAL_STREAM is inherited by all processes in a systemd login session, not just actual systemd service processes. This caused both the server and tray app to enter journald mode even when launched directly from a terminal.

This change replaces the JOURNAL_STREAM env var check in both files with sd_pid_get_unit(0), which reads the process's actual cgroup unit membership via /proc and cannot be inherited. Journald mode is now entered only when the process is genuinely running as the configured systemd unit.

The unit name defaults to "lemonade-server.service" but can be overridden at build time via the CMake cache variable LEMONADE_SYSTEMD_UNIT_NAME, or at runtime via the LEMONADE_SYSTEMD_UNIT environment variable.