### PR TITLE
Update NPU Exclusivity constraints in server_spec.md

### DIFF
--- a/docs/server/server_spec.md
+++ b/docs/server/server_spec.md
@@ -119,6 +119,7 @@ lemonade-server serve --max-loaded-models -1
 ### Model Types
 
 Models are categorized into these types:
+
 - **LLM** - Chat and completion models (default type)
 - **Embedding** - Models for generating text embeddings (identified by the `embeddings` label)
 - **Reranking** - Models for document reranking (identified by the `reranking` label)
@@ -129,7 +130,7 @@ Each type has its own independent LRU cache, all sharing the same slot limit set
 
 ### Device Constraints
 
-- **NPU Exclusivity:** Only one model can use the NPU at a time. Loading a new NPU model will evict any existing NPU model regardless of type or limits.
+- **NPU Exclusivity:** Only one model of each type supported by FastFlowLM (asr, llm, embedding) can be loaded at a time. Loading a new NPU model will evict any existing NPU model of the same type. For example, an LLM *and* an embedding model can be loaded simultaneously, but loading a second LLM will replace the currently loaded LLM. This limitation is **only** for multiple NPU models of the same type. NPU models can be loaded alongside CPU and GPU models.
 - **CPU/GPU:** No inherent limits beyond available RAM. Multiple models can coexist on CPU or GPU.
 
 ### Eviction Policy


### PR DESCRIPTION
Clarified NPU model loading constraints and added details about simultaneous loading of different model types.

This caused confusion, especially for me, regarding NPU exclusivity. You can load one of each type supported by FLM (asr, embed, llm) but not two of the same type.

For example, you can have one embeddings model and one asr model **and** one LLM, but if you load a second LLM it will replace the first LLM.

