### PR TITLE
Add a tool for updating model sizes

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -3,31 +3,31 @@
         "checkpoint": "amd/Qwen2.5-0.5B-Instruct-quantized_int4-float16-cpu-onnx",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 0.77
+        "size": 0.834
     },
     "Llama-3.2-1B-Instruct-CPU": {
         "checkpoint": "amd/Llama-3.2-1B-Instruct-awq-uint4-float16-cpu-onnx",
         "recipe": "ryzenai-llm",
         "suggested": false,
-        "size": 1.64
+        "size": 1.76
     },
     "Llama-3.2-3B-Instruct-CPU": {
         "checkpoint": "amd/Llama-3.2-3B-Instruct-awq-uint4-float16-cpu-onnx",
         "recipe": "ryzenai-llm",
         "suggested": false,
-        "size": 3.15
+        "size": 3.38
     },
     "Phi-3-Mini-Instruct-CPU": {
         "checkpoint": "amd/Phi-3-mini-4k-instruct_int4_float16_onnx_cpu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 2.23
+        "size": 2.39
     },
     "Qwen-1.5-7B-Chat-CPU": {
         "checkpoint": "amd/Qwen1.5-7B-Chat_uint4_asym_g128_float16_onnx_cpu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 5.89
+        "size": 6.32
     },
     "DeepSeek-R1-Distill-Llama-8B-CPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-awq-asym-uint4-g128-lmhead-onnx-cpu",
@@ -36,7 +36,7 @@
         "labels": [
             "reasoning"
         ],
