### PR TITLE
[codex] add appear-builtin model aliases

### DIFF
--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -41,6 +41,7 @@
 #include "lemon/utils/aixlog.hpp"
 
 static const std::vector<std::string> VALID_LABELS = {
+    "appear-builtin",
     "coding",
     "embeddings",
     "hot",

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -112,6 +112,12 @@ public:
     // Get model info by name
     ModelInfo get_model_info(const std::string& model_name);
 
+    // Resolve a public model reference to its canonical internal name.
+    std::string resolve_model_name(const std::string& model_name);
+
+    // Get the public name exposed by Lemonade APIs for a canonical model name.
+    std::string get_public_model_name(const std::string& model_name);
+
     // Check if model exists (in filtered list based on system capabilities)
     bool model_exists(const std::string& model_name);
 
@@ -186,8 +192,12 @@ private:
     // Cache of all models with their download status
     mutable std::mutex models_cache_mutex_;
     mutable std::map<std::string, ModelInfo> models_cache_;
+    mutable std::map<std::string, std::string> public_model_aliases_;  // public name -> canonical name
+    mutable std::map<std::string, std::string> canonical_public_names_;  // canonical name -> public name
     mutable std::map<std::string, std::string> filtered_out_models_;  // model_name -> filter reason
     mutable bool cache_valid_ = false;
+
+    void rebuild_public_model_aliases_locked();
 };
 
 } // namespace lemon

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -117,6 +117,7 @@ private:
     void evict_server(WrappedServer* server);
     void evict_all_servers();
     std::unique_ptr<WrappedServer> create_backend_server(const ModelInfo& model_info);
+    std::string resolve_model_name(const std::string& model_name) const;
 
     // Generic inference wrapper that handles locking and busy state
     template<typename Func>

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -19,6 +19,7 @@
 #include <set>
 #include <unordered_set>
 #include <iomanip>
+#include <cstring>
 #include <lemon/utils/aixlog.hpp>
 
 namespace fs = std::filesystem;
