### PR TITLE
Fix sd-cpp reporting GPU backends as CPU

### DIFF
--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -101,7 +101,7 @@ inline DeviceType get_device_type_from_recipe(const std::string& recipe) {
     } else if (recipe == "whispercpp") {
         return DEVICE_CPU;  // Whisper.cpp runs on CPU (with optional GPU acceleration)
     } else if (recipe == "sd-cpp") {
-        return DEVICE_CPU;  // stable-diffusion.cpp uses CPU (AVX2) by default
+        return DEVICE_CPU;  // Default; SDServer::load() overrides to DEVICE_GPU for rocm/vulkan backends
     } else if (recipe == "kokoro") {
         return DEVICE_CPU;  // Kokoros runs on CPU
     } else if (recipe == "experience") {

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -88,6 +88,14 @@ void SDServer::load(const std::string& model_name,
 
     RuntimeConfig::validate_backend_choice("sdcpp", backend);
 
+    // Update device type based on the actual backend selected.
+    // get_device_type_from_recipe() defaults sd-cpp to CPU, but rocm/vulkan are GPU backends.
+    if (backend == "rocm" || backend == "vulkan") {
+        device_type_ = DEVICE_GPU;
+    } else {
+        device_type_ = DEVICE_CPU;
+    }
+
     // Install sd-server if needed
     backend_manager_->install_backend(SPEC.recipe, backend);
 


### PR DESCRIPTION
SDServer::load() now updates device_type_ to DEVICE_GPU when the rocm or vulkan backend is selected. Previously, get_device_type_from_recipe() hardcoded sd-cpp as DEVICE_CPU regardless of the actual backend in use, causing rocm/vulkan image generation requests to be recorded under CPU in the usage stats.