### PR TITLE
Canonical model IDs with friendly-name precedence

### DIFF
--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -29,6 +29,54 @@ Custom model configuration involves two files, both located in the Lemonade cach
 
 See [configuration.md](./README.md) for more information about finding the cache directory.
 
+## Model naming spec
+
+Lemonade tracks three sources of models. Every model has a **canonical ID** of the form `<source>.<bare-name>`:
+
+| Canonical ID    | Source                                                                   |
+|-----------------|--------------------------------------------------------------------------|
+| `user.NAME`     | Model registered via `lemonade pull` (entry in `user_models.json`)       |
+| `extra.NAME`    | Model imported by dropping a GGUF in `--extra-models-dir`                |
+| `builtin.NAME`  | Model compiled into Lemonade's built-in catalog (`server_models.json`)   |
+
+The **bare name** `NAME` is an alias that always resolves to whichever source wins precedence for that name. Precedence is **registered > imported > built-in**.
+
+### What the API emits
+
+`/v1/models`, `/v1/models/{id}`, `lemonade list`, and the Ollama `/api/tags` endpoint emit each model with an `id` set to either:
+
+- the **bare name** if the model is the precedence-winner for its bare name, or
+- the **canonical-prefixed ID** if another source outranks it on the same bare name.
+
+For each bare name with collisions, the response contains one bare row plus one canonical-prefixed row per shadowed source.
+
+### What input forms are accepted
+
+Anywhere a model name is accepted (request bodies, CLI args, URL path parameters), all four forms work:
+
+- the bare name `NAME` — resolves to the winner
+- `user.NAME` — always the registered model (404 if none)
+- `extra.NAME` — always the imported model (404 if none)
+- `builtin.NAME` — always the built-in model (404 if none)
+
+`lemonade pull` rejects model names starting with `extra.` or `builtin.` since those prefixes are reserved.
+
+### CLI vs. GUI display
+
+The CLI (`lemonade list`) prints the API `id` verbatim. That means the Name column is always copy-paste-safe — every cell is a valid input to `lemonade load`, `lemonade delete`, `lemonade run`, etc.
+
+The Tauri desktop app and the web app apply a display transformation on top of the API id: bare ids render as `NAME`, and canonical-prefixed ids render as `NAME (registered)` / `NAME (imported)` / `NAME (builtin)`. The suffix appears only for shadowed sources.
+
+### Five reference cases
+
+| Sources                                         | `/v1/models` ids                                      | Resolution                                                                 |
+|-------------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------------|
+| built-in `Qwen2.5-Coder` only                   | `Qwen2.5-Coder`                                        | `Qwen2.5-Coder`, `builtin.Qwen2.5-Coder` → built-in                          |
+| built-in `Foo` + registered `Foo`               | `Foo`, `builtin.Foo`                                   | `Foo`/`user.Foo` → user; `builtin.Foo` → built-in                            |
+| built-in `Bar` + registered `Bar` + extra `Bar` | `Bar`, `extra.Bar`, `builtin.Bar`                      | `Bar`/`user.Bar` → user; `extra.Bar` → extra; `builtin.Bar` → built-in       |
+| built-in `Baz` + extra `Baz`                    | `Baz`, `builtin.Baz`                                   | `Baz`/`extra.Baz` → extra; `builtin.Baz` → built-in                          |
+| registered `MyModel` only                       | `MyModel`                                              | `MyModel`/`user.MyModel` → user; `builtin.MyModel` → 404                     |
+
 ## `user_models.json` Reference
 
 This file contains a JSON object where each key is a model name and each value defines the model's properties. Create this file in your cache directory if it doesn't exist.
@@ -121,7 +169,7 @@ For `sd-cpp` recipe models, you can specify default image generation parameters:
 
 ## `recipe_options.json` Reference
 
-This file configures per-model runtime settings. Each key is a **full model name** (including prefix like `user.` or `extra.`) and each value contains the settings for that model.
+This file configures per-model runtime settings. Each key is a **canonical model ID** — one of `user.NAME`, `extra.NAME`, or `builtin.NAME` (see the [Model naming spec](#model-naming-spec) above). Each value contains the settings for that model.
 
 ### Template
 
@@ -131,9 +179,14 @@ This file configures per-model runtime settings. Each key is a **full model name
         "ctx_size": 4096,
         "llamacpp_backend": "vulkan",
         "llamacpp_args": ""
+    },
+    "builtin.Qwen2.5-Coder-1.5B-Instruct": {
+        "ctx_size": 16384
     }
 }
 ```
+
+> **Migration:** Older Lemonade versions stored built-in entries under their bare name (e.g. `"Qwen2.5-Coder-1.5B-Instruct"` with no prefix). On first load with the current version, any bare key matching a known built-in is rewritten to `builtin.<name>` in place. An INFO log line reports the number of migrated keys. Bare keys that don't match a built-in are preserved unchanged.
 
 > **Note:** Per-model options can also be configured through the Lemonade desktop app's model settings, or via the `save_options` parameter in the [`/api/v1/load` endpoint](../../api/lemonade.md#post-v1load).
 
@@ -161,6 +214,8 @@ This file configures per-model runtime settings. Each key is a **full model name
     }
 }
 ```
