### PR TITLE
Sort tray includes alphabetically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,7 @@ Test utilities in `test/utils/` with `server_base.py` as the base class. Test de
 - C++17, `lemon::` namespace
 - `snake_case` for functions/variables, `CamelCase` for classes/types
 - 4-space indent, `#pragma once` for headers
+- Keep `#include` directives in alphabetical order within each include block
 - Platform guards: `#ifdef _WIN32`, `#ifdef __APPLE__`, `#ifdef __linux__`
 
 ### Python

--- a/src/cpp/tray/main.cpp
+++ b/src/cpp/tray/main.cpp
@@ -9,23 +9,22 @@
 //   Output binary: lemonade-tray
 
 #include "lemon_tray/tray_ui.h"
+#include <lemon/cli_parser.h>
+#include <lemon/server.h>
 #include <lemon/single_instance.h>
-#include <lemon/version.h>
 #include <lemon/utils/aixlog.hpp>
+#include <lemon/version.h>
 
+#include <atomic>
+#include <chrono>
 #include <iostream>
 #include <string>
 #include <thread>
-#include <chrono>
-#include <atomic>
-
 #include <CLI/CLI.hpp>
 #include <httplib.h>
 
 #ifdef _WIN32
 // Windows embeds the server
-#include <lemon/server.h>
-#include <lemon/cli_parser.h>
 #include <winsock2.h>
 #include <windows.h>
 

--- a/src/cpp/tray/platform/linux_tray.cpp
+++ b/src/cpp/tray/platform/linux_tray.cpp
@@ -3,13 +3,15 @@
 #include "lemon_tray/platform/linux_tray.h"
 #include "lemon_tray/platform/linux_systemd.h"
 #include <lemon/utils/aixlog.hpp>
+
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 #include <optional>
-#include <cstring>
-#include <cstdlib>
-#include <unistd.h>
 #include <utility>
+#include <unistd.h>
+
 #ifdef HAVE_SYSTEMD
 #include <systemd/sd-bus.h>
 #include <systemd/sd-daemon.h>

--- a/src/cpp/tray/platform/macos_tray.mm
+++ b/src/cpp/tray/platform/macos_tray.mm
@@ -1,14 +1,15 @@
 #ifdef __APPLE__
 
 #include "lemon_tray/platform/macos_tray.h"
+
 #include <iostream>
+#include <lemon/utils/aixlog.hpp>
 #include <memory>
 #include <string>
-#include <lemon/utils/aixlog.hpp>
 
 // macOS imports for system tray
-#import <Cocoa/Cocoa.h>
 #import <AppKit/AppKit.h>
+#import <Cocoa/Cocoa.h>
 #import <UserNotifications/UserNotifications.h>
 
 // -----------------------------------------------------------------------------

--- a/src/cpp/tray/platform/windows_tray.cpp
+++ b/src/cpp/tray/platform/windows_tray.cpp
@@ -1,10 +1,11 @@
 #ifdef _WIN32
 
 #include "lemon_tray/platform/windows_tray.h"
-#include <iostream>
+
 #include <codecvt>
-#include <locale>
+#include <iostream>
 #include <lemon/utils/aixlog.hpp>
+#include <locale>
 
 // Undefine Windows macros that conflict with our enums
 #ifdef ERROR

--- a/src/cpp/tray/tray_ui.cpp
+++ b/src/cpp/tray/tray_ui.cpp
@@ -1,26 +1,26 @@
 #include "lemon_tray/tray_ui.h"
-#include <lemon/version.h>
 #include <lemon/utils/path_utils.h>
+#include <lemon/version.h>
 
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <sstream>
-#include <filesystem>
-#include <algorithm>
 #include <thread>
-#include <chrono>
 
 #ifdef _WIN32
+#include "lemon_tray/platform/windows_tray.h"
+#include <shellapi.h>
 #include <winsock2.h>
 #include <windows.h>
-#include <shellapi.h>
-#include "lemon_tray/platform/windows_tray.h"
 #else
 #include <cstdlib>
-#include <unistd.h>
-#include <sys/wait.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/select.h>
+#include <sys/wait.h>
+#include <unistd.h>
 #endif
 
 


### PR DESCRIPTION
Closes #1445

## Summary
- sort include blocks alphabetically in `src/cpp/tray`
- document alphabetical include ordering in `AGENTS.md`