### PR TITLE
Adding args to llamacpp to use -np 4 and disable the kv unified cache which is hurting performance on Strix Halo iGPUs

### DIFF
--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -231,6 +231,10 @@ void LlamaCppServer::load(const std::string& model_name,
     // Disable llamacpp webui by default
     push_overridable_arg(args, llamacpp_args, "--no-webui");
 
+    // Use 4 parallel slots and disable unified KV cache
+    push_overridable_arg(args, llamacpp_args, "-np", "4");
+    push_overridable_arg(args, llamacpp_args, "--no-kv-unified");
+
     // Disable mmap on iGPU
     if (SystemInfo::get_has_igpu()) {
         push_overridable_arg(args, llamacpp_args, "--no-mmap");

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -231,9 +231,11 @@ void LlamaCppServer::load(const std::string& model_name,
     // Disable llamacpp webui by default
     push_overridable_arg(args, llamacpp_args, "--no-webui");
 
-    // Use 4 parallel slots and disable unified KV cache
-    push_overridable_arg(args, llamacpp_args, "-np", "4");
-    push_overridable_arg(args, llamacpp_args, "--no-kv-unified");
+    // Use 4 parallel slots and disable unified KV cache for ROCm
+    if (llamacpp_backend == "rocm") {
+        push_overridable_arg(args, llamacpp_args, "-np", "4");
+        push_overridable_arg(args, llamacpp_args, "--no-kv-unified");
+    }
 
     // Disable mmap on iGPU
     if (SystemInfo::get_has_igpu()) {


### PR DESCRIPTION
I am seeing some non-trivial performance degradation on my Strix Halo when using the ROCm backend when the unified kv cache is used, which is on by default. Updating the llamacpp launch args to remove that. 