@@ -75,6 +76,24 @@ static bool starts_with_ignore_case(const std::string& str, const std::string& p
 
 static bool contains_ignore_case(const std::string& str, const std::string& substr) {
     return to_lower(str).find(to_lower(substr)) != std::string::npos;
+}
+
+static constexpr const char* USER_MODEL_PREFIX = "user.";
+static constexpr const char* APPEAR_BUILTIN_LABEL = "appear-builtin";
+
+static bool has_label(const ModelInfo& info, const std::string& label) {
+    return std::find(info.labels.begin(), info.labels.end(), label) != info.labels.end();
+}
+
+static bool is_user_model_name(const std::string& model_name) {
+    return model_name.rfind(USER_MODEL_PREFIX, 0) == 0;
+}
+
+static std::string strip_user_model_prefix(const std::string& model_name) {
+    if (is_user_model_name(model_name)) {
+        return model_name.substr(std::strlen(USER_MODEL_PREFIX));
+    }
+    return model_name;
 }
 
 static std::string repo_id_to_cache_dir_name(const std::string& repo_id) {
@@ -903,7 +922,11 @@ std::map<std::string, ModelInfo> ModelManager::get_supported_models() {
 
     // Return copy of cache (all models, including their download status)
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    return models_cache_;
+    std::map<std::string, ModelInfo> public_models;
+    for (const auto& [name, info] : models_cache_) {
+        public_models[canonical_public_names_.count(name) ? canonical_public_names_.at(name) : name] = info;
+    }
+    return public_models;
 }
 
 static void load_checkpoints(ModelInfo& info, json& model_json) {
@@ -1145,6 +1168,8 @@ void ModelManager::build_cache() {
         models_cache_[name] = info;
     }
 
+    rebuild_public_model_aliases_locked();
+
     cache_valid_ = true;
     LOG(INFO, "ModelManager") << "Cache built: " << models_cache_.size()
               << " total, " << downloaded_count << " downloaded" << std::endl;
@@ -1252,6 +1277,7 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
     }
 
     models_cache_[model_name] = info;
+    rebuild_public_model_aliases_locked();
     LOG(INFO, "ModelManager") << "Added '" << model_name << "' to cache (downloaded=" << info.downloaded << ")" << std::endl;
 }
 
@@ -1311,6 +1337,7 @@ void ModelManager::remove_model_from_cache(const std::string& model_name) {
         bool is_user_model = model_name.substr(0, 5) == "user.";
         if (is_user_model || it->second.source == "local_upload") {
             models_cache_.erase(model_name);
+            rebuild_public_model_aliases_locked();
             LOG(INFO, "ModelManager") << "Removed '" << model_name << "' from cache" << std::endl;
         } else {
             // Registered model - just mark as not downloaded
@@ -1330,7 +1357,7 @@ std::map<std::string, ModelInfo> ModelManager::get_downloaded_models() {
     std::map<std::string, ModelInfo> downloaded;
     for (const auto& [name, info] : models_cache_) {
         if (info.downloaded) {
-            downloaded[name] = info;
+            downloaded[canonical_public_names_.count(name) ? canonical_public_names_.at(name) : name] = info;
         }
     }
     return downloaded;
@@ -2706,14 +2733,15 @@ void ModelManager::download_from_flm(const std::string& checkpoint,
 }
 
 void ModelManager::delete_model(const std::string& model_name) {
-    auto info = get_model_info(model_name);
+    std::string canonical_model_name = resolve_model_name(model_name);
+    auto info = get_model_info(canonical_model_name);
 
-    LOG(INFO, "ModelManager") << "Deleting model: " << model_name << std::endl;
+    LOG(INFO, "ModelManager") << "Deleting model: " << canonical_model_name << std::endl;
     LOG(INFO, "ModelManager") << "Checkpoint: " << info.checkpoint() << std::endl;
     LOG(INFO, "ModelManager") << "Recipe: " << info.recipe << std::endl;
 
     // Handle extra models (from --extra-models-dir) - these are user-managed external files
-    if (model_name.substr(0, 6) == "extra.") {
+    if (canonical_model_name.substr(0, 6) == "extra.") {
         throw std::runtime_error("Cannot delete extra models via API. Models in --extra-models-dir are user-managed. "
                                  "Delete the file directly from: " + info.checkpoint());
     }
@@ -2754,7 +2782,7 @@ void ModelManager::delete_model(const std::string& model_name) {
                 int exit_code = utils::ProcessManager::get_exit_code(handle);
                 if (exit_code != 0) {
                     LOG(ERROR, "ModelManager") << "FLM remove failed with exit code: " << exit_code << std::endl;
-                    throw std::runtime_error("Failed to delete FLM model " + model_name + ": FLM remove failed with exit code " + std::to_string(exit_code));
+                    throw std::runtime_error("Failed to delete FLM model " + canonical_model_name + ": FLM remove failed with exit code " + std::to_string(exit_code));
                 }
                 break;
             }
@@ -2764,14 +2792,14 @@ void ModelManager::delete_model(const std::string& model_name) {
         // Check if process is still running (timeout)
         if (utils::ProcessManager::is_running(handle)) {
             LOG(ERROR, "ModelManager") << "FLM remove timed out" << std::endl;
-            throw std::runtime_error("Failed to delete FLM model " + model_name + ": FLM remove timed out");
+            throw std::runtime_error("Failed to delete FLM model " + canonical_model_name + ": FLM remove timed out");
         }
 
-        LOG(INFO, "ModelManager") << "Successfully deleted FLM model: " << model_name << std::endl;
+        LOG(INFO, "ModelManager") << "Successfully deleted FLM model: " << canonical_model_name << std::endl;
 
         // Remove from user models if it's a user model
-        if (model_name.substr(0, 5) == "user.") {
-            std::string clean_name = model_name.substr(5);
+        if (canonical_model_name.substr(0, 5) == "user.") {
+            std::string clean_name = canonical_model_name.substr(5);
             json updated_user_models = user_models_;
             updated_user_models.erase(clean_name);
             save_user_models(updated_user_models);
@@ -2780,7 +2808,7 @@ void ModelManager::delete_model(const std::string& model_name) {
         }
 
         // Remove from cache after successful deletion
-        remove_model_from_cache(model_name);
+        remove_model_from_cache(canonical_model_name);
 
         return;
     }
@@ -2815,14 +2843,14 @@ void ModelManager::delete_model(const std::string& model_name) {
     std::string main_repo = checkpoint_to_repo_id(info.checkpoint("main"));
 
     // Check if the main repo is shared with another model
-    bool main_shared = is_repo_shared(main_repo, model_name, models_cache_);
+    bool main_shared = is_repo_shared(main_repo, canonical_model_name, models_cache_);
 
     if (!main_shared) {
         // No other model uses this repo — safe to delete the entire directory
         if (fs::exists(model_cache_path_fs)) {
             LOG(INFO, "ModelManager") << "Removing directory..." << std::endl;
             fs::remove_all(model_cache_path_fs);
-            LOG(INFO, "ModelManager") << "✓ Deleted model files: " << model_name << std::endl;
+            LOG(INFO, "ModelManager") << "✓ Deleted model files: " << canonical_model_name << std::endl;
         } else {
             LOG(INFO, "ModelManager") << "Warning: Model cache directory not found (may already be deleted)" << std::endl;
         }
@@ -2840,7 +2868,7 @@ void ModelManager::delete_model(const std::string& model_name) {
                 cleanup_empty_parents(file_path, model_cache_path_fs);
             }
         }
-        LOG(INFO, "ModelManager") << "✓ Deleted variant for: " << model_name << std::endl;
+        LOG(INFO, "ModelManager") << "✓ Deleted variant for: " << canonical_model_name << std::endl;
     }
 
     // Clean up non-main checkpoint files in their own repo dirs (multi-repo models)
@@ -2851,7 +2879,7 @@ void ModelManager::delete_model(const std::string& model_name) {
         std::string cp_repo = checkpoint_to_repo_id(checkpoint);
         if (cp_repo.empty() || cp_repo == main_repo) continue;
 
-        if (is_repo_shared(cp_repo, model_name, models_cache_)) {
+        if (is_repo_shared(cp_repo, canonical_model_name, models_cache_)) {
             LOG(INFO, "ModelManager") << "Keeping shared repo " << cp_repo
                         << " (used by other models)" << std::endl;
             continue;
@@ -2867,8 +2895,8 @@ void ModelManager::delete_model(const std::string& model_name) {
     }
 
     // Remove from user models if it's a user model
-    if (model_name.substr(0, 5) == "user.") {
-        std::string clean_name = model_name.substr(5);
+    if (canonical_model_name.substr(0, 5) == "user.") {
+        std::string clean_name = canonical_model_name.substr(5);
         json updated_user_models = user_models_;
         updated_user_models.erase(clean_name);
         save_user_models(updated_user_models);
@@ -2877,7 +2905,7 @@ void ModelManager::delete_model(const std::string& model_name) {
     }
 
     // Remove from cache after successful deletion
-    remove_model_from_cache(model_name);
+    remove_model_from_cache(canonical_model_name);
 }
 
 json ModelManager::cleanup_orphaned_cache(bool dry_run) {
@@ -2960,12 +2988,30 @@ ModelInfo ModelManager::get_model_info(const std::string& model_name) {
 
     // O(1) lookup in cache
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    auto it = models_cache_.find(model_name);
+    auto alias_it = public_model_aliases_.find(model_name);
+    std::string canonical_name = alias_it != public_model_aliases_.end() ? alias_it->second : model_name;
+    auto it = models_cache_.find(canonical_name);
     if (it != models_cache_.end()) {
         return it->second;
     }
 
     throw std::runtime_error("Model not found: " + model_name);
+}
+
+std::string ModelManager::resolve_model_name(const std::string& model_name) {
+    build_cache();
+
+    std::lock_guard<std::mutex> lock(models_cache_mutex_);
+    auto it = public_model_aliases_.find(model_name);
+    return it != public_model_aliases_.end() ? it->second : model_name;
+}
+
+std::string ModelManager::get_public_model_name(const std::string& model_name) {
+    build_cache();
+
+    std::lock_guard<std::mutex> lock(models_cache_mutex_);
+    auto it = canonical_public_names_.find(model_name);
+    return it != canonical_public_names_.end() ? it->second : model_name;
 }
 
 bool ModelManager::model_exists(const std::string& model_name) {
@@ -2974,30 +3020,49 @@ bool ModelManager::model_exists(const std::string& model_name) {
 
     // O(1) lookup in cache
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    return models_cache_.find(model_name) != models_cache_.end();
+    auto alias_it = public_model_aliases_.find(model_name);
+    std::string canonical_name = alias_it != public_model_aliases_.end() ? alias_it->second : model_name;
+    return models_cache_.find(canonical_name) != models_cache_.end();
 }
 
 bool ModelManager::model_exists_unfiltered(const std::string& model_name) {
-    // Check raw server_models_ JSON (before filtering)
     if (server_models_.contains(model_name)) {
         return true;
     }
-    // Also check user models
-    if (user_models_.contains(model_name)) {
-        return true;
+    if (is_user_model_name(model_name)) {
+        return user_models_.contains(strip_user_model_prefix(model_name));
     }
+
+    std::string canonical_name = resolve_model_name(model_name);
+    if (is_user_model_name(canonical_name)) {
+        return user_models_.contains(strip_user_model_prefix(canonical_name));
+    }
+
+    // Check raw server_models_ JSON (before filtering)
     return false;
 }
 
 ModelInfo ModelManager::get_model_info_unfiltered(const std::string& model_name) {
     ModelInfo info;
+    std::string registry_name = model_name;
+
+    if (!server_models_.contains(registry_name)) {
+        if (is_user_model_name(registry_name)) {
+            registry_name = strip_user_model_prefix(registry_name);
+        } else {
+            std::string canonical_name = resolve_model_name(model_name);
+            if (is_user_model_name(canonical_name)) {
+                registry_name = strip_user_model_prefix(canonical_name);
+            }
+        }
+    }
 
     // Check server models first
     json* model_json = nullptr;
-    if (server_models_.contains(model_name)) {
-        model_json = &server_models_[model_name];
-    } else if (user_models_.contains(model_name)) {
-        model_json = &user_models_[model_name];
+    if (server_models_.contains(registry_name)) {
+        model_json = &server_models_[registry_name];
+    } else if (user_models_.contains(registry_name)) {
+        model_json = &user_models_[registry_name];
     }
 
     if (!model_json) {
@@ -3005,7 +3070,8 @@ ModelInfo ModelManager::get_model_info_unfiltered(const std::string& model_name)
     }
 
     // Parse model info from JSON
-    info.model_name = model_name;
+    info.model_name = is_user_model_name(model_name) ? model_name
+        : (user_models_.contains(registry_name) ? std::string(USER_MODEL_PREFIX) + registry_name : registry_name);
     info.checkpoints["main"] = JsonUtils::get_or_default<std::string>(*model_json, "checkpoint", "");
     parse_legacy_mmproj(info, *model_json);
     load_checkpoints(info, *model_json);
@@ -3041,13 +3107,48 @@ std::string ModelManager::get_model_filter_reason(const std::string& model_name)
     // This is populated by filter_models_by_backend() during cache building
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
 
-    auto it = filtered_out_models_.find(model_name);
+    auto alias_it = public_model_aliases_.find(model_name);
+    std::string canonical_name = alias_it != public_model_aliases_.end() ? alias_it->second : model_name;
+    auto it = filtered_out_models_.find(canonical_name);
     if (it != filtered_out_models_.end()) {
         return it->second;
     }
 
     // Model wasn't filtered out (either it's available or doesn't exist)
     return "";
+}
+
+void ModelManager::rebuild_public_model_aliases_locked() {
+    public_model_aliases_.clear();
+    canonical_public_names_.clear();
+
+    for (const auto& [name, _] : models_cache_) {
+        public_model_aliases_[name] = name;
+        canonical_public_names_[name] = name;
+    }
+
+    for (const auto& [name, info] : models_cache_) {
+        if (!is_user_model_name(name) || !has_label(info, APPEAR_BUILTIN_LABEL)) {
+            continue;
+        }
+
+        std::string bare_name = strip_user_model_prefix(name);
+        if (server_models_.contains(bare_name)) {
+            LOG(INFO, "ModelManager") << "Skipping public alias '" << bare_name
+                      << "' for '" << name << "' because it collides with a built-in model" << std::endl;
+            continue;
+        }
+
+        auto existing = public_model_aliases_.find(bare_name);
+        if (existing != public_model_aliases_.end() && existing->second != name) {
+            LOG(INFO, "ModelManager") << "Skipping public alias '" << bare_name
+                      << "' for '" << name << "' because it collides with '" << existing->second << "'" << std::endl;
+            continue;
+        }
+
+        public_model_aliases_[bare_name] = name;
+        canonical_public_names_[name] = bare_name;
+    }
 }
 
 } // namespace lemon

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2822,7 +2822,21 @@ void ModelManager::delete_model(const std::string& model_name) {
 
     // Use resolved_path to find the model directory to delete
     if (info.resolved_path().empty()) {
-        throw std::runtime_error("Model has no resolved_path, cannot determine files to delete");
+        // Model exists in registry but has no downloaded files
+        // Just remove from user_models.json and cache
+        LOG(INFO, "ModelManager") << "Model not downloaded, removing from registry only" << std::endl;
+
+        if (is_user_model_name(canonical_model_name)) {
+            json updated_user_models = user_models_;
+            updated_user_models.erase(strip_user_model_prefix(canonical_model_name));
+            save_user_models(updated_user_models);
+            user_models_ = updated_user_models;
+            LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
+        }
+
+        remove_model_from_cache(canonical_model_name);
+        LOG(INFO, "ModelManager") << "Successfully removed model from registry: " << canonical_model_name << std::endl;
+        return;
     }
 
     // Find the models--* directory from resolved_path

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -19,7 +19,6 @@
 #include <set>
 #include <unordered_set>
 #include <iomanip>
-#include <cstring>
 #include <lemon/utils/aixlog.hpp>
 
 namespace fs = std::filesystem;
@@ -78,7 +77,8 @@ static bool contains_ignore_case(const std::string& str, const std::string& subs
     return to_lower(str).find(to_lower(substr)) != std::string::npos;
 }
 
-static constexpr const char* USER_MODEL_PREFIX = "user.";
+static constexpr const char USER_MODEL_PREFIX[] = "user.";
+static constexpr size_t USER_MODEL_PREFIX_LEN = sizeof(USER_MODEL_PREFIX) - 1;
 static constexpr const char* APPEAR_BUILTIN_LABEL = "appear-builtin";
 
 static bool has_label(const ModelInfo& info, const std::string& label) {
@@ -91,7 +91,7 @@ static bool is_user_model_name(const std::string& model_name) {
 
 static std::string strip_user_model_prefix(const std::string& model_name) {
     if (is_user_model_name(model_name)) {
-        return model_name.substr(std::strlen(USER_MODEL_PREFIX));
+        return model_name.substr(USER_MODEL_PREFIX_LEN);
     }
     return model_name;
 }
@@ -1184,9 +1184,9 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
 
     // Parse model name to get JSON key
     std::string json_key = model_name;
-    bool is_user_model = model_name.substr(0, 5) == "user.";
+    bool is_user_model = is_user_model_name(model_name);
     if (is_user_model) {
-        json_key = model_name.substr(5);
+        json_key = strip_user_model_prefix(model_name);
     }
 
     // Find in JSON
@@ -1334,7 +1334,7 @@ void ModelManager::remove_model_from_cache(const std::string& model_name) {
     if (it != models_cache_.end()) {
         // User models and local uploads should be removed entirely from cache
         // (they're not in server_models.json, so keeping them makes no sense)
-        bool is_user_model = model_name.substr(0, 5) == "user.";
+        bool is_user_model = is_user_model_name(model_name);
         if (is_user_model || it->second.source == "local_upload") {
             models_cache_.erase(model_name);
             rebuild_public_model_aliases_locked();
@@ -1599,8 +1599,8 @@ void ModelManager::register_user_model(const std::string& model_name,
                                       const std::string& source) {
     // Remove "user." prefix if present
     std::string clean_name = model_name;
-    if (clean_name.substr(0, 5) == "user.") {
-        clean_name = clean_name.substr(5);
+    if (is_user_model_name(clean_name)) {
+        clean_name = strip_user_model_prefix(clean_name);
     }
 
     // Filter only known, user-definable model props
@@ -1878,7 +1878,7 @@ void ModelManager::download_model(const std::string& model_name,
     // If checkpoint or recipe are provided, this is a model registration
     // and the model name must have the "user." prefix
     if (!actual_checkpoint.empty() || !actual_recipe.empty()) {
-        if (model_name.substr(0, 5) != "user.") {
+        if (!is_user_model_name(model_name)) {
             throw std::runtime_error(
                 "When providing 'checkpoint' or 'recipe', the model name must include the "
                 "`user.` prefix, for example `user.Phi-4-Mini-GGUF`. Received: " +
@@ -1903,7 +1903,7 @@ void ModelManager::download_model(const std::string& model_name,
 
         // Model not in registry - this must be a user model registration
         // Validate it has the "user." prefix
-        if (model_name.substr(0, 5) != "user.") {
+        if (!is_user_model_name(model_name)) {
             throw std::runtime_error(
                 "When registering a new model, the model name must include the "
                 "`user` namespace, for example `user.Phi-4-Mini-GGUF`. Received: " +
@@ -1998,7 +1998,7 @@ void ModelManager::download_model(const std::string& model_name,
     }
 
     // Register user models to user_models.json
-    if (model_name.substr(0, 5) == "user." && !model_registered) {
+    if (is_user_model_name(model_name) && !model_registered) {
         register_user_model(model_name, model_data);
     }
 
@@ -2798,10 +2798,9 @@ void ModelManager::delete_model(const std::string& model_name) {
         LOG(INFO, "ModelManager") << "Successfully deleted FLM model: " << canonical_model_name << std::endl;
 
         // Remove from user models if it's a user model
-        if (canonical_model_name.substr(0, 5) == "user.") {
-            std::string clean_name = canonical_model_name.substr(5);
+        if (is_user_model_name(canonical_model_name)) {
             json updated_user_models = user_models_;
-            updated_user_models.erase(clean_name);
+            updated_user_models.erase(strip_user_model_prefix(canonical_model_name));
             save_user_models(updated_user_models);
             user_models_ = updated_user_models;
             LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
@@ -2895,10 +2894,9 @@ void ModelManager::delete_model(const std::string& model_name) {
     }
 
     // Remove from user models if it's a user model
-    if (canonical_model_name.substr(0, 5) == "user.") {
-        std::string clean_name = canonical_model_name.substr(5);
+    if (is_user_model_name(canonical_model_name)) {
         json updated_user_models = user_models_;
-        updated_user_models.erase(clean_name);
+        updated_user_models.erase(strip_user_model_prefix(canonical_model_name));
         save_user_models(updated_user_models);
         user_models_ = updated_user_models;
         LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
@@ -3121,11 +3119,6 @@ std::string ModelManager::get_model_filter_reason(const std::string& model_name)
 void ModelManager::rebuild_public_model_aliases_locked() {
     public_model_aliases_.clear();
     canonical_public_names_.clear();
-
-    for (const auto& [name, _] : models_cache_) {
-        public_model_aliases_[name] = name;
-        canonical_public_names_[name] = name;
-    }
 
     for (const auto& [name, info] : models_cache_) {
         if (!is_user_model_name(name) || !has_label(info, APPEAR_BUILTIN_LABEL)) {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -924,7 +924,11 @@ std::map<std::string, ModelInfo> ModelManager::get_supported_models() {
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
     std::map<std::string, ModelInfo> public_models;
     for (const auto& [name, info] : models_cache_) {
-        public_models[canonical_public_names_.count(name) ? canonical_public_names_.at(name) : name] = info;
+        auto it = canonical_public_names_.find(name);
+        const std::string& public_name = it != canonical_public_names_.end() ? it->second : name;
+        ModelInfo public_info = info;
+        public_info.model_name = public_name;
+        public_models[public_name] = std::move(public_info);
     }
     return public_models;
 }
@@ -1357,7 +1361,11 @@ std::map<std::string, ModelInfo> ModelManager::get_downloaded_models() {
     std::map<std::string, ModelInfo> downloaded;
     for (const auto& [name, info] : models_cache_) {
         if (info.downloaded) {
-            downloaded[canonical_public_names_.count(name) ? canonical_public_names_.at(name) : name] = info;
+            auto it = canonical_public_names_.find(name);
+            const std::string& public_name = it != canonical_public_names_.end() ? it->second : name;
+            ModelInfo public_info = info;
+            public_info.model_name = public_name;
+            downloaded[public_name] = std::move(public_info);
         }
     }
     return downloaded;
@@ -3116,6 +3124,7 @@ std::string ModelManager::get_model_filter_reason(const std::string& model_name)
     return "";
 }
 
+// Must be called with models_cache_mutex_ held.
 void ModelManager::rebuild_public_model_aliases_locked() {
     public_model_aliases_.clear();
     canonical_public_names_.clear();

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3135,9 +3135,9 @@ void ModelManager::rebuild_public_model_aliases_locked() {
         }
 
         std::string bare_name = strip_user_model_prefix(name);
-        if (server_models_.contains(bare_name)) {
+        if (server_models_.contains(bare_name) || models_cache_.find(bare_name) != models_cache_.end()) {
             LOG(INFO, "ModelManager") << "Skipping public alias '" << bare_name
-                      << "' for '" << name << "' because it collides with a built-in model" << std::endl;
+                      << "' for '" << name << "' because it collides with an existing model" << std::endl;
             continue;
         }
 

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -39,6 +39,10 @@ WrappedServer* Router::find_server_by_model_name(const std::string& model_name) 
     return nullptr;
 }
 
+std::string Router::resolve_model_name(const std::string& model_name) const {
+    return model_name.empty() ? model_name : model_manager_->resolve_model_name(model_name);
+}
+
 WrappedServer* Router::get_most_recent_server() const {
     if (loaded_servers_.empty()) {
         return nullptr;
@@ -212,6 +216,7 @@ void Router::load_model(const std::string& model_name,
                        const ModelInfo& model_info,
                        RecipeOptions options,
                        bool do_not_upgrade) {
+    const std::string canonical_model_name = resolve_model_name(model_name);
     RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options());
 
     // Resolve settings: load overrides take precedence over per-model overrides which take precedence over defaults
@@ -232,7 +237,7 @@ void Router::load_model(const std::string& model_name,
     // Mark that we're now loading (prevents concurrent loads)
     is_loading_ = true;
 
-    LOG(DEBUG, "Router") << "Loading model: " << model_name
+    LOG(DEBUG, "Router") << "Loading model: " << canonical_model_name
             << " (checkpoint: " << model_info.checkpoint()
             << ", recipe: " << model_info.recipe
             << ", type: " << model_type_to_string(model_info.type)
@@ -240,7 +245,7 @@ void Router::load_model(const std::string& model_name,
 
     try {
         // Check if model is already loaded
-        WrappedServer* existing = find_server_by_model_name(model_name);
+        WrappedServer* existing = find_server_by_model_name(canonical_model_name);
         if (existing) {
         LOG(INFO, "Router") << "Model already loaded, updating access time" << std::endl;
             existing->update_access_time();
@@ -312,7 +317,7 @@ void Router::load_model(const std::string& model_name,
         std::unique_ptr<WrappedServer> new_server = create_backend_server(model_info);
 
         // Set model metadata
-        new_server->set_model_metadata(model_name, model_info.checkpoint(), model_type, device_type, effective_options);
+        new_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
         new_server->update_access_time();
 
         // CRITICAL: Release lock before slow backend startup
@@ -324,7 +329,7 @@ void Router::load_model(const std::string& model_name,
         std::string error_message;
 
         try {
-            new_server->load(model_name, model_info, effective_options, do_not_upgrade);
+            new_server->load(canonical_model_name, model_info, effective_options, do_not_upgrade);
             load_success = true;
         LOG(DEBUG, "Router") << "Backend started successfully" << std::endl;
         } catch (const std::exception& e) {
@@ -376,14 +381,14 @@ void Router::load_model(const std::string& model_name,
 
             // Create new server for retry
             std::unique_ptr<WrappedServer> retry_server = create_backend_server(model_info);
-            retry_server->set_model_metadata(model_name, model_info.checkpoint(), model_type, device_type, effective_options);
+            retry_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
             retry_server->update_access_time();
 
             lock.unlock();
 
         LOG(DEBUG, "Router") << "Retrying backend load..." << std::endl;
             try {
-                retry_server->load(model_name, model_info, effective_options, do_not_upgrade);
+                retry_server->load(canonical_model_name, model_info, effective_options, do_not_upgrade);
 
                 lock.lock();
 
@@ -425,7 +430,8 @@ void Router::unload_model(const std::string& model_name) {
     } else {
         // Unload specific model
     LOG(INFO, "Router") << "Unload model called: " << model_name << std::endl;
-        WrappedServer* server = find_server_by_model_name(model_name);
+        std::string canonical_model_name = resolve_model_name(model_name);
+        WrappedServer* server = find_server_by_model_name(canonical_model_name);
         if (!server) {
             throw std::runtime_error("Model not loaded: " + model_name);
         }
@@ -436,7 +442,7 @@ void Router::unload_model(const std::string& model_name) {
 std::string Router::get_loaded_model() const {
     std::lock_guard<std::mutex> lock(load_mutex_);
     WrappedServer* server = get_most_recent_server();
-    return server ? server->get_model_name() : "";
+    return server ? model_manager_->get_public_model_name(server->get_model_name()) : "";
 }
 
 std::string Router::get_loaded_recipe() const {
@@ -455,7 +461,7 @@ json Router::get_all_loaded_models() const {
 
     for (const auto& server : loaded_servers_) {
         json model_info;
-        model_info["model_name"] = server->get_model_name();
+        model_info["model_name"] = model_manager_->get_public_model_name(server->get_model_name());
         model_info["checkpoint"] = server->get_checkpoint();
         model_info["type"] = model_type_to_string(server->get_model_type());
         model_info["device"] = device_type_to_string(server->get_device_type());
@@ -495,12 +501,12 @@ bool Router::is_model_loaded() const {
 
 bool Router::is_model_loaded(const std::string& model_name) const {
     std::lock_guard<std::mutex> lock(load_mutex_);
-    return find_server_by_model_name(model_name) != nullptr;
+    return find_server_by_model_name(resolve_model_name(model_name)) != nullptr;
 }
 
 RecipeOptions Router::get_model_recipe_options(const std::string& model_name) const {
     std::lock_guard<std::mutex> lock(load_mutex_);
-    auto* server = find_server_by_model_name(model_name);
+    auto* server = find_server_by_model_name(resolve_model_name(model_name));
     if (server) return server->get_recipe_options();
     return RecipeOptions();
 }
@@ -509,7 +515,7 @@ ModelType Router::get_model_type(const std::string& model_name) const {
     std::lock_guard<std::mutex> lock(load_mutex_);
     WrappedServer* server = model_name.empty()
         ? get_most_recent_server()
-        : find_server_by_model_name(model_name);
+        : find_server_by_model_name(resolve_model_name(model_name));
     return server ? server->get_model_type() : ModelType::LLM;
 }
 
@@ -537,7 +543,7 @@ auto Router::execute_inference(const json& request, Func&& inference_func) -> de
             return ErrorResponse::from_exception(InvalidRequestException("No model specified in request"));
         }
 
-        server = find_server_by_model_name(requested_model);
+        server = find_server_by_model_name(resolve_model_name(requested_model));
         if (!server) {
             return ErrorResponse::from_exception(ModelNotLoadedException(requested_model));
         }
@@ -586,7 +592,7 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
             return;
         }
 
-        server = find_server_by_model_name(requested_model);
+        server = find_server_by_model_name(resolve_model_name(requested_model));
         if (!server) {
             std::string error_msg = "data: {\"error\":{\"message\":\"Model not loaded: " + requested_model + "\",\"type\":\"model_not_loaded\"}}\n\n";
             sink.write(error_msg.c_str(), error_msg.size());

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -483,7 +483,7 @@ void Server::setup_static_files(httplib::Server &web_server) {
         json filtered_models = json::object();
         for (const auto& [model_name, info] : models_map) {
             filtered_models[model_name] = {
-                {"model_name", info.model_name},
+                {"model_name", model_name},
                 {"checkpoint", info.checkpoint()},
                 {"recipe", info.recipe},
                 {"labels", info.labels},

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -29,6 +29,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import uuid
 
 from utils.server_base import wait_for_server
 from utils.test_models import (
@@ -543,6 +544,45 @@ sys.exit(0)
                 timeout=TIMEOUT_MODEL_OPERATION,
             )
             print(f"Import from JSON exit code: {result.returncode}")
+        finally:
+            if os.path.exists(json_file):
+                os.unlink(json_file)
+
+    def test_060a_import_json_file_with_appear_builtin_label(self):
+        """Import should preserve appear-builtin and expose the bare model name."""
+        canonical_name = f"user.ImportAlias-{uuid.uuid4().hex[:8]}"
+        public_name = canonical_name[5:]
+        json_data = {
+            "model_name": canonical_name,
+            "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
+            "recipe": "llamacpp",
+            "labels": ["appear-builtin"],
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json_file = f.name
+            json.dump(json_data, f)
+
+        try:
+            import_result = run_cli_command(
+                ["import", json_file],
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(import_result.returncode, 0)
+
+            list_result = run_cli_command(
+                ["list", "--downloaded"],
+                timeout=TIMEOUT_DEFAULT,
+            )
+            output = list_result.stdout + list_result.stderr
+            self.assertIn(public_name, output)
+            self.assertNotIn(canonical_name, output)
+
+            delete_result = run_cli_command(
+                ["delete", public_name],
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(delete_result.returncode, 0)
         finally:
             if os.path.exists(json_file):
                 os.unlink(json_file)

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -993,6 +993,67 @@ class EndpointTests(ServerTestBase):
             except Exception:
                 pass
 
+    def test_021b_appear_builtin_aliases_user_model(self):
+        """User models labeled appear-builtin should expose a bare public ID."""
+        canonical_name = f"user.AppearBuiltin-{uuid.uuid4().hex[:8]}"
+        public_name = canonical_name[5:]
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": canonical_name,
+                    "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
+                    "recipe": "llamacpp",
+                    "labels": ["appear-builtin"],
+                    "stream": False,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(response.status_code, 200)
+
+            models_response = requests.get(
+                f"{self.base_url}/models?show_all=true",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(models_response.status_code, 200)
+            model_ids = {model["id"] for model in models_response.json()["data"]}
+            self.assertIn(public_name, model_ids)
+            self.assertNotIn(canonical_name, model_ids)
+
+            model_info_response = requests.get(
+                f"{self.base_url}/models/{public_name}",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(model_info_response.status_code, 200)
+            self.assertEqual(model_info_response.json()["id"], public_name)
+
+            load_response = requests.post(
+                f"{self.base_url}/load",
+                json={"model_name": public_name},
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(load_response.status_code, 200)
+            self.assertEqual(load_response.json()["model_name"], public_name)
+
+            unload_response = requests.post(
+                f"{self.base_url}/unload",
+                json={"model_name": public_name},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(unload_response.status_code, 200)
+
+            print(f"[OK] appear-builtin alias exposed and accepted for {public_name}")
+        finally:
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": public_name},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+
     def _get_test_backend(self):
         """Get a lightweight test backend based on platform."""
         import sys

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -12,6 +12,7 @@ Usage:
 import base64
 import json
 import sys
+import uuid
 import requests
 
 try:
@@ -32,6 +33,7 @@ from utils.test_models import (
     SAMPLE_TOOL,
     TIMEOUT_MODEL_OPERATION,
     TIMEOUT_DEFAULT,
+    USER_MODEL_MAIN_CHECKPOINT,
 )
 
 OLLAMA_BASE_URL = f"http://localhost:{PORT}"
@@ -179,7 +181,52 @@ class OllamaTests(ServerTestBase):
             f"Model name should end with ':latest', got: {model['name']}",
         )
 
-    def test_007_pull_streaming_progress(self):
+    def test_007_user_model_appear_builtin_alias(self):
+        """Aliased user models should appear built-in through Ollama endpoints."""
+        canonical_name = f"user.OllamaAlias-{uuid.uuid4().hex[:8]}"
+        public_name = canonical_name[5:]
+
+        try:
+            pull_response = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": canonical_name,
+                    "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
+                    "recipe": "llamacpp",
+                    "labels": ["appear-builtin"],
+                    "stream": False,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(pull_response.status_code, 200)
+
+            tags_response = requests.get(
+                f"{OLLAMA_BASE_URL}/api/tags",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(tags_response.status_code, 200)
+            tag_names = {
+                model["model"].replace(":latest", "")
+                for model in tags_response.json()["models"]
+            }
+            self.assertIn(public_name, tag_names)
+            self.assertNotIn(canonical_name, tag_names)
+
+            show_response = requests.post(
+                f"{OLLAMA_BASE_URL}/api/show",
+                json={"name": public_name},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(show_response.status_code, 200)
+            self.assertIn("details", show_response.json())
+        finally:
+            requests.post(
+                f"{self.base_url}/delete",
+                json={"model_name": public_name},
+                timeout=TIMEOUT_DEFAULT,
+            )
+
+    def test_008_pull_streaming_progress(self):
         """Test /api/pull streams NDJSON progress with digest field."""
         self.ensure_model_pulled()
         response = requests.post(


### PR DESCRIPTION
## Summary
Add support for user models labeled `appear-builtin` to expose a bare public model name while keeping `user.*` as the canonical internal ID.

The purpose of this PR is to enable this workflow:

```
# Single-command model import with custom openclaw settings
lemonade import --directory openclaw --recipe-file Qwen3.5-35B-A3B-Q4_K_M.json

# Look, no "user."!
lemonade list | grep Qwen3.5-35B-A3B-Q4_K_M

Qwen3.5-35B-A3B-Q4_K_M                  Yes         llamacpp
```

## What Changed
- added centralized public-name alias generation and canonical lookup in `ModelManager`
- updated `Router` to resolve public model names before load, unload, and request dispatch while still reporting public names in status/listing surfaces
- allowed `appear-builtin` through the CLI label allowlist and fixed the server-rendered model bootstrap JSON to expose public names
- added regression tests for CLI import/list/delete, OpenAI-style model endpoints, and Ollama listing/show behavior

## Behavior
- `lemonade pull --label appear-builtin ...` and `lemonade import` recipes with `labels: ["appear-builtin"]` now make `user.Foo` appear publicly as `Foo`
- requests may use either `Foo` or `user.Foo`
- alias creation is skipped if `Foo` collides with an existing built-in or other public model name

## Validation
- `cmake --build --preset default --target lemond lemonade`
- `python3 -m py_compile test/server_endpoints.py test/server_cli2.py test/test_ollama.py`