### PR TITLE
Add static max context metadata to /models

### DIFF
--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -878,7 +878,7 @@ The generated audio file is returned as-is.
 ## `GET /v1/models`
 <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
 
-Returns a list of models available on the server in an OpenAI-compatible format. Each model object includes extended fields like `checkpoint`, `recipe`, `size`, `downloaded`, and `labels`.
+Returns a list of models available on the server in an OpenAI-compatible format. Each model object includes extended fields like `checkpoint`, `recipe`, `size`, `downloaded`, `labels`, and, when known, `max_context_window`.
 
 By default, only models available locally (downloaded) are shown, matching OpenAI API behavior.
 
@@ -912,6 +912,7 @@ curl http://localhost:13305/v1/models?show_all=true
       "checkpoint": "unsloth/Qwen3-0.6B-GGUF:Q4_0",
       "recipe": "llamacpp",
       "size": 0.38,
+      "max_context_window": 40960,
       "downloaded": true,
       "suggested": true,
       "labels": ["reasoning"]
@@ -961,6 +962,7 @@ curl http://localhost:13305/v1/models?show_all=true
   - `checkpoint` - Full checkpoint identifier on Hugging Face
   - `recipe` - Backend/device recipe used to load the model (e.g., `"ryzenai-llm"`, `"llamacpp"`, `"flm"`)
   - `size` - Model size in GB (omitted for models without size information)
+  - `max_context_window` - Optional integer indicating the maximum model-supported text context discovered from local static metadata. Currently populated for downloaded GGUF/llama.cpp models and installed FLM text-context models.
   - `downloaded` - Boolean indicating if the model is downloaded and available locally
   - `suggested` - Boolean indicating if the model is recommended for general use
   - `labels` - Array of tags describing the model (e.g., `"hot"`, `"reasoning"`, `"vision"`, `"embeddings"`, `"reranking"`, `"coding"`, `"tool-calling"`, `"image"`)
