### PR TITLE
follow up for LEMONADE_ADMIN_API_KEY

### DIFF
--- a/data/lemonade-server.service.in
+++ b/data/lemonade-server.service.in
@@ -11,6 +11,7 @@ WorkingDirectory=@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/lemonade
 # The env-file drop-in is kept for the few env vars lemond still reads:
 #   HF_TOKEN                 — HuggingFace authentication token
 #   LEMONADE_API_KEY         — require API-key auth on all routes
+#   LEMONADE_ADMIN_API_KEY   — API-key specific to internal routes
 EnvironmentFile=-/etc/lemonade/conf.d/*.conf
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/lemond
 Restart=on-failure

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -830,7 +830,7 @@ int main(int argc, char* argv[]) {
     // Global options (available to all subcommands)
     auto* host_opt = app.add_option("--host", config.host, "Server host")->default_val(config.host)->type_name("HOST")->envname("LEMONADE_HOST");
     auto* port_opt = app.add_option("--port", config.port, "Server port")->default_val(config.port)->type_name("PORT")->envname("LEMONADE_PORT");
-    auto* api_key_opt = app.add_option("--api-key", config.api_key, "API key for authentication")
+    app.add_option("--api-key", config.api_key, "API key for authentication")
         ->default_val(config.api_key)
         ->type_name("KEY")
         ->envname("LEMONADE_API_KEY");
@@ -964,11 +964,10 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (api_key_opt->count() == 0) {
-        const char* admin_api_key = std::getenv("LEMONADE_ADMIN_API_KEY");
-        if (admin_api_key && admin_api_key[0]) {
-            config.api_key = admin_api_key;
-        }
+    // If set, LEMONADE_ADMIN_API_KEY takes precedence over the regular API key
+    const char* admin_api_key = std::getenv("LEMONADE_ADMIN_API_KEY");
+    if (admin_api_key && admin_api_key[0]) {
+        config.api_key = admin_api_key;
     }
 
     // Create client


### PR DESCRIPTION
closes #1554.

Doesn't address point 3 because there is no internal websocket route so the current implementation already respects all API key rules.