### PR TITLE
feat(tray): add Max Loaded Models submenu

### DIFF
--- a/src/cpp/include/lemon_tray/tray_ui.h
+++ b/src/cpp/include/lemon_tray/tray_ui.h
@@ -58,6 +58,7 @@ private:
     std::pair<bool, std::vector<LoadedModelInfo>> fetch_server_state();
     std::vector<LoadedModelInfo> get_all_loaded_models();
     std::vector<ModelInfo> get_downloaded_models();
+    void fetch_runtime_config();
 
     // Menu
     void build_menu();
@@ -72,6 +73,7 @@ private:
     void on_unload_specific_model(const std::string& model_name);
     void on_change_port(int new_port);
     void on_change_context_size(int new_ctx_size);
+    void on_change_max_loaded_models(int new_max);
     void on_show_logs();
     void on_open_documentation();
     void on_quit();
@@ -94,6 +96,7 @@ private:
     // State
     int port_;
     std::string host_;
+    int max_loaded_models_ = 1;  // Mirrors server config; default 1 per configuration.md
     bool silent_;  // Suppress startup notification
     std::unique_ptr<TrayInterface> tray_;
 

--- a/src/cpp/tray/tray_ui.cpp
+++ b/src/cpp/tray/tray_ui.cpp
@@ -236,6 +236,22 @@ std::vector<LoadedModelInfo> TrayUI::get_all_loaded_models() {
     return fetch_server_state().second;
 }
 
+void TrayUI::fetch_runtime_config() {
+    try {
+        std::string body = http_get("/internal/config");
+        if (body.empty()) return;
+        auto config = nlohmann::json::parse(body);
+        if (config.contains("max_loaded_models") && config["max_loaded_models"].is_number_integer()) {
+            max_loaded_models_ = config["max_loaded_models"].get<int>();
+        }
+        if (config.contains("ctx_size") && config["ctx_size"].is_number_integer()) {
+            recipe_options_["ctx_size"] = config["ctx_size"].get<int>();
+        }
+    } catch (...) {
+        // Leave defaults in place if parsing fails
+    }
+}
+
 std::vector<ModelInfo> TrayUI::get_downloaded_models() {
     try {
         std::string body = http_get("/api/v1/models");
@@ -271,6 +287,7 @@ void TrayUI::build_menu() {
     // Fetch once, use for both the menu and the cache
     auto [reachable, loaded_models] = fetch_server_state();
     auto available_models = get_downloaded_models();
+    if (reachable) fetch_runtime_config();
 
     Menu menu = create_menu(loaded_models, available_models);
     tray_->set_menu(menu);
@@ -401,6 +418,20 @@ Menu TrayUI::create_menu(const std::vector<LoadedModelInfo>& loaded_models,
     }
     menu.add_item(MenuItem::Submenu("Context Size", ctx_submenu));
 
+    // Max Loaded Models submenu
+    auto max_models_submenu = std::make_shared<Menu>();
+    std::vector<std::pair<std::string, int>> max_models_options = {
+        {"1 (default)", 1}, {"2", 2}, {"3", 3}, {"5", 5}, {"7", 7}, {"Unlimited", -1},
+    };
+    for (const auto& [label, value] : max_models_options) {
+        max_models_submenu->add_item(MenuItem::Checkable(
+            label,
+            [this, v = value]() { on_change_max_loaded_models(v); },
+            value == max_loaded_models_
+        ));
+    }
+    menu.add_item(MenuItem::Submenu("Max Loaded Models", max_models_submenu));
+
     menu.add_separator();
     menu.add_item(MenuItem::Action("Documentation", [this]() { on_open_documentation(); }));
     menu.add_item(MenuItem::Action("Show Logs", [this]() { on_show_logs(); }));
@@ -496,6 +527,19 @@ void TrayUI::on_change_context_size(int new_ctx_size) {
         ? std::to_string(new_ctx_size / 1024) + "K"
         : std::to_string(new_ctx_size);
     show_notification("Context Size Changed", "Lemonade Server context size is now " + label);
+}
+
+void TrayUI::on_change_max_loaded_models(int new_max) {
+    nlohmann::json body;
+    body["max_loaded_models"] = new_max;
+    std::string result = http_post("/internal/set", body.dump());
+    if (!result.empty()) {
+        max_loaded_models_ = new_max;
+        build_menu();
+        std::string label = (new_max == -1) ? "Unlimited" : std::to_string(new_max);
+        show_notification("Max Loaded Models Changed",
+                          "Lemonade Server max loaded models is now " + label);
+    }
 }
 
 void TrayUI::on_show_logs() {


### PR DESCRIPTION
Closes https://github.com/lemonade-sdk/lemonade/issues/919

<img width="872" height="580" alt="image" src="https://github.com/user-attachments/assets/4a859da0-3e63-45cb-b115-80589e3ec528" />


## Summary

- Adds a **Max Loaded Models** submenu to the lemonade tray with options 1 (default), 2, 3, 5, 7, and Unlimited (-1). Selecting an option posts to `/internal/set`, mirroring the existing **Port** handler.
- Adds `fetch_runtime_config()` which queries `/internal/config` on each menu build, so the checkmark for both **Max Loaded Models** and **Context Size** reflects the live server config — including any external edits to `config.json`.