### PR TITLE
Fix server failing to start when device is offline

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -819,7 +819,7 @@ std::string Server::resolve_host_to_ip(int ai_family, const std::string& host) {
     struct addrinfo hints = {0};
     hints.ai_family = ai_family;
     hints.ai_socktype = SOCK_STREAM;
-    hints.ai_flags = AI_ADDRCONFIG; // Optional: Only return IPs configured on system
+    hints.ai_flags = 0; // No AI_ADDRCONFIG: allows loopback resolution when offline
 
     struct addrinfo *result = nullptr;
 
@@ -878,6 +878,11 @@ void Server::run() {
 
     std::string ipv4 = resolve_host_to_ip(AF_INET, host_);
     std::string ipv6 = resolve_host_to_ip(AF_INET6, host_);
+
+    if (ipv4.empty() && ipv6.empty()) {
+        throw std::runtime_error("Failed to resolve host '" + host_ + "' to any address. "
+                                 "Cannot start server.");
+    }
 
     running_ = true;
 


### PR DESCRIPTION
Remove AI_ADDRCONFIG from getaddrinfo() hints so that localhost resolves to 127.0.0.1 via /etc/hosts even when no non-loopback interfaces are up. Add a guard in Server::run() to throw a clear error if both IPv4 and IPv6 resolution return empty, preventing a silent no-op exit.

Log reproducing the issue:
```log
Starting Lemonade Server...
  Version: 9.4.1
  Port: 8000
  Host: localhost
  Log level: info
[Server] Detected systemd environment - will use journald for log streaming
[Server] HTTP server initialized with thread pool (8 threads)
[Router] Max loaded models per type: 1
[OllamaApi] Ollama-compatible routes registered
[Server] Static files mounted from: /app/bin/resources/static
[Server] Web app directory not found at: /app/bin/resources/web-app
[Server] Falling back to static status page at root
[Server] Routes setup complete
[OllamaApi] Ollama-compatible routes registered
[Server] Static files mounted from: /app/bin/resources/static
[Server] Web app directory not found at: /app/bin/resources/web-app
[Server] Falling back to static status page at root
[Server] Routes setup complete
[WebSocket] Allocated port: 9000
[Server] Starting on localhost:8000
[Server] Warning: resolution failed for localhost no IPv4 resolution found.
[Server] Resolved localhost (v6) -> ::1
[WebSocket] Server started on port 9000
[Server] WebSocket server started on port 8100
[Server] [Net Broadcast] Unable to broadcast my existance please use a RFC1918 IPv4,
[Server] [Net Broadcast] or hostname that resolves to RFC1918 IPv4.
[Server DEBUG] Creating new thread pool with 8 threads
Server failed to start within timeout

[Server] Shutdown signal received, exiting...
Error: Failed to start server
```