### PR TITLE
Stricter device check for ROCm (+gfx103X support)

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -193,6 +193,7 @@ static const std::map<std::string, std::string> DEVICE_FAMILY_NAMES = {
     // AMD iGPU/dGPU architectures (ROCm)
     {"gfx1150", "Radeon 880M/890M (Strix Point)"},
     {"gfx1151", "Radeon 8050S/8060S (Strix Halo)"},
+    {"gfx103X", "Radeon RX 6000 series (RDNA2)"},
     {"gfx110X", "Radeon RX 7000 series (RDNA3)"},
     {"gfx120X", "Radeon RX 9000 series (RDNA4)"},
 


### PR DESCRIPTION
Wrote in response to the [latest ROCm repo commit](https://github.com/lemonade-sdk/llamacpp-rocm/commit/0741e19615f1ee7ef40b181494d4b96271c7fdf6) and https://github.com/lemonade-sdk/lemonade/issues/1363

Since Lemonade's ROCm binaries are built with explicit device targets that are converted to a more generalized architecture-based binary name (except for gfx1150 and gfx1151), it is better to be explicit here as well.

This prevents AMD GPUs detected via KFD values from falsely claiming support and attempting to fetch non-existent binaries.

Also, this will allow the gfx103x family to be supported with the same definitions as the latest llamacpp-rocm commit.

I suppose there might be a better way to do this (like managing the supported family in the backend json file), but seems like this is the way to go without dramatically change the structure of this database.

