### PR TITLE
Add support for ROCm channels (For llama.cpp and stable diffusion)

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1623,6 +1623,163 @@ jobs:
           artifact-name: server-logs-apikey-windows-latest
 
   # ========================================================================
+  # TEST ROCM STABLE CHANNEL - Verify stable channel on Windows hosted runner
+  # ========================================================================
+
+  test-rocm-stable-channel:
+    name: Test ROCm Stable Channel (Windows)
+    runs-on: windows-latest
+    needs:
+      - build-lemonade-server-installer
+    env:
+      LEMONADE_CI_MODE: "True"
+      PYTHONIOENCODING: utf-8
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup (Windows)
+        shell: powershell
+        run: |
+          $cwd = (Get-Item .).FullName
+          echo "HF_HOME=$cwd\hf-cache" >> $Env:GITHUB_ENV
+          echo "LEMONADE_INSTALL_PATH=$cwd\lemonade_server_install" >> $Env:GITHUB_ENV
+
+      - name: Install Lemonade Server (Windows)
+        uses: ./.github/actions/install-lemonade-server-msi
+        with:
+          install-path: ${{ env.LEMONADE_INSTALL_PATH }}
+
+      - name: Set paths (Windows)
+        shell: powershell
+        run: |
+          echo "VENV_PYTHON=.venv/Scripts/python.exe" >> $Env:GITHUB_ENV
+          echo "SERVER_BINARY=$Env:LEMONADE_INSTALL_PATH\bin\lemonade-server.exe" >> $Env:GITHUB_ENV
+
+      - name: Setup Python and virtual environment
+        uses: ./.github/actions/setup-venv
+        with:
+          venv-name: '.venv'
+          python-version: '3.10'
+          requirements-file: 'test/requirements.txt'
+
+      - name: Set ROCm channel to stable
+        shell: bash
+        run: |
+          set -e
+          echo "Setting rocm_channel to stable in config.json"
+          "$VENV_PYTHON" -c "
+          import json
+          import os
+          from pathlib import Path
+
+          cache_dir = Path.home() / '.cache' / 'lemonade'
+          config_file = cache_dir / 'config.json'
+
+          # Create cache dir if needed
+          cache_dir.mkdir(parents=True, exist_ok=True)
+
+          # Load or create config
+          if config_file.exists():
+              with open(config_file, 'r') as f:
+                  config = json.load(f)
+          else:
+              config = {}
+
+          # Set rocm_channel to stable
+          config['rocm_channel'] = 'stable'
+
+          # Save config
+          with open(config_file, 'w') as f:
+              json.dump(config, f, indent=2)
+
+          print(f'Config updated: rocm_channel = stable')
+          "
+
+      - name: Verify ROCm stable channel configuration
+        shell: bash
+        run: |
+          set -e
+          echo "Verifying rocm_channel setting..."
+          "$VENV_PYTHON" -c "
+          import json
+          from pathlib import Path
+
+          config_file = Path.home() / '.cache' / 'lemonade' / 'config.json'
+
+          if not config_file.exists():
+              print('ERROR: config.json not found')
+              exit(1)
+
+          with open(config_file, 'r') as f:
+              config = json.load(f)
+
+          channel = config.get('rocm_channel', 'NOT_SET')
+          print(f'rocm_channel = {channel}')
+
+          if channel != 'stable':
+              print(f'ERROR: Expected rocm_channel=stable, got {channel}')
+              exit(1)
+
+          print('SUCCESS: rocm_channel is set to stable')
+          "
+
+      - name: Test channel switching with lemonade CLI
+        shell: bash
+        run: |
+          set -e
+          echo "Setting rocm_channel to stable via lemonade CLI..."
+
+          # Use lemonade config set to change the channel
+          "$SERVER_BINARY" config set rocm_channel=stable
+
+          echo "Verifying config was updated..."
+          "$VENV_PYTHON" -c "
+          import json
+          from pathlib import Path
+
+          config_file = Path.home() / '.cache' / 'lemonade' / 'config.json'
+
+          if not config_file.exists():
+              print('ERROR: config.json not found')
+              exit(1)
+
+          with open(config_file, 'r') as f:
+              config = json.load(f)
+
+          channel = config.get('rocm_channel', 'NOT_SET')
+          print(f'rocm_channel = {channel}')
+
+          if channel != 'stable':
+              print(f'ERROR: Expected rocm_channel=stable, got {channel}')
+              exit(1)
+
+          print('SUCCESS: rocm_channel set to stable via CLI')
+          "
+
+      - name: Test recipes command shows rocm backend
+        shell: bash
+        run: |
+          set -e
+          echo "Testing recipes command..."
+          "$SERVER_BINARY" recipes | tee recipes_output.txt
+
+          # Check that rocm backend is listed (not rocm-stable or rocm-preview)
+          if grep -q "rocm-stable" recipes_output.txt || grep -q "rocm-preview" recipes_output.txt; then
+              echo "ERROR: Found rocm-stable or rocm-preview in recipes output (should only show 'rocm')"
+              cat recipes_output.txt
+              exit 1
+          fi
+
+          echo "SUCCESS: Recipes output looks correct"
+
+      - name: Capture and upload server logs
+        if: always()
+        uses: ./.github/actions/capture-server-logs
+        with:
+          artifact-name: server-logs-rocm-stable-channel
+
+  # ========================================================================
   # RELEASE JOB - Add artifacts to GitHub release
   # ========================================================================
 

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       llamacpp_release: ${{ steps.llamacpp.outputs.release }}
       llamacpp_rocm_release: ${{ steps.llamacpp_rocm.outputs.release }}
+      llamacpp_rocm_preview_release: ${{ steps.llamacpp_rocm_preview.outputs.release }}
     steps:
       - name: Get latest llama.cpp release
         id: llamacpp
@@ -49,6 +50,15 @@ jobs:
         run: |
           RELEASE=$(gh api repos/lemonade-sdk/llamacpp-rocm/releases/latest --jq '.tag_name')
           echo "Latest llamacpp-rocm release: $RELEASE"
+          echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
+
+      - name: Get latest llamacpp-rocm-preview release
+        id: llamacpp_rocm_preview
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE=$(gh api repos/lemonade-sdk/llama.cpp/releases/latest --jq '.tag_name')
+          echo "Latest llamacpp-rocm-preview release: $RELEASE"
           echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
 
   # ========================================================================
@@ -71,6 +81,7 @@ jobs:
         env:
           LLAMACPP_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_release }}
           LLAMACPP_ROCM_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_rocm_release }}
+          LLAMACPP_ROCM_PREVIEW_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_rocm_preview_release }}
         run: |
           $ErrorActionPreference = "Stop"
           $path = "src/cpp/resources/backend_versions.json"
@@ -85,10 +96,22 @@ jobs:
           }
 
           $rocm = $env:LLAMACPP_ROCM_RELEASE
-          Write-Host "Updating llamacpp rocm to $rocm" -ForegroundColor Cyan
-          $old = $data.llamacpp.rocm
-          $data.llamacpp.rocm = $rocm
-          Write-Host "  llamacpp.rocm: $old -> $rocm"
+          Write-Host "Updating llamacpp rocm-nightly to $rocm" -ForegroundColor Cyan
+          $old = $data.llamacpp.'rocm-nightly'
+          $data.llamacpp.'rocm-nightly' = $rocm
+          Write-Host "  llamacpp.rocm-nightly: $old -> $rocm"
+
+          $rocmStable = $env:LLAMACPP_RELEASE
+          Write-Host "Updating llamacpp rocm-stable to $rocmStable" -ForegroundColor Cyan
+          $old = $data.llamacpp.'rocm-stable'
+          $data.llamacpp.'rocm-stable' = $rocmStable
+          Write-Host "  llamacpp.rocm-stable: $old -> $rocmStable"
+
+          $rocmPreview = $env:LLAMACPP_ROCM_PREVIEW_RELEASE
+          Write-Host "Updating llamacpp rocm-preview to $rocmPreview" -ForegroundColor Cyan
+          $old = $data.llamacpp.'rocm-preview'
+          $data.llamacpp.'rocm-preview' = $rocmPreview
+          Write-Host "  llamacpp.rocm-preview: $old -> $rocmPreview"
 
           $data | ConvertTo-Json -Depth 10 | Set-Content $path -Encoding UTF8
 
@@ -121,14 +144,21 @@ jobs:
   # Validate backends on self-hosted runner
   # ========================================================================
   validate:
-    name: Validate ${{ matrix.backend }}
+    name: Validate ${{ matrix.backend }}${{ matrix.channel && format(' ({0})', matrix.channel) || '' }}
     needs: [get-latest-releases, build]
     if: always() && needs.build.result == 'success'
     runs-on: [self-hosted, Windows, 128gb]
     strategy:
       fail-fast: false
       matrix:
-        backend: [vulkan, rocm]
+        include:
+          - backend: vulkan
+          - backend: rocm
+            channel: stable
+          - backend: rocm
+            channel: preview
+          - backend: rocm
+            channel: nightly
     steps:
       - uses: actions/checkout@v5
         with:
@@ -168,8 +198,10 @@ jobs:
           $ErrorActionPreference = "Stop"
           $lemondExe = (Resolve-Path "build\Release\lemond.exe").Path
           $backend = "${{ matrix.backend }}"
-          $logsDir = "server-logs-$backend"
-          $cacheDir = Join-Path $PWD "ci-cache-$backend"
+          $channel = "${{ matrix.channel }}"
+          $label = if ($channel) { "$backend-$channel" } else { $backend }
+          $logsDir = "server-logs-$label"
+          $cacheDir = Join-Path $PWD "ci-cache-$label"
           $venvPython = ".\.venv\Scripts\python.exe"
 
           New-Item -ItemType Directory -Force -Path $logsDir | Out-Null
@@ -192,9 +224,13 @@ jobs:
             $validationArgs = @(
               "test/validate_llamacpp.py",
               "--backend", $backend,
-              "--output", "llamacpp_validation_$backend.json",
+              "--output", "llamacpp_validation_$label.json",
               "--logs-dir", $logsDir
             )
+            if ($channel) {
+              $validationArgs += "--channel"
+              $validationArgs += $channel
+            }
             if ("${{ env.LITE_MODE }}" -eq "true") {
               $validationArgs += "--lite"
             }
@@ -215,16 +251,16 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: validation-results-${{ matrix.backend }}
-          path: llamacpp_validation_${{ matrix.backend }}.json
+          name: validation-results-${{ matrix.channel && format('{0}-{1}', matrix.backend, matrix.channel) || matrix.backend }}
+          path: llamacpp_validation_${{ matrix.channel && format('{0}-{1}', matrix.backend, matrix.channel) || matrix.backend }}.json
           retention-days: 30
 
       - name: Upload server logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: server-logs-${{ matrix.backend }}
-          path: server-logs-${{ matrix.backend }}/
+          name: server-logs-${{ matrix.channel && format('{0}-{1}', matrix.backend, matrix.channel) || matrix.backend }}
+          path: server-logs-${{ matrix.channel && format('{0}-{1}', matrix.backend, matrix.channel) || matrix.backend }}/
           retention-days: 30
           if-no-files-found: ignore
 