-        "size": 5.78
+        "size": 6.2
     },
     "DeepSeek-R1-Distill-Qwen-7B-CPU": {
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-awq-asym-uint4-g128-lmhead-onnx-cpu",
@@ -45,19 +45,19 @@
         "labels": [
             "reasoning"
         ],
-        "size": 5.78
+        "size": 6.2
     },
     "AMD-OLMo-1B-SFT-DPO-Hybrid": {
         "checkpoint": "amd/AMD-OLMo-1B-SFT-DPO-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 1.38
+        "size": 1.48
     },
     "CodeLlama-7b-Instruct-hf-Hybrid": {
         "checkpoint": "amd/CodeLlama-7b-Instruct-hf-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 6.74,
+        "size": 7.24,
         "labels": [
             "coding"
         ]
@@ -66,7 +66,7 @@
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.47,
+        "size": 9.09,
         "labels": [
             "reasoning"
         ]
@@ -75,7 +75,7 @@
         "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-1.5B-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 2.04,
+        "size": 2.19,
         "labels": [
             "reasoning"
         ]
@@ -84,7 +84,7 @@
         "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-7B-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.08,
+        "size": 8.67,
         "labels": [
             "reasoning"
         ]
@@ -93,109 +93,109 @@
         "checkpoint": "amd/Llama-2-7b-chat-hf-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 6.8
+        "size": 7.31
     },
     "Llama-2-7b-hf-Hybrid": {
         "checkpoint": "amd/Llama-2-7b-hf-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 6.8
+        "size": 7.31
     },
     "Llama-3.1-8B-Hybrid": {
         "checkpoint": "amd/Llama-3.1-8B-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.47
+        "size": 9.09
     },
     "Llama-3.2-1B-Hybrid": {
         "checkpoint": "amd/Llama-3.2-1B-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 1.76
+        "size": 1.89
     },
     "Llama-3.2-1B-Instruct-Hybrid": {
         "checkpoint": "amd/Llama-3.2-1B-Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 1.76
+        "size": 1.89
     },
     "Llama-3.2-3B-Hybrid": {
         "checkpoint": "amd/Llama-3.2-3B-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 3.98
+        "size": 4.28
     },
     "Llama-3.2-3B-Instruct-Hybrid": {
         "checkpoint": "amd/Llama-3.2-3B-Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 3.98
+        "size": 4.28
     },
     "Meta-Llama-3-8B-Hybrid": {
         "checkpoint": "amd/Meta-Llama-3-8B-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.44
+        "size": 9.06
     },
     "Meta-Llama-3.1-8B-Instruct-Hybrid": {
         "checkpoint": "amd/Meta-Llama-3.1-8B-Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.47
+        "size": 9.09
     },
     "Mistral-7B-Instruct-v0.1-Hybrid": {
         "checkpoint": "amd/Mistral-7B-Instruct-v0.1-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 7.3
+        "size": 7.84
     },
     "Mistral-7B-Instruct-v0.2-Hybrid": {
         "checkpoint": "amd/Mistral-7B-Instruct-v0.2-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 7.3
+        "size": 7.84
     },
     "Mistral-7B-Instruct-v0.3-Hybrid": {
         "checkpoint": "amd/Mistral-7B-Instruct-v0.3-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 7.31
+        "size": 7.85
     },
     "Mistral-7B-v0.3-Hybrid": {
         "checkpoint": "amd/Mistral-7B-v0.3-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 7.31
+        "size": 7.85
     },
     "Phi-3-mini-128k-instruct-Hybrid": {
         "checkpoint": "amd/Phi-3-mini-128k-instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 3.92
+        "size": 4.21
     },
     "Phi-3-mini-4k-instruct-Hybrid": {
         "checkpoint": "amd/Phi-3-mini-4k-instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 3.9
+        "size": 4.19
     },
     "Phi-3.5-mini-instruct-Hybrid": {
         "checkpoint": "amd/Phi-3.5-mini-instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 3.92
+        "size": 4.21
     },
     "Phi-4-mini-instruct-Hybrid": {
         "checkpoint": "amd/Phi-4-mini-instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 5.1
+        "size": 5.47
     },
     "Phi-4-mini-reasoning-Hybrid": {
         "checkpoint": "amd/Phi-4-mini-reasoning-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 5.1,
+        "size": 5.47,
         "labels": [
             "reasoning"
         ]
@@ -204,55 +204,55 @@
         "checkpoint": "amd/Qwen-2.5_1.5B_Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 2.02
+        "size": 2.17
     },
     "Qwen1.5-7B-Chat-Hybrid": {
         "checkpoint": "amd/Qwen1.5-7B-Chat-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.23
+        "size": 8.83
     },
     "Qwen2-1.5B-Hybrid": {
         "checkpoint": "amd/Qwen2-1.5B-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 2.04
+        "size": 2.19
     },
     "Qwen2-7B-Hybrid": {
         "checkpoint": "amd/Qwen2-7B-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.08
+        "size": 8.68
     },
     "Qwen2.5-0.5B-Instruct-Hybrid": {
         "checkpoint": "amd/Qwen2.5-0.5B-Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 0.77
+        "size": 0.828
     },
     "Qwen2.5-14B-instruct-Hybrid": {
         "checkpoint": "amd/Qwen2.5-14B-instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 15.31
+        "size": 16.5
     },
     "Qwen2.5-3B-Instruct-Hybrid": {
         "checkpoint": "amd/Qwen2.5_3B_Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 3.7
+        "size": 3.97
     },
     "Qwen2.5-7B-Instruct-Hybrid": {
         "checkpoint": "amd/Qwen2.5-7B-Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.06
+        "size": 8.65
     },
     "Qwen2.5-Coder-0.5B-Instruct-Hybrid": {
         "checkpoint": "amd/Qwen2.5-Coder-0.5B-Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 0.77,
+        "size": 0.828,
         "labels": [
             "coding"
         ]
@@ -261,7 +261,7 @@
         "checkpoint": "amd/Qwen2.5-Coder-1.5B-Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 2.02,
+        "size": 2.17,
         "labels": [
             "coding"
         ]
@@ -270,7 +270,7 @@
         "checkpoint": "amd/Qwen2.5-Coder-7B-Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.06,
+        "size": 8.65,
         "labels": [
             "coding"
         ]
@@ -279,7 +279,7 @@
         "checkpoint": "amd/Qwen3-1.7B-awq-quant-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 2.38,
+        "size": 2.55,
         "labels": [
             "reasoning"
         ]
@@ -288,7 +288,7 @@
         "checkpoint": "amd/Qwen3-14B-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 15.31,
+        "size": 16.5,
         "labels": [
             "reasoning"
         ]
@@ -297,7 +297,7 @@
         "checkpoint": "amd/Qwen3-4B-awq-quant-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 4.82,
+        "size": 5.17,
         "labels": [
             "reasoning"
         ]
@@ -306,7 +306,7 @@
         "checkpoint": "amd/Qwen3-8B-awq-quant-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.77,
+        "size": 9.42,
         "labels": [
             "reasoning"
         ]
@@ -315,31 +315,31 @@
         "checkpoint": "amd/SmolLM-135M-Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 0.22
+        "size": 0.232
     },
     "SmolLM2-135M-Instruct-Hybrid": {
         "checkpoint": "amd/SmolLM2-135M-Instruct-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 0.22
+        "size": 0.233
     },
     "chatglm3-6b-Hybrid": {
         "checkpoint": "amd/chatglm3-6b-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 6.43
+        "size": 6.9
     },
     "gemma-2-2b-Hybrid": {
         "checkpoint": "amd/gemma-2-2b-onnx-ryzenai-1.7-hybrid",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 3.76
+        "size": 4.04
     },
     "CodeLlama-7b-Instruct-hf-NPU": {
         "checkpoint": "amd/CodeLlama-7b-Instruct-hf-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 7.03,
+        "size": 7.54,
         "labels": [
             "coding"
         ]
@@ -348,7 +348,7 @@
         "checkpoint": "amd/DeepSeek-R1-Distill-Llama-8B-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.66,
+        "size": 9.3,
         "labels": [
             "reasoning"
         ]
@@ -357,7 +357,7 @@
         "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-1.5B-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 2.14,
+        "size": 2.3,
         "labels": [
             "reasoning"
         ]
@@ -366,7 +366,7 @@
         "checkpoint": "amd/DeepSeek-R1-Distill-Qwen-7B-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.26,
+        "size": 8.87,
         "labels": [
             "reasoning"
         ]
@@ -375,7 +375,7 @@
         "checkpoint": "amd/Gemma-3-4b-it-mm-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 6.22,
+        "size": 6.68,
         "labels": [
             "vision"
         ]
@@ -384,133 +384,133 @@
         "checkpoint": "amd/Llama-2-7b-chat-hf-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 6.95
+        "size": 7.47
     },
     "Llama-2-7b-hf-NPU": {
         "checkpoint": "amd/Llama-2-7b-hf-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 6.95
+        "size": 7.47
     },
     "Llama-3.1-8B-NPU": {
         "checkpoint": "amd/Llama-3.1-8B-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.66
+        "size": 9.3
     },
     "Llama-3.2-1B-Instruct-NPU": {
         "checkpoint": "amd/Llama-3.2-1B-Instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 1.82
+        "size": 1.96
     },
     "Llama-3.2-1B-NPU": {
         "checkpoint": "amd/Llama-3.2-1B-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 1.82
+        "size": 1.96
     },
     "Meta-Llama-3-8B-NPU": {
         "checkpoint": "amd/Meta-Llama-3-8B-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.6
+        "size": 9.23
     },
     "Meta-Llama-3.1-8B-Instruct-NPU": {
         "checkpoint": "amd/Meta-Llama-3.1-8B-Instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.66
+        "size": 9.3
     },
     "Mistral-7B-Instruct-v0.1-NPU": {
         "checkpoint": "amd/Mistral-7B-Instruct-v0.1-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 7.46
+        "size": 8.01
     },
     "Mistral-7B-Instruct-v0.2-NPU": {
         "checkpoint": "amd/Mistral-7B-Instruct-v0.2-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 7.46
+        "size": 8.01
     },
     "Mistral-7B-Instruct-v0.3-NPU": {
         "checkpoint": "amd/Mistral-7B-Instruct-v0.3-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 7.54
+        "size": 8.09
     },
     "Mistral-7B-v0.3-NPU": {
         "checkpoint": "amd/Mistral-7B-v0.3-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 7.54
+        "size": 8.09
     },
     "Phi-3-mini-128k-instruct-NPU": {
         "checkpoint": "amd/Phi-3-mini-128k-instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 4.05
+        "size": 4.35
     },
     "Phi-3-mini-4k-instruct-NPU": {
         "checkpoint": "amd/Phi-3-mini-4k-instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 4.0
+        "size": 4.3
     },
     "Phi-3.5-mini-instruct-NPU": {
         "checkpoint": "amd/Phi-3.5-mini-instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 4.05
+        "size": 4.35
     },
     "Phi-4-mini-instruct-NPU": {
         "checkpoint": "amd/Phi-4-mini-instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 5.21
+        "size": 5.59
     },
     "Qwen-2.5-1.5B-Instruct-NPU": {
         "checkpoint": "amd/Qwen-2.5_1.5B_Instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 2.1
+        "size": 2.25
     },
     "Qwen1.5-7B-Chat-NPU": {
         "checkpoint": "amd/Qwen1.5-7B-Chat-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.4
+        "size": 9.02
     },
     "Qwen2-1.5B-NPU": {
         "checkpoint": "amd/Qwen2-1.5B-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 2.14
+        "size": 2.3
     },
     "Qwen2-7B-NPU": {
         "checkpoint": "amd/Qwen2-7B-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.27
+        "size": 8.88
     },
     "Qwen2.5-3B-Instruct-NPU": {
         "checkpoint": "amd/Qwen2.5-3B-Instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 3.81
+        "size": 4.1
     },
     "Qwen2.5-7B-Instruct-NPU": {
         "checkpoint": "amd/Qwen2.5-7B-Instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.22
+        "size": 8.83
     },
     "Qwen2.5-Coder-1.5B-Instruct-NPU": {
         "checkpoint": "amd/Qwen2.5-Coder-1.5B-Instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 2.1,
+        "size": 2.25,
         "labels": [
             "coding"
         ]
@@ -519,7 +519,7 @@
         "checkpoint": "amd/Qwen2.5-Coder-7B-Instruct-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 8.22,
+        "size": 8.83,
         "labels": [
             "coding"
         ]
@@ -528,13 +528,13 @@
         "checkpoint": "amd/chatglm3-6b-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 6.55
+        "size": 7.04
     },
     "gpt-oss-20b-NPU": {
         "checkpoint": "amd/gpt-oss-20b-onnx-ryzenai-npu",
         "recipe": "ryzenai-llm",
         "suggested": true,
-        "size": 12.49
+        "size": 13.4
     },
     "Qwen3-0.6B-GGUF": {
         "checkpoint": "unsloth/Qwen3-0.6B-GGUF:Q4_0",
@@ -643,7 +643,7 @@
             "tool-calling",
             "hot"
         ],
