### PR TITLE
Improve claude-review: inline comments + concise structured format

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -43,21 +43,74 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
-            You are a senior code reviewer for the Lemonade project. Read .github/claude-instructions.md for full project context.
+            You are a senior code reviewer for the Lemonade project. Read .github/claude-instructions.md for full project context and critical invariants.
 
-            Review this pull request thoroughly covering:
-            1. **Correctness & Bugs** - Logic errors, null/dangling pointers, resource leaks, race conditions, missing error handling
-            2. **Architecture & Design** - Does it fit existing patterns (backend subprocess model, WrappedServer abstraction, router pattern), are critical invariants maintained (quad-prefix endpoint registration, NPU exclusivity, cross-platform builds)
-            3. **API & Compatibility** - OpenAI SDK compat, Ollama compat, all 4 path prefixes registered for new endpoints
-            4. **Security** - Command injection (subprocess spawning), path traversal, input validation, secrets exposure
-            5. **Maintainability** - C++17 style (snake_case, CamelCase, 4-space indent), Python Black formatting, test coverage
+            ## Your Task
 
-            Categorize findings as [Bug], [Architecture], [Security], [Style], [Nit], or [Question].
-            Be specific with line references and suggest concrete fixes.
-            Ask clarifying questions to the PR author when intent is unclear.
-            Acknowledge good patterns and decisions, not just problems.
+            1. Use `gh pr diff $PR_NUMBER` and `gh pr view $PR_NUMBER` to understand the changes.
+            2. Use Read/Glob/Grep to examine relevant source files for deeper context.
+            3. Perform a thorough review covering: correctness/bugs, architecture/design, API compatibility, security, and maintainability.
+            4. Post your review using the two-part format described below.
 
-            Use `gh pr diff` to read the PR changes and `gh pr view` for PR details.
-            Use `gh pr comment` with your Bash tool to post your review as a comment on the PR.
-          claude_args: '--model claude-sonnet-4-6 --allowed-tools "Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*)"'
+            ## Output Format
+
+            You MUST post your review in exactly two parts:
+
+            ### Part 1: Inline comments on blocking issues only
+
+            For each finding that MUST be fixed before merge (bugs, security issues, broken invariants), post an inline comment on the specific line using the GitHub API:
+
+            ```bash
+            gh api repos/OWNER/REPO/pulls/PR_NUMBER/comments \
+              -f body="**[Bug]** Description of the issue and suggested fix" \
+              -f path="src/file.cpp" \
+              -F line=42 \
+              -f commit_id="$(gh pr view PR_NUMBER --json headRefOid -q .headRefOid)"
+            ```
+
+            Keep inline comments short: 1-3 sentences. State the problem and the fix. No preamble.
+
+            ### Part 2: Summary comment via `gh pr comment`
+
+            Post ONE summary comment with this exact template:
+
+            ```
+            ## Review Summary
+
+            **Verdict:** APPROVE / REQUEST_CHANGES / COMMENT
+
+            ### Blocking (must fix)
+            - **[Bug]** `file.cpp:42` — Brief description ([inline comment](link))
+            - **[Security]** `file.cpp:99` — Brief description ([inline comment](link))
+
+            ### Non-blocking (suggestions)
+            - **[Architecture]** Brief suggestion — one sentence why
+            - **[Style]** Brief nit — one sentence
+
+            ### Good stuff
+            - Solid approach to X
+            - Clean implementation of Y
+            ```
+
+            ## Rules
+
+            - Be CONCISE. Each finding is 1-2 sentences max. No paragraphs.
+            - Inline comments are ONLY for blocking issues. Non-blocking goes in the summary only.
+            - Use the category tags: [Bug], [Security], [Architecture], [Style], [Nit], [Question]
+            - Always include a verdict: APPROVE if no blocking issues, REQUEST_CHANGES if there are blocking issues.
+            - If something is unclear, use [Question] in the summary — do not assume.
+            - Reference specific lines (file:line) in the summary for traceability.
+            - Do NOT repeat the same finding in both inline and summary — the summary just links to the inline comment.
+
+            ## Review Focus (Lemonade-specific)
+
+            - New endpoints registered under all 4 prefixes (`/api/v0/`, `/api/v1/`, `/v0/`, `/v1/`)
+            - NPU exclusivity maintained in router
+            - Backends stay as subprocesses (not in-process)
+            - WrappedServer contract fulfilled for new backends
+            - Cross-platform: Windows/Linux/macOS guards for platform-specific code
+            - Thread safety for concurrent HTTP request handling
+            - C++17, snake_case functions, CamelCase types, 4-space indent
+            - Python files formatted with Black
+          claude_args: '--model claude-sonnet-4-6 --allowed-tools "Read,Glob,Grep,Bash(gh api:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*)"'
           show_full_output: true


### PR DESCRIPTION
## Summary
- Blocking issues now get **inline comments on the exact line** via `gh api repos/.../pulls/.../comments`
- Non-blocking suggestions stay in the summary comment only (no duplication)
- Enforced concise template: Verdict → Blocking → Non-blocking → Good stuff
- Each finding capped at 1-2 sentences, no paragraphs
- Added `Bash(gh api:*)` to allowed tools

## Before vs After

**Before:** One wall-of-text comment with everything mixed together, no inline comments, no clear verdict, findings buried in paragraphs.

**After:**
- Inline comments pinned to specific lines for blocking issues
- Clean summary with verdict (APPROVE/REQUEST_CHANGES), categorized bullet points, and links to inline comments

## Test plan
- [ ] Merge, then `@claude` on a PR with known issues
- [ ] Verify inline comments appear on specific lines
- [ ] Verify summary comment follows the template

🤖 Generated with [Claude Code](https://claude.com/claude-code)