### PR TITLE
Feat persistent token usage stats UI

### DIFF
--- a/src/app/src/renderer/App.tsx
+++ b/src/app/src/renderer/App.tsx
@@ -49,7 +49,7 @@ const AppContent: React.FC = () => {
             setIsChatVisible(settings.layout.isChatVisible ?? DEFAULT_LAYOUT_SETTINGS.isChatVisible);
             setIsModelManagerVisible(settings.layout.isModelManagerVisible ?? DEFAULT_LAYOUT_SETTINGS.isModelManagerVisible);
             const savedView = settings.layout.leftPanelView;
-            if (savedView === 'models' || savedView === 'marketplace' || savedView === 'backends' || savedView === 'settings') {
+            if (savedView === 'models' || savedView === 'marketplace' || savedView === 'backends' || savedView === 'stats' || savedView === 'settings') {
               setLeftPanelView(savedView);
             }
             setIsLogsVisible(settings.layout.isLogsVisible ?? DEFAULT_LAYOUT_SETTINGS.isLogsVisible);

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { Boxes, ChevronRight, Cpu, Settings, SlidersHorizontal, Store, XIcon } from './components/Icons';
+import { Boxes, ChartNoAxesCombined, ChevronRight, Cpu, Settings, SlidersHorizontal, Store, XIcon } from './components/Icons';
 import { ModelInfo } from './utils/modelData';
 import { ToastContainer, useToast } from './Toast';
 import { useConfirmDialog } from './ConfirmDialog';
@@ -14,6 +14,7 @@ import ModelOptionsModal from "./ModelOptionsModal";
 import { RecipeOptions, recipeOptionsToApi } from "./recipes/recipeOptions";
 import SettingsPanel from './SettingsPanel';
 import BackendManager from './BackendManager';
+import StatsPanel from './StatsPanel';
 import ConnectedBackendRow from './components/ConnectedBackendRow';
 import MarketplacePanel, { MarketplaceCategory } from './MarketplacePanel';
 import { RECIPE_DISPLAY_NAMES } from './utils/recipeNames';
@@ -191,7 +192,7 @@ interface ModelJSON {
   image_defaults?: []
 }
 
-export type LeftPanelView = 'models' | 'backends' | 'marketplace' | 'settings';
+export type LeftPanelView = 'models' | 'backends' | 'marketplace' | 'stats' | 'settings';
 
 
 const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContentVisibilityChange, width = 280, currentView, onViewChange }) => {
@@ -1037,7 +1038,9 @@ const [searchQuery, setSearchQuery] = useState('');
       ? 'Backend Manager'
       : currentView === 'marketplace'
         ? 'Marketplace'
-        : 'Settings';
+        : currentView === 'stats'
+          ? 'Statistics'
+          : 'Settings';
 
   const searchPlaceholder = currentView === 'models'
     ? 'Search models...'
@@ -1045,7 +1048,9 @@ const [searchQuery, setSearchQuery] = useState('');
       ? 'Filter backends...'
       : currentView === 'marketplace'
         ? 'Filter marketplace...'
-        : 'Filter settings...';
+        : currentView === 'stats'
+          ? 'Filter dates...'
+          : 'Filter settings...';
   const showInlineFilterButton = currentView === 'models' || currentView === 'marketplace';
 
   const getModelStatus = (modelName: string) => {
@@ -1371,6 +1376,9 @@ const [searchQuery, setSearchQuery] = useState('');
           <button className={`left-panel-mode-btn ${currentView === 'marketplace' && isContentVisible ? 'active' : ''}`} onClick={() => handleRailClick('marketplace')} title="Marketplace" aria-label="Marketplace">
             <Store size={14} strokeWidth={1.9} />
           </button>
+          <button className={`left-panel-mode-btn ${currentView === 'stats' && isContentVisible ? 'active' : ''}`} onClick={() => handleRailClick('stats')} title="Statistics" aria-label="Statistics">
+            <ChartNoAxesCombined size={14} strokeWidth={1.9} />
+          </button>
           <div className="left-panel-mode-rail-spacer" />
           <button className={`left-panel-mode-btn ${currentView === 'settings' && isContentVisible ? 'active' : ''}`} onClick={() => handleRailClick('settings')} title="Settings" aria-label="Settings">
             <Settings size={14} strokeWidth={1.9} />
@@ -1623,6 +1631,7 @@ const [searchQuery, setSearchQuery] = useState('');
                 showSuccess={showSuccess}
               />
             )}
+            {currentView === 'stats' && <StatsPanel searchQuery={searchQuery} />}
             {currentView === 'settings' && <SettingsPanel isVisible={true} searchQuery={searchQuery} />}
           </div>
 

--- a/src/app/src/renderer/StatsPanel.tsx
+++ b/src/app/src/renderer/StatsPanel.tsx
@@ -200,13 +200,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
     };
   }, [lifetimeStats]);
 
