### PR TITLE
Forward GGML_METAL_NO_RESIDENCY env var to llama-server on macOS

### DIFF
--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -303,6 +303,17 @@ void LlamaCppServer::load(const std::string& model_name,
     }
 #endif
 
+#ifdef __APPLE__
+    // Forward GGML_METAL_NO_RESIDENCY to llama-server if set in the parent
+    // environment. Metal residency sets crash on paravirtualized GPUs (e.g.
+    // GitHub Actions macOS runners with MTLGPUFamilyApple5).
+    const char* no_residency = std::getenv("GGML_METAL_NO_RESIDENCY");
+    if (no_residency) {
+        env_vars.push_back({"GGML_METAL_NO_RESIDENCY", no_residency});
+        LOG(DEBUG, "LlamaCpp") << "Forwarding GGML_METAL_NO_RESIDENCY=" << no_residency << std::endl;
+    }
+#endif
+
     // Start process (inherit output if debug logging enabled, filter health check spam)
     // Keep llama-server output visible at info log level.
     bool inherit_llama_output = (log_level_ == "info") || is_debug();


### PR DESCRIPTION
## Summary
- Explicitly forwards `GGML_METAL_NO_RESIDENCY` from lemond's environment to the llama-server subprocess on macOS
- When lemond is started by launchd (e.g. after `.pkg` install), it does not inherit the shell environment, so the env var never reaches llama-server
- This fixes llama-server b8648 crashing on macOS CI runners (MTLGPUFamilyApple5 paravirtualized GPU) due to unsupported Metal residency sets

## Test plan
- [ ] Verify macOS CI tests pass with `GGML_METAL_NO_RESIDENCY=1` set in workflow
- [ ] Verify no regression on macOS when the env var is not set (normal user machines)