### PR TITLE
feat: built-in MTP support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
-project(lemon_cpp VERSION 10.5.0)
+project(lemon_cpp VERSION 10.5.1)
 
 # Export compile_commands.json for clangd/IntelliSense
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -1001,6 +1001,12 @@ Labels describe what a model can do. A model may carry multiple labels.
 |-------|-------------|
 | `realtime-transcription` | Supports the WebSocket `/realtime` endpoint for live microphone transcription. |
 
+**Runtime labels** — affect backend launch defaults:
+
+| Label | Description |
+|-------|-------------|
+| `mtp` | Enables llama.cpp MTP draft decoding defaults (`--spec-type draft-mtp --spec-draft-n-max 6`); users can override these with `llamacpp_args`. |
+
 **Characteristic labels** — informational, do not affect routing:
 
 | Label | Description |

--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -1005,7 +1005,7 @@ Labels describe what a model can do. A model may carry multiple labels.
 
 | Label | Description |
 |-------|-------------|
-| `mtp` | Enables llama.cpp MTP draft decoding defaults (`--spec-type draft-mtp --spec-draft-n-max 6`); users can override these with `llamacpp_args`. |
+| `mtp` | Enables llama.cpp MTP draft decoding defaults (`--spec-type draft-mtp --spec-draft-n-max 3 --spec-draft-p-min 0.75`); users can override these with `llamacpp_args`. |
 
 **Characteristic labels** — informational, do not affect routing:
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -165,7 +165,7 @@ lemonade pull MODEL_OR_CHECKPOINT [--checkpoint TYPE CHECKPOINT] [--recipe RECIP
 | `MODEL_OR_CHECKPOINT` | Registered model name, or `owner/repo[:variant]` Hugging Face checkpoint | Yes |
 | `--checkpoint TYPE CHECKPOINT` | Manual registration: add a checkpoint entry. Repeat for multi-component models such as `main` + `mmproj` or `main` + `vae`. | No |
 | `--recipe RECIPE` | Manual registration: recipe to associate with the new `user.*` model (`llamacpp`, `flm`, `ryzenai-llm`, `vllm`, `whispercpp`, `sd-cpp`, `kokoro`) | No |
-| `--label LABEL` | Manual registration: add a label to the new model. Repeatable. Valid: `coding`, `embeddings`, `hot`, `reasoning`, `reranking`, `tool-calling`, `vision` | No |
+| `--label LABEL` | Manual registration: add a label to the new model. Repeatable. Valid: `coding`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision` | No |
 
 **Happy path**
 

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -44,6 +44,7 @@ static const std::vector<std::string> VALID_LABELS = {
     "coding",
     "embeddings",
     "hot",
+    "mtp",
     "reasoning",
     "reranking",
     "tool-calling",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -966,6 +966,16 @@
         ],
         "size": 22.4
     },
+    "Qwen3.6-35B-A3B-MTP-GGUF": {
+        "checkpoint": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "tool-calling",
+            "mtp"
+        ],
+        "size": 22.9
+    },
     "Qwen3.6-27B-GGUF": {
         "checkpoint": "unsloth/Qwen3.6-27B-GGUF:Qwen3.6-27B-UD-Q4_K_XL.gguf",
         "mmproj": "mmproj-F16.gguf",
@@ -976,6 +986,17 @@
             "tool-calling"
         ],
         "size": 17.6
+    },
+    "Qwen3.6-27B-MTP-GGUF": {
+        "checkpoint": "unsloth/Qwen3.6-27B-MTP-GGUF:Qwen3.6-27B-UD-Q4_K_XL.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "tool-calling",
+            "mtp",
+            "hot"
+        ],
+        "size": 17.9
     },
     "Llama-4-Scout-17B-16E-Instruct-GGUF": {
         "checkpoint": "unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF:Q4_K_S",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -943,6 +943,17 @@
         ],
         "size": 68.4
     },
+    "Qwen3.5-122B-A10B-MTP-GGUF": {
+        "checkpoint": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF:UD-Q4_K_XL",
+        "mmproj": "mmproj-F16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "tool-calling",
+            "mtp"
+        ],
+        "size": 78.6
+    },
     "Qwen3.5-27B-GGUF": {
         "checkpoint": "unsloth/Qwen3.5-27B-GGUF:Qwen3.5-27B-UD-Q4_K_XL.gguf",
         "mmproj": "mmproj-F16.gguf",
@@ -968,6 +979,7 @@
     },
     "Qwen3.6-35B-A3B-MTP-GGUF": {
         "checkpoint": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+        "mmproj": "mmproj-F16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
         "labels": [
@@ -989,6 +1001,7 @@
     },
     "Qwen3.6-27B-MTP-GGUF": {
         "checkpoint": "unsloth/Qwen3.6-27B-MTP-GGUF:Qwen3.6-27B-UD-Q4_K_XL.gguf",
+        "mmproj": "mmproj-F16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
         "labels": [

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -324,7 +324,8 @@ void LlamaCppServer::load(const std::string& model_name,
     if (std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") != model_info.labels.end()) {
         LOG(INFO, "LlamaCpp") << "Model uses MTP, adding draft decoding defaults" << std::endl;
         push_overridable_arg(args, llamacpp_args, "--spec-type", "draft-mtp");
-        push_overridable_arg(args, llamacpp_args, "--spec-draft-n-max", "6");
+        push_overridable_arg(args, llamacpp_args, "--spec-draft-n-max", "3");
+        push_overridable_arg(args, llamacpp_args, "--spec-draft-p-min", "0.75");
     }
 
     // Disable llamacpp webui by default

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -8,10 +8,11 @@
 #include "lemon/utils/path_utils.h"
 #include "lemon/error_types.h"
 #include "lemon/system_info.h"
-#include <iostream>
-#include <filesystem>
-#include <lemon/utils/aixlog.hpp>
+#include <algorithm>
 #include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <lemon/utils/aixlog.hpp>
 #include <set>
 #ifdef __APPLE__
 #include <pwd.h>
@@ -319,6 +320,12 @@ void LlamaCppServer::load(const std::string& model_name,
 
     // Use legacy reasoning formatting
     push_overridable_arg(args, llamacpp_args, "--reasoning-format", "auto");
+
+    if (std::find(model_info.labels.begin(), model_info.labels.end(), "mtp") != model_info.labels.end()) {
+        LOG(INFO, "LlamaCpp") << "Model uses MTP, adding draft decoding defaults" << std::endl;
+        push_overridable_arg(args, llamacpp_args, "--spec-type", "draft-mtp");
+        push_overridable_arg(args, llamacpp_args, "--spec-draft-n-max", "6");
+    }
 
     // Disable llamacpp webui by default
     push_overridable_arg(args, llamacpp_args, "--no-webui");


### PR DESCRIPTION
- Adds an `mtp` label that indicates llama-server should be launched with mtp enablement args
- Adds Qwen3.6 MTP models to the registry