### PR TITLE
Fix macOS dev build: drop Linux-only libdrm and ad-hoc codesign default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1089,7 +1089,9 @@ if(APPLE)
         if(DEFINED ENV{DEVELOPER_ID_APPLICATION_IDENTITY})
             set(SIGNING_IDENTITY "$ENV{DEVELOPER_ID_APPLICATION_IDENTITY}")
         else()
-            set(SIGNING_IDENTITY "BBC1E1924FF481293CF0928B5DFFF8A6419D7DA0")
+            # Ad-hoc sign so local dev builds work without an Apple Developer cert.
+            # Distribution builds set DEVELOPER_ID_APPLICATION_IDENTITY explicitly.
+            set(SIGNING_IDENTITY "-")
         endif()
     endif()
 

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -191,6 +191,7 @@ If not found, the "Open app" menu option is hidden but everything else works.
 - Uses native system frameworks (Cocoa, Foundation)
 - ARM Macs use Metal backend by default for llama.cpp
 - macOS support is currently in beta; a signed and notarized `.pkg` installer is available from the [releases page](https://github.com/lemonade-sdk/lemonade/releases/latest)
+- Local Release builds are ad-hoc codesigned (`codesign --sign -`) so they run without an Apple Developer certificate. To sign with a real Developer ID, export `DEVELOPER_ID_APPLICATION_IDENTITY` before configuring CMake (see [Building and Notarizing for Distribution](#building-and-notarizing-for-distribution)).
 
 ## Building Installers
 

--- a/setup.sh
+++ b/setup.sh
@@ -218,7 +218,7 @@ else
             missing_packages+=("pkg-config" "libcurl-devel" "libopenssl-devel" "zlib-devel" "systemd-devel" "libdrm-devel" "libcap-devel" "libwebsockets-devel")
         fi
     elif [ "$OS" = "macos" ]; then
-        missing_packages+=("pkg-config" "curl" "openssl" "zlib" "libdrm")
+        missing_packages+=("pkg-config" "curl" "openssl" "zlib")
     fi
 fi
 


### PR DESCRIPTION
## Summary

Two bugs blocked a fresh-clone Mac dev setup. Both are fixed here.

- **`setup.sh`** added `libdrm` to the macOS `brew install` list, but libdrm is a Linux kernel API (Direct Rendering Manager). Brew refused with "Linux is required for this software," and `set -e` aborted setup before installing any of the other deps (ninja, pkg-config, pre-commit, rust). Removed `libdrm` from the macOS package list.
- **`CMakeLists.txt`** hardcoded an Apple Developer ID hash as the codesign fallback, so every Release build by an external contributor failed with "no identity found." Defaulted to `-` (ad-hoc) instead. Distribution builds still set `DEVELOPER_ID_APPLICATION_IDENTITY` explicitly per the existing notarization docs.
- **`docs/dev/getting-started.md`** got a one-line note in the macOS section explaining the ad-hoc default and how to override it.

After these, `./setup.sh && cmake --build --preset default` works cleanly on a fresh ARM Mac with no env vars.

## Test plan

- [x] `./setup.sh` runs to completion on macOS ARM with only `git`, `cmake`, `gcc` pre-installed (installs ninja, pkg-config, pre-commit, rust via brew/rustup)
- [x] `cmake --build --preset default` builds and ad-hoc signs `lemond`, `lemonade`, `lemonade-tray`, `lemonade-server`
- [x] `./build/lemond --version` runs (signature verifies as `Signature=adhoc`)
- [ ] Distribution build path with `DEVELOPER_ID_APPLICATION_IDENTITY` set still uses the supplied identity (untested — no cert handy, but logic unchanged)
- [ ] Linux build is unaffected (untested — no Linux changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)