### PR TITLE
Prefer system backend by default generally

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -13,10 +13,3 @@ override_dh_auto_test:
 
 override_dh_install:
 	dh_install
-	# On Ubuntu, prefer system llama.cpp by default
-ifeq (yes,$(shell dpkg-vendor --derives-from Ubuntu 2>/dev/null && echo yes))
-	jq '.llamacpp.prefer_system = true' debian/lemonade-server/usr/share/lemonade/defaults.json \
-		> debian/lemonade-server/usr/share/lemonade/defaults.json.tmp && \
-		mv debian/lemonade-server/usr/share/lemonade/defaults.json.tmp \
-		debian/lemonade-server/usr/share/lemonade/defaults.json
-endif

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -18,7 +18,7 @@
   "llamacpp": {
     "backend": "auto",
     "args": "",
-    "prefer_system": false,
+    "prefer_system": true,
     "rocm_bin": "builtin",
     "vulkan_bin": "builtin",
     "cpu_bin": "builtin"


### PR DESCRIPTION
It's a relatively high bar to overcome to install a system llama.cpp and GGML backend for HIP.  Users or packagers that have done this will likely want to be using the system llama.cpp anyway.

Prefer that by default.