### PR TITLE
Initial Lemonade RPC Support

### DIFF
--- a/docs/rpc-support.md
+++ b/docs/rpc-support.md
@@ -1,0 +1,111 @@
+# llama.cpp RPC Client/Server Support
+
+## Context
+
+llama.cpp supports distributed inference via RPC — an `rpc-server` process offloads tensor computation on a remote machine's GPU, and the main `llama-server` connects as an RPC client via `--rpc host1:port,host2:port`. This lets users split model inference across multiple machines.
+
+Lemonade now integrates RPC with two features:
+1. **`--rpc` per-model recipe option** — pass RPC server addresses when loading a llamacpp model
+2. **`lemonade rpc-server` CLI subcommand** — start the `rpc-server` binary that ships in the llama.cpp release archive
+
+## Changes
+
+### 1. Add `--rpc` recipe option (RPC client side)
+
+**`src/cpp/server/recipe_options.cpp`:**
+- Added `{"rpc", ""}` to `DEFAULTS`
+- Added `{"rpc", "--rpc"}` to `OPTION_TO_CLI_FLAG`
+- Added `"rpc"` to the llamacpp key list in `get_keys_for_recipe()`
+- Added `{"--rpc", {{"option_name", "rpc"}, {"type_name", "SERVERS"}, {"envname", "LEMONADE_RPC"}, {"help", "RPC server addresses for distributed inference (host:port,host:port)"}}}` to `CLI_OPTIONS`
+
+**`src/cpp/server/backends/llamacpp_server.cpp`:**
+- In `LlamaCppServer::load()`, reads the rpc option: `std::string rpc = options.get_option("rpc");`
+- Before the custom args validation block, adds the `--rpc` arg if non-empty:
+  ```cpp
+  if (!rpc.empty()) {
+      push_arg(args, reserved_flags, "--rpc", rpc);
+  }
+  ```
+
+### 2. Add `lemonade rpc-server` subcommand (RPC server side)
+
+**`src/cpp/cli/main.cpp`:**
+
+Added to `CliConfig`:
+```cpp
+std::string rpc_host = "0.0.0.0";
+int rpc_port = 50052;
+std::string rpc_backend;
+int rpc_mem = 0;
+```
+
+Registered subcommand (in "Server" group):
+```cpp
+CLI::App* rpc_server_cmd = app.add_subcommand("rpc-server",
+    "Start a llama.cpp RPC server for distributed inference")->group("Server");
+rpc_server_cmd->add_option("--rpc-host", config.rpc_host, "Host to bind to")->default_val("0.0.0.0");
+rpc_server_cmd->add_option("--rpc-port", config.rpc_port, "RPC server port")->default_val(50052);
+rpc_server_cmd->add_option("--backend", config.rpc_backend,
+    "llamacpp backend (vulkan/rocm/metal/cpu)")->type_name("BACKEND");
+rpc_server_cmd->add_option("--mem", config.rpc_mem, "Memory to allocate in MB")->type_name("MB");
+```
+
+> Note: `--rpc-host` and `--rpc-port` are used instead of `--host`/`--port` to avoid
+> conflicting with the global `--host`/`--port` options (which target the lemonade server).
+
+Added handler `handle_rpc_server_command`:
+1. If `--backend` not specified, defaults to `"vulkan"` on Linux/Windows, `"metal"` on macOS
+2. Calls `client.install_backend("llamacpp", backend)` to ensure the backend is installed
+3. Finds the `rpc-server` binary by searching the llamacpp install directory
+   (`get_downloaded_bin_dir() / "llamacpp" / backend`) using `std::filesystem::recursive_directory_iterator`
+4. Builds args: `--host <host> --port <port>` and optionally `--mem <mem>`
+5. Starts via `ProcessManager::start_process(exe, args, "", true, false, {})` with inherited output
+6. Waits for exit via `ProcessManager::wait_for_exit(handle, -1)`
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/cpp/server/recipe_options.cpp` | Add `rpc` option to defaults, CLI flags, keys, and CLI_OPTIONS |
+| `src/cpp/server/backends/llamacpp_server.cpp` | Pass `--rpc` arg to llama-server subprocess when option is set |
+| `src/cpp/cli/main.cpp` | Add `rpc-server` subcommand with handler |
+
+## Usage
+
+### Distributed inference (RPC client)
+
+On the machine running lemonade, pass the RPC server addresses when loading a model:
+
+```bash
+# Via CLI
+lemonade load my-model --rpc 192.168.1.100:50052
+
+# Multiple RPC servers
+lemonade load my-model --rpc 192.168.1.100:50052,192.168.1.101:50052
+
+# Via environment variable
+export LEMONADE_RPC=192.168.1.100:50052
+lemonade load my-model
+```
+
+### Starting an RPC server
+
+On the remote machine(s), start the RPC server:
+
+```bash
+# Default: binds to 0.0.0.0:50052 with vulkan backend
+lemonade rpc-server
+
+# Custom port and backend
+lemonade rpc-server --rpc-port 50053 --backend rocm
+
+# Limit memory usage
+lemonade rpc-server --mem 8192
+```
+
+## Verification
+
+1. **Build**: `cmake --build --preset default`
+2. **Test `--rpc` option**: `lemonade load <model> --rpc 192.168.1.100:50052` — check debug logs show `--rpc` in llama-server args
+3. **Test `rpc-server`**: `lemonade rpc-server --rpc-port 50053` — should install backend, find binary, start rpc-server
+4. **Regression tests**: `python test/server_cli.py` and `python test/server_endpoints.py`

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -6,6 +6,8 @@
 #include <lemon_cli/agent_launcher.h>
 #include <lemon/utils/process_manager.h>
 #include <lemon/utils/path_utils.h>
+#include <lemon/utils/http_client.h>
+#include <lemon/utils/json_utils.h>
 #include <lemon/utils/network_beacon.h>
 #include <lemon/utils/custom_args.h>
 #include <CLI/CLI.hpp>
@@ -1010,10 +1012,161 @@ static bool ensure_local_server_running(const CliConfig& config, const std::stri
     return false;
 }
 
-static int handle_rpc_server_command(lemonade::LemonadeClient& client, const CliConfig& config) {
-    if (!ensure_local_server_running(config, config.api_key)) {
+// Install llamacpp backend locally for rpc-server (no server API needed).
+// Returns 0 on success, non-zero on failure.
+static int install_llamacpp_locally(const std::string& backend) {
+    namespace fs = std::filesystem;
+
+    // Read version from backend_versions.json
+    std::string config_path = lemon::utils::get_resource_path("resources/backend_versions.json");
+    auto config = lemon::utils::JsonUtils::load_from_file(config_path);
+
+    if (!config.contains("llamacpp") || !config["llamacpp"].contains(backend)) {
+        std::cerr << "Error: backend_versions.json missing version for llamacpp:" << backend << std::endl;
         return 1;
     }
+    std::string version = config["llamacpp"][backend].get<std::string>();
+
+    std::string install_dir = (fs::path(lemon::utils::get_downloaded_bin_dir()) / "llamacpp" / backend).string();
+
+    // Check if already installed with correct version
+    std::string version_file = (fs::path(install_dir) / "version.txt").string();
+    if (fs::exists(version_file)) {
+        std::ifstream vf(version_file);
+        std::string installed_version;
+        std::getline(vf, installed_version);
+        if (installed_version == version) {
+            // Already up to date
+            return 0;
+        }
+        std::cout << "Upgrading llamacpp:" << backend << " from " << installed_version << " to " << version << std::endl;
+        fs::remove_all(install_dir);
+    }
+
+    // Determine repo and filename
+    std::string repo;
+    std::string filename;
+    bool is_tarball = false;
+
+    if (backend == "rocm") {
+        repo = "lemonade-sdk/llamacpp-rocm";
+        // Detect ROCm GPU architecture from KFD topology
+        std::string rocm_arch;
+#ifdef __linux__
+        // Read gfx_target_version from KFD topology nodes
+        for (int node = 0; node < 16; ++node) {
+            std::string props_path = "/sys/class/kfd/kfd/topology/nodes/" +
+                                     std::to_string(node) + "/properties";
+            std::ifstream props(props_path);
+            if (!props.is_open()) break;
+            std::string line;
+            while (std::getline(props, line)) {
+                if (line.find("gfx_target_version") == 0) {
+                    std::string val = line.substr(line.find_last_of(' ') + 1);
+                    // Skip CPUs (gfx_target_version 0)
+                    if (!val.empty() && val != "0") {
+                        // Convert e.g. "110501" to "gfx1151"
+                        // Format: MMNNRR where MM=major, NN=minor, RR=revision
+                        if (val.length() >= 4) {
+                            std::string major = val.substr(0, 2);
+                            int minor_int = std::stoi(val.substr(2, 2));
+                            int rev_int = val.length() >= 6 ? std::stoi(val.substr(4, 2)) : 0;
+                            rocm_arch = "gfx" + major + std::to_string(minor_int) + std::to_string(rev_int);
+                        }
+                        break;
+                    }
+                }
+            }
+            if (!rocm_arch.empty()) break;
+        }
+#endif
+        if (rocm_arch.empty()) {
+            std::cerr << "Error: Could not detect ROCm GPU architecture" << std::endl;
+            return 1;
+        }
+        std::cout << "Detected ROCm arch: " << rocm_arch << std::endl;
+#ifdef _WIN32
+        filename = "llama-" + version + "-windows-rocm-" + rocm_arch + "-x64.zip";
+#elif defined(__linux__)
+        filename = "llama-" + version + "-ubuntu-rocm-" + rocm_arch + "-x64.zip";
+#endif
+    } else if (backend == "metal") {
+        repo = "ggml-org/llama.cpp";
+#ifdef __APPLE__
+        filename = "llama-" + version + "-bin-macos-arm64.tar.gz";
+        is_tarball = true;
+#else
+        std::cerr << "Error: Metal backend only supported on macOS" << std::endl;
+        return 1;
+#endif
+    } else if (backend == "cpu") {
+        repo = "ggml-org/llama.cpp";
+#ifdef _WIN32
+        filename = "llama-" + version + "-bin-win-cpu-x64.zip";
+#elif defined(__linux__)
+        filename = "llama-" + version + "-bin-ubuntu-x64.tar.gz";
+        is_tarball = true;
+#else
+        std::cerr << "Error: CPU backend not supported on this platform" << std::endl;
+        return 1;
+#endif
+    } else {  // vulkan
+        repo = "ggml-org/llama.cpp";
+#ifdef _WIN32
+        filename = "llama-" + version + "-bin-win-vulkan-x64.zip";
+#elif defined(__linux__)
+        filename = "llama-" + version + "-bin-ubuntu-vulkan-x64.tar.gz";
+        is_tarball = true;
+#else
+        std::cerr << "Error: Vulkan backend not supported on this platform" << std::endl;
+        return 1;
+#endif
+    }
+
+    std::string url = "https://github.com/" + repo + "/releases/download/" + version + "/" + filename;
+
+    // Download to temp directory
+    fs::path tmp_dir = fs::temp_directory_path();
+    std::string archive_name = "llamacpp_" + backend + "_" + version + (is_tarball ? ".tar.gz" : ".zip");
+    std::string archive_path = (tmp_dir / archive_name).string();
+
+    std::cout << "Downloading llamacpp:" << backend << " " << version << "..." << std::endl;
+
+    auto progress_cb = lemon::utils::create_throttled_progress_callback();
+    auto result = lemon::utils::HttpClient::download_file(url, archive_path, progress_cb);
+    if (!result.success) {
+        std::cerr << "Error: Download failed: " << result.error_message << std::endl;
+        return 1;
+    }
+
+    // Extract
+    fs::create_directories(install_dir);
+    std::string extract_cmd;
+    if (is_tarball) {
+        extract_cmd = "tar -xzf \"" + archive_path + "\" -C \"" + install_dir + "\" --strip-components=1 --no-same-owner";
+    } else {
+        extract_cmd = "unzip -o -q \"" + archive_path + "\" -d \"" + install_dir + "\"";
+    }
+
+    int extract_result = system(extract_cmd.c_str());
+    fs::remove(archive_path);
+
+    if (extract_result != 0) {
+        std::cerr << "Error: Extraction failed" << std::endl;
+        fs::remove_all(install_dir);
+        return 1;
+    }
+
+    // Save version
+    std::ofstream vf(version_file);
+    vf << version;
+
+    std::cout << "Installed llamacpp:" << backend << " " << version << std::endl;
+    return 0;
+}
+
+static int handle_rpc_server_command(lemonade::LemonadeClient& client, const CliConfig& config) {
+    (void)client; // Server API not needed for local install
 
     std::string backend = config.rpc_backend;
 
@@ -1026,11 +1179,10 @@ static int handle_rpc_server_command(lemonade::LemonadeClient& client, const Cli
 #endif
     }
 
-    // Ensure the llamacpp backend is installed
-    std::cout << "Ensuring llamacpp:" << backend << " backend is installed..." << std::endl;
-    int install_result = client.install_backend("llamacpp", backend);
+    // Install the llamacpp backend locally (not via server API)
+    std::cout << "Ensuring llamacpp:" << backend << " backend is installed locally..." << std::endl;
+    int install_result = install_llamacpp_locally(backend);
     if (install_result != 0) {
-        std::cerr << "Error: Failed to install llamacpp:" << backend << " backend" << std::endl;
         return install_result;
     }
 
@@ -1077,11 +1229,24 @@ static int handle_rpc_server_command(lemonade::LemonadeClient& client, const Cli
         args.push_back(std::to_string(config.rpc_mem));
     }
 
+    // Set LD_LIBRARY_PATH to the install directory so the rpc-server can find
+    // its shared libraries (e.g. libggml.so). Some builds (notably ROCm) have
+    // a hardcoded RUNPATH from the CI build environment instead of $ORIGIN.
+    std::vector<std::pair<std::string, std::string>> env_vars;
+#ifndef _WIN32
+    std::string lib_path = install_dir;
+    const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
+    if (existing_ld_path && existing_ld_path[0] != '\0') {
+        lib_path = lib_path + ":" + std::string(existing_ld_path);
+    }
+    env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
+#endif
+
     // Start rpc-server with inherited output
     lemon::utils::ProcessHandle handle;
     try {
         handle = lemon::utils::ProcessManager::start_process(
-            rpc_exe, args, "", true, false, {});
+            rpc_exe, args, "", true, false, env_vars);
     } catch (const std::exception& e) {
         std::cerr << "Error: Failed to start rpc-server: " << e.what() << std::endl;
         return 1;

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -15,6 +15,7 @@
 #include <nlohmann/json.hpp>
 #include <algorithm>
 #include <chrono>
+#include <filesystem>
 #include <thread>
 #include <unordered_set>
 #include <functional>
@@ -29,6 +30,8 @@
 #else
     #include <arpa/inet.h>
     #include <netinet/in.h>
+    #include <signal.h>
+    #include <sys/stat.h>
     #include <sys/socket.h>
     #include <sys/wait.h>
     #include <fcntl.h>
@@ -51,6 +54,9 @@ static const std::vector<std::string> SUPPORTED_AGENTS = {
     "claude",
     "codex"
 };
+
+static bool try_live_check(const std::string& host, int port, const std::string& api_key,
+                           int timeout_ms = 500);
 
 static bool prompt_agent_selection(std::string& agent_out) {
     std::cout << "Select an agent to launch:" << std::endl;
@@ -110,6 +116,10 @@ struct CliConfig {
     bool codex_use_user_config = false;
     std::string codex_model_provider = "lemonade";
     std::string agent_args;
+    std::string rpc_host = "0.0.0.0";
+    int rpc_port = 50052;
+    std::string rpc_backend;
+    int rpc_mem = 0;
 };
 
 // Open a URL via the OS without invoking a shell (avoids shell injection).
@@ -433,7 +443,7 @@ static int handle_launch_command(lemonade::LemonadeClient& client, CliConfig& co
 
 // Attempt a quick liveness check against the given host:port
 static bool try_live_check(const std::string& host, int port, const std::string& api_key,
-                           int timeout_ms = 500) {
+                           int timeout_ms) {
     try {
         lemonade::LemonadeClient client(host, port, api_key);
         client.make_request("/live", "GET", "", "", timeout_ms, timeout_ms);
@@ -814,6 +824,272 @@ static int handle_scan_command(const CliConfig& config) {
     return 0;
 }
 
+static bool is_local_server_host(const std::string& host) {
+    return host.empty() || host == "127.0.0.1" || host == "localhost" || host == "0.0.0.0";
+}
+
+static std::string find_local_server_executable() {
+    namespace fs = std::filesystem;
+
+    fs::path exe_dir = lemon::utils::get_executable_dir();
+    std::vector<fs::path> candidates;
+
+#ifdef _WIN32
+    candidates.push_back(exe_dir / "LemonadeServer.exe");
+    candidates.push_back(exe_dir / "lemond.exe");
+#else
+    candidates.push_back(exe_dir / "lemond");
+#endif
+
+    for (const auto& candidate : candidates) {
+        if (fs::exists(candidate) && fs::is_regular_file(candidate)) {
+            return candidate.string();
+        }
+    }
+
+#ifdef _WIN32
+    return lemon::utils::find_executable_in_path("LemonadeServer.exe");
+#else
+    return lemon::utils::find_executable_in_path("lemond");
+#endif
+}
+
+#ifdef _WIN32
+static std::string escape_windows_arg(const std::string& arg) {
+    if (arg.find_first_of(" \t\"") == std::string::npos) {
+        return arg;
+    }
+
+    std::string escaped = "\"";
+    int backslashes = 0;
+    for (char c : arg) {
+        if (c == '\\') {
+            backslashes++;
+        } else if (c == '"') {
+            escaped.append(backslashes * 2 + 1, '\\');
+            escaped.push_back('"');
+            backslashes = 0;
+        } else {
+            escaped.append(backslashes, '\\');
+            escaped.push_back(c);
+            backslashes = 0;
+        }
+    }
+    escaped.append(backslashes * 2, '\\');
+    escaped.push_back('"');
+    return escaped;
+}
+#endif
+
+static bool start_detached_local_server(const CliConfig& config, std::string& error_message) {
+    std::string server_executable = find_local_server_executable();
+    if (server_executable.empty()) {
+        error_message = "No local server executable found. Start lemond manually or install/build the server binary first.";
+        return false;
+    }
+
+    std::vector<std::string> args;
+    args.push_back(lemon::utils::get_cache_dir());
+    args.push_back("--host");
+    args.push_back(config.host);
+    args.push_back("--port");
+    args.push_back(std::to_string(config.port));
+
+#ifdef _WIN32
+    std::string cmdline = escape_windows_arg(server_executable);
+    for (const auto& arg : args) {
+        cmdline += " " + escape_windows_arg(arg);
+    }
+
+    STARTUPINFOA si;
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    ZeroMemory(&pi, sizeof(pi));
+
+    DWORD creation_flags = CREATE_NEW_PROCESS_GROUP;
+    if (server_executable.find("LemonadeServer.exe") == std::string::npos) {
+        creation_flags |= CREATE_NO_WINDOW;
+    }
+
+    BOOL success = CreateProcessA(
+        server_executable.c_str(),
+        cmdline.data(),
+        nullptr,
+        nullptr,
+        FALSE,
+        creation_flags,
+        nullptr,
+        nullptr,
+        &si,
+        &pi
+    );
+
+    if (!success) {
+        DWORD win_error = GetLastError();
+        error_message = "Failed to start local server executable '" + server_executable +
+                        "' (error code " + std::to_string(win_error) + ")";
+        return false;
+    }
+
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+    return true;
+#else
+    pid_t pid = fork();
+    if (pid < 0) {
+        error_message = "Failed to fork while starting local server";
+        return false;
+    }
+
+    if (pid == 0) {
+        setsid();
+
+        int dev_null = open("/dev/null", O_RDWR);
+        if (dev_null >= 0) {
+            dup2(dev_null, STDIN_FILENO);
+            dup2(dev_null, STDOUT_FILENO);
+            dup2(dev_null, STDERR_FILENO);
+            if (dev_null > STDERR_FILENO) {
+                close(dev_null);
+            }
+        }
+
+        std::vector<char*> argv_ptrs;
+        argv_ptrs.push_back(const_cast<char*>(server_executable.c_str()));
+        for (const auto& arg : args) {
+            argv_ptrs.push_back(const_cast<char*>(arg.c_str()));
+        }
+        argv_ptrs.push_back(nullptr);
+
+        execvp(server_executable.c_str(), argv_ptrs.data());
+        _exit(1);
+    }
+
+    int status = 0;
+    pid_t wait_result = waitpid(pid, &status, WNOHANG);
+    if (wait_result == pid) {
+        error_message = "Local server exited immediately while starting";
+        return false;
+    }
+
+    return true;
+#endif
+}
+
+static bool ensure_local_server_running(const CliConfig& config, const std::string& api_key) {
+    if (try_live_check(config.host, config.port, api_key, 500)) {
+        return true;
+    }
+
+    if (!is_local_server_host(config.host)) {
+        std::cerr << "Error: No Lemonade server is reachable at " << config.host << ":" << config.port
+                  << ", and rpc-server only auto-starts a local server." << std::endl;
+        return false;
+    }
+
+    std::cout << "No local Lemonade server detected on " << config.host << ":" << config.port
+              << ". Starting one..." << std::endl;
+
+    std::string start_error;
+    if (!start_detached_local_server(config, start_error)) {
+        std::cerr << "Error: " << start_error << std::endl;
+        return false;
+    }
+
+    for (int attempt = 0; attempt < 150; ++attempt) {
+        if (try_live_check(config.host, config.port, api_key, 200)) {
+            std::cout << "Local Lemonade server is ready." << std::endl;
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    std::cerr << "Error: Local Lemonade server did not become ready on "
+              << config.host << ":" << config.port << " within 15 seconds." << std::endl;
+    return false;
+}
+
+static int handle_rpc_server_command(lemonade::LemonadeClient& client, const CliConfig& config) {
+    if (!ensure_local_server_running(config, config.api_key)) {
+        return 1;
+    }
+
+    std::string backend = config.rpc_backend;
+
+    // Default backend: vulkan on Linux/Windows, metal on macOS
+    if (backend.empty()) {
+#ifdef __APPLE__
+        backend = "metal";
+#else
+        backend = "vulkan";
+#endif
+    }
+
+    // Ensure the llamacpp backend is installed
+    std::cout << "Ensuring llamacpp:" << backend << " backend is installed..." << std::endl;
+    int install_result = client.install_backend("llamacpp", backend);
+    if (install_result != 0) {
+        std::cerr << "Error: Failed to install llamacpp:" << backend << " backend" << std::endl;
+        return install_result;
+    }
+
+    // Find the rpc-server binary in the llamacpp install directory
+    std::string install_dir = (std::filesystem::path(lemon::utils::get_downloaded_bin_dir()) / "llamacpp" / backend).string();
+
+#ifdef _WIN32
+    std::string rpc_binary_name = "rpc-server.exe";
+#else
+    std::string rpc_binary_name = "rpc-server";
+#endif
+
+    std::string rpc_exe;
+    if (std::filesystem::exists(install_dir)) {
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(install_dir)) {
+            if (entry.is_regular_file() && entry.path().filename() == rpc_binary_name) {
+                rpc_exe = entry.path().string();
+                break;
+            }
+        }
+    }
+
+    if (rpc_exe.empty()) {
+        std::cerr << "Error: " << rpc_binary_name << " not found in install directory: " << install_dir << std::endl;
+        return 1;
+    }
+
+#ifndef _WIN32
+    // Ensure the binary is executable
+    chmod(rpc_exe.c_str(), 0755);
+#endif
+
+    std::cout << "Starting rpc-server on " << config.rpc_host << ":" << config.rpc_port << std::endl;
+
+    // Build arguments
+    std::vector<std::string> args;
+    args.push_back("--host");
+    args.push_back(config.rpc_host);
+    args.push_back("--port");
+    args.push_back(std::to_string(config.rpc_port));
+
+    if (config.rpc_mem > 0) {
+        args.push_back("--mem");
+        args.push_back(std::to_string(config.rpc_mem));
+    }
+
+    // Start rpc-server with inherited output
+    lemon::utils::ProcessHandle handle;
+    try {
+        handle = lemon::utils::ProcessManager::start_process(
+            rpc_exe, args, "", true, false, {});
+    } catch (const std::exception& e) {
+        std::cerr << "Error: Failed to start rpc-server: " << e.what() << std::endl;
+        return 1;
+    }
+
+    return lemon::utils::ProcessManager::wait_for_exit(handle, -1);
+}
+
 int main(int argc, char* argv[]) {
     // CLI11 configuration
     CLI::App app{"Lemonade CLI - HTTP client for Lemonade Server"};
@@ -849,6 +1125,7 @@ int main(int argc, char* argv[]) {
     status_cmd->add_flag("--json", config.json_output, "Output status as JSON");
     CLI::App* logs_cmd = app.add_subcommand("logs", "Open server logs in the web UI")->group("Server");
     CLI::App* scan_cmd = app.add_subcommand("scan", "Scan for network beacons")->group("Server");
+    CLI::App* rpc_server_cmd = app.add_subcommand("rpc-server", "Start a llama.cpp RPC server for distributed inference")->group("Server");
 
     // Config commands
     CLI::App* config_cmd = app.add_subcommand("config", "View or modify server configuration")->group("Server");
@@ -942,6 +1219,12 @@ int main(int argc, char* argv[]) {
     // Scan options
     scan_cmd->add_option("--duration", config.scan_duration, "Scan duration in seconds")->default_val(config.scan_duration)->type_name("SECONDS");
 
+    // RPC server options
+    rpc_server_cmd->add_option("--rpc-host", config.rpc_host, "Host to bind to")->default_val("0.0.0.0");
+    rpc_server_cmd->add_option("--rpc-port", config.rpc_port, "RPC server port")->default_val(50052);
+    rpc_server_cmd->add_option("--backend", config.rpc_backend, "llamacpp backend (vulkan/rocm/metal/cpu)")->type_name("BACKEND");
+    rpc_server_cmd->add_option("--mem", config.rpc_mem, "Memory to allocate in MB")->type_name("MB");
+
     // Parse arguments
     CLI11_PARSE(app, argc, argv);
     config.codex_use_user_config = (provider_opt != nullptr && provider_opt->count() > 0);
@@ -1018,6 +1301,8 @@ int main(int argc, char* argv[]) {
         return 0;
     } else if (scan_cmd->count() > 0) {
         return handle_scan_command(config);
+    } else if (rpc_server_cmd->count() > 0) {
+        return handle_rpc_server_command(client, config);
     } else if (config_cmd->count() > 0) {
         if (config_set_cmd->count() > 0) {
             return handle_config_set(client, config_set_cmd->remaining());

--- a/src/cpp/cli/recipe_import.cpp
+++ b/src/cpp/cli/recipe_import.cpp
@@ -21,6 +21,7 @@ const std::vector<std::string> kKnownKeys = {
     "labels",
     "recipe",
     "recipe_options",
+    "rpc_required",
     "size"
 };
 

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -58,6 +58,9 @@ struct ModelInfo {
     ModelType type = ModelType::LLM;      // Model type for LRU cache management
     DeviceType device = DEVICE_NONE;      // Target device(s) for this model
 
+    // RPC requirement flag (for models requiring distributed inference)
+    bool rpc_required = false;
+
     // Image generation defaults (for sd-cpp models)
     ImageDefaults image_defaults;
 

--- a/src/cpp/include/lemon/recipe_options.h
+++ b/src/cpp/include/lemon/recipe_options.h
@@ -17,6 +17,7 @@ public:
     std::string to_log_string(bool resolve_defaults=true) const;
     RecipeOptions inherit(const RecipeOptions& options) const;
     json get_option(const std::string& opt) const;
+    void set_option(const std::string& key, const json& value);
     std::string get_recipe() const { return recipe_; };
 
 #ifdef LEMONADE_CLI

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -31,6 +31,10 @@ public:
     std::string models_dir() const;
     int ctx_size() const;
 
+    // RPC configuration
+    std::string rpc() const;
+    bool has_rpc() const;
+
     // Feature flags
     bool offline() const;
     bool disable_model_filtering() const;

--- a/src/cpp/legacy-cli/main.cpp
+++ b/src/cpp/legacy-cli/main.cpp
@@ -168,6 +168,7 @@ parse_serve_args(const std::vector<std::string>& args) {
         else if (arg == "--global-timeout") { config_set_args.push_back("global_timeout=" + next()); }
         else if (arg == "--max-loaded-models") { config_set_args.push_back("max_loaded_models=" + next()); }
         else if (arg == "--ctx-size") { config_set_args.push_back("ctx_size=" + next()); }
+        else if (arg == "--rpc") { config_set_args.push_back("rpc=" + next()); }
         else if (arg == "--llamacpp") { config_set_args.push_back("llamacpp.backend=" + next()); }
         else if (arg == "--llamacpp-args") { config_set_args.push_back("llamacpp.args=" + next()); }
         else if (arg == "--whispercpp") { config_set_args.push_back("whispercpp.backend=" + next()); }
@@ -408,8 +409,23 @@ static int discover_port(const fs::path &dir) {
     }
 }
 
-static int do_stop(const fs::path &dir) {
-    int port = discover_port(dir);
+static int do_stop(const fs::path &dir, const std::vector<std::string>& args) {
+    int port = 0;
+    for (size_t i = 1; i < args.size(); ++i) {
+        if (args[i] == "--port" && i + 1 < args.size()) {
+            try {
+                port = std::stoi(args[i + 1]);
+            } catch (...) {
+                std::cerr << "error: invalid port '" << args[i + 1] << "'" << std::endl;
+                return 1;
+            }
+            break;
+        }
+    }
+
+    if (port == 0) {
+        port = discover_port(dir);
+    }
     if (port == 0) port = 13305;
 
     httplib::Client client("127.0.0.1", port);
@@ -470,7 +486,7 @@ int main(int argc, char *argv[]) {
 
     // stop → discover port via lemonade status --json, then POST /internal/shutdown
     if (cmd == "stop") {
-        return do_stop(dir);
+        return do_stop(dir, args);
     }
 
     // Everything else → delegate to lemonade CLI

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -10,6 +10,7 @@
   "extra_models_dir": "",
   "models_dir": "auto",
   "ctx_size": 4096,
+  "rpc": "",
   "offline": false,
   "disable_model_filtering": false,
   "enable_dgpu_gtt": false,

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1353,5 +1353,15 @@
             "image"
         ],
         "size": 0.017
+    },
+    "MiniMax-M2.5-GGUF": {
+        "checkpoint": "unsloth/MiniMax-M2.5-GGUF:Q4_K_M",
+        "recipe": "llamacpp",
+        "rpc_required": true,
+        "labels": [
+            "coding",
+            "tool-calling"
+        ],
+        "size": 138.0
     }
 }

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -161,6 +161,7 @@ void LlamaCppServer::load(const std::string& model_name,
     int ctx_size = options.get_option("ctx_size");
     std::string llamacpp_backend = options.get_option("llamacpp_backend");
     std::string llamacpp_args = options.get_option("llamacpp_args");
+    std::string rpc = options.get_option("rpc");
 
     RuntimeConfig::validate_backend_choice("llamacpp", llamacpp_backend);
 
@@ -257,6 +258,11 @@ void LlamaCppServer::load(const std::string& model_name,
     std::string gpu_layers = use_gpu ? "99" : "0";  // 99 for GPU, 0 for CPU-only
     LOG(DEBUG, "LlamaCpp") << "ngl set to " << gpu_layers << std::endl;
     push_arg(args, reserved_flags, "-ngl", gpu_layers, std::vector<std::string>{"--gpu-layers", "--n-gpu-layers"});
+
+    // Add RPC server addresses for distributed inference
+    if (!rpc.empty()) {
+        push_arg(args, reserved_flags, "--rpc", rpc);
+    }
 
     // Validate and append custom arguments
     if (!llamacpp_args.empty()) {

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -162,6 +162,7 @@ static const EnvMapping env_mappings[] = {
     {"LEMONADE_NO_BROADCAST",            "no_broadcast",             nullptr},
     {"LEMONADE_EXTRA_MODELS_DIR",        "extra_models_dir",         nullptr},
     {"LEMONADE_CTX_SIZE",                "ctx_size",                 nullptr},
+    {"LEMONADE_RPC",                     "rpc",                      nullptr},
     {"LEMONADE_OFFLINE",                 "offline",                  nullptr},
     {"LEMONADE_DISABLE_MODEL_FILTERING", "disable_model_filtering",  nullptr},
     {"LEMONADE_ENABLE_DGPU_GTT",         "enable_dgpu_gtt",          nullptr},

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -47,7 +47,7 @@ static constexpr auto safe_dir_options = fs::directory_options::none;
 namespace lemon {
 
 // Properties which are defined by the user for model registration.
-static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults"};
+static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults", "rpc_required"};
 
 // Helper functions for string operations
 static std::string to_lower(const std::string& str) {
@@ -779,6 +779,7 @@ void ModelManager::build_cache() {
         info.recipe = JsonUtils::get_or_default<std::string>(value, "recipe", "");
         info.suggested = JsonUtils::get_or_default<bool>(value, "suggested", false);
         info.size = JsonUtils::get_or_default<double>(value, "size", 0.0);
+        info.rpc_required = JsonUtils::get_or_default<bool>(value, "rpc_required", false);
 
         if (value.contains("labels") && value["labels"].is_array()) {
             for (const auto& label : value["labels"]) {
@@ -820,6 +821,7 @@ void ModelManager::build_cache() {
         info.suggested = JsonUtils::get_or_default<bool>(value, "suggested", true);
         info.source = JsonUtils::get_or_default<std::string>(value, "source", "");
         info.size = JsonUtils::get_or_default<double>(value, "size", 0.0);
+        info.rpc_required = JsonUtils::get_or_default<bool>(value, "rpc_required", false);
 
         if (value.contains("labels") && value["labels"].is_array()) {
             for (const auto& label : value["labels"]) {
@@ -1351,7 +1353,9 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
 
         // Filter out models that are too large for system RAM
         // Heuristic: if model size > 80% of system RAM, filter it out
-        if (!filter_out && system_ram_gb > 0.0 && info.size > 0.0) {
+        // Skip this check for rpc_required models — they are designed for
+        // distributed inference across multiple machines.
+        if (!filter_out && !info.rpc_required && system_ram_gb > 0.0 && info.size > 0.0) {
             if (info.size > max_model_size_gb) {
                 filter_out = true;
                 std::ostringstream oss;

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -163,6 +163,10 @@ RecipeOptions RecipeOptions::inherit(const RecipeOptions& options) const {
     return RecipeOptions(recipe_, merged);
 }
 
+void RecipeOptions::set_option(const std::string& key, const json& value) {
+    options_[key] = value;
+}
+
 json RecipeOptions::get_option(const std::string& opt) const {
     if (options_.contains(opt)) {
         return options_[opt];

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -24,7 +24,9 @@ static const json DEFAULTS = {
     {"width", 512},
     {"height", 512},
     // FLM-specific options
-    {"flm_args", ""}       // Custom arguments to pass to flm serve
+    {"flm_args", ""},       // Custom arguments to pass to flm serve
+    // RPC option for distributed inference
+    {"rpc", ""}
 };
 
 // Mapping from flat option names to CLI flags (used by to_cli_options)
@@ -40,12 +42,13 @@ static const std::map<std::string, std::string> OPTION_TO_CLI_FLAG = {
     {"cfg_scale", "--cfg-scale"},
     {"width", "--width"},
     {"height", "--height"},
-    {"flm_args", "--flm-args"}
+    {"flm_args", "--flm-args"},
+    {"rpc", "--rpc"}
 };
 
 static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
     if (recipe == "llamacpp") {
-        return {"ctx_size", "llamacpp_backend", "llamacpp_args"};
+        return {"ctx_size", "llamacpp_backend", "llamacpp_args", "rpc"};
     } else if (recipe == "whispercpp") {
         return {"whispercpp_backend", "whispercpp_args"};
     } else if (recipe == "flm") {
@@ -190,7 +193,8 @@ static const json CLI_OPTIONS = {
     {"--cfg-scale", {{"option_name", "cfg_scale"}, {"type_name", "SCALE"}, {"envname", "LEMONADE_CFG_SCALE"}, {"help", "Classifier-free guidance scale"}}},
     {"--width", {{"option_name", "width"}, {"type_name", "PX"}, {"envname", "LEMONADE_WIDTH"}, {"help", "Image width in pixels"}}},
     {"--height", {{"option_name", "height"}, {"type_name", "PX"}, {"envname", "LEMONADE_HEIGHT"}, {"help", "Image height in pixels"}}},
-    {"--flm-args", {{"option_name", "flm_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_FLM_ARGS"}, {"help", "Custom arguments to pass to flm serve"}}}
+    {"--flm-args", {{"option_name", "flm_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_FLM_ARGS"}, {"help", "Custom arguments to pass to flm serve"}}},
+    {"--rpc", {{"option_name", "rpc"}, {"type_name", "SERVERS"}, {"envname", "LEMONADE_RPC"}, {"help", "RPC server addresses for distributed inference (host:port,host:port)"}}}
 };
 
 void RecipeOptions::add_cli_options(CLI::App& app, json& storage) {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -217,8 +217,38 @@ void Router::load_model(const std::string& model_name,
     // Resolve settings: load overrides take precedence over per-model overrides which take precedence over defaults
         RecipeOptions effective_options = options.inherit(model_info.recipe_options.inherit(default_opt));
 
-    LOG(DEBUG, "Router") << "Effective settings: " << effective_options.to_log_string() << std::endl;
+    // RPC resolution: check if model requires RPC for distributed inference
+    json rpc_json = effective_options.get_option("rpc");
+    std::string rpc_addr = rpc_json.is_string() ? rpc_json.get<std::string>() : "";
+    if (rpc_addr.empty() && model_info.rpc_required) {
+        // Model requires RPC but no address was provided by the user —
+        // check the server-wide config as fallback
+        rpc_addr = config_->has_rpc() ? config_->rpc() : "";
+        if (rpc_addr.empty()) {
+            throw std::runtime_error(
+                "Model '" + model_name + "' requires RPC for distributed inference. "
+                "Configure an RPC server with 'lemonade config set rpc=host:port' "
+                "or pass '--rpc host:port' when loading.");
+        }
+        // Inject the address into effective options
+        effective_options.set_option("rpc", rpc_addr);
+    }
 
+    // RPC requires the ROCm backend — the Vulkan backend classifies integrated
+    // GPUs as IGPU which causes llama.cpp to skip the local GPU when an RPC
+    // device is present, sending all layers to the remote node.
+    if (!rpc_addr.empty()) {
+        json backend_json = effective_options.get_option("llamacpp_backend");
+        std::string backend = backend_json.is_string() ? backend_json.get<std::string>() : "";
+        if (backend != "rocm") {
+            throw std::runtime_error(
+                "RPC requires the ROCm backend to use both local and remote GPUs. "
+                "Set the backend with 'lemonade config set llamacpp_backend=rocm' "
+                "or pass '--llamacpp-backend rocm' when loading.");
+        }
+    }
+
+    LOG(DEBUG, "Router") << "Effective settings: " << effective_options.to_log_string() << std::endl;
 
     // LOAD SERIALIZATION STRATEGY (from spec: point #2 in Additional Considerations)
     std::unique_lock<std::mutex> lock(load_mutex_);

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -253,6 +253,7 @@ json RuntimeConfig::recipe_options() const {
     }
 
     if (config_.contains("ctx_size")) result["ctx_size"] = config_["ctx_size"];
+    if (config_.contains("rpc")) result["rpc"] = config_["rpc"];
 
     return result;
 }
@@ -327,6 +328,10 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
         }
         if (value.get<int>() <= 0) {
             throw std::invalid_argument("'ctx_size' must be positive");
+        }
+    } else if (key == "rpc") {
+        if (!value.is_string()) {
+            throw std::invalid_argument("'rpc' must be a string");
         }
     } else if (key == "config_version") {
         if (!value.is_number_integer()) {

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -170,6 +170,18 @@ bool RuntimeConfig::enable_dgpu_gtt() const {
     return config_["enable_dgpu_gtt"].get<bool>();
 }
 
+std::string RuntimeConfig::rpc() const {
+    std::shared_lock lock(mutex_);
+    if (config_.contains("rpc") && config_["rpc"].is_string()) {
+        return config_["rpc"].get<std::string>();
+    }
+    return "";
+}
+
+bool RuntimeConfig::has_rpc() const {
+    return !rpc().empty();
+}
+
 json RuntimeConfig::backend_config(const std::string& backend_name) const {
     std::shared_lock lock(mutex_);
     if (config_.contains(backend_name) && config_[backend_name].is_object()) {
@@ -253,7 +265,6 @@ json RuntimeConfig::recipe_options() const {
     }
 
     if (config_.contains("ctx_size")) result["ctx_size"] = config_["ctx_size"];
-    if (config_.contains("rpc")) result["rpc"] = config_["rpc"];
 
     return result;
 }


### PR DESCRIPTION
Adding initial multi-device lemonade support. This adds an additional lemonade rpc-server which is a wrapper around llamacpp rpc, and then both `lemond` and `lemonade-server` can take an `--rpc` flag on how it can connect to RPC servers. 