### PR TITLE
Introduce per-backend args

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -38,9 +38,9 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
   "llamacpp": {
     "backend": "auto",
     "args": "",
-    "vulkan_args",
-    "rocm_args",
-    "cpu_args",
+    "vulkan_args": "",
+    "rocm_args": "",
+    "cpu_args": "",
 	"device": "",
     "prefer_system": false,
     "rocm_bin": "builtin",
@@ -108,7 +108,7 @@ Backend-specific settings are nested under their backend name:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `backend` | "auto" | Backend to use: "auto" means "choose for me" |
-| `args` | "" | Custom arguments to pass to llama-server (fallback) |
+| `args` | "" | Custom arguments to pass to llama-server (fallback, unused when backend-specific args defined) |
 | `*_args` | "" | Backend-specific custom arguments to pass to llama-server |
 | `device` | "" | Comma-separated list of devices to use for offloading. Empty is auto. |
 | `prefer_system` | false | Prefer system-installed llama.cpp over bundled |
@@ -118,7 +118,7 @@ Backend-specific settings are nested under their backend name:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `backend` | "auto" | Backend to use: "auto" means "choose for me" |
-| `args` | "" | Custom arguments to pass to whisper-server (fallback) |
+| `args` | "" | Custom arguments to pass to whisper-server (fallback, unused when backend-specific args defined) |
 | `*_args` | "" | Backend-specific custom arguments to pass to whisper-server |
 | `*_bin` | "builtin" | Backend binary selection — see [Backend binary selection](#backend-binary-selection) |
 
@@ -126,7 +126,7 @@ Backend-specific settings are nested under their backend name:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `backend` | "auto" | Backend to use: "auto" means "choose for me" |
-| `args` | "" | Custom arguments to pass to `sd-server` (fallback) |
+| `args` | "" | Custom arguments to pass to `sd-server` (fallback, unused when backend-specific args defined) |
 | `*_args` | "" | Backend-specific custom arguments to pass to `sd-server` |
 | `steps` | 20 | Number of inference steps |
 | `cfg_scale` | 7.0 | Classifier-free guidance scale |

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -20,7 +20,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
 
 ```json
 {
-  "config_version": 1,
+  "config_version": 2,
   "port": 13305,
   "host": "localhost",
   "log_level": "info",
@@ -38,6 +38,9 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
   "llamacpp": {
     "backend": "auto",
     "args": "",
+    "vulkan_args",
+    "rocm_args",
+    "cpu_args",
 	"device": "",
     "prefer_system": false,
     "rocm_bin": "builtin",
@@ -47,12 +50,17 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
   "whispercpp": {
     "backend": "auto",
     "args": "",
+    "cpu_args": "",
+    "npu_args": "",
     "cpu_bin": "builtin",
     "npu_bin": "builtin"
   },
   "sdcpp": {
     "backend": "auto",
     "args": "",
+    "cpu_args": "",
+    "rocm_args": "",
+    "vulkan_args": "",
     "steps": 20,
     "cfg_scale": 7.0,
     "width": 512,
@@ -100,7 +108,8 @@ Backend-specific settings are nested under their backend name:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `backend` | "auto" | Backend to use: "auto" means "choose for me" |
-| `args` | "" | Custom arguments to pass to llama-server |
+| `args` | "" | Custom arguments to pass to llama-server (fallback) |
+| `*_args` | "" | Backend-specific custom arguments to pass to llama-server |
 | `device` | "" | Comma-separated list of devices to use for offloading. Empty is auto. |
 | `prefer_system` | false | Prefer system-installed llama.cpp over bundled |
 | `*_bin` | "builtin" | Backend binary selection — see [Backend binary selection](#backend-binary-selection) |
@@ -109,14 +118,16 @@ Backend-specific settings are nested under their backend name:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `backend` | "auto" | Backend to use: "auto" means "choose for me" |
-| `args` | "" | Custom arguments to pass to whisper-server |
+| `args` | "" | Custom arguments to pass to whisper-server (fallback) |
+| `*_args` | "" | Backend-specific custom arguments to pass to whisper-server |
 | `*_bin` | "builtin" | Backend binary selection — see [Backend binary selection](#backend-binary-selection) |
 
 **sdcpp** — Image generation:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `backend` | "auto" | Backend to use: "auto" means "choose for me" |
-| `args` | "" | Custom arguments to pass to `sd-server` |
+| `args` | "" | Custom arguments to pass to `sd-server` (fallback) |
+| `*_args` | "" | Backend-specific custom arguments to pass to `sd-server` |
 | `steps` | 20 | Number of inference steps |
 | `cfg_scale` | 7.0 | Classifier-free guidance scale |
 | `width` | 512 | Image width in pixels |

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -20,7 +20,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
 
 ```json
 {
-  "config_version": 2,
+  "config_version": 1,
   "port": 13305,
   "host": "localhost",
   "log_level": "info",

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -50,7 +50,7 @@ public:
     /// Returns recipe options in the flat format that RecipeOptions/backends expect.
     /// Maps nested config to flat keys: llamacpp.backend -> llamacpp_backend,
     /// sdcpp.steps -> steps, etc.
-    json recipe_options() const;
+    json recipe_options(const std::string& backend) const;
 
     // --- Unified setter ---
     // Validates and applies changes, then calls side_effect_cb (outside lock)

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -1,5 +1,5 @@
 {
-  "config_version": 1,
+  "config_version": 2,
   "port": 13305,
   "host": "localhost",
   "websocket_port": "auto",
@@ -18,6 +18,9 @@
   "llamacpp": {
     "backend": "auto",
     "args": "",
+    "rocm_args": "",
+    "vulkan_args": "",
+    "cpu_args": "",
     "prefer_system": true,
     "rocm_bin": "builtin",
     "vulkan_bin": "builtin",
@@ -26,12 +29,17 @@
   "whispercpp": {
     "backend": "auto",
     "args": "",
+    "cpu_args": "",
+    "npu_args": "",
     "cpu_bin": "builtin",
     "npu_bin": "builtin"
   },
   "sdcpp": {
     "backend": "auto",
     "args": "",
+    "cpu_args": "",
+    "rocm_args": "",
+    "vulkan_args": "",
     "steps": 20,
     "cfg_scale": 7.0,
     "width": 512,

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -1,5 +1,5 @@
 {
-  "config_version": 2,
+  "config_version": 1,
   "port": 13305,
   "host": "localhost",
   "websocket_port": "auto",

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -197,6 +197,9 @@ static const EnvMapping env_mappings[] = {
     // llamacpp
     {"LEMONADE_LLAMACPP",                "llamacpp",  "backend"},
     {"LEMONADE_LLAMACPP_ARGS",           "llamacpp",  "args"},
+    {"LEMONADE_LLAMACPP_ROCM_ARGS",      "llamacpp",  "rocm_args"},
+    {"LEMONADE_LLAMACPP_VULKAN_ARGS",    "llamacpp",  "vulkan_args"},
+    {"LEMONADE_LLAMACPP_CPU_ARGS",       "llamacpp",  "cpu_args"},
     {"LEMONADE_LLAMACPP_DEVICE",         "llamacpp",  "device"},
     {"LEMONADE_LLAMACPP_PREFER_SYSTEM",  "llamacpp",  "prefer_system"},
     {"LEMONADE_LLAMACPP_ROCM_BIN",       "llamacpp",  "rocm_bin"},
@@ -205,11 +208,16 @@ static const EnvMapping env_mappings[] = {
     // whispercpp
     {"LEMONADE_WHISPERCPP",              "whispercpp", "backend"},
     {"LEMONADE_WHISPERCPP_ARGS",         "whispercpp", "args"},
+    {"LEMONADE_WHISPERCPP_CPU_ARGS",     "whispercpp", "cpu_args"},
+    {"LEMONADE_WHISPERCPP_NPU_ARGS",     "whispercpp", "npu_args"},
     {"LEMONADE_WHISPERCPP_CPU_BIN",      "whispercpp", "cpu_bin"},
     {"LEMONADE_WHISPERCPP_NPU_BIN",      "whispercpp", "npu_bin"},
     // sdcpp
     {"LEMONADE_SDCPP",                   "sdcpp", "backend"},
     {"LEMONADE_SDCPP_ARGS",              "sdcpp", "args"},
+    {"LEMONADE_SDCPP_CPU_ARGS",          "sdcpp", "cpu_args"},
+    {"LEMONADE_SDCPP_ROCM_ARGS",         "sdcpp", "rocm_args"},
+    {"LEMONADE_SDCPP_VULKAN_ARGS",       "sdcpp", "vulkan_args"},
     {"LEMONADE_STEPS",                   "sdcpp", "steps"},
     {"LEMONADE_CFG_SCALE",               "sdcpp", "cfg_scale"},
     {"LEMONADE_WIDTH",                   "sdcpp", "width"},

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -223,11 +223,13 @@ void Router::load_model(const std::string& model_name,
                        bool allow_reload_on_option_change) {
     const std::string canonical_model_name = resolve_model_name(model_name);
     const std::string backend_option = model_info.recipe + "_backend";
-    std::string backend = options.get_option(backend_option).get<std::string>();
-    backend = backend.empty() ? model_info.recipe_options.get_option(backend_option).get<std::string>() : backend;
-    RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options(backend));
 
-    // Resolve settings: load overrides take precedence over per-model overrides which take precedence over defaults
+    RecipeOptions tentative = options.inherit(model_info.recipe_options.inherit(
+    RecipeOptions(model_info.recipe, config_->recipe_options(""))));
+    const std::string backend = tentative.get_option(backend_option).get<std::string>();
+
+    // Second pass: rebuild defaults using the resolved backend
+    RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options(backend));
     RecipeOptions effective_options = options.inherit(model_info.recipe_options.inherit(default_opt));
 
     LOG(DEBUG, "Router") << "Effective settings: " << effective_options.to_log_string() << std::endl;

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -171,7 +171,7 @@ void Router::evict_all_servers() {
 
     // Unload all
     for (const auto& server : loaded_servers_) {
-    LOG(INFO, "Router") << "Unloading: " << server->get_model_name() << std::endl;
+        LOG(INFO, "Router") << "Unloading: " << server->get_model_name() << std::endl;
         server->unload();
     }
 
@@ -184,22 +184,22 @@ std::unique_ptr<WrappedServer> Router::create_backend_server(const ModelInfo& mo
     std::string log_level = config_->log_level();
 
     if (model_info.recipe == "whispercpp") {
-    LOG(DEBUG, "Router") << "Creating WhisperServer backend" << std::endl;
+        LOG(DEBUG, "Router") << "Creating WhisperServer backend" << std::endl;
         new_server = std::make_unique<backends::WhisperServer>(log_level, model_manager_, backend_manager_);
     } else if (model_info.recipe == "kokoro") {
-    LOG(DEBUG, "Router") << "Creating Kokoro backend" << std::endl;
+        LOG(DEBUG, "Router") << "Creating Kokoro backend" << std::endl;
         new_server = std::make_unique<backends::KokoroServer>(log_level, model_manager_, backend_manager_);
     } else if (model_info.recipe == "sd-cpp") {
-    LOG(DEBUG, "Router") << "Creating SDServer backend" << std::endl;
+        LOG(DEBUG, "Router") << "Creating SDServer backend" << std::endl;
         new_server = std::make_unique<backends::SDServer>(log_level, model_manager_, backend_manager_);
     } else if (model_info.recipe == "flm") {
-    LOG(DEBUG, "Router") << "Creating FastFlowLM backend" << std::endl;
+        LOG(DEBUG, "Router") << "Creating FastFlowLM backend" << std::endl;
         new_server = std::make_unique<backends::FastFlowLMServer>(log_level, model_manager_, backend_manager_);
     } else if (model_info.recipe == "ryzenai-llm") {
-    LOG(DEBUG, "Router") << "Creating RyzenAI-Server backend" << std::endl;
+        LOG(DEBUG, "Router") << "Creating RyzenAI-Server backend" << std::endl;
 
         std::string model_path = model_info.resolved_path();
-    LOG(DEBUG, "Router") << "Using model path: " << model_path << std::endl;
+        LOG(DEBUG, "Router") << "Using model path: " << model_path << std::endl;
 
         auto* ryzenai_server = new RyzenAIServer(model_info.model_name,
                                                   log_level == "debug", model_manager_, backend_manager_);
@@ -209,7 +209,7 @@ std::unique_ptr<WrappedServer> Router::create_backend_server(const ModelInfo& mo
         LOG(DEBUG, "Router") << "Creating vLLM backend" << std::endl;
         new_server = std::make_unique<backends::VLLMServer>(log_level, model_manager_, backend_manager_);
     } else {
-    LOG(DEBUG, "Router") << "Creating LlamaCpp backend" << std::endl;
+        LOG(DEBUG, "Router") << "Creating LlamaCpp backend" << std::endl;
         new_server = std::make_unique<backends::LlamaCppServer>(log_level, model_manager_, backend_manager_);
     }
 
@@ -222,13 +222,15 @@ void Router::load_model(const std::string& model_name,
                        bool do_not_upgrade,
                        bool allow_reload_on_option_change) {
     const std::string canonical_model_name = resolve_model_name(model_name);
-    RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options());
+    const std::string backend_option = model_info.recipe + "_backend";
+    std::string backend = options.get_option(backend_option).get<std::string>();
+    backend = backend.empty() ? model_info.recipe_options.get_option(backend_option).get<std::string>() : backend;
+    RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options(backend));
 
     // Resolve settings: load overrides take precedence over per-model overrides which take precedence over defaults
-        RecipeOptions effective_options = options.inherit(model_info.recipe_options.inherit(default_opt));
+    RecipeOptions effective_options = options.inherit(model_info.recipe_options.inherit(default_opt));
 
     LOG(DEBUG, "Router") << "Effective settings: " << effective_options.to_log_string() << std::endl;
-
 
     // LOAD SERIALIZATION STRATEGY (from spec: point #2 in Additional Considerations)
     std::unique_lock<std::mutex> lock(load_mutex_);
@@ -318,7 +320,7 @@ void Router::load_model(const std::string& model_name,
         if (max_models != -1 && current_count >= max_models) {
             WrappedServer* lru = find_lru_server_by_type(model_type);
             if (lru) {
-            LOG(INFO, "Router") << "Slot limit reached for type "
+                LOG(INFO, "Router") << "Slot limit reached for type "
                           << model_type_to_string(model_type)
                           << ", evicting LRU: " << lru->get_model_name() << std::endl;
                 evict_server(lru);
@@ -336,18 +338,18 @@ void Router::load_model(const std::string& model_name,
         lock.unlock();
 
         // Load the backend (this can take 30-60 seconds)
-    LOG(DEBUG, "Router") << "Starting backend (this may take a moment)..." << std::endl;
+        LOG(DEBUG, "Router") << "Starting backend (this may take a moment)..." << std::endl;
         bool load_success = false;
         std::string error_message;
 
         try {
             new_server->load(canonical_model_name, model_info, effective_options, do_not_upgrade);
             load_success = true;
-        LOG(DEBUG, "Router") << "Backend started successfully" << std::endl;
+            LOG(DEBUG, "Router") << "Backend started successfully" << std::endl;
         } catch (const std::exception& e) {
             error_message = e.what();
             load_success = false;
-        LOG(ERROR, "Router") << "Backend load failed: " << error_message << std::endl;
+            LOG(ERROR, "Router") << "Backend load failed: " << error_message << std::endl;
         }
 
         lock.lock();
@@ -365,7 +367,7 @@ void Router::load_model(const std::string& model_name,
             is_loading_ = false;
             load_cv_.notify_all();
 
-        LOG(INFO, "Router") << "Model loaded successfully. Total loaded: "
+            LOG(INFO, "Router") << "Model loaded successfully. Total loaded: "
                       << loaded_servers_.size() << std::endl;
         } else {
             // ERROR HANDLING (from spec: Error Handling section)
@@ -378,12 +380,12 @@ void Router::load_model(const std::string& model_name,
             load_cv_.notify_all();
 
             if (is_file_not_found) {
-            LOG(ERROR, "Router") << "File not found error, NOT evicting other models" << std::endl;
+                LOG(ERROR, "Router") << "File not found error, NOT evicting other models" << std::endl;
                 throw std::runtime_error(error_message);
             }
 
             // Nuclear option: evict all models and retry
-        LOG(WARNING, "Router") << "Load failed with non-file-not-found error, "
+            LOG(WARNING, "Router") << "Load failed with non-file-not-found error, "
                       << "evicting all models and retrying..." << std::endl;
 
             evict_all_servers();
@@ -398,7 +400,7 @@ void Router::load_model(const std::string& model_name,
 
             lock.unlock();
 
-        LOG(DEBUG, "Router") << "Retrying backend load..." << std::endl;
+            LOG(DEBUG, "Router") << "Retrying backend load..." << std::endl;
             try {
                 retry_server->load(canonical_model_name, model_info, effective_options, do_not_upgrade);
 
@@ -408,19 +410,19 @@ void Router::load_model(const std::string& model_name,
                 is_loading_ = false;
                 load_cv_.notify_all();
 
-            LOG(DEBUG, "Router") << "Retry successful!" << std::endl;
+                LOG(DEBUG, "Router") << "Retry successful!" << std::endl;
             } catch (const std::exception& retry_error) {
                 lock.lock();
                 is_loading_ = false;
                 load_cv_.notify_all();
 
-            LOG(ERROR, "Router") << "Retry also failed: " << retry_error.what() << std::endl;
+                LOG(ERROR, "Router") << "Retry also failed: " << retry_error.what() << std::endl;
                 throw;
             }
         }
 
     } catch (const std::exception& e) {
-    LOG(ERROR, "Router") << "Failed to load model: " << e.what() << std::endl;
+        LOG(ERROR, "Router") << "Failed to load model: " << e.what() << std::endl;
 
         if (!lock.owns_lock()) {
             lock.lock();
@@ -437,11 +439,11 @@ void Router::unload_model(const std::string& model_name) {
 
     if (model_name.empty()) {
         // Unload all models
-    LOG(INFO, "Router") << "Unload all models called" << std::endl;
+        LOG(INFO, "Router") << "Unload all models called" << std::endl;
         evict_all_servers();
     } else {
         // Unload specific model
-    LOG(INFO, "Router") << "Unload model called: " << model_name << std::endl;
+        LOG(INFO, "Router") << "Unload model called: " << model_name << std::endl;
         std::string canonical_model_name = resolve_model_name(model_name);
         WrappedServer* server = find_server_by_model_name(canonical_model_name);
         if (!server) {
@@ -594,12 +596,12 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
             }
         } catch (...) {
             // If JSON parsing fails, fall back to most recent server
-        LOG(DEBUG, "Router") << "Failed to parse request body for model extraction" << std::endl;
+            LOG(DEBUG, "Router") << "Failed to parse request body for model extraction" << std::endl;
         }
 
         // Find requested model - no fallback to avoid silent misrouting
         if (requested_model.empty()) {
-        LOG(ERROR, "Router") << "No model specified in streaming request" << std::endl;
+            LOG(ERROR, "Router") << "No model specified in streaming request" << std::endl;
             std::string error_msg = "data: {\"error\":{\"message\":\"No model specified in request\",\"type\":\"invalid_request_error\"}}\n\n";
             sink.write(error_msg.c_str(), error_msg.size());
             return;

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -291,7 +291,7 @@ json RuntimeConfig::recipe_options(const std::string& backend) const {
     if (config_.contains("llamacpp")) {
         const auto& lc = config_["llamacpp"];
         if (lc.contains("backend")) result["llamacpp_backend"] = resolve_auto(lc["backend"]);
-        if (lc.contains(backend_args)) {
+        if (lc.contains(backend_args) && lc[backend_args] != "") {
             result["llamacpp_args"] = lc[backend_args];
         } else if (lc.contains("args")) {
             result["llamacpp_args"] = lc["args"];
@@ -302,7 +302,7 @@ json RuntimeConfig::recipe_options(const std::string& backend) const {
     if (config_.contains("whispercpp")) {
         const auto& wc = config_["whispercpp"];
         if (wc.contains("backend")) result["whispercpp_backend"] = resolve_auto(wc["backend"]);
-        if (wc.contains(backend_args)) {
+        if (wc.contains(backend_args) && wc[backend_args] != "") {
             result["whispercpp_args"] = wc[backend_args];
         } else if (wc.contains("args")) {
             result["whispercpp_args"] = wc["args"];
@@ -312,7 +312,7 @@ json RuntimeConfig::recipe_options(const std::string& backend) const {
     if (config_.contains("sdcpp")) {
         const auto& sd = config_["sdcpp"];
         if (sd.contains("backend")) result["sd-cpp_backend"] = resolve_auto(sd["backend"]);
-        if (sd.contains(backend_args)) {
+        if (sd.contains(backend_args) && sd[backend_args] != "") {
             result["sdcpp_args"] = sd[backend_args];
         } else if (sd.contains("args")) {
             result["sdcpp_args"] = sd["args"];

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -275,7 +275,7 @@ double RuntimeConfig::backend_double(const std::string& backend,
     return 0.0;
 }
 
-json RuntimeConfig::recipe_options() const {
+json RuntimeConfig::recipe_options(const std::string& backend) const {
     std::shared_lock lock(mutex_);
     json result = json::object();
 
@@ -286,23 +286,37 @@ json RuntimeConfig::recipe_options() const {
         return val;
     };
 
+    const std::string backend_args = backend + "_args";
+
     if (config_.contains("llamacpp")) {
         const auto& lc = config_["llamacpp"];
         if (lc.contains("backend")) result["llamacpp_backend"] = resolve_auto(lc["backend"]);
-        if (lc.contains("args")) result["llamacpp_args"] = lc["args"];
+        if (lc.contains(backend_args)) {
+            result["llamacpp_args"] = lc[backend_args];
+        } else if (lc.contains("args")) {
+            result["llamacpp_args"] = lc["args"];
+        }
         if (lc.contains("device")) result["llamacpp_device"] = lc["device"];
     }
 
     if (config_.contains("whispercpp")) {
         const auto& wc = config_["whispercpp"];
         if (wc.contains("backend")) result["whispercpp_backend"] = resolve_auto(wc["backend"]);
-        if (wc.contains("args")) result["whispercpp_args"] = wc["args"];
+        if (wc.contains(backend_args)) {
+            result["whispercpp_args"] = wc[backend_args];
+        } else if (wc.contains("args")) {
+            result["whispercpp_args"] = wc["args"];
+        }
     }
 
     if (config_.contains("sdcpp")) {
         const auto& sd = config_["sdcpp"];
         if (sd.contains("backend")) result["sd-cpp_backend"] = resolve_auto(sd["backend"]);
-        if (sd.contains("args")) result["sdcpp_args"] = sd["args"];
+        if (sd.contains(backend_args)) {
+            result["sdcpp_args"] = sd[backend_args];
+        } else if (sd.contains("args")) {
+            result["sdcpp_args"] = sd["args"];
+        }
         if (sd.contains("steps")) result["steps"] = sd["steps"];
         if (sd.contains("cfg_scale")) result["cfg_scale"] = sd["cfg_scale"];
         if (sd.contains("width")) result["width"] = sd["width"];
@@ -427,7 +441,7 @@ void RuntimeConfig::validate_backend(const std::string& backend, const std::stri
         }
         validate_backend_choice(backend, value.get<std::string>());
     }
-    else if (key == "args") {
+    else if (key == "args" || key.find("_args") != std::string::npos) {
         if (!value.is_string()) {
             throw std::invalid_argument("'" + backend + "." + key + "' must be a string");
         }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2559,7 +2559,7 @@ void Server::handle_image_upscale(const httplib::Request& req, httplib::Response
 
             // Honor explicit config first (e.g. sdcpp.backend = "rocm").
             // "auto" in config.json is mapped to "" by recipe_options().
-            auto recipe_opts = config_->recipe_options();
+            auto recipe_opts = config_->recipe_options("");
             if (recipe_opts.contains("sd-cpp_backend") &&
                 recipe_opts["sd-cpp_backend"].is_string()) {
                 backend = recipe_opts["sd-cpp_backend"].get<std::string>();


### PR DESCRIPTION
Example:

`lemonade config set llamacpp.rocm_args="-b 4096 -ub 2048" llamacpp.vulkan_args="-b 1024 -ub 512"`

when loading a model with ROCm, the ROCm-specific args will be merged, when loading with Vulkan, those will be merged. If no backend-specific args are defined (etc), fallback to unprefixed "args". Works for all recipes that have multiple backends.

I also fixed indentation of log lines throughout `router.cpp` since many were misindented for some reasons.