### PR TITLE
Group user models and add log level control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ CLAUDE.local.md
 # WiX Toolset build artifacts
 *.msi
 *.wixpdb
+
+# Local dev folder
+local.dev/

--- a/docs/dev-getting-started.md
+++ b/docs/dev-getting-started.md
@@ -194,6 +194,15 @@ chmod +x build/app-appimage/lemonade-app-*.AppImage
 - The build uses static linking to minimize DLL dependencies
 - All dependencies are built from source (no external DLL requirements)
 - Security features enabled: Control Flow Guard, ASLR, DEP
+- **Troubleshooting:** If `npm run dev` or `cargo` commands fail with "program not found", ensure `%USERPROFILE%\.cargo\bin` is in your PATH. Add it permanently from PowerShell with a duplicate-safe update, then restart your IDE or terminal:
+  ```powershell
+  $cargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
+  $userPath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
+  if (($userPath -split ";") -notcontains $cargoBin) {
+      [System.Environment]::SetEnvironmentVariable("PATH", "$cargoBin;$userPath", "User")
+  }
+  ```
+- **Troubleshooting:** If Rust/Tauri fails with `link.exe` or `msvcrt.lib` errors, launch from a Visual Studio Developer shell and confirm `where link` lists the Visual Studio linker before Git's `link.exe`.
 
 **Linux:**
 - `lemond` is always headless on Linux (GTK-free, daemon-friendly); use `lemond` to start the server directly
@@ -661,7 +670,7 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 |-----|------|-------------|
 | `port` | int (1–65535) | HTTP rebind |
 | `host` | string | HTTP rebind |
-| `log_level` | string (`trace`, `debug`, `info`, `warning`, `error`, `fatal`, `none`) | Reconfigures log filter |
+| `log_level` | string (`trace`, `debug`, `info`, `notice`, `warning`, `error`, `critical`, `fatal`, `none`) | Reconfigures log filter |
 | `global_timeout` | int (positive) | Updates default HTTP client timeout |
 | `no_broadcast` | bool | Stops or starts UDP beacon |
 | `extra_models_dir` | string | Updates model manager search path |

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -76,7 +76,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
 |-----|------|---------|-------------|
 | `port` | int | 13305 | Port number for the HTTP server |
 | `host` | string | "localhost" | Address to bind for connections |
-| `log_level` | string | "info" | Logging level (trace, debug, info, warning, error, fatal, none) |
+| `log_level` | string | "info" | Logging level (trace, debug, info, notice, warning, error, critical, fatal, none) |
 | `global_timeout` | int | 300 | Timeout in seconds for HTTP, inference, and readiness checks |
 | `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
 | `no_broadcast` | bool | false | Disable UDP broadcasting for server discovery |

--- a/src/app/src/renderer/LogsWindow.tsx
+++ b/src/app/src/renderer/LogsWindow.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { getServerBaseUrl, onServerUrlChange, serverConfig } from './utils/serverConfig';
+import { getAPIKey, getServerBaseUrl, onServerUrlChange, serverConfig, serverFetch } from './utils/serverConfig';
 import { connectLogStream, LogEntry, LogStreamHandle } from './utils/logWebSocketClient';
 
 interface LogsWindowProps {
@@ -8,11 +8,18 @@ interface LogsWindowProps {
 }
 
 const BOTTOM_FOLLOW_THRESHOLD_PX = 60;
+const LOG_LEVELS = ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'none'] as const;
+type LogLevel = typeof LOG_LEVELS[number];
+
+const isLogLevel = (value: unknown): value is LogLevel =>
+  typeof value === 'string' && LOG_LEVELS.includes(value as LogLevel);
 
 const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'connected' | 'error' | 'disconnected'>('connecting');
   const [autoScroll, setAutoScroll] = useState(true);
+  const [logLevel, setLogLevel] = useState<LogLevel>('info');
+  const [isSettingLogLevel, setIsSettingLogLevel] = useState(false);
   const logsEndRef = useRef<HTMLDivElement>(null);
   const logsContentRef = useRef<HTMLDivElement>(null);
   const autoScrollRef = useRef(true);
@@ -51,6 +58,34 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
       setIsInitialized(true);
     });
   }, []);
+
+  useEffect(() => {
+    if (!isInitialized || !serverUrl) return;
+
+    const loadLogLevel = async () => {
+      try {
+        const headers: HeadersInit = {};
+        const apiKey = getAPIKey();
+        if (apiKey) {
+          headers.Authorization = `Bearer ${apiKey}`;
+        }
+
+        const response = await fetch(`${serverUrl}/internal/config`, { headers });
+        if (!response.ok) {
+          return;
+        }
+
+        const config = await response.json();
+        if (isLogLevel(config.log_level)) {
+          setLogLevel(config.log_level);
+        }
+      } catch (error) {
+        console.error('Failed to load log level:', error);
+      }
+    };
+
+    loadLogLevel();
+  }, [isInitialized, serverUrl]);
 
   // Listen for URL changes (covers both port changes and explicit URL updates)
   useEffect(() => {
@@ -211,6 +246,38 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
     scrollToBottom();
   };
 
+  const handleLogLevelChange = async (nextLevel: LogLevel) => {
+    if (!isLogLevel(nextLevel)) {
+      return;
+    }
+
+    const previousLevel = logLevel;
+    setLogLevel(nextLevel);
+    setIsSettingLogLevel(true);
+
+    try {
+      const response = await serverFetch('/log-level', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ level: nextLevel }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Server returned ${response.status}`);
+      }
+
+      const data = await response.json();
+      if (isLogLevel(data.level)) {
+        setLogLevel(data.level);
+      }
+    } catch (error) {
+      console.error('Failed to update log level:', error);
+      setLogLevel(previousLevel);
+    } finally {
+      setIsSettingLogLevel(false);
+    }
+  };
+
   if (!isVisible) return null;
 
   return (
@@ -218,6 +285,20 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
       <div className="logs-header">
         <h3>Server Logs</h3>
         <div className="logs-controls">
+          <label className="logs-level-control">
+            <span>Level</span>
+            <select
+              className="logs-level-select"
+              value={logLevel}
+              disabled={isSettingLogLevel}
+              onChange={(event) => handleLogLevelChange(event.target.value as LogLevel)}
+              title="Set server log level"
+            >
+              {LOG_LEVELS.map(level => (
+                <option key={level} value={level}>{level}</option>
+              ))}
+            </select>
+          </label>
           <span className={`connection-status status-${connectionStatus}`}>
             {connectionStatus === 'connecting' && '⟳ Connecting...'}
             {connectionStatus === 'connected' && '● Connected'}

--- a/src/app/src/renderer/LogsWindow.tsx
+++ b/src/app/src/renderer/LogsWindow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { getAPIKey, getServerBaseUrl, onServerUrlChange, serverConfig, serverFetch } from './utils/serverConfig';
 import { connectLogStream, LogEntry, LogStreamHandle } from './utils/logWebSocketClient';
 
@@ -8,7 +8,7 @@ interface LogsWindowProps {
 }
 
 const BOTTOM_FOLLOW_THRESHOLD_PX = 60;
-const LOG_LEVELS = ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'none'] as const;
+const LOG_LEVELS = ['trace', 'debug', 'info', 'notice', 'warning', 'error', 'critical', 'fatal', 'none'] as const;
 type LogLevel = typeof LOG_LEVELS[number];
 
 const isLogLevel = (value: unknown): value is LogLevel =>
