### PR TITLE
Add llamacpp:cuda backend for NVIDIA GPUs

### DIFF
--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -140,7 +140,7 @@ jobs:
   validate:
     name: Validate ${{ matrix.backend }}${{ matrix.channel && format(' ({0})', matrix.channel) || '' }}
     needs: [get-latest-releases, build]
-    if: always() && needs.build.result == 'success' && !matrix.skip
+    if: always() && needs.build.result == 'success'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -154,12 +154,12 @@ jobs:
           - backend: rocm
             channel: nightly
             runner: [self-hosted, Windows, 128gb, rocm]
-          # CUDA validation is defined but skipped until an NVIDIA self-hosted
-          # runner is available. To enable: add a runner with the 'cuda' label
-          # and remove the `if: false` condition below.
-          - backend: cuda
-            runner: [self-hosted, Windows, 128gb, cuda]
-            skip: true
+          # CUDA validation is prepared but intentionally disabled until an
+          # NVIDIA self-hosted runner is available. To enable it, uncomment this
+          # matrix entry.
+          #
+          # - backend: cuda
+          #   runner: [self-hosted, Windows, 128gb, cuda]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -140,7 +140,7 @@ jobs:
   validate:
     name: Validate ${{ matrix.backend }}${{ matrix.channel && format(' ({0})', matrix.channel) || '' }}
     needs: [get-latest-releases, build]
-    if: always() && needs.build.result == 'success'
+    if: always() && needs.build.result == 'success' && !matrix.skip
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -154,6 +154,12 @@ jobs:
           - backend: rocm
             channel: nightly
             runner: [self-hosted, Windows, 128gb, rocm]
+          # CUDA validation is defined but skipped until an NVIDIA self-hosted
+          # runner is available. To enable: add a runner with the 'cuda' label
+          # and remove the `if: false` condition below.
+          - backend: cuda
+            runner: [self-hosted, Windows, 128gb, cuda]
+            skip: true
     steps:
       - uses: actions/checkout@v5
         with:

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
   </thead>
   <tbody>
     <tr>
-      <td rowspan="7"><strong>Text generation</strong></td>
-      <td rowspan="5"><code>llamacpp</code></td>
+      <td rowspan="8"><strong>Text generation</strong></td>
+      <td rowspan="6"><code>llamacpp</code></td>
       <td><code>vulkan</code></td>
       <td><code>x86_64</code> CPU, AMD iGPU, AMD dGPU</td>
       <td>Windows, Linux</td>
@@ -142,6 +142,11 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td><code>rocm</code></td>
       <td>Supported AMD ROCm iGPU/dGPU families*</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>cuda</code></td>
+      <td>NVIDIA GPUs (Turing or newer)**</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>
@@ -244,6 +249,49 @@ lemonade backends
       <td><b>gfx110X</b> (RDNA3)</td>
       <td>Windows, Ubuntu</td>
       <td>Radeon PRO W7900/W7800/W7700/V710, RX 7900 XTX/XT/GRE, RX 7800 XT, RX 7700 XT</td>
+    </tr>
+  </tbody>
+</table>
+</details>
+
+<details>
+<summary><small><i>** See supported NVIDIA CUDA platforms</i></small></summary>
+
+<br>
+
+<table>
+  <thead>
+    <tr>
+      <th>Compute Capability</th>
+      <th>Architecture</th>
+      <th>GPU Models</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><b>sm_75</b></td>
+      <td>Turing</td>
+      <td>RTX 20-series, GTX 16-series, T4</td>
+    </tr>
+    <tr>
+      <td><b>sm_80</b> / <b>sm_86</b></td>
+      <td>Ampere</td>
+      <td>RTX 30-series, A100, A40</td>
+    </tr>
+    <tr>
+      <td><b>sm_89</b></td>
+      <td>Ada Lovelace</td>
+      <td>RTX 40-series, L40, L4</td>
+    </tr>
+    <tr>
+      <td><b>sm_90</b></td>
+      <td>Hopper</td>
+      <td>H100, H200</td>
+    </tr>
+    <tr>
+      <td><b>sm_100</b> / <b>sm_120</b></td>
+      <td>Blackwell</td>
+      <td>RTX 50-series, B100, B200</td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
   <tbody>
     <tr>
       <td rowspan="8"><strong>Text generation</strong></td>
-      <td rowspan="6"><code>llamacpp</code></td>
+      <td rowspan="5"><code>llamacpp</code></td>
       <td><code>vulkan</code></td>
       <td><code>x86_64</code> CPU, AMD iGPU, AMD dGPU</td>
       <td>Windows, Linux</td>

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
   <tbody>
     <tr>
       <td rowspan="8"><strong>Text generation</strong></td>
-      <td rowspan="5"><code>llamacpp</code></td>
+      <td rowspan="6"><code>llamacpp</code></td>
       <td><code>vulkan</code></td>
       <td><code>x86_64</code> CPU, AMD iGPU, AMD dGPU</td>
       <td>Windows, Linux</td>
@@ -142,6 +142,11 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td><code>rocm</code></td>
       <td>Supported AMD ROCm iGPU/dGPU families*</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>cuda</code></td>
+      <td>NVIDIA GPUs (Turing or newer)**</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>
@@ -250,6 +255,49 @@ lemonade backends
       <td><b>gfx110X</b> (RDNA3)</td>
       <td>Windows, Ubuntu</td>
       <td>Radeon PRO W7900/W7800/W7700/V710, RX 7900 XTX/XT/GRE, RX 7800 XT, RX 7700 XT</td>
+    </tr>
+  </tbody>
+</table>
+</details>
+
+<details>
+<summary><small><i>** See supported NVIDIA CUDA platforms</i></small></summary>
+
+<br>
+
+<table>
+  <thead>
+    <tr>
+      <th>Compute Capability</th>
+      <th>Architecture</th>
+      <th>GPU Models</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><b>sm_75</b></td>
+      <td>Turing</td>
+      <td>RTX 20-series, GTX 16-series, T4</td>
+    </tr>
+    <tr>
+      <td><b>sm_80</b> / <b>sm_86</b></td>
+      <td>Ampere</td>
+      <td>RTX 30-series, A100, A40</td>
+    </tr>
+    <tr>
+      <td><b>sm_89</b></td>
+      <td>Ada Lovelace</td>
+      <td>RTX 40-series, L40, L4</td>
+    </tr>
+    <tr>
+      <td><b>sm_90</b></td>
+      <td>Hopper</td>
+      <td>H100, H200</td>
+    </tr>
+    <tr>
+      <td><b>sm_100</b> / <b>sm_120</b></td>
+      <td>Blackwell</td>
+      <td>RTX 50-series, B100, B200</td>
     </tr>
   </tbody>
 </table>

