### PR TITLE
fix(app): normalize cleared server base URL to localhost mode

### DIFF
--- a/src/app/src/renderer/utils/serverConfig.ts
+++ b/src/app/src/renderer/utils/serverConfig.ts
@@ -121,7 +121,7 @@ class ServerConfig {
    * Check if using an explicit remote server URL
    */
   isRemoteServer(): boolean {
-    return this.explicitBaseUrl !== null;
+    return !!this.explicitBaseUrl;
   }
 
   /**
@@ -192,10 +192,12 @@ class ServerConfig {
     }
   }
 
-  private setUpdatedURL(baseURL: string) {
-    if (this.explicitBaseUrl != baseURL) {
-      console.log(`Base URL updated: ${this.explicitBaseUrl} -> ${baseURL}`);
-      this.explicitBaseUrl = baseURL;
+  private setUpdatedURL(baseURL: string | null) {
+    const nextBaseUrl = baseURL?.trim() || null;
+
+    if (this.explicitBaseUrl !== nextBaseUrl) {
+      console.log(`Base URL updated: ${this.explicitBaseUrl} -> ${nextBaseUrl}`);
+      this.explicitBaseUrl = nextBaseUrl;
       this.notifyPortListeners();
       this.notifyUrlListeners();
     }


### PR DESCRIPTION
## Summary

Normalize cleared or whitespace-only server base URLs back to `null` in ServerConfig.

This keeps `explicitBaseUrl` semantically consistent:

- `string` = explicit remote/server URL configured
- `null` = localhost mode with port discovery

## Why

PR #1956 fixes the early-return bug where desktop/Tauri mode skipped localhost port discovery when no explicit base URL was configured.

After that fix, the connection-settings listener is also active in localhost mode. When the user clears the configured base URL, the host can emit an empty string. Without normalization, `explicitBaseUrl` can become `""`, which is ambiguous and can make remote/local checks inconsistent.

This change treats empty or whitespace-only base URLs as local mode.

## Risk

Low. This only affects cleared/empty base URL updates and preserves existing behavior for real explicit URLs.