### PR TITLE
Switch self-hosted runner targeting to capability-based labels

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -735,42 +735,42 @@ jobs:
             script: server_llm.py
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan rocm"
-            runner: [rai300_400, Windows]
+            runner: [Windows, vulkan, rocm]
           - name: ryzenai
             script: server_llm.py
             extra_args: "--wrapped-server ryzenai"
             backends: "cpu hybrid npu"
-            runner: [rai300_400, Windows]
+            runner: [Windows, xdna2]
           - name: flm
             script: server_llm.py
             extra_args: "--wrapped-server flm"
             backends: "npu"
-            runner: [rai300_400, Windows]
+            runner: [Windows, xdna2]
           - name: whisper
             script: server_whisper.py
             extra_args: "--wrapped-server whispercpp"
             backends: "cpu npu"
-            runner: [rai300_400, Windows]
+            runner: [Windows, xdna2]
           - name: flm-whisper
             script: server_whisper.py
             extra_args: "--wrapped-server flm"
             backends: "npu"
-            runner: [rai300_400, Windows]
+            runner: [Windows, xdna2]
           - name: stable-diffusion
             script: server_sd.py
             extra_args: ""
             backends: "cpu"
-            runner: [rai300_400, Windows]
+            runner: [self-hosted, Windows]
           - name: text-to-speech
             script: server_tts.py
             extra_args: ""
             backends: ""
-            runner: [rai300_400, Windows]
+            runner: [self-hosted, Windows]
           - name: stable-diffusion (stx-halo)
             script: server_sd.py
             extra_args: ""
             backends: "rocm"
-            runner: [stx-halo, Windows]
+            runner: [Windows, rocm, stx-halo]
     env:
       LEMONADE_CI_MODE: "True"
       LEMONADE_CACHE_DIR: ".\\ci-cache"
@@ -846,7 +846,7 @@ jobs:
 
   test-deb-inference:
     name: Test .deb - ${{ matrix.name }}
-    runs-on: [rai300_400, Linux]
+    runs-on: ${{ matrix.runner }}
     needs: build-lemonade-deb
     # Skip inference tests when signing is enabled (tag pushes or manual workflow_dispatch)
     if: ${{ !startsWith(github.ref, 'refs/tags/') && inputs.enable_signing != true }}
@@ -858,22 +858,27 @@ jobs:
             script: server_llm.py
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan rocm"
+            runner: [Linux, vulkan, rocm]
           - name: stable-diffusion
             script: server_sd.py
             extra_args: ""
             backends: "cpu rocm"
+            runner: [Linux, rocm]
           - name: whisper
             script: server_whisper.py
             extra_args: "--wrapped-server whispercpp"
             backends: "cpu vulkan"
+            runner: [Linux, vulkan]
           - name: flm
             script: server_llm.py
             extra_args: "--wrapped-server flm"
             backends: "npu"
+            runner: [Linux, xdna2]
           - name: text-to-speech
             script: server_tts.py
             extra_args: ""
             backends: ""
+            runner: [self-hosted, Linux]
     env:
       LEMONADE_CI_MODE: "True"
       PYTHONIOENCODING: utf-8

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -147,18 +147,22 @@ jobs:
     name: Validate ${{ matrix.backend }}${{ matrix.channel && format(' ({0})', matrix.channel) || '' }}
     needs: [get-latest-releases, build]
     if: always() && needs.build.result == 'success'
-    runs-on: [self-hosted, Windows, 128gb]
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - backend: vulkan
+            runner: [self-hosted, Windows, 128gb, vulkan]
           - backend: rocm
             channel: stable
+            runner: [self-hosted, Windows, 128gb, rocm]
           - backend: rocm
             channel: preview
+            runner: [self-hosted, Windows, 128gb, rocm]
           - backend: rocm
             channel: nightly