-        "size": 43.7
+        "size": 48.0
     },
     "Nemotron-3-Nano-30B-A3B-GGUF": {
         "checkpoint": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF:Nemotron-3-Nano-30B-A3B-UD-Q4_K_XL.gguf",
@@ -660,7 +660,7 @@
         "labels": [
             "vision"
         ],
-        "size": 3.61
+        "size": 3.34
     },
     "Gemma-4-26B-A4B-it-GGUF": {
         "checkpoint": "unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M",
@@ -673,7 +673,7 @@
             "vision",
             "llamacpp"
         ],
-        "size": 16.9
+        "size": 18.1
     },
     "Gemma-4-31B-it-GGUF": {
         "checkpoint": "unsloth/gemma-4-31B-it-GGUF:Q4_K_M",
@@ -686,7 +686,7 @@
             "vision",
             "llamacpp"
         ],
-        "size": 18.3
+        "size": 19.5
     },
     "Gemma-4-E4B-it-GGUF": {
         "checkpoint": "unsloth/gemma-4-E4B-it-GGUF:Q4_K_M",
@@ -698,7 +698,7 @@
             "vision",
             "llamacpp"
         ],
-        "size": 5.0
+        "size": 5.97
     },
     "Gemma-4-E2B-it-GGUF": {
         "checkpoint": "unsloth/gemma-4-E2B-it-GGUF:Q4_K_M",
@@ -710,7 +710,7 @@
             "vision",
             "llamacpp"
         ],
