### PR TITLE
fix: auto-detect embedding/reranking labels for user-pulled models

### DIFF
--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -127,6 +128,30 @@ inline DeviceType get_device_type_from_recipe(const std::string& recipe) {
         return DEVICE_NONE;  // Experience recipes orchestrate multiple component models
     }
     return DEVICE_NONE;
+}
+
+// Infer capability labels from a model name or checkpoint string.
+// Used as a fallback when labels are not explicitly provided (e.g.
+// user-pulled models registered without the --label flag).
+inline std::vector<std::string> infer_labels_from_name(const std::string& model_name,
+                                                       const std::string& checkpoint = "") {
+    std::vector<std::string> labels;
+    auto to_lower = [](const std::string& s) {
+        std::string result = s;
+        std::transform(result.begin(), result.end(), result.begin(), ::tolower);
+        return result;
+    };
+    std::string name_lower = to_lower(model_name);
+    std::string checkpoint_lower = to_lower(checkpoint);
+    if (name_lower.find("embed") != std::string::npos ||
+        checkpoint_lower.find("embed") != std::string::npos) {
+        labels.push_back("embeddings");
+    }
+    if (name_lower.find("rerank") != std::string::npos ||
+        checkpoint_lower.find("rerank") != std::string::npos) {
+        labels.push_back("reranking");
+    }
+    return labels;
 }
 
 } // namespace lemon

--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -206,6 +207,28 @@ inline bool add_label_once(std::vector<std::string>& labels, const std::string& 
 inline DeviceType get_device_type_from_recipe(const std::string& recipe) {
     (void)recipe;
     return DEVICE_NONE;
+}
+
+inline std::vector<std::string> infer_labels_from_name(const std::string& model_name,
+                                                       const std::string& checkpoint = "") {
+    std::vector<std::string> labels;
+    auto to_lower = [](const std::string& s) {
+        std::string result = s;
+        std::transform(result.begin(), result.end(), result.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return result;
+    };
+    const std::string name_lower = to_lower(model_name);
+    const std::string checkpoint_lower = to_lower(checkpoint);
+    if (name_lower.find("embed") != std::string::npos ||
+        checkpoint_lower.find("embed") != std::string::npos) {
+        labels.push_back("embeddings");
+    }
+    if (name_lower.find("rerank") != std::string::npos ||
+        checkpoint_lower.find("rerank") != std::string::npos) {
+        labels.push_back("reranking");
+    }
+    return labels;
 }
 
 } // namespace lemon

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -1,4 +1,5 @@
 #include "lemon/hf_variants.h"
+#include "lemon/model_types.h"
 
 #include <algorithm>
 #include <cctype>
@@ -287,9 +288,9 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
     std::vector<std::string> labels;
     if (!vset.mmproj_files.empty()) labels.push_back("vision");
     {
-        std::string id_lower = to_lower(checkpoint);
-        if (id_lower.find("embed") != std::string::npos) labels.push_back("embeddings");
-        if (id_lower.find("rerank") != std::string::npos) labels.push_back("reranking");
+        // Model name is not yet chosen at this point; infer from checkpoint only.
+        auto inferred = infer_labels_from_name("", checkpoint);
+        labels.insert(labels.end(), inferred.begin(), inferred.end());
     }
 
     nlohmann::json out;

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -508,10 +508,8 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint,
             case DraftKind::None: break;
         }
     }
-    {
-        std::string id_lower = to_lower(checkpoint);
-        if (id_lower.find("embed") != std::string::npos) add_label_once(labels, "embeddings");
-        if (id_lower.find("rerank") != std::string::npos) add_label_once(labels, "reranking");
+    for (const auto& label : infer_labels_from_name("", checkpoint)) {
+        add_label_once(labels, label);
     }
     backends::ensure_deployment_label(labels, "llamacpp");
 

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -532,10 +532,8 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint,
             case DraftKind::None: break;
         }
     }
