### PR TITLE
feat: persistent background download queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -561,6 +561,7 @@ set(SOURCES_CORE
     src/cpp/server/cli_parser.cpp
     src/cpp/server/config_file.cpp
     src/cpp/server/model_manager.cpp
+    src/cpp/server/download_queue.cpp
     src/cpp/server/hf_variants.cpp
     src/cpp/server/wrapped_server.cpp
     src/cpp/server/streaming_proxy.cpp

--- a/src/cpp/include/lemon/download_queue.h
+++ b/src/cpp/include/lemon/download_queue.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+#include <atomic>
+#include <cstdint>
+#include <ctime>
+#include <nlohmann/json.hpp>
+#include "model_manager.h"
+
+namespace httplib { struct Response; }
+
+namespace lemon {
+
+enum class JobStatus {
+    Queued,
+    Running,
+    Complete,
+    Failed,
+    Cancelled
+};
+
+enum class CancelResult { Ok, NotFound, AlreadyTerminal };
+
+struct DownloadJob {
+    // Immutable after enqueue
+    std::string id;
+    std::string model_name;
+    nlohmann::json model_data;
+    bool do_not_upgrade = false;
+    int64_t created_at = 0;
+
+    // Mutable state (guarded by DownloadQueue::mutex_)
+    JobStatus status = JobStatus::Queued;
+    int64_t started_at = 0;
+    int64_t finished_at = 0;
+    std::string error;
+    DownloadProgress last_progress;
+
+    // Ring buffer of SSE event strings (guarded by DownloadQueue::mutex_)
+    static constexpr size_t kEventBufCap = 100;
+    std::deque<std::string> event_buffer;
+    uint64_t total_events = 0;  // monotonically increasing counter
+
+    // Atomic cancel flag — set without holding the mutex
+    std::atomic<bool> cancel_flag{false};
+
+    // Worker thread (one per job; joinable until shutdown)
+    std::thread worker_thread;
+};
+
+class DownloadQueue {
+public:
+    explicit DownloadQueue(ModelManager* model_manager, const std::string& cache_dir);
+    ~DownloadQueue();
+
+    // Enqueue a download. Returns job ID.
+    // If the model is already queued/running, returns the existing job ID.
+    std::string enqueue(const std::string& model_name,
+                        const nlohmann::json& model_data,
+                        bool do_not_upgrade);
+
+    CancelResult cancel(const std::string& id);
+
+    // Cancel all active jobs and join all worker threads.
+    void shutdown();
+
+    // Stream SSE events for a job. Replays buffered events then streams live.
+    // Sets res.status=404 and returns if job not found.
+    void stream_job(const std::string& id, httplib::Response& res);
+
+    // Thread-safe JSON serialisation of job list / single job.
+    nlohmann::json list_jobs_json() const;
+    nlohmann::json get_job_json(const std::string& id) const;
+
+    static std::string status_str(JobStatus s);
+    static bool is_terminal(JobStatus s);
+
+private:
+    void run_job(std::shared_ptr<DownloadJob> job);
+    void persist();
+    void load_persisted();
+    std::string generate_id();
+
+    static JobStatus status_from_str(const std::string& s);
+    static nlohmann::json progress_to_json(const DownloadProgress& p);
+    static nlohmann::json job_to_json_locked(const DownloadJob& job);
+
+    ModelManager* model_manager_;
+    std::string persist_path_;
+
+    mutable std::mutex mutex_;
+    std::condition_variable event_cv_;
+    std::vector<std::shared_ptr<DownloadJob>> jobs_;
+
+    std::atomic<uint32_t> next_id_;
+    bool shutdown_ = false;
+};
+
+} // namespace lemon

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -17,6 +17,7 @@
 #include "backend_manager.h"
 #include "websocket_server.h"
 #include "lemon/utils/network_beacon.h"
+#include "lemon/download_queue.h"
 
 namespace lemon {
 
@@ -75,6 +76,12 @@ private:
     void handle_responses(const httplib::Request& req, httplib::Response& res);
     void handle_pull(const httplib::Request& req, httplib::Response& res);
     void handle_pull_variants(const httplib::Request& req, httplib::Response& res);
+
+    // Download queue endpoints
+    void handle_downloads_list(const httplib::Request& req, httplib::Response& res);
+    void handle_download_status(const httplib::Request& req, httplib::Response& res);
+    void handle_download_cancel(const httplib::Request& req, httplib::Response& res);
+    void handle_download_stream(const httplib::Request& req, httplib::Response& res);
     void handle_load(const httplib::Request& req, httplib::Response& res);
     void handle_unload(const httplib::Request& req, httplib::Response& res);
     void handle_delete(const httplib::Request& req, httplib::Response& res);
@@ -150,6 +157,7 @@ private:
     std::unique_ptr<ModelManager> model_manager_;
     std::unique_ptr<BackendManager> backend_manager_;
     std::unique_ptr<WebSocketServer> websocket_server_;
+    std::unique_ptr<DownloadQueue> download_queue_;
 
     bool running_;
     std::atomic<bool> rebind_requested_{false};

--- a/src/cpp/server/download_queue.cpp
+++ b/src/cpp/server/download_queue.cpp
@@ -1,0 +1,429 @@
+#include <lemon/download_queue.h>
+#include <httplib.h>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <filesystem>
+#include <lemon/utils/aixlog.hpp>
+
+namespace fs = std::filesystem;
+
+namespace lemon {
+
+// ---- static helpers --------------------------------------------------------
+
+std::string DownloadQueue::status_str(JobStatus s) {
+    switch (s) {
+        case JobStatus::Queued:    return "queued";
+        case JobStatus::Running:   return "running";
+        case JobStatus::Complete:  return "complete";
+        case JobStatus::Failed:    return "failed";
+        case JobStatus::Cancelled: return "cancelled";
+    }
+    return "unknown";
+}
+
+JobStatus DownloadQueue::status_from_str(const std::string& s) {
+    if (s == "queued")    return JobStatus::Queued;
+    if (s == "running")   return JobStatus::Running;
+    if (s == "complete")  return JobStatus::Complete;
+    if (s == "failed")    return JobStatus::Failed;
+    if (s == "cancelled") return JobStatus::Cancelled;
+    return JobStatus::Failed;
+}
+
+bool DownloadQueue::is_terminal(JobStatus s) {
+    return s == JobStatus::Complete || s == JobStatus::Failed || s == JobStatus::Cancelled;
+}
+
+nlohmann::json DownloadQueue::progress_to_json(const DownloadProgress& p) {
+    return {
+        {"file", p.file},
+        {"file_index", p.file_index},
+        {"total_files", p.total_files},
+        {"bytes_downloaded", static_cast<uint64_t>(p.bytes_downloaded)},
+        {"bytes_total", static_cast<uint64_t>(p.bytes_total)},
+        {"total_download_size", static_cast<uint64_t>(p.total_download_size)},
+        {"bytes_previously_downloaded", static_cast<uint64_t>(p.bytes_previously_downloaded)},
+        {"percent", p.percent}
+    };
+}
+
+// Called with mutex_ already held.
+nlohmann::json DownloadQueue::job_to_json_locked(const DownloadJob& job) {
+    nlohmann::json j;
+    j["id"] = job.id;
+    j["model_name"] = job.model_name;
+    j["status"] = status_str(job.status);
+    j["created_at"] = job.created_at;
+    j["started_at"] = job.started_at > 0 ? nlohmann::json(job.started_at) : nlohmann::json(nullptr);
+    j["finished_at"] = job.finished_at > 0 ? nlohmann::json(job.finished_at) : nlohmann::json(nullptr);
+    j["error"] = job.error.empty() ? nlohmann::json(nullptr) : nlohmann::json(job.error);
+    j["progress"] = progress_to_json(job.last_progress);
+    return j;
+}
+
+// ---- ctor / dtor -----------------------------------------------------------
+
+DownloadQueue::DownloadQueue(ModelManager* model_manager, const std::string& cache_dir)
+    : model_manager_(model_manager),
+      persist_path_(cache_dir + "/download_queue.json"),
+      next_id_(static_cast<uint32_t>(std::time(nullptr))) {
+    load_persisted();
+}
+
+DownloadQueue::~DownloadQueue() {
+    shutdown();
+}
+
+// ---- generate_id -----------------------------------------------------------
+
+std::string DownloadQueue::generate_id() {
+    uint32_t val = next_id_.fetch_add(1);
+    std::ostringstream oss;
+    oss << "dl_" << std::hex << std::setw(8) << std::setfill('0') << val;
+    return oss.str();
+}
+
+// ---- enqueue ---------------------------------------------------------------
+
+std::string DownloadQueue::enqueue(const std::string& model_name,
+                                    const nlohmann::json& model_data,
+                                    bool do_not_upgrade) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Return existing job ID if this model is already active.
+    for (const auto& job : jobs_) {
+        if (job->model_name == model_name && !is_terminal(job->status)) {
+            LOG(INFO, "DownloadQueue") << "Model " << model_name
+                << " already downloading (job " << job->id << ")" << std::endl;
+            return job->id;
+        }
+    }
+
+    auto job = std::make_shared<DownloadJob>();
+    job->id = generate_id();
+    job->model_name = model_name;
+    job->model_data = model_data;
+    job->do_not_upgrade = do_not_upgrade;
+    job->created_at = static_cast<int64_t>(std::time(nullptr));
+
+    jobs_.push_back(job);
+
+    LOG(INFO, "DownloadQueue") << "Enqueued " << model_name << " as job " << job->id << std::endl;
+
+    // Spawn a dedicated thread per job (parallel downloads, matching current behaviour).
+    job->worker_thread = std::thread([this, job] { run_job(job); });
+
+    return job->id;
+}
+
+// ---- run_job ---------------------------------------------------------------
+
+void DownloadQueue::run_job(std::shared_ptr<DownloadJob> job) {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        job->status = JobStatus::Running;
+        job->started_at = static_cast<int64_t>(std::time(nullptr));
+    }
+    event_cv_.notify_all();
+
+    try {
+        DownloadProgressCallback cb = [this, job](const DownloadProgress& p) -> bool {
+            if (job->cancel_flag.load()) return false;
+
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                if (job->cancel_flag.load()) return false;
+
+                job->last_progress = p;
+
+                std::string type = p.complete ? "complete" : "progress";
+                std::string ev = "event: " + type + "\ndata: "
+                    + progress_to_json(p).dump() + "\n\n";
+
+                job->event_buffer.push_back(ev);
+                job->total_events++;
+                if (job->event_buffer.size() > DownloadJob::kEventBufCap) {
+                    job->event_buffer.pop_front();
+                }
+            }
+            event_cv_.notify_all();
+            return true;
+        };
+
+        model_manager_->download_model(
+            job->model_name, job->model_data, job->do_not_upgrade, cb);
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (job->status != JobStatus::Cancelled) {
+                job->status = JobStatus::Complete;
+                job->finished_at = static_cast<int64_t>(std::time(nullptr));
+                LOG(INFO, "DownloadQueue") << "Job " << job->id << " complete" << std::endl;
+            }
+        }
+
+    } catch (const std::exception& e) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::string msg = e.what();
+        bool cancelled = job->cancel_flag.load()
+            || msg.find("cancelled") != std::string::npos
+            || msg.find("Cancelled") != std::string::npos;
+
+        job->finished_at = static_cast<int64_t>(std::time(nullptr));
+
+        if (cancelled) {
+            job->status = JobStatus::Cancelled;
+            job->event_buffer.push_back("event: cancelled\ndata: {}\n\n");
+            LOG(INFO, "DownloadQueue") << "Job " << job->id << " cancelled" << std::endl;
+        } else {
+            job->status = JobStatus::Failed;
+            job->error = msg;
+            nlohmann::json err = {{"error", msg}};
+            job->event_buffer.push_back("event: error\ndata: " + err.dump() + "\n\n");
+            LOG(ERROR, "DownloadQueue") << "Job " << job->id << " failed: " << msg << std::endl;
+        }
+
+        job->total_events++;
+        if (job->event_buffer.size() > DownloadJob::kEventBufCap) {
+            job->event_buffer.pop_front();
+        }
+    }
+
+    event_cv_.notify_all();
+    persist();
+}
+
+// ---- cancel ----------------------------------------------------------------
+
+CancelResult DownloadQueue::cancel(const std::string& id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& job : jobs_) {
+        if (job->id == id) {
+            if (is_terminal(job->status)) return CancelResult::AlreadyTerminal;
+            job->cancel_flag = true;
+            LOG(INFO, "DownloadQueue") << "Cancel requested for job " << id << std::endl;
+            return CancelResult::Ok;
+        }
+    }
+    return CancelResult::NotFound;
+}
+
+// ---- shutdown --------------------------------------------------------------
+
+void DownloadQueue::shutdown() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (shutdown_) return;
+        shutdown_ = true;
+        for (const auto& job : jobs_) {
+            job->cancel_flag = true;
+        }
+    }
+    event_cv_.notify_all();
+
+    for (const auto& job : jobs_) {
+        if (job->worker_thread.joinable()) {
+            job->worker_thread.join();
+        }
+    }
+
+    persist();
+}
+
+// ---- stream_job ------------------------------------------------------------
+
+void DownloadQueue::stream_job(const std::string& id, httplib::Response& res) {
+    // Find the job under lock, then release before setting up the provider.
+    std::shared_ptr<DownloadJob> job;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& j : jobs_) {
+            if (j->id == id) { job = j; break; }
+        }
+    }
+
+    if (!job) {
+        res.status = 404;
+        res.set_content("{\"error\": \"Download job not found\"}", "application/json");
+        return;
+    }
+
+    res.set_header("Cache-Control", "no-cache");
+    res.set_header("Connection", "keep-alive");
+    res.set_header("X-Accel-Buffering", "no");
+
+    res.set_chunked_content_provider("text/event-stream",
+        [this, job](size_t offset, httplib::DataSink& sink) -> bool {
+            if (offset > 0) {
+                sink.done();
+                return false;
+            }
+
+            // Start replay from the oldest event currently in the buffer.
+            uint64_t next_abs = 0;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                uint64_t buf_start = job->total_events > job->event_buffer.size()
+                    ? job->total_events - static_cast<uint64_t>(job->event_buffer.size()) : 0;
+                next_abs = buf_start;
+            }
+
+            while (true) {
+                std::vector<std::string> to_send;
+                bool terminal = false;
+
+                {
+                    std::unique_lock<std::mutex> lock(mutex_);
+                    event_cv_.wait_for(lock, std::chrono::milliseconds(500), [&] {
+                        return next_abs < job->total_events
+                            || is_terminal(job->status)
+                            || shutdown_;
+                    });
+
+                    uint64_t buf_start = job->total_events > job->event_buffer.size()
+                        ? job->total_events - static_cast<uint64_t>(job->event_buffer.size()) : 0;
+
+                    // If the ring buffer wrapped past us, jump to its start.
+                    if (next_abs < buf_start) next_abs = buf_start;
+
+                    while (next_abs < job->total_events) {
+                        size_t idx = static_cast<size_t>(next_abs - buf_start);
+                        to_send.push_back(job->event_buffer[idx]);
+                        next_abs++;
+                    }
+
+                    terminal = is_terminal(job->status) && next_abs >= job->total_events;
+                }
+
+                for (const auto& ev : to_send) {
+                    if (!sink.write(ev.c_str(), ev.size())) {
+                        return false;  // client disconnected; download continues in background
+                    }
+                }
+
+                if (terminal || shutdown_) {
+                    sink.done();
+                    return false;
+                }
+            }
+        });
+}
+
+// ---- JSON accessors --------------------------------------------------------
+
+nlohmann::json DownloadQueue::list_jobs_json() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    nlohmann::json arr = nlohmann::json::array();
+    for (const auto& job : jobs_) {
+        arr.push_back(job_to_json_locked(*job));
+    }
+    return arr;
+}
+
+nlohmann::json DownloadQueue::get_job_json(const std::string& id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& job : jobs_) {
+        if (job->id == id) return job_to_json_locked(*job);
+    }
+    return nullptr;
+}
+
+// ---- persistence -----------------------------------------------------------
+
+void DownloadQueue::persist() {
+    nlohmann::json arr = nlohmann::json::array();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        // Collect terminal jobs; cap history at 100.
+        std::vector<size_t> terminal_indices;
+        for (size_t i = 0; i < jobs_.size(); i++) {
+            if (is_terminal(jobs_[i]->status)) terminal_indices.push_back(i);
+        }
+        size_t terminal_start = terminal_indices.size() > 100
+            ? terminal_indices.size() - 100 : 0;
+        std::vector<size_t> keep_terminal(
+            terminal_indices.begin() + static_cast<long>(terminal_start),
+            terminal_indices.end());
+
+        for (size_t i = 0; i < jobs_.size(); i++) {
+            const auto& job = jobs_[i];
+            bool terminal = is_terminal(job->status);
+
+            if (terminal) {
+                bool keep = false;
+                for (size_t idx : keep_terminal) {
+                    if (idx == i) { keep = true; break; }
+                }
+                if (!keep) continue;
+            }
+
+            nlohmann::json j;
+            j["id"] = job->id;
+            j["model_name"] = job->model_name;
+            j["model_data"] = job->model_data;
+            j["do_not_upgrade"] = job->do_not_upgrade;
+            j["created_at"] = job->created_at;
+            // Save Running jobs as Queued so they resume on restart.
+            JobStatus saved = (job->status == JobStatus::Running) ? JobStatus::Queued : job->status;
+            j["status"] = status_str(saved);
+            j["started_at"] = job->started_at;
+            j["finished_at"] = job->finished_at;
+            j["error"] = job->error;
+            arr.push_back(j);
+        }
+    }
+
+    std::string tmp = persist_path_ + ".tmp";
+    try {
+        std::ofstream f(tmp);
+        if (f) {
+            f << arr.dump(2);
+            f.close();
+            fs::rename(tmp, persist_path_);
+        }
+    } catch (...) {
+        // Persistence failure is non-fatal.
+    }
+}
+
+void DownloadQueue::load_persisted() {
+    try {
+        std::ifstream f(persist_path_);
+        if (!f) return;
+
+        nlohmann::json arr = nlohmann::json::parse(f);
+        if (!arr.is_array()) return;
+
+        for (const auto& j : arr) {
+            auto job = std::make_shared<DownloadJob>();
+            job->id = j.value("id", "");
+            job->model_name = j.value("model_name", "");
+            job->model_data = j.value("model_data", nlohmann::json::object());
+            job->do_not_upgrade = j.value("do_not_upgrade", false);
+            job->created_at = j.value("created_at", int64_t(0));
+            job->status = status_from_str(j.value("status", "failed"));
+            job->started_at = j.value("started_at", int64_t(0));
+            job->finished_at = j.value("finished_at", int64_t(0));
+            job->error = j.value("error", "");
+
+            if (job->id.empty() || job->model_name.empty()) continue;
+
+            jobs_.push_back(job);
+
+            // Re-run any downloads that were interrupted by a server restart.
+            // model_manager_'s .partial file support will resume from where they left off.
+            if (job->status == JobStatus::Queued) {
+                LOG(INFO, "DownloadQueue") << "Resuming interrupted download: "
+                    << job->model_name << " (" << job->id << ")" << std::endl;
+                job->worker_thread = std::thread([this, job] { run_job(job); });
+            }
+        }
+    } catch (...) {
+        // Corrupt or missing file — start fresh.
+    }
+}
+
+} // namespace lemon

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -144,6 +144,8 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
                                        model_manager_.get(),
                                        backend_manager_.get());
 
