### PR TITLE
fix: drop --oss flag from Codex agent launcher

### DIFF
--- a/src/cpp/cli/agent_launcher.cpp
+++ b/src/cpp/cli/agent_launcher.cpp
@@ -151,7 +151,6 @@ void configure_codex_agent(const std::string& base_url,
         {"LEMONADE_API_KEY", resolved_api_key}
     };
     config.extra_args = {
-        "--oss",
         "-m",
         model,
         "--config",


### PR DESCRIPTION
## Summary
- Remove the `--oss` flag from the Codex agent launcher configuration
- The `--oss` flag forced Codex into Ollama provider mode, which hardcodes port 11434 and ignores `OPENAI_BASE_URL`
- Without it, Codex uses the standard OpenAI-compatible provider that respects the already-configured `OPENAI_BASE_URL` pointing to Lemonade's actual port

Fixes #1504

## Test plan
- [ ] Run `lemonade launch codex` and verify Codex connects to the Lemonade server on its configured port (not 11434)
- [ ] Verify chat completions work end-to-end through the Codex CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)