### PR TITLE
feat(setup.sh): add rpm-ostree support for Fedora Atomic/Desktop environments

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -72,6 +72,8 @@ if ! command_exists pre-commit; then
         missing_packages+=("pre-commit")
     elif [ "$OS" = "linux" ] && command_exists apt; then
         missing_packages+=("pre-commit")
+    elif [ "$OS" = "linux" ] && command_exists rpm-ostree; then
+        missing_packages+=("pre-commit")
     elif [ "$OS" = "linux" ] && command_exists dnf; then
         missing_packages+=("pre-commit")
     elif [ "$OS" = "linux" ] && command_exists zypper; then
@@ -109,6 +111,8 @@ if [ ${#missing_tools[@]} -gt 0 ]; then
             missing_packages+=("git" "cmake" "ninja-build" "build-essential")
         elif command_exists pacman; then
             missing_packages+=("git" "cmake" "ninja" "base-devel")
+        elif command_exists rpm-ostree; then
+            missing_packages+=("git" "cmake" "ninja-build" "gcc" "gcc-c++" "make")
         elif command_exists dnf; then
             missing_packages+=("git" "cmake" "ninja-build" "gcc" "gcc-c++" "make")
         elif command_exists zypper; then
@@ -166,6 +170,19 @@ if command_exists pkg-config; then
                         libwebsockets) ;; # Not available in Arch repos, will use FetchContent
                     esac
                 done
+            elif command_exists rpm-ostree; then
+                # Map pkg-config names to rpm-ostree packages
+                for lib in "${missing_libs[@]}"; do
+                    case "$lib" in
+                        libcurl) missing_packages+=("libcurl-devel") ;;
+                        openssl) missing_packages+=("openssl-devel") ;;
+                        zlib) missing_packages+=("zlib-devel") ;;
+                        libsystemd) missing_packages+=("systemd-devel") ;;
+                        libdrm) missing_packages+=("libdrm-devel") ;;
+                        libcap) missing_packages+=("libcap-devel") ;;
+                        libwebsockets) missing_packages+=("libwebsockets-devel") ;;
+                    esac
+                done
             elif command_exists dnf; then
                 # Map pkg-config names to dnf packages
                 for lib in "${missing_libs[@]}"; do
@@ -212,6 +229,8 @@ else
             missing_packages+=("pkg-config" "curl" "libcurl4-openssl-dev" "libssl-dev" "zlib1g-dev" "libsystemd-dev" "libdrm-dev" "libcap-dev" "libwebsockets-dev")
         elif command_exists pacman; then
             missing_packages+=("pkgconf" "curl" "openssl" "zlib" "systemd" "libdrm" "libcap")
+        elif command_exists rpm-ostree; then
+            missing_packages+=("pkgconfig" "libcurl-devel" "openssl-devel" "zlib-devel" "systemd-devel" "libdrm-devel" "libcap-devel" "libwebsockets-devel")
         elif command_exists dnf; then
             missing_packages+=("pkgconfig" "libcurl-devel" "openssl-devel" "zlib-devel" "systemd-devel" "libdrm-devel" "libcap-devel" "libwebsockets-devel")
         elif command_exists zypper; then
@@ -244,6 +263,8 @@ if [ "$OS" = "linux" ] && command_exists pkg-config; then
             missing_tray_packages+=("libayatana-appindicator3-dev")
         elif command_exists pacman; then
             missing_tray_packages+=("libayatana-appindicator")
+        elif command_exists rpm-ostree; then
+            missing_tray_packages+=("libayatana-appindicator-gtk3-devel")
         elif command_exists dnf; then
             missing_tray_packages+=("libayatana-appindicator-gtk3-devel")
         elif command_exists zypper; then
@@ -262,6 +283,8 @@ if [ "$OS" = "linux" ] && command_exists pkg-config; then
                 missing_tray_packages+=("libdbusmenu-glib-dev")
             elif command_exists pacman; then
                 missing_tray_packages+=("libdbusmenu-glib")
+            elif command_exists rpm-ostree; then
+                missing_tray_packages+=("dbusmenu-glib-devel")
             elif command_exists dnf; then
                 missing_tray_packages+=("dbusmenu-glib-devel")
             elif command_exists zypper; then
