### PR TITLE
fix path to to the turbo version of z-image

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1316,9 +1316,9 @@
     },
     "Z-Image-Turbo": {
         "checkpoints": {
-            "main": "Comfy-Org/z_image:split_files/diffusion_models/z_image_bf16.safetensors",
-            "text_encoder": "Comfy-Org/z_image:split_files/text_encoders/qwen_3_4b.safetensors",
-            "vae": "Comfy-Org/z_image:split_files/vae/ae.safetensors"
+            "main": "Comfy-Org/z_image_turbo:split_files/diffusion_models/z_image_turbo_bf16.safetensors",
+            "text_encoder": "Comfy-Org/z_image_turbo:split_files/text_encoders/qwen_3_4b.safetensors",
+            "vae": "Comfy-Org/z_image_turbo:split_files/vae/ae.safetensors"
         },
         "recipe": "sd-cpp",
         "suggested": true,


### PR DESCRIPTION
Old paths were pointing to Z-Image (base) which is mostly meant for finetuning/training