### PR TITLE
docs for vLLM backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
-project(lemon_cpp VERSION 10.3.0)
+project(lemon_cpp VERSION 10.4.0)
 
 # Export compile_commands.json for clangd/IntelliSense
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/README.md
+++ b/README.md
@@ -259,10 +259,11 @@ lemonade backends
 
 | Under Development          | Under Consideration         | Recently Completed      |
 |---------------------------|-----------------------------|------------------------|
-| Native multi-modal tool calling |                              | Port app to Tauri      |
-| More whisper.cpp backends |                              | Embeddable binary release |
-| More SD.cpp backends      |                              | Image generation       |
-| MLX support               |                              | Speech-to-text         |
+| Native multi-modal tool calling |                              | vLLM backend            |
+| More whisper.cpp backends |                              | Port app to Tauri      |
+| More SD.cpp backends      |                              | Embeddable binary release |
+| MLX support               |                              | Image generation       |
+|                           |                              | Speech-to-text         |
 |                           |                              | Text-to-speech         |
 |                           |                              | Apps marketplace       |
 

--- a/docs/embeddable/backends.md
+++ b/docs/embeddable/backends.md
@@ -53,6 +53,7 @@ Follow these instructions if you want backends to be bundled into your app's ins
 At the time of this writing:
 -  `flm` is not available for packaging-time bundling *on Linux*.
 - `llamacpp:rocm` is not available for packaging-time bundling on any OS.
+- `vllm:rocm` is not available for packaging-time bundling on any OS — the install flow constructs a per-GPU-target release tag at runtime, so the host doing the packaging would need to share its `gfx_target` with the deployment machine.
 
 ### Installing Backends at Install-Time or Runtime
 

--- a/docs/embeddable/runtime.md
+++ b/docs/embeddable/runtime.md
@@ -161,6 +161,8 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 | `sdcpp_backend` | string |
 | `whispercpp_backend` | string |
 | `whispercpp_args` | string |
+| `vllm_backend` | string |
+| `vllm_args` | string |
 | `steps` | int (positive) |
 | `cfg_scale` | number |
 | `width` | int (positive) |

--- a/docs/gfx1151_linux.html
+++ b/docs/gfx1151_linux.html
@@ -30,6 +30,11 @@
           incorrect VGPR counts, causing crashes for various workloads.
         </p>
         <p>
