### PR TITLE
test(app): add regression guards for model options and collections

### DIFF
--- a/.github/workflows/docs_and_style.yml
+++ b/.github/workflows/docs_and_style.yml
@@ -9,6 +9,21 @@ permissions:
   contents: read
 
 jobs:
+
+  app-regression-tests:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-app-regression-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+      - name: Run app regression tests
+        run: node test/app/run-app-regression-tests.cjs
+
   markdown-link-check:
     runs-on: ubuntu-latest
     concurrency:

--- a/test/app/app-regression/README.md
+++ b/test/app/app-regression/README.md
@@ -1,0 +1,16 @@
+# App regression tests
+
+Run from the repository root:
+
+```bash
+node test/app/run-app-regression-tests.cjs
+```
+
+These tests are intentionally dependency-free: no Jest, no jsdom, no React
+runtime, and no TypeScript package are required. They use source-level guards
+for renderer regressions that are easy to introduce while changing Model
+Manager, Model Options, and OmniRouter collection logic.
+
+The suite is meant to be cheap enough for a precommit hook. Tests that cover
+feature-branch-only custom collection files skip cleanly on `main` when those
+files are not present.

--- a/test/app/app-regression/README.md
+++ b/test/app/app-regression/README.md
@@ -7,10 +7,14 @@ node test/app/run-app-regression-tests.cjs
 ```
 
 These tests are intentionally dependency-free: no Jest, no jsdom, no React
-runtime, and no TypeScript package are required. They use source-level guards
-for renderer regressions that are easy to introduce while changing Model
-Manager, Model Options, and OmniRouter collection logic.
+runtime, and no TypeScript package are required. They use focused source-level
+regression guards for renderer paths that are easy to break while changing
+Model Manager, Model Options, and OmniRouter collection logic.
 
-The suite is meant to be cheap enough for a precommit hook. Tests that cover
-feature-branch-only custom collection files skip cleanly on `main` when those
-files are not present.
+The suite is cheap enough for CI and local pre-commit use. It is wired into the
+`Docs And Style` GitHub Actions workflow, and can still be run directly with
+plain Node for fast local checks.
+
+Some tests are feature-aware. Custom-collection-specific checks skip cleanly on
+`main` when the feature files are not present, then become active on branches
+that add those files.

--- a/test/app/app-regression/collectionModels.test.cjs
+++ b/test/app/app-regression/collectionModels.test.cjs
@@ -1,0 +1,126 @@
+const assert = require('node:assert/strict');
+const {
+  readSource,
+  normalizeWhitespace,
+  assertIncludes,
+  assertMatches,
+} = require('./helpers/source.cjs');
+
+const COLLECTION_MODELS = 'src/app/src/renderer/utils/collectionModels.ts';
+
+function isExported(source, name) {
+  return new RegExp(`export\\s+(?:const|function)\\s+${name}\\b|export\\s*\\{[^}]*\\b${name}\\b[^}]*\\}`).test(source);
+}
+
+const tests = [
+  {
+    name: 'getCollectionComponents filters invalid component names without reordering',
+    run() {
+      const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
+      assertMatches(
+        source,
+        /Array\.isArray\(info\.composite_models\)[\s\S]*?info\.composite_models\.filter\(/,
+        'getCollectionComponents should only read array-valued composite_models.',
+      );
+      assertIncludes(
+        source,
+        "typeof name === 'string' && name.length > 0",
+        'getCollectionComponents should filter to non-empty string component names.',
+      );
+      assert.ok(
+        !/\.sort\(/.test(source.slice(source.indexOf('getCollectionComponents'), source.indexOf('export const isCollectionModel'))),
+        'Component order is semantically meaningful and must not be sorted.',
+      );
+    },
+  },
+  {
+    name: 'isCollectionModel requires recipe=collection and at least one component',
+    run() {
+      const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
+      assertMatches(
+        source,
+        /isCollectionModel[\s\S]*?info\.recipe === 'collection'[\s\S]*?getCollectionComponents\(info\)\.length > 0/,
+        'A collection model must be recipe=collection with at least one concrete component.',
+      );
+    },
+  },
+  {
+    name: 'collection downloaded state requires every component to be downloaded',
+    run() {
+      const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
+      assertMatches(
+        source,
+        /isModelEffectivelyDownloaded[\s\S]*?isCollectionModel\(info\)[\s\S]*?isCollectionFullyDownloaded\(modelName, modelsData\)[\s\S]*?info\?\.downloaded === true/,
+        'Downloaded state must delegate collections to component completeness and concrete models to info.downloaded.',
+      );
+      assertMatches(
+        source,
+        /isCollectionFullyDownloaded[\s\S]*?components\.length === 0\) return false[\s\S]*?components\.every\(\(component\) => modelsData\[component\]\?\.downloaded === true\)/,
+        'A collection is downloaded only when every component is downloaded.',
+      );
+    },
+  },
+  {
+    name: 'collection loaded state requires every component to be loaded',
+    run() {
+      const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
+      assertMatches(
+        source,
+        /isModelEffectivelyLoaded[\s\S]*?isCollectionModel\(info\)[\s\S]*?isCollectionFullyLoaded\(modelName, modelsData, loadedModels\)[\s\S]*?loadedModels\.has\(modelName\)/,
+        'Loaded state must delegate collections to component completeness and concrete models to loadedModels.has(modelName).',
+      );
+      assertMatches(
+        source,
+        /isCollectionFullyLoaded[\s\S]*?components\.length === 0\) return false[\s\S]*?components\.every\(\(component\) => loadedModels\.has\(component\)\)/,
+        'A collection is loaded only when every component is loaded.',
+      );
+    },
+  },
+  {
+    name: 'getCollectionImageModel picks the image-labeled component only',
+    run() {
+      const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
+      assertMatches(
+        source,
+        /getCollectionImageModel[\s\S]*?components\.find[\s\S]*?modelsData\[component\][\s\S]*?labels\?\.includes\('image'\)[\s\S]*?imageModel \|\| null/,
+        'Image tool routing must pick the component with the image label and otherwise return null.',
+      );
+    },
+  },
+  {
+    name: 'getCollectionPrimaryChatModel skips concrete non-chat components',
+    run() {
+      const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
+      const usesMainDenylist = source.includes("NON_LLM_LABELS = new Set(['image', 'speech', 'tts', 'audio', 'transcription', 'embeddings', 'embedding', 'reranking'])")
+        && /getCollectionPrimaryChatModel[\s\S]*?components\.find[\s\S]*?labels\.some\(\(label\) => NON_LLM_LABELS\.has\(label\)\)[\s\S]*?return explicitLLM \|\| components\[0\]/.test(source);
+      const usesCentralPlannerPredicate = /isChatPlannerCandidate/.test(source)
+        && /getCollectionPrimaryChatModel[\s\S]*?components\.find\(\(component\) => isChatPlannerCandidate\(modelsData\[component\]\)\)[\s\S]*?return explicitLLM \|\| components\[0\]/.test(source);
+
+      assert.ok(
+        usesMainDenylist || usesCentralPlannerPredicate,
+        'Primary chat selection should either use the main denylist or the centralized chat-planner predicate.',
+      );
+    },
+  },
+  {
+    name: 'collection helper exports stay stable for app and tool callers',
+    run() {
+      const source = readSource(COLLECTION_MODELS);
+      for (const name of [
+        'NON_LLM_LABELS',
+        'getCollectionComponents',
+        'isCollectionModel',
+        'isModelEffectivelyDownloaded',
+        'isModelEffectivelyLoaded',
+        'isCollectionFullyDownloaded',
+        'isCollectionFullyLoaded',
+        'getCollectionImageModel',
+        'getCollectionPrimaryChatModel',
+      ]) {
+        assert.ok(isExported(source, name), `${name} should remain exported.`);
+      }
+    },
+  },
+];
+
+module.exports = { tests };

--- a/test/app/app-regression/collectionModels.test.cjs
+++ b/test/app/app-regression/collectionModels.test.cjs
@@ -14,106 +14,85 @@ function isExported(source, name) {
 
 const tests = [
   {
-    name: 'getCollectionComponents filters invalid component names without reordering',
+    name: 'collection components preserve declared component order and ignore invalid entries',
     run() {
       const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
       assertMatches(
         source,
-        /Array\.isArray\(info\.composite_models\)[\s\S]*?info\.composite_models\.filter\(/,
-        'getCollectionComponents should only read array-valued composite_models.',
+        /getCollectionComponents[\s\S]*?Array\.isArray\(info\.composite_models\)[\s\S]*?info\.composite_models\.filter\(/,
+        'Collection components should only come from array-valued composite_models.',
       );
       assertIncludes(
         source,
         "typeof name === 'string' && name.length > 0",
-        'getCollectionComponents should filter to non-empty string component names.',
+        'Collection components should be filtered to non-empty strings.',
       );
-      assert.ok(
-        !/\.sort\(/.test(source.slice(source.indexOf('getCollectionComponents'), source.indexOf('export const isCollectionModel'))),
-        'Component order is semantically meaningful and must not be sorted.',
-      );
+      const componentBody = source.slice(source.indexOf('getCollectionComponents'), source.indexOf('isCollectionModel'));
+      assert.ok(!/\.sort\(/.test(componentBody), 'Component order is semantic and should not be sorted.');
     },
   },
   {
-    name: 'isCollectionModel requires recipe=collection and at least one component',
+    name: 'collection identity depends on recipe=collection and at least one component',
     run() {
       const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
       assertMatches(
         source,
         /isCollectionModel[\s\S]*?info\.recipe === 'collection'[\s\S]*?getCollectionComponents\(info\)\.length > 0/,
-        'A collection model must be recipe=collection with at least one concrete component.',
+        'A collection model should require recipe=collection and at least one concrete component.',
       );
     },
   },
   {
-    name: 'collection downloaded state requires every component to be downloaded',
+    name: 'collection downloaded and loaded state require every component',
     run() {
       const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
       assertMatches(
         source,
-        /isModelEffectivelyDownloaded[\s\S]*?isCollectionModel\(info\)[\s\S]*?isCollectionFullyDownloaded\(modelName, modelsData\)[\s\S]*?info\?\.downloaded === true/,
-        'Downloaded state must delegate collections to component completeness and concrete models to info.downloaded.',
+        /isCollectionFullyDownloaded[\s\S]*?components\.every\(\(component\) => modelsData\[component\]\?\.downloaded === true\)/,
+        'A collection should be downloaded only when every component is downloaded.',
       );
       assertMatches(
         source,
-        /isCollectionFullyDownloaded[\s\S]*?components\.length === 0\) return false[\s\S]*?components\.every\(\(component\) => modelsData\[component\]\?\.downloaded === true\)/,
-        'A collection is downloaded only when every component is downloaded.',
+        /isCollectionFullyLoaded[\s\S]*?components\.every\(\(component\) => loadedModels\.has\(component\)\)/,
+        'A collection should be loaded only when every component is loaded.',
       );
     },
   },
   {
-    name: 'collection loaded state requires every component to be loaded',
+    name: 'collection image routing uses the image-capable component',
     run() {
       const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
       assertMatches(
         source,
-        /isModelEffectivelyLoaded[\s\S]*?isCollectionModel\(info\)[\s\S]*?isCollectionFullyLoaded\(modelName, modelsData, loadedModels\)[\s\S]*?loadedModels\.has\(modelName\)/,
-        'Loaded state must delegate collections to component completeness and concrete models to loadedModels.has(modelName).',
-      );
-      assertMatches(
-        source,
-        /isCollectionFullyLoaded[\s\S]*?components\.length === 0\) return false[\s\S]*?components\.every\(\(component\) => loadedModels\.has\(component\)\)/,
-        'A collection is loaded only when every component is loaded.',
+        /getCollectionImageModel[\s\S]*?components\.find[\s\S]*?labels\?\.includes\('image'\)[\s\S]*?imageModel \|\| null/,
+        'Image tool routing should pick the image-labeled component and otherwise return null.',
       );
     },
   },
   {
-    name: 'getCollectionImageModel picks the image-labeled component only',
+    name: 'primary chat routing skips non-chat components before fallback',
     run() {
       const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
-      assertMatches(
-        source,
-        /getCollectionImageModel[\s\S]*?components\.find[\s\S]*?modelsData\[component\][\s\S]*?labels\?\.includes\('image'\)[\s\S]*?imageModel \|\| null/,
-        'Image tool routing must pick the component with the image label and otherwise return null.',
-      );
-    },
-  },
-  {
-    name: 'getCollectionPrimaryChatModel skips concrete non-chat components',
-    run() {
-      const source = normalizeWhitespace(readSource(COLLECTION_MODELS));
-      const usesMainDenylist = source.includes("NON_LLM_LABELS = new Set(['image', 'speech', 'tts', 'audio', 'transcription', 'embeddings', 'embedding', 'reranking'])")
-        && /getCollectionPrimaryChatModel[\s\S]*?components\.find[\s\S]*?labels\.some\(\(label\) => NON_LLM_LABELS\.has\(label\)\)[\s\S]*?return explicitLLM \|\| components\[0\]/.test(source);
+      const usesLocalDenylist = /NON_LLM_LABELS/.test(source)
+        && /getCollectionPrimaryChatModel[\s\S]*?components\.find[\s\S]*?!labels\.some[\s\S]*?NON_LLM_LABELS\.has\(label\)[\s\S]*?return explicitLLM \|\| components\[0\]/.test(source);
       const usesCentralPlannerPredicate = /isChatPlannerCandidate/.test(source)
         && /getCollectionPrimaryChatModel[\s\S]*?components\.find\(\(component\) => isChatPlannerCandidate\(modelsData\[component\]\)\)[\s\S]*?return explicitLLM \|\| components\[0\]/.test(source);
 
       assert.ok(
-        usesMainDenylist || usesCentralPlannerPredicate,
-        'Primary chat selection should either use the main denylist or the centralized chat-planner predicate.',
+        usesLocalDenylist || usesCentralPlannerPredicate,
+        'Primary chat selection should exclude known non-chat components before falling back to the first component.',
       );
     },
   },
   {
-    name: 'collection helper exports stay stable for app and tool callers',
+    name: 'collection helper public surface stays available to app callers',
     run() {
       const source = readSource(COLLECTION_MODELS);
       for (const name of [
-        'NON_LLM_LABELS',
         'getCollectionComponents',
         'isCollectionModel',
         'isModelEffectivelyDownloaded',
         'isModelEffectivelyLoaded',
-        'isCollectionFullyDownloaded',
-        'isCollectionFullyLoaded',
         'getCollectionImageModel',
         'getCollectionPrimaryChatModel',
       ]) {

--- a/test/app/app-regression/customCollections.optional.test.cjs
+++ b/test/app/app-regression/customCollections.optional.test.cjs
@@ -1,0 +1,128 @@
+const assert = require('node:assert/strict');
+const {
+  hasFile,
+  readSource,
+  normalizeWhitespace,
+  assertIncludes,
+  assertMatches,
+  countMatches,
+} = require('./helpers/source.cjs');
+
+const CUSTOM_COLLECTIONS = 'src/app/src/renderer/utils/customCollections.ts';
+const MODEL_DATA = 'src/app/src/renderer/utils/modelData.ts';
+const MODEL_MANAGER = 'src/app/src/renderer/ModelManager.tsx';
+const MODEL_SELECTOR = 'src/app/src/renderer/components/ModelSelector.tsx';
+const APP = 'src/app/src/renderer/App.tsx';
+
+function skipIfMissing() {
+  if (!hasFile(CUSTOM_COLLECTIONS)) {
+    return { skip: true, reason: 'customCollections.ts is not present on this branch' };
+  }
+  return null;
+}
+
+const tests = [
+  {
+    name: 'custom collection storage constants use collection terminology and localStorage versioning',
+    run() {
+      const skip = skipIfMissing();
+      if (skip) return skip;
+      const source = readSource(CUSTOM_COLLECTIONS);
+      assertIncludes(source, "CUSTOM_COLLECTION_PREFIX = 'collection.'", 'Custom collection ids should use collection.* ids.');
+      assertIncludes(source, "CUSTOM_COLLECTIONS_STORAGE_KEY = 'lemonade.customCollections.v1'", 'Storage key should be versioned.');
+      assertIncludes(source, 'CUSTOM_COLLECTIONS_EXPORT_VERSION = 1', 'Export format should be versioned.');
+    },
+  },
+  {
+    name: 'custom collection component list deduplicates while preserving role order',
+    run() {
+      const skip = skipIfMissing();
+      if (skip) return skip;
+      const source = normalizeWhitespace(readSource(CUSTOM_COLLECTIONS));
+      assertMatches(
+        source,
+        /getCustomCollectionComponentList[\s\S]*?const ordered = \[[\s\S]*?llm[\s\S]*?vision[\s\S]*?image[\s\S]*?edit[\s\S]*?transcription[\s\S]*?speech[\s\S]*?return Array\.from\(new Set\(ordered\)\)/,
+        'Component lists should preserve semantic role order and remove duplicates through Set insertion order.',
+      );
+    },
+  },
+  {
+    name: 'custom collection merge hides stale collections until every component is present',
+    run() {
+      const skip = skipIfMissing();
+      if (skip) return skip;
+      const source = normalizeWhitespace(readSource(CUSTOM_COLLECTIONS));
+      assertMatches(
+        source,
+        /mergeCustomCollectionsIntoModelsData[\s\S]*?components\.every\(\(component\) => merged\[component\]\)[\s\S]*?continue[\s\S]*?merged\[collection\.id\] = customCollectionToModelInfo/,
+        'Synthetic collection models should only be inserted when all referenced components exist.',
+      );
+    },
+  },
+  {
+    name: 'custom collection synthetic model metadata remains collection-shaped',
+    run() {
+      const skip = skipIfMissing();
+      if (skip) return skip;
+      const source = normalizeWhitespace(readSource(CUSTOM_COLLECTIONS));
+      assertMatches(source, /recipe: 'collection'/, 'Synthetic custom collections should use recipe=collection.');
+      assertMatches(source, /source: 'custom-collection'/, 'Synthetic custom collections should retain a source marker.');
+      assertMatches(source, /collection_source: 'custom'/, 'Synthetic custom collections should retain collection_source=custom.');
+      assertMatches(source, /collection_components: collection\.components/, 'Synthetic metadata should keep original role assignments.');
+    },
+  },
+  {
+    name: 'custom collection role options include only downloaded concrete compatible models',
+    run() {
+      const skip = skipIfMissing();
+      if (skip) return skip;
+      const source = normalizeWhitespace(readSource(CUSTOM_COLLECTIONS));
+      assertMatches(
+        source,
+        /isCollectionEligibleModel[\s\S]*?!info \|\| isCustomCollectionId\(modelId\) \|\| info\.recipe === 'collection' \|\| info\.downloaded !== true[\s\S]*?return false/,
+        'Role options must exclude missing, synthetic collection, and not-downloaded models.',
+      );
+      for (const label of ['vision', 'image', 'edit', 'transcription', 'speech']) {
+        assertIncludes(source, label, `Role filtering should mention ${label}.`);
+      }
+    },
+  },
+  {
+    name: 'custom collection refresh event is wired into model data refresh',
+    run() {
+      const skip = skipIfMissing();
+      if (skip) return skip;
+      const customSource = readSource(CUSTOM_COLLECTIONS);
+      const modelData = readSource(MODEL_DATA);
+      assertIncludes(customSource, "window.dispatchEvent(new CustomEvent('customCollectionsUpdated'))", 'Saving collections should dispatch refresh event.');
+      assertIncludes(modelData, 'mergeCustomCollectionsIntoModelsData', 'Model data should merge custom collections into server models.');
+    },
+  },
+  {
+    name: 'custom collection UI events are handled by App and exposed from ModelManager/selector',
+    run() {
+      const skip = skipIfMissing();
+      if (skip) return skip;
+      const app = readSource(APP);
+      const manager = readSource(MODEL_MANAGER);
+      assertIncludes(app, "openCustomCollection", 'App should listen for custom collection creation/import events.');
+      assertIncludes(app, "editCustomCollection", 'App should listen for custom collection edit events.');
+      assertIncludes(manager, 'renderCustomCollectionOptionsButton', 'ModelManager should expose an edit/options action for custom collections.');
+      if (hasFile(MODEL_SELECTOR)) {
+        const selector = readSource(MODEL_SELECTOR);
+        assertIncludes(selector, 'CUSTOM_COLLECTION_PREFIX', 'Model selector should display custom collections intentionally.');
+      }
+    },
+  },
+  {
+    name: 'custom collections do not reintroduce workflow terminology in new source files',
+    run() {
+      const skip = skipIfMissing();
+      if (skip) return skip;
+      const source = readSource(CUSTOM_COLLECTIONS);
+      assert.equal(countMatches(source, /workflow/gi), 0, 'customCollections.ts should not use workflow terminology.');
+    },
+  },
+];
+
+module.exports = { tests };

--- a/test/app/app-regression/helpers/source.cjs
+++ b/test/app/app-regression/helpers/source.cjs
@@ -1,0 +1,64 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+function filePath(relativePath) {
+  return path.join(repoRoot, relativePath);
+}
+
+function hasFile(relativePath) {
+  return fs.existsSync(filePath(relativePath));
+}
+
+function readSource(relativePath) {
+  const fullPath = filePath(relativePath);
+  assert.ok(fs.existsSync(fullPath), `Expected source file to exist: ${relativePath}`);
+  return fs.readFileSync(fullPath, 'utf8');
+}
+
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function normalizeWhitespace(source) {
+  return source.replace(/\s+/g, ' ').trim();
+}
+
+function assertIncludes(source, needle, message) {
+  assert.ok(source.includes(needle), message || `Expected source to include ${needle}`);
+}
+
+function assertNotIncludes(source, needle, message) {
+  assert.ok(!source.includes(needle), message || `Expected source not to include ${needle}`);
+}
+
+function assertMatches(source, pattern, message) {
+  assert.ok(pattern.test(source), message || `Expected source to match ${pattern}`);
+}
+
+function assertNotMatches(source, pattern, message) {
+  assert.ok(!pattern.test(source), message || `Expected source not to match ${pattern}`);
+}
+
+function countMatches(source, pattern) {
+  const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+  return Array.from(source.matchAll(new RegExp(pattern.source, flags))).length;
+}
+
+module.exports = {
+  repoRoot,
+  filePath,
+  hasFile,
+  readSource,
+  stripComments,
+  normalizeWhitespace,
+  assertIncludes,
+  assertNotIncludes,
+  assertMatches,
+  assertNotMatches,
+  countMatches,
+};

--- a/test/app/app-regression/lemonadeTools.test.cjs
+++ b/test/app/app-regression/lemonadeTools.test.cjs
@@ -1,0 +1,107 @@
+const assert = require('node:assert/strict');
+const {
+  readSource,
+  normalizeWhitespace,
+  assertIncludes,
+  assertMatches,
+} = require('./helpers/source.cjs');
+
+const LEMONADE_TOOLS = 'src/app/src/renderer/utils/lemonadeTools.ts';
+const TOOL_DEFINITIONS = 'src/app/src/renderer/utils/toolDefinitions.json';
+const IMAGE_CONFIG = 'src/app/src/renderer/utils/collectionImageConfig.ts';
+
+function readToolDefinitions() {
+  return JSON.parse(readSource(TOOL_DEFINITIONS));
+}
+
+const tests = [
+  {
+    name: 'tool definitions expose the expected OmniRouter tool names',
+    run() {
+      const names = readToolDefinitions().tools.map((tool) => tool.function.name).sort();
+      assert.deepEqual(names, [
+        'analyze_image',
+        'edit_image',
+        'generate_image',
+        'text_to_speech',
+        'transcribe_audio',
+      ]);
+    },
+  },
+  {
+    name: 'buildLemonadeTools maps label-required tools to matching collection components',
+    run() {
+      const source = normalizeWhitespace(readSource(LEMONADE_TOOLS));
+      const usesMainLabelSet = /const requiresLabels = def\.requires_labels[\s\S]*?const labelSet = new Set\(requiresLabels\)[\s\S]*?components\.find[\s\S]*?labels\.some\(l => labelSet\.has\(l\)\)[\s\S]*?models\[def\.function\.name\] = match/.test(source);
+      const usesSharedLabelHelper = /const requiresLabels = def\.requires_labels[\s\S]*?const match = findComponentWithAnyLabel\(requiresLabels\)[\s\S]*?models\[def\.function\.name\] = match/.test(source)
+        && /hasAnyModelLabel|componentHasAnyLabel/.test(source);
+
+      assert.ok(
+        usesMainLabelSet || usesSharedLabelHelper,
+        'Tools with requires_labels should map to a matching component using either the main label-set path or the shared label helper path.',
+      );
+    },
+  },
+  {
+    name: 'buildLemonadeTools maps LLM-required tools only through the selected planner model',
+    run() {
+      const source = normalizeWhitespace(readSource(LEMONADE_TOOLS));
+      const usesMainPlannerModel = /const llmModel = components\.find[\s\S]*?NON_LLM_LABELS\.has\(l\)[\s\S]*?\|\| components\[0\] \|\| ''/.test(source)
+        && /const requiresLlmLabels = def\.requires_llm_labels[\s\S]*?const llmLabels = modelsData\[llmModel\]\?\.labels \?\? \[\][\s\S]*?!llmLabels\.some\(l => labelSet\.has\(l\)\)\) continue[\s\S]*?models\[def\.function\.name\] = llmModel/.test(source);
+      const usesCentralPlannerPredicate = /isChatPlannerCandidate/.test(source)
+        && /const requiresLlmLabels = def\.requires_llm_labels[\s\S]*?const match = findComponentWithAnyLabel\(requiresLlmLabels, true\)[\s\S]*?models\[def\.function\.name\] = match/.test(source);
+
+      assert.ok(
+        usesMainPlannerModel || usesCentralPlannerPredicate,
+        'Tools with requires_llm_labels should route through either the main planner model path or the centralized chat-planner predicate path.',
+      );
+    },
+  },
+  {
+    name: 'image-size placeholders are materialized from the shared image config',
+    run() {
+      const source = normalizeWhitespace(readSource(LEMONADE_TOOLS));
+      const config = readSource(IMAGE_CONFIG);
+      assertMatches(config, /export const COLLECTION_IMAGE_SIZE = '512x256'/, 'Current collection image size should be explicit.');
+      assertMatches(
+        source,
+        /prop\.description\.includes\('\{image_size\}'\)[\s\S]*?replaceAll\('\{image_size\}', COLLECTION_IMAGE_SIZE\)/,
+        'Tool parameter descriptions should replace {image_size} at materialization time.',
+      );
+    },
+  },
+  {
+    name: 'toolDefinitions encode both aliases for TTS and transcription labels',
+    run() {
+      const definitions = readToolDefinitions();
+      const byName = Object.fromEntries(definitions.tools.map((tool) => [tool.function.name, tool]));
+      assert.deepEqual(byName.text_to_speech.requires_labels, ['tts', 'speech']);
+      assert.deepEqual(byName.transcribe_audio.requires_labels, ['audio', 'transcription']);
+      assert.deepEqual(byName.analyze_image.requires_llm_labels, ['vision']);
+    },
+  },
+  {
+    name: 'tool execution routes each tool to its dedicated OpenAI-compatible endpoint',
+    run() {
+      const source = normalizeWhitespace(readSource(LEMONADE_TOOLS));
+      assertIncludes(source, "serverFetch('/images/generations'", 'generate_image should call /images/generations.');
+      assertIncludes(source, "serverFetch('/images/edits'", 'edit_image should call /images/edits.');
+      assertIncludes(source, "serverFetch('/audio/speech'", 'text_to_speech should call /audio/speech.');
+      assertIncludes(source, "serverFetch('/audio/transcriptions'", 'transcribe_audio should call /audio/transcriptions.');
+      assertIncludes(source, "serverFetch('/chat/completions'", 'analyze_image should call /chat/completions.');
+    },
+  },
+  {
+    name: 'vision tool rejects arbitrary non-data image URLs before calling chat completions',
+    run() {
+      const source = normalizeWhitespace(readSource(LEMONADE_TOOLS));
+      assertMatches(
+        source,
+        /rawImageUrl\.startsWith\('data:image\/'\) \? rawImageUrl : ''[\s\S]*?context\.extractedImages/,
+        'Vision analysis should only use LLM-provided image_url when it is a data:image URL, otherwise fall back to extracted images.',
+      );
+    },
+  },
+];
+
+module.exports = { tests };

--- a/test/app/app-regression/lemonadeTools.test.cjs
+++ b/test/app/app-regression/lemonadeTools.test.cjs
@@ -29,32 +29,29 @@ const tests = [
     },
   },
   {
-    name: 'buildLemonadeTools maps label-required tools to matching collection components',
+    name: 'tool definitions keep canonical routing labels for each tool family',
     run() {
-      const source = normalizeWhitespace(readSource(LEMONADE_TOOLS));
-      const usesMainLabelSet = /const requiresLabels = def\.requires_labels[\s\S]*?const labelSet = new Set\(requiresLabels\)[\s\S]*?components\.find[\s\S]*?labels\.some\(l => labelSet\.has\(l\)\)[\s\S]*?models\[def\.function\.name\] = match/.test(source);
-      const usesSharedLabelHelper = /const requiresLabels = def\.requires_labels[\s\S]*?const match = findComponentWithAnyLabel\(requiresLabels\)[\s\S]*?models\[def\.function\.name\] = match/.test(source)
-        && /hasAnyModelLabel|componentHasAnyLabel/.test(source);
-
-      assert.ok(
-        usesMainLabelSet || usesSharedLabelHelper,
-        'Tools with requires_labels should map to a matching component using either the main label-set path or the shared label helper path.',
-      );
+      const definitions = readToolDefinitions();
+      const byName = Object.fromEntries(definitions.tools.map((tool) => [tool.function.name, tool]));
+      assert.ok(byName.generate_image.requires_labels.includes('image'), 'Image generation should require image capability.');
+      assert.ok(byName.edit_image.requires_labels.includes('edit'), 'Image editing should require edit capability.');
+      assert.ok(byName.text_to_speech.requires_labels.some((label) => label === 'tts' || label === 'speech'), 'TTS should require a speech/TTS label.');
+      assert.ok(byName.transcribe_audio.requires_labels.some((label) => label === 'audio' || label === 'transcription'), 'Transcription should require an audio/transcription label.');
+      assert.deepEqual(byName.analyze_image.requires_llm_labels, ['vision']);
     },
   },
   {
-    name: 'buildLemonadeTools maps LLM-required tools only through the selected planner model',
+    name: 'buildLemonadeTools keeps component matching separate from planner matching',
     run() {
       const source = normalizeWhitespace(readSource(LEMONADE_TOOLS));
-      const usesMainPlannerModel = /const llmModel = components\.find[\s\S]*?NON_LLM_LABELS\.has\(l\)[\s\S]*?\|\| components\[0\] \|\| ''/.test(source)
-        && /const requiresLlmLabels = def\.requires_llm_labels[\s\S]*?const llmLabels = modelsData\[llmModel\]\?\.labels \?\? \[\][\s\S]*?!llmLabels\.some\(l => labelSet\.has\(l\)\)\) continue[\s\S]*?models\[def\.function\.name\] = llmModel/.test(source);
-      const usesCentralPlannerPredicate = /isChatPlannerCandidate/.test(source)
-        && /const requiresLlmLabels = def\.requires_llm_labels[\s\S]*?const match = findComponentWithAnyLabel\(requiresLlmLabels, true\)[\s\S]*?models\[def\.function\.name\] = match/.test(source);
-
-      assert.ok(
-        usesMainPlannerModel || usesCentralPlannerPredicate,
-        'Tools with requires_llm_labels should route through either the main planner model path or the centralized chat-planner predicate path.',
+      assertMatches(
+        source,
+        /requiresLabels[\s\S]*?components\.find[\s\S]*?models\[def\.function\.name\] = match/,
+        'Tools with requires_labels should map to a concrete matching component.',
       );
+      const hasPlannerPath = /requiresLlmLabels[\s\S]*?models\[def\.function\.name\] = llmModel/.test(source)
+        || /requiresLlmLabels[\s\S]*?models\[def\.function\.name\] = match/.test(source);
+      assert.ok(hasPlannerPath, 'Tools with requires_llm_labels should route through the selected planner path.');
     },
   },
   {
@@ -68,16 +65,6 @@ const tests = [
         /prop\.description\.includes\('\{image_size\}'\)[\s\S]*?replaceAll\('\{image_size\}', COLLECTION_IMAGE_SIZE\)/,
         'Tool parameter descriptions should replace {image_size} at materialization time.',
       );
-    },
-  },
-  {
-    name: 'toolDefinitions encode both aliases for TTS and transcription labels',
-    run() {
-      const definitions = readToolDefinitions();
-      const byName = Object.fromEntries(definitions.tools.map((tool) => [tool.function.name, tool]));
-      assert.deepEqual(byName.text_to_speech.requires_labels, ['tts', 'speech']);
-      assert.deepEqual(byName.transcribe_audio.requires_labels, ['audio', 'transcription']);
-      assert.deepEqual(byName.analyze_image.requires_llm_labels, ['vision']);
     },
   },
   {
@@ -95,10 +82,15 @@ const tests = [
     name: 'vision tool rejects arbitrary non-data image URLs before calling chat completions',
     run() {
       const source = normalizeWhitespace(readSource(LEMONADE_TOOLS));
+      assertIncludes(
+        source,
+        "rawImageUrl.startsWith('data:image/')",
+        'Vision analysis should only forward explicit LLM image_url values when they are data:image URLs.',
+      );
       assertMatches(
         source,
-        /rawImageUrl\.startsWith\('data:image\/'\) \? rawImageUrl : ''[\s\S]*?context\.extractedImages/,
-        'Vision analysis should only use LLM-provided image_url when it is a data:image URL, otherwise fall back to extracted images.',
+        /if \(!imageUrl && context\.extractedImages\.length > 0\)[\s\S]*?context\.extractedImages\[context\.extractedImages\.length - 1\]\.dataUrl/,
+        'Vision analysis should fall back to the user-provided extracted image data URL.',
       );
     },
   },

--- a/test/app/app-regression/modelManagerActions.test.cjs
+++ b/test/app/app-regression/modelManagerActions.test.cjs
@@ -1,0 +1,102 @@
+const assert = require('node:assert/strict');
+const {
+  readSource,
+  normalizeWhitespace,
+  assertIncludes,
+  assertMatches,
+  countMatches,
+} = require('./helpers/source.cjs');
+
+const MODEL_MANAGER = 'src/app/src/renderer/ModelManager.tsx';
+
+const tests = [
+  {
+    name: 'normal model options button sets target model before opening modal',
+    run() {
+      const source = normalizeWhitespace(readSource(MODEL_MANAGER));
+      assertMatches(
+        source,
+        /renderLoadOptionsButton[\s\S]*?setOptionsModel\(modelName\)[\s\S]*?setShowModelOptionsModal\(true\)/,
+        'The normal settings button must set optionsModel before opening ModelOptionsModal.',
+      );
+    },
+  },
+  {
+    name: 'normal model options are still rendered for non-collection models',
+    run() {
+      const source = normalizeWhitespace(readSource(MODEL_MANAGER));
+      assertMatches(
+        source,
+        /!isCollection && renderLoadOptionsButton\(modelName\)/,
+        'Non-collection rows must keep the normal Model Options button.',
+      );
+    },
+  },
+  {
+    name: 'collection-specific options do not replace normal model options',
+    run() {
+      const source = normalizeWhitespace(readSource(MODEL_MANAGER));
+      if (!source.includes('renderCustomCollectionOptionsButton')) return { skip: true, reason: 'custom collection UI is not present on this branch' };
+      assertMatches(
+        source,
+        /isCustomCollectionId\(modelName\) && renderCustomCollectionOptionsButton\(modelName\)[\s\S]*?!isCollection && renderLoadOptionsButton\(modelName\)/,
+        'Custom collection options may be added, but normal concrete model options must remain available.',
+      );
+    },
+  },
+  {
+    name: 'exactly one ModelOptionsModal owner is mounted in ModelManager',
+    run() {
+      const source = readSource(MODEL_MANAGER);
+      assert.equal(countMatches(source, /<ModelOptionsModal\b/), 1, 'ModelManager should own one normal ModelOptionsModal instance.');
+    },
+  },
+  {
+    name: 'normal options cancel path closes and clears stale model id',
+    run() {
+      const source = normalizeWhitespace(readSource(MODEL_MANAGER));
+      assertMatches(
+        source,
+        /onCancel=\{\(\) => \{[\s\S]*?setShowModelOptionsModal\(false\)[\s\S]*?setOptionsModel\(null\)/,
+        'Closing ModelOptionsModal should clear both open state and stale optionsModel.',
+      );
+    },
+  },
+  {
+    name: 'normal options submit path still loads with recipe options',
+    run() {
+      const source = normalizeWhitespace(readSource(MODEL_MANAGER));
+      const submitStart = source.indexOf('onSubmit={(modelName, options) => {');
+      assert.notEqual(submitStart, -1, 'ModelOptionsModal submit should receive the selected model name and option state.');
+
+      const submitBlock = source.slice(submitStart, submitStart + 1200);
+      assertIncludes(submitBlock, 'setShowModelOptionsModal(false)', 'Submitting normal Model Options should close the modal.');
+      assertMatches(
+        submitBlock,
+        /modelName[\s\S]{0,700}(?:options|recipeOptionsToApi)|(?:options|recipeOptionsToApi)[\s\S]{0,700}modelName/,
+        'Submitting normal Model Options should keep both the selected model name and submitted options in the load path.',
+      );
+      assertIncludes(source, 'recipeOptionsToApi', 'Submitted frontend options should still be converted to API format somewhere in ModelManager.');
+    },
+  },
+  {
+    name: 'row actions keep load, delete, and options separated',
+    run() {
+      const source = normalizeWhitespace(readSource(MODEL_MANAGER));
+      assertMatches(
+        source,
+        /handle(?:Load|Download)Model/,
+        'Model rows should keep a concrete load/download action.',
+      );
+      assertIncludes(source, 'renderDeleteButton', 'Model rows should keep a delete action.');
+      assertIncludes(source, 'renderLoadOptionsButton', 'Model rows should keep a normal options action.');
+      assertMatches(
+        source,
+        /e\.stopPropagation\(\)[\s\S]*?setOptionsModel\(modelName\)/,
+        'Clicking the options action should stop row propagation before opening options.',
+      );
+    },
+  },
+];
+
+module.exports = { tests };

--- a/test/app/app-regression/modelManagerActions.test.cjs
+++ b/test/app/app-regression/modelManagerActions.test.cjs
@@ -22,7 +22,7 @@ const tests = [
     },
   },
   {
-    name: 'normal model options are still rendered for non-collection models',
+    name: 'normal model options remain available for concrete models',
     run() {
       const source = normalizeWhitespace(readSource(MODEL_MANAGER));
       assertMatches(
@@ -30,40 +30,29 @@ const tests = [
         /!isCollection && renderLoadOptionsButton\(modelName\)/,
         'Non-collection rows must keep the normal Model Options button.',
       );
+      if (source.includes('renderCustomCollectionOptionsButton')) {
+        assertMatches(
+          source,
+          /isCustomCollectionId\(modelName\) && renderCustomCollectionOptionsButton\(modelName\)[\s\S]*?!isCollection && renderLoadOptionsButton\(modelName\)/,
+          'Custom collection options may be added, but normal concrete model options must remain available.',
+        );
+      }
     },
   },
   {
-    name: 'collection-specific options do not replace normal model options',
-    run() {
-      const source = normalizeWhitespace(readSource(MODEL_MANAGER));
-      if (!source.includes('renderCustomCollectionOptionsButton')) return { skip: true, reason: 'custom collection UI is not present on this branch' };
-      assertMatches(
-        source,
-        /isCustomCollectionId\(modelName\) && renderCustomCollectionOptionsButton\(modelName\)[\s\S]*?!isCollection && renderLoadOptionsButton\(modelName\)/,
-        'Custom collection options may be added, but normal concrete model options must remain available.',
-      );
-    },
-  },
-  {
-    name: 'exactly one ModelOptionsModal owner is mounted in ModelManager',
+    name: 'ModelManager owns one normal ModelOptionsModal and clears it on cancel',
     run() {
       const source = readSource(MODEL_MANAGER);
       assert.equal(countMatches(source, /<ModelOptionsModal\b/), 1, 'ModelManager should own one normal ModelOptionsModal instance.');
-    },
-  },
-  {
-    name: 'normal options cancel path closes and clears stale model id',
-    run() {
-      const source = normalizeWhitespace(readSource(MODEL_MANAGER));
       assertMatches(
-        source,
+        normalizeWhitespace(source),
         /onCancel=\{\(\) => \{[\s\S]*?setShowModelOptionsModal\(false\)[\s\S]*?setOptionsModel\(null\)/,
         'Closing ModelOptionsModal should clear both open state and stale optionsModel.',
       );
     },
   },
   {
-    name: 'normal options submit path still loads with recipe options',
+    name: 'normal options submit still closes the modal and preserves model/options data flow',
     run() {
       const source = normalizeWhitespace(readSource(MODEL_MANAGER));
       const submitStart = source.indexOf('onSubmit={(modelName, options) => {');
@@ -83,11 +72,7 @@ const tests = [
     name: 'row actions keep load, delete, and options separated',
     run() {
       const source = normalizeWhitespace(readSource(MODEL_MANAGER));
-      assertMatches(
-        source,
-        /handle(?:Load|Download)Model/,
-        'Model rows should keep a concrete load/download action.',
-      );
+      assertMatches(source, /handle(?:Load|Download)Model/, 'Model rows should keep a concrete load/download action.');
       assertIncludes(source, 'renderDeleteButton', 'Model rows should keep a delete action.');
       assertIncludes(source, 'renderLoadOptionsButton', 'Model rows should keep a normal options action.');
       assertMatches(

--- a/test/app/app-regression/modelOptionsModal.test.cjs
+++ b/test/app/app-regression/modelOptionsModal.test.cjs
@@ -1,0 +1,104 @@
+const {
+  readSource,
+  normalizeWhitespace,
+  assertIncludes,
+  assertMatches,
+  assertNotMatches,
+  hasFile,
+} = require('./helpers/source.cjs');
+
+const MODAL = 'src/app/src/renderer/ModelOptionsModal.tsx';
+const CUSTOM_COLLECTIONS = 'src/app/src/renderer/utils/customCollections.ts';
+
+function beforeReturn(source, needle) {
+  const idx = source.indexOf(needle);
+  return idx === -1 ? source : source.slice(0, idx);
+}
+
+const tests = [
+  {
+    name: 'closed modal is explicitly allowed to render nothing',
+    run() {
+      const source = normalizeWhitespace(readSource(MODAL));
+      assertMatches(source, /if \(!isOpen[\s\S]*?return null/, 'Closed ModelOptionsModal should render nothing.');
+    },
+  },
+  {
+    name: 'opening the modal schedules the model-options fetch before any early return',
+    run() {
+      const source = normalizeWhitespace(readSource(MODAL));
+      const earlyReturnPrefix = beforeReturn(source, 'return null');
+      assertIncludes(earlyReturnPrefix, 'useEffect', 'The fetch useEffect must be declared before render returns.');
+      assertIncludes(source, 'serverFetch', 'ModelOptionsModal must fetch model details when opened.');
+    },
+  },
+  {
+    name: 'model detail fetch uses the selected model variable',
+    run() {
+      const source = normalizeWhitespace(readSource(MODAL));
+      assertMatches(
+        source,
+        /serverFetch\(`\/models\/\$\{[^}]*model[^}]*\}`\)/,
+        'ModelOptionsModal should request details for the selected model variable.',
+      );
+    },
+  },
+  {
+    name: 'model detail fetch is safe for ids that need URL encoding when the feature branch enables it',
+    run() {
+      const source = normalizeWhitespace(readSource(MODAL));
+      if (!source.includes('encodeURIComponent(model)') && !hasFile(CUSTOM_COLLECTIONS)) {
+        return { skip: true, reason: 'main does not yet include URL encoding for model ids' };
+      }
+      assertMatches(
+        source,
+        /serverFetch\(`\/models\/\$\{encodeURIComponent\(model\)\}`\)/,
+        'When enabled, model id encoding should be applied exactly at the /models/:id path segment.',
+      );
+    },
+  },
+  {
+    name: 'loading state is set before fetch and cleared in finally',
+    run() {
+      const source = normalizeWhitespace(readSource(MODAL));
+      assertMatches(source, /setIsLoading\(true\)[\s\S]*?serverFetch/, 'Loading state should be set before fetching options.');
+      assertMatches(source, /finally \{[\s\S]*?setIsLoading\(false\)/, 'Loading state should be cleared in finally.');
+    },
+  },
+  {
+    name: 'server response is converted from API recipe options into frontend state',
+    run() {
+      const source = normalizeWhitespace(readSource(MODAL));
+      assertIncludes(source, 'apiToRecipeOptions(recipe, recipeOptions)', 'Model Options should convert API recipe options into frontend option state.');
+    },
+  },
+  {
+    name: 'modal keeps explicit cancellation and escape/click-outside handlers',
+    run() {
+      const source = normalizeWhitespace(readSource(MODAL));
+      assertIncludes(source, "event.key === 'Escape'", 'Escape should close ModelOptionsModal.');
+      assertMatches(source, /cardRef\.current[\s\S]*?!cardRef\.current\.contains\(event\.target as Node\)[\s\S]*?onCancel\(\)/, 'Click outside should close ModelOptionsModal.');
+      assertIncludes(source, 'handleCancel', 'Cancel button should use an explicit handler.');
+    },
+  },
+  {
+    name: 'open modal must not be gated on recipe options being already populated when loading-shell fix is present',
+    run() {
+      const source = normalizeWhitespace(readSource(MODAL));
+      const hasOptionsGatedReturn = /if \(!isOpen \|\| !options\) return null/.test(source);
+      const hasOpenOnlyReturn = /if \(!isOpen\) return null/.test(source);
+
+      if (hasOptionsGatedReturn && !hasOpenOnlyReturn && !hasFile(CUSTOM_COLLECTIONS)) {
+        return { skip: true, reason: 'main has no loading-shell fix yet' };
+      }
+
+      assertNotMatches(
+        source,
+        /if \(!isOpen \|\| !options\) return null/,
+        'Regression guard: once loading-shell UI exists, an open modal must not return null just because options are still undefined.',
+      );
+    },
+  },
+];
+
+module.exports = { tests };

--- a/test/app/app-regression/modelOptionsModal.test.cjs
+++ b/test/app/app-regression/modelOptionsModal.test.cjs
@@ -33,7 +33,7 @@ const tests = [
     },
   },
   {
-    name: 'model detail fetch uses the selected model variable',
+    name: 'model detail fetch uses the selected model variable and encodes it when collections are enabled',
     run() {
       const source = normalizeWhitespace(readSource(MODAL));
       assertMatches(
@@ -41,34 +41,21 @@ const tests = [
         /serverFetch\(`\/models\/\$\{[^}]*model[^}]*\}`\)/,
         'ModelOptionsModal should request details for the selected model variable.',
       );
-    },
-  },
-  {
-    name: 'model detail fetch is safe for ids that need URL encoding when the feature branch enables it',
-    run() {
-      const source = normalizeWhitespace(readSource(MODAL));
-      if (!source.includes('encodeURIComponent(model)') && !hasFile(CUSTOM_COLLECTIONS)) {
-        return { skip: true, reason: 'main does not yet include URL encoding for model ids' };
+      if (hasFile(CUSTOM_COLLECTIONS)) {
+        assertMatches(
+          source,
+          /serverFetch\(`\/models\/\$\{encodeURIComponent\(model\)\}`\)/,
+          'Collection-enabled branches should encode the model id at the /models/:id path segment.',
+        );
       }
-      assertMatches(
-        source,
-        /serverFetch\(`\/models\/\$\{encodeURIComponent\(model\)\}`\)/,
-        'When enabled, model id encoding should be applied exactly at the /models/:id path segment.',
-      );
     },
   },
   {
-    name: 'loading state is set before fetch and cleared in finally',
+    name: 'loading state wraps the model detail request and response conversion',
     run() {
       const source = normalizeWhitespace(readSource(MODAL));
       assertMatches(source, /setIsLoading\(true\)[\s\S]*?serverFetch/, 'Loading state should be set before fetching options.');
       assertMatches(source, /finally \{[\s\S]*?setIsLoading\(false\)/, 'Loading state should be cleared in finally.');
-    },
-  },
-  {
-    name: 'server response is converted from API recipe options into frontend state',
-    run() {
-      const source = normalizeWhitespace(readSource(MODAL));
       assertIncludes(source, 'apiToRecipeOptions(recipe, recipeOptions)', 'Model Options should convert API recipe options into frontend option state.');
     },
   },

--- a/test/app/run-app-regression-tests.cjs
+++ b/test/app/run-app-regression-tests.cjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const suiteDir = path.join(__dirname, 'app-regression');
+const files = fs.readdirSync(suiteDir)
+  .filter((name) => name.endsWith('.test.cjs'))
+  .sort();
+
+let passed = 0;
+let skipped = 0;
+let failed = 0;
+
+async function main() {
+  for (const file of files) {
+    const mod = require(path.join(suiteDir, file));
+    const tests = Array.isArray(mod.tests) ? mod.tests : [];
+    for (const test of tests) {
+      const label = `${file} :: ${test.name}`;
+      try {
+        const result = await test.run();
+        if (result && result.skip) {
+          skipped += 1;
+          console.log(`SKIP ${label} - ${result.reason || 'skipped'}`);
+        } else {
+          passed += 1;
+          console.log(`PASS ${label}`);
+        }
+      } catch (error) {
+        failed += 1;
+        console.error(`FAIL ${label}`);
+        console.error(error && error.stack ? error.stack : error);
+      }
+    }
+  }
+
+  console.log(`\nApp regression tests: ${passed} passed, ${skipped} skipped, ${failed} failed.`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds lightweight app regression tests under `test/app` to catch UI and model-routing regressions before they reach review.

The tests are intentionally runnable with plain Node, without a renderer build, Tauri startup, `npm install`, Jest, or jsdom. This makes them suitable for a fast pre-commit or local smoke check.

Covered areas:

- Model Options modal wiring and loading-state regressions
- Model Manager row actions for load, delete, and options
- Collection model helper behavior
- OmniRouter tool mapping and endpoint routing
- Optional custom collection behavior when the feature branch files are present

## Why

A regression in the custom collection changes caused normal model settings to stop opening. These tests add targeted guards so similar issues are caught locally before review.

There a obvious pros and cons with it, I assumed it's the right direction in the lights of #1767 since the add the possibility of pre-commit checks.


The suite is (currently) branch-aware:

- On current `main`, feature-only custom collection tests are skipped.
- On the **custom collection branch** (#1769) , those tests become active.

## Test Plan

Run from the repository root:

```bash
node test/app/run-app-regression-tests.cjs
```

Observed results:

```text
current main:
App regression tests: 26 passed, 11 skipped, 0 failed.

custom collection branch before Model Options fix:
App regression tests: 35 passed, 0 skipped, 2 failed.
ModelOptionsModal regression guards fail as expected.

custom collection branch with fix:
App regression tests: 37 passed, 0 skipped, 0 failed.
```

No app rebuild is required for the test run.