### PR TITLE
Use $XDG_RUNTIME_DIR/lemonade for runtime artifacts on Linux

### DIFF
--- a/.github/actions/cleanup-processes-linux/action.yml
+++ b/.github/actions/cleanup-processes-linux/action.yml
@@ -85,11 +85,16 @@ runs:
         fi
 
         # Clean up lock files and PID files
+        # Check both /tmp (fallback) and $XDG_RUNTIME_DIR/lemonade (when set)
         echo ""
         echo "Cleaning up lock and PID files..."
         rm -f /tmp/lemonade*.lock 2>/dev/null || true
         rm -f /tmp/lemonade*.pid 2>/dev/null || true
         rm -f /tmp/lemonade-router.pid 2>/dev/null || true
+        if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+          rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.lock 2>/dev/null || true
+          rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.pid 2>/dev/null || true
+        fi
         echo "Lock and PID files cleaned."
 
         # Clean up log files
@@ -98,6 +103,9 @@ runs:
         rm -f /tmp/lemonade*.log 2>/dev/null || true
         rm -f /tmp/lemonade-server*.log 2>/dev/null || true
         rm -f /tmp/lemonade-router*.log 2>/dev/null || true
+        if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+          rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.log 2>/dev/null || true
+        fi
         echo "Log files cleaned."
 
         # Clean up installation directories

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -755,24 +755,34 @@ jobs:
       - name: Print server logs on failure
         if: failure()
         run: |
+          # Resolve runtime dir: $XDG_RUNTIME_DIR/lemonade when available, else /tmp
+          LEMON_RUNTIME_DIR="${XDG_RUNTIME_DIR:+${XDG_RUNTIME_DIR}/lemonade}"
+          LEMON_RUNTIME_DIR="${LEMON_RUNTIME_DIR:-/tmp}"
+
           echo "=== Server Log (if exists) ==="
-          if [ -f /tmp/lemonade-server.log ]; then
-            echo "Last 100 lines of /tmp/lemonade-server.log:"
-            tail -100 /tmp/lemonade-server.log
+          LOG_FILE="${LEMON_RUNTIME_DIR}/lemonade-server.log"
+          # Also check /tmp as a safety net when XDG was active but log went to fallback
+          if [ ! -f "$LOG_FILE" ]; then LOG_FILE="/tmp/lemonade-server.log"; fi
+          if [ -f "$LOG_FILE" ]; then
+            echo "Last 100 lines of ${LOG_FILE}:"
+            tail -100 "$LOG_FILE"
           else
-            echo "Log file /tmp/lemonade-server.log not found"
+            echo "Log file not found (checked ${LEMON_RUNTIME_DIR} and /tmp)"
           fi
 
           echo ""
           echo "=== Router PID file (if exists) ==="
-          if [ -f /tmp/lemonade-router.pid ]; then
-            cat /tmp/lemonade-router.pid
+          PID_FILE="${LEMON_RUNTIME_DIR}/lemonade-router.pid"
+          if [ ! -f "$PID_FILE" ]; then PID_FILE="/tmp/lemonade-router.pid"; fi
+          if [ -f "$PID_FILE" ]; then
+            cat "$PID_FILE"
           else
             echo "PID file not found"
           fi
 
           echo ""
           echo "=== Lock file status ==="
+          ls -la "${LEMON_RUNTIME_DIR}"/lemonade*.lock 2>/dev/null || true
           ls -la /tmp/lemonade*.lock 2>/dev/null || echo "No lock files found"
 
       - name: Cleanup

--- a/docs/dev-getting-started.md
+++ b/docs/dev-getting-started.md
@@ -166,12 +166,13 @@ chmod +x build/app-appimage/Lemonade-*.AppImage
 - Fully functional for server operations and model management
 - Uses permissively licensed dependencies only (MIT, Apache 2.0, BSD, curl license)
 - Clean .deb package with only runtime files (no development headers)
-- PID file system (`/tmp/lemonade-router.pid`) for reliable process management
+- PID file system for reliable process management
 - Proper graceful shutdown - all child processes cleaned up correctly
 - File locations:
   - Installed binaries: `/opt/bin`
   - Downloaded backends (llama-server, ryzenai-server): `~/.cache/lemonade/bin/`
   - Model downloads: `~/.cache/huggingface/` (follows HF conventions)
+  - Runtime files (PID, lock, log): `$XDG_RUNTIME_DIR/lemonade/` when set and writable, otherwise `/tmp/`
 
 **macOS (beta):**
 - Uses native system frameworks (Cocoa, Foundation)
@@ -617,7 +618,8 @@ The client automatically:
 - Only the `serve` command is blocked when a server is running
 - Commands like `status`, `list`, `pull`, `delete`, `stop` can run alongside an active server
 - Provides clear error messages with suggestions when blocked
