### PR TITLE
Fix validate_llamacpp.py tray crash on headless CI

### DIFF
--- a/test/validate_llamacpp.py
+++ b/test/validate_llamacpp.py
@@ -107,6 +107,9 @@ def start_server(server_binary, port):
     OS pipe buffer from filling up and blocking the subprocess.
     """
     cmd = [server_binary, "serve", "--port", str(port), "--log-level", "debug"]
+    # Add --no-tray on Windows or in CI environments (no display server in containers)
+    if os.name == "nt" or os.getenv("LEMONADE_CI_MODE"):
+        cmd.append("--no-tray")
     print(f"Starting server: {' '.join(cmd)}", flush=True)
     proc = subprocess.Popen(
         cmd,


### PR DESCRIPTION
## Summary
- `validate_llamacpp.py` was the only test script not passing `--no-tray` when `LEMONADE_CI_MODE` is set
- On headless Windows CI runners, `Shell_NotifyIconW` can fail (no desktop session), causing `lemonade-server serve` to exit immediately before any models are validated
- This was flaky — it passed when an interactive session happened to be available, and failed otherwise (e.g., [run 23368588621](https://github.com/lemonade-sdk/lemonade/actions/runs/23368588621/job/67988038174): 0/7 models passed)
- Adds the same `--no-tray` guard already used in `server_cli.py`, `server_cli2.py`, `server_base.py`, and `server_system_info.py`

## Test plan
- [ ] Re-run the "Validate New llama.cpp Release" workflow and confirm the vulkan/rocm jobs no longer fail due to tray initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)