### PR TITLE
Add a new configuration option to prevent installation of executables

### DIFF
--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -31,6 +31,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
   "models_dir": "auto",
   "ctx_size": 4096,
   "offline": false,
+  "no_fetch_executables": false,
   "disable_model_filtering": false,
   "enable_dgpu_gtt": false,
   "llamacpp": {
@@ -84,6 +85,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
 | `models_dir` | string | "auto" | Directory for cached model files. "auto" follows HF_HUB_CACHE / HF_HOME / platform default |
 | `ctx_size` | int | 4096 | Default context size for LLM models |
 | `offline` | bool | false | Skip model downloads |
+| `no_fetch_executables` | bool | false | Prevent downloading backend executable artifacts; backends must already be installed or use the system backend |
 | `disable_model_filtering` | bool | false | Show all models regardless of hardware capabilities |
 | `enable_dgpu_gtt` | bool | false | Include GTT for hardware-based model filtering |
 

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -33,6 +33,7 @@ public:
 
     // Feature flags
     bool offline() const;
+    bool no_fetch_executables() const;
     bool disable_model_filtering() const;
     bool enable_dgpu_gtt() const;
 

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -11,6 +11,7 @@
   "models_dir": "auto",
   "ctx_size": 4096,
   "offline": false,
+  "no_fetch_executables": false,
   "disable_model_filtering": false,
   "enable_dgpu_gtt": false,
   "llamacpp": {

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -1,5 +1,6 @@
 #include "lemon/backend_manager.h"
 #include "lemon/backends/backend_utils.h"
+#include "lemon/runtime_config.h"
 #include "lemon/system_info.h"
 #include "lemon/utils/path_utils.h"
 #include "lemon/utils/json_utils.h"
@@ -71,6 +72,13 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
     // System backend uses a pre-installed binary from PATH - nothing to install
     if (backend == "system") {
         return;
+    }
+
+    if (auto* cfg = RuntimeConfig::global()) {
+        if (cfg->no_fetch_executables()) {
+            throw std::runtime_error(
+                "Fetching executable artifacts is disabled");
+        }
     }
 
     auto params = get_install_params(recipe, backend);

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -163,6 +163,7 @@ static const EnvMapping env_mappings[] = {
     {"LEMONADE_EXTRA_MODELS_DIR",        "extra_models_dir",         nullptr},
     {"LEMONADE_CTX_SIZE",                "ctx_size",                 nullptr},
     {"LEMONADE_OFFLINE",                 "offline",                  nullptr},
+    {"LEMONADE_NO_FETCH_EXECUTABLES",     "no_fetch_executables",     nullptr},
     {"LEMONADE_DISABLE_MODEL_FILTERING", "disable_model_filtering",  nullptr},
     {"LEMONADE_ENABLE_DGPU_GTT",         "enable_dgpu_gtt",          nullptr},
     // llamacpp

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -160,6 +160,11 @@ bool RuntimeConfig::offline() const {
     return config_["offline"].get<bool>();
 }
 
+bool RuntimeConfig::no_fetch_executables() const {
+    std::shared_lock lock(mutex_);
+    return config_["no_fetch_executables"].get<bool>();
+}
+
 bool RuntimeConfig::disable_model_filtering() const {
     std::shared_lock lock(mutex_);
     return config_["disable_model_filtering"].get<bool>();
@@ -301,6 +306,7 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
             throw std::invalid_argument("'" + key + "' must be a string");
         }
     } else if (key == "no_broadcast" || key == "offline" ||
+               key == "no_fetch_executables" ||
                key == "disable_model_filtering" || key == "enable_dgpu_gtt") {
         if (!value.is_boolean()) {
             throw std::invalid_argument("'" + key + "' must be a boolean");

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -9,6 +9,7 @@
 #include "lemon/utils/path_utils.h"
 #include "lemon/streaming_proxy.h"
 #include "lemon/logging_config.h"
+#include "lemon/runtime_config.h"
 #include "lemon/system_info.h"
 #include "lemon/version.h"
 #include <iostream>
@@ -3068,6 +3069,11 @@ void Server::handle_system_info(const httplib::Request& req, httplib::Response& 
     // Enrich with release_url, download_filename, version from BackendManager config
     if (system_info.contains("recipes")) {
         enrich_recipes(system_info["recipes"]);
+    }
+
+    // Surface runtime config flags that affect client-side install/download UX.
+    if (auto* cfg = RuntimeConfig::global()) {
+        system_info["no_fetch_executables"] = cfg->no_fetch_executables();
     }
 
     res.set_content(system_info.dump(), "application/json");

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -911,9 +911,9 @@ json SystemInfo::build_recipes_info(const json& devices) {
             } else {
                 auto* cfg = RuntimeConfig::global();
                 bool no_fetch = cfg && cfg->no_fetch_executables();
-                backend["state"] = "installable";
+                backend["state"] = no_fetch ? "unsupported" : "installable";
                 std::string default_message = no_fetch
-                    ? "Backend is not installed."
+                    ? "Automatic backend install is disabled."
                     : "Backend is supported but not installed.";
                 backend["message"] = install_error.empty() ? default_message : install_error;
 

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -371,6 +371,11 @@ static std::string get_recipe_version(const std::string& recipe, const std::stri
 }
 
 static std::string get_install_command(const std::string& recipe, const std::string& backend) {
+    if (auto* cfg = RuntimeConfig::global()) {
+        if (cfg->no_fetch_executables()) {
+            return "";
+        }
+    }
     return "lemonade backends install " + recipe + ":" + backend;
 }
 
@@ -904,8 +909,13 @@ json SystemInfo::build_recipes_info(const json& devices) {
                 backend["action"] = get_install_command(def.recipe, def.backend);
 #endif
             } else {
+                auto* cfg = RuntimeConfig::global();
+                bool no_fetch = cfg && cfg->no_fetch_executables();
                 backend["state"] = "installable";
-                backend["message"] = install_error.empty() ? "Backend is supported but not installed." : install_error;
+                std::string default_message = no_fetch
+                    ? "Backend is not installed."
+                    : "Backend is supported but not installed.";
+                backend["message"] = install_error.empty() ? default_message : install_error;
 
                 // Special action for ROCm backend on llamacpp/sd-cpp if CWSR fix is missing
                 if ((def.recipe == "llamacpp" || def.recipe == "sd-cpp") && def.backend == "rocm"


### PR DESCRIPTION
When set users must use a system provided executable instead.

During [review in Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1120707
) there was push back on the maintainability of lemonade for security updates if Debian can't control the rollout of backends.  So I will plan to expand 'system' backend concept into more backends eventually.

But in the short term I'd like a configuration option that will block executable backend installation from Github artifacts.

---

This effectively means that only FLM and llama.cpp system backend "will work" in Debian, but I'll expand it as time goes on.