@@ -1001,10 +1003,11 @@ Returns a single model object with the same fields as described in the [models l
   "checkpoint": "unsloth/Qwen3-0.6B-GGUF:Q4_0",
   "recipe": "llamacpp",
   "size": 0.38,
+  "max_context_window": 40960,
   "downloaded": true,
   "suggested": true,
   "labels": ["reasoning"],
-  "recipe_options" {
+  "recipe_options": {
     "ctx_size": 8192,
     "llamacpp_args": "--no-mmap",
     "llamacpp_backend": "rocm"

--- a/src/app/src/renderer/ModelOptionsModal.tsx
+++ b/src/app/src/renderer/ModelOptionsModal.tsx
@@ -31,6 +31,51 @@ const getBackendDisplayName = (backend: string): string => {
   return BACKEND_DISPLAY_NAMES[backend] ?? backend;
 };
 
+const CONTEXT_SLIDER_MIN = 2048;
+const CONTEXT_SLIDER_THUMB_SIZE = 14;
+
+const formatContextSize = (value: number): string => {
+  if (value >= 1024 && value % 1024 === 0) {
+    return `${value / 1024}k`;
+  }
+  if (value >= 1024) {
+    return `${Math.round(value / 1024)}k`;
+  }
+  return String(value);
+};
+
+const getContextSliderMarks = (maxContextWindow?: number): number[] => {
+  if (!maxContextWindow || maxContextWindow < CONTEXT_SLIDER_MIN) {
+    return [];
+  }
+
+  const marks: number[] = [];
+  for (let value = CONTEXT_SLIDER_MIN; value < maxContextWindow; value *= 2) {
+    marks.push(value);
+  }
+
+  if (marks[marks.length - 1] !== maxContextWindow) {
+    marks.push(maxContextWindow);
+  }
+
+  return marks;
+};
+
+const contextSizeToSliderValue = (contextSize: number, maxContextWindow: number): number => {
+  const clamped = contextSize === 0
+    ? maxContextWindow
+    : Math.min(Math.max(contextSize, CONTEXT_SLIDER_MIN), maxContextWindow);
+  return Math.log2(clamped);
+};
+
+const sliderValueToContextSize = (sliderValue: number, maxContextWindow: number): number => {
+  const maxSliderValue = Math.log2(maxContextWindow);
+  if (sliderValue >= maxSliderValue - 0.0005) {
+    return maxContextWindow;
+  }
+  return Math.min(Math.round(2 ** sliderValue), maxContextWindow);
+};
+
 interface SettingsModalProps {
   isOpen: boolean;
   onSubmit: (modelName: string, options: RecipeOptions) => void;
@@ -152,6 +197,17 @@ const ModelOptionsModal: React.FC<SettingsModalProps> = ({ isOpen, onCancel, onS
     handleNumericChange(key, parsed);
   };
 
+  const commitContextSizeDraft = (key: string, draftValue: string, maxContextWindow: number): void => {
+    const trimmed = draftValue.trim();
+    if (trimmed === '') return;
+
+    const parsed = parseFloat(trimmed);
+    if (Number.isNaN(parsed)) return;
+
+    const clamped = parsed === 0 ? 0 : Math.min(Math.max(parsed, 1), maxContextWindow);
+    handleNumericChange(key, clamped);
+  };
+
   // Generic handler for string option changes
   const handleStringChange = (key: string, value: string) => {
     if (!options) return;
@@ -252,10 +308,15 @@ const ModelOptionsModal: React.FC<SettingsModalProps> = ({ isOpen, onCancel, onS
       const parsed = parseFloat(trimmed);
       if (Number.isNaN(parsed)) continue;
 
+      const maxContextWindow = key === 'ctxSize' ? modelInfo?.max_context_window : undefined;
+      const value = maxContextWindow
+        ? (parsed === 0 ? 0 : Math.min(Math.max(parsed, 1), maxContextWindow))
+        : clampOptionValue(key, parsed);
+
       submitOptions = {
         ...submitOptions,
         [key]: {
-          value: clampOptionValue(key, parsed),
+          value,
           useDefault: false,
         }
       } as RecipeOptions;
@@ -283,10 +344,97 @@ const ModelOptionsModal: React.FC<SettingsModalProps> = ({ isOpen, onCancel, onS
     return opt?.useDefault ?? true;
   };
 
+  const renderContextSizeField = (key: string) => {
+    const def = getOptionDefinition(key);
+    if (!def || def.type !== 'numeric') return null;
+
+    const value = getOptionValue<number>(key);
+    const maxContextWindow = modelInfo?.max_context_window;
+    if (value === undefined || !maxContextWindow || maxContextWindow < CONTEXT_SLIDER_MIN) return null;
+
+    const displayValue = numericDrafts[key] ?? String(value);
+    const parsedDraft = parseFloat(displayValue.trim());
+    const effectiveContextSize = !Number.isNaN(parsedDraft) ? parsedDraft : value;
+    const sliderValue = contextSizeToSliderValue(effectiveContextSize, maxContextWindow);
+    const marks = getContextSliderMarks(maxContextWindow);
+    const sliderMin = Math.log2(CONTEXT_SLIDER_MIN);
+    const sliderMax = Math.log2(maxContextWindow);
+    const sliderRange = Math.max(sliderMax - sliderMin, 0.0001);
+    const sliderProgress = ((sliderValue - sliderMin) / sliderRange) * 100;
+
+    return (
+      <div className="form-section context-size-section" key={key}>
+        <div className="context-size-label-row">
+          <label className="form-label" title={def.description}>{def.label.toLowerCase()}</label>
+        </div>
+        <div className="context-size-controls">
+          <input
+            type="range"
+            min={sliderMin}
+            max={sliderMax}
+            step={0.001}
+            value={sliderValue}
+            list="context-size-marks"
+            className="context-size-slider"
+            style={{ '--context-slider-progress': `${sliderProgress}%` } as React.CSSProperties}
+            aria-label="Context size"
+            onChange={(e) => {
+              clearNumericDraft(key);
+              handleNumericChange(key, sliderValueToContextSize(parseFloat(e.target.value), maxContextWindow));
+            }}
+          />
+          <datalist id="context-size-marks">
+            {marks.map(mark => (
+              <option key={mark} value={contextSizeToSliderValue(mark, maxContextWindow)} />
+            ))}
+          </datalist>
+          <input
+            type="text"
+            value={displayValue}
+            onChange={(e) => {
+              setNumericDrafts(prev => ({ ...prev, [key]: e.target.value }));
+            }}
+            onBlur={() => {
+              const draftValue = numericDrafts[key];
+              if (draftValue !== undefined) {
+                commitContextSizeDraft(key, draftValue, maxContextWindow);
+              }
+              clearNumericDraft(key);
+            }}
+            className="form-input context-size-input"
+            placeholder="auto"
+            inputMode="numeric"
+          />
+        </div>
+        <div className="context-size-ticks" aria-hidden="true">
+          {marks.map((mark) => {
+            const left = ((contextSizeToSliderValue(mark, maxContextWindow) - sliderMin) / sliderRange) * 100;
+            const thumbOffset = (CONTEXT_SLIDER_THUMB_SIZE / 2) - (left / 100) * CONTEXT_SLIDER_THUMB_SIZE;
+            return (
+              <span
+                key={mark}
+                className="context-size-tick"
+                style={{ left: `calc(${left}% + ${thumbOffset}px)` }}
+              />
+            );
+          })}
+        </div>
+        <div className="context-size-scale" aria-hidden="true">
+          <span>{formatContextSize(CONTEXT_SLIDER_MIN)}</span>
+          <span>{formatContextSize(maxContextWindow)}</span>
+        </div>
+      </div>
+    );
+  };
+
   // Render a numeric input field
   const renderNumericField = (key: string) => {
     const def = getOptionDefinition(key);
     if (!def || def.type !== 'numeric') return null;
+
+    if (key === 'ctxSize' && modelInfo?.max_context_window) {
+      return renderContextSizeField(key);
+    }
 
     const value = getOptionValue<number>(key);
     if (value === undefined) return null;

--- a/src/app/src/renderer/utils/modelData.ts
+++ b/src/app/src/renderer/utils/modelData.ts
@@ -18,6 +18,7 @@ export interface ModelInfo {
   labels?: string[];
   composite_models?: string[];
   max_prompt_length?: number;
+  max_context_window?: number;
   mmproj?: string;
   source?: string;
   model_name?: string;
@@ -84,6 +85,11 @@ const normalizeModelInfo = (info: unknown): ModelInfo | null => {
   const maxPromptLength = info['max_prompt_length'];
   if (typeof maxPromptLength === 'number' && Number.isFinite(maxPromptLength)) {
     normalized.max_prompt_length = maxPromptLength;
+  }
+
+  const maxContextWindow = info['max_context_window'];
+  if (typeof maxContextWindow === 'number' && Number.isFinite(maxContextWindow)) {
+    normalized.max_context_window = maxContextWindow;
   }
 
   const mmproj = info['mmproj'];
@@ -154,6 +160,10 @@ const fetchBuiltInModelsFromAPI = async (): Promise<ModelsData> => {
 
       if (typeof model.max_prompt_length === 'number' && Number.isFinite(model.max_prompt_length)) {
         modelInfo.max_prompt_length = model.max_prompt_length;
+      }
+
+      if (typeof model.max_context_window === 'number' && Number.isFinite(model.max_context_window)) {
+        modelInfo.max_context_window = model.max_context_window;
       }
 
       if (typeof model.mmproj === 'string' && model.mmproj) {

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -2621,6 +2621,133 @@ footer {
     background: var(--bg-secondary);
 }
 
+.context-size-section {
+    gap: 8px;
+}
+
+.context-size-label-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.context-size-controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 96px;
+    align-items: center;
+    gap: 12px;
+}
+
+.context-size-input {
+    min-width: 0;
+}
+
+.context-size-slider {
+    --context-slider-progress: 0%;
+    width: 100%;
+    height: 18px;
+    margin: 0;
+    appearance: none;
+    -webkit-appearance: none;
+    background: transparent;
+    cursor: pointer;
+}
+
+.context-size-slider:focus {
+    outline: none;
+}
+
+.context-size-slider::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 999px;
+    background: linear-gradient(
+        to right,
+        var(--text-link) 0%,
+        var(--text-link) var(--context-slider-progress),
+        var(--bg-slider) var(--context-slider-progress),
+        var(--bg-slider) 100%
+    );
+}
+
+.context-size-slider::-moz-range-track {
+    height: 4px;
+    border-radius: 999px;
+    background: var(--bg-slider);
+}
+
+.context-size-slider::-moz-range-progress {
+    height: 4px;
+    border-radius: 999px;
+    background: var(--text-link);
+}
+
+.context-size-slider::-webkit-slider-thumb {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 14px;
+    height: 14px;
+    margin-top: -5px;
+    border-radius: 50%;
+    border: 1px solid var(--text-link-hover);
+    background: var(--text-primary);
+    box-shadow: 0 1px 4px var(--bg-secondary-alpha-5);
+}
+
+.context-size-slider::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 1px solid var(--text-link-hover);
+    background: var(--text-primary);
+    box-shadow: 0 1px 4px var(--bg-secondary-alpha-5);
+}
+
+.context-size-slider:focus-visible::-webkit-slider-thumb {
+    outline: 2px solid var(--text-link);
+    outline-offset: 2px;
+}
+
+.context-size-slider:focus-visible::-moz-range-thumb {
+    outline: 2px solid var(--text-link);
+    outline-offset: 2px;
+}
+
+.context-size-ticks {
+    position: relative;
+    height: 8px;
+    margin: -2px 106px 0 0;
+}
+
+.context-size-tick {
+    position: absolute;
+    top: 0;
+    width: 1px;
+    height: 6px;
+    background: var(--border-6);
+    transform: translateX(-50%);
+}
+
+.context-size-scale {
+    display: flex;
+    justify-content: space-between;
+    margin-right: 108px;
+    color: var(--text-quaternary);
+    font-size: 0.6rem;
+}
+
+@media (max-width: 520px) {
+    .context-size-controls {
+        grid-template-columns: 1fr;
+        gap: 8px;
+    }
+
+    .context-size-ticks,
+    .context-size-scale {
+        margin-right: 0;
+    }
+}
+
 input::-webkit-calendar-picker-indicator {
     opacity: 0;
 }

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -77,6 +77,7 @@ struct ModelInfo {
     // parts — the -hf path drives the dual-clip (vision+audio) context correctly.
     bool hf_load = false;
     double size = 0.0;   // Model size in GB
+    int64_t max_context_window = 0;  // Static model-supported text context, when known
     RecipeOptions recipe_options;
 
     // Multi-model support fields

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -235,10 +235,8 @@ static int64_t read_gguf_context_length(const std::string& path) {
 
 static fs::path get_flm_models_dir_from_config_home() {
 #ifdef _WIN32
-    const char* appdata = std::getenv("APPDATA");
-    if (appdata && *appdata) return path_from_utf8(appdata) / "flm" / "models";
     const char* userprofile = std::getenv("USERPROFILE");
-    if (userprofile && *userprofile) return path_from_utf8(userprofile) / ".config" / "flm" / "models";
+    if (userprofile && *userprofile) return path_from_utf8(userprofile) / "flm" / "models";
     return fs::path();
 #else
     const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME");
@@ -253,10 +251,9 @@ static fs::path find_flm_config_path_from_repo_dir(const std::string& repo_dir) 
     if (repo_dir.empty()) return fs::path();
 
     std::vector<fs::path> candidates;
-    const char* flm_home = std::getenv("FLM_HOME");
-    if (flm_home && *flm_home) {
-        candidates.push_back(path_from_utf8(flm_home) / "models" / repo_dir / "config.json");
-        candidates.push_back(path_from_utf8(flm_home) / repo_dir / "config.json");
+    const char* flm_model_path = std::getenv("FLM_MODEL_PATH");
+    if (flm_model_path && *flm_model_path) {
+        candidates.push_back(path_from_utf8(flm_model_path) / "models" / repo_dir / "config.json");
     }
 
     fs::path config_home_models = get_flm_models_dir_from_config_home();

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -13,6 +13,8 @@
 #include <fstream>
 #include <algorithm>
 #include <cstdlib>
+#include <cstdint>
+#include <cstring>
 #include <sstream>
 #include <thread>
 #include <chrono>
@@ -20,6 +22,7 @@
 #include <tuple>
 #include <unordered_set>
 #include <iomanip>
+#include <limits>
 #include <lemon/utils/aixlog.hpp>
 
 namespace fs = std::filesystem;
@@ -84,6 +87,245 @@ static constexpr const char* APPEAR_BUILTIN_LABEL = "appear-builtin";
 
 static bool has_label(const ModelInfo& info, const std::string& label) {
     return std::find(info.labels.begin(), info.labels.end(), label) != info.labels.end();
+}
+
+template <typename T>
+static bool read_le(std::istream& in, T& value) {
+    in.read(reinterpret_cast<char*>(&value), sizeof(T));
+    return static_cast<bool>(in);
+}
+
+static bool read_gguf_string(std::istream& in, std::string& value) {
+    uint64_t len = 0;
+    if (!read_le(in, len)) return false;
+    if (len > 1024 * 1024) return false;
+    value.assign(static_cast<size_t>(len), '\0');
+    if (len == 0) return true;
+    in.read(&value[0], static_cast<std::streamsize>(len));
+    return static_cast<bool>(in);
+}
+
+static bool skip_bytes(std::istream& in, uint64_t bytes) {
+    if (bytes > static_cast<uint64_t>(std::numeric_limits<std::streamoff>::max())) return false;
+    in.seekg(static_cast<std::streamoff>(bytes), std::ios::cur);
+    return static_cast<bool>(in);
+}
+
+static uint64_t gguf_scalar_size(uint32_t type) {
+    switch (type) {
+        case 0:  // UINT8
+        case 1:  // INT8
+        case 7:  // BOOL
+            return 1;
+        case 2:  // UINT16
+        case 3:  // INT16
+            return 2;
+        case 4:  // UINT32
+        case 5:  // INT32
+        case 6:  // FLOAT32
+            return 4;
+        case 10: // UINT64
+        case 11: // INT64
+        case 12: // FLOAT64
+            return 8;
+        default:
+            return 0;
+    }
+}
+
+static bool skip_gguf_value(std::istream& in, uint32_t type);
+
+static bool read_gguf_integer_value(std::istream& in, uint32_t type, int64_t& value) {
+    switch (type) {
+        case 0: { uint8_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 1: { int8_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 2: { uint16_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 3: { int16_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 4: { uint32_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 5: { int32_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        case 10: {
+            uint64_t v = 0;
+            if (!read_le(in, v)) return false;
+            if (v > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) return false;
+            value = static_cast<int64_t>(v);
+            return true;
+        }
+        case 11: { int64_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
+        default:
+            return skip_gguf_value(in, type) && false;
+    }
+}
+
+static bool skip_gguf_value(std::istream& in, uint32_t type) {
+    if (type == 8) {  // STRING
+        std::string ignored;
+        return read_gguf_string(in, ignored);
+    }
+
+    if (type == 9) {  // ARRAY
+        uint32_t elem_type = 0;
+        uint64_t count = 0;
+        if (!read_le(in, elem_type) || !read_le(in, count)) return false;
+
+        if (elem_type == 8) {
+            for (uint64_t i = 0; i < count; ++i) {
+                std::string ignored;
+                if (!read_gguf_string(in, ignored)) return false;
+            }
+            return true;
+        }
+
+        if (elem_type == 9) return false;
+        uint64_t elem_size = gguf_scalar_size(elem_type);
+        if (elem_size == 0) return false;
+        if (count > std::numeric_limits<uint64_t>::max() / elem_size) return false;
+        return skip_bytes(in, count * elem_size);
+    }
+
+    uint64_t size = gguf_scalar_size(type);
+    return size > 0 && skip_bytes(in, size);
+}
+
+static int64_t read_gguf_context_length(const std::string& path) {
+    std::ifstream in(path_from_utf8(path), std::ios::binary);
+    if (!in) return 0;
+
+    char magic[4] = {};
+    in.read(magic, sizeof(magic));
+    if (!in || std::memcmp(magic, "GGUF", 4) != 0) return 0;
+
+    uint32_t version = 0;
+    uint64_t tensor_count = 0;
+    uint64_t kv_count = 0;
+    if (!read_le(in, version) || !read_le(in, tensor_count) || !read_le(in, kv_count)) return 0;
+    (void)version;
+    (void)tensor_count;
+
+    std::string architecture;
+    int64_t pending_context_length = 0;
+
+    for (uint64_t i = 0; i < kv_count; ++i) {
+        std::string key;
+        uint32_t type = 0;
+        if (!read_gguf_string(in, key) || !read_le(in, type)) return 0;
+
+        if (key == "general.architecture" && type == 8) {
+            if (!read_gguf_string(in, architecture)) return 0;
+            if (pending_context_length > 0) return pending_context_length;
+            continue;
+        }
+
+        const bool context_key = !architecture.empty() && key == architecture + ".context_length";
+        const bool possible_context_key = architecture.empty() && key.size() > std::strlen(".context_length") &&
+                                          ends_with_ignore_case(key, ".context_length");
+        if (context_key || possible_context_key) {
+            int64_t value = 0;
+            if (!read_gguf_integer_value(in, type, value)) return 0;
+            if (value <= 0) return 0;
+            if (context_key) return value;
+            pending_context_length = value;
+            continue;
+        }
+
+        if (!skip_gguf_value(in, type)) return 0;
+    }
+
+    return pending_context_length;
+}
+
+static fs::path get_flm_models_dir_from_config_home() {
+#ifdef _WIN32
+    const char* appdata = std::getenv("APPDATA");
+    if (appdata && *appdata) return path_from_utf8(appdata) / "flm" / "models";
+    const char* userprofile = std::getenv("USERPROFILE");
+    if (userprofile && *userprofile) return path_from_utf8(userprofile) / ".config" / "flm" / "models";
+    return fs::path();
+#else
+    const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME");
+    if (xdg_config_home && *xdg_config_home) return path_from_utf8(xdg_config_home) / "flm" / "models";
+    const char* home = std::getenv("HOME");
+    if (home && *home) return path_from_utf8(home) / ".config" / "flm" / "models";
+    return fs::path();
+#endif
+}
+
+static fs::path find_flm_config_path_from_repo_dir(const std::string& repo_dir) {
+    if (repo_dir.empty()) return fs::path();
+
+    std::vector<fs::path> candidates;
+    const char* flm_home = std::getenv("FLM_HOME");
+    if (flm_home && *flm_home) {
+        candidates.push_back(path_from_utf8(flm_home) / "models" / repo_dir / "config.json");
+        candidates.push_back(path_from_utf8(flm_home) / repo_dir / "config.json");
+    }
+
+    fs::path config_home_models = get_flm_models_dir_from_config_home();
+    if (!config_home_models.empty()) {
+        candidates.push_back(config_home_models / repo_dir / "config.json");
+    }
+
+    for (const auto& path : candidates) {
+        if (safe_exists(path)) return path;
+    }
+    return fs::path();
+}
+
+static std::string repo_dir_from_url(const std::string& url) {
+    std::string clean = url;
+    while (!clean.empty() && clean.back() == '/') clean.pop_back();
+    size_t query_pos = clean.find_first_of("?#");
+    if (query_pos != std::string::npos) clean = clean.substr(0, query_pos);
+
+    for (const std::string marker : {"/tree/", "/resolve/"}) {
+        size_t marker_pos = clean.find(marker);
+        if (marker_pos != std::string::npos) {
+            clean = clean.substr(0, marker_pos);
+            break;
+        }
+    }
+
+    size_t slash = clean.find_last_of('/');
+    return slash == std::string::npos ? clean : clean.substr(slash + 1);
+}
+
+static int64_t read_flm_max_context_window(const ModelInfo& info) {
+    if (info.type != ModelType::LLM) return 0;
+
+    std::string config_path = info.resolved_path("config");
+    if (config_path.empty()) return 0;
+
+    try {
+        json config = JsonUtils::load_from_file(config_path);
+        if (config.contains("max_position_embeddings") && config["max_position_embeddings"].is_number_integer()) {
+            int64_t value = config["max_position_embeddings"].get<int64_t>();
+            return value > 0 ? value : 0;
+        }
+        if (config.contains("text_config") && config["text_config"].is_object()) {
+            const auto& text_config = config["text_config"];
+            if (text_config.contains("max_position_embeddings") && text_config["max_position_embeddings"].is_number_integer()) {
+                int64_t value = text_config["max_position_embeddings"].get<int64_t>();
+                return value > 0 ? value : 0;
+            }
+        }
+    } catch (const std::exception& e) {
+        LOG(DEBUG, "ModelManager") << "Could not read FLM config metadata for "
+                                   << info.model_name << ": " << e.what() << std::endl;
+    }
+    return 0;
+}
+
+static void populate_static_max_context_window(ModelInfo& info) {
+    info.max_context_window = 0;
+    if (!info.downloaded) return;
+
+    if (info.recipe == "llamacpp") {
+        std::string gguf_path = info.resolved_path();
+        if (!gguf_path.empty() && ends_with_ignore_case(gguf_path, ".gguf") && safe_exists(path_from_utf8(gguf_path))) {
+            info.max_context_window = read_gguf_context_length(gguf_path);
+        }
+    } else if (info.recipe == "flm") {
+        info.max_context_window = read_flm_max_context_window(info);
+    }
 }
 
 static bool is_user_model_name(const std::string& model_name) {
@@ -1175,6 +1417,7 @@ void ModelManager::build_cache() {
     }
 
     for (auto& [name, info] : all_models) {
+        populate_static_max_context_window(info);
         models_cache_[name] = info;
     }
 
@@ -1287,6 +1530,7 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
         }
     }
 
+    populate_static_max_context_window(info);
     models_cache_[model_name] = info;
     rebuild_public_model_aliases_locked();
     LOG(INFO, "ModelManager") << "Added '" << model_name << "' to cache (downloaded=" << info.downloaded << ")" << std::endl;
@@ -1322,10 +1566,18 @@ void ModelManager::update_model_in_cache(const std::string& model_name, bool dow
         // The path changes now that files exist on disk
         if (downloaded) {
             resolve_all_model_paths(it->second);
+            if (it->second.recipe == "flm") {
+                cache_valid_ = false;
+                LOG(INFO, "ModelManager") << "Invalidated model cache after FLM download for '"
+                          << model_name << "'" << std::endl;
+                return;
+            }
+            populate_static_max_context_window(it->second);
             LOG(INFO, "ModelManager") << "Updated '" << model_name
                       << "' downloaded=" << downloaded
                       << ", resolved_path=" << it->second.resolved_path() << std::endl;
         } else {
+            it->second.max_context_window = 0;
             LOG(INFO, "ModelManager") << "Updated '" << model_name
                       << "' downloaded=" << downloaded << std::endl;
         }
@@ -1834,6 +2086,13 @@ std::vector<ModelInfo> ModelManager::get_flm_available_models() {
                     info.checkpoints["main"] = checkpoint;
                     info.recipe = "flm";
                     info.suggested = true; // All official FLM models are suggested
+
+                    if (JsonUtils::get_or_default<bool>(m, "installed", false) && m.contains("url") && m["url"].is_string()) {
+                        fs::path config_path = find_flm_config_path_from_repo_dir(repo_dir_from_url(m["url"].get<std::string>()));
+                        if (!config_path.empty()) {
+                            info.resolved_paths["config"] = path_to_utf8(config_path);
+                        }
+                    }
 
                     // Size in GB (footprint field contains disk size in GB)
                     if (m.contains("footprint") && m["footprint"].is_number()) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1301,6 +1301,10 @@ nlohmann::json Server::model_info_to_json(const std::string& model_id, const Mod
         model_json["size"] = info.size;
     }
 
+    if (info.max_context_window > 0) {
+        model_json["max_context_window"] = info.max_context_window;
+    }
+
     // Add image_defaults if present (for sd-cpp models)
     if (info.image_defaults.has_defaults) {
         json img_def = {

--- a/test/server_llm.py
+++ b/test/server_llm.py
@@ -20,6 +20,7 @@ Usage:
 """
 
 import asyncio
+import os
 import time
 import requests
 import numpy as np
@@ -66,6 +67,44 @@ class LLMTests(ServerTestBase):
     def setUpClass(cls):
         """Verify server and apply multi-model config."""
         super().setUpClass()
+
+    @skip_if_unsupported("static_max_context_window")
+    def test_000_model_info_includes_max_context_window(self):
+        """Downloaded GGUF and installed FLM text models expose static context metadata."""
+        model = self.get_test_model("llm")
+        headers = {}
+        api_key = os.environ.get("LEMONADE_API_KEY")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        response = requests.get(
+            f"{self.base_url}/models/{model}",
+            headers=headers,
+            timeout=TIMEOUT_DEFAULT,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        if not data.get("downloaded", False):
+            pull_response = requests.post(
+                f"{self.base_url}/pull",
+                json={"model_name": model, "stream": False},
+                headers=headers,
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            pull_response.raise_for_status()
+
+            response = requests.get(
+                f"{self.base_url}/models/{model}",
+                headers=headers,
+                timeout=TIMEOUT_DEFAULT,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        self.assertIn("max_context_window", data)
+        self.assertIsInstance(data["max_context_window"], int)
+        self.assertGreater(data["max_context_window"], 0)
 
     # =========================================================================
     # CHAT COMPLETIONS TESTS

--- a/test/utils/capabilities.py
+++ b/test/utils/capabilities.py
@@ -64,6 +64,7 @@ CAPABILITIES = {
                 "echo_parameter": False,
                 "generation_parameters": False,
                 "slots": True,
+                "static_max_context_window": True,
             },
             "test_models": {
                 "llm": "LFM2-1.2B-GGUF",
@@ -92,6 +93,7 @@ CAPABILITIES = {
                 "echo_parameter": False,
                 "generation_parameters": False,
                 "slots": False,
+                "static_max_context_window": False,
             },
             "test_models": {
                 "llm_cpu": "Qwen2.5-0.5B-Instruct-CPU",
@@ -120,6 +122,7 @@ CAPABILITIES = {
                 "echo_parameter": False,
                 "generation_parameters": False,
                 "slots": False,
+                "static_max_context_window": True,
             },
             "test_models": {
                 "llm": "llama3.2-1b-FLM",


### PR DESCRIPTION
Closes https://github.com/lemonade-sdk/lemonade/issues/1794

<img width="1218" height="776" alt="image" src="https://github.com/user-attachments/assets/e3d8a74e-a91d-4da6-b38d-396eb800eb6e" />

## Summary

Adds optional `max_context_window` metadata to OpenAI-compatible model responses when Lemonade can discover a model's static text context limit from local files.

- Parses downloaded GGUF headers for `general.architecture` and `<architecture>.context_length`.
- Reads installed FLM model `config.json` and uses `max_position_embeddings` for text-context models.
- Emits the field through the shared model serializer, so it appears in both `/v1/models` and `/v1/models/{model_id}` when known.
- Uses the metadata in the app's Load Options modal to show a context-size slider with power-of-two marks from 2k up to the model maximum, while keeping the editable text box in sync. Entering `0` remains valid and moves the slider to the maximum.
- Documents the field and adds a metadata regression test for llama.cpp and FLM.

This does not change runtime `ctx_size`, saved recipe options, or backend launch behavior.

## Demo

GGUF model:

```bash
curl -sS http://127.0.0.1:13305/v1/models/LFM2-1.2B-GGUF
```

Result:

```json
{"checkpoint":"LiquidAI/LFM2-1.2B-GGUF:LFM2-1.2B-Q4_K_M.gguf","checkpoints":{"main":"LiquidAI/LFM2-1.2B-GGUF:LFM2-1.2B-Q4_K_M.gguf"},"composite_models":[],"created":1234567890,"downloaded":true,"id":"LFM2-1.2B-GGUF","labels":[],"max_context_window":128000,"object":"model","owned_by":"lemonade","recipe":"llamacpp","recipe_options":{},"size":0.731,"suggested":true}
```

FLM model:

```bash
curl -sS http://127.0.0.1:13305/v1/models/gemma4-it-e2b-FLM
```

Result:

```json
{"checkpoint":"gemma4-it:e2b","checkpoints":{"main":"gemma4-it:e2b"},"composite_models":[],"created":1234567890,"downloaded":true,"id":"gemma4-it-e2b-FLM","labels":["vision","reasoning","tool-calling","audio","transcription"],"max_context_window":131072,"object":"model","owned_by":"lemonade","recipe":"flm","recipe_options":{},"size":6.0,"suggested":true}
```

## Validation

- `cmake --build --preset default --target lemond`
- `cmake --build --preset default --target web-app`
- `uv run python test/server_llm.py --wrapped-server llamacpp --backend cpu LLMTests.test_000_model_info_includes_max_context_window` (runner executed the full LLM class: 24 tests OK, 4 skipped)
- Targeted FLM unittest invocation for `LLMTests.test_000_model_info_includes_max_context_window`
- Manual curl checks for `LFM2-1.2B-GGUF` and `gemma4-it-e2b-FLM`