### PR TITLE
vllm: stop reporting update_required immediately after install

### DIFF
--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -53,6 +53,10 @@ struct DownloadOptions {
     int low_speed_limit = 1000;       // Minimum bytes/sec before timeout (1KB/s)
     int low_speed_time = 60;          // Seconds below low_speed_limit before timeout
     int connect_timeout = 30;         // Connection timeout in seconds
+    bool quiet_on_4xx = false;        // When true, lower 4xx HTTP errors from
+                                      // [Error] to [Debug]. Set by callers that
+                                      // are probing URLs they expect may 404
+                                      // (e.g. split-archive part discovery).
 };
 
 class HttpClient {

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -343,11 +343,19 @@ namespace lemon::backends {
                 http_progress_cb = utils::create_throttled_progress_callback();
             }
 
-            // Download the file
+            // Download the file. quiet_on_4xx because we may fall through to
+            // the split-archive path below — backends that publish only split
+            // parts (e.g. vLLM) will 404 here, and we don't want that to look
+            // alarming in the logs when the install actually succeeds via the
+            // fallback.
+            utils::DownloadOptions probe_opts;
+            probe_opts.quiet_on_4xx = true;
             auto download_result = utils::HttpClient::download_file(
                 url,
                 zip_path,
-                http_progress_cb
+                http_progress_cb,
+                {},
+                probe_opts
             );
 
             if (!download_result.success) {
@@ -373,9 +381,16 @@ namespace lemon::backends {
 
                         LOG(DEBUG, spec.log_name()) << "Trying part: " << part_filename << std::endl;
 
+                        // quiet_on_4xx because the loop probes one past the last
+                        // real part to detect end-of-list; the trailing 404 is
+                        // expected control flow, not an error.
+                        utils::DownloadOptions part_opts;
+                        part_opts.quiet_on_4xx = true;
                         auto part_result = utils::HttpClient::download_file(
                             part_url, part_path,
-                            utils::create_throttled_progress_callback()
+                            utils::create_throttled_progress_callback(),
+                            {},
+                            part_opts
                         );
 
                         if (!part_result.success) {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1015,6 +1015,18 @@ json SystemInfo::build_recipes_info(const json& devices) {
             bool has_expected = !expected_version.empty();
             bool latest_pin = is_bin_pinned_to_latest(def.recipe, def.backend);
             bool needs_update;
+
+            // Some recipes (e.g. vllm) install with per-GPU-target release
+            // tags (e.g. "{base}-gfx1151") via version_override, while
+            // backend_versions.json stores only the base. Treat
+            // "{expected}-{anything}" as a match for "{expected}" so the
+            // suffix doesn't perpetually trigger update_required.
+            auto versions_match = [](const std::string& installed,
+                                     const std::string& expected) {
+                if (installed == expected) return true;
+                const std::string prefix = expected + "-";
+                return installed.compare(0, prefix.size(), prefix) == 0;
+            };
 #if !defined(_WIN32)
             // On non-Windows, FLM is a system-managed package; a version newer
             // than the minimum required is acceptable.
@@ -1036,7 +1048,8 @@ json SystemInfo::build_recipes_info(const json& devices) {
                     && (!version_known
                         || version_compare(installed_version, expected_version) < 0);
             } else {
-                needs_update = has_expected && (!version_known || installed_version != expected_version);
+                needs_update = has_expected
+                    && (!version_known || !versions_match(installed_version, expected_version));
             }
 
             if (needs_update) {

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -652,7 +652,15 @@ DownloadResult HttpClient::download_file(const std::string& url,
                                  && final_result.http_code != 408
                                  && final_result.http_code != 429);
         if (is_permanent_4xx) {
-            LOG(ERROR, "HttpClient") << "[Download] " << final_result.error_message << std::endl;
+            // Callers that are deliberately probing for the existence of a
+            // URL (e.g. split-archive part discovery) set quiet_on_4xx to
+            // suppress the alarming [Error] log. The error is still returned
+            // to the caller via DownloadResult.
+            if (options.quiet_on_4xx) {
+                LOG(DEBUG, "HttpClient") << "[Download] " << final_result.error_message << std::endl;
+            } else {
+                LOG(ERROR, "HttpClient") << "[Download] " << final_result.error_message << std::endl;
+            }
             if (fs::exists(partial_path_fs)) {
                 fs::remove(partial_path_fs);
             }


### PR DESCRIPTION
Closes #1816.

The install path writes `version.txt = "{base}-{gfx_target}"` (e.g. `vllm0.20.1-rocm7.12.0-gfx1151`) via `version_override`, but `system_info.cpp::build_recipes_info` compared it against the base pin from `backend_versions.json` (`vllm0.20.1-rocm7.12.0`) — never equal, so `vllm:rocm` perpetually showed `update_required` and the desktop app prompted to download every load.

Fix: in the version comparison, treat `"{expected}-{anything}"` as a match for `"{expected}"`. Recipe-agnostic.

## Test plan

```
$ build/lemonade backends 2>&1 | grep '^vllm'
before:  vllm  rocm  update_required  Backend update is required before use.
after:   vllm  rocm  installed        vllm0.20.1-rocm7.12.0-gfx1151
```

- [x] `lemonade backends` no longer reports `update_required` post-install
- [x] Inference round-trip still works

<img width="1540" height="394" alt="image" src="https://github.com/user-attachments/assets/adcc8192-0d9c-45d5-99f8-4b1c18f2ec00" />
