### PR TITLE
CLI pull command: accept full huggingface urls

### DIFF
--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -120,6 +120,14 @@ std::string normalize_user_model_name(std::string name) {
     return prefix + name;
 }
 
+std::string strip_huggingface_url_prefix(const std::string& arg) {
+    static const std::string prefix = "https://huggingface.co/";
+    if (arg.rfind(prefix, 0) == 0) {
+        return arg.substr(prefix.size());
+    }
+    return arg;
+}
+
 void split_checkpoint_variant(const std::string& arg,
                               std::string& checkpoint, std::string& variant) {
     // HF repo ids never contain ':', so split on the last ':'.
@@ -145,12 +153,17 @@ std::string format_variant_label(const json& v) {
 
 }  // namespace
 
+std::string normalize_huggingface_checkpoint_arg(const std::string& arg) {
+    return strip_huggingface_url_prefix(arg);
+}
+
 int hf_pull_flow(lemonade::LemonadeClient& client,
                  const std::string& model_arg,
                  bool assume_yes) {
     std::string checkpoint;
     std::string variant;
-    split_checkpoint_variant(model_arg, checkpoint, variant);
+    std::string normalized_model_arg = normalize_huggingface_checkpoint_arg(model_arg);
+    split_checkpoint_variant(normalized_model_arg, checkpoint, variant);
 
     if (checkpoint.find('/') == std::string::npos) {
         std::cerr << "Error: '" << model_arg

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -225,7 +225,11 @@ static int handle_manual_pull_command(lemonade::LemonadeClient& client, const Cl
     model_data["recipe"] = config.recipe;
 
     if (!config.checkpoints.empty()) {
-        model_data["checkpoints"] = config.checkpoints;
+        nlohmann::json checkpoints = nlohmann::json::object();
+        for (const auto& [type, checkpoint] : config.checkpoints) {
+            checkpoints[type] = lemon_cli::normalize_huggingface_checkpoint_arg(checkpoint);
+        }
+        model_data["checkpoints"] = std::move(checkpoints);
     }
 
     if (!config.labels.empty()) {
@@ -255,12 +259,14 @@ static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig
         return handle_manual_pull_command(client, config);
     }
 
+    std::string normalized_model = lemon_cli::normalize_huggingface_checkpoint_arg(config.model);
+
     // If the argument looks like a Hugging Face checkpoint id (contains '/'),
     // run the interactive HF flow that discovers variants and auto-fills the
     // pull request. Otherwise treat it as a registered model name and pull by
     // model_name only.
-    if (config.model.find('/') != std::string::npos) {
-        return lemon_cli::hf_pull_flow(client, config.model, false);
+    if (normalized_model.find('/') != std::string::npos) {
+        return lemon_cli::hf_pull_flow(client, normalized_model, false);
     }
 
     nlohmann::json model_data;

--- a/src/cpp/include/lemon_cli/hf_pull.h
+++ b/src/cpp/include/lemon_cli/hf_pull.h
@@ -6,6 +6,11 @@
 
 namespace lemon_cli {
 
+// Accept either a bare Hugging Face repo id / checkpoint string or a full
+// huggingface.co URL and return the canonical checkpoint form expected by the
+// CLI and server (for example: owner/repo[:variant]).
+std::string normalize_huggingface_checkpoint_arg(const std::string& arg);
+
 // Pull a model from a Hugging Face checkpoint id, optionally with a variant
 // suffix (`owner/repo[:variant]`). Fetches /api/v1/pull/variants from lemond,
 // presents an interactive variant menu when needed, then issues /v1/pull.


### PR DESCRIPTION
Closes https://github.com/lemonade-sdk/lemonade/issues/1689

## Summary
- strip the exact https://huggingface.co/ prefix from pull checkpoint arguments
- apply the same normalization to both direct pull arguments and manual --checkpoint entries
- preserve existing pull behavior for all other inputs

## Why
Users sometimes paste full Hugging Face URLs into lemonade pull even though the CLI expects owner/repo. This change makes that common input form work without broadening behavior beyond the exact prefix.