### PR TITLE
feat: Add Ryzen AI NPU backend for Stable Diffusion image generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -583,6 +583,7 @@ set(SOURCES_CORE
     src/cpp/server/backends/kokoro_server.cpp
     src/cpp/server/backends/sd_server.cpp
     src/cpp/server/backends/vllm_server.cpp
+    src/cpp/server/backends/ryzenai_sd_server.cpp
     src/cpp/server/backends/backend_utils.cpp
     src/cpp/server/backend_manager.cpp
     src/cpp/server/ollama_api.cpp

--- a/docs/guide/configuration/multi-model.md
+++ b/docs/guide/configuration/multi-model.md
@@ -22,7 +22,7 @@ Each type has its own independent LRU cache, all sharing the same slot limit set
 
 ## Device Constraints
 
-- **NPU Exclusivity:** `flm`, `ryzenai-llm`, and `whispercpp` are mutually exclusive on the NPU.
+- **NPU Exclusivity:** `flm`, `ryzenai-llm`, `whispercpp`, and `sd-npu` are mutually exclusive on the NPU.
     - Loading a model from one of these backends will automatically evict all NPU models from the other backends.
     - `flm` supports loading 1 ASR model, 1 LLM, and 1 embedding model on the NPU at the same time.
     - `ryzenai-llm` supports loading exactly 1 LLM, which uses the entire NPU.

--- a/src/cpp/include/lemon/backends/ryzenai_sd_server.h
+++ b/src/cpp/include/lemon/backends/ryzenai_sd_server.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "../wrapped_server.h"
+#include "../server_capabilities.h"
+#include "../recipe_options.h"
+#include "../utils/process_manager.h"
+#include "backend_utils.h"
+#include <string>
+#include <filesystem>
+
+namespace lemon {
+namespace backends {
+
+class SDNPUServer : public WrappedServer, public IImageServer {
+public:
+    static InstallParams get_install_params(const std::string& backend, const std::string& version);
+
+    inline static const BackendSpec SPEC = BackendSpec(
+            "sd-npu",
+    #ifdef _WIN32
+            "ryzenai-sd-server.exe"
+    #else
+            "ryzenai-sd-server"
+    #endif
+        , get_install_params
+    );
+
+    explicit SDNPUServer(const std::string& log_level,
+                         ModelManager* model_manager,
+                         BackendManager* backend_manager);
+
+    ~SDNPUServer() override;
+
+    void load(const std::string& model_name,
+             const ModelInfo& model_info,
+             const RecipeOptions& options,
+             bool do_not_upgrade = false) override;
+
+    void unload() override;
+
+    // ICompletionServer implementation (not supported - return errors)
+    json chat_completion(const json& request) override;
+    json completion(const json& request) override;
+    json responses(const json& request) override;
+
+    // IImageServer implementation
+    json image_generations(const json& request) override;
+    json image_edits(const json& request) override;
+    json image_variations(const json& request) override;
+
+private:
+    // Resolve a size string ("WxH") from request, falling back to image_defaults_
+    std::string resolve_size(const nlohmann::json& request) const;
+    ImageDefaults image_defaults_;
+};
+
+} // namespace backends
+} // namespace lemon

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -20,6 +20,10 @@
     "rocm-stable": "master-569-ab6afe8",
     "rocm-preview": "master-569-ab6afe8"
   },
+  "sd-npu": {
+    "npu": "v0.1.0",
+    "cpu": "v0.1.0"
+  },
   "therock": {
     "version": "7.12.0",
     "architectures": [

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1505,5 +1505,117 @@
             "reasoning"
         ],
         "size": 18.6
+    },
+    "SD-Turbo-NPU": {
+        "checkpoint": "amd/stable-diffusion-turbo-amdnpu-onnx",
+        "recipe": "sd-npu",
+        "suggested": false,
+        "labels": [
+            "image",
+            "npu"
+        ],
+        "size": 2.0,
+        "image_defaults": {
+            "steps": 1,
+            "cfg_scale": 1.0,
+            "width": 512,
+            "height": 512
+        }
+    },
+    "SDXL-Turbo-NPU": {
+        "checkpoint": "amd/stable-diffusion-sdxl-turbo-amdnpu-onnx",
+        "recipe": "sd-npu",
+        "suggested": false,
+        "labels": [
+            "image",
+            "npu"
+        ],
+        "size": 6.0,
+        "image_defaults": {
+            "steps": 1,
+            "cfg_scale": 1.0,
+            "width": 1024,
+            "height": 1024
+        }
+    },
+    "SD-1.5-NPU": {
+        "checkpoint": "amd/stable-diffusion-1.5-amdnpu-onnx",
+        "recipe": "sd-npu",
+        "suggested": false,
+        "labels": [
+            "image",
+            "npu"
+        ],
+        "size": 3.5,
+        "image_defaults": {
+            "steps": 20,
+            "cfg_scale": 7.5,
+            "width": 512,
+            "height": 512
+        }
+    },
+    "SDXL-Base-NPU": {
+        "checkpoint": "amd/stable-diffusion-sdxl-base-amdnpu-onnx",
+        "recipe": "sd-npu",
+        "suggested": false,
+        "labels": [
+            "image",
+            "npu"
+        ],
+        "size": 6.9,
+        "image_defaults": {
+            "steps": 20,
+            "cfg_scale": 7.5,
+            "width": 1024,
+            "height": 1024
+        }
+    },
+    "Segmind-Vega-NPU": {
+        "checkpoint": "amd/stable-diffusion-segmind-vega-amdnpu-onnx",
+        "recipe": "sd-npu",
+        "suggested": false,
+        "labels": [
+            "image",
+            "npu"
+        ],
+        "size": 3.4,
+        "image_defaults": {
+            "steps": 20,
+            "cfg_scale": 7.5,
+            "width": 1024,
+            "height": 1024
+        }
+    },
+    "SD3-Medium-NPU": {
+        "checkpoint": "amd/stable-diffusion-3-medium-amdnpu-onnx",
+        "recipe": "sd-npu",
+        "suggested": false,
+        "labels": [
+            "image",
+            "npu"
+        ],
+        "size": 5.0,
+        "image_defaults": {
+            "steps": 8,
+            "cfg_scale": 7.0,
+            "width": 1024,
+            "height": 1024
+        }
+    },
+    "SD3.5-Medium-NPU": {
+        "checkpoint": "amd/stable-diffusion-3.5-medium-amdnpu-onnx",
+        "recipe": "sd-npu",
+        "suggested": false,
+        "labels": [
+            "image",
+            "npu"
+        ],
+        "size": 5.0,
+        "image_defaults": {
+            "steps": 8,
+            "cfg_scale": 7.0,
+            "width": 1024,
+            "height": 1024
+        }
     }
 }

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -3,6 +3,7 @@
 #include "lemon/backends/llamacpp_server.h"
 #include "lemon/backends/whisper_server.h"
 #include "lemon/backends/sd_server.h"
