### PR TITLE
feat: added model name copy button

### DIFF
--- a/src/app/src/renderer/ModelOptionsModal.tsx
+++ b/src/app/src/renderer/ModelOptionsModal.tsx
@@ -9,6 +9,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { serverFetch } from "./utils/serverConfig";
 import { ModelInfo } from "./utils/modelData";
 import { useSystem } from "./hooks/useSystem";
+import { writeClipboard } from "./utils/clipboardUtils";
 import {
   RecipeOptions,
   getOptionsForRecipe,
@@ -92,14 +93,21 @@ const ModelOptionsModal: React.FC<SettingsModalProps> = ({ isOpen, onCancel, onS
   const [numericDrafts, setNumericDrafts] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isModelNameCopied, setIsModelNameCopied] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const exportModelBtn = useRef<HTMLAnchorElement | null>(null);
+  const modelNameCopyTimeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Fetch options when modal opens
   useEffect(() => {
     if (!isOpen) return;
     let isMounted = true;
     setNumericDrafts({});
+    setIsModelNameCopied(false);
+    if (modelNameCopyTimeoutIdRef.current) {
+      clearTimeout(modelNameCopyTimeoutIdRef.current);
+      modelNameCopyTimeoutIdRef.current = null;
+    }
     void ensureSystemInfoLoaded();
 
     const fetchOptions = async () => {
@@ -138,6 +146,14 @@ const ModelOptionsModal: React.FC<SettingsModalProps> = ({ isOpen, onCancel, onS
     fetchOptions();
     return () => { isMounted = false; };
   }, [isOpen, model, ensureSystemInfoLoaded]);
+
+  useEffect(() => {
+    return () => {
+      if (modelNameCopyTimeoutIdRef.current) {
+        clearTimeout(modelNameCopyTimeoutIdRef.current);
+      }
+    };
+  }, []);
 
   // Handle click outside and escape key
   useEffect(() => {
@@ -264,6 +280,26 @@ const ModelOptionsModal: React.FC<SettingsModalProps> = ({ isOpen, onCancel, onS
     if (!options?.recipe) return;
     setNumericDrafts({});
     setOptions(createDefaultOptions(options.recipe));
+  };
+
+  const handleCopyModelName = async () => {
+    if (!modelName) return;
+
+    try {
+      await writeClipboard(modelName);
+      setIsModelNameCopied(true);
+
+      if (modelNameCopyTimeoutIdRef.current) {
+        clearTimeout(modelNameCopyTimeoutIdRef.current);
+      }
+
+      modelNameCopyTimeoutIdRef.current = setTimeout(() => {
+        setIsModelNameCopied(false);
+        modelNameCopyTimeoutIdRef.current = null;
+      }, 2000);
+    } catch (error) {
+      console.error('Failed to copy model name:', error);
+    }
   };
 
   const handleModelExport = () => {
@@ -595,7 +631,27 @@ const ModelOptionsModal: React.FC<SettingsModalProps> = ({ isOpen, onCancel, onS
             <div className="model-options-category-header">
               <h3>
                 <span className="model-options-field-label">Name:</span>{' '}
-                <span className="model-options-field-value">{modelName}</span>
+                <span className="model-options-name-row">
+                  <span className="model-options-field-value">{modelName}</span>
+                  <button
+                    type="button"
+                    className={`model-options-copy-button ${isModelNameCopied ? 'copied' : ''}`}
+                    onClick={handleCopyModelName}
+                    title={isModelNameCopied ? 'Copied model name' : 'Copy model name'}
+                    aria-label={isModelNameCopied ? 'Model name copied' : 'Copy model name'}
+                  >
+                    {isModelNameCopied ? (
+                      <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+                        <path d="M 2,7 L 5.5,10.5 L 12,3" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                      </svg>
+                    ) : (
+                      <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+                        <rect x="5" y="5" width="7" height="7" rx="1" fill="none" stroke="currentColor" strokeWidth="1.5"/>
+                        <path d="M 3,9 L 2,9 C 1.45,9 1,8.55 1,8 L 1,2 C 1,1.45 1.45,1 2,1 L 8,1 C 8.55,1 9,1.45 9,2 L 9,3" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+                      </svg>
+                    )}
+                  </button>
+                </span>
               </h3>
               <h5>
                 <span className="model-options-field-label">Checkpoint:</span>{' '}

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -1807,6 +1807,46 @@ footer {
     text-transform: none;
 }
 
+.model-options-name-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.model-options-copy-button {
+    width: 18px;
+    height: 18px;
+    padding: 2px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    vertical-align: middle;
+    transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.model-options-copy-button:hover {
+    color: var(--text-primary);
+    background: var(--bg-alpha-1);
+}
+
+.model-options-copy-button:focus-visible {
+    outline: 1px solid var(--border-5);
+    outline-offset: 2px;
+}
+
+.model-options-copy-button.copied {
+    color: var(--success-color);
+}
+
+.model-options-copy-button svg {
+    flex-shrink: 0;
+}
+
 .model-options-category-header .model-options-checkpoint-link {
     color: var(--text-link);
     text-decoration: none;

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -1814,18 +1814,11 @@ footer {
 }
 
 .model-options-copy-button {
-    width: 18px;
-    height: 18px;
-    padding: 2px;
     border: none;
     border-radius: 4px;
     background: transparent;
     color: var(--text-secondary);
     cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    vertical-align: middle;
     transition: color 0.15s ease, background-color 0.15s ease;
 }
 
@@ -1841,10 +1834,6 @@ footer {
 
 .model-options-copy-button.copied {
     color: var(--success-color);
-}
-
-.model-options-copy-button svg {
-    flex-shrink: 0;
 }
 
 .model-options-category-header .model-options-checkpoint-link {


### PR DESCRIPTION
## Summary

Adds a small copy button next to the model name in the Model Options modal.

closes #1903.

## Changes

- Add model-name copy action using the existing clipboard utility
- Show a temporary copied state after successful copy
- Add minimal, locally scoped styles for the copy button

## Testing

- Verified the Model Options modal opens correctly
- Verified clicking the copy button copies the model name to the clipboard
- Verified the copied state resets after a short delay
<img width="599" height="305" alt="image" src="https://github.com/user-attachments/assets/ca1b06ea-b571-4eeb-a99e-b7c4d9521b8c" />

Right after copying for a few seconds:

<img width="599" height="305" alt="image" src="https://github.com/user-attachments/assets/77f48545-d99f-4a45-aaec-40d6c84cf511" />
