### PR TITLE
Fix merge queue CI failures by running apt-get update before deb install

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1031,6 +1031,7 @@ jobs:
         run: |
           DEB_FILE="lemonade-server_${{ env.LEMONADE_VERSION }}_amd64.deb"
           echo "Installing .deb package: $DEB_FILE"
+          sudo apt-get update
           sudo apt install ./"$DEB_FILE"
 
           # Verify binaries installed


### PR DESCRIPTION
## Summary
- The `test-cli-endpoints` job in the merge queue CI was failing with 404 errors when `sudo apt install ./"$DEB_FILE"` tried to fetch dependencies (e.g. `libssh`) from the package index.
- Root cause: GitHub Actions `ubuntu-latest` runners ship with a stale apt package index, so dependency resolution can fail when packages have been updated in the upstream repositories.
- Fix: Add `sudo apt-get update` immediately before the `.deb` install to refresh the package index.

## Test plan
- [ ] Merge queue CI passes on a PR targeting `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)