### PR TITLE
doc: update Arch Linux NPU instructions

### DIFF
--- a/docs/flm_npu_linux.html
+++ b/docs/flm_npu_linux.html
@@ -51,7 +51,7 @@
             <option value="ubuntu-24">Ubuntu 24.04</option>
             <option value="ubuntu-25">Ubuntu 25.10</option>
             <option value="ubuntu-26">Ubuntu 26.04</option>
-            <option value="arch">Arch</option>
+            <option value="arch">Arch Linux</option>
             <option value="other">Other</option>
           </select>
         </div>
@@ -170,6 +170,9 @@
               </li>
               <li>Update kernel to 7.0-rc2 or later:<br>
                 <div class="code-block"><code>sudo pacman -Sy linux</code></div>
+              </li>
+              <li>For older kernels (6.18, 6.19), use the amdxdna-dkms package from AUR<br>
+                <div class="code-block"><code>paru -S amdxdna-dkms</code></div>
               </li>
               <li>Update linux-firmware to 20260221 or later:<br>
                 <div class="code-block"><code>sudo pacman -Sy linux-firmware</code></div>


### PR DESCRIPTION
Adds AUR package to the NPU instructions for older kernels