### PR TITLE
Merge arguments instead of replacing them.

### DIFF
--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -243,6 +243,7 @@ Explicitly load a registered model into memory. This is useful to ensure that th
 | `cfg_scale` | No | sd-cpp | Classifier-free guidance scale for image generation. Default: 7.0. |
 | `width` | No | sd-cpp | Image width in pixels. Default: 512. |
 | `height` | No | sd-cpp | Image height in pixels. Default: 512. |
+| `merge_args` | No | All | Boolean. If true (default), `*_args` values from global config and per-model config are merged (per-model takes priority). If false, per-model `*_args` replace global `*_args` entirely. |
 
 **Setting Priority:**
 
@@ -252,7 +253,6 @@ When loading a model, settings are applied in this priority order:
 3. Values from environment variables or server startup arguments (see [Server Configuration](../guide/configuration/README.md))
 4. Default hardcoded values in `lemond` (lowest priority)
 
-**`*_args` merge behavior:** For options ending in `_args` (e.g., `llamacpp_args`, `whispercpp_args`, `sdcpp_args`, `flm_args`, `vllm_args`), the CLI/API arguments are **merged** rather than replaced. The merge works at the flag level with higher priority settings taking priority.
 
 ### Per-model options
 

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -252,6 +252,8 @@ When loading a model, settings are applied in this priority order:
 3. Values from environment variables or server startup arguments (see [Server Configuration](../guide/configuration/README.md))
 4. Default hardcoded values in `lemond` (lowest priority)
 
