### PR TITLE
Fix: `GET /api/v1/system-info` returns 500 on non-English Windows locales

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -77,17 +77,17 @@ const std::map<std::string, std::string> ROCM_ARCH_MAPPING = {
     {"gfx1032", "gfx103X"},
     {"gfx1034", "gfx103X"},
     // Note: gfx1033, gfx1035, gfx1036 are NOT included (not confirmed as supported)
-    
+
     // RDNA3 family (gfx110X)
     {"gfx1100", "gfx110X"},
     {"gfx1101", "gfx110X"},
     {"gfx1102", "gfx110X"},
     {"gfx1103", "gfx110X"},
-    
+
     // RDNA3.5 iGPUs - explicit binary names (no family mapping)
     {"gfx1150", "gfx1150"},  // Maps to exact binary name
     {"gfx1151", "gfx1151"},  // Maps to exact binary name
-    
+
     // RDNA4 family (gfx120X)
     {"gfx1200", "gfx120X"},
     {"gfx1201", "gfx120X"},
@@ -1216,8 +1216,8 @@ std::string identify_rocm_arch_from_name(const std::string& device_name) {
     }
 
     // RDNA2 GPUs (gfx103X architecture)
-    // AMD Radeon RX 6800 XT, AMD Radeon RX 6800, AMD Radeon RX 6700 XT, 
-    // AMD Radeon RX 6700, AMD Radeon RX 6600 XT, AMD Radeon RX 6600, 
+    // AMD Radeon RX 6800 XT, AMD Radeon RX 6800, AMD Radeon RX 6700 XT,
+    // AMD Radeon RX 6700, AMD Radeon RX 6600 XT, AMD Radeon RX 6600,
     // AMD Radeon RX 6500 XT, AMD Radeon RX 6500
     if (device_lower.find("6800") != std::string::npos ||
         device_lower.find("6700") != std::string::npos ||
@@ -1976,6 +1976,10 @@ std::string WindowsSystemInfo::get_windows_power_setting() {
     if (rc != 0) {
         return "Windows power setting not found (command failed)";
     }
+
+    // Command output is in the system ANSI code page; convert to UTF-8
+    // so the string is safe for nlohmann::json::dump().
+    result = wmi::acp_to_utf8(result);
 
     // Extract power scheme name from parentheses
     // Output format: "Power Scheme GUID: ... (Power Scheme Name)"

--- a/src/cpp/server/utils/wmi_helper.cpp
+++ b/src/cpp/server/utils/wmi_helper.cpp
@@ -155,6 +155,19 @@ std::string wstring_to_string(const std::wstring& wstr) {
     return strTo;
 }
 
+std::string acp_to_utf8(const std::string& acp_str) {
+    if (acp_str.empty()) return std::string();
+
+    // ACP (system locale code page) -> Wide string
+    int wide_size = MultiByteToWideChar(CP_ACP, 0, acp_str.c_str(), (int)acp_str.size(), NULL, 0);
+    if (wide_size == 0) return acp_str;
+    std::wstring wstr(wide_size, 0);
+    MultiByteToWideChar(CP_ACP, 0, acp_str.c_str(), (int)acp_str.size(), &wstr[0], wide_size);
+
+    // Wide string -> UTF-8
+    return wstring_to_string(wstr);
+}
+
 std::string get_property_string(IWbemClassObject* pObj, const std::wstring& prop_name) {
     VARIANT vtProp;
     VariantInit(&vtProp);

--- a/src/cpp/server/utils/wmi_helper.h
+++ b/src/cpp/server/utils/wmi_helper.h
@@ -51,6 +51,7 @@ private:
 // Helper functions
 std::wstring string_to_wstring(const std::string& str);
 std::string wstring_to_string(const std::wstring& wstr);
+std::string acp_to_utf8(const std::string& acp_str);
 std::string get_property_string(IWbemClassObject* pObj, const std::wstring& prop_name);
 int get_property_int(IWbemClassObject* pObj, const std::wstring& prop_name);
 uint64_t get_property_uint64(IWbemClassObject* pObj, const std::wstring& prop_name);


### PR DESCRIPTION
Fixes #1435

## Problem

`_popen()` on Windows returns text in the system ANSI code page (ACP). On non-English locales, `powercfg /getactivescheme` returns a localized power scheme name (e.g., `バランス` meaning "Balanced" in Shift-JIS on Japanese Windows). Storing this as-is in `nlohmann::json` and calling `dump()` throws `json.exception.type_error.316` because the bytes are not valid UTF-8, causing an HTTP 500.

## Fix

Added `wmi::acp_to_utf8()` that converts ACP-encoded strings to UTF-8 via `MultiByteToWideChar(CP_ACP) → WideCharToMultiByte(CP_UTF8)`, and applied it to `_popen()` output in `get_windows_power_setting()`.

## Verification

Confirmed that `GET /api/v1/system-info` now returns HTTP 200 on Japanese Windows (CP932).
