### PR TITLE
Fix/http client low speed timeout

### DIFF
--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -50,8 +50,8 @@ struct DownloadOptions {
     int initial_retry_delay_ms = 1000; // Initial delay between retries (doubles each time)
     int max_retry_delay_ms = 60000;   // Maximum delay between retries (1 minute)
     bool resume_partial = true;       // Resume partial downloads if possible
-     int low_speed_limit = 0;       // Minimum bytes/sec before timeout (disabled — 0 = no limit)
-     int low_speed_time = 0;        // Seconds below low_speed_limit before timeout (disabled)
+    int low_speed_limit = 0;       // Minimum bytes/sec before timeout (disabled — 0 = no limit)
+    int low_speed_time = 0;        // Seconds below low_speed_limit before timeout (disabled)
     int connect_timeout = 30;         // Connection timeout in seconds
 };
 

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -50,8 +50,8 @@ struct DownloadOptions {
     int initial_retry_delay_ms = 1000; // Initial delay between retries (doubles each time)
     int max_retry_delay_ms = 60000;   // Maximum delay between retries (1 minute)
     bool resume_partial = true;       // Resume partial downloads if possible
-    int low_speed_limit = 1000;       // Minimum bytes/sec before timeout (1KB/s)
-    int low_speed_time = 60;          // Seconds below low_speed_limit before timeout
+     int low_speed_limit = 0;       // Minimum bytes/sec before timeout (disabled — 0 = no limit)
+     int low_speed_time = 0;        // Seconds below low_speed_limit before timeout (disabled)
     int connect_timeout = 30;         // Connection timeout in seconds
 };
 

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -136,11 +136,10 @@ HttpResponse HttpClient::post(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_.load());
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
-    // Add custom headers
+     // Add custom headers
     struct curl_slist* header_list = nullptr;
     header_list = curl_slist_append(header_list, "Content-Type: application/json");
     for (const auto& header : headers) {
@@ -198,8 +197,7 @@ HttpResponse HttpClient::post_multipart(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_.load());
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     CURLcode res = curl_easy_perform(curl);
@@ -274,8 +272,7 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, stream_write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &callback_data);
-    // Use provided timeout, or fallback to global default (set via --http-timeout)
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_.load());
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
     // Add custom headers


### PR DESCRIPTION
## Problem

Long streaming inference requests (chat completions, completions, responses) were
terminated after **300 seconds** with `CURL error: Timeout was reached`, even
mid-stream while tokens were actively generating. This affected all local inference
backends (llama.cpp Vulkan, etc.) where generation can exceed 5 minutes.

## Root Cause

`router.cpp` calls `forward_streaming_request()` with no timeout argument:

```cpp
server->forward_streaming_request("/v1/chat/completions", request_body, sink);
```

The default parameter in `wrapped_server.h:173` is `timeout_seconds = 0`, meaning
**"infinite"**. This `0` propagates correctly through `wrapped_server.cpp` →
`StreamingProxy` → `HttpClient::post_stream()`.

However, `http_client.cpp` had a ternary that silently promoted `0` to the global
default (300s):

```cpp
// BEFORE — wrong: treats 0 as "use default" instead of "infinite"
curl_easy_setopt(curl, CURLOPT_TIMEOUT,
    timeout_seconds > 0 ? timeout_seconds : default_timeout_seconds_.load());
```

Per libcurl docs, `CURLOPT_TIMEOUT = 0` means **no timeout**. The ternary inverted
this contract.

## Fix

Remove the ternary in `post()`, `post_multipart()`, and `post_stream()` — pass
`timeout_seconds` directly to `CURLOPT_TIMEOUT`:

```cpp
// AFTER — correct: 0 = infinite, n = hard deadline
curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
```

Callers that omit the argument still get the 300s default via the function parameter
default. Only streaming callers that explicitly pass `0` are affected — they now
correctly get infinite timeout.

Additionally, disabled `low_speed_limit/low_speed_time` defaults in `DownloadOptions`
(set to `0`) to prevent low-speed stall kills on slow token generation. Model
downloads in `model_manager.cpp` explicitly set these to `1000/60` — unchanged.

## Files Changed

- `src/cpp/server/utils/http_client.cpp` — removed ternary fallback in `post()`,
  `post_multipart()`, `post_stream()`
- `src/cpp/include/lemon/utils/http_client.h` — `DownloadOptions` defaults:
  `low_speed_limit = 0`, `low_speed_time = 0`

## Testing

Verified with llama.cpp Vulkan backend on Strix Halo (AMD Ryzen AI Max):
- Streaming completions now complete without abort regardless of generation time
- Model downloads still enforce low-speed timeout (unchanged)
- Short requests (<300s) unaffected

## No-Rebuild Workaround (not recommended)

Setting `--global-timeout 0` or `global_timeout: 0` in `config.json` technically
stops the 300s abort, but disables timeouts **globally** for all HTTP calls including
health checks, reachability probes, and non-streaming requests. This can cause
lemond to hang indefinitely on unresponsive backends.

This patch is the correct fix — it only affects calls that explicitly pass
`timeout_seconds = 0`, leaving all other timeouts intact.