-        "size": 3.1
+        "size": 4.09
     },
     "Bonsai-8B-gguf": {
         "checkpoint": "prism-ml/Bonsai-8B-gguf:Q1_0",
@@ -719,7 +719,7 @@
         "labels": [
             "llamacpp"
         ],
-        "size": 1.2
+        "size": 1.16
     },
     "Bonsai-4B-gguf": {
         "checkpoint": "prism-ml/Bonsai-4B-gguf:Q1_0",
@@ -728,7 +728,7 @@
         "labels": [
             "llamacpp"
         ],
-        "size": 0.6
+        "size": 0.572
     },
     "Bonsai-1.7B-gguf": {
         "checkpoint": "prism-ml/Bonsai-1.7B-gguf:Q1_0",
@@ -801,7 +801,7 @@
         "labels": [
             "vision"
         ],
-        "size": 2.85
+        "size": 2.99
     },
     "Qwen2.5-VL-7B-Instruct-GGUF": {
         "checkpoint": "ggml-org/Qwen2.5-VL-7B-Instruct-GGUF:Q4_K_M",
@@ -811,7 +811,7 @@
         "labels": [
             "vision"
         ],
-        "size": 4.68
+        "size": 6.04
     },
     "Qwen2.5-VL-3B-Instruct-GGUF": {
         "checkpoint": "ggml-org/Qwen2.5-VL-3B-Instruct-GGUF:Q4_K_M",
@@ -853,7 +853,7 @@
             "vision",
             "chat-transcription"
         ],
-        "size": 4.68
+        "size": 7.33
     },
     "Qwen2.5-Omni-3B-GGUF": {
         "checkpoint": "ggml-org/Qwen2.5-Omni-3B-GGUF:Q4_K_M",
@@ -865,7 +865,7 @@
             "vision",
             "chat-transcription"
         ],
-        "size": 2.10
+        "size": 4.73
     },
     "Qwen3-Next-80B-A3B-Instruct-GGUF": {
         "checkpoint": "unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF:Qwen3-Next-80B-A3B-Instruct-UD-Q4_K_XL.gguf",
@@ -874,7 +874,7 @@
         "labels": [
             "tool-calling"
         ],
-        "size": 45.1
+        "size": 46.1
     },
     "Qwen3.5-0.8B-GGUF": {
         "checkpoint": "unsloth/Qwen3.5-0.8B-GGUF:Qwen3.5-0.8B-UD-Q4_K_XL.gguf",
@@ -885,7 +885,7 @@
             "vision",
             "tool-calling"
         ],
-        "size": 0.56
+        "size": 0.764
     },
     "Qwen3.5-2B-GGUF": {
         "checkpoint": "unsloth/Qwen3.5-2B-GGUF:Qwen3.5-2B-UD-Q4_K_XL.gguf",
@@ -896,7 +896,7 @@
             "vision",
             "tool-calling"
         ],
-        "size": 1.34
+        "size": 2.01
     },
     "Qwen3.5-4B-GGUF": {
         "checkpoint": "unsloth/Qwen3.5-4B-GGUF:Qwen3.5-4B-UD-Q4_K_XL.gguf",
@@ -908,7 +908,7 @@
             "tool-calling",
             "hot"
         ],
-        "size": 2.91
+        "size": 3.58
     },
     "Qwen3.5-9B-GGUF": {
         "checkpoint": "unsloth/Qwen3.5-9B-GGUF:Qwen3.5-9B-UD-Q4_K_XL.gguf",
@@ -919,7 +919,7 @@
             "vision",
             "tool-calling"
         ],
-        "size": 5.97
+        "size": 6.88
     },
     "Qwen3.5-35B-A3B-GGUF": {
         "checkpoint": "unsloth/Qwen3.5-35B-A3B-GGUF:Qwen3.5-35B-A3B-UD-Q4_K_XL.gguf",
@@ -930,7 +930,7 @@
             "vision",
             "tool-calling"
         ],
-        "size": 19.7
+        "size": 23.1
     },
     "Qwen3.5-122B-A10B-GGUF": {
         "checkpoint": "unsloth/Qwen3.5-122B-A10B-GGUF:UD-Q4_K_XL",
@@ -941,7 +941,7 @@
             "vision",
             "tool-calling"
         ],
-        "size": 68.4
+        "size": 77.9
     },
     "Qwen3.5-122B-A10B-MTP-GGUF": {
         "checkpoint": "unsloth/Qwen3.5-122B-A10B-MTP-GGUF:UD-Q4_K_XL",
@@ -953,7 +953,7 @@
             "tool-calling",
             "mtp"
         ],
-        "size": 78.6
+        "size": 79.6
     },
     "Qwen3.5-27B-GGUF": {
         "checkpoint": "unsloth/Qwen3.5-27B-GGUF:Qwen3.5-27B-UD-Q4_K_XL.gguf",
@@ -964,7 +964,7 @@
             "vision",
             "tool-calling"
         ],
