### PR TITLE
fix: use same-origin WebSocket URL when page is served over HTTPS

### DIFF
--- a/src/app/src/renderer/utils/logWebSocketClient.ts
+++ b/src/app/src/renderer/utils/logWebSocketClient.ts
@@ -41,9 +41,12 @@ export async function connectLogStream(
     query.set('api_key', apiKey);
   }
 
+  const isSecure = window.location.protocol === 'https:';
+  const wsProto = isSecure ? 'wss' : 'ws';
+  const wsHost = isSecure ? window.location.host : `${getServerHost()}:${wsPort}`;
   const wsUrl = query.size > 0
-    ? `ws://${getServerHost()}:${wsPort}/logs/stream?${query.toString()}`
-    : `ws://${getServerHost()}:${wsPort}/logs/stream`;
+    ? `${wsProto}://${wsHost}/logs/stream?${query.toString()}`
+    : `${wsProto}://${wsHost}/logs/stream`;
   const socket = new WebSocket(wsUrl);
 
   socket.addEventListener('open', () => {

--- a/src/app/src/renderer/utils/websocketClient.ts
+++ b/src/app/src/renderer/utils/websocketClient.ts
@@ -28,7 +28,10 @@ export class TranscriptionWebSocket {
     if (apiKey) {
       query.set('api_key', apiKey);
     }
-    const wsUrl = `ws://${getServerHost()}:${wsPort}/realtime?${query.toString()}`;
+    const isSecure = window.location.protocol === 'https:';
+    const wsProto = isSecure ? 'wss' : 'ws';
+    const wsHost = isSecure ? window.location.host : `${getServerHost()}:${wsPort}`;
+    const wsUrl = `${wsProto}://${wsHost}/realtime?${query.toString()}`;
 
     console.log('[WebSocket] Connecting to:', wsUrl);
 


### PR DESCRIPTION
## Summary
- When the web UI is served behind an HTTPS reverse proxy, WebSocket connections fail due to mixed content (`https://` page trying to open `ws://`)
- Fix: when on HTTPS, use `wss://` with `window.location.host` (same origin) instead of a separate port, so the connection goes through the same proxy

## Changes
- `src/app/src/renderer/utils/websocketClient.ts` — use same-origin WSS for `/realtime` when on HTTPS
- `src/app/src/renderer/utils/logWebSocketClient.ts` — same fix for `/logs/stream`

## Reverse proxy setup

When serving Lemonade behind HTTPS, a reverse proxy is needed to route WebSocket paths to port 9000 and everything else to the HTTP server. Example Caddyfile:

```
:8888 {
    @ws path /realtime /logs/stream
    reverse_proxy @ws localhost:9000
    reverse_proxy localhost:8000
}
```

Then point your HTTPS proxy (e.g., Tailscale serve, Cloudflare tunnel) at `:8888`.

## Behavior
- **HTTP (direct access):** unchanged — `ws://host:port/path`
- **HTTPS (behind proxy):** `wss://same-origin/path` — works with any reverse proxy that routes WS paths to the WebSocket server

## Test plan
- [x] Verify direct HTTP access still works (no regression)
- [x] Verify HTTPS access via reverse proxy with Caddyfile above
- [x] Verify realtime transcription WebSocket connects over WSS
- [x] Verify log streaming WebSocket connects over WSS