### PR TITLE
test: add environment variable integration tests

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1057,8 +1057,6 @@ jobs:
         include:
           - os: macos-latest
             test_type: env-vars
-          - os: windows-latest
-            test_type: env-vars
     env:
       LEMONADE_CI_MODE: "True"
       PYTHONIOENCODING: utf-8
@@ -1163,14 +1161,7 @@ jobs:
               $VENV_PYTHON test/server_streaming_errors.py --server-binary "$SERVER_BINARY"
           elif [ "${{ matrix.test_type }}" = "env-vars" ]; then
               echo "Running environment variable tests..."
-              # Derive server binary path from SERVER_BINARY directory
-              BIN_DIR="$(dirname "$SERVER_BINARY")"
-              if [ "${{ runner.os }}" = "Windows" ]; then
-                  # lemond.exe is not in the MSI; LemonadeServer.exe embeds the same server
-                  LEMOND_BINARY="$BIN_DIR/LemonadeServer.exe"
-              else
-                  LEMOND_BINARY="$BIN_DIR/lemond"
-              fi
+              LEMOND_BINARY="$(dirname "$SERVER_BINARY")/lemond"
               $VENV_PYTHON test/server_env_vars.py --server-binary "$LEMOND_BINARY"
           fi
 

--- a/test/server_env_vars.py
+++ b/test/server_env_vars.py
@@ -28,6 +28,8 @@ BASE = f"http://localhost:{PORT}"
 HEALTH = f"{BASE}/v1/health"
 CONFIG = f"{BASE}/internal/config"
 
+IS_MACOS = platform.system() == "Darwin"
+
 
 def get_default_binary():
     test_dir = os.path.dirname(os.path.abspath(__file__))
@@ -117,12 +119,17 @@ class TestConfigEnvVars(unittest.TestCase):
             "LEMONADE_MAX_LOADED_MODELS": "3",
             # Recipe-option env vars
             "LEMONADE_CTX_SIZE": "2048",
-            "LEMONADE_LLAMACPP": "cpu",
-            "LEMONADE_LLAMACPP_ARGS": "--flash-attn on",
-            "LEMONADE_WHISPERCPP": "cpu",
-            "LEMONADE_WHISPERCPP_ARGS": "--convert",
-            "LEMONADE_FLM_ARGS": "--socket 20",
         }
+        if not IS_MACOS:
+            cls.env.update(
+                {
+                    "LEMONADE_LLAMACPP": "cpu",
+                    "LEMONADE_LLAMACPP_ARGS": "--flash-attn on",
+                    "LEMONADE_WHISPERCPP": "cpu",
+                    "LEMONADE_WHISPERCPP_ARGS": "--convert",
+                    "LEMONADE_FLM_ARGS": "--socket 20",
+                }
+            )
         cls.proc, cls.home_dir = start_server(cls.env)
         if not wait_for_server(HEALTH):
             out = cls.proc.stdout.read().decode() if cls.proc.stdout else ""
@@ -167,18 +174,23 @@ class TestConfigEnvVars(unittest.TestCase):
     def test_ctx_size(self):
         self.assertEqual(self.snapshot["ctx_size"], 2048)
 
+    @unittest.skipIf(IS_MACOS, "llamacpp backend selection not applicable on macOS")
     def test_llamacpp_backend(self):
         self.assertEqual(self.snapshot["llamacpp_backend"], "cpu")
 
+    @unittest.skipIf(IS_MACOS, "llamacpp args not applicable on macOS")
     def test_llamacpp_args(self):
         self.assertEqual(self.snapshot["llamacpp_args"], "--flash-attn on")
 
+    @unittest.skipIf(IS_MACOS, "whispercpp backend selection not applicable on macOS")
     def test_whispercpp_backend(self):
         self.assertEqual(self.snapshot["whispercpp_backend"], "cpu")
 
+    @unittest.skipIf(IS_MACOS, "whispercpp args not applicable on macOS")
     def test_whispercpp_args(self):
         self.assertEqual(self.snapshot["whispercpp_args"], "--convert")
 
+    @unittest.skipIf(IS_MACOS, "FLM is NPU-only, not available on macOS")
     def test_flm_args(self):
         self.assertEqual(self.snapshot["flm_args"], "--socket 20")
 


### PR DESCRIPTION
The purpose of this test is to validate that the auto-migration feature in #1464 works.

## Summary
- Adds `test/server_env_vars.py` with 23 tests that start `lemond` with specific env vars and verify they're reflected in `/internal/config` and `/v1/health`
- Covers: `LEMONADE_PORT`, `HOST`, `LOG_LEVEL`, `EXTRA_MODELS_DIR`, `GLOBAL_TIMEOUT`, `MAX_LOADED_MODELS`, `CTX_SIZE`, `LLAMACPP`, `LLAMACPP_ARGS`, `WHISPERCPP`, `WHISPERCPP_ARGS`, `FLM_ARGS`, `API_KEY`
- Also tests defaults and API key enforcement (401 without key, 200 with key)
- Added to `cpp_server_build_test_release.yml`: Linux (`.deb` matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)