### PR TITLE
Fix llamacpp and whispercpp reporting incorrect device types in stats

### DIFF
--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -93,13 +93,13 @@ inline ModelType get_model_type_from_labels(const std::vector<std::string>& labe
 // Determine device type from recipe
 inline DeviceType get_device_type_from_recipe(const std::string& recipe) {
     if (recipe == "llamacpp") {
-        return DEVICE_GPU;
+        return DEVICE_GPU;  // Default; LlamaCppServer::load() overrides to DEVICE_CPU for the cpu backend
     } else if (recipe == "ryzenai-llm") {
         return DEVICE_NPU;
     } else if (recipe == "flm") {
         return DEVICE_NPU;
     } else if (recipe == "whispercpp") {
-        return DEVICE_CPU;  // Whisper.cpp runs on CPU (with optional GPU acceleration)
+        return DEVICE_CPU;  // Default; WhisperServer::load() overrides to DEVICE_NPU/DEVICE_GPU for npu/vulkan backends
     } else if (recipe == "sd-cpp") {
         return DEVICE_CPU;  // Default; SDServer::load() overrides to DEVICE_GPU for rocm/vulkan backends
     } else if (recipe == "kokoro") {

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -166,6 +166,10 @@ void LlamaCppServer::load(const std::string& model_name,
 
     bool use_gpu = (llamacpp_backend != "cpu");
 
+    // Update device type based on the actual backend selected.
+    // get_device_type_from_recipe() defaults llamacpp to GPU, but the cpu backend runs on CPU.
+    device_type_ = use_gpu ? DEVICE_GPU : DEVICE_CPU;
+
     // Install llama-server if needed (use per-model backend)
     backend_manager_->install_backend(SPEC.recipe, llamacpp_backend);
 

--- a/src/cpp/server/backends/whisper_server.cpp
+++ b/src/cpp/server/backends/whisper_server.cpp
@@ -180,6 +180,16 @@ void WhisperServer::load(const std::string& model_name,
 
     RuntimeConfig::validate_backend_choice("whispercpp", whispercpp_backend);
 
+    // Update device type based on the actual backend selected.
+    // get_device_type_from_recipe() defaults whispercpp to CPU, but npu/vulkan use different devices.
+    if (whispercpp_backend == "npu") {
+        device_type_ = DEVICE_NPU;
+    } else if (whispercpp_backend == "vulkan") {
+        device_type_ = DEVICE_GPU;
+    } else {
+        device_type_ = DEVICE_CPU;
+    }
+
     backend_manager_->install_backend(SPEC.recipe, whispercpp_backend);
 
     std::string model_path = model_info.resolved_path();


### PR DESCRIPTION
llamacpp was hardcoded to DEVICE_GPU even when using the cpu backend. whispercpp was hardcoded to DEVICE_CPU even when using the npu or vulkan backend.

Both now override device_type_ in load() based on the actual backend selected, matching the pattern established for sd-cpp in #1553.