### PR TITLE
Replace model label dots with icons

### DIFF
--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { Boxes, ChevronRight, Cpu, Settings, SlidersHorizontal, Store, XIcon } from './components/Icons';
+import { Boxes, Brain, ChevronRight, Cpu, Eye, Flame, Layers, ListOrdered, Settings, SlidersHorizontal, Sparkles, SquareCode, Store, User, Wrench, XIcon } from './components/Icons';
 import { ModelInfo } from './utils/modelData';
 import { ToastContainer, useToast } from './Toast';
 import { useConfirmDialog } from './ConfirmDialog';
@@ -96,6 +96,54 @@ const MODEL_FAMILIES: ModelFamily[] = [
 type ModelListItem =
   | { type: 'model'; name: string; info: ModelInfo }
   | { type: 'family'; family: ModelFamily; members: { label: string; name: string; info: ModelInfo }[] };
+
+const MODEL_LABEL_DISPLAY_ORDER = [
+  'reasoning',
+  'coding',
+  'vision',
+  'hot',
+  'embeddings',
+  'reranking',
+  'tool-calling',
+  'custom',
+  'experience',
+];
+
+const sortModelLabelsForDisplay = (labels: string[]): string[] => {
+  const order = new Map(MODEL_LABEL_DISPLAY_ORDER.map((label, index) => [label, index]));
+  return [...labels].sort((a, b) => {
+    const aOrder = order.get(a) ?? Number.MAX_SAFE_INTEGER;
+    const bOrder = order.get(b) ?? Number.MAX_SAFE_INTEGER;
+    return aOrder - bOrder;
+  });
+};
+
+const ModalityIcon: React.FC<{ label: string; title: string }> = ({ label, title }) => {
+  const size = 11;
+  const strokeWidth = 2.2;
+  const icon = (() => {
+    switch (label) {
+      case 'reasoning': return <Brain size={size} strokeWidth={strokeWidth} />;
+      case 'coding': return <SquareCode size={size} strokeWidth={strokeWidth} />;
+      case 'vision': return <Eye size={size} strokeWidth={strokeWidth} />;
+      case 'hot': return <Flame size={size} strokeWidth={strokeWidth} />;
+      case 'embeddings': return <Layers size={size} strokeWidth={strokeWidth} />;
+      case 'reranking': return <ListOrdered size={size} strokeWidth={strokeWidth} />;
+      case 'tool-calling': return <Wrench size={size} strokeWidth={strokeWidth} />;
+      case 'custom': return <User size={size} strokeWidth={strokeWidth} />;
+      case 'experience': return <Sparkles size={size} strokeWidth={strokeWidth} />;
+      default: return null;
+    }
+  })();
+
+  if (!icon) return null;
+
+  return (
+    <span className={`model-label-icon label-${label}`} title={title}>
+      {icon}
+    </span>
+  );
+};
 
 // Types for Hugging Face API responses
 interface HFModelInfo {
@@ -1256,8 +1304,8 @@ const [searchQuery, setSearchQuery] = useState('');
           </div>
           {modelInfo.labels && modelInfo.labels.length > 0 && (
             <span className="model-labels">
-              {modelInfo.labels.map(label => (
-                <span key={label} className={`model-label label-${label}`} title={getCategoryLabel(label)} />
+              {sortModelLabelsForDisplay(modelInfo.labels).map(label => (
+                <ModalityIcon key={label} label={label} title={getCategoryLabel(label)} />
               ))}
             </span>
           )}
@@ -1294,8 +1342,8 @@ const [searchQuery, setSearchQuery] = useState('');
           <span className="model-name family-model-name">{family.displayName}</span>
           {sharedLabels && sharedLabels.length > 0 && (
             <span className="model-labels">
-              {sharedLabels.map(label => (
-                <span key={label} className={`model-label label-${label}`} title={getCategoryLabel(label)} />
+              {sortModelLabelsForDisplay(sharedLabels).map(label => (
+                <ModalityIcon key={label} label={label} title={getCategoryLabel(label)} />
               ))}
             </span>
           )}

--- a/src/app/src/renderer/components/Icons.tsx
+++ b/src/app/src/renderer/components/Icons.tsx
@@ -162,6 +162,77 @@ export const EjectIcon: React.FC = () => (
   </svg>
 );
 
+// Modality icons from lucide (https://lucide.dev) - ISC License.
+export const Brain: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96.44 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 4.44-2.54Z" />
+    <path d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96.44 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-4.44-2.54Z" />
+  </svg>
+);
+
+export const SquareCode: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <rect width="18" height="18" x="3" y="3" rx="2" />
+    <path d="m10 10-2 2 2 2" />
+    <path d="m14 14 2-2-2-2" />
+  </svg>
+);
+
+export const Eye: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+export const Flame: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M8.5 14.5A2.5 2.5 0 0 0 11 12c0-1.38-.5-2-1-3-1.072-2.143-.224-4.054 2-6 .5 2.5 2 4.9 4 6.5 2 1.6 3 3.5 3 5.5a7 7 0 1 1-14 0c0-1.153.433-2.294 1-3a2.5 2.5 0 0 0 2.5 2.5Z" />
+  </svg>
+);
+
+export const Layers: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="m12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.85a2 2 0 0 0 0 3.58l8.57 4.67a2 2 0 0 0 1.66 0l8.57-4.67a2 2 0 0 0 0-3.58Z" />
+    <path d="m2.6 14.16 8.57 4.67a2 2 0 0 0 1.66 0l8.57-4.67" />
+    <path d="m2.6 19 8.57 4.67a2 2 0 0 0 1.66 0L21.4 19" />
+  </svg>
+);
+
+export const ListOrdered: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <line x1="10" x2="21" y1="6" y2="6" />
+    <line x1="10" x2="21" y1="12" y2="12" />
+    <line x1="10" x2="21" y1="18" y2="18" />
+    <path d="M4 6h1v4" />
+    <path d="M4 10h2" />
+    <path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1" />
+  </svg>
+);
+
+export const Wrench: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z" />
+  </svg>
+);
+
+export const User: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);
+
+export const Sparkles: React.FC<IconProps> = ({ size = 16, strokeWidth = 2 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={strokeWidth} strokeLinecap="round" strokeLinejoin="round">
+    <path d="m12 3 1.912 5.813a2 2 0 0 0 1.275 1.275L21 12l-5.813 1.912a2 2 0 0 0-1.275 1.275L12 21l-1.912-5.813a2 2 0 0 0-1.275-1.275L3 12l5.813-1.912a2 2 0 0 0 1.275-1.275L12 3Z" />
+    <path d="M5 3v4" />
+    <path d="M19 17v4" />
+    <path d="M3 5h4" />
+    <path d="M17 19h4" />
+  </svg>
+);
+
 export const AudioUploadIcon: React.FC = () => (
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
     <path

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -1884,7 +1884,8 @@ footer {
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 4px 10px 4px 13px;
+    padding: 4px 12px;
+    border-left: 2px solid transparent;
     cursor: pointer;
     user-select: none;
 }
@@ -1900,6 +1901,8 @@ footer {
     align-items: center;
     justify-content: center;
     width: 12px;
+    margin-left: -3.5px;
+    margin-right: -3.5px;
     line-height: 1;
     color: var(--icon-hover);
     flex-shrink: 0;
@@ -2094,60 +2097,60 @@ footer {
 }
 
 .model-labels {
-    display: flex;
-    gap: 3px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     flex-shrink: 0;
     margin-left: auto;
     padding-right: 2px;
 }
 
-.model-label {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    display: inline-block;
+.model-label-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 16px;
     cursor: help;
+    color: var(--text-secondary);
+    opacity: 0.86;
+    flex-shrink: 0;
 }
 
-.model-label.label-reasoning {
-    background: var(--label-reasoning);
+.model-label-icon.label-reasoning {
+    color: var(--label-reasoning);
 }
 
-.model-label.label-coding {
-    background: var(--label-coding);
+.model-label-icon.label-coding {
+    color: var(--label-coding);
 }
 
-.model-label.label-vision {
-    background: var(--label-vision);
+.model-label-icon.label-vision {
+    color: var(--label-vision);
 }
 
-.model-label.label-hot {
-    background: var(--label-hot);
+.model-label-icon.label-hot {
+    color: var(--label-hot);
 }
 
-.model-label.label-embeddings {
-    background: var(--label-embeddings);
+.model-label-icon.label-embeddings {
+    color: var(--label-embeddings);
 }
 
-.model-label.label-reranking {
-    background: var(--label-reranking);
+.model-label-icon.label-reranking {
+    color: var(--label-reranking);
 }
 
-.model-label.label-tool-calling {
-    background: var(--label-tool-calling);
+.model-label-icon.label-tool-calling {
+    color: var(--label-tool-calling);
 }
 
-.model-label.label-custom {
-    background: var(--label-custom);
+.model-label-icon.label-custom {
+    color: var(--label-custom);
 }
 
-.model-label.label-experience {
-    width: 7px;
-    height: 7px;
-    border-radius: 1px;
-    transform: rotate(45deg);
-    background: #e2b757;
-    box-shadow: 0 0 2px rgba(226, 183, 87, 0.45);
+.model-label-icon.label-experience {
+    color: #e2b757;
 }
 
 .model-manager-footer {


### PR DESCRIPTION
## Summary

- Replace the small colored model label dots with colored modality icons.
- Preserve native title tooltips and use a canonical display order for label icons.
- Fixed pre-existing bug: Align family header chevrons and icons to the same rails used by regular model rows while keeping the original chevron size.

<img width="380" height="292" alt="image" src="https://github.com/user-attachments/assets/aec3ecd8-bc7e-44c8-93e0-94bcf9742e52" />

Idea and SVGs ported from https://github.com/lemonade-sdk/lemonade/pull/1657 by @anditherobot 