@@ -280,6 +303,8 @@ if [ "$OS" = "linux" ] && command_exists pkg-config; then
                 missing_tray_packages+=("libgtk-3-dev")
             elif command_exists pacman; then
                 missing_tray_packages+=("gtk3")
+            elif command_exists rpm-ostree; then
+                missing_tray_packages+=("gtk3-devel")
             elif command_exists dnf; then
                 missing_tray_packages+=("gtk3-devel")
             elif command_exists zypper; then
@@ -316,6 +341,8 @@ if [ "$OS" = "linux" ] && command_exists pkg-config; then
             tray_install_cmd="sudo apt install -y ${missing_tray_packages[*]}"
         elif command_exists pacman; then
             tray_install_cmd="sudo pacman -S --needed --noconfirm ${missing_tray_packages[*]}"
+        elif command_exists rpm-ostree; then
+            tray_install_cmd="rpm-ostree install -A --idempotent ${missing_tray_packages[*]}"
         elif command_exists dnf; then
             tray_install_cmd="sudo dnf install -y ${missing_tray_packages[*]}"
         elif command_exists zypper; then
@@ -339,6 +366,8 @@ if [ "$OS" = "linux" ] && command_exists pkg-config; then
                     maybe_sudo apt install -y "${missing_tray_packages[@]}"
                 elif command_exists pacman; then
                     maybe_sudo pacman -S --needed --noconfirm "${missing_tray_packages[@]}"
+                elif command_exists rpm-ostree; then
+                    maybe_sudo rpm-ostree install -A --idempotent "${missing_tray_packages[@]}"
                 elif command_exists dnf; then
                     maybe_sudo dnf install -y "${missing_tray_packages[@]}"
                 elif command_exists zypper; then
@@ -361,7 +390,7 @@ print_info "Checking Node.js and npm installation..."
 if ! command_exists node; then
     print_warning "Node.js not found"
     if [ "$OS" = "linux" ]; then
-        if command_exists apt || command_exists pacman || command_exists dnf || command_exists zypper; then
+        if command_exists apt || command_exists pacman || command_exists rpm-ostree || command_exists dnf || command_exists zypper; then
             missing_packages+=("nodejs" "npm")
         fi
     elif [ "$OS" = "macos" ]; then
@@ -397,6 +426,20 @@ if [ "$OS" = "linux" ]; then
         )
         for dep in "${tauri_dep_candidates[@]}"; do
             if ! dpkg -l "$dep" 2>/dev/null | grep -q "^ii"; then
+                tauri_linux_deps+=("$dep")
+            fi
+        done
+    elif command_exists rpm-ostree; then
+        tauri_dep_candidates=(
+            webkit2gtk4.1-devel
+            libsoup3-devel
+            librsvg2-devel
+            libappindicator-gtk3-devel
+            wget
+            file
+        )
+        for dep in "${tauri_dep_candidates[@]}"; do
+            if ! rpm -q "$dep" >/dev/null 2>&1; then
                 tauri_linux_deps+=("$dep")
             fi
         done
