### PR TITLE
packaging: Linux systemd/sysusers compliance for downstream distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1372,6 +1372,12 @@ if(UNIX AND NOT APPLE)
         ")
     endif()
 
+    # Install sysusers.d snippet so the 'lemonade' system user is created
+    install(FILES ${CMAKE_SOURCE_DIR}/data/lemonade.sysusers
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/sysusers.d
+        RENAME lemonade.conf
+    )
+
     # Install secrets.conf for LEMONADE_API_KEY (still loaded via EnvironmentFile)
     install(FILES ${CMAKE_SOURCE_DIR}/data/secrets.conf
         DESTINATION /etc/lemonade/conf.d

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1378,6 +1378,17 @@ if(UNIX AND NOT APPLE)
         RENAME lemonade.conf
     )
 
+    # Configure + install the user-mode systemd unit
+    configure_file(
+        ${CMAKE_SOURCE_DIR}/data/lemond-user.service.in
+        ${CMAKE_BINARY_DIR}/lemond-user.service
+        @ONLY
+    )
+    install(FILES ${CMAKE_BINARY_DIR}/lemond-user.service
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/user
+        RENAME lemond.service
+    )
+
     # Install secrets.conf for LEMONADE_API_KEY (still loaded via EnvironmentFile)
     install(FILES ${CMAKE_SOURCE_DIR}/data/secrets.conf
         DESTINATION /etc/lemonade/conf.d

--- a/data/lemonade.sysusers
+++ b/data/lemonade.sysusers
@@ -1,0 +1,2 @@
+#Type Name      ID  GECOS              Home directory     Shell
+u     lemonade  -   "Lemonade Server"  /var/lib/lemonade  -

--- a/data/lemond-user.service.in
+++ b/data/lemond-user.service.in
@@ -1,0 +1,25 @@
+[Unit]
+Description=Lemonade Server (user)
+Documentation=https://lemonade-server.ai/docs/
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h
+EnvironmentFile=-%E/lemonade/conf.d/*.conf
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/lemond
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5s
+KillSignal=SIGINT
+
+# Security hardening
+PrivateTmp=yes
+NoNewPrivileges=yes
+ProtectSystem=full
+RestrictRealtime=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+
+[Install]
+WantedBy=default.target

--- a/data/lemond.service.in
+++ b/data/lemond.service.in
@@ -7,7 +7,9 @@ After=network-online.target
 Type=simple
 User=lemonade
 Group=lemonade
-WorkingDirectory=@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/lemonade
+StateDirectory=lemonade
+StateDirectoryMode=0750
+WorkingDirectory=%S/lemonade
 # Server settings (port, host, models_dir, …) live in config.json, not env vars.
 # The env-file drop-in is kept for the few env vars lemond still reads:
 #   HF_TOKEN                 — HuggingFace authentication token
@@ -26,7 +28,6 @@ PrivateTmp=yes
 NoNewPrivileges=yes
 ProtectSystem=full
 ProtectHome=yes
-ReadWritePaths=@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/lemonade
 RestrictRealtime=yes
 RestrictNamespaces=yes
 LockPersonality=yes

--- a/data/lemond.service.in
+++ b/data/lemond.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Lemonade Server
+Documentation=https://lemonade-server.ai/docs/
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
## Summary

Brings the upstream `data/` packaging artifacts in line with the Fedora
packaging guidelines so distro packagers can drop hand-maintained copies.
Four self-contained commits, no functional change to the server itself:

1. **`packaging: add Documentation= to lemond.service`** — adds
   `Documentation=https://lemonade-server.ai/docs/` so `systemctl status`
   points sysadmins at the docs. Zero behavior change.
   ([Systemd guideline](https://docs.fedoraproject.org/en-US/packaging-guidelines/Systemd/))
2. **`packaging: manage lemond state dir with StateDirectory=`** — uses
   the systemd-idiomatic `StateDirectory=lemonade` /
   `StateDirectoryMode=0750` + `WorkingDirectory=%S/lemonade`, dropping
   the manually-pathed `WorkingDirectory` and the now-redundant
   `ReadWritePaths=`. systemd creates/owns the dir on every start.
   ([Systemd guideline](https://docs.fedoraproject.org/en-US/packaging-guidelines/Systemd/), `systemd.exec(5)`)
3. **`packaging: ship sysusers.d snippet for the lemonade system user`** —
   adds `data/lemonade.sysusers`, installed as
   `<prefix>/lib/sysusers.d/lemonade.conf`, so the `lemonade`
   user/group is created the guideline-mandated way (rpm auto-generates
   `Provides: user(lemonade)`/`group(lemonade)`).
   ([Users & Groups guideline](https://docs.fedoraproject.org/en-US/packaging-guidelines/UsersAndGroups/))
4. **`packaging: add a user-mode systemd unit`** — adds
   `data/lemond-user.service.in`, installed as
   `<prefix>/lib/systemd/user/lemond.service`, so users can
   `systemctl --user enable --now lemond`.
   ([Systemd guideline](https://docs.fedoraproject.org/en-US/packaging-guidelines/Systemd/),
   [Scriptlets guideline](https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/))

## Behavior-change callout

Commit 2 is a **minor behavior change**: systemd now owns and creates
`/var/lib/lemonade` on each start. For **system** services
`StateDirectory=` is always rooted at `/var/lib` (systemd ignores the
install prefix). With the conventional `/usr` prefix,
`%S/lemonade == /var/lib/lemonade` — i.e. the existing path, no change.
Non-`/usr` prefixes that expect state elsewhere should review this.

## Why

These guideline gaps are currently patched *in a downstream RPM*
(a hand-written user unit, a hand-written `sysusers.d` file, a `%post`
`chown`). Moving them upstream means every distro benefits, the unit
files stay consistent across distros, and the downstream spec can drop
a hand-maintained user unit, a hand-maintained sysusers file, and a
`%post chown`.

## Test Plan

Validated without a full server build (these changes are packaging
data + CMake install rules only):

- [x] `configure_file` with `-DCMAKE_INSTALL_PREFIX=/usr`:
      `@CMAKE_INSTALL_FULL_BINDIR@` → `/usr/bin`; `%S`/`%h`/`%E` pass
      through literally.
- [x] `systemd-analyze verify` (system unit) — exit 0, clean.
- [x] `systemd-analyze --user verify` (user unit) — exit 0, clean.
- [x] `systemd-sysusers --dry-run` against a clean root — creates
      group+user `lemonade`, home `/var/lib/lemonade`.
- [x] Install rules sit in the `if(UNIX AND NOT APPLE)` Linux branch;
      destinations with prefix `/usr`:
      `/usr/lib/systemd/system/lemond.service`,
      `/usr/lib/systemd/user/lemond.service`,
      `/usr/lib/sysusers.d/lemonade.conf`.
- [x] Confirmed the `/usr/local/share/lemonade-server` placeholder is
      `if(APPLE)`-gated and does not leak into the Linux install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)