### PR TITLE
Updated to pull llamacpp-rocm builds from the new consolodated llama.cpp-builds repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -245,7 +245,7 @@ that define the userspace API for system calls and ioctl operations.
 
 Binaries for llama.cpp are downloaded under the MIT license from
 https://github.com/ggml-org/llama.cpp, as well as
-https://github.com/lemonade-sdk/llamacpp-rocm (which uses
+https://github.com/lemonade-sdk/llama.cpp-builds (which uses
 https://github.com/ggml-org/llama.cpp to build them.)
 
 Lemonade SDK used the [ONNX TurnkeyML](https://github.com/onnx/turnkeyml)

--- a/docs/dev/philosophy.md
+++ b/docs/dev/philosophy.md
@@ -101,8 +101,8 @@ People use Lemonade to access the bleeding edge of AI. The latest models and fea
 <details>
 <summary>Example</summary>
 
-1. `lemonade-sdk/llamacpp-rocm` builds fresh artifacts every day.
-2. A GitHub action automatically validates and merges llamacpp-rocm upgrades into Lemonade weekly.
+1. `lemonade-sdk/llama.cpp-builds` builds fresh artifacts every day.
+2. A GitHub action automatically validates and merges llama.cpp-builds upgrades into Lemonade weekly.
 3. Users can `lemonade config set llamacpp.rocm_bin="latest"` to get new llamacpp without waiting for new Lemonade, if weekly is too slow for them.
 
 </details>

--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -27,7 +27,7 @@ Lemonade uses [llama.cpp](https://github.com/ggerganov/llama.cpp) as its primary
 - **Channel Options**:
   - **Preview** (default): Custom builds with latest optimizations from lemonade-sdk
   - **Stable**: Upstream llama.cpp releases with AMD ROCm support
-  - **Nightly**: Bleeding-edge builds from lemonade-sdk/llamacpp-rocm (experimental)
+  - **Nightly**: Bleeding-edge builds from lemonade-sdk/llama.cpp-builds (experimental)
 - **Installation**: Varies by channel (see below)
 
 ### Metal
@@ -85,7 +85,7 @@ The ROCm backend supports three channels to balance stability, performance, and 
   "rocm_channel": "nightly"
 }
 ```
-- **Source**: Nightly builds from [lemonade-sdk/llamacpp-rocm](https://github.com/lemonade-sdk/llamacpp-rocm)
+- **Source**: Nightly builds from [lemonade-sdk/llama.cpp-builds](https://github.com/lemonade-sdk/llama.cpp-builds)
 - **Binaries**: Architecture-specific builds (gfx1150, gfx1151, gfx103X, gfx110X, gfx120X)
 - **Updates**: Nightly builds with experimental features and latest upstream changes
 - **Platform**: Windows and Linux
@@ -127,7 +127,7 @@ You can pin `llamacpp.rocm_bin` to a specific release tag instead of using `"bui
 |---|---|---|
 | `preview` *(default)* | [lemonade-sdk/llama.cpp](https://github.com/lemonade-sdk/llama.cpp) | Lemonade-specific build tags |
 | `stable` | [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp) | Upstream tags, e.g. `b4888` |
-| `nightly` | [lemonade-sdk/llamacpp-rocm](https://github.com/lemonade-sdk/llamacpp-rocm) | Nightly tags, e.g. `b1260` |
+| `nightly` | [lemonade-sdk/llama.cpp-builds](https://github.com/lemonade-sdk/llama.cpp-builds) | Nightly tags, e.g. `b1260` |
 
 > **Always set `rocm_channel` to the correct channel before setting `rocm_bin` to a specific tag.** If the tag does not exist in the current channel's repository, the download will fail with HTTP 404.
 

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -158,7 +158,7 @@ InstallParams LlamaCppServer::get_install_params(const std::string& backend, con
         throw std::runtime_error("ROCm preview llamacpp is currently supported on Windows and Linux only");
 #endif
     } else if (resolved_backend == "rocm-nightly") {
-        params.repo = "lemonade-sdk/llamacpp-rocm";
+        params.repo = "lemonade-sdk/llama.cpp-builds";
         std::string target_arch = SystemInfo::get_rocm_arch();
         if (target_arch.empty()) {
             throw std::runtime_error(


### PR DESCRIPTION
With the goal of consolidating repositories where we build llamacpp, this updates the ROCm backend to fetch from the new repository. Other backends coming.