+#include "lemon/backends/ryzenai_sd_server.h"
 #include "lemon/backends/kokoro_server.h"
 #include "lemon/backends/ryzenaiserver.h"
 #include "lemon/backends/vllm_server.h"
@@ -38,6 +39,7 @@ namespace lemon::backends {
         if (recipe == "llamacpp") return &LlamaCppServer::SPEC;
         if (recipe == "whispercpp") return &WhisperServer::SPEC;
         if (recipe == "sd-cpp") return &SDServer::SPEC;
+        if (recipe == "sd-npu") return &SDNPUServer::SPEC;
         if (recipe == "kokoro") return &KokoroServer::SPEC;
         if (recipe == "ryzenai-llm") return &::lemon::RyzenAIServer::SPEC;
         if (recipe == "vllm") return &VLLMServer::SPEC;

--- a/src/cpp/server/backends/ryzenai_sd_server.cpp
+++ b/src/cpp/server/backends/ryzenai_sd_server.cpp
@@ -1,0 +1,352 @@
+#include "lemon/backends/ryzenai_sd_server.h"
+#include "lemon/backends/backend_utils.h"
+#include "lemon/backend_manager.h"
+#include "lemon/utils/http_client.h"
+#include "lemon/utils/process_manager.h"
+#include "lemon/utils/json_utils.h"
+#include "lemon/error_types.h"
+#include <iostream>
+#include <filesystem>
+#include <lemon/utils/aixlog.hpp>
+
+namespace fs = std::filesystem;
+using namespace lemon::utils;
+
+namespace lemon {
+namespace backends {
+
+InstallParams SDNPUServer::get_install_params(const std::string& /* backend */, const std::string& version) {
+    InstallParams params;
+    params.repo = "lemonade-sdk/ryzenai-sd-server";
+#ifdef _WIN32
+    params.filename = "ryzenai-sd-server-" + version + "-win-x64.zip";
+#elif defined(__linux__)
+    params.filename = "ryzenai-sd-server-" + version + "-Linux-x86_64.zip";
+#else
+    throw std::runtime_error("SD NPU server is only supported on Windows and Linux");
+#endif
+    return params;
+}
+
+SDNPUServer::SDNPUServer(const std::string& log_level, ModelManager* model_manager, BackendManager* backend_manager)
+    : WrappedServer("sd-npu-server", log_level, model_manager, backend_manager) {
+    LOG(DEBUG, "SDNPUServer") << "Created with log_level=" << log_level << std::endl;
+}
+
+SDNPUServer::~SDNPUServer() {
+    unload();
+}
+
+void SDNPUServer::load(const std::string& model_name,
+                       const ModelInfo& model_info,
+                       const RecipeOptions& options,
+                       bool /* do_not_upgrade */) {
+    LOG(INFO, "SDNPUServer") << "Loading model: " << model_name << std::endl;
+    LOG(DEBUG, "SDNPUServer") << "Per-model settings: " << options.to_log_string() << std::endl;
+
+    image_defaults_ = model_info.image_defaults;
+
+    // Determine backend (npu or cpu)
+    std::string backend = options.get_option("sd-npu_backend");
+    if (backend.empty()) {
+        backend = "npu";
+    }
+    bool use_cpu = (backend == "cpu");
+
+    device_type_ = use_cpu ? DEVICE_CPU : DEVICE_NPU;
+
+    // Get model path - NPU models are directories with ONNX files
+    std::string model_path = model_info.resolved_path("main");
+
+    if (model_path.empty()) {
+        throw std::runtime_error("Model path not found for: " + model_info.checkpoint());
+    }
+
+    if (!fs::exists(model_path)) {
+        throw std::runtime_error("Model path does not exist: " + model_path);
+    }
+
+    LOG(DEBUG, "SDNPUServer") << "Using model: " << model_path << std::endl;
+
+    // Install sd-npu-server if needed, then resolve the binary path
+    backend_manager_->install_backend(SPEC.recipe, backend);
+    std::string ryzenai_sd_server_path = BackendUtils::get_backend_binary_path(SPEC, backend);
+
+    // Choose a port
+    port_ = choose_port();
+    if (port_ == 0) {
+        throw std::runtime_error("Failed to find an available port");
+    }
+
+    LOG(INFO, "SDNPUServer") << "Starting server on port " << port_
+                            << " (backend: " << backend << ")" << std::endl;
+
+    // Resolve DD (DynamicDispatch) paths for NPU model loading.
+    // Priority: RyzenAI GenAI-SD install > RyzenAI deployment > empty (let subprocess default)
+    // Skipped when running in CPU mode.
+    std::string dd_root;
+    std::string dd_plugins;
+#ifdef _WIN32
+    if (!use_cpu) {
+        // Check RyzenAI 1.7.1 GenAI-SD paths first
+        fs::path genai_sd_lib = "C:/Program Files/RyzenAI/1.7.1/GenAI-SD/lib";
+        fs::path genai_sd_stx = genai_sd_lib / "transaction" / "stx";
+        fs::path deploy_lib = "C:/Program Files/RyzenAI/1.7.1/deployment";
+        fs::path deploy_stx = deploy_lib / "transaction" / "stx";
+
+        if (fs::exists(genai_sd_stx)) {
+            dd_root = genai_sd_lib.string();
+            dd_plugins = genai_sd_stx.string();
+        } else if (fs::exists(deploy_stx)) {
+            dd_root = deploy_lib.string();
+            dd_plugins = deploy_stx.string();
+        }
+    }
+#endif
+
+    // Build command line arguments
+    std::vector<std::string> args = {
+        "--server",
+        "--port", std::to_string(port_),
+        "--model-path", model_path
+    };
+
+    // Force CPU execution provider if requested
+    if (use_cpu) {
+        args.push_back("--force-cpu");
+    }
+
+    // Pass DD paths as CLI args so ryzenai-sd-server uses them
+    if (!dd_root.empty()) {
+        args.push_back("--dd-root");
+        args.push_back(dd_root);
+        args.push_back("--dd-plugins-root");
+        args.push_back(dd_plugins);
+    }
+
+    // Also set DD env vars for the subprocess
+    std::vector<std::pair<std::string, std::string>> env_vars;
+    if (!dd_root.empty()) {
+        env_vars.push_back({"DD_ROOT", dd_root});
+        env_vars.push_back({"DD_PLUGINS_ROOT", dd_plugins});
+        LOG(INFO, "SDNPUServer") << "DD_ROOT=" << dd_root << std::endl;
+        LOG(INFO, "SDNPUServer") << "DD_PLUGINS_ROOT=" << dd_plugins << std::endl;
+    }
+
+    // Launch the server process
+    process_handle_ = utils::ProcessManager::start_process(
+        ryzenai_sd_server_path,
+        args,
+        "",         // working_dir (empty = current)
+        is_debug(), // inherit_output
+        true,       // filter_health_logs (suppress noisy health-check output)
+        env_vars
+    );
+
+    if (process_handle_.pid == 0) {
+        throw std::runtime_error("Failed to start ryzenai-sd-server process");
+    }
+
+    LOG(INFO, "SDNPUServer") << "Process started with PID: " << process_handle_.pid << std::endl;
+
+    // Wait for server to be ready
+    if (!wait_for_ready("/health")) {
+        unload();
+        throw std::runtime_error("ryzenai-sd-server failed to start or become ready");
+    }
+
+    LOG(INFO, "SDNPUServer") << "NPU server is ready at http://127.0.0.1:" << port_ << std::endl;
+}
+
+void SDNPUServer::unload() {
+    if (process_handle_.pid != 0) {
+        LOG(INFO, "SDNPUServer") << "Stopping NPU server (PID: " << process_handle_.pid << ")" << std::endl;
+        utils::ProcessManager::stop_process(process_handle_);
+        process_handle_ = {nullptr, 0};
+        port_ = 0;
+    }
+}
+
+// ICompletionServer implementation - not supported for image generation
+json SDNPUServer::chat_completion(const json& /* request */) {
+    return ErrorResponse::from_exception(
+        UnsupportedOperationException("Chat completion", "sd-npu (image generation model)")
+    );
+}
+
+json SDNPUServer::completion(const json& /* request */) {
+    return ErrorResponse::from_exception(
+        UnsupportedOperationException("Text completion", "sd-npu (image generation model)")
+    );
+}
+
+json SDNPUServer::responses(const json& /* request */) {
+    return ErrorResponse::from_exception(
+        UnsupportedOperationException("Responses", "sd-npu (image generation model)")
+    );
+}
+
+std::string SDNPUServer::resolve_size(const json& request) const {
+    if (request.contains("size") && request["size"].is_string()) {
+        return request["size"].get<std::string>();
+    }
+    if (request.contains("width") && request.contains("height") &&
+        request["width"].is_number_integer() && request["height"].is_number_integer()) {
+        return std::to_string(request["width"].get<int>()) + "x"
+             + std::to_string(request["height"].get<int>());
+    }
+    if (image_defaults_.has_defaults) {
+        return std::to_string(image_defaults_.width) + "x"
+             + std::to_string(image_defaults_.height);
+    }
+    return "";
+}
+
+json SDNPUServer::image_generations(const json& request) {
+    json sd_request = request;
+
+    // Apply size from request, image_defaults, or leave absent
+    std::string size = resolve_size(request);
+    if (!size.empty()) {
+        sd_request["size"] = size;
+    }
+
+    // Build extra args for steps / cfg_scale / seed, using image_defaults as fallback
+    json extra_args;
+    if (request.contains("steps") && request["steps"].is_number_integer()) {
+        extra_args["steps"] = request["steps"].get<int>();
+    } else if (image_defaults_.has_defaults) {
+        extra_args["steps"] = image_defaults_.steps;
+    } else {
+        json steps_opt = recipe_options_.get_option("steps");
+        if (!steps_opt.is_null()) {
+            extra_args["steps"] = static_cast<int>(steps_opt);
+        }
+    }
+    if (request.contains("cfg_scale") && request["cfg_scale"].is_number()) {
+        extra_args["cfg_scale"] = request["cfg_scale"].get<float>();
+    } else if (image_defaults_.has_defaults) {
+        extra_args["cfg_scale"] = image_defaults_.cfg_scale;
+    } else {
+        json cfg_opt = recipe_options_.get_option("cfg_scale");
+        if (!cfg_opt.is_null()) {
+            extra_args["cfg_scale"] = static_cast<float>(cfg_opt);
+        }
+    }
+    if (request.contains("seed") && request["seed"].is_number_integer()) {
+        extra_args["seed"] = request["seed"].get<int>();
+    }
+
+    // Append extra args to prompt if any were set
+    if (!extra_args.empty()) {
+        std::string prompt = sd_request.value("prompt", "");
+        prompt += " <sd_cpp_extra_args>" + extra_args.dump() + "</sd_cpp_extra_args>";
+        sd_request["prompt"] = prompt;
+    }
+
+    LOG(DEBUG, "SDNPUServer") << "Forwarding request to ryzenai-sd-server: "
+                              << sd_request.dump(2) << std::endl;
+
+    // ryzenai-sd-server uses OpenAI-compatible /v1/images/generations endpoint
+    // Use extended timeout for image generation (can take several seconds on NPU)
+    return forward_request("/v1/images/generations", sd_request, utils::HttpClient::get_default_timeout());
+}
+
+json SDNPUServer::image_edits(const json& request) {
+    // Build extra args for steps / cfg_scale / seed, using image_defaults as fallback
+    json extra_args;
+    if (request.contains("steps") && request["steps"].is_number_integer()) {
+        extra_args["steps"] = request["steps"].get<int>();
+    } else if (image_defaults_.has_defaults) {
+        extra_args["steps"] = image_defaults_.steps;
+    }
+    if (request.contains("cfg_scale") && request["cfg_scale"].is_number()) {
+        extra_args["cfg_scale"] = request["cfg_scale"].get<float>();
+    } else if (image_defaults_.has_defaults) {
+        extra_args["cfg_scale"] = image_defaults_.cfg_scale;
+    }
+    if (request.contains("seed") && request["seed"].is_number_integer()) {
+        extra_args["seed"] = request["seed"].get<int>();
+    }
+
+    std::string prompt = request.value("prompt", "");
+    if (!extra_args.empty()) {
+        prompt += " <sd_cpp_extra_args>" + extra_args.dump() + "</sd_cpp_extra_args>";
+    }
+
+    std::vector<MultipartField> fields;
+    fields.push_back({"prompt", prompt, "", ""});
+    fields.push_back({"n", std::to_string(request.value("n", 1)), "", ""});
+
+    std::string size = resolve_size(request);
+    if (!size.empty()) {
+        fields.push_back({"size", size, "", ""});
+    }
+
+    if (request.contains("image_data")) {
+        std::string image_binary = JsonUtils::base64_decode(
+            request["image_data"].get<std::string>());
+        fields.push_back({"image[]", image_binary, "image.bin", "application/octet-stream"});
+    }
+    if (request.contains("mask_data")) {
+        std::string mask_binary = JsonUtils::base64_decode(
+            request["mask_data"].get<std::string>());
+        fields.push_back({"mask", mask_binary, "mask.bin", "application/octet-stream"});
+    }
+
+    LOG(DEBUG, "SDNPUServer") << "Forwarding image edits to /v1/images/edits (multipart)" << std::endl;
+
+    return forward_multipart_request("/v1/images/edits", fields, utils::HttpClient::get_default_timeout());
+}
+
+json SDNPUServer::image_variations(const json& request) {
+    json extra_args;
+    if (request.contains("steps") && request["steps"].is_number_integer()) {
+        extra_args["steps"] = request["steps"].get<int>();
+    } else if (image_defaults_.has_defaults) {
+        extra_args["steps"] = image_defaults_.steps;
+    }
+    if (request.contains("cfg_scale") && request["cfg_scale"].is_number()) {
+        extra_args["cfg_scale"] = request["cfg_scale"].get<float>();
+    } else if (image_defaults_.has_defaults) {
+        extra_args["cfg_scale"] = image_defaults_.cfg_scale;
+    }
+    if (request.contains("seed") && request["seed"].is_number_integer()) {
+        extra_args["seed"] = request["seed"].get<int>();
+    }
+    if (request.contains("strength") && request["strength"].is_number()) {
+        extra_args["strength"] = request["strength"].get<float>();
+    }
+
+    std::string prompt = request.value("prompt", "variation");
+    if (!extra_args.empty()) {
+        prompt += " <sd_cpp_extra_args>" + extra_args.dump() + "</sd_cpp_extra_args>";
+    }
+
+    std::vector<MultipartField> fields;
+    fields.push_back({"prompt", prompt, "", ""});
+    fields.push_back({"n", std::to_string(request.value("n", 1)), "", ""});
+
+    std::string size = resolve_size(request);
+    if (!size.empty()) {
+        fields.push_back({"size", size, "", ""});
+    }
+
+    // Forward strength as a form field for img2img
+    if (request.contains("strength") && request["strength"].is_number()) {
+        fields.push_back({"strength", std::to_string(request["strength"].get<float>()), "", ""});
+    }
+
+    if (request.contains("image_data")) {
+        std::string image_binary = JsonUtils::base64_decode(
+            request["image_data"].get<std::string>());
+        fields.push_back({"image[]", image_binary, "image.bin", "application/octet-stream"});
+    }
+
+    LOG(DEBUG, "SDNPUServer") << "Forwarding image variations to /v1/images/variations (multipart)" << std::endl;
+
+    return forward_multipart_request("/v1/images/variations", fields, utils::HttpClient::get_default_timeout());
+}
+
+} // namespace backends
+} // namespace lemon

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -956,6 +956,18 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
         return model_cache_path;  // Return directory even if index not found
     }
 
