### PR TITLE
fix: pass global-timeout to router and use it for sd-server proxy

### DIFF
--- a/src/cpp/include/lemon_tray/server_manager.h
+++ b/src/cpp/include/lemon_tray/server_manager.h
@@ -52,7 +52,8 @@ public:
         bool is_ephemeral,
         const std::string& host,
         int max_loaded_models,
-        const std::string& extra_models_dir
+        const std::string& extra_models_dir,
+        long global_timeout = 300
     );
 
     bool stop_server();
@@ -112,6 +113,7 @@ private:
     std::string api_key_;
     int port_;
     int max_loaded_models_;
+    long global_timeout_ = 300;
     nlohmann::json recipe_options_;
     bool show_console_;
     bool is_ephemeral_;  // Suppress output for ephemeral servers

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -252,8 +252,8 @@ json SDServer::image_generations(const json& request) {
     LOG(DEBUG, "SDServer") << "Forwarding request to sd-server: "
                   << sd_request.dump(2) << std::endl;
 
-    // Use base class forward_request with 10 minute timeout for image generation
-    return forward_request("/v1/images/generations", sd_request, 600);
+    // Image generation can take 20+ minutes for large models — use global timeout
+    return forward_request("/v1/images/generations", sd_request, utils::HttpClient::get_default_timeout());
 }
 
 json SDServer::image_edits(const json& request) {
@@ -307,7 +307,7 @@ json SDServer::image_edits(const json& request) {
                   << " size=" << request.value("size", "")
                   << std::endl;
 
-    return forward_multipart_request("/v1/images/edits", fields, 600);
+    return forward_multipart_request("/v1/images/edits", fields, utils::HttpClient::get_default_timeout());
 }
 
 json SDServer::image_variations(const json& request) {
@@ -335,7 +335,7 @@ json SDServer::image_variations(const json& request) {
                   << " size=" << request.value("size", "")
                   << std::endl;
 
-    return forward_multipart_request("/v1/images/edits", fields, 600);
+    return forward_multipart_request("/v1/images/edits", fields, utils::HttpClient::get_default_timeout());
 }
 
 } // namespace backends

--- a/src/cpp/tray/server_manager.cpp
+++ b/src/cpp/tray/server_manager.cpp
@@ -56,7 +56,8 @@ bool ServerManager::start_server(
     bool is_ephemeral,
     const std::string& host,
     int max_loaded_models,
-    const std::string& extra_models_dir)
+    const std::string& extra_models_dir,
+    long global_timeout)
 {
     if (is_server_running()) {
         LOG(DEBUG, "ServerManager") << "Server is already running" << std::endl;
@@ -67,6 +68,7 @@ bool ServerManager::start_server(
     port_ = port;
     recipe_options_ = recipe_options;
     max_loaded_models_ = max_loaded_models;
+    global_timeout_ = global_timeout;
     log_file_ = log_file;
     log_level_ = log_level;
     show_console_ = show_console;
@@ -228,7 +230,7 @@ bool ServerManager::stop_server() {
 bool ServerManager::restart_server() {
     stop_server();
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    return start_server(server_binary_path_, port_, recipe_options_, log_file_, log_level_, show_console_, false, host_, max_loaded_models_, extra_models_dir_);
+    return start_server(server_binary_path_, port_, recipe_options_, log_file_, log_level_, show_console_, false, host_, max_loaded_models_, extra_models_dir_, global_timeout_);
 }
 
 bool ServerManager::is_server_running() const {
@@ -362,6 +364,10 @@ bool ServerManager::spawn_process() {
     // Extra models directory
     if (!extra_models_dir_.empty()) {
         cmdline += " --extra-models-dir \"" + extra_models_dir_ + "\"";
+    }
+    // Global timeout (only if not default)
+    if (global_timeout_ != 300) {
+        cmdline += " --global-timeout " + std::to_string(global_timeout_);
     }
 
     LOG(DEBUG, "ServerManager") << "Starting server: " << cmdline << std::endl;
@@ -579,6 +585,14 @@ bool ServerManager::spawn_process() {
         if (!extra_models_dir_.empty()) {
             args.push_back("--extra-models-dir");
             args.push_back(extra_models_dir_.c_str());
+        }
+
+        // Global timeout (only if not default)
+        std::string global_timeout_str;
+        if (global_timeout_ != 300) {
+            args.push_back("--global-timeout");
+            global_timeout_str = std::to_string(global_timeout_);
+            args.push_back(global_timeout_str.c_str());
         }
 
         args.push_back(nullptr);

--- a/src/cpp/tray/tray_app.cpp
+++ b/src/cpp/tray/tray_app.cpp
@@ -1103,7 +1103,8 @@ bool TrayApp::start_ephemeral_server(int port) {
         true,   // is_ephemeral (suppress startup message)
         server_config_.host,  // Pass host to ServerManager
         server_config_.max_loaded_models,
-        server_config_.extra_models_dir  // Pass extra models directory
+        server_config_.extra_models_dir,  // Pass extra models directory
+        server_config_.global_timeout
     );
 
     if (!success) {
@@ -2272,7 +2273,8 @@ bool TrayApp::start_server() {
         is_service_active(), // is_ephemeral = true if systemd (suppress startup message)
         server_config_.host,        // Pass host to ServerManager
         server_config_.max_loaded_models,
-        server_config_.extra_models_dir  // Pass extra models directory
+        server_config_.extra_models_dir,  // Pass extra models directory
+        server_config_.global_timeout
     );
 
     // Start log tail thread to show logs in console


### PR DESCRIPTION
## Summary

- **sd_server.cpp**: Replace hardcoded 600s proxy timeouts with `get_default_timeout()` so image generation/edit/variation requests respect `LEMONADE_GLOBAL_TIMEOUT`
- **ServerManager**: Forward `global_timeout` from `lemonade-server` to `lemonade-router` via `--global-timeout` CLI arg (fixes env var not propagating through subprocess spawn)
- **TrayApp**: Pass `server_config_.global_timeout` through both `start_server()` call sites

## Context

Image generation models like Qwen Image Edit can take 30+ minutes on consumer GPUs (e.g. Radeon 8060S). The sd-server proxy had hardcoded 600s timeouts that couldn't be overridden, and `LEMONADE_GLOBAL_TIMEOUT` set in `/etc/lemonade/conf.d/` was never reaching the router because `ServerManager` didn't pass it as an arg.

Complementary to #1421 which fixes the HttpClient timeout semantics — this PR ensures the global timeout value actually reaches the router and is used by the sd-server proxy.

## Test plan

- [x] Set `LEMONADE_GLOBAL_TIMEOUT=3600` in `/etc/lemonade/conf.d/timeout.conf`
- [x] Verify `--global-timeout 3600` appears in router process args
- [x] Image edit request completes after 35m46s without timeout
- [ ] Verify default behavior (no env override) still works with 300s timeout
- [ ] Verify existing image generation models (Flux, SDXL) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)