### PR TITLE
Set the StartupWMClass by default

### DIFF
--- a/data/lemonade-web-app
+++ b/data/lemonade-web-app
@@ -16,7 +16,12 @@ if [ -f ~/.config/lemonade/lemonade.conf ]; then
     source ~/.config/lemonade/lemonade.conf
 fi
 
-URL="http://${LEMONADE_HOST}:${LEMONADE_PORT}/"
+# If listening on localhost always run on localhost for WMClass
+if [ "${LEMONADE_HOST}" = "0.0.0.0" ]; then
+    LEMONADE_HOST="localhost"
+fi
+
+URL="http://${LEMONADE_HOST}:${LEMONADE_PORT}/lemonade"
 
 # Prefer chromium based browsers otherwise xdg-open
 if [ "$(echo "${LEMONADE_PREFER_CHROMIUM:-true}" | tr '[:upper:]' '[:lower:]')" = "true" ]; then

--- a/data/lemonade-web-app.desktop
+++ b/data/lemonade-web-app.desktop
@@ -9,3 +9,4 @@ Icon=lemonade-app
 Terminal=false
 Categories=Development;Utility;
 Keywords=AI;LLM;GPU;NPU;Machine Learning;
+StartupWMClass=chrome-localhost__lemonade-Default


### PR DESCRIPTION
1. Use a dummy `/lemonade` endpoint at the end of the URL
2. If listening on 0.0.0.0, connect to localhost instead of 0.0.0.0.
3. Set `StartupWMClass` in desktop file to the localhost + dummy URL