### PR TITLE
Fix update-claude-instructions: use CLI instead of action

### DIFF
--- a/.github/workflows/update-claude-instructions.yml
+++ b/.github/workflows/update-claude-instructions.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   update-instructions:
@@ -26,27 +25,44 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: claude-sonnet-4-6
-          prompt: |
-            Your task is to update the file `.github/claude-instructions.md` to reflect the current state of the codebase. This file is used as context for Claude code reviews.
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
 
-            Do the following:
-            1. Read the current `.github/claude-instructions.md`
-            2. Analyze the codebase to find any changes since the file was last updated:
-               - New or removed endpoints in `src/cpp/server/server.cpp`
-               - New or removed backends (WrappedServer subclasses)
-               - Changes to the model registry format in `src/cpp/resources/server_models.json`
-               - New key files or architectural changes
-               - New test files in `test/`
-               - Changes to build configuration in `CMakeLists.txt`
-               - Changes to the Electron/web app structure
-            3. Update ONLY the sections that have actually changed. Do not rewrite sections that are still accurate.
-            4. Preserve the existing structure, formatting, and the "Critical Invariants" section (only update invariants if the code shows they have changed).
-            5. If nothing meaningful has changed, do not modify the file.
+      - name: Update claude-instructions.md
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          claude -p \
+            --model claude-sonnet-4-6 \
+            --allowedTools Read Glob Grep Edit Write \
+            --dangerously-skip-permissions \
+            --max-turns 10 \
+            --max-budget-usd 2.00 \
+            "Your task is to update the file .github/claude-instructions.md to reflect the current state of the codebase. This file is used as context for Claude code reviews.
 
-            IMPORTANT: Only update facts that are verifiable from the source code. Do not add speculative or aspirational content.
-          direct_prompt: true
-          allowed_tools: "Read,Glob,Grep,Edit,Write"
+          Do the following:
+          1. Read the current .github/claude-instructions.md
+          2. Analyze the codebase to find any changes since the file was last updated:
+             - New or removed endpoints in src/cpp/server/server.cpp
+             - New or removed backends (WrappedServer subclasses)
+             - Changes to the model registry format in src/cpp/resources/server_models.json
+             - New key files or architectural changes
+             - New test files in test/
+             - Changes to build configuration in CMakeLists.txt
+             - Changes to the Electron/web app structure
+          3. Update ONLY the sections that have actually changed. Do not rewrite sections that are still accurate.
+          4. Preserve the existing structure, formatting, and the Critical Invariants section (only update invariants if the code shows they have changed).
+          5. If nothing meaningful has changed, do not modify the file.
+
+          IMPORTANT: Only update facts that are verifiable from the source code. Do not add speculative or aspirational content."
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet .github/claude-instructions.md && echo "No changes" && exit 0
+          git add .github/claude-instructions.md
+          git commit -m "Auto-update claude-instructions.md
+
+          Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+          git push


### PR DESCRIPTION
## Summary
- `claude-code-action` doesn't support `push` events (`Unsupported event type: push`)
- Replaced with direct Claude Code CLI (`npm install -g @anthropic-ai/claude-code` + `claude --print`)
- Added explicit commit-and-push step that only commits if the file actually changed
- Removed invalid inputs (`model`, `direct_prompt`, `allowed_tools`) — now passed as CLI flags

## Test plan
- [ ] Merge to main with a change to `src/cpp/**` and verify the workflow runs
- [ ] Verify it updates `.github/claude-instructions.md` only if something changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)