### PR TITLE
fix(app): prevent wrong model selection during load

### DIFF
--- a/src/app/src/renderer/ChatWindow.tsx
+++ b/src/app/src/renderer/ChatWindow.tsx
@@ -155,6 +155,7 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isVisible, width }) => {
 
     const handleModelLoadStart = (e: CustomEvent) => {
       setSelectedModel(e.detail.modelId);
+      setUserHasSelectedModel(true);
     };
 
     window.addEventListener('modelLoadStart' as any, handleModelLoadStart);

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -336,7 +336,13 @@ void Router::load_model(const std::string& model_name,
         lock.lock();
 
         if (load_success) {
-            // Success: Add to loaded servers
+            // Success: Refresh access time so this model is returned by
+            // get_most_recent_server() (the pre-load timestamp from line 316
+            // may have been overtaken by other models serving requests while
+            // the lock was released during the slow backend load).
+            new_server->update_access_time();
+
+            // Add to loaded servers
             loaded_servers_.push_back(std::move(new_server));
 
             is_loading_ = false;


### PR DESCRIPTION
## Summary
Fixes #1380 — loading a model (e.g. Qwen3-0.6B-GGUF) could cause the UI to switch to a different model (e.g. Flux-2-Klein-4B), changing the entire experience panel.

**Root cause:** A race condition between the 30-60s backend load and the frontend's 5-second `/health` poll:
1. User clicks load → `modelLoadStart` sets the correct selection
2. During the slow backend load, `/health` returns the *previously active* model (the new one isn't in the server list yet)
3. The health poll overwrites the selection because `userHasSelectedModel` was `false`
4. Even after loading completes, `get_most_recent_server()` could return the wrong model because access time was only set *before* the load

**Fix (two changes):**
- **Frontend** (`ChatWindow.tsx`): Set `userHasSelectedModel(true)` on `modelLoadStart` so health polls don't overwrite the selection during loading. `modelLoadEnd` already resets this to `false`.
- **Backend** (`router.cpp`): Refresh `update_access_time()` after successful backend load so `/health` immediately reports the newly loaded model.

## Test plan
- [x] Load a model while other models are already active — verify the UI stays on the model you selected
- [x] Verify the loaded model appears correctly in the chat dropdown after load completes
- [x] Verify that manually switching models via the UI still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)