### PR TITLE
feat(app): add full custom sd.cpp model options

### DIFF
--- a/src/app/src/renderer/AddModelPanel.tsx
+++ b/src/app/src/renderer/AddModelPanel.tsx
@@ -36,6 +36,48 @@ const HIDDEN_RECIPE_OPTIONS = new Set(['collection']);
 
 const getRecipeLabel = (recipe: string): string => RECIPE_DISPLAY_NAMES[recipe] ?? recipe;
 
+type RecipeExample = {
+  name: string;
+  checkpoint: string;
+  textEncoderCheckpoint?: string;
+  vaeCheckpoint?: string;
+};
+
+const RECIPE_EXAMPLES: Record<string, RecipeExample> = {
+  'llamacpp': {
+    name: 'Gemma-3-4b-it-GGUF',
+    checkpoint: 'ggml-org/gemma-3-4b-it-GGUF:Q4_K_M',
+  },
+  'ryzenai-llm': {
+    name: 'Qwen2.5-0.5B-Instruct-CPU',
+    checkpoint: 'amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx',
+  },
+  'flm': {
+    name: 'Gemma-3-4B-FLM',
+    checkpoint: 'gemma3:4b',
+  },
+  'whispercpp': {
+    name: 'Whisper-Tiny',
+    checkpoint: 'ggerganov/whisper.cpp:ggml-tiny.bin',
+  },
+  'sd-cpp': {
+    name: 'Z-Image-Turbo',
+    checkpoint: 'Comfy-Org/z_image_turbo:split_files/diffusion_models/z_image_turbo_bf16.safetensors',
+    textEncoderCheckpoint: 'Comfy-Org/z_image_turbo:split_files/text_encoders/qwen_3_4b.safetensors',
+    vaeCheckpoint: 'Comfy-Org/z_image_turbo:split_files/vae/ae.safetensors',
+  },
+  'kokoro': {
+    name: 'kokoro-v1',
+    checkpoint: 'mikkoph/kokoro-onnx',
+  },
+  'vllm': {
+    name: 'Qwen3.5-0.8B-vLLM',
+    checkpoint: 'Qwen/Qwen3.5-0.8B',
+  },
+};
+
+const getRecipeExample = (recipe: string): RecipeExample => RECIPE_EXAMPLES[recipe] ?? RECIPE_EXAMPLES.llamacpp;
+
 const createEmptyForm = (initial?: AddModelInitialValues) => ({
   name: initial?.name ?? '',
   checkpoint: initial?.checkpoint ?? initial?.checkpoints?.main ?? '',
@@ -49,12 +91,23 @@ const createEmptyForm = (initial?: AddModelInitialValues) => ({
   reranking: initial?.reranking ?? false,
 });
 
+const hasRepoRelativeFilePath = (checkpoint: string): boolean => {
+  const separatorIndex = checkpoint.indexOf(':');
+  if (separatorIndex === -1) return false;
+  const variant = checkpoint.slice(separatorIndex + 1).trim();
+  return variant.includes('.');
+};
+
+const isGgufCheckpoint = (checkpoint: string): boolean => checkpoint.toLowerCase().includes('gguf');
+
 const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initialValues }) => {
   const { supportedRecipes, ensureSystemInfoLoaded } = useSystem();
   const [form, setForm] = useState(() => createEmptyForm(initialValues));
   const [error, setError] = useState<string | null>(null);
 
   const mmprojOptions = initialValues?.mmprojOptions ?? [];
+  const isSdCpp = form.recipe === 'sd-cpp';
+  const recipeExample = getRecipeExample(form.recipe);
 
   const getMmprojLabel = (filename: string): string =>
     filename.replace(/^mmproj-/i, '').replace(/^model-/i, '').replace(/\.gguf$/i, '');
@@ -97,20 +150,24 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
       setError('Recipe is required.');
       return;
     }
