### PR TITLE
Allow vs18 and fix system-info print

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,9 +16,17 @@
     },
     {
       "name": "windows",
-      "displayName": "Windows (Visual Studio)",
-      "description": "Build with Visual Studio generator on Windows",
+      "displayName": "Windows (Visual Studio 2022)",
+      "description": "Build with Visual Studio 2022 generator on Windows",
       "generator": "Visual Studio 17 2022",
+      "architecture": "x64",
+      "binaryDir": "${sourceDir}/build"
+    },
+    {
+      "name": "vs18",
+      "displayName": "Windows (Visual Studio 2026)",
+      "description": "Build with Visual Studio 2026 generator on Windows",
+      "generator": "Visual Studio 18 2026",
       "architecture": "x64",
       "binaryDir": "${sourceDir}/build"
     },
@@ -52,6 +60,11 @@
     {
       "name": "windows",
       "configurePreset": "windows",
+      "configuration": "Release"
+    },
+    {
+      "name": "vs18",
+      "configurePreset": "vs18",
       "configuration": "Release"
     },
     {

--- a/docs/dev-getting-started.md
+++ b/docs/dev-getting-started.md
@@ -53,7 +53,7 @@ Lemonade consists of these main executables:
 - Internet connection (first build downloads dependencies)
 
 **Windows:**
-- Visual Studio 2019 or later
+- Visual Studio 2022 or later (2022 and 2026 are supported via CMake presets)
 - WiX 5.x (only required for building the installer)
 
 **Linux:**
@@ -81,9 +81,14 @@ Build by running:
 cmake --build --preset default
 ```
 
-**Windows**
+**Windows (Visual Studio 2022)**
 ```powershell
 cmake --build --preset windows
+```
+
+**Windows (Visual Studio 2026)**
+```powershell
+cmake --build --preset vs18
 ```
 
 ### Build Outputs
@@ -109,9 +114,14 @@ Build the Electron app using CMake (requires Node.js 20+):
 cmake --build --preset default --target electron-app
 ```
 
-**Windows**
+**Windows (Visual Studio 2022)**
 ```powershell
 cmake --build --preset windows --target electron-app
+```
+
+**Windows (Visual Studio 2026)**
+```powershell
+cmake --build --preset vs18 --target electron-app
 ```
 
 This will:

--- a/setup.ps1
+++ b/setup.ps1
@@ -142,10 +142,21 @@ Write-Success "Build directory created"
 
 Write-Host ""
 
-# Configure with CMake presets
-Write-Info "Configuring CMake with presets..."
+# Detect Visual Studio version and select CMake preset
+$vswhereExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$cmakePreset = "windows"
 
-cmake --preset windows
+if (Test-Path $vswhereExe) {
+    $vsMajor = (& $vswhereExe -latest -property catalog_productLineVersion)
+    if ($vsMajor -eq "18") {
+        $cmakePreset = "vs18"
+    }
+    Write-Info "Detected Visual Studio v$vsMajor, using preset: $cmakePreset"
+} else {
+    Write-Warning "vswhere not found, defaulting to preset: windows"
+}
+
+cmake --preset $cmakePreset
 if ($LASTEXITCODE -ne 0) {
     Write-Error-Custom "CMake configuration failed"
     exit 1

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -2957,12 +2957,12 @@ json SystemInfoCache::get_system_info_with_cache() {
         } else {
             // Provide friendly message about why we're detecting hardware
             if (cache_exists) {
-                LOG(INFO, "Server") << "Collecting system info (Lemonade was updated)" << std::endl;
+                std::cout << "Collecting system info (Lemonade was updated)" << std::endl;
 
                 // Perform version-specific cleanup (e.g., removing stale backend binaries)
                 cache.perform_upgrade_cleanup();
             } else {
-                LOG(INFO, "Server") << "Collecting system info" << std::endl;
+                std::cout << "Collecting system info" << std::endl;
             }
 
             // Get system info (OS, Processor, Memory, OEM System, BIOS, etc.)


### PR DESCRIPTION
Previously, VS 17 (2022) was required for building on Windows. This PR enables VS 18 (2026) as well, which has worked well in my testing. 

To specify vs18 builds:

```
# VS 17 (default)

cmake --build --preset windows

# VS 18 (new)

cmake --build --preset vs18
```