### PR TITLE
Fix broken debug build on Linux

### DIFF
--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -1,5 +1,7 @@
 #include <lemon/recipe_options.h>
+#ifndef LEMONADE_CLI
 #include <lemon/system_info.h>
+#endif
 #include <nlohmann/json.hpp>
 #include <map>
 #ifdef LEMONADE_CLI
@@ -67,6 +69,7 @@ static bool is_empty_option(json option) {
            (option.is_string() && (option == "" || option == "auto"));
 }
 
+#ifndef LEMONADE_CLI
 static bool try_get_backend_options(const std::string& opt_name, SystemInfo::SupportedBackendsResult& result) {
     // Generic handling for any *_backend option
     // Pattern: {recipe}_backend -> get supported backends for {recipe}
@@ -83,6 +86,7 @@ static bool try_get_backend_options(const std::string& opt_name, SystemInfo::Sup
 
     return is_backend_option;
 }
+#endif
 
 std::vector<std::string> RecipeOptions::to_cli_options(const json& raw_options) {
     std::vector<std::string> cli;


### PR DESCRIPTION
Building of the "debug" target on Linux hosts was broken due to some outdated code that was never overhauled for debug.  This has been fixed.