### PR TITLE
add message about Linux FLM binary detection

### DIFF
--- a/docs/flm_npu_linux.html
+++ b/docs/flm_npu_linux.html
@@ -55,11 +55,15 @@
         <p>
           NOTE: This is a beta feature right now, and to use it you will need to
           run lemonade-server with the environment variable
-
+          <code>LEMONADE_FLM_LINUX_BETA=1</code> set.
+          <br><br>
           DOCKER USERS: The beta currently uses `which` to locate your flm binary.
           If you do not have which in your docker, it will fail to pull models with
           an error stating FLM cannot be installed automatically on linux.
-          <code>LEMONADE_FLM_LINUX_BETA=1</code> set.
+          <br><br>
+          Additionally, if you volume-mount your container so that `~/.cache/lemonade/hardware_info.json`
+          is saved between machine docker builds, you will need to delete the file on your host
+          so that it will rebuild a new one. This can prevent the FLM beta flag from being recognized.
         </p>
       </div>
 

--- a/docs/flm_npu_linux.html
+++ b/docs/flm_npu_linux.html
@@ -55,6 +55,10 @@
         <p>
           NOTE: This is a beta feature right now, and to use it you will need to
           run lemonade-server with the environment variable
+
+          DOCKER USERS: The beta currently uses `which` to locate your flm binary.
+          If you do not have which in your docker, it will fail to pull models with
+          an error stating FLM cannot be installed automatically on linux.
           <code>LEMONADE_FLM_LINUX_BETA=1</code> set.
         </p>
       </div>


### PR DESCRIPTION
REF: https://github.com/lemonade-sdk/lemonade/issues/1296

Add note to docker users regarding binary detection. Chose to refer to docker users as they are most likely to not have `which` installed.