+    // For sd-npu, find the snapshot directory containing ONNX component subdirectories
+    if (info.recipe == "sd-npu") {
+        if (safe_exists(model_cache_path_fs)) {
+            for (const auto& entry : fs::recursive_directory_iterator(model_cache_path_fs, safe_dir_options)) {
+                if (entry.is_directory() && entry.path().filename() == "unet") {
+                    return path_to_utf8(entry.path().parent_path());
+                }
+            }
+        }
+        return model_cache_path;
+    }
+
     // For whispercpp, find the .bin model file
     if (info.recipe == "whispercpp" && variant.empty()) {
         // No variant specified - use fallback logic to find any .bin file
@@ -1267,6 +1279,7 @@ void ModelManager::build_cache() {
         info.recipe = JsonUtils::get_or_default<std::string>(value, "recipe", "");
         info.suggested = JsonUtils::get_or_default<bool>(value, "suggested", false);
         info.hf_load = JsonUtils::get_or_default<bool>(value, "hf_load", false);
+        info.source = JsonUtils::get_or_default<std::string>(value, "source", "");
         info.size = JsonUtils::get_or_default<double>(value, "size", 0.0);
 
         if (value.contains("labels") && value["labels"].is_array()) {
@@ -2160,6 +2173,9 @@ void ModelManager::download_registered_model(const ModelInfo& info, bool do_not_
     // Use FLM pull for FLM models, otherwise download from HuggingFace
     if (info.recipe == "flm") {
         download_from_flm(info.checkpoint(), do_not_upgrade, progress_callback);
+    } else if (info.source == "local_path" || info.source == "local_upload") {
+        // Local models don't need downloading - files are already on disk
+        return;
     } else {
         download_from_huggingface(info, progress_callback);
     }

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -22,6 +22,8 @@ static const json DEFAULTS = {
     {"sdcpp_args", ""},
     {"whispercpp_backend", ""},  // "" means auto-detect (mapped from "auto" in config.json)
     {"whispercpp_args", ""},
+    // sd-npu backend selection ("npu" or "cpu")
+    {"sd-npu_backend", "npu"},
     // Image generation defaults (for sd-cpp recipe)
     // These are recipe-level defaults only, not CLI arguments — per reviewer guidance,
     // there are too many image gen params for CLI flags, and no universal defaults.
@@ -53,7 +55,8 @@ static const std::map<std::string, std::string> OPTION_TO_CLI_FLAG = {
     {"whispercpp_args", "--whispercpp-args"},
     {"flm_args", "--flm-args"},
     {"vllm_backend", "--vllm"},
-    {"vllm_args", "--vllm-args"}
+    {"vllm_args", "--vllm-args"},
+    {"sd-npu_backend", "--sd-npu"}
 };
 
 static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
@@ -69,6 +72,8 @@ static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
         return {"sd-cpp_backend", "sdcpp_args", "steps", "cfg_scale", "width", "height", "sampling_method", "flow_shift"};
     } else if (recipe == "vllm") {
         return {"ctx_size", "vllm_backend", "vllm_args"};
+    } else if (recipe == "sd-npu") {
+        return {"sd-npu_backend", "steps", "cfg_scale", "width", "height"};
     } else {
         return {};
     }

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -6,6 +6,7 @@
 #include "lemon/backends/kokoro_server.h"
 #include "lemon/backends/sd_server.h"
 #include "lemon/backends/vllm_server.h"
+#include "lemon/backends/ryzenai_sd_server.h"
 #include "lemon/server_capabilities.h"
 #include "lemon/error_types.h"
 #include "lemon/recipe_options.h"
@@ -192,6 +193,9 @@ std::unique_ptr<WrappedServer> Router::create_backend_server(const ModelInfo& mo
     } else if (model_info.recipe == "sd-cpp") {
     LOG(DEBUG, "Router") << "Creating SDServer backend" << std::endl;
         new_server = std::make_unique<backends::SDServer>(log_level, model_manager_, backend_manager_);
+    } else if (model_info.recipe == "sd-npu") {
+    LOG(DEBUG, "Router") << "Creating SDNPUServer backend" << std::endl;
+        new_server = std::make_unique<backends::SDNPUServer>(log_level, model_manager_, backend_manager_);
     } else if (model_info.recipe == "flm") {
     LOG(DEBUG, "Router") << "Creating FastFlowLM backend" << std::endl;
         new_server = std::make_unique<backends::FastFlowLMServer>(log_level, model_manager_, backend_manager_);
@@ -276,8 +280,9 @@ void Router::load_model(const std::string& model_name,
         // NPU EXCLUSIVITY CHECK (recipe-aware rules)
         // FLM can run up to 3 concurrent NPU processes (1 LLM + 1 audio + 1 embedding)
         // RyzenAI and WhisperCpp lock the entire NPU exclusively
+        // SD-NPU and SD-CPP can share max_loaded_models slots like FLM
         if (device_type & DEVICE_NPU) {
-            if (model_info.recipe == "ryzenai-llm" || model_info.recipe == "whispercpp") {
+            if (model_info.recipe == "ryzenai-llm" || model_info.recipe == "whispercpp" || model_info.recipe == "sd-npu") {
                 // Exclusive NPU recipes - evict ALL NPU servers
                 if (has_npu_server()) {
                     LOG(INFO, "Router") << model_info.recipe
@@ -287,7 +292,7 @@ void Router::load_model(const std::string& model_name,
             } else if (model_info.recipe == "flm") {
                 // FLM can coexist with other FLM types, but not with exclusive-NPU recipes
                 // 1. Evict any exclusive-NPU server (mutually exclusive)
-                for (const std::string& exclusive_recipe : {"ryzenai-llm", "whispercpp"}) {
+                for (const std::string& exclusive_recipe : {"ryzenai-llm", "whispercpp", "sd-npu"}) {
                     WrappedServer* exclusive_server = find_npu_server_by_recipe(exclusive_recipe);
                     if (exclusive_server) {
                         LOG(INFO, "Router") << "FLM cannot coexist with " << exclusive_recipe
@@ -303,6 +308,18 @@ void Router::load_model(const std::string& model_name,
                               << ", evicting..." << std::endl;
                     evict_server(same_type_flm);
                 }
+            } else if (model_info.recipe == "sd-cpp") {
+                // SD-CPP can coexist following normal max_loaded_models rules (handled below)
+                // Evict any exclusive-NPU server first
+                for (const std::string& exclusive_recipe : {"ryzenai-llm", "whispercpp", "sd-npu"}) {
+                    WrappedServer* exclusive_server = find_npu_server_by_recipe(exclusive_recipe);
+                    if (exclusive_server) {
+                        LOG(INFO, "Router") << "SD model cannot coexist with " << exclusive_recipe
+                                  << ", evicting: " << exclusive_server->get_model_name() << std::endl;
+                        evict_server(exclusive_server);
+                    }
+                }
+                // Normal LRU eviction will handle max_loaded_models for images
             } else {
                 // Unknown NPU recipe - default to exclusive access
                 if (has_npu_server()) {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -172,6 +172,11 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
         {"cpu", {"x86_64"}},
     }},
 
+    // ryzenai-sd-server - NPU backend for AMD XDNA2
+    {"sd-npu", "npu", {"windows"}, {
+        {"amd_npu", {"XDNA2"}},
+    }},
+
     // FLM - NPU (XDNA2)
     {"flm", "npu", {"windows", "linux"}, {
         {"amd_npu", {"XDNA2"}},

--- a/test/server_sd_npu.py
+++ b/test/server_sd_npu.py
@@ -1,0 +1,412 @@
+"""
+SD NPU image generation tests for Lemonade Server.
+
+Tests the /images/generations, /images/edits, and /images/variations endpoints
+with SD NPU models (ONNX-based Stable Diffusion on AMD Ryzen AI NPU).
+
+Usage:
+    python server_sd_npu.py
+    python server_sd_npu.py --server-binary /path/to/lemond
+"""
+
+import base64
+import io
+import struct
+import zlib
+import requests
+
+from utils.server_base import (
+    ServerTestBase,
+    run_server_tests,
+)
+from utils.test_models import (
+    SD_NPU_MODEL,
+    PORT,
+    TIMEOUT_MODEL_OPERATION,
+    TIMEOUT_DEFAULT,
+)
+
+
+def create_minimal_png(width=8, height=8):
+    """Create a minimal valid RGB PNG image as bytes, without external dependencies."""
+
+    def make_chunk(chunk_type, data):
+        c = chunk_type + data
+        return (
+            struct.pack(">I", len(data))
+            + c
+            + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+        )
+
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    row = b"\x00" + b"\xff\x00\x00" * width  # filter byte + red pixels per row
+    idat_data = zlib.compress(row * height)
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + make_chunk(b"IHDR", ihdr_data)
+        + make_chunk(b"IDAT", idat_data)
+        + make_chunk(b"IEND", b"")
+    )
+
+
+class SDNPUTests(ServerTestBase):
+    """Tests for SD NPU image generation."""
+
+    def test_001_basic_image_generation(self):
+        """Test basic image generation with SD NPU model."""
+        payload = {
+            "model": SD_NPU_MODEL,
+            "prompt": "A red circle",
+            "size": "512x512",
+            "n": 1,
+            "response_format": "b64_json",
+        }
+
+        print(f"[INFO] Sending image generation request with model {SD_NPU_MODEL}")
+
+        response = requests.post(
+            f"{self.base_url}/images/generations",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Image generation failed with status {response.status_code}: {response.text}",
+        )
+
+        result = response.json()
+        self.assertIn("data", result, "Response should contain 'data' field")
+        self.assertIsInstance(result["data"], list, "Data should be a list")
+        self.assertEqual(len(result["data"]), 1, "Should have 1 image")
+        self.assertIn("b64_json", result["data"][0], "Should contain base64 image")
+
+        # Verify base64 is valid
+        b64_data = result["data"][0]["b64_json"]
+        self.assertIsInstance(b64_data, str, "Base64 data should be a string")
+        self.assertGreater(len(b64_data), 1000, "Base64 data should be substantial")
+
+        # Try to decode to verify it's valid base64
+        try:
+            decoded = base64.b64decode(b64_data)
+            self.assertTrue(
+                decoded[:4] == b"\x89PNG",
+                "Decoded data should be a valid PNG",
+            )
+            print(f"[OK] Generated valid PNG image ({len(decoded)} bytes)")
+        except Exception as e:
+            self.fail(f"Failed to decode base64 image: {e}")
+
+        self.assertIn("created", result, "Response should contain 'created' timestamp")
+        print("[OK] Image generation successful")
+
+    def test_002_missing_prompt_error(self):
+        """Test error handling when prompt is missing."""
+        payload = {
+            "model": SD_NPU_MODEL,
+            "size": "512x512",
+            # No prompt
+        }
+
+        response = requests.post(
+            f"{self.base_url}/images/generations",
+            json=payload,
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        self.assertIn(
+            response.status_code,
+            [400, 422],
+            f"Expected 400 or 422 for missing prompt, got {response.status_code}",
+        )
+        print(f"[OK] Correctly rejected request without prompt: {response.status_code}")
+
+    def test_003_invalid_model_error(self):
+        """Test error handling with invalid model."""
+        payload = {
+            "model": "nonexistent-sd-npu-model-xyz-123",
+            "prompt": "A cat",
+            "size": "512x512",
+        }
+
+        response = requests.post(
+            f"{self.base_url}/images/generations",
+            json=payload,
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        self.assertIn(
+            response.status_code,
+            [400, 404, 422, 500],
+            f"Expected error for invalid model, got {response.status_code}",
+        )
+        print(f"[OK] Correctly rejected invalid model: {response.status_code}")
+
+    def test_004_image_generation_with_steps(self):
+        """Test image generation with custom steps parameter."""
+        payload = {
+            "model": SD_NPU_MODEL,
+            "prompt": "A blue square",
+            "size": "512x512",
+            "steps": 1,
+            "response_format": "b64_json",
+        }
+
+        print("[INFO] Testing image generation with steps=1")
+
+        response = requests.post(
+            f"{self.base_url}/images/generations",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Image generation with custom steps failed: {response.text}",
+        )
+
+        result = response.json()
+        self.assertIn("data", result)
+        self.assertIn("b64_json", result["data"][0])
+
+        b64_data = result["data"][0]["b64_json"]
+        decoded = base64.b64decode(b64_data)
+        self.assertTrue(decoded[:4] == b"\x89PNG", "Should be valid PNG")
+        print(f"[OK] Image generation with steps=1 successful ({len(decoded)} bytes)")
+
+    def test_005_image_generation_with_cfg_scale(self):
+        """Test image generation with custom cfg_scale parameter.
+        SD-Turbo is a distilled model that operates without classifier-free
+        guidance, so only cfg_scale <= 1.0 is valid for the NPU model."""
+        payload = {
+            "model": SD_NPU_MODEL,
+            "prompt": "A green triangle",
+            "size": "512x512",
+            "steps": 1,
+            "cfg_scale": 1.0,
+            "response_format": "b64_json",
+        }
+
+        print("[INFO] Testing image generation with cfg_scale=1.0")
+
+        response = requests.post(
+            f"{self.base_url}/images/generations",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Image generation with custom cfg_scale failed: {response.text}",
+        )
+
+        result = response.json()
+        self.assertIn("data", result)
+        self.assertIn("b64_json", result["data"][0])
+
+        b64_data = result["data"][0]["b64_json"]
+        decoded = base64.b64decode(b64_data)
+        self.assertTrue(decoded[:4] == b"\x89PNG", "Should be valid PNG")
+        print(
+            f"[OK] Image generation with cfg_scale=1.0 successful ({len(decoded)} bytes)"
+        )
+
+    def test_006_image_generation_with_seed(self):
+        """Test image generation with explicit seed parameter."""
+        payload = {
+            "model": SD_NPU_MODEL,
+            "prompt": "A yellow star",
+            "size": "512x512",
+            "steps": 1,
+            "seed": 12345,
+            "response_format": "b64_json",
+        }
+
+        print("[INFO] Testing image generation with seed=12345")
+
+        response = requests.post(
+            f"{self.base_url}/images/generations",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Image generation with seed failed: {response.text}",
+        )
+
+        result = response.json()
+        self.assertIn("data", result)
+        self.assertIn("b64_json", result["data"][0])
+
+        b64_data = result["data"][0]["b64_json"]
+        decoded = base64.b64decode(b64_data)
+        self.assertTrue(decoded[:4] == b"\x89PNG", "Should be valid PNG")
+        print(
+            f"[OK] Image generation with seed=12345 successful ({len(decoded)} bytes)"
+        )
+
+    def test_007_models_endpoint_returns_image_defaults(self):
+        """Test that /models endpoint returns image_defaults for SD NPU model."""
+        print("[INFO] Testing /models endpoint for image_defaults")
+
+        response = requests.get(f"{self.base_url}/models?show_all=true", timeout=60)
+
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Failed to get models: {response.text}",
+        )
+
+        result = response.json()
+        models = result.get("data", result) if isinstance(result, dict) else result
+
+        # Find the NPU model in the models list
+        sd_npu = None
+        for model in models:
+            if model.get("id") == SD_NPU_MODEL:
+                sd_npu = model
+                break
+
+        self.assertIsNotNone(sd_npu, f"{SD_NPU_MODEL} not found in /models response")
+
+        # Verify image_defaults exists
+        self.assertIn(
+            "image_defaults", sd_npu, f"{SD_NPU_MODEL} should have image_defaults"
+        )
+        defaults = sd_npu["image_defaults"]
+
+        self.assertIn("steps", defaults, "image_defaults should have steps")
+        self.assertIn("cfg_scale", defaults, "image_defaults should have cfg_scale")
+        self.assertIn("width", defaults, "image_defaults should have width")
+        self.assertIn("height", defaults, "image_defaults should have height")
+
+        print(f"[OK] {SD_NPU_MODEL} image_defaults verified: {defaults}")
+
+    def test_008_image_edit_not_multipart_error(self):
+        """Test that non-multipart requests to /images/edits return 400."""
+        response = requests.post(
+            f"{self.base_url}/images/edits",
+            json={"model": SD_NPU_MODEL, "prompt": "test"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            response.status_code,
+            400,
+            f"Expected 400 for non-multipart request, got {response.status_code}",
+        )
+        print(
+            f"[OK] Correctly rejected non-multipart edit request: {response.status_code}"
+        )
+
+    def test_009_image_edit_missing_image_error(self):
+        """Test that /images/edits returns 400 when image file is missing."""
+        response = requests.post(
+            f"{self.base_url}/images/edits",
+            data={"model": SD_NPU_MODEL, "prompt": "test"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            response.status_code,
+            400,
+            f"Expected 400 for missing image, got {response.status_code}",
+        )
+        print(
+            f"[OK] Correctly rejected edit request without image: {response.status_code}"
+        )
+
+    def test_010_image_edit_basic(self):
+        """Test basic image edit returns a valid PNG."""
+        png_bytes = create_minimal_png(512, 512)
+        print(f"[INFO] Sending image edit request with model {SD_NPU_MODEL}")
+
+        response = requests.post(
+            f"{self.base_url}/images/edits",
+            files={"image": ("test.png", io.BytesIO(png_bytes), "image/png")},
+            data={
+                "model": SD_NPU_MODEL,
+                "prompt": "A red circle",
+                "size": "512x512",
+                "n": "1",
+                "response_format": "b64_json",
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Image edit failed with status {response.status_code}: {response.text}",
+        )
+
+        result = response.json()
+        self.assertIn("data", result, "Response should contain 'data' field")
+        self.assertGreater(
+            len(result["data"]), 0, "Data should have at least one image"
+        )
+        b64_data = result["data"][0]["b64_json"]
+        decoded = base64.b64decode(b64_data)
+        self.assertTrue(decoded[:4] == b"\x89PNG", "Result should be a valid PNG")
+        print(f"[OK] Image edit successful ({len(decoded)} bytes)")
+
+    def test_011_image_variations_not_multipart_error(self):
+        """Test that non-multipart requests to /images/variations return 400."""
+        response = requests.post(
+            f"{self.base_url}/images/variations",
+            json={"model": SD_NPU_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            response.status_code,
+            400,
+            f"Expected 400 for non-multipart request, got {response.status_code}",
+        )
+        print(
+            f"[OK] Correctly rejected non-multipart variations request: {response.status_code}"
+        )
+
+    def test_012_image_variations_basic(self):
+        """Test basic image variations returns a valid PNG."""
+        png_bytes = create_minimal_png(512, 512)
+        print(f"[INFO] Sending image variations request with model {SD_NPU_MODEL}")
+
+        response = requests.post(
+            f"{self.base_url}/images/variations",
+            files={"image": ("test.png", io.BytesIO(png_bytes), "image/png")},
+            data={
+                "model": SD_NPU_MODEL,
+                "size": "512x512",
+                "n": "1",
+                "response_format": "b64_json",
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Image variations failed with status {response.status_code}: {response.text}",
+        )
+
+        result = response.json()
+        self.assertIn("data", result, "Response should contain 'data' field")
+        self.assertGreater(
+            len(result["data"]), 0, "Data should have at least one image"
+        )
+        b64_data = result["data"][0]["b64_json"]
+        decoded = base64.b64decode(b64_data)
+        self.assertTrue(decoded[:4] == b"\x89PNG", "Result should be a valid PNG")
+        print(f"[OK] Image variations successful ({len(decoded)} bytes)")
+
+
+if __name__ == "__main__":
+    run_server_tests(
+        SDNPUTests,
+        "SD NPU TESTS",
+        wrapped_server="sd-npu",
+        modality="stable_diffusion",
+    )

--- a/test/utils/capabilities.py
+++ b/test/utils/capabilities.py
@@ -167,6 +167,16 @@ CAPABILITIES = {
                 "image": "SD-Turbo",
             },
         },
+        "sd-npu": {
+            "backends": ["npu", "cpu"],
+            "supports": {
+                "image_generation": True,
+                "image_generation_b64": True,
+            },
+            "test_models": {
+                "image": "SD-Turbo-NPU",
+            },
+        },
     },
 }
 

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -203,6 +203,8 @@ def _build_runtime_config(additional_server_args=None):
         config["llamacpp"] = {"backend": backend}
     elif wrapped_server == "sd-cpp" and backend:
         config["sdcpp"] = {"backend": backend}
+    elif wrapped_server == "sd-npu" and backend:
+        config["sd-npu"] = {"backend": backend}
     elif wrapped_server == "whispercpp" and backend:
         config["whispercpp"] = {"backend": backend}
 
@@ -222,6 +224,9 @@ def _build_runtime_config(additional_server_args=None):
             i += 2
         elif arg == "--sdcpp" and i + 1 < len(additional):
             config["sdcpp"] = {"backend": additional[i + 1]}
+            i += 2
+        elif arg == "--sd-npu" and i + 1 < len(additional):
+            config["sd-npu"] = {"backend": additional[i + 1]}
             i += 2
         elif arg == "--whispercpp" and i + 1 < len(additional):
             config["whispercpp"] = {"backend": additional[i + 1]}

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -196,6 +196,9 @@ VISION_MODEL = "Qwen3.5-0.8B-GGUF"
 # Stable Diffusion test configuration
 SD_MODEL = "SD-Turbo"
 
+# SD NPU test configuration
+SD_NPU_MODEL = "SD-Turbo-NPU"
+
 # ESRGAN upscale model test configuration
 ESRGAN_MODEL = "RealESRGAN-x4plus"
 


### PR DESCRIPTION
Add SDNPUServer backend (sd-npu recipe) that manages ryzenai-sd-server as a subprocess for NPU-accelerated image generation on AMD Ryzen AI.

Backend integration:
- SDNPUServer class implementing IImageServer (generations, edits, variations)
- Recipe option defaults for sd-npu_backend, steps, cfg_scale, width, height
- NPU exclusivity enforcement (mutual exclusion with ryzenai-llm, whispercpp)
- Backend version pinned at v0.1.0 (npu and cpu variants)
- Router instantiation gated on sd-npu recipe

Models (7):
- SD-Turbo-NPU, SDXL-Turbo-NPU, SD-1.5-NPU, SDXL-Base-NPU, Segmind-Vega-NPU, SD3-Medium-NPU, SD3.5-Medium-NPU

Tests:
- test/server_sd_npu.py with txt2img, img2img, variations, size, and multi-model coverage
- Test utility updates (capabilities, server_base, test_models)