### PR TITLE
GUI: render canonical display names in LLM Chat model dropdown

### DIFF
--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Boxes, Brain, ChevronRight, Cpu, Eye, Flame, Layers, ListOrdered, Settings, SlidersHorizontal, Sparkles, SquareCode, Store, User, Wrench, XIcon } from './components/Icons';
 import { ModelInfo } from './utils/modelData';
+import { CANONICAL_PREFIXES, getModelDisplayName } from './utils/modelDisplayName';
 import { ToastContainer, useToast } from './Toast';
 import { useConfirmDialog } from './ConfirmDialog';
 import { serverFetch } from './utils/serverConfig';
@@ -210,28 +211,11 @@ interface DetectedBackend {
   mmprojFiles?: string[];
 }
 
-// Canonical-id prefixes emitted by `/v1/models`. Each maps to a parenthetical
-// source suffix that the GUI appends when a model is shadowed by a
-// higher-precedence source sharing the same bare name. Winners are emitted by
-// the server with no prefix and render as the bare name.
-const CANONICAL_PREFIXES: { prefix: string; suffix: string; sourceRank: number }[] = [
-  { prefix: 'user.',    suffix: ' (registered)', sourceRank: 1 },
-  { prefix: 'extra.',   suffix: ' (imported)', sourceRank: 2 },
-  { prefix: 'builtin.', suffix: ' (builtin)', sourceRank: 3 },
-];
-
 // Strip the canonical prefix (if any) to get the bare model name. Used for
 // family-regex matching and family grouping.
 const stripCanonicalPrefix = (modelName: string): string => {
   const match = CANONICAL_PREFIXES.find(p => modelName.startsWith(p.prefix));
   return match ? modelName.slice(match.prefix.length) : modelName;
-};
-
-// Render a model id as a human-readable display name. Bare ids (winners) render
-// as-is; canonical-prefixed ids (shadowed sources) render as "NAME (source)".
-const getModelDisplayName = (modelName: string): string => {
-  const match = CANONICAL_PREFIXES.find(p => modelName.startsWith(p.prefix));
-  return match ? modelName.slice(match.prefix.length) + match.suffix : modelName;
 };
 
 const hasCanonicalPrefix = (modelName: string): boolean =>

--- a/src/app/src/renderer/components/ModelSelector.tsx
+++ b/src/app/src/renderer/components/ModelSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useModels, DEFAULT_MODEL_ID } from '../hooks/useModels';
 import { isCollectionModel } from '../utils/collectionModels';
+import { getModelDisplayName } from '../utils/modelDisplayName';
 
 interface ModelSelectorProps {
   disabled: boolean;
@@ -33,7 +34,10 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ disabled }) => {
     : visibleDownloadedModels;
 
   const dropdownModels = searchQuery.trim()
-    ? allModels.filter(m => m.id.toLowerCase().includes(searchQuery.toLowerCase()))
+    ? allModels.filter(m => {
+        const q = searchQuery.toLowerCase();
+        return m.id.toLowerCase().includes(q) || getModelDisplayName(m.id).toLowerCase().includes(q);
+      })
     : allModels;
 
   useEffect(() => {
@@ -70,7 +74,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ disabled }) => {
         disabled={disabled}
         title={selectedModel}
       >
-        <span className="model-selector-label">{selectedModel}</span>
+        <span className="model-selector-label">{getModelDisplayName(selectedModel)}</span>
         <svg className="model-selector-chevron" width="10" height="10" viewBox="0 0 10 10">
           <path d="M2 3.5L5 6.5L8 3.5" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
         </svg>
@@ -86,7 +90,7 @@ const ModelSelector: React.FC<ModelSelectorProps> = ({ disabled }) => {
                 onClick={() => handleSelect(model.id)}
                 title={model.id}
               >
-                {model.id}
+                {getModelDisplayName(model.id)}
               </div>
             )) : (
               <div className="model-selector-empty">No models match</div>

--- a/src/app/src/renderer/utils/modelDisplayName.ts
+++ b/src/app/src/renderer/utils/modelDisplayName.ts
@@ -1,0 +1,16 @@
+// Canonical-prefix table for shadowed-source model IDs. A "shadowed" id is
+// emitted by the server with one of these prefixes when a higher-precedence
+// source already owns the bare name. Winners are emitted with no prefix and
+// render as the bare name.
+export const CANONICAL_PREFIXES: { prefix: string; suffix: string; sourceRank: number }[] = [
+  { prefix: 'user.',    suffix: ' (registered)', sourceRank: 1 },
+  { prefix: 'extra.',   suffix: ' (imported)', sourceRank: 2 },
+  { prefix: 'builtin.', suffix: ' (builtin)', sourceRank: 3 },
+];
+
+// Render a model id as a human-readable display name. Bare ids (winners) render
+// as-is; canonical-prefixed ids (shadowed sources) render as "NAME (source)".
+export const getModelDisplayName = (modelName: string): string => {
+  const match = CANONICAL_PREFIXES.find(p => modelName.startsWith(p.prefix));
+  return match ? modelName.slice(match.prefix.length) + match.suffix : modelName;
+};


### PR DESCRIPTION
## Summary
- The Active Models row in the Model Management panel rendered shadowed canonical ids (`user.*`, `extra.*`, `builtin.*`) as `Foo (registered)` / `(imported)` / `(builtin)`, but the LLM Chat panel's model dropdown showed the raw id. The dropdown trigger and each option now render the same display string as Active Models.
- Extracted `getModelDisplayName` and `CANONICAL_PREFIXES` from `ModelManager.tsx` into a new shared util at `src/app/src/renderer/utils/modelDisplayName.ts`. `ModelManager.tsx` and `components/ModelSelector.tsx` both import from it.
- The dropdown's text search now matches against both the raw id and the rendered display string, so typing e.g. `registered` surfaces user-registered models.
- Hover tooltips on the dropdown trigger and options still show the raw id, matching the Active Models tooltip.

## Demo

<img width="556" height="302" alt="image" src="https://github.com/user-attachments/assets/fd35955c-cfe7-40ca-bd1d-27ccc5dcdf1a" />

<img width="556" height="302" alt="image" src="https://github.com/user-attachments/assets/148cf046-abf3-42d6-a8b3-d7f6b90e1ba9" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)