### PR TITLE
Let vLLM choose model dtype automatically instead of forcing float16

### DIFF
--- a/src/cpp/server/backends/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm_server.cpp
@@ -149,10 +149,8 @@ void VLLMServer::load(const std::string& model_name,
     // Serve using the Lemonade model name so forwarded requests match
     args.push_back("--served-model-name");
     args.push_back(model_name);
-    // Default args for consumer GPU inference
+    // Keep eager execution for consumer GPU inference; leave dtype selection to vLLM.
     args.push_back("--enforce-eager");
-    args.push_back("--dtype");
-    args.push_back("float16");
     // Pass ctx_size through to vllm-server's --max-model-len. Trust the
     // user's value verbatim; the global default lives in defaults.json
     // (same as llamacpp). Larger values raise KV-cache memory and Triton


### PR DESCRIPTION
Lemonade previously passed --dtype float16 for every vLLM ROCm model. That forced BF16 checkpoints to be cast to FP16 even on GPUs and vLLM platforms that can load BF16 natively.

Remove the hard-coded dtype argument and leave dtype selection to vLLM's default behavior. vLLM resolves dtype from the Hugging Face model config when possible and falls back to a supported platform dtype when needed, while preserving FP16 for FP16 checkpoints. Lemonade still passes --enforce-eager and --max-model-len as before.

This is necessary as converting a bfloat16 model to float16 model when not needed, as is currently being done with the Qwen3.5 family of model for example, might degrade the quality of the model and its output because of the difference in fp representable range, as most models today are trained in bfloat16.

BF16 to FP16 conversion is lossy, so avoiding the forced conversion is the cleaner behavior when vLLM/GPU can load BF16 directly.

vLLM documentation:
https://docs.vllm.ai/en/latest/api/vllm/config/model/#__codelineno-0-1651
vLLM config exposes a `current_platform.supported_dtypes` and uses to determine whether a model should be converted.