### PR TITLE
Preserve backend error status

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -112,6 +112,42 @@ bool prepend_no_think_to_last_user_message(json& request_json) {
     return false;
 }
 
+bool valid_error_status(int status_code) {
+    return status_code >= 400 && status_code <= 599;
+}
+
+int get_error_status_code(const json& response, int default_status_code = 500) {
+    if (!response.contains("error") || !response["error"].is_object()) {
+        return default_status_code;
+    }
+
+    const auto& error = response["error"];
+    if (error.contains("status_code") && error["status_code"].is_number_integer()) {
+        int status_code = error["status_code"].get<int>();
+        if (valid_error_status(status_code)) {
+            return status_code;
+        }
+    }
+
+    if (error.contains("details") && error["details"].is_object()) {
+        const auto& details = error["details"];
+        if (details.contains("status_code") && details["status_code"].is_number_integer()) {
+            int status_code = details["status_code"].get<int>();
+            if (valid_error_status(status_code)) {
+                return status_code;
+            }
+        }
+    }
+
+    return default_status_code;
+}
+
+void set_error_response(const json& response, httplib::Response& res,
+                        int default_status_code = 500) {
+    res.status = get_error_status_code(response, default_status_code);
+    res.set_content(response.dump(), "application/json");
+}
+
 } // namespace
 
 
@@ -1515,6 +1551,12 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
 
             auto response = router_->chat_completion(request_json);
 