@@ -256,6 +292,7 @@ jobs:
         env:
           LLAMACPP_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_release }}
           LLAMACPP_ROCM_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_rocm_release }}
+          LLAMACPP_ROCM_PREVIEW_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_rocm_preview_release }}
         run: |
           python3 -c "
           import json, os
@@ -263,15 +300,18 @@ jobs:
           with open(path, 'r') as f:
               data = json.load(f)
           llamacpp = os.environ['LLAMACPP_RELEASE']
-          rocm = os.environ['LLAMACPP_ROCM_RELEASE']
+          rocm_preview = os.environ['LLAMACPP_ROCM_PREVIEW_RELEASE']
+          rocm_nightly = os.environ['LLAMACPP_ROCM_RELEASE']
           data['llamacpp']['vulkan'] = llamacpp
           data['llamacpp']['cpu'] = llamacpp
           data['llamacpp']['metal'] = llamacpp
-          data['llamacpp']['rocm'] = rocm
+          data['llamacpp']['rocm-stable'] = llamacpp
+          data['llamacpp']['rocm-nightly'] = rocm_nightly
+          data['llamacpp']['rocm-preview'] = rocm_preview
           with open(path, 'w') as f:
               json.dump(data, f, indent=2)
               f.write('\n')
-          print(f'Updated: vulkan/cpu/metal={llamacpp}, rocm={rocm}')
+          print(f'Updated: vulkan/cpu/metal/rocm-stable={llamacpp}, rocm-nightly={rocm_nightly}, rocm-preview={rocm_preview}')
           "
 
       - name: Generate PR body
@@ -279,25 +319,29 @@ jobs:
         env:
           LLAMACPP_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_release }}
           LLAMACPP_ROCM_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_rocm_release }}
+          LLAMACPP_ROCM_PREVIEW_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_rocm_preview_release }}
         run: |
           python3 << 'PYEOF'
           import json, os
 
           body_lines = []
           llamacpp = os.environ.get("LLAMACPP_RELEASE", "unknown")
-          rocm = os.environ.get("LLAMACPP_ROCM_RELEASE", "unknown")
+          rocm_nightly = os.environ.get("LLAMACPP_ROCM_RELEASE", "unknown")
+          rocm_preview = os.environ.get("LLAMACPP_ROCM_PREVIEW_RELEASE", "unknown")
 
           body_lines.append("## Auto-update llama.cpp backends")
           body_lines.append("")
-          body_lines.append(f"- **llama.cpp** (vulkan/cpu/metal): `{llamacpp}`")
-          body_lines.append(f"- **llamacpp-rocm**: `{rocm}`")
+          body_lines.append(f"- **llama.cpp** (vulkan/cpu/metal/rocm-stable): `{llamacpp}`")
+          body_lines.append(f"- **llamacpp-rocm** (rocm-nightly): `{rocm_nightly}`")
+          body_lines.append(f"- **llamacpp-rocm-preview**: `{rocm_preview}`")
           body_lines.append("")
           body_lines.append("## Validation Results")
           body_lines.append("")
           body_lines.append("| Model | Result | Response | input_tokens | output_tokens | time_to_first_token | tokens_per_second |")
           body_lines.append("|-------|--------|----------|--------------|---------------|---------------------|-------------------|")
 
-          for backend in ["vulkan", "rocm"]:
+          for backend in ["vulkan", "rocm-stable", "rocm-preview", "rocm-nightly"]:
+              # Labels match the artifact names produced by the validate job
               results_file = f"llamacpp_validation_{backend}.json"
               if not os.path.isfile(results_file):
                   body_lines.append(f"| _{backend}: no results_ | | | | | | |")
@@ -334,8 +378,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LLAMACPP_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_release }}
           LLAMACPP_ROCM_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_rocm_release }}
+          LLAMACPP_ROCM_PREVIEW_RELEASE: ${{ needs.get-latest-releases.outputs.llamacpp_rocm_preview_release }}
         run: |
-          BRANCH="auto/llamacpp-update-${LLAMACPP_RELEASE}-${LLAMACPP_ROCM_RELEASE}"
+          BRANCH="auto/llamacpp-update-${LLAMACPP_RELEASE}-${LLAMACPP_ROCM_RELEASE}-${LLAMACPP_ROCM_PREVIEW_RELEASE}"
 
           # Check if a PR already exists for this update
           EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
@@ -355,7 +400,7 @@ jobs:
 
           git checkout -b "$BRANCH"
           git add src/cpp/resources/backend_versions.json
-          git commit -m "Update llama.cpp to ${LLAMACPP_RELEASE}, rocm to ${LLAMACPP_ROCM_RELEASE}"
+          git commit -m "Update llama.cpp to ${LLAMACPP_RELEASE}, rocm-nightly to ${LLAMACPP_ROCM_RELEASE}, rocm-preview to ${LLAMACPP_ROCM_PREVIEW_RELEASE}"
           git push origin "$BRANCH"
 
           gh pr create \