+          This requirement applies to any ROCm backend on gfx1151 — <code>llamacpp:rocm</code>,
+          <code>sd-cpp:rocm-stable</code> / <code>sd-cpp:rocm-preview</code>, and
+          <code>vllm:rocm</code> all share the same kernel prerequisite.
+        </p>
+        <p>
           <strong>Technical details:</strong>
         </p>
         <ul>

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -164,7 +164,7 @@ lemonade pull MODEL_OR_CHECKPOINT [--checkpoint TYPE CHECKPOINT] [--recipe RECIP
 |--------|-------------|----------|
 | `MODEL_OR_CHECKPOINT` | Registered model name, or `owner/repo[:variant]` Hugging Face checkpoint | Yes |
 | `--checkpoint TYPE CHECKPOINT` | Manual registration: add a checkpoint entry. Repeat for multi-component models such as `main` + `mmproj` or `main` + `vae`. | No |
-| `--recipe RECIPE` | Manual registration: recipe to associate with the new `user.*` model (`llamacpp`, `flm`, `ryzenai-llm`, `whispercpp`, `sd-cpp`, `kokoro`) | No |
+| `--recipe RECIPE` | Manual registration: recipe to associate with the new `user.*` model (`llamacpp`, `flm`, `ryzenai-llm`, `vllm`, `whispercpp`, `sd-cpp`, `kokoro`) | No |
 | `--label LABEL` | Manual registration: add a label to the new model. Repeatable. Valid: `coding`, `embeddings`, `hot`, `reasoning`, `reranking`, `tool-calling`, `vision` | No |
 
 **Happy path**

--- a/docs/guide/configuration/vllm.md
+++ b/docs/guide/configuration/vllm.md
@@ -1,0 +1,71 @@
+# vLLM Backend Options
+
+Lemonade integrates [vLLM](https://github.com/vllm-project/vllm) as an experimental backend for AMD ROCm GPUs on Linux. vLLM's paged-attention KV-cache and continuous batching deliver much higher aggregate throughput than llama.cpp under concurrent load, at the cost of a heavier runtime footprint.
+
+> **Status: experimental.** All vLLM models in the registry carry the `experimental` label and are surfaced only when the experimental opt-in is enabled. The backend is currently validated only on **gfx1151 (Strix Halo / Radeon 8060S)**. Other AMD targets (`gfx1150`, `gfx110X`, `gfx120X`) have prebuilt wheels but have not been exercised end-to-end.
+
+## Available Backend
+
+### ROCm
+- **Platform**: Linux only
+- **Hardware**: AMD Ryzen AI MAX+ (Strix Halo, gfx1151) — validated. Prebuilt wheels also exist for `gfx1150` (Strix Point), `gfx110X` (RDNA3), and `gfx120X` (RDNA4) but are untested.
+- **Wheel**: `vllm-0.20.1+rocm721` from [wheels.vllm.ai/rocm/](https://wheels.vllm.ai/rocm/), packaged as a self-contained tarball by [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm).
+- **Bundle contents**: relocatable CPython 3.12, PyTorch 2.10.0+rocm7.12.0, ROCm 7.12.0 user-space libs, Triton, vLLM. No system Python / PyTorch / ROCm install required on the host.
+
+## Prerequisites
+
+### Kernel
+The kernel must export the CWSR (Context Wave Save/Restore) sysfs properties. Without them, ROCm dispatches on gfx1151 trigger `GCVM_L2_PROTECTION_FAULT` and the backend hangs. Mainline 6.18.4+ has the fix; some vendor kernels backport it. Lemonade blocks install of `vllm:rocm` on systems missing the fix and points users at [Kernel Update Required](https://lemonade-server.ai/gfx1151_linux.html).
+
+Quick check:
+```bash
+uname -r
+grep -E "cwsr_size|ctl_stack_size" /sys/class/kfd/kfd/topology/nodes/*/properties
+```
+
+### `amdgpu-dkms` collision
+The default Radeon repo (`amdgpu/30.30`) ships `amdgpu-dkms 6.16.13`, which overrides the kernel's built-in driver with a broken version. Either switch to `amdgpu/31.20` or uninstall `amdgpu-dkms` entirely — vLLM bundles its own ROCm user-space, so the DKMS package is not needed for inference. See [Kernel Update Required](https://lemonade-server.ai/gfx1151_linux.html) for the exact commands.
+
+## Install
+
+```bash
+# Install the backend (downloads ~2.5 GB split into two release assets).
+lemonade backends install vllm:rocm
+```
+
+Or via HTTP:
+```bash
+curl -X POST http://localhost:13305/api/v1/install \
+  -H 'Content-Type: application/json' \
+  -d '{"recipe": "vllm", "backend": "rocm"}'
+```
+
+The install fetches `vllm{version}-rocm{version}-{gfx_target}` (e.g. `vllm0.20.1-rocm7.12.0-gfx1151`) from [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm/releases). The base version is pinned in [`backend_versions.json`](https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/resources/backend_versions.json); the `-{gfx_target}` suffix is appended at runtime from `SystemInfo::get_rocm_arch()` so a single pin covers all supported architectures.
+
+## Use
+
+Models registered with the `vllm` recipe in [`server_models.json`](https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/resources/server_models.json) load automatically on first request. To register your own:
+
+```bash
+lemonade pull user.MyModel \
+  --checkpoint main Qwen/Qwen3-4B \
+  --recipe vllm
+```
+
+Standard OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/completions`) work as usual. Lemonade forwards requests to vLLM's child process, which exposes the engine's own private endpoints (e.g. `/metrics`, `/version`) on a backend-only port surfaced via `GET /v1/health` (`backend_url` field) — useful for observability but not proxied through Lemonade.
+
+## Tuning
+
+The vLLM child process is launched with sensible defaults for single-GPU APUs. To override, set `vllm_args` (free-form CLI args appended to `vllm-server`) and / or `vllm_backend`:
+
+```bash
+# Allow more concurrent sequences (default is what the bundled launcher sets).
+lemonade config set vllm_args="--max-num-seqs 128 --enable-prefix-caching"
+```
+
+## Known gotchas
+
+- **Cold first-load JIT.** Loading a new model size compiles HIP/Triton kernels for your GPU, taking 20 s – several minutes. Subsequent loads of the same shape hit the on-disk Triton cache.
+- **FP8 quantization on gfx1151.** vLLM 0.20.1 selects `TritonFp8BlockScaledMMKernel` for FP8 models on the 8060S, but no AMD-tuned kernel config exists for this GPU/shape — vLLM falls back to default configs and warns *"Performance might be sub-optimal."* Cold first-load can take 12+ minutes (longer than Lemonade's `wait_for_ready` timeout will tolerate). FP16 is the recommended precision today; revisit FP8 once AMD ships tuned configs.
+- **`huggingface-hub` shadowing.** Lemonade launches `vllm-server` with `PYTHONNOUSERSITE=1` so the bundled `huggingface_hub` is used. If a module-not-found error still appears, ensure `~/.local/lib/python3.12/site-packages/huggingface_hub` isn't being injected via `PYTHONPATH`.
+- **Long load times leave orphaned processes if interrupted.** If a load times out at the Lemonade level, vLLM's child `EngineCore` may continue running in the background and hold VRAM until killed. Look for a `VLLM::EngineCor` process and `kill -9` it before retrying.

--- a/docs/guide/configuration/vllm.md
+++ b/docs/guide/configuration/vllm.md
@@ -1,12 +1,11 @@
 # vLLM Backend Options
 
-Lemonade integrates [vLLM](https://github.com/vllm-project/vllm) as an experimental backend for AMD ROCm GPUs on Linux. vLLM brings three things to Lemonade that the existing backends can't:
+Lemonade integrates [vLLM](https://github.com/vllm-project/vllm) as an experimental backend for AMD ROCm GPUs on Linux. vLLM brings two core benefits:
 
 1. **Day-0 model support.** vLLM typically supports new transformer architectures within hours of their release on Hugging Face — checkpoints load directly, with no per-architecture porting.
-2. **True omni-modal support.** First-class support for any-to-any models like Qwen3-Omni that mix text, audio, image, and video across both input and output sides.
-3. **Concurrency and multi-GPU.** Paged-attention KV cache, continuous batching, and chunked prefill scale aggregate throughput with in-flight request count; tensor and pipeline parallelism are supported across multiple GPUs.
+2. **Concurrency and multi-GPU.** Paged-attention KV cache, continuous batching, and chunked prefill scale aggregate throughput with in-flight request count; tensor and pipeline parallelism are supported across multiple GPUs.
 
-> **Status: experimental.** All vLLM models in the registry carry the `experimental` label and are surfaced only when the experimental opt-in is enabled. The backend has been validated on **gfx1151 (Strix Halo)** and **gfx1150 (Strix Point)**. Prebuilt wheels also exist for `gfx110X` (RDNA3) and `gfx120X` (RDNA4) but those targets have not been exercised end-to-end yet.
+> **Status: experimental.** The backend has been validated on **gfx1151 (Strix Halo)** and **gfx1150 (Strix Point)**. Prebuilt wheels also exist for `gfx110X` (RDNA3) and `gfx120X` (RDNA4) but those targets have not been exercised end-to-end yet.
 
 ## Available Backend
 

--- a/docs/guide/configuration/vllm.md
+++ b/docs/guide/configuration/vllm.md
@@ -2,9 +2,9 @@
 
 Lemonade integrates [vLLM](https://github.com/vllm-project/vllm) as an experimental backend for AMD ROCm GPUs on Linux. vLLM brings three things to Lemonade that the existing backends can't:
 
-1. **Day-0 model support.** vLLM is typically the first inference engine to support new transformer architectures, often within hours of a model's release on Hugging Face. Because vLLM loads models directly from Hugging Face checkpoints (no per-architecture porting, no quantized GGUF conversion), most newly released models work without any code changes in Lemonade.
-2. **True omni-modal support.** vLLM has first-class support for vision-language models, audio inputs, embeddings, and reranking in addition to text generation — all from a single engine, sharing the same model registry and serving stack.
-3. **Improved concurrency and multi-GPU support.** vLLM's paged-attention KV cache, continuous batching, and chunked prefill deliver significantly higher aggregate throughput under concurrent load than llama.cpp. vLLM also natively supports tensor and pipeline parallelism across multiple GPUs.
+1. **Day-0 model support.** vLLM typically supports new transformer architectures within hours of their release on Hugging Face — checkpoints load directly, with no per-architecture porting.
+2. **True omni-modal support.** First-class support for any-to-any models like Qwen3-Omni that mix text, audio, image, and video across both input and output sides.
+3. **Concurrency and multi-GPU.** Paged-attention KV cache, continuous batching, and chunked prefill scale aggregate throughput with in-flight request count; tensor and pipeline parallelism are supported across multiple GPUs.
 
 > **Status: experimental.** All vLLM models in the registry carry the `experimental` label and are surfaced only when the experimental opt-in is enabled. The backend has been validated on **gfx1151 (Strix Halo)** and **gfx1150 (Strix Point)**. Prebuilt wheels also exist for `gfx110X` (RDNA3) and `gfx120X` (RDNA4) but those targets have not been exercised end-to-end yet.
 

--- a/docs/guide/configuration/vllm.md
+++ b/docs/guide/configuration/vllm.md
@@ -1,35 +1,27 @@
 # vLLM Backend Options
 
-Lemonade integrates [vLLM](https://github.com/vllm-project/vllm) as an experimental backend for AMD ROCm GPUs on Linux. vLLM's paged-attention KV-cache and continuous batching deliver much higher aggregate throughput than llama.cpp under concurrent load, at the cost of a heavier runtime footprint.
+Lemonade integrates [vLLM](https://github.com/vllm-project/vllm) as an experimental backend for AMD ROCm GPUs on Linux. vLLM brings three things to Lemonade that the existing backends can't:
 
-> **Status: experimental.** All vLLM models in the registry carry the `experimental` label and are surfaced only when the experimental opt-in is enabled. The backend is currently validated only on **gfx1151 (Strix Halo / Radeon 8060S)**. Other AMD targets (`gfx1150`, `gfx110X`, `gfx120X`) have prebuilt wheels but have not been exercised end-to-end.
+1. **Day-0 model support.** vLLM is typically the first inference engine to support new transformer architectures, often within hours of a model's release on Hugging Face. Because vLLM loads models directly from Hugging Face checkpoints (no per-architecture porting, no quantized GGUF conversion), most newly released models work without any code changes in Lemonade.
+2. **True omni-modal support.** vLLM has first-class support for vision-language models, audio inputs, embeddings, and reranking in addition to text generation — all from a single engine, sharing the same model registry and serving stack.
+3. **Improved concurrency and multi-GPU support.** vLLM's paged-attention KV cache, continuous batching, and chunked prefill deliver significantly higher aggregate throughput under concurrent load than llama.cpp. vLLM also natively supports tensor and pipeline parallelism across multiple GPUs.
+
+> **Status: experimental.** All vLLM models in the registry carry the `experimental` label and are surfaced only when the experimental opt-in is enabled. The backend has been validated on **gfx1151 (Strix Halo)** and **gfx1150 (Strix Point)**. Prebuilt wheels also exist for `gfx110X` (RDNA3) and `gfx120X` (RDNA4) but those targets have not been exercised end-to-end yet.
 
 ## Available Backend
 
 ### ROCm
 - **Platform**: Linux only
-- **Hardware**: AMD Ryzen AI MAX+ (Strix Halo, gfx1151) — validated. Prebuilt wheels also exist for `gfx1150` (Strix Point), `gfx110X` (RDNA3), and `gfx120X` (RDNA4) but are untested.
-- **Wheel**: `vllm-0.20.1+rocm721` from [wheels.vllm.ai/rocm/](https://wheels.vllm.ai/rocm/), packaged as a self-contained tarball by [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm).
-- **Bundle contents**: relocatable CPython 3.12, PyTorch 2.10.0+rocm7.12.0, ROCm 7.12.0 user-space libs, Triton, vLLM. No system Python / PyTorch / ROCm install required on the host.
+- **Hardware**: validated on gfx1151 (Strix Halo) and gfx1150 (Strix Point); prebuilt wheels also exist for gfx110X (RDNA3) and gfx120X (RDNA4)
+- **Bundle**: a self-contained tarball from [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm) with a relocatable Python interpreter, PyTorch (ROCm), the ROCm user-space libs, Triton, and vLLM. No system Python / PyTorch / ROCm install is required on the host.
 
 ## Prerequisites
 
-### Kernel
-The kernel must export the CWSR (Context Wave Save/Restore) sysfs properties. Without them, ROCm dispatches on gfx1151 trigger `GCVM_L2_PROTECTION_FAULT` and the backend hangs. Mainline 6.18.4+ has the fix; some vendor kernels backport it. Lemonade blocks install of `vllm:rocm` on systems missing the fix and points users at [Kernel Update Required](https://lemonade-server.ai/gfx1151_linux.html).
-
-Quick check:
-```bash
-uname -r
-grep -E "cwsr_size|ctl_stack_size" /sys/class/kfd/kfd/topology/nodes/*/properties
-```
-
-### `amdgpu-dkms` collision
-The default Radeon repo (`amdgpu/30.30`) ships `amdgpu-dkms 6.16.13`, which overrides the kernel's built-in driver with a broken version. Either switch to `amdgpu/31.20` or uninstall `amdgpu-dkms` entirely — vLLM bundles its own ROCm user-space, so the DKMS package is not needed for inference. See [Kernel Update Required](https://lemonade-server.ai/gfx1151_linux.html) for the exact commands.
+vLLM on AMD ROCm requires a kernel that exports the CWSR sysfs properties and an `amdgpu` setup that doesn't shadow the built-in driver. Both are covered with verification commands and fixes on the [Kernel Update Required](https://lemonade-server.ai/gfx1151_linux.html) page — that's the canonical reference; the same prerequisites apply to `llamacpp:rocm` and `sd-cpp:rocm-*`. Lemonade blocks install of `vllm:rocm` on systems missing the kernel fix and points users at that page.
 
 ## Install
 
 ```bash
-# Install the backend (downloads ~2.5 GB split into two release assets).
 lemonade backends install vllm:rocm
 ```
 
@@ -40,7 +32,7 @@ curl -X POST http://localhost:13305/api/v1/install \
   -d '{"recipe": "vllm", "backend": "rocm"}'
 ```
 
-The install fetches `vllm{version}-rocm{version}-{gfx_target}` (e.g. `vllm0.20.1-rocm7.12.0-gfx1151`) from [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm/releases). The base version is pinned in [`backend_versions.json`](https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/resources/backend_versions.json); the `-{gfx_target}` suffix is appended at runtime from `SystemInfo::get_rocm_arch()` so a single pin covers all supported architectures.
+The install fetches a per-GPU-target release (e.g. `…-gfx1151`, `…-gfx1150`) from [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm/releases). The base version is pinned in [`backend_versions.json`](https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/resources/backend_versions.json); the `-{gfx_target}` suffix is appended at runtime from `SystemInfo::get_rocm_arch()`, so a single pin covers all supported architectures.
 
 ## Use
 
@@ -52,20 +44,20 @@ lemonade pull user.MyModel \
   --recipe vllm
 ```
 
-Standard OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/completions`) work as usual. Lemonade forwards requests to vLLM's child process, which exposes the engine's own private endpoints (e.g. `/metrics`, `/version`) on a backend-only port surfaced via `GET /v1/health` (`backend_url` field) — useful for observability but not proxied through Lemonade.
+Standard OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/completions`) work as usual. Lemonade forwards requests to the vLLM child process, which exposes the engine's own private endpoints (e.g. `/metrics`, `/version`) on a backend-only port surfaced via `GET /v1/health` (`backend_url` field) — useful for observability but not proxied through Lemonade.
 
 ## Tuning
 
-The vLLM child process is launched with sensible defaults for single-GPU APUs. To override, set `vllm_args` (free-form CLI args appended to `vllm-server`) and / or `vllm_backend`:
+Free-form CLI args can be appended to `vllm-server` via `vllm_args`:
 
 ```bash
-# Allow more concurrent sequences (default is what the bundled launcher sets).
+# Allow more concurrent sequences and turn on prefix caching
 lemonade config set vllm_args="--max-num-seqs 128 --enable-prefix-caching"
 ```
 
 ## Known gotchas
 
-- **Cold first-load JIT.** Loading a new model size compiles HIP/Triton kernels for your GPU, taking 20 s – several minutes. Subsequent loads of the same shape hit the on-disk Triton cache.
-- **FP8 quantization on gfx1151.** vLLM 0.20.1 selects `TritonFp8BlockScaledMMKernel` for FP8 models on the 8060S, but no AMD-tuned kernel config exists for this GPU/shape — vLLM falls back to default configs and warns *"Performance might be sub-optimal."* Cold first-load can take 12+ minutes (longer than Lemonade's `wait_for_ready` timeout will tolerate). FP16 is the recommended precision today; revisit FP8 once AMD ships tuned configs.
+- **Cold first-load JIT.** Loading a new model size triggers a Triton kernel compile. Expect 20 s – several minutes the first time you hit a given model+shape; subsequent loads of the same shape are faster as kernels cache to disk.
+- **FP8 first-load is slow on gfx1151.** Cold-loading `Qwen/Qwen3-4B-FP8` took ~12 minutes in our test, exceeding Lemonade's default `wait_for_ready` timeout. The engine selects `TritonFp8BlockScaledMMKernel` and emits *"Using default W8A8 Block FP8 kernel config. Performance might be sub-optimal."* warnings — i.e. no AMD-tuned kernel configs are shipped for this GPU's exact shapes, so vLLM autotunes from defaults. FP16 is the most polished path today; FP8 should improve once AMD ships tuned configs.
 - **`huggingface-hub` shadowing.** Lemonade launches `vllm-server` with `PYTHONNOUSERSITE=1` so the bundled `huggingface_hub` is used. If a module-not-found error still appears, ensure `~/.local/lib/python3.12/site-packages/huggingface_hub` isn't being injected via `PYTHONPATH`.
-- **Long load times leave orphaned processes if interrupted.** If a load times out at the Lemonade level, vLLM's child `EngineCore` may continue running in the background and hold VRAM until killed. Look for a `VLLM::EngineCor` process and `kill -9` it before retrying.
+- **Long load times can leave orphaned processes if interrupted.** If a load times out at the Lemonade level, vLLM's child `EngineCore` may continue running in the background and hold VRAM until killed. Look for a `VLLM::EngineCor` process and `kill -9` it before retrying.

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -182,6 +182,7 @@
    Yes! Lemonade supports multiple execution modes:
 
    - **AMD Ryzen 7000/8000/200 series**: GPU acceleration via llama.cpp + Vulkan backend
+   - **AMD Ryzen AI MAX+ (Strix Halo) on Linux**: in addition to the above, the experimental `vllm:rocm` backend is supported on gfx1151 (see [vLLM configuration](configuration/vllm.md))
    - **Systems with Radeon GPUs**: Yes
    - **Any x86 CPU**: Yes
    - **Intel/NVIDIA systems**: CPU inference, with GPU support via the llama.cpp + Vulkan backend

--- a/docs/guide/install/ubuntu.md
+++ b/docs/guide/install/ubuntu.md
@@ -42,7 +42,3 @@ To build from source, see the [development](../../dev/README.md) guide.
     ```
     sudo snap install lemonade
     ```
-
-## AMD ROCm GPU acceleration (optional)
-
-If you have an AMD GPU and want to use the `llamacpp:rocm`, `sd-cpp:rocm-*`, or `vllm:rocm` backends, your kernel needs the CWSR fix. The fix is in mainline 6.18.4+ but may also be backported to vendor kernels. See [Kernel Update Required](https://lemonade-server.ai/gfx1151_linux.html) for the requirement and how to verify it on your system. The same page covers the `amdgpu-dkms` package collision that can mask the built-in driver.

--- a/docs/guide/install/ubuntu.md
+++ b/docs/guide/install/ubuntu.md
@@ -42,3 +42,7 @@ To build from source, see the [development](../../dev/README.md) guide.
     ```
     sudo snap install lemonade
     ```
+
+## AMD ROCm GPU acceleration (optional)
+
+If you have an AMD GPU and want to use the `llamacpp:rocm`, `sd-cpp:rocm-*`, or `vllm:rocm` backends, your kernel needs the CWSR fix. The fix is in mainline 6.18.4+ but may also be backported to vendor kernels. See [Kernel Update Required](https://lemonade-server.ai/gfx1151_linux.html) for the requirement and how to verify it on your system. The same page covers the `amdgpu-dkms` package collision that can mask the built-in driver.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - Custom Models: guide/configuration/custom-models.md
       - Running Many Models: guide/configuration/multi-model.md
       - llama.cpp: guide/configuration/llamacpp.md
+      - vLLM: guide/configuration/vllm.md
     - FAQ: guide/faq.md
   - Development:
     - Overview: dev/README.md

--- a/src/app/src/renderer/utils/recipeNames.ts
+++ b/src/app/src/renderer/utils/recipeNames.ts
@@ -6,5 +6,5 @@ export const RECIPE_DISPLAY_NAMES: Record<string, string> = {
   'whispercpp': 'Whisper.cpp',
   'sd-cpp': 'StableDiffusion.cpp',
   'kokoro': 'Kokoro',
-  'vllm': 'vLLM ROCm',
+  'vllm': 'vLLM ROCm (experimental)',
 };

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1469,44 +1469,40 @@
         ],
         "size": 0.017
     },
-    "Qwen3.5-0.8B-vllm": {
+    "Qwen3.5-0.8B-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-0.8B",
         "recipe": "vllm",
         "suggested": true,
         "labels": [
-            "reasoning",
-            "experimental"
+            "reasoning"
         ],
         "size": 1.6
     },
-    "Qwen3.5-2B-vllm": {
+    "Qwen3.5-2B-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-2B",
         "recipe": "vllm",
         "suggested": true,
         "labels": [
-            "reasoning",
-            "experimental"
+            "reasoning"
         ],
         "size": 4.0
     },
-    "Qwen3.5-4B-vllm": {
+    "Qwen3.5-4B-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-4B",
         "recipe": "vllm",
         "suggested": true,
         "labels": [
             "reasoning",
-            "hot",
-            "experimental"
+            "hot"
         ],
         "size": 8.2
     },
-    "Qwen3.5-9B-vllm": {
+    "Qwen3.5-9B-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-9B",
         "recipe": "vllm",
         "suggested": true,
         "labels": [
-            "reasoning",
-            "experimental"
+            "reasoning"
         ],
         "size": 18.6
     }


### PR DESCRIPTION
## Summary

The vLLM-ROCm backend landed on `main` in #1537. This PR updates the docs for the vLLM integration. 