+            runner: [self-hosted, Windows, 128gb, rocm]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/docs/self_hosted_runners.md
+++ b/docs/self_hosted_runners.md
@@ -4,7 +4,8 @@ This page documents how to set up and maintain self-hosted runners for lemonade-
 
 Topics:
  - [What are Self-Hosted Runners?](#what-are-self-hosted-runners)
- - [NPU Runner Setup](#npu-runner-setup)
+ - [Runner Labels](#runner-labels)
+ - [New Runner Setup](#new-runner-setup)
  - [Maintenance and Troubleshooting](#maintenance-and-troubleshooting)
     - [Check your runner's status](#check-your-runners-status)
     - [Actions are failing unexpectedly](#actions-are-failing-unexpectedly)
@@ -18,9 +19,49 @@ A "runner" is a computer that has installed GitHub's runner software, which runs
 
 You can read about all this here: [GitHub: About self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners).
 
-## NPU Runner Setup
+## Runner Labels
 
-This guide will help you set up a Ryzen AI laptop as a GitHub self-hosted runner. This will make the laptop available for on-demand and CI jobs that require NPU resources.
+Workflows target self-hosted runners by the labels the runner carries. We use two kinds of labels:
+
+### Capability labels
+
+These describe *what a runner can do*. A workflow should request only the capability labels it actually needs.
+
+| Label | Meaning | Typical workflows that request it |
+|-------|---------|-----------------------------------|
+| `vulkan` | Runner can execute Vulkan GPU workloads | llama.cpp Vulkan backend, whisper.cpp Vulkan backend |
+| `rocm` | Runner can execute ROCm GPU workloads | llama.cpp ROCm backend, stable-diffusion.cpp ROCm backend |
+| `cuda` | Runner can execute CUDA GPU workloads | TBD |
+| `xdna2` | Runner has a Ryzen AI 300/400 series NPU | `ryzenai` backend, `flm` (FastFlowLM) backend |
+
+A job that exercises more than one backend should request all the labels it needs (e.g., `[Windows, vulkan, rocm]` for a test that runs both Vulkan and ROCm cases). GitHub Actions requires the runner to carry *every* label in the `runs-on` list.
+
+CPU-only jobs should target GitHub-hosted runners when possible.
+
+### Hardware labels
+
+These pin a job to a specific hardware class when a capability label alone isn't enough to distinguish it. Combine them with a capability label.
+
+| Label | Hardware | When to use |
+|-------|----------|-------------|
+| `stx-halo` | Strix Halo (AMD Ryzen AI Max 300 series) | ROCm workloads that specifically need Strix Halo's iGPU, e.g., `[Windows, rocm, stx-halo]` |
+
+Add new hardware labels here as the pool grows.
+
+### Applying labels to a runner
+
+Capability and hardware labels must be present on each runner for the workflow to match. Add or remove them from the [runners page](https://github.com/organizations/lemonade-sdk/settings/actions/runners): click the runner, click the gear icon in the Labels section, and check/uncheck as needed. Apply only the labels that reflect the runner's real capabilities — never add `rocm` to a runner that can't actually run ROCm, for example, because that will cause workflows to be scheduled on a machine that can't complete them.
+
+### Typical label sets by hardware
+
+| Hardware | Labels to apply |
+|----------|-----------------|
+| Ryzen AI 300-series laptop (NPU + Vulkan iGPU + ROCm iGPU) | `xdna2`, `vulkan`, `rocm` |
+| Strix Halo | `xdna2`, `rocm`, `stx-halo` |
+
+## New Runner Setup
+
+This guide will help you set up a computer as a GitHub self-hosted runner.
 
 ### New Machine Setup
 
@@ -28,7 +69,7 @@ This guide will help you set up a Ryzen AI laptop as a GitHub self-hosted runner
     - The latest RyzenAI driver ONLY (do not install RyzenAI Software), which is [available here](https://ryzenai.docs.amd.com/en/latest/inst.html#install-npu-drivers)
     - [VS Code](https://code.visualstudio.com/Download)
     - [git](https://git-scm.com/downloads/win)
-- If your laptop has an Nvidia GPU, you must disable it in device manager
+- If your laptop has an Nvidia GPU, and you want the `rocm` capability instead of `cuda`, you must disable it in device manager
 - Open a PowerShell script in admin mode, and run `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned`
 - Go into Windows settings:
   - Go to system, power & battery, screen sleep & hibernate timeouts, and make it so the laptop never sleeps while plugged in. If you don't do this it can fall asleep during jobs.
@@ -43,28 +84,14 @@ These steps will place your machine in the `stx-test` pool, which is where we pu
     - Enable permissions by running `Set-ExecutionPolicy RemoteSigned`
     - When running `./config.cmd` in step 2, make the following choices:
          - Name of the runner group = `stx`
-         - For the runner name, call it `NAME-stx-NUMBER`, where NAME is your alias and NUMBER would tell you this is the Nth STX machine you've added.
-         - Apply the label `stx-test` as well as a label with your name to indicate that you are maintaining the runner.
+         - For the runner name, call it `NAME-TYPE-NUMBER`, where NAME is your alias and NUMBER would tell you this is the Nth machine of TYPE you've added. TYPE examples include `stx`, `stx-halo`, `phx`, etc.
+         - Apply capability labels (`xdna2`, `vulkan`, `rocm`, etc. and any hardware labels like `stx-halo`).
          - Accept the default for the work folder
          - You want the runner to function as a service (respond Y)
          - User account to use for the service = `NT AUTHORITY\SYSTEM` (not the default of `NT AUTHORITY\NETWORK SERVICE`)
 
 1. Follow the instructions here for Windows|Ubuntu, minding what we said in step 1: https://github.com/organizations/lemonade-sdk/settings/actions/runners/new
 1. You should see your runner show up in the `stx` runner group in the lemonade-sdk org
-
-### Runner Setup
-
-These steps will use GitHub Actions to run automated setup and validation for your new runner while it is still in the `stx-test` group.
-
-1. Go to the [lemonade ryzenai test action](https://github.com/lemonade-sdk/lemonade/actions/workflows/test_ryzenai.yml) and click "run workflow".
-    - Select `stx-test` as the runner group
-    - Click `Run workflow`
-1. The workflow should appear at the top of the queue. Click into it.
-    - Expand the `Set up job` section and make sure `Runner name:` refers to your new runner. Otherwise, the job may have gone to someone else's runner in the test group. You can re-queue the workflow until it lands on your runner.
-    - Wait for the workflow to finish successfully.
-1. Repeat step 1. Wait for it to finish successfully. Congrats, your new runner is working!
-1. Go to the stx Runner Group, click your new runner, and click the gear icon to change labels. Uncheck `stx-test` and check `stx`.
-1. Done!
 
 ## Maintenance and Troubleshooting
 
@@ -102,10 +129,11 @@ Also, if someone else's laptop is misbehaving and causing Actions to fail unexpe
 
 There are three options:
 
-Option 1, which is available to anyone in the `lemonade-sdk` org: remove the `rai300_400` label from the runner.
-- Workflows use `runs-on: rai300_400` to target runners with the `rai300_400` label. Removing this label from the runner will thus remove the runner from the pool.
-- Go to the [runners page](https://github.com/organizations/lemonade-sdk/settings/actions/runners), click the specific runner in question, click the gear icon in the Labels section, and uncheck `rai300_400`.
-- To reverse this action later, go back to the [runners page](https://github.com/organizations/lemonade-sdk/settings/actions/runners), click the gear icon, and check `rai300_400`.
+Option 1, which is available to anyone in the `lemonade-sdk` org: remove the runner's capability labels.
+- Workflows target runners by requesting capability labels like `xdna2`, `vulkan`, and `rocm` (see [Runner Labels](#runner-labels)). Removing every capability label from a runner will drain it completely — no workflow will match.
+- To drain the runner for only one backend (e.g., take it out of ROCm jobs but keep it available for NPU jobs), remove just that one capability label.
+- Go to the [runners page](https://github.com/organizations/lemonade-sdk/settings/actions/runners), click the specific runner in question, click the gear icon in the Labels section, and uncheck the capability labels you want to drain.
+- To reverse this action later, go back to the [runners page](https://github.com/organizations/lemonade-sdk/settings/actions/runners), click the gear icon, and re-check the labels you removed.
 
 Option 2, which requires physical/remote access to the laptop:
 - In a PowerShell terminal, run `Stop-Service "actions.runner.*"`.
@@ -128,7 +156,7 @@ Here are some general guidelines to observe when creating or modifying workflows
 - Place a 🌩️ emoji in the name of all of your self-host workflows, so that PR reviewers can see at a glance which workflows are using self-hosted resources.
     - Example: `name: Test Lemonade on NPU and Hybrid with OGA environment 🌩️`
 - Avoid triggering your workflow before anyone has had a chance to review it against these guidelines. To avoid triggers, do not include `on: pull request:` in your workflow until after a reviewer has signed off.
-- Only map a workflow with `runs on: rai300_400` if it actually requires Ryzen AI compute. If a step in your workflow can use generic compute (e.g., running a Hugging Face LLM on CPU), put that step on a generic non-self-hosted runner like `runs on: windows-latest`.
+- Request only the capability labels your job actually needs (see [Runner Labels](#runner-labels)). For example, `runs-on: [Windows, xdna2]` for NPU work, `runs-on: [Linux, vulkan, rocm]` for a job that exercises both GPU backends. Do not ask for `xdna2` or a GPU capability if your job is CPU-only — use `[self-hosted, Windows]` / `[self-hosted, Linux]`, or move the step to a GitHub-hosted runner like `runs-on: windows-latest` when possible.
 - Be very considerate about installing software on to the runners:
     - Installing software into the CWD (e.g., a path of `.\`) is always ok, because that will end up in `C:\actions-runner\_work\REPO`, which is always wiped between tests.
     - Installing software into `AppData`, `Program Files`, etc. is not advisable because that software will persist across tests. See the [setup](#npu-runner-setup) section to see which software is already expected on the system.

--- a/docs/self_hosted_runners.md
+++ b/docs/self_hosted_runners.md
@@ -77,7 +77,7 @@ This guide will help you set up a computer as a GitHub self-hosted runner.
 
 ### Runner Configuration
 
-These steps will place your machine in the `stx-test` pool, which is where we put machines while we are setting them up. In the next section we will finalize setup and then move the runner into the production pool.
+These steps will place your machine into the production pool.
 
 1. IMPORTANT: before doing step 2, read this:
     - Use a powershell administrator mode terminal
@@ -159,7 +159,7 @@ Here are some general guidelines to observe when creating or modifying workflows
 - Request only the capability labels your job actually needs (see [Runner Labels](#runner-labels)). For example, `runs-on: [Windows, xdna2]` for NPU work, `runs-on: [Linux, vulkan, rocm]` for a job that exercises both GPU backends. Do not ask for `xdna2` or a GPU capability if your job is CPU-only — use `[self-hosted, Windows]` / `[self-hosted, Linux]`, or move the step to a GitHub-hosted runner like `runs-on: windows-latest` when possible.
 - Be very considerate about installing software on to the runners:
     - Installing software into the CWD (e.g., a path of `.\`) is always ok, because that will end up in `C:\actions-runner\_work\REPO`, which is always wiped between tests.
-    - Installing software into `AppData`, `Program Files`, etc. is not advisable because that software will persist across tests. See the [setup](#npu-runner-setup) section to see which software is already expected on the system.
+    - Installing software into `AppData`, `Program Files`, etc. is not advisable because that software will persist across tests. See the [setup](#new-runner-setup) section to see which software is already expected on the system.
 - Always create new virtual environments in the CWD, for example `python -m venv .venv`.
     - This way, the virtual environment is located in `C:\actions-runner\_work\REPO`, which is wiped between tests.
     - Make sure to activate your virtual environment before running any `pip install` commands. Otherwise your workflow will modify the system Python installation!
@@ -178,9 +178,3 @@ Here are some general guidelines to observe when creating or modifying workflows
         - Example: `$Env:HF_HOME=".\hf-cache"`
     - Place your Lemonade cache directory inside the `_work` directory so that it will be wiped after each job.
         - Example: Pass the cache dir as the first argument to `lemond`: `lemond .\ci-cache`
-
-# License
-
-[Apache 2.0 License](../LICENSE)
-
-Copyright(C) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.


### PR DESCRIPTION
Closes #1686

## Summary

- Replace `rai300_400` hardware label with capability-based labels (`vulkan`, `rocm`, `cuda`, `xdna2`) so each workflow requests exactly the capabilities it needs. Hardware labels like `stx-halo` remain valid when combined with a capability.
- Refactor `test-deb-inference` and `validate_llamacpp` `validate` to per-matrix `runner:` lists so each entry targets only what it uses.
- Rewrite the label-related sections of `docs/self_hosted_runners.md` to define the new label taxonomy and update setup, take-offline, and workflow-authoring guidance.

### Label mapping at a glance

| Job / test | New labels |
|---|---|
| `test-exe-inference` llamacpp | `[Windows, vulkan, rocm]` |
| `test-exe-inference` ryzenai / flm / whisper / flm-whisper | `[Windows, xdna2]` |
| `test-exe-inference` stable-diffusion (cpu) / text-to-speech | `[self-hosted, Windows]` |
| `test-exe-inference` stable-diffusion (stx-halo) | `[Windows, rocm, stx-halo]` |
| `test-deb-inference` llamacpp | `[Linux, vulkan, rocm]` |
| `test-deb-inference` stable-diffusion | `[Linux, rocm]` |
| `test-deb-inference` whisper | `[Linux, vulkan]` |
| `test-deb-inference` flm | `[Linux, xdna2]` |
| `test-deb-inference` text-to-speech | `[self-hosted, Linux]` |
| `validate_llamacpp` vulkan | `[self-hosted, Windows, 128gb, vulkan]` |
| `validate_llamacpp` rocm (stable/preview/nightly) | `[self-hosted, Windows, 128gb, rocm]` |

### Precondition before merge

Every runner in the `stx` group must carry the capability labels matching its hardware (`xdna2` + the GPU capabilities it actually supports). A workflow leg will sit queued if no runner in the pool has all the labels in its `runs-on` list.

Closes #1686

## Test plan

- [x] Verify every runner in the `stx` group has the correct capability labels (per the new *Typical label sets by hardware* table in the docs).
- [ ] Trigger `C++ Server Build, Test, and Release` manually and confirm each matrix leg in `test-exe-inference` and `test-deb-inference` lands on a runner whose labels include the set it requested.
- [ ] Trigger `Validate New llama.cpp Release` manually and confirm `vulkan`, `rocm` (stable/preview/nightly) legs each land on a runner carrying the matching capability label plus `128gb`.
- [ ] Re-read `docs/self_hosted_runners.md` Runner Labels + Take-a-laptop-offline sections and confirm the instructions match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)