### PR TITLE
Modify fallback logic for GGUF variant handling

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -811,8 +811,11 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
             }
         }
 
-        // No match found - return first file as fallback
-        return all_gguf_files[0];
+        // No match found for the requested GGUF variant. Do not fall back to
+        // another quantization in the same Hugging Face repo; otherwise a
+        // custom download with a different quant can make a built-in model
+        // appear downloaded and allow deleting the wrong file.
+        return "";
     }
 
     // Everything else


### PR DESCRIPTION
When a model with the same name as one of Lemonade's "recommended" models with a different quant is downloaded, the UI shows that I've also downloaded the recommended quant
<img width="473" height="463" alt="image" src="https://github.com/user-attachments/assets/281a86e6-3534-43ec-9413-bee06931a3c2" />

Deleting the "recommended" one also deletes the user.  (as noted by BiSkiT on discord)

This can be very frustrating and should be fixed.