### PR TITLE
Drop support for user and external prefixes on models

### DIFF
--- a/src/app/src/renderer/AddModelPanel.tsx
+++ b/src/app/src/renderer/AddModelPanel.tsx
@@ -159,16 +159,13 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
           <label className="form-label" title="A unique name to identify your model in the catalog">
             Model Name
           </label>
-          <div className="input-with-prefix">
-            <span className="input-prefix">user.</span>
-            <input
-              type="text"
-              className="form-input with-prefix"
-              placeholder="Gemma-3-12b-it-GGUF"
-              value={form.name}
-              onChange={(e) => handleChange('name', e.target.value)}
-            />
-          </div>
+          <input
+            type="text"
+            className="form-input"
+            placeholder="Gemma-3-12b-it-GGUF"
+            value={form.name}
+            onChange={(e) => handleChange('name', e.target.value)}
+          />
         </div>
 
         <div className="form-section">

--- a/src/app/src/renderer/ChatWindow.tsx
+++ b/src/app/src/renderer/ChatWindow.tsx
@@ -208,7 +208,7 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isVisible, width }) => {
     setAddModelInitialValues(undefined);
     window.dispatchEvent(new CustomEvent('installModel', {
       detail: {
-        name: `user.${data.name}`,
+        name: data.name,
         registrationData: {
           checkpoint: data.checkpoint,
           recipe: data.recipe,

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -210,23 +210,8 @@ interface DetectedBackend {
   mmprojFiles?: string[];
 }
 
-const HIDDEN_MODEL_NAME_PREFIXES = ['user.', 'extra.'];
-
-const getModelDisplayName = (modelName: string): string => {
-  const prefix = HIDDEN_MODEL_NAME_PREFIXES.find(p => modelName.startsWith(p));
-  return prefix ? modelName.slice(prefix.length) : modelName;
-};
-
-const isNamespaceHiddenModel = (modelName: string): boolean =>
-  HIDDEN_MODEL_NAME_PREFIXES.some(prefix => modelName.startsWith(prefix));
-
 const getFamilyMemberLabel = (modelName: string, family: ModelFamily, match: RegExpExecArray): string => {
-  if (!isNamespaceHiddenModel(modelName)) return match[1];
-
-  const displayName = getModelDisplayName(modelName);
-  return displayName.startsWith(`${family.displayName}-`)
-    ? displayName.slice(family.displayName.length + 1)
-    : displayName;
+  return match[1];
 };
 
 function buildModelList(
@@ -241,7 +226,7 @@ function buildModelList(
     for (const m of models) {
       if (consumed.has(m.name)) continue;
       if (family.recipe && m.info.recipe !== family.recipe) continue;
-      const match = family.regex.exec(getModelDisplayName(m.name));
+      const match = family.regex.exec(m.name);
       if (match) {
         members.push({ label: getFamilyMemberLabel(m.name, family, match), name: m.name, info: m.info });
         consumed.add(m.name);
@@ -268,8 +253,8 @@ function buildModelList(
   // Merge and sort alphabetically by display name
   const allItems = [...familyItems, ...individualItems];
   allItems.sort((a, b) => {
-    const nameA = a.type === 'family' ? a.family.displayName : getModelDisplayName(a.name);
-    const nameB = b.type === 'family' ? b.family.displayName : getModelDisplayName(b.name);
+    const nameA = a.type === 'family' ? a.family.displayName : a.name;
+    const nameB = b.type === 'family' ? b.family.displayName : b.name;
     return nameA.localeCompare(nameB) || (
       a.type === 'model' && b.type === 'model' ? a.name.localeCompare(b.name) : 0
     );
@@ -463,8 +448,7 @@ const [searchQuery, setSearchQuery] = useState('');
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
       filtered = filtered.filter(model =>
-        model.name.toLowerCase().includes(query) ||
-        getModelDisplayName(model.name).toLowerCase().includes(query)
+        model.name.toLowerCase().includes(query)
       );
     }
 
@@ -659,7 +643,6 @@ const [searchQuery, setSearchQuery] = useState('');
       entries.push({ modelName, isLoading: true });
     }
     return entries.sort((a, b) =>
-      getModelDisplayName(a.modelName).localeCompare(getModelDisplayName(b.modelName)) ||
       a.modelName.localeCompare(b.modelName)
     );
   })();
@@ -939,7 +922,7 @@ const [searchQuery, setSearchQuery] = useState('');
     const checkpoint = backend.recipe === 'llamacpp'
       ? resolveGgufCheckpoint(hfModel.id, backend)
       : hfModel.id;
-    const modelName = `user.${resolveHfModelName(hfModel.id, backend)}`;
+    const modelName = resolveHfModelName(hfModel.id, backend);
     handleDownloadModel(modelName, { checkpoint, recipe: backend.recipe });
   }, [hfModelBackends, resolveGgufCheckpoint, resolveHfModelName, handleDownloadModel]);
 
@@ -1363,7 +1346,7 @@ const [searchQuery, setSearchQuery] = useState('');
         return s ? `• ${c} (${s.toFixed(1)} GB)` : `• ${c}`;
       });
       nameTooltip = `Collection of ${components.length} models:\n${lines.join('\n')}`;
-    } else if (displayName || getModelDisplayName(modelName) !== modelName) {
+    } else if (displayName) {
       nameTooltip = modelName;
     }
 
@@ -1377,7 +1360,7 @@ const [searchQuery, setSearchQuery] = useState('');
         <div className="model-item-content">
           <div className="model-info-left">
             <span className={`model-status-indicator ${statusClass}`} title={statusTitle}>●</span>
-            <span className="model-name" title={nameTooltip}>{displayName ?? getModelDisplayName(modelName)}</span>
+            <span className="model-name" title={nameTooltip}>{displayName ?? modelName}</span>
             <span className="model-size">{formatSize(getModelSize(modelName, modelInfo))}</span>
             {renderActionButtons(modelName, isHovered)}
           </div>
@@ -1675,7 +1658,7 @@ const [searchQuery, setSearchQuery] = useState('');
                         className={`loaded-model-indicator${isLoading ? ' loading' : ''}`}
                         title={isLoading ? 'Loading' : 'Loaded'}
                       />
-                      <span className="loaded-model-name" title={modelName}>{getModelDisplayName(modelName)}</span>
+                      <span className="loaded-model-name" title={modelName}>{modelName}</span>
                     </div>
                     {!isLoading && (
                       <button className="model-action-btn unload-btn active-model-eject-button" onClick={() => handleUnloadModel(modelName)} title="Eject model">

--- a/src/app/src/renderer/ModelOptionsModal.tsx
+++ b/src/app/src/renderer/ModelOptionsModal.tsx
@@ -267,10 +267,8 @@ const ModelOptionsModal: React.FC<SettingsModalProps> = ({ isOpen, onCancel, onS
   };
 
   const handleModelExport = () => {
-    let modelName = (modelInfo?.id as string).startsWith("user.") ? modelInfo?.id : `user.${modelInfo?.id}`;
-
     let modelToExport = {
-      "model_name": modelName,
+      "model_name": modelInfo?.id,
       "downloaded": modelInfo?.downloaded,
       "labels": modelInfo?.labels,
       "recipe": modelInfo?.recipe,

--- a/src/app/src/renderer/hooks/useModels.tsx
+++ b/src/app/src/renderer/hooks/useModels.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { ModelsData, ModelInfo, USER_MODEL_PREFIX, fetchSupportedModelsData } from '../utils/modelData';
+import { ModelsData, ModelInfo, fetchSupportedModelsData } from '../utils/modelData';
 import { onServerPortChange } from '../utils/serverConfig';
 import { isModelEffectivelyDownloaded } from '../utils/collectionModels';
 
@@ -60,10 +60,10 @@ export const ModelsProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       .map(([id, info]) => ({ id, info }));
   }, [modelsData]);
 
-  // Derive suggested models for Model Manager (suggested + user models)
+  // Derive suggested models for Model Manager
   const suggestedModels = useMemo<SuggestedModel[]>(() => {
     return Object.entries(modelsData)
-      .filter(([name, info]) => info.suggested || name.startsWith(USER_MODEL_PREFIX))
+      .filter(([name, info]) => info.suggested)
       .map(([name, info]) => ({ name, info }))
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [modelsData]);

--- a/src/app/src/renderer/utils/modelData.ts
+++ b/src/app/src/renderer/utils/modelData.ts
@@ -1,4 +1,3 @@
-export const USER_MODEL_PREFIX = 'user.';
 
 export interface ImageDefaults {
   steps?: number;

--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -119,8 +119,8 @@ bool prompt_variant(const std::vector<std::string>& labels,
 
 bool prompt_model_name(const std::string& default_name, std::string& out) {
     std::cout << "Choose a model name." << std::endl;
-    std::cout << "Press enter to use the default: user." << default_name << std::endl;
-    std::cout << "Or type a name starting with \"user.\" and press enter:" << std::endl;
+    std::cout << "Press enter to use the default: " << default_name << std::endl;
+    std::cout << "Or type a name and press enter:" << std::endl;
     std::cout << "> " << std::flush;
 
     std::string input;

--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -131,13 +131,6 @@ bool prompt_model_name(const std::string& default_name, std::string& out) {
     return true;
 }
 
-std::string normalize_user_model_name(std::string name) {
-    const std::string prefix = "user.";
-    if (name.rfind(prefix, 0) == 0) {
-        return name;
-    }
-    return prefix + name;
-}
 
 std::string strip_huggingface_url_prefix(const std::string& arg) {
     static const std::string prefix = "https://huggingface.co/";
@@ -270,7 +263,7 @@ int hf_pull_flow(lemonade::LemonadeClient& client,
 
         std::string suggested_name = variants_response.value("suggested_name", checkpoint);
         json pull_body;
-        pull_body["model_name"] = "user." + suggested_name;
+        pull_body["model_name"] = suggested_name;
         pull_body["checkpoint"] = checkpoint;
         pull_body["recipe"] = recipe;
 
@@ -320,7 +313,7 @@ int hf_pull_flow(lemonade::LemonadeClient& client,
         if (!prompt_model_name(default_model_name, model_name)) return 1;
     }
     json pull_body;
-    pull_body["model_name"] = normalize_user_model_name(model_name);
+    pull_body["model_name"] = model_name;
     pull_body["checkpoint"] = checkpoint + ":" + variant_name;
     pull_body["recipe"] = recipe;
 

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -41,7 +41,6 @@
 #include "lemon/utils/aixlog.hpp"
 
 static const std::vector<std::string> VALID_LABELS = {
-    "appear-builtin",
     "coding",
     "embeddings",
     "hot",

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -1070,16 +1070,16 @@ int main(int argc, char* argv[]) {
         ->required()
         ->type_name("MODEL_OR_CHECKPOINT");
     pull_cmd->add_option("--checkpoint", config.checkpoints,
-        "Add a TYPE CHECKPOINT pair for a custom user.* model. Repeat for multi-file models.")
+        "Add a TYPE CHECKPOINT pair for a custom model. Repeat for multi-file models.")
         ->group("Manual Configuration Options")
         ->type_name("TYPE CHECKPOINT")
         ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     pull_cmd->add_option("--recipe", config.recipe,
-        "Recipe for the custom user.* model (e.g., llamacpp, flm, sd-cpp, whispercpp)")
+        "Recipe for the custom model (e.g., llamacpp, flm, sd-cpp, whispercpp)")
         ->group("Manual Configuration Options")
         ->type_name("RECIPE")
         ->default_val(config.recipe);
-    pull_cmd->add_option("--label", config.labels, "Add a label to the custom user.* model")
+    pull_cmd->add_option("--label", config.labels, "Add a label to the custom model")
         ->group("Manual Configuration Options")
         ->type_name("LABEL")
         ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll)

--- a/src/cpp/cli/recipe_import.cpp
+++ b/src/cpp/cli/recipe_import.cpp
@@ -168,9 +168,6 @@ bool validate_and_transform_model_json(nlohmann::json& model_data) {
     }
 
     std::string model_name = model_data["model_name"].get<std::string>();
-    if (model_name.substr(0, 5) != "user.") {
-        model_data["model_name"] = "user." + model_name;
-    }
 
     if (!model_data.contains("recipe") || !model_data["recipe"].is_string()) {
         std::cerr << "Error: JSON file must contain a 'recipe' string field" << std::endl;

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -136,12 +136,6 @@ public:
     // Get model info by name
     ModelInfo get_model_info(const std::string& model_name);
 
-    // Resolve a public model reference to its canonical internal name.
-    std::string resolve_model_name(const std::string& model_name);
-
-    // Get the public name exposed by Lemonade APIs for a canonical model name.
-    std::string get_public_model_name(const std::string& model_name);
-
     // Check if model exists (in filtered list based on system capabilities)
     bool model_exists(const std::string& model_name);
 
@@ -216,12 +210,8 @@ private:
     // Cache of all models with their download status
     mutable std::mutex models_cache_mutex_;
     mutable std::map<std::string, ModelInfo> models_cache_;
-    mutable std::map<std::string, std::string> public_model_aliases_;  // public name -> canonical name
-    mutable std::map<std::string, std::string> canonical_public_names_;  // canonical name -> public name
     mutable std::map<std::string, std::string> filtered_out_models_;  // model_name -> filter reason
     mutable bool cache_valid_ = false;
-
-    void rebuild_public_model_aliases_locked();
 };
 
 } // namespace lemon

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -16,8 +16,8 @@ using json = nlohmann::json;
 
 // Thrown by ModelManager::download_model when a pull request names a model
 // that (a) is not registered, (b) is not in the filtered-out registry, and
-// (c) lacks the `user.` prefix that would make it a new-model registration
-// attempt.
+// (c) does not include checkpoint/recipe parameters that would make it a
+// new-model registration attempt.
 //
 // CONTRACT: the /pull HTTP handler catches this type and attaches
 // {"code": kUnknownModelErrorCode, ...} to the error response. The lemonade
@@ -167,6 +167,9 @@ public:
     void set_extra_models_dir(const std::string& dir);
 
     void save_model_options(const ModelInfo& info);
+
+    // Normalize a model name (strip legacy user./extra. prefixes for backwards compatibility)
+    std::string normalize_model_name(const std::string& model_name) const;
 
 private:
     json load_server_models();

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -123,7 +123,6 @@ private:
     void evict_server(WrappedServer* server);
     void evict_all_servers();
     std::unique_ptr<WrappedServer> create_backend_server(const ModelInfo& model_info);
-    std::string resolve_model_name(const std::string& model_name) const;
 
     // Generic inference wrapper that handles locking and busy state
     template<typename Func>

--- a/src/cpp/legacy-cli/main.cpp
+++ b/src/cpp/legacy-cli/main.cpp
@@ -77,7 +77,7 @@ static int print_pull_deprecation_message() {
         << "Examples:\n"
         << "  Built-in model: lemonade pull Qwen3-0.6B-GGUF\n"
         << "  Checkpoint:     lemonade pull unsloth/Qwen3-8B-GGUF:Q4_K_M\n"
-        << "  Manual pull:    lemonade pull user.MyModel --checkpoint main org/repo:Q4_K_M --recipe llamacpp\n";
+        << "  Manual pull:    lemonade pull MyModel --checkpoint main org/repo:Q4_K_M --recipe llamacpp\n";
     return 1;
 }
 

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1313,10 +1313,17 @@ void ModelManager::build_cache() {
     // Step 1.5: Discover models from extra_models_dir
     auto discovered_models = discover_extra_models();
     for (const auto& [name, info] : discovered_models) {
-        // Check for conflicts with registered models
-        if (all_models.find(name) != all_models.end()) {
-            LOG(INFO, "ModelManager") << "Warning: Discovered model '" << name
-                      << "' conflicts with registered model, skipping." << std::endl;
+        auto existing = all_models.find(name);
+        if (existing != all_models.end()) {
+            // Name conflict with registered model - prefer the downloaded model
+            if (info.downloaded && !existing->second.downloaded) {
+                LOG(INFO, "ModelManager") << "Discovered model '" << name
+                          << "' is downloaded, replacing undownloaded registered model" << std::endl;
+                all_models[name] = info;
+            } else {
+                LOG(INFO, "ModelManager") << "Discovered model '" << name
+                          << "' conflicts with registered model, keeping registered model" << std::endl;
+            }
             continue;
         }
         all_models[name] = info;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -81,8 +81,6 @@ static bool contains_ignore_case(const std::string& str, const std::string& subs
     return to_lower(str).find(to_lower(substr)) != std::string::npos;
 }
 
-static constexpr const char USER_MODEL_PREFIX[] = "user.";
-static constexpr size_t USER_MODEL_PREFIX_LEN = sizeof(USER_MODEL_PREFIX) - 1;
 static constexpr const char* APPEAR_BUILTIN_LABEL = "appear-builtin";
 
 static bool has_label(const ModelInfo& info, const std::string& label) {
@@ -339,16 +337,6 @@ static void populate_static_max_context_window(ModelInfo& info) {
     }
 }
 
-static bool is_user_model_name(const std::string& model_name) {
-    return model_name.rfind(USER_MODEL_PREFIX, 0) == 0;
-}
-
-static std::string strip_user_model_prefix(const std::string& model_name) {
-    if (is_user_model_name(model_name)) {
-        return model_name.substr(USER_MODEL_PREFIX_LEN);
-    }
-    return model_name;
-}
 
 static std::string repo_id_to_cache_dir_name(const std::string& repo_id) {
     std::string cache_dir_name = "models--";
@@ -760,7 +748,6 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
     LOG(INFO, "ModelManager") << "Scanning for GGUF models in: " << search_dir << std::endl;
 
     // Configuration for discovered models (single source of truth)
-    static constexpr const char* EXTRA_MODEL_PREFIX = "extra.";
     static constexpr const char* EXTRA_MODEL_RECIPE = "llamacpp";
     static constexpr const char* EXTRA_MODEL_SOURCE = "extra_models_dir";
 
@@ -813,7 +800,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
         // Skip mmproj files - they're part of multimodal models
         if (contains_ignore_case(filename, "mmproj")) continue;
 
-        std::string model_name = std::string(EXTRA_MODEL_PREFIX) + filename;
+        std::string model_name = filename;
         ModelInfo info = init_extra_model_info(model_name);
         info.checkpoints["main"] = gguf_path.string();
         info.resolved_paths["main"] = gguf_path.string();
@@ -867,7 +854,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
             continue;
         }
 
-        std::string model_name = std::string(EXTRA_MODEL_PREFIX) + dir_name;
+        std::string model_name = dir_name;
         ModelInfo info = init_extra_model_info(model_name);
         info.checkpoints["main"] = dir_path;
         info.resolved_paths["main"] = main_model_path.string();
@@ -1294,10 +1281,10 @@ void ModelManager::build_cache() {
         all_models[key] = info;
     }
 
-    // Load user models with "user." prefix
+    // Load user models
     for (auto& [key, value] : user_models_.items()) {
         ModelInfo info;
-        info.model_name = "user." + key;
+        info.model_name = key;
         info.checkpoints["main"] = JsonUtils::get_or_default<std::string>(value, "checkpoint", "");
         parse_legacy_mmproj(info, value);
         load_checkpoints(info, value);
@@ -1334,8 +1321,6 @@ void ModelManager::build_cache() {
     }
 
     // Step 1.5: Discover models from extra_models_dir
-    // All discovered models are prefixed with "extra." to avoid conflicts
-    // We still gracefully handle conflicts just in case, though
     auto discovered_models = discover_extra_models();
     for (const auto& [name, info] : discovered_models) {
         // Check for conflicts with registered models
@@ -1453,19 +1438,12 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
         return; // Will initialize on next access
     }
 
-    // Parse model name to get JSON key
-    std::string json_key = model_name;
-    bool is_user_model = is_user_model_name(model_name);
-    if (is_user_model) {
-        json_key = strip_user_model_prefix(model_name);
-    }
-
-    // Find in JSON
+    // Find in JSON (user models take precedence over built-in models)
     json* model_json = nullptr;
-    if (is_user_model && user_models_.contains(json_key)) {
-        model_json = &user_models_[json_key];
-    } else if (!is_user_model && server_models_.contains(json_key)) {
-        model_json = &server_models_[json_key];
+    if (user_models_.contains(model_name)) {
+        model_json = &user_models_[model_name];
+    } else if (server_models_.contains(model_name)) {
+        model_json = &server_models_[model_name];
     }
 
     if (!model_json) {
@@ -1487,7 +1465,9 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
         ? (*model_json)["recipe_options"] : json(nullptr);
     info.recipe_options = build_recipe_options(info, jro, model_name, recipe_options_);
 
-    info.suggested = JsonUtils::get_or_default<bool>(*model_json, "suggested", is_user_model);
+    // Custom models default to suggested=true, built-in models use their JSON value
+    bool is_custom_model = user_models_.contains(model_name);
+    info.suggested = JsonUtils::get_or_default<bool>(*model_json, "suggested", is_custom_model);
     info.hf_load = JsonUtils::get_or_default<bool>(*model_json, "hf_load", false);
     info.source = JsonUtils::get_or_default<std::string>(*model_json, "source", "");
 
@@ -1630,15 +1610,15 @@ void ModelManager::remove_model_from_cache(const std::string& model_name) {
 
     auto it = models_cache_.find(model_name);
     if (it != models_cache_.end()) {
-        // User models and local uploads should be removed entirely from cache
+        // Custom models and local uploads should be removed entirely from cache
         // (they're not in server_models.json, so keeping them makes no sense)
-        bool is_user_model = is_user_model_name(model_name);
-        if (is_user_model || it->second.source == "local_upload") {
+        bool is_custom_model = user_models_.contains(model_name);
+        if (is_custom_model || it->second.source == "local_upload") {
             models_cache_.erase(model_name);
             rebuild_public_model_aliases_locked();
             LOG(INFO, "ModelManager") << "Removed '" << model_name << "' from cache" << std::endl;
         } else {
-            // Registered model - just mark as not downloaded
+            // Built-in model - just mark as not downloaded
             it->second.downloaded = false;
             LOG(INFO, "ModelManager") << "Marked '" << model_name << "' as not downloaded" << std::endl;
         }
@@ -1902,12 +1882,6 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
 void ModelManager::register_user_model(const std::string& model_name,
                                       const json& model_data,
                                       const std::string& source) {
-    // Remove "user." prefix if present
-    std::string clean_name = model_name;
-    if (is_user_model_name(clean_name)) {
-        clean_name = strip_user_model_prefix(clean_name);
-    }
-
     // Filter only known, user-definable model props
     json model_entry;
     for (const std::string& prop : USER_DEFINED_MODEL_PROPS) {
@@ -1951,13 +1925,13 @@ void ModelManager::register_user_model(const std::string& model_name,
     }
 
     json updated_user_models = user_models_;
-    updated_user_models[clean_name] = model_entry;
+    updated_user_models[model_name] = model_entry;
 
     save_user_models(updated_user_models);
     user_models_ = updated_user_models;
 
     // Add new model to cache incrementally
-    add_model_to_cache("user." + clean_name);
+    add_model_to_cache(model_name);
 }
 
 // Find the FLM executable: install dir on Windows, system PATH on Linux.
@@ -2187,20 +2161,10 @@ void ModelManager::download_model(const std::string& model_name,
 
     std::string actual_recipe = model_data.value("recipe", "");
 
-    // If checkpoint or recipe are provided, this is a model registration
-    // and the model name must have the "user." prefix
-    if (!actual_checkpoint.empty() || !actual_recipe.empty()) {
-        if (!is_user_model_name(model_name)) {
-            throw std::runtime_error(
-                "When providing 'checkpoint' or 'recipe', the model name must include the "
-                "`user.` prefix, for example `user.Phi-4-Mini-GGUF`. Received: " +
-                model_name
-            );
-        }
-    }
-
     // Check if model exists in registry
     bool model_registered = model_exists(model_name);
+    bool is_builtin = server_models_.contains(model_name);
+    bool has_custom_params = !actual_checkpoint.empty() || !actual_recipe.empty();
 
     if (!model_registered) {
         // First, check if the model exists but was filtered out (unsupported recipe)
@@ -2213,16 +2177,7 @@ void ModelManager::download_model(const std::string& model_name,
             );
         }
 
-        // Model not in registry - this must be a user model registration
-        // Validate it has the "user." prefix
-        if (!is_user_model_name(model_name)) {
-            // See UnknownModelError contract in include/lemon/model_manager.h.
-            throw UnknownModelError(
-                "When registering a new model, the model name must include the "
-                "`user` namespace, for example `user.Phi-4-Mini-GGUF`. Received: " +
-                model_name
-            );
-        }
+        // Model not in registry - this is a custom model registration
 
         // Check that required arguments are provided
         if (actual_checkpoint.empty() || actual_recipe.empty()) {
@@ -2250,17 +2205,46 @@ void ModelManager::download_model(const std::string& model_name,
             }
         }
 
-        LOG(INFO, "ModelManager") << "Registering new user model: " << model_name << std::endl;
-    } else {
-        // Model is registered - if checkpoint not provided, look up from registry
-        // otherwise overwrite registration
-        if (actual_checkpoint.empty()) {
-            auto info = get_model_info(model_name);
-            actual_checkpoint = info.checkpoint();
-            actual_recipe = info.recipe;
+        LOG(INFO, "ModelManager") << "Registering new custom model: " << model_name << std::endl;
+    } else if (model_registered && has_custom_params) {
+        // User is providing custom parameters for an existing model (built-in or custom)
+        // This updates the model configuration - it does NOT create a duplicate model
+        auto existing_info = get_model_info(model_name);
+
+        if (is_builtin) {
+            LOG(WARNING, "ModelManager") << "⚠️  Updating configuration for built-in model '" << model_name << "'\n"
+                      << "    Old checkpoint: " << existing_info.checkpoint() << "\n"
+                      << "    New checkpoint: " << actual_checkpoint << "\n"
+                      << "    This affects ALL clients using this model name." << std::endl;
         } else {
-            model_registered = false;
+            LOG(INFO, "ModelManager") << "Updating configuration for custom model '" << model_name << "'\n"
+                      << "    Old checkpoint: " << existing_info.checkpoint() << "\n"
+                      << "    New checkpoint: " << actual_checkpoint << std::endl;
         }
+
+        // Validate GGUF models (llamacpp recipe) require a variant
+        if (actual_recipe == "llamacpp") {
+            std::string checkpoint_lower = actual_checkpoint;
+            std::transform(checkpoint_lower.begin(), checkpoint_lower.end(),
+                          checkpoint_lower.begin(), ::tolower);
+            if (checkpoint_lower.find("gguf") != std::string::npos &&
+                actual_checkpoint.find(':') == std::string::npos) {
+                throw std::runtime_error(
+                    "You are required to provide a 'variant' in the checkpoint field when "
+                    "registering a GGUF model. The variant is provided as CHECKPOINT:VARIANT. "
+                    "For example: Qwen/Qwen2.5-Coder-3B-Instruct-GGUF:Q4_0 or "
+                    "Qwen/Qwen2.5-Coder-3B-Instruct-GGUF:qwen2.5-coder-3b-instruct-q4_0.gguf"
+                );
+            }
+        }
+
+        // Treat as new registration to trigger download and save custom config
+        model_registered = false;
+    } else if (model_registered) {
+        // Model is registered and no custom params provided - pull using existing config
+        auto info = get_model_info(model_name);
+        actual_checkpoint = info.checkpoint();
+        actual_recipe = info.recipe;
     }
 
     // Parse checkpoint
@@ -2362,8 +2346,8 @@ void ModelManager::download_model(const std::string& model_name,
         return;
     }
 
-    // Register user models to user_models.json
-    if (is_user_model_name(model_name) && !model_registered) {
+    // Register custom models to user_models.json
+    if (!model_registered) {
         register_user_model(model_name, model_data);
     }
 
@@ -3175,7 +3159,7 @@ void ModelManager::delete_model(const std::string& model_name) {
     LOG(INFO, "ModelManager") << "Recipe: " << info.recipe << std::endl;
 
     // Handle extra models (from --extra-models-dir) - these are user-managed external files
-    if (canonical_model_name.substr(0, 6) == "extra.") {
+    if (info.source == "extra_models_dir") {
         throw std::runtime_error("Cannot delete extra models via API. Models in --extra-models-dir are user-managed. "
                                  "Delete the file directly from: " + info.checkpoint());
     }
@@ -3230,10 +3214,10 @@ void ModelManager::delete_model(const std::string& model_name) {
 
         LOG(INFO, "ModelManager") << "Successfully deleted FLM model: " << canonical_model_name << std::endl;
 
-        // Remove from user models if it's a user model
-        if (is_user_model_name(canonical_model_name)) {
+        // Remove from user models if it's a custom model
+        if (user_models_.contains(canonical_model_name)) {
             json updated_user_models = user_models_;
-            updated_user_models.erase(strip_user_model_prefix(canonical_model_name));
+            updated_user_models.erase(canonical_model_name);
             save_user_models(updated_user_models);
             user_models_ = updated_user_models;
             LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
@@ -3251,9 +3235,9 @@ void ModelManager::delete_model(const std::string& model_name) {
         // Just remove from user_models.json and cache
         LOG(INFO, "ModelManager") << "Model not downloaded, removing from registry only" << std::endl;
 
-        if (is_user_model_name(canonical_model_name)) {
+        if (user_models_.contains(canonical_model_name)) {
             json updated_user_models = user_models_;
-            updated_user_models.erase(strip_user_model_prefix(canonical_model_name));
+            updated_user_models.erase(canonical_model_name);
             save_user_models(updated_user_models);
             user_models_ = updated_user_models;
             LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
@@ -3340,10 +3324,10 @@ void ModelManager::delete_model(const std::string& model_name) {
         }
     }
 
-    // Remove from user models if it's a user model
-    if (is_user_model_name(canonical_model_name)) {
+    // Remove from user models if it's a custom model
+    if (user_models_.contains(canonical_model_name)) {
         json updated_user_models = user_models_;
-        updated_user_models.erase(strip_user_model_prefix(canonical_model_name));
+        updated_user_models.erase(canonical_model_name);
         save_user_models(updated_user_models);
         user_models_ = updated_user_models;
         LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
@@ -3474,17 +3458,9 @@ bool ModelManager::model_exists_unfiltered(const std::string& model_name) {
     if (server_models_.contains(model_name)) {
         return true;
     }
-    if (is_user_model_name(model_name)) {
-        return user_models_.contains(strip_user_model_prefix(model_name));
-    }
 
     std::string canonical_name = resolve_model_name(model_name);
-    if (is_user_model_name(canonical_name)) {
-        return user_models_.contains(strip_user_model_prefix(canonical_name));
-    }
-
-    // Check raw server_models_ JSON (before filtering)
-    return false;
+    return user_models_.contains(canonical_name);
 }
 
 ModelInfo ModelManager::get_model_info_unfiltered(const std::string& model_name) {
@@ -3492,14 +3468,8 @@ ModelInfo ModelManager::get_model_info_unfiltered(const std::string& model_name)
     std::string registry_name = model_name;
 
     if (!server_models_.contains(registry_name)) {
-        if (is_user_model_name(registry_name)) {
-            registry_name = strip_user_model_prefix(registry_name);
-        } else {
-            std::string canonical_name = resolve_model_name(model_name);
-            if (is_user_model_name(canonical_name)) {
-                registry_name = strip_user_model_prefix(canonical_name);
-            }
-        }
+        std::string canonical_name = resolve_model_name(model_name);
+        registry_name = canonical_name;
     }
 
     // Check server models first
@@ -3515,8 +3485,7 @@ ModelInfo ModelManager::get_model_info_unfiltered(const std::string& model_name)
     }
 
     // Parse model info from JSON
-    info.model_name = is_user_model_name(model_name) ? model_name
-        : (user_models_.contains(registry_name) ? std::string(USER_MODEL_PREFIX) + registry_name : registry_name);
+    info.model_name = registry_name;
     info.checkpoints["main"] = JsonUtils::get_or_default<std::string>(*model_json, "checkpoint", "");
     parse_legacy_mmproj(info, *model_json);
     load_checkpoints(info, *model_json);
@@ -3568,29 +3537,7 @@ std::string ModelManager::get_model_filter_reason(const std::string& model_name)
 void ModelManager::rebuild_public_model_aliases_locked() {
     public_model_aliases_.clear();
     canonical_public_names_.clear();
-
-    for (const auto& [name, info] : models_cache_) {
-        if (!is_user_model_name(name) || !has_label(info, APPEAR_BUILTIN_LABEL)) {
-            continue;
-        }
-
-        std::string bare_name = strip_user_model_prefix(name);
-        if (server_models_.contains(bare_name) || models_cache_.find(bare_name) != models_cache_.end()) {
-            LOG(INFO, "ModelManager") << "Skipping public alias '" << bare_name
-                      << "' for '" << name << "' because it collides with an existing model" << std::endl;
-            continue;
-        }
-
-        auto existing = public_model_aliases_.find(bare_name);
-        if (existing != public_model_aliases_.end() && existing->second != name) {
-            LOG(INFO, "ModelManager") << "Skipping public alias '" << bare_name
-                      << "' for '" << name << "' because it collides with '" << existing->second << "'" << std::endl;
-            continue;
-        }
-
-        public_model_aliases_[bare_name] = name;
-        canonical_public_names_[name] = bare_name;
-    }
+    // No longer populating public aliases - appear-builtin feature removed
 }
 
 } // namespace lemon

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -81,12 +81,6 @@ static bool contains_ignore_case(const std::string& str, const std::string& subs
     return to_lower(str).find(to_lower(substr)) != std::string::npos;
 }
 
-static constexpr const char* APPEAR_BUILTIN_LABEL = "appear-builtin";
-
-static bool has_label(const ModelInfo& info, const std::string& label) {
-    return std::find(info.labels.begin(), info.labels.end(), label) != info.labels.end();
-}
-
 template <typename T>
 static bool read_le(std::istream& in, T& value) {
     in.read(reinterpret_cast<char*>(&value), sizeof(T));
@@ -1173,15 +1167,7 @@ std::map<std::string, ModelInfo> ModelManager::get_supported_models() {
 
     // Return copy of cache (all models, including their download status)
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    std::map<std::string, ModelInfo> public_models;
-    for (const auto& [name, info] : models_cache_) {
-        auto it = canonical_public_names_.find(name);
-        const std::string& public_name = it != canonical_public_names_.end() ? it->second : name;
-        ModelInfo public_info = info;
-        public_info.model_name = public_name;
-        public_models[public_name] = std::move(public_info);
-    }
-    return public_models;
+    return models_cache_;
 }
 
 static void load_checkpoints(ModelInfo& info, json& model_json) {
@@ -1424,8 +1410,6 @@ void ModelManager::build_cache() {
         models_cache_[name] = info;
     }
 
-    rebuild_public_model_aliases_locked();
-
     cache_valid_ = true;
     LOG(INFO, "ModelManager") << "Cache built: " << models_cache_.size()
               << " total, " << downloaded_count << " downloaded" << std::endl;
@@ -1530,7 +1514,6 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
 
     populate_static_max_context_window(info);
     models_cache_[model_name] = info;
-    rebuild_public_model_aliases_locked();
     LOG(INFO, "ModelManager") << "Added '" << model_name << "' to cache (downloaded=" << info.downloaded << ")" << std::endl;
 }
 
@@ -1615,7 +1598,6 @@ void ModelManager::remove_model_from_cache(const std::string& model_name) {
         bool is_custom_model = user_models_.contains(model_name);
         if (is_custom_model || it->second.source == "local_upload") {
             models_cache_.erase(model_name);
-            rebuild_public_model_aliases_locked();
             LOG(INFO, "ModelManager") << "Removed '" << model_name << "' from cache" << std::endl;
         } else {
             // Built-in model - just mark as not downloaded
@@ -1638,11 +1620,7 @@ std::map<std::string, ModelInfo> ModelManager::get_downloaded_models() {
     std::map<std::string, ModelInfo> downloaded;
     for (const auto& [name, info] : models_cache_) {
         if (info.downloaded && info.recipe != "collection") {
-            auto it = canonical_public_names_.find(name);
-            const std::string& public_name = it != canonical_public_names_.end() ? it->second : name;
-            ModelInfo public_info = info;
-            public_info.model_name = public_name;
-            downloaded[public_name] = std::move(public_info);
+            downloaded[name] = info;
         }
     }
     return downloaded;
@@ -3151,10 +3129,9 @@ void ModelManager::download_from_flm(const std::string& checkpoint,
 }
 
 void ModelManager::delete_model(const std::string& model_name) {
-    std::string canonical_model_name = resolve_model_name(model_name);
-    auto info = get_model_info(canonical_model_name);
+    auto info = get_model_info(model_name);
 
-    LOG(INFO, "ModelManager") << "Deleting model: " << canonical_model_name << std::endl;
+    LOG(INFO, "ModelManager") << "Deleting model: " << model_name << std::endl;
     LOG(INFO, "ModelManager") << "Checkpoint: " << info.checkpoint() << std::endl;
     LOG(INFO, "ModelManager") << "Recipe: " << info.recipe << std::endl;
 
@@ -3199,7 +3176,7 @@ void ModelManager::delete_model(const std::string& model_name) {
                 int exit_code = utils::ProcessManager::get_exit_code(handle);
                 if (exit_code != 0) {
                     LOG(ERROR, "ModelManager") << "FLM remove failed with exit code: " << exit_code << std::endl;
-                    throw std::runtime_error("Failed to delete FLM model " + canonical_model_name + ": FLM remove failed with exit code " + std::to_string(exit_code));
+                    throw std::runtime_error("Failed to delete FLM model " + model_name + ": FLM remove failed with exit code " + std::to_string(exit_code));
                 }
                 break;
             }
@@ -3209,22 +3186,22 @@ void ModelManager::delete_model(const std::string& model_name) {
         // Check if process is still running (timeout)
         if (utils::ProcessManager::is_running(handle)) {
             LOG(ERROR, "ModelManager") << "FLM remove timed out" << std::endl;
-            throw std::runtime_error("Failed to delete FLM model " + canonical_model_name + ": FLM remove timed out");
+            throw std::runtime_error("Failed to delete FLM model " + model_name + ": FLM remove timed out");
         }
 
-        LOG(INFO, "ModelManager") << "Successfully deleted FLM model: " << canonical_model_name << std::endl;
+        LOG(INFO, "ModelManager") << "Successfully deleted FLM model: " << model_name << std::endl;
 
         // Remove from user models if it's a custom model
-        if (user_models_.contains(canonical_model_name)) {
+        if (user_models_.contains(model_name)) {
             json updated_user_models = user_models_;
-            updated_user_models.erase(canonical_model_name);
+            updated_user_models.erase(model_name);
             save_user_models(updated_user_models);
             user_models_ = updated_user_models;
             LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
         }
 
         // Remove from cache after successful deletion
-        remove_model_from_cache(canonical_model_name);
+        remove_model_from_cache(model_name);
 
         return;
     }
@@ -3235,16 +3212,16 @@ void ModelManager::delete_model(const std::string& model_name) {
         // Just remove from user_models.json and cache
         LOG(INFO, "ModelManager") << "Model not downloaded, removing from registry only" << std::endl;
 
-        if (user_models_.contains(canonical_model_name)) {
+        if (user_models_.contains(model_name)) {
             json updated_user_models = user_models_;
-            updated_user_models.erase(canonical_model_name);
+            updated_user_models.erase(model_name);
             save_user_models(updated_user_models);
             user_models_ = updated_user_models;
             LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
         }
 
-        remove_model_from_cache(canonical_model_name);
-        LOG(INFO, "ModelManager") << "Successfully removed model from registry: " << canonical_model_name << std::endl;
+        remove_model_from_cache(model_name);
+        LOG(INFO, "ModelManager") << "Successfully removed model from registry: " << model_name << std::endl;
         return;
     }
 
@@ -3273,14 +3250,14 @@ void ModelManager::delete_model(const std::string& model_name) {
     std::string main_repo = checkpoint_to_repo_id(info.checkpoint("main"));
 
     // Check if the main repo is shared with another model
-    bool main_shared = is_repo_shared(main_repo, canonical_model_name, models_cache_);
+    bool main_shared = is_repo_shared(main_repo, model_name, models_cache_);
 
     if (!main_shared) {
         // No other model uses this repo — safe to delete the entire directory
         if (fs::exists(model_cache_path_fs)) {
             LOG(INFO, "ModelManager") << "Removing directory..." << std::endl;
             fs::remove_all(model_cache_path_fs);
-            LOG(INFO, "ModelManager") << "✓ Deleted model files: " << canonical_model_name << std::endl;
+            LOG(INFO, "ModelManager") << "✓ Deleted model files: " << model_name << std::endl;
         } else {
             LOG(INFO, "ModelManager") << "Warning: Model cache directory not found (may already be deleted)" << std::endl;
         }
@@ -3298,7 +3275,7 @@ void ModelManager::delete_model(const std::string& model_name) {
                 cleanup_empty_parents(file_path, model_cache_path_fs);
             }
         }
-        LOG(INFO, "ModelManager") << "✓ Deleted variant for: " << canonical_model_name << std::endl;
+        LOG(INFO, "ModelManager") << "✓ Deleted variant for: " << model_name << std::endl;
     }
 
     // Clean up non-main checkpoint files in their own repo dirs (multi-repo models)
@@ -3309,7 +3286,7 @@ void ModelManager::delete_model(const std::string& model_name) {
         std::string cp_repo = checkpoint_to_repo_id(checkpoint);
         if (cp_repo.empty() || cp_repo == main_repo) continue;
 
-        if (is_repo_shared(cp_repo, canonical_model_name, models_cache_)) {
+        if (is_repo_shared(cp_repo, model_name, models_cache_)) {
             LOG(INFO, "ModelManager") << "Keeping shared repo " << cp_repo
                         << " (used by other models)" << std::endl;
             continue;
@@ -3325,16 +3302,16 @@ void ModelManager::delete_model(const std::string& model_name) {
     }
 
     // Remove from user models if it's a custom model
-    if (user_models_.contains(canonical_model_name)) {
+    if (user_models_.contains(model_name)) {
         json updated_user_models = user_models_;
-        updated_user_models.erase(canonical_model_name);
+        updated_user_models.erase(model_name);
         save_user_models(updated_user_models);
         user_models_ = updated_user_models;
         LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
     }
 
     // Remove from cache after successful deletion
-    remove_model_from_cache(canonical_model_name);
+    remove_model_from_cache(model_name);
 }
 
 json ModelManager::cleanup_orphaned_cache(bool dry_run) {
@@ -3417,30 +3394,12 @@ ModelInfo ModelManager::get_model_info(const std::string& model_name) {
 
     // O(1) lookup in cache
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    auto alias_it = public_model_aliases_.find(model_name);
-    std::string canonical_name = alias_it != public_model_aliases_.end() ? alias_it->second : model_name;
-    auto it = models_cache_.find(canonical_name);
+    auto it = models_cache_.find(model_name);
     if (it != models_cache_.end()) {
         return it->second;
     }
 
     throw std::runtime_error("Model not found: " + model_name);
-}
-
-std::string ModelManager::resolve_model_name(const std::string& model_name) {
-    build_cache();
-
-    std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    auto it = public_model_aliases_.find(model_name);
-    return it != public_model_aliases_.end() ? it->second : model_name;
-}
-
-std::string ModelManager::get_public_model_name(const std::string& model_name) {
-    build_cache();
-
-    std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    auto it = canonical_public_names_.find(model_name);
-    return it != canonical_public_names_.end() ? it->second : model_name;
 }
 
 bool ModelManager::model_exists(const std::string& model_name) {
@@ -3449,9 +3408,7 @@ bool ModelManager::model_exists(const std::string& model_name) {
 
     // O(1) lookup in cache
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    auto alias_it = public_model_aliases_.find(model_name);
-    std::string canonical_name = alias_it != public_model_aliases_.end() ? alias_it->second : model_name;
-    return models_cache_.find(canonical_name) != models_cache_.end();
+    return models_cache_.find(model_name) != models_cache_.end();
 }
 
 bool ModelManager::model_exists_unfiltered(const std::string& model_name) {
@@ -3459,18 +3416,12 @@ bool ModelManager::model_exists_unfiltered(const std::string& model_name) {
         return true;
     }
 
-    std::string canonical_name = resolve_model_name(model_name);
-    return user_models_.contains(canonical_name);
+    return user_models_.contains(model_name);
 }
 
 ModelInfo ModelManager::get_model_info_unfiltered(const std::string& model_name) {
     ModelInfo info;
     std::string registry_name = model_name;
-
-    if (!server_models_.contains(registry_name)) {
-        std::string canonical_name = resolve_model_name(model_name);
-        registry_name = canonical_name;
-    }
 
     // Check server models first
     json* model_json = nullptr;
@@ -3522,22 +3473,13 @@ std::string ModelManager::get_model_filter_reason(const std::string& model_name)
     // This is populated by filter_models_by_backend() during cache building
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
 
-    auto alias_it = public_model_aliases_.find(model_name);
-    std::string canonical_name = alias_it != public_model_aliases_.end() ? alias_it->second : model_name;
-    auto it = filtered_out_models_.find(canonical_name);
+    auto it = filtered_out_models_.find(model_name);
     if (it != filtered_out_models_.end()) {
         return it->second;
     }
 
     // Model wasn't filtered out (either it's available or doesn't exist)
     return "";
-}
-
-// Must be called with models_cache_mutex_ held.
-void ModelManager::rebuild_public_model_aliases_locked() {
-    public_model_aliases_.clear();
-    canonical_public_names_.clear();
-    // No longer populating public aliases - appear-builtin feature removed
 }
 
 } // namespace lemon

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -794,7 +794,11 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
         // Skip mmproj files - they're part of multimodal models
         if (contains_ignore_case(filename, "mmproj")) continue;
 
+        // Strip .gguf extension for cleaner model name
         std::string model_name = filename;
+        if (filename.length() > 5 && filename.rfind(".gguf") == filename.length() - 5) {
+            model_name = filename.substr(0, filename.length() - 5);
+        }
         ModelInfo info = init_extra_model_info(model_name);
         info.checkpoints["main"] = gguf_path.string();
         info.resolved_paths["main"] = gguf_path.string();
@@ -2099,9 +2103,10 @@ bool ModelManager::is_model_downloaded(const std::string& model_name) {
     // Build cache if needed
     build_cache();
 
-    // O(1) lookup - download status is in cache
+    // O(1) lookup - download status is in cache (with backwards compatibility)
+    std::string normalized = normalize_model_name(model_name);
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    auto it = models_cache_.find(model_name);
+    auto it = models_cache_.find(normalized);
     if (it != models_cache_.end()) {
         return it->second.downloaded;
     }
@@ -3394,9 +3399,10 @@ ModelInfo ModelManager::get_model_info(const std::string& model_name) {
     // Build cache if needed
     build_cache();
 
-    // O(1) lookup in cache
+    // O(1) lookup in cache (with backwards compatibility)
+    std::string normalized = normalize_model_name(model_name);
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    auto it = models_cache_.find(model_name);
+    auto it = models_cache_.find(normalized);
     if (it != models_cache_.end()) {
         return it->second;
     }
@@ -3404,26 +3410,44 @@ ModelInfo ModelManager::get_model_info(const std::string& model_name) {
     throw std::runtime_error("Model not found: " + model_name);
 }
 
+std::string ModelManager::normalize_model_name(const std::string& model_name) const {
+    // Backwards compatibility: strip legacy user./extra. prefixes if the model
+    // with the prefix doesn't exist but the unprefixed version does
+    if (model_name.rfind("user.", 0) == 0 || model_name.rfind("extra.", 0) == 0) {
+        std::string stripped = model_name.substr(model_name.find('.') + 1);
+
+        // Check if the unprefixed model exists in user_models_ (custom models)
+        if (user_models_.contains(stripped) && !user_models_.contains(model_name)) {
+            return stripped;
+        }
+    }
+
+    return model_name;
+}
+
 bool ModelManager::model_exists(const std::string& model_name) {
     // Build cache if needed
     build_cache();
 
-    // O(1) lookup in cache
+    // O(1) lookup in cache (with backwards compatibility)
+    std::string normalized = normalize_model_name(model_name);
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    return models_cache_.find(model_name) != models_cache_.end();
+    return models_cache_.find(normalized) != models_cache_.end();
 }
 
 bool ModelManager::model_exists_unfiltered(const std::string& model_name) {
-    if (server_models_.contains(model_name)) {
+    std::string normalized = normalize_model_name(model_name);
+
+    if (server_models_.contains(normalized)) {
         return true;
     }
 
-    return user_models_.contains(model_name);
+    return user_models_.contains(normalized);
 }
 
 ModelInfo ModelManager::get_model_info_unfiltered(const std::string& model_name) {
     ModelInfo info;
-    std::string registry_name = model_name;
+    std::string registry_name = normalize_model_name(model_name);
 
     // Check server models first
     json* model_json = nullptr;
@@ -3471,11 +3495,12 @@ std::string ModelManager::get_model_filter_reason(const std::string& model_name)
     // Ensure cache is built (this populates filtered_out_models_)
     build_cache();
 
-    // Look up in the filtered-out models cache
+    // Look up in the filtered-out models cache (with backwards compatibility)
     // This is populated by filter_models_by_backend() during cache building
+    std::string normalized = normalize_model_name(model_name);
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
 
-    auto it = filtered_out_models_.find(model_name);
+    auto it = filtered_out_models_.find(normalized);
     if (it != filtered_out_models_.end()) {
         return it->second;
     }

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3191,6 +3191,9 @@ void ModelManager::delete_model(const std::string& model_name) {
 
         LOG(INFO, "ModelManager") << "Successfully deleted FLM model: " << model_name << std::endl;
 
+        // Remove from cache first (while model is still in user_models_)
+        remove_model_from_cache(model_name);
+
         // Remove from user models if it's a custom model
         if (user_models_.contains(model_name)) {
             json updated_user_models = user_models_;
@@ -3199,9 +3202,6 @@ void ModelManager::delete_model(const std::string& model_name) {
             user_models_ = updated_user_models;
             LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
         }
-
-        // Remove from cache after successful deletion
-        remove_model_from_cache(model_name);
 
         return;
     }
@@ -3212,6 +3212,9 @@ void ModelManager::delete_model(const std::string& model_name) {
         // Just remove from user_models.json and cache
         LOG(INFO, "ModelManager") << "Model not downloaded, removing from registry only" << std::endl;
 
+        // Remove from cache first (while model is still in user_models_)
+        remove_model_from_cache(model_name);
+
         if (user_models_.contains(model_name)) {
             json updated_user_models = user_models_;
             updated_user_models.erase(model_name);
@@ -3220,7 +3223,6 @@ void ModelManager::delete_model(const std::string& model_name) {
             LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
         }
 
-        remove_model_from_cache(model_name);
         LOG(INFO, "ModelManager") << "Successfully removed model from registry: " << model_name << std::endl;
         return;
     }
@@ -3301,6 +3303,9 @@ void ModelManager::delete_model(const std::string& model_name) {
         }
     }
 
+    // Remove from cache first (while model is still in user_models_)
+    remove_model_from_cache(model_name);
+
     // Remove from user models if it's a custom model
     if (user_models_.contains(model_name)) {
         json updated_user_models = user_models_;
@@ -3309,9 +3314,6 @@ void ModelManager::delete_model(const std::string& model_name) {
         user_models_ = updated_user_models;
         LOG(INFO, "ModelManager") << "✓ Removed from user_models.json" << std::endl;
     }
-
-    // Remove from cache after successful deletion
-    remove_model_from_cache(model_name);
 }
 
 json ModelManager::cleanup_orphaned_cache(bool dry_run) {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2111,8 +2111,8 @@ bool ModelManager::is_model_downloaded(const std::string& model_name) {
     build_cache();
 
     // O(1) lookup - download status is in cache (with backwards compatibility)
-    std::string normalized = normalize_model_name(model_name);
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
+    std::string normalized = normalize_model_name(model_name);
     auto it = models_cache_.find(normalized);
     if (it != models_cache_.end()) {
         return it->second.downloaded;
@@ -3407,8 +3407,8 @@ ModelInfo ModelManager::get_model_info(const std::string& model_name) {
     build_cache();
 
     // O(1) lookup in cache (with backwards compatibility)
-    std::string normalized = normalize_model_name(model_name);
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
+    std::string normalized = normalize_model_name(model_name);
     auto it = models_cache_.find(normalized);
     if (it != models_cache_.end()) {
         return it->second;
@@ -3420,12 +3420,18 @@ ModelInfo ModelManager::get_model_info(const std::string& model_name) {
 std::string ModelManager::normalize_model_name(const std::string& model_name) const {
     // Backwards compatibility: strip legacy user./extra. prefixes if the model
     // with the prefix doesn't exist but the unprefixed version does
+    // NOTE: This must be called while holding models_cache_mutex_
     if (model_name.rfind("user.", 0) == 0 || model_name.rfind("extra.", 0) == 0) {
         std::string stripped = model_name.substr(model_name.find('.') + 1);
 
-        // Check if the unprefixed model exists in user_models_ (custom models)
-        if (user_models_.contains(stripped) && !user_models_.contains(model_name)) {
-            return stripped;
+        // Check the cache to see if the unprefixed version exists as a custom model
+        auto it = models_cache_.find(stripped);
+        if (it != models_cache_.end()) {
+            // Only apply backwards compat if it's actually a custom model
+            bool is_custom = std::find(it->second.labels.begin(), it->second.labels.end(), "custom") != it->second.labels.end();
+            if (is_custom && models_cache_.find(model_name) == models_cache_.end()) {
+                return stripped;
+            }
         }
     }
 
@@ -3437,8 +3443,8 @@ bool ModelManager::model_exists(const std::string& model_name) {
     build_cache();
 
     // O(1) lookup in cache (with backwards compatibility)
-    std::string normalized = normalize_model_name(model_name);
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
+    std::string normalized = normalize_model_name(model_name);
     return models_cache_.find(normalized) != models_cache_.end();
 }
 
@@ -3504,8 +3510,8 @@ std::string ModelManager::get_model_filter_reason(const std::string& model_name)
 
     // Look up in the filtered-out models cache (with backwards compatibility)
     // This is populated by filter_models_by_backend() during cache building
-    std::string normalized = normalize_model_name(model_name);
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
+    std::string normalized = normalize_model_name(model_name);
 
     auto it = filtered_out_models_.find(normalized);
     if (it != filtered_out_models_.end()) {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -41,7 +41,7 @@ WrappedServer* Router::find_server_by_model_name(const std::string& model_name) 
 }
 
 std::string Router::resolve_model_name(const std::string& model_name) const {
-    return model_name.empty() ? model_name : model_manager_->resolve_model_name(model_name);
+    return model_name;
 }
 
 WrappedServer* Router::get_most_recent_server() const {
@@ -221,7 +221,6 @@ void Router::load_model(const std::string& model_name,
                        RecipeOptions options,
                        bool do_not_upgrade,
                        bool allow_reload_on_option_change) {
-    const std::string canonical_model_name = resolve_model_name(model_name);
     RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options());
 
     // Resolve settings: load overrides take precedence over per-model overrides which take precedence over defaults
@@ -242,7 +241,7 @@ void Router::load_model(const std::string& model_name,
     // Mark that we're now loading (prevents concurrent loads)
     is_loading_ = true;
 
-    LOG(DEBUG, "Router") << "Loading model: " << canonical_model_name
+    LOG(DEBUG, "Router") << "Loading model: " << model_name
             << " (checkpoint: " << model_info.checkpoint()
             << ", recipe: " << model_info.recipe
             << ", type: " << model_type_to_string(model_info.type)
@@ -250,11 +249,11 @@ void Router::load_model(const std::string& model_name,
 
     try {
         // Check if model is already loaded
-        WrappedServer* existing = find_server_by_model_name(canonical_model_name);
+        WrappedServer* existing = find_server_by_model_name(model_name);
         if (existing) {
             if (allow_reload_on_option_change &&
                 existing->get_recipe_options().to_json() != effective_options.to_json()) {
-                LOG(INFO, "Router") << "Options changed, reloading model: " << canonical_model_name << std::endl;
+                LOG(INFO, "Router") << "Options changed, reloading model: " << model_name << std::endl;
                 evict_server(existing);
                 // Fall through to create and load with new options
             } else {
@@ -329,7 +328,7 @@ void Router::load_model(const std::string& model_name,
         std::unique_ptr<WrappedServer> new_server = create_backend_server(model_info);
 
         // Set model metadata
-        new_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
+        new_server->set_model_metadata(model_name, model_info.checkpoint(), model_type, device_type, effective_options);
         new_server->update_access_time();
 
         // CRITICAL: Release lock before slow backend startup
@@ -341,7 +340,7 @@ void Router::load_model(const std::string& model_name,
         std::string error_message;
 
         try {
-            new_server->load(canonical_model_name, model_info, effective_options, do_not_upgrade);
+            new_server->load(model_name, model_info, effective_options, do_not_upgrade);
             load_success = true;
         LOG(DEBUG, "Router") << "Backend started successfully" << std::endl;
         } catch (const std::exception& e) {
@@ -393,14 +392,14 @@ void Router::load_model(const std::string& model_name,
 
             // Create new server for retry
             std::unique_ptr<WrappedServer> retry_server = create_backend_server(model_info);
-            retry_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
+            retry_server->set_model_metadata(model_name, model_info.checkpoint(), model_type, device_type, effective_options);
             retry_server->update_access_time();
 
             lock.unlock();
 
         LOG(DEBUG, "Router") << "Retrying backend load..." << std::endl;
             try {
-                retry_server->load(canonical_model_name, model_info, effective_options, do_not_upgrade);
+                retry_server->load(model_name, model_info, effective_options, do_not_upgrade);
 
                 lock.lock();
 
@@ -442,8 +441,7 @@ void Router::unload_model(const std::string& model_name) {
     } else {
         // Unload specific model
     LOG(INFO, "Router") << "Unload model called: " << model_name << std::endl;
-        std::string canonical_model_name = resolve_model_name(model_name);
-        WrappedServer* server = find_server_by_model_name(canonical_model_name);
+        WrappedServer* server = find_server_by_model_name(model_name);
         if (!server) {
             throw std::runtime_error("Model not loaded: " + model_name);
         }
@@ -454,7 +452,7 @@ void Router::unload_model(const std::string& model_name) {
 std::string Router::get_loaded_model() const {
     std::lock_guard<std::mutex> lock(load_mutex_);
     WrappedServer* server = get_most_recent_server();
-    return server ? model_manager_->get_public_model_name(server->get_model_name()) : "";
+    return server ? server->get_model_name() : "";
 }
 
 std::string Router::get_loaded_recipe() const {
@@ -473,7 +471,7 @@ json Router::get_all_loaded_models() const {
 
     for (const auto& server : loaded_servers_) {
         json model_info;
-        model_info["model_name"] = model_manager_->get_public_model_name(server->get_model_name());
+        model_info["model_name"] = server->get_model_name();
         model_info["checkpoint"] = server->get_checkpoint();
         model_info["type"] = model_type_to_string(server->get_model_type());
         model_info["device"] = device_type_to_string(server->get_device_type());

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -40,9 +40,6 @@ WrappedServer* Router::find_server_by_model_name(const std::string& model_name) 
     return nullptr;
 }
 
-std::string Router::resolve_model_name(const std::string& model_name) const {
-    return model_name;
-}
 
 WrappedServer* Router::get_most_recent_server() const {
     if (loaded_servers_.empty()) {
@@ -512,12 +509,12 @@ bool Router::is_model_loaded() const {
 
 bool Router::is_model_loaded(const std::string& model_name) const {
     std::lock_guard<std::mutex> lock(load_mutex_);
-    return find_server_by_model_name(resolve_model_name(model_name)) != nullptr;
+    return find_server_by_model_name(model_name) != nullptr;
 }
 
 RecipeOptions Router::get_model_recipe_options(const std::string& model_name) const {
     std::lock_guard<std::mutex> lock(load_mutex_);
-    auto* server = find_server_by_model_name(resolve_model_name(model_name));
+    auto* server = find_server_by_model_name(model_name);
     if (server) return server->get_recipe_options();
     return RecipeOptions();
 }
@@ -526,7 +523,7 @@ ModelType Router::get_model_type(const std::string& model_name) const {
     std::lock_guard<std::mutex> lock(load_mutex_);
     WrappedServer* server = model_name.empty()
         ? get_most_recent_server()
-        : find_server_by_model_name(resolve_model_name(model_name));
+        : find_server_by_model_name(model_name);
     return server ? server->get_model_type() : ModelType::LLM;
 }
 
@@ -554,7 +551,7 @@ auto Router::execute_inference(const json& request, Func&& inference_func) -> de
             return ErrorResponse::from_exception(InvalidRequestException("No model specified in request"));
         }
 
-        server = find_server_by_model_name(resolve_model_name(requested_model));
+        server = find_server_by_model_name(requested_model);
         if (!server) {
             return ErrorResponse::from_exception(ModelNotLoadedException(requested_model));
         }
@@ -603,7 +600,7 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
             return;
         }
 
-        server = find_server_by_model_name(resolve_model_name(requested_model));
+        server = find_server_by_model_name(requested_model);
         if (!server) {
             std::string error_msg = "data: {\"error\":{\"message\":\"Model not loaded: " + requested_model + "\",\"type\":\"model_not_loaded\"}}\n\n";
             sink.write(error_msg.c_str(), error_msg.size());

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2746,23 +2746,11 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             LOG(INFO, "Server") << "   recipe: " << recipe << std::endl;
         }
 
-        // Validate: if checkpoint or recipe are provided, model name must have "user." prefix
-        if (!checkpoint.empty() || !recipe.empty()) {
-            if (model_name.substr(0, 5) != "user.") {
-                res.status = 400;
-                nlohmann::json error = {{"error",
-                    "When providing 'checkpoint' or 'recipe', the model name must include the "
-                    "`user.` prefix, for example `user.Phi-4-Mini-GGUF`. Received: " + model_name}};
-                res.set_content(error.dump(), "application/json");
-                return;
-            }
-        }
-
         // Local import mode: CLI has already copied files to HF cache, just resolve and register
         bool local_import = request_json.value("local_import", false);
         if (local_import) {
             std::string hf_cache = model_manager_->get_hf_cache_dir();
-            std::string model_name_clean = model_name.substr(5); // Remove "user." prefix
+            std::string model_name_clean = model_name;
             std::replace(model_name_clean.begin(), model_name_clean.end(), '/', '-');
             std::string dest_path = hf_cache + "/models--" + model_name_clean;
 
@@ -3128,7 +3116,7 @@ void Server::handle_params(const httplib::Request& req, httplib::Response& res) 
 // Called by handle_pull when local_import=true
 // Parameters:
 //   - dest_path: Directory where model files are located (already copied/uploaded)
-//   - model_name: Model name with "user." prefix
+//   - model_name: Model name
 //   - model_data: Request content
 //   - hf_cache: HuggingFace cache directory for computing relative paths
 void Server::resolve_and_register_local_model(

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -549,11 +549,10 @@ sys.exit(0)
                 os.unlink(json_file)
 
     def test_060a_import_json_file_with_appear_builtin_label(self):
-        """Import should preserve appear-builtin and expose the bare model name."""
-        canonical_name = f"ImportAlias-{uuid.uuid4().hex[:8]}"
-        public_name = canonical_name
+        """Import should preserve appear-builtin label on custom models."""
+        model_name = f"ImportAlias-{uuid.uuid4().hex[:8]}"
         json_data = {
-            "model_name": canonical_name,
+            "model_name": model_name,
             "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
             "recipe": "llamacpp",
             "labels": ["appear-builtin"],
@@ -575,11 +574,10 @@ sys.exit(0)
                 timeout=TIMEOUT_DEFAULT,
             )
             output = list_result.stdout + list_result.stderr
-            self.assertIn(public_name, output)
-            self.assertNotIn(canonical_name, output)
+            self.assertIn(model_name, output)
 
             delete_result = run_cli_command(
-                ["delete", public_name],
+                ["delete", model_name],
                 timeout=TIMEOUT_DEFAULT,
             )
             self.assertEqual(delete_result.returncode, 0)

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -1842,7 +1842,7 @@ class CLIHelpDocsConsistencyTests(unittest.TestCase):
             "Checkpoint:     lemonade pull unsloth/Qwen3-8B-GGUF:Q4_K_M", output
         )
         self.assertIn(
-            "Manual pull:    lemonade pull user.MyModel --checkpoint main org/repo:Q4_K_M --recipe llamacpp",
+            "Manual pull:    lemonade pull MyModel --checkpoint main org/repo:Q4_K_M --recipe llamacpp",
             output,
         )
 

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -548,14 +548,14 @@ sys.exit(0)
             if os.path.exists(json_file):
                 os.unlink(json_file)
 
-    def test_060a_import_json_file_with_appear_builtin_label(self):
-        """Import should preserve appear-builtin label on custom models."""
-        model_name = f"ImportAlias-{uuid.uuid4().hex[:8]}"
+    def test_060a_import_json_file_with_labels(self):
+        """Import should preserve labels on custom models."""
+        model_name = f"ImportLabeled-{uuid.uuid4().hex[:8]}"
         json_data = {
             "model_name": model_name,
             "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
             "recipe": "llamacpp",
-            "labels": ["appear-builtin"],
+            "labels": ["coding"],
         }
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -550,8 +550,8 @@ sys.exit(0)
 
     def test_060a_import_json_file_with_appear_builtin_label(self):
         """Import should preserve appear-builtin and expose the bare model name."""
-        canonical_name = f"user.ImportAlias-{uuid.uuid4().hex[:8]}"
-        public_name = canonical_name[5:]
+        canonical_name = f"ImportAlias-{uuid.uuid4().hex[:8]}"
+        public_name = canonical_name
         json_data = {
             "model_name": canonical_name,
             "checkpoint": USER_MODEL_MAIN_CHECKPOINT,

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1061,7 +1061,7 @@ class EndpointTests(ServerTestBase):
         if platform.system() == "Darwin":
             self.skipTest("sd-cpp pull tests are skipped on macOS in this suite")
 
-        model_name = f"user.Pull-Merge-Regression-{uuid.uuid4().hex[:8]}"
+        model_name = f"Pull-Merge-Regression-{uuid.uuid4().hex[:8]}"
         image_defaults = {
             "steps": 33,
             "cfg_scale": 8.5,
@@ -1146,8 +1146,8 @@ class EndpointTests(ServerTestBase):
 
     def test_021b_appear_builtin_aliases_user_model(self):
         """User models labeled appear-builtin should expose a bare public ID."""
-        canonical_name = f"user.AppearBuiltin-{uuid.uuid4().hex[:8]}"
-        public_name = canonical_name[5:]
+        canonical_name = f"AppearBuiltin-{uuid.uuid4().hex[:8]}"
+        public_name = canonical_name
 
         try:
             response = requests.post(

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1145,15 +1145,14 @@ class EndpointTests(ServerTestBase):
                 pass
 
     def test_021b_appear_builtin_aliases_user_model(self):
-        """User models labeled appear-builtin should expose a bare public ID."""
-        canonical_name = f"AppearBuiltin-{uuid.uuid4().hex[:8]}"
-        public_name = canonical_name
+        """Custom models with appear-builtin label should appear in model list."""
+        model_name = f"AppearBuiltin-{uuid.uuid4().hex[:8]}"
 
         try:
             response = requests.post(
                 f"{self.base_url}/pull",
                 json={
-                    "model_name": canonical_name,
+                    "model_name": model_name,
                     "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
                     "recipe": "llamacpp",
                     "labels": ["appear-builtin"],
@@ -1169,37 +1168,36 @@ class EndpointTests(ServerTestBase):
             )
             self.assertEqual(models_response.status_code, 200)
             model_ids = {model["id"] for model in models_response.json()["data"]}
-            self.assertIn(public_name, model_ids)
-            self.assertNotIn(canonical_name, model_ids)
+            self.assertIn(model_name, model_ids)
 
             model_info_response = requests.get(
-                f"{self.base_url}/models/{public_name}",
+                f"{self.base_url}/models/{model_name}",
                 timeout=TIMEOUT_DEFAULT,
             )
             self.assertEqual(model_info_response.status_code, 200)
-            self.assertEqual(model_info_response.json()["id"], public_name)
+            self.assertEqual(model_info_response.json()["id"], model_name)
 
             load_response = requests.post(
                 f"{self.base_url}/load",
-                json={"model_name": public_name},
+                json={"model_name": model_name},
                 timeout=TIMEOUT_MODEL_OPERATION,
             )
             self.assertEqual(load_response.status_code, 200)
-            self.assertEqual(load_response.json()["model_name"], public_name)
+            self.assertEqual(load_response.json()["model_name"], model_name)
 
             unload_response = requests.post(
                 f"{self.base_url}/unload",
-                json={"model_name": public_name},
+                json={"model_name": model_name},
                 timeout=TIMEOUT_DEFAULT,
             )
             self.assertEqual(unload_response.status_code, 200)
 
-            print(f"[OK] appear-builtin alias exposed and accepted for {public_name}")
+            print(f"[OK] Custom model with appear-builtin label: {model_name}")
         finally:
             try:
                 requests.post(
                     f"{self.base_url}/delete",
-                    json={"model_name": public_name},
+                    json={"model_name": model_name},
                     timeout=TIMEOUT_DEFAULT,
                 )
             except Exception:

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1144,9 +1144,9 @@ class EndpointTests(ServerTestBase):
             except Exception:
                 pass
 
-    def test_021b_appear_builtin_aliases_user_model(self):
-        """Custom models with appear-builtin label should appear in model list."""
-        model_name = f"AppearBuiltin-{uuid.uuid4().hex[:8]}"
+    def test_021b_custom_model_lifecycle(self):
+        """Custom models should appear in model list and support load/unload."""
+        model_name = f"CustomModel-{uuid.uuid4().hex[:8]}"
 
         try:
             response = requests.post(
@@ -1155,7 +1155,6 @@ class EndpointTests(ServerTestBase):
                     "model_name": model_name,
                     "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
                     "recipe": "llamacpp",
-                    "labels": ["appear-builtin"],
                     "stream": False,
                 },
                 timeout=TIMEOUT_MODEL_OPERATION,
@@ -1192,7 +1191,7 @@ class EndpointTests(ServerTestBase):
             )
             self.assertEqual(unload_response.status_code, 200)
 
-            print(f"[OK] Custom model with appear-builtin label: {model_name}")
+            print(f"[OK] Custom model lifecycle: {model_name}")
         finally:
             try:
                 requests.post(

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -186,9 +186,9 @@ class OllamaTests(ServerTestBase):
             f"Model name should end with ':latest', got: {model['name']}",
         )
 
-    def test_007_user_model_appear_builtin_alias(self):
-        """Custom models with appear-builtin label should appear through Ollama endpoints."""
-        model_name = f"OllamaAlias-{uuid.uuid4().hex[:8]}"
+    def test_007_custom_model_via_ollama(self):
+        """Custom models should appear through Ollama endpoints."""
+        model_name = f"OllamaCustom-{uuid.uuid4().hex[:8]}"
 
         try:
             pull_response = requests.post(
@@ -197,7 +197,6 @@ class OllamaTests(ServerTestBase):
                     "model_name": model_name,
                     "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
                     "recipe": "llamacpp",
-                    "labels": ["appear-builtin"],
                     "stream": False,
                 },
                 timeout=TIMEOUT_MODEL_OPERATION,

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -188,8 +188,8 @@ class OllamaTests(ServerTestBase):
 
     def test_007_user_model_appear_builtin_alias(self):
         """Aliased user models should appear built-in through Ollama endpoints."""
-        canonical_name = f"user.OllamaAlias-{uuid.uuid4().hex[:8]}"
-        public_name = canonical_name[5:]
+        canonical_name = f"OllamaAlias-{uuid.uuid4().hex[:8]}"
+        public_name = canonical_name
 
         try:
             pull_response = requests.post(
@@ -390,16 +390,12 @@ class OllamaTests(ServerTestBase):
         self.assertEqual(response.status_code, 200)
 
         chunks = [
-            json.loads(line.decode("utf-8"))
-            for line in response.iter_lines()
-            if line
+            json.loads(line.decode("utf-8")) for line in response.iter_lines() if line
         ]
         self.assertGreater(len(chunks), 0)
 
         tool_chunks = [
-            chunk
-            for chunk in chunks
-            if chunk.get("message", {}).get("tool_calls")
+            chunk for chunk in chunks if chunk.get("message", {}).get("tool_calls")
         ]
         self.assertGreater(len(tool_chunks), 0, "Expected a tool call chunk")
 

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -187,15 +187,14 @@ class OllamaTests(ServerTestBase):
         )
 
     def test_007_user_model_appear_builtin_alias(self):
-        """Aliased user models should appear built-in through Ollama endpoints."""
-        canonical_name = f"OllamaAlias-{uuid.uuid4().hex[:8]}"
-        public_name = canonical_name
+        """Custom models with appear-builtin label should appear through Ollama endpoints."""
+        model_name = f"OllamaAlias-{uuid.uuid4().hex[:8]}"
 
         try:
             pull_response = requests.post(
                 f"{self.base_url}/pull",
                 json={
-                    "model_name": canonical_name,
+                    "model_name": model_name,
                     "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
                     "recipe": "llamacpp",
                     "labels": ["appear-builtin"],
@@ -214,12 +213,11 @@ class OllamaTests(ServerTestBase):
                 model["model"].replace(":latest", "")
                 for model in tags_response.json()["models"]
             }
-            self.assertIn(public_name, tag_names)
-            self.assertNotIn(canonical_name, tag_names)
+            self.assertIn(model_name, tag_names)
 
             show_response = requests.post(
                 f"{OLLAMA_BASE_URL}/api/show",
-                json={"name": public_name},
+                json={"name": model_name},
                 timeout=TIMEOUT_DEFAULT,
             )
             self.assertEqual(show_response.status_code, 200)
@@ -227,7 +225,7 @@ class OllamaTests(ServerTestBase):
         finally:
             requests.post(
                 f"{self.base_url}/delete",
-                json={"model_name": public_name},
+                json={"model_name": model_name},
                 timeout=TIMEOUT_DEFAULT,
             )
 

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -203,7 +203,7 @@ ESRGAN_MODEL = "RealESRGAN-x4plus"
 TTS_MODEL = "kokoro-v1"
 
 # User models. The combinations of files seen here do not work but we will only test download
-USER_MODEL_NAME = "user.Dummy-Model"
+USER_MODEL_NAME = "Dummy-Model"
 USER_MODEL_MAIN_CHECKPOINT = (
     "unsloth/SmolLM2-135M-Instruct-GGUF:SmolLM2-135M-Instruct-Q2_K.gguf"
 )
@@ -214,11 +214,11 @@ USER_MODEL_TE_CHECKPOINT = (
 USER_MODEL_VAE_CHECKPOINT = "Comfy-Org/z_image:split_files/vae/ae.safetensors"
 
 # Models for shared-repo dependency testing (same repo, different quants)
-SHARED_REPO_MODEL_A_NAME = "user.SharedRepo-TestA"
+SHARED_REPO_MODEL_A_NAME = "SharedRepo-TestA"
 SHARED_REPO_MODEL_A_CHECKPOINT = (
     "unsloth/SmolLM2-135M-Instruct-GGUF:SmolLM2-135M-Instruct-Q2_K.gguf"
 )
-SHARED_REPO_MODEL_B_NAME = "user.SharedRepo-TestB"
+SHARED_REPO_MODEL_B_NAME = "SharedRepo-TestB"
 SHARED_REPO_MODEL_B_CHECKPOINT = (
     "unsloth/SmolLM2-135M-Instruct-GGUF:SmolLM2-135M-Instruct-Q4_K_M.gguf"
 )
@@ -227,11 +227,11 @@ SHARED_REPO_MODEL_B_CHECKPOINT = (
 # Scenario: Model A has main(repo1) + text_encoder(repo2-shared)
 #           Model B has main(repo3) + text_encoder(repo2-shared)
 # Deleting A must keep repo2 (still needed by B). Deleting B then cleans up repo2+repo3.
-MULTI_REPO_MODEL_A_NAME = "user.MultiRepo-TestA"
+MULTI_REPO_MODEL_A_NAME = "MultiRepo-TestA"
 MULTI_REPO_MODEL_A_MAIN = (
     "unsloth/SmolLM2-135M-Instruct-GGUF:SmolLM2-135M-Instruct-Q2_K.gguf"
 )
-MULTI_REPO_MODEL_B_NAME = "user.MultiRepo-TestB"
+MULTI_REPO_MODEL_B_NAME = "MultiRepo-TestB"
 MULTI_REPO_MODEL_B_MAIN = "Comfy-Org/z_image:split_files/vae/ae.safetensors"
 MULTI_REPO_SHARED_CHECKPOINT = (
     "mradermacher/SmolLM2-135M-Instruct-GGUF:SmolLM2-135M-Instruct.Q2_K.gguf"


### PR DESCRIPTION
Simplifies model naming by removing the requirement for user. prefix on custom models and extra. prefix on models from --extra-models-dir. Model names are now used directly, making Lemonade easier to integrate with external tools.                              
                                                                                                                                                                                                                                                                              
  Changes                                                                                                                                                                                                                                                                     
                                                                       
  Before:                                                                                                                                                                                                                                                                     
  lemonade pull user.MyModel --checkpoint repo/id:variant --recipe llamacpp
                                                                                                                                                                                                                                                                              
  After:                                                                                                                                                                                                                                                                      
  lemonade pull MyModel --checkpoint repo/id:variant --recipe llamacpp                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                              
  Key Behavior: Configuration Updates                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                              
  When you provide custom parameters (checkpoint/recipe) for a model name, you're updating that model's configuration, not creating a duplicate:                                                                                                                              
                                                                                                                                                                                                                                                                              
  # Update built-in model to use different checkpoint                                                                                                                                                                                                                         
  lemonade pull Qwen3-0.6B-GGUF --checkpoint different/repo:Q8_0 --recipe llamacpp                                                                                                                                                                                            
                                                                                                                                                                                                                                                                              
  What happens:                                                                                                                                                                                                                                                               
  - Saves custom configuration to user_models.json                                                                                                                                                                                                                            
  - Custom config takes precedence over built-in defaults                                                                                                                                                                                                                     
  - All clients using "Qwen3-0.6B-GGUF" now get the updated checkpoint 
  - Clear warning logged: ⚠ Updating configuration for built-in model 'Qwen3-0.6B-GGUF'                                                                                                                                                                                      
                                                                                                                                                                                                                                                                              
  To restore built-in:                                                                                                                                                                                                                                                        
  lemonade delete Qwen3-0.6B-GGUF  # Removes custom override, restores built-in                                                                                                                                                                                               
                                                                                                                                                                                                                                                                              
  Corner Cases Addressed                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                              
  1. Intentional override of built-in models - Allowed and logged with warning showing old/new checkpoint                                                                                                                                                                     
  2. Custom model updates - Logged with info showing configuration change                                                                                                                                                                                                     
  3. Multi-client environments - Warning indicates "This affects ALL clients using this model name"                                                                                                                                                                           
  4. Extra-models-dir collisions - Existing warning behavior preserved (skips conflicting models)                                                                                                                                                                             
                                                                                                                                                                                                                                                                              
  Implementation Details                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                              
  - Precedence: user_models.json overrides server_models.json (built-ins)                                                                                                                                                                                                     
  - Logging: Enhanced warnings when updating existing model configurations
  - Restoration: DELETE /v1/models/{name} removes custom config, restores built-in defaults                                                                                                                                                                                   
  - No prefixes anywhere: CLI, API, frontend, tests all updated                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                              
  Migration                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                              
  Existing user. and extra. prefixed models in user_models.json will need migration (manual or automated script). Consider providing a migration tool or documentation for users with existing custom models.                                                                 