+**`*_args` merge behavior:** For options ending in `_args` (e.g., `llamacpp_args`, `whispercpp_args`, `sdcpp_args`, `flm_args`, `vllm_args`), the CLI/API arguments are **merged** rather than replaced. The merge works at the flag level with higher priority settings taking priority.
+
 ### Per-model options
 
 You can configure recipe-specific options on a per-model basis. Lemonade manages a file called `recipe_options.json` in the user's Lemonade cache (default: `~/.cache/lemonade`). The available options depend on the model's recipe:

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -375,11 +375,13 @@ The following options are available depending on the recipe being used:
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--whispercpp BACKEND` | WhisperCpp backend to use | Auto-detected |
+| `--merge-args` / `--no-merge-args` | Merge global and model arguments when loading the model | `true` |
 
 **Notes:**
 - Use `--save-options` to persist your configuration for the model
 - Unspecified options will use the backend's default values
 - Backend options (`--llamacpp`, `--sdcpp`, `--whispercpp`) are auto-detected based on system capabilities
+- `--merge-args` controls whether `*_args` from global config are merged with per-model args (default: merge). Use `--no-merge-args` to replace global args entirely with per-model args.
 
 **Examples:**
 
@@ -398,6 +400,9 @@ lemonade load Qwen3-0.6B-GGUF --llamacpp vulkan
 
 # Load a llama.cpp model with custom arguments
 lemonade load Qwen3-0.6B-GGUF --llamacpp-args "--flash-attn on --no-mmap"
+
+# Load a model without merging global args (per-model args replace global entirely)
+lemonade load Qwen3-0.6B-GGUF --no-merge-args --llamacpp-args "--flash-attn on"
 
 # Load an image generation model with custom settings
 lemonade load Z-Image-Turbo --sdcpp rocm --steps 8 --cfg-scale 1 --width 1024 --height 1024
@@ -509,6 +514,7 @@ lemonade launch AGENT [--model MODEL_NAME] [options]
 | `--ctx-size SIZE` | Context size for the model | `4096` |
 | `--llamacpp BACKEND` | LlamaCpp backend to use | Auto-detected |
 | `--llamacpp-args ARGS` | Custom arguments to pass to llama-server (must not conflict with managed args) | `""` |
+| `--merge-args` / `--no-merge-args` | Merge global and model arguments when loading the model | `true` |
 
 **Notes:**
 - The model load request is asynchronous: launch starts the agent immediately while loading continues in the background.
@@ -543,6 +549,9 @@ lemonade launch codex --model Qwen3.5-0.8B-GGUF --provider my-provider
 
 # Launch an agent with custom llama.cpp arguments
 lemonade launch claude --model Qwen3.5-0.8B-GGUF --ctx-size 32768 --llamacpp-args "--flash-attn on --no-mmap"
+
+# Launch an agent without merging global args
+lemonade launch claude --model Qwen3.5-0.8B-GGUF --no-merge-args --llamacpp-args "--flash-attn on"
 
 # Pass additional arguments directly to the agent
 lemonade launch claude --model Qwen3.5-0.8B-GGUF --agent-args "--approval-mode never"

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -549,7 +549,6 @@ lemonade launch codex --model Qwen3.5-0.8B-GGUF --provider my-provider
 # Launch an agent with custom llama.cpp arguments
 lemonade launch claude --model Qwen3.5-0.8B-GGUF --ctx-size 32768 --llamacpp-args "--flash-attn on --no-mmap"
 
-
 # Pass additional arguments directly to the agent
 lemonade launch claude --model Qwen3.5-0.8B-GGUF --agent-args "--approval-mode never"
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -514,7 +514,6 @@ lemonade launch AGENT [--model MODEL_NAME] [options]
 | `--ctx-size SIZE` | Context size for the model | `4096` |
 | `--llamacpp BACKEND` | LlamaCpp backend to use | Auto-detected |
 | `--llamacpp-args ARGS` | Custom arguments to pass to llama-server (must not conflict with managed args) | `""` |
-| `--merge-args` / `--no-merge-args` | Merge global and model arguments when loading the model | `true` |
 
 **Notes:**
 - The model load request is asynchronous: launch starts the agent immediately while loading continues in the background.
@@ -550,8 +549,6 @@ lemonade launch codex --model Qwen3.5-0.8B-GGUF --provider my-provider
 # Launch an agent with custom llama.cpp arguments
 lemonade launch claude --model Qwen3.5-0.8B-GGUF --ctx-size 32768 --llamacpp-args "--flash-attn on --no-mmap"
 
-# Launch an agent without merging global args
-lemonade launch claude --model Qwen3.5-0.8B-GGUF --no-merge-args --llamacpp-args "--flash-attn on"
 
 # Pass additional arguments directly to the agent
 lemonade launch claude --model Qwen3.5-0.8B-GGUF --agent-args "--approval-mode never"

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -211,6 +211,8 @@ When loading a model, settings are resolved in this order (highest to lowest pri
 2. Per-model values from `recipe_options.json`
 3. Global configuration values, see [Server Configuration](./README.md)
 
+**`*_args` merge behavior:** For options ending in `_args` (e.g., `llamacpp_args`, `whispercpp_args`, `sdcpp_args`, `flm_args`, `vllm_args`), the CLI/API arguments are **merged** rather than replaced. The merge works at the flag level with higher priority settings taking priority.
+
 For full details, see the [load endpoint documentation](../../api/lemonade.md#post-v1load).
 
 ## See Also

--- a/src/app/src/renderer/recipes/recipeOptionsConfig.ts
+++ b/src/app/src/renderer/recipes/recipeOptionsConfig.ts
@@ -36,6 +36,7 @@ export interface LlamaOptions {
   ctxSize: NumericOption;
   llamacppBackend: StringOption;
   llamacppArgs: StringOption;
+  mergeArgs: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -43,12 +44,14 @@ export interface WhisperOptions {
   recipe: 'whispercpp';
   whispercppBackend: StringOption;
   whispercppArgs: StringOption;
+  mergeArgs: BooleanOption;
   saveOptions: BooleanOption;
 }
 
 export interface FlmOptions {
   recipe: 'flm';
   ctxSize: NumericOption;
+  mergeArgs: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -67,6 +70,7 @@ export interface StableDiffusionOptions {
   cfgScale: NumericOption;
   width: NumericOption;
   height: NumericOption;
+  mergeArgs: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -75,6 +79,7 @@ export interface VLLMOptions {
   ctxSize: NumericOption;
   vllmBackend: StringOption;
   vllmArgs: StringOption;
+  mergeArgs: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -142,6 +147,14 @@ export const OPTION_DEFINITIONS: Record<string, OptionDef> = {
     step: 1,
     label: 'Context Size',
     description: 'Context size for the model',
+  },
+
+  // Launch argument merging option
+  mergeArgs: {
+    type: 'boolean',
+    default: true,
+    label: 'Merge arguments',
+    description: 'Global and model arguments will be merged on model load',
   },
 
   // LlamaCpp-specific options
@@ -258,12 +271,12 @@ export type RecipeName = 'llamacpp' | 'whispercpp' | 'flm' | 'ryzenai-llm' | 'sd
  * This mirrors the C++ get_keys_for_recipe() function in recipe_options.cpp
  */
 export const RECIPE_OPTIONS_MAP: Record<RecipeName, string[]> = {
-  'llamacpp': ['ctxSize', 'llamacppBackend', 'llamacppArgs', 'saveOptions'],
-  'whispercpp': ['whispercppBackend', 'whispercppArgs', 'saveOptions'],
-  'flm': ['ctxSize', 'saveOptions'],
+  'llamacpp': ['ctxSize', 'llamacppBackend', 'llamacppArgs', 'mergeArgs', 'saveOptions'],
+  'whispercpp': ['whispercppBackend', 'whispercppArgs', 'mergeArgs', 'saveOptions'],
+  'flm': ['ctxSize', 'mergeArgs', 'saveOptions'],
   'ryzenai-llm': ['ctxSize', 'saveOptions'],
-  'sd-cpp': ['sdcppBackend', 'steps', 'cfgScale', 'width', 'height', 'saveOptions'],
-  'vllm': ['ctxSize', 'vllmBackend', 'vllmArgs', 'saveOptions'],
+  'sd-cpp': ['sdcppBackend', 'steps', 'cfgScale', 'width', 'height', 'mergeArgs', 'saveOptions'],
+  'vllm': ['ctxSize', 'vllmBackend', 'vllmArgs', 'mergeArgs', 'saveOptions'],
 };
 
 /**
@@ -289,6 +302,7 @@ export function getOptionDefinition(key: string): OptionDef | undefined {
 
 const FRONTEND_TO_API_MAP: Record<string, string> = {
   ctxSize: 'ctx_size',
+  mergeArgs: 'merge_args',
   llamacppBackend: 'llamacpp_backend',
   llamacppArgs: 'llamacpp_args',
   whispercppBackend: 'whispercpp_backend',

--- a/src/cpp/include/lemon/utils/custom_args.h
+++ b/src/cpp/include/lemon/utils/custom_args.h
@@ -42,8 +42,7 @@ inline std::vector<std::string> parse_custom_args(const std::string& custom_args
     return result;
 }
 
-inline std::map<std::string, std::vector<std::string>> build_custom_args_map(
-    const std::vector<std::string>& tokens) {
+inline std::map<std::string, std::vector<std::string>> build_custom_args_map(const std::vector<std::string>& tokens) {
     std::map<std::string, std::vector<std::string>> result;
     std::string last_flag;  // Track the most recently seen flag independently of map ordering
 
@@ -61,8 +60,7 @@ inline std::map<std::string, std::vector<std::string>> build_custom_args_map(
     return result;
 }
 
-inline std::string validate_custom_args(const std::string& custom_args_str,
-                                        const std::set<std::string>& reserved_flags) {
+inline std::string validate_custom_args(const std::string& custom_args_str, const std::set<std::string>& reserved_flags) {
     std::vector<std::string> custom_args = parse_custom_args(custom_args_str);
 
     for (const auto& arg : custom_args) {
@@ -87,6 +85,54 @@ inline std::string validate_custom_args(const std::string& custom_args_str,
     }
 
     return "";
+}
+
+inline std::string map_to_args_string(const std::map<std::string, std::vector<std::string>>& m) {
+    std::string result;
+    bool first = true;
+    for (const auto& [flag, values] : m) {
+        if (!first) result += " ";
+        first = false;
+        result += flag;
+        for (const auto& v : values) {
+            result += " " + v;
+        }
+    }
+    return result;
+}
+
+// Given a flag like "--flag" or "--no-flag", return the negation key.
+// "--no-<name>" ↔ "--<name>". Returns empty string if no negation exists.
+inline std::string negate_flag(const std::string& flag) {
+    if (flag.size() >= 5 && flag.compare(0, 5, "--no-") == 0) {
+        return "--" + flag.substr(5);
+    }
+    if (flag.size() >= 3 && flag.compare(0, 2, "--") == 0) {
+        return "--no-" + flag.substr(2);
+    }
+    return "";
+}
+
+inline std::map<std::string, std::vector<std::string>> merge_args_maps(
+    const std::map<std::string, std::vector<std::string>>& target,
+    const std::map<std::string, std::vector<std::string>>& incoming) {
+    std::map<std::string, std::vector<std::string>> merged = target;
+
+    // Remove binary-flag negations from incoming that conflict with target.
+    // Only flags without arguments are considered binary flags.
+    for (const auto& [flag, values] : incoming) {
+        if (values.empty()) {
+            std::string neg = negate_flag(flag);
+            if (!neg.empty() && merged.count(neg)) {
+                // Target has the opposite binary flag — skip this incoming flag
+                continue;
+            }
+        }
+        if (!merged.count(flag)) {
+            merged[flag] = values;
+        }
+    }
+    return merged;
 }
 
 } // namespace utils

--- a/src/cpp/include/lemon/utils/custom_args.h
+++ b/src/cpp/include/lemon/utils/custom_args.h
@@ -45,16 +45,16 @@ inline std::vector<std::string> parse_custom_args(const std::string& custom_args
 inline std::map<std::string, std::vector<std::string>> build_custom_args_map(
     const std::vector<std::string>& tokens) {
     std::map<std::string, std::vector<std::string>> result;
+    std::string last_flag;  // Track the most recently seen flag independently of map ordering
 
     for (const auto& token : tokens) {
         if (!token.empty() && token[0] == '-') {
             // This is a flag; start a new entry
             result[token] = {};
-        } else if (!result.empty()) {
+            last_flag = token;
+        } else if (!last_flag.empty()) {
             // Append to the most recently seen flag
-            auto it = result.end();
-            --it;
-            it->second.push_back(token);
+            result[last_flag].push_back(token);
         }
     }
 

--- a/src/cpp/include/lemon/utils/custom_args.h
+++ b/src/cpp/include/lemon/utils/custom_args.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <set>
 #include <string>
 #include <vector>
@@ -36,6 +37,25 @@ inline std::vector<std::string> parse_custom_args(const std::string& custom_args
 
     if (!current_arg.empty()) {
         result.push_back(current_arg);
+    }
+
+    return result;
+}
+
+inline std::map<std::string, std::vector<std::string>> build_custom_args_map(
+    const std::vector<std::string>& tokens) {
+    std::map<std::string, std::vector<std::string>> result;
+
+    for (const auto& token : tokens) {
+        if (!token.empty() && token[0] == '-') {
+            // This is a flag; start a new entry
+            result[token] = {};
+        } else if (!result.empty()) {
+            // Append to the most recently seen flag
+            auto it = result.end();
+            --it;
+            it->second.push_back(token);
+        }
     }
 
     return result;

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -14,6 +14,7 @@ using json = nlohmann::json;
 
 static const json DEFAULTS = {
     {"ctx_size", 4096},
+    {"merge_args", true},
     {"llamacpp_device", ""},
     {"llamacpp_backend", ""},  // Will be overridden dynamically
     {"llamacpp_args", ""},
@@ -43,6 +44,7 @@ static const json DEFAULTS = {
 // Runtime options (diffusion_fa, offload_to_cpu) go through --sdcpp-args.
 static const std::map<std::string, std::string> OPTION_TO_CLI_FLAG = {
     {"ctx_size", "--ctx-size"},
+    {"merge_args", "--merge-args"},
     {"llamacpp_backend", "--llamacpp"},
     {"llamacpp_device", "--llamacpp-device"},
     {"llamacpp_args", "--llamacpp-args"},
@@ -57,17 +59,17 @@ static const std::map<std::string, std::string> OPTION_TO_CLI_FLAG = {
 
 static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
     if (recipe == "llamacpp") {
-        return {"ctx_size", "llamacpp_device", "llamacpp_backend", "llamacpp_args"};
+        return {"ctx_size", "llamacpp_device", "llamacpp_backend", "llamacpp_args", "merge_args"};
     } else if (recipe == "whispercpp") {
-        return {"whispercpp_backend", "whispercpp_args"};
+        return {"whispercpp_backend", "whispercpp_args", "merge_args"};
     } else if (recipe == "flm") {
-        return {"ctx_size", "flm_args"};
+        return {"ctx_size", "flm_args", "merge_args"};
     } else if (recipe == "ryzenai-llm") {
         return {"ctx_size"};
     } else if (recipe == "sd-cpp") {
-        return {"sd-cpp_backend", "sdcpp_args", "steps", "cfg_scale", "width", "height", "sampling_method", "flow_shift"};
+        return {"sd-cpp_backend", "sdcpp_args", "steps", "cfg_scale", "width", "height", "sampling_method", "flow_shift", "merge_args"};
     } else if (recipe == "vllm") {
-        return {"ctx_size", "vllm_backend", "vllm_args"};
+        return {"ctx_size", "vllm_backend", "vllm_args", "merge_args"};
     } else {
         return {};
     }
@@ -140,7 +142,7 @@ RecipeOptions::RecipeOptions(const std::string& recipe, const json& options) {
 
 static std::string format_option_for_logging(const json& opt) {
     if (opt.is_null() || opt == "") return "(none)";
-    if (opt.is_boolean()) return opt.get<bool>() ? "1" : "0";
+    if (opt.is_boolean()) return opt.get<bool>() ? "true" : "false";
     if (opt.is_number_float()) return std::to_string((double) opt);
     if (opt.is_number_integer()) return std::to_string((int) opt);
     return opt;
@@ -165,60 +167,12 @@ std::string RecipeOptions::to_log_string(bool resolve_defaults) const {
     return log_string;
 }
 
-static std::string map_to_args_string(const std::map<std::string, std::vector<std::string>>& m) {
-    std::string result;
-    bool first = true;
-    for (const auto& [flag, values] : m) {
-        if (!first) result += " ";
-        first = false;
-        result += flag;
-        for (const auto& v : values) {
-            result += " " + v;
-        }
-    }
-    return result;
-}
-
-/// Given a flag like "--flag" or "--no-flag", return the negation key.
-/// "--no-<name>" ↔ "--<name>". Returns empty string if no negation exists.
-static std::string negate_flag(const std::string& flag) {
-    if (flag.size() >= 5 && flag.compare(0, 5, "--no-") == 0) {
-        return "--" + flag.substr(5);
-    }
-    if (flag.size() >= 3 && flag.compare(0, 2, "--") == 0) {
-        return "--no-" + flag.substr(2);
-    }
-    return "";
-}
-
-static std::map<std::string, std::vector<std::string>> merge_args_maps(
-    const std::map<std::string, std::vector<std::string>>& target,
-    const std::map<std::string, std::vector<std::string>>& incoming) {
-    std::map<std::string, std::vector<std::string>> merged = target;
-
-    // Remove binary-flag negations from incoming that conflict with target.
-    // Only flags without arguments are considered binary flags.
-    for (const auto& [flag, values] : incoming) {
-        if (values.empty()) {
-            std::string neg = negate_flag(flag);
-            if (!neg.empty() && merged.count(neg)) {
-                // Target has the opposite binary flag — skip this incoming flag
-                continue;
-            }
-        }
-        if (!merged.count(flag)) {
-            merged[flag] = values;
-        }
-    }
-    return merged;
-}
-
 RecipeOptions RecipeOptions::inherit(const RecipeOptions& options) const {
     json merged = options_;
+    bool merge_args = options_.contains("merge_args") ? options_["merge_args"].get<bool>() : options.get_option("merge_args").get<bool>();
 
     for (auto it = options.options_.begin(); it != options.options_.end(); ++it) {
-        if (it.key().size() >= 5 &&
-            it.key().substr(it.key().size() - 5) == "_args") {
+        if (merge_args && it.key().size() >= 5 && it.key().substr(it.key().size() - 5) == "_args") {
             // Special handling for _args options: parse, merge maps, re-stringify
             std::string target_str = "";
             if (merged.contains(it.key()) && merged[it.key()].is_string()) {
@@ -238,8 +192,8 @@ RecipeOptions RecipeOptions::inherit(const RecipeOptions& options) const {
                 auto target_map = lemon::utils::build_custom_args_map(target_tokens);
                 auto incoming_map = lemon::utils::build_custom_args_map(incoming_tokens);
 
-                auto merged_map = merge_args_maps(target_map, incoming_map);
-                merged[it.key()] = map_to_args_string(merged_map);
+                auto merged_map = lemon::utils::merge_args_maps(target_map, incoming_map);
+                merged[it.key()] = lemon::utils::map_to_args_string(merged_map);
             }
         } else if (!merged.contains(it.key()) && !is_empty_option(it.value())) {
             merged[it.key()] = it.value();
@@ -269,6 +223,7 @@ json RecipeOptions::get_option(const std::string& opt) const {
 // CLI_OPTIONS used only by the lemonade CLI client for add_cli_options
 static const json CLI_OPTIONS = {
     {"--ctx-size", {{"option_name", "ctx_size"}, {"type_name", "SIZE"}, {"envname", "LEMONADE_CTX_SIZE"}, {"help", "Context size for the model"}}},
+    {"--merge-args", {{"option_name", "merge_args"}, {"type_name", "BOOL"}, {"envname", "LEMONADE_MERGE_ARGS"}, {"help", "Merge global and model arguments when loading the model"}}},
     {"--llamacpp", {{"option_name", "llamacpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_LLAMACPP"}, {"help", "LlamaCpp backend to use"}}},
     {"--llamacpp-device", {{"option_name", "llamacpp_device"}, {"type_name", "DEVICES"}, {"envname", "LEMONADE_LLAMACPP_DEVICE"}, {"help", "Comma-separated list of accelerator devices to use (e.g. Vulkan0)"}}},
     {"--llamacpp-args", {{"option_name", "llamacpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_LLAMACPP_ARGS"}, {"help", "Custom arguments to pass to llama-server"}}},
@@ -295,6 +250,9 @@ void RecipeOptions::add_cli_options(CLI::App& app, json& storage) {
         } else if (defval.is_number_integer()) {
             o = app.add_option_function<int>(key, [opt_name, &storage = storage](int val) { storage[opt_name] = val; }, opt["help"]);
             o->default_val((int) defval);
+        } else if (defval.is_boolean()) {
+            o = app.add_flag_function(key + ",!" + lemon::utils::negate_flag(key), [opt_name, defval, &storage = storage](std::int64_t val) { storage[opt_name] = val == 0 ? defval.get<bool>() : val > 0; }, opt["help"]);
+            o->default_val((bool) defval);
         } else {
             o = app.add_option_function<std::string>(key, [opt_name, &storage = storage](const std::string& val) { storage[opt_name] = val; }, opt["help"]);
             o->default_val(defval);

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -1,7 +1,6 @@
 #include <lemon/recipe_options.h>
-#include <nlohmann/json.hpp>
 #include <lemon/utils/custom_args.h>
-#include <algorithm>
+#include <nlohmann/json.hpp>
 #include <map>
 #ifdef LEMONADE_CLI
 #include <CLI/CLI.hpp>
@@ -183,11 +182,10 @@ static std::string map_to_args_string(const std::map<std::string, std::vector<st
 /// Given a flag like "--flag" or "--no-flag", return the negation key.
 /// "--no-<name>" ↔ "--<name>". Returns empty string if no negation exists.
 static std::string negate_flag(const std::string& flag) {
-    if (flag.size() >= 5 && flag.substr(0, 5) == "--no-") {
+    if (flag.size() >= 5 && flag.compare(0, 5, "--no-") == 0) {
         return "--" + flag.substr(5);
     }
-    if (flag.size() >= 3 && flag.substr(0, 2) == "--" &&
-        flag.size() >= 5 && flag.substr(0, 5) != "--no-") {
+    if (flag.size() >= 3 && flag.compare(0, 2, "--") == 0) {
         return "--no-" + flag.substr(2);
     }
     return "";
@@ -229,14 +227,20 @@ RecipeOptions RecipeOptions::inherit(const RecipeOptions& options) const {
 
             std::string incoming_str = it.value().is_string() ? it.value() : "";
 
-            auto target_tokens = lemon::utils::parse_custom_args(target_str);
-            auto incoming_tokens = lemon::utils::parse_custom_args(incoming_str);
+            if (target_str.empty()) {
+                merged[it.key()] = incoming_str;
+            } else if (incoming_str.empty()) {
+                merged[it.key()] = target_str;
+            } else {
+                auto target_tokens = lemon::utils::parse_custom_args(target_str);
+                auto incoming_tokens = lemon::utils::parse_custom_args(incoming_str);
 
-            auto target_map = lemon::utils::build_custom_args_map(target_tokens);
-            auto incoming_map = lemon::utils::build_custom_args_map(incoming_tokens);
+                auto target_map = lemon::utils::build_custom_args_map(target_tokens);
+                auto incoming_map = lemon::utils::build_custom_args_map(incoming_tokens);
 
-            auto merged_map = merge_args_maps(target_map, incoming_map);
-            merged[it.key()] = map_to_args_string(merged_map);
+                auto merged_map = merge_args_maps(target_map, incoming_map);
+                merged[it.key()] = map_to_args_string(merged_map);
+            }
         } else if (!merged.contains(it.key()) && !is_empty_option(it.value())) {
             merged[it.key()] = it.value();
         }

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -1,12 +1,12 @@
 #include <lemon/recipe_options.h>
-#ifndef LEMONADE_CLI
-#include <lemon/system_info.h>
-#endif
 #include <nlohmann/json.hpp>
+#include <lemon/utils/custom_args.h>
 #include <algorithm>
 #include <map>
 #ifdef LEMONADE_CLI
 #include <CLI/CLI.hpp>
+#else
+#include <lemon/system_info.h>
 #endif
 
 namespace lemon {
@@ -166,11 +166,53 @@ std::string RecipeOptions::to_log_string(bool resolve_defaults) const {
     return log_string;
 }
 
+static std::string map_to_args_string(const std::map<std::string, std::vector<std::string>>& m) {
+    std::string result;
+    bool first = true;
+    for (const auto& [flag, values] : m) {
+        if (!first) result += " ";
+        first = false;
+        result += flag;
+        for (const auto& v : values) {
+            result += " " + v;
+        }
+    }
+    return result;
+}
+
+static std::map<std::string, std::vector<std::string>> merge_args_maps(
+    const std::map<std::string, std::vector<std::string>>& target,
+    const std::map<std::string, std::vector<std::string>>& incoming) {
+    std::map<std::string, std::vector<std::string>> merged = target;
+    for (const auto& [flag, values] : incoming) {
+        merged[flag] = values;  // incoming overrides target
+    }
+    return merged;
+}
+
 RecipeOptions RecipeOptions::inherit(const RecipeOptions& options) const {
     json merged = options_;
 
     for (auto it = options.options_.begin(); it != options.options_.end(); ++it) {
-        if (!merged.contains(it.key()) && !is_empty_option(it.value())) {
+        if (it.key().size() >= 5 &&
+            it.key().substr(it.key().size() - 5) == "_args") {
+            // Special handling for _args options: parse, merge maps, re-stringify
+            std::string target_str = "";
+            if (merged.contains(it.key()) && merged[it.key()].is_string()) {
+                target_str = merged[it.key()];
+            }
+
+            std::string incoming_str = it.value().is_string() ? it.value() : "";
+
+            auto target_tokens = lemon::utils::parse_custom_args(target_str);
+            auto incoming_tokens = lemon::utils::parse_custom_args(incoming_str);
+
+            auto target_map = lemon::utils::build_custom_args_map(target_tokens);
+            auto incoming_map = lemon::utils::build_custom_args_map(incoming_tokens);
+
+            auto merged_map = merge_args_maps(target_map, incoming_map);
+            merged[it.key()] = map_to_args_string(merged_map);
+        } else if (!merged.contains(it.key()) && !is_empty_option(it.value())) {
             merged[it.key()] = it.value();
         }
     }

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -180,12 +180,37 @@ static std::string map_to_args_string(const std::map<std::string, std::vector<st
     return result;
 }
 
+/// Given a flag like "--flag" or "--no-flag", return the negation key.
+/// "--no-<name>" ↔ "--<name>". Returns empty string if no negation exists.
+static std::string negate_flag(const std::string& flag) {
+    if (flag.size() >= 5 && flag.substr(0, 5) == "--no-") {
+        return "--" + flag.substr(5);
+    }
+    if (flag.size() >= 3 && flag.substr(0, 2) == "--" &&
+        flag.size() >= 5 && flag.substr(0, 5) != "--no-") {
+        return "--no-" + flag.substr(2);
+    }
+    return "";
+}
+
 static std::map<std::string, std::vector<std::string>> merge_args_maps(
     const std::map<std::string, std::vector<std::string>>& target,
     const std::map<std::string, std::vector<std::string>>& incoming) {
     std::map<std::string, std::vector<std::string>> merged = target;
+
+    // Remove binary-flag negations from incoming that conflict with target.
+    // Only flags without arguments are considered binary flags.
     for (const auto& [flag, values] : incoming) {
-        merged[flag] = values;  // incoming overrides target
+        if (values.empty()) {
+            std::string neg = negate_flag(flag);
+            if (!neg.empty() && merged.count(neg)) {
+                // Target has the opposite binary flag — skip this incoming flag
+                continue;
+            }
+        }
+        if (!merged.count(flag)) {
+            merged[flag] = values;
+        }
     }
     return merged;
 }


### PR DESCRIPTION
When dealing with *_args parameters in recipe options, the arguments from each "layer" are not replaced but merged. 

Binary flags are handled by following the common `--no-` pattern. Flags with multiple arguments are handled correctly. Aliases are not handled (i.e: if on one side you use the extend name and the other side uses the alias, both get into the final command line) because it would require keeping a list for each backend to handle them.

Example:

Global `llamacpp.args`: `"-b 1024 -ub 1024 --temp 1.0 --mmap"` 
Model `llamacpp_args`: `"--temp 0.6 --top-p 0.95 --top-k 40 --no-mmap"` 
Final params:  `"-b 1024 -ub 1024 --temp 0.6 --top-p 0.95 --top-k 40 --no-mmap"`
