### PR TITLE
Remove redundant logging

### DIFF
--- a/src/cpp/tray/server_manager.cpp
+++ b/src/cpp/tray/server_manager.cpp
@@ -123,11 +123,10 @@ bool ServerManager::start_server(
 
         // Success! Server is ready immediately
         if (!is_ephemeral) {
-            LOG(INFO, "ServerManager") << "Lemonade Server v" << LEMON_VERSION_STRING << " started on port " << port_ << std::endl;
+            LOG(INFO, "ServerManager") << "Lemonade Server v" << LEMON_VERSION_STRING << " started" << std::endl;
             // Display localhost for 0.0.0.0 since that's what users can actually visit in a browser
             std::string display_host = get_connection_host();
-            LOG(INFO, "ServerManager") << "API endpoint: http://" << display_host << ":" << port_ << "/api/v1" << std::endl;
-            LOG(INFO, "ServerManager") << "Connect your apps to the endpoint above." << std::endl;
+            LOG(INFO, "ServerManager") << "Connect your apps to API endpoint: http://" << display_host << ":" << port_ << "/api/v1" << std::endl;
             LOG(INFO, "ServerManager") << "Documentation: https://lemonade-server.ai/" << std::endl;
         }
 


### PR DESCRIPTION
I noticed that some messages were coming up multiple times, and it's because PID files were created multiple times!
Clean it all up, only create PID files once and show relevant logs.

A non-systemd start now shows:
```
╰─❮ ./build/lemonade-server serve
2026-03-04 07:44:04.197 [Info] (ServerManager) Lemonade Server v9.4.2 started
2026-03-04 07:44:04.197 [Info] (ServerManager) Connect your apps to API endpoint: http://127.0.0.1:8000/api/v1
2026-03-04 07:44:04.197 [Info] (ServerManager) Documentation: https://lemonade-server.ai/
Press Ctrl+C to stop
```