-    {
-        std::string id_lower = to_lower(checkpoint);
-        if (id_lower.find("embed") != std::string::npos) add_label_once(labels, "embeddings");
-        if (id_lower.find("rerank") != std::string::npos) add_label_once(labels, "reranking");
+    for (const auto& label : infer_labels_from_name("", checkpoint)) {
+        add_label_once(labels, label);
     }
     backends::ensure_deployment_label(labels, "llamacpp");
 

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1670,6 +1670,21 @@ void ModelManager::register_user_model(const std::string& model_name,
         labels.insert("audio");
     }
 
+    // Auto-detect embedding/reranking for user-pulled models that were
+    // registered without explicit --label flags. Curated server models
+    // already have labels; this catches the user model gap.
+    {
+        std::string checkpoint = model_data.value("checkpoint", "");
+        if (checkpoint.empty() && model_data.contains("checkpoints") &&
+            model_data["checkpoints"].is_object() &&
+            model_data["checkpoints"].contains("main") &&
+            model_data["checkpoints"]["main"].is_string()) {
+            checkpoint = model_data["checkpoints"]["main"].get<std::string>();
+        }
+        auto inferred = infer_labels_from_name(clean_name, checkpoint);
+        labels.insert(inferred.begin(), inferred.end());
+    }
+
     model_entry["labels"] = labels;
     model_entry["suggested"] = true; // Always set suggested=true for user models
 

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3792,7 +3792,9 @@ size_t ModelManager::count_cloud_models(const std::string& provider) const {
 // cannot describe a model, so the caller can refuse it in those words. The
 // returned set is meaningless when it is non-empty.
 static std::set<std::string> normalized_definition_labels(
-    const json& model_data, std::string* illegal = nullptr) {
+    const json& model_data,
+    const std::string& model_name,
+    std::string* illegal = nullptr) {
     const std::string recipe = model_data.value("recipe", std::string());
     std::vector<std::string> labels = {"custom"};
     for (const auto& label : model_data.value("labels", std::vector<std::string>{})) {
@@ -3802,6 +3804,27 @@ static std::set<std::string> normalized_definition_labels(
     if (model_data.value("vision", false)) add_label_once(labels, "vision");
     if (model_data.value("embedding", false)) add_label_once(labels, "embeddings");
     if (model_data.value("reranking", false)) add_label_once(labels, "reranking");
+
+    ModelType declared_mode = ModelType::LLM;
+    if (!find_deployment_mode(labels, declared_mode)) {
+        std::string checkpoint = model_data.value("checkpoint", std::string());
+        if (checkpoint.empty() && model_data.contains("checkpoints") &&
+            model_data["checkpoints"].is_object() &&
+            model_data["checkpoints"].contains("main") &&
+            model_data["checkpoints"]["main"].is_string()) {
+            checkpoint = model_data["checkpoints"]["main"].get<std::string>();
+        }
+        const auto inferred = infer_labels_from_name(model_name, checkpoint);
+        const auto& supported_modes = lemon::backends::supported_modes_for(recipe);
+        for (const auto& label : inferred) {
+            ModelType inferred_mode = ModelType::LLM;
+            if (!supported_modes.empty() &&
+                deployment_mode_of(label, inferred_mode) &&
+                lemon::backends::backend_serves_mode(recipe, inferred_mode)) {
+                add_label_once(labels, label);
+            }
+        }
+    }
 
     if (illegal != nullptr) {
         *illegal = lemon::backends::illegal_deployment_labels(labels, recipe);
@@ -3848,7 +3871,8 @@ void ModelManager::register_user_model(const std::string& model_name,
     // load, where an entry written by an older version is skipped rather than
     // blocking startup.
     std::string illegal;
-    std::set<std::string> labels = normalized_definition_labels(model_data, &illegal);
+    std::set<std::string> labels =
+        normalized_definition_labels(model_data, clean_name, &illegal);
     if (!illegal.empty()) {
         throw InvalidModelDefinitionError(describe_illegal_labels(model_name, illegal));
     }
@@ -6117,7 +6141,7 @@ std::optional<std::string> ModelManager::validate_collection_request(
             // it here, where the import can still be refused whole.
             if (!model_exists(bare) && def != nullptr) {
                 std::string illegal;
-                normalized_definition_labels(*def, &illegal);
+                normalized_definition_labels(*def, bare, &illegal);
                 if (!illegal.empty()) {
                     return describe_illegal_labels(component_name, illegal);
                 }
@@ -6156,7 +6180,8 @@ std::optional<std::string> ModelManager::validate_collection_request(
                 // Derive the type exactly as register_user_model() would once
                 // this inline definition is registered, so validation and
                 // runtime cannot disagree.
-                std::set<std::string> label_set = normalized_definition_labels(*def);
+                std::set<std::string> label_set =
+                    normalized_definition_labels(*def, bare_component_name(name));
                 return get_model_type_from_labels(
                     std::vector<std::string>(label_set.begin(), label_set.end()));
             }

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -4121,7 +4121,9 @@ size_t ModelManager::count_cloud_models(const std::string& provider) const {
 // cannot describe a model, so the caller can refuse it in those words. The
 // returned set is meaningless when it is non-empty.
 static std::set<std::string> normalized_definition_labels(
-    const json& model_data, std::string* illegal = nullptr) {
+    const json& model_data,
+    const std::string& model_name,
+    std::string* illegal = nullptr) {
     const std::string recipe = model_data.value("recipe", std::string());
     std::vector<std::string> labels = {"custom"};
     for (const auto& label : model_data.value("labels", std::vector<std::string>{})) {
@@ -4131,6 +4133,27 @@ static std::set<std::string> normalized_definition_labels(
     if (model_data.value("vision", false)) add_label_once(labels, "vision");
     if (model_data.value("embedding", false)) add_label_once(labels, "embeddings");
     if (model_data.value("reranking", false)) add_label_once(labels, "reranking");
+
+    ModelType declared_mode = ModelType::LLM;
+    if (!find_deployment_mode(labels, declared_mode)) {
+        std::string checkpoint = model_data.value("checkpoint", std::string());
+        if (checkpoint.empty() && model_data.contains("checkpoints") &&
+            model_data["checkpoints"].is_object() &&
+            model_data["checkpoints"].contains("main") &&
+            model_data["checkpoints"]["main"].is_string()) {
+            checkpoint = model_data["checkpoints"]["main"].get<std::string>();
+        }
+        const auto inferred = infer_labels_from_name(model_name, checkpoint);
+        const auto& supported_modes = lemon::backends::supported_modes_for(recipe);
+        for (const auto& label : inferred) {
+            ModelType inferred_mode = ModelType::LLM;
+            if (!supported_modes.empty() &&
+                deployment_mode_of(label, inferred_mode) &&
+                lemon::backends::backend_serves_mode(recipe, inferred_mode)) {
+                add_label_once(labels, label);
+            }
+        }
+    }
 
     if (illegal != nullptr) {
         *illegal = lemon::backends::illegal_deployment_labels(labels, recipe);
@@ -4177,7 +4200,8 @@ void ModelManager::register_user_model(const std::string& model_name,
     // load, where an entry written by an older version is skipped rather than
     // blocking startup.
     std::string illegal;
-    std::set<std::string> labels = normalized_definition_labels(model_data, &illegal);
+    std::set<std::string> labels =
+        normalized_definition_labels(model_data, clean_name, &illegal);
     if (!illegal.empty()) {
         throw InvalidModelDefinitionError(describe_illegal_labels(model_name, illegal));
     }
@@ -6451,7 +6475,7 @@ std::optional<std::string> ModelManager::validate_collection_request(
             // it here, where the import can still be refused whole.
             if (!model_exists(bare) && def != nullptr) {
                 std::string illegal;
-                normalized_definition_labels(*def, &illegal);
+                normalized_definition_labels(*def, bare, &illegal);
                 if (!illegal.empty()) {
                     return describe_illegal_labels(component_name, illegal);
                 }
@@ -6495,7 +6519,11 @@ std::optional<std::string> ModelManager::validate_collection_request(
                 if (!def) {
                     return std::nullopt;
                 }
-                std::set<std::string> label_set = normalized_definition_labels(*def);
+                // Derive the type exactly as register_user_model() would once
+                // this inline definition is registered, so validation and
+                // runtime cannot disagree.
+                std::set<std::string> label_set =
+                    normalized_definition_labels(*def, bare_component_name(name));
                 return get_model_type_from_labels(
                     std::vector<std::string>(label_set.begin(), label_set.end()));
             },

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -160,6 +160,14 @@ static void test_inline_capability_matches_registration(ModelManager& manager) {
     err = manager.validate_collection_request("user.RouterKit", emb_sem);
     check("legacy embedding:true accepted for semantic_similarity", !err.has_value());
 
+    json inferred_emb_sem = router_with_classifier(
+        "semantic_similarity",
+        json{{"model_name", "retriever"}, {"recipe", "llamacpp"},
+             {"checkpoint", "example/some-embed-model:Q4_K_M"}});
+    err = manager.validate_collection_request("user.RouterKit", inferred_emb_sem);
+    check("embedding checkpoint name is inferred for semantic_similarity",
+          !err.has_value());
+
     // Label-less regular llamacpp still defaults to LLM, valid as a classifier.
     json llm_clf = router_with_classifier(
         "classifier",
@@ -167,6 +175,39 @@ static void test_inline_capability_matches_registration(ModelManager& manager) {
              {"checkpoint", "example/reg:Q4_K_M"}});
     err = manager.validate_collection_request("user.RouterKit", llm_clf);
     check("label-less llamacpp still defaults to LLM (valid classifier)", !err.has_value());
+}
+
+static void test_inferred_deployment_labels(ModelManager& manager) {
+    manager.register_user_model(
+        "user.zembed-1-Q4_K_M-GGUF",
+        json{{"recipe", "llamacpp"},
+             {"checkpoint", "example/plain-checkpoint:Q4_K_M"}});
+    const auto embedding = manager.get_model_info("user.zembed-1-Q4_K_M-GGUF");
+    check("embedding name is registered in embedding mode",
+          embedding.type == lemon::ModelType::EMBEDDING &&
+          lemon::has_label(embedding.labels, "embeddings") &&
+          !lemon::has_label(embedding.labels, "chat"));
+
+    manager.register_user_model(
+        "user.CheckpointOnly",
+        json{{"recipe", "llamacpp"},
+             {"checkpoints", json{{"main", "example/my-reranker-v2:Q8_0"}}}});
+    const auto reranking = manager.get_model_info("user.CheckpointOnly");
+    check("main checkpoint name is registered in reranking mode",
+          reranking.type == lemon::ModelType::RERANKING &&
+          lemon::has_label(reranking.labels, "reranking") &&
+          !lemon::has_label(reranking.labels, "chat"));
+
+    manager.register_user_model(
+        "user.embed-chat",
+        json{{"recipe", "llamacpp"},
+             {"checkpoint", "example/embed-chat:Q4_K_M"},
+             {"labels", {"chat"}}});
+    const auto explicit_chat = manager.get_model_info("user.embed-chat");
+    check("explicit deployment mode takes precedence over name inference",
+          explicit_chat.type == lemon::ModelType::LLM &&
+          lemon::has_label(explicit_chat.labels, "chat") &&
+          !lemon::has_label(explicit_chat.labels, "embeddings"));
 }
 
 // A chat-indicator label (reasoning/vision/…) must not promote a non-chat
@@ -303,6 +344,7 @@ int main() {
     test_accepts_valid_router_policy(manager);
     test_rejects_bad_routing(manager);
     test_inline_capability_matches_registration(manager);
+    test_inferred_deployment_labels(manager);
     test_backend_capability_over_chat_indicator(manager);
     test_register_preserves_routing(manager);
 

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -161,6 +161,14 @@ static void test_inline_capability_matches_registration(ModelManager& manager) {
     err = manager.validate_collection_request("user.RouterKit", emb_sem);
     check("legacy embedding:true accepted for semantic_similarity", !err.has_value());
 
+    json inferred_emb_sem = router_with_classifier(
+        "semantic_similarity",
+        json{{"model_name", "retriever"}, {"recipe", "llamacpp"},
+             {"checkpoint", "example/some-embed-model:Q4_K_M"}});
+    err = manager.validate_collection_request("user.RouterKit", inferred_emb_sem);
+    check("embedding checkpoint name is inferred for semantic_similarity",
+          !err.has_value());
+
     // Label-less regular llamacpp still defaults to LLM, valid as a classifier.
     json llm_clf = router_with_classifier(
         "classifier",
@@ -168,6 +176,39 @@ static void test_inline_capability_matches_registration(ModelManager& manager) {
              {"checkpoint", "example/reg:Q4_K_M"}});
     err = manager.validate_collection_request("user.RouterKit", llm_clf);
     check("label-less llamacpp still defaults to LLM (valid classifier)", !err.has_value());
+}
+
+static void test_inferred_deployment_labels(ModelManager& manager) {
+    manager.register_user_model(
+        "user.zembed-1-Q4_K_M-GGUF",
+        json{{"recipe", "llamacpp"},
+             {"checkpoint", "example/plain-checkpoint:Q4_K_M"}});
+    const auto embedding = manager.get_model_info("user.zembed-1-Q4_K_M-GGUF");
+    check("embedding name is registered in embedding mode",
+          embedding.type == lemon::ModelType::EMBEDDING &&
+          lemon::has_label(embedding.labels, "embeddings") &&
+          !lemon::has_label(embedding.labels, "chat"));
+
+    manager.register_user_model(
+        "user.CheckpointOnly",
+        json{{"recipe", "llamacpp"},
+             {"checkpoints", json{{"main", "example/my-reranker-v2:Q8_0"}}}});
+    const auto reranking = manager.get_model_info("user.CheckpointOnly");
+    check("main checkpoint name is registered in reranking mode",
+          reranking.type == lemon::ModelType::RERANKING &&
+          lemon::has_label(reranking.labels, "reranking") &&
+          !lemon::has_label(reranking.labels, "chat"));
+
+    manager.register_user_model(
+        "user.embed-chat",
+        json{{"recipe", "llamacpp"},
+             {"checkpoint", "example/embed-chat:Q4_K_M"},
+             {"labels", {"chat"}}});
+    const auto explicit_chat = manager.get_model_info("user.embed-chat");
+    check("explicit deployment mode takes precedence over name inference",
+          explicit_chat.type == lemon::ModelType::LLM &&
+          lemon::has_label(explicit_chat.labels, "chat") &&
+          !lemon::has_label(explicit_chat.labels, "embeddings"));
 }
 
 // A chat-indicator label (reasoning/vision/…) must not promote a non-chat
@@ -483,6 +524,7 @@ int main() {
     test_accepts_valid_router_policy(manager);
     test_rejects_bad_routing(manager);
     test_inline_capability_matches_registration(manager);
+    test_inferred_deployment_labels(manager);
     test_backend_capability_over_chat_indicator(manager);
     test_filtered_classifier_component_does_not_drop_policy(manager);
     test_filtered_classifier_bare_name_resolves_through_alias(manager);

--- a/test/cpp/test_model_type_classifier.cpp
+++ b/test/cpp/test_model_type_classifier.cpp
@@ -11,11 +11,19 @@
 using lemon::ModelType;
 using lemon::get_model_type_from_labels;
 using lemon::model_type_to_string;
+using lemon::infer_labels_from_name;
 
 struct Case {
     const char* name;
     std::vector<std::string> labels;
     ModelType expected;
+};
+
+struct InferCase {
+    const char* name;
+    std::string model_name;
+    std::string checkpoint;
+    std::vector<std::string> expected;
 };
 
 int main() {
@@ -63,6 +71,39 @@ int main() {
         if (!ok) ++failures;
     }
 
-    std::printf("\n%d/%zu cases passed\n", static_cast<int>(cases.size() - failures), cases.size());
+    // --- infer_labels_from_name: substring detection for user-pulled models ---
+    const std::vector<InferCase> infer_cases = {
+        // "embed" substring triggers embeddings label
+        {"embed in name", "zembed-1-Q4_K_M-GGUF", "", {"embeddings"}},
+        {"embed in checkpoint", "my-model", "Abiray/zembed-1-Q4_K_M-GGUF:Q4_K_M", {"embeddings"}},
+        {"case insensitive", "NOMIC-EMBED-TEXT", "", {"embeddings"}},
+        {"checkpoint only (no name)", "", "org/some-embed-model-GGUF:Q4_K_S", {"embeddings"}},
+
+        // "rerank" substring triggers reranking label
+        {"rerank in name", "my-reranker-v2", "", {"reranking"}},
+        {"rerank in checkpoint", "custom-model", "org/my-reranker-v2:Q8_0", {"reranking"}},
+
+        // Both substrings present
+        {"embed and rerank together", "embed-rerank-model", "", {"embeddings", "reranking"}},
+
+        // No match — regular models unaffected
+        {"plain LLM", "Qwen3-4B", "Qwen/Qwen3-4B-GGUF:Q4_K_M", {}},
+        {"partial overlap not matched", "remember-bot", "", {}},
+        {"empty inputs", "", "", {}},
+    };
+
+    for (const auto& c : infer_cases) {
+        auto actual = infer_labels_from_name(c.model_name, c.checkpoint);
+        bool ok = (actual == c.expected);
+        if (!ok) {
+            std::printf("[FAIL] infer: %s\n", c.name);
+            ++failures;
+        } else {
+            std::printf("[PASS] infer: %s\n", c.name);
+        }
+    }
+
+    int total = static_cast<int>(cases.size() + infer_cases.size());
+    std::printf("\n%d/%d cases passed\n", total - failures, total);
     return failures == 0 ? 0 : 1;
 }

--- a/test/cpp/test_model_type_classifier.cpp
+++ b/test/cpp/test_model_type_classifier.cpp
@@ -13,6 +13,7 @@
 using lemon::ModelType;
 using lemon::find_deployment_mode;
 using lemon::get_model_type_from_labels;
+using lemon::infer_labels_from_name;
 using lemon::model_type_to_string;
 
 struct Case {
@@ -25,6 +26,13 @@ struct DeclaredCase {
     const char* name;
     std::vector<std::string> labels;
     bool expect_declared;
+};
+
+struct InferCase {
+    const char* name;
+    std::string model_name;
+    std::string checkpoint;
+    std::vector<std::string> expected;
 };
 
 int main() {
@@ -123,7 +131,34 @@ int main() {
         if (!ok) ++failures;
     }
 
-    const size_t total = cases.size() + declared_cases.size();
+    const std::vector<InferCase> infer_cases = {
+        {"embed in name", "zembed-1-Q4_K_M-GGUF", "", {"embeddings"}},
+        {"embed in checkpoint", "my-model", "Abiray/zembed-1-Q4_K_M-GGUF:Q4_K_M", {"embeddings"}},
+        {"case insensitive", "NOMIC-EMBED-TEXT", "", {"embeddings"}},
+        {"checkpoint only (no name)", "", "org/some-embed-model-GGUF:Q4_K_S", {"embeddings"}},
+
+        {"rerank in name", "my-reranker-v2", "", {"reranking"}},
+        {"rerank in checkpoint", "custom-model", "org/my-reranker-v2:Q8_0", {"reranking"}},
+
+        {"embed and rerank together", "embed-rerank-model", "", {"embeddings", "reranking"}},
+
+        {"plain LLM", "Qwen3-4B", "Qwen/Qwen3-4B-GGUF:Q4_K_M", {}},
+        {"partial overlap not matched", "remember-bot", "", {}},
+        {"empty inputs", "", "", {}},
+    };
+
+    for (const auto& c : infer_cases) {
+        const auto actual = infer_labels_from_name(c.model_name, c.checkpoint);
+        const bool ok = (actual == c.expected);
+        if (!ok) {
+            std::printf("[FAIL] infer: %s\n", c.name);
+            ++failures;
+        } else {
+            std::printf("[PASS] infer: %s\n", c.name);
+        }
+    }
+
+    const size_t total = cases.size() + declared_cases.size() + infer_cases.size();
     std::printf("\n%d/%zu cases passed\n", static_cast<int>(total - failures), total);
     return failures == 0 ? 0 : 1;
 }


### PR DESCRIPTION
Fixes #1745

## What
Embedding models pulled from the HuggingFace section in the Lemonade app are missing the `embeddings` label. The HF variants flow (`hf_variants.cpp`) generates the correct `suggested_labels`, but they are not carried through to `register_user_model()` in the app pull path. Without the label, the llamacpp backend does not pass `--embeddings` to llama-server, and `/v1/embeddings` returns 501.

Rather than tracing where the suggested labels are dropped in the app-to-server pipeline, this adds a safety net: `register_user_model()` now re-derives labels from the model name and checkpoint string using a shared `infer_labels_from_name()` utility. This ensures user models with "embed" or "rerank" in their name are labeled correctly regardless of how they were registered. Curated server models are unaffected, as they already carry explicit labels.

The same utility replaces the inline detection in `hf_variants.cpp`, eliminating duplication.

## File Change
Changes:
- `model_types.h`: new `infer_labels_from_name()` : shared substring detection for "embed" / "rerank" in model name or checkpoint
- `hf_variants.cpp`: replaced inline detection with shared function
- `model_manager.cpp`: call shared function in `register_user_model()`
- `test_model_type_classifier.cpp`: 10 new test cases

## Test
Tested: `zembed-1-Q4_K_M-GGUF` pulled via app UI now receives the `embeddings` label automatically. Unit tests: 26/26 pass.