### PR TITLE
Drop "default" args for `lemonade-router`

### DIFF
--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -144,14 +144,6 @@ void RecipeOptions::add_cli_options(CLI::App& app, json& storage) {
             const auto& result = backend_cache[recipe];
             std::string default_backend = result.backends.empty() ? "" : result.backends[0];
 
-            // Pre-populate storage with the dynamically detected default so it's
-            // available even when the user doesn't explicitly pass the flag.
-            // (add_option_function's callback only fires on explicit CLI input,
-            // and default_val only affects help text display.)
-            if (!default_backend.empty()) {
-                storage[opt_name] = default_backend;
-            }
-
             o = app.add_option_function<std::string>(key, [opt_name, &storage = storage](const std::string& val) { storage[opt_name] = val; }, opt["help"]);
             o->default_val(default_backend);
             o->check(CLI::IsMember(result.backends));
@@ -256,6 +248,22 @@ RecipeOptions RecipeOptions::inherit(const RecipeOptions& options) const {
 }
 
 json RecipeOptions::get_option(const std::string& opt) const {
-    return options_.contains(opt) ? options_[opt] : DEFAULTS[opt];
+    if (options_.contains(opt)) {
+        return options_[opt];
+    }
+
+    // Dynamic defaults for backends if not explicitly set
+    const std::string backend_suffix = "_backend";
+    if (opt.size() > backend_suffix.size() &&
+        opt.compare(opt.size() - backend_suffix.size(), backend_suffix.size(), backend_suffix) == 0) {
+
+        std::string recipe = opt.substr(0, opt.size() - backend_suffix.size());
+        auto result = SystemInfo::get_supported_backends(recipe);
+        if (!result.backends.empty()) {
+            return result.backends[0];
+        }
+    }
+
+    return DEFAULTS.contains(opt) ? DEFAULTS[opt] : json();
 }
 }

--- a/src/cpp/tray/server_manager.cpp
+++ b/src/cpp/tray/server_manager.cpp
@@ -366,8 +366,10 @@ bool ServerManager::spawn_process() {
         }
     }
 
-    // Multi-model support
-    cmdline += " --max-loaded-models " + std::to_string(max_loaded_models_);
+    // Multi-model support (only if not default)
+    if (max_loaded_models_ != 1) {
+        cmdline += " --max-loaded-models " + std::to_string(max_loaded_models_);
+    }
     // Extra models directory
     if (!extra_models_dir_.empty()) {
         cmdline += " --extra-models-dir \"" + extra_models_dir_ + "\"";
@@ -558,13 +560,17 @@ bool ServerManager::spawn_process() {
 
         std::vector<const char*> args;
         args.push_back(server_binary_path_.c_str());
+
         args.push_back("--port");
         std::string port_str = std::to_string(port_);
         args.push_back(port_str.c_str());
         args.push_back("--host");
         args.push_back(host_.c_str());
-        args.push_back("--log-level");
-        args.push_back(log_level_.c_str());
+
+        if (log_level_ != "info") {
+            args.push_back("--log-level");
+            args.push_back(log_level_.c_str());
+        }
 
         std::vector<std::string> recipe_cli = lemon::RecipeOptions::to_cli_options(recipe_options_);
 
@@ -572,10 +578,13 @@ bool ServerManager::spawn_process() {
             args.push_back(arg.c_str());
         }
 
-        // Multi-model support
-        args.push_back("--max-loaded-models");
-        std::string max_models_str = std::to_string(max_loaded_models_);
-        args.push_back(max_models_str.c_str());
+        // Multi-model support (only if not default)
+        std::string max_models_str;
+        if (max_loaded_models_ != 1) {
+            args.push_back("--max-loaded-models");
+            max_models_str = std::to_string(max_loaded_models_);
+            args.push_back(max_models_str.c_str());
+        }
 
         // Extra models directory
         if (!extra_models_dir_.empty()) {


### PR DESCRIPTION
As the backend manager has been introduced it doesn't really make sense to pass arguments from lemonade-server to lemonade-router unless a user has changed the defaults.