### PR TITLE
macOS: use posix_spawn instead of fork+exec for child processes and patch HOME so its not null and doesn't throws a segfault in llama.cpp 

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -6,7 +6,7 @@
     "rocm-stable": "b8653",
     "rocm-preview": "b8705",
     "rocm-nightly": "b1238",
-    "metal": "b8460",
+    "metal": "b8884",
     "cpu": "b8766"
   },
   "whispercpp": {

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -438,6 +438,11 @@ void LlamaCppServer::load(const std::string& model_name,
     // get a minimal env from launchd and do not inherit HOME, so llama-server
     // crashes before the model ever loads. Terminal/sudo spawns preserve
     // HOME and do not hit this.
+    //
+    // Upstream fix in flight: https://github.com/ggml-org/llama.cpp/pull/22263
+    // Once that PR merges and lemonade's pinned llama.cpp version (in
+    // src/cpp/resources/backend_versions.json) includes it, this HOME
+    // fallback can be deleted.
     const char* home = std::getenv("HOME");
     if (!home || home[0] == '\0') {
         struct passwd* pw = getpwuid(getuid());

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -13,6 +13,10 @@
 #include <lemon/utils/aixlog.hpp>
 #include <cstdlib>
 #include <set>
+#ifdef __APPLE__
+#include <pwd.h>
+#include <unistd.h>
+#endif
 
 #ifdef _WIN32
     #include <windows.h>
@@ -424,6 +428,22 @@ void LlamaCppServer::load(const std::string& model_name,
     if (no_residency) {
         env_vars.push_back({"GGML_METAL_NO_RESIDENCY", no_residency});
         LOG(DEBUG, "LlamaCpp") << "Forwarding GGML_METAL_NO_RESIDENCY=" << no_residency << std::endl;
+    }
+
+    // Ensure HOME is set in the child. llama.cpp b8884+ (libllama-common's
+    // fs_get_cache_directory / hf_cache::migrate_old_cache_to_hf_cache)
+    // calls getenv("HOME") during CLI arg parsing and passes the result
+    // straight into std::string without a NULL check, segfaulting when
+    // HOME is unset. LaunchDaemons installed at /Library/LaunchDaemons/
+    // get a minimal env from launchd and do not inherit HOME, so llama-server
+    // crashes before the model ever loads. Terminal/sudo spawns preserve
+    // HOME and do not hit this.
+    const char* home = std::getenv("HOME");
+    if (!home || home[0] == '\0') {
+        struct passwd* pw = getpwuid(getuid());
+        std::string fallback_home = (pw && pw->pw_dir) ? pw->pw_dir : "/var/root";
+        env_vars.push_back({"HOME", fallback_home});
+        LOG(DEBUG, "LlamaCpp") << "Parent HOME unset; setting child HOME=" << fallback_home << std::endl;
     }
 #endif
 

--- a/src/cpp/server/utils/process_manager.cpp
+++ b/src/cpp/server/utils/process_manager.cpp
@@ -39,6 +39,10 @@
 #ifdef __linux__
 #include <sys/prctl.h>  // PR_SET_PDEATHSIG — kill child when parent dies
 #endif
+#ifdef __APPLE__
+#include <spawn.h>      // posix_spawn — fork-safe child creation on macOS
+extern char** environ;
+#endif
 #ifdef HAVE_LIBCAP
 #include <sys/capability.h>
 #endif
@@ -432,6 +436,106 @@ ProcessHandle ProcessManager::start_process(
         }
     }
 
+#if defined(__APPLE__)
+    // macOS: use posix_spawn instead of fork()+execvp().
+    //
+    // Apple has long documented that fork() is unsafe when the parent process
+    // has initialized higher-level frameworks (CoreFoundation / Security /
+    // Metal / XPC / libdispatch). The child inherits Mach-port rights and
+    // XPC-bootstrap handles that cannot be cleanly reset, and execvp() does
+    // not scrub that process-level state. The result is silent corruption
+    // of services reached via XPC — most visibly MTLCompilerService, which
+    // llama-server's ggml-metal probe depends on in builds from b8884+.
+    // posix_spawn is Apple's supported path for clean child creation.
+    posix_spawn_file_actions_t file_actions;
+    posix_spawn_file_actions_init(&file_actions);
+
+    if (inherit_output && filter_health_logs) {
+        posix_spawn_file_actions_addclose(&file_actions, stdout_pipe[0]);
+        posix_spawn_file_actions_addclose(&file_actions, stderr_pipe[0]);
+        posix_spawn_file_actions_adddup2(&file_actions, stdout_pipe[1], STDOUT_FILENO);
+        posix_spawn_file_actions_adddup2(&file_actions, stderr_pipe[1], STDERR_FILENO);
+        posix_spawn_file_actions_addclose(&file_actions, stdout_pipe[1]);
+        posix_spawn_file_actions_addclose(&file_actions, stderr_pipe[1]);
+    } else if (!inherit_output) {
+        posix_spawn_file_actions_addopen(&file_actions, STDOUT_FILENO, "/dev/null", O_WRONLY, 0);
+        posix_spawn_file_actions_adddup2(&file_actions, STDOUT_FILENO, STDERR_FILENO);
+    }
+
+    if (!working_dir.empty()) {
+        // `addchdir_np` is deprecated on macOS 26+ in favor of the portable
+        // `addchdir`, but `addchdir` is not declared by older SDKs we still
+        // build against. Keep the Darwin-specific call and suppress the
+        // deprecation warning until the minimum SDK is macOS 26.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        posix_spawn_file_actions_addchdir_np(&file_actions, working_dir.c_str());
+#pragma clang diagnostic pop
+    }
+
+    posix_spawnattr_t attr;
+    posix_spawnattr_init(&attr);
+    // CLOEXEC_DEFAULT (Apple extension): every FD in the parent is closed in
+    // the child unless explicitly re-added via file_actions. This plugs FD
+    // leaks of listening sockets, log files, and kqueue handles.
+    // SETSIGDEF + full sigset: reset any SIG_IGN the parent installed
+    // (notably SIGPIPE) so the child starts with default dispositions.
+    sigset_t default_signals;
+    sigfillset(&default_signals);
+    posix_spawnattr_setsigdefault(&attr, &default_signals);
+    posix_spawnattr_setflags(&attr, POSIX_SPAWN_CLOEXEC_DEFAULT | POSIX_SPAWN_SETSIGDEF);
+
+    // Build envp: parent environ minus any keys we override, plus env_vars.
+    std::vector<std::string> env_strings;
+    for (char** e = environ; e && *e; ++e) {
+        bool override_existing = false;
+        for (const auto& env_pair : env_vars) {
+            std::string prefix = env_pair.first + "=";
+            if (std::strncmp(*e, prefix.c_str(), prefix.size()) == 0) {
+                override_existing = true;
+                break;
+            }
+        }
+        if (!override_existing) {
+            env_strings.emplace_back(*e);
+        }
+    }
+    for (const auto& env_pair : env_vars) {
+        env_strings.emplace_back(env_pair.first + "=" + env_pair.second);
+    }
+    std::vector<char*> envp;
+    envp.reserve(env_strings.size() + 1);
+    for (auto& s : env_strings) {
+        envp.push_back(&s[0]);
+    }
+    envp.push_back(nullptr);
+
+    std::vector<char*> argv_ptrs;
+    argv_ptrs.reserve(args.size() + 2);
+    argv_ptrs.push_back(const_cast<char*>(executable.c_str()));
+    for (const auto& arg : args) {
+        argv_ptrs.push_back(const_cast<char*>(arg.c_str()));
+    }
+    argv_ptrs.push_back(nullptr);
+
+    pid_t pid = 0;
+    int spawn_rc = posix_spawnp(&pid, executable.c_str(), &file_actions, &attr,
+                                argv_ptrs.data(), envp.data());
+
+    posix_spawn_file_actions_destroy(&file_actions);
+    posix_spawnattr_destroy(&attr);
+
+    if (spawn_rc != 0) {
+        if (inherit_output && filter_health_logs) {
+            close(stdout_pipe[0]);
+            close(stdout_pipe[1]);
+            close(stderr_pipe[0]);
+            close(stderr_pipe[1]);
+        }
+        throw std::runtime_error(
+            std::string("posix_spawn failed: ") + strerror(spawn_rc));
+    }
+#else
     pid_t pid = fork();
 
     if (pid < 0) {
@@ -495,6 +599,7 @@ ProcessHandle ProcessManager::start_process(
         std::cerr << "Failed to execute: " << executable << std::endl;
         _exit(1);
     }
+#endif
 
     // Parent process
     handle.pid = pid;

--- a/test/server_env_vars.py
+++ b/test/server_env_vars.py
@@ -170,15 +170,19 @@ class TestConfigEnvVars(unittest.TestCase):
     def test_ctx_size(self):
         self.assertEqual(self.snapshot["ctx_size"], 2048)
 
+    @unittest.skipIf(IS_MACOS, "llamacpp backend selection not applicable on macOS")
     def test_llamacpp_backend(self):
         self.assertEqual(self.snapshot["llamacpp"]["backend"], "cpu")
 
+    @unittest.skipIf(IS_MACOS, "llamacpp args not applicable on macOS")
     def test_llamacpp_args(self):
         self.assertEqual(self.snapshot["llamacpp"]["args"], "--flash-attn on")
 
+    @unittest.skipIf(IS_MACOS, "whispercpp backend selection not applicable on macOS")
     def test_whispercpp_backend(self):
         self.assertEqual(self.snapshot["whispercpp"]["backend"], "cpu")
 
+    @unittest.skipIf(IS_MACOS, "whispercpp args not applicable on macOS")
     def test_whispercpp_args(self):
         self.assertEqual(self.snapshot["whispercpp"]["args"], "--convert")
 

--- a/test/server_env_vars.py
+++ b/test/server_env_vars.py
@@ -170,23 +170,18 @@ class TestConfigEnvVars(unittest.TestCase):
     def test_ctx_size(self):
         self.assertEqual(self.snapshot["ctx_size"], 2048)
 
-    @unittest.skipIf(IS_MACOS, "llamacpp backend selection not applicable on macOS")
     def test_llamacpp_backend(self):
         self.assertEqual(self.snapshot["llamacpp"]["backend"], "cpu")
 
-    @unittest.skipIf(IS_MACOS, "llamacpp args not applicable on macOS")
     def test_llamacpp_args(self):
         self.assertEqual(self.snapshot["llamacpp"]["args"], "--flash-attn on")
 
-    @unittest.skipIf(IS_MACOS, "whispercpp backend selection not applicable on macOS")
     def test_whispercpp_backend(self):
         self.assertEqual(self.snapshot["whispercpp"]["backend"], "cpu")
 
-    @unittest.skipIf(IS_MACOS, "whispercpp args not applicable on macOS")
     def test_whispercpp_args(self):
         self.assertEqual(self.snapshot["whispercpp"]["args"], "--convert")
 
-    @unittest.skipIf(IS_MACOS, "FLM is NPU-only, not available on macOS")
     def test_flm_args(self):
         self.assertEqual(self.snapshot["flm"]["args"], "--socket 20")
 

--- a/test/server_env_vars.py
+++ b/test/server_env_vars.py
@@ -182,6 +182,7 @@ class TestConfigEnvVars(unittest.TestCase):
     def test_whispercpp_args(self):
         self.assertEqual(self.snapshot["whispercpp"]["args"], "--convert")
 
+    @unittest.skipIf(IS_MACOS, "FLM is NPU-only, not available on macOS")
     def test_flm_args(self):
         self.assertEqual(self.snapshot["flm"]["args"], "--socket 20")
 


### PR DESCRIPTION
Problem: lemond spawns llama-server via fork()+execvp(). On macOS, fork() leaves the child with corrupted Mach-port and XPC-bootstrap state that execvp() does not reset. llama.cpp b8884+ now runs a ggml-metal probe at startup that calls [MTLDevice newLibraryWithSource:] — which routes through MTLCompilerService XPC — and dies on the broken channel before the model is opened. Direct terminal runs work; only lemond-spawned children fail (~130ms, exit code -1).

Fix: on __APPLE__, replace fork()+execvp() with posix_spawn. Preserves pipe/working-dir semantics. Adds POSIX_SPAWN_CLOEXEC_DEFAULT to avoid leaking lemond FDs into the child, and POSIX_SPAWN_SETSIGDEF to reset inherited SIG_IGN dispositions. Linux and Windows paths unchanged.