### PR TITLE
Remove some duplication in RecipeOptions

### DIFF
--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -51,7 +51,6 @@ static const json CLI_OPTIONS = {
     {"--sdcpp", {
         {"option_name", "sd-cpp_backend"},
         {"type_name", "BACKEND"},
-        {"allowed_values", {"cpu", "rocm"}},
         {"envname", "LEMONADE_SDCPP"},
         {"help", "SD.cpp backend to use (cpu for CPU, rocm for AMD GPU)"}
     }},
@@ -59,7 +58,6 @@ static const json CLI_OPTIONS = {
     {"--whispercpp", {
         {"option_name", "whispercpp_backend"},
         {"type_name", "BACKEND"},
-        {"allowed_values", {"cpu", "npu", "vulkan"}},
         {"envname", "LEMONADE_WHISPERCPP"},
         {"help", "WhisperCpp backend to use"}
     }},
@@ -113,40 +111,40 @@ static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
     }
 }
 
-static const bool is_empty_option(json option) {
+static bool is_empty_option(json option) {
     return (option.is_number() && (option == -1)) ||
            (option.is_string() && (option == ""));
 }
 
-void RecipeOptions::add_cli_options(CLI::App& app, json& storage) {
-    // Cache for supported backends per recipe (computed once per recipe)
-    static std::map<std::string, SystemInfo::SupportedBackendsResult> backend_cache;
+static bool try_get_backend_options(const std::string& opt_name, SystemInfo::SupportedBackendsResult& result) {
+    // Generic handling for any *_backend option
+    // Pattern: {recipe}_backend -> get supported backends for {recipe}
+    const std::string backend_suffix = "_backend";
+    bool is_backend_option = opt_name.size() > backend_suffix.size() &&
+        opt_name.compare(opt_name.size() - backend_suffix.size(), backend_suffix.size(), backend_suffix) == 0;
 
+    if (is_backend_option) {
+        // Extract recipe name (everything before "_backend")
+        std::string recipe = opt_name.substr(0, opt_name.size() - backend_suffix.size());
+        auto tmp = SystemInfo::get_supported_backends(recipe);
+        result.backends = tmp.backends;
+    }
+
+    return is_backend_option;
+}
+
+void RecipeOptions::add_cli_options(CLI::App& app, json& storage) {
     for (auto& [key, opt] : CLI_OPTIONS.items()) {
         const std::string opt_name = opt["option_name"];
         CLI::Option* o;
         json defval = DEFAULTS[opt_name];
 
-        // Generic handling for any *_backend option
-        // Pattern: {recipe}_backend -> get supported backends for {recipe}
-        const std::string backend_suffix = "_backend";
-        bool is_backend_option = opt_name.size() > backend_suffix.size() &&
-            opt_name.compare(opt_name.size() - backend_suffix.size(), backend_suffix.size(), backend_suffix) == 0;
-
-        if (is_backend_option) {
-            // Extract recipe name (everything before "_backend")
-            std::string recipe = opt_name.substr(0, opt_name.size() - backend_suffix.size());
-
-            // Get supported backends (cached)
-            if (backend_cache.find(recipe) == backend_cache.end()) {
-                backend_cache[recipe] = SystemInfo::get_supported_backends(recipe);
-            }
-            const auto& result = backend_cache[recipe];
-            std::string default_backend = result.backends.empty() ? "" : result.backends[0];
-
+        SystemInfo::SupportedBackendsResult backend_result;
+        if (try_get_backend_options(opt_name, backend_result)) {
+            std::string default_backend = backend_result.backends.empty() ? "" : backend_result.backends[0];
             o = app.add_option_function<std::string>(key, [opt_name, &storage = storage](const std::string& val) { storage[opt_name] = val; }, opt["help"]);
             o->default_val(default_backend);
-            o->check(CLI::IsMember(result.backends));
+            o->check(CLI::IsMember(backend_result.backends));
         } else if (defval.is_number_float()) {
             o = app.add_option_function<double>(key, [opt_name, &storage = storage](double val) { storage[opt_name] = val; }, opt["help"]);
             o->default_val((double) defval);
@@ -201,14 +199,6 @@ RecipeOptions::RecipeOptions(const std::string& recipe, const json& options) {
     }
 }
 
-static const std::string inherit_string(const std::string& a, const std::string& b) {
-    return a.empty() ? a : b;
-}
-
-static const int inherit_int(int a, int b) {
-    return a != -1 ? a : b;
-}
-
 static std::string format_option_for_logging(const json& opt) {
     if (opt.is_number_float()) return std::to_string((double) opt);
     if (opt.is_number_integer()) return std::to_string((int) opt);
@@ -253,14 +243,10 @@ json RecipeOptions::get_option(const std::string& opt) const {
     }
 
     // Dynamic defaults for backends if not explicitly set
-    const std::string backend_suffix = "_backend";
-    if (opt.size() > backend_suffix.size() &&
-        opt.compare(opt.size() - backend_suffix.size(), backend_suffix.size(), backend_suffix) == 0) {
-
-        std::string recipe = opt.substr(0, opt.size() - backend_suffix.size());
-        auto result = SystemInfo::get_supported_backends(recipe);
-        if (!result.backends.empty()) {
-            return result.backends[0];
+    SystemInfo::SupportedBackendsResult backend_result;
+    if (try_get_backend_options(opt, backend_result)) {
+        if (!backend_result.backends.empty()) {
+            return backend_result.backends[0];
         }
     }
 


### PR DESCRIPTION
- extract the duplicated logic to detect available and default backend options from `add_cli_options` and `get_option`
- remove some unused functions
- removed `allowed_values` for `--whispercpp` and `--sdcpp` since these are auto-detected just like `--llamacpp` (keeping them made the help message strange)

No changes in behavior (except for cleaner help message), just a small code cleanup.

@superm1 the first point was the feedback I was giving in #1262. Please see if it makes sense to you