### PR TITLE
CLI: check the models list before sending pull endpoint requests

### DIFF
--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -1,5 +1,4 @@
 #include "lemon_cli/lemonade_client.h"
-#include "lemon/model_manager.h"  // for lemon::kUnknownModelErrorCode
 #include <httplib.h>
 #include <iostream>
 #include <iomanip>
@@ -486,8 +485,9 @@ int LemonadeClient::pull_model(const json& model_data) {
         }, LONG_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
 
         if (!state.success) {
-            // See UnknownModelError contract in include/lemon/model_manager.h.
-            if (state.error_code == lemon::kUnknownModelErrorCode) {
+            // Wire-protocol constant; server-side definition and contract live in
+            // include/lemon/model_manager.h (kUnknownModelErrorCode). Keep in sync.
+            if (state.error_code == "unknown_model") {
                 state.error_message =
                     "No built-in model with the name '" + model_name + "' is registered.\n\n"
                     "If you meant a built-in model, run `lemonade list` to see available models.\n"

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -1,4 +1,5 @@
 #include "lemon_cli/lemonade_client.h"
+#include "lemon/model_manager.h"  // for lemon::kUnknownModelErrorCode
 #include <httplib.h>
 #include <iostream>
 #include <iomanip>
@@ -470,8 +471,11 @@ int LemonadeClient::pull_model(const json& model_data) {
             } else if (event_type == "error") {
                 try {
                     auto error_json = json::parse(event_data);
-                    if (error_json.contains("error")) {
+                    if (error_json.contains("error") && error_json["error"].is_string()) {
                         state.error_message = error_json["error"].get<std::string>();
+                    }
+                    if (error_json.contains("code") && error_json["code"].is_string()) {
+                        state.error_code = error_json["code"].get<std::string>();
                     }
                 } catch (...) {
                     state.error_message = event_data;
@@ -482,6 +486,14 @@ int LemonadeClient::pull_model(const json& model_data) {
         }, LONG_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
 
         if (!state.success) {
+            // See UnknownModelError contract in include/lemon/model_manager.h.
+            if (state.error_code == lemon::kUnknownModelErrorCode) {
+                state.error_message =
+                    "No built-in model with the name '" + model_name + "' is registered.\n\n"
+                    "If you meant a built-in model, run `lemonade list` to see available models.\n"
+                    "If you meant to add a custom model from Hugging Face, run `lemonade pull CHECKPOINT`.";
+            }
+
             if (!state.error_message.empty()) {
                 throw std::runtime_error(state.error_message);
             }

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -264,7 +264,6 @@ static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig
 
     nlohmann::json model_data;
     model_data["model_name"] = config.model;
-
     return client.pull_model(model_data);
 }
 

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -238,34 +238,6 @@ static bool has_manual_pull_options(const CliConfig& config) {
     return !config.checkpoints.empty() || !config.recipe.empty() || !config.labels.empty();
 }
 
-static bool model_list_contains(const std::vector<lemonade::ModelInfo>& models,
-                                const std::string& model_name) {
-    return std::any_of(models.begin(), models.end(),
-                       [&model_name](const lemonade::ModelInfo& model) {
-                           return model.id == model_name;
-                       });
-}
-
-static int print_unknown_pull_target_error(lemonade::LemonadeClient& client,
-                                           const std::string& model_name) {
-    std::vector<lemonade::ModelInfo> available_models = client.get_models(false);
-    if (model_list_contains(available_models, model_name)) {
-        return -1;
-    }
-
-    std::vector<lemonade::ModelInfo> all_models = client.get_models(true);
-    if (model_list_contains(all_models, model_name)) {
-        return -1;
-    }
-
-    std::cerr << "Error pulling model: No built-in model with the name '" << model_name
-              << "' is registered.\n\n"
-              << "If you meant a built-in model, run `lemonade list` to see available models.\n"
-              << "If you meant to add a custom model from Hugging Face, run `lemonade pull CHECKPOINT`."
-              << std::endl;
-    return 1;
-}
-
 static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig& config) {
     if (has_manual_pull_options(config)) {
         if (config.checkpoints.empty()) {
@@ -292,11 +264,6 @@ static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig
 
     nlohmann::json model_data;
     model_data["model_name"] = config.model;
-
-    int preflight_result = print_unknown_pull_target_error(client, config.model);
-    if (preflight_result != -1) {
-        return preflight_result;
-    }
 
     return client.pull_model(model_data);
 }

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -238,6 +238,34 @@ static bool has_manual_pull_options(const CliConfig& config) {
     return !config.checkpoints.empty() || !config.recipe.empty() || !config.labels.empty();
 }
 
+static bool model_list_contains(const std::vector<lemonade::ModelInfo>& models,
+                                const std::string& model_name) {
+    return std::any_of(models.begin(), models.end(),
+                       [&model_name](const lemonade::ModelInfo& model) {
+                           return model.id == model_name;
+                       });
+}
+
+static int print_unknown_pull_target_error(lemonade::LemonadeClient& client,
+                                           const std::string& model_name) {
+    std::vector<lemonade::ModelInfo> available_models = client.get_models(false);
+    if (model_list_contains(available_models, model_name)) {
+        return -1;
+    }
+
+    std::vector<lemonade::ModelInfo> all_models = client.get_models(true);
+    if (model_list_contains(all_models, model_name)) {
+        return -1;
+    }
+
+    std::cerr << "Error pulling model: No built-in model with the name '" << model_name
+              << "' is registered.\n\n"
+              << "If you meant a built-in model, run `lemonade list` to see available models.\n"
+              << "If you meant to add a custom model from Hugging Face, run `lemonade pull CHECKPOINT`."
+              << std::endl;
+    return 1;
+}
+
 static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig& config) {
     if (has_manual_pull_options(config)) {
         if (config.checkpoints.empty()) {
@@ -264,6 +292,12 @@ static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig
 
     nlohmann::json model_data;
     model_data["model_name"] = config.model;
+
+    int preflight_result = print_unknown_pull_target_error(client, config.model);
+    if (preflight_result != -1) {
+        return preflight_result;
+    }
+
     return client.pull_model(model_data);
 }
 

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdexcept>
 #include <string>
 #include <map>
 #include <vector>
@@ -12,6 +13,22 @@
 namespace lemon {
 
 using json = nlohmann::json;
+
+// Thrown by ModelManager::download_model when a pull request names a model
+// that (a) is not registered, (b) is not in the filtered-out registry, and
+// (c) lacks the `user.` prefix that would make it a new-model registration
+// attempt.
+//
+// CONTRACT: the /pull HTTP handler catches this type and attaches
+// {"code": kUnknownModelErrorCode, ...} to the error response. The lemonade
+// CLI keys off that code (NOT the message string) to replace the message with
+// a friendlier one that points at `lemonade list` and `lemonade pull
+// CHECKPOINT`. Do not change kUnknownModelErrorCode without updating the CLI.
+class UnknownModelError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+constexpr const char* kUnknownModelErrorCode = "unknown_model";
 
 // Progress information for download operations
 struct DownloadProgress {

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -21,9 +21,10 @@ using json = nlohmann::json;
 //
 // CONTRACT: the /pull HTTP handler catches this type and attaches
 // {"code": kUnknownModelErrorCode, ...} to the error response. The lemonade
-// CLI keys off that code (NOT the message string) to replace the message with
-// a friendlier one that points at `lemonade list` and `lemonade pull
-// CHECKPOINT`. Do not change kUnknownModelErrorCode without updating the CLI.
+// CLI keys off that code to replace the message with a friendlier one that
+// points at `lemonade list` and `lemonade pull CHECKPOINT`. The CLI inlines
+// the "unknown_model" literal to avoid pulling this server header into the
+// CLI; update cli/lemonade_client.cpp in lockstep if this constant changes.
 class UnknownModelError : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -35,6 +35,7 @@ struct StreamingRequestState {
     int last_percent = -1;
     bool success = false;
     std::string error_message;
+    std::string error_code;
     bool total_size_printed = false;
     uint64_t last_file_size = 0;
     std::chrono::steady_clock::time_point file_start_time;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1912,7 +1912,8 @@ void ModelManager::download_model(const std::string& model_name,
         // Model not in registry - this must be a user model registration
         // Validate it has the "user." prefix
         if (!is_user_model_name(model_name)) {
-            throw std::runtime_error(
+            // See UnknownModelError contract in include/lemon/model_manager.h.
+            throw UnknownModelError(
                 "When registering a new model, the model name must include the "
                 "`user` namespace, for example `user.Phi-4-Mini-GGUF`. Received: " +
                 model_name

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2659,6 +2659,11 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             res.set_content(response.dump(), "application/json");
         }
 
+    } catch (const lemon::UnknownModelError& e) {
+        LOG(ERROR, "Server") << "ERROR in handle_pull: " << e.what() << std::endl;
+        res.status = 400;
+        nlohmann::json error = {{"error", e.what()}, {"code", lemon::kUnknownModelErrorCode}};
+        res.set_content(error.dump(), "application/json");
     } catch (const std::exception& e) {
         LOG(ERROR, "Server") << "ERROR in handle_pull: " << e.what() << std::endl;
         res.status = 500;
@@ -3713,6 +3718,10 @@ void Server::stream_download_operation(
                     sink.write(event.c_str(), event.size());
                 }
 
+            } catch (const lemon::UnknownModelError& e) {
+                nlohmann::json error_data = {{"error", e.what()}, {"code", lemon::kUnknownModelErrorCode}};
+                std::string event = "event: error\ndata: " + error_data.dump() + "\n\n";
+                sink.write(event.c_str(), event.size());
             } catch (const std::exception& e) {
                 std::string error_msg = e.what();
                 if (error_msg != "Download cancelled") {


### PR DESCRIPTION
Closes #1601

## What changed

Replaces the cryptic `"When registering a new model, the model name must include the `user` namespace..."` error from `lemonade pull <unknown-name>` with a friendlier hint pointing at `lemonade list` and `lemonade pull CHECKPOINT`.

## How

A typed `UnknownModelError` on the server side (`src/cpp/include/lemon/model_manager.h`) wraps the one specific case where the requested name is not a registered built-in, not a hardware-filtered registered model, and lacks the `user.` prefix that would make it a new-model registration attempt. The `/pull` handler catches this type and attaches a structured `{"code": "unknown_model"}` tag to the error response (both streaming and non-streaming paths). The CLI keys off that **code** to rewrite the error in `LemonadeClient::pull_model`.

Every other error path (server down, 401 auth, registered-but-unsupported model, malformed manual pull, missing checkpoint/recipe) throws a plain `std::runtime_error` with no code, so the server's specific message flows through verbatim.

## Key scenarios

**1. Unknown name — friendly rewrite**
```
$ build/lemonade pull not-a-model
Pulling model: not-a-model
Error pulling model: No built-in model with the name 'not-a-model' is registered.

If you meant a built-in model, run `lemonade list` to see available models.
If you meant to add a custom model from Hugging Face, run `lemonade pull CHECKPOINT`.
```

**2. Manual pull missing `user.` prefix — server message preserved**
```
$ build/lemonade pull Foo --checkpoint llamacpp unsloth/Phi-3-mini-GGUF --recipe llamacpp
Pulling model: Foo
Error pulling model: When providing 'checkpoint' or 'recipe', the model name must include the `user.` prefix, for example `user.Phi-4-Mini-GGUF`. Received: Foo
```

**3. `user.Foo` without checkpoint/recipe — server message preserved**
```
$ build/lemonade pull user.NotExisting
Pulling model: user.NotExisting
Error pulling model: Model user.NotExisting is not registered with Lemonade Server. To register and install it, provide the `checkpoint` and `recipe` arguments, as well as the optional `reasoning` and `mmproj` arguments as appropriate.
```

## Notes on review feedback

- **No more CLI preflight**: the earlier `get_models(false)` + `get_models(true)` preflight is gone. This eliminates the uncaught-exception regression on server-down / bad-API-key paths, and also eliminates the false-negative on registered-but-hardware-filtered models (which `/api/v1/models?show_all=true` does not return).
