### PR TITLE
Recommend ffmpeg in Debian package for whisper audio conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1258,6 +1258,10 @@ if(UNIX AND NOT APPLE)
         set(CPACK_PACKAGE_NAME "lemonade-server")
 
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcurl4, libssl3, libz1, unzip, libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, xdg-utils, libatspi2.0-0, libsecret-1-0, libasound2t64, fonts-katex")
+        # whisper.cpp can use ffmpeg for input audio resampling and/or
+        # transcoding, but it is not required for server startup or WAV-only
+        # transcription flows.
+        set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "ffmpeg")
         set(CPACK_DEBIAN_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
 
         # Install Electron app
@@ -1338,7 +1342,7 @@ if(UNIX AND NOT APPLE)
     else()
         set(CPACK_PACKAGE_NAME "lemonade-server")
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcurl4, libssl3, libz1, unzip, fonts-katex")
-        set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "chromium-browser | google-chrome-stable | chromium")
+        set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "ffmpeg, chromium-browser | google-chrome-stable | chromium")
         set(CPACK_DEBIAN_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}.deb")
     endif()
     # Control scripts for debian package

--- a/docs/dev-getting-started.md
+++ b/docs/dev-getting-started.md
@@ -240,7 +240,8 @@ Creates `lemonade-server_<VERSION>_amd64.deb` (e.g., `lemonade-server_9.0.3_amd6
 - Installs to `/opt/bin/` (executables)
 - Installs resources to `/opt/share/lemonade-server/`
 - Creates desktop entry in `/opt/share/applications/`
-- Declares dependencies: libcurl4, libssl3, libz1
+- Declares dependencies: `libcurl4`, `libssl3`, `libz1`, `unzip`, `fonts-katex`
+- Recommends: `ffmpeg` for whisper.cpp audio resampling and/or transcoding, plus a Chromium-compatible browser for `lemonade-web-app`
 - Package size: ~2.2 MB (clean, runtime-only package)
 - Includes postinst script that creates writable `/opt/share/lemonade-server/llama/` directory
 

--- a/docs/server/server_integration.md
+++ b/docs/server/server_integration.md
@@ -187,6 +187,8 @@ msiexec /i lemonade.msi /qn ALLUSERS=1 INSTALLDIR="C:\Program Files (x86)\Lemona
 
 The Debian package installer handles all system configuration automatically, including setting up a systemd service for managing the Lemonade Server.
 
+On Linux, the package also recommends `ffmpeg` so whisper.cpp can resample and/or transcode audio inputs when needed.
+
 If you would prefer to manage the lifecycle of the server process manually, the service can be disabled and manually run as well.
 
 ### Systemd Service Management


### PR DESCRIPTION
## Summary
- recommend `ffmpeg` in the Debian package so whisper.cpp can resample and/or transcode audio inputs when needed, which is most of the time; OpenWebUI sends mp3 ; OpenWhispr sends webm, etc. 
- keep `ffmpeg` out of hard dependencies because it is not required for server startup or WAV-only transcription flows
- update the Debian package build/install docs to reflect the extra recommendation

## Testing
- `cmake -S . -B /tmp/lemonade-build -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release`
- `cpack -G DEB` in `/tmp/lemonade-build`
- `dpkg-deb -I /tmp/lemonade-build/lemonade-server_9.4.2_amd64.deb`

## Comments
If --convert moves into a whisper.cpp default config option after #1310 , I am guessing we would move this from Recommends to Depends, but given it seems to be needed for most common client side audio containers, Suggests doesn't seem strong enough @superm1 

## For Consideration
I have not seen it used (if at all); but there is an Enhances tag that might be used to build relationships in the app store / package manager UI .. `Enhances: open-wispr`  might be the original intent of this tag, and while it is hard to say a deterministic tool like a widget-library enhances open-whispr, it does seem more appropriate that adding a powerful multi-backend llm router to do free and private transcription does enhance it in non-deterministic ways as more and more models and backends are supported through an single openai compatible endpoint. 

It surfaces other companion projects that are mature enough to also have Debian packages and steers users towards the package variant vs. one-time tarballs, shell script installers, and other forms of passive technical debt. 

```bash
$ dpkg -l | grep -n open-whispr
2842:ii  open-whispr                                   1.5.5                                        amd64
```