### PR TITLE
fix(download manager): restore model download state across renderer r…

### DIFF
--- a/.github/workflows/server_download_registry.yml
+++ b/.github/workflows/server_download_registry.yml
@@ -1,0 +1,94 @@
+name: Server Download Registry Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  LEMONADE_DISABLE_SYSTEMD_JOURNAL: "1"
+  LEMONADE_CI_MODE: "True"
+  PYTHONIOENCODING: utf-8
+  HF_HOME: ${{ github.workspace }}/hf-cache
+  LEMONADE_CACHE_DIR: ${{ github.workspace }}/ci-cache
+
+jobs:
+  server-download-registry-tests:
+    name: Server download registry tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    container:
+      image: ghcr.io/lemonade-sdk/lemonade/build-environment:ubuntu24.04
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          clean: true
+          fetch-depth: 0
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Configure CMake
+        run: cmake --preset default -DBUILD_WEB_APP=OFF
+
+      - name: Build server binaries
+        run: cmake --build --preset default --target lemond lemonade
+
+      - name: Install Python test dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -r test/requirements.txt
+
+      - name: Start lemond
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./build/lemond > /tmp/lemond-download-registry.log 2>&1 &
+          echo "$!" > /tmp/lemond-download-registry.pid
+
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:13305/live > /dev/null 2>&1; then
+              echo "lemond is healthy"
+              exit 0
+            fi
+            echo "Waiting for lemond... ($i/30)"
+            sleep 2
+          done
+
+          echo "ERROR: lemond did not become healthy"
+          cat /tmp/lemond-download-registry.log || true
+          exit 1
+
+      - name: Run server download registry tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          .venv/bin/python test/server_downloads.py --cli-binary ./build/lemonade
+
+      - name: Show lemond logs on failure
+        if: failure()
+        run: cat /tmp/lemond-download-registry.log || true
+
+      - name: Stop lemond
+        if: always()
+        shell: bash
+        run: |
+          if [ -f /tmp/lemond-download-registry.pid ]; then
+            kill "$(cat /tmp/lemond-download-registry.pid)" 2>/dev/null || true
+          fi
+          pkill -f lemond 2>/dev/null || true

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -10,6 +10,8 @@ We have designed a set of Lemonade-specific endpoints to enable client applicati
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | [`/v1/pull`](#post-v1pull) | Install a model |
+| `GET` | [`/v1/downloads`](#get-v1downloads) | List server-owned model download jobs |
+| `POST` | [`/v1/downloads/control`](#post-v1downloadscontrol) | Pause, cancel, or remove server-owned model download jobs |
 | `GET` | [`/v1/pull/variants`](#get-v1pullvariants) | Enumerate GGUF variants for a Hugging Face checkpoint |
 | `POST` | [`/v1/delete`](#post-v1delete) | Delete a model |
 | `POST` | [`/v1/load`](#post-v1load) | Load a model |
@@ -36,6 +38,7 @@ The Lemonade Server built-in model registry has a collection of model names that
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `stream` | No | If `true`, returns Server-Sent Events (SSE) with download progress. Defaults to `false`. |
+| `subscribe` | No | Only applies when `stream=true`. If `false`, the server starts a background model download job and returns a JSON snapshot immediately instead of keeping the HTTP response subscribed to SSE progress. Defaults to `true` for backwards compatibility. |
 
 **Install a Model that is Already Registered**
 
@@ -128,6 +131,169 @@ data: {"file_index":2,"total_files":2,"percent":100}
 | `progress` | Sent during download with current file and byte progress |
 | `complete` | Sent when all files are downloaded successfully |
 | `error` | Sent if download fails, with `error` field containing the message |
+
+### Server-owned download mode (`stream=true`, `subscribe=false`)
+
+By default, `stream=true` keeps the `/v1/pull` HTTP response subscribed to Server-Sent Events until the download finishes. Clients that need download state to survive a renderer reload, tab close, or reconnect can also send `subscribe=false`.
+
+When `stream=true` and `subscribe=false`, `/v1/pull` starts a server-owned model download job and returns a JSON snapshot immediately. The job continues on the server. Clients can poll [`GET /v1/downloads`](#get-v1downloads) to restore progress and can use [`POST /v1/downloads/control`](#post-v1downloadscontrol) to pause, cancel, or remove the job.
+
+Example request:
+
+```bash
+curl -X POST http://localhost:13305/v1/pull \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_name": "Qwen2.5-0.5B-Instruct-CPU",
+    "stream": true,
+    "subscribe": false
+  }'
+```
+
+Example response:
+
+```json
+{
+  "id": "model:Qwen2.5-0.5B-Instruct-CPU",
+  "type": "model",
+  "model_name": "Qwen2.5-0.5B-Instruct-CPU",
+  "status": "downloading",
+  "running": true,
+  "file": "",
+  "file_index": 0,
+  "total_files": 0,
+  "bytes_downloaded": 0,
+  "bytes_total": 0,
+  "total_download_size": 0,
+  "bytes_previously_downloaded": 0,
+  "completed_files_bytes": 0,
+  "cumulative_bytes_downloaded": 0,
+  "overall_bytes_downloaded": 0,
+  "percent": 0,
+  "complete": false
+}
+```
+
+## `GET /v1/downloads`
+<sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
+
+List server-owned model download jobs that were started with `POST /v1/pull` using `stream=true` and `subscribe=false`.
+
+This endpoint is intended for clients that need to restore download-manager state after a reload or reconnect. Active, paused, cancelled, and errored jobs remain visible until the client removes them. Completed jobs remain visible briefly so clients can observe completion and refresh model state.
+
+### Example request
+
+```bash
+curl http://localhost:13305/v1/downloads
+```
+
+### Response format
+
+```json
+[
+  {
+    "id": "model:Qwen2.5-0.5B-Instruct-CPU",
+    "type": "model",
+    "model_name": "Qwen2.5-0.5B-Instruct-CPU",
+    "status": "downloading",
+    "running": true,
+    "file": "model.gguf",
+    "file_index": 1,
+    "total_files": 2,
+    "bytes_downloaded": 1073741824,
+    "bytes_total": 2684354560,
+    "total_download_size": 2684355584,
+    "bytes_previously_downloaded": 0,
+    "completed_files_bytes": 0,
+    "cumulative_bytes_downloaded": 1073741824,
+    "overall_bytes_downloaded": 1073741824,
+    "percent": 40,
+    "complete": false
+  }
+]
+```
+
+### Download job fields
+
+| Field | Description |
+|-------|-------------|
+| `id` | Stable download id. Model downloads use `model:<model_name>`. |
+| `type` | Download type. Currently `model` for server-owned jobs. |
+| `model_name` | Lemonade model name associated with the job. |
+| `status` | Current state: `downloading`, `paused`, `cancelled`, `completed`, or `error`. |
+| `running` | Whether the download worker is still active. A terminal-looking status may still have `running=true` while the worker is releasing resources. |
+| `file`, `file_index`, `total_files` | Current file progress within the download. |
+| `bytes_downloaded`, `bytes_total`, `percent` | Current-file byte progress as reported by the downloader. |
+| `total_download_size` | Total expected bytes across all files when known. |
+| `bytes_previously_downloaded` | Bytes already present on disk for the current file when resuming or skipping existing data. |
+| `completed_files_bytes` | Bytes from files completed before the current file. |
+| `cumulative_bytes_downloaded`, `overall_bytes_downloaded` | Total bytes downloaded across the whole job. `overall_bytes_downloaded` is kept as a compatibility alias. |
+| `complete` | `true` when the download completed successfully. |
+| `error` | Error message, present only for failed jobs. |
+
+## `POST /v1/downloads/control`
+<sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
+
+Control a server-owned model download job.
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `id` | Yes | Download id returned by `POST /v1/pull` or `GET /v1/downloads`, for example `model:Qwen2.5-0.5B-Instruct-CPU`. |
+| `action` | Yes | One of `pause`, `cancel`, or `remove`. |
+
+### Actions
+
+| Action | Description |
+|--------|-------------|
+| `pause` | Requests the worker to stop and keeps the job visible as `paused`. The worker may briefly report `running=true` while it unwinds. |
+| `cancel` | Requests the worker to stop and marks the job as `cancelled`. Clients should wait for `running=false` before deleting partial files. |
+| `remove` | Removes a stopped job from the server registry. If the worker is still running, the server keeps the job visible and treats the request as a cancel request until the worker stops. |
+
+### Example request
+
+```bash
+curl -X POST http://localhost:13305/v1/downloads/control \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "model:Qwen2.5-0.5B-Instruct-CPU",
+    "action": "pause"
+  }'
+```
+
+### Response format
+
+For `pause` and `cancel`, the endpoint returns the latest job snapshot:
+
+```json
+{
+  "id": "model:Qwen2.5-0.5B-Instruct-CPU",
+  "type": "model",
+  "model_name": "Qwen2.5-0.5B-Instruct-CPU",
+  "status": "paused",
+  "running": false,
+  "file": "model.gguf",
+  "file_index": 1,
+  "total_files": 2,
+  "bytes_downloaded": 1073741824,
+  "bytes_total": 2684354560,
+  "percent": 40,
+  "complete": false
+}
+```
+
+For `remove`, the endpoint returns:
+
+```json
+{"status":"ok"}
+```
+
+If the job is already missing and `action` is `remove`, the endpoint returns:
+
+```json
+{"status":"ok","missing":true}
+```
 
 ## `GET /v1/pull/variants`
 <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>

--- a/src/app/src/renderer/App.tsx
+++ b/src/app/src/renderer/App.tsx
@@ -42,7 +42,7 @@ const AppContent: React.FC = () => {
   const startHeightRef = useRef(0);
   // Auto-open the manager when a tab first discovers active downloads, but
   // respect a user close while those same downloads are still active. Without
-  // this, the 750 ms /downloads poll reopens the panel immediately.
+  // this, the 2 s /downloads poll reopens the panel immediately.
   const suppressDownloadAutoOpenRef = useRef(false);
 
   // Load saved layout settings on mount

--- a/src/app/src/renderer/App.tsx
+++ b/src/app/src/renderer/App.tsx
@@ -10,6 +10,7 @@ import StatusBar from './StatusBar';
 import { ModelsProvider } from './hooks/useModels';
 import { SystemProvider } from './hooks/useSystem';
 import { DEFAULT_LAYOUT_SETTINGS } from './utils/appSettings';
+import { downloadTracker } from './utils/downloadTracker';
 import '../../styles/index.css';
 
 const LAYOUT_CONSTANTS = {
@@ -39,6 +40,10 @@ const AppContent: React.FC = () => {
   const startYRef = useRef(0);
   const startWidthRef = useRef(0);
   const startHeightRef = useRef(0);
+  // Auto-open the manager when a tab first discovers active downloads, but
+  // respect a user close while those same downloads are still active. Without
+  // this, the 750 ms /downloads poll reopens the panel immediately.
+  const suppressDownloadAutoOpenRef = useRef(false);
 
   // Load saved layout settings on mount
   useEffect(() => {
@@ -107,32 +112,62 @@ const AppContent: React.FC = () => {
     return () => clearTimeout(timeoutId);
   }, [saveLayoutSettings, layoutLoaded]);
 
-  // Listen for download start events to automatically open download manager
-  // and download completion events from chat to close it
+  // Listen for download events to automatically open the download manager.
   useEffect(() => {
+    const isVisibleStatus = (status?: string) =>
+      status === 'downloading' || status === 'paused' || status === 'error';
+
+    const openIfActive = (downloads = downloadTracker.getActiveDownloads()) => {
+      const hasVisibleDownload = downloads.some((d: any) => isVisibleStatus(d?.status));
+      if (!hasVisibleDownload) {
+        suppressDownloadAutoOpenRef.current = false;
+        return false;
+      }
+      if (!suppressDownloadAutoOpenRef.current) {
+        setIsDownloadManagerVisible(true);
+      }
+      return true;
+    };
+
     const handleDownloadStart = () => {
+      suppressDownloadAutoOpenRef.current = false;
       setIsDownloadManagerVisible(true);
     };
 
-    // When a chat-initiated download completes, minimize the download manager
+    const handleDownloadSignal = (e: any) => {
+      const downloads = Array.isArray(e.detail?.downloads) ? e.detail.downloads : downloadTracker.getActiveDownloads();
+      openIfActive(downloads);
+    };
+
     const handleChatDownloadComplete = () => {
+      suppressDownloadAutoOpenRef.current = true;
       setIsDownloadManagerVisible(false);
     };
 
+    downloadTracker.startServerPolling();
+
     window.addEventListener('download:started' as any, handleDownloadStart);
+    window.addEventListener('download:update' as any, handleDownloadSignal);
+    window.addEventListener('download:snapshot' as any, handleDownloadSignal);
     window.addEventListener('download:chatComplete' as any, handleChatDownloadComplete);
+
+    void downloadTracker.hydrateFromServer().then(() => openIfActive());
 
     const handleOpenExternalContent = (e: any) => {
       if (e.detail?.url) {
         setExternalContentUrl(e.detail.url);
         setIsChatVisible(true);
-        setIsDownloadManagerVisible(false);
+        if (!openIfActive()) {
+          setIsDownloadManagerVisible(false);
+        }
       }
     };
     window.addEventListener('open-external-content' as any, handleOpenExternalContent);
 
     return () => {
       window.removeEventListener('download:started' as any, handleDownloadStart);
+      window.removeEventListener('download:update' as any, handleDownloadSignal);
+      window.removeEventListener('download:snapshot' as any, handleDownloadSignal);
       window.removeEventListener('download:chatComplete' as any, handleChatDownloadComplete);
       window.removeEventListener('open-external-content' as any, handleOpenExternalContent);
     };
@@ -292,8 +327,21 @@ const AppContent: React.FC = () => {
   };
 
   const handleCloseDownloadManager = useCallback(() => {
+    suppressDownloadAutoOpenRef.current = true;
     setIsDownloadManagerVisible(false);
   }, []);
+
+  const handleToggleDownloadManager = useCallback(() => {
+    if (isDownloadManagerVisible) {
+      suppressDownloadAutoOpenRef.current = true;
+      setIsDownloadManagerVisible(false);
+      return;
+    }
+
+    suppressDownloadAutoOpenRef.current = false;
+    setIsDownloadManagerVisible(true);
+    void downloadTracker.hydrateFromServer();
+  }, [isDownloadManagerVisible]);
 
   return (
     <>
@@ -307,7 +355,7 @@ const AppContent: React.FC = () => {
         isLogsVisible={isLogsVisible}
         onToggleLogs={() => setIsLogsVisible(!isLogsVisible)}
         isDownloadManagerVisible={isDownloadManagerVisible}
-        onToggleDownloadManager={() => setIsDownloadManagerVisible(!isDownloadManagerVisible)}
+        onToggleDownloadManager={handleToggleDownloadManager}
       />
       <DownloadManager
         isVisible={isDownloadManagerVisible}

--- a/src/app/src/renderer/DownloadManager.tsx
+++ b/src/app/src/renderer/DownloadManager.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { deleteModel, uninstallBackend } from './utils/backendInstaller';
+import { controlDownload, deleteModel, uninstallBackend, waitForDownloadStatus } from './utils/backendInstaller';
+import { downloadTracker } from './utils/downloadTracker';
 
 export interface DownloadItem {
   id: string;
@@ -23,6 +24,10 @@ export interface DownloadItem {
   // server doesn't emit a cumulative download size, instead of extrapolating
   // from the first file or two (which overshoots badly for FLM pulls).
   declaredTotalBytes?: number;
+  // Server-owned jobs can be terminal from the UI point of view while the
+  // worker is still unwinding. Keep this so resume waits until pause is real.
+  running?: boolean;
+  updatedAt?: number;
 }
 
 interface DownloadManagerProps {
@@ -31,10 +36,17 @@ interface DownloadManagerProps {
 }
 
 const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose }) => {
-  const [downloads, setDownloads] = useState<DownloadItem[]>([]);
+  const [downloads, setDownloads] = useState<DownloadItem[]>(() => downloadTracker.getActiveDownloads());
   const [expandedDownloads, setExpandedDownloads] = useState<Set<string>>(new Set());
   // Track models that are currently being deleted to prevent retry during cleanup
   const [deletingModels, setDeletingModels] = useState<Set<string>>(new Set());
+
+  const getPanelDownloads = (): DownloadItem[] => downloadTracker.getActiveDownloads();
+
+  const forceServerSync = async (): Promise<DownloadItem[]> => {
+    await downloadTracker.hydrateFromServer();
+    return getPanelDownloads();
+  };
 
   useEffect(() => {
     // Listen for download events from the global download tracker
@@ -68,16 +80,37 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
       ));
     };
 
+    const handleDownloadRemoved = (event: CustomEvent<{ id: string }>) => {
+      const { id } = event.detail;
+      setDownloads(prev => prev.filter(d => d.id !== id));
+    };
+
+    const handleDownloadSnapshot = () => {
+      setDownloads(getPanelDownloads());
+    };
+
     window.addEventListener('download:update' as any, handleDownloadUpdate);
     window.addEventListener('download:complete' as any, handleDownloadComplete);
     window.addEventListener('download:error' as any, handleDownloadError);
+    window.addEventListener('download:removed' as any, handleDownloadRemoved);
+    window.addEventListener('download:snapshot' as any, handleDownloadSnapshot);
+
+    downloadTracker.connectServerEvents();
+    void forceServerSync().then(setDownloads);
 
     return () => {
       window.removeEventListener('download:update' as any, handleDownloadUpdate);
       window.removeEventListener('download:complete' as any, handleDownloadComplete);
       window.removeEventListener('download:error' as any, handleDownloadError);
+      window.removeEventListener('download:removed' as any, handleDownloadRemoved);
+      window.removeEventListener('download:snapshot' as any, handleDownloadSnapshot);
     };
   }, []);
+
+  useEffect(() => {
+    if (!isVisible) return;
+    void forceServerSync().then(setDownloads);
+  }, [isVisible]);
 
   const formatBytes = (bytes: number): string => {
     if (bytes === 0) return '0 B';
@@ -123,79 +156,171 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
     }
   };
 
-  const handlePauseDownload = (download: DownloadItem) => {
-    if (download.abortController) {
-      download.abortController.abort();
-    }
-    setDownloads(prev => prev.map(d =>
-      d.id === download.id ? { ...d, status: 'paused' as const } : d
-    ));
+  const isModelDownloadId = (downloadId?: string): boolean => downloadId?.startsWith('model:') === true;
 
-    // Dispatch event for other components to react
-    window.dispatchEvent(new CustomEvent('download:paused', {
-      detail: { id: download.id, modelName: download.modelName }
-    }));
+  const usesServerDownloadControl = (download: DownloadItem | undefined, downloadId?: string): boolean => {
+    // TODO: Backend downloads remain renderer-owned until the follow-up PR wires them into the server registry.
+    return download?.downloadType === 'model' || isModelDownloadId(download?.id ?? downloadId);
   };
 
-  const handleCancelDownload = async (download: DownloadItem) => {
-    // Mark as deleting to prevent retry during cleanup
-    setDeletingModels(prev => new Set(prev).add(download.modelName));
+  const hasLocalDownloadOwner = (download: DownloadItem): boolean => {
+    return !!download.abortController && !download.abortController.signal.aborted;
+  };
 
-    // First, abort the download to stop any active streams
-    if (download.abortController) {
-      download.abortController.abort();
-    }
-
-    // Update UI to show deleting status (visual feedback during cleanup)
+  const handlePauseDownload = async (download: DownloadItem) => {
+    // UI feedback must be immediate. Keep the tracker owner intact until the
+    // server confirms; otherwise the local fallback cannot abort the owner.
     setDownloads(prev => prev.map(d =>
-      d.id === download.id ? { ...d, status: 'deleting' as const } : d
+      d.id === download.id ? { ...d, status: 'paused' as const, running: true } : d
     ));
 
-    // Dispatch event for other components to react
-    window.dispatchEvent(new CustomEvent('download:cancelled', {
-      detail: { id: download.id, modelName: download.modelName }
-    }));
+    if (!usesServerDownloadControl(download)) {
+      downloadTracker.requestPause(download.id);
+      return;
+    }
 
-    // Wait for the download stream to fully close and release file handles
-    // We listen for the cleanup-complete event with a timeout fallback
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(() => {
-        cleanup();
-        resolve();
-      }, 2000); // Fallback timeout if event doesn't fire
+    try {
+      const snapshot = await controlDownload(download.id, 'pause');
+      if (snapshot) {
+        downloadTracker.applyServerDownload(snapshot);
+      }
+    } catch (error) {
+      console.error('Error pausing model download via server registry:', error);
+      if (hasLocalDownloadOwner(download)) {
+        downloadTracker.requestPause(download.id);
+        return;
+      }
 
+      alert('Could not pause the server-owned download. Refreshing download state.');
+      void forceServerSync().then(setDownloads);
+    }
+  };
+
+  const waitForLocalDownloadCleanup = (download: DownloadItem, timeoutMs = 30000): Promise<boolean> => {
+    return new Promise<boolean>((resolve) => {
       const cleanup = () => {
         window.removeEventListener('download:cleanup-complete' as any, handler);
         clearTimeout(timeout);
       };
 
       const handler = (event: CustomEvent) => {
-        if (event.detail.id === download.id) {
+        if (event.detail?.id === download.id || event.detail?.modelName === download.modelName) {
           cleanup();
-          resolve();
+          resolve(true);
         }
       };
 
+      const timeout = setTimeout(() => {
+        cleanup();
+        resolve(false);
+      }, timeoutMs);
+
       window.addEventListener('download:cleanup-complete' as any, handler);
     });
+  };
 
-    // Clean up partial downloads via the unified helpers
+  const cleanupDownloadedFiles = async (download: DownloadItem): Promise<void> => {
+    if (download.downloadType === 'backend') {
+      const [recipe, backend] = download.modelName.split(':');
+      await uninstallBackend(recipe, backend);
+    } else {
+      await deleteModel(download.modelName);
+    }
+  };
+
+  const ensureDownloadStopped = async (
+    download: DownloadItem,
+    statuses: Array<'paused' | 'cancelled' | 'completed' | 'error'>,
+    actionDescription: string,
+  ): Promise<boolean> => {
+    if (download.running !== true) return true;
+
     try {
-      if (download.downloadType === 'backend') {
-        const [recipe, backend] = download.modelName.split(':');
-        await uninstallBackend(recipe, backend);
-      } else {
-        await deleteModel(download.modelName);
-      }
+      await waitForDownloadStatus(download.id, statuses, 30000, false);
+      return true;
     } catch (error) {
-      console.error('Error deleting partial download files:', error);
-      alert(`Download cancelled, but failed to delete files: ${error instanceof Error ? error.message : 'Unknown error'}\nPartial files may remain on disk.`);
+      console.warn(`Timed out waiting for download to stop before ${actionDescription}:`, error);
+      alert(`Cannot ${actionDescription} yet: the download worker is still stopping. Please try again once it finishes.`);
+      void forceServerSync().then(setDownloads);
+      return false;
+    }
+  };
+
+  const cancelViaLocalOwner = async (download: DownloadItem): Promise<void> => {
+    const cleanupComplete = waitForLocalDownloadCleanup(download);
+    downloadTracker.requestCancel(download.id);
+    const released = await cleanupComplete;
+
+    if (!released) {
+      alert('Download cancellation was requested, but the worker did not confirm that files were released. Partial files were not deleted.');
+      void forceServerSync().then(setDownloads);
+      return;
+    }
+
+    try {
+      await cleanupDownloadedFiles(download);
+      downloadTracker.removeDownload(download.id);
+      setDownloads(prev => prev.filter(d => d.id !== download.id));
+    } catch (deleteError) {
+      console.error('Error deleting partial download files:', deleteError);
+      alert(`Download cancelled, but failed to delete files: ${deleteError instanceof Error ? deleteError.message : 'Unknown error'}
+Partial files may remain on disk.`);
+    }
+  };
+
+  const handleCancelDownload = async (download: DownloadItem) => {
+    // Cancel is a two-step operation: first ask the owner to stop, then delete
+    // partial files only after the worker reports running=false. This avoids
+    // deleting files while the downloader still has open handles.
+    setDeletingModels(prev => new Set(prev).add(download.modelName));
+    setDownloads(prev => prev.map(d =>
+      d.id === download.id ? { ...d, status: 'cancelled' as const, running: true } : d
+    ));
+
+    try {
+      if (!usesServerDownloadControl(download)) {
+        await cancelViaLocalOwner(download);
+        return;
+      }
+
+      const snapshot = await controlDownload(download.id, 'cancel');
+      if (snapshot) {
+        downloadTracker.applyServerDownload(snapshot);
+      }
+
+      const stopped = snapshot?.running === true
+        ? await ensureDownloadStopped(
+            { ...download, running: true },
+            ['cancelled', 'completed', 'error'],
+            'delete partial files',
+          )
+        : true;
+
+      if (!stopped) return;
+
+      const latestSnapshot = (await downloadTracker.hydrateFromServer())
+        .find(item => item.id === download.id);
+      const finalStatus = latestSnapshot?.status
+        ?? downloadTracker.getDownload(download.id)?.status
+        ?? snapshot?.status
+        ?? 'cancelled';
+
+      if (finalStatus !== 'completed') {
+        await cleanupDownloadedFiles(download);
+      }
+
+      downloadTracker.removeDownload(download.id);
+      setDownloads(prev => prev.filter(d => d.id !== download.id));
+      void controlDownload(download.id, 'remove').catch(() => {});
+    } catch (error) {
+      console.error('Error cancelling model download via server registry:', error);
+      if (hasLocalDownloadOwner(download)) {
+        await cancelViaLocalOwner(download);
+      } else {
+        alert('Could not cancel the server-owned download. Refreshing download state.');
+        void forceServerSync().then(setDownloads);
+      }
     } finally {
-      // Mark as cancelled now that deletion is complete
-      setDownloads(prev => prev.map(d =>
-        d.id === download.id ? { ...d, status: 'cancelled' as const } : d
-      ));
-      // Remove from deleting set
       setDeletingModels(prev => {
         const newSet = new Set(prev);
         newSet.delete(download.modelName);
@@ -205,31 +330,28 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
   };
 
   const handleDeleteDownload = async (download: DownloadItem) => {
+    const stopped = await ensureDownloadStopped(download, ['paused'], 'delete partial files');
+    if (!stopped) return;
+
     // Mark as deleting to prevent retry during cleanup
     setDeletingModels(prev => new Set(prev).add(download.modelName));
 
     // Update UI to show deleting status
     setDownloads(prev => prev.map(d =>
-      d.id === download.id ? { ...d, status: 'deleting' as const } : d
+      d.id === download.id ? { ...d, status: 'deleting' as const, running: false } : d
     ));
 
-    // Clean up files via the unified helpers
     try {
-      if (download.downloadType === 'backend') {
-        const [recipe, backend] = download.modelName.split(':');
-        await uninstallBackend(recipe, backend);
-      } else {
-        await deleteModel(download.modelName);
-      }
+      await cleanupDownloadedFiles(download);
 
       // Only remove from downloads list if deletion was successful
-      handleRemoveDownload(download.id);
+      await handleRemoveDownload(download.id);
     } catch (error) {
       console.error('Error deleting download files:', error);
       alert(`Error deleting files: ${error instanceof Error ? error.message : 'Unknown error'}`);
       // Revert status on error
       setDownloads(prev => prev.map(d =>
-        d.id === download.id ? { ...d, status: 'paused' as const } : d
+        d.id === download.id ? { ...d, status: 'paused' as const, running: false } : d
       ));
     } finally {
       // Remove from deleting set
@@ -241,57 +363,125 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
     }
   };
 
-  const handleResumeDownload = (download: DownloadItem) => {
-    // Dispatch event to trigger a new download
+  const handleResumeDownload = async (download: DownloadItem) => {
+    // The server marks the row as paused as soon as pause is requested, but the
+    // worker can still be unwinding. If we immediately POST /pull again, the
+    // resume request can block while start_download_job joins the old worker.
+    // Wait for running=false first when the snapshot tells us it is still
+    // pausing; if the server row briefly disappears we still proceed.
+    if (download.running === true) {
+      try {
+        await waitForDownloadStatus(download.id, ['paused'], 30000, true);
+      } catch (error) {
+        console.warn('Timed out waiting for paused download to stop before resume; trying resume anyway:', error);
+      }
+    }
+
+    setDownloads(prev => prev.map(d =>
+      d.id === download.id ? { ...d, status: 'downloading' as const, running: true, startTime: Date.now(), bytesResumed: d.bytesDownloaded } : d
+    ));
+
+    // Dispatch event to trigger the same model/backend pull path. The server
+    // deduplicates by stable download id, so this resumes the existing job
+    // instead of creating a second independent renderer-owned download.
     window.dispatchEvent(new CustomEvent('download:resume', {
       detail: { modelName: download.modelName, downloadType: download.downloadType }
     }));
+  };
 
-    // Remove the paused download from the list as a new one will be created
-    handleRemoveDownload(download.id);
+  const waitForDeleteCleanup = async (modelName: string): Promise<void> => {
+    if (!deletingModels.has(modelName)) return;
+
+    // Wait for deletion to complete before retrying. This preserves the
+    // existing UX without letting retry race with partial-file cleanup.
+    await new Promise<void>((resolve) => {
+      const checkInterval = setInterval(() => {
+        setDeletingModels(prev => {
+          if (!prev.has(modelName)) {
+            clearInterval(checkInterval);
+            resolve();
+          }
+          return prev;
+        });
+      }, 100);
+
+      // Timeout after 10 seconds
+      setTimeout(() => {
+        clearInterval(checkInterval);
+        resolve();
+      }, 10000);
+    });
+  };
+
+  const removeServerDownloadBeforeRetry = async (download: DownloadItem): Promise<boolean> => {
+    const stopped = await ensureDownloadStopped(
+      download,
+      ['paused', 'cancelled', 'completed', 'error'],
+      'retry download',
+    );
+    if (!stopped) return false;
+
+    // Critical ordering for stable model download ids:
+    // remove/dismiss the terminal server row BEFORE emitting download:retry.
+    // Emitting first can start a new /pull with the same id, and a later
+    // /downloads/control remove for the old row can erase/cancel the fresh job.
+    try {
+      await controlDownload(download.id, 'remove');
+      setDownloads(prev => prev.filter(d => d.id !== download.id));
+      downloadTracker.removeDownload(download.id);
+      return true;
+    } catch (error) {
+      console.error('Error removing old server download before retry:', error);
+      alert('Could not clear the old download entry before retrying. Refreshing download state.');
+      void forceServerSync().then(setDownloads);
+      return false;
+    }
   };
 
   const handleRetryDownload = async (download: DownloadItem) => {
-    // Check if this model is currently being deleted
-    if (deletingModels.has(download.modelName)) {
-      // Wait for deletion to complete before retrying
-      // We'll poll the deletingModels set until the model is no longer being deleted
-      await new Promise<void>((resolve) => {
-        const checkInterval = setInterval(() => {
-          setDeletingModels(prev => {
-            if (!prev.has(download.modelName)) {
-              clearInterval(checkInterval);
-              resolve();
-            }
-            return prev;
-          });
-        }, 100);
+    await waitForDeleteCleanup(download.modelName);
 
-        // Timeout after 10 seconds
-        setTimeout(() => {
-          clearInterval(checkInterval);
-          resolve();
-        }, 10000);
-      });
+    if (usesServerDownloadControl(download)) {
+      const removed = await removeServerDownloadBeforeRetry(download);
+      if (!removed) return;
     }
 
-    // Dispatch event to trigger a new download
+    // Dispatch event to trigger a new download. For server-owned model
+    // downloads, the old terminal row has already been removed above, so there
+    // is no delayed remove request that can hit the freshly-created job.
     window.dispatchEvent(new CustomEvent('download:retry', {
       detail: { modelName: download.modelName, downloadType: download.downloadType }
     }));
 
-    // Remove the cancelled download from the list as a new one will be created
-    handleRemoveDownload(download.id);
+    if (!usesServerDownloadControl(download)) {
+      // Renderer-owned backend downloads still use unique ids, so removing the
+      // old local row after starting the retry cannot delete the fresh attempt.
+      void handleRemoveDownload(download.id);
+    }
   };
 
-  const handleRemoveDownload = (downloadId: string) => {
+  const handleRemoveDownload = async (downloadId: string) => {
+    const download = downloads.find(d => d.id === downloadId) || downloadTracker.getActiveDownloads().find(d => d.id === downloadId);
+    if (download?.running === true) {
+      alert('Cannot remove this download yet: the download worker is still stopping.');
+      void forceServerSync().then(setDownloads);
+      return;
+    }
+
     setDownloads(prev => prev.filter(d => d.id !== downloadId));
+    downloadTracker.removeDownload(downloadId);
+    if (usesServerDownloadControl(download, downloadId)) {
+      void controlDownload(downloadId, 'remove').catch(() => {});
+    }
   };
 
   const handleClearCompleted = () => {
-    setDownloads(prev => prev.filter(d =>
-      d.status !== 'completed' && d.status !== 'error' && d.status !== 'cancelled' && d.status !== 'paused'
-    ));
+    const removable = downloads.filter(d =>
+      d.running !== true && (d.status === 'completed' || d.status === 'error')
+    );
+    for (const download of removable) {
+      void handleRemoveDownload(download.id);
+    }
   };
 
   const toggleExpanded = (downloadId: string) => {
@@ -306,7 +496,7 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
     });
   };
 
-  const activeDownloads = downloads.filter(d => d.status === 'downloading').length;
+  const activeDownloads = downloads.filter(d => d.status === 'downloading' || d.running === true).length;
   const completedDownloads = downloads.filter(d => d.status === 'completed').length;
 
   if (!isVisible) return null;
@@ -408,7 +598,7 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
                             )}
                             {download.status === 'paused' && (
                               <>
-                                Paused • File {download.fileIndex}/{download.totalFiles} • {formatBytes(download.bytesDownloaded)} / {formatBytes(download.bytesTotal)}
+                                {download.running === true ? 'Pausing' : 'Paused'} • File {download.fileIndex}/{download.totalFiles} • {formatBytes(download.bytesDownloaded)} / {formatBytes(download.bytesTotal)}
                               </>
                             )}
                             {download.status === 'completed' && (
@@ -456,10 +646,13 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
                         )}
                         {download.status === 'paused' && (
                           <>
+                            {download.running === true && (
+                              <span className="download-eta">Pausing...</span>
+                            )}
                             <button
                               className="download-action-btn resume-btn"
                               onClick={() => handleResumeDownload(download)}
-                              title="Resume download"
+                              title={download.running === true ? "Finish pausing, then resume" : "Resume download"}
                             >
                               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                                 <polygon points="5,3 19,12 5,21" fill="currentColor"/>
@@ -468,11 +661,23 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
                             <button
                               className="download-action-btn delete-btn"
                               onClick={() => handleDeleteDownload(download)}
-                              title="Delete partial download"
+                              title={download.running === true ? "Finish pausing before deleting" : "Delete partial download"}
+                              disabled={download.running === true}
                             >
                               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                                 <polyline points="3,6 5,6 21,6"/>
                                 <path d="M19,6v14a2,2,0,0,1-2,2H7a2,2,0,0,1-2-2V6m3,0V4a2,2,0,0,1,2-2h4a2,2,0,0,1,2,2V6"/>
+                              </svg>
+                            </button>
+                            <button
+                              className="download-action-btn remove-btn"
+                              onClick={() => void handleRemoveDownload(download.id)}
+                              title={download.running === true ? "Finish pausing before removing" : "Remove from list"}
+                              disabled={download.running === true}
+                            >
+                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                <line x1="18" y1="6" x2="6" y2="18"/>
+                                <line x1="6" y1="6" x2="18" y2="18"/>
                               </svg>
                             </button>
                           </>
@@ -481,22 +686,50 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
                           <span className="download-deleting-text">Deleting...</span>
                         )}
                         {download.status === 'cancelled' && (
-                          <button
-                            className="download-action-btn retry-btn"
-                            onClick={() => handleRetryDownload(download)}
-                            title="Retry download"
-                            disabled={deletingModels.has(download.modelName)}
-                          >
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                              <polyline points="23,4 23,10 17,10"/>
-                              <path d="M20.49,15a9,9,0,1,1-2.12-9.36L23,10"/>
-                            </svg>
-                          </button>
+                          download.running === true ? (
+                            <span className="download-deleting-text">Cancelling...</span>
+                          ) : (
+                            <>
+                              <button
+                                className="download-action-btn retry-btn"
+                                onClick={() => handleRetryDownload(download)}
+                                title="Retry download"
+                                disabled={deletingModels.has(download.modelName)}
+                              >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                  <polyline points="23,4 23,10 17,10"/>
+                                  <path d="M20.49,15a9,9,0,1,1-2.12-9.36L23,10"/>
+                                </svg>
+                              </button>
+                              <button
+                                className="download-action-btn delete-btn"
+                                onClick={() => handleDeleteDownload(download)}
+                                title="Delete partial download"
+                                disabled={deletingModels.has(download.modelName)}
+                              >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                  <polyline points="3,6 5,6 21,6"/>
+                                  <path d="M19,6v14a2,2,0,0,1-2,2H7a2,2,0,0,1-2-2V6m3,0V4a2,2,0,0,1,2-2h4a2,2,0,0,1,2,2V6"/>
+                                </svg>
+                              </button>
+                              <button
+                                className="download-action-btn remove-btn"
+                                onClick={() => void handleRemoveDownload(download.id)}
+                                title="Remove from list"
+                                disabled={deletingModels.has(download.modelName)}
+                              >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                  <line x1="18" y1="6" x2="6" y2="18"/>
+                                  <line x1="6" y1="6" x2="18" y2="18"/>
+                                </svg>
+                              </button>
+                            </>
+                          )
                         )}
                         {(download.status === 'completed' || download.status === 'error') && (
                           <button
                             className="download-action-btn remove-btn"
-                            onClick={() => handleRemoveDownload(download.id)}
+                            onClick={() => void handleRemoveDownload(download.id)}
                             title="Remove from list"
                           >
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -559,7 +792,7 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
           )}
         </div>
 
-        {downloads.some(d => d.status === 'completed' || d.status === 'error' || d.status === 'cancelled' || d.status === 'paused' || d.status === 'deleting') && (
+        {downloads.some(d => d.status === 'completed' || d.status === 'error') && (
           <div className="download-manager-footer">
             <button
               className="clear-completed-btn"

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -880,14 +880,24 @@ const [searchQuery, setSearchQuery] = useState('');
         return;
       }
 
-      // Don't start a second download if one is already running for this
-      // model. Without this guard, downloadTracker.startDownload would abort
-      // the in-flight request, which surfaces as "Download cancelled" in the
-      // first call's catch block.
+      // Do not start a second download if this renderer owns a live request or
+      // the server-owned download registry reports one. A restored UI row alone
+      // is not authoritative after reload, because it has no fetch stream or
+      // AbortController.
       if (downloadTracker.isActive(modelName)) {
         showWarning(`Download for "${modelName}" is already in progress.`);
         return;
       }
+
+      const serverDownloadActive = await downloadTracker.hasActiveServerDownload(modelName);
+      if (serverDownloadActive) {
+        showWarning(`Download for "${modelName}" is already in progress.`);
+        return;
+      }
+
+      // If the only thing left is a stale renderer-local row, remove it so the
+      // real /pull request can be sent and the server can resume from disk.
+      downloadTracker.clearStaleModelDownload(modelName);
 
       // Add to loading state to show loading indicator
       setLoadingModels(prev => new Set(prev).add(modelName));

--- a/src/app/src/renderer/utils/backendInstaller.ts
+++ b/src/app/src/renderer/utils/backendInstaller.ts
@@ -1,4 +1,5 @@
 import { downloadTracker } from './downloadTracker';
+import type { DownloadProgressEvent } from './downloadTracker';
 import { serverFetch } from './serverConfig';
 import { fetchSystemInfoData, Recipes } from './systemData';
 import { ModelsData } from './modelData';
@@ -49,6 +50,191 @@ export class DownloadAbortError extends Error {
 
 /** @deprecated Use DownloadAbortError instead */
 export const PullModelAbortError = DownloadAbortError;
+
+const SERVER_DOWNLOAD_POLL_INTERVAL_MS = 500;
+const SERVER_DOWNLOAD_SNAPSHOT_ERROR_TIMEOUT_MS = 300_000;
+
+export async function controlDownload(downloadId: string, action: 'pause' | 'cancel' | 'remove'): Promise<DownloadProgressEvent | undefined> {
+  const response = await serverFetch('/downloads/control', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id: downloadId, action }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(extractServerErrorMessage(errorText, response.statusText));
+  }
+
+  if (action === 'remove') return undefined;
+  return await response.json().catch(() => undefined);
+}
+
+function serverSnapshotMatchesDownloadId(item: DownloadProgressEvent, downloadId: string): boolean {
+  return item.id === downloadId ||
+    (!item.id && item.model_name != null && downloadId === `model:${item.model_name}`);
+}
+
+export async function waitForDownloadStatus(
+  downloadId: string,
+  statuses: Array<'paused' | 'cancelled' | 'completed' | 'error'>,
+  timeoutMs = 15000,
+  allowMissing = true,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await serverFetch('/downloads');
+      if (response.ok) {
+        const downloads = await response.json();
+        const download = Array.isArray(downloads)
+          ? downloads.find((item: DownloadProgressEvent) => serverSnapshotMatchesDownloadId(item, downloadId))
+          : undefined;
+        if (!download) {
+          if (allowMissing) return;
+        } else if (statuses.includes(download.status) && download.running !== true) {
+          return;
+        }
+      }
+    } catch {
+      // Keep waiting. This is only used as a cleanup barrier.
+    }
+    await new Promise(resolve => setTimeout(resolve, 250));
+  }
+
+  throw new Error(`Timed out waiting for download ${downloadId} to reach ${statuses.join(', ')}`);
+}
+
+
+
+async function isModelDownloadedOnServer(modelName: string): Promise<boolean> {
+  try {
+    const response = await serverFetch('/models?show_all=true', { cache: 'no-store' });
+    if (!response.ok) return false;
+
+    const data = await response.json();
+    const modelList = Array.isArray(data) ? data : data.data || [];
+    const model = modelList.find((m: any) => m.id === modelName || m.name === modelName);
+    return model?.downloaded === true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForServerDownloadTerminal(
+  downloadId: string,
+  modelName: string,
+  abortController: AbortController,
+  getAbortReason: () => 'paused' | 'cancelled' | undefined,
+  initialJobSeen = false,
+): Promise<void> {
+  let sawServerJob = initialJobSeen;
+  let consecutiveMissingSnapshots = 0;
+  let snapshotErrorsStartedAt: number | undefined;
+
+  while (true) {
+    if (abortController.signal.aborted) {
+      throw new DownloadAbortError(getAbortReason() ?? 'paused');
+    }
+
+    let snapshot: DownloadProgressEvent | undefined;
+    try {
+      snapshot = (await downloadTracker.hydrateFromServer({ throwOnError: true }))
+        .find(item => item.id === downloadId || item.model_name === modelName);
+    } catch (error) {
+      const now = Date.now();
+      snapshotErrorsStartedAt ??= now;
+      if (now - snapshotErrorsStartedAt >= SERVER_DOWNLOAD_SNAPSHOT_ERROR_TIMEOUT_MS) {
+        throw new Error(`Timed out refreshing server download state: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+
+      console.warn('Failed to refresh server download snapshot; keeping current state:', error);
+      await new Promise(resolve => setTimeout(resolve, SERVER_DOWNLOAD_POLL_INTERVAL_MS));
+      continue;
+    }
+
+    snapshotErrorsStartedAt = undefined;
+
+    if (!snapshot) {
+      if (sawServerJob) {
+        consecutiveMissingSnapshots += 1;
+        if (consecutiveMissingSnapshots >= 10) {
+          // Terminal jobs are intentionally short-lived server-side. If a tab was
+          // asleep or briefly disconnected, a successful job may have expired
+          // before this waiter saw its completed snapshot. Verify the model state
+          // before treating a missing row as cancellation.
+          if (await isModelDownloadedOnServer(modelName)) {
+            downloadTracker.completeDownload(downloadId);
+            window.dispatchEvent(new CustomEvent('modelsUpdated'));
+            return;
+          }
+          downloadTracker.removeDownload(downloadId);
+          throw new DownloadAbortError(getAbortReason() ?? 'cancelled');
+        }
+      }
+    } else {
+      sawServerJob = true;
+      consecutiveMissingSnapshots = 0;
+      const stopped = snapshot.running !== true;
+      if (snapshot.status === 'completed' && stopped) return;
+      if (snapshot.status === 'paused' && stopped) throw new DownloadAbortError('paused');
+      if (snapshot.status === 'cancelled' && stopped) throw new DownloadAbortError('cancelled');
+      if (snapshot.status === 'error' && stopped) throw new Error(snapshot.error || 'Unknown download error');
+    }
+
+    await new Promise(resolve => setTimeout(resolve, SERVER_DOWNLOAD_POLL_INTERVAL_MS));
+  }
+}
+
+async function consumeLegacyPullStream(response: Response, downloadId: string): Promise<void> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error('No response body');
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let currentEventType = 'progress';
+  let downloadCompleted = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+
+      for (const line of lines) {
+        if (line.startsWith('event:')) {
+          currentEventType = line.substring(6).trim();
+        } else if (line.startsWith('data:')) {
+          try {
+            const data = JSON.parse(line.substring(5).trim());
+            if (currentEventType === 'progress') {
+              downloadTracker.updateProgress(downloadId, data);
+            } else if (currentEventType === 'complete') {
+              downloadTracker.completeDownload(downloadId);
+              downloadCompleted = true;
+            } else if (currentEventType === 'error') {
+              throw new Error(data.error || 'Unknown download error');
+            }
+          } catch (parseError) {
+            if (!(parseError instanceof SyntaxError)) throw parseError;
+            console.error('Failed to parse SSE data:', line, parseError);
+          }
+        } else if (line.trim() === '') {
+          currentEventType = 'progress';
+        }
+      }
+    }
+  } catch (streamError) {
+    if (!downloadCompleted) throw streamError;
+  }
+
+  if (!downloadCompleted) {
+    downloadTracker.completeDownload(downloadId);
+  }
+}
 
 /**
  * Install a backend with Download Manager integration.
@@ -325,27 +511,26 @@ export async function pullModel(
 ): Promise<void> {
   const showInDownloadManager = options?.showInDownloadManager ?? true;
   const abortController = new AbortController();
+  const declaredTotalBytes = options?.declaredSizeGB
+    ? Math.round(options.declaredSizeGB * 1024 * 1024 * 1024)
+    : undefined;
+  const downloadId = downloadTracker.getStableDownloadId(modelName, 'model');
 
-  let downloadId: string | undefined;
   if (showInDownloadManager) {
-    const declaredTotalBytes = options?.declaredSizeGB
-      ? Math.round(options.declaredSizeGB * 1024 * 1024 * 1024)
-      : undefined;
-    downloadId = downloadTracker.startDownload(
+    downloadTracker.startDownload(
       modelName,
       abortController,
       'model',
       options?.collectionComponents,
       declaredTotalBytes,
     );
+    downloadTracker.startServerPolling();
     window.dispatchEvent(new CustomEvent('download:started', { detail: { modelName } }));
   }
 
-  let downloadCompleted = false;
   let isPaused = false;
   let isCancelled = false;
 
-  // Listen for pause/cancel events from Download Manager UI
   const handleCancel = (event: Event) => {
     const detail = (event as CustomEvent).detail;
     if (detail.modelName === modelName) {
@@ -353,6 +538,7 @@ export async function pullModel(
       abortController.abort();
     }
   };
+
   const handlePause = (event: Event) => {
     const detail = (event as CustomEvent).detail;
     if (detail.modelName === modelName) {
@@ -365,10 +551,13 @@ export async function pullModel(
   window.addEventListener('download:paused', handlePause);
 
   try {
-    // Build request body — include registration data for custom models
-    let requestBody: Record<string, unknown> = { model_name: modelName, stream: true };
+    const requestBody: Record<string, unknown> = {
+      model_name: modelName,
+      stream: true,
+      subscribe: false,
+    };
 
-    if(options?.registrationData) {
+    if (options?.registrationData) {
       Object.assign(requestBody, options.registrationData);
     }
 
@@ -377,6 +566,7 @@ export async function pullModel(
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(requestBody),
       signal: abortController.signal,
+      cache: 'no-store',
     });
 
     if (!response.ok) {
@@ -384,96 +574,48 @@ export async function pullModel(
       throw new Error(`Failed to download model: ${errorText || response.statusText}`);
     }
 
-    const reader = response.body?.getReader();
-    if (!reader) {
-      throw new Error('No response body');
-    }
-
-    const decoder = new TextDecoder();
-    let buffer = '';
-    let currentEventType = 'progress';
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || '';
-
-        for (const line of lines) {
-          if (line.startsWith('event:')) {
-            currentEventType = line.substring(6).trim();
-          } else if (line.startsWith('data:')) {
-            // Parse JSON separately so server errors aren't swallowed
-            let data;
-            try {
-              data = JSON.parse(line.substring(5).trim());
-            } catch {
-              console.error('Failed to parse SSE data:', line);
-              continue;
-            }
-
-            if (currentEventType === 'progress' && downloadId) {
-              downloadTracker.updateProgress(downloadId, data);
-            } else if (currentEventType === 'complete') {
-              if (downloadId) {
-                downloadTracker.completeDownload(downloadId);
-              }
-              downloadCompleted = true;
-            } else if (currentEventType === 'error') {
-              const errorMsg = data.error || 'Unknown error';
-              if (downloadId) {
-                downloadTracker.failDownload(downloadId, errorMsg);
-              }
-              throw new Error(errorMsg);
-            }
-          } else if (line.trim() === '') {
-            currentEventType = 'progress';
-          }
-        }
-      }
-    } catch (streamError) {
-      // If we already got the complete event, ignore stream errors
-      if (!downloadCompleted) {
-        throw streamError;
-      }
-    }
-
-    if (!downloadCompleted && downloadId) {
-      downloadTracker.completeDownload(downloadId);
-    }
-
-    // Notify all components that models have been updated
-    window.dispatchEvent(new CustomEvent('modelsUpdated'));
-  } catch (error: any) {
-    // If download completed successfully, ignore any connection-close errors
-    if (downloadCompleted) {
+    const contentType = response.headers.get('Content-Type') || '';
+    if (contentType.includes('text/event-stream')) {
+      await consumeLegacyPullStream(response, downloadId);
       window.dispatchEvent(new CustomEvent('modelsUpdated'));
       return;
     }
 
+    const startedSnapshot = await response.json();
+    downloadTracker.applyServerDownload(startedSnapshot);
+
+    await waitForServerDownloadTerminal(
+      downloadId,
+      modelName,
+      abortController,
+      () => isCancelled ? 'cancelled' : (isPaused ? 'paused' : undefined),
+      true,
+    );
+
+    // The terminal server snapshot is applied inside waitForServerDownloadTerminal,
+    // which emits modelsUpdated once. Avoid a second local completion/update here.
+  } catch (error: any) {
+    if (error instanceof DownloadAbortError) {
+      throw error;
+    }
+
     if (error.name === 'AbortError') {
-      if (isPaused && downloadId) {
-        downloadTracker.pauseDownload(downloadId);
+      if (isPaused) {
+        downloadTracker.pauseDownload(downloadId, false);
         throw new DownloadAbortError('paused');
-      } else {
-        if (downloadId) {
-          downloadTracker.cancelDownload(downloadId);
-        }
-        // Signal that file handles are released so DownloadManager can clean up
+      }
+      if (isCancelled) {
+        downloadTracker.cancelDownload(downloadId, false);
         window.dispatchEvent(new CustomEvent('download:cleanup-complete', {
           detail: { id: downloadId, modelName }
         }));
         throw new DownloadAbortError('cancelled');
       }
-    } else {
-      if (downloadId) {
-        downloadTracker.failDownload(downloadId, error.message || 'Unknown error');
-      }
-      throw error;
+      return;
     }
+
+    downloadTracker.failDownload(downloadId, error.message || 'Unknown error');
+    throw error;
   } finally {
     window.removeEventListener('download:cancelled', handleCancel);
     window.removeEventListener('download:paused', handlePause);

--- a/src/app/src/renderer/utils/downloadTracker.ts
+++ b/src/app/src/renderer/utils/downloadTracker.ts
@@ -1,6 +1,7 @@
 import { DownloadItem } from '../DownloadManager';
 import { serverFetch } from './serverConfig';
 
+const ACTIVE_SERVER_DOWNLOAD_POLL_INTERVAL_MS = 2000;
 const TERMINAL_DOWNLOAD_VISIBILITY_MS = 30000;
 
 export interface DownloadProgressEvent {
@@ -43,6 +44,7 @@ class DownloadTracker {
   private completedDownloadsFinalized = new Set<string>();
   private completedModelDownloadsNotified = new Set<string>();
   private serverPollStarted = false;
+  private serverPollTimer: number | undefined;
   private readonly tabId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
   private readonly crossTabChannel?: BroadcastChannel;
 
@@ -120,6 +122,7 @@ class DownloadTracker {
       preExistingBytes: new Map(),
     });
     this.emitUpdate(downloadItem);
+    this.scheduleServerPoll(0);
     // Wake up other tabs immediately. They still hydrate from the server as the
     // source of truth, but no longer need a refresh or a full poll interval to
     // discover that a download has started elsewhere.
@@ -196,6 +199,11 @@ class DownloadTracker {
     const totalPreExistingBytes = Array.from(cumulative.preExistingBytes.values())
       .reduce((sum, bytes) => sum + bytes, 0);
 
+    // A restored tab should not treat bytes downloaded before the restore as
+    // bytes/sec for this renderer session. Preserve the restored baseline and
+    // still honor server-reported resume bytes for genuine resumed downloads.
+    const speedBaselineBytes = Math.max(download.bytesResumed || 0, totalPreExistingBytes);
+
     // Calculate overall percent
     let overallPercent: number;
     if (cumulativeBytesTotal > 0) {
@@ -230,7 +238,7 @@ class DownloadTracker {
       bytesDownloaded: displayBytesDownloaded,
       bytesTotal: cumulativeBytesTotal,
       percent: overallPercent,
-      bytesResumed: totalPreExistingBytes,
+      bytesResumed: speedBaselineBytes,
       status: progress.status ?? download.status,
       running: progress.running ?? download.running,
       error: progress.error ?? download.error,
@@ -250,6 +258,28 @@ class DownloadTracker {
 
   private isServerActive(progress: DownloadProgressEvent): boolean {
     return progress.running === true || progress.status === 'downloading';
+  }
+
+  private getProgressDownloadedBytes(progress: DownloadProgressEvent): number {
+    const serverCumulativeBytes = typeof progress.cumulative_bytes_downloaded === 'number'
+      ? progress.cumulative_bytes_downloaded
+      : (typeof progress.overall_bytes_downloaded === 'number' ? progress.overall_bytes_downloaded : undefined);
+    if (typeof serverCumulativeBytes === 'number') {
+      return Math.max(0, serverCumulativeBytes);
+    }
+
+    const completedFilesBytes = typeof progress.completed_files_bytes === 'number'
+      ? progress.completed_files_bytes
+      : 0;
+    const currentFileBytes = typeof progress.bytes_downloaded === 'number'
+      ? progress.bytes_downloaded
+      : 0;
+    return Math.max(0, completedFilesBytes + currentFileBytes);
+  }
+
+  private hasServerPollWork(downloads?: DownloadProgressEvent[]): boolean {
+    return (downloads ?? Array.from(this.activeDownloads.values()))
+      .some(download => this.isServerActive(download as DownloadProgressEvent));
   }
 
   private reopenIfServerActive(downloadId: string, progress: DownloadProgressEvent): void {
@@ -320,6 +350,9 @@ class DownloadTracker {
       }
 
       this.applyServerDownloads(downloads);
+      if (this.serverPollStarted && this.hasServerPollWork(downloads)) {
+        this.scheduleServerPoll(ACTIVE_SERVER_DOWNLOAD_POLL_INTERVAL_MS);
+      }
       return downloads;
     } catch (error) {
       if (options?.throwOnError) {
@@ -331,10 +364,25 @@ class DownloadTracker {
   }
 
   startServerPolling(): void {
-    if (this.serverPollStarted) return;
     this.serverPollStarted = true;
-    window.setInterval(() => void this.hydrateFromServer(), 2000);
-    void this.hydrateFromServer();
+    this.scheduleServerPoll(0);
+  }
+
+  private scheduleServerPoll(delayMs: number): void {
+    if (typeof window === 'undefined') return;
+    if (this.serverPollTimer !== undefined) return;
+
+    this.serverPollTimer = window.setTimeout(() => {
+      this.serverPollTimer = undefined;
+      void this.pollServerDownloads();
+    }, delayMs);
+  }
+
+  private async pollServerDownloads(): Promise<void> {
+    const downloads = await this.hydrateFromServer();
+    if (this.hasServerPollWork(downloads) || this.hasServerPollWork()) {
+      this.scheduleServerPoll(ACTIVE_SERVER_DOWNLOAD_POLL_INTERVAL_MS);
+    }
   }
 
   // Backwards-compatible name used by existing callers.
@@ -522,6 +570,7 @@ class DownloadTracker {
 
   private ensureDownload(downloadId: string, modelName: string, progress: DownloadProgressEvent): void {
     if (this.activeDownloads.has(downloadId)) return;
+    const restoredBytesDownloaded = this.getProgressDownloadedBytes(progress);
 
     this.activeDownloads.set(downloadId, {
       id: downloadId,
@@ -535,7 +584,7 @@ class DownloadTracker {
       status: progress.status ?? 'downloading',
       error: progress.error,
       startTime: Date.now(),
-      bytesResumed: 0,
+      bytesResumed: restoredBytesDownloaded,
       downloadType: progress.type,
       running: progress.running,
       updatedAt: Date.now(),

--- a/src/app/src/renderer/utils/downloadTracker.ts
+++ b/src/app/src/renderer/utils/downloadTracker.ts
@@ -1,6 +1,14 @@
 import { DownloadItem } from '../DownloadManager';
+import { serverFetch } from './serverConfig';
+
+const TERMINAL_DOWNLOAD_VISIBILITY_MS = 30000;
 
 export interface DownloadProgressEvent {
+  id?: string;
+  type?: 'model' | 'backend';
+  model_name?: string;
+  status?: DownloadItem['status'];
+  running?: boolean;
   file: string;
   file_index: number;
   total_files: number;
@@ -9,7 +17,19 @@ export interface DownloadProgressEvent {
   percent: number;
   total_download_size?: number;  // Total bytes across ALL files in this download
   bytes_previously_downloaded?: number;  // Bytes already on disk for current file (resume/skip)
+  completed_files_bytes?: number;  // Server-side bytes from files completed before current file
+  cumulative_bytes_downloaded?: number;  // Server-side total bytes downloaded across files
+  overall_bytes_downloaded?: number;  // Alias kept for older in-flight snapshots
+  complete?: boolean;
+  error?: string;
 }
+
+type DownloadCrossTabMessage = {
+  source: string;
+  type: 'remove' | 'sync';
+  id: string;
+  modelName?: string;
+};
 
 class DownloadTracker {
   private activeDownloads: Map<string, DownloadItem>;
@@ -19,10 +39,25 @@ class DownloadTracker {
     fileSizes: Map<number, number>;  // Map of file_index -> file size
     preExistingBytes: Map<number, number>;  // Map of file_index -> bytes already on disk
   }>;
+  private dismissedDownloads = new Set<string>();
+  private completedDownloadsFinalized = new Set<string>();
+  private completedModelDownloadsNotified = new Set<string>();
+  private serverPollStarted = false;
+  private readonly tabId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  private readonly crossTabChannel?: BroadcastChannel;
 
   constructor() {
     this.activeDownloads = new Map();
     this.cumulativeData = new Map();
+
+    if (typeof BroadcastChannel !== 'undefined') {
+      this.crossTabChannel = new BroadcastChannel('lemonade-download-manager');
+      this.crossTabChannel.onmessage = event => this.handleCrossTabMessage(event.data);
+    }
+  }
+
+  getStableDownloadId(modelName: string, downloadType?: 'model' | 'backend'): string {
+    return `${downloadType === 'backend' ? 'backend' : 'model'}:${modelName}`;
   }
 
   /**
@@ -47,12 +82,13 @@ class DownloadTracker {
           }
         }
         // Remove the old entry
-        this.activeDownloads.delete(id);
-        this.cumulativeData.delete(id);
+        this.removeLocalDownload(id, download.modelName);
       }
     }
 
-    const downloadId = `${modelName}-${Date.now()}`;
+    const downloadId = downloadType === 'model'
+      ? this.getStableDownloadId(modelName, downloadType)
+      : `${modelName}-${Date.now()}`;
 
     const downloadItem: DownloadItem = {
       id: downloadId,
@@ -70,8 +106,13 @@ class DownloadTracker {
       downloadType,
       collectionComponents,
       declaredTotalBytes,
+      running: downloadType === 'model' ? true : undefined,
+      updatedAt: Date.now(),
     };
 
+    this.dismissedDownloads.delete(downloadId);
+    this.completedDownloadsFinalized.delete(downloadId);
+    this.completedModelDownloadsNotified.delete(downloadId);
     this.activeDownloads.set(downloadId, downloadItem);
     this.cumulativeData.set(downloadId, {
       completedFilesBytes: 0,
@@ -79,6 +120,10 @@ class DownloadTracker {
       preExistingBytes: new Map(),
     });
     this.emitUpdate(downloadItem);
+    // Wake up other tabs immediately. They still hydrate from the server as the
+    // source of truth, but no longer need a refresh or a full poll interval to
+    // discover that a download has started elsewhere.
+    this.postCrossTabMessage({ type: 'sync', id: downloadId, modelName });
 
     return downloadId;
   }
@@ -88,7 +133,7 @@ class DownloadTracker {
    */
   updateProgress(downloadId: string, progress: DownloadProgressEvent): void {
     const download = this.activeDownloads.get(downloadId);
-    if (!download) return;
+    if (!download || this.dismissedDownloads.has(downloadId)) return;
 
     const cumulative = this.cumulativeData.get(downloadId);
     if (!cumulative) return;
@@ -105,8 +150,21 @@ class DownloadTracker {
       }
     }
 
+    // If the server owns the job, prefer its cumulative snapshot. This keeps
+    // reload/new-tab recovery correct for multi-file downloads.
+    if (typeof progress.completed_files_bytes === 'number') {
+      cumulative.completedFilesBytes = Math.max(
+        cumulative.completedFilesBytes,
+        progress.completed_files_bytes,
+      );
+    }
+
+    const serverCumulativeBytes = typeof progress.cumulative_bytes_downloaded === 'number'
+      ? progress.cumulative_bytes_downloaded
+      : (typeof progress.overall_bytes_downloaded === 'number' ? progress.overall_bytes_downloaded : undefined);
+
     // If we moved to a new file, add the previous file's size to completed bytes
-    if (progress.file_index > download.fileIndex) {
+    if (serverCumulativeBytes == null && progress.file_index > download.fileIndex) {
       // Only add the previous file's size if we have it tracked
       // Use 0 as fallback - if we never got byte data for a file, we can't count it
       // Note: download.bytesTotal is the CUMULATIVE total, not the individual file size!
@@ -115,7 +173,8 @@ class DownloadTracker {
     }
 
     // Calculate cumulative totals
-    const cumulativeBytesDownloaded = cumulative.completedFilesBytes + progress.bytes_downloaded;
+    const cumulativeBytesDownloaded = serverCumulativeBytes ??
+      (cumulative.completedFilesBytes + progress.bytes_downloaded);
 
     // Determine total download size:
     // 1. Server-reported total (covers all files) — best option
@@ -159,6 +218,10 @@ class DownloadTracker {
       ? Math.min(cumulativeBytesDownloaded, cumulativeBytesTotal)
       : cumulativeBytesDownloaded;
 
+    const shouldReleaseLocalOwner = progress.status != null &&
+      progress.status !== 'downloading' &&
+      progress.running !== true;
+
     const updatedDownload: DownloadItem = {
       ...download,
       fileName: progress.file,
@@ -168,10 +231,115 @@ class DownloadTracker {
       bytesTotal: cumulativeBytesTotal,
       percent: overallPercent,
       bytesResumed: totalPreExistingBytes,
+      status: progress.status ?? download.status,
+      running: progress.running ?? download.running,
+      error: progress.error ?? download.error,
+      abortController: shouldReleaseLocalOwner ? undefined : download.abortController,
+      updatedAt: Date.now(),
     };
 
     this.activeDownloads.set(downloadId, updatedDownload);
     this.emitUpdate(updatedDownload);
+  }
+
+  private getDownloadIdFromProgress(progress: DownloadProgressEvent): string | undefined {
+    if (progress.id) return progress.id;
+    if (!progress.model_name) return undefined;
+    return this.getStableDownloadId(progress.model_name, progress.type);
+  }
+
+  private isServerActive(progress: DownloadProgressEvent): boolean {
+    return progress.running === true || progress.status === 'downloading';
+  }
+
+  private reopenIfServerActive(downloadId: string, progress: DownloadProgressEvent): void {
+    if (!this.isServerActive(progress)) return;
+
+    // A stable model id may be reused by a later attempt in another tab. A
+    // fresh active server snapshot must therefore override any prior local
+    // dismissal/finalization for that same logical model download.
+    this.dismissedDownloads.delete(downloadId);
+    this.completedDownloadsFinalized.delete(downloadId);
+    this.completedModelDownloadsNotified.delete(downloadId);
+
+    const existing = this.activeDownloads.get(downloadId);
+    if (existing && existing.status !== 'downloading' && existing.running !== true) {
+      this.activeDownloads.delete(downloadId);
+      this.cumulativeData.delete(downloadId);
+    }
+  }
+
+  applyServerDownload(progress: DownloadProgressEvent): void {
+    const modelName = progress.model_name;
+    const downloadId = this.getDownloadIdFromProgress(progress);
+    if (!downloadId || !modelName) return;
+
+    this.reopenIfServerActive(downloadId, progress);
+    if (this.dismissedDownloads.has(downloadId)) return;
+
+    this.ensureDownload(downloadId, modelName, progress);
+    this.updateProgress(downloadId, progress);
+
+    if ((progress.status === 'completed' || progress.complete) && progress.running !== true) {
+      this.emitModelsUpdatedOnce(downloadId, progress);
+      this.completeDownload(downloadId);
+    }
+  }
+
+  applyServerDownloads(downloads: DownloadProgressEvent[]): void {
+    const serverIds = new Set(
+      downloads
+        .map(download => this.getDownloadIdFromProgress(download))
+        .filter((id): id is string => Boolean(id)),
+    );
+    downloads.forEach(download => this.applyServerDownload(download));
+
+    for (const [id, download] of Array.from(this.activeDownloads.entries())) {
+      if (!id.startsWith('model:') || serverIds.has(id)) continue;
+
+      const localOwnerIsGone = !download.abortController || download.abortController.signal.aborted;
+      const localRowIsNotActivelyDownloading = download.status !== 'downloading';
+      if (localOwnerIsGone || localRowIsNotActivelyDownloading) {
+        this.removeLocalDownload(id, download.modelName);
+      }
+    }
+
+    this.emitSnapshot();
+  }
+
+  async hydrateFromServer(options?: { throwOnError?: boolean }): Promise<DownloadProgressEvent[]> {
+    try {
+      const response = await serverFetch('/downloads', { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch downloads: ${response.status} ${response.statusText}`);
+      }
+
+      const downloads = await response.json();
+      if (!Array.isArray(downloads)) {
+        throw new Error('Download snapshot response was not an array');
+      }
+
+      this.applyServerDownloads(downloads);
+      return downloads;
+    } catch (error) {
+      if (options?.throwOnError) {
+        throw error;
+      }
+      // Polling is best-effort; keep local state on transient server errors.
+      return [];
+    }
+  }
+
+  startServerPolling(): void {
+    if (this.serverPollStarted) return;
+    this.serverPollStarted = true;
+    window.setInterval(() => void this.hydrateFromServer(), 2000);
+    void this.hydrateFromServer();
+  }
+
+  // Backwards-compatible name used by existing callers.
+  connectServerEvents(): void {
+    this.startServerPolling();
   }
 
   /**
@@ -179,22 +347,31 @@ class DownloadTracker {
    */
   completeDownload(downloadId: string): void {
     const download = this.activeDownloads.get(downloadId);
-    if (!download) return;
+    if (!download || this.completedDownloadsFinalized.has(downloadId)) return;
+
+    this.completedDownloadsFinalized.add(downloadId);
 
     const completedDownload: DownloadItem = {
       ...download,
       status: 'completed',
+      running: false,
       percent: 100,
+      updatedAt: Date.now(),
     };
 
     this.activeDownloads.set(downloadId, completedDownload);
+    this.emitUpdate(completedDownload);
     this.emitComplete(downloadId);
 
-    // Remove from active downloads and cumulative data after a delay
+    // Keep completed rows visible for the same terminal visibility window as
+    // the server registry so reload/new-tab snapshots do not re-add a row that
+    // this tab removed too early.
     setTimeout(() => {
-      this.activeDownloads.delete(downloadId);
-      this.cumulativeData.delete(downloadId);
-    }, 1000);
+      if (this.activeDownloads.get(downloadId)?.status === 'completed') {
+        this.dismissDownload(downloadId);
+        this.removeLocalDownload(downloadId, download.modelName);
+      }
+    }, TERMINAL_DOWNLOAD_VISIBILITY_MS);
   }
 
   /**
@@ -207,11 +384,14 @@ class DownloadTracker {
     const failedDownload: DownloadItem = {
       ...download,
       status: 'error',
+      running: false,
       error,
+      updatedAt: Date.now(),
     };
 
     this.activeDownloads.set(downloadId, failedDownload);
     this.emitError(downloadId, error);
+    this.emitUpdate(failedDownload);
 
     // Clean up cumulative data
     this.cumulativeData.delete(downloadId);
@@ -220,17 +400,20 @@ class DownloadTracker {
   /**
    * Pause a download
    */
-  pauseDownload(downloadId: string): void {
+  pauseDownload(downloadId: string, abort = true): void {
     const download = this.activeDownloads.get(downloadId);
     if (!download) return;
 
-    if (download.abortController) {
+    if (abort && download.abortController) {
       download.abortController.abort();
     }
 
     const pausedDownload: DownloadItem = {
       ...download,
       status: 'paused',
+      running: abort ? false : download.running,
+      abortController: abort ? undefined : download.abortController,
+      updatedAt: Date.now(),
     };
 
     this.activeDownloads.set(downloadId, pausedDownload);
@@ -240,31 +423,46 @@ class DownloadTracker {
   /**
    * Cancel a download
    */
-  cancelDownload(downloadId: string): void {
+  cancelDownload(downloadId: string, abort = true): void {
     const download = this.activeDownloads.get(downloadId);
-    if (!download) return;
-
-    if (download.abortController) {
+    if (abort && download?.abortController) {
       download.abortController.abort();
     }
 
-    const cancelledDownload: DownloadItem = {
-      ...download,
-      status: 'cancelled',
-    };
+    this.dismissDownload(downloadId);
+    this.removeLocalDownload(downloadId, download?.modelName, true);
+  }
 
-    this.activeDownloads.set(downloadId, cancelledDownload);
-    this.emitUpdate(cancelledDownload);
+  requestPause(downloadId: string): void {
+    const download = this.activeDownloads.get(downloadId);
+    if (!download) return;
+    if (download.abortController) {
+      window.dispatchEvent(new CustomEvent('download:paused', { detail: { id: downloadId, modelName: download.modelName } }));
+    }
+    this.pauseDownload(downloadId, Boolean(download.abortController));
+  }
 
-    // Clean up cumulative data
-    this.cumulativeData.delete(downloadId);
+  requestCancel(downloadId: string): void {
+    const download = this.activeDownloads.get(downloadId);
+    if (!download) return;
+    if (download.abortController) {
+      window.dispatchEvent(new CustomEvent('download:cancelled', { detail: { id: downloadId, modelName: download.modelName } }));
+    }
+    this.cancelDownload(downloadId, Boolean(download.abortController));
+  }
+
+  removeDownload(downloadId: string): void {
+    const modelName = this.activeDownloads.get(downloadId)?.modelName;
+    this.dismissDownload(downloadId);
+    this.removeLocalDownload(downloadId, modelName, true);
   }
 
   /**
    * Get all active downloads
    */
   getActiveDownloads(): DownloadItem[] {
-    return Array.from(this.activeDownloads.values());
+    return Array.from(this.activeDownloads.values())
+      .filter(download => !this.dismissedDownloads.has(download.id));
   }
 
   /**
@@ -278,7 +476,7 @@ class DownloadTracker {
    * Get download by model name
    */
   getDownloadByModelName(modelName: string): DownloadItem | undefined {
-    return Array.from(this.activeDownloads.values()).find(
+    return this.getActiveDownloads().find(
       download => download.modelName === modelName
     );
   }
@@ -288,7 +486,99 @@ class DownloadTracker {
    */
   isDownloading(modelName: string): boolean {
     const download = this.getDownloadByModelName(modelName);
-    return download?.status === 'downloading';
+    return Boolean(download?.abortController && download.status === 'downloading' && !download.abortController.signal.aborted);
+  }
+
+  /**
+   * Check whether this tab owns a live request for `modelName`.
+   */
+  isActive(modelName: string): boolean {
+    return this.isDownloading(modelName);
+  }
+
+  clearStaleModelDownload(modelName: string): void {
+    for (const [id, download] of Array.from(this.activeDownloads.entries())) {
+      if (download.modelName === modelName && !download.abortController) {
+        this.removeLocalDownload(id, modelName);
+      }
+    }
+  }
+
+  async hasActiveServerDownload(modelName: string): Promise<boolean> {
+    const downloads = await this.hydrateFromServer();
+    return downloads.some(download => download.model_name === modelName && (
+      download.running === true ||
+      download.status === 'downloading'
+    ));
+  }
+
+  private emitModelsUpdatedOnce(downloadId: string, progress: DownloadProgressEvent): void {
+    const downloadType = progress.type ?? this.activeDownloads.get(downloadId)?.downloadType;
+    if (downloadType !== 'model' || this.completedModelDownloadsNotified.has(downloadId)) return;
+
+    this.completedModelDownloadsNotified.add(downloadId);
+    window.dispatchEvent(new CustomEvent('modelsUpdated'));
+  }
+
+  private ensureDownload(downloadId: string, modelName: string, progress: DownloadProgressEvent): void {
+    if (this.activeDownloads.has(downloadId)) return;
+
+    this.activeDownloads.set(downloadId, {
+      id: downloadId,
+      modelName,
+      fileName: progress.file,
+      fileIndex: progress.file_index,
+      totalFiles: progress.total_files,
+      bytesDownloaded: 0,
+      bytesTotal: progress.total_download_size ?? progress.bytes_total ?? 0,
+      percent: progress.percent ?? 0,
+      status: progress.status ?? 'downloading',
+      error: progress.error,
+      startTime: Date.now(),
+      bytesResumed: 0,
+      downloadType: progress.type,
+      running: progress.running,
+      updatedAt: Date.now(),
+    });
+    this.cumulativeData.set(downloadId, {
+      completedFilesBytes: 0,
+      fileSizes: new Map(),
+      preExistingBytes: new Map(),
+    });
+  }
+
+  private postCrossTabMessage(message: Omit<DownloadCrossTabMessage, 'source'>): void {
+    this.crossTabChannel?.postMessage({ ...message, source: this.tabId });
+  }
+
+  private handleCrossTabMessage(message: DownloadCrossTabMessage): void {
+    if (!message || message.source === this.tabId) return;
+
+    if (message.type === 'remove') {
+      this.dismissDownload(message.id);
+      this.removeLocalDownload(message.id, message.modelName);
+      return;
+    }
+
+    if (message.type === 'sync') {
+      void this.hydrateFromServer();
+    }
+  }
+
+  private dismissDownload(downloadId: string): void {
+    this.dismissedDownloads.add(downloadId);
+  }
+
+  private removeLocalDownload(downloadId: string, modelName?: string, broadcast = false): void {
+    this.activeDownloads.delete(downloadId);
+    this.cumulativeData.delete(downloadId);
+    this.completedDownloadsFinalized.delete(downloadId);
+    this.completedModelDownloadsNotified.delete(downloadId);
+    if (broadcast) {
+      this.postCrossTabMessage({ type: 'remove', id: downloadId, modelName });
+    }
+    window.dispatchEvent(new CustomEvent('download:removed', { detail: { id: downloadId, modelName } }));
+    this.emitSnapshot();
   }
 
   /**
@@ -300,18 +590,6 @@ class DownloadTracker {
         detail: download,
       })
     );
-  }
-
-  /**
-   * Check whether a download for `modelName` is currently in-flight
-   * (downloading or paused — i.e. not finished/errored/cancelled).
-   */
-  isActive(modelName: string): boolean {
-    for (const d of this.activeDownloads.values()) {
-      if (d.modelName !== modelName) continue;
-      if (d.status === 'downloading' || d.status === 'paused') return true;
-    }
-    return false;
   }
 
   /**
@@ -334,6 +612,10 @@ class DownloadTracker {
         detail: { id: downloadId, error },
       })
     );
+  }
+
+  private emitSnapshot(): void {
+    window.dispatchEvent(new CustomEvent('download:snapshot', { detail: { downloads: this.getActiveDownloads() } }));
   }
 }
 

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -10,6 +10,10 @@
 #include <memory>
 #include <atomic>
 #include <chrono>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <vector>
 #include <httplib.h>
 #include "runtime_config.h"
 #include "router.h"
@@ -102,10 +106,53 @@ private:
     // Enrich recipes JSON with release_url, download_filename, version from BackendManager
     void enrich_recipes(json& recipes);
 
-    // Shared SSE streaming helper for download operations
+    // Download manager endpoints and server-owned download jobs
+    void handle_downloads(const httplib::Request& req, httplib::Response& res);
+    void handle_download_control(const httplib::Request& req, httplib::Response& res);
+
+    // Shared SSE streaming helper for legacy download operations. The operation
+    // remains tied to this response for backwards compatibility.
     void stream_download_operation(
         httplib::Response& res,
         std::function<void(DownloadProgressCallback)> operation);
+
+    struct DownloadJob {
+        std::string id;
+        std::string type;
+        std::string display_name;
+        std::string status;
+        std::string cancel_action;
+        std::string error;
+        nlohmann::json progress;
+        uint64_t completed_files_bytes = 0;
+        uint64_t current_file_bytes_total = 0;
+        int current_file_index = -1;
+        bool cancel_requested = false;
+        // Set by the worker's progress callback once the downloader has actually
+        // observed a pause/cancel request and stopped before completion. This
+        // prevents a late UI request from overriding a successful operation that
+        // already returned normally.
+        bool stop_acknowledged = false;
+        bool running = false;
+        std::chrono::steady_clock::time_point terminal_since;
+        // Protects worker publication/join. A job can be visible in the registry
+        // while start_download_job is still joining the previous worker; removals
+        // and shutdown must wait until the new worker thread is either assigned
+        // or known to be absent before deciding whether to join.
+        mutable std::mutex worker_mutex;
+        std::thread worker;
+    };
+
+    nlohmann::json download_progress_to_json(const DownloadProgress& progress);
+    nlohmann::json download_job_to_json(const std::shared_ptr<DownloadJob>& job);
+    bool is_download_job_visible(const std::shared_ptr<DownloadJob>& job) const;
+    std::shared_ptr<DownloadJob> start_download_job(
+        const std::string& download_id,
+        const std::string& download_type,
+        const std::string& display_name,
+        std::function<void(DownloadProgressCallback)> operation);
+    void join_download_job(const std::shared_ptr<DownloadJob>& job);
+    void cancel_download_jobs();
 
     // Helper function for local model resolution and registration
     void resolve_and_register_local_model(
@@ -163,6 +210,9 @@ private:
     std::unique_ptr<ModelManager> model_manager_;
     std::unique_ptr<BackendManager> backend_manager_;
     std::unique_ptr<WebSocketServer> websocket_server_;
+
+    std::mutex downloads_mutex_;
+    std::map<std::string, std::shared_ptr<DownloadJob>> download_jobs_;
 
     bool running_;
     std::atomic<bool> shutdown_requested_{false};

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -525,6 +525,120 @@ static void cleanup_empty_parents(const fs::path& file_path, const fs::path& sto
     }
 }
 
+
+static std::string normalized_relative_path(const fs::path& path, const fs::path& root) {
+    std::string rel = path_to_utf8(path.lexically_relative(root));
+    std::replace(rel.begin(), rel.end(), '\\', '/');
+    return rel;
+}
+
+static void remove_file_or_throw(const fs::path& path, const std::string& description) {
+    if (!safe_exists(path)) {
+        return;
+    }
+
+    LOG(INFO, "ModelManager") << "Removing " << description << ": "
+                              << path_to_utf8(path) << std::endl;
+    std::error_code ec;
+    fs::remove(path, ec);
+    if (ec) {
+        throw std::runtime_error("Failed to remove " + description + " '" +
+                                 path_to_utf8(path) + "': " + ec.message());
+    }
+}
+
+static void remove_stale_manifest_for_partial(const fs::path& partial_path,
+                                              const fs::path& stop_dir) {
+    fs::path parent = partial_path.parent_path();
+    for (int i = 0; i < 8 && !parent.empty() && parent != stop_dir; ++i) {
+        fs::path manifest_path = parent / ".download_manifest.json";
+        if (safe_exists(manifest_path)) {
+            remove_file_or_throw(manifest_path, "stale download manifest");
+            cleanup_empty_parents(manifest_path, stop_dir);
+            return;
+        }
+        parent = parent.parent_path();
+    }
+}
+
+static bool cleanup_incomplete_hf_model_cache(const ModelInfo& info,
+                                              const std::string& canonical_model_name,
+                                              const std::map<std::string, ModelInfo>& models_cache) {
+    const std::string main_checkpoint = info.checkpoint("main");
+    const std::string main_repo = checkpoint_to_repo_id(main_checkpoint);
+    if (main_repo.empty()) {
+        return false;
+    }
+
+    fs::path model_cache_path = path_from_utf8(get_hf_cache_dir()) / repo_id_to_cache_dir_name(main_repo);
+    if (!safe_exists(model_cache_path)) {
+        return false;
+    }
+
+    // If no other model references this HF repo, delete the whole incomplete
+    // repo cache. That removes .partial files, stale manifests, any files that
+    // finished before cancellation, refs, and blobs in one atomic intent.
+    if (!is_repo_shared(main_repo, canonical_model_name, models_cache)) {
+        LOG(INFO, "ModelManager") << "Removing incomplete model cache: "
+                                  << path_to_utf8(model_cache_path) << std::endl;
+        std::error_code ec;
+        fs::remove_all(model_cache_path, ec);
+        if (ec) {
+            throw std::runtime_error("Failed to remove incomplete model cache '" +
+                                     path_to_utf8(model_cache_path) + "': " + ec.message());
+        }
+        return true;
+    }
+
+    // Shared repos must not be removed wholesale. Remove only the resumable
+    // partial for this model's requested variant, plus the manifest that made
+    // that partial visible as an incomplete download.
+    const std::string variant = checkpoint_to_variant(main_checkpoint);
+    if (variant.empty()) {
+        LOG(INFO, "ModelManager") << "Keeping shared incomplete cache for " << main_repo
+                                  << " because the model has no exact variant" << std::endl;
+        return false;
+    }
+
+    fs::path snapshots_dir = model_cache_path / "snapshots";
+    if (!safe_exists(snapshots_dir)) {
+        return false;
+    }
+
+    std::string normalized_variant = variant;
+    std::replace(normalized_variant.begin(), normalized_variant.end(), '\\', '/');
+
+    bool removed_any = false;
+    std::error_code ec;
+    for (const auto& entry : fs::recursive_directory_iterator(snapshots_dir, safe_dir_options, ec)) {
+        if (ec) break;
+
+        const fs::path partial_path = entry.path();
+        const std::string rel = normalized_relative_path(partial_path, snapshots_dir);
+        const std::string filename = partial_path.filename().string();
+        const bool matches_variant_partial =
+            filename == variant + ".partial" ||
+            rel == normalized_variant + ".partial" ||
+            rel.rfind("/" + normalized_variant + ".partial") != std::string::npos;
+
+        if (!matches_variant_partial) {
+            continue;
+        }
+
+        remove_file_or_throw(partial_path, "incomplete model download partial");
+        remove_stale_manifest_for_partial(partial_path, model_cache_path);
+        cleanup_empty_parents(partial_path, model_cache_path);
+        removed_any = true;
+    }
+
+    if (!removed_any) {
+        LOG(INFO, "ModelManager") << "No incomplete cache artifacts found for shared repo "
+                                  << main_repo << std::endl;
+    }
+
+    return removed_any;
+}
+
 // Structure to hold identified GGUF files
 struct GGUFFiles {
     std::map<std::string, std::string> core_files;  // {"variant": "file.gguf", "mmproj": "file.mmproj"}
@@ -3297,11 +3411,20 @@ void ModelManager::delete_model(const std::string& model_name) {
         return;
     }
 
-    // Use resolved_path to find the model directory to delete
+    // Use resolved_path to find the model directory to delete.
+    // Cancelled or interrupted downloads may not have a resolved model path yet,
+    // but they can still leave resumable .partial files and manifests in the HF
+    // cache. Clean those artifacts before falling back to registry-only cleanup.
     if (info.resolved_path().empty()) {
-        // Model exists in registry but has no downloaded files
-        // Just remove from user_models.json and cache
-        LOG(INFO, "ModelManager") << "Model not downloaded, removing from registry only" << std::endl;
+        bool removed_incomplete_cache = cleanup_incomplete_hf_model_cache(
+            info,
+            canonical_model_name,
+            models_cache_
+        );
+
+        if (!removed_incomplete_cache) {
+            LOG(INFO, "ModelManager") << "Model not downloaded, removing from registry only" << std::endl;
+        }
 
         if (is_user_model_name(canonical_model_name)) {
             json updated_user_models = user_models_;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -239,6 +239,7 @@ void Server::setup_http_servers() {
 }
 
 Server::~Server() {
+    cancel_download_jobs();
     stop();
 }
 
@@ -463,6 +464,15 @@ void Server::setup_routes(httplib::Server &web_server) {
     register_get("pull/variants", [this](const httplib::Request& req, httplib::Response& res) {
         handle_pull_variants(req, res);
     });
+
+    register_get("downloads", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_downloads(req, res);
+    });
+
+    register_post("downloads/control", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_download_control(req, res);
+    });
+
 
     register_post("load", [this](const httplib::Request& req, httplib::Response& res) {
         handle_load(req, res);
@@ -2886,6 +2896,7 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
         std::string recipe = request_json.value("recipe", "");
         bool do_not_upgrade = request_json.value("do_not_upgrade", false);
         bool stream = request_json.value("stream", false);
+        bool subscribe = request_json.value("subscribe", true);
 
         LOG(INFO, "Server") << "Pulling model: " << model_name << std::endl;
         if (!checkpoint.empty()) {
@@ -2945,10 +2956,29 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
         }
 
         if (stream) {
-            // SSE streaming mode - send progress events via shared helper
-            stream_download_operation(res, [this, model_name, request_json, do_not_upgrade](DownloadProgressCallback progress_cb) {
+            auto operation = [this, model_name, request_json, do_not_upgrade](DownloadProgressCallback progress_cb) {
                 model_manager_->download_model(model_name, request_json, do_not_upgrade, progress_cb);
-            });
+            };
+
+            if (!subscribe) {
+                // Server-owned mode for desktop UI reload/new-tab recovery.
+                // Legacy streamed /pull behavior is unchanged.
+                auto job = start_download_job("model:" + model_name, "model", model_name, operation);
+                nlohmann::json response;
+                {
+                    // The worker can update the shared job immediately after
+                    // start_download_job returns, so copy the response while
+                    // holding the same mutex used by the progress callback.
+                    std::lock_guard<std::mutex> lock(downloads_mutex_);
+                    response = download_job_to_json(job);
+                }
+                res.set_content(response.dump(), "application/json");
+                return;
+            }
+
+            // Backward-compatible SSE streaming mode: tie the operation to this
+            // response exactly as before.
+            stream_download_operation(res, operation);
         } else {
             // Legacy synchronous mode - blocks until complete
             model_manager_->download_model(model_name, request_json, do_not_upgrade);
@@ -3866,6 +3896,7 @@ void Server::handle_shutdown(const httplib::Request& req, httplib::Response& res
     // Stop the HTTP listener and exit asynchronously (allows response to be sent first)
     std::thread([this]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        cancel_download_jobs();
         stop();
         std::exit(0);
     }).detach();
@@ -4090,6 +4121,248 @@ void Server::apply_config_side_effects(const json& applied_changes) {
     }
 }
 
+
+// ============================================================================
+// Server-owned Download Manager state
+// ============================================================================
+
+namespace {
+
+constexpr auto DOWNLOAD_TERMINAL_VISIBILITY = std::chrono::seconds(30);
+
+} // namespace
+
+nlohmann::json Server::download_progress_to_json(const DownloadProgress& p) {
+    nlohmann::json event_data;
+    event_data["file"] = p.file;
+    event_data["file_index"] = p.file_index;
+    event_data["total_files"] = p.total_files;
+    event_data["bytes_downloaded"] = static_cast<uint64_t>(p.bytes_downloaded);
+    event_data["bytes_total"] = static_cast<uint64_t>(p.bytes_total);
+    event_data["total_download_size"] = static_cast<uint64_t>(p.total_download_size);
+    event_data["bytes_previously_downloaded"] = static_cast<uint64_t>(p.bytes_previously_downloaded);
+    event_data["percent"] = p.percent;
+    event_data["complete"] = p.complete;
+    if (!p.error.empty()) {
+        event_data["error"] = p.error;
+    }
+    return event_data;
+}
+
+nlohmann::json Server::download_job_to_json(const std::shared_ptr<DownloadJob>& job) {
+    nlohmann::json item = job->progress.is_object() ? job->progress : nlohmann::json::object();
+    item["id"] = job->id;
+    item["type"] = job->type;
+    item["model_name"] = job->display_name;
+    item["status"] = job->status;
+    item["running"] = job->running;
+    if (!job->error.empty()) {
+        item["error"] = job->error;
+    }
+    return item;
+}
+
+bool Server::is_download_job_visible(const std::shared_ptr<DownloadJob>& job) const {
+    if (!job) return false;
+    if (job->running) {
+        return true;
+    }
+    if (job->status == "downloading" || job->status == "paused" || job->status == "error") {
+        return true;
+    }
+    if (job->status == "cancelled") {
+        // Cancelled downloads may still have partial files on disk. Keep them
+        // discoverable across reloads/restarts until the UI explicitly removes
+        // the row after cleanup, retry, or user dismissal.
+        return true;
+    }
+    if (job->status == "completed") {
+        return job->terminal_since.time_since_epoch().count() > 0 &&
+               std::chrono::steady_clock::now() - job->terminal_since < DOWNLOAD_TERMINAL_VISIBILITY;
+    }
+    return false;
+}
+
+void Server::join_download_job(const std::shared_ptr<DownloadJob>& job) {
+    // Download workers capture `this`, so they must never outlive Server. Move
+    // the thread out under the job-local mutex, then join without holding either
+    // worker_mutex or downloads_mutex_. This avoids both data races on
+    // std::thread and deadlocks with progress callbacks.
+    if (!job) return;
+
+    std::thread worker;
+    {
+        std::lock_guard<std::mutex> lock(job->worker_mutex);
+        if (!job->worker.joinable()) return;
+        if (job->worker.get_id() == std::this_thread::get_id()) return;
+        worker = std::move(job->worker);
+    }
+
+    worker.join();
+}
+
+std::shared_ptr<Server::DownloadJob> Server::start_download_job(
+    const std::string& download_id,
+    const std::string& download_type,
+    const std::string& display_name,
+    std::function<void(DownloadProgressCallback)> operation) {
+
+    std::shared_ptr<DownloadJob> old_job;
+    auto job = std::make_shared<DownloadJob>();
+    job->id = download_id;
+    job->type = download_type;
+    job->display_name = display_name;
+    job->status = "downloading";
+    job->running = true;
+    job->progress = {
+        {"id", download_id},
+        {"type", download_type},
+        {"model_name", display_name},
+        {"file", ""},
+        {"file_index", 0},
+        {"total_files", 0},
+        {"bytes_downloaded", 0},
+        {"bytes_total", 0},
+        {"total_download_size", 0},
+        {"bytes_previously_downloaded", 0},
+        {"completed_files_bytes", 0},
+        {"cumulative_bytes_downloaded", 0},
+        {"overall_bytes_downloaded", 0},
+        {"percent", 0},
+        {"complete", false}
+    };
+
+    std::unique_lock<std::mutex> worker_lock(job->worker_mutex);
+
+    {
+        std::lock_guard<std::mutex> lock(downloads_mutex_);
+        auto existing = download_jobs_.find(download_id);
+        if (existing != download_jobs_.end()) {
+            if (existing->second->running || existing->second->status == "downloading") {
+                return existing->second;
+            }
+            old_job = existing->second;
+        }
+        download_jobs_[download_id] = job;
+    }
+
+    join_download_job(old_job);
+
+    job->worker = std::thread([this, job, operation = std::move(operation)]() mutable {
+        try {
+            DownloadProgressCallback progress_cb = [this, job](const DownloadProgress& p) -> bool {
+                std::lock_guard<std::mutex> lock(downloads_mutex_);
+                // Completion wins over a very late pause/cancel request. If the
+                // downloader is reporting its final complete event, record it and
+                // let the operation return successfully instead of turning a fully
+                // written model into a cancelled/paused row.
+                if (job->cancel_requested && !p.complete) {
+                    job->stop_acknowledged = true;
+                    return false;
+                }
+
+                if (job->current_file_index != p.file_index) {
+                    if (job->current_file_index >= 0 && p.file_index > job->current_file_index) {
+                        job->completed_files_bytes += job->current_file_bytes_total;
+                    }
+                    job->current_file_index = p.file_index;
+                    job->current_file_bytes_total = 0;
+                }
+                if (p.bytes_total > 0) {
+                    job->current_file_bytes_total = std::max<uint64_t>(
+                        job->current_file_bytes_total,
+                        static_cast<uint64_t>(p.bytes_total));
+                }
+
+                const uint64_t total_download_size = static_cast<uint64_t>(p.total_download_size);
+                uint64_t cumulative_bytes = job->completed_files_bytes + static_cast<uint64_t>(p.bytes_downloaded);
+                if (p.complete && total_download_size > 0) {
+                    cumulative_bytes = total_download_size;
+                } else if (total_download_size > 0) {
+                    cumulative_bytes = std::min(cumulative_bytes, total_download_size);
+                }
+
+                job->progress = download_progress_to_json(p);
+                job->progress["completed_files_bytes"] = job->completed_files_bytes;
+                job->progress["cumulative_bytes_downloaded"] = cumulative_bytes;
+                job->progress["overall_bytes_downloaded"] = cumulative_bytes;
+                job->status = p.complete ? "completed" : "downloading";
+                // terminal_since is the time the worker has actually stopped, not
+                // the time a terminal status first becomes visible. Keeping it
+                // empty while running=true prevents /downloads from expiring the
+                // row before other tabs can observe that files are released.
+                job->terminal_since = std::chrono::steady_clock::time_point{};
+                job->error.clear();
+                return true;
+            };
+
+            operation(progress_cb);
+
+            std::lock_guard<std::mutex> lock(downloads_mutex_);
+            if (job->cancel_requested && job->stop_acknowledged) {
+                job->status = job->cancel_action == "cancel" ? "cancelled" : "paused";
+                job->progress["complete"] = false;
+            } else {
+                // The operation returned normally without acknowledging a stop
+                // request. Treat that as success; a late pause/cancel button must
+                // not erase or delete a completed download.
+                job->status = "completed";
+                job->progress["complete"] = true;
+                job->progress["percent"] = 100;
+                const uint64_t total_download_size = job->progress.value("total_download_size", uint64_t{0});
+                if (total_download_size > 0) {
+                    job->progress["cumulative_bytes_downloaded"] = total_download_size;
+                    job->progress["overall_bytes_downloaded"] = total_download_size;
+                }
+            }
+            job->running = false;
+            job->terminal_since = (job->status == "completed" || job->status == "cancelled")
+                ? std::chrono::steady_clock::now()
+                : std::chrono::steady_clock::time_point{};
+        } catch (const lemon::UnknownModelError& e) {
+            std::lock_guard<std::mutex> lock(downloads_mutex_);
+            LOG(ERROR, "DownloadManager") << "worker unknown-model error id=" << job->id
+                                           << " error=\"" << e.what() << "\"" << std::endl;
+            job->status = "error";
+            job->terminal_since = std::chrono::steady_clock::time_point{};
+            job->error = e.what();
+            job->progress["error"] = e.what();
+            job->progress["code"] = lemon::kUnknownModelErrorCode;
+            job->running = false;
+        } catch (const std::exception& e) {
+            bool cancel_requested = false;
+            {
+                std::lock_guard<std::mutex> lock(downloads_mutex_);
+                cancel_requested = job->cancel_requested;
+            }
+
+            if (!cancel_requested) {
+                LOG(ERROR, "DownloadManager") << "worker exception id=" << job->id
+                                               << " error=\"" << e.what() << "\"" << std::endl;
+            }
+
+            std::lock_guard<std::mutex> lock(downloads_mutex_);
+            if (job->cancel_requested) {
+                job->status = job->cancel_action == "cancel" ? "cancelled" : "paused";
+                job->error.clear();
+            } else {
+                job->status = "error";
+                job->terminal_since = std::chrono::steady_clock::time_point{};
+                job->error = e.what();
+                job->progress["error"] = e.what();
+            }
+            job->running = false;
+            if (job->status == "cancelled") {
+                job->terminal_since = std::chrono::steady_clock::now();
+            }
+        }
+    });
+    worker_lock.unlock();
+
+    return job;
+}
+
+
 // ============================================================================
 // Shared SSE streaming helper for download operations
 // ============================================================================
@@ -4165,6 +4438,144 @@ void Server::stream_download_operation(
             return false;
         });
 }
+
+
+
+void Server::handle_downloads(const httplib::Request&, httplib::Response& res) {
+    nlohmann::json response = nlohmann::json::array();
+    std::vector<std::shared_ptr<DownloadJob>> expired_jobs;
+    const auto now = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard<std::mutex> lock(downloads_mutex_);
+        for (auto it = download_jobs_.begin(); it != download_jobs_.end();) {
+            const auto& job = it->second;
+            if (is_download_job_visible(job)) {
+                response.push_back(download_job_to_json(job));
+                ++it;
+                continue;
+            }
+
+            const bool expired_terminal = job &&
+                !job->running &&
+                job->status == "completed" &&
+                job->terminal_since.time_since_epoch().count() > 0 &&
+                now - job->terminal_since >= DOWNLOAD_TERMINAL_VISIBILITY;
+
+            if (expired_terminal) {
+                expired_jobs.push_back(job);
+                it = download_jobs_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    for (auto& job : expired_jobs) {
+        join_download_job(job);
+    }
+
+    res.set_content(response.dump(), "application/json");
+}
+
+
+void Server::handle_download_control(const httplib::Request& req, httplib::Response& res) {
+    try {
+        auto request_json = nlohmann::json::parse(req.body);
+        std::string id = request_json.value("id", "");
+        std::string action = request_json.value("action", "");
+
+        if (id.empty() || action.empty()) {
+            res.status = 400;
+            res.set_content("{\"error\": \"Both 'id' and 'action' are required\"}", "application/json");
+            return;
+        }
+
+        nlohmann::json response_json;
+        std::shared_ptr<DownloadJob> job_to_join;
+
+        {
+            std::lock_guard<std::mutex> lock(downloads_mutex_);
+            auto it = download_jobs_.find(id);
+            if (it == download_jobs_.end()) {
+                if (action == "remove") {
+                    res.set_content("{\"status\": \"ok\", \"missing\": true}", "application/json");
+                    return;
+                }
+                res.status = 404;
+                res.set_content("{\"error\": \"Download not found\"}", "application/json");
+                return;
+            }
+
+            auto job = it->second;
+            if (action == "pause" || action == "cancel") {
+                const bool terminal = job->status == "completed" ||
+                    job->status == "cancelled" ||
+                    job->status == "error";
+
+                if (!terminal) {
+                    job->cancel_requested = true;
+                    job->cancel_action = action;
+                    job->status = action == "cancel" ? "cancelled" : "paused";
+                    // Paused jobs remain visible until resumed/removed. A cancel
+                    // request for an already-stopped job has no worker that will
+                    // later stamp terminal_since, so start the terminal visibility
+                    // window here to avoid leaving a stale hidden registry entry.
+                    job->terminal_since = (action == "cancel" && !job->running)
+                        ? std::chrono::steady_clock::now()
+                        : std::chrono::steady_clock::time_point{};
+                }
+
+                response_json = download_job_to_json(job);
+            } else if (action == "remove") {
+                if (job->running) {
+                    // A remove request must not make the job disappear while the
+                    // worker may still hold file handles. Convert it to a cancel
+                    // request and keep the job visible until running=false.
+                    job->cancel_requested = true;
+                    job->cancel_action = "cancel";
+                    if (job->status != "completed" && job->status != "error") {
+                        job->status = "cancelled";
+                        job->terminal_since = std::chrono::steady_clock::time_point{};
+                    }
+                    response_json = download_job_to_json(job);
+                } else {
+                    job_to_join = job;
+                    download_jobs_.erase(it);
+                    response_json = {{"status", "ok"}};
+                }
+            } else {
+                res.status = 400;
+                res.set_content("{\"error\": \"Unsupported download action\"}", "application/json");
+                return;
+            }
+        }
+
+        join_download_job(job_to_join);
+        res.set_content(response_json.dump(), "application/json");
+    } catch (const std::exception& e) {
+        res.status = 400;
+        nlohmann::json error = {{"error", e.what()}};
+        res.set_content(error.dump(), "application/json");
+    }
+}
+
+void Server::cancel_download_jobs() {
+    std::vector<std::shared_ptr<DownloadJob>> jobs;
+    {
+        std::lock_guard<std::mutex> lock(downloads_mutex_);
+        for (auto& [id, job] : download_jobs_) {
+            job->cancel_requested = true;
+            job->cancel_action = "cancel";
+            jobs.push_back(job);
+        }
+    }
+
+    for (auto& job : jobs) {
+        join_download_job(job);
+    }
+}
+
 
 // ============================================================================
 // Backend management endpoints

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -148,6 +148,15 @@ void set_error_response(const json& response, httplib::Response& res,
     res.set_content(response.dump(), "application/json");
 }
 
+bool is_quiet_polling_path(const std::string& path) {
+    return path == "/api/v0/downloads" || path == "/api/v1/downloads" ||
+           path == "/v0/downloads" || path == "/v1/downloads" ||
+           path == "/api/v0/system-stats" || path == "/api/v1/system-stats" ||
+           path == "/v0/system-stats" || path == "/v1/system-stats" ||
+           path == "/api/v0/stats" || path == "/api/v1/stats" ||
+           path == "/v0/stats" || path == "/v1/stats";
+}
+
 } // namespace
 
 
@@ -246,11 +255,8 @@ Server::~Server() {
 void Server::log_request(const httplib::Request& req) {
     if (req.path != "/api/v0/health" && req.path != "/api/v1/health" &&
         req.path != "/v0/health" && req.path != "/v1/health" &&
-        req.path != "/api/v0/system-stats" && req.path != "/api/v1/system-stats" &&
-        req.path != "/v0/system-stats" && req.path != "/v1/system-stats" &&
-        req.path != "/api/v0/stats" && req.path != "/api/v1/stats" &&
-        req.path != "/v0/stats" && req.path != "/v1/stats" &&
-        req.path != "/live") {
+        req.path != "/live" &&
+        !is_quiet_polling_path(req.path)) {
         LOG(DEBUG, "Server") << req.method << " " << req.path << std::endl;
     }
 }
@@ -939,10 +945,7 @@ void Server::setup_http_logger(httplib::Server &web_server) {
         // Skip logging health checks and stats endpoints to reduce log noise
         if (req.path == "/api/v0/health" || req.path == "/api/v1/health" ||
             req.path == "/v0/health" || req.path == "/v1/health" || req.path == "/live" ||
-            req.path == "/api/v0/system-stats" || req.path == "/api/v1/system-stats" ||
-            req.path == "/v0/system-stats" || req.path == "/v1/system-stats" ||
-            req.path == "/api/v0/stats" || req.path == "/api/v1/stats" ||
-            req.path == "/v0/stats" || req.path == "/v1/stats") {
+            is_quiet_polling_path(req.path)) {
             return;
         }
 

--- a/test/server_downloads.py
+++ b/test/server_downloads.py
@@ -1,0 +1,99 @@
+"""
+Server-owned download registry tests for Lemonade Server.
+
+Usage:
+    python test/server_downloads.py
+    python test/server_downloads.py --cli-binary /path/to/lemonade
+"""
+
+import time
+import uuid
+
+import requests
+
+from utils.server_base import ServerTestBase, run_server_tests
+from utils.test_models import PORT, TIMEOUT_DEFAULT
+
+
+class ServerDownloadRegistryTests(ServerTestBase):
+    """Tests the non-SSE model download registry path used by the desktop UI."""
+
+    def _get_downloads(self):
+        response = requests.get(
+            f"http://localhost:{PORT}/api/v1/downloads",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        response.raise_for_status()
+        data = response.json()
+        self.assertIsInstance(data, list)
+        return data
+
+    def _control_download(self, download_id, action):
+        response = requests.post(
+            f"http://localhost:{PORT}/api/v1/downloads/control",
+            json={"id": download_id, "action": action},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _wait_for_status(self, download_id, statuses, timeout=10):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            downloads = self._get_downloads()
+            match = next((item for item in downloads if item.get("id") == download_id), None)
+            if match and match.get("status") in statuses and match.get("running") is not True:
+                return match
+            time.sleep(0.25)
+        self.fail(f"Timed out waiting for {download_id} to reach one of {statuses}")
+
+    def test_001_pull_subscribe_false_registers_download_and_control_can_remove(self):
+        """POST /pull with subscribe=false registers a server-owned job visible via /downloads."""
+        model_name = f"Definitely-Not-A-Real-Download-Test-Model-{uuid.uuid4().hex}"
+        download_id = f"model:{model_name}"
+
+        # Use an intentionally unknown model so the test exercises the registry
+        # path without downloading a real model from Hugging Face. The initial
+        # response should still be a JSON job snapshot, not an SSE stream.
+        response = requests.post(
+            f"http://localhost:{PORT}/api/v1/pull",
+            json={
+                "model_name": model_name,
+                "stream": True,
+                "subscribe": False,
+            },
+            timeout=TIMEOUT_DEFAULT,
+        )
+        response.raise_for_status()
+
+        snapshot = response.json()
+        self.assertEqual(snapshot.get("id"), download_id)
+        self.assertEqual(snapshot.get("type"), "model")
+        self.assertEqual(snapshot.get("model_name"), model_name)
+        self.assertIn(snapshot.get("status"), {"downloading", "error"})
+
+        terminal = self._wait_for_status(download_id, {"error"})
+        self.assertIn("error", terminal)
+
+        removed = self._control_download(download_id, "remove")
+        self.assertEqual(removed.get("status"), "ok")
+
+        downloads_after_remove = self._get_downloads()
+        self.assertFalse(
+            any(item.get("id") == download_id for item in downloads_after_remove),
+            "removed download job should not remain visible",
+        )
+
+    def test_002_download_control_validates_required_fields(self):
+        """The control endpoint rejects malformed requests with a client error."""
+        response = requests.post(
+            f"http://localhost:{PORT}/api/v1/downloads/control",
+            json={"action": "remove"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+
+if __name__ == "__main__":
+    run_server_tests(ServerDownloadRegistryTests, "SERVER DOWNLOAD REGISTRY TESTS")


### PR DESCRIPTION

## Summary

This PR makes UI-started model downloads survive renderer reloads and new tabs.

Previously, a model download could continue correctly in the backend, but the UI
Download Manager lost track of it after F5 or when opening another tab. The fix
keeps these downloads server-owned and rehydrates the Download Manager from the
backend download registry.

The implementation keeps the legacy streaming download paths unchanged and limits
the new behavior to UI-started model downloads that opt out of the SSE
subscription.

In addition, the PR hardens pause/cancel lifecycle handling so terminal download
states are only treated as final after the backend worker has actually stopped.


## Changes

- Start UI model downloads with subscribe:false so the backend owns the job.
- Rehydrate the Download Manager from /downloads on renderer startup.
- Keep stable model download IDs so reloads and new tabs can match existing jobs.
- Share pause/resume/cancel/remove state across tabs through the backend registry.
- Reconcile restored UI rows against the backend snapshot so cancelled or removed
- paused downloads disappear from other tabs as well.
- Preserve legacy SSE behavior for existing streaming download paths.
- Wait for running !== true before treating paused/cancelled/error states as terminal in the renderer.
- Harden backend download worker lifecycle synchronization for pause/resume/cancel flows.


## Validation

- Verified that a model download remains visible in the Download Manager after F5.
- Verified that opening a new tab restores the active backend download.
- Verified pause/resume state is reflected across tabs.
- Verified cancel/remove after pausing in one tab is reflected in other tabs.
- Verified paused/cancelled states are only finalized after backend worker stop.
- Verified duplicate UI pulls reuse the same backend-owned download job.
- Verified legacy streaming download behavior remains unchanged.

Made also a full cycle test script (locally) and Tested:
- npm run test:downloads -- --base-url http://127.0.0.1:13305/api/v1 --model Tiny-Test-Model-GGUF
- Passes server-owned model download lifecycle:
  snapshot recovery, pause barrier, resume, cancel barrier, and remove.
  
## Notes

This PR #1764 will be adapted to bring that fix also to backends as follow up PR.