+            if (response.contains("error")) {
+                LOG(ERROR, "Server") << "Backend returned error response: " << response["error"].dump() << std::endl;
+                set_error_response(response, res);
+                return;
+            }
+
             // Debug: Check if response contains tool_calls
             if (response.contains("choices") && response["choices"].is_array() && !response["choices"].empty()) {
                 auto& first_choice = response["choices"][0];
@@ -1702,8 +1744,7 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
             // Check if response contains an error
             if (response.contains("error")) {
                 LOG(ERROR, "Server") << "Backend returned error response: " << response["error"].dump() << std::endl;
-                res.status = 500;
-                res.set_content(response.dump(), "application/json");
+                set_error_response(response, res);
                 return;
             }
 
@@ -2756,6 +2797,12 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
             LOG(INFO, "Server") << "POST /api/v1/responses - Non-streaming" << std::endl;
 
             auto response = router_->responses(request_json);
+
+            if (response.contains("error")) {
+                LOG(ERROR, "Server") << "Responses backend error: " << response["error"].dump() << std::endl;
+                set_error_response(response, res);
+                return;
+            }
 
             LOG(INFO, "Server") << "200 OK" << std::endl;
             res.set_content(response.dump(), "application/json");

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -4,12 +4,86 @@
 #include <lemon/streaming_proxy.h>
 #include <lemon/error_types.h>
 #include <httplib.h>
+#include <algorithm>
+#include <cctype>
 #include <thread>
 #include <chrono>
 #include <iostream>
 #include <lemon/utils/aixlog.hpp>
 
 namespace lemon {
+
+namespace {
+
+std::string lower_copy(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+bool is_context_window_error(const std::string& message) {
+    const std::string lowered = lower_copy(message);
+    return lowered.find("exceeds the available context size") != std::string::npos ||
+           lowered.find("context length exceeded") != std::string::npos;
+}
+
+std::string extract_backend_error_message(const json& backend_response) {
+    if (backend_response.is_object() && backend_response.contains("error")) {
+        const auto& error = backend_response["error"];
+        if (error.is_string()) {
+            return error.get<std::string>();
+        }
+        if (error.is_object() && error.contains("message") && error["message"].is_string()) {
+            return error["message"].get<std::string>();
+        }
+        return error.dump();
+    }
+    if (backend_response.is_string()) {
+        return backend_response.get<std::string>();
+    }
+    return backend_response.dump();
+}
+
+json create_backend_error_response(const std::string& server_name, int status_code,
+                                   const json& backend_response) {
+    std::string message = extract_backend_error_message(backend_response);
+    if (message.empty()) {
+        message = server_name + " request failed";
+    }
+
+    json error = {
+        {"message", message},
+        {"type", status_code >= 400 && status_code < 500
+            ? "invalid_request_error"
+            : ErrorType::BACKEND_ERROR},
+        {"status_code", status_code},
+        {"details", {
+            {"backend", server_name},
+            {"response", backend_response}
+        }}
+    };
+
+    if (backend_response.is_object() && backend_response.contains("error") &&
+        backend_response["error"].is_object()) {
+        const auto& backend_error = backend_response["error"];
+        if (backend_error.contains("type") && backend_error["type"].is_string()) {
+            error["type"] = backend_error["type"];
+        }
+        if (backend_error.contains("code")) {
+            error["code"] = backend_error["code"];
+        }
+    }
+
+    if (is_context_window_error(message)) {
+        error["type"] = "invalid_request_error";
+        error["code"] = "context_length_exceeded";
+    }
+
+    return {{"error", error}};
+}
+
+} // namespace
 
 int WrappedServer::choose_port() {
     port_ = utils::ProcessManager::find_free_port(8001);
@@ -95,13 +169,10 @@ json WrappedServer::forward_request(const std::string& endpoint, const json& req
                 error_details = response.body;
             }
 
-            return ErrorResponse::create(
-                server_name_ + " request failed",
-                ErrorType::BACKEND_ERROR,
-                {
-                    {"status_code", response.status_code},
-                    {"response", error_details}
-                }
+            return create_backend_error_response(
+                server_name_,
+                response.status_code,
+                error_details
             );
         }
     } catch (const std::exception& e) {

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -275,6 +275,8 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
         print(f"\n=== Starting test: {self._testMethodName} ===")
         _stop_server()
         os.environ.pop("MOCK_LLAMA_REQUEST_PATH", None)
+        os.environ.pop("MOCK_LLAMA_ERROR_STATUS", None)
+        os.environ.pop("MOCK_LLAMA_ERROR_RESPONSE", None)
         os.environ["PATH"] = self.original_path  # Ensure PATH is clean before each test
         self._write_llama_server(
             DUMMY_LLAMA_SERVER_WINDOWS

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -67,13 +67,15 @@ class ReusableHTTPServer(ThreadingHTTPServer):
 
 
 capture_path = os.environ.get("MOCK_LLAMA_REQUEST_PATH", "")
+error_status = int(os.environ.get("MOCK_LLAMA_ERROR_STATUS", "0") or "0")
+error_response = os.environ.get("MOCK_LLAMA_ERROR_RESPONSE", "")
 port = int(get_arg("--port", "13305"))
 
 
 class Handler(BaseHTTPRequestHandler):
-    def _send_json(self, payload):
+    def _send_json(self, payload, status=200):
         body = json.dumps(payload).encode("utf-8")
-        self.send_response(200)
+        self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
@@ -95,6 +97,10 @@ class Handler(BaseHTTPRequestHandler):
         if capture_path:
             with open(capture_path, "w", encoding="utf-8") as handle:
                 handle.write(body)
+
+        if error_response:
+            self._send_json(json.loads(error_response), status=error_status or 400)
+            return
 
         request_json = json.loads(body)
         if request_json.get("stream"):
@@ -526,6 +532,54 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
         self.assertEqual(forwarded_request["messages"][-1]["content"], "Say hello.")
         self.assertNotIn("thinking", forwarded_request)
         self.assertNotIn("enable_thinking", forwarded_request)
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"), "System backend only supported on Linux"
+    )
+    def test_008_backend_context_error_preserves_http_status(self):
+        """Verify backend context-window errors stay HTTP 400 and OpenAI-shaped."""
+        self._write_llama_server(MOCK_LLAMA_SERVER_PYTHON)
+        self._add_dummy_llama_server_to_path()
+
+        error_message = (
+            "request (67311 tokens) exceeds the available context size "
+            "(65536 tokens), try increasing it"
+        )
+        os.environ["MOCK_LLAMA_ERROR_STATUS"] = "400"
+        os.environ["MOCK_LLAMA_ERROR_RESPONSE"] = json.dumps(
+            {"error": {"message": error_message, "type": "invalid_request_error"}}
+        )
+        self.addCleanup(os.environ.pop, "MOCK_LLAMA_ERROR_STATUS", None)
+        self.addCleanup(os.environ.pop, "MOCK_LLAMA_ERROR_RESPONSE", None)
+
+        _stop_server()
+        _start_server(wrapped_server="llamacpp", backend="system")
+        self._ensure_model_pulled()
+
+        load_response = requests.post(
+            f"http://localhost:{PORT}/api/v1/load",
+            json={"model_name": ENDPOINT_TEST_MODEL, "llamacpp_backend": "system"},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(load_response.status_code, 200)
+
+        response = requests.post(
+            f"http://localhost:{PORT}/api/v1/chat/completions",
+            json={
+                "model": ENDPOINT_TEST_MODEL,
+                "messages": [{"role": "user", "content": "Say hello."}],
+                "stream": False,
+                "max_tokens": 8,
+            },
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        error = response.json()["error"]
+        self.assertEqual(error["type"], "invalid_request_error")
+        self.assertEqual(error["code"], "context_length_exceeded")
+        self.assertEqual(error["status_code"], 400)
+        self.assertIn("exceeds the available context size", error["message"])
 
 
 def _run_tests():


### PR DESCRIPTION
## Summary
- Preserve wrapped-backend JSON error payloads instead of replacing them with generic 500s.
- Return preserved backend HTTP status codes from chat completions, completions, and responses handlers (non-streaming paths only; streaming SSE error propagation is out of scope).
- Convert llama.cpp context-window failures into OpenAI-shaped `invalid_request_error` responses with `code=context_length_exceeded`, while keeping backend details for debugging.
- Add a system-backend regression path that can mock llama.cpp non-2xx error responses.

## Server Validation
- Started `build/lemond --host 127.0.0.1 --port 13305` from this branch.
- Loaded cached `Qwen3.6-35B-A3B-GGUF` successfully through `POST /api/v1/load`.
- Sent an over-context `POST /api/v1/chat/completions`; Lemonade returned HTTP `400` with `type=invalid_request_error`, `code=context_length_exceeded`, `status_code=400`, and preserved llama.cpp backend details including `n_ctx=65536` and `n_prompt_tokens=80010`.

## Tests
- `python3 -m py_compile test/test_llamacpp_system_backend.py`
- `git diff --check`
- `cmake --build --preset default --target lemond`

## Not Completed
- Full `test/test_llamacpp_system_backend.py` with `build/lemonade-server` starts the server but fails before the new regression on existing system-backend availability expectations: this host reports the dummy `llama-server` as `unsupported` because system llama.cpp requires the HIP plugin on AMD GPU hosts.
