### PR TITLE
docs: rename LEMONADE_LLAMACPP_BACKEND to LEMONADE_LLAMACPP in documentation

### DIFF
--- a/docs/assets/install-selector.js
+++ b/docs/assets/install-selector.js
@@ -613,9 +613,9 @@ function renderQuickStart() {
   -p 8000:8000 \\
   -v lemonade-cache:/root/.cache/huggingface \\
   -v lemonade-llama:/opt/lemonade/llama \\
-  -e LEMONADE_LLAMACPP_BACKEND=vulkan \\
+  -e LEMONADE_LLAMACPP=vulkan \\
   ghcr.io/lemonade-sdk/lemonade-server:latest`);
-      notes = `<div class="lmn-note"><strong>Tip:</strong> To select a specific backend, update the LEMONADE_LLAMACPP_BACKEND environment variable: <code>LEMONADE_LLAMACPP_BACKEND=vulkan</code></div>`;
+      notes = `<div class="lmn-note"><strong>Tip:</strong> To select a specific backend, update the LEMONADE_LLAMACPP environment variable: <code>LEMONADE_LLAMACPP=vulkan</code></div>`;
     }
 
     if (fw === 'llama' && dev === 'cpu') {
@@ -624,9 +624,9 @@ function renderQuickStart() {
   -p 8000:8000 \\
   -v lemonade-cache:/root/.cache/huggingface \\
   -v lemonade-llama:/opt/lemonade/llama \\
-  -e LEMONADE_LLAMACPP_BACKEND=cpu \\
+  -e LEMONADE_LLAMACPP=cpu \\
   ghcr.io/lemonade-sdk/lemonade-server:latest`);
-      notes = `<div class="lmn-note"><strong>Tip:</strong> To select a specific backend, update the LEMONADE_LLAMACPP_BACKEND environment variable: <code>LEMONADE_LLAMACPP_BACKEND=cpu</code></div>`;
+      notes = `<div class="lmn-note"><strong>Tip:</strong> To select a specific backend, update the LEMONADE_LLAMACPP environment variable: <code>LEMONADE_LLAMACPP=cpu</code></div>`;
     }
   }
 

--- a/src/cpp/DOCKER_GUIDE.md
+++ b/src/cpp/DOCKER_GUIDE.md
@@ -13,7 +13,7 @@ docker run -d \
   -v lemonade-cache:/root/.cache/huggingface \
   -v lemonade-llama:/opt/lemonade/llama \
   -v lemonade-recipe:/root/.cache/lemonade \
-  -e LEMONADE_LLAMACPP_BACKEND=cpu \
+  -e LEMONADE_LLAMACPP=cpu \
   ghcr.io/lemonade-sdk/lemonade-server:latest
 ```
 
@@ -26,7 +26,7 @@ docker run -d \
   -v lemonade-cache:/root/.cache/huggingface \
   -v lemonade-llama:/opt/lemonade/llama \
   -v lemonade-recipe:/root/.cache/lemonade \
-  -e LEMONADE_LLAMACPP_BACKEND=cpu \
+  -e LEMONADE_LLAMACPP=cpu \
   ghcr.io/lemonade-sdk/lemonade-server:v9.1.3 \
   ./lemond --host 0.0.0.0 --port 5000
 ```
@@ -42,7 +42,7 @@ docker run -d \
   -v lemonade-cache:/root/.cache/huggingface \
   -v lemonade-llama:/opt/lemonade/llama \
   -v lemonade-recipe:/root/.cache/lemonade \
-  -e LEMONADE_LLAMACPP_BACKEND=rocm \
+  -e LEMONADE_LLAMACPP=rocm \
   --device=/dev/kfd \
   --device=/dev/dri \
   ghcr.io/lemonade-sdk/lemonade-server:latest
@@ -72,7 +72,7 @@ services:
       # Persist model options and other backend binaries
       - lemonade-recipe:/root/.cache/lemonade
     environment:
-      - LEMONADE_LLAMACPP_BACKEND=cpu
+      - LEMONADE_LLAMACPP=cpu
     restart: unless-stopped
 
 volumes:
@@ -261,7 +261,7 @@ services:
       # Persist model options and other backend binaries
       - lemonade-recipe:/root/.cache/lemonade
     environment:
-      - LEMONADE_LLAMACPP_BACKEND=cpu
+      - LEMONADE_LLAMACPP=cpu
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
The environment variable for selecting the llama.cpp backend was renamed
from `LEMONADE_LLAMACPP_BACKEND` to `LEMONADE_LLAMACPP` in the codebase.
This PR updates the documentation to match.

## Changes

- `docs/assets/install-selector.js`: Updated Docker quick-start snippets and
  tip notes to use `LEMONADE_LLAMACPP` instead of `LEMONADE_LLAMACPP_BACKEND`
  (4 occurrences across vulkan and cpu sections)
- `src/cpp/DOCKER_GUIDE.md`: Updated all Docker run commands and Compose
  environment blocks to use `LEMONADE_LLAMACPP` (5 occurrences across CPU,
  GPU/ROCm, and Compose examples)

## Why

Using the old variable name in docs would cause Docker deployments to silently
ignore the backend setting, falling back to the default instead of the
user-specified value.

No code or behavior changes , documentation only.
