### PR TITLE
Improve download UX and correctness

### DIFF
--- a/src/app/src/renderer/DownloadManager.tsx
+++ b/src/app/src/renderer/DownloadManager.tsx
@@ -10,6 +10,9 @@ export interface DownloadItem {
   totalFiles: number;
   bytesDownloaded: number;
   bytesTotal: number;
+  // True when bytesTotal is only the amount known so far, not the real final total.
+  // Used for backend split archives or runtime follow-up steps whose later sizes are not known yet.
+  bytesTotalIsLowerBound?: boolean;
   percent: number;
   status: 'downloading' | 'paused' | 'completed' | 'error' | 'cancelled' | 'deleting';
   error?: string;
@@ -116,8 +119,15 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
     if (bytes === 0) return '0 B';
     const k = 1024;
     const sizes = ['B', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
     return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
+  };
+
+  const formatTotalBytes = (download: DownloadItem): string => {
+    if (download.bytesTotalIsLowerBound && download.bytesTotal > 0) {
+      return `${formatBytes(download.bytesTotal)}+`;
+    }
+    return formatBytes(download.bytesTotal);
   };
 
   const formatSpeed = (bytesPerSecond: number): string => {
@@ -134,6 +144,11 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
 
   const calculateETA = (download: DownloadItem): string => {
     if (download.status !== 'downloading' || download.bytesDownloaded === 0) {
+      return '--';
+    }
+
+    // Unknown lower-bound totals cannot produce a meaningful remaining-time estimate.
+    if (download.bytesTotalIsLowerBound) {
       return '--';
     }
 
@@ -593,16 +608,16 @@ Partial files may remain on disk.`);
                           <span className="download-file-info">
                             {download.status === 'downloading' && (
                               <>
-                                File {download.fileIndex}/{download.totalFiles} • {formatBytes(download.bytesDownloaded)} / {formatBytes(download.bytesTotal)}
+                                File {download.fileIndex}/{download.totalFiles} • {formatBytes(download.bytesDownloaded)} / {formatTotalBytes(download)}
                               </>
                             )}
                             {download.status === 'paused' && (
                               <>
-                                {download.running === true ? 'Pausing' : 'Paused'} • File {download.fileIndex}/{download.totalFiles} • {formatBytes(download.bytesDownloaded)} / {formatBytes(download.bytesTotal)}
+                                {download.running === true ? 'Pausing' : 'Paused'} • File {download.fileIndex}/{download.totalFiles} • {formatBytes(download.bytesDownloaded)} / {formatTotalBytes(download)}
                               </>
                             )}
                             {download.status === 'completed' && (
-                              <>Completed • {formatBytes(download.bytesTotal)}</>
+                              <>Completed • {formatTotalBytes(download)}</>
                             )}
                             {download.status === 'error' && (
                               <>Error: {download.error || 'Unknown error'}</>
@@ -775,7 +790,7 @@ Partial files may remain on disk.`);
                             </div>
                             <div className="download-detail-row">
                               <span className="download-detail-label">Total Size:</span>
-                              <span className="download-detail-value">{formatBytes(download.bytesTotal)}</span>
+                              <span className="download-detail-value">{formatTotalBytes(download)}</span>
                             </div>
                             <div className="download-detail-row">
                               <span className="download-detail-label">Speed:</span>

--- a/src/app/src/renderer/DownloadManager.tsx
+++ b/src/app/src/renderer/DownloadManager.tsx
@@ -171,11 +171,13 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
     }
   };
 
