### PR TITLE
Build web app by default on Windows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ cmake --build --preset default --target tauri-app    # Linux / macOS
 cmake --build --preset windows --target tauri-app    # Windows (VS 2022)
 cmake --build --preset vs18 --target tauri-app       # Windows (VS 2026)
 
-# 4. Web app (auto-built on non-Windows; manual on Windows)
+# 4. Web app (auto-built on all platforms)
 cmake --build --preset default --target web-app         # Linux / macOS
 cmake --build --preset windows --target web-app         # Windows
 
@@ -108,7 +108,7 @@ cd build && cpack -G RPM     # .rpm
 
 CMake presets: `default` (Ninja, Release), `windows` (VS 2022), `vs18` (VS 2026), `debug` (Ninja, Debug).
 
-CMake options: `BUILD_WEB_APP` (ON by default on non-Windows), `BUILD_TAURI_APP` (Linux only, include Tauri desktop app in deb), `LEMONADE_SYSTEMD_UNIT_NAME` (default: `lemond.service`).
+CMake options: `BUILD_WEB_APP` (ON by default on all platforms), `BUILD_TAURI_APP` (Linux only, include Tauri desktop app in deb), `LEMONADE_SYSTEMD_UNIT_NAME` (default: `lemond.service`).
 
 ## Testing
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -922,13 +922,8 @@ endif()
 # Web App Integration (Cross-Platform)
 # ============================================================
 
-# On Windows, disable automatic build by default (can be enabled with -DBUILD_WEB_APP=ON)
-# On other platforms, enable automatic build by default (can be disabled with -DBUILD_WEB_APP=OFF)
-if(WIN32)
-    option(BUILD_WEB_APP "Build the Web app automatically" OFF)
-else()
-    option(BUILD_WEB_APP "Build the Web app automatically" ON)
-endif()
+# Enable automatic web app build on all platforms (can be disabled with -DBUILD_WEB_APP=OFF)
+option(BUILD_WEB_APP "Build the Web app automatically" ON)
 
 # Check if webpack is available for system-package mode
 if(USE_SYSTEM_NODEJS_MODULES)


### PR DESCRIPTION
Enables automatic web app build on Windows by default, matching Linux and macOS. Saves a manual `--target web-app` step during Windows development; can still be disabled with `-DBUILD_WEB_APP=OFF`.

Not sure why it was like this before but it was annoying!