### PR TITLE
fix: add PCI revision 0x20 (Krackan Point) to XDNA2 NPU detection

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1315,7 +1315,7 @@ static std::string identify_npu_arch_linux() {
                 if (device_str == "0x17f0") {
                     if (revision_str == "0x10" ||
                         revision_str == "0x11" ||
-                        revision_str == "0x12")
+                        revision_str == "0x20")
                         return "XDNA2";
                 }
             }


### PR DESCRIPTION
The PCI fallback path in identify_npu_arch_linux() does not recognize revision 0x20 for PCI device 0x17f0, causing Krackan Point NPUs to show the FLM recipe as "unsupported" when the ioctl detection path is unavailable (e.g. user not in the render group).

Revision 0x20 is confirmed as XDNA2 (AIE2 architecture) by the upstream kernel driver device table:

  drivers/accel/amdxdna/amdxdna_pci_drv.c:
    { 0x17f0, 0x10, &dev_npu4_info },  /* Strix Point    */
    { 0x17f0, 0x11, &dev_npu5_info },  /* Strix Halo     */
    { 0x17f0, 0x20, &dev_npu6_info },  /* Krackan Point  */

  drivers/accel/amdxdna/npu6_regs.c:
    const struct amdxdna_dev_info dev_npu6_info = {
        ...
        .ops = &aie2_ops,  /* XDNA2 / AIE2 */
    };

All three revisions share the same AIE2 ops and npu4 firmware path.

Ref: https://github.com/amd/xdna-driver/blob/main/src/driver/amdxdna/amdxdna_pci_drv.c#L62-L64