-- **Linux-specific:** Uses PID file (`/tmp/lemonade-router.pid`) for efficient server discovery and port detection
+- **Linux-specific:** Uses a PID file (`lemonade-router.pid`) for efficient server discovery and port detection
+  - Stored in `$XDG_RUNTIME_DIR/lemonade/` when the XDG runtime directory is set and writable, otherwise falls back to `/tmp/`
   - Avoids port scanning, finds exact server PID and port instantly
   - Validated on read (checks if process is still alive)
   - Automatically cleaned up on graceful shutdown

--- a/src/cpp/include/lemon/single_instance.h
+++ b/src/cpp/include/lemon/single_instance.h
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <sys/file.h>
 #include <errno.h>
+#include "lemon/utils/path_utils.h"
 #endif
 
 namespace lemon {
@@ -39,7 +40,7 @@ public:
 
         return false;
 #else
-        std::string lock_file = "/tmp/lemonade_" + app_name + ".lock";
+        std::string lock_file = utils::get_runtime_dir() + "/lemonade_" + app_name + ".lock";
         int fd = open(lock_file.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0666);
 
         // If the file exists and has been created by another user, let's try again in read-only mode

--- a/src/cpp/include/lemon/utils/path_utils.h
+++ b/src/cpp/include/lemon/utils/path_utils.h
@@ -40,6 +40,15 @@ bool run_flm_validate(const std::string& flm_path, std::string& error_message);
 std::string get_cache_dir();
 
 /**
+ * Returns a per-user runtime directory for lemonade's PID/lock/log files.
+ * On Unix, uses $XDG_RUNTIME_DIR/lemonade when $XDG_RUNTIME_DIR is set,
+ * exists, and is writable (creates the subdirectory if needed).
+ * Falls back to /tmp when XDG_RUNTIME_DIR is unset or unusable (e.g. CI).
+ * On Windows, returns the system temp directory.
+ */
+std::string get_runtime_dir();
+
+/**
  * Get the directory where backend executables will be downloaded.
  * This is in the user's cache directory (~/.cache/lemonade/bin on all platforms)
  * to support All Users installations where the install directory may be read-only.

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -84,14 +84,14 @@ Server::Server(int port, const std::string& host, const std::string& log_level,
             log_file_path_ = "";  // Empty signals journald usage
             std::cout << "[Server] Detected systemd environment - will use journald for log streaming" << std::endl;
         } else {
-            log_file_path_ = "/tmp/lemonade-server.log";
+            log_file_path_ = utils::get_runtime_dir() + "/lemonade-server.log";
         }
     } else {
         if (unit_name) free(unit_name);
-        log_file_path_ = "/tmp/lemonade-server.log";
+        log_file_path_ = utils::get_runtime_dir() + "/lemonade-server.log";
     }
 #else
-    log_file_path_ = "/tmp/lemonade-server.log";
+    log_file_path_ = utils::get_runtime_dir() + "/lemonade-server.log";
 #endif
 #endif
 

--- a/src/cpp/server/utils/path_utils.cpp
+++ b/src/cpp/server/utils/path_utils.cpp
@@ -204,6 +204,37 @@ std::string get_cache_dir() {
     return ".cache/lemonade";
 }
 
+std::string get_runtime_dir() {
+#ifdef _WIN32
+    char temp_path[MAX_PATH];
+    GetTempPathA(MAX_PATH, temp_path);
+    return std::string(temp_path);
+#else
+    // Use $XDG_RUNTIME_DIR/lemonade only when the base directory is set,
+    // actually exists on disk, and is writable by the current process.
+    // This guards against CI environments, containers, or minimal systems
+    // where the variable might be set but the directory is absent/unwritable.
+    const char* xdg = std::getenv("XDG_RUNTIME_DIR");
+    if (xdg && xdg[0] != '\0') {
+        std::error_code ec;
+        fs::path base(xdg);
+        if (fs::is_directory(base, ec) && !ec && access(xdg, W_OK) == 0) {
+            fs::path lemon_dir = base / "lemonade";
+            ec.clear();
+            fs::create_directory(lemon_dir, ec);
+            // Treat "already exists as a directory" as success: some platforms
+            // set ec to EEXIST even though the standard says they shouldn't.
+            std::error_code ec2;
+            if (!ec || fs::is_directory(lemon_dir, ec2)) {
+                return lemon_dir.string();
+            }
+        }
+    }
+    // Fallback: /tmp for CI runners and systems without XDG session support
+    return "/tmp";
+#endif
+}
+
 std::string get_downloaded_bin_dir() {
     // Use cache directory on all platforms for consistent multi-user support
     // This is important for All Users installs on Windows where Program Files is read-only

--- a/src/cpp/tray/server_manager.cpp
+++ b/src/cpp/tray/server_manager.cpp
@@ -44,6 +44,7 @@
 // Use cpp-httplib for HTTP client (must be after Windows headers on Windows)
 // Note: Not using OpenSSL support since we only connect to localhost
 #include "lemon_tray/server_manager.h"
+#include "lemon/utils/path_utils.h"
 
 namespace lemon_tray {
 
@@ -777,7 +778,7 @@ bool ServerManager::terminate_router_tree() {
 }
 
 void ServerManager::write_pid_file() {
-    std::string pid_file_path = "/tmp/lemonade-router.pid";
+    std::string pid_file_path = lemon::utils::get_runtime_dir() + "/lemonade-router.pid";
     DEBUG_LOG(this, "write_pid_file() called - PID: " << server_pid_ << ", Port: " << port_);
 
     std::ofstream pid_file(pid_file_path);
@@ -793,7 +794,7 @@ void ServerManager::write_pid_file() {
 }
 
 void ServerManager::remove_pid_file() {
-    std::string pid_file_path = "/tmp/lemonade-router.pid";
+    std::string pid_file_path = lemon::utils::get_runtime_dir() + "/lemonade-router.pid";
     if (remove(pid_file_path.c_str()) == 0) {
         DEBUG_LOG(this, "Removed PID file: " << pid_file_path);
     }

--- a/src/cpp/tray/tray_app.cpp
+++ b/src/cpp/tray/tray_app.cpp
@@ -1129,7 +1129,8 @@ std::pair<int, int> TrayApp::get_server_info() {
     }
 
     // Unix: Read from PID file
-    std::ifstream pid_file("/tmp/lemonade-router.pid");
+    std::string pid_file_path = lemon::utils::get_runtime_dir() + "/lemonade-router.pid";
+    std::ifstream pid_file(pid_file_path);
     if (pid_file.is_open()) {
         int pid, port;
         pid_file >> pid >> port;
@@ -1148,7 +1149,7 @@ std::pair<int, int> TrayApp::get_server_info() {
         }
 
         // Stale PID file, remove it
-        remove("/tmp/lemonade-router.pid");
+        remove(pid_file_path.c_str());
     }
 
     // Port-based fallback: no PID file, or stale PID with no HTTP response
@@ -2165,7 +2166,7 @@ int TrayApp::execute_stop_command() {
         if (router_gone && tray_gone && all_children_gone) {
             // Additional check: verify the lock file can be acquired
             // This is a belt-and-suspenders check to ensure the lock is truly released
-            std::string lock_file = "/tmp/lemonade_Server.lock";
+            std::string lock_file = lemon::utils::get_runtime_dir() + "/lemonade_Server.lock";
             int fd = open(lock_file.c_str(), O_RDWR | O_CREAT, 0666);
             if (fd != -1) {
                 if (flock(fd, LOCK_EX | LOCK_NB) == 0) {
@@ -2249,16 +2250,16 @@ bool TrayApp::start_server() {
                 log_file_ = "-";  // Special value: don't redirect stdout/stderr
                 DEBUG_LOG(this, "Detected systemd environment - logging will go to journal");
             } else {
-                log_file_ = "/tmp/lemonade-server.log";
+                log_file_ = lemon::utils::get_runtime_dir() + "/lemonade-server.log";
                 DEBUG_LOG(this, "Using default log file: " << log_file_);
             }
         } else {
             if (unit_name) free(unit_name);
-            log_file_ = "/tmp/lemonade-server.log";
+            log_file_ = lemon::utils::get_runtime_dir() + "/lemonade-server.log";
             DEBUG_LOG(this, "Using default log file: " << log_file_);
         }
         #else
-        log_file_ = "/tmp/lemonade-server.log";
+        log_file_ = lemon::utils::get_runtime_dir() + "/lemonade-server.log";
         DEBUG_LOG(this, "Using default log file: " << log_file_);
         #endif
         #endif


### PR DESCRIPTION
Replace hardcoded /tmp paths for PID files, lock files, and log files with a new lemon::utils::get_runtime_dir() helper that returns $XDG_RUNTIME_DIR/lemonade when the XDG runtime directory is set, exists on disk, and is writable by the current process — falling back to /tmp otherwise to preserve existing behaviour in CI and containers.

Three guards prevent the XDG path from being used in unsupported environments: the env var must be non-empty, the base directory must exist as a real directory, and the process must have write access. The lemonade/ subdirectory is created automatically if needed.

All call sites are updated: single_instance.h (lock files), server.cpp and tray_app.cpp (log file), server_manager.cpp and tray_app.cpp (PID file), and tray_app.cpp (stop-command lock check). Windows continues to use GetTempPathA().

CI cleanup scripts are updated to remove files from both /tmp and $XDG_RUNTIME_DIR/lemonade so either code path is fully cleaned up. The "Print server logs on failure" step resolves the runtime dir dynamically and falls back to /tmp as a safety net.

Documentation in docs/dev-getting-started.md is updated to reflect the new runtime file locations in the Linux platform notes and the single-instance protection description.