### PR TITLE
build: enforce web-app target ordering before executable POST_BUILD copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1122,6 +1122,19 @@ endif()
 # Add tray application subdirectory
 add_subdirectory(src/cpp/tray)
 
+# When the web app is auto-built, force it to finish before any executable's
+# POST_BUILD step copies build/resources/ to build/<config>/resources/.
+# Without this, parallel MSBuild can race and leave build/<config>/resources/web-app
+# empty, so lemond logs "Web app directory not found" at startup.
+if(CAN_BUILD_WEB_APP AND BUILD_WEB_APP AND TARGET web-app)
+    if(TARGET ${EXECUTABLE_NAME})
+        add_dependencies(${EXECUTABLE_NAME} web-app)
+    endif()
+    if(TARGET LemonadeServer)
+        add_dependencies(LemonadeServer web-app)
+    endif()
+endif()
+
 # Add CLI application subdirectory
 add_subdirectory(src/cpp/cli)
 


### PR DESCRIPTION
## Summary

- The `web-app` custom target (ALL) had no dependency relationship with `lemond` or `LemonadeServer`. Both executables have a POST_BUILD step that copies `build/resources/` → `build/<config>/resources/`, which is how the staged web-app under `build/resources/web-app/` lands next to the executable.
- Without an explicit dependency, parallel MSBuild can run the executable's POST_BUILD before `web-app` finishes, leaving `build/<config>/resources/web-app/` empty. At startup `lemond` then logs `Web app directory not found at: …/build/Release/resources/web-app` and falls back to the static status page.
- Fix: add `add_dependencies(${EXECUTABLE_NAME} web-app)` and `add_dependencies(LemonadeServer web-app)` in the root `CMakeLists.txt`, gated on `CAN_BUILD_WEB_APP AND BUILD_WEB_APP AND TARGET web-app` so the manual (opt-in) `web-app` target in the `BUILD_WEB_APP=OFF` branch is untouched.

## Test plan

- [x] On Windows with `BUILD_WEB_APP=ON`: clean web-app outputs, run `cmake --build --preset windows`, confirm `Web app build completed successfully` precedes both `LemonadeServer` and `lemond` POST_BUILD copy lines and that `build/Release/resources/web-app/` is populated.
- [ ] CI: confirm Linux and Windows builds still succeed.
- [ ] With `BUILD_WEB_APP=OFF`: build `lemond` without invoking `--target web-app` and confirm no new dependency is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)