### PR TITLE
fix: rpm builds not working on fedora 43

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -278,7 +278,7 @@ jobs:
     name: Build Lemonade .rpm Package
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:43
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     steps:
@@ -899,7 +899,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-lemonade-rpm
     container:
-      image: fedora:latest
+      image: fedora:43
     env:
       LEMONADE_VERSION: ${{ needs.build-lemonade-rpm.outputs.version }}
     steps:

--- a/.github/workflows/linux_distro_builds.yml
+++ b/.github/workflows/linux_distro_builds.yml
@@ -32,7 +32,7 @@ jobs:
             image: debian:trixie
             python: python3
           - distro: Fedora
-            image: fedora:latest
+            image: fedora:43
             python: python3
           - distro: openSUSE
             image: opensuse/tumbleweed:latest

--- a/setup.sh
+++ b/setup.sh
@@ -169,7 +169,7 @@ if command_exists pkg-config; then
     print_success "pkg-config is installed"
 
     # Check for required libraries using pkg-config
-    libs_to_check=("libcurl" "openssl" "zlib" "libsystemd" "libdrm" "libcap" "libwebsockets")
+    libs_to_check=("libcurl" "openssl" "zlib" "libsystemd" "libdrm" "libcap")
     missing_libs=()
 
     for lib in "${libs_to_check[@]}"; do
@@ -219,7 +219,6 @@ if command_exists pkg-config; then
                         libsystemd) missing_packages+=("systemd-devel") ;;
                         libdrm) missing_packages+=("libdrm-devel") ;;
                         libcap) missing_packages+=("libcap-devel") ;;
-                        libwebsockets) missing_packages+=("libwebsockets-devel") ;;
                     esac
                 done
             elif command_exists dnf; then
@@ -232,7 +231,6 @@ if command_exists pkg-config; then
                         libsystemd) missing_packages+=("systemd-devel") ;;
                         libdrm) missing_packages+=("libdrm-devel") ;;
                         libcap) missing_packages+=("libcap-devel") ;;
-                        libwebsockets) missing_packages+=("libwebsockets-devel") ;;
                     esac
                 done
             elif command_exists zypper; then


### PR DESCRIPTION
**Fixes #1753**

## Issue
RPM builds not working on older Fedora release.

## Explanation
- Container images for Arch and Fedora are pinned to latest release.
- Fedora 44 was released a couple of weeks ago, due to which rpm built on the latest image broke compatibility for older releases.
- Fedora, unlike Arch isn't truly a rolling release so image built on a newer release wouldn't always work on older release

## Chages
Pinned image versions to 43 for compatibility.

## Additionally
If even older releases are to be supported the version could be bumped down further since fedora does maintain compatibility for a few releases.

