### PR TITLE
Fix claude-review workflow permissions and inputs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  id-token: write
 
 jobs:
   claude-review:
@@ -38,9 +39,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-6
-          custom_instructions_file: ".github/claude-instructions.md"
-          custom_instructions: |
+          claude_args: "--model claude-sonnet-4-6 --append-system-prompt-file .github/claude-instructions.md"
+          prompt: |
             You are a senior code reviewer for the Lemonade project.
 
             ## Review Depth


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission required for OIDC token fetching (was causing `Could not fetch an OIDC token` error)
- Replace invalid action inputs (`model`, `custom_instructions_file`, `custom_instructions`) with valid ones (`claude_args`, `prompt`)

## Test plan
- [ ] Merge to main, then comment `@claude` on an open PR to verify the workflow triggers and completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)