-  const isModelDownloadId = (downloadId?: string): boolean => downloadId?.startsWith('model:') === true;
+  const isServerDownloadId = (downloadId?: string): boolean =>
+    downloadId?.startsWith('model:') === true || downloadId?.startsWith('backend:') === true;
 
   const usesServerDownloadControl = (download: DownloadItem | undefined, downloadId?: string): boolean => {
-    // TODO: Backend downloads remain renderer-owned until the follow-up PR wires them into the server registry.
-    return download?.downloadType === 'model' || isModelDownloadId(download?.id ?? downloadId);
+    return download?.downloadType === 'model' ||
+      download?.downloadType === 'backend' ||
+      isServerDownloadId(download?.id ?? downloadId);
   };
 
   const hasLocalDownloadOwner = (download: DownloadItem): boolean => {

--- a/src/app/src/renderer/utils/backendInstaller.ts
+++ b/src/app/src/renderer/utils/backendInstaller.ts
@@ -72,7 +72,8 @@ export async function controlDownload(downloadId: string, action: 'pause' | 'can
 
 function serverSnapshotMatchesDownloadId(item: DownloadProgressEvent, downloadId: string): boolean {
   return item.id === downloadId ||
-    (!item.id && item.model_name != null && downloadId === `model:${item.model_name}`);
+    (!item.id && item.model_name != null && downloadId === `model:${item.model_name}`) ||
+    (!item.id && item.model_name != null && downloadId === `backend:${item.model_name}`);
 }
 
 export async function waitForDownloadStatus(
@@ -116,6 +117,16 @@ async function isModelDownloadedOnServer(modelName: string): Promise<boolean> {
     const modelList = Array.isArray(data) ? data : data.data || [];
     const model = modelList.find((m: any) => m.id === modelName || m.name === modelName);
     return model?.downloaded === true;
+  } catch {
+    return false;
+  }
+}
+
+async function isBackendInstalledOnServer(recipe: string, backend: string): Promise<boolean> {
+  try {
+    const systemData = await fetchSystemInfoData();
+    const backendState = systemData.info?.recipes?.[recipe]?.backends?.[backend]?.state;
+    return backendState === 'installed' || backendState === 'update_available';
   } catch {
     return false;
   }
@@ -186,6 +197,68 @@ async function waitForServerDownloadTerminal(
   }
 }
 
+
+async function waitForBackendDownloadTerminal(
+  downloadId: string,
+  displayName: string,
+  recipe: string,
+  backend: string,
+  abortController: AbortController,
+): Promise<void> {
+  let sawServerJob = false;
+  let consecutiveMissingSnapshots = 0;
+  let snapshotErrorsStartedAt: number | undefined;
+
+  while (true) {
+    if (abortController.signal.aborted) {
+      throw new DownloadAbortError('paused');
+    }
+
+    let snapshot: DownloadProgressEvent | undefined;
+    try {
+      snapshot = (await downloadTracker.hydrateFromServer({ throwOnError: true }))
+        .find(item => item.id === downloadId || item.model_name === displayName);
+    } catch (error) {
+      const now = Date.now();
+      snapshotErrorsStartedAt ??= now;
+      if (now - snapshotErrorsStartedAt >= SERVER_DOWNLOAD_SNAPSHOT_ERROR_TIMEOUT_MS) {
+        throw new Error(`Timed out refreshing backend download state: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+
+      console.warn('Failed to refresh backend download snapshot; keeping current state:', error);
+      await new Promise(resolve => setTimeout(resolve, SERVER_DOWNLOAD_POLL_INTERVAL_MS));
+      continue;
+    }
+
+    snapshotErrorsStartedAt = undefined;
+
+    if (!snapshot) {
+      if (sawServerJob) {
+        consecutiveMissingSnapshots += 1;
+        if (consecutiveMissingSnapshots >= 10) {
+          if (await isBackendInstalledOnServer(recipe, backend)) {
+            downloadTracker.completeDownload(downloadId);
+            window.dispatchEvent(new CustomEvent('backendsUpdated'));
+            return;
+          }
+          downloadTracker.removeDownload(downloadId);
+          throw new DownloadAbortError('cancelled');
+        }
+      }
+    } else {
+      sawServerJob = true;
+      consecutiveMissingSnapshots = 0;
+      const stopped = snapshot.running !== true;
+      if (snapshot.status === 'completed' && stopped) return;
+      if (snapshot.status === 'paused' && stopped) throw new DownloadAbortError('paused');
+      if (snapshot.status === 'cancelled' && stopped) throw new DownloadAbortError('cancelled');
+      if (snapshot.status === 'error' && stopped) throw new Error(snapshot.error || 'Unknown backend install error');
+    }
+
+    await new Promise(resolve => setTimeout(resolve, SERVER_DOWNLOAD_POLL_INTERVAL_MS));
+  }
+}
+
 async function consumeLegacyPullStream(response: Response, downloadId: string): Promise<void> {
   const reader = response.body?.getReader();
   if (!reader) throw new Error('No response body');
@@ -248,42 +321,21 @@ export async function installBackend(
 ): Promise<string | void> {
   const displayName = `${recipe}:${backend}`;
   const abortController = new AbortController();
+  const downloadId = downloadTracker.getStableDownloadId(displayName, 'backend');
 
-  let downloadId: string | undefined;
   if (showInDownloadManager) {
-    downloadId = downloadTracker.startDownload(displayName, abortController, 'backend');
-    window.dispatchEvent(new CustomEvent('download:started', { detail: { modelName: displayName } }));
+    downloadTracker.startDownload(displayName, abortController, 'backend');
+    downloadTracker.startServerPolling();
+    window.dispatchEvent(new CustomEvent('download:started', { detail: { modelName: displayName, downloadType: 'backend' } }));
   }
-
-  let isPaused = false;
-  let isCancelled = false;
-  let downloadCompleted = false;
-
-  // Listen for pause/cancel events from Download Manager UI
-  const handleCancel = (event: Event) => {
-    const detail = (event as CustomEvent).detail;
-    if (detail.modelName === displayName) {
-      isCancelled = true;
-      abortController.abort();
-    }
-  };
-  const handlePause = (event: Event) => {
-    const detail = (event as CustomEvent).detail;
-    if (detail.modelName === displayName) {
-      isPaused = true;
-      abortController.abort();
-    }
-  };
-
-  window.addEventListener('download:cancelled', handleCancel);
-  window.addEventListener('download:paused', handlePause);
 
   try {
     const response = await serverFetch('/install', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ recipe, backend, stream: true }),
+      body: JSON.stringify({ recipe, backend, stream: true, subscribe: false }),
       signal: abortController.signal,
+      cache: 'no-store',
     });
 
     if (!response.ok) {
@@ -291,114 +343,37 @@ export async function installBackend(
       throw new Error(`Failed: ${errorText || response.statusText}`);
     }
 
-    // Server returns JSON with an action URL when manual setup is needed
-    const contentType = response.headers.get('Content-Type') || '';
-    if (contentType.includes('application/json')) {
-      const data = await response.json();
-      if (data.action) {
-        if (downloadId) {
-          downloadTracker.completeDownload(downloadId);
-        }
-        window.dispatchEvent(new CustomEvent('open-external-content', { detail: { url: data.action } }));
-        return 'action';
+    const data = await response.json();
+    if (data.action) {
+      if (showInDownloadManager) {
+        downloadTracker.completeDownload(downloadId);
       }
+      window.dispatchEvent(new CustomEvent('open-external-content', { detail: { url: data.action } }));
+      return 'action';
     }
 
-    const reader = response.body?.getReader();
-    if (!reader) {
-      throw new Error('No response body');
+    if (showInDownloadManager) {
+      downloadTracker.applyServerDownload(data);
+      await waitForBackendDownloadTerminal(downloadId, displayName, recipe, backend, abortController);
+      // Backend completion is applied through the server snapshot; downloadTracker
+      // emits backendsUpdated once for backend jobs when the terminal snapshot arrives.
+    } else {
+      await waitForBackendDownloadTerminal(downloadId, displayName, recipe, backend, abortController);
     }
-
-    const decoder = new TextDecoder();
-    let buffer = '';
-    let currentEventType = 'progress';
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || '';
-
-        for (const line of lines) {
-          if (line.startsWith('event:')) {
-            currentEventType = line.substring(6).trim();
-          } else if (line.startsWith('data:')) {
-            try {
-              const data = JSON.parse(line.substring(5).trim());
-
-              if (currentEventType === 'progress' && downloadId) {
-                downloadTracker.updateProgress(downloadId, data);
-              } else if (currentEventType === 'complete') {
-                if (downloadId) {
-                  downloadTracker.completeDownload(downloadId);
-                }
-                downloadCompleted = true;
-              } else if (currentEventType === 'error') {
-                const errorMsg = data.error || 'Unknown error';
-                if (downloadId) {
-                  downloadTracker.failDownload(downloadId, errorMsg);
-                }
-                throw new Error(errorMsg);
-              }
-            } catch (parseError) {
-              // Re-throw application errors (e.g. from 'error' events); only
-              // swallow JSON parse failures so the stream can continue.
-              if (!(parseError instanceof SyntaxError)) {
-                throw parseError;
-              }
-              console.error('Failed to parse SSE data:', line, parseError);
-            }
-          } else if (line.trim() === '') {
-            currentEventType = 'progress';
-          }
-        }
-      }
-    } catch (streamError) {
-      // If we already got the complete event, ignore stream errors
-      if (!downloadCompleted) {
-        throw streamError;
-      }
-    }
-
-    if (!downloadCompleted && downloadId) {
-      downloadTracker.completeDownload(downloadId);
-    }
-
-    // Notify system context so BackendManager updates its status
-    window.dispatchEvent(new CustomEvent('backendsUpdated'));
   } catch (error: any) {
-    // If download completed successfully, ignore any connection-close errors
-    if (downloadCompleted) {
-      window.dispatchEvent(new CustomEvent('backendsUpdated'));
-      return;
+    if (error instanceof DownloadAbortError) {
+      throw error;
     }
 
     if (error.name === 'AbortError') {
-      if (isPaused && downloadId) {
-        downloadTracker.pauseDownload(downloadId);
-        throw new DownloadAbortError('paused');
-      } else {
-        if (downloadId) {
-          downloadTracker.cancelDownload(downloadId);
-        }
-        // Signal that file handles are released so DownloadManager can clean up
-        window.dispatchEvent(new CustomEvent('download:cleanup-complete', {
-          detail: { id: downloadId, modelName: displayName }
-        }));
-        throw new DownloadAbortError('cancelled');
-      }
-    } else {
-      if (downloadId) {
-        downloadTracker.failDownload(downloadId, error.message || 'Unknown error');
-      }
-      throw error;
+      downloadTracker.pauseDownload(downloadId, false);
+      throw new DownloadAbortError('paused');
     }
-  } finally {
-    window.removeEventListener('download:cancelled', handleCancel);
-    window.removeEventListener('download:paused', handlePause);
+
+    if (showInDownloadManager) {
+      downloadTracker.failDownload(downloadId, error.message || 'Unknown error');
+    }
+    throw error;
   }
 }
 

--- a/src/app/src/renderer/utils/downloadTracker.ts
+++ b/src/app/src/renderer/utils/downloadTracker.ts
@@ -108,6 +108,7 @@ class DownloadTracker {
       downloadType,
       collectionComponents,
       declaredTotalBytes,
+      bytesTotalIsLowerBound: false,
       running: downloadType === 'model' ? true : undefined,
       updatedAt: Date.now(),
     };
@@ -183,16 +184,24 @@ class DownloadTracker {
     // 1. Server-reported total (covers all files) — best option
     // 2. Declared size from the model registry — honest number, honors what the
     //    bar shows elsewhere, no extrapolation artifacts
-    // 3. Local sum of known file sizes — only accurate once every file's total
-    //    has been observed
+    // 3. Local sum of known file sizes — only accurate after every file's total
+    //    has been observed. Before then, keep byte-level progress as a known
+    //    lower bound for display, and use file-count progress for percentage.
     let cumulativeBytesTotal: number;
+    let bytesTotalIsLowerBound = false;
+    const knownSizes = Array.from(cumulative.fileSizes.values());
+    const knownSizesTotal = knownSizes.reduce((sum, size) => sum + size, 0);
+    const knownBytesLowerBound = Math.max(cumulativeBytesDownloaded, knownSizesTotal);
+
     if (progress.total_download_size && progress.total_download_size > 0) {
       cumulativeBytesTotal = progress.total_download_size;
     } else if (download.declaredTotalBytes && download.declaredTotalBytes > 0) {
       cumulativeBytesTotal = download.declaredTotalBytes;
     } else {
-      const knownSizes = Array.from(cumulative.fileSizes.values());
-      cumulativeBytesTotal = knownSizes.reduce((sum, size) => sum + size, 0);
+      const knowEveryFileSize =
+        progress.total_files > 0 && cumulative.fileSizes.size >= progress.total_files;
+      cumulativeBytesTotal = knowEveryFileSize ? knownSizesTotal : knownBytesLowerBound;
+      bytesTotalIsLowerBound = !knowEveryFileSize && knownBytesLowerBound > 0;
     }
 
     // Sum all pre-existing bytes across files for accurate speed calculation
@@ -206,8 +215,8 @@ class DownloadTracker {
 
     // Calculate overall percent
     let overallPercent: number;
-    if (cumulativeBytesTotal > 0) {
-      // Have byte-level data: calculate from cumulative bytes
+    if (cumulativeBytesTotal > 0 && !bytesTotalIsLowerBound) {
+      // Have byte-level data against a real total: calculate from cumulative bytes
       overallPercent = Math.round((cumulativeBytesDownloaded / cumulativeBytesTotal) * 100);
     } else if (progress.total_files > 0) {
       // No byte data at all: estimate from file count + intra-file percent from server
@@ -218,8 +227,17 @@ class DownloadTracker {
       overallPercent = 0;
     }
 
-    // Cap percentage at 100% to handle edge cases where byte tracking is incomplete
+    // Cap percentage at 100% to handle edge cases where byte tracking is incomplete.
     overallPercent = Math.min(overallPercent, 100);
+
+    // Do not display a live download as 100% until the terminal completion signal arrives.
+    // Backend installs can spend time extracting or installing runtime follow-up artifacts
+    // after the last byte of the current file has arrived.
+    const progressIsTerminal = progress.complete === true ||
+      (progress.status === 'completed' && progress.running !== true);
+    if (!progressIsTerminal && progress.status !== 'error' && progress.status !== 'cancelled' && overallPercent >= 100) {
+      overallPercent = 99;
+    }
 
     // Cap bytesDownloaded to not exceed bytesTotal for display consistency
     const displayBytesDownloaded = cumulativeBytesTotal > 0
@@ -237,6 +255,7 @@ class DownloadTracker {
       totalFiles: progress.total_files,
       bytesDownloaded: displayBytesDownloaded,
       bytesTotal: cumulativeBytesTotal,
+      bytesTotalIsLowerBound,
       percent: overallPercent,
       bytesResumed: speedBaselineBytes,
       status: progress.status ?? download.status,
@@ -580,6 +599,7 @@ class DownloadTracker {
       totalFiles: progress.total_files,
       bytesDownloaded: 0,
       bytesTotal: progress.total_download_size ?? progress.bytes_total ?? 0,
+      bytesTotalIsLowerBound: false,
       percent: progress.percent ?? 0,
       status: progress.status ?? 'downloading',
       error: progress.error,

--- a/src/app/src/renderer/utils/downloadTracker.ts
+++ b/src/app/src/renderer/utils/downloadTracker.ts
@@ -43,6 +43,7 @@ class DownloadTracker {
   private dismissedDownloads = new Set<string>();
   private completedDownloadsFinalized = new Set<string>();
   private completedModelDownloadsNotified = new Set<string>();
+  private completedBackendDownloadsNotified = new Set<string>();
   private serverPollStarted = false;
   private serverPollTimer: number | undefined;
   private readonly tabId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
@@ -88,7 +89,7 @@ class DownloadTracker {
       }
     }
 
-    const downloadId = downloadType === 'model'
+    const downloadId = downloadType === 'model' || downloadType === 'backend'
       ? this.getStableDownloadId(modelName, downloadType)
       : `${modelName}-${Date.now()}`;
 
@@ -109,13 +110,14 @@ class DownloadTracker {
       collectionComponents,
       declaredTotalBytes,
       bytesTotalIsLowerBound: false,
-      running: downloadType === 'model' ? true : undefined,
+      running: downloadType === 'model' || downloadType === 'backend' ? true : undefined,
       updatedAt: Date.now(),
     };
 
     this.dismissedDownloads.delete(downloadId);
     this.completedDownloadsFinalized.delete(downloadId);
     this.completedModelDownloadsNotified.delete(downloadId);
+    this.completedBackendDownloadsNotified.delete(downloadId);
     this.activeDownloads.set(downloadId, downloadItem);
     this.cumulativeData.set(downloadId, {
       completedFilesBytes: 0,
@@ -331,6 +333,7 @@ class DownloadTracker {
 
     if ((progress.status === 'completed' || progress.complete) && progress.running !== true) {
       this.emitModelsUpdatedOnce(downloadId, progress);
+      this.emitBackendUpdatedOnce(downloadId, progress);
       this.completeDownload(downloadId);
     }
   }
@@ -344,7 +347,7 @@ class DownloadTracker {
     downloads.forEach(download => this.applyServerDownload(download));
 
     for (const [id, download] of Array.from(this.activeDownloads.entries())) {
-      if (!id.startsWith('model:') || serverIds.has(id)) continue;
+      if (!(id.startsWith('model:') || id.startsWith('backend:')) || serverIds.has(id)) continue;
 
       const localOwnerIsGone = !download.abortController || download.abortController.signal.aborted;
       const localRowIsNotActivelyDownloading = download.status !== 'downloading';
@@ -587,6 +590,14 @@ class DownloadTracker {
     window.dispatchEvent(new CustomEvent('modelsUpdated'));
   }
 
+  private emitBackendUpdatedOnce(downloadId: string, progress: DownloadProgressEvent): void {
+    const downloadType = progress.type ?? this.activeDownloads.get(downloadId)?.downloadType;
+    if (downloadType !== 'backend' || this.completedBackendDownloadsNotified.has(downloadId)) return;
+
+    this.completedBackendDownloadsNotified.add(downloadId);
+    window.dispatchEvent(new CustomEvent('backendsUpdated'));
+  }
+
   private ensureDownload(downloadId: string, modelName: string, progress: DownloadProgressEvent): void {
     if (this.activeDownloads.has(downloadId)) return;
     const restoredBytesDownloaded = this.getProgressDownloadedBytes(progress);
@@ -643,6 +654,7 @@ class DownloadTracker {
     this.cumulativeData.delete(downloadId);
     this.completedDownloadsFinalized.delete(downloadId);
     this.completedModelDownloadsNotified.delete(downloadId);
+    this.completedBackendDownloadsNotified.delete(downloadId);
     if (broadcast) {
       this.postCrossTabMessage({ type: 'remove', id: downloadId, modelName });
     }

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -10,6 +10,9 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <functional>
+#include <map>
+#include <vector>
 #include <thread>
 #include <lemon/utils/aixlog.hpp>
 
@@ -170,6 +173,24 @@ bool will_install_therock(const std::string& os, const json& backend_versions) {
     }
 
     return true;
+}
+
+bool is_therock_installed_for_current_arch(const json& backend_versions) {
+    if (!backend_versions.contains("therock") ||
+        !backend_versions["therock"].contains("version")) {
+        return false;
+    }
+
+    const std::string rocm_arch = SystemInfo::get_rocm_arch();
+    if (rocm_arch.empty()) {
+        return false;
+    }
+
+    const std::string version = backend_versions["therock"]["version"].get<std::string>();
+    const fs::path version_file =
+        fs::path(backends::BackendUtils::get_therock_install_dir(rocm_arch, version)) / "version.txt";
+
+    return read_version_file(version_file) == version;
 }
 
 void install_therock_if_needed(const std::string& os, const json& backend_versions,
@@ -425,34 +446,169 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
         throw std::runtime_error("[BackendManager] Unknown recipe: " + recipe);
     }
 
-    // Check if we need to install additional runtime components after the main backend
-    bool needs_therock = (recipe == "llamacpp" || recipe == "sd-cpp") &&
-                         resolved_backend == "rocm-stable" &&
-                         will_install_therock(get_current_os(), backend_versions_);
+    // Check if we need to download additional runtime components after the main backend.
+    // `will_install_therock` intentionally answers whether TheRock is applicable
+    // for this OS/arch/config; it does not check Lemonade's local TheRock cache.
+    // Do that here before inflating the install to a multi-file UX flow.
+    const bool needs_therock_download = (recipe == "llamacpp" || recipe == "sd-cpp") &&
+                                        resolved_backend == "rocm-stable" &&
+                                        will_install_therock(get_current_os(), backend_versions_) &&
+                                        !is_therock_installed_for_current_arch(backend_versions_);
 
-    // Wrap the progress callback to adjust file indices if runtime download follows
-    DownloadProgressCallback wrapped_progress_cb;
-    if (progress_cb && (needs_therock)) {
-        wrapped_progress_cb = [progress_cb](const DownloadProgress& p) -> bool {
-            DownloadProgress adjusted = p;
-            // Adjust to indicate this is file 1 of 2
-            adjusted.file_index = 1;
-            adjusted.total_files = 2;
-            // Suppress the completion event - we'll send it after the runtime download
-            if (p.complete) {
-                adjusted.complete = false;
+    struct RuntimeInstallStep {
+        std::string name;
+        std::function<void(DownloadProgressCallback)> install;
+    };
+
+    std::vector<RuntimeInstallStep> runtime_steps;
+    if (needs_therock_download) {
+        const std::string os = get_current_os();
+        runtime_steps.push_back({
+            "TheRock runtime",
+            [this, os](DownloadProgressCallback runtime_progress_cb) {
+                install_therock_if_needed(os, backend_versions_, runtime_progress_cb);
             }
-            return progress_cb(adjusted);
-        };
-    } else {
-        wrapped_progress_cb = progress_cb;
+        });
     }
 
-    backends::BackendUtils::install_from_github(
-        *spec, params.version, params.repo, params.filename, resolved_backend, wrapped_progress_cb);
+    // Track known logical file sizes. total_download_size is only forwarded
+    // once it is the real total across every logical file. This prevents a
+    // runtime-follow-up install from inheriting a backend-only total size.
+    std::map<int, size_t> logical_file_sizes;
+    auto known_total_download_size = [&logical_file_sizes](int total_files) -> size_t {
+        size_t total = 0;
+        for (int index = 1; index <= total_files; ++index) {
+            auto it = logical_file_sizes.find(index);
+            if (it == logical_file_sizes.end() || it->second == 0) {
+                return 0;
+            }
+            total += it->second;
+        }
+        return total;
+    };
 
-    if (needs_therock) {
-        install_therock_if_needed(get_current_os(), backend_versions_, progress_cb);
+    auto normalize_progress = [&logical_file_sizes, &known_total_download_size](
+                                  const DownloadProgress& p,
+                                  int logical_file_index,
+                                  int logical_total_files,
+                                  bool allow_complete) -> DownloadProgress {
+        DownloadProgress adjusted = p;
+        adjusted.file_index = logical_file_index;
+        adjusted.total_files = logical_total_files;
+
+        if (adjusted.bytes_total > 0) {
+            logical_file_sizes[logical_file_index] = adjusted.bytes_total;
+        }
+
+        // Only set total_download_size when it is the true full total.
+        adjusted.total_download_size = known_total_download_size(logical_total_files);
+
+        if (!allow_complete && adjusted.complete) {
+            adjusted.complete = false;
+        }
+
+        return adjusted;
+    };
+
+    int backend_total_files = 1;
+    DownloadProgressCallback backend_progress_cb = progress_cb;
+    if (progress_cb && !runtime_steps.empty()) {
+        const int runtime_file_count = static_cast<int>(runtime_steps.size());
+        backend_progress_cb = [progress_cb,
+                               runtime_file_count,
+                               &backend_total_files,
+                               &normalize_progress](const DownloadProgress& p) -> bool {
+            backend_total_files = p.total_files > 0 ? p.total_files : 1;
+            const int logical_file_index = p.file_index > 0 ? p.file_index : 1;
+            const int logical_total_files = backend_total_files + runtime_file_count;
+            return progress_cb(normalize_progress(
+                p, logical_file_index, logical_total_files, /*allow_complete=*/false));
+        };
+    }
+
+    const std::string backend_install_dir =
+        backends::BackendUtils::get_install_directory(spec->recipe, resolved_backend);
+    const bool backend_install_dir_existed_before = fs::exists(backend_install_dir);
+
+    bool completion_reported = false;
+
+    try {
+        backends::BackendUtils::install_from_github(
+            *spec, params.version, params.repo, params.filename, resolved_backend, backend_progress_cb);
+
+        const int logical_total_files = backend_total_files + static_cast<int>(runtime_steps.size());
+        for (size_t i = 0; i < runtime_steps.size(); ++i) {
+            const int logical_file_index = backend_total_files + static_cast<int>(i) + 1;
+            const bool is_last_runtime_step = (i + 1 == runtime_steps.size());
+            bool runtime_reported_progress = false;
+            bool runtime_reported_completion = false;
+            DownloadProgress last_runtime_progress;
+
+            DownloadProgressCallback runtime_progress_cb;
+            if (progress_cb) {
+                runtime_progress_cb = [progress_cb,
+                                       logical_file_index,
+                                       logical_total_files,
+                                       is_last_runtime_step,
+                                       &completion_reported,
+                                       &runtime_reported_progress,
+                                       &runtime_reported_completion,
+                                       &last_runtime_progress,
+                                       &normalize_progress](const DownloadProgress& p) -> bool {
+                    runtime_reported_progress = true;
+                    DownloadProgress adjusted = normalize_progress(
+                        p, logical_file_index, logical_total_files, is_last_runtime_step);
+                    if (adjusted.complete) {
+                        runtime_reported_completion = true;
+                        completion_reported = true;
+                    }
+                    last_runtime_progress = adjusted;
+                    return progress_cb(adjusted);
+                };
+            }
+
+            runtime_steps[i].install(runtime_progress_cb);
+
+            if (!progress_cb) {
+                continue;
+            }
+
+            if (!runtime_reported_progress) {
+                DownloadProgress skipped;
+                skipped.file = runtime_steps[i].name;
+                skipped.file_index = logical_file_index;
+                skipped.total_files = logical_total_files;
+                skipped.percent = 100;
+                skipped.complete = is_last_runtime_step;
+                completion_reported = completion_reported || skipped.complete;
+                progress_cb(skipped);
+            } else if (is_last_runtime_step && !runtime_reported_completion) {
+                last_runtime_progress.file_index = logical_file_index;
+                last_runtime_progress.total_files = logical_total_files;
+                last_runtime_progress.percent = 100;
+                last_runtime_progress.complete = true;
+                completion_reported = true;
+                progress_cb(last_runtime_progress);
+            }
+        }
+
+        if (progress_cb && !runtime_steps.empty() && !completion_reported) {
+            DownloadProgress complete_progress;
+            complete_progress.file = runtime_steps.back().name;
+            complete_progress.file_index = logical_total_files;
+            complete_progress.total_files = logical_total_files;
+            complete_progress.percent = 100;
+            complete_progress.complete = true;
+            progress_cb(complete_progress);
+        }
+    } catch (...) {
+        // If the backend was newly created and a required runtime fails, roll
+        // back the backend so the status does not look ready with missing deps.
+        if (!backend_install_dir_existed_before) {
+            std::error_code cleanup_ec;
+            fs::remove_all(backend_install_dir, cleanup_ec);
+        }
+        throw;
     }
 }
 

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -240,7 +240,22 @@ namespace lemon::backends {
         if (backend == "system") {
             return "";
         }
-        std::string install_dir = get_install_directory(spec.recipe, backend);
+
+        // Normalize the public rocm backend name to the configured channel before
+        // reading version.txt. get_backend_binary_path() already does this when
+        // locating the executable; version detection must use the same install
+        // directory or ROCm backends remain stuck in update_required after a
+        // successful install.
+        std::string resolved_backend = backend;
+        if ((spec.recipe == "llamacpp" || spec.recipe == "sd-cpp") && backend == "rocm") {
+            std::string channel = "stable";
+            if (auto* cfg = RuntimeConfig::global()) {
+                channel = cfg->rocm_channel_for_recipe(spec.recipe);
+            }
+            resolved_backend = "rocm-" + channel;
+        }
+
+        std::string install_dir = get_install_directory(spec.recipe, resolved_backend);
         return get_version_file(install_dir);
     }
 
@@ -301,6 +316,15 @@ namespace lemon::backends {
                     needs_install = true;
                     fs::remove_all(install_dir);
                 }
+            } else if (!needs_install && !expected_version.empty()) {
+                // If the executable exists but version.txt is missing, SystemInfo
+                // reports update_required because it cannot prove the installed
+                // binary matches the current Lemonade baseline. Treat this like a
+                // version mismatch rather than a 0B no-op completion.
+                LOG(INFO, spec.log_name()) << "Installed executable is missing version.txt; reinstalling "
+                        << spec.binary << " version " << expected_version << std::endl;
+                needs_install = true;
+                fs::remove_all(install_dir);
             }
         }
 

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -376,9 +376,7 @@ namespace lemon::backends {
                 }
                 // 404 = no manifest = single-file release; fall through.
             }
-            const bool has_single = !is_split;
-
-            if (has_single) {
+            if (!is_split) {
                 std::string url = base_download_url + filename;
                 LOG(DEBUG, spec.log_name()) << "Downloading from: " << url << std::endl;
 
@@ -407,14 +405,14 @@ namespace lemon::backends {
                                              " - " + download_result.error_message);
                 }
             } else {
-                // Split-archive path. Assets known up front, so progress can
-                // report cumulative bytes against a (mostly) accurate total.
+                // Split-archive path. Part names are known up front, but the
+                // total byte size is not. Report per-part bytes and let the
+                // caller/frontend aggregate by file_index / total_files.
                 LOG(INFO, spec.log_name()) << "Downloading " << part_assets.size()
                                            << " split parts from " << repo << "@"
                                            << expected_version << std::endl;
 
                 std::ofstream combined(zip_path, std::ios::binary);
-                size_t cumulative_downloaded = 0;
                 int part_index = 0;
                 const int total_parts = static_cast<int>(part_assets.size());
                 for (const auto& part_filename : part_assets) {
@@ -426,25 +424,23 @@ namespace lemon::backends {
                                                 << part_index << "/" << total_parts
                                                 << ": " << part_filename << std::endl;
 
-                    // Per-part progress wrapper. Reports cumulative bytes
-                    // across all parts so the GUI bar climbs continuously
-                    // instead of resetting between parts.
+                    // Per-part progress wrapper. Keep byte fields scoped to
+                    // the current part; do not synthesize total_download_size
+                    // unless the true total across all parts is known.
                     utils::ProgressCallback part_http_cb;
                     if (progress_cb) {
-                        size_t cumulative_snapshot = cumulative_downloaded;
                         int idx_snapshot = part_index;
                         std::string name_snapshot = part_filename;
-                        part_http_cb = [&progress_cb, name_snapshot, idx_snapshot, total_parts, cumulative_snapshot]
+                        part_http_cb = [&progress_cb, name_snapshot, idx_snapshot, total_parts]
                                       (size_t downloaded, size_t total) -> bool {
                             DownloadProgress p;
                             p.file = name_snapshot;
                             p.file_index = idx_snapshot;
                             p.total_files = total_parts;
-                            p.bytes_downloaded = cumulative_snapshot + downloaded;
-                            p.bytes_total = cumulative_snapshot + total;
-                            p.total_download_size = p.bytes_total;
-                            p.percent = p.bytes_total > 0
-                                ? static_cast<int>((p.bytes_downloaded * 100) / p.bytes_total)
+                            p.bytes_downloaded = downloaded;
+                            p.bytes_total = total;
+                            p.percent = total > 0
+                                ? static_cast<int>((downloaded * 100) / total)
                                 : 0;
                             p.complete = false;
                             return progress_cb(p);
@@ -468,11 +464,6 @@ namespace lemon::backends {
                     std::ifstream part_in(part_path, std::ios::binary);
                     combined << part_in.rdbuf();
                     part_in.close();
-                    std::error_code part_size_ec;
-                    std::uintmax_t part_size = fs::file_size(part_path, part_size_ec);
-                    if (!part_size_ec) {
-                        cumulative_downloaded += part_size;
-                    }
                     fs::remove(part_path);
                 }
                 combined.close();
@@ -532,18 +523,20 @@ namespace lemon::backends {
             fs::remove(zip_path);
 
             // Send completion event now that installation is fully done.
-            // download_result is from the single-file attempt and reports
-            // misleading ~9 bytes from the 404 response body when the archive
-            // was actually fetched via the multi-part fallback. Use the
-            // verified on-disk archive size (captured into file_size above,
-            // before zip_path was deleted) so the GUI shows the real total.
+            // For split archives the combined on-disk size is only known after
+            // all parts have been downloaded, so intermediate progress events
+            // intentionally do not claim a total_download_size.
             if (progress_cb) {
+                const int archive_total_files = is_split ? static_cast<int>(part_assets.size()) : 1;
                 DownloadProgress p;
                 p.file = filename;
-                p.file_index = 1;
-                p.total_files = 1;
-                p.bytes_downloaded = static_cast<size_t>(file_size);
-                p.bytes_total = static_cast<size_t>(file_size);
+                p.file_index = archive_total_files;
+                p.total_files = archive_total_files;
+                if (!is_split) {
+                    p.bytes_downloaded = static_cast<size_t>(file_size);
+                    p.bytes_total = static_cast<size_t>(file_size);
+                    p.total_download_size = static_cast<size_t>(file_size);
+                }
                 p.percent = 100;
                 p.complete = true;
                 progress_cb(p);
@@ -699,8 +692,8 @@ namespace lemon::backends {
             http_progress_cb = [&progress_cb, &filename](size_t downloaded, size_t total) -> bool {
                 DownloadProgress p;
                 p.file = filename;
-                p.file_index = 2;  // TheRock is the second file (after llama.cpp binary)
-                p.total_files = 2;
+                p.file_index = 1;
+                p.total_files = 1;
                 p.bytes_downloaded = downloaded;
                 p.bytes_total = total;
                 p.percent = total > 0 ? static_cast<int>((downloaded * 100) / total) : 0;
@@ -769,8 +762,8 @@ namespace lemon::backends {
         if (progress_cb) {
             DownloadProgress p;
             p.file = filename;
-            p.file_index = 2;  // TheRock is the second file
-            p.total_files = 2;
+            p.file_index = 1;
+            p.total_files = 1;
             p.bytes_downloaded = download_result.bytes_downloaded;
             p.bytes_total = download_result.total_bytes;
             p.percent = 100;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -4591,6 +4591,7 @@ void Server::handle_install(const httplib::Request& req, httplib::Response& res)
         std::string recipe = request_json.value("recipe", "");
         std::string backend = request_json.value("backend", "");
         bool stream = request_json.value("stream", false);
+        bool subscribe = request_json.value("subscribe", true);
         bool force = request_json.value("force", false);
 
         if (recipe.empty() || backend.empty()) {
@@ -4643,11 +4644,27 @@ void Server::handle_install(const httplib::Request& req, httplib::Response& res)
         }
 
         if (stream) {
-            stream_download_operation(res, [this, recipe, backend, force](DownloadProgressCallback progress_cb) {
+            auto operation = [this, recipe, backend, force](DownloadProgressCallback progress_cb) {
                 backend_manager_->install_backend(recipe, backend, force, progress_cb);
                 SystemInfoCache::invalidate_recipes();
                 model_manager_->invalidate_models_cache();
-            });
+            };
+
+            if (!subscribe) {
+                // Server-owned mode for desktop UI reload/new-tab recovery.
+                // Legacy streamed /install behavior is unchanged.
+                const std::string display_name = recipe + ":" + backend;
+                auto job = start_download_job("backend:" + display_name, "backend", display_name, operation);
+                nlohmann::json response;
+                {
+                    std::lock_guard<std::mutex> lock(downloads_mutex_);
+                    response = download_job_to_json(job);
+                }
+                res.set_content(response.dump(), "application/json");
+                return;
+            }
+
+            stream_download_operation(res, operation);
         } else {
             backend_manager_->install_backend(recipe, backend, force);
             SystemInfoCache::invalidate_recipes();


### PR DESCRIPTION
## Summary
(1st edit: completely  reworked) (2nd edit: server owned download path integrated form PR #1948 )

Improves backend install progress for multi-artifact downloads.

Backend installs are not always a single file: vLLM ROCm can use split archives, and ROCm-stable backends may need a TheRock runtime after the backend archive. This PR makes progress reporting consistent across those cases without changing how artifacts are selected, downloaded, or extracted.

TL;DR: Progress now follows the actual install steps instead of relying on hardcoded assumptions about one or two files.

## What changed

- Split archive parts report progress as individual logical files.
- `total_download_size` is only used when the real full total is known.
- Backend + runtime installs are treated as one logical install flow.
- Completion is only reported after all required backend/runtime work is done.
- Already-installed runtimes are not shown as extra download steps.
- Newly created backend installs are rolled back if a required runtime step fails.
- The Download Manager uses file-count progress until all file sizes are known.
- Unknown follow-up sizes are shown as a known lower bound, e.g. `1.5 GB+`.

## Why this is safer

This makes backend installs safer because the UI no longer has to infer completion from partial progress data.

The install flow now has clearer invariants:

- current-file bytes describe the current file only
- total size is only used when it is actually known
- completion means the whole backend install is complete
- runtime steps are only included when they actually need to run

This reduces the risk of showing a backend as complete while required follow-up work is still pending, and it prevents partially installed backend directories from being left behind when a runtime step fails.

## Why this is future-proof

The old flow effectively assumed simple cases: one backend archive, or one backend archive plus one runtime step.

The new flow models backend installation as a sequence of logical files/steps. That makes it easier to support future backend layouts, for example:

- split archives with more than two parts
- multiple runtime artifacts
- backend installs where some follow-up artifacts are already present
- future backends that mix archive parts and runtime dependencies

Adding another runtime step should not require reworking progress semantics again; it should only add another step to the install sequence.

## Why this is low risk

This does **not** change the actual install mechanism:

- no new download sources
- no release selection changes
- no archive extraction changes
- no backend version resolution changes
- no changes to HuggingFace/model downloads

The PR only makes progress metadata, completion timing, and cleanup behavior more accurate for existing backend install flows.

## Scope

Limited to backend install progress, display, and cleanup after failed runtime installs.

Model downloads are intentionally untouched because the HuggingFace manifest path already has explicit file sizes, total size, resume handling, and validation.

## Validation

Manually checked:

- vLLM ROCm split archive progress continues across parts
- lower-bound total size is shown while later sizes are unknown
- ROCm-stable + TheRock completes only after TheRock finishes
- normal single-archive backend installs still behave normally
- llama.cpp ROCm with TheRock missing shows runtime as a follow-up step
- llama.cpp ROCm with TheRock already installed stays a normal single backend download