### PR TITLE
fix(app): don't skip port discovery when no explicit base URL is set

### DIFF
--- a/src/app/src/renderer/utils/serverConfig.ts
+++ b/src/app/src/renderer/utils/serverConfig.ts
@@ -64,10 +64,9 @@ class ServerConfig {
         if (baseUrl) {
           console.log('Using explicit server base URL:', baseUrl);
           this.explicitBaseUrl = baseUrl;
+          this.initialized = true;
+          return;
         }
-
-        this.initialized = true;
-        return;
       }
 
       // No explicit URL - use localhost with port discovery


### PR DESCRIPTION
The init early-return fired even when getServerBaseUrl() returned nothing, so the desktop app stayed pinned to the default port 13305 and never registered the beacon/connection-settings listeners. Works by luck when lemond is on 13305, breaks on any other port (e.g. flatpak).

Move the return inside the `if (baseUrl)` branch so the localhost case falls through to port discovery, like the web-app branch above it.