### PR TITLE
Drop AMD iGPU vs dGPU designations

### DIFF
--- a/docs/server/server_spec.md
+++ b/docs/server/server_spec.md
@@ -1866,13 +1866,14 @@ curl "http://localhost:13305/api/v1/system-info"
       "available": true,
       "family": "x86_64"
     },
-    "amd_igpu": {
-      "name": "AMD Radeon(TM) 890M Graphics",
-      "vram_gb": 0.5,
-      "available": true,
-      "family": "gfx1150"
-    },
-    "amd_dgpu": [],
+    "amd_gpu": [
+      {
+        "name": "AMD Radeon(TM) 890M Graphics",
+        "vram_gb": 0.5,
+        "available": true,
+        "family": "gfx1150"
+      }
+    ],
     "amd_npu": {
       "name": "AMD Ryzen AI 9 HX 375 w/ Radeon 890M",
       "power_mode": "Default",
@@ -1885,14 +1886,14 @@ curl "http://localhost:13305/api/v1/system-info"
       "default_backend": "vulkan",
       "backends": {
         "vulkan": {
-          "devices": ["cpu", "amd_igpu"],
+          "devices": ["cpu", "amd_gpu"],
           "state": "installed",
           "message": "",
           "action": "",
           "version": "b7869"
         },
         "rocm": {
-          "devices": ["amd_igpu"],
+          "devices": ["amd_gpu"],
           "state": "installable",
           "message": "Backend is supported but not installed.",
           "action": "lemonade backends install llamacpp:rocm"
@@ -1973,8 +1974,7 @@ curl "http://localhost:13305/api/v1/system-info"
 
 - `devices` - Hardware devices detected on the system (no software/support information)
   - `cpu` - CPU information (name, cores, threads)
-  - `amd_igpu` - AMD integrated GPU (if present)
-  - `amd_dgpu` - Array of AMD discrete GPUs (if present)
+  - `amd_gpu` - Array of AMD GPUs, both integrated and discrete (if present)
   - `nvidia_dgpu` - Array of NVIDIA discrete GPUs (if present)
   - `amd_npu` - AMD NPU device (if present)
 

--- a/docs/server/server_spec.md
+++ b/docs/server/server_spec.md
@@ -1975,7 +1975,7 @@ curl "http://localhost:13305/api/v1/system-info"
 - `devices` - Hardware devices detected on the system (no software/support information)
   - `cpu` - CPU information (name, cores, threads)
   - `amd_gpu` - Array of AMD GPUs, both integrated and discrete (if present)
-  - `nvidia_dgpu` - Array of NVIDIA discrete GPUs (if present)
+  - `nvidia_gpu` - Array of NVIDIA GPUs (if present)
   - `amd_npu` - AMD NPU device (if present)
 
 - `recipes` - Software recipes and their backend support status

--- a/src/app/src/renderer/AboutModal.tsx
+++ b/src/app/src/renderer/AboutModal.tsx
@@ -78,7 +78,7 @@ const AboutModal: React.FC<AboutModalProps> = ({ isOpen, onClose }) => {
         considerAmdGpu(info.devices?.amd_igpu);
         info.devices?.amd_dgpu?.forEach(considerAmdGpu);
 
-        info.devices?.nvidia_dgpu?.forEach((gpu) => {
+        info.devices?.nvidia_gpu?.forEach((gpu) => {
           if (gpu?.name) gpus.push(gpu.name);
         });
 

--- a/src/app/src/renderer/utils/systemData.ts
+++ b/src/app/src/renderer/utils/systemData.ts
@@ -11,7 +11,7 @@ interface Devices {
   amd_igpu: GPUDevice;
   cpu: CPUInfo;
   npu: NPUInfo;
-  nvidia_dgpu: GPUDevice[];
+  nvidia_gpu: GPUDevice[];
 }
 
 interface Device {

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -60,7 +60,7 @@ public:
     virtual CPUInfo get_cpu_device() = 0;
     virtual GPUInfo get_amd_igpu_device() = 0;
     virtual std::vector<GPUInfo> get_amd_dgpu_devices() = 0;
-    virtual std::vector<GPUInfo> get_nvidia_dgpu_devices() = 0;
+    virtual std::vector<GPUInfo> get_nvidia_gpu_devices() = 0;
     virtual NPUInfo get_npu_device() = 0;
 
     // Common methods (can be overridden for detailed platform info)
@@ -122,7 +122,7 @@ public:
     CPUInfo get_cpu_device() override;
     GPUInfo get_amd_igpu_device() override;
     std::vector<GPUInfo> get_amd_dgpu_devices() override;
-    std::vector<GPUInfo> get_nvidia_dgpu_devices() override;
+    std::vector<GPUInfo> get_nvidia_gpu_devices() override;
     NPUInfo get_npu_device() override;
 
     // Override to add Windows-specific fields
@@ -153,7 +153,7 @@ public:
     CPUInfo get_cpu_device() override;
     GPUInfo get_amd_igpu_device() override;
     std::vector<GPUInfo> get_amd_dgpu_devices() override;
-    std::vector<GPUInfo> get_nvidia_dgpu_devices() override;
+    std::vector<GPUInfo> get_nvidia_gpu_devices() override;
     NPUInfo get_npu_device() override;
 
     // Override to add Linux-specific fields
@@ -183,7 +183,7 @@ public:
     CPUInfo get_cpu_device() override;
     GPUInfo get_amd_igpu_device() override;
     std::vector<GPUInfo> get_amd_dgpu_devices() override;
-    std::vector<GPUInfo> get_nvidia_dgpu_devices() override;
+    std::vector<GPUInfo> get_nvidia_gpu_devices() override;
     NPUInfo get_npu_device() override;
 
     // Override to add macOS-specific fields

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -133,12 +133,10 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
     }},
     {"llamacpp", "vulkan", {"windows", "linux"}, {
         {"cpu", {"x86_64"}},
-        {"amd_igpu", {}},      // all iGPU families
-        {"amd_dgpu", {}},      // all dGPU families
+        {"amd_gpu", {}},      // all AMD GPU families
     }},
     {"llamacpp", "rocm", {"windows", "linux"}, {
-        {"amd_igpu", {"gfx1150", "gfx1151"}},                      // STX Point/Halo iGPUs (explicit binaries)
-        {"amd_dgpu", {"gfx103X", "gfx110X", "gfx120X"}},          // RDNA2/3/4 dGPUs (family binaries)
+        {"amd_gpu", {"gfx1150", "gfx1151", "gfx103X", "gfx110X", "gfx120X"}},  // STX iGPUs + RDNA2/3/4 dGPUs
     }},
     {"llamacpp", "cpu", {"windows", "linux"}, {
         {"cpu", {"x86_64"}},
@@ -162,13 +160,12 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
 
     // stable-diffusion.cpp - ROCm backend for AMD GPUs
     {"sd-cpp", "rocm", {"windows", "linux"}, {
-        {"amd_igpu", {
+        {"amd_gpu", {
 #ifdef __linux__
             "gfx1150",   // Strix Point - Linux only (ROCm not yet supported on Windows)
 #endif
-            "gfx1151"
+            "gfx1151", "gfx103X", "gfx110X", "gfx120X"
         }},
-        {"amd_dgpu", {"gfx103X", "gfx110X", "gfx120X"}},
     }},
 
     // stable-diffusion.cpp - CPU backend (Windows/Linux x86_64)
@@ -198,7 +195,7 @@ static const std::map<std::string, std::string> DEVICE_FAMILY_NAMES = {
     {"x86_64", "x86-64 processors"},
     {"arm64", "ARM64 processors"},
 
-    // AMD iGPU/dGPU architectures (ROCm)
+    // AMD GPU architectures (ROCm)
     {"gfx1150", "Radeon 880M/890M (Strix Point)"},
     {"gfx1151", "Radeon 8050S/8060S (Strix Halo)"},
     {"gfx103X", "Radeon RX 6000 series (RDNA2)"},
@@ -212,8 +209,7 @@ static const std::map<std::string, std::string> DEVICE_FAMILY_NAMES = {
 // Maps device types to human-readable names (for error messages)
 static const std::map<std::string, std::string> DEVICE_TYPE_NAMES = {
     {"cpu", "CPU"},
-    {"amd_igpu", "AMD iGPU"},
-    {"amd_dgpu", "AMD dGPU"},
+    {"amd_gpu", "AMD GPU"},
     {"amd_npu", "AMD NPU"},
     {"nvidia_dgpu", "NVIDIA GPU"},
     {"metal", "MacOS Metal GPU"}
@@ -225,7 +221,7 @@ static std::string get_family_name(const std::string& family) {
     return it != DEVICE_FAMILY_NAMES.end() ? it->second : family;
 }
 
-// Get human-readable name for a device type (e.g., "amd_igpu" -> "AMD iGPU")
+// Get human-readable name for a device type (e.g., "amd_gpu" -> "AMD GPU")
 static std::string get_device_type_name(const std::string& device_type) {
     auto it = DEVICE_TYPE_NAMES.find(device_type);
     return it != DEVICE_TYPE_NAMES.end() ? it->second : device_type;
@@ -271,7 +267,7 @@ std::string SystemInfo::get_unsupported_backend_error(const std::string& recipe,
 
 // Detected device with its family
 struct DetectedDevice {
-    std::string type;      // "cpu", "amd_igpu", "amd_dgpu", "amd_npu"
+    std::string type;      // "cpu", "amd_gpu", "amd_npu"
     std::string name;      // Full device name
     std::string family;    // "x86_64", "gfx1150", "XDNA2", etc.
     bool present;
@@ -450,54 +446,55 @@ json SystemInfo::get_device_dict() {
         };
     }
 
-    // Get AMD iGPU info - with fault tolerance
+    // Get AMD GPU info (both integrated and discrete) - with fault tolerance
     try {
-        auto amd_igpu = get_amd_igpu_device();
-        devices["amd_igpu"] = {
-            {"name", amd_igpu.name},
-            {"vram_gb", amd_igpu.vram_gb},
-            {"virtual_mem_gb", amd_igpu.virtual_gb},
-            {"available", amd_igpu.available}
-        };
-        devices["amd_igpu"]["family"] = identify_rocm_arch_from_name(amd_igpu.name);
-        if (!amd_igpu.error.empty()) {
-            devices["amd_igpu"]["error"] = amd_igpu.error;
-        }
-    } catch (const std::exception& e) {
-        devices["amd_igpu"] = {
-            {"name", "Unknown"},
-            {"available", true},  // Assume available - trust the user
-            {"error", std::string("Detection exception: ") + e.what()}
-        };
-    }
+        devices["amd_gpu"] = json::array();
 
-    // Get AMD dGPU info - with fault tolerance
-    try {
-        auto amd_dgpus = get_amd_dgpu_devices();
-        devices["amd_dgpu"] = json::array();
-        for (const auto& gpu : amd_dgpus) {
+        auto amd_igpu = get_amd_igpu_device();
+        if (amd_igpu.available) {
             json gpu_json = {
-                {"name", gpu.name},
-                {"available", gpu.available}
+                {"name", amd_igpu.name},
+                {"available", amd_igpu.available}
             };
-            if (gpu.vram_gb > 0) {
-                gpu_json["vram_gb"] = gpu.vram_gb;
+            if (amd_igpu.vram_gb > 0) {
+                gpu_json["vram_gb"] = amd_igpu.vram_gb;
             }
-            if (gpu.virtual_gb > 0) {
-                gpu_json["virtual_mem_gb"] = gpu.virtual_gb;
+            if (amd_igpu.virtual_gb > 0) {
+                gpu_json["virtual_mem_gb"] = amd_igpu.virtual_gb;
             }
-            if (!gpu.driver_version.empty()) {
-                gpu_json["driver_version"] = gpu.driver_version;
+            gpu_json["family"] = identify_rocm_arch_from_name(amd_igpu.name);
+            if (!amd_igpu.error.empty()) {
+                gpu_json["error"] = amd_igpu.error;
             }
-            gpu_json["family"] = identify_rocm_arch_from_name(gpu.name);
-            if (!gpu.error.empty()) {
-                gpu_json["error"] = gpu.error;
+            devices["amd_gpu"].push_back(gpu_json);
+        }
+
+        auto amd_dgpus = get_amd_dgpu_devices();
+        for (const auto& gpu : amd_dgpus) {
+            if (gpu.available) {
+                json gpu_json = {
+                    {"name", gpu.name},
+                    {"available", gpu.available}
+                };
+                if (gpu.vram_gb > 0) {
+                    gpu_json["vram_gb"] = gpu.vram_gb;
+                }
+                if (gpu.virtual_gb > 0) {
+                    gpu_json["virtual_mem_gb"] = gpu.virtual_gb;
+                }
+                if (!gpu.driver_version.empty()) {
+                    gpu_json["driver_version"] = gpu.driver_version;
+                }
+                gpu_json["family"] = identify_rocm_arch_from_name(gpu.name);
+                if (!gpu.error.empty()) {
+                    gpu_json["error"] = gpu.error;
+                }
+                devices["amd_gpu"].push_back(gpu_json);
             }
-            devices["amd_dgpu"].push_back(gpu_json);
         }
     } catch (const std::exception& e) {
-        devices["amd_dgpu"] = json::array();
-        devices["amd_dgpu_error"] = std::string("Detection exception: ") + e.what();
+        devices["amd_gpu"] = json::array();
+        devices["amd_gpu_error"] = std::string("Detection exception: ") + e.what();
     }
 
     // Get NVIDIA dGPU info - with fault tolerance
@@ -646,32 +643,15 @@ json SystemInfo::build_recipes_info(const json& devices) {
         detected_devices.push_back({"cpu", "CPU", "", true});
     }
 
-    // AMD iGPU
-    if (devices.contains("amd_igpu") && devices["amd_igpu"].is_object()) {
-        const auto& igpu = devices["amd_igpu"];
-        if (igpu.value("available", false)) {
-            std::string name = igpu.value("name", "");
-            std::string family = igpu.value("family", "");
-            if (!name.empty()) {
-                detected_devices.push_back({
-                    "amd_igpu",
-                    name,
-                    family,
-                    true
-                });
-            }
-        }
-    }
-
-    // AMD dGPUs
-    if (devices.contains("amd_dgpu") && devices["amd_dgpu"].is_array()) {
-        for (const auto& gpu : devices["amd_dgpu"]) {
+    // AMD GPUs
+    if (devices.contains("amd_gpu") && devices["amd_gpu"].is_array()) {
+        for (const auto& gpu : devices["amd_gpu"]) {
             if (gpu.value("available", false)) {
                 std::string name = gpu.value("name", "");
                 std::string family = gpu.value("family", "");
                 if (!name.empty()) {
                     detected_devices.push_back({
-                        "amd_dgpu",
+                        "amd_gpu",
                         name,
                         family,
                         true
@@ -859,7 +839,7 @@ json SystemInfo::build_recipes_info(const json& devices) {
                     : missing_devices[0];
 
                 // For AMD GPUs, include the detected family in the message
-                if (device_type == "amd_dgpu" || device_type == "amd_igpu") {
+                if (device_type == "amd_gpu") {
                     // Find the detected GPU family for this device type
                     std::string detected_family;
                     for (const auto& detected : detected_devices) {
@@ -1405,23 +1385,9 @@ std::string SystemInfo::get_rocm_arch() {
 
         const auto& devices = system_info["devices"];
 
-        // Check iGPU first
-        if (devices.contains("amd_igpu") && devices["amd_igpu"].is_object()) {
-            const auto& igpu = devices["amd_igpu"];
-            if (igpu.value("available", false)) {
-                std::string name = igpu.value("name", "");
-                if (!name.empty()) {
-                    std::string arch = identify_rocm_arch_from_name(name);
-                    if (!arch.empty()) {
-                        return arch;
-                    }
-                }
-            }
-        }
-
-        // Check dGPUs
-        if (devices.contains("amd_dgpu") && devices["amd_dgpu"].is_array()) {
-            for (const auto& gpu : devices["amd_dgpu"]) {
+        // Check AMD GPUs
+        if (devices.contains("amd_gpu") && devices["amd_gpu"].is_array()) {
+            for (const auto& gpu : devices["amd_gpu"]) {
                 if (gpu.value("available", false)) {
                     std::string name = gpu.value("name", "");
                     if (!name.empty()) {
@@ -1441,24 +1407,13 @@ std::string SystemInfo::get_rocm_arch() {
 }
 
 bool SystemInfo::get_has_igpu() {
-    // Returns if the device is an iGPU. Only AMD iGPUs are detected at the moment
+    // Detect at runtime using OS-level iGPU detection
+    // Linux: checks for absence of board_info in sysfs (iGPUs don't have it)
+    // Windows: checks GPU name against discrete GPU keywords
     try {
-        // Use cached system info to avoid re-detecting GPUs
-        json system_info = SystemInfoCache::get_system_info_with_cache();
-
-        if (!system_info.contains("devices")) {
-            return false;
-        }
-
-        const auto& devices = system_info["devices"];
-
-        // Check iGPU first
-        if (devices.contains("amd_igpu") && devices["amd_igpu"].is_object()) {
-            const auto& igpu = devices["amd_igpu"];
-            if (igpu.value("available", false)) {
-                return true;
-            }
-        }
+        auto sys_info = create_system_info();
+        GPUInfo igpu = sys_info->get_amd_igpu_device();
+        return igpu.available;
     } catch (...) {
         // Detection failed
     }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -211,7 +211,7 @@ static const std::map<std::string, std::string> DEVICE_TYPE_NAMES = {
     {"cpu", "CPU"},
     {"amd_gpu", "AMD GPU"},
     {"amd_npu", "AMD NPU"},
-    {"nvidia_dgpu", "NVIDIA GPU"},
+    {"nvidia_gpu", "NVIDIA GPU"},
     {"metal", "MacOS Metal GPU"}
 };
 
@@ -499,9 +499,9 @@ json SystemInfo::get_device_dict() {
 
     // Get NVIDIA dGPU info - with fault tolerance
     try {
-        auto nvidia_dgpus = get_nvidia_dgpu_devices();
-        devices["nvidia_dgpu"] = json::array();
-        for (const auto& gpu : nvidia_dgpus) {
+        auto nvidia_gpus = get_nvidia_gpu_devices();
+        devices["nvidia_gpu"] = json::array();
+        for (const auto& gpu : nvidia_gpus) {
             json gpu_json = {
                 {"name", gpu.name},
                 {"available", gpu.available}
@@ -515,11 +515,11 @@ json SystemInfo::get_device_dict() {
             if (!gpu.error.empty()) {
                 gpu_json["error"] = gpu.error;
             }
-            devices["nvidia_dgpu"].push_back(gpu_json);
+            devices["nvidia_gpu"].push_back(gpu_json);
         }
     } catch (const std::exception& e) {
-        devices["nvidia_dgpu"] = json::array();
-        devices["nvidia_dgpu_error"] = std::string("Detection exception: ") + e.what();
+        devices["nvidia_gpu"] = json::array();
+        devices["nvidia_gpu_error"] = std::string("Detection exception: ") + e.what();
     }
 
     // Get NPU info - with fault tolerance
@@ -1584,7 +1584,7 @@ std::vector<GPUInfo> WindowsSystemInfo::get_amd_dgpu_devices() {
     return detect_amd_gpus("discrete");
 }
 
-std::vector<GPUInfo> WindowsSystemInfo::get_nvidia_dgpu_devices() {
+std::vector<GPUInfo> WindowsSystemInfo::get_nvidia_gpu_devices() {
     std::vector<GPUInfo> gpus;
 
     wmi::WMIConnection wmi;
@@ -2030,7 +2030,7 @@ std::vector<GPUInfo> LinuxSystemInfo::get_amd_dgpu_devices() {
     return detect_amd_gpus("discrete");
 }
 
-std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_dgpu_devices() {
+std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
     std::vector<GPUInfo> gpus;
 
     // Execute lspci to find GPUs
@@ -2595,7 +2595,7 @@ std::vector<GPUInfo> MacOSSystemInfo::get_amd_dgpu_devices() {
     return {gpu};
 }
 
-std::vector<GPUInfo> MacOSSystemInfo::get_nvidia_dgpu_devices() {
+std::vector<GPUInfo> MacOSSystemInfo::get_nvidia_gpu_devices() {
     GPUInfo gpu;
     gpu.available = false;
     gpu.error = "NVIDIA GPUs not detected on macOS";

--- a/src/cpp/server/utils/process_manager.cpp
+++ b/src/cpp/server/utils/process_manager.cpp
@@ -259,9 +259,30 @@ ProcessHandle ProcessManager::start_process(
     HANDLE stdout_write = nullptr;
     HANDLE stderr_read = nullptr;
     HANDLE stderr_write = nullptr;
+    HANDLE nul_input = nullptr;
+
+    bool use_filtered_output = (inherit_output && filter_health_logs);
+
+    if (inherit_output && !filter_health_logs) {
+        const HANDLE std_in = GetStdHandle(STD_INPUT_HANDLE);
+        const HANDLE std_out = GetStdHandle(STD_OUTPUT_HANDLE);
+        const HANDLE std_err = GetStdHandle(STD_ERROR_HANDLE);
+
+        const bool invalid_stdio =
+            (std_in == nullptr || std_in == INVALID_HANDLE_VALUE) ||
+            (std_out == nullptr || std_out == INVALID_HANDLE_VALUE) ||
+            (std_err == nullptr || std_err == INVALID_HANDLE_VALUE);
+
+        if (invalid_stdio) {
+            use_filtered_output = true;
+            LOG(WARNING, "ProcessManager")
+                << "Parent std handles are unavailable; enabling filtered output capture"
+                << std::endl;
+        }
+    }
 
     // If inherit_output is true, either use pipes with filtering or direct inheritance
-    if (inherit_output && filter_health_logs) {
+    if (inherit_output && use_filtered_output) {
         // Create pipes for stdout and stderr to filter output
         SECURITY_ATTRIBUTES sa;
         sa.nLength = sizeof(SECURITY_ATTRIBUTES);
@@ -283,6 +304,15 @@ ProcessHandle ProcessManager::start_process(
 
         si.dwFlags = STARTF_USESTDHANDLES;
         si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+        if (si.hStdInput == nullptr || si.hStdInput == INVALID_HANDLE_VALUE) {
+            nul_input = CreateFileA("NUL", GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (nul_input != INVALID_HANDLE_VALUE) {
+                SetHandleInformation(nul_input, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
+                si.hStdInput = nul_input;
+            } else {
+                si.hStdInput = nullptr;
+            }
+        }
         si.hStdOutput = stdout_write;
         si.hStdError = stderr_write;
 
@@ -319,7 +349,7 @@ ProcessHandle ProcessManager::start_process(
         nullptr,
         nullptr,
         TRUE,  // Inherit handles
-        (inherit_output && !filter_health_logs) ? 0 : CREATE_NO_WINDOW,
+        (inherit_output && !use_filtered_output) ? 0 : CREATE_NO_WINDOW,
         environment_block.empty() ? nullptr : environment_block.data(),
         working_dir.empty() ? nullptr : working_dir.c_str(),
         &si,
@@ -352,7 +382,12 @@ ProcessHandle ProcessManager::start_process(
         std::string full_error = "Failed to start process '" + executable +
                                 "': " + error_msg + " (Error code: " + std::to_string(error) + ")";
         LOG(ERROR, "ProcessManager") << full_error << std::endl;
+        if (nul_input && nul_input != INVALID_HANDLE_VALUE) CloseHandle(nul_input);
         throw std::runtime_error(full_error);
+    }
+
+    if (nul_input && nul_input != INVALID_HANDLE_VALUE) {
+        CloseHandle(nul_input);
     }
 
     // Close write ends of pipes in parent process
@@ -360,7 +395,7 @@ ProcessHandle ProcessManager::start_process(
     if (stderr_write) CloseHandle(stderr_write);
 
     // Start filter threads if needed
-    if (inherit_output && filter_health_logs) {
+    if (inherit_output && use_filtered_output) {
         CreateThread(nullptr, 0, output_filter_thread, stdout_read, 0, nullptr);
         CreateThread(nullptr, 0, output_filter_thread, stderr_read, 0, nullptr);
     }

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -638,7 +638,7 @@ class EndpointTests(ServerTestBase):
         self.assertIsInstance(devices, dict)
 
         # Check required device types
-        required_devices = ["cpu", "amd_igpu", "amd_dgpu", "amd_npu"]
+        required_devices = ["cpu", "amd_gpu", "amd_npu"]
         for device in required_devices:
             self.assertIn(device, devices, f"Missing device type: {device}")
 

--- a/test/test_flm_status.py
+++ b/test/test_flm_status.py
@@ -120,13 +120,14 @@ NPU_HARDWARE = {
             "available": True,
             "family": "x86_64",
         },
-        "amd_igpu": {
-            "name": "AMD Radeon 890M",
-            "vram_gb": 8.0,
-            "available": True,
-            "family": "gfx1150",
-        },
-        "amd_dgpu": [],
+        "amd_gpu": [
+            {
+                "name": "AMD Radeon 890M",
+                "vram_gb": 8.0,
+                "available": True,
+                "family": "gfx1150",
+            }
+        ],
         "nvidia_dgpu": [],
         "amd_npu": {
             "name": "AMD Ryzen AI 9 HX 370",
@@ -154,8 +155,7 @@ NO_NPU_HARDWARE = {
             "available": True,
             "family": "x86_64",
         },
-        "amd_igpu": {"name": "None", "available": False, "family": ""},
-        "amd_dgpu": [],
+        "amd_gpu": [],
         "nvidia_dgpu": [],
         "amd_npu": {"name": "None", "available": False, "family": ""},
     },

--- a/test/test_flm_status.py
+++ b/test/test_flm_status.py
@@ -128,7 +128,7 @@ NPU_HARDWARE = {
                 "family": "gfx1150",
             }
         ],
-        "nvidia_dgpu": [],
+        "nvidia_gpu": [],
         "amd_npu": {
             "name": "AMD Ryzen AI 9 HX 370",
             "available": True,
@@ -156,7 +156,7 @@ NO_NPU_HARDWARE = {
             "family": "x86_64",
         },
         "amd_gpu": [],
-        "nvidia_dgpu": [],
+        "nvidia_gpu": [],
         "amd_npu": {"name": "None", "available": False, "family": ""},
     },
 }


### PR DESCRIPTION
Some artifacts have content for both dGPU and APU in the same binary and this fixes that distinction.