### PR TITLE
Expose wrapped backend process IDs in /health

### DIFF
--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -431,6 +431,7 @@ curl http://localhost:13305/v1/health
       "type": "llm",
       "device": "gpu npu",
       "recipe": "ryzenai-llm",
+      "pid": 12345,
       "recipe_options": {
         "ctx_size": 4096
       },
@@ -443,6 +444,7 @@ curl http://localhost:13305/v1/health
       "type": "embedding",
       "device": "gpu",
       "recipe": "llamacpp",
+      "pid": 12346,
       "recipe_options": {
         "ctx_size": 8192,
         "llamacpp_args": "--no-mmap",
@@ -474,8 +476,9 @@ curl http://localhost:13305/v1/health
   - `type` - Model type: `"llm"`, `"embedding"`, or `"reranking"`
   - `device` - Space-separated device list: `"cpu"`, `"gpu"`, `"npu"`, or combinations like `"gpu npu"`
   - `backend_url` - URL of the backend server process handling this model (useful for debugging)
-  - `recipe`: - Backend/device recipe used to load the model (e.g., `"ryzenai-llm"`, `"llamacpp"`, `"flm"`)
-  - `recipe_options`: - Options used to load the model (e.g., `"ctx_size"`, `"llamacpp_backend"`, `"llamacpp_args"`, `"whispercpp_args"`)
+  - `pid` - The Process ID (PID) of the backend engine handling this model
+  - `recipe` - Backend/device recipe used to load the model (e.g., `"ryzenai-llm"`, `"llamacpp"`, `"flm"`)
+  - `recipe_options` - Options used to load the model (e.g., `"ctx_size"`, `"llamacpp_backend"`, `"llamacpp_args"`, `"whispercpp_args"`)
 - `max_models` - Maximum number of models that can be loaded simultaneously per type (set via `max_loaded_models` in [Server Configuration](../guide/configuration/README.md)):
   - `llm` - Maximum LLM/chat models
   - `embedding` - Maximum embedding models

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -111,6 +111,7 @@ public:
     ModelType get_model_type() const { return model_type_; }
     DeviceType get_device_type() const { return device_type_; }
     RecipeOptions get_recipe_options() const { return recipe_options_; }
+    int get_process_id() const { return process_handle_.pid; }
 
     // Load a model and start the server
     virtual void load(const std::string& model_name,

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -478,6 +478,7 @@ json Router::get_all_loaded_models() const {
         model_info["type"] = model_type_to_string(server->get_model_type());
         model_info["device"] = device_type_to_string(server->get_device_type());
         model_info["backend_url"] = server->get_address();  // For debugging port issues
+        model_info["pid"] = server->get_process_id();
         RecipeOptions recipe_options =  server->get_recipe_options();
         model_info["recipe"] = recipe_options.get_recipe();
         model_info["recipe_options"] = recipe_options.to_json();

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -21,7 +21,6 @@ Usage:
 """
 
 import platform
-import time
 import uuid
 import requests
 from openai import NotFoundError
@@ -79,6 +78,21 @@ class EndpointTests(ServerTestBase):
     def setUp(self):
         """Set up each test."""
         super().setUp()
+
+    def _get_loaded_model_info(self, model_name):
+        """Return loaded model info from /health for a model, or None."""
+        health = requests.get(f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT).json()
+        for model in health.get("all_models_loaded", []):
+            if model["model_name"] == model_name:
+                return model
+        return None
+
+    def _assert_loaded_model_pid(self, model_info):
+        """Assert /health exposes a usable wrapped backend process ID."""
+        self.assertIsNotNone(model_info, "Model should appear in /health")
+        self.assertIn("pid", model_info)
+        self.assertIsInstance(model_info["pid"], int)
+        self.assertGreater(model_info["pid"], 0)
 
     def test_000_endpoints_registered(self):
         """Verify all expected endpoints are registered on both v0 and v1."""
@@ -343,18 +357,9 @@ class EndpointTests(ServerTestBase):
         data = response.json()
         self.assertEqual(data["status"], "success")
 
-        # Verify model is loaded via health endpoint
-        health_response = requests.get(
-            f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
-        )
-        self.assertEqual(health_response.status_code, 200)
-        health_data = health_response.json()
-
-        # Check model appears in all_models_loaded
-        loaded_models = [
-            m["model_name"] for m in health_data.get("all_models_loaded", [])
-        ]
-        self.assertIn(ENDPOINT_TEST_MODEL, loaded_models)
+        # Verify model is loaded via health endpoint and exposes backend PID
+        loaded_model = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self._assert_loaded_model_pid(loaded_model)
 
         print(f"[OK] Loaded model: {ENDPOINT_TEST_MODEL}")
 
@@ -476,10 +481,9 @@ class EndpointTests(ServerTestBase):
         """Test that /load is idempotent: loading an already-loaded model with
         the same options is a no-op (no eviction or reload).
 
-        Uses wall-clock time as the proof signal: a no-op /load returns in
-        milliseconds, while even a tiny model reload takes several seconds.
-        (backend_url is not a stable identity — WrappedServer::choose_port
-        can pick the same port after a restart.)"""
+        Uses the wrapped backend process ID as the proof signal: a no-op
+        /load keeps the same backend process, while an eviction/reload starts
+        a different process."""
         # Ensure model is loaded (this may take seconds for the initial load)
         response = requests.post(
             f"{self.base_url}/load",
@@ -487,27 +491,33 @@ class EndpointTests(ServerTestBase):
             timeout=TIMEOUT_MODEL_OPERATION,
         )
         self.assertEqual(response.status_code, 200)
+        loaded_before = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self._assert_loaded_model_pid(loaded_before)
 
         # Second /load with the same options — should be a no-op
-        t0 = time.monotonic()
         response = requests.post(
             f"{self.base_url}/load",
             json={"model_name": ENDPOINT_TEST_MODEL},
             timeout=TIMEOUT_MODEL_OPERATION,
         )
-        elapsed = time.monotonic() - t0
         self.assertEqual(response.status_code, 200)
+        loaded_after = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self._assert_loaded_model_pid(loaded_after)
 
-        # A no-op returns in <1s; a real reload takes several seconds
-        self.assertLess(
-            elapsed,
-            2.0,
-            f"Idempotent /load took {elapsed:.1f}s — expected <2s for a no-op",
+        self.assertEqual(
+            loaded_after["pid"],
+            loaded_before["pid"],
+            "Idempotent /load should keep the same wrapped backend process",
         )
-        print(f"[OK] Idempotent /load with same options was a no-op ({elapsed:.3f}s)")
+        print(
+            f"[OK] Idempotent /load with same options kept PID "
+            f"{loaded_after['pid']}"
+        )
 
     def test_012b_load_reloads_on_option_change(self):
-        """Test that /load evicts and reloads when options differ."""
+        """Test that /load evicts and reloads when options differ.
+
+        The changed PID proves the wrapped backend process was replaced."""
         # Ensure model is loaded with default options (no ctx_size override)
         requests.post(
             f"{self.base_url}/unload",
@@ -521,15 +531,9 @@ class EndpointTests(ServerTestBase):
         )
         self.assertEqual(response.status_code, 200)
 
-        # Verify no ctx_size in loaded options
-        health_before = requests.get(
-            f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
-        ).json()
-        opts_before = {}
-        for m in health_before.get("all_models_loaded", []):
-            if m["model_name"] == ENDPOINT_TEST_MODEL:
-                opts_before = m.get("recipe_options", {})
-                break
+        loaded_before = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self._assert_loaded_model_pid(loaded_before)
+        opts_before = loaded_before.get("recipe_options", {})
         self.assertNotEqual(
             opts_before.get("ctx_size"),
             2048,
@@ -545,23 +549,24 @@ class EndpointTests(ServerTestBase):
         )
         self.assertEqual(response.status_code, 200)
 
-        # Verify the new options are applied (proves a reload occurred)
-        health_after = requests.get(
-            f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
-        ).json()
-        opts_after = {}
-        for m in health_after.get("all_models_loaded", []):
-            if m["model_name"] == ENDPOINT_TEST_MODEL:
-                opts_after = m.get("recipe_options", {})
-                break
+        loaded_after = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self._assert_loaded_model_pid(loaded_after)
+        opts_after = loaded_after.get("recipe_options", {})
         self.assertEqual(
             opts_after.get("ctx_size"),
             custom_ctx,
             "Option-change /load should reload with new options",
         )
+        self.assertNotEqual(
+            loaded_after["pid"],
+            loaded_before["pid"],
+            "Option-change /load should replace the wrapped backend process",
+        )
 
         print(
-            f"[OK] /load with different options triggered reload (ctx_size={custom_ctx})"
+            f"[OK] /load with different options replaced PID "
+            f"{loaded_before['pid']} -> {loaded_after['pid']} "
+            f"(ctx_size={custom_ctx})"
         )
 
     def test_012c_load_noop_when_already_loaded_by_inference(self):
@@ -574,9 +579,8 @@ class EndpointTests(ServerTestBase):
         models). The fix makes this decision atomic inside load_mutex_.
 
         We make this deterministic by loading via inference first (wait
-        for completion), then calling /load. Wall-clock time proves
-        whether a reload occurred: a no-op returns in milliseconds, a
-        reload takes seconds even for a tiny model."""
+        for completion), then calling /load. The wrapped backend process ID
+        proves whether a reload occurred."""
         # Ensure clean slate
         requests.post(
             f"{self.base_url}/unload",
@@ -595,37 +599,29 @@ class EndpointTests(ServerTestBase):
             timeout=TIMEOUT_MODEL_OPERATION,
         )
         self.assertEqual(inference_response.status_code, 200)
+        loaded_before = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self._assert_loaded_model_pid(loaded_before)
 
         # Now /load the same model — should no-op, not evict+reload
-        t0 = time.monotonic()
         load_response = requests.post(
             f"{self.base_url}/load",
             json={"model_name": ENDPOINT_TEST_MODEL},
             timeout=TIMEOUT_MODEL_OPERATION,
         )
-        elapsed = time.monotonic() - t0
         self.assertEqual(load_response.status_code, 200)
 
-        # A no-op returns in <1s; the old evict+reload took seconds
-        self.assertLess(
-            elapsed,
-            2.0,
-            f"/load after auto-load took {elapsed:.1f}s — expected <2s "
-            f"(old code would evict and reload)",
-        )
-
-        # Model should still be loaded
-        health = requests.get(f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT).json()
-        loaded = [
-            m
-            for m in health.get("all_models_loaded", [])
-            if m["model_name"] == ENDPOINT_TEST_MODEL
-        ]
+        loaded_after = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self._assert_loaded_model_pid(loaded_after)
         self.assertEqual(
-            len(loaded), 1, "Model should appear exactly once in loaded list"
+            loaded_after["pid"],
+            loaded_before["pid"],
+            "/load after auto-load should keep the same wrapped backend process",
         )
 
-        print(f"[OK] /load after auto-load was a no-op ({elapsed:.3f}s)")
+        print(
+            f"[OK] /load after auto-load was a no-op and kept PID "
+            f"{loaded_after['pid']}"
+        )
 
     def test_013_unload_specific_model(self):
         """Test unloading a specific model by name."""


### PR DESCRIPTION
## Summary

Adds the wrapped backend process ID to loaded model entries returned by `/health`.

The process ID stays the same when `/load` is called repeatedly for an already-loaded model, which gives us a stable signal that the backend process was reused instead of restarted. This is more reliable than checking elapsed time.

## Changes

- Added `WrappedServer::get_process_id()`.
- Added `pid` to each loaded model entry in `Router::get_all_loaded_models()`.
- Updated endpoint tests to verify `/load` idempotency using stable backend PIDs instead of timing checks.
- Documented the new `/health` `pid` field.

## New `/health` Response Example

After loading `Llama-3.2-3B-Instruct-GGUF`, `/v1/health` now includes `pid` on the loaded model entry:

```json
{
  "all_models_loaded": [
    {
      "backend_url": "http://127.0.0.1:8001/v1",
      "checkpoint": "unsloth/Llama-3.2-3B-Instruct-GGUF:Llama-3.2-3B-Instruct-UD-Q4_K_XL.gguf",
      "device": "gpu",
      "last_use": 298263822,
      "model_name": "Llama-3.2-3B-Instruct-GGUF",
      "pid": 55752,
      "recipe": "llamacpp",
      "recipe_options": {
        "ctx_size": 4096
      },
      "type": "llm"
    }
  ],
  "model_loaded": "Llama-3.2-3B-Instruct-GGUF",
  "status": "ok",
  "version": "10.3.0",
  "websocket_port": 9000
}
```

## Windows 11 Verification

```powershell
python test/server_endpoints.py
```

Result: all 35 tests passed.

Checked `/health`:

```powershell
Invoke-RestMethod "http://localhost:13305/v1/health" | ConvertTo-Json -Depth 10
```

Confirmed the loaded model entry included:

```json
"model_name": "Llama-3.2-3B-Instruct-GGUF",
"pid": 55752,
"recipe": "llamacpp"
```

Called `/load` repeatedly for the same model:

```powershell
Invoke-RestMethod -Method Post -Uri "http://localhost:13305/v1/load" -ContentType "application/json" -Body $body
Invoke-RestMethod -Method Post -Uri "http://localhost:13305/v1/load" -ContentType "application/json" -Body $body
```

Confirmed `/health` still returned the same PID:

```json
"pid": 55752
```

Confirmed the PID maps to the live wrapped backend process on Windows:

```powershell
Get-Process -Id 55752
```

Output showed:

```text
Id     ProcessName
55752  llama-server
```

## Issue

Fixes #1663