-  const valueSummary = bucketMode === 'day' ? chartSummary : {
-    totalTokens: lifetimeSummary.totalTokens,
-    input: lifetimeSummary.totalInput,
-    output: lifetimeSummary.totalOutput,
-    requests: lifetimeSummary.requests,
-    avgTokensPerRequest: lifetimeSummary.avgTokensPerRequest,
-  };
+  const valueSummary = chartSummary;
 
   const recentRows = useMemo(() => {
     return [...chartPoints].reverse().slice(0, 8);

--- a/src/app/src/renderer/StatsPanel.tsx
+++ b/src/app/src/renderer/StatsPanel.tsx
@@ -1,0 +1,820 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { RefreshIcon, XIcon } from './components/Icons';
+import { onServerUrlChange, serverConfig } from './utils/serverConfig';
+
+type BucketMap = Record<string, {
+  requests?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+}>;
+
+interface LifetimeStats {
+  requests?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  started_at?: string;
+  updated_at?: string;
+  bucket_timezone?: string;
+  persistence_path?: string;
+  by_day?: BucketMap;
+  by_hour?: BucketMap;
+}
+
+interface StatsPanelProps {
+  searchQuery: string;
+}
+
+interface UsagePoint {
+  bucket: string;
+  label: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  requests: number;
+}
+
+type BucketMode = 'day' | 'hour';
+type DayRangePreset = '7d' | '30d' | '90d' | '365d' | 'all';
+
+const DAY_RANGE_PRESETS: Array<{ key: DayRangePreset; label: string; days: number | null }> = [
+  { key: '7d', label: 'Past 7 days', days: 7 },
+  { key: '30d', label: 'Past 30 days', days: 30 },
+  { key: '90d', label: 'N days', days: 90 },
+  { key: '365d', label: 'Past year', days: 365 },
+  { key: 'all', label: 'All time', days: null },
+];
+
+const HOURLY_SLOT_COUNT = 24;
+const SYSTEM_USES_12_HOUR_CLOCK = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+}).resolvedOptions().hour12 === true;
+
+const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
+  const [lifetimeStats, setLifetimeStats] = useState<LifetimeStats | null>(null);
+  const [bucketMode, setBucketMode] = useState<BucketMode>('day');
+  const [dayRangePreset, setDayRangePreset] = useState<DayRangePreset>('30d');
+  const [customDayCount, setCustomDayCount] = useState(90);
+  const [selectedDay, setSelectedDay] = useState('');
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = useCallback(async (refresh = false) => {
+    if (refresh) {
+      setIsRefreshing(true);
+    } else {
+      setIsLoading(true);
+    }
+
+    try {
+      const response = await serverConfig.fetch('/stats');
+      if (!response.ok) {
+        throw new Error(`Stats request failed with ${response.status}`);
+      }
+
+      const data = await response.json();
+      setLifetimeStats(data.lifetime ?? null);
+      setError(null);
+    } catch (fetchError) {
+      console.error('Failed to load lifetime stats:', fetchError);
+      setError('Unable to load server usage stats.');
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStats();
+
+    const intervalId = window.setInterval(() => {
+      fetchStats(true);
+    }, 30000);
+
+    const handleInferenceComplete = () => {
+      fetchStats(true);
+    };
+
+    window.addEventListener('inference-complete', handleInferenceComplete);
+    const unsubscribe = onServerUrlChange(() => {
+      fetchStats();
+    });
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.removeEventListener('inference-complete', handleInferenceComplete);
+      unsubscribe();
+    };
+  }, [fetchStats]);
+
+  const availableDays = useMemo(() => {
+    return Object.keys(lifetimeStats?.by_day ?? {}).sort((a, b) => a.localeCompare(b));
+  }, [lifetimeStats]);
+
+  useEffect(() => {
+    if (!availableDays.length) {
+      if (selectedDay) {
+        setSelectedDay('');
+      }
+      return;
+    }
+
+    if (!selectedDay || !availableDays.includes(selectedDay)) {
+      setSelectedDay(availableDays[availableDays.length - 1]);
+    }
+  }, [availableDays, selectedDay]);
+
+  const dayPoints = useMemo<UsagePoint[]>(() => {
+    const entries = Object.entries(lifetimeStats?.by_day ?? {}).sort(([a], [b]) => a.localeCompare(b));
+    const dayLimit = resolveDayLimit(dayRangePreset, customDayCount);
+    const trimmed = dayLimit === null ? entries : entries.slice(-dayLimit);
+
+    return trimmed.map(([bucket, value]) => makeUsagePoint(bucket, formatDayLabel(bucket), value));
+  }, [customDayCount, dayRangePreset, lifetimeStats]);
+
+  const hourlyPoints = useMemo<UsagePoint[]>(() => {
+    if (!selectedDay) {
+      return [];
+    }
+
+    const hours = new Map(Object.entries(lifetimeStats?.by_hour ?? {}));
+    const points: UsagePoint[] = [];
+
+    for (let hour = 0; hour < HOURLY_SLOT_COUNT; hour += 1) {
+      const bucket = `${selectedDay}T${String(hour).padStart(2, '0')}:00:00`;
+      const value = hours.get(bucket) ?? {};
+      points.push(makeUsagePoint(bucket, formatHourTickLabel(hour), value));
+    }
+
+    return points;
+  }, [lifetimeStats, selectedDay]);
+
+  const basePoints = bucketMode === 'day' ? dayPoints : hourlyPoints;
+
+  const filteredPoints = useMemo(() => {
+    const trimmed = searchQuery.trim().toLowerCase();
+    if (!trimmed) {
+      return basePoints;
+    }
+
+    return basePoints.filter((point) =>
+      point.bucket.toLowerCase().includes(trimmed) ||
+      point.label.toLowerCase().includes(trimmed)
+    );
+  }, [basePoints, searchQuery]);
+
+  const chartPoints = filteredPoints.length > 0 ? filteredPoints : basePoints;
+
+  const chartSummary = useMemo(() => {
+    const totals = chartPoints.reduce((acc, point) => {
+      acc.input += point.inputTokens;
+      acc.output += point.outputTokens;
+      acc.requests += point.requests;
+      return acc;
+    }, { input: 0, output: 0, requests: 0 });
+
+    const totalTokens = totals.input + totals.output;
+
+    return {
+      totalTokens,
+      input: totals.input,
+      output: totals.output,
+      requests: totals.requests,
+      avgTokensPerRequest: totals.requests > 0 ? totalTokens / totals.requests : 0,
+    };
+  }, [chartPoints]);
+
+  const lifetimeSummary = useMemo(() => {
+    const totalInput = lifetimeStats?.input_tokens ?? 0;
+    const totalOutput = lifetimeStats?.output_tokens ?? 0;
+    const requests = lifetimeStats?.requests ?? 0;
+    const totalTokens = totalInput + totalOutput;
+
+    return {
+      requests,
+      totalInput,
+      totalOutput,
+      totalTokens,
+      avgTokensPerRequest: requests > 0 ? totalTokens / requests : 0,
+    };
+  }, [lifetimeStats]);
+
+  const valueSummary = bucketMode === 'day' ? chartSummary : {
+    totalTokens: lifetimeSummary.totalTokens,
+    input: lifetimeSummary.totalInput,
+    output: lifetimeSummary.totalOutput,
+    requests: lifetimeSummary.requests,
+    avgTokensPerRequest: lifetimeSummary.avgTokensPerRequest,
+  };
+
+  const recentRows = useMemo(() => {
+    return [...chartPoints].reverse().slice(0, 8);
+  }, [chartPoints]);
+
+  const utilizationSummary = useMemo(() => {
+    const allDayPoints = Object.entries(lifetimeStats?.by_day ?? {})
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([bucket, value]) => makeUsagePoint(bucket, formatDayLabel(bucket), value));
+    const allHourPoints = Object.entries(lifetimeStats?.by_hour ?? {})
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([bucket, value]) => makeUsagePoint(bucket, bucket, value));
+
+    const activeDays = allDayPoints.filter((point) => point.totalTokens > 0).length;
+    const activeHours = allHourPoints.filter((point) => point.totalTokens > 0).length;
+    const peakDay = allDayPoints.reduce<UsagePoint | null>((best, point) => {
+      if (!best || point.totalTokens > best.totalTokens) {
+        return point;
+      }
+      return best;
+    }, null);
+    const peakHour = allHourPoints.reduce<UsagePoint | null>((best, point) => {
+      if (!best || point.totalTokens > best.totalTokens) {
+        return point;
+      }
+      return best;
+    }, null);
+
+    return {
+      activeDays,
+      activeHours,
+      avgTokensPerActiveDay: activeDays > 0 ? lifetimeSummary.totalTokens / activeDays : 0,
+      peakDayLabel: peakDay ? formatDateHeading(peakDay.bucket) : 'No activity yet',
+      peakDayTokens: peakDay?.totalTokens ?? 0,
+      peakHourLabel: peakHour ? formatHourBucketHeading(peakHour.bucket) : 'No activity yet',
+      peakHourTokens: peakHour?.totalTokens ?? 0,
+    };
+  }, [lifetimeStats, lifetimeSummary.totalTokens]);
+
+  return (
+    <div className="stats-panel">
+      <div className="stats-hero">
+        <div className="stats-hero-copy">
+          <div className="stats-kicker">SERVER LIFETIME</div>
+          <h2>Usage trends</h2>
+          <p>
+            See whether the local accelerator is being used steadily or sitting idle,
+            with day-range and single-day hourly views.
+          </p>
+        </div>
+        <div className="stats-hero-actions">
+          <button
+            className="stats-expand-btn"
+            onClick={() => setIsExpanded(true)}
+            title="Open larger chart"
+            aria-label="Open larger chart"
+          >
+            Zoom
+          </button>
+          <button
+            className={`stats-refresh-btn ${isRefreshing ? 'spinning' : ''}`}
+            onClick={() => fetchStats(true)}
+            title="Refresh stats"
+            aria-label="Refresh stats"
+          >
+            <RefreshIcon />
+          </button>
+        </div>
+      </div>
+
+      <div className="stats-summary-grid">
+        <div className="stats-summary-card">
+          <span className="stats-summary-label">Lifetime tokens</span>
+          <strong>{formatNumber(lifetimeSummary.totalTokens)}</strong>
+          <span className="stats-summary-meta">All persisted prompt and completion tokens</span>
+        </div>
+        <div className="stats-summary-card">
+          <span className="stats-summary-label">{bucketMode === 'day' ? 'Selected range' : 'Selected day'}</span>
+          <strong>{formatNumber(valueSummary.totalTokens)}</strong>
+          <span className="stats-summary-meta">
+            {bucketMode === 'day' ? 'Visible token volume in chart' : `${formatDateHeading(selectedDay)} token flow`}
+          </span>
+        </div>
+        <div className="stats-summary-card">
+          <span className="stats-summary-label">Lifetime requests</span>
+          <strong>{formatNumber(lifetimeSummary.requests)}</strong>
+          <span className="stats-summary-meta">{formatCompactNumber(lifetimeSummary.avgTokensPerRequest)} avg tokens per request</span>
+        </div>
+        <div className="stats-summary-card">
+          <span className="stats-summary-label">Output share</span>
+          <strong>{formatPercent(lifetimeSummary.totalOutput, lifetimeSummary.totalTokens)}</strong>
+          <span className="stats-summary-meta">
+            {formatNumber(lifetimeSummary.totalOutput)} output vs {formatNumber(lifetimeSummary.totalInput)} input
+          </span>
+        </div>
+      </div>
+
+      <div className="stats-chart-shell">
+        <div className="stats-chart-toolbar">
+          <div>
+            <div className="stats-chart-title">
+              {bucketMode === 'day' ? 'Token flow by day' : 'Token flow by hour'}
+            </div>
+            <div className="stats-chart-subtitle">
+              {bucketMode === 'day'
+                ? describeDayRange(dayRangePreset, customDayCount)
+                : `24-hour view for ${formatDateHeading(selectedDay)}`}
+              {searchQuery.trim().length > 0 ? ` matching "${searchQuery.trim()}"` : ''}
+            </div>
+          </div>
+          <div className="stats-bucket-toggle">
+            <button
+              type="button"
+              className={bucketMode === 'day' ? 'active' : ''}
+              onClick={() => setBucketMode('day')}
+            >
+              Per day
+            </button>
+            <button
+              type="button"
+              className={bucketMode === 'hour' ? 'active' : ''}
+              onClick={() => setBucketMode('hour')}
+            >
+              Per hour
+            </button>
+          </div>
+        </div>
+
+        {bucketMode === 'day' ? (
+          <div className="stats-controls">
+            <div className="stats-chip-group">
+              {DAY_RANGE_PRESETS.map((preset) => (
+                <button
+                  key={preset.key}
+                  type="button"
+                  className={`stats-chip ${dayRangePreset === preset.key ? 'active' : ''}`}
+                  onClick={() => setDayRangePreset(preset.key)}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+            {dayRangePreset === '90d' && (
+              <label className="stats-inline-control">
+                <span>Days</span>
+                <input
+                  type="number"
+                  min="1"
+                  max="3650"
+                  value={customDayCount}
+                  onChange={(event) => setCustomDayCount(clampDayCount(event.target.value))}
+                />
+              </label>
+            )}
+          </div>
+        ) : (
+          <div className="stats-controls">
+            <label className="stats-inline-control">
+              <span>Day</span>
+              <input
+                type="date"
+                value={selectedDay}
+                min={availableDays[0] ?? ''}
+                max={availableDays[availableDays.length - 1] ?? ''}
+                onChange={(event) => setSelectedDay(event.target.value)}
+              />
+            </label>
+          </div>
+        )}
+
+        <ChartSection
+          points={chartPoints}
+          mode={bucketMode}
+          isLoading={isLoading}
+          error={error}
+          expanded={false}
+          onExpand={() => setIsExpanded(true)}
+        />
+      </div>
+
+      <div className="stats-detail-grid">
+        <div className="stats-detail-card">
+          <div className="stats-detail-heading">Current view</div>
+          <div className="stats-detail-subheading">
+            Quick read on visible throughput and usage density
+          </div>
+          <div className="stats-insight-grid">
+            <div className="stats-insight-pill">
+              <span>Visible requests</span>
+              <strong>{formatNumber(chartSummary.requests)}</strong>
+            </div>
+            <div className="stats-insight-pill">
+              <span>Input tokens</span>
+              <strong>{formatCompactNumber(chartSummary.input)}</strong>
+            </div>
+            <div className="stats-insight-pill">
+              <span>Output tokens</span>
+              <strong>{formatCompactNumber(chartSummary.output)}</strong>
+            </div>
+            <div className="stats-insight-pill">
+              <span>Avg/request</span>
+              <strong>{formatCompactNumber(chartSummary.avgTokensPerRequest)}</strong>
+            </div>
+          </div>
+        </div>
+
+        <div className="stats-detail-card">
+          <div className="stats-detail-heading">Utilization</div>
+          <div className="stats-detail-subheading">
+            High-signal indicators for whether the local accelerator is being put to work
+          </div>
+          <div className="stats-meta-list">
+            <div className="stats-meta-row">
+              <span>Active days</span>
+              <strong>{formatNumber(utilizationSummary.activeDays)}</strong>
+            </div>
+            <div className="stats-meta-row">
+              <span>Active hours</span>
+              <strong>{formatNumber(utilizationSummary.activeHours)}</strong>
+            </div>
+            <div className="stats-meta-row">
+              <span>Avg tokens / active day</span>
+              <strong>{formatCompactNumber(utilizationSummary.avgTokensPerActiveDay)}</strong>
+            </div>
+            <div className="stats-meta-row">
+              <span>Peak day</span>
+              <strong>{utilizationSummary.peakDayLabel}</strong>
+              <small>{formatCompactNumber(utilizationSummary.peakDayTokens)} tokens</small>
+            </div>
+            <div className="stats-meta-row">
+              <span>Peak hour</span>
+              <strong>{utilizationSummary.peakHourLabel}</strong>
+              <small>{formatCompactNumber(utilizationSummary.peakHourTokens)} tokens</small>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="stats-detail-card">
+        <div className="stats-detail-heading">
+          Recent {bucketMode === 'day' ? 'days' : 'hours'}
+        </div>
+        <div className="stats-detail-subheading">
+          Useful for spotting bursts, idle windows, and uneven workload distribution
+        </div>
+        {recentRows.length === 0 ? (
+          <div className="stats-empty-state compact">No matching buckets.</div>
+        ) : (
+          <div className="stats-table">
+            {recentRows.map((row) => (
+              <div key={row.bucket} className="stats-table-row">
+                <div className="stats-table-period">
+                  <span>{row.label}</span>
+                  <small>{row.requests} req</small>
+                </div>
+                <div className="stats-table-values">
+                  <span>{formatCompactNumber(row.inputTokens)} in</span>
+                  <span>{formatCompactNumber(row.outputTokens)} out</span>
+                  <strong>{formatCompactNumber(row.totalTokens)} total</strong>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {isExpanded && (
+        <div className="stats-overlay" onMouseDown={(event) => {
+          if (event.target === event.currentTarget) {
+            setIsExpanded(false);
+          }
+        }}>
+          <div className="stats-overlay-card" onMouseDown={(event) => event.stopPropagation()}>
+            <div className="stats-overlay-header">
+              <div>
+                <div className="stats-chart-title">
+                  {bucketMode === 'day' ? 'Expanded daily token flow' : 'Expanded hourly token flow'}
+                </div>
+                <div className="stats-chart-subtitle">
+                  {bucketMode === 'day'
+                    ? describeDayRange(dayRangePreset, customDayCount)
+                    : `24-hour view for ${formatDateHeading(selectedDay)}`}
+                </div>
+              </div>
+              <button
+                className="stats-overlay-close"
+                onClick={() => setIsExpanded(false)}
+                title="Close expanded chart"
+                aria-label="Close expanded chart"
+              >
+                <XIcon size={16} strokeWidth={2.2} />
+              </button>
+            </div>
+            <ChartSection
+              points={chartPoints}
+              mode={bucketMode}
+              isLoading={isLoading}
+              error={error}
+              expanded={true}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface ChartSectionProps {
+  points: UsagePoint[];
+  mode: BucketMode;
+  isLoading: boolean;
+  error: string | null;
+  expanded: boolean;
+  onExpand?: () => void;
+}
+
+const ChartSection: React.FC<ChartSectionProps> = ({
+  points,
+  mode,
+  isLoading,
+  error,
+  expanded,
+  onExpand,
+}) => {
+  const [hoveredPointIndex, setHoveredPointIndex] = useState<number | null>(null);
+  const chartGeometry = useMemo(() => {
+    const width = 920;
+    const height = expanded ? 430 : 260;
+    const paddingX = expanded ? 34 : 22;
+    const paddingTop = 18;
+    const paddingBottom = expanded ? 64 : 38;
+    const innerWidth = width - paddingX * 2;
+    const innerHeight = height - paddingTop - paddingBottom;
+    const maxTokens = Math.max(...points.map((point) => point.totalTokens), 1);
+
+    const xForIndex = (index: number) => {
+      if (points.length <= 1) {
+        return width / 2;
+      }
+      return paddingX + (index / (points.length - 1)) * innerWidth;
+    };
+
+    const yForValue = (value: number) => {
+      const normalized = value / maxTokens;
+      return paddingTop + innerHeight - normalized * innerHeight;
+    };
+
+    const buildPath = (values: number[]) => values.map((value, index) => {
+      const x = xForIndex(index);
+      const y = yForValue(value);
+      return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`;
+    }).join(' ');
+
+    const totalPath = buildPath(points.map((point) => point.totalTokens));
+    const inputPath = buildPath(points.map((point) => point.inputTokens));
+    const outputPath = buildPath(points.map((point) => point.outputTokens));
+    const areaPath = points.length > 0
+      ? `${totalPath} L ${xForIndex(points.length - 1).toFixed(2)} ${(height - paddingBottom).toFixed(2)} L ${xForIndex(0).toFixed(2)} ${(height - paddingBottom).toFixed(2)} Z`
+      : '';
+
+    const gridLines = 4;
+    const yTicks = Array.from({ length: gridLines + 1 }, (_, index) => {
+      const value = Math.round((maxTokens / gridLines) * (gridLines - index));
+      const y = paddingTop + (innerHeight / gridLines) * index;
+      return { value, y };
+    });
+
+    return {
+      width,
+      height,
+      paddingX,
+      paddingBottom,
+      totalPath,
+      inputPath,
+      outputPath,
+      areaPath,
+      xForIndex,
+      yTicks,
+      yForValue,
+    };
+  }, [expanded, points]);
+
+  return (
+    <>
+      <div className="stats-chart-legend">
+        <span><i className="stats-swatch input" />Input</span>
+        <span><i className="stats-swatch output" />Output</span>
+        {!expanded && onExpand && (
+          <button className="stats-link-button" onClick={onExpand}>
+            Open large chart
+          </button>
+        )}
+      </div>
+
+      <div className={`stats-chart-frame ${expanded ? 'expanded' : ''}`}>
+        {isLoading ? (
+          <div className="stats-empty-state">Loading stats…</div>
+        ) : error ? (
+          <div className="stats-empty-state error">{error}</div>
+        ) : points.length === 0 ? (
+          <div className="stats-empty-state">No bucketed token data yet.</div>
+        ) : (
+          <>
+            <svg className="stats-chart" viewBox={`0 0 ${chartGeometry.width} ${chartGeometry.height}`} preserveAspectRatio="none">
+              <defs>
+                <linearGradient id={expanded ? 'stats-area-gradient-large' : 'stats-area-gradient'} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#f7b500" stopOpacity="0.45" />
+                  <stop offset="100%" stopColor="#f7b500" stopOpacity="0.02" />
+                </linearGradient>
+              </defs>
+
+              {chartGeometry.yTicks.map((tick) => (
+                <g key={tick.y}>
+                  <line
+                    className="stats-grid-line"
+                    x1={chartGeometry.paddingX}
+                    y1={tick.y}
+                    x2={chartGeometry.width - chartGeometry.paddingX}
+                    y2={tick.y}
+                  />
+                  <text x="4" y={tick.y + 4} className="stats-grid-label">
+                    {formatCompactNumber(tick.value)}
+                  </text>
+                </g>
+              ))}
+
+              {chartGeometry.areaPath && (
+                <path
+                  className="stats-area-path"
+                  d={chartGeometry.areaPath}
+                  fill={`url(#${expanded ? 'stats-area-gradient-large' : 'stats-area-gradient'})`}
+                />
+              )}
+              <path className="stats-line input" d={chartGeometry.inputPath} />
+              <path className="stats-line output" d={chartGeometry.outputPath} />
+
+              {points.map((point, index) => (
+                <g key={point.bucket}>
+                  <circle
+                    className="stats-point-hitbox"
+                    cx={chartGeometry.xForIndex(index)}
+                    cy={chartGeometry.yForValue(point.totalTokens)}
+                    r={expanded ? 11 : 9}
+                    onMouseEnter={() => setHoveredPointIndex(index)}
+                    onMouseLeave={() => setHoveredPointIndex((current) => (current === index ? null : current))}
+                  />
+                  {shouldShowXAxisLabel(mode, index, points.length) && (
+                    <text
+                      className={`stats-x-label ${expanded ? 'expanded' : ''}`}
+                      x={chartGeometry.xForIndex(index)}
+                      y={chartGeometry.height - 11}
+                      textAnchor="middle"
+                    >
+                      {point.label}
+                    </text>
+                  )}
+                </g>
+              ))}
+            </svg>
+            {hoveredPointIndex !== null && points[hoveredPointIndex] && (
+              <div
+                className={`stats-hover-card ${expanded ? 'expanded' : ''} ${chartGeometry.yForValue(points[hoveredPointIndex].totalTokens) < 92 ? 'below' : ''}`}
+                style={{
+                  left: `${(chartGeometry.xForIndex(hoveredPointIndex) / chartGeometry.width) * 100}%`,
+                  top: `${(chartGeometry.yForValue(points[hoveredPointIndex].totalTokens) / chartGeometry.height) * 100}%`,
+                }}
+              >
+                <div className="stats-hover-title">{points[hoveredPointIndex].bucket}</div>
+                <div className="stats-hover-row"><span>Total</span><strong>{formatNumber(points[hoveredPointIndex].totalTokens)}</strong></div>
+                <div className="stats-hover-row"><span>Input</span><strong>{formatNumber(points[hoveredPointIndex].inputTokens)}</strong></div>
+                <div className="stats-hover-row"><span>Output</span><strong>{formatNumber(points[hoveredPointIndex].outputTokens)}</strong></div>
+                <div className="stats-hover-row"><span>Requests</span><strong>{formatNumber(points[hoveredPointIndex].requests)}</strong></div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+};
+
+function makeUsagePoint(bucket: string, label: string, value: { requests?: number; input_tokens?: number; output_tokens?: number }): UsagePoint {
+  const inputTokens = value.input_tokens ?? 0;
+  const outputTokens = value.output_tokens ?? 0;
+
+  return {
+    bucket,
+    label,
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    requests: value.requests ?? 0,
+  };
+}
+
+function resolveDayLimit(preset: DayRangePreset, customDayCount: number): number | null {
+  const range = DAY_RANGE_PRESETS.find((entry) => entry.key === preset);
+  if (!range) {
+    return 30;
+  }
+  if (range.days !== null) {
+    return range.days;
+  }
+  if (preset === 'all') {
+    return null;
+  }
+  return customDayCount;
+}
+
+function describeDayRange(preset: DayRangePreset, customDayCount: number): string {
+  if (preset === '90d') {
+    return `Past ${customDayCount} days`;
+  }
+  return DAY_RANGE_PRESETS.find((entry) => entry.key === preset)?.label ?? 'Past 30 days';
+}
+
+function clampDayCount(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    return 1;
+  }
+  return Math.max(1, Math.min(3650, parsed));
+}
+
+function shouldShowXAxisLabel(mode: BucketMode, index: number, totalCount: number): boolean {
+  if (totalCount <= 8) {
+    return true;
+  }
+  if (mode === 'hour') {
+    return index % 2 === 0 || index === totalCount - 1;
+  }
+  const step = Math.max(1, Math.ceil(totalCount / 6));
+  return index % step === 0 || index === totalCount - 1;
+}
+
+function formatNumber(value: number): string {
+  return value.toLocaleString();
+}
+
+function formatCompactNumber(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    notation: 'compact',
+    maximumFractionDigits: value >= 100 ? 0 : 1,
+  }).format(value);
+}
+
+function formatPercent(value: number, total: number): string {
+  if (total <= 0) {
+    return '0%';
+  }
+  return `${((value / total) * 100).toFixed(1)}%`;
+}
+
+function formatDayLabel(bucket: string): string {
+  const date = new Date(`${bucket}T00:00:00`);
+  if (Number.isNaN(date.getTime())) {
+    return bucket;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+}
+
+function formatHourTickLabel(hour: number): string {
+  const date = new Date(Date.UTC(2026, 0, 1, hour, 0, 0));
+  if (SYSTEM_USES_12_HOUR_CLOCK) {
+    return new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      hour12: true,
+      timeZone: 'UTC',
+    }).format(date);
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    hour12: false,
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+function formatDateHeading(value: string): string {
+  if (!value) {
+    return 'No day selected';
+  }
+  const date = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function formatHourBucketHeading(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+  }).format(date);
+}
+
+export default StatsPanel;

--- a/src/app/src/renderer/StatsPanel.tsx
+++ b/src/app/src/renderer/StatsPanel.tsx
@@ -8,6 +8,14 @@ type BucketMap = Record<string, {
   output_tokens?: number;
 }>;
 
+interface ModelStats {
+  requests?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  by_day?: BucketMap;
+  by_hour?: BucketMap;
+}
+
 interface LifetimeStats {
   requests?: number;
   input_tokens?: number;
@@ -18,6 +26,7 @@ interface LifetimeStats {
   persistence_path?: string;
   by_day?: BucketMap;
   by_hour?: BucketMap;
+  by_model?: Record<string, ModelStats>;
 }
 
 interface StatsPanelProps {
@@ -55,6 +64,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
   const [dayRangePreset, setDayRangePreset] = useState<DayRangePreset>('30d');
   const [customDayCount, setCustomDayCount] = useState(90);
   const [selectedDay, setSelectedDay] = useState('');
+  const [selectedModel, setSelectedModel] = useState('');
   const [isExpanded, setIsExpanded] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -108,9 +118,21 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
     };
   }, [fetchStats]);
 
-  const availableDays = useMemo(() => {
-    return Object.keys(lifetimeStats?.by_day ?? {}).sort((a, b) => a.localeCompare(b));
+  const availableModels = useMemo(() => {
+    return Object.keys(lifetimeStats?.by_model ?? {}).sort((a, b) => a.localeCompare(b));
   }, [lifetimeStats]);
+
+  // The active stats source: either the selected model's slice or the full aggregate
+  const activeStats = useMemo<Pick<LifetimeStats, 'requests' | 'input_tokens' | 'output_tokens' | 'by_day' | 'by_hour'>>(() => {
+    if (selectedModel && lifetimeStats?.by_model?.[selectedModel]) {
+      return lifetimeStats.by_model[selectedModel];
+    }
+    return lifetimeStats ?? {};
+  }, [lifetimeStats, selectedModel]);
+
+  const availableDays = useMemo(() => {
+    return Object.keys(activeStats?.by_day ?? {}).sort((a, b) => a.localeCompare(b));
+  }, [activeStats]);
 
   useEffect(() => {
     if (!availableDays.length) {
@@ -126,19 +148,19 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
   }, [availableDays, selectedDay]);
 
   const dayPoints = useMemo<UsagePoint[]>(() => {
-    const entries = Object.entries(lifetimeStats?.by_day ?? {}).sort(([a], [b]) => a.localeCompare(b));
+    const entries = Object.entries(activeStats?.by_day ?? {}).sort(([a], [b]) => a.localeCompare(b));
     const dayLimit = resolveDayLimit(dayRangePreset, customDayCount);
     const trimmed = dayLimit === null ? entries : entries.slice(-dayLimit);
 
     return trimmed.map(([bucket, value]) => makeUsagePoint(bucket, formatDayLabel(bucket), value));
-  }, [customDayCount, dayRangePreset, lifetimeStats]);
+  }, [customDayCount, dayRangePreset, activeStats]);
 
   const hourlyPoints = useMemo<UsagePoint[]>(() => {
     if (!selectedDay) {
       return [];
     }
 
-    const hours = new Map(Object.entries(lifetimeStats?.by_hour ?? {}));
+    const hours = new Map(Object.entries(activeStats?.by_hour ?? {}));
     const points: UsagePoint[] = [];
 
     for (let hour = 0; hour < HOURLY_SLOT_COUNT; hour += 1) {
@@ -148,7 +170,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
     }
 
     return points;
-  }, [lifetimeStats, selectedDay]);
+  }, [activeStats, selectedDay]);
 
   const basePoints = bucketMode === 'day' ? dayPoints : hourlyPoints;
 
@@ -186,9 +208,9 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
   }, [chartPoints]);
 
   const lifetimeSummary = useMemo(() => {
-    const totalInput = lifetimeStats?.input_tokens ?? 0;
-    const totalOutput = lifetimeStats?.output_tokens ?? 0;
-    const requests = lifetimeStats?.requests ?? 0;
+    const totalInput = activeStats?.input_tokens ?? 0;
+    const totalOutput = activeStats?.output_tokens ?? 0;
+    const requests = activeStats?.requests ?? 0;
     const totalTokens = totalInput + totalOutput;
 
     return {
@@ -198,7 +220,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
       totalTokens,
       avgTokensPerRequest: requests > 0 ? totalTokens / requests : 0,
     };
-  }, [lifetimeStats]);
+  }, [activeStats]);
 
   const valueSummary = chartSummary;
 
@@ -207,10 +229,10 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
   }, [chartPoints]);
 
   const utilizationSummary = useMemo(() => {
-    const allDayPoints = Object.entries(lifetimeStats?.by_day ?? {})
+    const allDayPoints = Object.entries(activeStats?.by_day ?? {})
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([bucket, value]) => makeUsagePoint(bucket, formatDayLabel(bucket), value));
-    const allHourPoints = Object.entries(lifetimeStats?.by_hour ?? {})
+    const allHourPoints = Object.entries(activeStats?.by_hour ?? {})
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([bucket, value]) => makeUsagePoint(bucket, bucket, value));
 
@@ -238,7 +260,37 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
       peakHourLabel: peakHour ? formatHourBucketHeading(peakHour.bucket) : 'No activity yet',
       peakHourTokens: peakHour?.totalTokens ?? 0,
     };
-  }, [lifetimeStats, lifetimeSummary.totalTokens]);
+  }, [activeStats, lifetimeSummary.totalTokens]);
+
+  const renderModelSelector = () => {
+    if (availableModels.length === 0) {
+      return null;
+    }
+    return (
+      <div className="stats-controls">
+        <div className="stats-chip-group">
+          <button
+            key="all"
+            type="button"
+            className={`stats-chip ${selectedModel === '' ? 'active' : ''}`}
+            onClick={() => setSelectedModel('')}
+          >
+            All Models
+          </button>
+          {availableModels.map((model) => (
+            <button
+              key={model}
+              type="button"
+              className={`stats-chip ${selectedModel === model ? 'active' : ''}`}
+              onClick={() => setSelectedModel(model)}
+            >
+              {model}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  };
 
   const renderRangeControls = () => (
     bucketMode === 'day' ? (
@@ -317,9 +369,11 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
 
       <div className="stats-summary-grid">
         <div className="stats-summary-card">
-          <span className="stats-summary-label">Lifetime tokens</span>
+          <span className="stats-summary-label">{selectedModel ? 'Model tokens' : 'Lifetime tokens'}</span>
           <strong>{formatNumber(lifetimeSummary.totalTokens)}</strong>
-          <span className="stats-summary-meta">All persisted prompt and completion tokens</span>
+          <span className="stats-summary-meta">
+            {selectedModel ? `All persisted tokens for ${selectedModel}` : 'All persisted prompt and completion tokens'}
+          </span>
         </div>
         <div className="stats-summary-card">
           <span className="stats-summary-label">{bucketMode === 'day' ? 'Selected range' : 'Selected day'}</span>
@@ -329,7 +383,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
           </span>
         </div>
         <div className="stats-summary-card">
-          <span className="stats-summary-label">Lifetime requests</span>
+          <span className="stats-summary-label">{selectedModel ? 'Model requests' : 'Lifetime requests'}</span>
           <strong>{formatNumber(lifetimeSummary.requests)}</strong>
           <span className="stats-summary-meta">{formatCompactNumber(lifetimeSummary.avgTokensPerRequest)} avg tokens per request</span>
         </div>
@@ -373,6 +427,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
           </div>
         </div>
 
+        {renderModelSelector()}
         {renderRangeControls()}
 
         <ChartSection
@@ -516,6 +571,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
                 <XIcon size={16} strokeWidth={2.2} />
               </button>
             </div>
+            {renderModelSelector()}
             {renderRangeControls()}
             <ChartSection
               points={chartPoints}

--- a/src/app/src/renderer/StatsPanel.tsx
+++ b/src/app/src/renderer/StatsPanel.tsx
@@ -27,6 +27,7 @@ interface LifetimeStats {
   by_day?: BucketMap;
   by_hour?: BucketMap;
   by_model?: Record<string, ModelStats>;
+  by_device_type?: Record<string, ModelStats>;
 }
 
 interface StatsPanelProps {
@@ -65,6 +66,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
   const [customDayCount, setCustomDayCount] = useState(90);
   const [selectedDay, setSelectedDay] = useState('');
   const [selectedModel, setSelectedModel] = useState('');
+  const [selectedDeviceType, setSelectedDeviceType] = useState('');
   const [isExpanded, setIsExpanded] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -122,13 +124,20 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
     return Object.keys(lifetimeStats?.by_model ?? {}).sort((a, b) => a.localeCompare(b));
   }, [lifetimeStats]);
 
-  // The active stats source: either the selected model's slice or the full aggregate
+  const availableDeviceTypes = useMemo(() => {
+    return Object.keys(lifetimeStats?.by_device_type ?? {}).sort((a, b) => a.localeCompare(b));
+  }, [lifetimeStats]);
+
+  // The active stats source: selected model, selected device type, or the full aggregate
   const activeStats = useMemo<Pick<LifetimeStats, 'requests' | 'input_tokens' | 'output_tokens' | 'by_day' | 'by_hour'>>(() => {
     if (selectedModel && lifetimeStats?.by_model?.[selectedModel]) {
       return lifetimeStats.by_model[selectedModel];
     }
+    if (selectedDeviceType && lifetimeStats?.by_device_type?.[selectedDeviceType]) {
+      return lifetimeStats.by_device_type[selectedDeviceType];
+    }
     return lifetimeStats ?? {};
-  }, [lifetimeStats, selectedModel]);
+  }, [lifetimeStats, selectedModel, selectedDeviceType]);
 
   const availableDays = useMemo(() => {
     return Object.keys(activeStats?.by_day ?? {}).sort((a, b) => a.localeCompare(b));
@@ -262,33 +271,59 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
     };
   }, [activeStats, lifetimeSummary.totalTokens]);
 
-  const renderModelSelector = () => {
-    if (availableModels.length === 0) {
+  const renderFilterSelectors = () => {
+    if (availableModels.length === 0 && availableDeviceTypes.length === 0) {
       return null;
     }
     return (
-      <div className="stats-controls">
-        <div className="stats-chip-group">
-          <button
-            key="all"
-            type="button"
-            className={`stats-chip ${selectedModel === '' ? 'active' : ''}`}
-            onClick={() => setSelectedModel('')}
-          >
-            All Models
-          </button>
-          {availableModels.map((model) => (
-            <button
-              key={model}
-              type="button"
-              className={`stats-chip ${selectedModel === model ? 'active' : ''}`}
-              onClick={() => setSelectedModel(model)}
-            >
-              {model}
-            </button>
-          ))}
-        </div>
-      </div>
+      <>
+        {availableModels.length > 0 && (
+          <div className="stats-controls">
+            <div className="stats-chip-group">
+              <button
+                type="button"
+                className={`stats-chip ${selectedModel === '' ? 'active' : ''}`}
+                onClick={() => { setSelectedModel(''); setSelectedDeviceType(''); }}
+              >
+                All Models
+              </button>
+              {availableModels.map((model) => (
+                <button
+                  key={model}
+                  type="button"
+                  className={`stats-chip ${selectedModel === model ? 'active' : ''}`}
+                  onClick={() => { setSelectedModel(model); setSelectedDeviceType(''); }}
+                >
+                  {model}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+        {availableDeviceTypes.length > 0 && (
+          <div className="stats-controls">
+            <div className="stats-chip-group">
+              <button
+                type="button"
+                className={`stats-chip ${selectedDeviceType === '' && selectedModel === '' ? 'active' : ''}`}
+                onClick={() => { setSelectedDeviceType(''); setSelectedModel(''); }}
+              >
+                All Devices
+              </button>
+              {availableDeviceTypes.map((device) => (
+                <button
+                  key={device}
+                  type="button"
+                  className={`stats-chip ${selectedDeviceType === device ? 'active' : ''}`}
+                  onClick={() => { setSelectedDeviceType(device); setSelectedModel(''); }}
+                >
+                  {device.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </>
     );
   };
 
@@ -369,10 +404,10 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
 
       <div className="stats-summary-grid">
         <div className="stats-summary-card">
-          <span className="stats-summary-label">{selectedModel ? 'Model tokens' : 'Lifetime tokens'}</span>
+          <span className="stats-summary-label">{selectedModel ? 'Model tokens' : selectedDeviceType ? 'Device tokens' : 'Lifetime tokens'}</span>
           <strong>{formatNumber(lifetimeSummary.totalTokens)}</strong>
           <span className="stats-summary-meta">
-            {selectedModel ? `All persisted tokens for ${selectedModel}` : 'All persisted prompt and completion tokens'}
+            {selectedModel ? `All persisted tokens for ${selectedModel}` : selectedDeviceType ? `All persisted tokens on ${selectedDeviceType.toUpperCase()}` : 'All persisted prompt and completion tokens'}
           </span>
         </div>
         <div className="stats-summary-card">
@@ -383,7 +418,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
           </span>
         </div>
         <div className="stats-summary-card">
-          <span className="stats-summary-label">{selectedModel ? 'Model requests' : 'Lifetime requests'}</span>
+          <span className="stats-summary-label">{selectedModel ? 'Model requests' : selectedDeviceType ? 'Device requests' : 'Lifetime requests'}</span>
           <strong>{formatNumber(lifetimeSummary.requests)}</strong>
           <span className="stats-summary-meta">{formatCompactNumber(lifetimeSummary.avgTokensPerRequest)} avg tokens per request</span>
         </div>
@@ -427,7 +462,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
           </div>
         </div>
 
-        {renderModelSelector()}
+        {renderFilterSelectors()}
         {renderRangeControls()}
 
         <ChartSection
@@ -571,7 +606,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
                 <XIcon size={16} strokeWidth={2.2} />
               </button>
             </div>
-            {renderModelSelector()}
+            {renderFilterSelectors()}
             {renderRangeControls()}
             <ChartSection
               points={chartPoints}

--- a/src/app/src/renderer/StatsPanel.tsx
+++ b/src/app/src/renderer/StatsPanel.tsx
@@ -246,6 +246,50 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
     };
   }, [lifetimeStats, lifetimeSummary.totalTokens]);
 
+  const renderRangeControls = () => (
+    bucketMode === 'day' ? (
+      <div className="stats-controls">
+        <div className="stats-chip-group">
+          {DAY_RANGE_PRESETS.map((preset) => (
+            <button
+              key={preset.key}
+              type="button"
+              className={`stats-chip ${dayRangePreset === preset.key ? 'active' : ''}`}
+              onClick={() => setDayRangePreset(preset.key)}
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+        {dayRangePreset === '90d' && (
+          <label className="stats-inline-control">
+            <span>Days</span>
+            <input
+              type="number"
+              min="1"
+              max="3650"
+              value={customDayCount}
+              onChange={(event) => setCustomDayCount(clampDayCount(event.target.value))}
+            />
+          </label>
+        )}
+      </div>
+    ) : (
+      <div className="stats-controls">
+        <label className="stats-inline-control">
+          <span>Day</span>
+          <input
+            type="date"
+            value={selectedDay}
+            min={availableDays[0] ?? ''}
+            max={availableDays[availableDays.length - 1] ?? ''}
+            onChange={(event) => setSelectedDay(event.target.value)}
+          />
+        </label>
+      </div>
+    )
+  );
+
   return (
     <div className="stats-panel">
       <div className="stats-hero">
@@ -335,47 +379,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
           </div>
         </div>
 
-        {bucketMode === 'day' ? (
-          <div className="stats-controls">
-            <div className="stats-chip-group">
-              {DAY_RANGE_PRESETS.map((preset) => (
-                <button
-                  key={preset.key}
-                  type="button"
-                  className={`stats-chip ${dayRangePreset === preset.key ? 'active' : ''}`}
-                  onClick={() => setDayRangePreset(preset.key)}
-                >
-                  {preset.label}
-                </button>
-              ))}
-            </div>
-            {dayRangePreset === '90d' && (
-              <label className="stats-inline-control">
-                <span>Days</span>
-                <input
-                  type="number"
-                  min="1"
-                  max="3650"
-                  value={customDayCount}
-                  onChange={(event) => setCustomDayCount(clampDayCount(event.target.value))}
-                />
-              </label>
-            )}
-          </div>
-        ) : (
-          <div className="stats-controls">
-            <label className="stats-inline-control">
-              <span>Day</span>
-              <input
-                type="date"
-                value={selectedDay}
-                min={availableDays[0] ?? ''}
-                max={availableDays[availableDays.length - 1] ?? ''}
-                onChange={(event) => setSelectedDay(event.target.value)}
-              />
-            </label>
-          </div>
-        )}
+        {renderRangeControls()}
 
         <ChartSection
           points={chartPoints}
@@ -481,7 +485,8 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
         }}>
           <div className="stats-overlay-card" onMouseDown={(event) => event.stopPropagation()}>
             <div className="stats-overlay-header">
-              <div>
+              <div className="stats-overlay-header-main">
+                <div>
                 <div className="stats-chart-title">
                   {bucketMode === 'day' ? 'Expanded daily token flow' : 'Expanded hourly token flow'}
                 </div>
@@ -489,6 +494,23 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
                   {bucketMode === 'day'
                     ? describeDayRange(dayRangePreset, customDayCount)
                     : `24-hour view for ${formatDateHeading(selectedDay)}`}
+                </div>
+                </div>
+                <div className="stats-bucket-toggle overlay">
+                  <button
+                    type="button"
+                    className={bucketMode === 'day' ? 'active' : ''}
+                    onClick={() => setBucketMode('day')}
+                  >
+                    Per day
+                  </button>
+                  <button
+                    type="button"
+                    className={bucketMode === 'hour' ? 'active' : ''}
+                    onClick={() => setBucketMode('hour')}
+                  >
+                    Per hour
+                  </button>
                 </div>
               </div>
               <button
@@ -500,6 +522,7 @@ const StatsPanel: React.FC<StatsPanelProps> = ({ searchQuery }) => {
                 <XIcon size={16} strokeWidth={2.2} />
               </button>
             </div>
+            {renderRangeControls()}
             <ChartSection
               points={chartPoints}
               mode={bucketMode}
@@ -532,6 +555,7 @@ const ChartSection: React.FC<ChartSectionProps> = ({
   onExpand,
 }) => {
   const [hoveredPointIndex, setHoveredPointIndex] = useState<number | null>(null);
+  const shouldShowSeriesMarkers = points.length <= 3;
   const chartGeometry = useMemo(() => {
     const width = 920;
     const height = expanded ? 430 : 260;
@@ -546,12 +570,54 @@ const ChartSection: React.FC<ChartSectionProps> = ({
       if (points.length <= 1) {
         return width / 2;
       }
+      if (points.length === 2) {
+        return width * (index === 0 ? 0.32 : 0.68);
+      }
       return paddingX + (index / (points.length - 1)) * innerWidth;
+    };
+
+    const hoverBandForIndex = (index: number) => {
+      if (points.length <= 1) {
+        return {
+          x: paddingX,
+          width: width - paddingX * 2,
+        };
+      }
+
+      const currentX = xForIndex(index);
+      const prevX = index > 0 ? xForIndex(index - 1) : currentX - (xForIndex(index + 1) - currentX);
+      const nextX = index < points.length - 1 ? xForIndex(index + 1) : currentX + (currentX - xForIndex(index - 1));
+      const left = index === 0 ? paddingX : (prevX + currentX) / 2;
+      const right = index === points.length - 1 ? width - paddingX : (currentX + nextX) / 2;
+
+      return {
+        x: left,
+        width: Math.max(12, right - left),
+      };
     };
 
     const yForValue = (value: number) => {
       const normalized = value / maxTokens;
       return paddingTop + innerHeight - normalized * innerHeight;
+    };
+
+    const hoverZoneForPoint = (point: UsagePoint) => {
+      if (point.totalTokens <= 0) {
+        return null;
+      }
+
+      const ys = [
+        yForValue(point.inputTokens),
+        yForValue(point.outputTokens),
+        yForValue(point.totalTokens),
+      ];
+      const top = Math.max(paddingTop, Math.min(...ys) - 18);
+      const bottom = Math.min(height - paddingBottom, Math.max(...ys) + 18);
+
+      return {
+        y: top,
+        height: Math.max(28, bottom - top),
+      };
     };
 
     const buildPath = (values: number[]) => values.map((value, index) => {
@@ -560,12 +626,8 @@ const ChartSection: React.FC<ChartSectionProps> = ({
       return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`;
     }).join(' ');
 
-    const totalPath = buildPath(points.map((point) => point.totalTokens));
     const inputPath = buildPath(points.map((point) => point.inputTokens));
     const outputPath = buildPath(points.map((point) => point.outputTokens));
-    const areaPath = points.length > 0
-      ? `${totalPath} L ${xForIndex(points.length - 1).toFixed(2)} ${(height - paddingBottom).toFixed(2)} L ${xForIndex(0).toFixed(2)} ${(height - paddingBottom).toFixed(2)} Z`
-      : '';
 
     const gridLines = 4;
     const yTicks = Array.from({ length: gridLines + 1 }, (_, index) => {
@@ -579,11 +641,11 @@ const ChartSection: React.FC<ChartSectionProps> = ({
       height,
       paddingX,
       paddingBottom,
-      totalPath,
       inputPath,
       outputPath,
-      areaPath,
       xForIndex,
+      hoverBandForIndex,
+      hoverZoneForPoint,
       yTicks,
       yForValue,
     };
@@ -633,25 +695,54 @@ const ChartSection: React.FC<ChartSectionProps> = ({
                 </g>
               ))}
 
-              {chartGeometry.areaPath && (
-                <path
-                  className="stats-area-path"
-                  d={chartGeometry.areaPath}
-                  fill={`url(#${expanded ? 'stats-area-gradient-large' : 'stats-area-gradient'})`}
+              {points.map((point, index) => (
+                <line
+                  key={`x-grid-${point.bucket}`}
+                  className={`stats-grid-line vertical ${shouldShowXAxisLabel(mode, index, points.length) ? 'major' : ''}`}
+                  x1={chartGeometry.xForIndex(index)}
+                  y1={chartGeometry.yTicks[0].y}
+                  x2={chartGeometry.xForIndex(index)}
+                  y2={chartGeometry.height - chartGeometry.paddingBottom}
                 />
-              )}
+              ))}
+
               <path className="stats-line input" d={chartGeometry.inputPath} />
               <path className="stats-line output" d={chartGeometry.outputPath} />
 
               {points.map((point, index) => (
                 <g key={point.bucket}>
+                  {chartGeometry.hoverZoneForPoint(point) && (
+                    <rect
+                      className="stats-hover-band"
+                      x={chartGeometry.hoverBandForIndex(index).x}
+                      y={chartGeometry.hoverZoneForPoint(point)!.y}
+                      width={chartGeometry.hoverBandForIndex(index).width}
+                      height={chartGeometry.hoverZoneForPoint(point)!.height}
+                      onMouseEnter={() => setHoveredPointIndex(index)}
+                      onMouseLeave={() => setHoveredPointIndex((current) => (current === index ? null : current))}
+                    />
+                  )}
+                  {shouldShowSeriesMarkers && (
+                    <>
+                      <circle
+                        className="stats-series-point input"
+                        cx={chartGeometry.xForIndex(index)}
+                        cy={chartGeometry.yForValue(point.inputTokens)}
+                        r={expanded ? 4.2 : 3.4}
+                      />
+                      <circle
+                        className="stats-series-point output"
+                        cx={chartGeometry.xForIndex(index)}
+                        cy={chartGeometry.yForValue(point.outputTokens)}
+                        r={expanded ? 4.2 : 3.4}
+                      />
+                    </>
+                  )}
                   <circle
                     className="stats-point-hitbox"
                     cx={chartGeometry.xForIndex(index)}
                     cy={chartGeometry.yForValue(point.totalTokens)}
                     r={expanded ? 11 : 9}
-                    onMouseEnter={() => setHoveredPointIndex(index)}
-                    onMouseLeave={() => setHoveredPointIndex((current) => (current === index ? null : current))}
                   />
                   {shouldShowXAxisLabel(mode, index, points.length) && (
                     <text
@@ -667,19 +758,29 @@ const ChartSection: React.FC<ChartSectionProps> = ({
               ))}
             </svg>
             {hoveredPointIndex !== null && points[hoveredPointIndex] && (
-              <div
-                className={`stats-hover-card ${expanded ? 'expanded' : ''} ${chartGeometry.yForValue(points[hoveredPointIndex].totalTokens) < 92 ? 'below' : ''}`}
-                style={{
-                  left: `${(chartGeometry.xForIndex(hoveredPointIndex) / chartGeometry.width) * 100}%`,
-                  top: `${(chartGeometry.yForValue(points[hoveredPointIndex].totalTokens) / chartGeometry.height) * 100}%`,
-                }}
-              >
-                <div className="stats-hover-title">{points[hoveredPointIndex].bucket}</div>
-                <div className="stats-hover-row"><span>Total</span><strong>{formatNumber(points[hoveredPointIndex].totalTokens)}</strong></div>
-                <div className="stats-hover-row"><span>Input</span><strong>{formatNumber(points[hoveredPointIndex].inputTokens)}</strong></div>
-                <div className="stats-hover-row"><span>Output</span><strong>{formatNumber(points[hoveredPointIndex].outputTokens)}</strong></div>
-                <div className="stats-hover-row"><span>Requests</span><strong>{formatNumber(points[hoveredPointIndex].requests)}</strong></div>
-              </div>
+              (() => {
+                const hoveredPoint = points[hoveredPointIndex];
+                const xPercent = (chartGeometry.xForIndex(hoveredPointIndex) / chartGeometry.width) * 100;
+                const yPercent = (chartGeometry.yForValue(hoveredPoint.totalTokens) / chartGeometry.height) * 100;
+                const horizontalClass = xPercent > 82 ? 'align-right' : xPercent < 18 ? 'align-left' : '';
+                const verticalClass = chartGeometry.yForValue(hoveredPoint.totalTokens) < 92 ? 'below' : '';
+
+                return (
+                  <div
+                    className={`stats-hover-card ${expanded ? 'expanded' : ''} ${horizontalClass} ${verticalClass}`}
+                    style={{
+                      left: `${xPercent}%`,
+                      top: `${yPercent}%`,
+                    }}
+                  >
+                    <div className="stats-hover-title">{hoveredPoint.bucket}</div>
+                    <div className="stats-hover-row total"><span><i className="stats-hover-swatch total" />Total</span><strong>{formatNumber(hoveredPoint.totalTokens)}</strong></div>
+                    <div className="stats-hover-row input"><span><i className="stats-hover-swatch input" />Input</span><strong>{formatNumber(hoveredPoint.inputTokens)}</strong></div>
+                    <div className="stats-hover-row output"><span><i className="stats-hover-swatch output" />Output</span><strong>{formatNumber(hoveredPoint.outputTokens)}</strong></div>
+                    <div className="stats-hover-row requests"><span>Requests</span><strong>{formatNumber(hoveredPoint.requests)}</strong></div>
+                  </div>
+                );
+              })()
             )}
           </>
         )}

--- a/src/app/src/renderer/components/Icons.tsx
+++ b/src/app/src/renderer/components/Icons.tsx
@@ -86,6 +86,17 @@ export const Settings: React.FC<IconProps> = ({ size = 24, strokeWidth = 2 }) =>
   </svg>
 );
 
+export const ChartNoAxesCombined: React.FC<IconProps> = ({ size = 24, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 16v5" />
+    <path d="M16 14v7" />
+    <path d="M20 10v11" />
+    <path d="m22 3-8.5 8.5-5-5L2 13" />
+    <path d="M4 18v3" />
+    <path d="M8 14v7" />
+  </svg>
+);
+
 export const SlidersHorizontal: React.FC<IconProps> = ({ size = 24, strokeWidth = 2 }) => (
   <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
     <path d="M10 5H3" />

--- a/src/app/src/renderer/utils/appSettings.ts
+++ b/src/app/src/renderer/utils/appSettings.ts
@@ -21,7 +21,7 @@ export interface StringSetting {
 export interface LayoutSettings {
   isChatVisible: boolean;
   isModelManagerVisible: boolean;
-  leftPanelView: 'models' | 'marketplace' | 'backends' | 'settings';
+  leftPanelView: 'models' | 'marketplace' | 'backends' | 'stats' | 'settings';
   isLogsVisible: boolean;
   modelManagerWidth: number;
   chatWidth: number;
@@ -241,7 +241,7 @@ export const mergeWithDefaultSettings = (incoming?: Partial<AppSettings>): AppSe
     if (typeof rawLayout.isModelManagerVisible === 'boolean') {
       defaults.layout.isModelManagerVisible = rawLayout.isModelManagerVisible;
     }
-    if (rawLayout.leftPanelView === 'models' || rawLayout.leftPanelView === 'marketplace' || rawLayout.leftPanelView === 'backends' || rawLayout.leftPanelView === 'settings') {
+    if (rawLayout.leftPanelView === 'models' || rawLayout.leftPanelView === 'marketplace' || rawLayout.leftPanelView === 'backends' || rawLayout.leftPanelView === 'stats' || rawLayout.leftPanelView === 'settings') {
       defaults.layout.leftPanelView = rawLayout.leftPanelView;
     }
     if (typeof rawLayout.isLogsVisible === 'boolean') {

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1802,6 +1802,10 @@ footer {
     background: rgba(255, 255, 255, 0.03);
 }
 
+.stats-bucket-toggle.overlay {
+    flex-shrink: 0;
+}
+
 .stats-bucket-toggle button {
     border: none;
     background: transparent;
@@ -1819,12 +1823,12 @@ footer {
 
 .stats-chart-legend {
     display: flex;
-    gap: 12px;
+    gap: 18px;
     align-items: center;
     flex-wrap: wrap;
-    margin-bottom: 10px;
-    font-size: 0.62rem;
-    color: #8b8b8b;
+    margin-bottom: 12px;
+    font-size: 0.66rem;
+    color: #97a1b8;
 }
 
 .stats-chart-legend span {
@@ -1835,21 +1839,27 @@ footer {
 
 .stats-swatch {
     display: inline-block;
-    width: 10px;
-    height: 10px;
+    width: 9px;
+    height: 9px;
+    border-radius: 999px;
+    border: 2px solid currentColor;
+    background: transparent;
 }
 
 .stats-swatch.input {
-    background: #5dd39e;
+    color: #39d98a;
 }
 
 .stats-swatch.output {
-    background: #6ea8ff;
+    color: #4ea3ff;
 }
 
 .stats-chart-frame {
     min-height: 250px;
     position: relative;
+    border: 1px solid rgba(78, 107, 168, 0.18);
+    background: linear-gradient(180deg, rgba(29, 34, 47, 0.94), rgba(22, 27, 38, 0.96));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
 }
 
 .stats-chart-frame.expanded {
@@ -1863,14 +1873,21 @@ footer {
 }
 
 .stats-grid-line {
-    stroke: rgba(255, 255, 255, 0.06);
+    stroke: rgba(79, 96, 143, 0.28);
     stroke-width: 1;
-    stroke-dasharray: 4 8;
+}
+
+.stats-grid-line.vertical {
+    stroke: rgba(79, 96, 143, 0.18);
+}
+
+.stats-grid-line.vertical.major {
+    stroke: rgba(79, 96, 143, 0.26);
 }
 
 .stats-grid-label,
 .stats-x-label {
-    fill: #808080;
+    fill: #8f9bb4;
     font-size: 11px;
 }
 
@@ -1880,26 +1897,41 @@ footer {
     font-weight: 500;
 }
 
-.stats-area-path {
-    fill: url(#stats-area-gradient);
-}
-
 .stats-line {
     fill: none;
-    stroke-width: 2.4;
+    stroke-width: 2.6;
     vector-effect: non-scaling-stroke;
+    stroke-linecap: round;
+    stroke-linejoin: round;
 }
 
 .stats-line.input {
-    stroke: #5dd39e;
-    stroke-width: 1.6;
-    opacity: 0.95;
+    stroke: #39d98a;
+    filter: drop-shadow(0 0 4px rgba(57, 217, 138, 0.18));
 }
 
 .stats-line.output {
-    stroke: #6ea8ff;
-    stroke-width: 1.6;
-    opacity: 0.95;
+    stroke: #4ea3ff;
+    filter: drop-shadow(0 0 4px rgba(78, 163, 255, 0.18));
+}
+
+.stats-series-point {
+    stroke-width: 2;
+}
+
+.stats-series-point.input {
+    fill: #182b24;
+    stroke: #39d98a;
+}
+
+.stats-series-point.output {
+    fill: #162335;
+    stroke: #4ea3ff;
+}
+
+.stats-hover-band {
+    fill: transparent;
+    cursor: crosshair;
 }
 
 .stats-point-hitbox {
@@ -1911,10 +1943,10 @@ footer {
     position: absolute;
     transform: translate(-50%, calc(-100% - 14px));
     min-width: 150px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    background: rgba(14, 14, 14, 0.97);
-    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
-    padding: 10px;
+    border: 1px solid rgba(86, 98, 128, 0.45);
+    background: rgba(32, 38, 53, 0.96);
+    box-shadow: 0 14px 34px rgba(0, 0, 0, 0.38);
+    padding: 11px 12px;
     pointer-events: none;
     z-index: 3;
 }
@@ -1923,22 +1955,44 @@ footer {
     transform: translate(-50%, 14px);
 }
 
+.stats-hover-card.align-left {
+    transform: translate(0, calc(-100% - 14px));
+}
+
+.stats-hover-card.align-left.below {
+    transform: translate(0, 14px);
+}
+
+.stats-hover-card.align-right {
+    transform: translate(-100%, calc(-100% - 14px));
+}
+
+.stats-hover-card.align-right.below {
+    transform: translate(-100%, 14px);
+}
+
 .stats-hover-card.expanded {
     min-width: 170px;
 }
 
 .stats-hover-title {
-    font-size: 0.62rem;
-    color: #e8d4a4;
-    margin-bottom: 7px;
+    font-size: 0.68rem;
+    color: #d9e0f0;
+    margin-bottom: 8px;
 }
 
 .stats-hover-row {
     display: flex;
     justify-content: space-between;
     gap: 10px;
-    font-size: 0.63rem;
-    color: #8d8d8d;
+    font-size: 0.66rem;
+    color: #aab3c6;
+}
+
+.stats-hover-row span {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
 }
 
 .stats-hover-row + .stats-hover-row {
@@ -1946,8 +2000,27 @@ footer {
 }
 
 .stats-hover-row strong {
-    color: #f1f1f1;
+    color: #f1f4fa;
     font-weight: 600;
+}
+
+.stats-hover-swatch {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+}
+
+.stats-hover-swatch.total {
+    background: #f0c14b;
+}
+
+.stats-hover-swatch.input {
+    background: #39d98a;
+}
+
+.stats-hover-swatch.output {
+    background: #4ea3ff;
 }
 
 .stats-detail-grid {
@@ -2135,6 +2208,15 @@ footer {
     margin-bottom: 10px;
 }
 
+.stats-overlay-header-main {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    flex: 1;
+    min-width: 0;
+}
+
 .stats-overlay-close {
     width: 32px;
     height: 32px;
@@ -2161,6 +2243,11 @@ footer {
 
     .stats-controls {
         align-items: stretch;
+    }
+
+    .stats-overlay-header,
+    .stats-overlay-header-main {
+        flex-direction: column;
     }
 
     .stats-insight-grid {

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1552,6 +1552,622 @@ footer {
     padding: var(--mm-stack-gap) 0 8px;
 }
 
+.stats-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 0 var(--mm-section-pad-x) 10px;
+}
+
+.stats-hero {
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 14px;
+    padding: 16px 16px 14px;
+    border: 1px solid rgba(255, 207, 92, 0.14);
+    background:
+        radial-gradient(circle at top left, rgba(245, 190, 48, 0.16), transparent 38%),
+        linear-gradient(145deg, rgba(24, 24, 24, 0.96), rgba(12, 12, 12, 0.98));
+}
+
+.stats-hero-actions {
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.stats-hero::after {
+    content: '';
+    position: absolute;
+    inset: auto -60px -70px auto;
+    width: 180px;
+    height: 180px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255, 190, 11, 0.22), rgba(255, 190, 11, 0));
+    pointer-events: none;
+}
+
+.stats-hero-copy {
+    position: relative;
+    z-index: 1;
+    min-width: 0;
+}
+
+.stats-kicker {
+    font-size: 0.58rem;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    color: #cfa24c;
+    margin-bottom: 6px;
+}
+
+.stats-hero h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    line-height: 1.1;
+    color: #f6f1de;
+    font-weight: 600;
+}
+
+.stats-hero p {
+    margin: 8px 0 0;
+    max-width: 28ch;
+    font-size: 0.72rem;
+    line-height: 1.5;
+    color: #b8b0a0;
+}
+
+.stats-refresh-btn {
+    width: 30px;
+    height: 30px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+    color: #e8c66e;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.stats-expand-btn,
+.stats-link-button,
+.stats-overlay-close {
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+    color: #d7d7d7;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.stats-expand-btn {
+    height: 30px;
+    padding: 0 10px;
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.stats-refresh-btn:hover {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 207, 92, 0.28);
+    color: #f6d37d;
+}
+
+.stats-expand-btn:hover,
+.stats-link-button:hover,
+.stats-overlay-close:hover {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 207, 92, 0.2);
+    color: #f0f0f0;
+}
+
+.stats-refresh-btn.spinning svg {
+    animation: stats-spin 0.9s linear infinite;
+}
+
+@keyframes stats-spin {
+    to { transform: rotate(360deg); }
+}
+
+.stats-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+}
+
+.stats-summary-card,
+.stats-detail-card,
+.stats-chart-shell {
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    background: linear-gradient(180deg, rgba(16, 16, 16, 0.98), rgba(10, 10, 10, 0.98));
+}
+
+.stats-summary-card {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 12px;
+    min-width: 0;
+}
+
+.stats-summary-label {
+    font-size: 0.56rem;
+    color: #8d8d8d;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.stats-summary-card strong {
+    font-size: 1.05rem;
+    color: #f4f0e4;
+    font-weight: 600;
+}
+
+.stats-summary-meta {
+    font-size: 0.63rem;
+    color: #777;
+}
+
+.stats-chart-shell {
+    padding: 12px;
+}
+
+.stats-chart-toolbar {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.stats-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-bottom: 10px;
+}
+
+.stats-chip-group {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.stats-chip {
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.025);
+    color: #969696;
+    padding: 6px 9px;
+    font-size: 0.62rem;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.stats-chip.active {
+    color: #f4d48d;
+    background: rgba(244, 176, 0, 0.12);
+    border-color: rgba(244, 176, 0, 0.2);
+}
+
+.stats-inline-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: #8e8e8e;
+    font-size: 0.63rem;
+}
+
+.stats-inline-control span {
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.stats-inline-control input {
+    height: 30px;
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    background: rgba(255, 255, 255, 0.03);
+    color: #ddd;
+    padding: 0 8px;
+    min-width: 120px;
+}
+
+.stats-chart-title,
+.stats-detail-heading {
+    font-size: 0.76rem;
+    color: #efefef;
+    letter-spacing: 0.15px;
+}
+
+.stats-chart-subtitle,
+.stats-detail-subheading {
+    margin-top: 2px;
+    font-size: 0.64rem;
+    color: #767676;
+}
+
+.stats-bucket-toggle {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.stats-bucket-toggle button {
+    border: none;
+    background: transparent;
+    color: #9a9a9a;
+    padding: 6px 9px;
+    font-size: 0.62rem;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.stats-bucket-toggle button.active {
+    background: rgba(255, 206, 88, 0.14);
+    color: #f3d27b;
+}
+
+.stats-chart-legend {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 10px;
+    font-size: 0.62rem;
+    color: #8b8b8b;
+}
+
+.stats-chart-legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.stats-swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+}
+
+.stats-swatch.input {
+    background: #5dd39e;
+}
+
+.stats-swatch.output {
+    background: #6ea8ff;
+}
+
+.stats-chart-frame {
+    min-height: 250px;
+    position: relative;
+}
+
+.stats-chart-frame.expanded {
+    min-height: 430px;
+}
+
+.stats-chart {
+    width: 100%;
+    height: 250px;
+    display: block;
+}
+
+.stats-grid-line {
+    stroke: rgba(255, 255, 255, 0.06);
+    stroke-width: 1;
+    stroke-dasharray: 4 8;
+}
+
+.stats-grid-label,
+.stats-x-label {
+    fill: #808080;
+    font-size: 11px;
+}
+
+.stats-x-label.expanded {
+    fill: #d2d2d2;
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.stats-area-path {
+    fill: url(#stats-area-gradient);
+}
+
+.stats-line {
+    fill: none;
+    stroke-width: 2.4;
+    vector-effect: non-scaling-stroke;
+}
+
+.stats-line.input {
+    stroke: #5dd39e;
+    stroke-width: 1.6;
+    opacity: 0.95;
+}
+
+.stats-line.output {
+    stroke: #6ea8ff;
+    stroke-width: 1.6;
+    opacity: 0.95;
+}
+
+.stats-point-hitbox {
+    fill: transparent;
+    cursor: crosshair;
+}
+
+.stats-hover-card {
+    position: absolute;
+    transform: translate(-50%, calc(-100% - 14px));
+    min-width: 150px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(14, 14, 14, 0.97);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+    padding: 10px;
+    pointer-events: none;
+    z-index: 3;
+}
+
+.stats-hover-card.below {
+    transform: translate(-50%, 14px);
+}
+
+.stats-hover-card.expanded {
+    min-width: 170px;
+}
+
+.stats-hover-title {
+    font-size: 0.62rem;
+    color: #e8d4a4;
+    margin-bottom: 7px;
+}
+
+.stats-hover-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    font-size: 0.63rem;
+    color: #8d8d8d;
+}
+
+.stats-hover-row + .stats-hover-row {
+    margin-top: 4px;
+}
+
+.stats-hover-row strong {
+    color: #f1f1f1;
+    font-weight: 600;
+}
+
+.stats-detail-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 8px;
+}
+
+.stats-insight-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.stats-insight-pill {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 10px;
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.stats-insight-pill span {
+    font-size: 0.58rem;
+    color: #7b7b7b;
+    text-transform: uppercase;
+    letter-spacing: 0.35px;
+}
+
+.stats-insight-pill strong {
+    font-size: 0.82rem;
+    color: #f0f0f0;
+    font-weight: 600;
+}
+
+.stats-detail-card {
+    padding: 12px;
+}
+
+.stats-table {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.stats-table-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 7px 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.stats-table-row:first-child {
+    border-top: none;
+    padding-top: 2px;
+}
+
+.stats-table-period {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    min-width: 0;
+}
+
+.stats-table-period span {
+    font-size: 0.69rem;
+    color: #ececec;
+}
+
+.stats-table-period small {
+    font-size: 0.6rem;
+    color: #707070;
+}
+
+.stats-table-values {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    text-align: right;
+    white-space: nowrap;
+}
+
+.stats-table-values span {
+    font-size: 0.64rem;
+    color: #9d9d9d;
+}
+
+.stats-table-values strong {
+    font-size: 0.68rem;
+    color: #f4d48d;
+    font-weight: 600;
+}
+
+.stats-meta-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.stats-meta-row {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    font-size: 0.66rem;
+    color: #797979;
+    padding: 8px 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.stats-meta-row:first-child {
+    padding-top: 0;
+    border-top: none;
+}
+
+.stats-meta-row strong {
+    color: #ececec;
+    font-weight: 500;
+    text-align: left;
+    line-height: 1.4;
+}
+
+.stats-meta-row small {
+    font-size: 0.6rem;
+    color: #8d8d8d;
+}
+
+.stats-empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 220px;
+    text-align: center;
+    color: #777;
+    font-size: 0.72rem;
+    border: 1px dashed rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.015);
+}
+
+.stats-empty-state.compact {
+    min-height: 80px;
+}
+
+.stats-empty-state.error {
+    color: #d6a7a7;
+}
+
+.stats-link-button {
+    margin-left: auto;
+    padding: 5px 8px;
+    font-size: 0.6rem;
+}
+
+.stats-overlay {
+    position: fixed;
+    inset: 32px 0 24px;
+    z-index: 1200;
+    background: rgba(0, 0, 0, 0.72);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 18px;
+    backdrop-filter: blur(10px);
+}
+
+.stats-overlay-card {
+    width: min(1200px, calc(100vw - 48px));
+    max-height: calc(100vh - 96px);
+    overflow: auto;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: linear-gradient(180deg, rgba(14, 14, 14, 0.98), rgba(8, 8, 8, 0.99));
+    padding: 16px;
+}
+
+.stats-overlay-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 10px;
+}
+
+.stats-overlay-close {
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+@media (max-width: 1180px) {
+    .stats-detail-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 760px) {
+    .stats-summary-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .stats-chart-toolbar {
+        flex-direction: column;
+    }
+
+    .stats-controls {
+        align-items: stretch;
+    }
+
+    .stats-insight-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 .model-category {
     margin-bottom: 4px;
 }

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -107,6 +107,14 @@ private:
         }
     };
 
+    struct ModelStats {
+        uint64_t requests = 0;
+        uint64_t input_tokens = 0;
+        uint64_t output_tokens = 0;
+        std::map<std::string, UsageBucket> by_day;
+        std::map<std::string, UsageBucket> by_hour;
+    };
+
     struct LifetimeUsageStats {
         uint64_t requests = 0;
         uint64_t input_tokens = 0;
@@ -115,6 +123,7 @@ private:
         std::string updated_at;
         std::map<std::string, UsageBucket> by_day;
         std::map<std::string, UsageBucket> by_hour;
+        std::map<std::string, ModelStats> by_model;
     };
 
     // Multi-model support: Manage multiple WrappedServers

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -164,7 +164,8 @@ private:
     static json usage_buckets_to_json(const std::map<std::string, UsageBucket>& buckets);
     void load_usage_stats();
     void persist_usage_stats_locked() const;
-    void record_usage_locked(int input_tokens, int output_tokens, std::time_t recorded_at);
+    void record_usage_locked(const std::string& model_name, const std::string& device_type, int input_tokens, int output_tokens, std::time_t recorded_at);
+    void add_tokens_locked(const std::string& model_name, const std::string& device_type, int input_tokens, int output_tokens, std::time_t recorded_at);
     json get_lifetime_usage_stats() const;
 };
 

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -132,6 +132,7 @@ private:
 
     mutable std::mutex stats_mutex_;
     LifetimeUsageStats lifetime_usage_stats_;
+    Telemetry last_completed_telemetry_;
     std::string usage_stats_path_;
 
     // Helper methods for multi-model management

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -124,6 +124,7 @@ private:
         std::map<std::string, UsageBucket> by_day;
         std::map<std::string, UsageBucket> by_hour;
         std::map<std::string, ModelStats> by_model;
+        std::map<std::string, ModelStats> by_device_type;
     };
 
     // Multi-model support: Manage multiple WrappedServers

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -1,16 +1,18 @@
 #pragma once
 
-#include <string>
+#include <condition_variable>
+#include <ctime>
+#include <map>
 #include <memory>
 #include <mutex>
-#include <condition_variable>
+#include <string>
 #include <vector>
-#include <nlohmann/json.hpp>
 #include <httplib.h>
-#include "wrapped_server.h"
-#include "model_manager.h"
+#include <nlohmann/json.hpp>
 #include "backend_manager.h"
+#include "model_manager.h"
 #include "runtime_config.h"
+#include "wrapped_server.h"
 
 namespace lemon {
 
@@ -91,6 +93,30 @@ public:
     void update_prompt_tokens(int prompt_tokens);
 
 private:
+    struct UsageBucket {
+        uint64_t requests = 0;
+        uint64_t input_tokens = 0;
+        uint64_t output_tokens = 0;
+
+        json to_json() const {
+            return {
+                {"requests", requests},
+                {"input_tokens", input_tokens},
+                {"output_tokens", output_tokens}
+            };
+        }
+    };
+
+    struct LifetimeUsageStats {
+        uint64_t requests = 0;
+        uint64_t input_tokens = 0;
+        uint64_t output_tokens = 0;
+        std::string started_at;
+        std::string updated_at;
+        std::map<std::string, UsageBucket> by_day;
+        std::map<std::string, UsageBucket> by_hour;
+    };
+
     // Multi-model support: Manage multiple WrappedServers
     std::vector<std::unique_ptr<WrappedServer>> loaded_servers_;
 
@@ -103,6 +129,10 @@ private:
     mutable std::mutex load_mutex_;              // Protects loading state and loaded_servers_
     bool is_loading_ = false;                    // True when a load operation is in progress
     std::condition_variable load_cv_;            // Signals when load completes
+
+    mutable std::mutex stats_mutex_;
+    LifetimeUsageStats lifetime_usage_stats_;
+    std::string usage_stats_path_;
 
     // Helper methods for multi-model management
     WrappedServer* find_server_by_model_name(const std::string& model_name) const;
@@ -125,6 +155,16 @@ private:
     // Generic streaming wrapper
     template<typename Func>
     void execute_streaming(const std::string& request_body, httplib::DataSink& sink, Func&& streaming_func);
+
+    static std::tm get_local_time(std::time_t time_value);
+    static std::string format_timestamp(std::time_t time_value);
+    static std::string format_day_bucket(std::time_t time_value);
+    static std::string format_hour_bucket(std::time_t time_value);
+    static json usage_buckets_to_json(const std::map<std::string, UsageBucket>& buckets);
+    void load_usage_stats();
+    void persist_usage_stats_locked() const;
+    void record_usage_locked(int input_tokens, int output_tokens, std::time_t recorded_at);
+    json get_lifetime_usage_stats() const;
 };
 
 } // namespace lemon

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -142,6 +142,8 @@ public:
     // Get telemetry data
     Telemetry get_telemetry() const { return telemetry_; }
 
+    void reset_telemetry() { telemetry_.reset(); }
+
     // Set telemetry data (for non-streaming requests)
     void set_telemetry(int input_tokens, int output_tokens,
                       double time_to_first_token, double tokens_per_second) {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -776,6 +776,7 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
         {
             std::lock_guard<std::mutex> stats_lock(stats_mutex_);
             Telemetry telemetry = server->get_telemetry();
+            last_completed_telemetry_ = telemetry;
             record_usage_locked(telemetry.input_tokens, telemetry.output_tokens, std::time(nullptr));
         }
         server->set_busy(false);
@@ -886,11 +887,10 @@ json Router::image_variations(const json& request) {
 }
 
 json Router::get_stats() const {
-    std::lock_guard<std::mutex> lock(load_mutex_);
-    json stats = Telemetry().to_json();
-    WrappedServer* server = get_most_recent_server();
-    if (server) {
-        stats = server->get_telemetry().to_json();
+    json stats;
+    {
+        std::lock_guard<std::mutex> stats_lock(stats_mutex_);
+        stats = last_completed_telemetry_.to_json();
     }
     stats["lifetime"] = get_lifetime_usage_stats();
     return stats;
@@ -905,6 +905,10 @@ void Router::update_telemetry(int input_tokens, int output_tokens,
                              time_to_first_token, tokens_per_second);
     }
     std::lock_guard<std::mutex> stats_lock(stats_mutex_);
+    last_completed_telemetry_.input_tokens = input_tokens;
+    last_completed_telemetry_.output_tokens = output_tokens;
+    last_completed_telemetry_.time_to_first_token = time_to_first_token;
+    last_completed_telemetry_.tokens_per_second = tokens_per_second;
     record_usage_locked(input_tokens, output_tokens, std::time(nullptr));
 }
 
@@ -914,6 +918,8 @@ void Router::update_prompt_tokens(int prompt_tokens) {
     if (server) {
         server->set_prompt_tokens(prompt_tokens);
     }
+    std::lock_guard<std::mutex> stats_lock(stats_mutex_);
+    last_completed_telemetry_.prompt_tokens = prompt_tokens;
 }
 
 void Router::chat_completion_stream(const std::string& request_body, httplib::DataSink& sink) {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -1,21 +1,29 @@
 #include "lemon/router.h"
-#include "lemon/backends/llamacpp_server.h"
 #include "lemon/backends/fastflowlm_server.h"
-#include "lemon/backends/ryzenaiserver.h"
-#include "lemon/backends/whisper_server.h"
 #include "lemon/backends/kokoro_server.h"
+#include "lemon/backends/llamacpp_server.h"
+#include "lemon/backends/ryzenaiserver.h"
 #include "lemon/backends/sd_server.h"
-#include "lemon/server_capabilities.h"
+#include "lemon/backends/whisper_server.h"
 #include "lemon/error_types.h"
 #include "lemon/recipe_options.h"
-#include <iostream>
+#include "lemon/server_capabilities.h"
+#include "lemon/utils/path_utils.h"
 #include <algorithm>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 #include <lemon/utils/aixlog.hpp>
 
 namespace lemon {
+namespace fs = std::filesystem;
 
 Router::Router(RuntimeConfig* config, ModelManager* model_manager, BackendManager* backend_manager)
-    : config_(config), model_manager_(model_manager), backend_manager_(backend_manager) {
+    : config_(config), model_manager_(model_manager), backend_manager_(backend_manager),
+      usage_stats_path_(utils::get_cache_dir() + "/token_usage_stats.json") {
 
     int max = config_->max_loaded_models();
     if (max == -1) {
@@ -23,11 +31,176 @@ Router::Router(RuntimeConfig* config, ModelManager* model_manager, BackendManage
     } else {
     LOG(DEBUG, "Router") << "Max loaded models per type: " << max << std::endl;
     }
+
+    load_usage_stats();
 }
 
 Router::~Router() {
     LOG(DEBUG, "Router") << "Destructor: unloading all models" << std::endl;
     unload_model("");  // Unload all
+}
+
+std::tm Router::get_local_time(std::time_t time_value) {
+    std::tm tm_value{};
+#ifdef _WIN32
+    localtime_s(&tm_value, &time_value);
+#else
+    localtime_r(&time_value, &tm_value);
+#endif
+    return tm_value;
+}
+
+std::string Router::format_timestamp(std::time_t time_value) {
+    std::tm tm_value = get_local_time(time_value);
+    std::ostringstream oss;
+    oss << std::put_time(&tm_value, "%Y-%m-%dT%H:%M:%S");
+    return oss.str();
+}
+
+std::string Router::format_day_bucket(std::time_t time_value) {
+    std::tm tm_value = get_local_time(time_value);
+    std::ostringstream oss;
+    oss << std::put_time(&tm_value, "%Y-%m-%d");
+    return oss.str();
+}
+
+std::string Router::format_hour_bucket(std::time_t time_value) {
+    std::tm tm_value = get_local_time(time_value);
+    std::ostringstream oss;
+    oss << std::put_time(&tm_value, "%Y-%m-%dT%H:00:00");
+    return oss.str();
+}
+
+json Router::usage_buckets_to_json(const std::map<std::string, UsageBucket>& buckets) {
+    json result = json::object();
+    for (const auto& [bucket, usage] : buckets) {
+        result[bucket] = usage.to_json();
+    }
+    return result;
+}
+
+void Router::load_usage_stats() {
+    std::lock_guard<std::mutex> stats_lock(stats_mutex_);
+
+    const std::time_t now = std::time(nullptr);
+    lifetime_usage_stats_.started_at = format_timestamp(now);
+    lifetime_usage_stats_.updated_at = lifetime_usage_stats_.started_at;
+
+    try {
+        fs::path stats_path = utils::path_from_utf8(usage_stats_path_);
+        fs::create_directories(stats_path.parent_path());
+
+        if (!fs::exists(stats_path)) {
+            persist_usage_stats_locked();
+            return;
+        }
+
+        std::ifstream file(stats_path);
+        if (!file) {
+            LOG(WARNING, "Router") << "Failed to open usage stats file: " << usage_stats_path_ << std::endl;
+            return;
+        }
+
+        json persisted = json::parse(file, nullptr, false);
+        if (persisted.is_discarded() || !persisted.is_object()) {
+            LOG(WARNING, "Router") << "Ignoring invalid usage stats file: " << usage_stats_path_ << std::endl;
+            return;
+        }
+
+        lifetime_usage_stats_.requests = persisted.value("requests", 0ULL);
+        lifetime_usage_stats_.input_tokens = persisted.value("input_tokens", 0ULL);
+        lifetime_usage_stats_.output_tokens = persisted.value("output_tokens", 0ULL);
+        lifetime_usage_stats_.started_at = persisted.value("started_at", lifetime_usage_stats_.started_at);
+        lifetime_usage_stats_.updated_at = persisted.value("updated_at", lifetime_usage_stats_.updated_at);
+
+        if (persisted.contains("by_day") && persisted["by_day"].is_object()) {
+            for (const auto& [bucket, value] : persisted["by_day"].items()) {
+                lifetime_usage_stats_.by_day[bucket] = {
+                    value.value("requests", 0ULL),
+                    value.value("input_tokens", 0ULL),
+                    value.value("output_tokens", 0ULL)
+                };
+            }
+        }
+
+        if (persisted.contains("by_hour") && persisted["by_hour"].is_object()) {
+            for (const auto& [bucket, value] : persisted["by_hour"].items()) {
+                lifetime_usage_stats_.by_hour[bucket] = {
+                    value.value("requests", 0ULL),
+                    value.value("input_tokens", 0ULL),
+                    value.value("output_tokens", 0ULL)
+                };
+            }
+        }
+    } catch (const std::exception& e) {
+        LOG(WARNING, "Router") << "Failed to load usage stats: " << e.what() << std::endl;
+    }
+}
+
+void Router::persist_usage_stats_locked() const {
+    try {
+        fs::path stats_path = utils::path_from_utf8(usage_stats_path_);
+        fs::create_directories(stats_path.parent_path());
+
+        json persisted = {
+            {"requests", lifetime_usage_stats_.requests},
+            {"input_tokens", lifetime_usage_stats_.input_tokens},
+            {"output_tokens", lifetime_usage_stats_.output_tokens},
+            {"started_at", lifetime_usage_stats_.started_at},
+            {"updated_at", lifetime_usage_stats_.updated_at},
+            {"by_day", usage_buckets_to_json(lifetime_usage_stats_.by_day)},
+            {"by_hour", usage_buckets_to_json(lifetime_usage_stats_.by_hour)}
+        };
+
+        std::ofstream file(stats_path);
+        if (!file) {
+            LOG(WARNING, "Router") << "Failed to persist usage stats to: " << usage_stats_path_ << std::endl;
+            return;
+        }
+
+        file << persisted.dump(2);
+    } catch (const std::exception& e) {
+        LOG(WARNING, "Router") << "Failed to persist usage stats: " << e.what() << std::endl;
+    }
+}
+
+void Router::record_usage_locked(int input_tokens, int output_tokens, std::time_t recorded_at) {
+    if (input_tokens <= 0 && output_tokens <= 0) {
+        return;
+    }
+
+    UsageBucket& day_bucket = lifetime_usage_stats_.by_day[format_day_bucket(recorded_at)];
+    UsageBucket& hour_bucket = lifetime_usage_stats_.by_hour[format_hour_bucket(recorded_at)];
+
+    lifetime_usage_stats_.requests++;
+    lifetime_usage_stats_.input_tokens += static_cast<uint64_t>(std::max(input_tokens, 0));
+    lifetime_usage_stats_.output_tokens += static_cast<uint64_t>(std::max(output_tokens, 0));
+    lifetime_usage_stats_.updated_at = format_timestamp(recorded_at);
+
+    day_bucket.requests++;
+    day_bucket.input_tokens += static_cast<uint64_t>(std::max(input_tokens, 0));
+    day_bucket.output_tokens += static_cast<uint64_t>(std::max(output_tokens, 0));
+
+    hour_bucket.requests++;
+    hour_bucket.input_tokens += static_cast<uint64_t>(std::max(input_tokens, 0));
+    hour_bucket.output_tokens += static_cast<uint64_t>(std::max(output_tokens, 0));
+
+    persist_usage_stats_locked();
+}
+
+json Router::get_lifetime_usage_stats() const {
+    std::lock_guard<std::mutex> stats_lock(stats_mutex_);
+    return {
+        {"requests", lifetime_usage_stats_.requests},
+        {"input_tokens", lifetime_usage_stats_.input_tokens},
+        {"output_tokens", lifetime_usage_stats_.output_tokens},
+        {"started_at", lifetime_usage_stats_.started_at},
+        {"updated_at", lifetime_usage_stats_.updated_at},
+        {"bucket_timezone", "server_local_time"},
+        {"persistence_path", usage_stats_path_},
+        {"by_day", usage_buckets_to_json(lifetime_usage_stats_.by_day)},
+        {"by_hour", usage_buckets_to_json(lifetime_usage_stats_.by_hour)}
+    };
 }
 
 WrappedServer* Router::find_server_by_model_name(const std::string& model_name) const {
@@ -593,12 +766,18 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
             return;
         }
 
+        server->reset_telemetry();
         server->set_busy(true);
         server->update_access_time();
     }
 
     try {
         streaming_func(server);
+        {
+            std::lock_guard<std::mutex> stats_lock(stats_mutex_);
+            Telemetry telemetry = server->get_telemetry();
+            record_usage_locked(telemetry.input_tokens, telemetry.output_tokens, std::time(nullptr));
+        }
         server->set_busy(false);
     } catch (...) {
         server->set_busy(false);
@@ -708,11 +887,13 @@ json Router::image_variations(const json& request) {
 
 json Router::get_stats() const {
     std::lock_guard<std::mutex> lock(load_mutex_);
+    json stats = Telemetry().to_json();
     WrappedServer* server = get_most_recent_server();
-    if (!server) {
-        return ErrorResponse::from_exception(ModelNotLoadedException());
+    if (server) {
+        stats = server->get_telemetry().to_json();
     }
-    return server->get_telemetry().to_json();
+    stats["lifetime"] = get_lifetime_usage_stats();
+    return stats;
 }
 
 void Router::update_telemetry(int input_tokens, int output_tokens,
@@ -723,6 +904,8 @@ void Router::update_telemetry(int input_tokens, int output_tokens,
         server->set_telemetry(input_tokens, output_tokens,
                              time_to_first_token, tokens_per_second);
     }
+    std::lock_guard<std::mutex> stats_lock(stats_mutex_);
+    record_usage_locked(input_tokens, output_tokens, std::time(nullptr));
 }
 
 void Router::update_prompt_tokens(int prompt_tokens) {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -133,16 +133,16 @@ void Router::load_usage_stats() {
             }
         }
 
-        if (persisted.contains("by_model") && persisted["by_model"].is_object()) {
-            for (const auto& [model_name, model_data] : persisted["by_model"].items()) {
-                ModelStats& model = lifetime_usage_stats_.by_model[model_name];
-                model.requests = model_data.value("requests", 0ULL);
-                model.input_tokens = model_data.value("input_tokens", 0ULL);
-                model.output_tokens = model_data.value("output_tokens", 0ULL);
+        auto load_model_stats = [&](const json& source, std::map<std::string, ModelStats>& dest) {
+            for (const auto& [key, data] : source.items()) {
+                ModelStats& stats = dest[key];
+                stats.requests = data.value("requests", 0ULL);
+                stats.input_tokens = data.value("input_tokens", 0ULL);
+                stats.output_tokens = data.value("output_tokens", 0ULL);
 
-                if (model_data.contains("by_day") && model_data["by_day"].is_object()) {
-                    for (const auto& [bucket, value] : model_data["by_day"].items()) {
-                        model.by_day[bucket] = {
+                if (data.contains("by_day") && data["by_day"].is_object()) {
+                    for (const auto& [bucket, value] : data["by_day"].items()) {
+                        stats.by_day[bucket] = {
                             value.value("requests", 0ULL),
                             value.value("input_tokens", 0ULL),
                             value.value("output_tokens", 0ULL)
@@ -150,9 +150,9 @@ void Router::load_usage_stats() {
                     }
                 }
 
-                if (model_data.contains("by_hour") && model_data["by_hour"].is_object()) {
-                    for (const auto& [bucket, value] : model_data["by_hour"].items()) {
-                        model.by_hour[bucket] = {
+                if (data.contains("by_hour") && data["by_hour"].is_object()) {
+                    for (const auto& [bucket, value] : data["by_hour"].items()) {
+                        stats.by_hour[bucket] = {
                             value.value("requests", 0ULL),
                             value.value("input_tokens", 0ULL),
                             value.value("output_tokens", 0ULL)
@@ -160,6 +160,14 @@ void Router::load_usage_stats() {
                     }
                 }
             }
+        };
+
+        if (persisted.contains("by_model") && persisted["by_model"].is_object()) {
+            load_model_stats(persisted["by_model"], lifetime_usage_stats_.by_model);
+        }
+
+        if (persisted.contains("by_device_type") && persisted["by_device_type"].is_object()) {
+            load_model_stats(persisted["by_device_type"], lifetime_usage_stats_.by_device_type);
         }
     } catch (const std::exception& e) {
         LOG(WARNING, "Router") << "Failed to load usage stats: " << e.what() << std::endl;
@@ -171,16 +179,19 @@ void Router::persist_usage_stats_locked() const {
         fs::path stats_path = utils::path_from_utf8(usage_stats_path_);
         fs::create_directories(stats_path.parent_path());
 
-        json by_model_json = json::object();
-        for (const auto& [model_name, model_stats] : lifetime_usage_stats_.by_model) {
-            by_model_json[model_name] = {
-                {"requests", model_stats.requests},
-                {"input_tokens", model_stats.input_tokens},
-                {"output_tokens", model_stats.output_tokens},
-                {"by_day", usage_buckets_to_json(model_stats.by_day)},
-                {"by_hour", usage_buckets_to_json(model_stats.by_hour)}
-            };
-        }
+        auto serialize_model_stats = [&](const std::map<std::string, ModelStats>& stats_map) {
+            json result = json::object();
+            for (const auto& [key, stats] : stats_map) {
+                result[key] = {
+                    {"requests", stats.requests},
+                    {"input_tokens", stats.input_tokens},
+                    {"output_tokens", stats.output_tokens},
+                    {"by_day", usage_buckets_to_json(stats.by_day)},
+                    {"by_hour", usage_buckets_to_json(stats.by_hour)}
+                };
+            }
+            return result;
+        };
 
         json persisted = {
             {"requests", lifetime_usage_stats_.requests},
@@ -190,7 +201,8 @@ void Router::persist_usage_stats_locked() const {
             {"updated_at", lifetime_usage_stats_.updated_at},
             {"by_day", usage_buckets_to_json(lifetime_usage_stats_.by_day)},
             {"by_hour", usage_buckets_to_json(lifetime_usage_stats_.by_hour)},
-            {"by_model", by_model_json}
+            {"by_model", serialize_model_stats(lifetime_usage_stats_.by_model)},
+            {"by_device_type", serialize_model_stats(lifetime_usage_stats_.by_device_type)}
         };
 
         std::ofstream file(stats_path);
@@ -248,6 +260,24 @@ void Router::record_usage_locked(const std::string& model_name, const std::strin
         model_hour.output_tokens += out_tokens;
     }
 
+    // Per-device-type stats
+    if (!device_type.empty()) {
+        ModelStats& dev = lifetime_usage_stats_.by_device_type[device_type];
+        dev.requests++;
+        dev.input_tokens += in_tokens;
+        dev.output_tokens += out_tokens;
+
+        UsageBucket& dev_day = dev.by_day[day_key];
+        dev_day.requests++;
+        dev_day.input_tokens += in_tokens;
+        dev_day.output_tokens += out_tokens;
+
+        UsageBucket& dev_hour = dev.by_hour[hour_key];
+        dev_hour.requests++;
+        dev_hour.input_tokens += in_tokens;
+        dev_hour.output_tokens += out_tokens;
+    }
+
     persist_usage_stats_locked();
 }
 
@@ -282,22 +312,35 @@ void Router::add_tokens_locked(const std::string& model_name, const std::string&
         model.by_hour[hour_key].output_tokens += out_tokens;
     }
 
+    if (!device_type.empty()) {
+        ModelStats& dev = lifetime_usage_stats_.by_device_type[device_type];
+        dev.input_tokens += in_tokens;
+        dev.output_tokens += out_tokens;
+        dev.by_day[day_key].input_tokens += in_tokens;
+        dev.by_day[day_key].output_tokens += out_tokens;
+        dev.by_hour[hour_key].input_tokens += in_tokens;
+        dev.by_hour[hour_key].output_tokens += out_tokens;
+    }
+
     persist_usage_stats_locked();
 }
 
 json Router::get_lifetime_usage_stats() const {
     std::lock_guard<std::mutex> stats_lock(stats_mutex_);
 
-    json by_model_json = json::object();
-    for (const auto& [model_name, model_stats] : lifetime_usage_stats_.by_model) {
-        by_model_json[model_name] = {
-            {"requests", model_stats.requests},
-            {"input_tokens", model_stats.input_tokens},
-            {"output_tokens", model_stats.output_tokens},
-            {"by_day", usage_buckets_to_json(model_stats.by_day)},
-            {"by_hour", usage_buckets_to_json(model_stats.by_hour)}
-        };
-    }
+    auto model_stats_to_json = [&](const std::map<std::string, ModelStats>& stats_map) {
+        json result = json::object();
+        for (const auto& [key, stats] : stats_map) {
+            result[key] = {
+                {"requests", stats.requests},
+                {"input_tokens", stats.input_tokens},
+                {"output_tokens", stats.output_tokens},
+                {"by_day", usage_buckets_to_json(stats.by_day)},
+                {"by_hour", usage_buckets_to_json(stats.by_hour)}
+            };
+        }
+        return result;
+    };
 
     return {
         {"requests", lifetime_usage_stats_.requests},
@@ -309,7 +352,8 @@ json Router::get_lifetime_usage_stats() const {
         {"persistence_path", usage_stats_path_},
         {"by_day", usage_buckets_to_json(lifetime_usage_stats_.by_day)},
         {"by_hour", usage_buckets_to_json(lifetime_usage_stats_.by_hour)},
-        {"by_model", by_model_json}
+        {"by_model", model_stats_to_json(lifetime_usage_stats_.by_model)},
+        {"by_device_type", model_stats_to_json(lifetime_usage_stats_.by_device_type)}
     };
 }
 
@@ -894,8 +938,7 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
             std::lock_guard<std::mutex> stats_lock(stats_mutex_);
             Telemetry telemetry = server->get_telemetry();
             last_completed_telemetry_ = telemetry;
-            record_usage_locked(server->get_model_name(), device_type_to_string(server->get_device_type()),
-                                telemetry.input_tokens, telemetry.output_tokens, std::time(nullptr));
+            record_usage_locked(server->get_model_name(), device_type_to_string(server->get_device_type()), telemetry.input_tokens, telemetry.output_tokens, std::time(nullptr));
         }
         server->set_busy(false);
     } catch (...) {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -164,26 +164,50 @@ void Router::persist_usage_stats_locked() const {
     }
 }
 
-void Router::record_usage_locked(int input_tokens, int output_tokens, std::time_t recorded_at) {
+void Router::record_usage_locked(const std::string& model_name, const std::string& device_type, int input_tokens, int output_tokens, std::time_t recorded_at) {
+    const auto in_tokens = static_cast<uint64_t>(std::max(input_tokens, 0));
+    const auto out_tokens = static_cast<uint64_t>(std::max(output_tokens, 0));
+    const std::string day_key = format_day_bucket(recorded_at);
+    const std::string hour_key = format_hour_bucket(recorded_at);
+    UsageBucket& day_bucket = lifetime_usage_stats_.by_day[day_key];
+    UsageBucket& hour_bucket = lifetime_usage_stats_.by_hour[hour_key];
+
+    lifetime_usage_stats_.requests++;
+    lifetime_usage_stats_.input_tokens += in_tokens;
+    lifetime_usage_stats_.output_tokens += out_tokens;
+    lifetime_usage_stats_.updated_at = format_timestamp(recorded_at);
+
+    day_bucket.requests++;
+    day_bucket.input_tokens += in_tokens;
+    day_bucket.output_tokens += out_tokens;
+
+    hour_bucket.requests++;
+    hour_bucket.input_tokens += in_tokens;
+    hour_bucket.output_tokens += out_tokens;
+
+    persist_usage_stats_locked();
+}
+
+// Patches token counts onto already-recorded buckets without incrementing request counts.
+// Called by update_telemetry() after execute_inference() has already counted the request.
+void Router::add_tokens_locked(const std::string& model_name, const std::string& device_type, int input_tokens, int output_tokens, std::time_t recorded_at) {
     if (input_tokens <= 0 && output_tokens <= 0) {
         return;
     }
 
-    UsageBucket& day_bucket = lifetime_usage_stats_.by_day[format_day_bucket(recorded_at)];
-    UsageBucket& hour_bucket = lifetime_usage_stats_.by_hour[format_hour_bucket(recorded_at)];
+    const auto in_tokens = static_cast<uint64_t>(std::max(input_tokens, 0));
+    const auto out_tokens = static_cast<uint64_t>(std::max(output_tokens, 0));
+    const std::string day_key = format_day_bucket(recorded_at);
+    const std::string hour_key = format_hour_bucket(recorded_at);
 
-    lifetime_usage_stats_.requests++;
-    lifetime_usage_stats_.input_tokens += static_cast<uint64_t>(std::max(input_tokens, 0));
-    lifetime_usage_stats_.output_tokens += static_cast<uint64_t>(std::max(output_tokens, 0));
+    lifetime_usage_stats_.input_tokens += in_tokens;
+    lifetime_usage_stats_.output_tokens += out_tokens;
     lifetime_usage_stats_.updated_at = format_timestamp(recorded_at);
 
-    day_bucket.requests++;
-    day_bucket.input_tokens += static_cast<uint64_t>(std::max(input_tokens, 0));
-    day_bucket.output_tokens += static_cast<uint64_t>(std::max(output_tokens, 0));
-
-    hour_bucket.requests++;
-    hour_bucket.input_tokens += static_cast<uint64_t>(std::max(input_tokens, 0));
-    hour_bucket.output_tokens += static_cast<uint64_t>(std::max(output_tokens, 0));
+    lifetime_usage_stats_.by_day[day_key].input_tokens += in_tokens;
+    lifetime_usage_stats_.by_day[day_key].output_tokens += out_tokens;
+    lifetime_usage_stats_.by_hour[hour_key].input_tokens += in_tokens;
+    lifetime_usage_stats_.by_hour[hour_key].output_tokens += out_tokens;
 
     persist_usage_stats_locked();
 }
@@ -724,6 +748,13 @@ auto Router::execute_inference(const json& request, Func&& inference_func) -> de
     try {
         auto response = inference_func(server);
         server->set_busy(false);
+        // Record the request. Token counts are 0 here; for LLM completions, update_telemetry
+        // will later add the actual token counts via add_tokens_locked without double-counting.
+        {
+            std::lock_guard<std::mutex> stats_lock(stats_mutex_);
+            record_usage_locked(server->get_model_name(), device_type_to_string(server->get_device_type()),
+                                0, 0, std::time(nullptr));
+        }
         return response;
     } catch (...) {
         server->set_busy(false);
@@ -900,6 +931,8 @@ void Router::update_telemetry(int input_tokens, int output_tokens,
                               double time_to_first_token, double tokens_per_second) {
     std::lock_guard<std::mutex> lock(load_mutex_);
     WrappedServer* server = get_most_recent_server();
+    std::string model_name = server ? server->get_model_name() : "";
+    std::string device_type = server ? device_type_to_string(server->get_device_type()) : "";
     if (server) {
         server->set_telemetry(input_tokens, output_tokens,
                              time_to_first_token, tokens_per_second);
@@ -909,7 +942,7 @@ void Router::update_telemetry(int input_tokens, int output_tokens,
     last_completed_telemetry_.output_tokens = output_tokens;
     last_completed_telemetry_.time_to_first_token = time_to_first_token;
     last_completed_telemetry_.tokens_per_second = tokens_per_second;
-    record_usage_locked(input_tokens, output_tokens, std::time(nullptr));
+    add_tokens_locked(model_name, device_type, input_tokens, output_tokens, std::time(nullptr));
 }
 
 void Router::update_prompt_tokens(int prompt_tokens) {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -132,6 +132,35 @@ void Router::load_usage_stats() {
                 };
             }
         }
+
+        if (persisted.contains("by_model") && persisted["by_model"].is_object()) {
+            for (const auto& [model_name, model_data] : persisted["by_model"].items()) {
+                ModelStats& model = lifetime_usage_stats_.by_model[model_name];
+                model.requests = model_data.value("requests", 0ULL);
+                model.input_tokens = model_data.value("input_tokens", 0ULL);
+                model.output_tokens = model_data.value("output_tokens", 0ULL);
+
+                if (model_data.contains("by_day") && model_data["by_day"].is_object()) {
+                    for (const auto& [bucket, value] : model_data["by_day"].items()) {
+                        model.by_day[bucket] = {
+                            value.value("requests", 0ULL),
+                            value.value("input_tokens", 0ULL),
+                            value.value("output_tokens", 0ULL)
+                        };
+                    }
+                }
+
+                if (model_data.contains("by_hour") && model_data["by_hour"].is_object()) {
+                    for (const auto& [bucket, value] : model_data["by_hour"].items()) {
+                        model.by_hour[bucket] = {
+                            value.value("requests", 0ULL),
+                            value.value("input_tokens", 0ULL),
+                            value.value("output_tokens", 0ULL)
+                        };
+                    }
+                }
+            }
+        }
     } catch (const std::exception& e) {
         LOG(WARNING, "Router") << "Failed to load usage stats: " << e.what() << std::endl;
     }
@@ -142,6 +171,17 @@ void Router::persist_usage_stats_locked() const {
         fs::path stats_path = utils::path_from_utf8(usage_stats_path_);
         fs::create_directories(stats_path.parent_path());
 
+        json by_model_json = json::object();
+        for (const auto& [model_name, model_stats] : lifetime_usage_stats_.by_model) {
+            by_model_json[model_name] = {
+                {"requests", model_stats.requests},
+                {"input_tokens", model_stats.input_tokens},
+                {"output_tokens", model_stats.output_tokens},
+                {"by_day", usage_buckets_to_json(model_stats.by_day)},
+                {"by_hour", usage_buckets_to_json(model_stats.by_hour)}
+            };
+        }
+
         json persisted = {
             {"requests", lifetime_usage_stats_.requests},
             {"input_tokens", lifetime_usage_stats_.input_tokens},
@@ -149,7 +189,8 @@ void Router::persist_usage_stats_locked() const {
             {"started_at", lifetime_usage_stats_.started_at},
             {"updated_at", lifetime_usage_stats_.updated_at},
             {"by_day", usage_buckets_to_json(lifetime_usage_stats_.by_day)},
-            {"by_hour", usage_buckets_to_json(lifetime_usage_stats_.by_hour)}
+            {"by_hour", usage_buckets_to_json(lifetime_usage_stats_.by_hour)},
+            {"by_model", by_model_json}
         };
 
         std::ofstream file(stats_path);
@@ -165,25 +206,47 @@ void Router::persist_usage_stats_locked() const {
 }
 
 void Router::record_usage_locked(const std::string& model_name, const std::string& device_type, int input_tokens, int output_tokens, std::time_t recorded_at) {
+    if (input_tokens <= 0 && output_tokens <= 0) {
+        return;
+    }
+
     const auto in_tokens = static_cast<uint64_t>(std::max(input_tokens, 0));
     const auto out_tokens = static_cast<uint64_t>(std::max(output_tokens, 0));
     const std::string day_key = format_day_bucket(recorded_at);
     const std::string hour_key = format_hour_bucket(recorded_at);
-    UsageBucket& day_bucket = lifetime_usage_stats_.by_day[day_key];
-    UsageBucket& hour_bucket = lifetime_usage_stats_.by_hour[hour_key];
 
     lifetime_usage_stats_.requests++;
     lifetime_usage_stats_.input_tokens += in_tokens;
     lifetime_usage_stats_.output_tokens += out_tokens;
     lifetime_usage_stats_.updated_at = format_timestamp(recorded_at);
 
+    UsageBucket& day_bucket = lifetime_usage_stats_.by_day[day_key];
     day_bucket.requests++;
     day_bucket.input_tokens += in_tokens;
     day_bucket.output_tokens += out_tokens;
 
+    UsageBucket& hour_bucket = lifetime_usage_stats_.by_hour[hour_key];
     hour_bucket.requests++;
     hour_bucket.input_tokens += in_tokens;
     hour_bucket.output_tokens += out_tokens;
+
+    // Per-model stats
+    if (!model_name.empty()) {
+        ModelStats& model = lifetime_usage_stats_.by_model[model_name];
+        model.requests++;
+        model.input_tokens += in_tokens;
+        model.output_tokens += out_tokens;
+
+        UsageBucket& model_day = model.by_day[day_key];
+        model_day.requests++;
+        model_day.input_tokens += in_tokens;
+        model_day.output_tokens += out_tokens;
+
+        UsageBucket& model_hour = model.by_hour[hour_key];
+        model_hour.requests++;
+        model_hour.input_tokens += in_tokens;
+        model_hour.output_tokens += out_tokens;
+    }
 
     persist_usage_stats_locked();
 }
@@ -209,11 +272,33 @@ void Router::add_tokens_locked(const std::string& model_name, const std::string&
     lifetime_usage_stats_.by_hour[hour_key].input_tokens += in_tokens;
     lifetime_usage_stats_.by_hour[hour_key].output_tokens += out_tokens;
 
+    if (!model_name.empty()) {
+        ModelStats& model = lifetime_usage_stats_.by_model[model_name];
+        model.input_tokens += in_tokens;
+        model.output_tokens += out_tokens;
+        model.by_day[day_key].input_tokens += in_tokens;
+        model.by_day[day_key].output_tokens += out_tokens;
+        model.by_hour[hour_key].input_tokens += in_tokens;
+        model.by_hour[hour_key].output_tokens += out_tokens;
+    }
+
     persist_usage_stats_locked();
 }
 
 json Router::get_lifetime_usage_stats() const {
     std::lock_guard<std::mutex> stats_lock(stats_mutex_);
+
+    json by_model_json = json::object();
+    for (const auto& [model_name, model_stats] : lifetime_usage_stats_.by_model) {
+        by_model_json[model_name] = {
+            {"requests", model_stats.requests},
+            {"input_tokens", model_stats.input_tokens},
+            {"output_tokens", model_stats.output_tokens},
+            {"by_day", usage_buckets_to_json(model_stats.by_day)},
+            {"by_hour", usage_buckets_to_json(model_stats.by_hour)}
+        };
+    }
+
     return {
         {"requests", lifetime_usage_stats_.requests},
         {"input_tokens", lifetime_usage_stats_.input_tokens},
@@ -223,7 +308,8 @@ json Router::get_lifetime_usage_stats() const {
         {"bucket_timezone", "server_local_time"},
         {"persistence_path", usage_stats_path_},
         {"by_day", usage_buckets_to_json(lifetime_usage_stats_.by_day)},
-        {"by_hour", usage_buckets_to_json(lifetime_usage_stats_.by_hour)}
+        {"by_hour", usage_buckets_to_json(lifetime_usage_stats_.by_hour)},
+        {"by_model", by_model_json}
     };
 }
 
@@ -808,7 +894,8 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
             std::lock_guard<std::mutex> stats_lock(stats_mutex_);
             Telemetry telemetry = server->get_telemetry();
             last_completed_telemetry_ = telemetry;
-            record_usage_locked(telemetry.input_tokens, telemetry.output_tokens, std::time(nullptr));
+            record_usage_locked(server->get_model_name(), device_type_to_string(server->get_device_type()),
+                                telemetry.input_tokens, telemetry.output_tokens, std::time(nullptr));
         }
         server->set_busy(false);
     } catch (...) {

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -794,9 +794,13 @@ class EndpointTests(ServerTestBase):
         self.assertEqual(response.status_code, 200)
 
         data = response.json()
-        # Stats fields per server_spec.md (may not all be present if no inference done)
-        # Just verify it returns valid JSON
         self.assertIsInstance(data, dict)
+        self.assertIn("lifetime", data)
+        self.assertIsInstance(data["lifetime"], dict)
+        self.assertIn("input_tokens", data["lifetime"])
+        self.assertIn("output_tokens", data["lifetime"])
+        self.assertIn("by_day", data["lifetime"])
+        self.assertIn("by_hour", data["lifetime"])
 
         print(f"[OK] /stats endpoint returned: {list(data.keys())}")
 


### PR DESCRIPTION
Adds a **Statistics** view to the Electron / web app that visualises the persistent token usage stats served by `GET /stats`.

Supersedes #1489. **Depends on #1678** — this PR reads the `lifetime` object written by that PR; without the backend changes there's nothing to show.

## What's new

A new left-panel view (`leftPanelView: 'stats'`) accessible from the mode rail, with a refreshable dashboard built entirely on `/stats`. No new endpoints; no new backend code.

### Summary cards (4)

Each card is filter-aware — the labels and values change when a model or device filter is active:

- **Lifetime / Model / Device tokens** — total tokens across the current scope, with input/output context in the sub-label
- **Selected range / Selected day tokens** — matches whatever the chart is currently showing
- **Lifetime / Model / Device requests** — with avg tokens per request
- **Output share** — output vs input token mix (percentage + raw counts)

### Chart

- **Per-day / Per-hour** toggle. Per-day plots `by_day` buckets; per-hour plots the 24 hourly buckets for one selected day.
- **Range presets** in day mode: 7d, 30d, 90d (with a custom day-count input), 365d, all time.
- **Date picker** in hour mode, bounded by the first and last day that actually have data.
- **Hover tooltip** showing per-bucket input/output/total/requests.
- **Zoom** button expands into a full-screen overlay for a larger chart.

### Filters

Filter chips appear only when the backend actually has data in those buckets:

- **Model chips** (`All Models` + one per `by_model` key) — pulls stats from `lifetime.by_model[...]`
- **Device chips** (`All Devices` + one per `by_device_type` key, e.g. `CPU` / `GPU` / `NPU`) — pulls stats from `lifetime.by_device_type[...]`

Model and device chips are mutually exclusive; picking one resets the other. With neither selected the dashboard shows the top-level lifetime aggregate.

### Detail cards

- **Current view** — visible requests / input / output / avg per request for whatever's in the chart
- **Utilization** — active days, active hours, avg tokens per active day, peak day, peak hour (high-signal "is the accelerator being used?" indicators)
- **Recent days/hours table** — per-bucket breakdown that follows the chart mode

## Live updates

`StatsPanel` refetches `/stats` on mount, every 30 s, whenever the server URL changes, and whenever the window dispatches an `inference-complete` event — so using the chat panel makes numbers tick up in real time without a manual refresh.

## Commits

- `Add stats dashboard to app` — introduces `StatsPanel.tsx`, wires a new `stats` value into `LeftPanelView` / `leftPanelView` settings, adds a rail icon, extends `ModelManager` title/search-placeholder switches, adds ~700 lines of CSS for the panel/chart/overlay
- `Refine stats chart interactions` — polish pass on hover/tooltip/markers/range-preset behaviour
- `fix: Selected day tokens showing lifetime totals in hour mode` — `valueSummary` was assigned `lifetimeSummary` in hour mode, which made the "Selected day" card mirror "Lifetime tokens". `chartSummary` already sums the 24 hourly buckets for the selected day, so `valueSummary` can simply always be `chartSummary`.
- `Add model selector to stats dashboard` — `by_model` chips and model-scoped summaries
- `Add device filter to stats dashboard` — `by_device_type` chips and device-scoped summaries

## Scope / non-changes

- No backend or API changes in this PR — all data comes from `GET /stats` as provided by #1678.
- No new dependencies. Chart is hand-rolled SVG to stay consistent with the existing pure-CSS / no-charting-library approach (per `AGENTS.md`).
- `leftPanelView` union in `appSettings.ts` gains `'stats'`; existing saved settings continue to load (the loader only accepts the known values).

## Test plan

- [ ] `cmake --build --preset default --target electron-app`
- [ ] Launch the app, open the new **Statistics** rail icon, confirm it loads without errors when `/stats` is empty (fresh install) and when populated
- [ ] Run a few chat completions; verify summary cards and chart update live (within ~1 s via `inference-complete`, and fall back to 30 s poll if the event is missed)
- [ ] Toggle Per-day / Per-hour, cycle the range presets (7d / 30d / 90d custom count / 365d / all), confirm the date picker in hour mode is bounded by available days
- [ ] Exercise the model chip filter with two different loaded models, then the device chip filter; confirm the two filters reset each other and the summary-card labels change to "Model …" / "Device …"
- [ ] Click **Zoom**, verify the overlay mirrors chart/filter state and can be dismissed via the ✕ button or backdrop click
- [ ] Reload the app; confirm that `leftPanelView: 'stats'` persists across restarts
- [ ] Run `cmake --build --preset default --target web-app`; confirm the same panel works in the browser build served from `/app`

## Follow-ups / out of scope

- The backend's pre-existing zero-token early-return in `record_usage_locked` means `lifetime.requests` counters don't tick for non-LLM requests (image gen / TTS / audio transcription) or for zero-token LLM responses. That's a backend issue tracked against #1678, not this PR. When it's fixed, the "Output share" card and "Avg/request" values for those request types become more meaningful automatically.