### PR TITLE
fix(whisper): honor global_timeout instead of hard-coded 300s

### DIFF
--- a/src/cpp/server/backends/whisper_server.cpp
+++ b/src/cpp/server/backends/whisper_server.cpp
@@ -504,7 +504,11 @@ json WhisperServer::forward_multipart_audio_request(const std::string& file_path
     const std::string url = "http://127.0.0.1:" + std::to_string(port_) + "/inference";
     LOG(DEBUG, "WhisperServer") << "Sending multipart request to " << url << std::endl;
 
-    auto res = utils::HttpClient::post_multipart(url, fields, 300);
+    // Pass 0 so HttpClient falls back to its default timeout, which is kept in
+    // sync with `global_timeout` in config.json (see server.cpp). Hard-coding 300
+    // caused long-form audio (~35+ min on slower backends) to fail regardless of
+    // the user's configuration.
+    auto res = utils::HttpClient::post_multipart(url, fields, 0);
 
     LOG(DEBUG, "WhisperServer") << "Response status: " << res.status_code << std::endl;
     LOG(DEBUG, "WhisperServer") << "Response body: " << res.body << std::endl;
@@ -591,7 +595,9 @@ json WhisperServer::forward_multipart_audio_data(const std::string& audio_data,
     const std::string url = "http://127.0.0.1:" + std::to_string(port_) + "/inference";
     LOG(DEBUG, "WhisperServer") << "Sending multipart request to " << url << " (direct data)" << std::endl;
 
-    auto res = utils::HttpClient::post_multipart(url, fields, 300);
+    // See the note on the file-path variant above: 0 inherits the configured
+    // global timeout so long transcriptions aren't artificially capped at 300s.
+    auto res = utils::HttpClient::post_multipart(url, fields, 0);
 
     LOG(DEBUG, "WhisperServer") << "Response status: " << res.status_code << std::endl;
 


### PR DESCRIPTION
## Summary

Closes #1736.

`WhisperServer::forward_multipart_audio_request` and `forward_multipart_audio_data` both hard-coded a 300-second timeout when forwarding to the internal `whisper-server`:

```cpp
auto res = utils::HttpClient::post_multipart(url, fields, 300);
```

This causes transcription of long-form audio (≳35 min on slower Vulkan backends) to reliably fail with HTTP 500 / `"CURL error: Timeout was reached"`, regardless of `global_timeout` in `config.json`.

## Fix

Pass `0` instead of the literal `300`. `HttpClient::post_multipart` already treats `0` as "use the default":

https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/server/utils/http_client.cpp#L202

```cpp
curl_easy_setopt(curl, CURLOPT_TIMEOUT,
                 timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_.load());
```

…and `server.cpp` already keeps `default_timeout_seconds_` in sync with `config_->global_timeout()` on startup and on config changes. No plumbing of `RuntimeConfig` through `WhisperServer` is needed — just stop shadowing the configured value.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Default config (`global_timeout=300`) | 300s cap | 300s cap (unchanged) |
| User sets `global_timeout=1800` | still 300s cap (bug) | 1800s cap |
| Short audio (<35 min at 14× RT) | works | works |
| Long audio that would exceed `global_timeout` | fails mid-stream | fails at configured timeout |

No functional regression for users on defaults; fixes the documented knob for users who need longer.

## Testing

Build verified locally (`cmake --build --preset default --target lemond`). I didn't run the integration test suite against the patched binary because my local test harness was fighting the systemd unit's ownership model; logical correctness follows from the existing `HttpClient` semantics cited above, and CI will cover the rest.

The original reproduction from #1736:

```bash
curl -sS -X POST http://localhost:13305/v1/audio/transcriptions \
  -F "file=@long.wav;type=audio/wav" \
  -F "model=Whisper-Large-v3-Turbo" \
  -F "response_format=verbose_json" --max-time 2000 \
  -w "\nHTTP %{http_code}  total=%{time_total}s\n"
```

fails with `total=300.7s` on main regardless of `global_timeout`. With this patch and `global_timeout=1800`, it should proceed to actual inference completion (~380s on a 90-min audio on Vulkan iGPU in the reporter's setup).

Signed-off-by: Murilo Vasconcelos <muriloime@gmail.com>