### PR TITLE
Warm model cache asynchronously

### DIFF
--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -95,7 +95,7 @@ struct ModelInfo {
 
 class ModelManager {
 public:
-    ModelManager();
+    explicit ModelManager(const std::string& extra_models_dir = "");
 
     // Invalidate the models cache (e.g. after backend install/uninstall)
     void invalidate_models_cache();

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -129,6 +129,9 @@ private:
     // Helper function to convert ModelInfo to JSON (used by models endpoints)
     nlohmann::json model_info_to_json(const std::string& model_id, const ModelInfo& info);
 
+    // Warm model list cache in the background after startup dependencies are initialized
+    void start_model_cache_warmup();
+
     // Helper function to generate detailed model error responses (not found, not supported, load failure)
     nlohmann::json create_model_error(const std::string& requested_model, const std::string& exception_msg);
     // System stats helper methods
@@ -143,6 +146,7 @@ private:
 
     std::thread http_v4_thread_;
     std::thread http_v6_thread_;
+    std::thread model_cache_warmup_thread_;
 
 
     std::unique_ptr<httplib::Server> http_server_;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -449,10 +449,15 @@ static GGUFFiles identify_gguf_models(
     return result;
 }
 
-ModelManager::ModelManager() {
+ModelManager::ModelManager(const std::string& extra_models_dir)
+    : extra_models_dir_(extra_models_dir) {
     server_models_ = load_server_models();
     user_models_ = load_optional_json(get_user_models_file());
     recipe_options_ = load_optional_json(get_recipe_options_file());
+
+    if (!extra_models_dir_.empty()) {
+        LOG(INFO, "ModelManager") << "Extra models directory set to: " << extra_models_dir_ << std::endl;
+    }
 }
 
 std::string ModelManager::get_user_models_file() {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3908,6 +3908,9 @@ void Server::apply_config_side_effects(const json& applied_changes) {
             model_manager_->invalidate_models_cache();
         } else if (value.is_object()) {
             // Nested backend section change (llamacpp / whispercpp / sdcpp / ryzenai / kokoro).
+            // Recipe defaults (e.g. default_backend) are derived from these settings, so
+            // drop the memoized recipes so the next /system-info recomputes them.
+            SystemInfoCache::invalidate_recipes();
             // Look for *_bin sub-keys and trigger a hot-swap of the affected backend.
             for (auto& [sub_key, sub_value] : value.items()) {
                 if (sub_key.size() >= 4

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -132,10 +132,7 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
     // Set global HttpClient timeout
     utils::HttpClient::set_default_timeout(config->global_timeout());
 
-    model_manager_ = std::make_unique<ModelManager>();
-
-    // Set extra models directory for GGUF discovery
-    model_manager_->set_extra_models_dir(config_->extra_models_dir());
+    model_manager_ = std::make_unique<ModelManager>(config_->extra_models_dir());
 
     backend_manager_ = std::make_unique<BackendManager>();
     BackendManager::set_global(backend_manager_.get());
@@ -164,6 +161,26 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
         router_.get(),
         config_->host(),
         config_->websocket_port());
+
+    start_model_cache_warmup();
+}
+
+void Server::start_model_cache_warmup() {
+    if (model_cache_warmup_thread_.joinable()) {
+        return;
+    }
+
+    model_cache_warmup_thread_ = std::thread([this]() {
+        try {
+            LOG(DEBUG, "Server") << "Warming model list cache..." << std::endl;
+            model_manager_->get_supported_models();
+            LOG(DEBUG, "Server") << "Model list cache warmup complete" << std::endl;
+        } catch (const std::exception& e) {
+            LOG(WARNING, "Server") << "Model list cache warmup failed: " << e.what() << std::endl;
+        } catch (...) {
+            LOG(WARNING, "Server") << "Model list cache warmup failed with unknown error" << std::endl;
+        }
+    });
 }
 
 void Server::setup_http_servers() {
@@ -1046,6 +1063,10 @@ void Server::stop() {
             }
         }
         LOG(INFO, "Server") << "Cleanup complete" << std::endl;
+    }
+
+    if (model_cache_warmup_thread_.joinable()) {
+        model_cache_warmup_thread_.join();
     }
 }
 


### PR DESCRIPTION
## Summary

- Warm the `ModelManager` model list cache asynchronously during `lemond` startup.
- Pass `extra_models_dir` into `ModelManager` construction so discovery configuration is initialized before cache warmup.
- Keep warmup success logs at debug level while preserving warning logs for failures.

## Impact

This removes the first `/v1/models` cache-build pause for normal startup flows while preserving the existing cache mutex behavior for concurrent requests and invalidation.

Benchmark after starting `lemond`, waiting 5 seconds, then timing `curl http://localhost:13305/v1/models`:

- Before: `0.436339s`
- After: `0.000943s`

On Windows the improvement is even more striking, it can reduce a ~10 second wait to instant.