### PR TITLE
Fix config.json paths in configuration docs

### DIFF
--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -8,9 +8,9 @@ Lemonade Server starts automatically with the OS after installation. Configurati
 
 All settings are in `config.json`, located in the lemonade cache directory:
 
-- **Linux (systemd):** `/var/lib/lemonade/config.json`
+- **Linux (systemd):** `/var/lib/lemonade/.cache/lemonade/config.json`
 - **Windows:** `%USERPROFILE%\.cache\lemonade\config.json`
-- **macOS:** `~/Library/Application Support/lemonade/config.json`
+- **macOS:** `/Library/Application Support/lemonade/.cache/config.json`
 
 If `config.json` doesn't exist, it's created automatically with default values on first run.
 
@@ -171,7 +171,7 @@ If the server won't start and CLI arguments aren't sufficient, you can edit conf
 
 ```bash
 # Linux
-sudo nano /var/lib/lemonade/config.json
+sudo nano /var/lib/lemonade/.cache/lemonade/config.json
 sudo systemctl restart lemonade-server
 
 # Windows — edit with your preferred text editor:


### PR DESCRIPTION
## Summary
- **Linux:** path was `/var/lib/lemonade/config.json`, but `get_cache_dir()` returns `$HOME/.cache/lemonade` and the `lemonade` systemd user has `HOME=/var/lib/lemonade`, so the actual path is `/var/lib/lemonade/.cache/lemonade/config.json`
- **macOS:** path was `~/Library/Application Support/lemonade/config.json`, but lemond runs as root via LaunchDaemons so `get_cache_dir()` takes the root branch returning `/Library/Application Support/lemonade/.cache/config.json`

## Test plan
- [x] Verified Linux path matches running systemd service
- [x] Traced macOS path through `path_utils.cpp` root code path + LaunchDaemons plist

🤖 Generated with [Claude Code](https://claude.com/claude-code)