-        "size": 16.7
+        "size": 18.5
     },
     "Qwen3.6-35B-A3B-GGUF": {
         "checkpoint": "unsloth/Qwen3.6-35B-A3B-GGUF:Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
@@ -976,7 +976,7 @@
             "tool-calling",
             "hot"
         ],
-        "size": 22.4
+        "size": 23.3
     },
     "Qwen3.6-35B-A3B-MTP-GGUF": {
         "checkpoint": "unsloth/Qwen3.6-35B-A3B-MTP-GGUF:Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
@@ -988,7 +988,7 @@
             "tool-calling",
             "mtp"
         ],
-        "size": 22.9
+        "size": 23.8
     },
     "Qwen3.6-27B-GGUF": {
         "checkpoint": "unsloth/Qwen3.6-27B-GGUF:Qwen3.6-27B-UD-Q4_K_XL.gguf",
@@ -999,7 +999,7 @@
             "vision",
             "tool-calling"
         ],
-        "size": 17.6
+        "size": 18.5
     },
     "Qwen3.6-27B-MTP-GGUF": {
         "checkpoint": "unsloth/Qwen3.6-27B-MTP-GGUF:Qwen3.6-27B-UD-Q4_K_XL.gguf",
@@ -1012,7 +1012,7 @@
             "mtp",
             "hot"
         ],
-        "size": 17.9
+        "size": 18.8
     },
     "Llama-4-Scout-17B-16E-Instruct-GGUF": {
         "checkpoint": "unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF:Q4_K_S",
@@ -1022,7 +1022,7 @@
         "labels": [
             "vision"
         ],
-        "size": 61.5
+        "size": 63.2
     },
     "Cogito-v2-llama-109B-MoE-GGUF": {
         "checkpoint": "unsloth/cogito-v2-preview-llama-109B-MoE-GGUF:Q4_K_M",
@@ -1032,7 +1032,7 @@
         "labels": [
             "vision"
         ],
-        "size": 65.3
+        "size": 65.4
     },
     "nomic-embed-text-v1-GGUF": {
         "checkpoint": "nomic-ai/nomic-embed-text-v1-GGUF:Q4_K_S",
@@ -1086,7 +1086,7 @@
         "labels": [
             "reranking"
         ],
-        "size": 0.53
+        "size": 0.636
     },
     "jina-reranker-v1-tiny-en-GGUF": {
         "checkpoint": "mradermacher/jina-reranker-v1-tiny-en-GGUF:Q8_0",
@@ -1095,7 +1095,7 @@
         "labels": [
             "reranking"
         ],
-        "size": 0.03
+        "size": 0.0367
     },
     "Devstral-Small-2507-GGUF": {
         "checkpoint": "mistralai/Devstral-Small-2507_gguf:Q4_K_M",
@@ -1114,7 +1114,7 @@
         "labels": [
             "coding"
         ],
-        "size": 19.85
+        "size": 39.7
     },
     "gpt-oss-120b-GGUF": {
         "checkpoint": "unsloth/gpt-oss-120b-GGUF:Q4_K_M",
@@ -1124,7 +1124,7 @@
             "reasoning",
             "tool-calling"
         ],
-        "size": 62.7
+        "size": 62.8
     },
     "gpt-oss-20b-GGUF": {
         "checkpoint": "unsloth/gpt-oss-20b-GGUF:Q4_K_M",
@@ -1145,7 +1145,7 @@
             "reasoning",
             "tool-calling"
         ],
-        "size": 63.3
+        "size": 63.4
     },
     "gpt-oss-20b-mxfp4-GGUF": {
         "checkpoint": "ggml-org/gpt-oss-20b-GGUF",
@@ -1165,7 +1165,7 @@
         "labels": [
             "reasoning"
         ],
-        "size": 73.1
+        "size": 67.7
     },
     "GLM-4.7-Flash-GGUF": {
         "checkpoint": "unsloth/GLM-4.7-Flash-GGUF:GLM-4.7-Flash-UD-Q4_K_XL.gguf",
@@ -1174,7 +1174,7 @@
         "labels": [
             "tool-calling"
         ],
-        "size": 17.6
+        "size": 17.5
     },
     "Playable1-GGUF": {
         "checkpoint": "playable/Playable1-GGUF:Playable1-q4_k_m.gguf",
@@ -1198,7 +1198,7 @@
         "checkpoint": "LiquidAI/LFM2-8B-A1B-GGUF:Q4_K_M",
         "recipe": "llamacpp",
         "suggested": true,
-        "size": 4.8
+        "size": 5.04
     },
     "LFM2-24B-A2B-GGUF": {
         "checkpoint": "LiquidAI/LFM2-24B-A2B-GGUF:Q4_K_M",
@@ -1230,7 +1230,7 @@
             "transcription",
             "realtime-transcription"
         ],
