### PR TITLE
Use vendor directory in /opt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ endif()
 if(APPLE)
     set(CMAKE_IGNORE_PATH "/opt/homebrew/lib" "/opt/homebrew/include")
 endif()
-# Set default install prefix to /opt on Linux if not specified
+# Set default install prefix to /opt/lemonade on Linux if not specified
 if(UNIX AND NOT APPLE AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(CMAKE_INSTALL_PREFIX "/opt" CACHE PATH "Install prefix" FORCE)
+    set(CMAKE_INSTALL_PREFIX "/opt/lemonade" CACHE PATH "Install prefix" FORCE)
 endif()
 
 # Include GNUInstallDirs for standard installation directories

--- a/docs/dev-getting-started.md
+++ b/docs/dev-getting-started.md
@@ -136,7 +136,7 @@ This will:
 The tray app searches for the Electron app in these locations:
 - **Windows installed**: `../app/lemonade-app.exe` (relative to bin/ directory)
 - **Windows development**: `../app/win-unpacked/lemonade-app.exe` (from build/Release/)
-- **Linux installed**: `/opt/share/lemonade-server/app/lemonade-app`
+- **Linux installed**: `/opt/lemonade/share/lemonade-server/app/lemonade-app`
 - **Linux development**: `../app/linux-unpacked/lemonade-app` (from build/)
 
 If not found, the "Open app" menu option is hidden but everything else works.
@@ -190,7 +190,7 @@ chmod +x build/app-appimage/lemonade-app-*.AppImage
 - Clean .deb package with only runtime files (no development headers)
 - Proper graceful shutdown - all child processes cleaned up correctly
 - File locations:
-  - Installed binaries: `/opt/bin`
+  - Installed binaries: `/opt/lemonade/bin`
   - Downloaded backends (llama-server, ryzenai-server): `~/.cache/lemonade/bin/`
   - Model downloads: `~/.cache/huggingface/` (follows HF conventions)
   - Runtime files (lock, log): `$XDG_RUNTIME_DIR/lemonade/` when set and writable, otherwise `/tmp/`
@@ -250,13 +250,13 @@ cpack
 **Package Output:**
 
 Creates `lemonade-server_<VERSION>_amd64.deb` (e.g., `lemonade-server_9.0.3_amd64.deb`) which:
-- Installs to `/opt/bin/` (executables)
-- Installs resources to `/opt/share/lemonade-server/`
-- Creates desktop entry in `/opt/share/applications/`
+- Installs to `/opt/lemonade/bin/` (executables)
+- Installs resources to `/opt/lemonade/share/lemonade-server/`
+- Creates desktop entry in `/opt/lemonade/share/applications/`
 - Declares dependencies: `libcurl4`, `libssl3`, `libz1`, `unzip`, `fonts-katex`
 - Recommends: `ffmpeg` for whisper.cpp audio resampling and/or transcoding, plus a Chromium-compatible browser for `lemonade-web-app`
 - Package size: ~2.2 MB (clean, runtime-only package)
-- Includes postinst script that creates writable `/opt/share/lemonade-server/llama/` directory
+- Includes postinst script that creates writable `/opt/lemonade/share/lemonade-server/llama/` directory
 
 **Installation:**
 

--- a/src/cpp/postinst-rpm
+++ b/src/cpp/postinst-rpm
@@ -6,11 +6,11 @@ if ! getent group lemonade > /dev/null 2>&1; then
 fi
 
 if ! getent passwd lemonade > /dev/null 2>&1; then
-    useradd -m -r -g lemonade -d /opt/var/lib/lemonade -s /usr/sbin/nologin lemonade > /dev/null 2>&1 || true
+    useradd -m -r -g lemonade -d /opt/lemonade/var/lib/lemonade -s /usr/sbin/nologin lemonade > /dev/null 2>&1 || true
 fi
 
-mkdir -p /opt/var/lib/lemonade
-chown lemonade:lemonade /opt/var/lib/lemonade > /dev/null 2>&1 || true
+mkdir -p /opt/lemonade/var/lib/lemonade
+chown lemonade:lemonade /opt/lemonade/var/lib/lemonade > /dev/null 2>&1 || true
 
 usermod -a -G render lemonade > /dev/null 2>&1 || true
 

--- a/src/cpp/server/utils/path_utils.cpp
+++ b/src/cpp/server/utils/path_utils.cpp
@@ -148,7 +148,7 @@ std::string get_resource_path(const std::string& relative_path) {
     std::vector<std::string> install_prefixes = {
         "/Library/Application Support/Lemonade",  // macOS system install location
         "/usr/local/share/lemonade-server",
-        "/opt/share/lemonade-server",
+        "/opt/lemonade/share/lemonade-server",
         "/usr/share/lemonade-server"
     };
 


### PR DESCRIPTION
According to Linux packaging conventions, each item in /opt should be a self-contained folder. This allows packages to co-exist without stepping on each other.

Items to be considered for a different PR:
TODO just use the regular FHS directories instead of /opt
TODO use systemd-sysusers and systemd-tmpfiles instead of postinst-rpm
