### PR TITLE
docs(docker): document Web UI logs setup by exposing WebSocket port

### DIFF
--- a/src/cpp/DOCKER_GUIDE.md
+++ b/src/cpp/DOCKER_GUIDE.md
@@ -370,5 +370,17 @@ Server not starting: Check logs with:
 docker logs lemonade-server
 ```
 
+If you want to view the logs on the web UI, you need to expose the websocket port as well:
+
+```bash
+docker run -d \
+  --name lemonade-server \
+  -p 13305:13305 \
+  -p 9000:9000 \
+  -v lemonade-cache:/root/.cache/huggingface \
+  -v lemonade-llama:/opt/lemonade/llama \
+  ghcr.io/lemonade-sdk/lemonade-server:latest
+```
+
 - Model download fails: Ensure /root/.cache/huggingface volume is writable
 - Vulkan errors on CPU-only machine: The server will fallback to CPU backend automatically


### PR DESCRIPTION
### Summary
This PR updates the Docker guide to explain how to view server logs in the web UI when running Lemonade in a container.

#### Why
Users can start the container successfully but still miss web UI logs if only the API port is published. This clarifies the required port mapping and reduces setup confusion.

#### Scope
Documentation only