### PR TITLE
feat: remove env var to config.json migration path; document runtime env vars

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -262,6 +262,24 @@ lemond [cache_dir] [--port PORT] [--host HOST]
 - **--port** — Port to serve on (overrides config.json, persisted). Use as a fallback if the server cannot start.
 - **--host** — Address to bind (overrides config.json, persisted). Use as a fallback if the server cannot start.
 
+## Environment Variables
+
+Lemonade reads a small set of environment variables on **every** launch. They cover API-key authentication and Hugging Face cache/auth.
+
+> **Server settings are not configured through environment variables.** Port, host, backends, and the other `config.json` settings are read from `config.json` only — there is no `LEMONADE_*` override for them. To change a setting, use `lemonade config set` (recommended), edit `config.json`, or use the `lemond --port`/`--host` fallback. See [Editing Configuration](#editing-configuration).
+
+| Environment variable | Purpose |
+|----------------------|---------|
+| `LEMONADE_API_KEY` | API key required on regular API endpoints. See [API Key and Security](#api-key-and-security). |
+| `LEMONADE_ADMIN_API_KEY` | Admin API key that also unlocks internal endpoints; takes precedence over `LEMONADE_API_KEY`. See [API Key and Security](#api-key-and-security). |
+| `HF_HUB_CACHE` | Direct path to the Hugging Face hub cache. Used to locate downloaded models when `models_dir` is `"auto"`. |
+| `HF_HOME` | Base Hugging Face directory; the cache is taken to be `$HF_HOME/hub`. Used when `HF_HUB_CACHE` is unset and `models_dir` is `"auto"`. |
+| `HF_TOKEN` | Hugging Face access token used to download gated or private model repositories. |
+
+> When `models_dir` is `"auto"`, the model cache is resolved in this order: `HF_HUB_CACHE`, then `$HF_HOME/hub`, then the platform default (`~/.cache/huggingface/hub`). Setting `models_dir` to an explicit path in `config.json` overrides all three.
+
+> The `lemonade` CLI client (not `lemond`) additionally reads `LEMONADE_HOST`, `LEMONADE_PORT`, and `LEMONADE_API_KEY`/`LEMONADE_ADMIN_API_KEY` at runtime to choose which server to connect to. See [CLI → Global Options](../cli.md#global-options).
+
 ## API Key and Security
 
 ### Regular API Key

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -70,7 +70,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
     "vulkan_bin": "builtin"
   },
   "flm": {
-    "args": "",
+    "args": ""
   },
   "ryzenai": {
     "server_bin": "builtin"

--- a/docs/guide/install/docker.md
+++ b/docs/guide/install/docker.md
@@ -25,14 +25,24 @@ docker run -d \
   -v lemonade-cache:/root/.cache/huggingface \
   -v lemonade-llama:/opt/lemonade/llama \
   -v lemonade-recipe:/root/.cache/lemonade \
-  -e LEMONADE_LLAMACPP=cpu \
   ghcr.io/lemonade-sdk/lemonade-server:v9.1.3 \
   ./lemond --host 0.0.0.0 --port 5000
 ```
 
 > This will run the server on port 5000 inside the container, mapped to port 4000 on your host.
 
-### Docker Run with CPU backend
+### Selecting a backend
+
+The server auto-detects a llama.cpp backend and falls back to CPU when no GPU is available, so most deployments need no extra configuration. To pin a specific backend (or change any other setting), use `config.json` in the cache directory — the `lemonade-recipe` volume above persists it across restarts. Server settings are **not** read from environment variables.
+
+Start the container, then set the backend with the bundled CLI and restart so it takes effect:
+
+```bash
+docker exec lemonade-server ./lemonade config set llamacpp.backend=cpu
+docker restart lemonade-server
+```
+
+Alternatively, bind-mount a prepared `config.json` over the cache directory at startup:
 
 ```bash
 docker run -d \
@@ -41,10 +51,19 @@ docker run -d \
   -v lemonade-cache:/root/.cache/huggingface \
   -v lemonade-llama:/opt/lemonade/llama \
   -v lemonade-recipe:/root/.cache/lemonade \
-  -e LEMONADE_LLAMACPP=cpu \
+  -v "$(pwd)/config.json:/root/.cache/lemonade/config.json:ro" \
   ghcr.io/lemonade-sdk/lemonade-server:latest
 ```
 
+where `config.json` selects the backend:
+
+```json
+{
+  "llamacpp": {
+    "backend": "cpu"
+  }
+}
+```
 
 ### Docker Run with AMD GPU Passthrough using ROCm
 
@@ -55,13 +74,12 @@ docker run -d \
   -v lemonade-cache:/root/.cache/huggingface \
   -v lemonade-llama:/opt/lemonade/llama \
   -v lemonade-recipe:/root/.cache/lemonade \
-  -e LEMONADE_LLAMACPP=rocm \
   --device=/dev/kfd \
   --device=/dev/dri \
   ghcr.io/lemonade-sdk/lemonade-server:latest
 ```
 
-> This will run the server using the ROCm backend as the default for llama.cpp.
+> This passes the AMD GPU devices into the container. Select the ROCm backend with `lemonade config set llamacpp.backend=rocm` (see [Selecting a backend](#selecting-a-backend)).
 
 ### Other Docker Methods
 
@@ -84,8 +102,6 @@ services:
       - lemonade-llama:/opt/lemonade/llama
       # Persist model options and other backend binaries
       - lemonade-recipe:/root/.cache/lemonade
-    environment:
-      - LEMONADE_LLAMACPP=cpu
     restart: unless-stopped
 
 volumes:
@@ -94,7 +110,7 @@ volumes:
   lemonade-recipe:
 ```
 
-> You can add more services as needed, or add host devices for the ROCM backend.
+> You can add more services as needed, or add host devices for the ROCM backend. To pin a backend or change other settings, see [Selecting a backend](#selecting-a-backend).
 
 3. Run the following command in the directory containing your docker-compose.yml:
 
@@ -273,8 +289,6 @@ services:
       - lemonade-llama:/opt/lemonade/llama
       # Persist model options and other backend binaries
       - lemonade-recipe:/root/.cache/lemonade
-    environment:
-      - LEMONADE_LLAMACPP=cpu
     restart: unless-stopped
 
 volumes:

--- a/src/cpp/include/lemon/config_file.h
+++ b/src/cpp/include/lemon/config_file.h
@@ -27,10 +27,6 @@ public:
     static void save(const std::string& cache_dir, const json& config);
 
 private:
-    /// When config.json doesn't exist yet, read legacy LEMONADE_* environment
-    /// variables and overlay them on top of defaults.  Returns the merged config.
-    static json migrate_from_env(const json& defaults);
-
     static std::shared_mutex file_mutex_;
 };
 

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -2,12 +2,8 @@
 #include "lemon/utils/json_utils.h"
 #include "lemon/utils/path_utils.h"
 
-#include <algorithm>
-#include <cstdlib>
 #include <filesystem>
 #include <fstream>
-#include <sstream>
-#include <vector>
 
 #include <lemon/utils/aixlog.hpp>
 
@@ -76,7 +72,7 @@ json ConfigFile::load(const std::string& cache_dir) {
         if (!fs::exists(cache_path)) {
             fs::create_directories(cache_path);
         }
-        json config = migrate_from_env(defaults);
+        json config = defaults;
         migrate_deprecated_rocm_preview_channel(config);
         save(cache_dir, config);
         return config;
@@ -168,128 +164,6 @@ void ConfigFile::save(const std::string& cache_dir, const json& config) {
         }
         fs::remove(temp_path);
     }
-}
-
-// ---------------------------------------------------------------------------
-// Environment-variable migration
-// ---------------------------------------------------------------------------
-
-struct EnvMapping {
-    const char* env_name;
-    const char* top_key;
-    const char* nested_key; // nullptr for top-level keys
-};
-
-static const EnvMapping env_mappings[] = {
-    // Top-level settings
-    {"LEMONADE_PORT",                    "port",                     nullptr},
-    {"LEMONADE_HOST",                    "host",                     nullptr},
-    {"LEMONADE_LOG_LEVEL",               "log_level",                nullptr},
-    {"LEMONADE_GLOBAL_TIMEOUT",          "global_timeout",           nullptr},
-    {"LEMONADE_MAX_LOADED_MODELS",       "max_loaded_models",        nullptr},
-    {"LEMONADE_NO_BROADCAST",            "no_broadcast",             nullptr},
-    {"LEMONADE_EXTRA_MODELS_DIR",        "extra_models_dir",         nullptr},
-    {"LEMONADE_CTX_SIZE",                "ctx_size",                 nullptr},
-    {"LEMONADE_OFFLINE",                 "offline",                  nullptr},
-    {"LEMONADE_NO_FETCH_EXECUTABLES",     "no_fetch_executables",     nullptr},
-    {"LEMONADE_DISABLE_MODEL_FILTERING", "disable_model_filtering",  nullptr},
-    {"LEMONADE_ENABLE_DGPU_GTT",         "enable_dgpu_gtt",          nullptr},
-    // llamacpp
-    {"LEMONADE_LLAMACPP",                "llamacpp",  "backend"},
-    {"LEMONADE_LLAMACPP_ARGS",           "llamacpp",  "args"},
-    {"LEMONADE_LLAMACPP_ROCM_ARGS",      "llamacpp",  "rocm_args"},
-    {"LEMONADE_LLAMACPP_VULKAN_ARGS",    "llamacpp",  "vulkan_args"},
-    {"LEMONADE_LLAMACPP_CPU_ARGS",       "llamacpp",  "cpu_args"},
-    {"LEMONADE_LLAMACPP_DEVICE",         "llamacpp",  "device"},
-    {"LEMONADE_LLAMACPP_PREFER_SYSTEM",  "llamacpp",  "prefer_system"},
-    {"LEMONADE_LLAMACPP_ROCM_BIN",       "llamacpp",  "rocm_bin"},
-    {"LEMONADE_LLAMACPP_VULKAN_BIN",     "llamacpp",  "vulkan_bin"},
-    {"LEMONADE_LLAMACPP_CPU_BIN",        "llamacpp",  "cpu_bin"},
-    // whispercpp
-    {"LEMONADE_WHISPERCPP",              "whispercpp", "backend"},
-    {"LEMONADE_WHISPERCPP_ARGS",         "whispercpp", "args"},
-    {"LEMONADE_WHISPERCPP_CPU_ARGS",     "whispercpp", "cpu_args"},
-    {"LEMONADE_WHISPERCPP_NPU_ARGS",     "whispercpp", "npu_args"},
-    {"LEMONADE_WHISPERCPP_CPU_BIN",      "whispercpp", "cpu_bin"},
-    {"LEMONADE_WHISPERCPP_NPU_BIN",      "whispercpp", "npu_bin"},
-    // sdcpp
-    {"LEMONADE_SDCPP",                   "sdcpp", "backend"},
-    {"LEMONADE_SDCPP_ARGS",              "sdcpp", "args"},
-    {"LEMONADE_SDCPP_CPU_ARGS",          "sdcpp", "cpu_args"},
-    {"LEMONADE_SDCPP_ROCM_ARGS",         "sdcpp", "rocm_args"},
-    {"LEMONADE_SDCPP_VULKAN_ARGS",       "sdcpp", "vulkan_args"},
-    {"LEMONADE_STEPS",                   "sdcpp", "steps"},
-    {"LEMONADE_CFG_SCALE",               "sdcpp", "cfg_scale"},
-    {"LEMONADE_WIDTH",                   "sdcpp", "width"},
-    {"LEMONADE_HEIGHT",                  "sdcpp", "height"},
-    {"LEMONADE_SDCPP_CPU_BIN",           "sdcpp", "cpu_bin"},
-    {"LEMONADE_SDCPP_ROCM_BIN",          "sdcpp", "rocm_bin"},
-    {"LEMONADE_SDCPP_VULKAN_BIN",        "sdcpp", "vulkan_bin"},
-    // flm
-    {"LEMONADE_FLM_ARGS",               "flm", "args"},
-    // ryzenai
-    {"LEMONADE_RYZENAI_SERVER_BIN",      "ryzenai", "server_bin"},
-    // kokoro
-    {"LEMONADE_KOKORO_CPU_BIN",          "kokoro", "cpu_bin"},
-};
-
-/// Parse a string value to match the JSON type of the corresponding default.
-static json parse_env_value(const std::string& value, const json& default_val) {
-    if (default_val.is_boolean()) {
-        std::string lower = value;
-        std::transform(lower.begin(), lower.end(), lower.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
-        return (lower == "1" || lower == "true" || lower == "yes");
-    }
-    if (default_val.is_number_integer()) {
-        try { return std::stoi(value); } catch (...) { return default_val; }
-    }
-    if (default_val.is_number_float()) {
-        try { return std::stod(value); } catch (...) { return default_val; }
-    }
-    return value;
-}
-
-json ConfigFile::migrate_from_env(const json& defaults) {
-    json overlay = json::object();
-    std::vector<std::string> migrated;
-
-    for (const auto& m : env_mappings) {
-        std::string val = utils::get_environment_variable_utf8(m.env_name);
-        if (val.empty()) continue;
-
-        // Look up the default to determine the expected type
-        json default_val;
-        if (m.nested_key == nullptr) {
-            if (defaults.contains(m.top_key)) default_val = defaults[m.top_key];
-        } else {
-            if (defaults.contains(m.top_key) && defaults[m.top_key].contains(m.nested_key))
-                default_val = defaults[m.top_key][m.nested_key];
-        }
-
-        json parsed = parse_env_value(val, default_val);
-
-        if (m.nested_key == nullptr) {
-            overlay[m.top_key] = parsed;
-        } else {
-            if (!overlay.contains(m.top_key)) overlay[m.top_key] = json::object();
-            overlay[m.top_key][m.nested_key] = parsed;
-        }
-
-        migrated.push_back(m.env_name);
-    }
-
-    if (!migrated.empty()) {
-        std::ostringstream oss;
-        for (size_t i = 0; i < migrated.size(); ++i) {
-            if (i > 0) oss << ", ";
-            oss << migrated[i];
-        }
-        LOG(INFO) << "Migrated config.json from environment variables: "
-                  << oss.str() << std::endl;
-    }
-
-    return utils::JsonUtils::merge(defaults, overlay);
 }
 
 } // namespace lemon

--- a/test/server_env_vars.py
+++ b/test/server_env_vars.py
@@ -1,8 +1,11 @@
 """
 Environment variable tests for lemond.
 
-Verifies that legacy LEMONADE_* environment variables are picked up by lemond
-(migrated into config.json on first startup) and reflected in the runtime config.
+Covers the runtime environment variables lemond reads on every launch
+(LEMONADE_API_KEY, LEMONADE_ADMIN_API_KEY, HF_HUB_CACHE) and verifies that the
+legacy LEMONADE_* config-seeding variables are now ignored. Server settings are
+seeded directly into config.json, since the env-var -> config.json migration
+path was removed (see https://github.com/lemonade-sdk/lemonade/issues/1981).
 
 Usage:
     # Build lemond first, then:
@@ -11,8 +14,8 @@ Usage:
 """
 
 import argparse
+import json
 import os
-import platform
 import subprocess
 import sys
 import tempfile
@@ -27,8 +30,6 @@ from utils.server_base import wait_for_server
 BASE = f"http://localhost:{PORT}"
 HEALTH = f"{BASE}/v1/health"
 CONFIG = f"{BASE}/internal/config"
-
-IS_MACOS = platform.system() == "Darwin"
 
 _lemond_binary = get_default_lemond_binary()
 
@@ -48,8 +49,14 @@ def shutdown_existing_server():
             break
 
 
-def start_server(env_overrides=None):
-    """Start lemond with given env overrides in an isolated temp cache dir.
+def start_server(env_overrides=None, config_overrides=None):
+    """Start lemond in an isolated temp cache dir with a seeded config.json.
+
+    The env-var -> config.json migration path was removed, so server settings
+    (port, host, broadcast) are seeded directly into config.json via
+    ``config_overrides``. ``env_overrides`` still applies to the process
+    environment for the runtime variables lemond reads on every launch (e.g.
+    LEMONADE_API_KEY, HF_HUB_CACHE).
 
     Returns (subprocess.Popen, cache_dir).
     """
@@ -61,11 +68,15 @@ def start_server(env_overrides=None):
             del env[k]
     cache_dir = tempfile.mkdtemp(prefix="lemon_test_")
     env["LEMONADE_CACHE_DIR"] = cache_dir
-    env["LEMONADE_PORT"] = str(PORT)
-    env["LEMONADE_HOST"] = "localhost"
-    env["LEMONADE_NO_BROADCAST"] = "1"
     if env_overrides:
         env.update(env_overrides)
+
+    # Seed config.json so the server binds to the test port without broadcasting.
+    config = {"port": PORT, "host": "localhost", "no_broadcast": True}
+    if config_overrides:
+        config.update(config_overrides)
+    with open(os.path.join(cache_dir, "config.json"), "w", encoding="utf-8") as f:
+        json.dump(config, f)
 
     proc = subprocess.Popen(
         [_lemond_binary],
@@ -101,46 +112,26 @@ def get_config():
 
 
 # ---------------------------------------------------------------------------
-# Test: server config env vars reflected in /internal/config
+# Test: config.json settings reflected in /internal/config
 # ---------------------------------------------------------------------------
 
 
-class TestConfigEnvVars(unittest.TestCase):
-    """Start lemond once with all config-based env vars set, verify snapshot."""
+class TestConfigJsonSeeding(unittest.TestCase):
+    """Server settings come from config.json, verified in the runtime snapshot."""
 
     proc = None
 
     @classmethod
     def setUpClass(cls):
-        cls.env = {
-            "LEMONADE_PORT": str(PORT),
-            "LEMONADE_HOST": "localhost",
-            "LEMONADE_LOG_LEVEL": "debug",
-            "LEMONADE_EXTRA_MODELS_DIR": "/tmp/lemon_extra_models_test",
-            "LEMONADE_GLOBAL_TIMEOUT": "999",
-            "LEMONADE_MAX_LOADED_MODELS": "3",
-            # Recipe-option env vars
-            "LEMONADE_CTX_SIZE": "2048",
-        }
-        if IS_MACOS:
-            # On macOS the platform defaults are metal for llamacpp/whispercpp
-            cls.env.update(
-                {
-                    "LEMONADE_LLAMACPP": "metal",
-                    "LEMONADE_WHISPERCPP": "metal",
-                }
-            )
-        else:
-            cls.env.update(
-                {
-                    "LEMONADE_LLAMACPP": "cpu",
-                    "LEMONADE_LLAMACPP_ARGS": "--flash-attn on",
-                    "LEMONADE_WHISPERCPP": "cpu",
-                    "LEMONADE_WHISPERCPP_ARGS": "--convert",
-                    "LEMONADE_FLM_ARGS": "--socket 20",
-                }
-            )
-        cls.proc, cls.cache_dir = start_server(cls.env)
+        cls.proc, cls.cache_dir = start_server(
+            config_overrides={
+                "log_level": "debug",
+                "extra_models_dir": "/tmp/lemon_extra_models_test",
+                "global_timeout": 999,
+                "max_loaded_models": 3,
+                "ctx_size": 2048,
+            }
+        )
         wait_for_server(port=PORT)
         cls.snapshot = get_config()
 
@@ -178,26 +169,54 @@ class TestConfigEnvVars(unittest.TestCase):
     def test_ctx_size(self):
         self.assertEqual(self.snapshot["ctx_size"], 2048)
 
-    def test_llamacpp_backend(self):
-        expected = "metal" if IS_MACOS else "cpu"
-        self.assertEqual(self.snapshot["llamacpp"]["backend"], expected)
 
-    @unittest.skipIf(IS_MACOS, "llamacpp args not applicable on macOS")
-    def test_llamacpp_args(self):
-        self.assertEqual(self.snapshot["llamacpp"]["args"], "--flash-attn on")
+# ---------------------------------------------------------------------------
+# Test: legacy config-seeding env vars are ignored (migration removed)
+# ---------------------------------------------------------------------------
 
-    def test_whispercpp_backend(self):
-        # On macOS the default is metal; on other platforms it's cpu
-        expected = "metal" if IS_MACOS else "cpu"
-        self.assertEqual(self.snapshot["whispercpp"]["backend"], expected)
 
-    @unittest.skipIf(IS_MACOS, "whispercpp args not applicable on macOS")
-    def test_whispercpp_args(self):
-        self.assertEqual(self.snapshot["whispercpp"]["args"], "--convert")
+class TestLegacySeedingEnvVarsIgnored(unittest.TestCase):
+    """Legacy LEMONADE_* config-seeding vars must no longer affect config.
 
-    @unittest.skipIf(IS_MACOS, "FLM is NPU-only, not available on macOS")
-    def test_flm_args(self):
-        self.assertEqual(self.snapshot["flm"]["args"], "--socket 20")
+    The env-var -> config.json migration was removed (issue #1981). Setting the
+    old seeding variables must have no effect; the runtime config keeps its
+    defaults. Only config.json and the documented runtime variables apply.
+    """
+
+    proc = None
+
+    @classmethod
+    def setUpClass(cls):
+        # These previously would have been migrated into config.json on first
+        # run. They must now be ignored. config.json is left at defaults for the
+        # keys under test (start_server only seeds port/host/no_broadcast).
+        cls.proc, cls.cache_dir = start_server(
+            env_overrides={
+                "LEMONADE_LOG_LEVEL": "debug",
+                "LEMONADE_GLOBAL_TIMEOUT": "999",
+                "LEMONADE_MAX_LOADED_MODELS": "7",
+                "LEMONADE_CTX_SIZE": "2048",
+            }
+        )
+        wait_for_server(port=PORT)
+        cls.snapshot = get_config()
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.proc:
+            stop_server(cls.proc)
+
+    def test_log_level_default(self):
+        self.assertEqual(self.snapshot["log_level"], "info")
+
+    def test_global_timeout_default(self):
+        self.assertEqual(self.snapshot["global_timeout"], 300)
+
+    def test_max_loaded_models_default(self):
+        self.assertEqual(self.snapshot["max_loaded_models"], 1)
+
+    def test_ctx_size_default(self):
+        self.assertEqual(self.snapshot["ctx_size"], 4096)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

`lemond` historically read a large set of `LEMONADE_*` environment variables that *seeded* `config.json` on first run (the `migrate_from_env` path). That migration was only ever meant to be temporary — a way to move users off the old environment-variable setup and onto `config.json`. Per the discussion below and #1981, it is now removed: **server settings are configured via `config.json` only.**

This PR started as documentation for the full env-var set; following review it instead removes the migration and documents the environment variables `lemond` actually keeps.

Closes #1981

### What changes

- **Remove the migration path** — drop `migrate_from_env()`, the `env_mappings` table, and `parse_env_value()` from `config_file.cpp` (and the header declaration). When `config.json` does not exist it is created from defaults. The unrelated `rocm=preview` → `rocm_channel=stable` config migration is kept.
- **Tests** — `test/server_env_vars.py` seeds `config.json` directly instead of relying on `LEMONADE_PORT`/`LEMONADE_HOST`/`LEMONADE_NO_BROADCAST`, and adds a regression test asserting the legacy seeding variables are now ignored.
- **Docs** — document the variables `lemond` reads at runtime (`LEMONADE_API_KEY`, `LEMONADE_ADMIN_API_KEY`, `HF_HUB_CACHE`/`HF_HOME`/`HF_TOKEN`) and state that server settings come from `config.json`; update the Docker guide to select a backend via `config.json` (`lemonade config set`, or a bind-mounted `config.json`) instead of `-e LEMONADE_LLAMACPP=...`.

### Not affected (read directly, never went through the migration)

- Runtime auth/cache vars: `LEMONADE_API_KEY`, `LEMONADE_ADMIN_API_KEY`, `HF_*`, `LEMONADE_CACHE_DIR`.
- The `lemonade` CLI client's connection vars (`LEMONADE_HOST`, `LEMONADE_PORT`) and the `lemonade launch` recipe-option env vars (`#ifdef LEMONADE_CLI`).

### ⚠️ Breaking change

Containers/deployments that configured the **server** via `LEMONADE_*` (e.g. `-e LEMONADE_LLAMACPP=cpu`) must switch to `config.json`. The Docker guide is updated to show how.

### Testing

- `lemond` builds clean.
- `python test/server_env_vars.py` — 34/34 pass (config.json seeding, legacy-vars-ignored regression, API-key, and HF-cache tests).