-    if (checkpoint.toLowerCase().includes('gguf') && !checkpoint.includes(':')) {
+    if (recipe === 'sd-cpp' && !hasRepoRelativeFilePath(checkpoint)) {
+      setError('StableDiffusion.cpp checkpoints must include the full file path relative to the Hugging Face repo, for example repo/model:path/to/model.safetensors or repo/model:path/to/model.gguf.');
+      return;
+    }
+    if (recipe !== 'sd-cpp' && isGgufCheckpoint(checkpoint) && !checkpoint.includes(':')) {
       setError('GGUF checkpoints must include a variant using the CHECKPOINT:VARIANT syntax.');
       return;
     }
-    if (hasSdComponents && recipe !== 'sd-cpp') {
-      setError('Text encoder and VAE checkpoints are only supported for StableDiffusion.cpp models.');
+    if (recipe === 'vllm' && isGgufCheckpoint(checkpoint)) {
+      setError('vLLM checkpoints should use a Hugging Face model repo, not a GGUF file or GGUF repo.');
       return;
     }
-    if (hasSdComponents && (!textEncoderCheckpoint || !vaeCheckpoint)) {
+    if (recipe === 'sd-cpp' && hasSdComponents && (!textEncoderCheckpoint || !vaeCheckpoint)) {
       setError('Provide both text encoder and VAE checkpoints for sd-cpp component models.');
       return;
     }
-    if ((textEncoderCheckpoint && !textEncoderCheckpoint.includes(':')) || (vaeCheckpoint && !vaeCheckpoint.includes(':'))) {
-      setError('Additional sd-cpp checkpoints must include exact variants using the CHECKPOINT:VARIANT syntax.');
+    if (recipe === 'sd-cpp' && ((textEncoderCheckpoint && !hasRepoRelativeFilePath(textEncoderCheckpoint)) || (vaeCheckpoint && !hasRepoRelativeFilePath(vaeCheckpoint)))) {
+      setError('Additional sd-cpp checkpoints must use the full repo-relative file path, for example repo/model:path/to/file.safetensors or repo/model:path/to/file.gguf.');
       return;
     }
 
@@ -121,11 +178,11 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
         ? { main: checkpoint, text_encoder: textEncoderCheckpoint, vae: vaeCheckpoint }
         : undefined,
       recipe,
-      mmproj: form.mmproj.trim() || undefined,
+      mmproj: !isSdCpp ? (form.mmproj.trim() || undefined) : undefined,
       reasoning: form.reasoning,
-      vision: form.vision,
-      embedding: form.embedding,
-      reranking: form.reranking,
+      vision: !isSdCpp ? form.vision : false,
+      embedding: !isSdCpp ? form.embedding : false,
+      reranking: !isSdCpp ? form.reranking : false,
     });
   };
 
@@ -141,7 +198,7 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
     return React.createElement('option', { key: f, value: f }, label);
   });
 
