### PR TITLE
Dockerfile: libxrt2 & libxrt-npu2 dependencies for fastflowlm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ COPY --from=builder /app/build/resources ./resources
 RUN FLM_VERSION=$(jq -r '.flm.npu' ./resources/backend_versions.json) && \
     FLM_VERSION_NUM=$(echo $FLM_VERSION | sed 's/^v//') && \
     curl -L -o fastflowlm.deb "https://github.com/FastFlowLM/FastFlowLM/releases/download/${FLM_VERSION}/fastflowlm_${FLM_VERSION_NUM}_ubuntu24.04_amd64.deb" && \
-    apt install -y ./fastflowlm.deb && \
+    apt-get update && apt-get install -y libxrt2 libxrt-npu2 && \
+    apt-get install -y ./fastflowlm.deb && \
     rm fastflowlm.deb
 
 # Make executables executable


### PR DESCRIPTION
Docker image build was failing. 
Maybe FLM_VERSION has changed recently and/or fastflowlm.deb changed its dependencies.

Whatever the reason, installing libxrt2 and libxrt2-npu seems to fix the issue.
Using apt-get instead of apt simply avoids an annoying warning.
