### PR TITLE
Update the hot models for mid april 2026

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -873,8 +873,7 @@
         "suggested": true,
         "labels": [
             "vision",
-            "tool-calling",
-            "hot"
+            "tool-calling"
         ],
         "size": 19.7
     },
@@ -885,8 +884,7 @@
         "suggested": true,
         "labels": [
             "vision",
-            "tool-calling",
-            "hot"
+            "tool-calling"
         ],
         "size": 68.4
     },


### PR DESCRIPTION
Closes #1674 

This PR accomplishes two things:
- Unblocks llamacpp auto-upgrade by taking the 122B model out of it - this model was always marginal to fit on Windows and causes stability issues.
- Adjusts the hot models list for what is actually hot in mid april 2026.