### PR TITLE
fix(logs): build WebSocket URL from full server base URL

### DIFF
--- a/src/app/src/renderer/utils/logWebSocketClient.ts
+++ b/src/app/src/renderer/utils/logWebSocketClient.ts
@@ -1,4 +1,4 @@
-import { getAPIKey, getServerHost, getWebSocketProtocol, serverFetch } from './serverConfig';
+import { getAPIKey, getServerBaseUrl, getWebSocketProtocol, serverFetch } from './serverConfig';
 
 export interface LogEntry {
   seq: number;
@@ -41,9 +41,15 @@ export async function connectLogStream(
     query.set('api_key', apiKey);
   }
 
-  const wsUrl = query.size > 0
-    ? `${getWebSocketProtocol()}://${getServerHost()}:${wsPort}/logs/stream?${query.toString()}`
-    : `${getWebSocketProtocol()}://${getServerHost()}:${wsPort}/logs/stream`;
+  // Construct the websocket URL from the configured server base URL so that
+  // hostname resolution, IPv6 vs IPv4, and any custom hostnames are preserved.
+  // Replace the port with the websocket port advertised by the server.
+  const base = new URL(getServerBaseUrl());
+  base.port = String(wsPort);
+  const baseHost = base.host; // includes hostname:port
+  const wsPath = '/logs/stream';
+  const wsQuery = query.size > 0 ? `?${query.toString()}` : '';
+  const wsUrl = `${getWebSocketProtocol()}://${baseHost}${wsPath}${wsQuery}`;
   const socket = new WebSocket(wsUrl);
 
   socket.addEventListener('open', () => {

--- a/src/app/src/renderer/utils/logWebSocketClient.ts
+++ b/src/app/src/renderer/utils/logWebSocketClient.ts
@@ -1,4 +1,4 @@
-import { getAPIKey, getServerBaseUrl, getWebSocketProtocol, serverFetch } from './serverConfig';
+import { buildWebSocketUrl, serverFetch } from './serverConfig';
 
 export interface LogEntry {
   seq: number;
@@ -35,21 +35,7 @@ export async function connectLogStream(
     throw new Error('Server did not advertise a websocket port');
   }
 
-  const query = new URLSearchParams();
-  const apiKey = getAPIKey();
-  if (apiKey) {
-    query.set('api_key', apiKey);
-  }
-
-  // Construct the websocket URL from the configured server base URL so that
-  // hostname resolution, IPv6 vs IPv4, and any custom hostnames are preserved.
-  // Replace the port with the websocket port advertised by the server.
-  const base = new URL(getServerBaseUrl());
-  base.port = String(wsPort);
-  const baseHost = base.host; // includes hostname:port
-  const wsPath = '/logs/stream';
-  const wsQuery = query.size > 0 ? `?${query.toString()}` : '';
-  const wsUrl = `${getWebSocketProtocol()}://${baseHost}${wsPath}${wsQuery}`;
+  const wsUrl = buildWebSocketUrl('/logs/stream', wsPort);
   const socket = new WebSocket(wsUrl);
 
   socket.addEventListener('open', () => {

--- a/src/app/src/renderer/utils/serverConfig.ts
+++ b/src/app/src/renderer/utils/serverConfig.ts
@@ -149,14 +149,6 @@ class ServerConfig {
   }
 
   /**
-   * Get the server hostname
-   */
-  getServerHost(): string {
-    const url = new URL(this.getServerBaseUrl());
-    return url.hostname;
-  }
-
-  /**
    * Get the server API key
    */
   getAPIKey(): string {
@@ -164,6 +156,28 @@ class ServerConfig {
       return this.apiKey;
     }
     return '';
+  }
+
+  /**
+   * Build a WebSocket URL for an endpoint served on the websocket port
+   * advertised by /health. Going through URL rather than string concat is
+   * what makes this correct for IPv6 literals — URL.host preserves the
+   * brackets that hostname does not. The configured API key is appended
+   * automatically when set.
+   */
+  buildWebSocketUrl(path: string, wsPort: number, query?: URLSearchParams): string {
+    const url = new URL(this.getServerBaseUrl());
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    url.port = String(wsPort);
+    url.pathname = url.pathname.replace(/\/$/, '') + path;
+
+    const params = new URLSearchParams(query);
+    const apiKey = this.getAPIKey();
+    if (apiKey) {
+      params.set('api_key', apiKey);
+    }
+    url.search = params.toString();
+    return url.toString();
   }
 
   /**
@@ -346,11 +360,11 @@ export const serverConfig = new ServerConfig();
 // Export convenience functions
 export const getApiBaseUrl = () => serverConfig.getApiBaseUrl();
 export const getServerBaseUrl = () => serverConfig.getServerBaseUrl();
-export const getServerHost = () => serverConfig.getServerHost();
 export const getAPIKey = () => serverConfig.getAPIKey();
 export const getServerPort = () => serverConfig.getPort();
 export const discoverServerPort = () => serverConfig.discoverPort();
-export const getWebSocketProtocol = () => new URL(serverConfig.getServerBaseUrl()).protocol === 'https:' ? 'wss' : 'ws';
+export const buildWebSocketUrl = (path: string, wsPort: number, query?: URLSearchParams) =>
+  serverConfig.buildWebSocketUrl(path, wsPort, query);
 export const isRemoteServer = () => serverConfig.isRemoteServer();
 export const onServerPortChange = (listener: PortChangeListener) => serverConfig.onPortChange(listener);
 export const onServerUrlChange = (listener: UrlChangeListener) => serverConfig.onUrlChange(listener);

--- a/src/app/src/renderer/utils/websocketClient.ts
+++ b/src/app/src/renderer/utils/websocketClient.ts
@@ -2,7 +2,7 @@
  * WebSocket client for realtime transcription.
  * Uses a raw WebSocket with OpenAI Realtime API message format.
  */
-import { getAPIKey, getServerHost, getWebSocketProtocol, serverFetch } from './serverConfig';
+import { buildWebSocketUrl, serverFetch } from './serverConfig';
 
 export interface TranscriptionCallbacks {
   /** Called with transcription text. isFinal=false for interim results that replace previous interim. */
@@ -24,12 +24,7 @@ export class TranscriptionWebSocket {
    */
   private constructor(wsPort: number, model: string, callbacks: TranscriptionCallbacks) {
     this.wsPort = wsPort;
-    const query = new URLSearchParams({ model });
-    const apiKey = getAPIKey();
-    if (apiKey) {
-      query.set('api_key', apiKey);
-    }
-    const wsUrl = `${getWebSocketProtocol()}://${getServerHost()}:${wsPort}/realtime?${query.toString()}`;
+    const wsUrl = buildWebSocketUrl('/realtime', wsPort, new URLSearchParams({ model }));
 
     console.log('[WebSocket] Connecting to:', wsUrl);
 


### PR DESCRIPTION
Previously the client assembled the WebSocket URL using only the bare hostname plus the websocket_port from /api/v1/health. This breaks for IPv6 literals (missing brackets), custom hostnames, and any config where the HTTP and WebSocket hosts differ, leaving the UI stuck on 'Connecting...'.

Fix: parse the full server base URL and replace only the port with the websocket_port value reported by /health, preserving the scheme conversion (http->ws, https->wss), hostname, and any path prefix.

Tested on:
- localhost (IPv4)
- lemond.service restart + desktop app restart
- View -> Logs transitions from 'Connecting...' to 'Connected'

Closes #1835 