### PR TITLE
fix: ensure recipe_options.json values are applied at model load time

### DIFF
--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -81,6 +81,9 @@ public:
     // Get downloaded models
     std::map<std::string, ModelInfo> get_downloaded_models();
 
+    // Get saved per-model recipe options from recipe_options.json
+    nlohmann::json get_saved_recipe_options(const std::string& model_name) const;
+
     // Filter models by available backends
     std::map<std::string, ModelInfo> filter_models_by_backend(
         const std::map<std::string, ModelInfo>& models);

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -257,6 +257,13 @@ ModelManager::ModelManager() {
     recipe_options_ = load_optional_json(get_recipe_options_file());
 }
 
+json ModelManager::get_saved_recipe_options(const std::string& model_name) const {
+    if (recipe_options_.contains(model_name) && !recipe_options_[model_name].is_null()) {
+        return recipe_options_[model_name];
+    }
+    return json::object();
+}
+
 std::string ModelManager::get_user_models_file() {
     return get_cache_dir() + "/user_models.json";
 }

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -214,10 +214,18 @@ void Router::load_model(const std::string& model_name,
                        bool do_not_upgrade) {
     RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options());
 
-    // Resolve settings: load overrides take precedence over per-model overrides which take precedence over defaults
-        RecipeOptions effective_options = options.inherit(model_info.recipe_options.inherit(default_opt));
+    // Also look up per-model saved options directly from recipe_options.json
+    // This ensures saved options are applied even if build_cache missed them
+    RecipeOptions saved_opt = model_info.recipe_options;
+    auto saved_json = model_manager_->get_saved_recipe_options(model_name);
+    if (!saved_json.empty()) {
+        saved_opt = RecipeOptions(model_info.recipe, saved_json);
+    }
 
-    LOG(DEBUG, "Router") << "Effective settings: " << effective_options.to_log_string() << std::endl;
+    // Resolve settings: load overrides > per-model saved options > defaults
+    RecipeOptions effective_options = options.inherit(saved_opt.inherit(default_opt));
+
+    LOG(INFO, "Router") << "Loading " << model_name << " with: " << effective_options.to_log_string(true) << std::endl;
 
 
     // LOAD SERIALIZATION STRATEGY (from spec: point #2 in Additional Considerations)


### PR DESCRIPTION
## Summary

Per-model recipe options (e.g. `ctx_size`) saved in `~/.cache/lemonade/recipe_options.json` were not reliably reaching the llama-server subprocess. Models would always launch with the default `ctx_size=4096` even when `recipe_options.json` specified a different value.

## Root Cause

The existing code in `ModelManager::build_cache()` merges recipe options by model name (line 890), but due to cache timing the merged values were sometimes not present in `model_info.recipe_options` when `Router::load_model()` resolved the effective options. This meant the llama-server subprocess was always launched with the code default of `ctx_size=4096`.

## Reproduction

1. Set a custom `ctx_size` in `~/.cache/lemonade/recipe_options.json`:
   ```json
   {"Qwen3.5-35B-A3B-GGUF": {"ctx_size": 16384}}
   ```
2. Start lemond and load the model
3. Check the llama-server subprocess args — `--ctx-size` will show `4096` instead of `16384`

## Fix

Added a direct lookup of `recipe_options.json` in `Router::load_model()` as a safety net. This ensures saved per-model options always take effect regardless of cache state.

### Changes
- **model_manager.h/cpp**: Add `get_saved_recipe_options(model_name)` to expose the raw recipe_options_ map
- **router.cpp**: Look up saved options directly at load time and merge into the options resolution chain

The options resolution order remains: load-time overrides > per-model saved options > global defaults.

## Verification

After this fix, the llama-server subprocess correctly receives `--ctx-size 16384` when set in `recipe_options.json`:

```
[Info] (Router) Loading Qwen3.5-35B-A3B-GGUF with: ctx_size=16384, llamacpp_backend=vulkan, llamacpp_args=(none)
```

## Test plan
- [ ] Set `ctx_size` in `recipe_options.json` for a model, verify it appears in llama-server subprocess args
- [ ] Verify default `ctx_size=4096` still applies when no override is set
- [ ] Verify `llamacpp_args` from recipe_options.json also flows through
- [ ] Verify load-time options (e.g. from API request) still take precedence over saved options

🤖 Generated with [Claude Code](https://claude.com/claude-code)