+
+(Use `builtin.NAME` here if you're overriding a built-in model's defaults, or `extra.NAME` for an `--extra-models-dir` GGUF.)
 
 Then load the model:
 ```bash

--- a/src/app/src/renderer/AddModelPanel.tsx
+++ b/src/app/src/renderer/AddModelPanel.tsx
@@ -159,16 +159,13 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
           <label className="form-label" title="A unique name to identify your model in the catalog">
             Model Name
           </label>
-          <div className="input-with-prefix">
-            <span className="input-prefix">user.</span>
-            <input
-              type="text"
-              className="form-input with-prefix"
-              placeholder="Gemma-3-12b-it-GGUF"
-              value={form.name}
-              onChange={(e) => handleChange('name', e.target.value)}
-            />
-          </div>
+          <input
+            type="text"
+            className="form-input"
+            placeholder="Gemma-3-12b-it-GGUF"
+            value={form.name}
+            onChange={(e) => handleChange('name', e.target.value)}
+          />
         </div>
 
         <div className="form-section">

--- a/src/app/src/renderer/ChatWindow.tsx
+++ b/src/app/src/renderer/ChatWindow.tsx
@@ -203,9 +203,10 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isVisible, width }) => {
   const handleAddModelInstall = (data: ModelInstallData) => {
     setShowAddModelForm(false);
     setAddModelInitialValues(undefined);
+    const modelName = data.name.startsWith('user.') ? data.name : `user.${data.name}`;
     window.dispatchEvent(new CustomEvent('installModel', {
       detail: {
-        name: `user.${data.name}`,
+        name: modelName,
         registrationData: {
           checkpoint: data.checkpoint,
           recipe: data.recipe,

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -238,12 +238,15 @@ const hasCanonicalPrefix = (modelName: string): boolean =>
   CANONICAL_PREFIXES.some(p => modelName.startsWith(p.prefix));
 
 const getFamilyMemberLabel = (modelName: string, family: ModelFamily, match: RegExpExecArray): string => {
-  if (!hasCanonicalPrefix(modelName)) return match[1];
+  const prefixInfo = CANONICAL_PREFIXES.find(p => modelName.startsWith(p.prefix));
+  if (!prefixInfo) return match[1];
 
   const bare = stripCanonicalPrefix(modelName);
-  return bare.startsWith(`${family.displayName}-`)
+  const inner = bare.startsWith(`${family.displayName}-`)
     ? bare.slice(family.displayName.length + 1)
     : bare;
+  // Keep the source suffix on collapsed family rows so shadowed sources stay distinguishable.
+  return inner + prefixInfo.suffix;
 };
 
 function buildModelList(

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -210,23 +210,40 @@ interface DetectedBackend {
   mmprojFiles?: string[];
 }
 
-const HIDDEN_MODEL_NAME_PREFIXES = ['user.', 'extra.'];
+// Canonical-id prefixes emitted by `/v1/models`. Each maps to a parenthetical
+// source suffix that the GUI appends when a model is shadowed by a
+// higher-precedence source sharing the same bare name. Winners are emitted by
+// the server with no prefix and render as the bare name.
+const CANONICAL_PREFIXES: { prefix: string; suffix: string }[] = [
+  { prefix: 'user.',    suffix: ' (registered)' },
+  { prefix: 'extra.',   suffix: ' (imported)' },
+  { prefix: 'builtin.', suffix: ' (builtin)' },
+];
 
-const getModelDisplayName = (modelName: string): string => {
-  const prefix = HIDDEN_MODEL_NAME_PREFIXES.find(p => modelName.startsWith(p));
-  return prefix ? modelName.slice(prefix.length) : modelName;
+// Strip the canonical prefix (if any) to get the bare model name. Used for
+// family-regex matching and family grouping.
+const stripCanonicalPrefix = (modelName: string): string => {
+  const match = CANONICAL_PREFIXES.find(p => modelName.startsWith(p.prefix));
+  return match ? modelName.slice(match.prefix.length) : modelName;
 };
 
-const isNamespaceHiddenModel = (modelName: string): boolean =>
-  HIDDEN_MODEL_NAME_PREFIXES.some(prefix => modelName.startsWith(prefix));
+// Render a model id as a human-readable display name. Bare ids (winners) render
+// as-is; canonical-prefixed ids (shadowed sources) render as "NAME (source)".
+const getModelDisplayName = (modelName: string): string => {
+  const match = CANONICAL_PREFIXES.find(p => modelName.startsWith(p.prefix));
+  return match ? modelName.slice(match.prefix.length) + match.suffix : modelName;
+};
+
+const hasCanonicalPrefix = (modelName: string): boolean =>
+  CANONICAL_PREFIXES.some(p => modelName.startsWith(p.prefix));
 
 const getFamilyMemberLabel = (modelName: string, family: ModelFamily, match: RegExpExecArray): string => {
-  if (!isNamespaceHiddenModel(modelName)) return match[1];
+  if (!hasCanonicalPrefix(modelName)) return match[1];
 
-  const displayName = getModelDisplayName(modelName);
-  return displayName.startsWith(`${family.displayName}-`)
-    ? displayName.slice(family.displayName.length + 1)
-    : displayName;
+  const bare = stripCanonicalPrefix(modelName);
+  return bare.startsWith(`${family.displayName}-`)
+    ? bare.slice(family.displayName.length + 1)
+    : bare;
 };
 
 function buildModelList(
@@ -241,7 +258,7 @@ function buildModelList(
     for (const m of models) {
       if (consumed.has(m.name)) continue;
       if (family.recipe && m.info.recipe !== family.recipe) continue;
-      const match = family.regex.exec(getModelDisplayName(m.name));
+      const match = family.regex.exec(stripCanonicalPrefix(m.name));
       if (match) {
         members.push({ label: getFamilyMemberLabel(m.name, family, match), name: m.name, info: m.info });
         consumed.add(m.name);

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -214,10 +214,10 @@ interface DetectedBackend {
 // source suffix that the GUI appends when a model is shadowed by a
 // higher-precedence source sharing the same bare name. Winners are emitted by
 // the server with no prefix and render as the bare name.
-const CANONICAL_PREFIXES: { prefix: string; suffix: string }[] = [
-  { prefix: 'user.',    suffix: ' (registered)' },
-  { prefix: 'extra.',   suffix: ' (imported)' },
-  { prefix: 'builtin.', suffix: ' (builtin)' },
+const CANONICAL_PREFIXES: { prefix: string; suffix: string; sourceRank: number }[] = [
+  { prefix: 'user.',    suffix: ' (registered)', sourceRank: 1 },
+  { prefix: 'extra.',   suffix: ' (imported)', sourceRank: 2 },
+  { prefix: 'builtin.', suffix: ' (builtin)', sourceRank: 3 },
 ];
 
 // Strip the canonical prefix (if any) to get the bare model name. Used for
@@ -237,16 +237,25 @@ const getModelDisplayName = (modelName: string): string => {
 const hasCanonicalPrefix = (modelName: string): boolean =>
   CANONICAL_PREFIXES.some(p => modelName.startsWith(p.prefix));
 
-const getFamilyMemberLabel = (modelName: string, family: ModelFamily, match: RegExpExecArray): string => {
-  const prefixInfo = CANONICAL_PREFIXES.find(p => modelName.startsWith(p.prefix));
-  if (!prefixInfo) return match[1];
+const getSourceSortRank = (modelName: string): number => {
+  const match = CANONICAL_PREFIXES.find(p => modelName.startsWith(p.prefix));
+  return match?.sourceRank ?? 0;
+};
 
+const stripSourceSuffix = (label: string): string => {
+  const match = CANONICAL_PREFIXES.find(p => label.endsWith(p.suffix));
+  return match ? label.slice(0, -match.suffix.length) : label;
+};
+
+const getFamilyMemberLabel = (modelName: string, family: ModelFamily): string => {
+  const prefixInfo = CANONICAL_PREFIXES.find(p => modelName.startsWith(p.prefix));
   const bare = stripCanonicalPrefix(modelName);
-  const inner = bare.startsWith(`${family.displayName}-`)
-    ? bare.slice(family.displayName.length + 1)
+  const relativeName = bare.startsWith(family.displayName)
+    ? bare.slice(family.displayName.length).replace(/^[-_.]/, '')
     : bare;
+  const label = relativeName.endsWith('-GGUF') ? relativeName.slice(0, -'-GGUF'.length) : relativeName;
   // Keep the source suffix on collapsed family rows so shadowed sources stay distinguishable.
-  return inner + prefixInfo.suffix;
+  return label + (prefixInfo?.suffix ?? '');
 };
 
 function buildModelList(
@@ -263,15 +272,24 @@ function buildModelList(
       if (family.recipe && m.info.recipe !== family.recipe) continue;
       const match = family.regex.exec(stripCanonicalPrefix(m.name));
       if (match) {
-        members.push({ label: getFamilyMemberLabel(m.name, family, match), name: m.name, info: m.info });
+        members.push({ label: getFamilyMemberLabel(m.name, family), name: m.name, info: m.info });
         consumed.add(m.name);
       }
     }
     if (members.length > 1) {
       members.sort((a, b) => {
-        const sizeA = parseFloat(a.label);
-        const sizeB = parseFloat(b.label);
-        if (Number.isFinite(sizeA) && Number.isFinite(sizeB)) return sizeA - sizeB;
+        const baseLabelA = stripSourceSuffix(a.label);
+        const baseLabelB = stripSourceSuffix(b.label);
+        const sizeA = parseFloat(baseLabelA);
+        const sizeB = parseFloat(baseLabelB);
+        if (Number.isFinite(sizeA) && Number.isFinite(sizeB) && sizeA !== sizeB) return sizeA - sizeB;
+
+        const baseCompare = baseLabelA.localeCompare(baseLabelB, undefined, { numeric: true });
+        if (baseCompare !== 0) return baseCompare;
+
+        const sourceCompare = getSourceSortRank(a.name) - getSourceSortRank(b.name);
+        if (sourceCompare !== 0) return sourceCompare;
+
         return a.label.localeCompare(b.label, undefined, { numeric: true });
       });
       familyItems.push({ type: 'family', family, members });

--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -119,10 +119,8 @@ bool prompt_variant(const std::vector<std::string>& labels,
 
 bool prompt_model_name(const std::string& default_name, std::string& out) {
     std::cout << "Choose a model name." << std::endl;
-    std::cout << "Press enter to use the default: user." << default_name << std::endl;
-    std::cout << "Or type a name starting with \"user.\" and press enter." << std::endl;
-    std::cout << "(In `lemonade list` the name will appear without the \"user.\" prefix" << std::endl;
-    std::cout << " unless it collides with a built-in or imported model.)" << std::endl;
+    std::cout << "Press enter to use the default: " << default_name << std::endl;
+    std::cout << "Or type a custom name and press enter." << std::endl;
     std::cout << "> " << std::flush;
 
     std::string input;
@@ -277,8 +275,8 @@ int hf_pull_flow(lemonade::LemonadeClient& client,
         pull_body["recipe"] = recipe;
 
         std::cout << "Pulling " << checkpoint
-                  << " as " << pull_body["model_name"].get<std::string>() << std::endl;
-        return client.pull_model(pull_body);
+                  << " as " << suggested_name << std::endl;
+        return client.pull_model(pull_body, suggested_name);
     }
 
     // Resolve variant by case-insensitive name match.
@@ -339,9 +337,9 @@ int hf_pull_flow(lemonade::LemonadeClient& client,
     }
 
     std::cout << "Pulling " << pull_body["checkpoint"].get<std::string>()
-              << " as " << pull_body["model_name"].get<std::string>() << std::endl;
+              << " as " << model_name << std::endl;
 
-    return client.pull_model(pull_body);
+    return client.pull_model(pull_body, model_name);
 }
 
 }  // namespace lemon_cli

--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -120,7 +120,9 @@ bool prompt_variant(const std::vector<std::string>& labels,
 bool prompt_model_name(const std::string& default_name, std::string& out) {
     std::cout << "Choose a model name." << std::endl;
     std::cout << "Press enter to use the default: user." << default_name << std::endl;
-    std::cout << "Or type a name starting with \"user.\" and press enter:" << std::endl;
+    std::cout << "Or type a name starting with \"user.\" and press enter." << std::endl;
+    std::cout << "(In `lemonade list` the name will appear without the \"user.\" prefix" << std::endl;
+    std::cout << " unless it collides with a built-in or imported model.)" << std::endl;
     std::cout << "> " << std::flush;
 
     std::string input;

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -49,6 +49,27 @@ static std::regex build_name_filter_regex(const std::string& name_filter) {
     return std::regex(regex_pattern, std::regex_constants::ECMAScript | std::regex_constants::icase);
 }
 
+static bool starts_with(const std::string& value, const std::string& prefix) {
+    return value.rfind(prefix, 0) == 0;
+}
+
+static std::string strip_canonical_prefix(const std::string& model_name) {
+    static const std::vector<std::string> prefixes = {"user.", "extra.", "builtin."};
+    for (const auto& prefix : prefixes) {
+        if (starts_with(model_name, prefix)) {
+            return model_name.substr(prefix.size());
+        }
+    }
+    return model_name;
+}
+
+static int model_source_sort_rank(const std::string& model_name) {
+    if (starts_with(model_name, "user.")) return 1;
+    if (starts_with(model_name, "extra.")) return 2;
+    if (starts_with(model_name, "builtin.")) return 3;
+    return 0;
+}
+
 HttpError::HttpError(int status, std::string body, const std::string& message)
     : std::runtime_error(message), status_code_(status), response_body_(std::move(body)) {}
 
@@ -341,9 +362,25 @@ int LemonadeClient::list_models(bool show_all, const std::string& name_filter) c
             const std::regex filter_regex = build_name_filter_regex(name_filter);
             models.erase(
                 std::remove_if(models.begin(), models.end(),
-                    [&](const ModelInfo& m) { return !std::regex_search(m.id, filter_regex); }),
+                    [&](const ModelInfo& m) {
+                        return !std::regex_search(m.id, filter_regex) &&
+                               !std::regex_search(strip_canonical_prefix(m.id), filter_regex);
+                    }),
                 models.end());
         }
+
+        std::sort(models.begin(), models.end(),
+            [](const ModelInfo& a, const ModelInfo& b) {
+                const std::string bare_a = strip_canonical_prefix(a.id);
+                const std::string bare_b = strip_canonical_prefix(b.id);
+                const int bare_compare = bare_a.compare(bare_b);
+                if (bare_compare != 0) return bare_compare < 0;
+
+                const int source_compare = model_source_sort_rank(a.id) - model_source_sort_rank(b.id);
+                if (source_compare != 0) return source_compare < 0;
+
+                return a.id < b.id;
+            });
 
         if (models.empty()) {
             std::cout << "No models available" << std::endl;
@@ -494,7 +531,7 @@ static bool parse_sse_progress(const std::string& event_data, StreamingRequestSt
     }
 }
 
-int LemonadeClient::pull_model(const json& model_data) {
+int LemonadeClient::pull_model(const json& model_data, const std::string& display_name) {
     try {
         // Validate that model field exists in model_data
         if (!model_data.contains("model_name") || !model_data["model_name"].is_string()) {
@@ -503,7 +540,8 @@ int LemonadeClient::pull_model(const json& model_data) {
         }
 
         std::string model_name = model_data["model_name"].get<std::string>();
-        std::cout << "Pulling model: " << model_name << std::endl;
+        std::string output_name = display_name.empty() ? model_name : display_name;
+        std::cout << "Pulling model: " << output_name << std::endl;
 
         json request_body = model_data;
         request_body["stream"] = true;
@@ -551,7 +589,7 @@ int LemonadeClient::pull_model(const json& model_data) {
             throw std::runtime_error("Model pull failed");
         }
 
-        std::cout << "Model pulled successfully: " << model_name << std::endl;
+        std::cout << "Model pulled successfully: " << output_name << std::endl;
         return 0;
     } catch (const HttpError& e) {
         std::cerr << "Error pulling model: " << extract_server_error_message(e) << std::endl;

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -355,6 +355,12 @@ int LemonadeClient::list_models(bool show_all, const std::string& name_filter) c
                   << "Details" << std::endl;
         std::cout << std::string(100, '-') << std::endl;
 
+        // Model Name is the API id emitted verbatim by `/v1/models`. For each
+        // bare name, the precedence-winning source (registered > imported >
+        // builtin) shows as the bare name; any shadowed sources show as their
+        // canonical id (user.NAME / extra.NAME / builtin.NAME). Either form is
+        // valid input to `lemonade load`, `lemonade delete`, etc., so the
+        // column is always copy-paste-safe.
         for (const auto& model : models) {
             std::string downloaded = model.downloaded ? "Yes" : "No";
             std::string details = model.recipe.empty() ? "-" : model.recipe;

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -41,7 +41,6 @@
 #include "lemon/utils/aixlog.hpp"
 
 static const std::vector<std::string> VALID_LABELS = {
-    "appear-builtin",
     "coding",
     "embeddings",
     "hot",

--- a/src/cpp/cli/recipe_import.cpp
+++ b/src/cpp/cli/recipe_import.cpp
@@ -169,16 +169,17 @@ bool validate_and_transform_model_json(nlohmann::json& model_data) {
     }
 
     std::string model_name = model_data["model_name"].get<std::string>();
-    if (auto canon = lemon::parse_canonical_id(model_name)) {
-        if (lemon::is_reserved_for_registration(canon->source)) {
-            std::cerr << "Error: Model names with 'extra.' / 'builtin.' prefixes are reserved. "
-                      << "Use 'user.<name>' for import." << std::endl;
-            return false;
-        }
-        // Already user.* — leave as-is.
-    } else {
+    if (lemon::is_reserved_registration_name(model_name)) {
+        std::cerr << "Error: Model names with 'extra.' / 'builtin.' prefixes are reserved, "
+                  << "including as bare-name parts of a 'user.' alias. "
+                  << "Use 'user.<name>' for import where <name> does not begin "
+                  << "with 'extra.' or 'builtin.'." << std::endl;
+        return false;
+    }
+    if (!lemon::parse_canonical_id(model_name)) {
         model_data["model_name"] = "user." + model_name;
     }
+    // Already user.* — leave as-is.
 
     if (!model_data.contains("recipe") || !model_data["recipe"].is_string()) {
         std::cerr << "Error: JSON file must contain a 'recipe' string field" << std::endl;

--- a/src/cpp/cli/recipe_import.cpp
+++ b/src/cpp/cli/recipe_import.cpp
@@ -1,5 +1,6 @@
 #include "lemon_cli/recipe_import.h"
 
+#include "lemon/model_manager.h"
 #include "lemon/utils/http_client.h"
 
 #include <algorithm>
@@ -168,7 +169,14 @@ bool validate_and_transform_model_json(nlohmann::json& model_data) {
     }
 
     std::string model_name = model_data["model_name"].get<std::string>();
-    if (model_name.substr(0, 5) != "user.") {
+    if (auto canon = lemon::parse_canonical_id(model_name)) {
+        if (lemon::is_reserved_for_registration(canon->source)) {
+            std::cerr << "Error: Model names with 'extra.' / 'builtin.' prefixes are reserved. "
+                      << "Use 'user.<name>' for import." << std::endl;
+            return false;
+        }
+        // Already user.* — leave as-is.
+    } else {
         model_data["model_name"] = "user." + model_name;
     }
 

--- a/src/cpp/include/lemon/canonical_id.h
+++ b/src/cpp/include/lemon/canonical_id.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace lemon {
+
+// ----------------------------------------------------------------------------
+// Canonical model IDs
+// ----------------------------------------------------------------------------
+//
+// Every model has a canonical ID of the form `<source>.<bare-name>`:
+//   user.NAME    — model registered via `lemonade pull` (entry in user_models.json)
+//   extra.NAME   — model discovered in --extra-models-dir
+//   builtin.NAME — model compiled into server_models.json
+//
+// `/v1/models` and Ollama `/api/tags` emit the bare name when a model is the
+// precedence-winner for its bare name (precedence: Registered > Imported >
+// Builtin), or the canonical-prefixed ID when shadowed. Bare names are accepted
+// as input anywhere a model name is accepted and resolve to the winner.
+//
+// Display strings like "NAME (registered)" / "NAME (imported)" / "NAME (builtin)"
+// are a GUI concern only. The C++ server emits canonical IDs only; the Tauri
+// renderer applies the (registered)/(imported)/(builtin) suffix transform.
+
+enum class ModelSource { Registered, Imported, Builtin };
+
+struct CanonicalId {
+    ModelSource source;
+    std::string bare_name;
+    std::string full() const;
+};
+
+inline const char* canonical_prefix(ModelSource source) {
+    switch (source) {
+        case ModelSource::Registered: return "user.";
+        case ModelSource::Imported:   return "extra.";
+        case ModelSource::Builtin:    return "builtin.";
+    }
+    return "";
+}
+
+inline std::string canonical_id(ModelSource source, const std::string& bare_name) {
+    return std::string(canonical_prefix(source)) + bare_name;
+}
+
+inline std::string CanonicalId::full() const {
+    return canonical_id(source, bare_name);
+}
+
+inline std::optional<CanonicalId> parse_canonical_id(const std::string& id) {
+    static constexpr const char USER_PREFIX[] = "user.";
+    static constexpr const char EXTRA_PREFIX[] = "extra.";
+    static constexpr const char BUILTIN_PREFIX[] = "builtin.";
+    if (id.rfind(USER_PREFIX, 0) == 0) {
+        return CanonicalId{ModelSource::Registered, id.substr(sizeof(USER_PREFIX) - 1)};
+    }
+    if (id.rfind(EXTRA_PREFIX, 0) == 0) {
+        return CanonicalId{ModelSource::Imported, id.substr(sizeof(EXTRA_PREFIX) - 1)};
+    }
+    if (id.rfind(BUILTIN_PREFIX, 0) == 0) {
+        return CanonicalId{ModelSource::Builtin, id.substr(sizeof(BUILTIN_PREFIX) - 1)};
+    }
+    return std::nullopt;
+}
+
+inline int precedence_rank(ModelSource source) {
+    switch (source) {
+        case ModelSource::Registered: return 0;
+        case ModelSource::Imported:   return 1;
+        case ModelSource::Builtin:    return 2;
+    }
+    return 99;
+}
+
+// Only Registered (user.*) is creatable via the pull/import flows. Imported
+// (extra.*) is discovered from disk and Builtin (builtin.*) ships in the
+// binary, so both prefixes are reserved when accepting new-model registrations.
+inline bool is_reserved_for_registration(ModelSource source) {
+    return source == ModelSource::Imported || source == ModelSource::Builtin;
+}
+
+} // namespace lemon

--- a/src/cpp/include/lemon/canonical_id.h
+++ b/src/cpp/include/lemon/canonical_id.h
@@ -80,4 +80,26 @@ inline bool is_reserved_for_registration(ModelSource source) {
     return source == ModelSource::Imported || source == ModelSource::Builtin;
 }
 
+// Reject a registration name when its source token is reserved, OR when it's a
+// user.* alias whose bare-name part itself begins with a reserved source token
+// (e.g. user.builtin.Foo, user.extra.Foo). The latter would otherwise hijack
+// the builtin.<bare> / extra.<bare> alias slot in the public-alias map and
+// break the spec's "builtin.X always means built-in X" contract.
+inline bool is_reserved_registration_name(const std::string& model_name) {
+    auto canon = parse_canonical_id(model_name);
+    if (!canon) {
+        return false;
+    }
+    if (is_reserved_for_registration(canon->source)) {
+        return true;
+    }
+    if (canon->source == ModelSource::Registered) {
+        if (auto inner = parse_canonical_id(canon->bare_name);
+            inner && is_reserved_for_registration(inner->source)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 } // namespace lemon

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <functional>
 #include <nlohmann/json.hpp>
+#include "canonical_id.h"
 #include "model_types.h"
 #include "recipe_options.h"
 

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -77,7 +77,7 @@ public:
 
     // Model management commands
     int list_models(bool show_all, const std::string& name_filter = "") const;
-    int pull_model(const nlohmann::json& model_data);
+    int pull_model(const nlohmann::json& model_data, const std::string& display_name = "");
     int delete_model(const std::string& model_name) const;
     int load_model(const std::string& model_name, const nlohmann::json& recipe_options, bool save_options = false) const;
     int unload_model(const std::string& model_name) const;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -83,10 +83,19 @@ static bool contains_ignore_case(const std::string& str, const std::string& subs
 
 static constexpr const char USER_MODEL_PREFIX[] = "user.";
 static constexpr size_t USER_MODEL_PREFIX_LEN = sizeof(USER_MODEL_PREFIX) - 1;
-static constexpr const char* APPEAR_BUILTIN_LABEL = "appear-builtin";
 
 static bool has_label(const ModelInfo& info, const std::string& label) {
     return std::find(info.labels.begin(), info.labels.end(), label) != info.labels.end();
+}
+
+// Built-ins are keyed bare in models_cache_; user.* and extra.* keys already
+// include their canonical prefix. This helper returns the canonical ID for any
+// cache key, which is the form used by recipe_options.json on disk.
+static std::string cache_key_to_canonical_id(const std::string& cache_key) {
+    if (parse_canonical_id(cache_key)) {
+        return cache_key;
+    }
+    return canonical_id(ModelSource::Builtin, cache_key);
 }
 
 template <typename T>
@@ -412,9 +421,12 @@ static void parse_image_defaults(ModelInfo& info, const json& model_json) {
 // Build merged recipe options: image_defaults -> JSON recipe_options -> user-saved overrides.
 // json_recipe_options: pre-extracted recipe_options for this model (from build_cache's
 // two-phase pattern). Pass a null json if the model JSON should be read directly instead.
+// saved_recipe_options_key: canonical ID (user.* / extra.* / builtin.*) under which the
+// user's saved options are keyed in recipe_options.json. Translate from the cache key with
+// cache_key_to_canonical_id() before calling.
 static RecipeOptions build_recipe_options(const ModelInfo& info,
                                           const json& json_recipe_options,
-                                          const std::string& model_name,
+                                          const std::string& saved_recipe_options_key,
                                           const json& saved_recipe_options) {
     json base_options = json::object();
 
@@ -438,8 +450,8 @@ static RecipeOptions build_recipe_options(const ModelInfo& info,
     }
 
     // Layer 3: User-saved recipe options override everything
-    if (JsonUtils::has_key(saved_recipe_options, model_name)) {
-        auto saved = saved_recipe_options[model_name];
+    if (JsonUtils::has_key(saved_recipe_options, saved_recipe_options_key)) {
+        auto saved = saved_recipe_options[saved_recipe_options_key];
         for (auto& [key, value] : saved.items()) {
             base_options[key] = value;
         }
@@ -707,6 +719,39 @@ ModelManager::ModelManager(const std::string& extra_models_dir)
     server_models_ = load_server_models();
     user_models_ = load_optional_json(get_user_models_file());
     recipe_options_ = load_optional_json(get_recipe_options_file());
+
+    // One-shot migration of recipe_options.json: older Lemonade keyed built-in
+    // entries by bare name; the current spec requires a canonical "builtin."
+    // prefix so each source is addressable distinctly even on shadowing.
+    {
+        int migrated = 0;
+        json migrated_options = json::object();
+        for (auto it = recipe_options_.begin(); it != recipe_options_.end(); ++it) {
+            const std::string& key = it.key();
+            if (parse_canonical_id(key)) {
+                migrated_options[key] = it.value();
+            } else if (server_models_.contains(key)) {
+                migrated_options[canonical_id(ModelSource::Builtin, key)] = it.value();
+                ++migrated;
+            } else {
+                // Preserve unknown bare keys (likely stale built-ins) — avoids silent data loss.
+                migrated_options[key] = it.value();
+            }
+        }
+        if (migrated > 0) {
+            recipe_options_ = std::move(migrated_options);
+            try {
+                fs::path dir = fs::path(get_recipe_options_file()).parent_path();
+                fs::create_directories(dir);
+                JsonUtils::save_to_file(recipe_options_, get_recipe_options_file());
+                LOG(INFO, "ModelManager") << "migrated " << migrated
+                          << " legacy recipe_options keys to builtin. prefix" << std::endl;
+            } catch (const std::exception& e) {
+                LOG(WARNING, "ModelManager") << "Could not persist migrated recipe_options.json: "
+                                              << e.what() << std::endl;
+            }
+        }
+    }
 
     if (!extra_models_dir_.empty()) {
         LOG(INFO, "ModelManager") << "Extra models directory set to: " << extra_models_dir_ << std::endl;
@@ -1174,8 +1219,9 @@ void ModelManager::save_user_models(const json& user_models) {
 
 void ModelManager::save_model_options(const ModelInfo& info) {
     LOG(INFO, "ModelManager") << "Saving options for model: " << info.model_name << std::endl;
-    // Persist changes
-    recipe_options_[info.model_name] = info.recipe_options.to_json();
+    // Persist under canonical ID (built-ins are keyed bare in cache but
+    // recipe_options.json stores them as builtin.<name>).
+    recipe_options_[cache_key_to_canonical_id(info.model_name)] = info.recipe_options.to_json();
     update_model_options_in_cache(info);
     save_user_json(get_recipe_options_file(), recipe_options_);
 }
@@ -1334,14 +1380,15 @@ void ModelManager::build_cache() {
     }
 
     // Step 1.5: Discover models from extra_models_dir
-    // All discovered models are prefixed with "extra." to avoid conflicts
-    // We still gracefully handle conflicts just in case, though
+    // All discovered models are prefixed with "extra." so they have distinct
+    // canonical IDs from any user. or builtin. records that may share a bare
+    // name. Bare-name collisions are surfaced via the friendly-name layer in
+    // rebuild_public_model_aliases_locked, not by dropping records here.
     auto discovered_models = discover_extra_models();
     for (const auto& [name, info] : discovered_models) {
-        // Check for conflicts with registered models
         if (all_models.find(name) != all_models.end()) {
             LOG(INFO, "ModelManager") << "Warning: Discovered model '" << name
-                      << "' conflicts with registered model, skipping." << std::endl;
+                      << "' conflicts with another extra.* registration; skipping." << std::endl;
             continue;
         }
         all_models[name] = info;
@@ -1359,10 +1406,12 @@ void ModelManager::build_cache() {
         }
     }
 
-    // Populate recipe options
+    // Populate recipe options. recipe_options.json is keyed by canonical ID
+    // (user.*, extra.*, builtin.*) — built-ins are keyed bare in the cache, so
+    // we translate before lookup.
     for (auto& [name, info] : all_models) {
         json jro = json_recipe_options.count(name) ? json_recipe_options[name] : json(nullptr);
-        info.recipe_options = build_recipe_options(info, jro, name, recipe_options_);
+        info.recipe_options = build_recipe_options(info, jro, cache_key_to_canonical_id(name), recipe_options_);
     }
 
     // Step 2: Filter by backend availability
@@ -1485,7 +1534,7 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
     parse_image_defaults(info, *model_json);
     json jro = (model_json->contains("recipe_options") && (*model_json)["recipe_options"].is_object())
         ? (*model_json)["recipe_options"] : json(nullptr);
-    info.recipe_options = build_recipe_options(info, jro, model_name, recipe_options_);
+    info.recipe_options = build_recipe_options(info, jro, cache_key_to_canonical_id(model_name), recipe_options_);
 
     info.suggested = JsonUtils::get_or_default<bool>(*model_json, "suggested", is_user_model);
     info.hf_load = JsonUtils::get_or_default<bool>(*model_json, "hf_load", false);
@@ -3465,52 +3514,80 @@ bool ModelManager::model_exists(const std::string& model_name) {
 }
 
 bool ModelManager::model_exists_unfiltered(const std::string& model_name) {
+    // Direct match in server_models_ (built-ins are keyed bare).
     if (server_models_.contains(model_name)) {
         return true;
     }
-    if (is_user_model_name(model_name)) {
-        return user_models_.contains(strip_user_model_prefix(model_name));
+    if (auto canon = parse_canonical_id(model_name)) {
+        switch (canon->source) {
+            case ModelSource::Registered:
+                return user_models_.contains(canon->bare_name);
+            case ModelSource::Builtin:
+                return server_models_.contains(canon->bare_name);
+            case ModelSource::Imported:
+                // extra.* models are filesystem-discovered; not in either JSON registry.
+                return false;
+        }
     }
 
     std::string canonical_name = resolve_model_name(model_name);
-    if (is_user_model_name(canonical_name)) {
-        return user_models_.contains(strip_user_model_prefix(canonical_name));
+    if (auto canon = parse_canonical_id(canonical_name)) {
+        switch (canon->source) {
+            case ModelSource::Registered:
+                return user_models_.contains(canon->bare_name);
+            case ModelSource::Builtin:
+                return server_models_.contains(canon->bare_name);
+            case ModelSource::Imported:
+                return false;
+        }
     }
-
-    // Check raw server_models_ JSON (before filtering)
-    return false;
+    return server_models_.contains(canonical_name);
 }
 
 ModelInfo ModelManager::get_model_info_unfiltered(const std::string& model_name) {
     ModelInfo info;
     std::string registry_name = model_name;
+    bool is_user_lookup = false;
 
-    if (!server_models_.contains(registry_name)) {
-        if (is_user_model_name(registry_name)) {
-            registry_name = strip_user_model_prefix(registry_name);
-        } else {
-            std::string canonical_name = resolve_model_name(model_name);
-            if (is_user_model_name(canonical_name)) {
-                registry_name = strip_user_model_prefix(canonical_name);
+    auto try_resolve = [&](const std::string& name) -> bool {
+        if (server_models_.contains(name)) {
+            registry_name = name;
+            is_user_lookup = false;
+            return true;
+        }
+        if (auto canon = parse_canonical_id(name)) {
+            if (canon->source == ModelSource::Builtin && server_models_.contains(canon->bare_name)) {
+                registry_name = canon->bare_name;
+                is_user_lookup = false;
+                return true;
+            }
+            if (canon->source == ModelSource::Registered && user_models_.contains(canon->bare_name)) {
+                registry_name = canon->bare_name;
+                is_user_lookup = true;
+                return true;
             }
         }
+        return false;
+    };
+
+    if (!try_resolve(model_name)) {
+        try_resolve(resolve_model_name(model_name));
     }
 
-    // Check server models first
     json* model_json = nullptr;
-    if (server_models_.contains(registry_name)) {
-        model_json = &server_models_[registry_name];
-    } else if (user_models_.contains(registry_name)) {
+    if (is_user_lookup && user_models_.contains(registry_name)) {
         model_json = &user_models_[registry_name];
+    } else if (!is_user_lookup && server_models_.contains(registry_name)) {
+        model_json = &server_models_[registry_name];
     }
 
     if (!model_json) {
         throw std::runtime_error("Model not found in registry: " + model_name);
     }
 
-    // Parse model info from JSON
-    info.model_name = is_user_model_name(model_name) ? model_name
-        : (user_models_.contains(registry_name) ? std::string(USER_MODEL_PREFIX) + registry_name : registry_name);
+    info.model_name = is_user_lookup
+        ? canonical_id(ModelSource::Registered, registry_name)
+        : registry_name;
     info.checkpoints["main"] = JsonUtils::get_or_default<std::string>(*model_json, "checkpoint", "");
     parse_legacy_mmproj(info, *model_json);
     load_checkpoints(info, *model_json);
@@ -3559,31 +3636,70 @@ std::string ModelManager::get_model_filter_reason(const std::string& model_name)
 }
 
 // Must be called with models_cache_mutex_ held.
+//
+// Populates two maps that drive the friendly-name / canonical-ID system:
+//
+//   public_model_aliases_ — input alias → cache key (canonical name in cache):
+//     - <bare> → cache key of the precedence-winner for that bare name
+//     - builtin.<X> → bare cache key X (built-ins are keyed bare in the cache)
+//     - user.<X>, extra.<X> resolve directly via cache lookup fallback in the
+//       callers, so no identity entries are required here
+//
+//   canonical_public_names_ — cache key → wire-format ID emitted by the API:
+//     - winner cache keys → bare name
+//     - shadowed cache keys → canonical-prefixed ID (user.X / extra.X / builtin.X)
+//
+// Precedence: Registered > Imported > Builtin.
 void ModelManager::rebuild_public_model_aliases_locked() {
     public_model_aliases_.clear();
     canonical_public_names_.clear();
 
-    for (const auto& [name, info] : models_cache_) {
-        if (!is_user_model_name(name) || !has_label(info, APPEAR_BUILTIN_LABEL)) {
-            continue;
-        }
+    struct Entry {
+        std::string cache_key;
+        ModelSource source;
+    };
+    std::map<std::string, std::vector<Entry>> by_bare;
 
-        std::string bare_name = strip_user_model_prefix(name);
-        if (server_models_.contains(bare_name) || models_cache_.find(bare_name) != models_cache_.end()) {
-            LOG(INFO, "ModelManager") << "Skipping public alias '" << bare_name
-                      << "' for '" << name << "' because it collides with an existing model" << std::endl;
-            continue;
+    for (const auto& [cache_key, info] : models_cache_) {
+        ModelSource source;
+        std::string bare;
+        if (auto canon = parse_canonical_id(cache_key)) {
+            source = canon->source;
+            bare = canon->bare_name;
+        } else {
+            // Unprefixed cache keys are built-ins (server_models.json).
+            source = ModelSource::Builtin;
+            bare = cache_key;
         }
+        by_bare[bare].push_back({cache_key, source});
+    }
 
-        auto existing = public_model_aliases_.find(bare_name);
-        if (existing != public_model_aliases_.end() && existing->second != name) {
-            LOG(INFO, "ModelManager") << "Skipping public alias '" << bare_name
-                      << "' for '" << name << "' because it collides with '" << existing->second << "'" << std::endl;
-            continue;
+    for (auto& [bare, entries] : by_bare) {
+        std::sort(entries.begin(), entries.end(),
+                  [](const Entry& a, const Entry& b) {
+                      return precedence_rank(a.source) < precedence_rank(b.source);
+                  });
+
+        const Entry& winner = entries.front();
+        public_model_aliases_[bare] = winner.cache_key;
+        canonical_public_names_[winner.cache_key] = bare;
+
+        for (size_t i = 1; i < entries.size(); ++i) {
+            const Entry& shadowed = entries[i];
+            std::string canonical = canonical_id(shadowed.source, bare);
+            canonical_public_names_[shadowed.cache_key] = canonical;
+            if (canonical != shadowed.cache_key) {
+                public_model_aliases_[canonical] = shadowed.cache_key;
+            }
         }
+    }
 
-        public_model_aliases_[bare_name] = name;
-        canonical_public_names_[name] = bare_name;
+    // Always accept builtin.<X> as an input alias for the bare cache key,
+    // even when no other source shadows the built-in.
+    for (const auto& [cache_key, _info] : models_cache_) {
+        if (parse_canonical_id(cache_key)) continue;
+        std::string canonical = canonical_id(ModelSource::Builtin, cache_key);
+        public_model_aliases_.try_emplace(canonical, cache_key);
     }
 }
 

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -867,7 +867,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
         // Skip mmproj files - they're part of multimodal models
         if (contains_ignore_case(filename, "mmproj")) continue;
 
-        std::string model_name = std::string(EXTRA_MODEL_PREFIX) + filename;
+        std::string model_name = std::string(EXTRA_MODEL_PREFIX) + gguf_path.stem().string();
         ModelInfo info = init_extra_model_info(model_name);
         info.checkpoints["main"] = gguf_path.string();
         info.resolved_paths["main"] = gguf_path.string();

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -723,6 +723,15 @@ ModelManager::ModelManager(const std::string& extra_models_dir)
     // One-shot migration of recipe_options.json: older Lemonade keyed built-in
     // entries by bare name; the current spec requires a canonical "builtin."
     // prefix so each source is addressable distinctly even on shadowing.
+    //
+    // Normalize to an object before iterating — a corrupted file may parse as
+    // null, array, or scalar, and json::iterator::key() throws on non-objects.
+    if (!recipe_options_.is_object()) {
+        if (!recipe_options_.is_null()) {
+            LOG(WARNING, "ModelManager") << "recipe_options.json is not a JSON object; resetting to empty object" << std::endl;
+        }
+        recipe_options_ = json::object();
+    }
     {
         int migrated = 0;
         json migrated_options = json::object();

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1400,7 +1400,11 @@ void Server::handle_model_by_id(const httplib::Request& req, httplib::Response& 
 
     if (model_manager_->model_exists(model_id)) {
         auto info = model_manager_->get_model_info(model_id);
-        res.set_content(model_info_to_json(model_id, info).dump(), "application/json");
+        // Emit the wire-format id (bare for the precedence-winner, canonical-prefixed
+        // for shadowed sources), regardless of which form the client requested.
+        std::string canonical_cache_key = model_manager_->resolve_model_name(model_id);
+        std::string wire_id = model_manager_->get_public_model_name(canonical_cache_key);
+        res.set_content(model_info_to_json(wire_id, info).dump(), "application/json");
     } else {
         res.status = 404;
         auto error_response = create_model_error(model_id, "Model not found");
@@ -2797,7 +2801,18 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             LOG(INFO, "Server") << "   recipe: " << recipe << std::endl;
         }
 
-        // Validate: if checkpoint or recipe are provided, model name must have "user." prefix
+        // Reject reserved prefixes — extra.* / builtin.* cannot be created via
+        // /pull. Then enforce the existing rule that explicit checkpoint/recipe
+        // requires the user.* prefix.
+        if (auto canon = lemon::parse_canonical_id(model_name);
+            canon && lemon::is_reserved_for_registration(canon->source)) {
+            res.status = 400;
+            nlohmann::json error = {{"error",
+                "Model names with 'extra.' / 'builtin.' prefixes are reserved. "
+                "Use 'user.<name>' for registration. Received: " + model_name}};
+            res.set_content(error.dump(), "application/json");
+            return;
+        }
         if (!checkpoint.empty() || !recipe.empty()) {
             if (model_name.substr(0, 5) != "user.") {
                 res.status = 400;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2802,14 +2802,17 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
         }
 
         // Reject reserved prefixes — extra.* / builtin.* cannot be created via
-        // /pull. Then enforce the existing rule that explicit checkpoint/recipe
-        // requires the user.* prefix.
-        if (auto canon = lemon::parse_canonical_id(model_name);
-            canon && lemon::is_reserved_for_registration(canon->source)) {
+        // /pull, and user.extra.* / user.builtin.* are also rejected because
+        // their bare-name part ("extra.X" / "builtin.X") would otherwise hijack
+        // the corresponding canonical alias slot. Then enforce the existing rule
+        // that explicit checkpoint/recipe requires the user.* prefix.
+        if (lemon::is_reserved_registration_name(model_name)) {
             res.status = 400;
             nlohmann::json error = {{"error",
-                "Model names with 'extra.' / 'builtin.' prefixes are reserved. "
-                "Use 'user.<name>' for registration. Received: " + model_name}};
+                "Model names with 'extra.' / 'builtin.' prefixes are reserved, "
+                "including as bare-name parts of a 'user.' alias. "
+                "Use 'user.<name>' for registration where <name> does not begin "
+                "with 'extra.' or 'builtin.'. Received: " + model_name}};
             res.set_content(error.dump(), "application/json");
             return;
         }

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -550,45 +550,6 @@ sys.exit(0)
             if os.path.exists(json_file):
                 os.unlink(json_file)
 
-    def test_060a_import_json_file_with_appear_builtin_label(self):
-        """Import should preserve appear-builtin and expose the bare model name."""
-        canonical_name = f"user.ImportAlias-{uuid.uuid4().hex[:8]}"
-        public_name = canonical_name[5:]
-        json_data = {
-            "model_name": canonical_name,
-            "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
-            "recipe": "llamacpp",
-            "labels": ["appear-builtin"],
-        }
-
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            json_file = f.name
-            json.dump(json_data, f)
-
-        try:
-            import_result = run_cli_command(
-                ["import", json_file],
-                timeout=TIMEOUT_MODEL_OPERATION,
-            )
-            self.assertEqual(import_result.returncode, 0)
-
-            list_result = run_cli_command(
-                ["list", "--downloaded"],
-                timeout=TIMEOUT_DEFAULT,
-            )
-            output = list_result.stdout + list_result.stderr
-            self.assertIn(public_name, output)
-            self.assertNotIn(canonical_name, output)
-
-            delete_result = run_cli_command(
-                ["delete", public_name],
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(delete_result.returncode, 0)
-        finally:
-            if os.path.exists(json_file):
-                os.unlink(json_file)
-
     def test_061_import_malformed_json(self):
         """Test import command with malformed JSON file should fail."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -1474,6 +1474,44 @@ sys.exit(0)
         )
         print(f"Delete model exit code: {result.returncode}")
 
+    def test_090a_naming_spec_list_shows_canonical_shadowed_rows(self):
+        """`list` prints API ids verbatim, so shadowed sources appear under their canonical IDs.
+
+        Verifies the copy-paste-safe contract: when a user.* shadows a built-in,
+        the list shows both `<bare>` (winner) and `builtin.<bare>` (shadowed),
+        and either string is directly usable in `lemonade load`/`delete`.
+        """
+        bare = ENDPOINT_TEST_MODEL  # known built-in
+        user_canonical = f"user.{bare}"
+
+        try:
+            pull_response = requests.post(
+                f"http://localhost:{PORT}/api/v1/pull",
+                json={
+                    "model_name": user_canonical,
+                    "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
+                    "recipe": "llamacpp",
+                    "stream": False,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(pull_response.status_code, 200)
+
+            result = self.assertCommandSucceeds(["list"], timeout=TIMEOUT_DEFAULT)
+            output = result.stdout + result.stderr
+
+            # Winner appears as bare id; shadowed built-in appears under its canonical id.
+            self.assertIn(bare, output)
+            self.assertIn(f"builtin.{bare}", output)
+            # The user.* canonical form must NOT appear in output — winners emit bare.
+            self.assertNotIn(user_canonical, output)
+
+            print(
+                f"[OK] list shows both {bare} (user winner) and builtin.{bare} (shadowed)"
+            )
+        finally:
+            run_cli_command(["delete", user_canonical], timeout=TIMEOUT_DEFAULT)
+
     def test_091_delete_preserves_shared_repo(self):
         """Test that deleting one model preserves files used by another model sharing the same repo."""
         # Import two user models that share the same HF repo (different GGUF quants)

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -20,7 +20,10 @@ Usage:
     python server_endpoints.py
 """
 
+import os
 import platform
+import shutil
+import tempfile
 import uuid
 import requests
 from openai import NotFoundError
@@ -1334,6 +1337,153 @@ class EndpointTests(ServerTestBase):
                 )
             except Exception:
                 pass
+
+    def _set_extra_models_dir(self, value):
+        """Swap extra_models_dir via /internal/set; returns the prior value."""
+        prior = (
+            requests.get(
+                f"http://localhost:{PORT}/internal/config", timeout=TIMEOUT_DEFAULT
+            )
+            .json()
+            .get("extra_models_dir", "")
+        )
+        response = requests.post(
+            f"http://localhost:{PORT}/internal/set",
+            json={"extra_models_dir": value},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            response.status_code, 200, f"/internal/set failed: {response.text}"
+        )
+        return prior
+
+    def _write_stub_gguf(self, directory, bare_name):
+        """Drop a stub GGUF in a subdir so extras discovery emits extra.<bare_name>."""
+        import struct
+
+        sub_dir = os.path.join(directory, bare_name)
+        os.makedirs(sub_dir, exist_ok=True)
+        with open(os.path.join(sub_dir, "model.gguf"), "wb") as f:
+            f.write(b"GGUF")
+            f.write(struct.pack("<I", 3))  # version
+            f.write(struct.pack("<Q", 0))  # tensor_count
+            f.write(struct.pack("<Q", 0))  # kv_count
+
+    def test_021g_naming_spec_three_way_collision(self):
+        """Naming spec: built-in + user.* + extra.* all sharing a bare name.
+
+        The user.* wins precedence; the other two appear under their canonical IDs.
+        """
+        bare = ENDPOINT_TEST_MODEL  # known built-in
+        user_canonical = f"user.{bare}"
+        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_3way_")
+        self._write_stub_gguf(extra_dir, bare)
+
+        prior_dir = self._set_extra_models_dir(extra_dir)
+        try:
+            pull_response = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": user_canonical,
+                    "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
+                    "recipe": "llamacpp",
+                    "stream": False,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(pull_response.status_code, 200)
+
+            models_response = requests.get(
+                f"{self.base_url}/models?show_all=true", timeout=TIMEOUT_DEFAULT
+            )
+            self.assertEqual(models_response.status_code, 200)
+            ids = {m["id"] for m in models_response.json()["data"]}
+
+            self.assertIn(bare, ids, "Winner emits bare id")
+            self.assertIn(f"extra.{bare}", ids, "Imported source under canonical id")
+            self.assertIn(f"builtin.{bare}", ids, "Built-in under canonical id")
+            self.assertNotIn(
+                user_canonical,
+                ids,
+                "Winning user.* not also emitted under canonical id",
+            )
+
+            bare_resp = requests.get(
+                f"{self.base_url}/models/{bare}", timeout=TIMEOUT_DEFAULT
+            ).json()
+            user_resp = requests.get(
+                f"{self.base_url}/models/{user_canonical}", timeout=TIMEOUT_DEFAULT
+            ).json()
+            extra_resp = requests.get(
+                f"{self.base_url}/models/extra.{bare}", timeout=TIMEOUT_DEFAULT
+            ).json()
+            builtin_resp = requests.get(
+                f"{self.base_url}/models/builtin.{bare}", timeout=TIMEOUT_DEFAULT
+            ).json()
+
+            self.assertEqual(bare_resp["checkpoint"], user_resp["checkpoint"])
+            self.assertNotEqual(extra_resp["checkpoint"], bare_resp["checkpoint"])
+            self.assertNotEqual(builtin_resp["checkpoint"], bare_resp["checkpoint"])
+            self.assertNotEqual(extra_resp["checkpoint"], builtin_resp["checkpoint"])
+
+            print(
+                f"[OK] three-way collision: bare/{bare}, extra.{bare}, builtin.{bare}"
+            )
+        finally:
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": user_canonical},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+            self._set_extra_models_dir(prior_dir)
+            shutil.rmtree(extra_dir, ignore_errors=True)
+
+    def test_021h_naming_spec_extra_shadows_builtin(self):
+        """Naming spec: extra.* + built-in (no user.*); extra wins precedence."""
+        bare = ENDPOINT_TEST_MODEL
+        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_shadow_")
+        self._write_stub_gguf(extra_dir, bare)
+
+        prior_dir = self._set_extra_models_dir(extra_dir)
+        try:
+            models_response = requests.get(
+                f"{self.base_url}/models?show_all=true", timeout=TIMEOUT_DEFAULT
+            )
+            self.assertEqual(models_response.status_code, 200)
+            ids = {m["id"] for m in models_response.json()["data"]}
+
+            self.assertIn(
+                bare, ids, "extra wins precedence over builtin; emits bare id"
+            )
+            self.assertIn(f"builtin.{bare}", ids, "shadowed builtin under canonical id")
+            self.assertNotIn(
+                f"extra.{bare}",
+                ids,
+                "winning extra.* not also emitted under canonical id",
+            )
+
+            bare_resp = requests.get(
+                f"{self.base_url}/models/{bare}", timeout=TIMEOUT_DEFAULT
+            ).json()
+            extra_resp = requests.get(
+                f"{self.base_url}/models/extra.{bare}", timeout=TIMEOUT_DEFAULT
+            ).json()
+            builtin_resp = requests.get(
+                f"{self.base_url}/models/builtin.{bare}", timeout=TIMEOUT_DEFAULT
+            ).json()
+
+            self.assertEqual(bare_resp["checkpoint"], extra_resp["checkpoint"])
+            self.assertNotEqual(bare_resp["checkpoint"], builtin_resp["checkpoint"])
+
+            print(
+                f"[OK] extra shadows built-in: bare/{bare} -> extra, builtin.{bare} -> built-in"
+            )
+        finally:
+            self._set_extra_models_dir(prior_dir)
+            shutil.rmtree(extra_dir, ignore_errors=True)
 
     def _get_test_backend(self):
         """Get a lightweight test backend based on platform."""

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -969,6 +969,9 @@ class EndpointTests(ServerTestBase):
             recipe = "llamacpp"
         recipe_backend = f"{recipe}_backend"
 
+        # Bare-name alias for a unique user.* registration — what `/v1/models` emits.
+        public_name = USER_MODEL_NAME.split(".", 1)[1]
+
         # Verify model is not in downloaded list
         models_response = requests.get(
             f"{self.base_url}/models", timeout=TIMEOUT_DEFAULT
@@ -976,7 +979,7 @@ class EndpointTests(ServerTestBase):
         models_data = models_response.json()
         model_ids = [m["id"] for m in models_data["data"]]
         self.assertNotIn(
-            USER_MODEL_NAME, model_ids, "Model should be deleted before pull test"
+            public_name, model_ids, "Model should be deleted before pull test"
         )
 
         # Now pull the model
@@ -1001,14 +1004,16 @@ class EndpointTests(ServerTestBase):
         self.assertIn("status", data)
         self.assertEqual(data["status"], "success")
 
-        # Verify model is now in downloaded list
+        # Verify model is now in downloaded list. Under the model-naming spec the
+        # API emits a unique user.* registration as its bare name; both forms are
+        # accepted as input and resolve to the same record.
         models_response = requests.get(
             f"{self.base_url}/models/" + USER_MODEL_NAME, timeout=TIMEOUT_DEFAULT
         )
         model_data = models_response.json()
         self.assertIn("id", model_data)
         self.assertEqual(
-            model_data["id"], USER_MODEL_NAME, "Model should be downloaded after pull"
+            model_data["id"], public_name, "Model should be downloaded after pull"
         )
         self.assertIn("checkpoints", model_data)
         self.assertIn("main", model_data["checkpoints"])
@@ -1144,62 +1149,187 @@ class EndpointTests(ServerTestBase):
             except Exception:
                 pass
 
-    def test_021b_appear_builtin_aliases_user_model(self):
-        """User models labeled appear-builtin should expose a bare public ID."""
-        canonical_name = f"user.AppearBuiltin-{uuid.uuid4().hex[:8]}"
-        public_name = canonical_name[5:]
-
-        try:
+    def test_021c_naming_spec_pull_rejects_reserved_prefixes(self):
+        """Naming spec: /pull rejects extra.* / builtin.* model names."""
+        for reserved in [
+            f"extra.Rejected-{uuid.uuid4().hex[:6]}",
+            f"builtin.Rejected-{uuid.uuid4().hex[:6]}",
+        ]:
             response = requests.post(
                 f"{self.base_url}/pull",
                 json={
-                    "model_name": canonical_name,
+                    "model_name": reserved,
                     "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
                     "recipe": "llamacpp",
-                    "labels": ["appear-builtin"],
+                    "stream": False,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                response.status_code,
+                400,
+                f"Expected 400 for reserved prefix '{reserved}', got "
+                f"{response.status_code}: {response.text}",
+            )
+            self.assertIn("reserved", response.text.lower())
+        print("[OK] /pull rejects extra.* and builtin.* prefixes")
+
+    def test_021d_naming_spec_builtin_canonical_alias(self):
+        """Naming spec: builtin.<name> resolves to the same model as the bare name."""
+        bare_response = requests.get(
+            f"{self.base_url}/models/{ENDPOINT_TEST_MODEL}",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(bare_response.status_code, 200)
+        self.assertEqual(bare_response.json()["id"], ENDPOINT_TEST_MODEL)
+
+        canonical_response = requests.get(
+            f"{self.base_url}/models/builtin.{ENDPOINT_TEST_MODEL}",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(canonical_response.status_code, 200)
+        # When the built-in is the precedence-winner (no shadowing), the API
+        # emits the bare id regardless of which form the client requested.
+        self.assertEqual(canonical_response.json()["id"], ENDPOINT_TEST_MODEL)
+        self.assertEqual(
+            canonical_response.json()["checkpoint"],
+            bare_response.json()["checkpoint"],
+        )
+        print(f"[OK] builtin.{ENDPOINT_TEST_MODEL} alias resolves to bare id")
+
+    def test_021e_naming_spec_user_shadows_builtin(self):
+        """Naming spec: a user.X registration shadows a built-in X.
+
+        The user model wins precedence and emits as the bare name; the built-in
+        is shadowed and emits as builtin.X. Both must remain visible.
+        """
+        user_canonical = f"user.{ENDPOINT_TEST_MODEL}"
+        shadowed_id = f"builtin.{ENDPOINT_TEST_MODEL}"
+
+        try:
+            pull_response = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": user_canonical,
+                    "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
+                    "recipe": "llamacpp",
                     "stream": False,
                 },
                 timeout=TIMEOUT_MODEL_OPERATION,
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(pull_response.status_code, 200)
 
             models_response = requests.get(
                 f"{self.base_url}/models?show_all=true",
                 timeout=TIMEOUT_DEFAULT,
             )
             self.assertEqual(models_response.status_code, 200)
-            model_ids = {model["id"] for model in models_response.json()["data"]}
-            self.assertIn(public_name, model_ids)
-            self.assertNotIn(canonical_name, model_ids)
+            model_ids = {m["id"] for m in models_response.json()["data"]}
 
-            model_info_response = requests.get(
-                f"{self.base_url}/models/{public_name}",
+            self.assertIn(
+                ENDPOINT_TEST_MODEL,
+                model_ids,
+                "Bare id should be present (user model winner)",
+            )
+            self.assertIn(
+                shadowed_id,
+                model_ids,
+                "Shadowed built-in should expose its builtin.<name> id",
+            )
+            self.assertNotIn(
+                user_canonical,
+                model_ids,
+                "Winning user model should NOT also appear under user.<name>",
+            )
+
+            # All four input forms must resolve.
+            for input_id in [ENDPOINT_TEST_MODEL, user_canonical, shadowed_id]:
+                r = requests.get(
+                    f"{self.base_url}/models/{input_id}",
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                self.assertEqual(r.status_code, 200, f"Failed to resolve {input_id}")
+
+            # Bare and user.* should resolve to the same record (the user model).
+            bare_info = requests.get(
+                f"{self.base_url}/models/{ENDPOINT_TEST_MODEL}",
                 timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(model_info_response.status_code, 200)
-            self.assertEqual(model_info_response.json()["id"], public_name)
-
-            load_response = requests.post(
-                f"{self.base_url}/load",
-                json={"model_name": public_name},
-                timeout=TIMEOUT_MODEL_OPERATION,
-            )
-            self.assertEqual(load_response.status_code, 200)
-            self.assertEqual(load_response.json()["model_name"], public_name)
-
-            unload_response = requests.post(
-                f"{self.base_url}/unload",
-                json={"model_name": public_name},
+            ).json()
+            user_info = requests.get(
+                f"{self.base_url}/models/{user_canonical}",
                 timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(unload_response.status_code, 200)
+            ).json()
+            self.assertEqual(bare_info["checkpoint"], user_info["checkpoint"])
+            self.assertEqual(bare_info["id"], user_info["id"])  # both emit bare
 
-            print(f"[OK] appear-builtin alias exposed and accepted for {public_name}")
+            # builtin.* should resolve to a different record (the built-in).
+            builtin_info = requests.get(
+                f"{self.base_url}/models/{shadowed_id}",
+                timeout=TIMEOUT_DEFAULT,
+            ).json()
+            self.assertEqual(builtin_info["id"], shadowed_id)
+            self.assertNotEqual(builtin_info["checkpoint"], bare_info["checkpoint"])
+
+            print(f"[OK] user.{ENDPOINT_TEST_MODEL} shadows built-in cleanly")
         finally:
             try:
                 requests.post(
                     f"{self.base_url}/delete",
-                    json={"model_name": public_name},
+                    json={"model_name": user_canonical},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+
+    def test_021f_naming_spec_unique_registered(self):
+        """Naming spec: a unique user.<name> with no built-in collision emits as bare."""
+        bare = f"NameSpec-Unique-{uuid.uuid4().hex[:8]}"
+        canonical = f"user.{bare}"
+
+        try:
+            pull_response = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": canonical,
+                    "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
+                    "recipe": "llamacpp",
+                    "stream": False,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(pull_response.status_code, 200)
+
+            models_response = requests.get(
+                f"{self.base_url}/models?show_all=true",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(models_response.status_code, 200)
+            model_ids = {m["id"] for m in models_response.json()["data"]}
+            self.assertIn(bare, model_ids)
+            self.assertNotIn(canonical, model_ids)
+            self.assertNotIn(f"builtin.{bare}", model_ids)
+
+            # Bare and user.* both resolve; builtin.* must 404.
+            for ok_id in [bare, canonical]:
+                r = requests.get(
+                    f"{self.base_url}/models/{ok_id}",
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                self.assertEqual(r.status_code, 200)
+                self.assertEqual(r.json()["id"], bare)
+
+            builtin_response = requests.get(
+                f"{self.base_url}/models/builtin.{bare}",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(builtin_response.status_code, 404)
+
+            print(f"[OK] unique user.{bare} emits as bare id with no collision")
+        finally:
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": canonical},
                     timeout=TIMEOUT_DEFAULT,
                 )
             except Exception:

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1153,10 +1153,15 @@ class EndpointTests(ServerTestBase):
                 pass
 
     def test_021c_naming_spec_pull_rejects_reserved_prefixes(self):
-        """Naming spec: /pull rejects extra.* / builtin.* model names."""
+        """Naming spec: /pull rejects extra.* / builtin.* model names, including
+        as the bare-name part of a user.* alias (e.g. user.builtin.Foo)."""
         for reserved in [
             f"extra.Rejected-{uuid.uuid4().hex[:6]}",
             f"builtin.Rejected-{uuid.uuid4().hex[:6]}",
+            # user.<reserved>.<bare> must also be rejected — otherwise it would
+            # hijack the builtin.<bare> / extra.<bare> alias slot.
+            f"user.builtin.Hijack-{uuid.uuid4().hex[:6]}",
+            f"user.extra.Hijack-{uuid.uuid4().hex[:6]}",
         ]:
             response = requests.post(
                 f"{self.base_url}/pull",
@@ -1175,7 +1180,9 @@ class EndpointTests(ServerTestBase):
                 f"{response.status_code}: {response.text}",
             )
             self.assertIn("reserved", response.text.lower())
-        print("[OK] /pull rejects extra.* and builtin.* prefixes")
+        print(
+            "[OK] /pull rejects extra.*/builtin.* and user.extra.*/user.builtin.* names"
+        )
 
     def test_021d_naming_spec_builtin_canonical_alias(self):
         """Naming spec: builtin.<name> resolves to the same model as the bare name."""

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1376,6 +1376,17 @@ class EndpointTests(ServerTestBase):
             f.write(struct.pack("<Q", 0))  # tensor_count
             f.write(struct.pack("<Q", 0))  # kv_count
 
+    def _write_root_stub_gguf(self, directory, filename):
+        """Drop a stub GGUF directly in extra_models_dir."""
+        import struct
+
+        os.makedirs(directory, exist_ok=True)
+        with open(os.path.join(directory, filename), "wb") as f:
+            f.write(b"GGUF")
+            f.write(struct.pack("<I", 3))  # version
+            f.write(struct.pack("<Q", 0))  # tensor_count
+            f.write(struct.pack("<Q", 0))  # kv_count
+
     def test_021g_naming_spec_three_way_collision(self):
         """Naming spec: built-in + user.* + extra.* all sharing a bare name.
 
@@ -1488,6 +1499,38 @@ class EndpointTests(ServerTestBase):
             print(
                 f"[OK] extra shadows built-in: bare/{bare} -> extra, builtin.{bare} -> built-in"
             )
+        finally:
+            self._set_extra_models_dir(prior_dir)
+            shutil.rmtree(extra_dir, ignore_errors=True)
+
+    def test_021i_extra_root_gguf_emits_stem_name(self):
+        """Root-level extra_models_dir GGUF files emit the filename stem."""
+        bare = "Qwen3.5-4B-UD-Q4_K_XL"
+        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_root_")
+        self._write_root_stub_gguf(extra_dir, f"{bare}.gguf")
+
+        prior_dir = self._set_extra_models_dir(extra_dir)
+        try:
+            models_response = requests.get(
+                f"{self.base_url}/models?show_all=true", timeout=TIMEOUT_DEFAULT
+            )
+            self.assertEqual(models_response.status_code, 200)
+            ids = {m["id"] for m in models_response.json()["data"]}
+
+            self.assertIn(bare, ids)
+            self.assertNotIn(f"{bare}.gguf", ids)
+
+            bare_resp = requests.get(
+                f"{self.base_url}/models/{bare}", timeout=TIMEOUT_DEFAULT
+            )
+            self.assertEqual(bare_resp.status_code, 200)
+            self.assertEqual(bare_resp.json()["id"], bare)
+            self.assertEqual(
+                bare_resp.json()["checkpoint"],
+                os.path.join(extra_dir, f"{bare}.gguf"),
+            )
+
+            print(f"[OK] root GGUF emits stem: {bare}")
         finally:
             self._set_extra_models_dir(prior_dir)
             shutil.rmtree(extra_dir, ignore_errors=True)

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -186,51 +186,6 @@ class OllamaTests(ServerTestBase):
             f"Model name should end with ':latest', got: {model['name']}",
         )
 
-    def test_007_user_model_appear_builtin_alias(self):
-        """Aliased user models should appear built-in through Ollama endpoints."""
-        canonical_name = f"user.OllamaAlias-{uuid.uuid4().hex[:8]}"
-        public_name = canonical_name[5:]
-
-        try:
-            pull_response = requests.post(
-                f"{self.base_url}/pull",
-                json={
-                    "model_name": canonical_name,
-                    "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
-                    "recipe": "llamacpp",
-                    "labels": ["appear-builtin"],
-                    "stream": False,
-                },
-                timeout=TIMEOUT_MODEL_OPERATION,
-            )
-            self.assertEqual(pull_response.status_code, 200)
-
-            tags_response = requests.get(
-                f"{OLLAMA_BASE_URL}/api/tags",
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(tags_response.status_code, 200)
-            tag_names = {
-                model["model"].replace(":latest", "")
-                for model in tags_response.json()["models"]
-            }
-            self.assertIn(public_name, tag_names)
-            self.assertNotIn(canonical_name, tag_names)
-
-            show_response = requests.post(
-                f"{OLLAMA_BASE_URL}/api/show",
-                json={"name": public_name},
-                timeout=TIMEOUT_DEFAULT,
-            )
-            self.assertEqual(show_response.status_code, 200)
-            self.assertIn("details", show_response.json())
-        finally:
-            requests.post(
-                f"{self.base_url}/delete",
-                json={"model_name": public_name},
-                timeout=TIMEOUT_DEFAULT,
-            )
-
     def test_008_pull_streaming_progress(self):
         """Test /api/pull streams NDJSON progress with digest field."""
         self.ensure_model_pulled()
@@ -390,16 +345,12 @@ class OllamaTests(ServerTestBase):
         self.assertEqual(response.status_code, 200)
 
         chunks = [
-            json.loads(line.decode("utf-8"))
-            for line in response.iter_lines()
-            if line
+            json.loads(line.decode("utf-8")) for line in response.iter_lines() if line
         ]
         self.assertGreater(len(chunks), 0)
 
         tool_chunks = [
-            chunk
-            for chunk in chunks
-            if chunk.get("message", {}).get("tool_calls")
+            chunk for chunk in chunks if chunk.get("message", {}).get("tool_calls")
         ]
         self.assertGreater(len(tool_chunks), 0, "Expected a tool call chunk")
 


### PR DESCRIPTION
## Summary

- Every model now has a canonical ID (`user.NAME` / `extra.NAME` / `builtin.NAME`). The bare name `NAME` is an alias resolved by precedence: registered > imported > built-in.
- `/v1/models`, `/v1/models/{id}`, Ollama `/api/tags`, and `lemonade list` emit the bare name for the precedence-winner and the canonical-prefixed ID for shadowed sources, so no model is ever hidden because another source shares its name.
- `extra.*` filesystem-discovered entries are no longer silently dropped when they collide with a `user.*` entry; the GUI shows them with a `(imported)` suffix, the CLI shows them under their `extra.*` canonical id (copy-paste safe).
- `recipe_options.json` migrates legacy bare keys to `builtin.NAME` on startup (one-shot, logged at INFO).
- The deprecated `appear-builtin` label feature is removed; the new precedence rule subsumes it.
- `/pull` and `lemonade import` now reject `extra.*` / `builtin.*` model names (reserved prefixes).
- Tauri renderer applies a `(registered)` / `(imported)` / `(builtin)` display suffix to shadowed rows.
- Documentation: new "Model naming spec" section in `docs/guide/configuration/custom-models.md` with the precedence rule, emission rule, and five reference cases.

## Demo

GUI shows user, extra, and builtin models in harmony as long as there are no collisions. The `(builtin)` suffix elegant resolves the one collision we have:

<img width="704" height="528" alt="image" src="https://github.com/user-attachments/assets/a3be4b3c-5e12-4e9a-bdf0-da9649d96101" /> 

Streamlined CLI pull experience:

<img width="1496" height="836" alt="image" src="https://github.com/user-attachments/assets/b43a0111-db21-4840-ab98-155327a222bb" />

Registered models show in `lemonade list` without prefixes:

<img width="556" height="176" alt="image" src="https://github.com/user-attachments/assets/506e16d9-26c5-4fa9-80ec-6e3fd6aa215a" />

No `user.` visible in Lemonade Launch:

<img width="1246" height="1230" alt="image" src="https://github.com/user-attachments/assets/9c277339-d7cc-4cc7-975a-c5f95ea13964" />

Nor in claude code itself:

<img width="762" height="280" alt="image" src="https://github.com/user-attachments/assets/d12cbe55-5e25-4141-b064-24fc68c442a6" />

 

## Test plan

- [x] `cmake --build --preset default` — clean build on macOS arm64
- [x] `python test/server_endpoints.py` — 38/38 pass (1 skipped)
- [x] `python test/server_cli.py` — 8/8 pass
- [x] `python test/server_cli2.py` — 54/54 pass (4 skipped)
- [x] `python test/test_ollama.py` — 27/27 pass (2 skipped)
- [x] New tests cover the four most-important reference cases (unique built-in, user-shadows-builtin, three-way input resolution, unique registered) plus reserved-prefix rejection
- [x] Manual: seeded a `recipe_options.json` with a bare key matching a built-in; restart rewrites it to `builtin.<name>` and the INFO log line is emitted; value applies on load
- [x] Linux build/test (CI)
- [x] Windows build/test (CI)
- [x] Spot-check the desktop app to verify shadowed rows render with the correct suffix

## Notes

- The `appear-builtin` label is removed but existing `"labels": ["appear-builtin"]` entries in users' `user_models.json` are left untouched as dead data — no automatic rewrite of user-owned files.
- The CLI deliberately does **not** apply the display-suffix transform so that copy-paste between `lemonade list` and `lemonade load` / `delete` / `run` always works. The canonical prefix on shadowed rows conveys source.
- Downgrade caveat: an older Lemonade binary won't apply settings keyed under `builtin.NAME` until those keys are reverted to bare names. Logged at INFO during migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)