### PR TITLE
Fix Claude Code Guide

### DIFF
--- a/docs/server/apps/claude-code.md
+++ b/docs/server/apps/claude-code.md
@@ -8,15 +8,15 @@ This guide focuses on the most common launch flows.
 
 1. Install Claude Code:
 
-```bash
-curl -fsSL https://claude.ai/install.sh | bash
-```
+    ```bash
+    curl -fsSL https://claude.ai/install.sh | bash
+    ```
 
-or:
+    or:
 
-```bash
-npm install -g @anthropic-ai/claude-code
-```
+    ```bash
+    npm install -g @anthropic-ai/claude-code
+    ```
 
 2. Make sure Lemonade Server is running (`lemond`).
 
@@ -39,6 +39,7 @@ lemonade launch claude
 ```
 
 You will get an interactive menu where you can:
+
 - Select a recipe to import and launch.
 - Browse downloaded models.
 - Browse recommended llama.cpp models (download may be required), then launch.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
       - AnythingLLM: server/apps/anythingLLM.md
       - CodeGPT: server/apps/codeGPT.md
       - Continue: server/apps/continue.md
+      - Claude Code: server/apps/claude-code.md
       - Mindcraft: server/apps/mindcraft.md
       - OpenHands: server/apps/open-hands.md
       - Open WebUI: server/apps/open-webui.md


### PR DESCRIPTION
Includes some fixes to the Claude Code guide. 

Adds the guide to mkdocs.yml (should add the guide to the index) and corrects some minor formatting issues in the guide itself.