### PR TITLE
Fix libcurl timeout for large prompts

### DIFF
--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -72,19 +72,19 @@ public:
     static HttpResponse post(const std::string& url,
                             const std::string& body,
                             const std::map<std::string, std::string>& headers = {},
-                            long timeout_seconds = 300);
+                            long timeout_seconds = -1);
 
     // Multipart form data POST request
     static HttpResponse post_multipart(const std::string& url,
                                        const std::vector<MultipartField>& fields,
-                                       long timeout_seconds = 300);
+                                       long timeout_seconds = -1);
 
     // Streaming POST request (calls callback for each chunk as it arrives)
     static HttpResponse post_stream(const std::string& url,
                                    const std::string& body,
                                    StreamCallback stream_callback,
                                    const std::map<std::string, std::string>& headers = {},
-                                   long timeout_seconds = 300);
+                                   long timeout_seconds = -1);
 
     // Download file to disk with automatic retry and resume support
     static DownloadResult download_file(const std::string& url,

--- a/src/cpp/server/cli_parser.cpp
+++ b/src/cpp/server/cli_parser.cpp
@@ -58,7 +58,16 @@ static void add_serve_options(CLI::App* serve, ServerConfig& config) {
                    "Global timeout for HTTP requests, inference, and readiness checks in seconds")
         ->envname("LEMONADE_GLOBAL_TIMEOUT")
         ->type_name("SECONDS")
-        ->default_val(config.global_timeout);
+        ->default_val(config.global_timeout)
+        ->transform([](std::string val) {
+            try {
+                long t = std::stol(val);
+                if (t > 0 && t < 300) return std::string("300");
+            } catch (...) {
+                // Ignore invalid values, let CLI11 handle them
+            }
+            return val;
+        });
 
     // Multi-model support: Max loaded models per type slot
     serve->add_option("--max-loaded-models", config.max_loaded_models,

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -120,8 +120,8 @@ HttpResponse HttpClient::post(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_);
+    // Use provided timeout (0 = infinite), or fallback to global default (set via --global-timeout)
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds >= 0 ? timeout_seconds : default_timeout_seconds_);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     // Add custom headers
@@ -182,8 +182,8 @@ HttpResponse HttpClient::post_multipart(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_);
+    // Use provided timeout (0 = infinite), or fallback to global default (set via --global-timeout)
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds >= 0 ? timeout_seconds : default_timeout_seconds_);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     CURLcode res = curl_easy_perform(curl);
@@ -258,8 +258,8 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, stream_write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &callback_data);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_);
+    // Use provided timeout (0 = infinite), or fallback to global default (set via --global-timeout)
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds >= 0 ? timeout_seconds : default_timeout_seconds_);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     // Add custom headers


### PR DESCRIPTION
Addresses #1364 where large prompts timed out exactly at 5 minutes due to the global timeout overriding the default behavior.
- Changes `HttpClient` to default to `-1` to fallback to default
- Passes `0` to curl directly for infinite
- Constrains `--global-timeout` to be minimum 300 or infinite