-  const showMmproj = mmprojOptions.length > 0 || !initialValues;
+  const showMmproj = !isSdCpp && (mmprojOptions.length > 0 || !initialValues);
   const mmprojField: React.ReactNode = showMmproj
     ? React.createElement(
         'div',
@@ -190,23 +247,35 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
           <input
             type="text"
             className="form-input"
-            placeholder="Gemma-3-12b-it-GGUF"
+            placeholder={recipeExample.name}
             value={form.name}
             onChange={(e) => handleChange('name', e.target.value)}
           />
         </div>
 
         <div className="form-section">
-          <label className="form-label" title="Hugging Face model path (repo/model:quantization)">
-            Checkpoint
+          <label
+            className="form-label"
+            title={isSdCpp
+              ? 'Hugging Face repo and exact model file path relative to the repo'
+              : form.recipe === 'vllm'
+                ? 'Hugging Face model repository for vLLM; do not use GGUF checkpoints'
+                : 'Hugging Face model path, for example repo/model or repo/model:variant'}
+          >
+            {isSdCpp ? 'Main checkpoint' : 'Checkpoint'}
           </label>
           <input
             type="text"
             className="form-input"
-            placeholder="unsloth/gemma-3-12b-it-GGUF:Q4_0"
+            placeholder={recipeExample.checkpoint}
             value={form.checkpoint}
             onChange={(e) => handleChange('checkpoint', e.target.value)}
           />
+          {isSdCpp && (
+            <span className="settings-description">
+              Use the full repo-relative file path. StableDiffusion.cpp checkpoints can be .safetensors or .gguf when supported by the model/backend.
+            </span>
+          )}
         </div>
 
         <div className="form-section">
@@ -227,25 +296,31 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
 
         <div className="form-section">
           <label className="form-label">More info</label>
-          {form.recipe === 'sd-cpp' && (
+          {isSdCpp && (
             <div className="form-subsection">
               <label
                 className="form-label-secondary"
-                title="Optional component checkpoints for sd.cpp models with separate text encoder or VAE files"
+                title="Optional text encoder checkpoint for sd.cpp models with separate component files"
               >
-                sd.cpp component checkpoints (Optional)
+                Text encoder checkpoint (Optional)
               </label>
               <input
                 type="text"
                 className="form-input"
-                placeholder="Text encoder CHECKPOINT:VARIANT"
+                placeholder={recipeExample.textEncoderCheckpoint}
                 value={form.textEncoderCheckpoint}
                 onChange={(e) => handleChange('textEncoderCheckpoint', e.target.value)}
               />
+              <label
+                className="form-label-secondary"
+                title="Optional VAE checkpoint for sd.cpp models with separate component files"
+              >
+                VAE checkpoint (Optional)
+              </label>
               <input
                 type="text"
                 className="form-input"
-                placeholder="VAE CHECKPOINT:VARIANT"
+                placeholder={recipeExample.vaeCheckpoint}
                 value={form.vaeCheckpoint}
                 onChange={(e) => handleChange('vaeCheckpoint', e.target.value)}
               />
@@ -254,52 +329,54 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
           {mmprojField}
         </div>
 
-        <div className="settings-section-container">
-          <div className="settings-section">
-            <label className="settings-checkbox-label">
-              <input
-                type="checkbox"
-                className="settings-checkbox"
-                checked={form.embedding}
-                onChange={(e) => handleChange('embedding', e.target.checked)}
-              />
-              <div className="settings-checkbox-content">
-                <span className="settings-label-text">Embedding</span>
-                <span className="settings-description">Select this box if your model outputs numerical vectors that capture semantic meaning. This enables the <code>--embeddings</code> flag in llama.cpp</span>
-              </div>
-            </label>
-          </div>
+        {!isSdCpp && (
+          <div className="settings-section-container">
+            <div className="settings-section">
+              <label className="settings-checkbox-label">
+                <input
+                  type="checkbox"
+                  className="settings-checkbox"
+                  checked={form.embedding}
+                  onChange={(e) => handleChange('embedding', e.target.checked)}
+                />
+                <div className="settings-checkbox-content">
+                  <span className="settings-label-text">Embedding</span>
+                  <span className="settings-description">Select this box if your model outputs numerical vectors that capture semantic meaning. This enables the <code>--embeddings</code> flag in llama.cpp</span>
+                </div>
+              </label>
+            </div>
 
-          <div className="settings-section">
-            <label className="settings-checkbox-label">
-              <input
-                type="checkbox"
-                className="settings-checkbox"
-                checked={form.reranking}
-                onChange={(e) => handleChange('reranking', e.target.checked)}
-              />
-              <div className="settings-checkbox-content">
-                <span className="settings-label-text">Reranking</span>
-                <span className="settings-description">Select this box if your model reorders a list of inputs based on relevance to a query. This enables the <code>--reranking</code> flag in llama.cpp</span>
-              </div>
-            </label>
-          </div>
+            <div className="settings-section">
+              <label className="settings-checkbox-label">
+                <input
+                  type="checkbox"
+                  className="settings-checkbox"
+                  checked={form.reranking}
+                  onChange={(e) => handleChange('reranking', e.target.checked)}
+                />
+                <div className="settings-checkbox-content">
+                  <span className="settings-label-text">Reranking</span>
+                  <span className="settings-description">Select this box if your model reorders a list of inputs based on relevance to a query. This enables the <code>--reranking</code> flag in llama.cpp</span>
+                </div>
+              </label>
+            </div>
 
-          <div className="settings-section">
-            <label className="settings-checkbox-label">
-              <input
-                type="checkbox"
-                className="settings-checkbox"
-                checked={form.vision}
-                onChange={(e) => handleChange('vision', e.target.checked)}
-              />
-              <div className="settings-checkbox-content">
-                <span className="settings-label-text">Vision</span>
-                <span className="settings-description">Select this box if your model can respond to combinations of image and text. If selected, llama.cpp will be run with <code>--mmproj &lt;path&gt;</code> for multimodal input.</span>
-              </div>
-            </label>
+            <div className="settings-section">
+              <label className="settings-checkbox-label">
+                <input
+                  type="checkbox"
+                  className="settings-checkbox"
+                  checked={form.vision}
+                  onChange={(e) => handleChange('vision', e.target.checked)}
+                />
+                <div className="settings-checkbox-content">
+                  <span className="settings-label-text">Vision</span>
+                  <span className="settings-description">Select this box if your model can respond to combinations of image and text. If selected, llama.cpp will be run with <code>--mmproj &lt;path&gt;</code> for multimodal input.</span>
+                </div>
+              </label>
+            </div>
           </div>
-        </div>
+        )}
 
         {error && <div className="form-error">{error}</div>}
       </div>

--- a/src/app/src/renderer/AddModelPanel.tsx
+++ b/src/app/src/renderer/AddModelPanel.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { useSystem } from './hooks/useSystem';
+import { RECIPE_DISPLAY_NAMES } from './utils/recipeNames';
 
 export interface AddModelInitialValues {
   name: string;
   checkpoint: string;
   recipe: string;
+  checkpoints?: Record<string, string>;
   mmprojOptions?: string[];
   vision?: boolean;
   reranking?: boolean;
@@ -15,6 +17,7 @@ export interface ModelInstallData {
   name: string;
   checkpoint: string;
   recipe: string;
+  checkpoints?: Record<string, string>;
   mmproj?: string;
   reasoning?: boolean;
   vision?: boolean;
@@ -28,16 +31,17 @@ interface AddModelPanelProps {
   initialValues?: AddModelInitialValues;
 }
 
-const RECIPE_LABELS: Record<string, string> = {
-  'llamacpp': 'Llama.cpp GPU',
-  'flm': 'FastFlowLM NPU',
-  'ryzenai-llm': 'Ryzen AI LLM',
-};
+const FALLBACK_RECIPE_OPTIONS = ['llamacpp', 'flm', 'ryzenai-llm'];
+const HIDDEN_RECIPE_OPTIONS = new Set(['collection']);
+
+const getRecipeLabel = (recipe: string): string => RECIPE_DISPLAY_NAMES[recipe] ?? recipe;
 
 const createEmptyForm = (initial?: AddModelInitialValues) => ({
   name: initial?.name ?? '',
-  checkpoint: initial?.checkpoint ?? '',
+  checkpoint: initial?.checkpoint ?? initial?.checkpoints?.main ?? '',
   recipe: initial?.recipe ?? 'llamacpp',
+  textEncoderCheckpoint: initial?.checkpoints?.text_encoder ?? '',
+  vaeCheckpoint: initial?.checkpoints?.vae ?? '',
   mmproj: '',
   reasoning: false,
   vision: initial?.vision ?? false,
@@ -46,7 +50,7 @@ const createEmptyForm = (initial?: AddModelInitialValues) => ({
 });
 
 const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initialValues }) => {
-  const { supportedRecipes } = useSystem();
+  const { supportedRecipes, ensureSystemInfoLoaded } = useSystem();
   const [form, setForm] = useState(() => createEmptyForm(initialValues));
   const [error, setError] = useState<string | null>(null);
 
@@ -54,6 +58,10 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
 
   const getMmprojLabel = (filename: string): string =>
     filename.replace(/^mmproj-/i, '').replace(/^model-/i, '').replace(/\.gguf$/i, '');
+
+  useEffect(() => {
+    void ensureSystemInfoLoaded();
+  }, [ensureSystemInfoLoaded]);
 
   useEffect(() => {
     const newForm = createEmptyForm(initialValues);
@@ -73,6 +81,9 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
     const name = form.name.trim();
     const checkpoint = form.checkpoint.trim();
     const recipe = form.recipe.trim();
+    const textEncoderCheckpoint = form.textEncoderCheckpoint.trim();
+    const vaeCheckpoint = form.vaeCheckpoint.trim();
+    const hasSdComponents = Boolean(textEncoderCheckpoint || vaeCheckpoint);
 
     if (!name) {
       setError('Model name is required.');
@@ -90,10 +101,25 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
       setError('GGUF checkpoints must include a variant using the CHECKPOINT:VARIANT syntax.');
       return;
     }
+    if (hasSdComponents && recipe !== 'sd-cpp') {
+      setError('Text encoder and VAE checkpoints are only supported for StableDiffusion.cpp models.');
+      return;
+    }
+    if (hasSdComponents && (!textEncoderCheckpoint || !vaeCheckpoint)) {
+      setError('Provide both text encoder and VAE checkpoints for sd-cpp component models.');
+      return;
+    }
+    if ((textEncoderCheckpoint && !textEncoderCheckpoint.includes(':')) || (vaeCheckpoint && !vaeCheckpoint.includes(':'))) {
+      setError('Additional sd-cpp checkpoints must include exact variants using the CHECKPOINT:VARIANT syntax.');
+      return;
+    }
 
     onInstall({
       name,
       checkpoint,
+      checkpoints: recipe === 'sd-cpp' && hasSdComponents
+        ? { main: checkpoint, text_encoder: textEncoderCheckpoint, vae: vaeCheckpoint }
+        : undefined,
       recipe,
       mmproj: form.mmproj.trim() || undefined,
       reasoning: form.reasoning,
@@ -103,10 +129,12 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
     });
   };
 
-  const filteredSupportedRecipes = Object.keys(supportedRecipes).filter(r => r in RECIPE_LABELS);
-  const recipeOptions = filteredSupportedRecipes.length > 0
-    ? filteredSupportedRecipes
-    : Object.keys(RECIPE_LABELS);
+  const supportedRecipeOptions = Object.keys(supportedRecipes)
+    .filter(recipe => !HIDDEN_RECIPE_OPTIONS.has(recipe))
+    .sort((a, b) => getRecipeLabel(a).localeCompare(getRecipeLabel(b)));
+  const recipeOptions = supportedRecipeOptions.length > 0
+    ? supportedRecipeOptions
+    : FALLBACK_RECIPE_OPTIONS;
 
   const mmprojOptionElements = mmprojOptions.map((f: string) => {
     const label = getMmprojLabel(f);
@@ -191,7 +219,7 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
             <option value="">Select a recipe...</option>
             {recipeOptions.map(recipe => (
               <option key={recipe} value={recipe}>
-                {RECIPE_LABELS[recipe] ?? recipe}
+                {getRecipeLabel(recipe)}
               </option>
             ))}
           </select>
@@ -199,6 +227,30 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
 
         <div className="form-section">
           <label className="form-label">More info</label>
+          {form.recipe === 'sd-cpp' && (
+            <div className="form-subsection">
+              <label
+                className="form-label-secondary"
+                title="Optional component checkpoints for sd.cpp models with separate text encoder or VAE files"
+              >
+                sd.cpp component checkpoints (Optional)
+              </label>
+              <input
+                type="text"
+                className="form-input"
+                placeholder="Text encoder CHECKPOINT:VARIANT"
+                value={form.textEncoderCheckpoint}
+                onChange={(e) => handleChange('textEncoderCheckpoint', e.target.value)}
+              />
+              <input
+                type="text"
+                className="form-input"
+                placeholder="VAE CHECKPOINT:VARIANT"
+                value={form.vaeCheckpoint}
+                onChange={(e) => handleChange('vaeCheckpoint', e.target.value)}
+              />
+            </div>
+          )}
           {mmprojField}
         </div>
 

--- a/src/app/src/renderer/ChatWindow.tsx
+++ b/src/app/src/renderer/ChatWindow.tsx
@@ -209,6 +209,7 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isVisible, width }) => {
         name: modelName,
         registrationData: {
           checkpoint: data.checkpoint,
+          checkpoints: data.checkpoints,
           recipe: data.recipe,
           mmproj: data.mmproj,
           reasoning: data.reasoning,

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -314,7 +314,7 @@ interface ModelJSON {
   recipe: string,
   recipe_options?: object,
   checkpoint?: string,
-  checkpoints?: string[],
+  checkpoints?: Record<string, string>,
   downloaded?: boolean,
   labels?: string[],
   size?: number,

--- a/src/app/src/renderer/utils/backendInstaller.ts
+++ b/src/app/src/renderer/utils/backendInstaller.ts
@@ -25,7 +25,7 @@ function extractServerErrorMessage(errorText: string, fallback: string): string 
  */
 export interface ModelRegistrationData {
   checkpoint?: string;
-  checkpoints?: string[];
+  checkpoints?: Record<string, string>;
   recipe: string;
   mmproj?: string;
   reasoning?: boolean;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1039,17 +1039,8 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
         return all_bin_files[0];
     }
 
-    // For GGUF-backed recipes, find the GGUF file with advanced sharded model support.
-    // sd-cpp supports GGUF checkpoints too; those can be registered with a quant alias
-    // such as CHECKPOINT:Q8_0, and download_from_huggingface() resolves that alias to
-    // the concrete filename. Use the same resolver here so load finds the downloaded file.
-    auto is_direct_non_gguf_variant = [](const std::string& value) {
-        return ends_with_ignore_case(value, ".safetensors");
-    };
-    const bool should_resolve_gguf = type == "main" &&
-        (info.recipe == "llamacpp" ||
-         (info.recipe == "sd-cpp" && !is_direct_non_gguf_variant(variant)));
-    if (should_resolve_gguf) {
+    // For llamacpp, find the GGUF file with advanced sharded model support
+    if (info.recipe == "llamacpp" && type == "main") {
         if (!safe_exists(model_cache_path_fs)) {
             return model_cache_path;  // Return directory path even if not found
         }
@@ -1973,39 +1964,6 @@ void ModelManager::register_user_model(const std::string& model_name,
     for (const std::string& prop : USER_DEFINED_MODEL_PROPS) {
         if (model_data.contains(prop)) {
             model_entry[prop] = model_data[prop];
-        }
-    }
-
-    // Preserve existing named checkpoints when an older or partial client
-    // re-registers the same user model with only the legacy top-level
-    // `checkpoint` field. This keeps sd-cpp component checkpoints such as
-    // text_encoder and vae from being dropped by a refresh/re-pull round trip.
-    if (user_models_.contains(clean_name) && user_models_[clean_name].is_object()) {
-        const json& existing_entry = user_models_[clean_name];
-        if (existing_entry.contains("checkpoints") && existing_entry["checkpoints"].is_object()) {
-            std::string requested_main;
-            if (model_entry.contains("checkpoints") && model_entry["checkpoints"].is_object()) {
-                requested_main = JsonUtils::get_or_default<std::string>(model_entry["checkpoints"], "main", "");
-            }
-            if (requested_main.empty()) {
-                requested_main = JsonUtils::get_or_default<std::string>(model_entry, "checkpoint", "");
-            }
-
-            std::string existing_main = JsonUtils::get_or_default<std::string>(existing_entry["checkpoints"], "main", "");
-            if (existing_main.empty()) {
-                existing_main = JsonUtils::get_or_default<std::string>(existing_entry, "checkpoint", "");
-            }
-
-            if (!existing_main.empty() && (requested_main.empty() || requested_main == existing_main)) {
-                if (!model_entry.contains("checkpoints") || !model_entry["checkpoints"].is_object()) {
-                    model_entry["checkpoints"] = json::object();
-                }
-                for (const auto& [key, value] : existing_entry["checkpoints"].items()) {
-                    if (!model_entry["checkpoints"].contains(key)) {
-                        model_entry["checkpoints"][key] = value;
-                    }
-                }
-            }
         }
     }
 

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1039,8 +1039,19 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
         return all_bin_files[0];
     }
 
-    // For llamacpp, find the GGUF file with advanced sharded model support
-    if (info.recipe == "llamacpp" && type == "main") {
+    // For GGUF-backed recipes, find the GGUF file with advanced sharded model support.
+    // sd-cpp supports GGUF checkpoints too; those can be registered with a quant alias
+    // such as CHECKPOINT:Q8_0, and download_from_huggingface() resolves that alias to
+    // the concrete filename. Use the same resolver here so load finds the downloaded file.
+    auto is_direct_non_gguf_variant = [](const std::string& value) {
+        return ends_with_ignore_case(value, ".safetensors") ||
+               ends_with_ignore_case(value, ".pth") ||
+               ends_with_ignore_case(value, ".ckpt");
+    };
+    const bool should_resolve_gguf = type == "main" &&
+        (info.recipe == "llamacpp" ||
+         (info.recipe == "sd-cpp" && !is_direct_non_gguf_variant(variant)));
+    if (should_resolve_gguf) {
         if (!safe_exists(model_cache_path_fs)) {
             return model_cache_path;  // Return directory path even if not found
         }

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1044,9 +1044,7 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
     // such as CHECKPOINT:Q8_0, and download_from_huggingface() resolves that alias to
     // the concrete filename. Use the same resolver here so load finds the downloaded file.
     auto is_direct_non_gguf_variant = [](const std::string& value) {
-        return ends_with_ignore_case(value, ".safetensors") ||
-               ends_with_ignore_case(value, ".pth") ||
-               ends_with_ignore_case(value, ".ckpt");
+        return ends_with_ignore_case(value, ".safetensors");
     };
     const bool should_resolve_gguf = type == "main" &&
         (info.recipe == "llamacpp" ||
@@ -1975,6 +1973,39 @@ void ModelManager::register_user_model(const std::string& model_name,
     for (const std::string& prop : USER_DEFINED_MODEL_PROPS) {
         if (model_data.contains(prop)) {
             model_entry[prop] = model_data[prop];
+        }
+    }
+
+    // Preserve existing named checkpoints when an older or partial client
+    // re-registers the same user model with only the legacy top-level
+    // `checkpoint` field. This keeps sd-cpp component checkpoints such as
+    // text_encoder and vae from being dropped by a refresh/re-pull round trip.
+    if (user_models_.contains(clean_name) && user_models_[clean_name].is_object()) {
+        const json& existing_entry = user_models_[clean_name];
+        if (existing_entry.contains("checkpoints") && existing_entry["checkpoints"].is_object()) {
+            std::string requested_main;
+            if (model_entry.contains("checkpoints") && model_entry["checkpoints"].is_object()) {
+                requested_main = JsonUtils::get_or_default<std::string>(model_entry["checkpoints"], "main", "");
+            }
+            if (requested_main.empty()) {
+                requested_main = JsonUtils::get_or_default<std::string>(model_entry, "checkpoint", "");
+            }
+
+            std::string existing_main = JsonUtils::get_or_default<std::string>(existing_entry["checkpoints"], "main", "");
+            if (existing_main.empty()) {
+                existing_main = JsonUtils::get_or_default<std::string>(existing_entry, "checkpoint", "");
+            }
+
+            if (!existing_main.empty() && (requested_main.empty() || requested_main == existing_main)) {
+                if (!model_entry.contains("checkpoints") || !model_entry["checkpoints"].is_object()) {
+                    model_entry["checkpoints"] = json::object();
+                }
+                for (const auto& [key, value] : existing_entry["checkpoints"].items()) {
+                    if (!model_entry["checkpoints"].contains(key)) {
+                        model_entry["checkpoints"][key] = value;
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Expands manual custom model registration to support backend-reported recipes and optional StableDiffusion.cpp component checkpoints.

## Changes

- Populate the Add Model recipe dropdown from supported backend recipes
- Reuse shared recipe display names
- Add optional text encoder and VAE checkpoint fields for StableDiffusion.cpp models
- Pass named component checkpoints through the existing custom model install flow
- Support resolving sd.cpp GGUF variants such as `CHECKPOINT:Q8_0` to the downloaded `.gguf` file

## Testing

- Verified the Add Model dialog still defaults to Llama.cpp
- Verified StableDiffusion.cpp appears as a selectable recipe when supported
- Verified a custom sd.cpp model can be installed with main, text encoder, and VAE checkpoints
- Verified existing cached component files are reused during install
- Verified sd.cpp GGUF variant checkpoints resolve to the downloaded GGUF file