### PR TITLE
fix: resolve rocm channel when checking expected sd-cpp/llamacpp version

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -465,11 +465,24 @@ static std::string get_expected_backend_version(const std::string& recipe, const
     if (!backend_versions.contains(recipe)) {
         return "";
     }
+
+    // sd-cpp and llamacpp expose a single "rocm" backend but store per-channel
+    // version pins ("rocm-stable", "rocm-nightly") in backend_versions.json.
+    // Mirror the resolution done by BackendUtils::get_backend_version().
+    std::string resolved_backend = backend;
+    if ((recipe == "llamacpp" || recipe == "sd-cpp") && backend == "rocm") {
+        std::string channel = "stable";
+        if (auto* cfg = RuntimeConfig::global()) {
+            channel = cfg->rocm_channel_for_recipe(recipe);
+        }
+        resolved_backend = "rocm-" + channel;
+    }
+
     const auto& recipe_config = backend_versions[recipe];
-    if (!recipe_config.contains(backend) || !recipe_config[backend].is_string()) {
+    if (!recipe_config.contains(resolved_backend) || !recipe_config[resolved_backend].is_string()) {
         return "";
     }
-    return recipe_config[backend].get<std::string>();
+    return recipe_config[resolved_backend].get<std::string>();
 }
 
 // ============================================================================


### PR DESCRIPTION
I was reviewing #1922 and I saw "sd-cpp:rocm is `installed` on master-506-1f30df9", when it should have said `update_required`. This PR fixes it.

## Summary

- `lemonade backends` was rendering stale on-disk versions of `sd-cpp:rocm` (and `llamacpp:rocm`) as `installed` instead of `update_required` when `backend_versions.json` was bumped.
- Root cause: `system_info.cpp::get_expected_backend_version()` queried `backend_versions.json[recipe][backend]` with the raw backend name `"rocm"`, but sd-cpp and llamacpp store per-channel pins under `"rocm-stable"` / `"rocm-nightly"`. The lookup returned empty, `has_expected` stayed false, and the update check at `system_info.cpp:1091` was skipped.
- Fix: apply the same `rocm` → `rocm-{channel}` resolution that `BackendUtils::get_backend_version()` (`backend_utils.cpp:247-275`) already performs, so the display path sees the real pin.
- The install/load path was unaffected — `BackendUtils::get_backend_version()` and `resolve_sdcpp_backend()` already resolved the channel correctly there. This is purely a fix to the status display.