--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -34,7 +34,7 @@ Lemonade uses [llama.cpp](https://github.com/ggerganov/llama.cpp) as its primary
 - **Hardware**: NVIDIA GPUs with Compute Capability 7.5+ (Turing, Ampere, Ada, Hopper, Blackwell)
 - **Use Case**: NVIDIA GPU-optimized inference
 - **Performance**: Optimized for NVIDIA hardware, typically outperforms Vulkan on supported GPUs
-- **Source**: Per-architecture builds from [Phqen1x/llamacpp-cuda](https://github.com/Phqen1x/llamacpp-cuda)
+- **Source**: Per-architecture builds from [Phqen1x/llama.cpp-builds](https://github.com/Phqen1x/llama.cpp-builds)
 - **Binaries**: Compute-capability-specific builds (sm_75, sm_80, sm_86, sm_89, sm_90, sm_100, sm_120)
 - **Runtime**: Bundled CUDA runtime libraries (no system-wide CUDA toolkit installation required)
 - **Notes**: On Windows, .7z extraction requires the bsdtar bundled with Windows 11 22H2+. On Linux, the build is shipped as .tar.xz and extracts with the system `tar`.

--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -29,6 +29,16 @@ Lemonade uses [llama.cpp](https://github.com/ggerganov/llama.cpp) as its primary
   - **Nightly**: Bleeding-edge builds from lemonade-sdk/llamacpp-rocm (experimental)
 - **Installation**: Varies by channel (see below)
 
+### CUDA
+- **Platform**: Windows, Linux
+- **Hardware**: NVIDIA GPUs with Compute Capability 7.5+ (Turing, Ampere, Ada, Hopper, Blackwell)
+- **Use Case**: NVIDIA GPU-optimized inference
+- **Performance**: Optimized for NVIDIA hardware, typically outperforms Vulkan on supported GPUs
+- **Source**: Per-architecture builds from [Phqen1x/llamacpp-cuda](https://github.com/Phqen1x/llamacpp-cuda)
+- **Binaries**: Compute-capability-specific builds (sm_75, sm_80, sm_86, sm_89, sm_90, sm_100, sm_120)
+- **Runtime**: Bundled CUDA runtime libraries (no system-wide CUDA toolkit installation required)
+- **Notes**: On Windows, .7z extraction requires the bsdtar bundled with Windows 11 22H2+. On Linux, the build is shipped as .tar.xz and extracts with the system `tar`.
+
 ### Metal
 - **Platform**: macOS only
 - **Hardware**: Apple Silicon (M1/M2/M3/M4) and Intel Macs with Metal support
@@ -125,8 +135,9 @@ lemonade config set llamacpp.rocm_bin=b1260
 
 ### Decision Tree
 
-1. **Do you have an NVIDIA or Intel GPU?**
-   - Use **Vulkan**
+1. **Do you have an NVIDIA GPU (Turing or newer)?**
+   - Try **CUDA** first for best performance
+   - Fall back to **Vulkan** if you encounter issues
 
 2. **Do you have an AMD GPU?**
    - **For Radeon RX 6000/7000 or Ryzen AI iGPU**:
@@ -135,10 +146,13 @@ lemonade config set llamacpp.rocm_bin=b1260
    - **For older AMD GPUs (RX 5000 and earlier)**:
      - Use **Vulkan** (ROCm not supported)
 
-3. **Do you have Apple Silicon?**
+3. **Do you have an Intel GPU or older NVIDIA GPU?**
+   - Use **Vulkan**
+
+4. **Do you have Apple Silicon?**
    - Use **Metal**
 
-4. **No GPU or unsupported GPU?**
+5. **No GPU or unsupported GPU?**
    - Use **CPU**
 
 ### ROCm Channel Selection
@@ -157,13 +171,15 @@ lemonade config set llamacpp.rocm_bin=b1260
 ## Platform Specifics
 
 ### Linux
-- All backends supported (CPU, Vulkan, ROCm, System)
+- All backends supported (CPU, Vulkan, ROCm, CUDA, System)
 - ROCm requires compatible AMD GPU (see above)
+- CUDA requires compatible NVIDIA GPU (see above)
 - System backend requires manual llama-server installation
 
 ### Windows
-- Supported: CPU, Vulkan, ROCm
+- Supported: CPU, Vulkan, ROCm, CUDA
 - ROCm requires compatible AMD GPU
+- CUDA requires compatible NVIDIA GPU and Windows 11 22H2+ (for bundled bsdtar that extracts .7z assets)
 - No system backend support
 
 ### macOS

--- a/docs/llamacpp.md
+++ b/docs/llamacpp.md
@@ -30,6 +30,16 @@ Lemonade uses [llama.cpp](https://github.com/ggerganov/llama.cpp) as its primary
   - **Nightly**: Bleeding-edge builds from lemonade-sdk/llamacpp-rocm (experimental)
 - **Installation**: Varies by channel (see below)
 
+### CUDA
+- **Platform**: Windows, Linux
+- **Hardware**: NVIDIA GPUs with Compute Capability 7.5+ (Turing, Ampere, Ada, Hopper, Blackwell)
+- **Use Case**: NVIDIA GPU-optimized inference
+- **Performance**: Optimized for NVIDIA hardware, typically outperforms Vulkan on supported GPUs
+- **Source**: Per-architecture builds from [Phqen1x/llamacpp-cuda](https://github.com/Phqen1x/llamacpp-cuda)
+- **Binaries**: Compute-capability-specific builds (sm_75, sm_80, sm_86, sm_89, sm_90, sm_100, sm_120)
+- **Runtime**: Bundled CUDA runtime libraries (no system-wide CUDA toolkit installation required)
+- **Notes**: On Windows, .7z extraction requires the bsdtar bundled with Windows 11 22H2+. On Linux, the build is shipped as .tar.xz and extracts with the system `tar`.
+
 ### Metal
 - **Platform**: macOS only
 - **Hardware**: Apple Silicon (M1/M2/M3/M4) and Intel Macs with Metal support
@@ -123,8 +133,9 @@ lemonade backend install llamacpp:rocm
 
 ### Decision Tree
 
-1. **Do you have an NVIDIA or Intel GPU?**
-   - Use **Vulkan**
+1. **Do you have an NVIDIA GPU (Turing or newer)?**
+   - Try **CUDA** first for best performance
+   - Fall back to **Vulkan** if you encounter issues
 
 2. **Do you have an AMD GPU?**
    - **For Radeon RX 6000/7000 or Ryzen AI iGPU**:
@@ -133,10 +144,13 @@ lemonade backend install llamacpp:rocm
    - **For older AMD GPUs (RX 5000 and earlier)**:
      - Use **Vulkan** (ROCm not supported)
 
-3. **Do you have Apple Silicon?**
+3. **Do you have an Intel GPU or older NVIDIA GPU?**
+   - Use **Vulkan**
+
+4. **Do you have Apple Silicon?**
    - Use **Metal**
 
-4. **No GPU or unsupported GPU?**
+5. **No GPU or unsupported GPU?**
    - Use **CPU**
 
 ### ROCm Channel Selection
@@ -160,13 +174,15 @@ lemonade backend install llamacpp:rocm
 ## Platform Specifics
 
 ### Linux
-- All backends supported (CPU, Vulkan, ROCm, System)
+- All backends supported (CPU, Vulkan, ROCm, CUDA, System)
 - ROCm requires compatible AMD GPU (see above)
+- CUDA requires compatible NVIDIA GPU (see above)
 - System backend requires manual llama-server installation
 
 ### Windows
-- Supported: CPU, Vulkan, ROCm
+- Supported: CPU, Vulkan, ROCm, CUDA
 - ROCm requires compatible AMD GPU
+- CUDA requires compatible NVIDIA GPU and Windows 11 22H2+ (for bundled bsdtar that extracts .7z assets)
 - No system backend support
 
 ### macOS

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -56,6 +56,14 @@ namespace lemon::backends {
         */
         static bool extract_tarball(const std::string& tarball_path, const std::string& dest_dir, const std::string& backend_name);
 
+        /**
+        * Extract 7z files (uses bsdtar/libarchive on Windows 11 22H2+ and Linux)
+        * @param archive_path Path to the .7z file
+        * @param dest_dir Destination directory to extract to
+        * @return true if extraction was successful, false otherwise
+        */
+        static bool extract_seven_zip(const std::string& archive_path, const std::string& dest_dir, const std::string& backend_name);
+
 
         /**
         * Detect if archive is tar or zip

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -65,6 +65,14 @@ namespace lemon::backends {
         */
         static bool extract_tarball(const std::string& tarball_path, const std::string& dest_dir, const std::string& backend_name);
 
+        /**
+        * Extract 7z files (uses bsdtar/libarchive on Windows 11 22H2+ and Linux)
+        * @param archive_path Path to the .7z file
+        * @param dest_dir Destination directory to extract to
+        * @return true if extraction was successful, false otherwise
+        */
+        static bool extract_seven_zip(const std::string& archive_path, const std::string& dest_dir, const std::string& backend_name);
+
 
         /**
         * Detect if archive is tar or zip

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -102,6 +102,7 @@ public:
 
     // Device support detection
     static std::string get_rocm_arch();
+    static std::string get_cuda_arch();
 
     // Detect if the device is an iGPU
     static bool get_has_igpu();
@@ -210,6 +211,10 @@ std::unique_ptr<SystemInfo> create_system_info();
 // Helper to identify ROCm architecture from GPU name
 // Returns architecture string (e.g., "gfx1150", "gfx1151", "gfx110X", "gfx120X") or empty string if not recognized
 std::string identify_rocm_arch_from_name(const std::string& device_name);
+
+// Helper to identify CUDA Compute Capability from a marketing GPU name
+// Returns an sm_XX token (e.g., "sm_75", "sm_86", "sm_120") or empty string if not recognized
+std::string identify_cuda_arch_from_name(const std::string& device_name);
 
 // Check if kernel has CWSR fix for Strix Halo
 bool needs_gfx1151_cwsr_fix();

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -22,6 +22,8 @@ struct CPUInfo : DeviceInfo {
 };
 
 struct GPUInfo : DeviceInfo {
+    int index = -1;  // NVIDIA only: physical device index from nvidia-smi, when available
+    std::string uuid;  // NVIDIA only: stable GPU UUID from nvidia-smi (preferred for CUDA_VISIBLE_DEVICES)
     std::string driver_version;
     std::string compute_capability;  // NVIDIA only: "MAJOR.MINOR" from nvidia-smi (e.g. "8.6")
     double vram_gb = 0.0;
@@ -104,6 +106,13 @@ public:
     // Device support detection
     static std::string get_rocm_arch();
     static std::string get_cuda_arch();
+
+    // CUDA release assets are architecture-specific (sm_89, sm_120, etc.).
+    // Return the physical CUDA device indices whose compute capability matches
+    // the selected release architecture, so callers can hide incompatible GPUs
+    // with CUDA_VISIBLE_DEVICES while still using all GPUs of the same arch.
+    static std::vector<int> get_cuda_device_indices_for_arch(const std::string& arch);
+    static std::string get_cuda_visible_devices_for_arch(const std::string& arch);
 
     // Detect if the device is an iGPU
     static bool get_has_igpu();

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -23,6 +23,7 @@ struct CPUInfo : DeviceInfo {
 
 struct GPUInfo : DeviceInfo {
     std::string driver_version;
+    std::string compute_capability;  // NVIDIA only: "MAJOR.MINOR" from nvidia-smi (e.g. "8.6")
     double vram_gb = 0.0;
     double virtual_gb = 0.0;
 };
@@ -102,6 +103,7 @@ public:
 
     // Device support detection
     static std::string get_rocm_arch();
+    static std::string get_cuda_arch();
 
     // Detect if the device is an iGPU
     static bool get_has_igpu();
@@ -210,6 +212,10 @@ std::unique_ptr<SystemInfo> create_system_info();
 // Helper to identify ROCm architecture from GPU name
 // Returns architecture string (e.g., "gfx1150", "gfx1151", "gfx110X", "gfx120X") or empty string if not recognized
 std::string identify_rocm_arch_from_name(const std::string& device_name);
+
+// Helper to identify CUDA Compute Capability from a marketing GPU name
+// Returns an sm_XX token (e.g., "sm_75", "sm_86", "sm_120") or empty string if not recognized
+std::string identify_cuda_arch_from_name(const std::string& device_name);
 
 // Check if kernel has CWSR fix for Strix Halo
 bool needs_gfx1151_cwsr_fix();

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -6,6 +6,7 @@
     "rocm-stable": "b8653",
     "rocm-preview": "b8705",
     "rocm-nightly": "b1238",
+    "cuda": "b1007",
     "metal": "b8884",
     "cpu": "b8766"
   },

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -4,7 +4,7 @@
     "vulkan": "b9253",
     "rocm-stable": "b9247",
     "rocm-nightly": "b1274",
-    "cuda": "b1007",
+    "cuda": "b1016",
     "metal": "b9253",
     "cpu": "b9253"
   },

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -4,6 +4,7 @@
     "vulkan": "b9253",
     "rocm-stable": "b9247",
     "rocm-nightly": "b1274",
+    "cuda": "b1007",
     "metal": "b9253",
     "cpu": "b9253"
   },

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -21,6 +21,7 @@
     "prefer_system": true,
     "rocm_bin": "builtin",
     "vulkan_bin": "builtin",
+    "cuda_bin": "builtin",
     "cpu_bin": "builtin"
   },
   "whispercpp": {

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -24,6 +24,7 @@
     "prefer_system": true,
     "rocm_bin": "builtin",
     "vulkan_bin": "builtin",
+    "cuda_bin": "builtin",
     "cpu_bin": "builtin"
   },
   "whispercpp": {

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -101,14 +101,17 @@ namespace lemon::backends {
         std::string command;
         fs::create_directories(dest_dir);
         LOG(DEBUG, backend_name) << "Extracting tarball to " << dest_dir << std::endl;
+        // Use the auto-detect form `-xf` (instead of `-xzf`) so we transparently
+        // handle .tar.gz, .tar.xz, .tar.bz2, etc. — the Phqen1x/llamacpp-cuda
+        // Linux release ships .tar.xz.
 #ifdef _WIN32
         if (!is_native_tar_available()) {
             LOG(ERROR, backend_name) << "Error: 'tar' command not found. Windows 10 (17063+) required." << std::endl;
             return false;
         }
-        command = get_native_tar_path() + " -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
+        command = get_native_tar_path() + " -xf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
 #else
-        command = "tar -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
+        command = "tar -xf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
 #endif
         int result = system(command.c_str());
         if (result != 0) {
@@ -118,15 +121,66 @@ namespace lemon::backends {
         return true;
     }
 
+    static bool ends_with(const std::string& s, const std::string& suffix) {
+        return s.size() >= suffix.size() &&
+            s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+    }
+
     static bool is_tarball(const std::string& filename) {
-        return (filename.size() > 7) && (filename.substr(filename.size() - 7) == ".tar.gz");
+        // Any tar variant we know how to feed to `tar -xf`.
+        return ends_with(filename, ".tar.gz") ||
+               ends_with(filename, ".tgz") ||
+               ends_with(filename, ".tar.xz") ||
+               ends_with(filename, ".txz") ||
+               ends_with(filename, ".tar.bz2") ||
+               ends_with(filename, ".tbz2");
+    }
+
+    static bool is_seven_zip(const std::string& filename) {
+        return ends_with(filename, ".7z");
+    }
+
+    bool BackendUtils::extract_seven_zip(const std::string& archive_path, const std::string& dest_dir, const std::string& backend_name) {
+        // Windows ships bsdtar (libarchive) as `tar.exe` since Windows 11 22H2,
+        // which transparently reads .7z. On Linux, GNU tar cannot open .7z, so
+        // we require either `bsdtar` (libarchive-tools) or `7z`/`7za` (p7zip).
+        std::string command;
+        fs::create_directories(dest_dir);
+        LOG(DEBUG, backend_name) << "Extracting 7z to " << dest_dir << std::endl;
+#ifdef _WIN32
+        if (!is_native_tar_available()) {
+            LOG(ERROR, backend_name) << "Error: 'tar' command not found. Windows 11 22H2+ required for .7z support." << std::endl;
+            return false;
+        }
+        command = get_native_tar_path() + " -xf \"" + archive_path + "\" -C \"" + dest_dir + "\" --strip-components=1";
+#else
+        // Prefer bsdtar (libarchive) — handles .7z natively. Fall back to 7z/7za.
+        if (system("command -v bsdtar > /dev/null 2>&1") == 0) {
+            command = "bsdtar -xf \"" + archive_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
+        } else if (system("command -v 7z > /dev/null 2>&1") == 0) {
+            command = "7z x -y -o\"" + dest_dir + "\" \"" + archive_path + "\" > /dev/null";
+        } else if (system("command -v 7za > /dev/null 2>&1") == 0) {
+            command = "7za x -y -o\"" + dest_dir + "\" \"" + archive_path + "\" > /dev/null";
+        } else {
+            LOG(ERROR, backend_name) << "Error: .7z extraction requires 'bsdtar' (libarchive-tools) or '7z'/'7za' (p7zip). Please install one of these." << std::endl;
+            return false;
+        }
+#endif
+        int result = system(command.c_str());
+        if (result != 0) {
+            LOG(ERROR, backend_name) << "Extraction failed with code: " << result << std::endl;
+            return false;
+        }
+        return true;
     }
 
     // Helper to extract archive files based on extension
     bool BackendUtils::extract_archive(const std::string& archive_path, const std::string& dest_dir, const std::string& backend_name) {
-        // Check if it's a tar.gz file
         if (is_tarball(archive_path)) {
             return extract_tarball(archive_path, dest_dir, backend_name);
+        }
+        if (is_seven_zip(archive_path)) {
+            return extract_seven_zip(archive_path, dest_dir, backend_name);
         }
         // Default to ZIP extraction
         return extract_zip(archive_path, dest_dir, backend_name);

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -103,14 +103,17 @@ namespace lemon::backends {
         std::string command;
         fs::create_directories(dest_dir);
         LOG(DEBUG, backend_name) << "Extracting tarball to " << dest_dir << std::endl;
+        // Use the auto-detect form `-xf` (instead of `-xzf`) so we transparently
+        // handle .tar.gz, .tar.xz, .tar.bz2, etc. — the Phqen1x/llamacpp-cuda
+        // Linux release ships .tar.xz.
 #ifdef _WIN32
         if (!is_native_tar_available()) {
             LOG(ERROR, backend_name) << "Error: 'tar' command not found. Windows 10 (17063+) required." << std::endl;
             return false;
         }
-        command = get_native_tar_path() + " -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
+        command = get_native_tar_path() + " -xf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
 #else
-        command = "tar -xzf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
+        command = "tar -xf \"" + tarball_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
 #endif
         int result = system(command.c_str());
         if (result != 0) {
@@ -120,8 +123,70 @@ namespace lemon::backends {
         return true;
     }
 
+    static bool ends_with(const std::string& s, const std::string& suffix) {
+        return s.size() >= suffix.size() &&
+            s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+    }
+
     static bool is_tarball(const std::string& filename) {
-        return (filename.size() > 7) && (filename.substr(filename.size() - 7) == ".tar.gz");
+        // Any tar variant we know how to feed to `tar -xf`.
+        return ends_with(filename, ".tar.gz") ||
+               ends_with(filename, ".tgz") ||
+               ends_with(filename, ".tar.xz") ||
+               ends_with(filename, ".txz") ||
+               ends_with(filename, ".tar.bz2") ||
+               ends_with(filename, ".tbz2");
+    }
+
+    static bool is_seven_zip(const std::string& filename) {
+        return ends_with(filename, ".7z");
+    }
+
+    bool BackendUtils::extract_seven_zip(const std::string& archive_path, const std::string& dest_dir, const std::string& backend_name) {
+        // Windows ships bsdtar (libarchive) as `tar.exe` since Windows 11 22H2,
+        // which transparently reads .7z. On Linux, GNU tar cannot open .7z, so
+        // we require either `bsdtar` (libarchive-tools) or `7z`/`7za` (p7zip).
+        std::string command;
+        fs::create_directories(dest_dir);
+        LOG(DEBUG, backend_name) << "Extracting 7z to " << dest_dir << std::endl;
+#ifdef _WIN32
+        // Windows System32\tar.exe is bsdtar (libarchive) on Windows 11 22H2+,
+        // which can read .7z. Probe with `--list` first to confirm .7z support;
+        // older tar.exe (from Windows 10) will exit non-zero for .7z archives.
+        if (!is_native_tar_available()) {
+            LOG(ERROR, backend_name) << "Error: 'tar' command not found. Windows 11 22H2+ required for .7z support." << std::endl;
+            return false;
+        }
+        {
+            std::string probe_cmd = get_native_tar_path() + " --list -f \"" + archive_path + "\" >nul 2>&1";
+            std::string unused;
+            if (lemon::utils::ProcessManager::run_command(probe_cmd, unused, 10) != 0) {
+                LOG(ERROR, backend_name) << "Error: tar.exe cannot read this .7z archive. Windows 11 22H2+ (bsdtar/libarchive) required." << std::endl;
+                return false;
+            }
+        }
+        command = get_native_tar_path() + " -xf \"" + archive_path + "\" -C \"" + dest_dir + "\" --strip-components=1";
+#else
+        // Prefer bsdtar (libarchive) — handles .7z natively. Fall back to 7z/7za.
+        if (system("command -v bsdtar > /dev/null 2>&1") == 0) {
+            command = "bsdtar -xf \"" + archive_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
+        } else if (system("command -v 7z > /dev/null 2>&1") == 0) {
+            // 7z does not support --strip-components; binaries are found via
+            // recursive search in find_executable_in_install_dir regardless.
+            command = "7z x -y -o\"" + dest_dir + "\" \"" + archive_path + "\" > /dev/null";
+        } else if (system("command -v 7za > /dev/null 2>&1") == 0) {
+            command = "7za x -y -o\"" + dest_dir + "\" \"" + archive_path + "\" > /dev/null";
+        } else {
+            LOG(ERROR, backend_name) << "Error: .7z extraction requires 'bsdtar' (libarchive-tools) or '7z'/'7za' (p7zip). Please install one of these." << std::endl;
+            return false;
+        }
+#endif
+        int result = system(command.c_str());
+        if (result != 0) {
+            LOG(ERROR, backend_name) << "Extraction failed with code: " << result << std::endl;
+            return false;
+        }
+        return true;
     }
 
     static fs::path get_backend_download_cache_dir() {
@@ -132,9 +197,11 @@ namespace lemon::backends {
 
     // Helper to extract archive files based on extension
     bool BackendUtils::extract_archive(const std::string& archive_path, const std::string& dest_dir, const std::string& backend_name) {
-        // Check if it's a tar.gz file
         if (is_tarball(archive_path)) {
             return extract_tarball(archive_path, dest_dir, backend_name);
+        }
+        if (is_seven_zip(archive_path)) {
+            return extract_seven_zip(archive_path, dest_dir, backend_name);
         }
         // Default to ZIP extraction
         return extract_zip(archive_path, dest_dir, backend_name);
@@ -341,10 +408,16 @@ namespace lemon::backends {
             // Create install directory
             fs::create_directories(install_dir);
 
+            // Preserve the actual filename (sanitised for use in a path) so that
+            // extract_archive() dispatches to the correct extractor based on extension,
+            // and architecture-specific assets (e.g. sm_86 vs sm_89) don't collide.
             fs::path cache_dir = get_backend_download_cache_dir();
-            std::string zip_name = backend == "" ? spec.recipe : spec.recipe + "_" + backend;
-            std::string zip_ext = is_tarball(filename) ? ".tar.gz" : ".zip";
-            std::string zip_path = (cache_dir / (zip_name + "_" + expected_version + zip_ext)).string();
+            std::string zip_name = backend.empty() ? spec.recipe : spec.recipe + "_" + backend;
+            std::string safe_filename = filename;
+            for (char& ch : safe_filename) {
+                if (ch == '/' || ch == '\\' || ch == ':') ch = '_';
+            }
+            std::string zip_path = (cache_dir / (zip_name + "_" + expected_version + "_" + safe_filename)).string();
 
             LOG(DEBUG, spec.log_name()) << "Downloading to: " << zip_path << std::endl;
 

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -164,7 +164,10 @@ namespace lemon::backends {
                 return false;
             }
         }
-        command = get_native_tar_path() + " -xf \"" + archive_path + "\" -C \"" + dest_dir + "\" --strip-components=1";
+        // Note: do NOT use --strip-components=1 here. The CUDA .7z archives from
+        // Phqen1x/llama.cpp-builds have no top-level directory — files sit at the
+        // archive root. Stripping would discard every entry and produce an empty dir.
+        command = get_native_tar_path() + " -xf \"" + archive_path + "\" -C \"" + dest_dir + "\"";
 #else
         LOG(ERROR, backend_name) << "Error: .7z backend archives are only expected on Windows. Linux CUDA assets should be .tar.xz." << std::endl;
         return false;
@@ -245,10 +248,21 @@ namespace lemon::backends {
 
     std::string BackendUtils::find_executable_in_install_dir(const std::string& install_dir, const std::string& binary_name) {
         if (fs::exists(install_dir)) {
+            // On Windows, executables have a .exe extension that may not be in binary_name
+#ifdef _WIN32
+            const std::string binary_name_exe = binary_name + ".exe";
+#endif
             // This could be optimized with a cache but saving a few milliseconds every few minutes/hours is not going to do much
             for (const fs::directory_entry& dir_entry : fs::recursive_directory_iterator(install_dir)) {
-                if (dir_entry.is_regular_file() && dir_entry.path().filename() == binary_name) {
-                    return dir_entry.path().string();
+                if (dir_entry.is_regular_file()) {
+                    const auto& fname = dir_entry.path().filename();
+                    if (fname == binary_name
+#ifdef _WIN32
+                        || fname == binary_name_exe
+#endif
+                    ) {
+                        return dir_entry.path().string();
+                    }
                 }
             }
         }

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -143,9 +143,8 @@ namespace lemon::backends {
     }
 
     bool BackendUtils::extract_seven_zip(const std::string& archive_path, const std::string& dest_dir, const std::string& backend_name) {
-        // Windows ships bsdtar (libarchive) as `tar.exe` since Windows 11 22H2,
-        // which transparently reads .7z. On Linux, GNU tar cannot open .7z, so
-        // we require either `bsdtar` (libarchive-tools) or `7z`/`7za` (p7zip).
+        // CUDA Windows release assets are .7z and use the existing native tar.exe path.
+        // Linux CUDA assets are .tar.xz, so Linux should not require bsdtar/7z/p7zip.
         std::string command;
         fs::create_directories(dest_dir);
         LOG(DEBUG, backend_name) << "Extracting 7z to " << dest_dir << std::endl;
@@ -167,19 +166,8 @@ namespace lemon::backends {
         }
         command = get_native_tar_path() + " -xf \"" + archive_path + "\" -C \"" + dest_dir + "\" --strip-components=1";
 #else
-        // Prefer bsdtar (libarchive) — handles .7z natively. Fall back to 7z/7za.
-        if (system("command -v bsdtar > /dev/null 2>&1") == 0) {
-            command = "bsdtar -xf \"" + archive_path + "\" -C \"" + dest_dir + "\" --strip-components=1 --no-same-owner";
-        } else if (system("command -v 7z > /dev/null 2>&1") == 0) {
-            // 7z does not support --strip-components; binaries are found via
-            // recursive search in find_executable_in_install_dir regardless.
-            command = "7z x -y -o\"" + dest_dir + "\" \"" + archive_path + "\" > /dev/null";
-        } else if (system("command -v 7za > /dev/null 2>&1") == 0) {
-            command = "7za x -y -o\"" + dest_dir + "\" \"" + archive_path + "\" > /dev/null";
-        } else {
-            LOG(ERROR, backend_name) << "Error: .7z extraction requires 'bsdtar' (libarchive-tools) or '7z'/'7za' (p7zip). Please install one of these." << std::endl;
-            return false;
-        }
+        LOG(ERROR, backend_name) << "Error: .7z backend archives are only expected on Windows. Linux CUDA assets should be .tar.xz." << std::endl;
+        return false;
 #endif
         int result = system(command.c_str());
         if (result != 0) {
@@ -408,10 +396,15 @@ namespace lemon::backends {
             // Create install directory
             fs::create_directories(install_dir);
 
+            std::string url = "https://github.com/" + repo + "/releases/download/" +
+                            expected_version + "/" + filename;
+
+            // Download archive to cache directory.
             // Preserve the actual filename (sanitised for use in a path) so that
             // extract_archive() dispatches to the correct extractor based on extension,
             // and architecture-specific assets (e.g. sm_86 vs sm_89) don't collide.
-            fs::path cache_dir = get_backend_download_cache_dir();
+            fs::path cache_dir = fs::temp_directory_path();
+            fs::create_directories(cache_dir);
             std::string zip_name = backend.empty() ? spec.recipe : spec.recipe + "_" + backend;
             std::string safe_filename = filename;
             for (char& ch : safe_filename) {

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -112,6 +112,10 @@ static bool is_llamacpp_rocm_backend(const std::string& backend) {
     return backend == "rocm-stable" || backend == "rocm-preview" || backend == "rocm-nightly";
 }
 
+static bool is_llamacpp_cuda_backend(const std::string& backend) {
+    return backend == "cuda";
+}
+
 static std::string trim_version_prefix(const std::string& version) {
     if (!version.empty() && version[0] == 'v') {
         return version.substr(1);
@@ -180,6 +184,23 @@ InstallParams LlamaCppServer::get_install_params(const std::string& backend, con
         params.filename = "llama-" + version + "-bin-ubuntu-rocm-7.2-x64.tar.gz";
 #else
         throw std::runtime_error("ROCm stable llamacpp is currently supported on Windows and Linux only");
+#endif
+    } else if (resolved_backend == "cuda") {
+        params.repo = "Phqen1x/llamacpp-cuda";
+        std::string target_arch = SystemInfo::get_cuda_arch();
+        if (target_arch.empty()) {
+            throw std::runtime_error(
+                SystemInfo::get_unsupported_backend_error("llamacpp", "cuda")
+            );
+        }
+        // Phqen1x/llamacpp-cuda releases publish per-Compute-Capability binaries
+        // and do not embed the build tag in the asset filename.
+#ifdef _WIN32
+        params.filename = "llama-windows-cuda-" + target_arch + "-x64.7z";
+#elif defined(__linux__)
+        params.filename = "llama-ubuntu-cuda-" + target_arch + "-x64.tar.xz";
+#else
+        throw std::runtime_error("CUDA llamacpp is currently supported on Windows and Linux only");
 #endif
     } else if (resolved_backend == "metal") {
         params.repo = "ggml-org/llama.cpp";
@@ -296,8 +317,9 @@ void LlamaCppServer::load(const std::string& model_name,
     }
     push_reserved(reserved_flags, "--mmproj", std::vector<std::string>{"-mm", "-mmu", "--mmproj-url", "--no-mmproj", "--mmproj-auto", "--no-mmproj-auto", "--mmproj-offload", "--no-mmproj-offload"});
 
-    // Enable context shift for vulkan/rocm (not supported on Metal)
-    if (llamacpp_backend == "vulkan" || is_llamacpp_rocm_backend(llamacpp_backend)) {
+    // Enable context shift for vulkan/rocm/cuda (not supported on Metal)
+    if (llamacpp_backend == "vulkan" || is_llamacpp_rocm_backend(llamacpp_backend) ||
+        is_llamacpp_cuda_backend(llamacpp_backend)) {
         push_overridable_arg(args, llamacpp_args, "--context-shift");
         push_overridable_arg(args, llamacpp_args, "--keep", "16");
     } else {
@@ -382,6 +404,20 @@ void LlamaCppServer::load(const std::string& model_name,
 
         env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
         LOG(DEBUG, "LlamaCpp") << "Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
+    } else if (is_llamacpp_cuda_backend(llamacpp_backend)) {
+        // The Phqen1x/llamacpp-cuda Linux tarballs ship the bundled CUDA runtime
+        // (libcudart.so, libcublas.so, etc.) alongside llama-server, so add the
+        // executable's directory to LD_LIBRARY_PATH like we do for ROCm.
+        fs::path exe_dir = fs::path(executable).parent_path();
+        std::string lib_path = exe_dir.string();
+
+        const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
+        if (existing_ld_path && strlen(existing_ld_path) > 0) {
+            lib_path = lib_path + ":" + std::string(existing_ld_path);
+        }
+
+        env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
+        LOG(DEBUG, "LlamaCpp") << "Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
     }
 #else
     // For ROCm on Windows with gfx1151, set OCL_SET_SVMSIZE
@@ -417,6 +453,19 @@ void LlamaCppServer::load(const std::string& model_name,
             env_vars.push_back({"OCL_SET_SVM_SIZE", "262144"});
             LOG(DEBUG, "LlamaCpp") << "Setting OCL_SET_SVM_SIZE=262144 for gfx1151 (enables loading larger models)" << std::endl;
         }
+    } else if (is_llamacpp_cuda_backend(llamacpp_backend)) {
+        // CUDA Windows builds bundle cudart64_*.dll, cublas64_*.dll, etc. next to
+        // llama-server.exe. Prepend the executable directory to PATH so the loader
+        // resolves them before any system-wide CUDA install.
+        fs::path exe_dir = fs::path(executable).parent_path();
+        std::string new_path = exe_dir.string();
+
+        const char* existing_path = std::getenv("PATH");
+        if (existing_path && strlen(existing_path) > 0) {
+            new_path += ";" + std::string(existing_path);
+        }
+        env_vars.push_back({"PATH", new_path});
+        LOG(DEBUG, "LlamaCpp") << "Prepending CUDA exe dir to PATH: " << exe_dir.string() << std::endl;
     }
 #endif
 

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -112,6 +112,10 @@ static bool is_llamacpp_rocm_backend(const std::string& backend) {
     return backend == "rocm-stable" || backend == "rocm-nightly";
 }
 
+static bool is_llamacpp_cuda_backend(const std::string& backend) {
+    return backend == "cuda";
+}
+
 static std::string trim_version_prefix(const std::string& version) {
     if (!version.empty() && version[0] == 'v') {
         return version.substr(1);
@@ -171,6 +175,23 @@ InstallParams LlamaCppServer::get_install_params(const std::string& backend, con
         params.filename = "llama-" + version + "-ubuntu-rocm-" + target_arch + "-x64.zip";
 #else
         throw std::runtime_error("ROCm nightly llamacpp only supported on Windows and Linux");
+#endif
+    } else if (resolved_backend == "cuda") {
+        params.repo = "Phqen1x/llama.cpp";
+        std::string target_arch = SystemInfo::get_cuda_arch();
+        if (target_arch.empty()) {
+            throw std::runtime_error(
+                SystemInfo::get_unsupported_backend_error("llamacpp", "cuda")
+            );
+        }
+        // Phqen1x/llama.cpp releases publish per-Compute-Capability binaries
+        // and do not embed the build tag in the asset filename.
+#ifdef _WIN32
+        params.filename = "llama-windows-cuda-" + target_arch + "-x64.7z";
+#elif defined(__linux__)
+        params.filename = "llama-ubuntu-cuda-" + target_arch + "-x64.tar.xz";
+#else
+        throw std::runtime_error("CUDA llamacpp is currently supported on Windows and Linux only");
 #endif
     } else if (resolved_backend == "metal") {
         params.repo = "ggml-org/llama.cpp";
@@ -309,8 +330,9 @@ void LlamaCppServer::load(const std::string& model_name,
     }
     push_reserved(reserved_flags, "--mmproj", std::vector<std::string>{"-mm", "-mmu", "--mmproj-url", "--no-mmproj", "--mmproj-auto", "--no-mmproj-auto", "--mmproj-offload", "--no-mmproj-offload"});
 
-    // Enable context shift for vulkan/rocm (not supported on Metal)
-    if (llamacpp_backend == "vulkan" || is_llamacpp_rocm_backend(llamacpp_backend)) {
+    // Enable context shift for vulkan/rocm/cuda (not supported on Metal)
+    if (llamacpp_backend == "vulkan" || is_llamacpp_rocm_backend(llamacpp_backend) ||
+        is_llamacpp_cuda_backend(llamacpp_backend)) {
         push_overridable_arg(args, llamacpp_args, "--context-shift");
         push_overridable_arg(args, llamacpp_args, "--keep", "16");
     } else {
@@ -397,6 +419,20 @@ void LlamaCppServer::load(const std::string& model_name,
 
         env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
         LOG(DEBUG, "LlamaCpp") << "Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
+    } else if (is_llamacpp_cuda_backend(llamacpp_backend)) {
+        // The Phqen1x/llamacpp-cuda Linux tarballs ship the bundled CUDA runtime
+        // (libcudart.so, libcublas.so, etc.) alongside llama-server, so add the
+        // executable's directory to LD_LIBRARY_PATH like we do for ROCm.
+        fs::path exe_dir = fs::path(executable).parent_path();
+        std::string lib_path = exe_dir.string();
+
+        const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
+        if (existing_ld_path && strlen(existing_ld_path) > 0) {
+            lib_path = lib_path + ":" + std::string(existing_ld_path);
+        }
+
+        env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
+        LOG(DEBUG, "LlamaCpp") << "Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
     }
 #else
     // For ROCm on Windows with gfx1151, set OCL_SET_SVMSIZE
@@ -427,6 +463,19 @@ void LlamaCppServer::load(const std::string& model_name,
             env_vars.push_back({"OCL_SET_SVM_SIZE", "262144"});
             LOG(DEBUG, "LlamaCpp") << "Setting OCL_SET_SVM_SIZE=262144 for gfx1151 (enables loading larger models)" << std::endl;
         }
+    } else if (is_llamacpp_cuda_backend(llamacpp_backend)) {
+        // CUDA Windows builds bundle cudart64_*.dll, cublas64_*.dll, etc. next to
+        // llama-server.exe. Prepend the executable directory to PATH so the loader
+        // resolves them before any system-wide CUDA install.
+        fs::path exe_dir = fs::path(executable).parent_path();
+        std::string new_path = exe_dir.string();
+
+        const char* existing_path = std::getenv("PATH");
+        if (existing_path && strlen(existing_path) > 0) {
+            new_path += ";" + std::string(existing_path);
+        }
+        env_vars.push_back({"PATH", new_path});
+        LOG(DEBUG, "LlamaCpp") << "Prepending CUDA exe dir to PATH: " << exe_dir.string() << std::endl;
     }
 #endif
 

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -10,6 +10,7 @@
 #include "lemon/system_info.h"
 #include <algorithm>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 #include <lemon/utils/aixlog.hpp>
@@ -176,20 +177,31 @@ InstallParams LlamaCppServer::get_install_params(const std::string& backend, con
 #else
         throw std::runtime_error("ROCm nightly llamacpp only supported on Windows and Linux");
 #endif
+    } else if (resolved_backend == "rocm-stable") {
+        params.repo = "lemonade-sdk/llama.cpp";
+        std::string therock_ver = get_therock_version();
+#ifdef _WIN32
+        params.filename = "llama-" + version + "-bin-win-rocm-" + therock_ver + "-x64.zip";
+#elif defined(__linux__)
+        params.filename = "llama-" + version + "-bin-ubuntu-rocm-" + therock_ver + "-x64.tar.gz";
+#else
+        throw std::runtime_error("ROCm stable llamacpp is currently supported on Windows and Linux only");
+#endif
     } else if (resolved_backend == "cuda") {
-        params.repo = "Phqen1x/llama.cpp";
+        params.repo = "Phqen1x/llama.cpp-builds";
         std::string target_arch = SystemInfo::get_cuda_arch();
         if (target_arch.empty()) {
             throw std::runtime_error(
                 SystemInfo::get_unsupported_backend_error("llamacpp", "cuda")
             );
         }
-        // Phqen1x/llama.cpp releases publish per-Compute-Capability binaries
-        // and do not embed the build tag in the asset filename.
+        // Phqen1x/llama.cpp-builds releases publish per-Compute-Capability binaries
+        // and embed the build tag in the asset filename, e.g.
+        // llama-b1011-ubuntu-cuda-sm_120-x64.tar.xz.
 #ifdef _WIN32
-        params.filename = "llama-windows-cuda-" + target_arch + "-x64.7z";
+        params.filename = "llama-" + version + "-windows-cuda-" + target_arch + "-x64.7z";
 #elif defined(__linux__)
-        params.filename = "llama-ubuntu-cuda-" + target_arch + "-x64.tar.xz";
+        params.filename = "llama-" + version + "-ubuntu-cuda-" + target_arch + "-x64.tar.xz";
 #else
         throw std::runtime_error("CUDA llamacpp is currently supported on Windows and Linux only");
 #endif
@@ -420,7 +432,7 @@ void LlamaCppServer::load(const std::string& model_name,
         env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
         LOG(DEBUG, "LlamaCpp") << "Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
     } else if (is_llamacpp_cuda_backend(llamacpp_backend)) {
-        // The Phqen1x/llamacpp-cuda Linux tarballs ship the bundled CUDA runtime
+        // The llama.cpp-builds Linux tarballs ship the bundled CUDA runtime
         // (libcudart.so, libcublas.so, etc.) alongside llama-server, so add the
         // executable's directory to LD_LIBRARY_PATH like we do for ROCm.
         fs::path exe_dir = fs::path(executable).parent_path();
@@ -478,6 +490,42 @@ void LlamaCppServer::load(const std::string& model_name,
         LOG(DEBUG, "LlamaCpp") << "Prepending CUDA exe dir to PATH: " << exe_dir.string() << std::endl;
     }
 #endif
+
+    // CUDA release assets are architecture-specific. On mixed NVIDIA systems
+    // the latest sm_120-only binary will be installed. So an older sm-Verion is mot
+    // supported. Hide incompatible NV GPUs by default, keep all GPUs that match the selected
+    // release architecture so homogeneous multi-GPU systems still use multiple cards.
+    if (is_llamacpp_cuda_backend(llamacpp_backend)) {
+        const char* existing_visible_devices = std::getenv("CUDA_VISIBLE_DEVICES");
+        const char* existing_llama_device = std::getenv("LLAMA_ARG_DEVICE");
+        const bool has_visible_override = existing_visible_devices && existing_visible_devices[0] != '\0';
+        const bool has_llama_device_override = existing_llama_device && existing_llama_device[0] != '\0';
+
+        if (!llamacpp_device.empty()) {
+            LOG(INFO, "LlamaCpp")
+                << "Using explicit llama.cpp CUDA device selection: " << llamacpp_device
+                << std::endl;
+        } else if (has_visible_override) {
+            LOG(INFO, "LlamaCpp")
+                << "Respecting existing CUDA_VISIBLE_DEVICES=" << existing_visible_devices
+                << std::endl;
+        } else if (has_llama_device_override) {
+            LOG(INFO, "LlamaCpp")
+                << "Respecting existing LLAMA_ARG_DEVICE=" << existing_llama_device
+                << std::endl;
+        } else {
+            std::string cuda_arch = SystemInfo::get_cuda_arch();
+            std::string visible_devices = SystemInfo::get_cuda_visible_devices_for_arch(cuda_arch);
+            if (!cuda_arch.empty() && !visible_devices.empty()) {
+                env_vars.push_back({"CUDA_VISIBLE_DEVICES", visible_devices});
+                LOG(INFO, "LlamaCpp")
+                    << "Restricting CUDA_VISIBLE_DEVICES to " << visible_devices
+                    << " for " << cuda_arch
+                    << " CUDA asset; matching same-arch GPUs remain available for multi-GPU offload"
+                    << std::endl;
+            }
+        }
+    }
 
 #ifdef __APPLE__
     // Forward GGML_METAL_NO_RESIDENCY to llama-server if set in the parent

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -172,6 +172,7 @@ static const EnvMapping env_mappings[] = {
     {"LEMONADE_LLAMACPP_PREFER_SYSTEM",  "llamacpp",  "prefer_system"},
     {"LEMONADE_LLAMACPP_ROCM_BIN",       "llamacpp",  "rocm_bin"},
     {"LEMONADE_LLAMACPP_VULKAN_BIN",     "llamacpp",  "vulkan_bin"},
+    {"LEMONADE_LLAMACPP_CUDA_BIN",       "llamacpp",  "cuda_bin"},
     {"LEMONADE_LLAMACPP_CPU_BIN",        "llamacpp",  "cpu_bin"},
     // whispercpp
     {"LEMONADE_WHISPERCPP",              "whispercpp", "backend"},

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -204,6 +204,7 @@ static const EnvMapping env_mappings[] = {
     {"LEMONADE_LLAMACPP_PREFER_SYSTEM",  "llamacpp",  "prefer_system"},
     {"LEMONADE_LLAMACPP_ROCM_BIN",       "llamacpp",  "rocm_bin"},
     {"LEMONADE_LLAMACPP_VULKAN_BIN",     "llamacpp",  "vulkan_bin"},
+    {"LEMONADE_LLAMACPP_CUDA_BIN",       "llamacpp",  "cuda_bin"},
     {"LEMONADE_LLAMACPP_CPU_BIN",        "llamacpp",  "cpu_bin"},
     // whispercpp
     {"LEMONADE_WHISPERCPP",              "whispercpp", "backend"},

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -72,6 +72,21 @@ const std::vector<std::string> NVIDIA_DISCRETE_GPU_KEYWORDS = {
     "a100", "a40", "a30", "a10", "a6000", "a5000", "a4000", "a2000"
 };
 
+// CUDA Compute Capability targets that the Phqen1x/llamacpp-cuda release pipeline
+// publishes binaries for. Each entry is a literal `sm_XX` token that appears in the
+// release asset filename (e.g. llama-windows-cuda-sm_86-x64.7z).
+// Empty string means "no CUDA binary for this compute capability" — skip for
+// get_cuda_arch / install filenames.
+const std::set<std::string> CUDA_SUPPORTED_ARCHS = {
+    "sm_75",   // Turing       (RTX 20, GTX 16, T4, Quadro RTX)
+    "sm_80",   // Ampere DC    (A100)
+    "sm_86",   // Ampere       (RTX 30, A40, A6000, A4000)
+    "sm_89",   // Ada Lovelace (RTX 40, L40, L4)
+    "sm_90",   // Hopper       (H100, H200)
+    "sm_100",  // Blackwell DC (B100, B200)
+    "sm_120",  // Blackwell    (RTX 50)
+};
+
 // ROCm architecture mapping - maps specific gfx architectures to their family (download target).
 // Empty string means "no ROCm binary for this ISA" — skip for get_rocm_arch / install filenames.
 const std::map<std::string, std::string> ROCM_ARCH_MAPPING = {
@@ -139,6 +154,9 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
     {"llamacpp", "rocm", {"windows", "linux"}, {
         {"amd_gpu", {"gfx1150", "gfx1151", "gfx103X", "gfx110X", "gfx120X"}},  // STX iGPUs + RDNA2/3/4 dGPUs
     }},
+    {"llamacpp", "cuda", {"windows", "linux"}, {
+        {"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120"}},
+    }},
     {"llamacpp", "cpu", {"windows", "linux"}, {
         {"cpu", {"x86_64"}},
     }},
@@ -200,6 +218,15 @@ static const std::map<std::string, std::string> DEVICE_FAMILY_NAMES = {
     {"gfx103X", "Radeon RX 6000 series (RDNA2)"},
     {"gfx110X", "Radeon RX 7000 series (RDNA3)"},
     {"gfx120X", "Radeon RX 9000 series (RDNA4)"},
+
+    // NVIDIA GPU compute capabilities (CUDA)
+    {"sm_75",  "GeForce RTX 20 / GTX 16 series (Turing)"},
+    {"sm_80",  "NVIDIA A100 (Ampere)"},
+    {"sm_86",  "GeForce RTX 30 / A40 / A6000 (Ampere)"},
+    {"sm_89",  "GeForce RTX 40 / L40 / L4 (Ada Lovelace)"},
+    {"sm_90",  "NVIDIA H100 / H200 (Hopper)"},
+    {"sm_100", "NVIDIA B100 / B200 (Blackwell)"},
+    {"sm_120", "GeForce RTX 50 series (Blackwell)"},
 
     // NPU architectures
     {"XDNA2", "AMD XDNA 2"},
@@ -285,6 +312,7 @@ static std::string get_current_os() {
 
 // Forward declarations for helper functions
 std::string identify_rocm_arch_from_name(const std::string& device_name);
+std::string identify_cuda_arch_from_name(const std::string& device_name);
 std::string identify_npu_arch();
 static std::string read_version_file(const fs::path& version_file);
 static std::string get_expected_backend_version(const std::string& recipe, const std::string& backend);
@@ -561,6 +589,9 @@ json SystemInfo::get_device_dict() {
                 {"name", gpu.name},
                 {"available", gpu.available}
             };
+            if (gpu.available && !gpu.name.empty()) {
+                gpu_json["family"] = identify_cuda_arch_from_name(gpu.name);
+            }
             if (gpu.vram_gb > 0) {
                 gpu_json["vram_gb"] = gpu.vram_gb;
             }
@@ -707,6 +738,24 @@ json SystemInfo::build_recipes_info(const json& devices) {
                 if (!name.empty()) {
                     detected_devices.push_back({
                         "amd_gpu",
+                        name,
+                        family,
+                        true
+                    });
+                }
+            }
+        }
+    }
+
+    // NVIDIA GPUs
+    if (devices.contains("nvidia_gpu") && devices["nvidia_gpu"].is_array()) {
+        for (const auto& gpu : devices["nvidia_gpu"]) {
+            if (gpu.value("available", false)) {
+                std::string name = gpu.value("name", "");
+                std::string family = gpu.value("family", "");
+                if (!name.empty()) {
+                    detected_devices.push_back({
+                        "nvidia_gpu",
                         name,
                         family,
                         true
@@ -894,8 +943,8 @@ json SystemInfo::build_recipes_info(const json& devices) {
                     ? wrong_family[0]
                     : missing_devices[0];
 
-                // For AMD GPUs, include the detected family in the message
-                if (device_type == "amd_gpu") {
+                // For AMD/NVIDIA GPUs, include the detected family in the message
+                if (device_type == "amd_gpu" || device_type == "nvidia_gpu") {
                     // Find the detected GPU family for this device type
                     std::string detected_family;
                     for (const auto& detected : detected_devices) {
@@ -1232,6 +1281,132 @@ std::string SystemInfo::get_system_llamacpp_version() {
     return "unknown";
 }
 
+// Map a CUDA Compute Capability "MAJOR.MINOR" string (as reported by nvidia-smi
+// --query-gpu=compute_cap) to the sm_XX token used in llamacpp-cuda release filenames.
+// Returns empty if the value cannot be parsed.
+static std::string compute_cap_to_sm(const std::string& compute_cap) {
+    size_t dot = compute_cap.find('.');
+    if (dot == std::string::npos) return "";
+    std::string major = compute_cap.substr(0, dot);
+    std::string minor = compute_cap.substr(dot + 1);
+    if (major.empty() || minor.empty()) return "";
+    // major*10 + minor, e.g. "8.6" -> "sm_86", "12.0" -> "sm_120"
+    try {
+        int m = std::stoi(major);
+        int n = std::stoi(minor);
+        return "sm_" + std::to_string(m * 10 + n);
+    } catch (...) {
+        return "";
+    }
+}
+
+// Helper to identify CUDA Compute Capability from a marketing GPU name.
+// Returns an sm_XX token (e.g. "sm_86") when the model can be inferred, or an empty
+// string otherwise. This is the fallback path used when nvidia-smi compute_cap is
+// not available; it intentionally only covers GPUs the llamacpp-cuda backend ships
+// binaries for (CUDA_SUPPORTED_ARCHS).
+std::string identify_cuda_arch_from_name(const std::string& device_name) {
+    std::string device_lower = device_name;
+    std::transform(device_lower.begin(), device_lower.end(), device_lower.begin(), ::tolower);
+
+    if (device_lower.find("nvidia") == std::string::npos &&
+        device_lower.find("geforce") == std::string::npos &&
+        device_lower.find("rtx") == std::string::npos &&
+        device_lower.find("gtx") == std::string::npos &&
+        device_lower.find("quadro") == std::string::npos &&
+        device_lower.find("tesla") == std::string::npos &&
+        device_lower.find("titan") == std::string::npos) {
+        // Allow bare datacenter SKUs ("a100", "h100", etc.) below.
+        if (device_lower.find("a100") == std::string::npos &&
+            device_lower.find("a40")  == std::string::npos &&
+            device_lower.find("a30")  == std::string::npos &&
+            device_lower.find("a10")  == std::string::npos &&
+            device_lower.find("h100") == std::string::npos &&
+            device_lower.find("h200") == std::string::npos &&
+            device_lower.find("b100") == std::string::npos &&
+            device_lower.find("b200") == std::string::npos &&
+            device_lower.find("l40")  == std::string::npos &&
+            device_lower.find("l4")   == std::string::npos) {
+            return "";
+        }
+    }
+
+    // Blackwell datacenter (sm_100): B100, B200
+    if (device_lower.find("b100") != std::string::npos ||
+        device_lower.find("b200") != std::string::npos) {
+        return "sm_100";
+    }
+
+    // Hopper (sm_90): H100, H200
+    if (device_lower.find("h100") != std::string::npos ||
+        device_lower.find("h200") != std::string::npos) {
+        return "sm_90";
+    }
+
+    // Ampere datacenter (sm_80): A100
+    if (device_lower.find("a100") != std::string::npos) {
+        return "sm_80";
+    }
+
+    // Blackwell consumer (sm_120): RTX 50 series (5090/5080/5070/5060/...)
+    if (device_lower.find("rtx 50") != std::string::npos ||
+        device_lower.find("rtx50")  != std::string::npos ||
+        device_lower.find("5090")   != std::string::npos ||
+        device_lower.find("5080")   != std::string::npos ||
+        device_lower.find("5070")   != std::string::npos ||
+        device_lower.find("5060")   != std::string::npos) {
+        return "sm_120";
+    }
+
+    // Ada Lovelace (sm_89): RTX 40 series, L40, L4
+    if (device_lower.find("rtx 40") != std::string::npos ||
+        device_lower.find("rtx40")  != std::string::npos ||
+        device_lower.find("4090")   != std::string::npos ||
+        device_lower.find("4080")   != std::string::npos ||
+        device_lower.find("4070")   != std::string::npos ||
+        device_lower.find("4060")   != std::string::npos ||
+        device_lower.find("l40")    != std::string::npos ||
+        device_lower.find("l4")     != std::string::npos) {
+        return "sm_89";
+    }
+
+    // Ampere consumer / pro (sm_86): RTX 30 series, A40, A6000, A4000, A2000, A30, A10
+    if (device_lower.find("rtx 30") != std::string::npos ||
+        device_lower.find("rtx30")  != std::string::npos ||
+        device_lower.find("3090")   != std::string::npos ||
+        device_lower.find("3080")   != std::string::npos ||
+        device_lower.find("3070")   != std::string::npos ||
+        device_lower.find("3060")   != std::string::npos ||
+        device_lower.find("3050")   != std::string::npos ||
+        device_lower.find("a40")    != std::string::npos ||
+        device_lower.find("a30")    != std::string::npos ||
+        device_lower.find("a10")    != std::string::npos ||
+        device_lower.find("a6000")  != std::string::npos ||
+        device_lower.find("a5000")  != std::string::npos ||
+        device_lower.find("a4000")  != std::string::npos ||
+        device_lower.find("a2000")  != std::string::npos) {
+        return "sm_86";
+    }
+
+    // Turing (sm_75): RTX 20 series, GTX 16 series, T4, Quadro RTX
+    if (device_lower.find("rtx 20") != std::string::npos ||
+        device_lower.find("rtx20")  != std::string::npos ||
+        device_lower.find("2080")   != std::string::npos ||
+        device_lower.find("2070")   != std::string::npos ||
+        device_lower.find("2060")   != std::string::npos ||
+        device_lower.find("gtx 16") != std::string::npos ||
+        device_lower.find("gtx16")  != std::string::npos ||
+        device_lower.find("1660")   != std::string::npos ||
+        device_lower.find("1650")   != std::string::npos ||
+        device_lower.find("titan rtx") != std::string::npos ||
+        device_lower.find("quadro rtx") != std::string::npos ||
+        device_lower.find(" t4")    != std::string::npos) {
+        return "sm_75";
+    }
+
+    return "";
+}
+
 // Helper to identify ROCm architecture from GPU name.
 // Returns the mapped family (or exact gfx115x target); map value may be "" to skip ROCm for that ISA.
 // If not in ROCM_ARCH_MAPPING, returns the raw detected arch for other unsupported GPUs.
@@ -1526,6 +1701,49 @@ std::string SystemInfo::get_rocm_arch() {
     }
 
     return "";  // No supported architecture found
+}
+
+std::string SystemInfo::get_cuda_arch() {
+    // Returns the CUDA Compute Capability (sm_XX) for the best available NVIDIA GPU
+    // on this system, or an empty string if no compatible GPU is found. Mirrors
+    // get_rocm_arch(): reads the cached system_info, then either uses the
+    // compute_cap reported by nvidia-smi (preferred) or falls back to
+    // identify_cuda_arch_from_name() against the marketing name.
+    try {
+        json system_info = SystemInfoCache::get_system_info_with_cache();
+
+        if (!system_info.contains("devices")) {
+            return "";
+        }
+
+        const auto& devices = system_info["devices"];
+
+        if (devices.contains("nvidia_gpu") && devices["nvidia_gpu"].is_array()) {
+            for (const auto& gpu : devices["nvidia_gpu"]) {
+                if (!gpu.value("available", false)) continue;
+
+                // Prefer the cached family (set during device detection from
+                // nvidia-smi compute_cap), falling back to the marketing name
+                // for older drivers that do not expose compute_cap.
+                std::string family = gpu.value("family", "");
+                if (!family.empty() && CUDA_SUPPORTED_ARCHS.count(family)) {
+                    return family;
+                }
+
+                std::string name = gpu.value("name", "");
+                if (!name.empty()) {
+                    std::string arch = identify_cuda_arch_from_name(name);
+                    if (!arch.empty() && CUDA_SUPPORTED_ARCHS.count(arch)) {
+                        return arch;
+                    }
+                }
+            }
+        }
+    } catch (...) {
+        // Detection failed
+    }
+
+    return "";
 }
 
 bool SystemInfo::get_has_igpu() {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -72,9 +72,9 @@ const std::vector<std::string> NVIDIA_DISCRETE_GPU_KEYWORDS = {
     "a100", "a40", "a30", "a10", "a6000", "a5000", "a4000", "a2000"
 };
 
-// CUDA Compute Capability targets that the Phqen1x/llama.cpp release pipeline
+// CUDA Compute Capability targets that the Phqen1x/llama.cpp-builds release pipeline
 // publishes binaries for. Each entry is a literal `sm_XX` token that appears in the
-// release asset filename (e.g. llama-windows-cuda-sm_86-x64.7z).
+// release asset filename (e.g. llama-ubuntu-cuda-sm_86-x64.tar.xz).
 // Empty string means "no CUDA binary for this compute capability" — skip for
 // get_cuda_arch / install filenames.
 const std::set<std::string> CUDA_SUPPORTED_ARCHS = {
@@ -330,6 +330,7 @@ static std::string get_current_os() {
 std::string identify_rocm_arch_from_name(const std::string& device_name);
 std::string identify_cuda_arch_from_name(const std::string& device_name);
 std::string identify_npu_arch();
+static std::string compute_cap_to_sm(const std::string& compute_cap);
 static std::string read_version_file(const fs::path& version_file);
 static std::string get_expected_backend_version(const std::string& recipe, const std::string& backend);
 
@@ -619,6 +620,12 @@ json SystemInfo::get_device_dict() {
                 {"name", gpu.name},
                 {"available", gpu.available}
             };
+            if (gpu.index >= 0) {
+                gpu_json["index"] = gpu.index;
+            }
+            if (!gpu.uuid.empty()) {
+                gpu_json["uuid"] = gpu.uuid;
+            }
             if (gpu.available) {
                 std::string family;
                 const bool has_compute_cap = !gpu.compute_capability.empty();
@@ -1444,9 +1451,9 @@ std::string identify_cuda_arch_from_name(const std::string& device_name) {
         {"sm_100", {"b100", "b200"}},
         {"sm_90",  {"h100", "h200"}},
         {"sm_89",  {"rtx 40", "rtx40", "4090", "4080", "4070", "4060", "l40", " l4"}},
+        {"sm_80",  {"a100"}},
         {"sm_86",  {"rtx 30", "rtx30", "3090", "3080", "3070", "3060", "3050",
                     "a40", "a30", "a10", "a6000", "a5000", "a4000", "a2000"}},
-        {"sm_80",  {"a100"}},
         {"sm_75",  {"rtx 20", "rtx20", "2080", "2070", "2060",
                     "gtx 16", "gtx16", "1660", "1650",
                     "titan rtx", "quadro rtx", " t4"}},
@@ -1756,6 +1763,34 @@ std::string SystemInfo::get_rocm_arch() {
     return "";  // No supported architecture found
 }
 
+static int cuda_sm_value(const std::string& arch) {
+    if (arch.size() <= 3 || arch.substr(0, 3) != "sm_") {
+        return 0;
+    }
+    try {
+        return std::stoi(arch.substr(3));
+    } catch (...) {
+        return 0;
+    }
+}
+
+static std::string cuda_arch_from_gpu_json(const json& gpu) {
+    std::string family = gpu.value("family", "");
+    if (!family.empty() && CUDA_SUPPORTED_ARCHS.count(family)) {
+        return family;
+    }
+
+    std::string name = gpu.value("name", "");
+    if (!name.empty()) {
+        std::string name_arch = identify_cuda_arch_from_name(name);
+        if (!name_arch.empty() && CUDA_SUPPORTED_ARCHS.count(name_arch)) {
+            return name_arch;
+        }
+    }
+
+    return "";
+}
+
 std::string SystemInfo::get_cuda_arch() {
     // Returns the sm_XX token for the best available NVIDIA GPU on this system.
     // On multi-GPU systems, selects the GPU with the highest supported compute
@@ -1780,27 +1815,11 @@ std::string SystemInfo::get_cuda_arch() {
         for (const auto& gpu : devices["nvidia_gpu"]) {
             if (!gpu.value("available", false)) continue;
 
-            std::string arch;
-            std::string family = gpu.value("family", "");
-            if (!family.empty() && CUDA_SUPPORTED_ARCHS.count(family)) {
-                arch = family;
-            } else {
-                std::string name = gpu.value("name", "");
-                if (!name.empty()) {
-                    std::string name_arch = identify_cuda_arch_from_name(name);
-                    if (!name_arch.empty() && CUDA_SUPPORTED_ARCHS.count(name_arch)) {
-                        arch = name_arch;
-                    }
-                }
-            }
-
-            if (!arch.empty() && arch.size() > 3 && arch.substr(0, 3) == "sm_") {
-                int sm_val = 0;
-                try { sm_val = std::stoi(arch.substr(3)); } catch (...) {}
-                if (sm_val > best_sm_val) {
-                    best_sm_val = sm_val;
-                    best_arch = arch;
-                }
+            std::string arch = cuda_arch_from_gpu_json(gpu);
+            int sm_val = cuda_sm_value(arch);
+            if (sm_val > best_sm_val) {
+                best_sm_val = sm_val;
+                best_arch = arch;
             }
         }
 
@@ -1810,6 +1829,98 @@ std::string SystemInfo::get_cuda_arch() {
     }
 
     return "";
+}
+
+std::vector<int> SystemInfo::get_cuda_device_indices_for_arch(const std::string& arch) {
+    std::vector<int> indices;
+    if (arch.empty()) {
+        return indices;
+    }
+
+    try {
+        json system_info = SystemInfoCache::get_system_info_with_cache();
+        if (!system_info.contains("devices")) {
+            return indices;
+        }
+
+        const auto& devices = system_info["devices"];
+        if (!devices.contains("nvidia_gpu") || !devices["nvidia_gpu"].is_array()) {
+            return indices;
+        }
+
+        int ordinal = 0;
+        for (const auto& gpu : devices["nvidia_gpu"]) {
+            if (!gpu.value("available", false)) {
+                ordinal++;
+                continue;
+            }
+
+            if (cuda_arch_from_gpu_json(gpu) == arch) {
+                int index = gpu.value("index", -1);
+                if (index < 0) {
+                    index = ordinal;
+                }
+                indices.push_back(index);
+            }
+            ordinal++;
+        }
+    } catch (...) {
+        indices.clear();
+    }
+
+    return indices;
+}
+
+std::string SystemInfo::get_cuda_visible_devices_for_arch(const std::string& arch) {
+    // CUDA_VISIBLE_DEVICES accepts GPU UUIDs. Prefer UUIDs over numeric indices because
+    // CUDA runtime ordinals and nvidia-smi/NVML indices can differ on mixed systems.
+    // Passing a numeric nvidia-smi index can therefore accidentally expose the wrong GPU
+    // (e.g. selecting sm_120 but making an sm_89 RTX 4090 visible as CUDA0).
+    std::vector<std::string> devices_to_expose;
+    if (arch.empty()) {
+        return "";
+    }
+
+    try {
+        json system_info = SystemInfoCache::get_system_info_with_cache();
+        if (!system_info.contains("devices")) {
+            return "";
+        }
+
+        const auto& devices = system_info["devices"];
+        if (!devices.contains("nvidia_gpu") || !devices["nvidia_gpu"].is_array()) {
+            return "";
+        }
+
+        int ordinal = 0;
+        for (const auto& gpu : devices["nvidia_gpu"]) {
+            if (!gpu.value("available", false)) {
+                ordinal++;
+                continue;
+            }
+
+            if (cuda_arch_from_gpu_json(gpu) == arch) {
+                std::string uuid = gpu.value("uuid", "");
+                if (!uuid.empty()) {
+                    devices_to_expose.push_back(uuid);
+                } else {
+                    // Fallback only for detection paths that lack UUIDs. This is less robust
+                    // than UUIDs because numeric CUDA ordinals can differ from nvidia-smi indices.
+                    devices_to_expose.push_back(std::to_string(ordinal));
+                }
+            }
+            ordinal++;
+        }
+    } catch (...) {
+        devices_to_expose.clear();
+    }
+
+    std::ostringstream ss;
+    for (size_t i = 0; i < devices_to_expose.size(); ++i) {
+        if (i > 0) ss << ",";
+        ss << devices_to_expose[i];
+    }
+    return ss.str();
 }
 
 bool SystemInfo::get_has_igpu() {
@@ -1916,6 +2027,8 @@ std::unique_ptr<SystemInfo> create_system_info() {
 // ============================================================================
 
 struct NvidiaSmiGpuInfo {
+    int index = -1;
+    std::string uuid;          // e.g. "GPU-..."
     std::string name;
     std::string compute_cap;   // e.g. "8.6"
     std::string driver_version;
@@ -1924,7 +2037,7 @@ struct NvidiaSmiGpuInfo {
 
 // Query nvidia-smi for all GPUs. Returns one entry per GPU or an empty vector
 // if nvidia-smi is not available (e.g. drivers not installed).
-// Uses: nvidia-smi --query-gpu=name,compute_cap,driver_version,memory.total
+// Uses: nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total
 //                  --format=csv,noheader,nounits
 static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
     std::vector<NvidiaSmiGpuInfo> result;
@@ -1932,13 +2045,13 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
 
 #ifdef _WIN32
     int rc = lemon::utils::ProcessManager::run_command(
-        "nvidia-smi --query-gpu=name,compute_cap,driver_version,memory.total "
+        "nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total "
         "--format=csv,noheader,nounits 2>NUL",
         output, 10);
     if (rc != 0 || output.empty()) return result;
 #else
     FILE* pipe = popen(
-        "nvidia-smi --query-gpu=name,compute_cap,driver_version,memory.total "
+        "nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total "
         "--format=csv,noheader,nounits 2>/dev/null", "r");
     if (!pipe) return result;
     char buffer[512];
@@ -1959,8 +2072,8 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
         line = trim(line);
         if (line.empty()) continue;
 
-        // Fields: name, compute_cap, driver_version, memory_mb
-        // Separated by ", ". Split from the right so names with commas are handled.
+        // Fields: index, uuid, name, compute_cap, driver_version, memory_mb.
+        // Split the right side first so names with commas are handled.
         std::string remaining = line;
         std::vector<std::string> tail;
         for (int i = 0; i < 3; i++) {
@@ -1972,7 +2085,30 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
         if (tail.size() != 3) continue;
 
         NvidiaSmiGpuInfo info;
-        info.name           = trim(remaining);
+        size_t first_comma = remaining.find(", ");
+        size_t second_comma = first_comma == std::string::npos
+            ? std::string::npos
+            : remaining.find(", ", first_comma + 2);
+
+        if (first_comma != std::string::npos && second_comma != std::string::npos) {
+            try {
+                info.index = std::stoi(trim(remaining.substr(0, first_comma)));
+            } catch (...) {
+                info.index = static_cast<int>(result.size());
+            }
+            info.uuid = trim(remaining.substr(first_comma + 2, second_comma - first_comma - 2));
+            info.name = trim(remaining.substr(second_comma + 2));
+        } else if (first_comma != std::string::npos) {
+            try {
+                info.index = std::stoi(trim(remaining.substr(0, first_comma)));
+            } catch (...) {
+                info.index = static_cast<int>(result.size());
+            }
+            info.name = trim(remaining.substr(first_comma + 2));
+        } else {
+            info.index = static_cast<int>(result.size());
+            info.name = trim(remaining);
+        }
         info.compute_cap    = tail[0];
         info.driver_version = tail[1];
         try {
@@ -2072,6 +2208,8 @@ std::vector<GPUInfo> WindowsSystemInfo::get_nvidia_gpu_devices() {
     if (!smi_gpus.empty()) {
         for (const auto& smi : smi_gpus) {
             GPUInfo gpu;
+            gpu.index              = smi.index;
+            gpu.uuid               = smi.uuid;
             gpu.name               = smi.name;
             gpu.available          = true;
             gpu.compute_capability = smi.compute_cap;
@@ -2550,6 +2688,8 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
     if (!smi_gpus.empty()) {
         for (const auto& smi : smi_gpus) {
             GPUInfo gpu;
+            gpu.index              = smi.index;
+            gpu.uuid               = smi.uuid;
             gpu.name               = smi.name;
             gpu.available          = true;
             gpu.compute_capability = smi.compute_cap;

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -72,6 +72,21 @@ const std::vector<std::string> NVIDIA_DISCRETE_GPU_KEYWORDS = {
     "a100", "a40", "a30", "a10", "a6000", "a5000", "a4000", "a2000"
 };
 
+// CUDA Compute Capability targets that the Phqen1x/llama.cpp release pipeline
+// publishes binaries for. Each entry is a literal `sm_XX` token that appears in the
+// release asset filename (e.g. llama-windows-cuda-sm_86-x64.7z).
+// Empty string means "no CUDA binary for this compute capability" — skip for
+// get_cuda_arch / install filenames.
+const std::set<std::string> CUDA_SUPPORTED_ARCHS = {
+    "sm_75",   // Turing       (RTX 20, GTX 16, T4, Quadro RTX)
+    "sm_80",   // Ampere DC    (A100)
+    "sm_86",   // Ampere       (RTX 30, A40, A6000, A4000)
+    "sm_89",   // Ada Lovelace (RTX 40, L40, L4)
+    "sm_90",   // Hopper       (H100, H200)
+    "sm_100",  // Blackwell DC (B100, B200)
+    "sm_120",  // Blackwell    (RTX 50)
+};
+
 // ROCm architecture mapping - maps specific gfx architectures to their family (download target).
 // Empty string means "no ROCm binary for this ISA" — skip for get_rocm_arch / install filenames.
 const std::map<std::string, std::string> ROCM_ARCH_MAPPING = {
@@ -131,6 +146,9 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
     {"llamacpp", "metal", {"macos"},
     {
         {"metal", {}},
+    }},
+    {"llamacpp", "cuda", {"windows", "linux"}, {
+        {"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120"}},
     }},
     {"llamacpp", "vulkan", {"windows", "linux"}, {
         {"cpu", {"x86_64"}},
@@ -217,6 +235,15 @@ static const std::map<std::string, std::string> DEVICE_FAMILY_NAMES = {
     {"gfx110X", "Radeon RX 7000 series (RDNA3)"},
     {"gfx120X", "Radeon RX 9000 series (RDNA4)"},
 
+    // NVIDIA GPU compute capabilities (CUDA)
+    {"sm_75",  "GeForce RTX 20 / GTX 16 series (Turing)"},
+    {"sm_80",  "NVIDIA A100 (Ampere)"},
+    {"sm_86",  "GeForce RTX 30 / A40 / A6000 (Ampere)"},
+    {"sm_89",  "GeForce RTX 40 / L40 / L4 (Ada Lovelace)"},
+    {"sm_90",  "NVIDIA H100 / H200 (Hopper)"},
+    {"sm_100", "NVIDIA B100 / B200 (Blackwell)"},
+    {"sm_120", "GeForce RTX 50 series (Blackwell)"},
+
     // NPU architectures
     {"XDNA2", "AMD XDNA 2"},
 };
@@ -301,6 +328,7 @@ static std::string get_current_os() {
 
 // Forward declarations for helper functions
 std::string identify_rocm_arch_from_name(const std::string& device_name);
+std::string identify_cuda_arch_from_name(const std::string& device_name);
 std::string identify_npu_arch();
 static std::string read_version_file(const fs::path& version_file);
 static std::string get_expected_backend_version(const std::string& recipe, const std::string& backend);
@@ -591,6 +619,22 @@ json SystemInfo::get_device_dict() {
                 {"name", gpu.name},
                 {"available", gpu.available}
             };
+            if (gpu.available) {
+                std::string family;
+                const bool has_compute_cap = !gpu.compute_capability.empty();
+                if (has_compute_cap) {
+                    // Primary: derive sm_XX from nvidia-smi compute_cap (e.g. "8.6" -> "sm_86").
+                    // Keep the derived value even when unsupported so availability logic can
+                    // surface a precise "Unsupported GPU: sm_XX" message.
+                    family = compute_cap_to_sm(gpu.compute_capability);
+                    gpu_json["compute_capability"] = gpu.compute_capability;
+                }
+                if (family.empty() && !has_compute_cap && !gpu.name.empty()) {
+                    // Fallback only when compute_cap is unavailable.
+                    family = identify_cuda_arch_from_name(gpu.name);
+                }
+                gpu_json["family"] = family;
+            }
             if (gpu.vram_gb > 0) {
                 gpu_json["vram_gb"] = gpu.vram_gb;
             }
@@ -737,6 +781,24 @@ json SystemInfo::build_recipes_info(const json& devices) {
                 if (!name.empty()) {
                     detected_devices.push_back({
                         "amd_gpu",
+                        name,
+                        family,
+                        true
+                    });
+                }
+            }
+        }
+    }
+
+    // NVIDIA GPUs
+    if (devices.contains("nvidia_gpu") && devices["nvidia_gpu"].is_array()) {
+        for (const auto& gpu : devices["nvidia_gpu"]) {
+            if (gpu.value("available", false)) {
+                std::string name = gpu.value("name", "");
+                std::string family = gpu.value("family", "");
+                if (!name.empty()) {
+                    detected_devices.push_back({
+                        "nvidia_gpu",
                         name,
                         family,
                         true
@@ -953,8 +1015,8 @@ json SystemInfo::build_recipes_info(const json& devices) {
                     ? wrong_family[0]
                     : missing_devices[0];
 
-                // For AMD GPUs, include the detected family in the message
-                if (device_type == "amd_gpu") {
+                // For AMD/NVIDIA GPUs, include the detected family in the message
+                if (device_type == "amd_gpu" || device_type == "nvidia_gpu") {
                     // Find the detected GPU family for this device type
                     std::string detected_family;
                     for (const auto& detected : detected_devices) {
@@ -964,7 +1026,26 @@ json SystemInfo::build_recipes_info(const json& devices) {
                         }
                     }
 
-                    if (!detected_family.empty()) {
+                    if (device_type == "nvidia_gpu" && devices.contains("nvidia_gpu") && devices["nvidia_gpu"].is_array()) {
+                        std::string detected_compute_cap;
+                        for (const auto& gpu : devices["nvidia_gpu"]) {
+                            if (!gpu.value("available", false)) continue;
+                            std::string cc = gpu.value("compute_capability", "");
+                            if (!cc.empty()) {
+                                detected_compute_cap = cc;
+                                break;
+                            }
+                        }
+                        if (!detected_family.empty() && !detected_compute_cap.empty()) {
+                            message = "Unsupported GPU: " + detected_family + " (compute capability " + detected_compute_cap + ")";
+                        } else if (!detected_family.empty()) {
+                            message = "Unsupported GPU: " + detected_family;
+                        } else if (!detected_compute_cap.empty()) {
+                            message = "Unsupported GPU (compute capability " + detected_compute_cap + ")";
+                        } else {
+                            message = "Unsupported GPU";
+                        }
+                    } else if (!detected_family.empty()) {
                         message = "Unsupported GPU: " + detected_family;
                     } else {
                         message = "Unsupported GPU";
@@ -1314,6 +1395,71 @@ std::string SystemInfo::get_system_llamacpp_version() {
     return "unknown";
 }
 
+// Map a CUDA Compute Capability "MAJOR.MINOR" string (as reported by nvidia-smi
+// --query-gpu=compute_cap) to the sm_XX token used in llamacpp-cuda release filenames.
+// Returns empty if the value cannot be parsed.
+static std::string compute_cap_to_sm(const std::string& compute_cap) {
+    size_t dot = compute_cap.find('.');
+    if (dot == std::string::npos) return "";
+    std::string major = compute_cap.substr(0, dot);
+    std::string minor = compute_cap.substr(dot + 1);
+    if (major.empty() || minor.empty()) return "";
+    // major*10 + minor, e.g. "8.6" -> "sm_86", "12.0" -> "sm_120"
+    try {
+        int m = std::stoi(major);
+        int n = std::stoi(minor);
+        return "sm_" + std::to_string(m * 10 + n);
+    } catch (...) {
+        return "";
+    }
+}
+
+// Helper to identify CUDA Compute Capability from a marketing GPU name.
+// Returns an sm_XX token (e.g. "sm_86") when the model can be inferred, or an
+// empty string otherwise. This is the fallback path used when nvidia-smi
+// compute_cap is not available; it intentionally only covers GPUs for which
+// the llamacpp-cuda backend ships binaries (CUDA_SUPPORTED_ARCHS).
+//
+// IMPORTANT: nvidia-smi compute_cap is preferred — only extend this table for
+// GPUs that are confirmed to have a supported sm_XX binary.
+std::string identify_cuda_arch_from_name(const std::string& device_name) {
+    std::string n = device_name;
+    std::transform(n.begin(), n.end(), n.begin(), ::tolower);
+
+    // Quick guard: require at least one NVIDIA identifier substring
+    static const std::vector<std::string> NVIDIA_IDS = {
+        "nvidia", "geforce", "rtx", "gtx", "quadro", "tesla", "titan",
+        "a100", "a40", "a30", "a10", "h100", "h200", "b100", "b200", "l40",
+    };
+    bool is_nvidia = false;
+    for (const auto& id : NVIDIA_IDS) {
+        if (n.find(id) != std::string::npos) { is_nvidia = true; break; }
+    }
+    if (!is_nvidia) return "";
+
+    // Compact table: {sm_XX, {substrings that identify the architecture}}.
+    // Listed highest-to-lowest; first match wins.
+    static const std::vector<std::pair<std::string, std::vector<std::string>>> TABLE = {
+        {"sm_120", {"rtx 50", "rtx50", "5090", "5080", "5070", "5060"}},
+        {"sm_100", {"b100", "b200"}},
+        {"sm_90",  {"h100", "h200"}},
+        {"sm_89",  {"rtx 40", "rtx40", "4090", "4080", "4070", "4060", "l40", " l4"}},
+        {"sm_86",  {"rtx 30", "rtx30", "3090", "3080", "3070", "3060", "3050",
+                    "a40", "a30", "a10", "a6000", "a5000", "a4000", "a2000"}},
+        {"sm_80",  {"a100"}},
+        {"sm_75",  {"rtx 20", "rtx20", "2080", "2070", "2060",
+                    "gtx 16", "gtx16", "1660", "1650",
+                    "titan rtx", "quadro rtx", " t4"}},
+    };
+
+    for (const auto& [sm, keywords] : TABLE) {
+        for (const auto& kw : keywords) {
+            if (n.find(kw) != std::string::npos) return sm;
+        }
+    }
+    return "";
+}
+
 // Helper to identify ROCm architecture from GPU name.
 // Returns the mapped family (or exact gfx115x target); map value may be "" to skip ROCm for that ISA.
 // If not in ROCM_ARCH_MAPPING, returns the raw detected arch for other unsupported GPUs.
@@ -1610,6 +1756,62 @@ std::string SystemInfo::get_rocm_arch() {
     return "";  // No supported architecture found
 }
 
+std::string SystemInfo::get_cuda_arch() {
+    // Returns the sm_XX token for the best available NVIDIA GPU on this system.
+    // On multi-GPU systems, selects the GPU with the highest supported compute
+    // capability. Uses the cached family field (populated from nvidia-smi during
+    // device detection), falling back to marketing-name inference for older drivers.
+    try {
+        json system_info = SystemInfoCache::get_system_info_with_cache();
+
+        if (!system_info.contains("devices")) {
+            return "";
+        }
+
+        const auto& devices = system_info["devices"];
+
+        if (!devices.contains("nvidia_gpu") || !devices["nvidia_gpu"].is_array()) {
+            return "";
+        }
+
+        std::string best_arch;
+        int best_sm_val = 0;
+
+        for (const auto& gpu : devices["nvidia_gpu"]) {
+            if (!gpu.value("available", false)) continue;
+
+            std::string arch;
+            std::string family = gpu.value("family", "");
+            if (!family.empty() && CUDA_SUPPORTED_ARCHS.count(family)) {
+                arch = family;
+            } else {
+                std::string name = gpu.value("name", "");
+                if (!name.empty()) {
+                    std::string name_arch = identify_cuda_arch_from_name(name);
+                    if (!name_arch.empty() && CUDA_SUPPORTED_ARCHS.count(name_arch)) {
+                        arch = name_arch;
+                    }
+                }
+            }
+
+            if (!arch.empty() && arch.size() > 3 && arch.substr(0, 3) == "sm_") {
+                int sm_val = 0;
+                try { sm_val = std::stoi(arch.substr(3)); } catch (...) {}
+                if (sm_val > best_sm_val) {
+                    best_sm_val = sm_val;
+                    best_arch = arch;
+                }
+            }
+        }
+
+        return best_arch;
+    } catch (...) {
+        // Detection failed
+    }
+
+    return "";
+}
+
 bool SystemInfo::get_has_igpu() {
     // Detect at runtime using OS-level iGPU detection
     // Linux: checks for absence of board_info in sysfs (iGPUs don't have it)
@@ -1710,6 +1912,79 @@ std::unique_ptr<SystemInfo> create_system_info() {
 }
 
 // ============================================================================
+// NVIDIA detection helper
+// ============================================================================
+
+struct NvidiaSmiGpuInfo {
+    std::string name;
+    std::string compute_cap;   // e.g. "8.6"
+    std::string driver_version;
+    double vram_gb = 0.0;
+};
+
+// Query nvidia-smi for all GPUs. Returns one entry per GPU or an empty vector
+// if nvidia-smi is not available (e.g. drivers not installed).
+// Uses: nvidia-smi --query-gpu=name,compute_cap,driver_version,memory.total
+//                  --format=csv,noheader,nounits
+static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
+    std::vector<NvidiaSmiGpuInfo> result;
+    std::string output;
+
+#ifdef _WIN32
+    int rc = lemon::utils::ProcessManager::run_command(
+        "nvidia-smi --query-gpu=name,compute_cap,driver_version,memory.total "
+        "--format=csv,noheader,nounits 2>NUL",
+        output, 10);
+    if (rc != 0 || output.empty()) return result;
+#else
+    FILE* pipe = popen(
+        "nvidia-smi --query-gpu=name,compute_cap,driver_version,memory.total "
+        "--format=csv,noheader,nounits 2>/dev/null", "r");
+    if (!pipe) return result;
+    char buffer[512];
+    while (fgets(buffer, sizeof(buffer), pipe) != nullptr) output += buffer;
+    pclose(pipe);
+    if (output.empty()) return result;
+#endif
+
+    auto trim = [](std::string s) -> std::string {
+        size_t start = s.find_first_not_of(" \t\r\n");
+        size_t end   = s.find_last_not_of(" \t\r\n");
+        return (start == std::string::npos) ? "" : s.substr(start, end - start + 1);
+    };
+
+    std::istringstream ss(output);
+    std::string line;
+    while (std::getline(ss, line)) {
+        line = trim(line);
+        if (line.empty()) continue;
+
+        // Fields: name, compute_cap, driver_version, memory_mb
+        // Separated by ", ". Split from the right so names with commas are handled.
+        std::string remaining = line;
+        std::vector<std::string> tail;
+        for (int i = 0; i < 3; i++) {
+            size_t pos = remaining.rfind(", ");
+            if (pos == std::string::npos) break;
+            tail.insert(tail.begin(), trim(remaining.substr(pos + 2)));
+            remaining = remaining.substr(0, pos);
+        }
+        if (tail.size() != 3) continue;
+
+        NvidiaSmiGpuInfo info;
+        info.name           = trim(remaining);
+        info.compute_cap    = tail[0];
+        info.driver_version = tail[1];
+        try {
+            double mem_mb = std::stod(tail[2]);
+            info.vram_gb = mem_mb / 1024.0;
+        } catch (...) {}
+        result.push_back(info);
+    }
+    return result;
+}
+
+// ============================================================================
 // Windows implementation
 // ============================================================================
 
@@ -1791,6 +2066,23 @@ std::vector<GPUInfo> WindowsSystemInfo::get_amd_dgpu_devices() {
 std::vector<GPUInfo> WindowsSystemInfo::get_nvidia_gpu_devices() {
     std::vector<GPUInfo> gpus;
 
+    // Primary: nvidia-smi gives us name, compute capability, driver version, and VRAM
+    // in one query. This is more reliable than WMI for compute capability.
+    auto smi_gpus = query_nvidia_smi();
+    if (!smi_gpus.empty()) {
+        for (const auto& smi : smi_gpus) {
+            GPUInfo gpu;
+            gpu.name               = smi.name;
+            gpu.available          = true;
+            gpu.compute_capability = smi.compute_cap;
+            gpu.driver_version     = smi.driver_version;
+            gpu.vram_gb            = smi.vram_gb;
+            gpus.push_back(gpu);
+        }
+        return gpus;
+    }
+
+    // Fallback: WMI (for systems where nvidia-smi is not in PATH)
     wmi::WMIConnection wmi;
     if (!wmi.is_valid()) {
         GPUInfo gpu;
@@ -1803,12 +2095,10 @@ std::vector<GPUInfo> WindowsSystemInfo::get_nvidia_gpu_devices() {
     wmi.query(L"SELECT * FROM Win32_VideoController", [&gpus, this](IWbemClassObject* pObj) {
         std::string name = wmi::get_property_string(pObj, L"Name");
 
-        // Check if this is an NVIDIA GPU
         if (name.find("NVIDIA") != std::string::npos) {
             std::string name_lower = name;
             std::transform(name_lower.begin(), name_lower.end(), name_lower.begin(), ::tolower);
 
-            // Most NVIDIA GPUs are discrete
             bool is_discrete = true;
             for (const auto& keyword : NVIDIA_DISCRETE_GPU_KEYWORDS) {
                 if (name_lower.find(keyword) != std::string::npos) {
@@ -1822,17 +2112,13 @@ std::vector<GPUInfo> WindowsSystemInfo::get_nvidia_gpu_devices() {
                 gpu.name = name;
                 gpu.available = true;
 
-                // Get driver version - try multiple methods
                 std::string driver_version = get_driver_version("NVIDIA");
                 if (driver_version.empty()) {
                     driver_version = wmi::get_property_string(pObj, L"DriverVersion");
                 }
                 gpu.driver_version = driver_version.empty() ? "Unknown" : driver_version;
 
-                // Try dxdiag first (most reliable for dedicated memory)
                 gpu.vram_gb = get_gpu_vram_dxdiag(name);
-
-                // Fallback to nvidia-smi if dxdiag fails
                 if (gpu.vram_gb == 0.0) {
                     gpu.vram_gb = get_nvidia_vram_smi();
                 }
@@ -2258,7 +2544,23 @@ std::vector<GPUInfo> LinuxSystemInfo::get_amd_dgpu_devices() {
 std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
     std::vector<GPUInfo> gpus;
 
-    // Execute lspci to find GPUs
+    // Primary: nvidia-smi is always present when NVIDIA drivers are installed and
+    // gives us compute capability directly — no marketing-name guessing needed.
+    auto smi_gpus = query_nvidia_smi();
+    if (!smi_gpus.empty()) {
+        for (const auto& smi : smi_gpus) {
+            GPUInfo gpu;
+            gpu.name               = smi.name;
+            gpu.available          = true;
+            gpu.compute_capability = smi.compute_cap;
+            gpu.driver_version     = smi.driver_version;
+            gpu.vram_gb            = smi.vram_gb;
+            gpus.push_back(gpu);
+        }
+        return gpus;
+    }
+
+    // Fallback: lspci (for systems where nvidia-smi is unavailable)
     FILE* pipe = popen("lspci 2>/dev/null | grep -iE 'vga|3d|display'", "r");
     if (!pipe) {
         GPUInfo gpu;
@@ -2275,53 +2577,25 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
     }
     pclose(pipe);
 
-    // Parse NVIDIA GPUs
     for (const auto& line : lspci_lines) {
         if (line.find("NVIDIA") != std::string::npos || line.find("nvidia") != std::string::npos) {
-            // Extract device name
             std::string name;
             size_t pos = line.find(": ");
             if (pos != std::string::npos) {
                 name = line.substr(pos + 2);
-                // Remove newline
-                if (!name.empty() && name.back() == '\n') {
-                    name.pop_back();
-                }
+                if (!name.empty() && name.back() == '\n') name.pop_back();
             } else {
                 name = line;
             }
 
-            // Check if discrete (most NVIDIA GPUs are discrete)
-            std::string name_lower = name;
-            std::transform(name_lower.begin(), name_lower.end(), name_lower.begin(), ::tolower);
-
-            bool is_discrete = true;  // Default to discrete for NVIDIA
-            for (const auto& keyword : NVIDIA_DISCRETE_GPU_KEYWORDS) {
-                if (name_lower.find(keyword) != std::string::npos) {
-                    is_discrete = true;
-                    break;
-                }
-            }
-
-            if (is_discrete) {
-                GPUInfo gpu;
-                gpu.name = name;
-                gpu.available = true;
-
-                // Get driver version
-                gpu.driver_version = get_nvidia_driver_version();
-                if (gpu.driver_version.empty()) {
-                    gpu.driver_version = "Unknown";
-                }
-
-                // Get VRAM
-                double vram = get_nvidia_vram();
-                if (vram > 0.0) {
-                    gpu.vram_gb = vram;
-                }
-
-                gpus.push_back(gpu);
-            }
+            GPUInfo gpu;
+            gpu.name = name;
+            gpu.available = true;
+            gpu.driver_version = get_nvidia_driver_version();
+            if (gpu.driver_version.empty()) gpu.driver_version = "Unknown";
+            double vram = get_nvidia_vram();
+            if (vram > 0.0) gpu.vram_gb = vram;
+            gpus.push_back(gpu);
         }
     }
 

--- a/test/test_cuda_arch_mapping.py
+++ b/test/test_cuda_arch_mapping.py
@@ -187,6 +187,7 @@ class TestIdentifyCudaArchFromName(unittest.TestCase):
             ("NVIDIA GTX 1660 Super", "sm_75"),
             ("NVIDIA H100 PCIe", "sm_90"),
             ("NVIDIA A100-SXM4-80GB", "sm_80"),
+            ("NVIDIA A10", "sm_86"),
             ("NVIDIA A40", "sm_86"),
         ]
         for name, expected in cases:

--- a/test/test_cuda_arch_mapping.py
+++ b/test/test_cuda_arch_mapping.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+CPU-runnable unit tests for CUDA compute capability -> sm_XX mapping logic.
+
+These tests replicate the C++ compute_cap_to_sm() and
+identify_cuda_arch_from_name() functions so the mapping can be validated
+without NVIDIA hardware or a running server.
+
+Run with: python -m pytest test/test_cuda_arch_mapping.py
+      or: python test/test_cuda_arch_mapping.py
+"""
+
+import unittest
+
+# ---------------------------------------------------------------------------
+# Python replica of system_info.cpp::compute_cap_to_sm()
+# ---------------------------------------------------------------------------
+
+CUDA_SUPPORTED_ARCHS = {
+    "sm_75",  # Turing
+    "sm_80",  # Ampere DC
+    "sm_86",  # Ampere
+    "sm_89",  # Ada Lovelace
+    "sm_90",  # Hopper
+    "sm_100",  # Blackwell DC
+    "sm_120",  # Blackwell consumer
+}
+
+
+def compute_cap_to_sm(compute_cap: str) -> str:
+    """
+    Convert a "MAJOR.MINOR" compute-capability string from nvidia-smi to the
+    sm_XX token used in llamacpp-cuda release asset filenames.
+    Returns "" if the value cannot be parsed.
+    """
+    dot = compute_cap.find(".")
+    if dot == -1:
+        return ""
+    major, minor = compute_cap[:dot], compute_cap[dot + 1 :]
+    if not major or not minor:
+        return ""
+    try:
+        return f"sm_{int(major) * 10 + int(minor)}"
+    except ValueError:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Python replica of system_info.cpp::identify_cuda_arch_from_name() (compact)
+# ---------------------------------------------------------------------------
+
+_NAME_ARCH_TABLE = [
+    # Blackwell DC (sm_100)
+    (["b100", "b200"], "sm_100"),
+    # Hopper (sm_90)
+    (["h100", "h200"], "sm_90"),
+    # Ampere DC (sm_80)
+    (["a100"], "sm_80"),
+    # Blackwell consumer (sm_120)
+    (["rtx 50", "rtx50", "5090", "5080", "5070", "5060"], "sm_120"),
+    # Ada Lovelace (sm_89)
+    (["rtx 40", "rtx40", "4090", "4080", "4070", "4060", "l40", " l4"], "sm_89"),
+    # Ampere consumer/pro (sm_86)
+    (
+        [
+            "rtx 30",
+            "rtx30",
+            "3090",
+            "3080",
+            "3070",
+            "3060",
+            "3050",
+            "a40",
+            "a30",
+            "a10",
+            "a6000",
+            "a5000",
+            "a4000",
+            "a2000",
+        ],
+        "sm_86",
+    ),
+    # Turing (sm_75)
+    (
+        [
+            "rtx 20",
+            "rtx20",
+            "2080",
+            "2070",
+            "2060",
+            "gtx 16",
+            "gtx16",
+            "1660",
+            "1650",
+            "titan rtx",
+            "quadro rtx",
+            " t4",
+        ],
+        "sm_75",
+    ),
+]
+
+
+def identify_cuda_arch_from_name(device_name: str) -> str:
+    """Compact fallback: infer sm_XX from GPU marketing name."""
+    name = device_name.lower()
+    # Require at least one NVIDIA identifier
+    nvidia_ids = [
+        "nvidia",
+        "geforce",
+        "rtx",
+        "gtx",
+        "quadro",
+        "tesla",
+        "titan",
+        "a100",
+        "a40",
+        "a30",
+        "a10",
+        "h100",
+        "h200",
+        "b100",
+        "b200",
+        "l40",
+        "l4",
+    ]
+    if not any(kw in name for kw in nvidia_ids):
+        return ""
+    for keywords, sm in _NAME_ARCH_TABLE:
+        if any(kw in name for kw in keywords):
+            return sm
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCapToSm(unittest.TestCase):
+    def test_valid_mappings(self):
+        cases = [
+            ("7.5", "sm_75"),
+            ("8.0", "sm_80"),
+            ("8.6", "sm_86"),
+            ("8.9", "sm_89"),
+            ("9.0", "sm_90"),
+            ("10.0", "sm_100"),
+            ("12.0", "sm_120"),
+        ]
+        for cap, expected in cases:
+            with self.subTest(cap=cap):
+                self.assertEqual(compute_cap_to_sm(cap), expected)
+
+    def test_unsupported_but_parseable(self):
+        # Should still parse even if not in CUDA_SUPPORTED_ARCHS
+        self.assertEqual(compute_cap_to_sm("6.1"), "sm_61")
+        self.assertEqual(compute_cap_to_sm("5.0"), "sm_50")
+
+    def test_invalid_inputs(self):
+        for bad in ["", "86", "8", ".", "abc", "8.x"]:
+            with self.subTest(bad=bad):
+                self.assertEqual(compute_cap_to_sm(bad), "")
+
+    def test_supported_arch_membership(self):
+        for cap in ["7.5", "8.0", "8.6", "8.9", "9.0", "10.0", "12.0"]:
+            sm = compute_cap_to_sm(cap)
+            self.assertIn(
+                sm, CUDA_SUPPORTED_ARCHS, f"{cap} -> {sm} not in supported set"
+            )
+
+    def test_unsupported_arch_not_in_set(self):
+        for cap in ["6.1", "7.0", "5.0"]:
+            sm = compute_cap_to_sm(cap)
+            self.assertNotIn(
+                sm, CUDA_SUPPORTED_ARCHS, f"{cap} -> {sm} unexpectedly in supported set"
+            )
+
+
+class TestIdentifyCudaArchFromName(unittest.TestCase):
+    def test_known_consumer_gpus(self):
+        cases = [
+            ("NVIDIA GeForce RTX 3080", "sm_86"),
+            ("NVIDIA GeForce RTX 4090", "sm_89"),
+            ("NVIDIA GeForce RTX 2080 Ti", "sm_75"),
+            ("NVIDIA GeForce RTX 5090", "sm_120"),
+            ("NVIDIA GTX 1660 Super", "sm_75"),
+            ("NVIDIA H100 PCIe", "sm_90"),
+            ("NVIDIA A100-SXM4-80GB", "sm_80"),
+            ("NVIDIA A40", "sm_86"),
+        ]
+        for name, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(identify_cuda_arch_from_name(name), expected)
+
+    def test_non_nvidia_returns_empty(self):
+        for name in ["AMD Radeon RX 7900 XTX", "Intel Arc A770", "Apple M3", ""]:
+            with self.subTest(name=name):
+                self.assertEqual(identify_cuda_arch_from_name(name), "")
+
+    def test_unsupported_nvidia_returns_empty(self):
+        # Kepler/Maxwell/Pascal — not in CUDA_SUPPORTED_ARCHS
+        for name in ["NVIDIA GTX 1080 Ti", "NVIDIA GTX 980", "NVIDIA Tesla K80"]:
+            with self.subTest(name=name):
+                result = identify_cuda_arch_from_name(name)
+                # May return an sm_XX token but it won't be in the supported set
+                if result:
+                    self.assertNotIn(result, CUDA_SUPPORTED_ARCHS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/utils/capabilities.py
+++ b/test/utils/capabilities.py
@@ -41,6 +41,7 @@ CAPABILITIES = {
             "backends": [
                 "vulkan",
                 "rocm",
+                "cuda",
                 "metal",
                 "cpu",
                 "system",

--- a/test/validate_llamacpp.py
+++ b/test/validate_llamacpp.py
@@ -257,11 +257,12 @@ def main():
         choices=[
             "vulkan",
             "rocm",
+            "cuda",
             "cpu",
             "metal",
             "system",
         ],
-        help="Backend to test (vulkan, rocm, cpu, metal, system)",
+        help="Backend to test (vulkan, rocm, cuda, cpu, metal, system)",
     )
     parser.add_argument(
         "--channel",


### PR DESCRIPTION
Mirrors the existing rocm integration to add CUDA support via per-Compute-Capability builds from Phqen1x/llamacpp-cuda. Detects nvidia_gpu devices, picks an sm_XX target (sm_75 through sm_120), downloads the matching .7z (Windows) or .tar.xz (Linux) asset, and prepends the bundled CUDA runtime libs to PATH/LD_LIBRARY_PATH so cudart/cublas resolve before any system-wide CUDA install.