@@ -20,6 +20,7 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
   const [autoScroll, setAutoScroll] = useState(true);
   const [logLevel, setLogLevel] = useState<LogLevel>('info');
   const [isSettingLogLevel, setIsSettingLogLevel] = useState(false);
+  const [serverSupportsLogLevel, setServerSupportsLogLevel] = useState(false);
   const logsEndRef = useRef<HTMLDivElement>(null);
   const logsContentRef = useRef<HTMLDivElement>(null);
   const autoScrollRef = useRef(true);
@@ -51,41 +52,34 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
     });
   };
 
-  // Wait for serverConfig to initialize and get the correct URL
+  // Initialize server configuration and load the current log level
   useEffect(() => {
-    serverConfig.waitForInit().then(() => {
-      setServerUrl(getServerBaseUrl());
+    const init = async () => {
+      await serverConfig.waitForInit();
+      const url = getServerBaseUrl();
+      setServerUrl(url);
       setIsInitialized(true);
-    });
-  }, []);
 
-  useEffect(() => {
-    if (!isInitialized || !serverUrl) return;
-
-    const loadLogLevel = async () => {
       try {
-        const headers: HeadersInit = {};
-        const apiKey = getAPIKey();
-        if (apiKey) {
-          headers.Authorization = `Bearer ${apiKey}`;
-        }
-
-        const response = await fetch(`${serverUrl}/internal/config`, { headers });
-        if (!response.ok) {
-          return;
-        }
+        // Using serverFetch with the full URL to reach the root-level /internal/config
+        // endpoint while benefiting from automatic authentication and init-waiting.
+        const response = await serverFetch(`${url}/internal/config`);
+        if (!response.ok) return;
 
         const config = await response.json();
-        if (isLogLevel(config.log_level)) {
-          setLogLevel(config.log_level);
+        if ('log_level' in config) {
+          setServerSupportsLogLevel(true);
+          if (isLogLevel(config.log_level)) {
+            setLogLevel(config.log_level);
+          }
         }
       } catch (error) {
         console.error('Failed to load log level:', error);
       }
     };
 
-    loadLogLevel();
-  }, [isInitialized, serverUrl]);
+    init();
+  }, []);
 
   // Listen for URL changes (covers both port changes and explicit URL updates)
   useEffect(() => {
@@ -278,6 +272,28 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
     }
   };
 
