### PR TITLE
Consolidate "Add a model" and "Import a model" into a single entry point

### DIFF
--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1226,12 +1226,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
 
           {currentView === 'models' && (
             <div className="model-manager-footer">
+              <input ref={addModelFromJSONRef} type="file" accept=".json" onChange={handleUploadModel} style={{ display: 'none' }}/>
               {!showAddModelForm ? (
                 <div className="add-model-buttons-container">
-                  <input ref={addModelFromJSONRef} type="file" accept=".json" onChange={handleUploadModel} style={{ display: 'none' }}/>
-                  <button className="add-model-button" onClick={() => addModelFromJSONRef.current?.click()} title="Import JSON">
-                    Import a model
-                  </button>
                   <button
                     className="add-model-button"
                     onClick={() => {
@@ -1335,6 +1332,16 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
                     </div>
                   </div>
 
+                  <div className="form-import-hint">
+                    <span>Have a config file?</span>
+                    <button
+                      className="import-json-link"
+                      onClick={() => addModelFromJSONRef.current?.click()}
+                      title="Load model configuration from a JSON file on your machine"
+                    >
+                      Import from JSON
+                    </button>
+                  </div>
                   <div className="form-actions">
                     <button className="install-button" onClick={handleInstallModel}>
                       Install

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2222,7 +2222,6 @@ footer {
     font-size: 0.65rem;
     color: #999;
     font-weight: 400;
-    margin-top: 8px;
     margin-bottom: 4px;
     display: flex;
     align-items: center;
@@ -2329,7 +2328,6 @@ footer {
 }
 
 .form-subsection {
-    margin-top: 8px;
     padding-left: 8px;
 }
 
@@ -2449,6 +2447,32 @@ footer {
     color: #777;
 }
 
+.form-import-hint {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.6rem;
+    color: #555;
+    padding-top: 6px;
+}
+.import-json-link {
+    padding: 0;
+    background: none;
+    border: none;
+    color: #888;
+    font-size: 0.6rem;
+    cursor: pointer;
+    transition: color 0.2s ease;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+.import-json-link:hover {
+    color: #ccc;
+}
+.import-json-link:focus {
+    outline: none;
+    color: #ccc;
+}
 /* Chat Window Styles */
 .chat-window {
     background: #0a0a0a;


### PR DESCRIPTION
# Description

The Model Manager footer had two separate buttons: “Add a model” and “Import a model.” The names are very similar, making it difficult to immediately understand the difference between them. This should be clear and require no explanation.

This also wasted valuable vertical space in a sidebar panel where every pixel counts: two full-width stacked buttons for what is fundamentally one action with two input methods.

## Fix
* Single "Add a model" button replaces both. One entry point, no ambiguity.
* JSON import lives inside the form as a subtle inline hint ("Have a config file? Import from JSON") 
* Reclaimed lost vertical space

## Before
<img width="451" height="893" alt="image" src="https://github.com/user-attachments/assets/d850df5d-cb79-4fac-b909-c5d82740394a" />

## After
<img width="356" height="1048" alt="image" src="https://github.com/user-attachments/assets/f6dc08c9-a9bf-4396-9507-6dfa64db367a" />
<img width="347" height="250" alt="image" src="https://github.com/user-attachments/assets/53a502f7-4849-483c-b594-fc3618895e4c" />

