### PR TITLE
ROCm-Backend: added and tested docker image functionality with ROCm

### DIFF
--- a/docs/assets/install-selector.js
+++ b/docs/assets/install-selector.js
@@ -613,9 +613,18 @@ function renderQuickStart() {
   -p 13305:13305 \\
   -v lemonade-cache:/root/.cache/huggingface \\
   -v lemonade-llama:/opt/lemonade/llama \\
-  -e LEMONADE_LLAMACPP_BACKEND=vulkan \\
+  -e LEMONADE_LLAMACPP=vulkan \\
   ghcr.io/lemonade-sdk/lemonade-server:latest`);
-      notes = `<div class="lmn-note"><strong>Tip:</strong> To select a specific backend, update the LEMONADE_LLAMACPP_BACKEND environment variable: <code>LEMONADE_LLAMACPP_BACKEND=vulkan</code></div>`;
+      notes = `<div class="lmn-note"><strong>Tip:</strong> To use ROCm instead of Vulkan, replace <code>-e LEMONADE_LLAMACPP=vulkan</code> with <code>-e LEMONADE_LLAMACPP=rocm</code> and add the ROCm device flags. The full ROCm command:<pre style="margin:0.6em 0 0;background:linear-gradient(135deg, #2c3e50 0%, #34495e 100%);color:#fff;padding:0.7em 1em;border-radius:6px;font-size:0.92em;overflow-x:auto;line-height:1.6">docker run -d \
+  --name lemonade-server \
+  -p 13305:13305 \
+  -v lemonade-cache:/root/.cache/huggingface \
+  -v lemonade-llama:/opt/lemonade/llama \
+  -e LEMONADE_LLAMACPP=rocm \
+  --device=/dev/kfd \
+  --device=/dev/dri \
+  --group-add video \
+  ghcr.io/lemonade-sdk/lemonade-server:latest</pre></div>`;
     }
 
     if (fw === 'llama' && dev === 'cpu') {
@@ -624,9 +633,9 @@ function renderQuickStart() {
   -p 13305:13305 \\
   -v lemonade-cache:/root/.cache/huggingface \\
   -v lemonade-llama:/opt/lemonade/llama \\
-  -e LEMONADE_LLAMACPP_BACKEND=cpu \\
+  -e LEMONADE_LLAMACPP=cpu \\
   ghcr.io/lemonade-sdk/lemonade-server:latest`);
-      notes = `<div class="lmn-note"><strong>Tip:</strong> To select a specific backend, update the LEMONADE_LLAMACPP_BACKEND environment variable: <code>LEMONADE_LLAMACPP_BACKEND=cpu</code></div>`;
+      notes = `<div class="lmn-note"><strong>Tip:</strong> To select a specific backend, update the LEMONADE_LLAMACPP environment variable: <code>LEMONADE_LLAMACPP=cpu</code></div>`;
     }
   }
 

--- a/docs/assets/install-selector.js
+++ b/docs/assets/install-selector.js
@@ -615,15 +615,15 @@ function renderQuickStart() {
   -v lemonade-llama:/opt/lemonade/llama \\
   -e LEMONADE_LLAMACPP=vulkan \\
   ghcr.io/lemonade-sdk/lemonade-server:latest`);
-      notes = `<div class="lmn-note"><strong>Tip:</strong> To use ROCm instead of Vulkan, replace <code>-e LEMONADE_LLAMACPP=vulkan</code> with <code>-e LEMONADE_LLAMACPP=rocm</code> and add the ROCm device flags. The full ROCm command:<pre style="margin:0.6em 0 0;background:linear-gradient(135deg, #2c3e50 0%, #34495e 100%);color:#fff;padding:0.7em 1em;border-radius:6px;font-size:0.92em;overflow-x:auto;line-height:1.6">docker run -d \
-  --name lemonade-server \
-  -p 13305:13305 \
-  -v lemonade-cache:/root/.cache/huggingface \
-  -v lemonade-llama:/opt/lemonade/llama \
-  -e LEMONADE_LLAMACPP=rocm \
-  --device=/dev/kfd \
-  --device=/dev/dri \
-  --group-add video \
+      notes = `<div class="lmn-note"><strong>Tip:</strong> To use ROCm instead of Vulkan, replace <code>-e LEMONADE_LLAMACPP=vulkan</code> with <code>-e LEMONADE_LLAMACPP=rocm</code> and add the ROCm device flags. The full ROCm command:<pre style="margin:0.6em 0 0;background:linear-gradient(135deg, #2c3e50 0%, #34495e 100%);color:#fff;padding:0.7em 1em;border-radius:6px;font-size:0.92em;overflow-x:auto;line-height:1.6">docker run -d \\
+  --name lemonade-server \\
+  -p 13305:13305 \\
+  -v lemonade-cache:/root/.cache/huggingface \\
+  -v lemonade-llama:/opt/lemonade/llama \\
+  -e LEMONADE_LLAMACPP=rocm \\
+  --device=/dev/kfd \\
+  --device=/dev/dri \\
+  --group-add video \\
   ghcr.io/lemonade-sdk/lemonade-server:latest</pre></div>`;
     }
 

