### PR TITLE
Add Llama-3.2-3B-Fluxed model to server models

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1242,7 +1242,7 @@
         }
     },
     "Llama-3.2-3B-Fluxed-GGUF": {
-        "checkpoint": "mradermacher/Llama-3.2-3B-Fluxed-uncensored-GGUF",
+        "checkpoint": "mradermacher/Llama-3.2-3B-Fluxed-uncensored-GGUF:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": true,
         "size": 1.9

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1241,6 +1241,12 @@
             "height": 1024
         }
     },
+    "Llama-3.2-3B-Fluxed-GGUF": {
+        "checkpoint": "mradermacher/Llama-3.2-3B-Fluxed-uncensored-GGUF",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "size": 1.9
+    },
     "Lemonade Ultra": {
         "checkpoint": "",
         "recipe": "experience",


### PR DESCRIPTION
This is a nice companion to image generation models, giving unimaginative folks like me a way to elaborate a vague image prompt into something more expressive.

"A penguin and a raccoon dressed as spies, noir film style" can turn into ... well, something expressive and weird, entertaining on its own or a good prompt to edit.

One absolutely can do `lemonade-server pull user.fluxed --checkpoint mradermacher/Llama-3.2-3B-Fluxed-uncensored-GGUF:Q4_K_M --recipe llamacpp`, this is just easier. Feel free to reject if it would lead to the suggested models getting cluttered though...