### PR TITLE
pull: remove the variants cap in cli and gui

### DIFF
--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -61,12 +61,22 @@ void trim(std::string& s) {
 // of them) or a free-text variant name (e.g. "UD-IQ2_M" or a full filename),
 // which is passed straight through to /v1/pull. Returns the chosen variant
 // name in `out`. Returns false on EOF or empty input.
-bool prompt_variant(const std::vector<std::string>& labels,
-                    const std::vector<std::string>& names,
-                    std::string& out) {
+constexpr size_t kShortVariantMenuLimit = 5;
+
+bool prompt_variant_menu(const std::vector<std::string>& labels,
+                         const std::vector<std::string>& names,
+                         std::string& out,
+                         bool show_all) {
+    const size_t visible_count =
+        show_all ? labels.size() : std::min(labels.size(), kShortVariantMenuLimit);
+
     std::cout << "Select a variant:" << std::endl;
-    for (size_t i = 0; i < labels.size(); ++i) {
+    for (size_t i = 0; i < visible_count; ++i) {
         std::cout << "  " << (i + 1) << ") " << labels[i] << std::endl;
+    }
+    if (!show_all && labels.size() > visible_count) {
+        std::cout << "  " << (visible_count + 1) << ") Browse all "
+                  << labels.size() << " variants" << std::endl;
     }
     std::cout << "Enter number, or type any variant name: " << std::flush;
 
@@ -78,12 +88,15 @@ bool prompt_variant(const std::vector<std::string>& labels,
         return false;
     }
 
-    // Try to parse as a number first.
     size_t parsed_chars = 0;
     try {
         int selected = std::stoi(input, &parsed_chars);
         if (parsed_chars == input.size()) {
-            if (selected < 1 || static_cast<size_t>(selected) > names.size()) {
+            if (!show_all && labels.size() > visible_count &&
+                selected == static_cast<int>(visible_count + 1)) {
+                return prompt_variant_menu(labels, names, out, true);
+            }
+            if (selected < 1 || static_cast<size_t>(selected) > visible_count) {
                 std::cerr << "Error: selection out of range." << std::endl;
                 return false;
             }
@@ -96,6 +109,12 @@ bool prompt_variant(const std::vector<std::string>& labels,
 
     out = input;
     return true;
+}
+
+bool prompt_variant(const std::vector<std::string>& labels,
+                    const std::vector<std::string>& names,
+                    std::string& out) {
+    return prompt_variant_menu(labels, names, out, false);
 }
 
 bool prompt_model_name(const std::string& default_name, std::string& out) {

--- a/src/cpp/include/lemon/hf_variants.h
+++ b/src/cpp/include/lemon/hf_variants.h
@@ -33,8 +33,7 @@ struct GgufVariantSet {
 // for the GGUF branch.
 GgufVariantSet enumerate_gguf_variants(
     const std::vector<std::string>& repo_files,
-    const std::vector<std::pair<std::string, uint64_t>>& file_sizes = {},
-    size_t max_variants = 0);
+    const std::vector<std::pair<std::string, uint64_t>>& file_sizes = {});
 
 // Build the JSON response body for GET /api/v{0,1}/pull/variants.
 //

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -77,17 +77,11 @@ int quant_priority(const std::string& q) {
     return it == priority.end() ? 100 : it->second;
 }
 
-// Maximum number of variants returned by the endpoint. The CLI menu
-// supplements this with a free-text "type any variant" option for users who
-// need a quant that didn't make the top-N cut.
-constexpr size_t kMaxVariants = 5;
-
 }  // namespace
 
 GgufVariantSet enumerate_gguf_variants(
     const std::vector<std::string>& repo_files,
-    const std::vector<std::pair<std::string, uint64_t>>& file_sizes,
-    size_t max_variants) {
+    const std::vector<std::pair<std::string, uint64_t>>& file_sizes) {
     GgufVariantSet result;
 
     std::unordered_map<std::string, uint64_t> size_by_file;
@@ -190,13 +184,6 @@ GgufVariantSet enumerate_gguf_variants(
                   return a.name < b.name;
               });
 
-    // Cap to the top-N variants. The CLI surfaces a free-text option so the
-    // user can still install any quant they like, even if it didn't make the
-    // shortlist.
-    if (max_variants > 0 && result.variants.size() > max_variants) {
-        result.variants.resize(max_variants);
-    }
-
     return result;
 }
 
@@ -291,7 +278,7 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
         return out;
     }
 
-    auto vset = enumerate_gguf_variants(repo_files, file_sizes, kMaxVariants);
+    auto vset = enumerate_gguf_variants(repo_files, file_sizes);
     if (vset.variants.empty()) {
         throw std::runtime_error("No supported model files (.gguf or ONNX RyzenAI) found in repository " + checkpoint);
     }


### PR DESCRIPTION
closes #1599

## GUI Demo

<img width="898" height="1036" alt="image" src="https://github.com/user-attachments/assets/0c23c74f-d42c-439d-889a-df421c860f14" />


## CLI Demo

```
jfowers@jfowers-GMK:~/lsdk/lemonade$ build/lemonade pull unsloth/Qwen3-0.6B-GGUF
Select a variant:
  1) Q4_K_M  (1 file, 378.3 MB)
  2) UD-Q4_K_XL  (1 file, 386.6 MB)
  3) Q8_0  (1 file, 609.8 MB)
  4) Q4_0  (1 file, 364.5 MB)
  5) BF16  (1 file, 1.1 GB)
  6) Browse all 26 variants
Enter number, or type any variant name: 6
Select a variant:
  1) Q4_K_M  (1 file, 378.3 MB)
  2) UD-Q4_K_XL  (1 file, 386.6 MB)
  3) Q8_0  (1 file, 609.8 MB)
  4) Q4_0  (1 file, 364.5 MB)
  5) BF16  (1 file, 1.1 GB)
  6) IQ4_NL  (1 file, 363.9 MB)
  7) IQ4_XS  (1 file, 350.8 MB)
  8) Q2_K  (1 file, 282.5 MB)
  9) Q2_K_L  (1 file, 282.5 MB)
  10) Q3_K_M  (1 file, 331.0 MB)
  11) Q3_K_S  (1 file, 308.1 MB)
  12) Q4_1  (1 file, 390.1 MB)
  13) Q4_K_S  (1 file, 365.5 MB)
  14) Q5_K_M  (1 file, 423.8 MB)
  15) Q5_K_S  (1 file, 416.4 MB)
  16) Q6_K  (1 file, 472.2 MB)
  17) UD-IQ1_M  (1 file, 210.5 MB)
  18) UD-IQ1_S  (1 file, 204.7 MB)
  19) UD-IQ2_M  (1 file, 256.3 MB)
  20) UD-IQ2_XXS  (1 file, 223.2 MB)
  21) UD-IQ3_XXS  (1 file, 269.0 MB)
  22) UD-Q2_K_XL  (1 file, 287.7 MB)
  23) UD-Q3_K_XL  (1 file, 340.1 MB)
  24) UD-Q5_K_XL  (1 file, 425.7 MB)
  25) UD-Q6_K_XL  (1 file, 549.8 MB)
  26) UD-Q8_K_XL  (1 file, 805.2 MB)
Enter number, or type any variant name: 17
Choose a model name.
Press enter to use the default: user.Qwen3-0.6B-GGUF-UD-IQ1_M
Or type a name starting with "user." and press enter:
> 
Pulling unsloth/Qwen3-0.6B-GGUF:UD-IQ1_M as user.Qwen3-0.6B-GGUF-UD-IQ1_M
Pulling model: user.Qwen3-0.6B-GGUF-UD-IQ1_M
Total: 0.2 GB, 2 files
[1/2] Qwen3-0.6B-UD-IQ1_M.gguf (210.5 MB)
  Progress: 100% (210.5/210.5 MB) 86.2 MB/s    [2/2] config.json (0.0 MB)
  Progress: 100% (0.0/0.0 MB)    
Model pulled successfully: user.Qwen3-0.6B-GGUF-UD-IQ1_M
```