### PR TITLE
fix(sd-cpp): update macOS metal asset filename

### DIFF
--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -91,7 +91,7 @@ InstallParams SDServer::get_install_params(const std::string& backend, const std
 
     if (resolved_backend == "metal") {
 #if defined(__APPLE__)
-        params.filename = "sd-" + short_version + "-bin-Darwin-arm64-metal.zip";
+        params.filename = "sd-" + short_version + "-bin-Darwin-macOS-15.7.4-arm64.zip";
 #endif
     } else if (is_rocm_backend(resolved_backend)) {
         std::string target_arch = SystemInfo::get_rocm_arch();


### PR DESCRIPTION
Upstream stable-diffusion.cpp renamed the macOS release asset from `sd-<ver>-bin-Darwin-arm64-metal.zip` to `sd-<ver>-bin-Darwin-macOS-15.7.4-arm64.zip`. Backend install was 404ing on macOS as a result.

## Test plan
- [ ] `lemonade pull` an sd-cpp model on macOS arm64 and confirm the metal backend downloads/extracts