### PR TITLE
Add bonsai family of models

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -713,8 +713,7 @@
         "recipe": "llamacpp",
         "suggested": true,
         "labels": [
-            "llamacpp",
-	        "hot"
+            "llamacpp"
         ],
         "size": 1.2
     },

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -708,6 +708,33 @@
         ],
         "size": 3.1
     },
+    "Bonsai-8B-gguf": {
+        "checkpoint": "prism-ml/Bonsai-8B-gguf:Q1_0",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "llamacpp"
+        ],
+        "size": 1.2
+    },
+    "Bonsai-4B-gguf": {
+        "checkpoint": "prism-ml/Bonsai-4B-gguf:Q1_0",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "llamacpp"
+        ],
+        "size": 0.6
+    },
+    "Bonsai-1.7B-gguf": {
+        "checkpoint": "prism-ml/Bonsai-1.7B-gguf:Q1_0",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "llamacpp"
+        ],
+        "size": 0.25
+    },
     "Phi-4-mini-instruct-GGUF": {
         "checkpoint": "unsloth/Phi-4-mini-instruct-GGUF:Phi-4-mini-instruct-Q4_K_M.gguf",
         "recipe": "llamacpp",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -713,7 +713,8 @@
         "recipe": "llamacpp",
         "suggested": true,
         "labels": [
-            "llamacpp"
+            "llamacpp",
+	        "hot"
         ],
         "size": 1.2
     },


### PR DESCRIPTION
Adds PrismML's 1 bit bonsai family of models.

<img width="1500" height="680" alt="image" src="https://github.com/user-attachments/assets/1af5d3af-6055-4e5f-89b4-08d6e7165de8" />