### PR TITLE
Fix Ollama image input test

### DIFF
--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -472,10 +472,10 @@ class OllamaTests(ServerTestBase):
         )
         self.assertEqual(response.status_code, 200)
 
-        # 1x1 red PNG (smallest valid PNG)
+        # 10x10 red PNG to avoid backend assertions on tiny images.
         png_b64 = (
-            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4"
-            "2mP8/58BAwAI/AL+hc2rNAAAAABJRU5ErkJggg=="
+            "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFElEQVR42mP4"
+            "z8DwnxjMMKqQvgoBksPHOXvuG4oAAAAASUVORK5CYII="
         )
 
         response = requests.post(


### PR DESCRIPTION
<img width="1093" height="247" alt="image" src="https://github.com/user-attachments/assets/047c88cd-bebe-41e1-bcf8-5f9444b29476" />

Fixes Ollama image input test failure, 1x1 is no longer the smallest valid image input