### PR TITLE
fix: missing file size in custom models

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2357,6 +2357,7 @@ void ModelManager::download_registered_model(const ModelInfo& info, bool do_not_
     std::string canonical_model_name = resolve_model_name(info.model_name);
     if (is_user_model_name(canonical_model_name))
     {
+        std::lock_guard<std::mutex> lock(models_cache_mutex_);
         auto it = models_cache_.find(info.model_name);
         if (it != models_cache_.end())
         {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1771,6 +1771,26 @@ void ModelManager::update_model_in_cache(const std::string& model_name, bool dow
             LOG(INFO, "ModelManager") << "Updated '" << model_name
                       << "' downloaded=" << downloaded << std::endl;
         }
+        // Calculate size in GB
+        uintmax_t total_size = 0;
+        for (auto& [type, path] : it->second.resolved_paths) {
+            try {
+                total_size += fs::file_size(path);
+            } catch (...) {
+                // skip inaccessible entries
+            }
+        }
+        double file_size_gb = static_cast<double>(total_size) / (1024.0 * 1024.0 * 1024.0);
+        if (file_size_gb < 1.0)
+        {
+            it->second.size = std::round(file_size_gb * 1000) / 1000;
+        } else if (file_size_gb < 10.0)
+        {
+            it->second.size = std::round(file_size_gb * 100) / 100;
+        } else
+        {
+            it->second.size = std::round(file_size_gb * 10) / 10;
+        }
 
         // Recompute downloaded status for any collections that
         // depend on this model, so the collection reflects component changes
@@ -2333,6 +2353,22 @@ void ModelManager::download_registered_model(const ModelInfo& info, bool do_not_
 
     // Update cache after successful download
     update_model_in_cache(info.model_name, true);
+
+    std::string canonical_model_name = resolve_model_name(info.model_name);
+    if (is_user_model_name(canonical_model_name))
+    {
+        auto it = models_cache_.find(info.model_name);
+        if (it != models_cache_.end())
+        {
+            json updated_user_models = user_models_;
+            auto model = updated_user_models.find(strip_user_model_prefix(canonical_model_name));
+            if (model != updated_user_models.end()) {
+                (*model)["size"] = it->second.size;
+                user_models_ = updated_user_models;
+                save_user_models(updated_user_models);
+            }
+        }
+    }
 }
 
 void ModelManager::download_model(const std::string& model_name,


### PR DESCRIPTION
Fixes #1641. However I don't like how this works.

1.  The **server models** and the **user models** only report the main model file size. We don't calculate the .mmproj file size.

For example for a model like PaddleOCR it will report 893MB while it is double.

```
-rw-r--r-- 1 lemonade lemonade 893M May 13 23:08 PaddleOCR-VL-1.5.gguf
-rw-r--r-- 1 lemonade lemonade 841M May 13 23:09 PaddleOCR-VL-1.5-mmproj.gguf

```

2. It only works when we download new models. We might need a way to "repair" broken models like this.