### PR TITLE
Consolidate sd ci jobs and remove stx-halo requirement

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -759,18 +759,13 @@ jobs:
           - name: stable-diffusion
             script: server_sd.py
             extra_args: ""
-            backends: "cpu"
-            runner: [self-hosted, Windows]
+            backends: "cpu rocm"
+            runner: [Windows, rocm]
           - name: text-to-speech
             script: server_tts.py
             extra_args: ""
             backends: ""
             runner: [self-hosted, Windows]
-          - name: stable-diffusion (stx-halo)
-            script: server_sd.py
-            extra_args: ""
-            backends: "rocm"
-            runner: [Windows, rocm, stx-halo]
     env:
       LEMONADE_CI_MODE: "True"
       LEMONADE_CACHE_DIR: ".\\ci-cache"


### PR DESCRIPTION
Alternative to https://github.com/lemonade-sdk/lemonade/pull/1724 that consolidates the CPU and ROCm jobs onto the same runner, in the same style as the other tests.