### PR TITLE
Attempt to preserve capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -701,6 +701,21 @@ elseif(UNIX)
                 LEMONADE_SYSTEMD_UNIT_NAME="${LEMONADE_SYSTEMD_UNIT_NAME}")
         endif()
     endif()
+
+    # Link libcap for capability management on Linux
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        if(PkgConfig_FOUND)
+            pkg_check_modules(LIBCAP QUIET libcap)
+            if(LIBCAP_FOUND)
+                target_include_directories(${EXECUTABLE_NAME} PRIVATE ${LIBCAP_INCLUDE_DIRS})
+                target_link_libraries(${EXECUTABLE_NAME} PRIVATE ${LIBCAP_LIBRARIES})
+                target_compile_definitions(${EXECUTABLE_NAME} PRIVATE HAVE_LIBCAP)
+                message(STATUS "libcap found - capability inheritance will be enabled")
+            else()
+                message(STATUS "libcap not found - capability inheritance will be disabled")
+            endif()
+        endif()
+    endif()
 endif()
 
 # ============================================================

--- a/data/lemonade-server.service.in
+++ b/data/lemonade-server.service.in
@@ -13,7 +13,7 @@ ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/lemonade-server serve
 Restart=on-failure
 RestartSec=5s
 KillSignal=SIGINT
-LimitMEMLOCK=infinity
+AmbientCapabilities=CAP_SYS_RESOURCE
 
 # Security hardening
 PrivateTmp=yes

--- a/setup.sh
+++ b/setup.sh
@@ -122,7 +122,7 @@ if command_exists pkg-config; then
     print_success "pkg-config is installed"
 
     # Check for required libraries using pkg-config
-    libs_to_check=("libcurl" "openssl" "zlib" "libsystemd" "libdrm")
+    libs_to_check=("libcurl" "openssl" "zlib" "libsystemd" "libdrm" "libcap")
     missing_libs=()
 
     for lib in "${libs_to_check[@]}"; do
@@ -145,6 +145,7 @@ if command_exists pkg-config; then
                         zlib) missing_packages+=("zlib1g-dev") ;;
                         libsystemd) missing_packages+=("libsystemd-dev") ;;
                         libdrm) missing_packages+=("libdrm-dev") ;;
+                        libcap) missing_packages+=("libcap-dev") ;;
                     esac
                 done
             elif command_exists pacman; then
@@ -156,6 +157,7 @@ if command_exists pkg-config; then
                         zlib) missing_packages+=("zlib") ;;
                         libsystemd) missing_packages+=("systemd") ;;
                         libdrm) missing_packages+=("libdrm") ;;
+                        libcap) missing_packages+=("libcap") ;;
                     esac
                 done
             elif command_exists dnf; then
@@ -167,6 +169,7 @@ if command_exists pkg-config; then
                         zlib) missing_packages+=("zlib-devel") ;;
                         libsystemd) missing_packages+=("systemd-devel") ;;
                         libdrm) missing_packages+=("libdrm-devel") ;;
+                        libcap) missing_packages+=("libcap-devel") ;;
                     esac
                 done
             fi
@@ -186,11 +189,11 @@ else
     print_warning "pkg-config not found, assuming libraries need to be installed"
     if [ "$OS" = "linux" ]; then
         if command_exists apt; then
-            missing_packages+=("pkg-config" "libcurl4-openssl-dev" "libssl-dev" "zlib1g-dev" "libsystemd-dev" "libdrm-dev")
+            missing_packages+=("pkg-config" "libcurl4-openssl-dev" "libssl-dev" "zlib1g-dev" "libsystemd-dev" "libdrm-dev" "libcap-dev")
         elif command_exists pacman; then
-            missing_packages+=("pkgconf" "curl" "openssl" "zlib" "systemd" "libdrm")
+            missing_packages+=("pkgconf" "curl" "openssl" "zlib" "systemd" "libdrm" "libcap")
         elif command_exists dnf; then
-            missing_packages+=("pkgconfig" "libcurl-devel" "openssl-devel" "zlib-devel" "systemd-devel" "libdrm-devel")
+            missing_packages+=("pkgconfig" "libcurl-devel" "openssl-devel" "zlib-devel" "systemd-devel" "libdrm-devel" "libcap-devel")
         fi
     elif [ "$OS" = "macos" ]; then
         missing_packages+=("pkg-config" "curl" "openssl" "zlib" "libdrm")

--- a/src/cpp/server/utils/process_manager.cpp
+++ b/src/cpp/server/utils/process_manager.cpp
@@ -36,6 +36,10 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <errno.h>
+#ifdef HAVE_LIBCAP
+#include <sys/capability.h>
+#include <sys/prctl.h>
+#endif
 #endif
 
 namespace lemon {
@@ -68,6 +72,44 @@ static void log_process_line(const std::string& line) {
         LOG(INFO, "Process") << line << std::endl;
     }
 }
+
+#ifdef HAVE_LIBCAP
+// Helper function to preserve capabilities across exec()
+// This allows child processes to inherit CAP_SYS_RESOURCE and other capabilities
+// from the parent process when available
+static void preserve_capabilities_for_exec() {
+    // Get the current process capabilities
+    cap_t caps = cap_get_proc();
+    if (!caps) {
+        // If we can't get capabilities, just proceed without them
+        // This is not a fatal error - the process will run with default permissions
+        return;
+    }
+
+    // Check if we have any effective capabilities worth preserving
+    cap_flag_value_t has_sys_resource = CAP_CLEAR;
+    cap_get_flag(caps, CAP_SYS_RESOURCE, CAP_EFFECTIVE, &has_sys_resource);
+
+    // Only proceed if we actually have CAP_SYS_RESOURCE or other useful caps
+    if (has_sys_resource == CAP_SET) {
+        // Set the capability as inheritable so it survives exec()
+        cap_value_t cap_list[] = {CAP_SYS_RESOURCE};
+
+        // Mark CAP_SYS_RESOURCE as inheritable
+        if (cap_set_flag(caps, CAP_INHERITABLE, 1, cap_list, CAP_SET) == 0) {
+            // Apply the modified capability set
+            if (cap_set_proc(caps) == 0) {
+                // Enable ambient capabilities (requires Linux 4.3+)
+                // This ensures the capability is both inherited and effective in the child
+                // Ignore errors as ambient caps might not be supported on older kernels
+                prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_SYS_RESOURCE, 0, 0);
+            }
+        }
+    }
+
+    cap_free(caps);
+}
+#endif
 
 #ifdef _WIN32
 // Helper function to escape arguments for Windows command line
@@ -387,6 +429,12 @@ ProcessHandle ProcessManager::start_process(
                 close(dev_null);
             }
         }
+
+#ifdef HAVE_LIBCAP
+        // Preserve capabilities (e.g., CAP_SYS_RESOURCE) across exec
+        // This allows the child process to inherit capabilities from the parent
+        preserve_capabilities_for_exec();
+#endif
 
         // Prepare argv
         std::vector<char*> argv_ptrs;
@@ -823,6 +871,11 @@ int ProcessManager::run_process_with_output(
         if (!working_dir.empty()) {
             chdir(working_dir.c_str());
         }
+
+#ifdef HAVE_LIBCAP
+        // Preserve capabilities (e.g., CAP_SYS_RESOURCE) across exec
+        preserve_capabilities_for_exec();
+#endif
 
         // Prepare argv
         std::vector<char*> argv_ptrs;


### PR DESCRIPTION
Rather than giving lemonade-server/lemonade-router free reign on memory resources, instead give them the ability to control resource limits.  Then pass the resource limits into child processes using libcap.
