### PR TITLE
Fixing opencode unreachable on Windows bug

### DIFF
--- a/src/cpp/cli/agent_launcher.cpp
+++ b/src/cpp/cli/agent_launcher.cpp
@@ -184,10 +184,11 @@ void configure_opencode_agent(const std::string& model,
                               AgentConfig& config) {
     const std::string resolved_api_key = api_key.empty() ? kDefaultAgentApiKey : api_key;
 
-    config.binary_name = "opencode";
 #ifdef _WIN32
-    config.binary_alternatives = {"opencode.cmd", "opencode.exe"};
+    config.binary_name = "opencode.cmd";
+    config.binary_alternatives = {"opencode.exe", "opencode"};
 #else
+    config.binary_name = "opencode";
     config.binary_alternatives = {};
 #endif
     config.fallback_paths = {


### PR DESCRIPTION
On Windows, `npm i -g opencode-ai` installs three files in `AppData/Roaming/npm`: opencode, opencode.cmd, and opencode.ps1. Since the default is the Unix opencode file, which is not supported on Windows, opencode.cmd is never tried, causing `lemonade launch opencode` to fail.
The fix is to make opencode.cmd the default on Windows.