### PR TITLE
fix: ignore stdout from flm version --json to ensure we only get valid json

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1431,11 +1431,11 @@ std::vector<std::string> ModelManager::get_flm_installed_models() {
 
     // Run 'flm list --filter installed --quiet --json' to get only installed models
     // Use the full path to flm.exe to avoid PATH issues
-    std::string command = "\"" + flm_path + "\" list --filter installed --quiet --json";
-
 #ifdef _WIN32
+    std::string command = "\"" + flm_path + "\" list --filter installed --quiet --json 2>NUL";
     FILE* pipe = _popen(command.c_str(), "r");
 #else
+    std::string command = "\"" + flm_path + "\" list --filter installed --quiet --json 2>/dev/null";
     FILE* pipe = popen(command.c_str(), "r");
 #endif
 
@@ -1512,11 +1512,11 @@ std::vector<ModelInfo> ModelManager::get_flm_available_models() {
     }
 
     // Run 'flm list --json' to get all available models
-    std::string command = "\"" + flm_path + "\" list --json";
-
 #ifdef _WIN32
+    std::string command = "\"" + flm_path + "\" list --json 2>NUL";
     FILE* pipe = _popen(command.c_str(), "r");
 #else
+    std::string command = "\"" + flm_path + "\" list --json 2>/dev/null";
     FILE* pipe = popen(command.c_str(), "r");
 #endif
 


### PR DESCRIPTION
When  FLM_CONFIG_PATH is set, flm is mixing a log message into the output of "flm version --json". Now that https://github.com/FastFlowLM/FastFlowLM/pull/402 has been merged, that is now sent to stderr instead, so we should only capture stdout and assume it's json.