### PR TITLE
Respect configured backend defaults

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -790,14 +790,30 @@ json SystemInfo::build_recipes_info(const json& devices) {
 
     // Explicit backend selections in config.json define the recipe default
     // reported to clients. "auto" falls back to RECIPE_DEFS preference order.
+    // Unknown backend names (e.g., a renamed or removed backend left in
+    // config.json) are dropped with a warning so the recipe still gets a
+    // valid default_backend from the fallback path below.
     std::map<std::string, std::string> configured_default_backends;
     if (auto* cfg = RuntimeConfig::global()) {
+        std::set<std::string> processed_recipes;
         for (const auto& def : RECIPE_DEFS) {
+            if (!processed_recipes.insert(def.recipe).second) continue;
             std::string section = RuntimeConfig::recipe_to_config_section(def.recipe);
             std::string backend = cfg->backend_string(section, "backend");
-            if (!backend.empty() && backend != "auto") {
-                configured_default_backends[def.recipe] = backend;
+            if (backend.empty() || backend == "auto") continue;
+            bool known = std::any_of(RECIPE_DEFS.begin(), RECIPE_DEFS.end(),
+                [&](const RecipeBackendDef& d) {
+                    return d.recipe == def.recipe && d.backend == backend;
+                });
+            if (!known) {
+                LOG(WARNING, "Server")
+                    << "Ignoring unknown configured backend '" << backend
+                    << "' for recipe '" << def.recipe
+                    << "'; falling back to RECIPE_DEFS preference order."
+                    << std::endl;
+                continue;
             }
+            configured_default_backends[def.recipe] = backend;
         }
     }
 

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -788,6 +788,19 @@ json SystemInfo::build_recipes_info(const json& devices) {
         detected_devices.push_back({"metal", "Apple Metal", "metal", true});
     }
 
+    // Explicit backend selections in config.json define the recipe default
+    // reported to clients. "auto" falls back to RECIPE_DEFS preference order.
+    std::map<std::string, std::string> configured_default_backends;
+    if (auto* cfg = RuntimeConfig::global()) {
+        for (const auto& def : RECIPE_DEFS) {
+            std::string section = RuntimeConfig::recipe_to_config_section(def.recipe);
+            std::string backend = cfg->backend_string(section, "backend");
+            if (!backend.empty() && backend != "auto") {
+                configured_default_backends[def.recipe] = backend;
+            }
+        }
+    }
+
     // Default to preferring system llamacpp on Linux AMD systems.
     // This can be overridden with LEMONADE_LLAMACPP_PREFER_SYSTEM=true/false.
     bool prefer_llamacpp_system = false;
@@ -1100,8 +1113,17 @@ json SystemInfo::build_recipes_info(const json& devices) {
         }
         recipes[def.recipe]["backends"][def.backend] = backend;
 
-        // First supported backend in RECIPE_DEFS order becomes the default.
-        // Skip 'system' backend unless explicitly preferred via env var.
+        auto configured_default = configured_default_backends.find(def.recipe);
+        if (configured_default != configured_default_backends.end()) {
+            if (def.backend == configured_default->second) {
+                recipes[def.recipe]["default_backend"] = def.backend;
+            }
+            continue;
+        }
+
+        // First supported backend in RECIPE_DEFS order becomes the default when
+        // the recipe backend is auto-selected. Skip 'system' backend unless
+        // explicitly preferred via env var.
         bool skip_as_default = (def.backend == "system" && !prefer_llamacpp_system);
         if (supported && !skip_as_default && !recipes[def.recipe].contains("default_backend")) {
             recipes[def.recipe]["default_backend"] = def.backend;


### PR DESCRIPTION
## Summary

- Use explicit backend selections from runtime config as the recipe `default_backend` reported by `/system-info`.
- Preserve the existing `RECIPE_DEFS` preference order when backend config is unset or set to `auto`.

## Root Cause

The GUI pre-flight installs the recipe `default_backend` from `/system-info`. For `llamacpp.backend=rocm`, `/system-info` still reported the hardcoded Linux default (`vulkan`), so the GUI installed Vulkan before `/load` honored the configured ROCm backend and installed ROCm separately.

## Validation

- `cmake --build --preset default --target lemond`
- Started a disposable local `lemond`, posted `{"llamacpp":{"backend":"rocm"}}` to `/internal/set`, and confirmed `/api/v1/system-info` reports `recipes.llamacpp.default_backend` as `rocm`.
- Pre-commit hooks run by `git commit` passed.