+    download_queue_ = std::make_unique<DownloadQueue>(model_manager_.get(), cache_dir_);
+
     LOG(DEBUG, "Server") << "Debug logging enabled - subprocess output will be visible" << std::endl;
 
     const char* api_key_env = std::getenv("LEMONADE_API_KEY");
@@ -380,6 +382,39 @@ void Server::setup_routes(httplib::Server &web_server) {
 
     register_get("pull/variants", [this](const httplib::Request& req, httplib::Response& res) {
         handle_pull_variants(req, res);
+    });
+
+    // Download queue endpoints.
+    // Register /stream routes before bare /{id} routes to avoid prefix ambiguity.
+    auto register_get_regex = [this, &web_server](const std::string& pattern,
+        std::function<void(const httplib::Request&, httplib::Response&)> handler) {
+        web_server.Get("/api/v0/" + pattern, handler);
+        web_server.Get("/api/v1/" + pattern, handler);
+        web_server.Get("/v0/" + pattern, handler);
+        web_server.Get("/v1/" + pattern, handler);
+    };
+    auto register_delete_regex = [this, &web_server](const std::string& pattern,
+        std::function<void(const httplib::Request&, httplib::Response&)> handler) {
+        web_server.Delete("/api/v0/" + pattern, handler);
+        web_server.Delete("/api/v1/" + pattern, handler);
+        web_server.Delete("/v0/" + pattern, handler);
+        web_server.Delete("/v1/" + pattern, handler);
+    };
+
+    register_get_regex(R"(downloads/([^/]+)/stream)",
+        [this](const httplib::Request& req, httplib::Response& res) {
+            handle_download_stream(req, res);
+        });
+    register_get_regex(R"(downloads/([^/]+))",
+        [this](const httplib::Request& req, httplib::Response& res) {
+            handle_download_status(req, res);
+        });
+    register_delete_regex(R"(downloads/([^/]+))",
+        [this](const httplib::Request& req, httplib::Response& res) {
+            handle_download_cancel(req, res);
+        });
+    register_get("downloads", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_downloads_list(req, res);
     });
 
     register_post("load", [this](const httplib::Request& req, httplib::Response& res) {
@@ -1007,6 +1042,12 @@ void Server::stop() {
     if (running_) {
         LOG(INFO, "Server") << "Stopping HTTP server..." << std::endl;
         udp_beacon_.stopBroadcasting();
+
+        if (download_queue_) {
+            LOG(INFO, "Server") << "Shutting down download queue..." << std::endl;
+            download_queue_->shutdown();
+        }
+
         http_server_v6_->stop();
         http_server_->stop();
         running_ = false;
@@ -2598,11 +2639,9 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             request_json["model"].get<std::string>() :
             request_json["model_name"].get<std::string>();
 
-        // Extract optional parameters
         std::string checkpoint = request_json.value("checkpoint", "");
         std::string recipe = request_json.value("recipe", "");
         bool do_not_upgrade = request_json.value("do_not_upgrade", false);
-        bool stream = request_json.value("stream", false);
 
         LOG(INFO, "Server") << "Pulling model: " << model_name << std::endl;
         if (!checkpoint.empty()) {
@@ -2624,7 +2663,7 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             }
         }
 
-        // Local import mode: CLI has already copied files to HF cache, just resolve and register
+        // Local import: synchronous (local filesystem only, no network I/O)
         bool local_import = request_json.value("local_import", false);
         if (local_import) {
             std::string hf_cache = model_manager_->get_hf_cache_dir();
@@ -2634,9 +2673,7 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
 
             LOG(INFO, "Server") << "Local import mode - resolving files in: " << dest_path << std::endl;
 
-            resolve_and_register_local_model(
-                dest_path, model_name, request_json, hf_cache
-            );
+            resolve_and_register_local_model(dest_path, model_name, request_json, hf_cache);
 
             nlohmann::json response = {
                 {"status", "success"},
@@ -2647,18 +2684,16 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             return;
         }
 
-        if (stream) {
-            // SSE streaming mode - send progress events via shared helper
-            stream_download_operation(res, [this, model_name, request_json, do_not_upgrade](DownloadProgressCallback progress_cb) {
-                model_manager_->download_model(model_name, request_json, do_not_upgrade, progress_cb);
-            });
-        } else {
-            // Legacy synchronous mode - blocks until complete
-            model_manager_->download_model(model_name, request_json, do_not_upgrade);
-
-            nlohmann::json response = {{"status", "success"}, {"model_name", model_name}};
-            res.set_content(response.dump(), "application/json");
-        }
+        // Enqueue background download. Returns immediately with a job ID.
+        // Use GET /downloads/{job_id}/stream for live SSE progress updates.
+        std::string job_id = download_queue_->enqueue(model_name, request_json, do_not_upgrade);
+        res.status = 202;
+        nlohmann::json response = {
+            {"job_id", job_id},
+            {"status", "queued"},
+            {"model_name", model_name}
+        };
+        res.set_content(response.dump(), "application/json");
 
     } catch (const lemon::UnknownModelError& e) {
         LOG(ERROR, "Server") << "ERROR in handle_pull: " << e.what() << std::endl;
@@ -2705,6 +2740,50 @@ void Server::handle_pull_variants(const httplib::Request& req, httplib::Response
         nlohmann::json error = {{"error", e.what()}};
         res.set_content(error.dump(), "application/json");
     }
+}
+
+// ============================================================================
+// Download queue endpoint handlers
+// ============================================================================
+
+void Server::handle_downloads_list(const httplib::Request& /*req*/, httplib::Response& res) {
+    nlohmann::json response = {{"jobs", download_queue_->list_jobs_json()}};
+    res.set_content(response.dump(), "application/json");
+}
+
+void Server::handle_download_status(const httplib::Request& req, httplib::Response& res) {
+    std::string id = req.matches[1];
+    nlohmann::json job = download_queue_->get_job_json(id);
+    if (job.is_null()) {
+        res.status = 404;
+        res.set_content("{\"error\": \"Download job not found\"}", "application/json");
+        return;
+    }
+    res.set_content(job.dump(), "application/json");
+}
+
+void Server::handle_download_cancel(const httplib::Request& req, httplib::Response& res) {
+    std::string id = req.matches[1];
+    switch (download_queue_->cancel(id)) {
+        case CancelResult::NotFound:
+            res.status = 404;
+            res.set_content("{\"error\": \"Download job not found\"}", "application/json");
+            break;
+        case CancelResult::AlreadyTerminal:
+            res.status = 409;
+            res.set_content("{\"error\": \"Job is already in a terminal state\"}", "application/json");
+            break;
+        case CancelResult::Ok:
+            res.set_content(
+                nlohmann::json{{"id", id}, {"status", "cancelling"}}.dump(),
+                "application/json");
+            break;
+    }
+}
+
+void Server::handle_download_stream(const httplib::Request& req, httplib::Response& res) {
+    std::string id = req.matches[1];
+    download_queue_->stream_job(id, res);
 }
 
 void Server::handle_load(const httplib::Request& req, httplib::Response& res) {

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -44,6 +44,46 @@ from utils.test_models import (
 )
 
 
+def pull_and_wait(base_url, pull_body, timeout=TIMEOUT_MODEL_OPERATION):
+    """POST /pull and block until the download job completes. Returns True on success."""
+    response = requests.post(
+        f"{base_url}/pull",
+        json=pull_body,
+        timeout=TIMEOUT_DEFAULT,
+    )
+    if response.status_code not in (200, 202):
+        return False
+
+    data = response.json()
+    # Legacy sync path (local_import) still returns 200 + status=success.
+    if response.status_code == 200:
+        return data.get("status") == "success"
+
+    job_id = data.get("job_id")
+    if not job_id:
+        return False
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        status_resp = requests.get(
+            f"{base_url}/downloads/{job_id}",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        if status_resp.status_code != 200:
+            return False
+        job = status_resp.json()
+        status = job.get("status")
+        if status == "complete":
+            return True
+        if status in ("failed", "cancelled"):
+            print(f"[pull_and_wait] Job {job_id} ended with status={status}: {job.get('error')}")
+            return False
+        time.sleep(2)
+
+    print(f"[pull_and_wait] Timed out waiting for job {job_id}")
+    return False
+
+
 class EndpointTests(ServerTestBase):
     """Tests for inference-agnostic endpoints."""
 
@@ -65,16 +105,15 @@ class EndpointTests(ServerTestBase):
             return
 
         print(f"\n[SETUP] Ensuring {ENDPOINT_TEST_MODEL} is pulled...")
-        response = requests.post(
-            f"http://localhost:{PORT}/api/v1/pull",
-            json={"model_name": ENDPOINT_TEST_MODEL},
-            timeout=TIMEOUT_MODEL_OPERATION,
+        ok = pull_and_wait(
+            f"http://localhost:{PORT}/api/v1",
+            {"model_name": ENDPOINT_TEST_MODEL},
         )
-        if response.status_code == 200:
+        if ok:
             print(f"[SETUP] {ENDPOINT_TEST_MODEL} is ready")
             cls._model_pulled = True
         else:
-            print(f"[SETUP] Warning: pull returned {response.status_code}")
+            print(f"[SETUP] Warning: pull failed for {ENDPOINT_TEST_MODEL}")
 
     def setUp(self):
         """Set up each test."""
@@ -100,6 +139,7 @@ class EndpointTests(ServerTestBase):
             "images/generations",
             "install",
             "uninstall",
+            "downloads",
         ]
 
         session = requests.Session()
@@ -231,8 +271,8 @@ class EndpointTests(ServerTestBase):
 
         print("[OK] NotFoundError raised for non-existent model")
 
-    def test_007_pull_model_non_streaming(self):
-        """Test pulling/downloading a model (non-streaming mode)."""
+    def test_007_pull_model(self):
+        """Test pulling/downloading a model via the async download queue."""
         # First delete model if it exists to ensure we're actually testing pull
         delete_response = requests.post(
             f"{self.base_url}/delete",
@@ -252,17 +292,30 @@ class EndpointTests(ServerTestBase):
             ENDPOINT_TEST_MODEL, model_ids, "Model should be deleted before pull test"
         )
 
-        # Now pull the model
+        # POST /pull → 202 Accepted with a job ID
         response = requests.post(
             f"{self.base_url}/pull",
-            json={"model_name": ENDPOINT_TEST_MODEL, "stream": False},
-            timeout=TIMEOUT_MODEL_OPERATION,
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 202)
 
         data = response.json()
+        self.assertIn("job_id", data)
         self.assertIn("status", data)
-        self.assertEqual(data["status"], "success")
+        self.assertEqual(data["status"], "queued")
+        job_id = data["job_id"]
+
+        # Poll GET /downloads/{job_id} until complete
+        ok = pull_and_wait(self.base_url, {"model_name": ENDPOINT_TEST_MODEL})
+        self.assertTrue(ok, "Download job should complete successfully")
+
+        # Verify job is reported as complete
+        status_resp = requests.get(
+            f"{self.base_url}/downloads/{job_id}", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(status_resp.status_code, 200)
+        self.assertEqual(status_resp.json().get("status"), "complete")
 
         # Verify model is now in downloaded list
         models_response = requests.get(
@@ -274,11 +327,11 @@ class EndpointTests(ServerTestBase):
             ENDPOINT_TEST_MODEL, model_ids, "Model should be downloaded after pull"
         )
 
-        print(f"[OK] Pull (non-streaming): model={ENDPOINT_TEST_MODEL}")
+        print(f"[OK] Pull (async): model={ENDPOINT_TEST_MODEL}, job={job_id}")
 
     def test_008_pull_model_streaming(self):
-        """Test pulling a model with streaming progress events."""
-        # First delete model to ensure we're actually testing pull
+        """Test GET /downloads/{id}/stream delivers SSE progress events."""
+        # First delete model to ensure a real download occurs
         delete_response = requests.post(
             f"{self.base_url}/delete",
             json={"model_name": ENDPOINT_TEST_MODEL},
@@ -286,49 +339,102 @@ class EndpointTests(ServerTestBase):
         )
         self.assertIn(delete_response.status_code, [200, 422])
 
-        # Pull with streaming
+        # Enqueue the download
         response = requests.post(
             f"{self.base_url}/pull",
-            json={"model_name": ENDPOINT_TEST_MODEL, "stream": True},
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 202)
+        job_id = response.json()["job_id"]
+
+        # Connect to the SSE stream for this job
+        stream_response = requests.get(
+            f"{self.base_url}/downloads/{job_id}/stream",
             timeout=TIMEOUT_MODEL_OPERATION,
             stream=True,
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(stream_response.status_code, 200)
 
-        # Parse SSE events
+        # Parse SSE events until the terminal event arrives
         events_received = []
         complete_received = False
 
-        for line in response.iter_lines():
+        for line in stream_response.iter_lines():
             if line:
                 line_str = line.decode("utf-8")
                 if line_str.startswith("event:"):
                     event_type = line_str.split(":", 1)[1].strip()
                     events_received.append(event_type)
-                    if event_type == "complete":
+                    if event_type in ("complete", "error", "cancelled"):
                         complete_received = True
+                        break
 
-        # Should have received progress and complete events
         self.assertTrue(
-            complete_received
-            or "progress" in events_received
-            or len(events_received) > 0,
-            f"Expected streaming events, got: {events_received}",
+            complete_received or len(events_received) > 0,
+            f"Expected SSE events from /downloads/{job_id}/stream, got: {events_received}",
         )
 
         # Verify model is now in downloaded list
         models_response = requests.get(
             f"{self.base_url}/models", timeout=TIMEOUT_DEFAULT
         )
-        models_data = models_response.json()
-        model_ids = [m["id"] for m in models_data["data"]]
+        model_ids = [m["id"] for m in models_response.json()["data"]]
         self.assertIn(
             ENDPOINT_TEST_MODEL,
             model_ids,
             "Model should be downloaded after streaming pull",
         )
 
-        print(f"[OK] Pull (streaming): received events: {set(events_received)}")
+        print(f"[OK] Pull (SSE stream): job={job_id}, events: {set(events_received)}")
+
+    def test_008a_download_queue_endpoints(self):
+        """Test GET /downloads list and single-job status endpoints."""
+        # Enqueue a pull so there is at least one job to inspect
+        response = requests.post(
+            f"{self.base_url}/pull",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 202)
+        job_id = response.json()["job_id"]
+
+        # GET /downloads should return a list containing this job
+        list_resp = requests.get(f"{self.base_url}/downloads", timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(list_resp.status_code, 200)
+        list_data = list_resp.json()
+        self.assertIn("jobs", list_data)
+        self.assertIsInstance(list_data["jobs"], list)
+        job_ids_in_list = [j["id"] for j in list_data["jobs"]]
+        self.assertIn(job_id, job_ids_in_list, "Enqueued job should appear in /downloads")
+
+        # GET /downloads/{id} should return the individual job
+        status_resp = requests.get(
+            f"{self.base_url}/downloads/{job_id}", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(status_resp.status_code, 200)
+        job = status_resp.json()
+        self.assertEqual(job["id"], job_id)
+        self.assertIn(job["status"], ("queued", "running", "complete", "failed", "cancelled"))
+        self.assertIn("model_name", job)
+        self.assertIn("progress", job)
+
+        # GET /downloads/{unknown} should return 404
+        not_found = requests.get(
+            f"{self.base_url}/downloads/dl_00000000", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(not_found.status_code, 404)
+
+        # Wait for this download to finish before proceeding
+        pull_and_wait(self.base_url, {"model_name": ENDPOINT_TEST_MODEL})
+
+        # After completion the job should report complete
+        final = requests.get(
+            f"{self.base_url}/downloads/{job_id}", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(final.json().get("status"), "complete")
+
+        print(f"[OK] Download queue endpoints: job={job_id}")
 
     def test_009_load_model_basic(self):
         """Test loading a model into memory."""
@@ -749,11 +855,7 @@ class EndpointTests(ServerTestBase):
         self.assertNotIn(ENDPOINT_TEST_MODEL, model_ids)
 
         # Re-pull for subsequent tests (stats test needs a model)
-        requests.post(
-            f"{self.base_url}/pull",
-            json={"model_name": ENDPOINT_TEST_MODEL},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
+        pull_and_wait(self.base_url, {"model_name": ENDPOINT_TEST_MODEL})
 
         print(f"[OK] Deleted and re-pulled model: {ENDPOINT_TEST_MODEL}")
 
@@ -984,9 +1086,9 @@ class EndpointTests(ServerTestBase):
         )
 
         # Now pull the model
-        response = requests.post(
-            f"{self.base_url}/pull",
-            json={
+        ok = pull_and_wait(
+            self.base_url,
+            {
                 "model_name": USER_MODEL_NAME,
                 "checkpoints": {
                     "main": USER_MODEL_MAIN_CHECKPOINT,
@@ -995,15 +1097,9 @@ class EndpointTests(ServerTestBase):
                 },
                 "recipe": recipe,
                 "recipe_options": {recipe_backend: "cpu"},
-                "stream": False,
             },
-            timeout=TIMEOUT_MODEL_OPERATION,
         )
-        self.assertEqual(response.status_code, 200)
-
-        data = response.json()
-        self.assertIn("status", data)
-        self.assertEqual(data["status"], "success")
+        self.assertTrue(ok, "Multi-checkpoint pull should complete successfully")
 
         # Verify model is now in downloaded list
         models_response = requests.get(
@@ -1080,9 +1176,9 @@ class EndpointTests(ServerTestBase):
         }
 
         try:
-            response = requests.post(
-                f"{self.base_url}/pull",
-                json={
+            ok = pull_and_wait(
+                self.base_url,
+                {
                     "model_name": model_name,
                     "checkpoints": {
                         # Use a different main quant than USER_MODEL_NAME so this test's
@@ -1095,11 +1191,9 @@ class EndpointTests(ServerTestBase):
                     "recipe": "sd-cpp",
                     "image_defaults": image_defaults,
                     "recipe_options": recipe_options,
-                    "stream": False,
                 },
-                timeout=TIMEOUT_MODEL_OPERATION,
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertTrue(ok, "Pull should complete successfully")
 
             model_info_response = requests.get(
                 f"{self.base_url}/models/{model_name}",
@@ -1154,18 +1248,16 @@ class EndpointTests(ServerTestBase):
         public_name = canonical_name[5:]
 
         try:
-            response = requests.post(
-                f"{self.base_url}/pull",
-                json={
+            ok = pull_and_wait(
+                self.base_url,
+                {
                     "model_name": canonical_name,
                     "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
                     "recipe": "llamacpp",
                     "labels": ["appear-builtin"],
-                    "stream": False,
                 },
-                timeout=TIMEOUT_MODEL_OPERATION,
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertTrue(ok, "Pull should complete successfully")
 
             models_response = requests.get(
                 f"{self.base_url}/models?show_all=true",


### PR DESCRIPTION
**Background download queue**

Right now if you close the browser tab while a model is downloading, the download just dies. This PR fixes that — downloads now run in the background inside `lemond` and keep going regardless of what the client does.

`POST /pull` returns immediately with a job ID instead of blocking, and there are a few new endpoints to track what's happening:

- `GET /downloads` — see all jobs
- `GET /downloads/{id}` — check a specific one
- `DELETE /downloads/{id}` — cancel it
- `GET /downloads/{id}/stream` — SSE stream for live progress (reconnect-safe, replays recent events)

The queue is also saved to disk, so if the server restarts mid-download it picks up where it left off using the existing `.partial` file resume support.

**Breaking change:** `POST /pull` now returns `202` with a `job_id` instead of either blocking synchronously or streaming SSE directly. If you're using `stream=true` today, switch to `GET /downloads/{id}/stream` after the pull. The CLI (`lemonade pull`) will need a follow-up update too.

Tests are updated to poll for completion via `GET /downloads/{id}` rather than waiting on the pull response.