### PR TITLE
Fix flakey Ollama vision test

### DIFF
--- a/src/cpp/server/ollama_api.cpp
+++ b/src/cpp/server/ollama_api.cpp
@@ -86,6 +86,19 @@ static std::string extract_quantization_level(const std::string& checkpoint) {
 }
 
 // ============================================================================
+// Check if a router/backend response is an error and send HTTP 500 if so.
+// Returns true if an error was handled (caller should return immediately).
+// ============================================================================
+static bool send_backend_error(const json& response, httplib::Response& res) {
+    if (!response.contains("error")) return false;
+    LOG(ERROR, "OllamaApi") << "Backend returned error: " << response["error"].dump() << std::endl;
+    res.status = 500;
+    json error = {{"error", response["error"].value("message", "backend error")}};
+    res.set_content(error.dump(), "application/json");
+    return true;
+}
+
+// ============================================================================
 // Ollama → OpenAI option name mapping (ollama_key → openai_key)
 // Options where both names are the same use identical strings.
 // ============================================================================
@@ -635,6 +648,9 @@ void OllamaApi::handle_chat(const httplib::Request& req, httplib::Response& res)
             LOG(INFO, "OllamaApi") << "POST /api/chat - Non-streaming (model: " << model << ")" << std::endl;
 
             auto openai_response = router_->chat_completion(openai_req);
+
+            if (send_backend_error(openai_response, res)) return;
+
             auto ollama_response = convert_openai_chat_to_ollama(openai_response, model);
             res.set_content(ollama_response.dump(), "application/json");
         }
@@ -761,6 +777,8 @@ void OllamaApi::handle_generate(const httplib::Request& req, httplib::Response& 
 
             auto openai_response = router_->completion(openai_req);
 
+            if (send_backend_error(openai_response, res)) return;
+
             // Convert to Ollama generate format
             json ollama_res;
             ollama_res["model"] = model;
@@ -865,6 +883,8 @@ void OllamaApi::handle_generate_image(const json& request_json, httplib::Respons
         }
 
         auto openai_response = router_->image_generations(openai_req);
+
+        if (send_backend_error(openai_response, res)) return;
 
         // Convert OpenAI response to Ollama format
         json ollama_res;
@@ -1129,6 +1149,8 @@ void OllamaApi::handle_embed(const httplib::Request& req, httplib::Response& res
 
         auto openai_response = router_->embeddings(openai_req);
 
+        if (send_backend_error(openai_response, res)) return;
+
         // Convert OpenAI response to Ollama embed format
         json ollama_res;
         ollama_res["model"] = model;
@@ -1195,6 +1217,8 @@ void OllamaApi::handle_embeddings(const httplib::Request& req, httplib::Response
         }
 
         auto openai_response = router_->embeddings(openai_req);
+
+        if (send_backend_error(openai_response, res)) return;
 
         // Convert to legacy Ollama format (single embedding)
         json ollama_res;

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -131,7 +131,7 @@ TEST_AUDIO_URL = (
 )
 
 # Vision model test configuration
-VISION_MODEL = "Gemma-3-4b-it-GGUF"
+VISION_MODEL = "Qwen3.5-0.8B-GGUF"
 
 # Stable Diffusion test configuration
 SD_MODEL = "SD-Turbo"


### PR DESCRIPTION
Closes #1500 

Attempting to stop the Ollama Vision test from frequently flaking in CI, or at least provide us more actionable info when it does flake.

Making the test model much smaller can only be good for robot health, anyways.

## Summary
- **Switch vision test model** from `Gemma-3-4b-it-GGUF` (3.6 GB) to `Qwen3.5-0.8B-GGUF` (0.56 GB). The 4B model intermittently exceeded the 300s internal curl timeout on CPU-only CI runners, causing the test to fail.
- **Add error handling to Ollama API handlers**. When backend errors (e.g. timeouts) occurred, the Ollama translation layer silently converted them into malformed HTTP 200 responses with missing fields (no `message` in chat responses). Now all non-streaming handlers (`handle_chat`, `handle_generate`, `handle_generate_image`, `handle_embed`, `handle_embeddings`) check for error responses and return proper HTTP 500 — matching the pattern already used in `server.cpp`.

## Root cause
`test_021_chat_with_image_input` loads a 4B vision model on CPU-only GitHub Actions runners. Inference sometimes takes >300s, hitting the internal curl timeout. The resulting `NetworkException` error was returned as JSON `{"error": {...}}` by the router, but `handle_chat` passed it directly to `convert_openai_chat_to_ollama` without checking. That function found no `choices` key, so it produced `{"model": "...", "created_at": "...", "done": true}` — a valid-looking HTTP 200 response with no `message` field, causing the assertion failure.