### PR TITLE
Make lemonade available in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ WORKDIR /opt/lemonade
 # Copy built executables and resources from builder
 COPY --from=builder /app/build/lemond ./lemond
 COPY --from=builder /app/build/lemonade-server ./lemonade-server
+COPY --from=builder /app/build/lemonade ./lemonade
 COPY --from=builder /app/build/resources ./resources
 
 # Download and install FLM using version from backend_versions.json


### PR DESCRIPTION
The changes to `lemonade-server` -> `lemond` & `lemonade` weren't propagated to `Dockerfile` making some functionality inaccessible to container users.