### PR TITLE
fix: vLLM memory behavior on APUs

### DIFF
--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -43,6 +43,10 @@
   "flm": {
     "args": ""
   },
+  "vllm": {
+    "backend": "auto",
+    "args": ""
+  },
   "ryzenai": {
     "server_bin": "builtin"
   },

--- a/src/cpp/server/backends/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm_server.cpp
@@ -175,6 +175,14 @@ void VLLMServer::load(const std::string& model_name,
     // enable prompt caching
     args.push_back("--enable-prefix-caching");
 
+    // Avoid vLLM's default gpu_memory_utilization=0.92 on shared-memory systems.
+    // Keep this overridable through vllm_args for users that want another limit.
+    if (vllm_args.find("--gpu-memory-utilization") == std::string::npos &&
+        vllm_args.find("--kv-cache-memory-bytes") == std::string::npos) {
+        args.push_back("--kv-cache-memory-bytes");
+        args.push_back("4G");
+    }
+
     // Append custom vllm_args if provided
     if (!vllm_args.empty()) {
         LOG(DEBUG, "vLLM") << "Adding custom arguments: " << vllm_args << std::endl;

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -30,7 +30,7 @@ RuntimeConfig* RuntimeConfig::global() {
 }
 
 static const std::vector<std::string> s_backend_names = {
-    "llamacpp", "whispercpp", "sdcpp", "flm", "ryzenai", "kokoro"
+    "llamacpp", "whispercpp", "sdcpp", "flm", "vllm", "ryzenai", "kokoro"
 };
 
 static bool is_backend_name(const std::string& key) {
@@ -312,6 +312,12 @@ json RuntimeConfig::recipe_options() const {
     if (config_.contains("flm")) {
         const auto& flm = config_["flm"];
         if (flm.contains("args")) result["flm_args"] = flm["args"];
+    }
+
+    if (config_.contains("vllm")) {
+        const auto& vl = config_["vllm"];
+        if (vl.contains("backend")) result["vllm_backend"] = resolve_auto(vl["backend"]);
+        if (vl.contains("args")) result["vllm_args"] = vl["args"];
     }
 
     if (config_.contains("ctx_size")) result["ctx_size"] = config_["ctx_size"];


### PR DESCRIPTION
## Summary
- wire `vllm.backend` / `vllm.args` into runtime config
- default vLLM KV cache to 4G when no memory option is set

## Why
vLLM defaults to `gpu_memory_utilization=0.92`, which is unsafe on shared-memory/UMA systems that have a high RAM for GPU setup e.g. 120 / 128 GB on Strix Halo and can OOM the host even for the smallest models.

## Notes
Draft PR for discussion. Users can still override memory behavior with `--kv-cache-memory-bytes` or `--gpu-memory-utilization` in `vllm.args`.
Let us discuss what is the best option to handle memory for vLLM.

100% safe if you want to try out and had memory issues before. At least a 64 GB Ram system recommended. 