-        "size": 0.142
+        "size": 0.148
     },
     "Whisper-Small": {
         "checkpoints": {
@@ -1243,7 +1243,7 @@
             "transcription",
             "realtime-transcription"
         ],
-        "size": 0.466
+        "size": 0.488
     },
     "Whisper-Medium": {
         "checkpoints": {
@@ -1256,7 +1256,7 @@
             "transcription",
             "realtime-transcription"
         ],
-        "size": 1.42
+        "size": 1.53
     },
     "Whisper-Large-v3": {
         "checkpoints": {
@@ -1269,7 +1269,7 @@
             "transcription",
             "realtime-transcription"
         ],
-        "size": 2.87
+        "size": 3.1
     },
     "Whisper-Large-v3-Turbo": {
         "checkpoints": {
@@ -1283,7 +1283,7 @@
             "realtime-transcription",
             "hot"
         ],
-        "size": 1.55
+        "size": 1.62
     },
     "SD-Turbo": {
         "checkpoint": "stabilityai/sd-turbo:sd_turbo.safetensors",
@@ -1292,7 +1292,7 @@
         "labels": [
             "image"
         ],
-        "size": 5.2,
+        "size": 5.21,
         "image_defaults": {
             "steps": 4,
             "cfg_scale": 1.0,
@@ -1306,7 +1306,7 @@
         "labels": [
             "image"
         ],
-        "size": 2.0,
+        "size": 2.02,
         "image_defaults": {
             "steps": 4,
             "cfg_scale": 1.0,
@@ -1321,7 +1321,7 @@
         "labels": [
             "image"
         ],
-        "size": 6.9,
+        "size": 6.94,
         "image_defaults": {
             "steps": 4,
             "cfg_scale": 1.0,
@@ -1336,7 +1336,7 @@
         "labels": [
             "image"
         ],
-        "size": 4.3,
+        "size": 7.7,
         "image_defaults": {
             "steps": 20,
             "cfg_scale": 7.5,
@@ -1351,7 +1351,7 @@
         "labels": [
             "image"
         ],
-        "size": 6.9,
+        "size": 6.94,
         "image_defaults": {
             "steps": 20,
             "cfg_scale": 7.5,
@@ -1371,7 +1371,7 @@
             "image",
             "edit"
         ],
-        "size": 16.0,
+        "size": 16.1,
         "image_defaults": {
             "steps": 4,
             "cfg_scale": 1,
@@ -1391,7 +1391,7 @@
             "image",
             "edit"
         ],
-        "size": 18.0,
+        "size": 19.0,
         "image_defaults": {
             "steps": 4,
             "cfg_scale": 1,
@@ -1410,7 +1410,7 @@
         "labels": [
             "image"
         ],
-        "size": 10.0,
+        "size": 18.2,
         "image_defaults": {
             "steps": 20,
             "cfg_scale": 2.5,
@@ -1434,7 +1434,7 @@
         "labels": [
             "image"
         ],
-        "size": 12.0,
+        "size": 19.4,
         "image_defaults": {
             "steps": 20,
             "cfg_scale": 2.5,
@@ -1458,7 +1458,7 @@
         "labels": [
             "image"
         ],
-        "size": 20.0,
+        "size": 20.7,
         "image_defaults": {
             "steps": 9,
             "cfg_scale": 1,
@@ -1495,7 +1495,7 @@
         "labels": [
             "tts"
         ],
-        "size": 0.34
+        "size": 0.354
     },
     "RealESRGAN-x4plus": {
         "checkpoint": "amd/realesrgan-x4plus:RealESRGAN_x4plus.pth",
@@ -1524,7 +1524,7 @@
         "labels": [
             "reasoning"
         ],
-        "size": 1.6
+        "size": 1.77
     },
     "Qwen3.5-2B-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-2B",
@@ -1533,7 +1533,7 @@
         "labels": [
             "reasoning"
         ],
-        "size": 4.0
+        "size": 4.57
     },
     "Qwen3.5-4B-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-4B",
@@ -1543,7 +1543,7 @@
             "reasoning",
             "hot"
         ],
-        "size": 8.2
+        "size": 9.34
     },
     "Qwen3.5-9B-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-9B",
@@ -1552,6 +1552,6 @@
         "labels": [
             "reasoning"
         ],
-        "size": 18.6
+        "size": 19.3
     }
 }

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1114,7 +1114,7 @@
         "labels": [
             "coding"
         ],
-        "size": 39.7
+        "size": 19.9
     },
     "gpt-oss-120b-GGUF": {
         "checkpoint": "unsloth/gpt-oss-120b-GGUF:Q4_K_M",

--- a/tools/model_sizes.py
+++ b/tools/model_sizes.py
@@ -40,6 +40,8 @@ DIRECT_FILE_SUFFIXES = (
     ".bin",
     ".rai",
 )
+# Matches the `-NNNNN-of-NNNNN` shard suffix on GGUF filenames.
+SHARD_RE = re.compile(r"-\d{5}-of-\d{5}(?=\.gguf$|$)", re.IGNORECASE)
 
 
 def extract_quant(s: str):
@@ -105,7 +107,16 @@ def files_for_variant(files, variant: str):
             q = extract_quant(name)
             if q and q.upper() == target:
                 root.append((name, size))
-    return folder or root
+    if folder:
+        return folder
+    # Some repos publish both a single concat file (e.g. `model-q4_k_m.gguf`)
+    # and an equivalent shard set (e.g. `model-q4_k_m-00001-of-00003.gguf`)
+    # for the same quant. They represent the same logical variant, so pick
+    # whichever set is present — preferring the single file when both exist.
+    singles = [(n, s) for n, s in root if not SHARD_RE.search(n)]
+    if singles:
+        return singles
+    return root
 
 
 def parse_checkpoint(ckpt: str):

--- a/tools/model_sizes.py
+++ b/tools/model_sizes.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Compute model sizes (and approximate parameter counts) from the HuggingFace API.
+
+Reads server_models.json, queries HF for every checkpoint each model declares
+(mirroring the variant matching in src/cpp/server/hf_variants.cpp), and prints
+a table of computed vs. current sizes. Never touches the local HF cache.
+
+Defaults to dry-run. Pass --update to write the computed sizes back to
+server_models.json (only entries that have a `size` field are written; the
+new value is in gigabytes, decimal).
+
+Usage:
+  tools/model_sizes.py src/cpp/resources/server_models.json --all
+  tools/model_sizes.py src/cpp/resources/server_models.json --models Qwen3.5-4B-GGUF "Ultra Collection"
+  tools/model_sizes.py src/cpp/resources/server_models.json --all --update
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Quant token regex — ported from src/cpp/server/hf_variants.cpp::quant_regex().
+QUANT_RE = re.compile(
+    r"(?:^|[-._/])((?:UD[-_])?(?:Q\d+(?:_\d)?(?:_K)?(?:_(?:M|S|L|XL|XXL))?"
+    r"|IQ\d+(?:_(?:M|S|L|XS|XXS|NL))?|F(?:16|32)|BF16|MXFP\d+(?:_MOE)?))"
+    r"(?=[-._/]|\.gguf$|$)",
+    re.IGNORECASE,
+)
+DIRECT_FILE_SUFFIXES = (
+    ".safetensors",
+    ".pth",
+    ".ckpt",
+    ".gguf",
+    ".onnx",
+    ".bin",
+    ".rai",
+)
+
+
+def extract_quant(s: str):
+    m = QUANT_RE.search(s)
+    return m.group(1).upper() if m else None
+
+
+def fetch_repo(repo_id: str, cache: dict):
+    """Return {files: [(name, size)], params: int|None} for a repo, or None on failure."""
+    if repo_id in cache:
+        return cache[repo_id]
+    url = f"https://huggingface.co/api/models/{repo_id}?blobs=true"
+    headers = {}
+    tok = os.environ.get("HF_TOKEN")
+    if tok:
+        headers["Authorization"] = f"Bearer {tok}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+    except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError) as e:
+        print(f"  ! HF API error for {repo_id}: {e}", file=sys.stderr)
+        cache[repo_id] = None
+        return None
+    files = [
+        (s["rfilename"], int(s.get("size") or 0))
+        for s in data.get("siblings", [])
+        if "rfilename" in s
+    ]
+    params = None
+    if isinstance(data.get("gguf"), dict):
+        params = data["gguf"].get("total")
+    elif isinstance(data.get("safetensors"), dict):
+        params = data["safetensors"].get("total")
+    cache[repo_id] = {"files": files, "params": params}
+    return cache[repo_id]
+
+
+def files_for_variant(files, variant: str):
+    """Return [(name, size)] for the variant — mirrors hf_variants.cpp."""
+    if not variant or variant == "*":
+        return list(files)
+    for name, size in files:
+        if name == variant:
+            return [(name, size)]
+    if variant.lower().endswith(DIRECT_FILE_SUFFIXES):
+        for name, size in files:
+            if os.path.basename(name) == variant:
+                return [(name, size)]
+        return []
+    target = variant.upper()
+    folder, root = [], []
+    for name, size in files:
+        ln = name.lower()
+        if not ln.endswith(".gguf") or "mmproj" in ln:
+            continue
+        sl = name.find("/")
+        if sl > 0:
+            folder_q = extract_quant(name[:sl]) or name[:sl]
+            if folder_q.upper() == target or name[:sl] == variant:
+                folder.append((name, size))
+        else:
+            q = extract_quant(name)
+            if q and q.upper() == target:
+                root.append((name, size))
+    return folder or root
+
+
+def parse_checkpoint(ckpt: str):
+    if ":" in ckpt:
+        return tuple(ckpt.split(":", 1))
+    return ckpt, ""
+
+
+def compute(name, registry, cache, seen=None):
+    """Returns (size_bytes, params, status) where status is 'ok', 'error', or 'empty'.
+
+    Collections recurse; params are taken once per unique HF repo so models
+    sharing a repo (mmproj in main repo) aren't double-counted.
+    """
+    if seen is None:
+        seen = set()
+    if name in seen:
+        return 0, 0, "ok"
+    seen.add(name)
+
+    entry = registry.get(name)
+    if entry is None:
+        return None, None, "error"
+
+    if entry.get("recipe", "").startswith("collection."):
+        total_size, total_params = 0, 0
+        for comp in entry.get("components", []):
+            cs, cp, _ = compute(comp, registry, cache, seen)
+            if cs is not None:
+                total_size += cs
+            if cp is not None:
+                total_params += cp
+        return total_size, total_params, "ok"
+
+    sources = []
+    if entry.get("checkpoint"):
+        sources.append(("main", entry["checkpoint"]))
+    for k, v in (entry.get("checkpoints") or {}).items():
+        if k == "npu_cache":
+            continue
+        sources.append((k, v))
+    if not sources:
+        return None, None, "empty"
+
+    total_size = 0
+    seen_repos = set()
+    total_params = 0
+    main_repo = None
+    any_match = False
+    for label, ckpt in sources:
+        repo_id, variant = parse_checkpoint(ckpt)
+        if label == "main":
+            main_repo = repo_id
+        info = fetch_repo(repo_id, cache)
+        if info is None:
+            return None, None, "error"
+        matched = files_for_variant(info["files"], variant)
+        if matched:
+            any_match = True
+        else:
+            print(
+                f"  ! no files matched in {repo_id} for variant '{variant}'",
+                file=sys.stderr,
+            )
+        for _, sz in matched:
+            total_size += sz
+        if repo_id not in seen_repos:
+            seen_repos.add(repo_id)
+            if info["params"]:
+                total_params += info["params"]
+
+    mmproj = entry.get("mmproj")
+    if mmproj and main_repo:
+        info = fetch_repo(main_repo, cache)
+        if info:
+            for nm, sz in info["files"]:
+                if nm == mmproj or os.path.basename(nm) == mmproj:
+                    total_size += sz
+                    break
+
+    return total_size, (total_params or None), ("ok" if any_match else "empty")
+
+
+def round_gb(b: int) -> float:
+    g = b / 1e9
+    if g >= 10:
+        return round(g, 1)
+    if g >= 1:
+        return round(g, 2)
+    if g >= 0.1:
+        return round(g, 3)
+    return round(g, 4)
+
+
+def fmt_params(p):
+    if not p:
+        return "—"
+    for unit, scale in [("T", 1e12), ("B", 1e9), ("M", 1e6), ("K", 1e3)]:
+        if p >= scale:
+            return f"{p / scale:.2f}{unit}"
+    return str(p)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("models_json", type=Path)
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument(
+        "--all", action="store_true", help="Process every entry in the registry"
+    )
+    g.add_argument(
+        "--models", nargs="+", metavar="NAME", help="Process the listed models"
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="Write computed sizes back to JSON (default: dry-run)",
+    )
+    args = parser.parse_args()
+
+    with open(args.models_json) as f:
+        registry = json.load(f)
+
+    if args.all:
+        targets = list(registry.keys())
+    else:
+        unknown = [n for n in args.models if n not in registry]
+        if unknown:
+            sys.exit(f"Unknown model(s): {', '.join(unknown)}")
+        targets = args.models
+
+    cache = {}
+    rows = []
+    print(f"Querying HF API for {len(targets)} model(s)...\n", file=sys.stderr)
+    for i, name in enumerate(targets, 1):
+        print(f"[{i}/{len(targets)}] {name}", file=sys.stderr)
+        sz, pa, status = compute(name, registry, cache)
+        entry = registry[name]
+        rows.append(
+            {
+                "name": name,
+                "recipe": entry.get("recipe", "—"),
+                "old": entry.get("size"),
+                "new_gb": round_gb(sz) if sz else None,
+                "params": pa,
+                "status": status,
+            }
+        )
+
+    # Table
+    print()
+    name_w = max(max(len(r["name"]) for r in rows), len("Model"))
+    recipe_w = max(max(len(r["recipe"]) for r in rows), len("Recipe"))
+    print(
+        f"{'Model':<{name_w}}  {'Recipe':<{recipe_w}}  {'Old (GB)':>10}  {'New (GB)':>10}  {'Δ':>9}  {'~Params':>10}"
+    )
+    print("-" * (name_w + recipe_w + 4 + 10 + 2 + 10 + 2 + 9 + 2 + 10))
+    changes = []
+    errors = []
+    for r in rows:
+        old_s = f"{r['old']:.4g}" if r["old"] is not None else "—"
+        new_s = (
+            f"{r['new_gb']:.4g}"
+            if r["new_gb"] is not None
+            else ("ERR" if r["status"] == "error" else "—")
+        )
+        if (
+            r["old"] is not None
+            and r["new_gb"] is not None
+            and abs(r["new_gb"] - r["old"]) >= 0.005
+        ):
+            delta_s = f"{r['new_gb'] - r['old']:+.4g}"
+            changes.append(r)
+        else:
+            delta_s = ""
+        if r["status"] == "error":
+            errors.append(r["name"])
+        print(
+            f"{r['name']:<{name_w}}  {r['recipe']:<{recipe_w}}  {old_s:>10}  {new_s:>10}  {delta_s:>9}  {fmt_params(r['params']):>10}"
+        )
+
+    print()
+    print(f"Changes:   {len(changes)}")
+    print(f"Errors:    {len(errors)}")
+    if errors:
+        for n in errors:
+            print(f"  ! {n}", file=sys.stderr)
+
+    if args.update:
+        if not changes:
+            print("\nNo changes to write.")
+            return
+        for r in changes:
+            registry[r["name"]]["size"] = r["new_gb"]
+        with open(args.models_json, "w") as f:
+            json.dump(registry, f, indent=4)
+            f.write("\n")
+        print(f"\nWrote {len(changes)} update(s) to {args.models_json}")
+    else:
+        print(f"\n(dry-run) Re-run with --update to apply {len(changes)} change(s).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Most model sizes in server_models.json were off by a bit.

For models with mmproj files, the model sizes often did not include the mmproj and could be off by ~1 GB.

The PR fixes the model sizes and adds a script that uses the HF API to get correct sizes.

Usage:
```
  tools/model_sizes.py src/cpp/resources/server_models.json --all
  tools/model_sizes.py src/cpp/resources/server_models.json --models Qwen3.5-4B-GGUF "Ultra Collection"
  tools/model_sizes.py src/cpp/resources/server_models.json --all --update
```