### PR TITLE
fix: use wss:// for WebSocket connections when served over HTTPS (#1583)

### DIFF
--- a/src/app/src/renderer/utils/logWebSocketClient.ts
+++ b/src/app/src/renderer/utils/logWebSocketClient.ts
@@ -1,4 +1,4 @@
-import { getAPIKey, getServerHost, serverFetch } from './serverConfig';
+import { getAPIKey, getServerHost, getWebSocketProtocol, serverFetch } from './serverConfig';
 
 export interface LogEntry {
   seq: number;
@@ -42,8 +42,8 @@ export async function connectLogStream(
   }
 
   const wsUrl = query.size > 0
-    ? `ws://${getServerHost()}:${wsPort}/logs/stream?${query.toString()}`
-    : `ws://${getServerHost()}:${wsPort}/logs/stream`;
+    ? `${getWebSocketProtocol()}://${getServerHost()}:${wsPort}/logs/stream?${query.toString()}`
+    : `${getWebSocketProtocol()}://${getServerHost()}:${wsPort}/logs/stream`;
   const socket = new WebSocket(wsUrl);
 
   socket.addEventListener('open', () => {

--- a/src/app/src/renderer/utils/serverConfig.ts
+++ b/src/app/src/renderer/utils/serverConfig.ts
@@ -350,6 +350,7 @@ export const getServerHost = () => serverConfig.getServerHost();
 export const getAPIKey = () => serverConfig.getAPIKey();
 export const getServerPort = () => serverConfig.getPort();
 export const discoverServerPort = () => serverConfig.discoverPort();
+export const getWebSocketProtocol = () => new URL(serverConfig.getServerBaseUrl()).protocol === 'https:' ? 'wss' : 'ws';
 export const isRemoteServer = () => serverConfig.isRemoteServer();
 export const onServerPortChange = (listener: PortChangeListener) => serverConfig.onPortChange(listener);
 export const onServerUrlChange = (listener: UrlChangeListener) => serverConfig.onUrlChange(listener);

--- a/src/app/src/renderer/utils/websocketClient.ts
+++ b/src/app/src/renderer/utils/websocketClient.ts
@@ -2,7 +2,7 @@
  * WebSocket client for realtime transcription.
  * Uses a raw WebSocket with OpenAI Realtime API message format.
  */
-import { getAPIKey, getServerHost, serverFetch } from './serverConfig';
+import { getAPIKey, getServerHost, getWebSocketProtocol, serverFetch } from './serverConfig';
 
 export interface TranscriptionCallbacks {
   /** Called with transcription text. isFinal=false for interim results that replace previous interim. */
@@ -28,7 +28,7 @@ export class TranscriptionWebSocket {
     if (apiKey) {
       query.set('api_key', apiKey);
     }
-    const wsUrl = `ws://${getServerHost()}:${wsPort}/realtime?${query.toString()}`;
+    const wsUrl = `${getWebSocketProtocol()}://${getServerHost()}:${wsPort}/realtime?${query.toString()}`;
 
     console.log('[WebSocket] Connecting to:', wsUrl);
 


### PR DESCRIPTION
@ianbmacdonald I have moved your PR here, now I can make a few changes myself too :)
https://github.com/lemonade-sdk/lemonade/pull/1583

Summary

WebSocket URLs in the web app were hardcoded to ws://, causing mixed-content errors when Lemonade is served behind an HTTPS reverse proxy
Adds a getWebSocketProtocol() helper that derives ws or wss from the server base URL protocol
Both WebSocket clients (log streaming and realtime transcription) now use the correct protocol automatically
This is the narrow protocol-only fix. A broader external_url config for full reverse proxy support (including same-origin WebSocket routing) is available on [feat/external-url-config](https://github.com/ianbmacdonald/lemonade/tree/feat/external-url-config) and described in https://github.com/lemonade-sdk/lemonade/issues/472#issuecomment-4207315161.

Test plan

 Load web app over http:// — WebSocket connections should use ws:// (unchanged behavior)
 Load web app over https:// via reverse proxy — WebSocket connections should use wss://, no mixed-content errors in browser console
 Verify log streaming and realtime transcription connect successfully in both modes
Fixes https://github.com/lemonade-sdk/lemonade/issues/472

🤖 Generated with [Claude Code](https://claude.com/claude-code)