### PR TITLE
Fix a return before closing file descriptor on linux npu utilization check.

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3404,6 +3404,7 @@ double Server::get_npu_utilization() {
             std::string state;
             if (power_file >> state) {
                 if (state != "D0") {
+                    close(fd);
                     return 0.0;
                 }
             }


### PR DESCRIPTION
On the linux NPU utilization path, when power_state != D0 we returned 0.0 without closing the /dev/accel/accel0 fd that was opened a few lines earlier. Stats endpoints poll this regularly while the NPU is asleep, so it leaked one fd per call.