+  const getSeverityPriority = (level: string): number => {
+    const p: Record<string, number> = {
+      'trace': 0,
+      'debug': 1,
+      'info': 2,
+      'notice': 3,
+      'warning': 4,
+      'warn': 4,
+      'error': 5,
+      'critical': 6,
+      'fatal': 6,
+      'none': 10
+    };
+    return p[level.toLowerCase()] ?? 2; // Default to info
+  };
+
+  const filteredLogs = useMemo(() => {
+    if (logLevel === 'none') return [];
+    const threshold = getSeverityPriority(logLevel);
+    return logs.filter((log: LogEntry) => getSeverityPriority(log.severity) >= threshold);
+  }, [logs, logLevel]);
+
   if (!isVisible) return null;
 
   return (
@@ -285,20 +301,22 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
       <div className="logs-header">
         <h3>Server Logs</h3>
         <div className="logs-controls">
-          <label className="logs-level-control">
-            <span>Level</span>
-            <select
-              className="logs-level-select"
-              value={logLevel}
-              disabled={isSettingLogLevel}
-              onChange={(event) => handleLogLevelChange(event.target.value as LogLevel)}
-              title="Set server log level"
-            >
-              {LOG_LEVELS.map(level => (
-                <option key={level} value={level}>{level}</option>
-              ))}
-            </select>
-          </label>
+          {serverSupportsLogLevel && (
+            <label className="logs-level-control">
+              <span>Level</span>
+              <select
+                className="logs-level-select"
+                value={logLevel}
+                disabled={isSettingLogLevel}
+                onChange={(event) => handleLogLevelChange(event.target.value as LogLevel)}
+                title="Set server log level"
+              >
+                {LOG_LEVELS.map(level => (
+                  <option key={level} value={level}>{level}</option>
+                ))}
+              </select>
+            </label>
+          )}
           <span className={`connection-status status-${connectionStatus}`}>
             {connectionStatus === 'connecting' && '⟳ Connecting...'}
             {connectionStatus === 'connected' && '● Connected'}
@@ -316,8 +334,10 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
         </div>
       </div>
       <div className="logs-content" ref={logsContentRef}>
-        {logs.length === 0 && connectionStatus === 'connected' && (
-          <div className="logs-placeholder">Waiting for logs...</div>
+        {filteredLogs.length === 0 && connectionStatus === 'connected' && (
+          <div className="logs-placeholder">
+            {logLevel === 'none' ? 'Logging is disabled' : 'Waiting for logs...'}
+          </div>
         )}
         {logs.length === 0 && connectionStatus === 'error' && (
           <div className="logs-error">
@@ -327,7 +347,7 @@ const LogsWindow: React.FC<LogsWindowProps> = ({ isVisible, height }) => {
           </div>
         )}
         <pre className="logs-text">
-          {logs.map((log) => (
+          {filteredLogs.map((log: LogEntry) => (
             <div key={log.seq} className="log-line">
               {log.line}
             </div>

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { Boxes, ChevronRight, Cpu, Settings, SlidersHorizontal, Store, XIcon } from './components/Icons';
+import { Boxes, ChevronRight, Cpu, Settings, SlidersHorizontal, Store, XIcon, Brain, SquareCode, Eye, Flame, Layers, ListOrdered, Wrench, User, Sparkles } from './components/Icons';
 import { ModelInfo } from './utils/modelData';
 import { ToastContainer, useToast } from './Toast';
 import { useConfirmDialog } from './ConfirmDialog';
@@ -19,89 +19,7 @@ import MarketplacePanel, { MarketplaceCategory } from './MarketplacePanel';
 import { RECIPE_DISPLAY_NAMES } from './utils/recipeNames';
 import { EjectIcon } from './components/Icons';
 import { getExperienceComponents, isExperienceFullyDownloaded, isExperienceFullyLoaded, isExperienceModel, isModelEffectivelyDownloaded } from './utils/experienceModels';
-
-interface ModelFamily {
-  displayName: string;
-  regex: RegExp;
-}
-
-const SIZE_TOKEN = String.raw`(\d+\.?\d*B(?:-A\d+\.?\d*B)?)`;
-const FLM_SIZE_TOKEN = String.raw`(\d+\.?\d*[bm])`;
-
-function buildFamilyRegex(prefix: string, suffix = '-GGUF$'): RegExp {
-  return new RegExp(`^${prefix}-${SIZE_TOKEN}${suffix}`);
-}
-
-function buildFlmFamilyRegex(prefix: string): RegExp {
-  return new RegExp(`^${prefix}-${FLM_SIZE_TOKEN}-FLM$`);
-}
-
-const MODEL_FAMILIES: ModelFamily[] = [
-  // Standardized family matching: capture *B or *B-A*B.
-  {
-    displayName: 'Qwen3',
-    regex: buildFamilyRegex('Qwen3'),
-  },
-  {
-    displayName: 'Qwen3-Instruct-2507',
-    regex: buildFamilyRegex('Qwen3', '-Instruct-2507-GGUF$'),
-  },
-  {
-    displayName: 'Qwen3.5',
-    regex: buildFamilyRegex('Qwen3\\.5'),
-  },
-  {
-    displayName: 'Qwen3-Embedding',
-    regex: buildFamilyRegex('Qwen3-Embedding'),
-  },
-  {
-    displayName: 'Qwen2.5-VL-Instruct',
-    regex: buildFamilyRegex('Qwen2\\.5-VL', '-Instruct-GGUF$'),
-  },
-  {
-    displayName: 'Qwen3-VL-Instruct',
-    regex: buildFamilyRegex('Qwen3-VL', '-Instruct-GGUF$'),
-  },
-  {
-    displayName: 'Llama-3.2-Instruct',
-    regex: buildFamilyRegex('Llama-3\\.2', '-Instruct-GGUF$'),
-  },
-  {
-    displayName: 'gpt-oss',
-    regex: /^gpt-oss-(\d+\.?\d*b)-mxfp4?-GGUF$/,
-  },
-  {
-    displayName: 'LFM2',
-    regex: buildFamilyRegex('LFM2'),
-  },
-  // FLM families
-  {
-    displayName: 'gemma3',
-    regex: buildFlmFamilyRegex('gemma3'),
-  },
-  {
-    displayName: 'lfm2',
-    regex: buildFlmFamilyRegex('lfm2'),
-  },
-  {
-    displayName: 'llama3.2',
-    regex: buildFlmFamilyRegex('llama3\\.2'),
-  },
-  {
-    displayName: 'qwen3',
-    regex: buildFlmFamilyRegex('qwen3'),
-  },
-];
-
-type ModelListItem =
-  | { type: 'model'; name: string; info: ModelInfo }
-  | { type: 'family'; family: ModelFamily; members: { label: string; name: string; info: ModelInfo }[] }
-  | {
-      type: 'dynamic-group';
-      groupName: string;
-      defaultExpanded: boolean;
-      members: { label: string; name: string; info: ModelInfo }[];
-    };
+import { buildModelList, ModelListItem, ModelFamily, MODEL_FAMILIES } from './utils/modelGrouping';
 
 // Types for Hugging Face API responses
 interface HFModelInfo {
@@ -136,73 +54,44 @@ interface DetectedBackend {
   mmprojFiles?: string[];
 }
 
-function buildModelList(
-  models: Array<{ name: string; info: ModelInfo }>
-): ModelListItem[] {
-  // Build family groups
-  const consumed = new Set<string>();
-  const familyItems: ModelListItem[] = [];
-
-  for (const family of MODEL_FAMILIES) {
-    const members: { label: string; name: string; info: ModelInfo }[] = [];
-    for (const m of models) {
-      const match = family.regex.exec(m.name);
-      if (match) {
-        members.push({ label: match[1], name: m.name, info: m.info });
-        consumed.add(m.name);
-      }
+const ModalityIcon = ({ label, getCategoryLabel, onHover }: {
+  label: string,
+  getCategoryLabel: (l: string) => string,
+  onHover: (text: string | null, x: number, y: number) => void
+}) => {
+  const size = 11;
+  const strokeWidth = 2.2;
+  const icon = (() => {
+    switch (label) {
+      case 'reasoning': return <Brain size={size} strokeWidth={strokeWidth} />;
+      case 'coding': return <SquareCode size={size} strokeWidth={strokeWidth} />;
+      case 'vision': return <Eye size={size} strokeWidth={strokeWidth} />;
+      case 'hot': return <Flame size={size} strokeWidth={strokeWidth} />;
+      case 'embeddings': return <Layers size={size} strokeWidth={strokeWidth} />;
+      case 'reranking': return <ListOrdered size={size} strokeWidth={strokeWidth} />;
+      case 'tool-calling': return <Wrench size={size} strokeWidth={strokeWidth} />;
+      case 'custom': return <User size={size} strokeWidth={strokeWidth} />;
+      case 'experience': return <Sparkles size={size} strokeWidth={strokeWidth} />;
+      default: return null;
     }
-    if (members.length > 1) {
-      members.sort((a, b) => parseFloat(a.label) - parseFloat(b.label));
-      familyItems.push({ type: 'family', family, members });
-    } else {
-      members.forEach(m => consumed.delete(m.name));
-    }
-  }
+  })();
 
-  const remainingModels = models.filter(m => !consumed.has(m.name));
-  const dynamicCandidates = new Map<string, { label: string; name: string; info: ModelInfo }[]>();
+  if (!icon) return null;
 
-  for (const model of remainingModels) {
-    const segments = model.name.split('.');
-    if (segments.length < 3) continue;
-    const groupName = segments.slice(0, 2).join('.');
-    const label = segments.slice(2).join('.');
-    if (!dynamicCandidates.has(groupName)) {
-      dynamicCandidates.set(groupName, []);
-    }
-    dynamicCandidates.get(groupName)!.push({ label, name: model.name, info: model.info });
-  }
+  return (
+    <span
+      className="model-label-icon-wrapper"
+      onMouseEnter={(e) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        onHover(getCategoryLabel(label), rect.left + rect.width / 2, rect.top);
+      }}
+      onMouseLeave={() => onHover(null, 0, 0)}
+    >
+      {icon}
+    </span>
+  );
+};
 
-  const dynamicallyGrouped = new Set<string>();
-  const dynamicGroupItems: ModelListItem[] = [];
-  for (const [groupName, members] of dynamicCandidates) {
-    if (members.length < 2) continue;
-    members.sort((a, b) => a.label.localeCompare(b.label));
-    members.forEach(member => dynamicallyGrouped.add(member.name));
-    dynamicGroupItems.push({
-      type: 'dynamic-group',
-      groupName,
-      defaultExpanded: groupName.startsWith('user.'),
-      members,
-    });
-  }
-
-  // Build individual items for non-consumed and non-dynamically-grouped models
-  const individualItems: ModelListItem[] = remainingModels
-    .filter(m => !dynamicallyGrouped.has(m.name))
-    .map(m => ({ type: 'model' as const, name: m.name, info: m.info }));
-
-  // Merge and sort alphabetically by display name
-  const allItems = [...familyItems, ...dynamicGroupItems, ...individualItems];
-  allItems.sort((a, b) => {
-    const nameA = a.type === 'family' ? a.family.displayName : a.type === 'dynamic-group' ? a.groupName : a.name;
-    const nameB = b.type === 'family' ? b.family.displayName : b.type === 'dynamic-group' ? b.groupName : b.name;
-    return nameA.localeCompare(nameB);
-  });
-
-  return allItems;
-}
 
 interface ModelManagerProps {
   isContentVisible: boolean;
@@ -242,6 +131,7 @@ const [searchQuery, setSearchQuery] = useState('');
   const [loadedModels, setLoadedModels] = useState<Set<string>>(new Set());
   const [loadingModels, setLoadingModels] = useState<Set<string>>(new Set());
   const [hoveredModel, setHoveredModel] = useState<string | null>(null);
+  const [tooltip, setTooltip] = useState<{ text: string, x: number, y: number } | null>(null);
   const [optionsModel, setOptionsModel] = useState<string | null>(null);
   const [showModelOptionsModal, setShowModelOptionsModal] = useState(false);
   const [selectedMarketplaceCategory, setSelectedMarketplaceCategory] = useState<string>('all');
@@ -260,8 +150,15 @@ const [searchQuery, setSearchQuery] = useState('');
   const [detectingBackendFor, setDetectingBackendFor] = useState<string | null>(null);
   const hfSearchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const handleModalityHover = useCallback((text: string | null, x: number, y: number) => {
+    if (text) {
+      setTooltip({ text, x, y });
+    } else {
+      setTooltip(null);
+    }
+  }, []);
 
-  const { toasts, removeToast, showError, showSuccess, showWarning } = useToast();
+  const { toasts, removeToast, showError, showSuccess, showWarning, showInfo } = useToast();
   const { confirm, ConfirmDialog } = useConfirmDialog();
 
   const fetchCurrentLoadedModel = useCallback(async () => {
@@ -1219,6 +1116,7 @@ const [searchQuery, setSearchQuery] = useState('');
   ) => {
     const { isDownloaded, isLoaded, statusClass, statusTitle } = getModelStatus(modelName);
     const isHovered = hoveredModel === hoverKey;
+
     return (
       <div
         key={modelName}
@@ -1227,19 +1125,21 @@ const [searchQuery, setSearchQuery] = useState('');
         onMouseLeave={() => setHoveredModel(null)}
       >
         <div className="model-item-content">
-          <div className="model-info-left">
-            <span className={`model-status-indicator ${statusClass}`} title={statusTitle}>●</span>
-            <span className="model-name">{displayName ?? modelName}</span>
-            <span className="model-size">{formatSize(modelInfo.size)}</span>
-            {renderActionButtons(modelName, isHovered)}
+          <div className="model-info-row-primary">
+            <div className="model-info-left">
+              <span className={`model-status-indicator ${statusClass}`} title={statusTitle}>●</span>
+              <span className="model-name">{displayName ?? modelName}</span>
+              <span className="model-size">{formatSize(modelInfo.size)}</span>
+              {modelInfo.labels && modelInfo.labels.length > 0 && (
+                <span className="model-labels">
+                  {modelInfo.labels.map(label => (
+                    <ModalityIcon key={label} label={label} getCategoryLabel={getCategoryLabel} onHover={handleModalityHover} />
+                  ))}
+                </span>
+              )}
+              {renderActionButtons(modelName, isHovered)}
+            </div>
           </div>
-          {modelInfo.labels && modelInfo.labels.length > 0 && (
-            <span className="model-labels">
-              {modelInfo.labels.map(label => (
-                <span key={label} className={`model-label label-${label}`} title={getCategoryLabel(label)} />
-              ))}
-            </span>
-          )}
         </div>
       </div>
     );
@@ -1270,6 +1170,7 @@ const [searchQuery, setSearchQuery] = useState('');
 
     // Collect shared labels from first member (labels are shared at family level)
     const sharedLabels = members[0]?.info.labels;
+    const allDownloaded = members.every(m => getModelDownloadedState(m.name, m.info));
 
     return (
       <div key={family.displayName} className="model-family-group">
@@ -1282,9 +1183,9 @@ const [searchQuery, setSearchQuery] = useState('');
           </span>
           <span className="model-name family-model-name">{family.displayName}</span>
           {sharedLabels && sharedLabels.length > 0 && (
-            <span className="model-labels">
+            <span className="model-labels" style={{ marginLeft: '4px' }}>
               {sharedLabels.map(label => (
-                <span key={label} className={`model-label label-${label}`} title={getCategoryLabel(label)} />
+                <ModalityIcon key={label} label={label} getCategoryLabel={getCategoryLabel} onHover={handleModalityHover} />
               ))}
             </span>
           )}
@@ -1713,6 +1614,19 @@ const [searchQuery, setSearchQuery] = useState('');
 
         </div>}
       </div>
+      {tooltip && (
+        <div
+          className="model-modality-tooltip"
+          style={{
+            position: 'fixed',
+            left: `${tooltip.x}px`,
+            top: `${tooltip.y - 8}px`,
+            transform: 'translate(-50%, -100%)',
+          }}
+        >
+          {tooltip.text}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -95,7 +95,13 @@ const MODEL_FAMILIES: ModelFamily[] = [
 
 type ModelListItem =
   | { type: 'model'; name: string; info: ModelInfo }
-  | { type: 'family'; family: ModelFamily; members: { label: string; name: string; info: ModelInfo }[] };
+  | { type: 'family'; family: ModelFamily; members: { label: string; name: string; info: ModelInfo }[] }
+  | {
+      type: 'dynamic-group';
+      groupName: string;
+      defaultExpanded: boolean;
+      members: { label: string; name: string; info: ModelInfo }[];
+    };
 
 // Types for Hugging Face API responses
 interface HFModelInfo {
@@ -154,16 +160,44 @@ function buildModelList(
     }
   }
 
-  // Build individual items for non-consumed models
-  const individualItems: ModelListItem[] = models
-    .filter(m => !consumed.has(m.name))
+  const remainingModels = models.filter(m => !consumed.has(m.name));
+  const dynamicCandidates = new Map<string, { label: string; name: string; info: ModelInfo }[]>();
+
+  for (const model of remainingModels) {
+    const segments = model.name.split('.');
+    if (segments.length < 3) continue;
+    const groupName = segments.slice(0, 2).join('.');
+    const label = segments.slice(2).join('.');
+    if (!dynamicCandidates.has(groupName)) {
+      dynamicCandidates.set(groupName, []);
+    }
+    dynamicCandidates.get(groupName)!.push({ label, name: model.name, info: model.info });
+  }
+
+  const dynamicallyGrouped = new Set<string>();
+  const dynamicGroupItems: ModelListItem[] = [];
+  for (const [groupName, members] of dynamicCandidates) {
+    if (members.length < 2) continue;
+    members.sort((a, b) => a.label.localeCompare(b.label));
+    members.forEach(member => dynamicallyGrouped.add(member.name));
+    dynamicGroupItems.push({
+      type: 'dynamic-group',
+      groupName,
+      defaultExpanded: groupName.startsWith('user.'),
+      members,
+    });
+  }
+
+  // Build individual items for non-consumed and non-dynamically-grouped models
+  const individualItems: ModelListItem[] = remainingModels
+    .filter(m => !dynamicallyGrouped.has(m.name))
     .map(m => ({ type: 'model' as const, name: m.name, info: m.info }));
 
   // Merge and sort alphabetically by display name
-  const allItems = [...familyItems, ...individualItems];
+  const allItems = [...familyItems, ...dynamicGroupItems, ...individualItems];
   allItems.sort((a, b) => {
-    const nameA = a.type === 'family' ? a.family.displayName : a.name;
-    const nameB = b.type === 'family' ? b.family.displayName : b.name;
+    const nameA = a.type === 'family' ? a.family.displayName : a.type === 'dynamic-group' ? a.groupName : a.name;
+    const nameB = b.type === 'family' ? b.family.displayName : b.type === 'dynamic-group' ? b.groupName : b.name;
     return nameA.localeCompare(nameB);
   });
 
@@ -213,6 +247,8 @@ const [searchQuery, setSearchQuery] = useState('');
   const [selectedMarketplaceCategory, setSelectedMarketplaceCategory] = useState<string>('all');
   const [marketplaceCategories, setMarketplaceCategories] = useState<MarketplaceCategory[]>([]);
   const [expandedFamilies, setExpandedFamilies] = useState<Set<string>>(new Set());
+  const [expandedDynamicGroups, setExpandedDynamicGroups] = useState<Set<string>>(new Set());
+  const initializedDynamicGroupsRef = useRef<Set<string>>(new Set());
   const filterAnchorRef = useRef<HTMLDivElement | null>(null);
   // HuggingFace search state
   const [hfSearchResults, setHfSearchResults] = useState<HFModelInfo[]>([]);
@@ -434,6 +470,25 @@ const [searchQuery, setSearchQuery] = useState('');
     ),
     [groupedModels]
   );
+
+  useEffect(() => {
+    const groupsToExpand = new Set<string>();
+    Object.values(builtModelLists).forEach((items) => {
+      items.forEach((item) => {
+        if (item.type === 'dynamic-group' && item.defaultExpanded && !initializedDynamicGroupsRef.current.has(item.groupName)) {
+          groupsToExpand.add(item.groupName);
+          initializedDynamicGroupsRef.current.add(item.groupName);
+        }
+      });
+    });
+
+    if (groupsToExpand.size === 0) return;
+    setExpandedDynamicGroups(prev => {
+      const next = new Set(prev);
+      groupsToExpand.forEach(groupName => next.add(groupName));
+      return next;
+    });
+  }, [builtModelLists]);
 
   // Auto-expand the single category if only one is available
   useEffect(() => {
@@ -1162,12 +1217,12 @@ const [searchQuery, setSearchQuery] = useState('');
     modelName: string, modelInfo: ModelInfo, hoverKey: string,
     displayName?: string, extraClass?: string
   ) => {
-    const { isDownloaded, statusClass, statusTitle } = getModelStatus(modelName);
+    const { isDownloaded, isLoaded, statusClass, statusTitle } = getModelStatus(modelName);
     const isHovered = hoveredModel === hoverKey;
     return (
       <div
         key={modelName}
-        className={`model-item model-catalog-item ${extraClass ?? ''} ${isDownloaded ? 'downloaded' : ''}`}
+        className={`model-item model-catalog-item ${extraClass ?? ''} ${isDownloaded ? 'downloaded' : ''} ${isLoaded ? 'loaded' : ''}`}
         onMouseEnter={() => setHoveredModel(hoverKey)}
         onMouseLeave={() => setHoveredModel(null)}
       >
@@ -1195,6 +1250,16 @@ const [searchQuery, setSearchQuery] = useState('');
       const next = new Set(prev);
       if (next.has(familyName)) next.delete(familyName);
       else next.add(familyName);
+      return next;
+    });
+  };
+
+  const toggleDynamicGroup = (groupName: string) => {
+    setExpandedDynamicGroups(prev => {
+      const next = new Set(prev);
+      if (next.has(groupName)) next.delete(groupName);
+      else next.add(groupName);
+      initializedDynamicGroupsRef.current.add(groupName);
       return next;
     });
   };
@@ -1231,6 +1296,37 @@ const [searchQuery, setSearchQuery] = useState('');
                 m.name, m.info,
                 `family-${family.displayName}-${m.label}`,
                 m.label, 'model-family-member-row'
+              )
+            )}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const renderDynamicGroupItem = (item: Extract<ModelListItem, { type: 'dynamic-group' }>) => {
+    const { groupName, members } = item;
+    const isExpanded = expandedDynamicGroups.has(groupName);
+
+    return (
+      <div key={groupName} className="model-dynamic-group">
+        <div
+          className="model-dynamic-group-header"
+          onClick={() => toggleDynamicGroup(groupName)}
+        >
+          <span className={`family-chevron ${isExpanded ? 'expanded' : ''}`}>
+            <ChevronRight size={11} strokeWidth={2.1} />
+          </span>
+          <span className="model-name dynamic-group-name">{groupName}</span>
+          <span className="category-count">({members.length})</span>
+        </div>
+        {isExpanded && (
+          <div className="model-dynamic-group-members-list">
+            {members.map(m =>
+              renderModelItem(
+                m.name, m.info,
+                `dynamic-${groupName}-${m.label}`,
+                m.label, 'model-dynamic-group-member-row'
               )
             )}
           </div>
@@ -1321,6 +1417,9 @@ const [searchQuery, setSearchQuery] = useState('');
                 {listItems.map(item => {
                   if (item.type === 'family') {
                     return renderFamilyItem(item);
+                  }
+                  if (item.type === 'dynamic-group') {
+                    return renderDynamicGroupItem(item);
                   }
                   return renderModelItem(item.name, item.info, item.name);
                 })}
@@ -1523,6 +1622,7 @@ const [searchQuery, setSearchQuery] = useState('');
                         <span className="hf-model-name" title={hfModel.id}>{hfModel.id}</span>
                         {size !== undefined && <span className="hf-model-size">{formatSize(size / (1024 ** 3))}</span>}
                         <span className="hf-model-meta">↓ {formatDownloads(hfModel.downloads)}</span>
+                        <span className="hf-source-pill">Hugging Face</span>
                         {isDetecting && <span className="hf-search-spinner" />}
                         <div className="hf-model-actions">
                           {!isDetecting && backend && (

--- a/src/app/src/renderer/TitleBar.tsx
+++ b/src/app/src/renderer/TitleBar.tsx
@@ -42,7 +42,9 @@ const TitleBar: React.FC<TitleBarProps> = ({
 
   useEffect(() => {
     if (!window.api?.onMaximizeChange) {
-      console.warn('window.api.onMaximizeChange is unavailable. Running outside Tauri?');
+      if (!isWebApp) {
+        console.warn('window.api.onMaximizeChange is unavailable. Running outside Tauri?');
+      }
       return;
     }
 

--- a/src/app/src/renderer/components/Icons.tsx
+++ b/src/app/src/renderer/components/Icons.tsx
@@ -156,6 +156,85 @@ export const EjectIcon: React.FC = () => (
   </svg>
 );
 
+export const DownloadIcon: React.FC<IconProps> = ({ size = 24, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);
+
+// Modality Icons
+export const Brain: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96.44 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 4.44-2.54Z" />
+    <path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96.44 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-4.44-2.54Z" />
+  </svg>
+);
+
+export const SquareCode: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <rect width="18" height="18" x="3" y="3" rx="2" />
+    <path d="m10 10-2 2 2 2" />
+    <path d="m14 14 2-2-2-2" />
+  </svg>
+);
+
+export const Eye: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+export const Flame: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5Z" />
+  </svg>
+);
+
+export const Layers: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.85a2 2 0 0 0 0 3.58l8.57 4.67a2 2 0 0 0 1.66 0l8.57-4.67a2 2 0 0 0 0-3.58Z" />
+    <path d="m2.6 14.16 8.57 4.67a2 2 0 0 0 1.66 0l8.57-4.67" />
+    <path d="m2.6 19 8.57 4.67a2 2 0 0 0 1.66 0L21.4 19" />
+  </svg>
+);
+
+export const ListOrdered: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <line x1="10" x2="21" y1="6" y2="6" />
+    <line x1="10" x2="21" y1="12" y2="12" />
+    <line x1="10" x2="21" y1="18" y2="18" />
+    <path d="M4 6h1v4" />
+    <path d="M4 10h2" />
+    <path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1" />
+  </svg>
+);
+
+export const Wrench: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z" />
+  </svg>
+);
+
+export const User: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);
+
+export const Sparkles: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="m12 3 1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3Z" />
+    <path d="M5 3v4" />
+    <path d="M19 17v4" />
+    <path d="M3 5h4" />
+    <path d="M17 19h4" />
+  </svg>
+);
+
 export const MicrophoneIcon: React.FC<{ active?: boolean }> = ({ active = false }) => (
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
     <path

--- a/src/app/src/renderer/utils/modelGrouping.ts
+++ b/src/app/src/renderer/utils/modelGrouping.ts
@@ -1,0 +1,173 @@
+import { ModelInfo } from './modelData';
+
+export interface ModelFamily {
+  displayName: string;
+  regex: RegExp;
+}
+
+const SIZE_TOKEN = String.raw`(\d+\.?\d*B(?:-A\d+\.?\d*B)?)`;
+const FLM_SIZE_TOKEN = String.raw`(\d+\.?\d*[bm])`;
+
+function buildFamilyRegex(prefix: string, suffix = '-GGUF$'): RegExp {
+  return new RegExp(`^${prefix}-${SIZE_TOKEN}${suffix}`);
+}
+
+function buildFlmFamilyRegex(prefix: string): RegExp {
+  return new RegExp(`^${prefix}-${FLM_SIZE_TOKEN}-FLM$`);
+}
+
+export const MODEL_FAMILIES: ModelFamily[] = [
+  // Standardized family matching: capture *B or *B-A*B.
+  {
+    displayName: 'Qwen3',
+    regex: buildFamilyRegex('Qwen3'),
+  },
+  {
+    displayName: 'Qwen3-Instruct-2507',
+    regex: buildFamilyRegex('Qwen3', '-Instruct-2507-GGUF$'),
+  },
+  {
+    displayName: 'Qwen3.5',
+    regex: buildFamilyRegex('Qwen3\\.5'),
+  },
+  {
+    displayName: 'Qwen3-Embedding',
+    regex: buildFamilyRegex('Qwen3-Embedding'),
+  },
+  {
+    displayName: 'Qwen2.5-VL-Instruct',
+    regex: buildFamilyRegex('Qwen2\\.5-VL', '-Instruct-GGUF$'),
+  },
+  {
+    displayName: 'Qwen3-VL-Instruct',
+    regex: buildFamilyRegex('Qwen3-VL', '-Instruct-GGUF$'),
+  },
+  {
+    displayName: 'Llama-3.2-Instruct',
+    regex: buildFamilyRegex('Llama-3\\.2', '-Instruct-GGUF$'),
+  },
+  {
+    displayName: 'gpt-oss',
+    regex: /^gpt-oss-(\d+\.?\d*b)-mxfp4?-GGUF$/,
+  },
+  {
+    displayName: 'LFM2',
+    regex: buildFamilyRegex('LFM2'),
+  },
+  // FLM families
+  {
+    displayName: 'gemma3',
+    regex: buildFlmFamilyRegex('gemma3'),
+  },
+  {
+    displayName: 'lfm2',
+    regex: buildFlmFamilyRegex('lfm2'),
+  },
+  {
+    displayName: 'llama3.2',
+    regex: buildFlmFamilyRegex('llama3\\.2'),
+  },
+  {
+    displayName: 'qwen3',
+    regex: buildFlmFamilyRegex('qwen3'),
+  },
+];
+
+export type ModelListItem =
+  | { type: 'model'; name: string; info: ModelInfo }
+  | { type: 'family'; family: ModelFamily; members: { label: string; name: string; info: ModelInfo }[] }
+  | {
+      type: 'dynamic-group';
+      groupName: string;
+      defaultExpanded: boolean;
+      members: { label: string; name: string; info: ModelInfo }[];
+    };
+
+/**
+ * Builds a structured model list from a flat array of models,
+ * grouping them into families and dynamic groups based on naming patterns.
+ */
+export function buildModelList(
+  models: Array<{ name: string; info: ModelInfo }>
+): ModelListItem[] {
+  // Build family groups
+  const consumed = new Set<string>();
+  const familyItems: ModelListItem[] = [];
+
+  for (const family of MODEL_FAMILIES) {
+    const members: { label: string; name: string; info: ModelInfo }[] = [];
+    for (const m of models) {
+      const match = family.regex.exec(m.name);
+      if (match) {
+        members.push({ label: match[1], name: m.name, info: m.info });
+        consumed.add(m.name);
+      }
+    }
+    if (members.length > 1) {
+      // Sort members (usually by size token like 8B)
+      members.sort((a, b) => {
+        const floatA = parseFloat(a.label);
+        const floatB = parseFloat(b.label);
+        if (!isNaN(floatA) && !isNaN(floatB)) {
+          return floatA - floatB;
+        }
+        return a.label.localeCompare(b.label);
+      });
+      familyItems.push({ type: 'family', family, members });
+    } else {
+      members.forEach(m => consumed.delete(m.name));
+    }
+  }
+
+  const remainingModels = models.filter(m => !consumed.has(m.name));
+  const dynamicCandidates = new Map<string, { label: string; name: string; info: ModelInfo }[]>();
+
+  for (const model of remainingModels) {
+    const segments = model.name.split('.');
+    if (segments.length < 2) continue;
+
+    // For 3+ segments, group by the first two (e.g., user.provider).
+    // For 2 segments, group by the first segment (e.g., provider).
+    const groupName = segments.length >= 3 ? segments.slice(0, 2).join('.') : segments[0];
+    const label = segments.length >= 3 ? segments.slice(2).join('.') : segments[1];
+
+    if (!dynamicCandidates.has(groupName)) {
+      dynamicCandidates.set(groupName, []);
+    }
+    dynamicCandidates.get(groupName)!.push({ label, name: model.name, info: model.info });
+  }
+
+  const dynamicallyGrouped = new Set<string>();
+  const dynamicGroupItems: ModelListItem[] = [];
+  for (const [groupName, members] of dynamicCandidates) {
+    if (members.length < 2) continue;
+    members.sort((a, b) => a.label.localeCompare(b.label));
+    members.forEach(member => dynamicallyGrouped.add(member.name));
+    dynamicGroupItems.push({
+      type: 'dynamic-group',
+      groupName,
+      defaultExpanded: groupName.startsWith('user.'),
+      members,
+    });
+  }
+
+  // Build individual items for non-consumed and non-dynamically-grouped models
+  const individualItems: ModelListItem[] = remainingModels
+    .filter(m => !dynamicallyGrouped.has(m.name))
+    .map(m => ({ type: 'model' as const, name: m.name, info: m.info }));
+
+  // Helper for sorting display names
+  const getItemName = (item: ModelListItem) => {
+    switch (item.type) {
+      case 'family': return item.family.displayName;
+      case 'dynamic-group': return item.groupName;
+      default: return item.name;
+    }
+  };
+
+  // Merge and sort alphabetically by display name
+  const allItems = [...familyItems, ...dynamicGroupItems, ...individualItems];
+  allItems.sort((a, b) => getItemName(a).localeCompare(getItemName(b)));
+
+  return allItems;
+}

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2054,13 +2054,16 @@ footer {
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 4px 10px 4px 13px;
+    padding: 6px 10px 6px 13px;
     cursor: pointer;
     user-select: none;
+    background: rgba(255, 255, 255, 0.015);
+    border-radius: 4px;
+    margin: 1px 0;
 }
 
 .model-family-header:hover {
-    background: rgba(255, 255, 255, 0.03);
+    background: rgba(255, 255, 255, 0.035);
 }
 
 .family-chevron {
@@ -2095,15 +2098,17 @@ footer {
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 4px 10px 4px 13px;
+    padding: 6px 10px 6px 13px;
     cursor: pointer;
     user-select: none;
     background: rgba(255, 255, 255, 0.025);
-    border-left: 2px solid rgba(255, 255, 255, 0.08);
+    border-left: 2px solid rgba(255, 255, 255, 0.1);
+    border-radius: 0 4px 4px 0;
+    margin: 2px 0;
 }
 
 .model-dynamic-group-header:hover {
-    background: rgba(255, 255, 255, 0.045);
+    background: rgba(255, 255, 255, 0.05);
 }
 
 .dynamic-group-name {
@@ -2121,11 +2126,22 @@ footer {
 
 .model-item-content {
     display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 4px;
+    overflow: hidden;
+    min-height: 32px;
+}
+
+.model-info-row-primary {
+    display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 8px;
-    overflow: hidden;
-    min-height: 18px;
+    width: 100%;
+}
+
+.model-info-row-secondary {
+    display: none;
 }
 
 .model-actions {
@@ -2290,60 +2306,58 @@ footer {
 }
 
 .model-labels {
-    display: flex;
-    gap: 3px;
+    display: inline-flex;
+    gap: 4px;
     flex-shrink: 0;
-    margin-left: auto;
-    padding-right: 2px;
+    align-items: center;
+    margin-left: 2px;
 }
+
+.model-label-icon-wrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0.55;
+    transition: all 0.2s ease;
+    color: var(--text-secondary);
+}
+
+.model-label-icon-wrapper:hover {
+    opacity: 1;
+    transform: translateY(-1px);
+}
+
+.model-modality-tooltip {
+    background: #2a2a2a;
+    color: #e0e0e0;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 0.65rem;
+    pointer-events: none;
+    z-index: 10000;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    font-weight: 500;
+}
+
+/* Modality-specific colors for icons */
+.model-label-icon-wrapper[title*="Reasoning"] { color: #6495ED; }
+.model-label-icon-wrapper[title*="Coding"] { color: #48BB78; }
+.model-label-icon-wrapper[title*="Vision"] { color: #9F7AEA; }
+.model-label-icon-wrapper[title*="Hot"] { color: #F56565; }
+.model-label-icon-wrapper[title*="Embeddings"] { color: #ED8936; }
+.model-label-icon-wrapper[title*="Reranking"] { color: #D69E2E; }
+.model-label-icon-wrapper[title*="Tool Calling"] { color: #38B2AC; }
+.model-label-icon-wrapper[title*="Custom"] { color: #FAD02C; }
+.model-label-icon-wrapper[title*="Experience"] { color: #e2b757; }
 
 .model-label {
-    width: 8px;
-    height: 8px;
+    width: 6px;
+    height: 6px;
     border-radius: 50%;
     display: inline-block;
-    cursor: help;
-}
-
-.model-label.label-reasoning {
-    background: #6495ED;
-}
-
-.model-label.label-coding {
-    background: #48BB78;
-}
-
-.model-label.label-vision {
-    background: #9F7AEA;
-}
-
-.model-label.label-hot {
-    background: #F56565;
-}
-
-.model-label.label-embeddings {
-    background: #ED8936;
-}
-
-.model-label.label-reranking {
-    background: #D69E2E;
-}
-
-.model-label.label-tool-calling {
-    background: #38B2AC;
-}
-
-.model-label.label-custom {
-    background: #FAD02C;
-}
-
-.model-label.label-experience {
-    width: 7px;
-    height: 7px;
-    border-radius: 1px;
-    transform: rotate(45deg);
-    background: #e2b757;
-    box-shadow: 0 0 2px rgba(226, 183, 87, 0.45);
+    background: currentColor;
 }
 
 .model-manager-footer {

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1562,6 +1562,17 @@ footer {
     flex-shrink: 0;
 }
 
+.hf-source-pill {
+    font-size: 0.56rem;
+    color: var(--text-quaternary);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 3px;
+    padding: 1px 5px;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
 .hf-quant-select {
     font-size: 0.62rem;
     background: rgba(255, 255, 255, 0.04);
@@ -2017,6 +2028,24 @@ footer {
     border-left-color: #666;
 }
 
+.model-catalog-item.downloaded {
+    background: rgba(255, 255, 255, 0.018);
+}
+
+.model-catalog-item.downloaded:hover {
+    background: rgba(255, 255, 255, 0.055);
+}
+
+.model-catalog-item.loaded {
+    background: rgba(76, 175, 80, 0.09);
+    border-left-color: rgba(76, 175, 80, 0.65);
+}
+
+.model-catalog-item.loaded:hover {
+    background: rgba(76, 175, 80, 0.13);
+    border-left-color: rgba(76, 175, 80, 0.85);
+}
+
 .model-family-group {
     margin: 0;
 }
@@ -2056,6 +2085,38 @@ footer {
 
 .model-family-member-row {
     padding-left: 28px;
+}
+
+.model-dynamic-group {
+    margin: 2px 0;
+}
+
+.model-dynamic-group-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px 4px 13px;
+    cursor: pointer;
+    user-select: none;
+    background: rgba(255, 255, 255, 0.025);
+    border-left: 2px solid rgba(255, 255, 255, 0.08);
+}
+
+.model-dynamic-group-header:hover {
+    background: rgba(255, 255, 255, 0.045);
+}
+
+.dynamic-group-name {
+    font-weight: 560;
+    color: var(--text-primary);
+}
+
+.model-dynamic-group-members-list {
+    padding-left: 8px;
+}
+
+.model-dynamic-group-member-row {
+    padding-left: 30px;
 }
 
 .model-item-content {
@@ -4741,6 +4802,34 @@ input::-webkit-calendar-picker-indicator {
     display: flex;
     gap: 10px;
     align-items: center;
+}
+
+.logs-level-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.68rem;
+    color: var(--text-secondary);
+}
+
+.logs-level-select {
+    font-size: 0.68rem;
+    padding: 3px 22px 3px 8px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.logs-level-select:focus {
+    outline: none;
+    border-color: #555;
+}
+
+.logs-level-select:disabled {
+    opacity: 0.65;
+    cursor: default;
 }
 
 .connection-status {

--- a/src/cpp/include/lemon/utils/aixlog.hpp
+++ b/src/cpp/include/lemon/utils/aixlog.hpp
@@ -191,8 +191,10 @@ static Severity to_severity(std::string severity, Severity def = Severity::info)
         return Severity::warning;
     else if (severity == "error")
         return Severity::error;
-    else if (severity == "fatal")
+    else if (severity == "fatal" || severity == "critical")
         return Severity::fatal;
+    else if (severity == "none")
+        return static_cast<Severity>(10);
     else
         return def;
 }

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -12,7 +12,7 @@ namespace fs = std::filesystem;
 namespace lemon {
 
 const std::vector<std::string> RuntimeConfig::valid_log_levels_ = {
-    "trace", "debug", "info", "warning", "error", "fatal", "none"
+    "trace", "debug", "info", "notice", "warning", "error", "critical", "fatal", "none"
 };
 
 // Global instance pointer (set once at startup, read from any thread after)
@@ -294,7 +294,7 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
         if (std::find(valid_log_levels_.begin(), valid_log_levels_.end(), level)
             == valid_log_levels_.end()) {
             throw std::invalid_argument(
-                "'log_level' must be one of: trace, debug, info, warning, error, fatal, none");
+                "'log_level' must be one of: trace, debug, info, notice, warning, error, critical, fatal, none");
         }
     } else if (key == "extra_models_dir" || key == "models_dir") {
         if (!value.is_string()) {

--- a/test/test_log_level.py
+++ b/test/test_log_level.py
@@ -1,0 +1,158 @@
+"""
+Tests for server log level control.
+Verifies that log level can be changed via /log-level and /internal/set,
+and that the changes are reflected in the server configuration.
+"""
+
+import unittest
+import requests
+import json
+import time
+
+from utils.server_base import (
+    ServerTestBase,
+    run_server_tests,
+)
+from utils.test_models import (
+    PORT,
+    TIMEOUT_DEFAULT,
+)
+
+
+class LogLevelTests(ServerTestBase):
+    """Tests for log level control."""
+
+    def test_log_level_via_dedicated_endpoint(self):
+        """Test changing log level via the dedicated /log-level endpoint."""
+        # 1. Get initial level
+        response = requests.get(f"{self.internal_config_url}", timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(response.status_code, 200)
+        initial_level = response.json().get("log_level")
+        print(f"Initial log level: {initial_level}")
+
+        # 2. Change to debug
+        target_level = "debug" if initial_level != "debug" else "info"
+        print(f"Changing log level to {target_level} via /log-level...")
+        response = requests.post(
+            f"{self.base_url}/log-level",
+            json={"level": target_level},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data.get("status"), "success")
+        self.assertEqual(data.get("level"), target_level)
+
+        # 3. Verify in config
+        response = requests.get(f"{self.internal_config_url}", timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("log_level"), target_level)
+        print(f"[OK] Log level verified as {target_level} in config")
+
+        # 4. Restore initial level
+        print(f"Restoring log level to {initial_level}...")
+        requests.post(
+            f"{self.base_url}/log-level",
+            json={"level": initial_level},
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+    def test_log_level_via_config_set(self):
+        """Test changing log level via the generic /internal/set endpoint (used by CLI)."""
+        # 1. Get initial level
+        response = requests.get(f"{self.internal_config_url}", timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(response.status_code, 200)
+        initial_level = response.json().get("log_level")
+
+        # 2. Change to warning via /internal/set
+        target_level = "warning" if initial_level != "warning" else "error"
+        print(f"Changing log level to {target_level} via /internal/set...")
+        response = requests.post(
+            f"{self.base_url}/internal/set",
+            json={"log_level": target_level},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # 3. Verify in config
+        response = requests.get(f"{self.internal_config_url}", timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("log_level"), target_level)
+        print(f"[OK] Log level verified as {target_level} in config via /internal/set")
+
+        # 4. Restore initial level
+        requests.post(
+            f"{self.base_url}/internal/set",
+            json={"log_level": initial_level},
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+    def test_log_level_critical(self):
+        """Test that the 'critical' log level is accepted and reflected."""
+        print("Testing log level 'critical'...")
+        response = requests.post(
+            f"{self.base_url}/log-level",
+            json={"level": "critical"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("level"), "critical")
+
+        # Verify in config
+        response = requests.get(f"{self.internal_config_url}", timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(response.json().get("log_level"), "critical")
+        print("[OK] Log level 'critical' verified")
+
+    def test_log_level_notice(self):
+        """Test that the 'notice' log level is accepted and reflected."""
+        print("Testing log level 'notice'...")
+        response = requests.post(
+            f"{self.base_url}/log-level",
+            json={"level": "notice"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("level"), "notice")
+        print("[OK] Log level 'notice' verified")
+
+    def test_log_level_fatal(self):
+        """Test that the 'fatal' log level is accepted and reflected."""
+        print("Testing log level 'fatal'...")
+        response = requests.post(
+            f"{self.base_url}/log-level",
+            json={"level": "fatal"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("level"), "fatal")
+        print("[OK] Log level 'fatal' verified")
+
+    def test_log_level_none(self):
+        """Test that the 'none' log level is accepted and reflected."""
+        print("Testing log level 'none'...")
+        response = requests.post(
+            f"{self.base_url}/log-level",
+            json={"level": "none"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json().get("level"), "none")
+
+        # Verify in config
+        response = requests.get(f"{self.internal_config_url}", timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(response.json().get("log_level"), "none")
+        print("[OK] Log level 'none' verified")
+
+    def test_invalid_log_level(self):
+        """Test that invalid log levels are rejected."""
+        response = requests.post(
+            f"{self.base_url}/log-level",
+            json={"level": "invalid_level_name"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 400)
+        print("[OK] Invalid log level rejected with 400")
+
+
+if __name__ == "__main__":
+    run_server_tests(LogLevelTests, "LOG LEVEL TESTS")


### PR DESCRIPTION
What it includes:

  - One-level grouping for dot-delimited model names after existing regex family
    grouping.
  - user.* groups expand by default so newly downloaded user models stay visible.
  - Grouped model rows keep the existing load, delete, and settings controls.
  - Loaded and downloaded model rows get clearer visual highlights.
  - Hugging Face search results now show a Hugging Face source pill.        
  - Logs panel now has a log-level dropdown.
  - Log-level dropdown reads current server config, only allows supported levels,
    and posts changes to /log-level.

  Testing:

  - Ran npm run build:renderer
  - Build passed

Closes #1643