### PR TITLE
Fix realtime stop commit after VAD final

### DIFF
--- a/src/app/src/renderer/hooks/useVoiceTranscription.ts
+++ b/src/app/src/renderer/hooks/useVoiceTranscription.ts
@@ -94,8 +94,15 @@ export function useVoiceTranscription({
     wsToCloseRef.current?.close();
   }, []);
 
-  // Manual-stop path: commit buffered audio so the server transcribes it, then
-  // keep the socket alive until the 'completed' response arrives.
+  const closeCommittedWs = useCallback(() => {
+    if (wsToCloseRef.current) {
+      wsToCloseRef.current.close();
+      wsToCloseRef.current = null;
+    }
+  }, []);
+
+  // Manual-stop path: ask the server to finish any active VAD speech window,
+  // then keep the socket alive until the server replies with completed/cleared.
   const closeWs = useCallback(() => {
     if (wsClientRef.current) {
       wsClientRef.current.commitAudio();
@@ -127,13 +134,12 @@ export function useVoiceTranscription({
     setInputValueRef.current(newValue);
     if (textareaRef?.current) adjustTextareaHeight(textareaRef.current);
 
-    // After manual stop the committed buffer produces one last 'completed' —
-    // close the socket cleanly once it arrives.
+    // After manual stop, close the socket once the server finishes or discards
+    // the pending buffer.
     if (isFinal && !isRecordingRef.current && wsToCloseRef.current) {
-      wsToCloseRef.current.close();
-      wsToCloseRef.current = null;
+      closeCommittedWs();
     }
-  }, [textareaRef]);
+  }, [textareaRef, closeCommittedWs]);
 
   const start = useCallback(async () => {
     if (!activeModel) {
@@ -157,6 +163,7 @@ export function useVoiceTranscription({
       wsClientRef.current = await TranscriptionWebSocket.connect(modelToUse, {
         onTranscription: handleTranscription,
         onSpeechEvent: () => {},
+        onAudioBufferCleared: closeCommittedWs,
         onError: (err) => onError(err),
       });
       await new Promise(r => setTimeout(r, 500));

--- a/src/app/src/renderer/utils/websocketClient.ts
+++ b/src/app/src/renderer/utils/websocketClient.ts
@@ -9,6 +9,7 @@ export interface TranscriptionCallbacks {
   onTranscription: (text: string, isFinal: boolean) => void;
   onSpeechEvent: (event: 'started' | 'stopped') => void;
   onError?: (error: string) => void;
+  onAudioBufferCleared?: () => void;
   onConnected?: () => void;
   onDisconnected?: () => void;
 }
@@ -61,6 +62,9 @@ export class TranscriptionWebSocket {
             break;
           case 'input_audio_buffer.speech_stopped':
             callbacks.onSpeechEvent('stopped');
+            break;
+          case 'input_audio_buffer.cleared':
+            callbacks.onAudioBufferCleared?.();
             break;
           case 'conversation.item.input_audio_transcription.delta':
             // Interim result - replaces previous interim text

--- a/src/cpp/include/lemon/realtime_session.h
+++ b/src/cpp/include/lemon/realtime_session.h
@@ -44,6 +44,7 @@ struct RealtimeSession {
 
     // Timestamps for audio tracking
     int64_t audio_start_ms = 0;  // Start of current speech segment
+    std::atomic<bool> vad_speech_window_open{false};
 
     // Interim transcription state
     int64_t last_interim_transcription_ms = 0;  // When we last fired an interim transcription

--- a/src/cpp/server/realtime_session.cpp
+++ b/src/cpp/server/realtime_session.cpp
@@ -56,6 +56,7 @@ void RealtimeSessionManager::apply_turn_detection_config(
         session->turn_detection_enabled = false;
         session->turn_detection_config = nullptr;
         session->vad.reset();
+        session->vad_speech_window_open = false;
         session->last_interim_transcription_ms = 0;
         return;
     }
@@ -213,6 +214,7 @@ void RealtimeSessionManager::process_vad(std::shared_ptr<RealtimeSession> sessio
         case SimpleVAD::Event::SpeechStart: {
             LOG(DEBUG, "RealtimeSession") << "VAD: SpeechStart detected" << std::endl;
             session->audio_start_ms = session->vad.speech_start_ms();
+            session->vad_speech_window_open = true;
             session->last_interim_transcription_ms = 0;  // Reset interim tracking for new utterance
 
             if (session->send_message) {
@@ -238,6 +240,7 @@ void RealtimeSessionManager::process_vad(std::shared_ptr<RealtimeSession> sessio
             }
 
             // Trigger final transcription (clears buffer)
+            session->vad_speech_window_open = false;
             transcribe_and_send(session);
             break;
         }
@@ -307,7 +310,30 @@ void RealtimeSessionManager::transcribe_interim(std::shared_ptr<RealtimeSession>
 
 void RealtimeSessionManager::commit_audio(const std::string& session_id) {
     auto session = get_session(session_id);
-    if (!session || session->audio_buffer.empty()) {
+    if (!session) {
+        return;
+    }
+
+    if (session->turn_detection_enabled.load() && !session->vad_speech_window_open.load()) {
+        if (!session->audio_buffer.empty()) {
+            LOG(DEBUG, "RealtimeSession")
+                << "Ignoring commit with no active VAD speech window; clearing buffered audio"
+                << std::endl;
+        }
+        session->audio_buffer.clear();
+        session->vad.reset();
+        session->last_interim_transcription_ms = 0;
+
+        if (session->send_message) {
+            json msg = {
+                {"type", "input_audio_buffer.cleared"}
+            };
+            session->send_message(msg);
+        }
+        return;
+    }
+
+    if (session->audio_buffer.empty()) {
         return;
     }
 
@@ -320,6 +346,7 @@ void RealtimeSessionManager::commit_audio(const std::string& session_id) {
     }
 
     // Trigger transcription
+    session->vad_speech_window_open = false;
     transcribe_and_send(session);
 }
 
@@ -331,6 +358,7 @@ void RealtimeSessionManager::clear_audio(const std::string& session_id) {
 
     session->audio_buffer.clear();
     session->vad.reset();
+    session->vad_speech_window_open = false;
 
     if (session->send_message) {
         json msg = {
@@ -350,6 +378,7 @@ void RealtimeSessionManager::transcribe_and_send(std::shared_ptr<RealtimeSession
     std::string model = session->model;
     session->audio_buffer.clear();
     session->vad.reset();
+    session->vad_speech_window_open = false;
     session->last_interim_transcription_ms = 0;  // Reset for next utterance
 
     // Dispatch transcription to worker thread so it doesn't block the WebSocket callback


### PR DESCRIPTION
Alternative to #1737

## Root cause

Realtime mic capture keeps appending audio after VAD has already detected `SpeechEnd` and finalized the real utterance. The GUI then sends `input_audio_buffer.commit` when the mic button is clicked to stop recording. The server treated any non-empty buffer as transcribable speech, so the post-VAD silence/noise tail was sent to Whisper and could hallucinate text such as `Thank you.` or `[BLANK_AUDIO]`.

## Fix

Track whether VAD currently has an open speech window. With turn detection enabled, `commit` now only transcribes if that window is still open. If VAD already finalized the utterance, the server clears the leftover buffer and sends OpenAI-compatible `input_audio_buffer.cleared`. The GUI handles that event as a valid stop response and closes the pending websocket.

## Validation

Observed log after the fix (see last log line):

```text
2026-04-25 13:34:13.456 [Info] (WebSocket) New connection from: 127.0.0.1 (id: 12)
2026-04-25 13:34:14.492 [Debug] (RealtimeSession) VAD: SpeechStart detected
2026-04-25 13:34:15.005 [Debug] (RealtimeSession) Firing interim transcription at 1023ms
2026-04-25 13:34:15.005 [Debug] (RealtimeSession) Calling Whisper interim transcription (32804 bytes)...
2026-04-25 13:34:15.005 [Debug] (WhisperServer) Audio data size: 32804 bytes (no file I/O)
2026-04-25 13:34:15.005 [Debug] (WhisperServer) Sending multipart request to http://127.0.0.1:8003/inference (direct data)
2026-04-25 13:34:15.234 [Debug] (WhisperServer) Response status: 200
2026-04-25 13:34:15.234 [Debug] (RealtimeSession) Whisper interim response: {"text":" - Put a hat.\n"}
2026-04-25 13:34:15.234 [Debug] (RealtimeSession) Sending interim transcript to client: " - Put a hat.
2026-04-25 13:34:15.234 [Debug] (RealtimeSession) "
2026-04-25 13:34:15.517 [Debug] (RealtimeSession) Audio buffer: 1535ms (24570 samples)
2026-04-25 13:34:15.517 [Debug] (RealtimeSession) VAD: RMS=0.34 speech_active=1
2026-04-25 13:34:16.028 [Debug] (RealtimeSession) Firing interim transcription at 2047ms
2026-04-25 13:34:16.028 [Debug] (RealtimeSession) Calling Whisper interim transcription (65564 bytes)...
2026-04-25 13:34:16.028 [Debug] (WhisperServer) Audio data size: 65564 bytes (no file I/O)
2026-04-25 13:34:16.028 [Debug] (WhisperServer) Sending multipart request to http://127.0.0.1:8003/inference (direct data)
2026-04-25 13:34:16.265 [Debug] (WhisperServer) Response status: 200
2026-04-25 13:34:16.265 [Debug] (RealtimeSession) Whisper interim response: {"text":" Put a hat on the cat.\n"}
2026-04-25 13:34:16.265 [Debug] (RealtimeSession) Sending interim transcript to client: " Put a hat on the cat.
2026-04-25 13:34:16.265 [Debug] (RealtimeSession) "
2026-04-25 13:34:17.052 [Debug] (RealtimeSession) Firing interim transcription at 3071ms
2026-04-25 13:34:17.052 [Debug] (RealtimeSession) Calling Whisper interim transcription (98324 bytes)...
2026-04-25 13:34:17.052 [Debug] (WhisperServer) Audio data size: 98324 bytes (no file I/O)
2026-04-25 13:34:17.052 [Debug] (WhisperServer) Sending multipart request to http://127.0.0.1:8003/inference (direct data)
2026-04-25 13:34:17.137 [Debug] (RealtimeSession) VAD: SpeechEnd detected, triggering transcription
2026-04-25 13:34:17.138 [Debug] (RealtimeSession) Calling Whisper final transcription (101054 bytes)...
2026-04-25 13:34:17.138 [Debug] (WhisperServer) Audio data size: 101054 bytes (no file I/O)
2026-04-25 13:34:17.138 [Debug] (WhisperServer) Sending multipart request to http://127.0.0.1:8003/inference (direct data)
2026-04-25 13:34:17.223 [Debug] (RealtimeSession) Audio buffer: 85ms (1365 samples)
2026-04-25 13:34:17.223 [Debug] (RealtimeSession) VAD: RMS=0.00 speech_active=0
2026-04-25 13:34:17.294 [Debug] (WhisperServer) Response status: 200
2026-04-25 13:34:17.294 [Debug] (RealtimeSession) Whisper interim response: {"text":" Put a hat on the cat.\n"}
2026-04-25 13:34:17.294 [Debug] (RealtimeSession) Sending interim transcript to client: " Put a hat on the cat.
2026-04-25 13:34:17.294 [Debug] (RealtimeSession) "
2026-04-25 13:34:17.529 [Debug] (WhisperServer) Response status: 200
2026-04-25 13:34:17.529 [Debug] (RealtimeSession) Whisper final response: {"text":" Put a hat on the cat.\n"}
2026-04-25 13:34:17.529 [Debug] (RealtimeSession) Sending final transcript to client: " Put a hat on the cat.
2026-04-25 13:34:17.529 [Debug] (RealtimeSession) "
2026-04-25 13:34:17.620 [Debug] (RealtimeSession) Ignoring commit with no active VAD speech window; clearing buffered audio
```
