### PR TITLE
keep quotes during arg merging

### DIFF
--- a/src/cpp/include/lemon/utils/custom_args.h
+++ b/src/cpp/include/lemon/utils/custom_args.h
@@ -8,7 +8,7 @@
 namespace lemon {
 namespace utils {
 
-inline std::vector<std::string> parse_custom_args(const std::string& custom_args_str) {
+inline std::vector<std::string> parse_custom_args(const std::string& custom_args_str, bool keep_quotes = false) {
     std::vector<std::string> result;
     if (custom_args_str.empty()) {
         return result;
@@ -24,6 +24,9 @@ inline std::vector<std::string> parse_custom_args(const std::string& custom_args
             quote_char = c;
         } else if (in_quotes && c == quote_char) {
             in_quotes = false;
+            if (keep_quotes) {
+                current_arg = quote_char + current_arg + quote_char;
+            }
             quote_char = '\0';
         } else if (!in_quotes && c == ' ') {
             if (!current_arg.empty()) {

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -186,8 +186,8 @@ RecipeOptions RecipeOptions::inherit(const RecipeOptions& options) const {
             } else if (incoming_str.empty()) {
                 merged[it.key()] = target_str;
             } else {
-                auto target_tokens = lemon::utils::parse_custom_args(target_str);
-                auto incoming_tokens = lemon::utils::parse_custom_args(incoming_str);
+                auto target_tokens = lemon::utils::parse_custom_args(target_str, true);
+                auto incoming_tokens = lemon::utils::parse_custom_args(incoming_str, true);
 
                 auto target_map = lemon::utils::build_custom_args_map(target_tokens);
                 auto incoming_map = lemon::utils::build_custom_args_map(incoming_tokens);


### PR DESCRIPTION
Argument parsing strips quotes from the argument - this is correct when using the arguments to launch the program but when merging/reassembling arguments this can break the command line. This PR fixes this.