### PR TITLE
fix: classify FLM whisper as AUDIO deployment mode

### DIFF
--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -96,7 +96,9 @@ inline ModelType get_model_type_from_labels(const std::vector<std::string>& labe
         if (label == "reranking") {
             return ModelType::RERANKING;
         }
-        if (label == "audio") {
+        if (label == "audio" ||
+            label == "transcription" ||
+            label == "realtime-transcription") {
             return ModelType::AUDIO;
         }
         if (label == "image") {

--- a/test/cpp/test_model_type_classifier.cpp
+++ b/test/cpp/test_model_type_classifier.cpp
@@ -24,6 +24,11 @@ int main() {
         // indicators → AUDIO deployment mode.
         {"whisper-v3:turbo equivalent", {"audio", "transcription"}, ModelType::AUDIO},
         {"audio alone", {"audio"}, ModelType::AUDIO},
+        // Current `flm list --json` reports whisper as
+        // ["realtime-transcription","transcription"] without "audio".
+        {"FLM whisper labels", {"realtime-transcription", "transcription"}, ModelType::AUDIO},
+        {"transcription alone", {"transcription"}, ModelType::AUDIO},
+        {"realtime-transcription alone", {"realtime-transcription"}, ModelType::AUDIO},
 
         // Embedding / reranking / image / tts models keep their existing mapping.
         {"embedding (plural)", {"embeddings"}, ModelType::EMBEDDING},


### PR DESCRIPTION
## Summary

`get_model_type_from_labels` only recognises the literal label `"audio"`, but current FastFlowLM (≥ 0.9.40) reports whisper as `["realtime-transcription", "transcription"]` — no `"audio"`. As a result, FLM-recipe whisper models fall through to `ModelType::LLM`, the FastFlowLMServer is spawned in chat mode (without `--asr 1`), and `Router::audio_transcriptions` rejects every realtime call with `Audio transcription not supported by FLM llm model`. The voice-transcription panel never receives a transcript.

This patch recognises both `"transcription"` and `"realtime-transcription"` as audio-mode indicators alongside `"audio"`. Chat-indicator labels still win in the first pass, so multimodal any-to-text chat models (e.g. Gemma 4) that carry vision/reasoning/tool-calling **and** transcription continue to deploy as LLM — already covered by the existing `Gemma-4-style any-to-text` regression test.

## Reproduction (before this fix)

```
$ curl -s http://localhost:13305/api/v1/health | jq '.all_models_loaded[0] | {model_name, recipe, type}'
{
  "model_name": "whisper-v3-turbo-FLM",
  "recipe": "flm",
  "type": "llm"   # should be "audio"
}

$ curl -s -X POST http://localhost:13305/api/v1/audio/transcriptions \
       -F file=@jfk.wav -F model=whisper-v3-turbo-FLM
{"error":{"message":"Audio transcription not supported by FLM llm model","type":"unsupported_operation"}}
```

After the patch, the same model loads with `"type": "audio"`, the FLM server starts as `flm serve --asr 1 …`, and the call returns the transcribed text.

## Tests

`test/cpp/test_model_type_classifier.cpp` is extended with three cases:

- `{"realtime-transcription", "transcription"}` → `AUDIO` (the actual current FLM whisper labels)
- `{"transcription"}` → `AUDIO`
- `{"realtime-transcription"}` → `AUDIO`

All 19 cases (existing + new) pass:

```
$ g++ -std=c++17 -I src/cpp/include test/cpp/test_model_type_classifier.cpp -o classifier_test && ./classifier_test
[PASS] whisper-v3:turbo equivalent  (got=audio, want=audio)
[PASS] audio alone  (got=audio, want=audio)
[PASS] FLM whisper labels  (got=audio, want=audio)
[PASS] transcription alone  (got=audio, want=audio)
[PASS] realtime-transcription alone  (got=audio, want=audio)
... (Gemma-4-style any-to-text and audio+chat regression tests still PASS) ...
19/19 cases passed
```

## Test plan

- [x] Added new label combinations to `test_model_type_classifier.cpp`
- [x] Standalone classifier test — all PASS
- [x] End-to-end verified against a built lemonade with the patch: `whisper-v3-turbo-FLM` loads with `type=audio`, `flm serve --asr 1` is invoked, the browser realtime panel receives `conversation.item.input_audio_transcription.completed` events.
