### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
     <img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Code style: black" /></a>
   <a href="https://star-history.com/#lemonade-sdk/lemonade">
     <img src="https://img.shields.io/badge/Star%20History-View-brightgreen" alt="Star History Chart" /></a>
+  <a href="https://deepwiki.com/lemonade-sdk/lemonade">
+    <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
 </p>
 <p align="center">
   <img src="https://github.com/lemonade-sdk/assets/blob/main/docs/banner_02.png?raw=true" alt="Lemonade Banner" />


### PR DESCRIPTION
Happy for this to be rejected, but would be handy for the [DeepWiki](https://deepwiki.com/lemonade-sdk/lemonade) to be kept in sync with code changes.

The wiki is very useful for new contributors when understanding the code base. For myself, it has been useful understanding how the various components in the project work together before contributing. Additionally, their MCP server and "chat' options are useful for tracing bugs.