### PR TITLE
Fix claude-review: grant write permissions for issues and PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,8 +10,8 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
-  issues: read
+  pull-requests: write
+  issues: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Summary
- Change `pull-requests` and `issues` permissions from `read` to `write`

## Context
Follow-up to #1332. The `github_token` bypass requires explicit write permissions in the workflow's `permissions` block. Previously, the OIDC flow obtained its own token with broader access, but now that we pass `github_token` directly, the workflow permissions apply — and `read` causes a 403 when the action tries to post comments.

Failed run: https://github.com/lemonade-sdk/lemonade/actions/runs/22875468859/job/66365901413

## Test plan
- [ ] Trigger `@claude` on a PR and verify it can post comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)