### PR TITLE
Fix model size filtering

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1229,6 +1229,10 @@ bool parse_TF_env_var(const char* env_var_name) {
                    std::string(env) == "yes");
 }
 
+static bool is_gpu_device_key(const std::string& dev_type) {
+    return dev_type.find("gpu") != std::string::npos;
+}
+
 std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
     const std::map<std::string, ModelInfo>& models) {
 
@@ -1270,10 +1274,14 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
                          hardware["amd_npu"].is_object() &&
                          hardware["amd_npu"].value("available", false);
 
-    double largest_mem_pool_gb = 0.0;
+    double largest_gpu_mem_pool_gb = 0.0;
     double curr_mem_pool_gb = 0.0;
 
     for (const auto& [dev_type, devices] : hardware.items()) {
+        if (!is_gpu_device_key(dev_type)) {
+            continue;
+        }
+
         // Because we have mixed types this just makes every device_type an array.
         nlohmann::json dev_list = devices.is_array() ? devices : nlohmann::json{devices};
 
@@ -1286,7 +1294,7 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
 
         for (const auto& dev : dev_list) {
             curr_mem_pool_gb = get_max_memory_of_device(dev, dev_mem_alloc_behavior);
-            largest_mem_pool_gb = largest_mem_pool_gb < curr_mem_pool_gb ? curr_mem_pool_gb : largest_mem_pool_gb;
+            largest_gpu_mem_pool_gb = largest_gpu_mem_pool_gb < curr_mem_pool_gb ? curr_mem_pool_gb : largest_gpu_mem_pool_gb;
         }
     }
 
@@ -1294,8 +1302,7 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
     if (system_info.contains("Physical Memory") && system_info["Physical Memory"].is_string()) {
         system_ram_gb = parse_physical_memory_gb(system_info["Physical Memory"].get<std::string>());
     }
-
-    double max_model_size_gb = largest_mem_pool_gb > (system_ram_gb * 0.8) ? largest_mem_pool_gb : (system_ram_gb * 0.8);
+    double max_cpu_model_size_gb = system_ram_gb > 0.0 ? (system_ram_gb * 0.8) : 0.0;
 
     std::string processor = "Unknown";
     std::string os_version = "Unknown";
@@ -1311,18 +1318,20 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
         LOG(INFO, "ModelManager") << "Backend availability:" << std::endl;
         LOG(INFO, "ModelManager") << "  - NPU hardware: " << (npu_available ? "Yes" : "No") << std::endl;
         if (system_ram_gb > 0.0) {
-            LOG(INFO, "ModelManager") << "  - System RAM: " << std::fixed << std::setprecision(1) << system_ram_gb
-                      << " GB (max model size: " << max_model_size_gb << " GB)" << std::endl;
+            LOG(INFO, "ModelManager") << "  - System RAM: " << std::fixed << std::setprecision(1) << system_ram_gb << std::endl;
+            LOG(INFO, "ModelManager") << "  - CPU model memory limit: " << std::fixed << std::setprecision(1) << max_cpu_model_size_gb << std::endl;
         }
-        if (largest_mem_pool_gb > 0.0) {
-            LOG(INFO, "ModelManager") << "  - Largest memory pool: " << std::fixed << std::setprecision(1) << largest_mem_pool_gb << std::endl;
+        if (largest_gpu_mem_pool_gb > 0.0) {
+            LOG(INFO, "ModelManager") << "  - Largest GPU memory pool: " << std::fixed << std::setprecision(1) << largest_gpu_mem_pool_gb << std::endl;
         }
         debug_printed = true;
     }
 
-    int filtered_count = 0;
     for (const auto& [name, info] : models) {
         const std::string& recipe = info.recipe;
+        DeviceType device = info.device != DEVICE_NONE ? info.device : get_device_type_from_recipe(recipe);
+        bool uses_cpu = (device & DEVICE_CPU) != DEVICE_NONE;
+        bool uses_gpu = (device & DEVICE_GPU) != DEVICE_NONE;
         bool filter_out = false;
         std::string filter_reason;
 
@@ -1349,18 +1358,26 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
                            "Only llamacpp models are supported on macOS.";
         }
 
-        // Filter out models that are too large for system RAM
-        // Heuristic: if model size > 80% of system RAM, filter it out
-        if (!filter_out && system_ram_gb > 0.0 && info.size > 0.0) {
-            if (info.size > max_model_size_gb) {
-                filter_out = true;
-                std::ostringstream oss;
-                oss << std::fixed << std::setprecision(1);
-                oss << "This model requires approximately " << info.size << " GB of memory, "
-                    << "but your system only has " << system_ram_gb << " GB of RAM. "
-                    << "Models larger than " << max_model_size_gb << " GB (80% of system RAM) are filtered out.";
-                filter_reason = oss.str();
-            }
+        // Filter out GPU-targeted models that are too large for the detected GPU memory pool.
+        if (!filter_out && uses_gpu && largest_gpu_mem_pool_gb > 0.0 && info.size > largest_gpu_mem_pool_gb) {
+            filter_out = true;
+            std::ostringstream oss;
+            oss << std::fixed << std::setprecision(1);
+            oss << "This GPU-targeted model requires approximately " << info.size << " GB of memory, "
+                << "but the largest detected GPU memory pool is " << largest_gpu_mem_pool_gb << " GB. "
+                << "GPU models larger than the available GPU memory pool are filtered out.";
+            filter_reason = oss.str();
+        }
+
+        // Filter out CPU-targeted models that are too large for system RAM.
+        if (!filter_out && uses_cpu && max_cpu_model_size_gb > 0.0 && info.size > max_cpu_model_size_gb) {
+            filter_out = true;
+            std::ostringstream oss;
+            oss << std::fixed << std::setprecision(1);
+            oss << "This CPU-targeted model requires approximately " << info.size << " GB of memory, "
+                << "but your system has " << system_ram_gb << " GB of RAM. "
+                << "CPU models larger than " << max_cpu_model_size_gb << " GB (80% of system RAM) are filtered out.";
+            filter_reason = oss.str();
         }
 
         // Special rule: filter out gpt-oss-20b-FLM on Windows systems with less than 64 GB RAM
@@ -1376,7 +1393,6 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
 #endif
 
         if (filter_out) {
-            filtered_count++;
             // Store the filter reason for later lookup
             filtered_out_models_[name] = filter_reason;
             continue;


### PR DESCRIPTION
For some reason the logic was looking at the system memory rather than the memory pool available by the GPU.  This exposes models that can't possibly load on a 32GB config to such a config.