### PR TITLE
Fix : Add 'vision' label to Qwen MTP models

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -949,6 +949,7 @@
         "recipe": "llamacpp",
         "suggested": true,
         "labels": [
+            "vision",
             "tool-calling",
             "mtp"
         ],
@@ -983,6 +984,7 @@
         "recipe": "llamacpp",
         "suggested": true,
         "labels": [
+            "vision",
             "tool-calling",
             "mtp"
         ],
@@ -1005,6 +1007,7 @@
         "recipe": "llamacpp",
         "suggested": true,
         "labels": [
+            "vision",
             "tool-calling",
             "mtp",
             "hot"


### PR DESCRIPTION
Small follow up on PR #1944  to add vision labels.