--- a/docs/assets/install-selector.js
+++ b/docs/assets/install-selector.js
@@ -556,6 +556,7 @@ function renderQuickStart() {
   }
 
   let commands = ['lemonade-server -h'];
+  let dockerROCmCommand = '';
 
   if (fw === 'oga') {
     if (dev === 'npu') {
@@ -615,7 +616,7 @@ function renderQuickStart() {
   -v lemonade-llama:/opt/lemonade/llama \\
   -e LEMONADE_LLAMACPP=vulkan \\
   ghcr.io/lemonade-sdk/lemonade-server:latest`);
-      notes = `<div class="lmn-note"><strong>Tip:</strong> To use ROCm instead of Vulkan, replace <code>-e LEMONADE_LLAMACPP=vulkan</code> with <code>-e LEMONADE_LLAMACPP=rocm</code> and add the ROCm device flags. The full ROCm command:<pre style="margin:0.6em 0 0;background:linear-gradient(135deg, #2c3e50 0%, #34495e 100%);color:#fff;padding:0.7em 1em;border-radius:6px;font-size:0.92em;overflow-x:auto;line-height:1.6">docker run -d \\
+      dockerROCmCommand = `docker run -d \\
   --name lemonade-server \\
   -p 13305:13305 \\
   -v lemonade-cache:/root/.cache/huggingface \\
@@ -624,7 +625,8 @@ function renderQuickStart() {
   --device=/dev/kfd \\
   --device=/dev/dri \\
   --group-add video \\
-  ghcr.io/lemonade-sdk/lemonade-server:latest</pre></div>`;
+  ghcr.io/lemonade-sdk/lemonade-server:latest`;
+      notes = `<div class="lmn-note"><strong>Tip:</strong> To use ROCm instead of Vulkan, replace <code>-e LEMONADE_LLAMACPP=vulkan</code> with <code>-e LEMONADE_LLAMACPP=rocm</code> and add the ROCm device flags. The full ROCm command:<pre id="lmn-rocm-pre-block"></pre></div>`;
     }
 
     if (fw === 'llama' && dev === 'cpu') {
@@ -651,8 +653,27 @@ function renderQuickStart() {
         return `<div class="lmn-command-line"><span>${safeLine}</span><button class="lmn-copy-btn" title="Copy" onclick="lmnCopyLine(event, ${idx})">📋</button></div>`;
       }).join('');
     }
+    const rocmPre = document.getElementById('lmn-rocm-pre-block');
+    if (rocmPre && dockerROCmCommand) {
+      const safe = dockerROCmCommand.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      rocmPre.innerHTML = `<div class="lmn-command-line"><span>${safe}</span><button class="lmn-copy-btn" title="Copy" onclick="lmnCopyDockerRocmLine(event)">📋</button></div>`;
+    }
   }, 0);
 }
+
+window.lmnCopyDockerRocmLine = function(e) {
+  e.stopPropagation();
+  const pre = document.getElementById('lmn-rocm-pre-block');
+  if (!pre) return;
+  const span = pre.querySelector('.lmn-command-line span');
+  if (span) {
+    navigator.clipboard.writeText(span.textContent);
+    const btn = e.currentTarget;
+    const old = btn.textContent;
+    btn.textContent = '✔';
+    setTimeout(() => { btn.textContent = old; }, 900);
+  }
+};
 
 window.lmnCopyLine = function(e, idx) {
   e.stopPropagation();

--- a/src/cpp/DOCKER_GUIDE.md
+++ b/src/cpp/DOCKER_GUIDE.md
@@ -13,7 +13,6 @@ docker run -d \
   -v lemonade-cache:/root/.cache/huggingface \
   -v lemonade-llama:/opt/lemonade/llama \
   -v lemonade-recipe:/root/.cache/lemonade \
-  -e LEMONADE_LLAMACPP_BACKEND=cpu \
   ghcr.io/lemonade-sdk/lemonade-server:latest
 ```
 
@@ -26,12 +25,26 @@ docker run -d \
   -v lemonade-cache:/root/.cache/huggingface \
   -v lemonade-llama:/opt/lemonade/llama \
   -v lemonade-recipe:/root/.cache/lemonade \
-  -e LEMONADE_LLAMACPP_BACKEND=cpu \
+  -e LEMONADE_LLAMACPP=cpu \
   ghcr.io/lemonade-sdk/lemonade-server:v9.1.3 \
   ./lemond --host 0.0.0.0 --port 5000
 ```
 
 > This will run the server on port 5000 inside the container, mapped to port 4000 on your host.
+
+### Docker Run with CPU backend
+
+```bash
+docker run -d \
+  --name lemonade-server \
+  -p 13305:13305 \
+  -v lemonade-cache:/root/.cache/huggingface \
+  -v lemonade-llama:/opt/lemonade/llama \
+  -v lemonade-recipe:/root/.cache/lemonade \
+  -e LEMONADE_LLAMACPP=cpu \
+  ghcr.io/lemonade-sdk/lemonade-server:latest
+```
+
 
 ### Docker Run with AMD GPU Passthrough using ROCm
 
@@ -42,7 +55,7 @@ docker run -d \
   -v lemonade-cache:/root/.cache/huggingface \
   -v lemonade-llama:/opt/lemonade/llama \
   -v lemonade-recipe:/root/.cache/lemonade \
-  -e LEMONADE_LLAMACPP_BACKEND=rocm \
+  -e LEMONADE_LLAMACPP=rocm \
   --device=/dev/kfd \
   --device=/dev/dri \
   ghcr.io/lemonade-sdk/lemonade-server:latest
@@ -72,7 +85,7 @@ services:
       # Persist model options and other backend binaries
       - lemonade-recipe:/root/.cache/lemonade
     environment:
-      - LEMONADE_LLAMACPP_BACKEND=cpu
+      - LEMONADE_LLAMACPP=cpu
     restart: unless-stopped
 
 volumes:
@@ -261,7 +274,7 @@ services:
       # Persist model options and other backend binaries
       - lemonade-recipe:/root/.cache/lemonade
     environment:
-      - LEMONADE_LLAMACPP_BACKEND=cpu
+      - LEMONADE_LLAMACPP=cpu
     restart: unless-stopped
 
 volumes:

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -164,6 +164,8 @@ void LlamaCppServer::load(const std::string& model_name,
 
     RuntimeConfig::validate_backend_choice("llamacpp", llamacpp_backend);
 
+    LOG(INFO, "LlamaCpp") << "Using LlamaCpp Backend: " << llamacpp_backend << std::endl;
+
     bool use_gpu = (llamacpp_backend != "cpu");
 
     // Update device type based on the actual backend selected.


### PR DESCRIPTION
## Summary

- Expands the install-selector tip for Vulkan to include a full ready-to-copy ROCm `docker run`
  command with the required `--device=/dev/kfd`, `--device=/dev/dri`, and `--group-add video` flags.
- Adds an `INFO` log line in `llamacpp_server.cpp` that reports the selected backend at load time,
  making it easier to verify backend selection from logs.
- Updates the `LEMONADE_LLAMACPP_BACKEND` environment variable to `LEMONADE_LLAMACPP` throughout
  documentation and Docker examples to match the recent changes.
- Adds a dedicated "Docker Run with CPU backend" section to `DOCKER_GUIDE.md`.

## Test plan

- [x] Verified Docker image starts correctly with `LEMONADE_LLAMACPP=rocm` on an AMD GPU host
- [x] Confirmed GPU utilization via `rocm-smi` during inference
- [x] Confirmed `LEMONADE_LLAMACPP=cpu` and `LEMONADE_LLAMACPP=vulkan` still work as expected
- [x] Checked log output shows "Using LlamaCpp Backend: rocm/vulkan" on model load
- [x] Reviewed install-selector rendering for the Vulkan GPU path in a browser
