### PR TITLE
fix: fail fast on insufficient disk space instead of retry loop

### DIFF
--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -37,6 +37,7 @@ struct DownloadResult {
     size_t bytes_downloaded = 0;      // Bytes downloaded in this attempt
     size_t total_bytes = 0;           // Total file size (if known)
     bool can_resume = false;          // Whether partial download can be resumed
+    bool disk_full = false;            // True if download failed due to insufficient disk space
 };
 
 // Progress callback returns bool: true = continue, false = cancel download

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2051,7 +2051,9 @@ void ModelManager::download_from_manifest(const json& manifest, std::map<std::st
         for (const auto& file_desc : manifest["files"]) {
             std::string filename = file_desc["name"].get<std::string>();
             size_t file_size = file_desc["size"].get<size_t>();
-            std::string output_path = download_path + "/" + filename;
+            // Per-file download_path for multi-repo models; fall back to top-level
+            std::string file_download_path = file_desc.value("download_path", download_path);
+            std::string output_path = file_download_path + "/" + filename;
             std::string partial_path = output_path + ".partial";
             fs::path output_path_fs = path_from_utf8(output_path);
             fs::path partial_path_fs = path_from_utf8(partial_path);

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -17,6 +17,7 @@
 #include <thread>
 #include <chrono>
 #include <set>
+#include <tuple>
 #include <unordered_set>
 #include <iomanip>
 #include <lemon/utils/aixlog.hpp>
@@ -2045,9 +2046,11 @@ void ModelManager::download_from_manifest(const json& manifest, std::map<std::st
 
     // Pre-flight disk space check: fail fast before downloading anything.
     // Subtract bytes already on disk (completed files + partial downloads)
-    // so resumed downloads aren't falsely rejected.
+    // so resumed downloads aren't falsely rejected. Group by target path first,
+    // then fold paths that share the same space info so shared filesystems are
+    // checked against the combined remaining download size.
     {
-        size_t bytes_already_on_disk = 0;
+        std::map<std::string, size_t> bytes_needed_by_target_path;
         for (const auto& file_desc : manifest["files"]) {
             std::string filename = file_desc["name"].get<std::string>();
             size_t file_size = file_desc["size"].get<size_t>();
@@ -2057,28 +2060,55 @@ void ModelManager::download_from_manifest(const json& manifest, std::map<std::st
             std::string partial_path = output_path + ".partial";
             fs::path output_path_fs = path_from_utf8(output_path);
             fs::path partial_path_fs = path_from_utf8(partial_path);
+            size_t bytes_needed_for_file = file_size;
             if (safe_exists(output_path_fs) && !safe_exists(partial_path_fs)) {
-                bytes_already_on_disk += file_size;
+                bytes_needed_for_file = 0;
             } else if (safe_exists(partial_path_fs)) {
                 // Cap credit to manifest size — partial can't save more than the file costs
                 size_t partial_size = fs::file_size(partial_path_fs);
-                bytes_already_on_disk += (std::min)(partial_size, file_size);
+                size_t bytes_already_on_disk = (std::min)(partial_size, file_size);
+                // Clamp to zero: manifest can contain size=0 entries while partials exist.
+                bytes_needed_for_file = (file_size > bytes_already_on_disk)
+                    ? file_size - bytes_already_on_disk
+                    : 0;
+            }
+
+            if (bytes_needed_for_file > 0) {
+                bytes_needed_by_target_path[file_download_path] += bytes_needed_for_file;
             }
         }
 
-        // Clamp to zero: manifest can contain size=0 entries while partials exist
-        size_t bytes_needed = (total_download_size > bytes_already_on_disk)
-            ? total_download_size - bytes_already_on_disk
-            : 0;
-        std::error_code ec;
-        auto si = fs::space(fs::path(download_path), ec);
-        if (!ec && bytes_needed > si.available) {
+        using SpaceSignature = std::tuple<uintmax_t, uintmax_t, uintmax_t>;
+        std::map<SpaceSignature, std::pair<size_t, std::string>> bytes_needed_by_filesystem;
+        for (const auto& [target_path, bytes_needed] : bytes_needed_by_target_path) {
+            std::error_code ec;
+            auto si = fs::space(path_from_utf8(target_path), ec);
+            if (ec) {
+                continue;
+            }
+
+            auto key = std::make_tuple(si.capacity, si.free, si.available);
+            auto& grouped_entry = bytes_needed_by_filesystem[key];
+            grouped_entry.first += bytes_needed;
+            if (grouped_entry.second.empty()) {
+                grouped_entry.second = target_path;
+            }
+        }
+
+        for (const auto& [space_signature, grouped_entry] : bytes_needed_by_filesystem) {
+            size_t bytes_needed = grouped_entry.first;
+            uintmax_t available = std::get<2>(space_signature);
+            const std::string& target_path = grouped_entry.second;
+            if (bytes_needed <= available) {
+                continue;
+            }
+
             std::ostringstream oss;
             oss << "Insufficient disk space: download requires "
                 << std::fixed << std::setprecision(1)
                 << (bytes_needed / (1024.0 * 1024.0 * 1024.0)) << " GB but only "
-                << (si.available / (1024.0 * 1024.0 * 1024.0)) << " GB is available on "
-                << download_path;
+                << (available / (1024.0 * 1024.0 * 1024.0)) << " GB is available on "
+                << target_path;
             throw std::runtime_error(oss.str());
         }
     }

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2043,15 +2043,33 @@ void ModelManager::download_from_manifest(const json& manifest, std::map<std::st
         total_download_size += file_desc["size"].get<size_t>();
     }
 
-    // Pre-flight disk space check: fail fast before downloading anything
+    // Pre-flight disk space check: fail fast before downloading anything.
+    // Subtract bytes already on disk (completed files + partial downloads)
+    // so resumed downloads aren't falsely rejected.
     {
+        size_t bytes_already_on_disk = 0;
+        for (const auto& file_desc : manifest["files"]) {
+            std::string filename = file_desc["name"].get<std::string>();
+            size_t file_size = file_desc["size"].get<size_t>();
+            std::string output_path = download_path + "/" + filename;
+            std::string partial_path = output_path + ".partial";
+            fs::path output_path_fs = path_from_utf8(output_path);
+            fs::path partial_path_fs = path_from_utf8(partial_path);
+            if (safe_exists(output_path_fs) && !safe_exists(partial_path_fs)) {
+                bytes_already_on_disk += file_size;
+            } else if (safe_exists(partial_path_fs)) {
+                bytes_already_on_disk += fs::file_size(partial_path_fs);
+            }
+        }
+
+        size_t bytes_needed = total_download_size - bytes_already_on_disk;
         std::error_code ec;
         auto si = fs::space(fs::path(download_path), ec);
-        if (!ec && total_download_size > si.available) {
+        if (!ec && bytes_needed > si.available) {
             std::ostringstream oss;
             oss << "Insufficient disk space: download requires "
                 << std::fixed << std::setprecision(1)
-                << (total_download_size / (1024.0 * 1024.0 * 1024.0)) << " GB but only "
+                << (bytes_needed / (1024.0 * 1024.0 * 1024.0)) << " GB but only "
                 << (si.available / (1024.0 * 1024.0 * 1024.0)) << " GB is available on "
                 << download_path;
             throw std::runtime_error(oss.str());

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2058,11 +2058,16 @@ void ModelManager::download_from_manifest(const json& manifest, std::map<std::st
             if (safe_exists(output_path_fs) && !safe_exists(partial_path_fs)) {
                 bytes_already_on_disk += file_size;
             } else if (safe_exists(partial_path_fs)) {
-                bytes_already_on_disk += fs::file_size(partial_path_fs);
+                // Cap credit to manifest size — partial can't save more than the file costs
+                size_t partial_size = fs::file_size(partial_path_fs);
+                bytes_already_on_disk += (std::min)(partial_size, file_size);
             }
         }
 
-        size_t bytes_needed = total_download_size - bytes_already_on_disk;
+        // Clamp to zero: manifest can contain size=0 entries while partials exist
+        size_t bytes_needed = (total_download_size > bytes_already_on_disk)
+            ? total_download_size - bytes_already_on_disk
+            : 0;
         std::error_code ec;
         auto si = fs::space(fs::path(download_path), ec);
         if (!ec && bytes_needed > si.available) {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2043,6 +2043,21 @@ void ModelManager::download_from_manifest(const json& manifest, std::map<std::st
         total_download_size += file_desc["size"].get<size_t>();
     }
 
+    // Pre-flight disk space check: fail fast before downloading anything
+    {
+        std::error_code ec;
+        auto si = fs::space(fs::path(download_path), ec);
+        if (!ec && total_download_size > si.available) {
+            std::ostringstream oss;
+            oss << "Insufficient disk space: download requires "
+                << std::fixed << std::setprecision(1)
+                << (total_download_size / (1024.0 * 1024.0 * 1024.0)) << " GB but only "
+                << (si.available / (1024.0 * 1024.0 * 1024.0)) << " GB is available on "
+                << download_path;
+            throw std::runtime_error(oss.str());
+        }
+    }
+
     for (const auto& file_desc : manifest["files"]) {
         file_index++;
         std::string filename = file_desc["name"].get<std::string>();

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -398,6 +398,7 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
 
     if (res != CURLE_OK) {
         bool retryable = false;
+        bool disk_full = false;
         switch (res) {
             case CURLE_COULDNT_CONNECT:
             case CURLE_COULDNT_RESOLVE_HOST:
@@ -410,6 +411,17 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
             case CURLE_SSL_CONNECT_ERROR:
                 retryable = true;
                 break;
+            case CURLE_WRITE_ERROR: {
+                // CURLE_WRITE_ERROR (23) typically means disk full.
+                // Check available disk space to confirm.
+                std::error_code ec;
+                auto si = fs::space(output_path_fs.parent_path(), ec);
+                if (!ec && si.available < 1024 * 1024) {  // Less than 1 MB free
+                    disk_full = true;
+                }
+                retryable = false;
+                break;
+            }
             default:
                 retryable = false;
         }
@@ -419,9 +431,20 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
             current_file_size = fs::file_size(output_path_fs);
         }
         result.can_resume = retryable && (current_file_size > 0);
+        result.disk_full = disk_full;
 
         std::ostringstream oss;
-        oss << "Download failed: " << result.curl_error << " (CURL code: " << result.curl_code << ")";
+        if (disk_full) {
+            oss << "Disk full: not enough space to complete download";
+            std::error_code ec;
+            auto si = fs::space(output_path_fs.parent_path(), ec);
+            if (!ec) {
+                oss << " (" << std::fixed << std::setprecision(1)
+                    << (si.available / (1024.0 * 1024.0)) << " MB free)";
+            }
+        } else {
+            oss << "Download failed: " << result.curl_error << " (CURL code: " << result.curl_code << ")";
+        }
         if (result.bytes_downloaded > 0) {
             oss << "\n  Downloaded " << (result.bytes_downloaded / (1024.0 * 1024.0)) << " MB before failure";
         }
@@ -579,6 +602,12 @@ DownloadResult HttpClient::download_file(const std::string& url,
         // If cancelled by user, return immediately without retrying
         if (final_result.cancelled) {
             LOG(INFO, "Download") << " Cancelled by user" << std::endl;
+            return final_result;
+        }
+
+        // If disk is full, fail immediately — retrying will just waste bandwidth
+        if (final_result.disk_full) {
+            LOG(ERROR, "HttpClient") << "[Download] " << final_result.error_message << std::endl;
             return final_result;
         }
 

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -2,6 +2,7 @@
 #include <lemon/utils/path_utils.h>
 #include <lemon/utils/aixlog.hpp>
 #include <curl/curl.h>
+#include <iomanip>
 #include <sstream>
 #include <stdexcept>
 #include <iostream>
@@ -35,6 +36,21 @@ struct ProgressData {
     ProgressCallback callback;
     bool cancelled = false;  // Set to true when callback returns false
 };
+
+static fs::path get_disk_space_probe_path(const fs::path& output_path) {
+    fs::path probe_path = output_path.parent_path();
+    if (!probe_path.empty()) {
+        return probe_path;
+    }
+
+    std::error_code ec;
+    fs::path current_path = fs::current_path(ec);
+    if (!ec && !current_path.empty()) {
+        return current_path;
+    }
+
+    return fs::path(".");
+}
 
 // CURL progress callback - returns non-zero to abort transfer
 static int progress_callback(void* clientp, curl_off_t dltotal, curl_off_t dlnow,
@@ -399,6 +415,7 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
     if (res != CURLE_OK) {
         bool retryable = false;
         bool disk_full = false;
+        const fs::path disk_space_probe_path = get_disk_space_probe_path(output_path_fs);
         switch (res) {
             case CURLE_COULDNT_CONNECT:
             case CURLE_COULDNT_RESOLVE_HOST:
@@ -415,7 +432,7 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
                 // CURLE_WRITE_ERROR (23) typically means disk full.
                 // Check available disk space to confirm.
                 std::error_code ec;
-                auto si = fs::space(output_path_fs.parent_path(), ec);
+                auto si = fs::space(disk_space_probe_path, ec);
                 if (!ec && si.available < 1024 * 1024) {  // Less than 1 MB free
                     disk_full = true;
                 }
@@ -437,7 +454,7 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
         if (disk_full) {
             oss << "Disk full: not enough space to complete download";
             std::error_code ec;
-            auto si = fs::space(output_path_fs.parent_path(), ec);
+            auto si = fs::space(disk_space_probe_path, ec);
             if (!ec) {
                 oss << " (" << std::fixed << std::setprecision(1)
                     << (si.available / (1024.0 * 1024.0)) << " MB free)";


### PR DESCRIPTION
## Summary
- Adds a **pre-flight disk space check** before downloading model files, comparing available space against the total download size. Fails immediately with a clear error message (e.g., "download requires 16.8 GB but only 0.0 GB is available") instead of starting the download.
- Detects `CURLE_WRITE_ERROR` (code 23) + low available disk as a **fatal non-retryable condition**, preventing the retry loop from deleting the partial file and re-downloading from scratch repeatedly.  
- Adds a `disk_full` flag to `DownloadResult` to short-circuit the retry loop.

## Problem
When a large model download (e.g., 16.8 GB Gemma 4) fills the disk, curl returns error 23 (`CURLE_WRITE_ERROR`). The existing retry logic treated this as a non-resumable error: it deleted the ~13 GB partial file and retried from zero — hitting the same wall each time in an infinite loop, burning bandwidth and I/O.  In a session today, one host was redownloading a 16GB Gemma4 model at 1Gbps for an hour, as I walked away after the download started, and it just looped .. 2.5min per 16GB a LOT of times .. copied a lemonade config with the wrong `HF_HOME` from another device into lemonade's `conf.d`

## Test plan
- [x] Tested on a machine with insufficient disk space — error returned instantly with clear message
- [x] Verified the error surfaces correctly in both the Download Manager panel and toast notification
- [x] Verify normal downloads still work on machines with sufficient space
- [x] Verify resume behavior is unaffected for network interruptions

🤖 Looked a the diffs; 100% vibed with Claude including deploy and testing using debian package on Debian 13