### PR TITLE
No more partial responses: use timeout: time-to-first-byte, then minimum rate

### DIFF
--- a/src/cpp/include/lemon/streaming_proxy.h
+++ b/src/cpp/include/lemon/streaming_proxy.h
@@ -40,14 +40,14 @@ public:
         const std::string& request_body,
         httplib::DataSink& sink,
         std::function<void(const TelemetryData&)> on_complete = nullptr,
-        long timeout_seconds = 300
+        long timeout_seconds = 0
     );
 
     static void forward_byte_stream(
         const std::string& backend_url,
         const std::string& request_body,
         httplib::DataSink& sink,
-        long timeout_seconds = 300
+        long timeout_seconds = 0
     );
 
 private:

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -73,19 +73,21 @@ public:
     static HttpResponse post(const std::string& url,
                             const std::string& body,
                             const std::map<std::string, std::string>& headers = {},
-                            long timeout_seconds = 300);
+                            long timeout_seconds = 0);
 
     // Multipart form data POST request
     static HttpResponse post_multipart(const std::string& url,
                                        const std::vector<MultipartField>& fields,
-                                       long timeout_seconds = 300);
+                                       long timeout_seconds = 0);
 
     // Streaming POST request (calls callback for each chunk as it arrives)
+    // If timeout_seconds is 0, it uses inactivity timeout (low_speed_limit/time)
+    // instead of a total request timeout.
     static HttpResponse post_stream(const std::string& url,
                                    const std::string& body,
                                    StreamCallback stream_callback,
                                    const std::map<std::string, std::string>& headers = {},
-                                   long timeout_seconds = 300);
+                                   long timeout_seconds = 0);
 
     // Download file to disk with automatic retry and resume support
     static DownloadResult download_file(const std::string& url,

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -30,6 +30,34 @@ static size_t write_file_callback(void* ptr, size_t size, size_t nmemb, void* st
     return written;
 }
 
+struct FirstByteTimeout {
+    long initial_timeout_seconds{};
+    std::chrono::steady_clock::time_point start_time;
+};
+
+static int first_byte_timeout_callback(void* clientp, curl_off_t dltotal, curl_off_t dlnow,
+                                       curl_off_t ultotal, curl_off_t ulnow) {
+    // If we have received any data, don't time out here;
+    // CURLOPT_LOW_SPEED_LIMIT and CURLOPT_LOW_SPEED_TIME will apply instead
+    if (dlnow > 0) {
+        return 0;
+    }
+
+    // Handle timeout while waiting for the first byte
+    const auto* data = static_cast<FirstByteTimeout*>(clientp);
+
+    // Check how much time has passed
+    const auto now = std::chrono::steady_clock::now();
+    const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - data->start_time).count();
+
+    if (elapsed > data->initial_timeout_seconds) {
+        LOG(ERROR, "HttpClient") << "Initial timeout of " << data->initial_timeout_seconds
+                                 << "s reached before receiving any data" << std::endl;
+        return 1; // Non-zero return value aborts the transfer
+    }
+    return 0; // Not timed out
+}
+
 // Callback for download progress
 struct ProgressData {
     ProgressCallback callback;
@@ -120,8 +148,30 @@ HttpResponse HttpClient::post(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_.load());
+    if (timeout_seconds == 0) {
+        // Use first byte timeout if timeout_seconds is 0 (set via --http-timeout)
+        FirstByteTimeout timeout;
+        timeout.initial_timeout_seconds = default_timeout_seconds_.load();
+        timeout.start_time = std::chrono::steady_clock::now();
+
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0L);
+        // curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L);
+
+        // Timeout if the LOW_SPEED_LIMIT rate is below the limit for LOW_SPEED_TIME duration
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 10L); // 10 bytes/sec
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 60L);  // 60 seconds
+
+        // Custom progress callback to enforce initial wait for first byte
+        curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, first_byte_timeout_callback);
+        curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &timeout);
+        curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    } else if (timeout_seconds > 0) {
+        // Use provided timeout
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
+    } else {
+        // Fall back to global default (set via --http-timeout)
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, default_timeout_seconds_.load());
+    }
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     // Add custom headers
@@ -182,8 +232,29 @@ HttpResponse HttpClient::post_multipart(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_.load());
+    if (timeout_seconds == 0) {
+        // Use first byte timeout if timeout_seconds is 0 (set via --http-timeout)
+        FirstByteTimeout timeout;
+        timeout.initial_timeout_seconds = default_timeout_seconds_.load();
+        timeout.start_time = std::chrono::steady_clock::now();
+
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0L);
+
+        // Timeout if the LOW_SPEED_LIMIT rate is below the limit for LOW_SPEED_TIME duration
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 10L); // 10 bytes/sec
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 60L);  // 60 seconds
+
+        // Custom progress callback to enforce initial wait for first byte
+        curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, first_byte_timeout_callback);
+        curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &timeout);
+        curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    } else if (timeout_seconds > 0) {
+        // Use provided timeout
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
+    } else {
+        // Fall back to global default (set via --http-timeout)
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, default_timeout_seconds_.load());
+    }
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     CURLcode res = curl_easy_perform(curl);
@@ -258,8 +329,31 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, stream_write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &callback_data);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_.load());
+
+    if (timeout_seconds == 0) {
+        // Use first byte timeout if timeout_seconds is 0 (set via --http-timeout)
+        FirstByteTimeout timeout;
+        timeout.initial_timeout_seconds = default_timeout_seconds_.load();
+        timeout.start_time = std::chrono::steady_clock::now();
+
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0L);
+
+        // Timeout if the LOW_SPEED_LIMIT rate is below the limit for LOW_SPEED_TIME duration
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 10L); // 10 bytes/sec
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 60L);  // 60 seconds
+
+        // Custom progress callback to enforce initial wait for first byte
+        curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, first_byte_timeout_callback);
+        curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &timeout);
+        curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    } else if (timeout_seconds > 0) {
+        // Use provided timeout
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
+    } else {
+        // Fall back to global default (set via --http-timeout)
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, default_timeout_seconds_.load());
+    }
+
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     // Add custom headers

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -167,7 +167,6 @@ void WrappedServer::forward_streaming_request(const std::string& endpoint,
 
         if (sse) {
             // Use StreamingProxy to forward the SSE stream with telemetry callback
-            // Use INFERENCE_TIMEOUT_SECONDS (0 = infinite) as chat completions can take a long time
             StreamingProxy::forward_sse_stream(url, request_body, sink,
                 [this](const StreamingProxy::TelemetryData& telemetry) {
                     // Save telemetry to member variable


### PR DESCRIPTION
This enables timeouts appropriate for streaming responses, by waiting for a given timeout until the first byte, then timing out if the transfer rate is too low for too long.

Before: Partial response received. 5 minute timeout stops processing mid-response.
```
2026-04-06 10:58:15.345 [Info] (Process) srv  log_server_r: done request: POST /v1/chat/completions 127.0.0.1 200
2026-04-06 11:03:13.757 [Error] (HttpClient) CURL error: Timeout was reached
```


After: Full response received, taking 7 minutes. Wait 5 minutes for the first byte, then time out if transfer rate is too slow for too long.
```
2026-04-06 11:07:03.567 [Info] (Process) srv  log_server_r: done request: POST /v1/chat/completions 127.0.0.1 200
2026-04-06 11:14:03.402 [Info] (Process) slot print_timing: id  3 | task 0 |
2026-04-06 11:14:03.402 [Info] (Process) prompt eval time =    2207.52 ms /    88 tokens (   25.09 ms per token,    39.86 tokens per second)
2026-04-06 11:14:03.402 [Info] (Process)        eval time =  419834.65 ms /  2193 tokens (  191.44 ms per token,     5.22 tokens per second)
2026-04-06 11:14:03.402 [Info] (Process)       total time =  422042.17 ms /  2281 tokens
2026-04-06 11:14:03.402 [Info] (Process) slot      release: id  3 | task 0 | stop processing: n_tokens = 2280, truncated = 0
2026-04-06 11:14:03.402 [Info] (Process) srv  update_slots: all slots are idle
2026-04-06 11:14:03.402 [Info] (Server) Streaming completed - 200 OK
```

It's a little cumbersome to test, but it looks good to me, and it worked for my basic testing. Probably good if somebody else tests it too before merging.