### PR TITLE
feat(cli): improve download progress display for lemonade pull

### DIFF
--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -287,7 +287,8 @@ int LemonadeClient::list_models(bool show_all) const {
 
 // Helper function to parse SSE progress events
 static bool parse_sse_progress(const std::string& event_data, std::string& last_file, int& last_percent,
-                                  std::string& error_message) {
+                                  std::string& error_message, bool& total_size_printed,
+                                  uint64_t& last_file_size) {
     try {
         auto json_data = json::parse(event_data);
 
@@ -298,9 +299,23 @@ static bool parse_sse_progress(const std::string& event_data, std::string& last_
             // Use uint64_t explicitly to avoid JSON type inference issues with large numbers
             uint64_t bytes_downloaded = json_data.value("bytes_downloaded", (uint64_t)0);
             uint64_t bytes_total = json_data.value("bytes_total", (uint64_t)0);
+            uint64_t bytes_prev = json_data.value("bytes_previously_downloaded", (uint64_t)0);
+            uint64_t total_download_size = json_data.value("total_download_size", (uint64_t)0);
+
+            // Print total download size once on first event
+            if (!total_size_printed && total_download_size > 0 && total_files > 0) {
+                double size_gb = total_download_size / (1024.0 * 1024.0 * 1024.0);
+                std::cout << "Total: " << std::fixed << std::setprecision(1)
+                          << size_gb << " GB, " << total_files << " files" << std::endl;
+                total_size_printed = true;
+            }
 
             if (file != last_file) {
-                if (!last_file.empty()) {
+                // First event for this file — remember its size for progress display
+                last_file_size = bytes_total;
+
+                // Add newline after progress bar (carriage-return based), but not after "(already downloaded)"
+                if (!last_file.empty() && last_percent != 100) {
                     std::cout << std::endl;
                 }
                 std::cout << "[" << file_index << "/" << total_files << "] " << file;
@@ -308,20 +323,33 @@ static bool parse_sse_progress(const std::string& event_data, std::string& last_
                     std::cout << " (" << std::fixed << std::setprecision(1)
                             << (bytes_total / (1024.0 * 1024.0)) << " MB)";
                 }
+
+                // Check if already downloaded: bytes_prev equals the KNOWN file size
+                bool is_already_downloaded = bytes_prev > 0 && bytes_prev == bytes_total;
+                if (is_already_downloaded) {
+                    std::cout << " (already downloaded)";
+                    last_percent = 100;
+                } else {
+                    last_percent = -1;
+                }
                 std::cout << std::endl;
                 last_file = file;
-                last_percent = -1;
+            } else if (last_percent != 100 && bytes_prev > 0 && bytes_prev == last_file_size) {
+                // Completion event: bytes_prev matches known file size (not a redirect artifact)
+                std::cout << "\r" << std::string(80, ' ') << "\r  (already downloaded)" << std::endl;
+                last_percent = 100;
             }
 
-            if (bytes_total > 0 && json_data.contains("percent") && json_data["percent"].is_number_integer()) {
-                int percent = json_data["percent"].get<int>();
-
-                if (percent != last_percent) {
-                    std::cout << "\r  Progress: " << percent << "% ("
+            // Show progress bar using the known file size as denominator
+            if (last_percent != 100 && last_file_size > 0) {
+                int display_percent = static_cast<int>((bytes_downloaded * 100) / last_file_size);
+                if (display_percent > 100) display_percent = 100;
+                if (display_percent != last_percent) {
+                    std::cout << "\r  Progress: " << display_percent << "% ("
                             << std::fixed << std::setprecision(1)
                             << (bytes_downloaded / (1024.0 * 1024.0)) << "/"
-                            << (bytes_total / (1024.0 * 1024.0)) << " MB)" << std::flush;
-                    last_percent = percent;
+                            << (last_file_size / (1024.0 * 1024.0)) << " MB)" << std::flush;
+                    last_percent = display_percent;
                 }
             }
         }
@@ -360,7 +388,7 @@ int LemonadeClient::pull_model(const json& model_data) {
                 std::cout << std::endl;
                 state.success = true;
             } else {
-                parse_sse_progress(event_data, state.last_file, state.last_percent, state.error_message);
+                parse_sse_progress(event_data, state.last_file, state.last_percent, state.error_message, state.total_size_printed, state.last_file_size);
             }
         }, 86400, 30);
 
@@ -570,7 +598,7 @@ int LemonadeClient::install_backend(const std::string& recipe, const std::string
                 std::cout << std::endl;
                 state.success = true;
             } else {
-                parse_sse_progress(event_data, state.last_file, state.last_percent, state.error_message);
+                parse_sse_progress(event_data, state.last_file, state.last_percent, state.error_message, state.total_size_printed, state.last_file_size);
             }
         }, 86400, 30);
         if (!state.success) {

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <functional>
+#include <cstdint>
 #include <nlohmann/json.hpp>
 
 // Forward declaration for httplib
@@ -19,6 +20,8 @@ struct StreamingRequestState {
     int last_percent = -1;
     bool success = false;
     std::string error_message;
+    bool total_size_printed = false;
+    uint64_t last_file_size = 0;
 };
 
 // Model information structure

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2004,12 +2004,16 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
             // GGUF model: Use identify_gguf_models to determine which files to download
             GGUFFiles gguf_files = identify_gguf_models(main_repo_id, main_variant, repo_files);
 
-            // Combine core files and sharded files into one list
+            // Combine core files and sharded files into one list (avoiding duplicates)
+            std::unordered_set<std::string> added_files;
             for (const auto& [key, filename] : gguf_files.core_files) {
                 files_to_download[main_repo_id].push_back(filename);
+                added_files.insert(filename);
             }
             for (const auto& filename : gguf_files.sharded_files) {
-                files_to_download[main_repo_id].push_back(filename);
+                if (added_files.find(filename) == added_files.end()) {
+                    files_to_download[main_repo_id].push_back(filename);
+                }
             }
         }
 


### PR DESCRIPTION
Noticed working on #1386 the file count is actually wrong (6 instead of 5) and in #1385 the pull output skips files and could be improved.  This PR builds on #1386 and improves the output for the cli. 

```bash
$ lemonade pull Qwen3.5-122B-A10B-GGUF
Pulling model: Qwen3.5-122B-A10B-GGUF
Total: 72.6 GB, 5 files
[1/5] UD-Q4_K_XL/Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf (10.4 MB)
  (already downloaded)                                                          
[2/5] UD-Q4_K_XL/Qwen3.5-122B-A10B-UD-Q4_K_XL-00002-of-00003.gguf (47341.1 MB)
  Progress: 100% (47341.1/47341.1 MB)
[3/5] UD-Q4_K_XL/Qwen3.5-122B-A10B-UD-Q4_K_XL-00003-of-00003.gguf (26110.0 MB)
  Progress: 100% (26110.0/26110.0 MB)
[4/5] config.json (0.0 MB)
  Progress: 100% (0.0/0.0 MB)
[5/5] mmproj-F16.gguf (866.6 MB)
  Progress: 100% (866.6/866.6 MB)
Model pulled successfully: Qwen3.5-122B-A10B-GGUF
```

## Summary
- Show total download size and file count header (`Total: 72.6 GB, 5 files`)
- Label already-downloaded files as `(already downloaded)` instead of silently skipping
- Fix progress bar denominator for resumed downloads (was showing resume offset as 100% instead of actual file size)
- Fix duplicate shard in GGUF folder-variant downloads (`identify_gguf_models` added the first shard to both `core_files` and `sharded_files`)

## Dependencies
- Depends on PR #1386 for server-side `total_download_size` and `bytes_previously_downloaded` SSE fields

## Test plan
- [x] `lemonade pull` with a fully downloaded model shows all files as `(already downloaded)`
- [x] `lemonade pull` resuming a partial download shows correct progress percentage relative to full file size
- [x] Sharded GGUF models with folder variants (e.g. `UD-Q4_K_XL/`) show correct file count without duplicates
- [x] `lemonade pull` for a fresh download shows smooth 0→100% progress per file

Tested on current main, combined with #1386 on Ubuntu resolute 26.04.

# Before
<img width="1320" height="279" alt="image" src="https://github.com/user-attachments/assets/a7fd8ce2-c871-4d6a-ac76-331eb7afa6f4" />
# After
<img width="1348" height="565" alt="image" src="https://github.com/user-attachments/assets/251a545e-9bfb-413d-afc9-69645ff03fa4" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)