### PR TITLE
fix: update bug report template with current CLI commands

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,4 @@
-name: "🐛 Bug Report"
+﻿name: "🐛 Bug Report"
 description: Report a bug or unexpected behavior in Lemonade
 labels: ["bug"]
 body:
@@ -26,7 +26,7 @@ body:
     id: version
     attributes:
       label: Lemonade Version
-      description: "Run `lemonade-server --version` or check the About dialog in the app."
+      description: "Run `lemonade --version` or check the About dialog in the app."
       placeholder: "e.g. 9.4.2"
     validations:
       required: true
@@ -35,7 +35,7 @@ body:
     id: gpu
     attributes:
       label: GPU / APU Model
-      description: "Which GPU or APU are you using? You can find this in `lemonade-server status` output."
+      description: "Which GPU or APU are you using? Run `lemonade scan` to see detected devices."
       placeholder: "e.g. AMD Radeon RX 7900 XTX, AMD Ryzen AI 9 HX 370"
     validations:
       required: false
@@ -72,8 +72,8 @@ body:
       label: Steps to Reproduce
       description: Step-by-step instructions to reproduce the issue.
       placeholder: |
-        1. Start lemonade-server with `lemonade-server serve`
-        2. Load model X with `lemonade-server run <model>`
+        1. Start the server with `lemond`
+        2. Load model X with `lemonade run <model>`
         3. Send a request to ...
         4. See error ...
     validations:
@@ -100,23 +100,24 @@ body:
         **How to collect logs:**
         1. Start (or restart) the server with debug logging:
            ```
-           lemonade-server serve --log-level debug
+           lemond --log-level debug
            ```
         2. Reproduce the issue.
         3. Copy the relevant log output and paste it below, or attach the log file.
 
         **Log file locations:**
         - **Windows:** `%LOCALAPPDATA%\lemonade\logs\`
-        - **Linux/macOS:** `~/.local/share/lemonade/logs/` or run `lemonade-server logs`
+        - **Linux/macOS:** `~/.local/share/lemonade/logs/` or run `lemonade logs`
 
         **Additional diagnostic commands (run these and paste the output):**
-        - `lemonade-server status` — shows server info, loaded models, and GPU details
-        - `lemonade-server recipes` — shows installed backends and driver status
+        - `lemonade status` — shows server info and loaded models
+         - `lemonade scan` — shows detected GPU/APU devices
+        - `lemonade recipes` — shows installed backends and driver status
 
         **Platform-specific tips:**
         - **Windows:** Check Event Viewer (Application log) if the server crashes silently.
-        - **Linux:** If using systemd, check `journalctl -u lemonade-server` for service logs.
-        - **macOS:** Check Console.app or run `log show --predicate 'process == "lemonade-server"' --last 5m`
+        - **Linux:** If using systemd, check `journalctl -u lemond` for service logs.
+        - **macOS:** Check Console.app or run `log show --predicate 'process == "lemond"' --last 5m`
       render: shell
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,4 @@
-﻿name: "🐛 Bug Report"
+name: "🐛 Bug Report"
 description: Report a bug or unexpected behavior in Lemonade
 labels: ["bug"]
 body:
@@ -35,7 +35,7 @@ body:
     id: gpu
     attributes:
       label: GPU / APU Model
-      description: "Which GPU or APU are you using? Run `lemonade scan` to see detected devices."
+      description: "Which GPU or APU are you using? You can find this in your system settings (Device Manager on Windows, `lspci | grep -i vga` on Linux, or About This Mac on macOS)."
       placeholder: "e.g. AMD Radeon RX 7900 XTX, AMD Ryzen AI 9 HX 370"
     validations:
       required: false
@@ -111,7 +111,7 @@ body:
 
         **Additional diagnostic commands (run these and paste the output):**
         - `lemonade status` — shows server info and loaded models
-         - `lemonade scan` — shows detected GPU/APU devices
+         
         - `lemonade recipes` — shows installed backends and driver status
 
         **Platform-specific tips:**

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -72,10 +72,9 @@ body:
       label: Steps to Reproduce
       description: Step-by-step instructions to reproduce the issue.
       placeholder: |
-        1. Start the server with `lemond`
-        2. Load model X with `lemonade run <model>`
-        3. Send a request to ...
-        4. See error ...
+        1. Load model X with `lemonade run <model>`
+        2. Send a request to ...
+        3. See error ...
     validations:
       required: true
 
@@ -98,9 +97,9 @@ body:
         Please reproduce the issue with debug logging enabled and paste the relevant log output below.
 
         **How to collect logs:**
-        1. Start (or restart) the server with debug logging:
+        1. Set the server to debug logging:
            ```
-           lemond --log-level debug
+           lemonade config set log_level=debug
            ```
         2. Reproduce the issue.
         3. Copy the relevant log output and paste it below, or attach the log file.
@@ -112,7 +111,7 @@ body:
         **Additional diagnostic commands (run these and paste the output):**
         - `lemonade status` — shows server info and loaded models
          
-        - `lemonade recipes` — shows installed backends and driver status
+        - `lemonade backends` — shows installed backends and driver status
 
         **Platform-specific tips:**
         - **Windows:** Check Event Viewer (Application log) if the server crashes silently.


### PR DESCRIPTION
Replace deprecated \lemonade-server\ references with current CLI commands in the bug report template.

Changes:
- \lemonade-server --version\ → \lemonade --version\
- \lemonade-server serve\ → \lemond\
- \lemonade-server status\ → \lemonade status\
- \lemonade-server recipes\ → \lemonade recipes\
- \lemonade-server logs\ → \lemonade logs\
- GPU/APU field: updated guidance since no CLI command currently pretty-prints GPU/APU info from the \/system-info\ endpoint. Directs users to check system settings or use platform-native commands.

Note: There is currently no \lemonade\ CLI command that displays detected GPU/APU devices. The data exists in the \/api/v1/system-info\ endpoint but isn't exposed via CLI. A follow-up could add a \lemonade system-info\ command.

Fixes #1885