@@ -493,6 +536,8 @@ if [ ${#missing_packages[@]} -gt 0 ]; then
             else
                 install_cmd="sudo pacman -Syu --needed --noconfirm ${missing_packages[*]}"
             fi
+        elif command_exists rpm-ostree; then
+            install_cmd="rpm-ostree install -A --idempotent ${missing_packages[*]}"
         elif command_exists dnf; then
             if is_root; then
                 install_cmd="dnf install -y ${missing_packages[*]}"
@@ -549,6 +594,8 @@ if [ ${#missing_packages[@]} -gt 0 ]; then
             fi
         elif command_exists pacman; then
             maybe_sudo pacman -Syu --needed --noconfirm ${missing_packages[@]}
+        elif command_exists rpm-ostree; then
+            maybe_sudo rpm-ostree install -A --idempotent ${missing_packages[@]}
         elif command_exists dnf; then
             maybe_sudo dnf install -y ${missing_packages[@]}
         elif command_exists zypper; then
@@ -603,6 +650,8 @@ if [ ${#tauri_linux_deps[@]} -gt 0 ] || [ "$rust_needs_install" = true ]; then
         if command_exists apt; then
             maybe_sudo apt update
             maybe_sudo apt install -y "${tauri_linux_deps[@]}"
+        elif command_exists rpm-ostree; then
+            maybe_sudo rpm-ostree install -A --idempotent "${tauri_linux_deps[@]}"
         elif command_exists dnf; then
             maybe_sudo dnf install -y "${tauri_linux_deps[@]}"
         elif command_exists pacman; then
@@ -625,6 +674,10 @@ if [ ${#tauri_linux_deps[@]} -gt 0 ] || [ "$rust_needs_install" = true ]; then
                 fi
             elif command_exists pacman; then
                 if maybe_sudo pacman -S --needed --noconfirm rust; then
+                    rust_install_ok=true
+                fi
+            elif command_exists rpm-ostree; then
+                if maybe_sudo rpm-ostree install -A --idempotent rust cargo; then
                     rust_install_ok=true
                 fi
             elif command_exists dnf; then

--- a/setup.sh
+++ b/setup.sh
@@ -32,6 +32,11 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# Check if system is managed by rpm-ostree
+is_rpm_ostree() {
+    command_exists rpm-ostree && rpm-ostree status >/dev/null 2>&1
+}
+
 # Check if running as root
 is_root() {
     [ "$(id -u)" -eq 0 ]
@@ -60,7 +65,7 @@ print_info "Lemonade Development Setup"
 print_info "Operating System: $OS"
 echo ""
 
-if [ "$OS" = "linux" ] && command_exists rpm-ostree; then
+if [ "$OS" = "linux" ] && is_rpm_ostree; then
     print_warning "============================================"
     print_warning " rpm-ostree detected (Fedora Atomic/Desktop)"
     print_warning "============================================"
@@ -106,7 +111,7 @@ if ! command_exists pre-commit; then
         missing_packages+=("pre-commit")
     elif [ "$OS" = "linux" ] && command_exists apt; then
         missing_packages+=("pre-commit")
-    elif [ "$OS" = "linux" ] && command_exists rpm-ostree; then
+    elif [ "$OS" = "linux" ] && is_rpm_ostree; then
         missing_packages+=("pre-commit")
     elif [ "$OS" = "linux" ] && command_exists dnf; then
         missing_packages+=("pre-commit")
@@ -145,7 +150,7 @@ if [ ${#missing_tools[@]} -gt 0 ]; then
             missing_packages+=("git" "cmake" "ninja-build" "build-essential")
         elif command_exists pacman; then
             missing_packages+=("git" "cmake" "ninja" "base-devel")
-        elif command_exists rpm-ostree; then
+        elif is_rpm_ostree; then
             missing_packages+=("git" "cmake" "ninja-build" "gcc" "gcc-c++" "make")
         elif command_exists dnf; then
             missing_packages+=("git" "cmake" "ninja-build" "gcc" "gcc-c++" "make")
@@ -204,7 +209,7 @@ if command_exists pkg-config; then
                         libwebsockets) ;; # Not available in Arch repos, will use FetchContent
                     esac
                 done
-            elif command_exists rpm-ostree; then
+            elif is_rpm_ostree; then
                 # Map pkg-config names to rpm-ostree packages
                 for lib in "${missing_libs[@]}"; do
                     case "$lib" in
@@ -263,7 +268,7 @@ else
             missing_packages+=("pkg-config" "curl" "libcurl4-openssl-dev" "libssl-dev" "zlib1g-dev" "libsystemd-dev" "libdrm-dev" "libcap-dev" "libwebsockets-dev")
         elif command_exists pacman; then
             missing_packages+=("pkgconf" "curl" "openssl" "zlib" "systemd" "libdrm" "libcap")
-        elif command_exists rpm-ostree; then
+        elif is_rpm_ostree; then
             missing_packages+=("pkgconfig" "libcurl-devel" "openssl-devel" "zlib-devel" "systemd-devel" "libdrm-devel" "libcap-devel" "libwebsockets-devel")
         elif command_exists dnf; then
             missing_packages+=("pkgconfig" "libcurl-devel" "openssl-devel" "zlib-devel" "systemd-devel" "libdrm-devel" "libcap-devel" "libwebsockets-devel")
@@ -297,7 +302,7 @@ if [ "$OS" = "linux" ] && command_exists pkg-config; then
             missing_tray_packages+=("libayatana-appindicator3-dev")
         elif command_exists pacman; then
             missing_tray_packages+=("libayatana-appindicator")
-        elif command_exists rpm-ostree; then
+        elif is_rpm_ostree; then
             missing_tray_packages+=("libayatana-appindicator-gtk3-devel")
         elif command_exists dnf; then
             missing_tray_packages+=("libayatana-appindicator-gtk3-devel")
@@ -317,7 +322,7 @@ if [ "$OS" = "linux" ] && command_exists pkg-config; then
                 missing_tray_packages+=("libdbusmenu-glib-dev")
             elif command_exists pacman; then
                 missing_tray_packages+=("libdbusmenu-glib")
-            elif command_exists rpm-ostree; then
+            elif is_rpm_ostree; then
                 missing_tray_packages+=("dbusmenu-glib-devel")
             elif command_exists dnf; then
                 missing_tray_packages+=("dbusmenu-glib-devel")
@@ -337,7 +342,7 @@ if [ "$OS" = "linux" ] && command_exists pkg-config; then
                 missing_tray_packages+=("libgtk-3-dev")
             elif command_exists pacman; then
                 missing_tray_packages+=("gtk3")
-            elif command_exists rpm-ostree; then
+            elif is_rpm_ostree; then
                 missing_tray_packages+=("gtk3-devel")
             elif command_exists dnf; then
                 missing_tray_packages+=("gtk3-devel")
@@ -375,7 +380,7 @@ if [ "$OS" = "linux" ] && command_exists pkg-config; then
             tray_install_cmd="sudo apt install -y ${missing_tray_packages[*]}"
         elif command_exists pacman; then
             tray_install_cmd="sudo pacman -S --needed --noconfirm ${missing_tray_packages[*]}"
-        elif command_exists rpm-ostree; then
+        elif is_rpm_ostree; then
             tray_install_cmd="rpm-ostree install -A --idempotent ${missing_tray_packages[*]}"
         elif command_exists dnf; then
             tray_install_cmd="sudo dnf install -y ${missing_tray_packages[*]}"
@@ -400,7 +405,7 @@ if [ "$OS" = "linux" ] && command_exists pkg-config; then
                     maybe_sudo apt install -y "${missing_tray_packages[@]}"
                 elif command_exists pacman; then
                     maybe_sudo pacman -S --needed --noconfirm "${missing_tray_packages[@]}"
-                elif command_exists rpm-ostree; then
+                elif is_rpm_ostree; then
                     maybe_sudo rpm-ostree install -A --idempotent "${missing_tray_packages[@]}"
                 elif command_exists dnf; then
                     maybe_sudo dnf install -y "${missing_tray_packages[@]}"
@@ -424,7 +429,7 @@ print_info "Checking Node.js and npm installation..."
 if ! command_exists node; then
     print_warning "Node.js not found"
     if [ "$OS" = "linux" ]; then
-        if command_exists apt || command_exists pacman || command_exists rpm-ostree || command_exists dnf || command_exists zypper; then
+        if command_exists apt || command_exists pacman || is_rpm_ostree || command_exists dnf || command_exists zypper; then
             missing_packages+=("nodejs" "npm")
         fi
     elif [ "$OS" = "macos" ]; then
@@ -463,7 +468,7 @@ if [ "$OS" = "linux" ]; then
                 tauri_linux_deps+=("$dep")
             fi
         done
-    elif command_exists rpm-ostree; then
+    elif is_rpm_ostree; then
         tauri_dep_candidates=(
             webkit2gtk4.1-devel
             libsoup3-devel
@@ -570,7 +575,7 @@ if [ ${#missing_packages[@]} -gt 0 ]; then
             else
                 install_cmd="sudo pacman -Syu --needed --noconfirm ${missing_packages[*]}"
             fi
-        elif command_exists rpm-ostree; then
+        elif is_rpm_ostree; then
             install_cmd="rpm-ostree install -A --idempotent ${missing_packages[*]}"
         elif command_exists dnf; then
             if is_root; then
@@ -628,7 +633,7 @@ if [ ${#missing_packages[@]} -gt 0 ]; then
             fi
         elif command_exists pacman; then
             maybe_sudo pacman -Syu --needed --noconfirm ${missing_packages[@]}
-        elif command_exists rpm-ostree; then
+        elif is_rpm_ostree; then
             maybe_sudo rpm-ostree install -A --idempotent ${missing_packages[@]}
         elif command_exists dnf; then
             maybe_sudo dnf install -y ${missing_packages[@]}
@@ -684,7 +689,7 @@ if [ ${#tauri_linux_deps[@]} -gt 0 ] || [ "$rust_needs_install" = true ]; then
         if command_exists apt; then
             maybe_sudo apt update
             maybe_sudo apt install -y "${tauri_linux_deps[@]}"
-        elif command_exists rpm-ostree; then
+        elif is_rpm_ostree; then
             maybe_sudo rpm-ostree install -A --idempotent "${tauri_linux_deps[@]}"
         elif command_exists dnf; then
             maybe_sudo dnf install -y "${tauri_linux_deps[@]}"
@@ -710,7 +715,7 @@ if [ ${#tauri_linux_deps[@]} -gt 0 ] || [ "$rust_needs_install" = true ]; then
                 if maybe_sudo pacman -S --needed --noconfirm rust; then
                     rust_install_ok=true
                 fi
-            elif command_exists rpm-ostree; then
+            elif is_rpm_ostree; then
                 if maybe_sudo rpm-ostree install -A --idempotent rust cargo; then
                     rust_install_ok=true
                 fi

--- a/setup.sh
+++ b/setup.sh
@@ -60,6 +60,40 @@ print_info "Lemonade Development Setup"
 print_info "Operating System: $OS"
 echo ""
 
+if [ "$OS" = "linux" ] && command_exists rpm-ostree; then
+    print_warning "============================================"
+    print_warning " rpm-ostree detected (Fedora Atomic/Desktop)"
+    print_warning "============================================"
+    echo ""
+    print_warning "Installing packages via rpm-ostree modifies"
+    print_warning "the immutable OS image by creating a new"
+    print_warning "boot entry with your changes layered on top."
+    echo ""
+    print_warning "This means:"
+    print_warning "  - Your system image will be altered"
+    print_warning "  - Future OS updates may require manual"
+    print_warning "    intervention to resolve conflicts"
+    print_warning "  - You can revert via 'rpm-ostree undo'"
+    print_warning "    or by selecting the previous boot entry"
+    echo ""
+    print_warning "Consider using a development container or"
+    print_warning "a mutable installation for building instead."
+    print_warning "============================================"
+    echo ""
+
+    if [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; then
+        print_info "CI environment detected, proceeding automatically."
+    else
+        read -p "Do you want to continue anyway? (y/N): " -n 1 -r
+        echo ""
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            print_error "Aborted by user."
+            exit 1
+        fi
+    fi
+    echo ""
+fi
+
 # Arrays to track missing dependencies
 missing_packages=()
 install_commands=()


### PR DESCRIPTION
Summary

- Add rpm-ostree package manager detection and support to setup.sh for Fedora Atomic/Desktop environments (Silverblue, Kinoite, Aurora, etc.)
- Covers all dependency installation paths: build tools, libraries, tray dependencies, Tauri dependencies, and Rust toolchain
- Uses rpm-ostree install -A for package installation, consistent with existing DNF/Fedora packaging conventions

Changes

- Detect rpm-ostree command availability alongside existing package managers (apt, pacman, dnf, zypper)
- Add rpm-ostree-specific package lists for: pre-commit, build essentials, pkg-config libraries, tray (libayatana-appindicator, dbusmenu, gtk3), Tauri (webkit2gtk4.1, libsoup3, librsvg2, etc.), and Rust/Cargo
- Include rpm-ostree in Node.js detection guard and all install command branches