### PR TITLE
Add qwen3.6-35b-a3b

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -901,6 +901,18 @@
         ],
         "size": 16.7
     },
+    "Qwen3.6-35B-A3B-GGUF": {
+        "checkpoint": "unsloth/Qwen3.6-35B-A3B-GGUF:Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+        "mmproj": "mmproj-F16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "vision",
+            "tool-calling",
+            "hot"
+        ],
+        "size": 22.4
+    },
     "Llama-4-Scout-17B-16E-Instruct-GGUF": {
         "checkpoint": "unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF:Q4_K_S",
         "mmproj": "mmproj-F16.gguf",


### PR DESCRIPTION
Qwen 3.6 35B A3B uses the same architecture as the Qwen 3.5 family of models (qwen35moe). 

Testing locally, this works well on lemonade's currently packaged versions of llamacpp.

<img width="1587" height="291" alt="image" src="https://github.com/user-attachments/assets/d32fdf26-644a-436f-9391-fe001e4e2b12" />