--- a/docs/llamacpp.md
+++ b/docs/llamacpp.md
@@ -1,0 +1,174 @@
+# llama.cpp Backend Options
+
+Lemonade uses [llama.cpp](https://github.com/ggerganov/llama.cpp) as its primary LLM inference backend, supporting multiple hardware acceleration options. This document explains the available backends and how to choose between them.
+
+## Available Backends
+
+### CPU
+- **Platform**: Windows, Linux, macOS
+- **Hardware**: All x86_64 processors
+- **Use Case**: Universal fallback, no GPU required
+- **Performance**: Slowest option, suitable for small models or testing
+- **Installation**: Automatically available via upstream llama.cpp releases
+
+### Vulkan
+- **Platform**: Windows, Linux
+- **Hardware**: AMD GPUs (iGPU and dGPU), NVIDIA GPUs, Intel GPUs
+- **Use Case**: Cross-vendor GPU acceleration
+- **Performance**: Good performance across all GPU vendors
+- **Installation**: Automatically available via upstream llama.cpp releases
+- **Notes**: Recommended for most GPU users
+
+### ROCm
+- **Platform**: Windows, Linux
+- **Hardware**: AMD Radeon RX 6000/7000 series (RDNA2/RDNA3/RDNA4), AMD Ryzen AI iGPUs (Strix Point/Halo)
+- **Use Case**: AMD GPU-optimized inference
+- **Performance**: Optimized for AMD hardware, may outperform Vulkan on supported GPUs
+- **Channel Options**:
+  - **Preview** (default): Custom builds with latest optimizations from lemonade-sdk
+  - **Stable**: Upstream llama.cpp releases with AMD ROCm support
+  - **Nightly**: Bleeding-edge builds from lemonade-sdk/llamacpp-rocm (experimental)
+- **Installation**: Varies by channel (see below)
+
+### Metal
+- **Platform**: macOS only
+- **Hardware**: Apple Silicon (M1/M2/M3/M4) and Intel Macs with Metal support
+- **Use Case**: macOS GPU acceleration
+- **Performance**: Optimized for Apple Silicon
+- **Installation**: Automatically available via upstream llama.cpp releases
+
+### System
+- **Platform**: Linux only
+- **Hardware**: Depends on system-installed llama-server binary
+- **Use Case**: Advanced users with custom llama.cpp builds
+- **Performance**: Depends on build configuration
+- **Installation**: Requires manual installation of `llama-server` in system PATH
+- **Notes**: Not enabled by default; set `LEMONADE_LLAMACPP_PREFER_SYSTEM=true` in config
+
+## ROCm Channel Configuration
+
+The ROCm backend supports three channels to balance stability, performance, and access to latest features:
+
+### Preview Channel (Default)
+```json
+{
+  "rocm_channel": "preview"
+}
+```
+- **Source**: Custom builds from [lemonade-sdk/llama.cpp](https://github.com/lemonade-sdk/llama.cpp)
+- **Binaries**: Common builds for supported architectures
+- **Updates**: Frequent updates with latest optimizations and fixes
+- **Platform**: Windows and Linux
+- **Runtime**: Requires runtime for both Windows and Linux to be installed separately.
+- **Best For**: Users who want the latest performance optimizations
+
+### Stable Channel
+```json
+{
+  "rocm_channel": "stable"
+}
+```
+- **Source**: Upstream [llama.cpp](https://github.com/ggerganov/llama.cpp) releases
+- **Binaries**:
+  - **Windows**: Self-contained HIP binaries (no separate runtime needed)
+  - **Linux**: Binaries built against ROCm 7.2 runtime
+- **Updates**: Follows upstream llama.cpp release cycle
+- **Platform**: Windows and Linux
+- **Runtime**:
+  - Windows: Self-contained, no runtime installation required
+  - Linux: Downloads AMD ROCm 7.2.1 runtime if not present at `/opt/rocm`
+- **Best For**: Users who prefer stable, tested releases aligned with upstream
+
+### Nightly Channel
+```json
+{
+  "rocm_channel": "nightly"
+}
+```
+- **Source**: Nightly builds from [lemonade-sdk/llamacpp-rocm](https://github.com/lemonade-sdk/llamacpp-rocm)
+- **Binaries**: Architecture-specific builds (gfx1150, gfx1151, gfx103X, gfx110X, gfx120X)
+- **Updates**: Nightly builds with experimental features and latest upstream changes
+- **Platform**: Windows and Linux
+- **Runtime**: Bundled runtime on Linux, TheRock ROCm dependencies
+- **Best For**: Developers and testers who want bleeding-edge features and are comfortable with potential instability
+
+### Changing Channels
+
+To switch between channels, update your `config.json`:
+
+```json
+{
+  "rocm_channel": "stable"
+}
+```
+
+Or use the Lemonade CLI:
+```bash
+# Switch to stable channel
+lemonade config set rocm_channel stable
+
+# Switch to preview channel (default)
+lemonade config set rocm_channel preview
+
+# Switch to nightly channel (experimental)
+lemonade config set rocm_channel nightly
+```
+
+After changing channels, you'll need to reinstall the ROCm backend:
+```bash
+lemonade backend install llamacpp rocm
+```
+
+## Choosing the Right Backend
+
+### Decision Tree
+
+1. **Do you have an NVIDIA or Intel GPU?**
+   - Use **Vulkan**
+
+2. **Do you have an AMD GPU?**
+   - **For Radeon RX 6000/7000 or Ryzen AI iGPU**:
+     - Try **ROCm** first for best performance
+     - Fall back to **Vulkan** if you encounter issues
+   - **For older AMD GPUs (RX 5000 and earlier)**:
+     - Use **Vulkan** (ROCm not supported)
+
+3. **Do you have Apple Silicon?**
+   - Use **Metal**
+
+4. **No GPU or unsupported GPU?**
+   - Use **CPU**
+
+### ROCm Channel Selection
+
+- **Use Preview** if you:
+  - Want the best performance on AMD hardware
+  - Are comfortable with frequent updates
+  - Are testing new models or features
+
+- **Use Stable** if you:
+  - Prefer stability over latest features
+  - Want upstream llama.cpp compatibility
+  - Are deploying in production
+
+- **Use Nightly** if you:
+  - Want bleeding-edge experimental features
+  - Are testing unreleased llama.cpp functionality
+  - Are comfortable with potential bugs and instability
+  - Are a developer contributing to lemonade or llama.cpp
+
+## Platform Specifics
+
+### Linux
+- All backends supported (CPU, Vulkan, ROCm, System)
+- ROCm requires compatible AMD GPU (see above)
+- System backend requires manual llama-server installation
+
+### Windows
+- Supported: CPU, Vulkan, ROCm
+- ROCm requires compatible AMD GPU
+- No system backend support
+
+### macOS
+- Supported: CPU, Metal
+- Metal recommended for all Macs with Metal support

--- a/docs/llamacpp.md
+++ b/docs/llamacpp.md
@@ -105,18 +105,18 @@ To switch between channels, update your `config.json`:
 Or use the Lemonade CLI:
 ```bash
 # Switch to stable channel
-lemonade config set rocm_channel stable
+lemonade config set rocm_channel=stable
 
 # Switch to preview channel (default)
-lemonade config set rocm_channel preview
+lemonade config set rocm_channel=preview
 
 # Switch to nightly channel (experimental)
-lemonade config set rocm_channel nightly
+lemonade config set rocm_channel=nightly
 ```
 
 After changing channels, you'll need to reinstall the ROCm backend:
 ```bash
-lemonade backend install llamacpp rocm
+lemonade backend install llamacpp:rocm
 ```
 
 ## Choosing the Right Backend

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -72,6 +72,22 @@ namespace lemon::backends {
         /** Get the latest version number for the given recipe/backend */
         static std::string get_backend_version(const std::string& recipe, const std::string& backend);
 
+        /** Check if ROCm libraries are installed system-wide (Linux only) */
+        static bool is_rocm_installed_system_wide();
+
+        /** Get TheRock installation directory for a specific architecture and version */
+        static std::string get_therock_install_dir(const std::string& arch, const std::string& version);
+
+        /** Download and install TheRock ROCm tarball for the specified architecture (Linux only) */
+        static void install_therock(const std::string& arch, const std::string& version,
+                                   DownloadProgressCallback progress_cb = nullptr);
+
+        /** Clean up old TheRock versions, keeping only the specified version */
+        static void cleanup_old_therock_versions(const std::string& current_version);
+
+        /** Get TheRock lib directory path if available, or empty string if not needed */
+        static std::string get_therock_lib_path(const std::string& rocm_arch);
+
         /** Get the path to the backend's binary. Gives precedence to the path set through environment variables, if set. Throws if not found. */
         static std::string get_backend_binary_path(const BackendSpec& spec, const std::string& backend);
 

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -36,6 +36,7 @@ public:
     bool no_fetch_executables() const;
     bool disable_model_filtering() const;
     bool enable_dgpu_gtt() const;
+    std::string rocm_channel() const;
 
     // Backend settings (nested)
     json backend_config(const std::string& backend_name) const;

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -1,8 +1,11 @@
 {
   "comment": "This configuration file controls which llama.cpp, whisper.cpp, sd.cpp, ryzenai-llm, and FLM versions are downloaded for each backend. You can modify these values to pin specific versions without rebuilding the application.",
+  "rocm-stable-runtime": "v7.2.1",
   "llamacpp": {
     "vulkan": "b8766",
-    "rocm": "b1238",
+    "rocm-stable": "b8653",
+    "rocm-preview": "b8705",
+    "rocm-nightly": "b1238",
     "metal": "b8460",
     "cpu": "b8766"
   },
@@ -13,8 +16,36 @@
     "npu": "v1.8.2"
   },
   "sd-cpp": {
-    "cpu": "master-506-1f30df9",
-    "rocm": "master-506-1f30df9"
+    "cpu": "master-569-ab6afe8",
+    "rocm-stable": "master-569-ab6afe8",
+    "rocm-preview": "master-569-ab6afe8"
+  },
+  "therock": {
+    "version": "7.12.0",
+    "architectures": [
+      "gfx908",
+      "gfx90a",
+      "gfx942",
+      "gfx1100",
+      "gfx1101",
+      "gfx1102",
+      "gfx1151",
+      "gfx1150",
+      "gfx1200",
+      "gfx1201"
+    ],
+    "url_mapping": {
+      "gfx908": "gfx90X-dcgpu",
+      "gfx90a": "gfx90X-dcgpu",
+      "gfx942": "gfx94X-dcgpu",
+      "gfx1100": "gfx110X-all",
+      "gfx1101": "gfx110X-all",
+      "gfx1102": "gfx110X-all",
+      "gfx1151": "gfx1151",
+      "gfx1150": "gfx1150",
+      "gfx1200": "gfx120X-all",
+      "gfx1201": "gfx120X-all"
+    }
   },
   "ryzenai-llm": {
     "npu": "v1.7.0"

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -14,6 +14,7 @@
   "no_fetch_executables": false,
   "disable_model_filtering": false,
   "enable_dgpu_gtt": false,
+  "rocm_channel": "preview",
   "llamacpp": {
     "backend": "auto",
     "args": "",

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -2,17 +2,315 @@
 #include "lemon/backends/backend_utils.h"
 #include "lemon/runtime_config.h"
 #include "lemon/system_info.h"
-#include "lemon/utils/path_utils.h"
+#include "lemon/utils/http_client.h"
 #include "lemon/utils/json_utils.h"
-#include <iostream>
-#include <filesystem>
-#include <thread>
+#include "lemon/utils/path_utils.h"
 #include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <thread>
 #include <lemon/utils/aixlog.hpp>
 
 namespace fs = std::filesystem;
 
 namespace lemon {
+
+namespace {
+
+static const char* ROCM_STABLE_RUNTIME_DIR = "rocm-stable-runtime";
+
+std::string get_current_os() {
+#ifdef _WIN32
+    return "windows";
+#elif defined(__APPLE__)
+    return "macos";
+#elif defined(__linux__)
+    return "linux";
+#else
+    return "unknown";
+#endif
+}
+
+std::string normalize_backend_name(const std::string& recipe, const std::string& backend) {
+    if ((recipe == "llamacpp" || recipe == "sd-cpp") && backend == "rocm") {
+        // Map "rocm" to the appropriate channel based on config
+        std::string channel = "preview";  // default to preview for now
+        if (auto* cfg = RuntimeConfig::global()) {
+            channel = cfg->rocm_channel();
+        }
+        return "rocm-" + channel;
+    }
+    return backend;
+}
+
+std::string get_backend_runtime_version(const json& backend_versions,
+                                        const std::string& recipe,
+                                        const std::string& backend_type) {
+    const std::string runtime_key = backend_type + "-runtime";
+
+    if (backend_versions.contains(runtime_key) &&
+        backend_versions[runtime_key].is_string()) {
+        return backend_versions[runtime_key].get<std::string>();
+    }
+
+    if (backend_versions.contains(recipe) &&
+        backend_versions[recipe].is_object() &&
+        backend_versions[recipe].contains(runtime_key) &&
+        backend_versions[recipe][runtime_key].is_string()) {
+        return backend_versions[recipe][runtime_key].get<std::string>();
+    }
+
+    // Only fall back to llamacpp runtime version if the recipe is llamacpp
+    if (recipe == "llamacpp" &&
+        backend_versions.contains("llamacpp") &&
+        backend_versions["llamacpp"].is_object() &&
+        backend_versions["llamacpp"].contains(runtime_key) &&
+        backend_versions["llamacpp"][runtime_key].is_string()) {
+        return backend_versions["llamacpp"][runtime_key].get<std::string>();
+    }
+
+    throw std::runtime_error("backend_versions.json is missing runtime version for: " + recipe + ":" + runtime_key);
+}
+
+std::string trim(const std::string& value) {
+    const auto first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) {
+        return "";
+    }
+    const auto last = value.find_last_not_of(" \t\r\n");
+    return value.substr(first, last - first + 1);
+}
+
+std::string normalize_runtime_version(const std::string& version) {
+    std::string normalized = trim(version);
+    if (!normalized.empty() && normalized[0] == 'v') {
+        normalized.erase(0, 1);
+    }
+    return normalized;
+}
+
+bool runtime_version_matches_expected(const std::string& discovered_version,
+                                      const std::string& expected_version) {
+    const std::string discovered = normalize_runtime_version(discovered_version);
+    const std::string expected = normalize_runtime_version(expected_version);
+
+    if (discovered.empty() || expected.empty()) {
+        return false;
+    }
+
+    if (discovered == expected) {
+        return true;
+    }
+
+    return discovered.rfind(expected + ".", 0) == 0;
+}
+
+std::string read_version_file(const fs::path& version_file) {
+    if (!fs::exists(version_file)) {
+        return "";
+    }
+
+    std::ifstream file(version_file);
+    if (!file.is_open()) {
+        return "";
+    }
+
+    std::string version;
+    std::getline(file, version);
+    return trim(version);
+}
+
+bool has_matching_system_rocm_runtime(const std::string& expected_runtime_version) {
+    const fs::path version_file = "/opt/rocm/.info/version";
+    const std::string system_version = read_version_file(version_file);
+    return runtime_version_matches_expected(system_version, expected_runtime_version);
+}
+
+bool has_matching_installed_rocm_stable_runtime(const std::string& install_dir,
+                                                const std::string& expected_runtime_version) {
+    const fs::path info_version_file = fs::path(install_dir) / ".info" / "version";
+    const std::string installed_runtime_version = read_version_file(info_version_file);
+    return runtime_version_matches_expected(installed_runtime_version, expected_runtime_version);
+}
+
+std::string get_rocm_stable_runtime_asset_filename(const std::string& version) {
+    std::string normalized_version = normalize_runtime_version(version);
+    if (normalized_version.empty()) {
+        throw std::runtime_error("Invalid ROCm stable runtime version in backend_versions.json");
+    }
+    return "rocm-" + normalized_version + "-runtime-libs.tar.gz";
+}
+
+void install_rocm_stable_runtime_if_needed(const std::string& os,
+                                           const backends::BackendSpec& spec,
+                                           const json& backend_versions,
+                                           DownloadProgressCallback progress_cb) {
+    // ROCm stable runtime is only needed on Linux.
+    // On Windows, the llama.cpp HIP binaries are self-contained.
+    if (os != "linux") {
+        return;
+    }
+    const std::string backend_type = "rocm-stable";
+    const std::string version = get_backend_runtime_version(backend_versions, spec.recipe, backend_type);
+    const std::string repo = "lemonade-sdk/rocm-stable";
+    const std::string filename = get_rocm_stable_runtime_asset_filename(version);
+    const std::string install_dir = backends::BackendUtils::get_install_directory(ROCM_STABLE_RUNTIME_DIR, "");
+    const std::string expected_runtime_version = normalize_runtime_version(version);
+
+    if (has_matching_system_rocm_runtime(expected_runtime_version)) {
+        LOG(DEBUG, "BackendManager")
+            << "Detected compatible system ROCm runtime version at /opt/rocm/.info/version: "
+            << expected_runtime_version << std::endl;
+        return;
+    }
+
+    if (has_matching_installed_rocm_stable_runtime(install_dir, expected_runtime_version)) {
+        LOG(DEBUG, "BackendManager")
+            << "Detected compatible bundled ROCm stable runtime version in "
+            << install_dir << std::endl;
+        return;
+    }
+
+    fs::remove_all(install_dir);
+    fs::create_directories(install_dir);
+
+    const std::string url = "https://github.com/" + repo + "/releases/download/" + version + "/" + filename;
+    std::string archive_basename = filename;
+    for (char& ch : archive_basename) {
+        if (ch == '/' || ch == '\\' || ch == ':') {
+            ch = '_';
+        }
+    }
+    const std::string archive_path = (fs::temp_directory_path() /
+        ("llamacpp_rocm_stable_runtime_" + version + "_" + archive_basename)).string();
+
+    // Remove any stale archive from a previous failed download. The HTTP downloader
+    // supports resume-by-default, which is undesirable here because older attempts
+    // may have cached an HTML error page under the same temp filename.
+    std::error_code archive_ec;
+    fs::remove(archive_path, archive_ec);
+
+    utils::ProgressCallback http_progress_cb;
+    if (progress_cb) {
+        http_progress_cb = [&progress_cb, &filename](size_t downloaded, size_t total) -> bool {
+            DownloadProgress p;
+            p.file = filename;
+            p.file_index = 2;  // ROCm runtime is the second file
+            p.total_files = 2;  // Backend binary + ROCm runtime
+            p.bytes_downloaded = downloaded;
+            p.bytes_total = total;
+            p.percent = total > 0 ? static_cast<int>((downloaded * 100) / total) : 0;
+            p.complete = false;
+            return progress_cb(p);
+        };
+    } else {
+        http_progress_cb = utils::create_throttled_progress_callback();
+    }
+
+    auto download_result = utils::HttpClient::download_file(url, archive_path, http_progress_cb);
+    if (!download_result.success) {
+        throw std::runtime_error("Failed to download ROCm stable runtime from: " + url +
+                                 " - " + download_result.error_message);
+    }
+
+    if (!backends::BackendUtils::extract_archive(archive_path, install_dir, spec.log_name())) {
+        fs::remove(archive_path);
+        fs::remove_all(install_dir);
+        throw std::runtime_error("Failed to extract ROCm stable runtime archive: " + archive_path);
+    }
+
+    fs::remove(archive_path);
+
+    if (progress_cb) {
+        DownloadProgress p;
+        p.file = filename;
+        p.file_index = 2;  // ROCm runtime is the second file
+        p.total_files = 2;  // Backend binary + ROCm runtime
+        p.bytes_downloaded = download_result.bytes_downloaded;
+        p.bytes_total = download_result.total_bytes;
+        p.percent = 100;
+        p.complete = true;  // Now we can send the completion event
+        progress_cb(p);
+    }
+}
+
+void uninstall_rocm_stable_runtime_if_needed(const std::string& os) {
+    // ROCm stable runtime is only used on Linux.
+    // On Windows, the llama.cpp HIP binaries are self-contained.
+    if (os != "linux") {
+        return;
+    }
+    std::string runtime_dir = backends::BackendUtils::get_install_directory(ROCM_STABLE_RUNTIME_DIR, "");
+    if (fs::exists(runtime_dir)) {
+        std::error_code ec;
+        fs::remove_all(runtime_dir, ec);
+        if (ec && fs::exists(runtime_dir)) {
+            throw std::runtime_error("Failed to remove " + runtime_dir + ": " + ec.message());
+        }
+    }
+}
+
+bool will_install_therock(const std::string& os, const json& backend_versions) {
+    // TheRock is needed on Linux and Windows for ROCm preview channel.
+    if (os != "linux" && os != "windows") {
+        return false;
+    }
+
+    // Get TheRock version from backend_versions.json
+    if (!backend_versions.contains("therock") || !backend_versions["therock"].contains("version")) {
+        return false;
+    }
+    std::string therock_version = backend_versions["therock"]["version"].get<std::string>();
+    std::string expected_rocm_version = normalize_runtime_version(therock_version);
+
+    // Check if system ROCm matches TheRock version - if so, don't need TheRock
+    if (backends::BackendUtils::is_rocm_installed_system_wide() &&
+        has_matching_system_rocm_runtime(expected_rocm_version)) {
+        LOG(DEBUG, "BackendManager")
+            << "System ROCm " << expected_rocm_version
+            << " matches TheRock version, skipping TheRock installation" << std::endl;
+        return false;
+    }
+
+    // Get ROCm architecture
+    std::string rocm_arch = SystemInfo::get_rocm_arch();
+    if (rocm_arch.empty()) {
+        return false;
+    }
+
+    // Check if this architecture is supported
+    if (backend_versions["therock"].contains("architectures") &&
+        backend_versions["therock"]["architectures"].is_array()) {
+        bool arch_supported = false;
+        for (const auto& arch : backend_versions["therock"]["architectures"]) {
+            if (arch.is_string() && arch.get<std::string>() == rocm_arch) {
+                arch_supported = true;
+                break;
+            }
+        }
+        if (!arch_supported) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void install_therock_if_needed(const std::string& os, const json& backend_versions,
+                              DownloadProgressCallback progress_cb = nullptr) {
+    if (!will_install_therock(os, backend_versions)) {
+        return;
+    }
+
+    std::string rocm_arch = SystemInfo::get_rocm_arch();
+    std::string version = backend_versions["therock"]["version"].get<std::string>();
+
+    // Install TheRock for this architecture
+    backends::BackendUtils::install_therock(rocm_arch, version, progress_cb);
+}
+
+} // namespace
 
 BackendManager::BackendManager() {
     try {
@@ -25,9 +323,11 @@ BackendManager::BackendManager() {
 }
 
 std::string BackendManager::get_version_from_config(const std::string& recipe, const std::string& backend) {
+    std::string resolved_backend = normalize_backend_name(recipe, backend);
+
     // The "system" backend doesn't have a version in backend_versions.json
     // because it uses a pre-installed binary from the system PATH
-    if (backend == "system") {
+    if (resolved_backend == "system") {
         return "";
     }
 
@@ -35,10 +335,10 @@ std::string BackendManager::get_version_from_config(const std::string& recipe, c
         throw std::runtime_error("backend_versions.json is missing '" + recipe + "' section");
     }
     const auto& recipe_config = backend_versions_[recipe];
-    if (!recipe_config.contains(backend) || !recipe_config[backend].is_string()) {
-        throw std::runtime_error("backend_versions.json is missing version for: " + recipe + ":" + backend);
+    if (!recipe_config.contains(resolved_backend) || !recipe_config[resolved_backend].is_string()) {
+        throw std::runtime_error("backend_versions.json is missing version for: " + recipe + ":" + resolved_backend);
     }
-    return recipe_config[backend].get<std::string>();
+    return recipe_config[resolved_backend].get<std::string>();
 }
 
 // ============================================================================
@@ -50,27 +350,30 @@ std::string BackendManager::get_version_from_config(const std::string& recipe, c
 // ============================================================================
 
 BackendManager::InstallParams BackendManager::get_install_params(const std::string& recipe, const std::string& backend) {
+    std::string resolved_backend = normalize_backend_name(recipe, backend);
+
     auto* spec = backends::try_get_spec_for_recipe(recipe);
     if (!spec) {
         throw std::runtime_error("[BackendManager] Unknown recipe: " + recipe);
     }
-    std::string version = get_version_from_config(recipe, backend);
+    std::string version = get_version_from_config(recipe, resolved_backend);
 
     if (!spec->install_params_fn) {
         throw std::runtime_error("No install params function for recipe: " + recipe);
     }
 
-    auto params = spec->install_params_fn(backend, version);
+    auto params = spec->install_params_fn(resolved_backend, version);
     return {params.repo, params.filename, version};
 }
 
 void BackendManager::install_backend(const std::string& recipe, const std::string& backend,
                                      bool force,
                                      DownloadProgressCallback progress_cb) {
-    LOG(DEBUG, "BackendManager") << "Installing " << recipe << ":" << backend << std::endl;
+    std::string resolved_backend = normalize_backend_name(recipe, backend);
+    LOG(DEBUG, "BackendManager") << "Installing " << recipe << ":" << resolved_backend << std::endl;
 
     // System backend uses a pre-installed binary from PATH - nothing to install
-    if (backend == "system") {
+    if (resolved_backend == "system") {
         return;
     }
 
@@ -81,25 +384,61 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
         }
     }
 
-    auto params = get_install_params(recipe, backend);
+    auto params = get_install_params(recipe, resolved_backend);
     auto* spec = backends::try_get_spec_for_recipe(recipe);
     if (!spec) {
         throw std::runtime_error("[BackendManager] Unknown recipe: " + recipe);
+    }
+
+    // Check if we need to install additional runtime components after the main backend
+    bool needs_rocm_stable_runtime = (recipe == "llamacpp" || recipe == "sd-cpp") &&
+                                      resolved_backend == "rocm-stable" &&
+                                      get_current_os() == "linux";
+
+    bool needs_therock = (recipe == "llamacpp" || recipe == "sd-cpp") &&
+                         resolved_backend == "rocm-preview" &&
+                         will_install_therock(get_current_os(), backend_versions_);
+
+    // Wrap the progress callback to adjust file indices if runtime download follows
+    DownloadProgressCallback wrapped_progress_cb;
+    if (progress_cb && (needs_rocm_stable_runtime || needs_therock)) {
+        wrapped_progress_cb = [progress_cb](const DownloadProgress& p) -> bool {
+            DownloadProgress adjusted = p;
+            // Adjust to indicate this is file 1 of 2
+            adjusted.file_index = 1;
+            adjusted.total_files = 2;
+            // Suppress the completion event - we'll send it after the runtime download
+            if (p.complete) {
+                adjusted.complete = false;
+            }
+            return progress_cb(adjusted);
+        };
+    } else {
+        wrapped_progress_cb = progress_cb;
     }
 
     backends::BackendUtils::install_from_github(
-        *spec, params.version, params.repo, params.filename, backend, progress_cb);
+        *spec, params.version, params.repo, params.filename, resolved_backend, wrapped_progress_cb);
+
+    if (needs_rocm_stable_runtime) {
+        install_rocm_stable_runtime_if_needed(get_current_os(), *spec, backend_versions_, progress_cb);
+    }
+
+    if (needs_therock) {
+        install_therock_if_needed(get_current_os(), backend_versions_, progress_cb);
+    }
 }
 
 void BackendManager::uninstall_backend(const std::string& recipe, const std::string& backend) {
-    LOG(DEBUG, "BackendManager") << "Uninstalling " << recipe << ":" << backend << std::endl;
+    std::string resolved_backend = normalize_backend_name(recipe, backend);
+    LOG(DEBUG, "BackendManager") << "Uninstalling " << recipe << ":" << resolved_backend << std::endl;
 
     auto* spec = backends::try_get_spec_for_recipe(recipe);
     if (!spec) {
         throw std::runtime_error("[BackendManager] Unknown recipe: " + recipe);
     }
 
-    std::string install_dir = backends::BackendUtils::get_install_directory(spec->recipe, backend);
+    std::string install_dir = backends::BackendUtils::get_install_directory(spec->recipe, resolved_backend);
 
     if (fs::exists(install_dir)) {
         // On Windows, antivirus scanning or indexing can briefly lock files after extraction.
@@ -118,6 +457,10 @@ void BackendManager::uninstall_backend(const std::string& recipe, const std::str
         LOG(DEBUG, "BackendManager") << "Nothing to uninstall at: " << install_dir << std::endl;
     }
 
+    if (recipe == "llamacpp" && resolved_backend == "rocm-stable") {
+        uninstall_rocm_stable_runtime_if_needed(get_current_os());
+    }
+
 }
 
 // ============================================================================
@@ -126,7 +469,7 @@ void BackendManager::uninstall_backend(const std::string& recipe, const std::str
 
 std::string BackendManager::get_latest_version(const std::string& recipe, const std::string& backend) {
     try {
-        return get_version_from_config(recipe, backend);
+        return get_version_from_config(recipe, normalize_backend_name(recipe, backend));
     } catch (...) {
         return "";
     }
@@ -168,7 +511,8 @@ json BackendManager::get_all_backends_status() {
 
 std::string BackendManager::get_release_url(const std::string& recipe, const std::string& backend) {
     try {
-        auto params = get_install_params(recipe, backend);
+        std::string resolved_backend = normalize_backend_name(recipe, backend);
+        auto params = get_install_params(recipe, resolved_backend);
         return "https://github.com/" + params.repo + "/releases/tag/" + params.version;
     } catch (...) {
         return "";
@@ -177,7 +521,8 @@ std::string BackendManager::get_release_url(const std::string& recipe, const std
 
 std::string BackendManager::get_download_filename(const std::string& recipe, const std::string& backend) {
     try {
-        auto params = get_install_params(recipe, backend);
+        std::string resolved_backend = normalize_backend_name(recipe, backend);
+        auto params = get_install_params(recipe, resolved_backend);
         return params.filename;
     } catch (...) {
         return "";
@@ -187,7 +532,9 @@ std::string BackendManager::get_download_filename(const std::string& recipe, con
 BackendManager::BackendEnrichment BackendManager::get_backend_enrichment(const std::string& recipe, const std::string& backend) {
     BackendEnrichment result;
     try {
-        auto params = get_install_params(recipe, backend);
+        std::string resolved_backend = normalize_backend_name(recipe, backend);
+        // All standard recipes (including ryzenai-llm): one get_install_params() call gives us everything
+        auto params = get_install_params(recipe, resolved_backend);
         result.release_url = "https://github.com/" + params.repo + "/releases/tag/" + params.version;
         result.download_filename = params.filename;
         result.version = params.version;

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -16,8 +16,10 @@
 #include <fstream>
 #include <iostream>
 #include <cstdlib>
+#include <cstring>
 #include <lemon/utils/aixlog.hpp>
 #include <algorithm>
+#include <vector>
 #include <nlohmann/json.hpp>
 
 #ifdef _WIN32
@@ -143,8 +145,15 @@ namespace lemon::backends {
 
         std::string section = RuntimeConfig::recipe_to_config_section(recipe);
 
+        // Normalize backend name for config lookup: "rocm-preview"/"rocm-stable"/"rocm-nightly" -> "rocm"
+        std::string config_backend = backend;
+        if ((recipe == "llamacpp" || recipe == "sd-cpp") &&
+            (backend == "rocm-preview" || backend == "rocm-stable" || backend == "rocm-nightly")) {
+            config_backend = "rocm";
+        }
+
         // Build the config key: e.g. "vulkan_bin", "cpu_bin", "server_bin"
-        std::string bin_key = backend.empty() ? "server_bin" : (backend + "_bin");
+        std::string bin_key = config_backend.empty() ? "server_bin" : (config_backend + "_bin");
 
         std::string bin_value = cfg->backend_string(section, bin_key);
 
@@ -180,13 +189,23 @@ namespace lemon::backends {
             throw std::runtime_error(spec.binary + " not found in PATH");
         }
 
-        std::string exe_path = find_external_backend_binary(spec.recipe, backend);
+        // Resolve "rocm" to actual channel for backends that support ROCm channels
+        std::string resolved_backend = backend;
+        if ((spec.recipe == "llamacpp" || spec.recipe == "sd-cpp") && backend == "rocm") {
+            std::string channel = "preview";  // default to preview
+            if (auto* cfg = RuntimeConfig::global()) {
+                channel = cfg->rocm_channel();
+            }
+            resolved_backend = "rocm-" + channel;
+        }
+
+        std::string exe_path = find_external_backend_binary(spec.recipe, resolved_backend);
 
         if (!exe_path.empty()) {
             return exe_path;
         }
 
-        std::string install_dir = get_install_directory(spec.recipe, backend);
+        std::string install_dir = get_install_directory(spec.recipe, resolved_backend);
         exe_path = find_executable_in_install_dir(install_dir, spec.binary);
 
         if (!exe_path.empty()) {
@@ -210,6 +229,16 @@ namespace lemon::backends {
     }
 
     std::string BackendUtils::get_backend_version(const std::string& recipe, const std::string& backend) {
+        std::string resolved_backend = backend;
+        if ((recipe == "llamacpp" || recipe == "sd-cpp") && backend == "rocm") {
+            // Map "rocm" to the appropriate channel based on config
+            std::string channel = "preview";  // default to preview for now
+            if (auto* cfg = RuntimeConfig::global()) {
+                channel = cfg->rocm_channel();
+            }
+            resolved_backend = "rocm-" + channel;
+        }
+
         std::string config_path = utils::get_resource_path("resources/backend_versions.json");
 
         json config = utils::JsonUtils::load_from_file(config_path);
@@ -219,13 +248,13 @@ namespace lemon::backends {
         }
 
         const auto& recipe_config = config[recipe];
-        const std::string backend_id = recipe + ":" + backend;
+        const std::string backend_id = recipe + ":" + resolved_backend;
 
-        if (!recipe_config.contains(backend) || !recipe_config[backend].is_string()) {
+        if (!recipe_config.contains(resolved_backend) || !recipe_config[resolved_backend].is_string()) {
             throw std::runtime_error("backend_versions.json is missing version for backend: " + backend_id);
         }
 
-        std::string version = recipe_config[backend].get<std::string>();
+        std::string version = recipe_config[resolved_backend].get<std::string>();
         return version;
     }
 
@@ -382,5 +411,250 @@ namespace lemon::backends {
                 progress_cb(p);
             }
         }
+    }
+    bool BackendUtils::is_rocm_installed_system_wide() {
+#ifndef __linux__
+        return false;
+#else
+        // Only check /opt/rocm for system-wide installation
+        // (/usr is handled by the system backend separately)
+        fs::path rocm_root("/opt/rocm");
+
+        // Check for libamdhip64.so in lib directories
+        std::vector<std::string> lib_subdirs = {"lib", "lib64"};
+        bool found_lib = false;
+
+        for (const auto& lib_subdir : lib_subdirs) {
+            fs::path lib_path = rocm_root / lib_subdir / "libamdhip64.so";
+            if (fs::exists(lib_path)) {
+                found_lib = true;
+                break;
+            }
+        }
+
+        if (!found_lib) {
+            LOG(DEBUG, "BackendUtils") << "No system-wide ROCm installation detected at /opt/rocm" << std::endl;
+            return false;
+        }
+
+        // Verify with version file
+        std::vector<std::string> version_paths = {
+            (rocm_root / ".info" / "version").string(),
+            (rocm_root / "share" / "rocm" / "version").string(),
+            (rocm_root / "version").string()
+        };
+
+        for (const auto& version_path : version_paths) {
+            if (fs::exists(version_path)) {
+                LOG(DEBUG, "BackendUtils") << "Found system ROCm at /opt/rocm with version file: "
+                          << version_path << std::endl;
+                return true;
+            }
+        }
+
+        // If we found the lib but no version file, log a warning but still accept it
+        LOG(DEBUG, "BackendUtils") << "Found ROCm libraries at /opt/rocm (no version file found)" << std::endl;
+        return true;
+#endif
+    }
+
+    std::string BackendUtils::get_therock_install_dir(const std::string& arch, const std::string& version) {
+        fs::path therock_base = fs::path(utils::get_downloaded_bin_dir()) / "therock";
+        return (therock_base / (arch + "-" + version)).string();
+    }
+
+    void BackendUtils::cleanup_old_therock_versions(const std::string& current_version) {
+#ifdef __linux__
+        fs::path therock_base = fs::path(utils::get_downloaded_bin_dir()) / "therock";
+
+        if (!fs::exists(therock_base)) {
+            return;
+        }
+
+        try {
+            for (const auto& entry : fs::directory_iterator(therock_base)) {
+                if (entry.is_directory()) {
+                    std::string dir_name = entry.path().filename().string();
+                    size_t dash_pos = dir_name.rfind('-');
+                    if (dash_pos != std::string::npos) {
+                        std::string version = dir_name.substr(dash_pos + 1);
+                        if (version != current_version) {
+                            LOG(DEBUG, "BackendUtils") << "Cleaning up old TheRock version: " << dir_name << std::endl;
+                            fs::remove_all(entry.path());
+                        }
+                    }
+                }
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING, "BackendUtils") << "Failed to cleanup old TheRock versions: " << e.what() << std::endl;
+        }
+#endif
+    }
+
+    void BackendUtils::install_therock(const std::string& arch, const std::string& version,
+                                       DownloadProgressCallback progress_cb) {
+#if !defined(__linux__) && !defined(_WIN32)
+        throw std::runtime_error("TheRock is only supported on Linux and Windows");
+#else
+        std::string install_dir = get_therock_install_dir(arch, version);
+        std::string version_file = (fs::path(install_dir) / "version.txt").string();
+
+        if (fs::exists(install_dir) && fs::exists(version_file)) {
+            std::string installed_version;
+            std::ifstream vf(version_file);
+            std::getline(vf, installed_version);
+            vf.close();
+
+            if (installed_version == version) {
+                LOG(DEBUG, "BackendUtils") << "TheRock " << arch << "-" << version << " already installed" << std::endl;
+                return;
+            }
+        }
+
+        LOG(INFO, "BackendUtils") << "Installing TheRock ROCm " << version << " for " << arch << std::endl;
+
+        fs::create_directories(install_dir);
+
+        std::string config_path = utils::get_resource_path("resources/backend_versions.json");
+        json config = utils::JsonUtils::load_from_file(config_path);
+
+        std::string url_variant = arch;
+        if (config.contains("therock") && config["therock"].contains("url_mapping") &&
+            config["therock"]["url_mapping"].contains(arch)) {
+            url_variant = config["therock"]["url_mapping"][arch].get<std::string>();
+        }
+
+#ifdef _WIN32
+        std::string platform = "windows";
+#else
+        std::string platform = "linux";
+#endif
+        std::string filename = "therock-dist-" + platform + "-" + url_variant + "-" + version + ".tar.gz";
+        std::string url = "https://repo.amd.com/rocm/tarball/" + filename;
+
+        fs::path cache_dir = fs::temp_directory_path();
+        std::string tarball_path = (cache_dir / filename).string();
+
+        LOG(DEBUG, "BackendUtils") << "Downloading TheRock from: " << url << std::endl;
+        LOG(DEBUG, "BackendUtils") << "Downloading to: " << tarball_path << std::endl;
+
+        // Create progress callback for download
+        utils::ProgressCallback http_progress_cb;
+        if (progress_cb) {
+            http_progress_cb = [&progress_cb, &filename](size_t downloaded, size_t total) -> bool {
+                DownloadProgress p;
+                p.file = filename;
+                p.file_index = 2;  // TheRock is the second file (after llama.cpp binary)
+                p.total_files = 2;
+                p.bytes_downloaded = downloaded;
+                p.bytes_total = total;
+                p.percent = total > 0 ? static_cast<int>((downloaded * 100) / total) : 0;
+                p.complete = false;
+                return progress_cb(p);
+            };
+        } else {
+            http_progress_cb = utils::create_throttled_progress_callback();
+        }
+
+        auto download_result = utils::HttpClient::download_file(
+            url,
+            tarball_path,
+            http_progress_cb
+        );
+
+        if (!download_result.success) {
+            throw std::runtime_error("Failed to download TheRock from: " + url +
+                                    " - " + download_result.error_message);
+        }
+
+        LOG(DEBUG, "BackendUtils") << "TheRock download complete" << std::endl;
+
+        if (!fs::exists(tarball_path)) {
+            throw std::runtime_error("Downloaded TheRock tarball does not exist: " + tarball_path);
+        }
+
+        std::uintmax_t file_size = fs::file_size(tarball_path);
+        LOG(DEBUG, "BackendUtils") << "Downloaded tarball size: "
+                                    << (file_size / 1024 / 1024) << " MB" << std::endl;
+
+        if (!extract_tarball(tarball_path, install_dir, "TheRock")) {
+            fs::remove(tarball_path);
+            fs::remove_all(install_dir);
+            throw std::runtime_error("Failed to extract TheRock tarball: " + tarball_path);
+        }
+
+#ifdef _WIN32
+        // On Windows, DLLs are in bin/ (lib/ contains only import .lib files)
+        fs::path runtime_dir = fs::path(install_dir) / "bin";
+        if (!fs::exists(runtime_dir)) {
+            fs::remove(tarball_path);
+            fs::remove_all(install_dir);
+            throw std::runtime_error("TheRock extraction failed: bin directory not found");
+        }
+        LOG(DEBUG, "BackendUtils") << "TheRock bin directory verified at: " << runtime_dir << std::endl;
+#else
+        // On Linux, shared libraries are in lib/
+        fs::path runtime_dir = fs::path(install_dir) / "lib";
+        if (!fs::exists(runtime_dir)) {
+            fs::remove(tarball_path);
+            fs::remove_all(install_dir);
+            throw std::runtime_error("TheRock extraction failed: lib directory not found");
+        }
+        LOG(DEBUG, "BackendUtils") << "TheRock lib directory verified at: " << runtime_dir << std::endl;
+#endif
+
+        std::ofstream vf(version_file);
+        vf << version;
+        vf.close();
+
+        fs::remove(tarball_path);
+        cleanup_old_therock_versions(version);
+
+        // Send completion notification
+        if (progress_cb) {
+            DownloadProgress p;
+            p.file = filename;
+            p.file_index = 2;  // TheRock is the second file
+            p.total_files = 2;
+            p.bytes_downloaded = download_result.bytes_downloaded;
+            p.bytes_total = download_result.total_bytes;
+            p.percent = 100;
+            p.complete = true;
+            progress_cb(p);
+        }
+
+        LOG(INFO, "BackendUtils") << "TheRock installation complete" << std::endl;
+#endif
+    }
+
+    std::string BackendUtils::get_therock_lib_path(const std::string& rocm_arch) {
+#if !defined(__linux__) && !defined(_WIN32)
+        return "";
+#else
+        std::string config_path = utils::get_resource_path("resources/backend_versions.json");
+        json config = utils::JsonUtils::load_from_file(config_path);
+
+        if (!config.contains("therock") || !config["therock"].contains("version")) {
+            throw std::runtime_error("backend_versions.json is missing 'therock.version'");
+        }
+
+        std::string version = config["therock"]["version"].get<std::string>();
+
+        // Only return the path if TheRock is already installed
+        std::string install_dir = get_therock_install_dir(rocm_arch, version);
+        if (fs::exists(install_dir)) {
+#ifdef _WIN32
+            // On Windows, DLLs are in bin/ (lib/ contains only import .lib files)
+            std::string lib_path = (fs::path(install_dir) / "bin").string();
+#else
+            // On Linux, shared libraries are in lib/
+            std::string lib_path = (fs::path(install_dir) / "lib").string();
+#endif
+            LOG(DEBUG, "BackendUtils") << "Returning TheRock runtime path: " << lib_path << std::endl;
+            return lib_path;
+        }
+
+        return "";
+#endif
     }
 } // namespace lemon::backends

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -4,6 +4,8 @@
 #include "lemon/runtime_config.h"
 #include "lemon/utils/custom_args.h"
 #include "lemon/utils/process_manager.h"
+#include "lemon/utils/json_utils.h"
+#include "lemon/utils/path_utils.h"
 #include "lemon/error_types.h"
 #include "lemon/system_info.h"
 #include <iostream>
@@ -32,6 +34,7 @@ namespace backends {
 static const int EMBEDDING_CTX_SIZE = 8192;
 static const int EMBEDDING_BATCH_SIZE = 8192;
 static const int EMBEDDING_UBATCH_SIZE = 8192;
+static const char* ROCM_STABLE_RUNTIME_DIR = "rocm-stable-runtime";
 
 // Helper to push reserved flags and their aliases
 static void push_reserved(std::set<std::string>& reserved,
@@ -89,19 +92,73 @@ static void push_overridable_arg(std::vector<std::string>& args,
     }
 }
 
+static std::string resolve_llamacpp_backend(const std::string& backend) {
+    if (backend == "rocm") {
+        // Map "rocm" to the appropriate channel based on config
+        std::string channel = "preview";  // default to preview for now
+        if (auto* cfg = RuntimeConfig::global()) {
+            channel = cfg->rocm_channel();
+        }
+        return "rocm-" + channel;
+    }
+    return backend;
+}
+
+static bool is_llamacpp_rocm_backend(const std::string& backend) {
+    return backend == "rocm-stable" || backend == "rocm-preview" || backend == "rocm-nightly";
+}
+
+static std::string trim_version_prefix(const std::string& version) {
+    if (!version.empty() && version[0] == 'v') {
+        return version.substr(1);
+    }
+    return version;
+}
+
+static std::string trim_to_major_minor(const std::string& version) {
+    // Trim to MAJOR.MINOR format (e.g., "7.12.0" -> "7.12")
+    std::string trimmed = trim_version_prefix(version);
+    size_t second_dot = trimmed.find('.', trimmed.find('.') + 1);
+    if (second_dot != std::string::npos) {
+        return trimmed.substr(0, second_dot);
+    }
+    return trimmed;
+}
+
+static std::string get_therock_version() {
+    auto config = JsonUtils::load_from_file(utils::get_resource_path("resources/backend_versions.json"));
+    if (!config.contains("therock") || !config["therock"].is_object() ||
+        !config["therock"].contains("version") || !config["therock"]["version"].is_string()) {
+        throw std::runtime_error("backend_versions.json is missing 'therock.version'");
+    }
+    return trim_to_major_minor(config["therock"]["version"].get<std::string>());
+}
+
 InstallParams LlamaCppServer::get_install_params(const std::string& backend, const std::string& version) {
     InstallParams params;
 
-    if (backend == "system") {
+    const std::string resolved_backend = resolve_llamacpp_backend(backend);
+
+    if (resolved_backend == "system") {
         return params; // Return empty params for system backend
     }
 
-    if (backend == "rocm") {
+    if (resolved_backend == "rocm-preview") {
+        params.repo = "lemonade-sdk/llama.cpp";
+        std::string therock_ver = get_therock_version();
+#ifdef _WIN32
+        params.filename = "llama-" + version + "-bin-win-rocm-" + therock_ver + "-x64.zip";
+#elif defined(__linux__)
+        params.filename = "llama-" + version + "-bin-ubuntu-rocm-" + therock_ver + "-x64.tar.gz";
+#else
+        throw std::runtime_error("ROCm preview llamacpp is currently supported on Windows and Linux only");
+#endif
+    } else if (resolved_backend == "rocm-nightly") {
         params.repo = "lemonade-sdk/llamacpp-rocm";
         std::string target_arch = SystemInfo::get_rocm_arch();
         if (target_arch.empty()) {
             throw std::runtime_error(
-                SystemInfo::get_unsupported_backend_error("llamacpp", "rocm")
+                SystemInfo::get_unsupported_backend_error("llamacpp", "rocm-nightly")
             );
         }
 #ifdef _WIN32
@@ -109,16 +166,25 @@ InstallParams LlamaCppServer::get_install_params(const std::string& backend, con
 #elif defined(__linux__)
         params.filename = "llama-" + version + "-ubuntu-rocm-" + target_arch + "-x64.zip";
 #else
-        throw std::runtime_error("ROCm llamacpp only supported on Windows and Linux");
+        throw std::runtime_error("ROCm nightly llamacpp only supported on Windows and Linux");
 #endif
-    } else if (backend == "metal") {
+    } else if (resolved_backend == "rocm-stable") {
+        params.repo = "ggml-org/llama.cpp";
+#ifdef _WIN32
+        params.filename = "llama-" + version + "-bin-win-hip-radeon-x64.zip";
+#elif defined(__linux__)
+        params.filename = "llama-" + version + "-bin-ubuntu-rocm-7.2-x64.tar.gz";
+#else
+        throw std::runtime_error("ROCm stable llamacpp is currently supported on Windows and Linux only");
+#endif
+    } else if (resolved_backend == "metal") {
         params.repo = "ggml-org/llama.cpp";
 #ifdef __APPLE__
         params.filename = "llama-" + version + "-bin-macos-arm64.tar.gz";
 #else
         throw std::runtime_error("Metal llamacpp only supported on macOS");
 #endif
-    } else if (backend == "cpu") {
+    } else if (resolved_backend == "cpu") {
         params.repo = "ggml-org/llama.cpp";
 #ifdef _WIN32
         params.filename = "llama-" + version + "-bin-win-cpu-x64.zip";
@@ -159,10 +225,11 @@ void LlamaCppServer::load(const std::string& model_name,
     LOG(DEBUG, "LlamaCpp") << "Per-model settings: " << options.to_log_string() << std::endl;
 
     int ctx_size = options.get_option("ctx_size");
-    std::string llamacpp_backend = options.get_option("llamacpp_backend");
+    std::string llamacpp_backend_option = options.get_option("llamacpp_backend");
+    std::string llamacpp_backend = resolve_llamacpp_backend(llamacpp_backend_option);
     std::string llamacpp_args = options.get_option("llamacpp_args");
 
-    RuntimeConfig::validate_backend_choice("llamacpp", llamacpp_backend);
+    RuntimeConfig::validate_backend_choice("llamacpp", llamacpp_backend_option);
 
     LOG(INFO, "LlamaCpp") << "Using LlamaCpp Backend: " << llamacpp_backend << std::endl;
 
@@ -226,7 +293,7 @@ void LlamaCppServer::load(const std::string& model_name,
     push_reserved(reserved_flags, "--mmproj", std::vector<std::string>{"-mm", "-mmu", "--mmproj-url", "--no-mmproj", "--mmproj-auto", "--no-mmproj-auto", "--mmproj-offload", "--no-mmproj-offload"});
 
     // Enable context shift for vulkan/rocm (not supported on Metal)
-    if (llamacpp_backend == "vulkan" || llamacpp_backend == "rocm") {
+    if (llamacpp_backend == "vulkan" || is_llamacpp_rocm_backend(llamacpp_backend)) {
         push_overridable_arg(args, llamacpp_args, "--context-shift");
         push_overridable_arg(args, llamacpp_args, "--keep", "16");
     } else {
@@ -283,10 +350,25 @@ void LlamaCppServer::load(const std::string& model_name,
     // For ROCm on Linux, set LD_LIBRARY_PATH to include the ROCm library directory
     std::vector<std::pair<std::string, std::string>> env_vars;
 #ifndef _WIN32
-    if (llamacpp_backend == "rocm") {
+    if (is_llamacpp_rocm_backend(llamacpp_backend)) {
         // Get the directory containing the executable (where ROCm .so files are)
         fs::path exe_dir = fs::path(executable).parent_path();
         std::string lib_path = exe_dir.string();
+
+        if (llamacpp_backend == "rocm-stable") {
+            std::string runtime_dir = BackendUtils::get_install_directory(ROCM_STABLE_RUNTIME_DIR, "");
+            if (fs::exists(runtime_dir)) {
+                lib_path = runtime_dir + ":" + lib_path;
+            }
+        } else if (llamacpp_backend == "rocm-preview") {
+            std::string rocm_arch = SystemInfo::get_rocm_arch();
+            if (!rocm_arch.empty()) {
+                std::string therock_lib = BackendUtils::get_therock_lib_path(rocm_arch);
+                if (!therock_lib.empty()) {
+                    lib_path = therock_lib + ":" + lib_path;
+                }
+            }
+        }
 
         // Preserve existing LD_LIBRARY_PATH if it exists
         const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
@@ -300,7 +382,32 @@ void LlamaCppServer::load(const std::string& model_name,
 #else
     // For ROCm on Windows with gfx1151, set OCL_SET_SVMSIZE
     // This is a patch to enable loading larger models
-    if (llamacpp_backend == "rocm") {
+    if (is_llamacpp_rocm_backend(llamacpp_backend)) {
+        std::string new_path;
+
+        if (llamacpp_backend == "rocm-stable") {
+            std::string runtime_dir = BackendUtils::get_install_directory(ROCM_STABLE_RUNTIME_DIR, "");
+            if (fs::exists(runtime_dir)) {
+                new_path = runtime_dir;
+            }
+        } else if (llamacpp_backend == "rocm-preview") {
+            std::string rocm_arch = SystemInfo::get_rocm_arch();
+            if (!rocm_arch.empty()) {
+                std::string therock_bin = BackendUtils::get_therock_lib_path(rocm_arch);
+                if (!therock_bin.empty()) {
+                    new_path = therock_bin;
+                }
+            }
+        }
+
+        if (!new_path.empty()) {
+            const char* existing_path = std::getenv("PATH");
+            if (existing_path && strlen(existing_path) > 0) {
+                new_path += ";" + std::string(existing_path);
+            }
+            env_vars.push_back({"PATH", new_path});
+        }
+
         std::string arch = lemon::SystemInfo::get_rocm_arch();
         if (arch == "gfx1151") {
             env_vars.push_back({"OCL_SET_SVM_SIZE", "262144"});

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -36,6 +36,10 @@ std::string resolve_sdcpp_backend(const std::string& backend) {
         if (auto* cfg = RuntimeConfig::global()) {
             channel = cfg->rocm_channel();
         }
+        // sd.cpp has no nightly build - fall back to preview
+        if (channel == "nightly") {
+            channel = "preview";
+        }
         return "rocm-" + channel;
     }
     return backend;

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -6,6 +6,7 @@
 #include "lemon/utils/http_client.h"
 #include "lemon/utils/process_manager.h"
 #include "lemon/utils/json_utils.h"
+#include "lemon/utils/path_utils.h"
 #include "lemon/error_types.h"
 #include "lemon/system_info.h"
 #include <httplib.h>
@@ -22,9 +23,67 @@ using namespace lemon::utils;
 namespace lemon {
 namespace backends {
 
+static const char* ROCM_STABLE_RUNTIME_DIR = "rocm-stable-runtime";
+
+namespace {
+bool is_rocm_backend(const std::string& backend) {
+    return backend == "rocm" || backend == "rocm-stable" || backend == "rocm-preview";
+}
+
+std::string resolve_sdcpp_backend(const std::string& backend) {
+    if (backend == "rocm") {
+        std::string channel = "preview";
+        if (auto* cfg = RuntimeConfig::global()) {
+            channel = cfg->rocm_channel();
+        }
+        return "rocm-" + channel;
+    }
+    return backend;
+}
+
+std::string trim_version_prefix(const std::string& version) {
+    if (!version.empty() && version[0] == 'v') {
+        return version.substr(1);
+    }
+    return version;
+}
+
+std::string trim_to_major_minor(const std::string& version) {
+    // Trim to MAJOR.MINOR format (e.g., "7.12.0" -> "7.12")
+    std::string trimmed = trim_version_prefix(version);
+    size_t second_dot = trimmed.find('.', trimmed.find('.') + 1);
+    if (second_dot != std::string::npos) {
+        return trimmed.substr(0, second_dot);
+    }
+    return trimmed;
+}
+
+std::string get_rocm_stable_runtime_version() {
+    auto config = JsonUtils::load_from_file(utils::get_resource_path("resources/backend_versions.json"));
+
+    if (config.contains("rocm-stable-runtime") && config["rocm-stable-runtime"].is_string()) {
+        return trim_version_prefix(config["rocm-stable-runtime"].get<std::string>());
+    }
+
+    throw std::runtime_error("backend_versions.json is missing 'rocm-stable-runtime'");
+}
+
+std::string get_therock_version() {
+    auto config = JsonUtils::load_from_file(utils::get_resource_path("resources/backend_versions.json"));
+    if (!config.contains("therock") || !config["therock"].is_object() ||
+        !config["therock"].contains("version") || !config["therock"]["version"].is_string()) {
+        throw std::runtime_error("backend_versions.json is missing 'therock.version'");
+    }
+    // stable-diffusion.cpp release assets include full ROCm runtime version in filenames
+    // (for example: rocm-7.12.0), so keep the patch component.
+    return trim_version_prefix(config["therock"]["version"].get<std::string>());
+}
+}
+
 InstallParams SDServer::get_install_params(const std::string& backend, const std::string& version) {
     InstallParams params;
-    params.repo = "superm1/stable-diffusion.cpp";
+    params.repo = "lemonade-sdk/stable-diffusion.cpp";
+    std::string resolved_backend = resolve_sdcpp_backend(backend);
 
     // Transform version for URL (master-NNN-HASH -> master-HASH)
     std::string short_version = version;
@@ -37,23 +96,36 @@ InstallParams SDServer::get_install_params(const std::string& backend, const std
         }
     }
 
-    if (backend == "rocm") {
+    if (is_rocm_backend(resolved_backend)) {
         std::string target_arch = SystemInfo::get_rocm_arch();
+
         if (target_arch.empty()) {
             throw std::runtime_error(
                 SystemInfo::get_unsupported_backend_error("sd-cpp", "rocm")
             );
         }
 #ifdef _WIN32
-        params.filename = "sd-" + short_version + "-bin-win-rocm-x64.zip";
+        if (resolved_backend == "rocm-stable") {
+            // Windows stable diffusion artifacts are currently built against ROCm 7.1.1
+            // and don't follow the rocm-stable-runtime version from backend_versions.json
+            params.filename = "sd-" + short_version + "-bin-win-rocm-7.1.1-x64.zip";
+        } else {  // rocm-preview
+            params.filename = "sd-" + short_version + "-bin-win-rocm-" + get_therock_version() + "-x64.zip";
+        }
 #elif defined(__linux__)
-        params.filename = "sd-" + short_version + "-bin-Linux-Ubuntu-24.04-x86_64-rocm.zip";
+    if (resolved_backend == "rocm-stable") {
+        params.filename = "sd-" + short_version + "-bin-Linux-Ubuntu-24.04-x86_64-rocm-" +
+                  get_rocm_stable_runtime_version() + ".zip";
+    } else {
+        params.filename = "sd-" + short_version + "-bin-Linux-Ubuntu-24.04-x86_64-rocm-" +
+                  get_therock_version() + ".zip";
+    }
 #else
         throw std::runtime_error("ROCm sd.cpp only supported on Windows and Linux");
 #endif
     } else {
         // CPU build (default)
-#ifdef _WIN32
+    #ifdef _WIN32
         params.filename = "sd-" + short_version + "-bin-win-avx2-x64.zip";
 #elif defined(__linux__)
         params.filename = "sd-" + short_version + "-bin-Linux-Ubuntu-24.04-x86_64.zip";
@@ -84,6 +156,7 @@ void SDServer::load(const std::string& model_name,
     LOG(DEBUG, "SDServer") << "Per-model settings: " << options.to_log_string() << std::endl;
 
     std::string backend = options.get_option("sd-cpp_backend");
+    std::string resolved_backend = resolve_sdcpp_backend(backend);
     std::string sdcpp_args = options.get_option("sdcpp_args");
 
     RuntimeConfig::validate_backend_choice("sdcpp", backend);
@@ -181,6 +254,21 @@ void SDServer::load(const std::string& model_name,
     // For Linux, always set LD_LIBRARY_PATH to include executable directory
     std::string lib_path = exe_dir.string();
 
+    if (resolved_backend == "rocm-stable") {
+        std::string runtime_dir = BackendUtils::get_install_directory(ROCM_STABLE_RUNTIME_DIR, "");
+        if (fs::exists(runtime_dir)) {
+            lib_path = runtime_dir + ":" + lib_path;
+        }
+    } else if (resolved_backend == "rocm-preview") {
+        std::string rocm_arch = SystemInfo::get_rocm_arch();
+        if (!rocm_arch.empty()) {
+            std::string therock_lib = BackendUtils::get_therock_lib_path(rocm_arch);
+            if (!therock_lib.empty()) {
+                lib_path = therock_lib + ":" + lib_path;
+            }
+        }
+    }
+
     const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
     if (existing_ld_path && strlen(existing_ld_path) > 0) {
         lib_path = lib_path + ":" + std::string(existing_ld_path);
@@ -191,10 +279,26 @@ void SDServer::load(const std::string& model_name,
 #else
     // ROCm builds on Windows require hipblaslt.dll, rocblas.dll, amdhip64.dll, etc.
     // These DLLs are distributed alongside sd-server.exe but need PATH to be set for loading
-    if (backend == "rocm") {
+    if (is_rocm_backend(resolved_backend)) {
         // Add executable directory to PATH for ROCm runtime DLLs
         // This allows the sd-server.exe to find required HIP/ROCm libraries at runtime
         std::string new_path = exe_dir.string();
+
+        if (resolved_backend == "rocm-stable") {
+            std::string runtime_dir = BackendUtils::get_install_directory(ROCM_STABLE_RUNTIME_DIR, "");
+            if (fs::exists(runtime_dir)) {
+                new_path = runtime_dir + ";" + new_path;
+            }
+        } else if (resolved_backend == "rocm-preview") {
+            std::string rocm_arch = SystemInfo::get_rocm_arch();
+            if (!rocm_arch.empty()) {
+                std::string therock_bin = BackendUtils::get_therock_lib_path(rocm_arch);
+                if (!therock_bin.empty()) {
+                    new_path = therock_bin + ";" + new_path;
+                }
+            }
+        }
+
         const char* existing_path = std::getenv("PATH");
         if (existing_path && strlen(existing_path) > 0) {
             new_path = new_path + ";" + std::string(existing_path);

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -3,6 +3,7 @@
 #include <lemon/system_info.h>
 #endif
 #include <nlohmann/json.hpp>
+#include <algorithm>
 #include <map>
 #ifdef LEMONADE_CLI
 #include <CLI/CLI.hpp>

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -175,6 +175,11 @@ bool RuntimeConfig::enable_dgpu_gtt() const {
     return config_["enable_dgpu_gtt"].get<bool>();
 }
 
+std::string RuntimeConfig::rocm_channel() const {
+    std::shared_lock lock(mutex_);
+    return config_["rocm_channel"].get<std::string>();
+}
+
 json RuntimeConfig::backend_config(const std::string& backend_name) const {
     std::shared_lock lock(mutex_);
     if (config_.contains(backend_name) && config_[backend_name].is_object()) {
@@ -340,6 +345,14 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
         }
         if (value.get<int>() < 1) {
             throw std::invalid_argument("'config_version' must be >= 1");
+        }
+    } else if (key == "rocm_channel") {
+        if (!value.is_string()) {
+            throw std::invalid_argument("'rocm_channel' must be a string");
+        }
+        std::string channel = value.get<std::string>();
+        if (channel != "preview" && channel != "stable" && channel != "nightly") {
+            throw std::invalid_argument("'rocm_channel' must be either 'preview', 'stable', or 'nightly'");
         }
     } else if (is_backend_name(key)) {
         if (!value.is_object()) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2424,18 +2424,56 @@ void Server::handle_image_upscale(const httplib::Request& req, httplib::Response
 
         std::vector<std::pair<std::string, std::string>> env_vars;
         std::filesystem::path cli_dir = cli_exe.parent_path();
+
+        std::string resolved_backend = backend;
+        if (backend == "rocm") {
+            std::string channel = "preview";
+            if (config_) {
+                channel = config_->rocm_channel();
+            }
+            resolved_backend = "rocm-" + channel;
+        }
 #ifndef _WIN32
         std::string lib_path = cli_dir.string();
+
+        if (resolved_backend == "rocm-stable") {
+            std::string runtime_dir = lemon::backends::BackendUtils::get_install_directory(
+                "rocm-stable-runtime", ""
+            );
+            if (std::filesystem::exists(runtime_dir)) {
+                lib_path = runtime_dir + ":" + lib_path;
+            }
+        } else if (resolved_backend == "rocm-preview") {
+            std::string rocm_arch = SystemInfo::get_rocm_arch();
+            if (!rocm_arch.empty()) {
+                std::string therock_lib = lemon::backends::BackendUtils::get_therock_lib_path(rocm_arch);
+                if (!therock_lib.empty()) {
+                    lib_path = therock_lib + ":" + lib_path;
+                }
+            }
+        }
+
         const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
         if (existing_ld_path && strlen(existing_ld_path) > 0) {
             lib_path = lib_path + ":" + std::string(existing_ld_path);
         }
         env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
 #else
-        if (backend == "rocm") {
+        if (resolved_backend == "rocm-stable" || resolved_backend == "rocm-preview") {
             std::string new_path = cli_dir.string();
+
+            if (resolved_backend == "rocm-preview") {
+                std::string rocm_arch = SystemInfo::get_rocm_arch();
+                if (!rocm_arch.empty()) {
+                    std::string therock_bin = lemon::backends::BackendUtils::get_therock_lib_path(rocm_arch);
+                    if (!therock_bin.empty()) {
+                        new_path = therock_bin + ";" + new_path;
+                    }
+                }
+            }
+
             const char* existing_path = std::getenv("PATH");
-            if (existing_path) new_path += ";" + std::string(existing_path);
+            if (existing_path && strlen(existing_path) > 0) new_path += ";" + std::string(existing_path);
             env_vars.push_back({"PATH", new_path});
         }
 #endif

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -123,7 +123,7 @@ struct RecipeBackendDef {
 //
 // Empty family set {} means "all families of that device type"
 static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
-    // llamacpp with multiple backends (order = preference: system > metal > vulkan > rocm > cpu)
+    // llamacpp with multiple backends (order = preference)
     {"llamacpp", "system", {"linux"}, {
         {"cpu", {"x86_64"}}, // Placeholder, actual check is PATH-based
     }},
@@ -161,9 +161,7 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
     // stable-diffusion.cpp - ROCm backend for AMD GPUs
     {"sd-cpp", "rocm", {"windows", "linux"}, {
         {"amd_gpu", {
-#ifdef __linux__
-            "gfx1150",   // Strix Point - Linux only (ROCm not yet supported on Windows)
-#endif
+            "gfx1150",
             "gfx1151", "gfx103X", "gfx110X", "gfx120X"
         }},
     }},
@@ -301,8 +299,10 @@ static bool device_matches_constraint(const std::string& device_family,
 
 // Generic installation check
 static bool is_recipe_installed(const std::string& recipe, const std::string& backend, std::string& error_message) {
+    bool is_llamacpp_rocm_backend = recipe == "llamacpp" && backend == "rocm";
+
     // Special handling for ROCm backends on gfx1151 (Strix Halo) if kernel CWSR fix is missing
-    if ((recipe == "llamacpp" || recipe == "sd-cpp") && backend == "rocm") {
+    if ((recipe == "sd-cpp" && backend == "rocm") || is_llamacpp_rocm_backend) {
         if (needs_gfx1151_cwsr_fix()) {
             error_message = "Linux kernel missing support";
             return false;
@@ -721,7 +721,8 @@ json SystemInfo::build_recipes_info(const json& devices) {
         detected_devices.push_back({"metal", "Apple Metal", "metal", true});
     }
 
-    // Check if user prefers system llamacpp backend (off by default)
+    // Default to preferring system llamacpp on Linux AMD systems.
+    // This can be overridden with LEMONADE_LLAMACPP_PREFER_SYSTEM=true/false.
     bool prefer_llamacpp_system = false;
     if (auto* cfg = RuntimeConfig::global()) {
         prefer_llamacpp_system = cfg->backend_bool("llamacpp", "prefer_system");
@@ -917,8 +918,11 @@ json SystemInfo::build_recipes_info(const json& devices) {
                     : "Backend is supported but not installed.";
                 backend["message"] = install_error.empty() ? default_message : install_error;
 
-                // Special action for ROCm backend on llamacpp/sd-cpp if CWSR fix is missing
-                if ((def.recipe == "llamacpp" || def.recipe == "sd-cpp") && def.backend == "rocm"
+                bool is_rocm_backend = (def.recipe == "sd-cpp" && def.backend == "rocm") ||
+                    (def.recipe == "llamacpp" && def.backend == "rocm");
+
+                // Special action for ROCm backends on llamacpp/sd-cpp if CWSR fix is missing
+                if (is_rocm_backend
                     && !install_error.empty() && needs_gfx1151_cwsr_fix()) {
                     backend["action"] = "Visit https://lemonade-server.ai/gfx1151_linux.html";
                 } else {

--- a/test/utils/capabilities.py
+++ b/test/utils/capabilities.py
@@ -38,7 +38,13 @@ def get_current_config():
 CAPABILITIES = {
     "llm": {
         "llamacpp": {
-            "backends": ["vulkan", "rocm", "metal", "cpu"],
+            "backends": [
+                "vulkan",
+                "rocm",
+                "metal",
+                "cpu",
+                "system",
+            ],
             "supports": {
                 "chat_completions": True,
                 "chat_completions_streaming": True,

--- a/test/validate_llamacpp.py
+++ b/test/validate_llamacpp.py
@@ -111,6 +111,22 @@ def get_hot_llamacpp_models(base_url):
     return hot_models
 
 
+def set_rocm_channel(base_url, channel):
+    """Configure the ROCm channel in lemond via the params API."""
+    print(f"Setting rocm_channel={channel} via /params", flush=True)
+    response, body = request_json(
+        "POST",
+        f"{base_url}/params",
+        timeout=TIMEOUT_DEFAULT,
+        json={"rocm_channel": channel},
+    )
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"Failed to set rocm_channel: HTTP {response.status_code} - {body}"
+        )
+    print(f"Params response: {body}", flush=True)
+
+
 def install_backend(base_url, backend):
     """Install or update the requested llama.cpp backend through the API."""
     print(f"Installing llamacpp backend via /install: {backend}", flush=True)
@@ -248,6 +264,12 @@ def main():
         help="Backend to test (vulkan, rocm, cpu, metal, system)",
     )
     parser.add_argument(
+        "--channel",
+        default=None,
+        choices=["stable", "preview", "nightly"],
+        help="Channel for backends that support multiple releases (e.g. rocm)",
+    )
+    parser.add_argument(
         "--port",
         type=int,
         default=PORT,
@@ -275,10 +297,16 @@ def main():
     )
     args = parser.parse_args()
 
+    # Label used for output filenames and artifact names
+    label = f"{args.backend}-{args.channel}" if args.channel else args.backend
+
     base_url = f"http://localhost:{args.port}/api/v1"
-    output_path = args.output or f"llamacpp_validation_{args.backend}.json"
+    output_path = args.output or f"llamacpp_validation_{label}.json"
 
     require_running_server(base_url, args.port)
+
+    if args.channel:
+        set_rocm_channel(base_url, args.channel)
 
     print("Unloading all models for clean state...", flush=True)
     try:

--- a/test/validate_llamacpp.py
+++ b/test/validate_llamacpp.py
@@ -238,8 +238,14 @@ def main():
     parser.add_argument(
         "--backend",
         required=True,
-        choices=["vulkan", "rocm", "cpu", "metal"],
-        help="Backend to test (vulkan, rocm, cpu, metal)",
+        choices=[
+            "vulkan",
+            "rocm",
+            "cpu",
+            "metal",
+            "system",
+        ],
+        help="Backend to test (vulkan, rocm, cpu, metal, system)",
     )
     parser.add_argument(
         "--port",


### PR DESCRIPTION
The ROCm stable runtime utilizes the AMD released  ROCm runtimes (stable and preview) and the upstream llama.cpp artifacts.