### PR TITLE
feat: added GGUF auto labeling for tools and vision

### DIFF
--- a/src/app/src/renderer/AddModelPanel.tsx
+++ b/src/app/src/renderer/AddModelPanel.tsx
@@ -8,6 +8,7 @@ export interface AddModelInitialValues {
   recipe: string;
   checkpoints?: Record<string, string>;
   mmprojOptions?: string[];
+  labels?: string[];
   vision?: boolean;
   reranking?: boolean;
   embedding?: boolean;
@@ -19,6 +20,7 @@ export interface ModelInstallData {
   recipe: string;
   checkpoints?: Record<string, string>;
   mmproj?: string;
+  labels?: string[];
   reasoning?: boolean;
   vision?: boolean;
   embedding?: boolean;
@@ -171,6 +173,8 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
       return;
     }
 
+    const labels = (initialValues?.labels ?? []).filter(label => label !== 'vision');
+
     onInstall({
       name,
       checkpoint,
@@ -179,6 +183,7 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
         : undefined,
       recipe,
       mmproj: !isSdCpp ? (form.mmproj.trim() || undefined) : undefined,
+      labels,
       reasoning: form.reasoning,
       vision: !isSdCpp ? form.vision : false,
       embedding: !isSdCpp ? form.embedding : false,

--- a/src/app/src/renderer/ChatWindow.tsx
+++ b/src/app/src/renderer/ChatWindow.tsx
@@ -224,6 +224,7 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isVisible, width }) => {
           checkpoints: data.checkpoints,
           recipe: data.recipe,
           mmproj: data.mmproj,
+          labels: data.labels,
           reasoning: data.reasoning,
           vision: data.vision,
           embedding: data.embedding,

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -992,14 +992,17 @@ const [searchQuery, setSearchQuery] = useState('');
       ? resolveGgufCheckpoint(hfModel.id, backend)
       : hfModel.id;
     const modelName = `user.${resolveHfModelName(hfModel.id, backend)}`;
-    const labels = backend.suggestedLabels ?? [];
+    const labels = new Set(backend.suggestedLabels ?? []);
+    const mmproj = backend.mmprojFiles?.[0];
+    if (mmproj) labels.add('vision');
     handleDownloadModel(modelName, {
       checkpoint,
       recipe: backend.recipe,
-      labels,
-      vision: labels.includes('vision') || (backend.mmprojFiles?.length ?? 0) > 0,
-      embedding: labels.includes('embeddings'),
-      reranking: labels.includes('reranking'),
+      mmproj,
+      labels: Array.from(labels),
+      vision: labels.has('vision'),
+      embedding: labels.has('embeddings'),
+      reranking: labels.has('reranking'),
     });
   }, [hfModelBackends, resolveGgufCheckpoint, resolveHfModelName, handleDownloadModel]);
 

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -222,6 +222,7 @@ interface DetectedBackend {
   suggestedName?: string;
   quantizations?: GGUFQuantization[];
   mmprojFiles?: string[];
+  suggestedLabels?: string[];
 }
 
 // Strip the canonical prefix (if any) to get the bare model name. Used for
@@ -795,6 +796,7 @@ const [searchQuery, setSearchQuery] = useState('');
               mmproj_files: string[];
               recipe: string;
               suggested_name?: string;
+              suggested_labels?: string[];
             } = await variantsRes.json();
             if (payload.variants && payload.variants.length > 0) {
               const quantizations: GGUFQuantization[] = payload.variants.map(v => ({
@@ -802,6 +804,9 @@ const [searchQuery, setSearchQuery] = useState('');
                 quantization: v.name,
                 size: v.size_bytes || undefined,
               }));
+              const suggestedLabels = Array.isArray(payload.suggested_labels)
+                ? payload.suggested_labels.filter((label): label is string => typeof label === 'string')
+                : [];
               setHfModelBackends((prev: Record<string, DetectedBackend | null>) => ({
                 ...prev,
                 [modelId]: {
@@ -810,6 +815,7 @@ const [searchQuery, setSearchQuery] = useState('');
                   suggestedName: payload.suggested_name,
                   quantizations,
                   mmprojFiles: payload.mmproj_files && payload.mmproj_files.length > 0 ? payload.mmproj_files : undefined,
+                  suggestedLabels,
                 },
               }));
               if (!hfSelectedQuantizations[modelId]) {
@@ -986,7 +992,15 @@ const [searchQuery, setSearchQuery] = useState('');
       ? resolveGgufCheckpoint(hfModel.id, backend)
       : hfModel.id;
     const modelName = `user.${resolveHfModelName(hfModel.id, backend)}`;
-    handleDownloadModel(modelName, { checkpoint, recipe: backend.recipe });
+    const labels = backend.suggestedLabels ?? [];
+    handleDownloadModel(modelName, {
+      checkpoint,
+      recipe: backend.recipe,
+      labels,
+      vision: labels.includes('vision') || (backend.mmprojFiles?.length ?? 0) > 0,
+      embedding: labels.includes('embeddings'),
+      reranking: labels.includes('reranking'),
+    });
   }, [hfModelBackends, resolveGgufCheckpoint, resolveHfModelName, handleDownloadModel]);
 
   // Debounced HF search effect - to avoid HF API rate limit error
@@ -1859,6 +1873,7 @@ const [searchQuery, setSearchQuery] = useState('');
                                     ? resolveGgufCheckpoint(hfModel.id, backend)
                                     : hfModel.id;
                                   const idLower = hfModel.id.toLowerCase();
+                                  const labels = backend.suggestedLabels ?? [];
                                   window.dispatchEvent(new CustomEvent('openAddModel', {
                                     detail: {
                                       initialValues: {
@@ -1866,9 +1881,10 @@ const [searchQuery, setSearchQuery] = useState('');
                                         checkpoint,
                                         recipe: backend.recipe,
                                         mmprojOptions: backend.mmprojFiles,
-                                        vision: (backend.mmprojFiles?.length ?? 0) > 0,
-                                        reranking: idLower.includes('rerank'),
-                                        embedding: idLower.includes('embed'),
+                                        labels,
+                                        vision: labels.includes('vision') || (backend.mmprojFiles?.length ?? 0) > 0,
+                                        reranking: labels.includes('reranking') || idLower.includes('rerank'),
+                                        embedding: labels.includes('embeddings') || idLower.includes('embed'),
                                       },
                                     },
                                   }));

--- a/src/app/src/renderer/utils/backendInstaller.ts
+++ b/src/app/src/renderer/utils/backendInstaller.ts
@@ -30,6 +30,7 @@ export interface ModelRegistrationData {
   components?: string[];
   recipe: string;
   mmproj?: string;
+  labels?: string[];
   reasoning?: boolean;
   vision?: boolean;
   embedding?: boolean;

--- a/src/cpp/include/lemon/gguf_capabilities.h
+++ b/src/cpp/include/lemon/gguf_capabilities.h
@@ -72,29 +72,40 @@ inline uint64_t scalar_size(uint32_t type) {
     }
 }
 
+inline bool is_stable_vision_metadata_key(const std::string& key) {
+    return key == "general.architecture" || key == "general.basename" ||
+           key == "general.name" || key == "general.finetune" ||
+           contains(key, "clip.vision") || contains(key, "mmproj");
+}
+
+inline bool is_chat_template_key(const std::string& key) {
+    return key == "tokenizer.chat_template" || contains(key, ".chat_template");
+}
+
 inline void inspect_string(const std::string& key, const std::string& value, GgufCapabilities& caps) {
     const std::string k = to_lower(key);
     const std::string v = to_lower(value);
-    const std::string combined = k + "\n" + v;
 
-    if (contains(k, "vision") || contains(k, "image") || contains(k, "mmproj") || contains(k, "clip.vision")) {
+    // Vision is intentionally inferred only from stable metadata keys. Avoid
+    // scanning arbitrary strings such as prompts or chat templates; those can
+    // mention images/tools even for text-only or embedding models.
+    if (is_stable_vision_metadata_key(k) &&
+        (contains(v, "vision") || contains(v, "image") || contains(v, "mmproj") ||
+         contains(v, "multimodal") || contains(v, "multi-modal") ||
+         contains(v, "qwen2vl") || contains(v, "qwen2_5_vl") || contains(v, "qwen3vl") ||
+         contains(v, "mllama") || contains(v, "llava") || contains(v, "pixtral") ||
+         contains(v, "paligemma"))) {
         caps.vision = true;
     }
 
-    if (contains(v, "vision") || contains(v, "image") || contains(v, "mmproj") ||
-        contains(v, "multimodal") || contains(v, "multi-modal") ||
-        contains(v, "qwen2vl") || contains(v, "qwen2_5_vl") || contains(v, "qwen3vl") ||
-        contains(v, "mllama") || contains(v, "llava") || contains(v, "pixtral") ||
-        contains(v, "paligemma")) {
-        caps.vision = true;
-    }
-
-    if ((contains(k, "chat_template") || contains(k, "tool")) &&
-        (contains(combined, "tool_call") || contains(combined, "tool-call") ||
-         contains(combined, "function_call") || contains(combined, "function-call") ||
-         contains(combined, "<tool") || contains(combined, "</tool") ||
-         contains(combined, " tools") || contains(combined, "\"tools\"") ||
-         contains(combined, "'tools'"))) {
+    // Tool support belongs in tokenizer.chat_template. Do not infer it from
+    // arbitrary GGUF metadata keys or values.
+    if (is_chat_template_key(k) &&
+        (contains(v, "tool_call") || contains(v, "tool-call") ||
+         contains(v, "function_call") || contains(v, "function-call") ||
+         contains(v, "<tool") || contains(v, "</tool") ||
+         contains(v, " tools") || contains(v, "\"tools\"") ||
+         contains(v, "'tools'"))) {
         caps.tool_calling = true;
     }
 }

--- a/src/cpp/include/lemon/gguf_capabilities.h
+++ b/src/cpp/include/lemon/gguf_capabilities.h
@@ -1,0 +1,190 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <istream>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace lemon {
+
+struct GgufCapabilities {
+    bool vision = false;
+    bool tool_calling = false;
+};
+
+namespace gguf_capabilities_detail {
+
+template <typename T>
+bool read_le(std::istream& in, T& value) {
+    in.read(reinterpret_cast<char*>(&value), sizeof(T));
+    return static_cast<bool>(in);
+}
+
+inline std::string to_lower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return s;
+}
+
+inline bool contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+inline bool read_string(std::istream& in, std::string& value) {
+    uint64_t len = 0;
+    if (!read_le(in, len)) return false;
+    if (len > 16 * 1024 * 1024) return false;
+    value.assign(static_cast<size_t>(len), '\0');
+    if (len == 0) return true;
+    in.read(&value[0], static_cast<std::streamsize>(len));
+    return static_cast<bool>(in);
+}
+
+inline bool skip_bytes(std::istream& in, uint64_t bytes) {
+    if (bytes > static_cast<uint64_t>(std::numeric_limits<std::streamoff>::max())) return false;
+    in.seekg(static_cast<std::streamoff>(bytes), std::ios::cur);
+    return static_cast<bool>(in);
+}
+
+inline uint64_t scalar_size(uint32_t type) {
+    switch (type) {
+        case 0:  // UINT8
+        case 1:  // INT8
+        case 7:  // BOOL
+            return 1;
+        case 2:  // UINT16
+        case 3:  // INT16
+            return 2;
+        case 4:  // UINT32
+        case 5:  // INT32
+        case 6:  // FLOAT32
+            return 4;
+        case 10: // UINT64
+        case 11: // INT64
+        case 12: // FLOAT64
+            return 8;
+        default:
+            return 0;
+    }
+}
+
+inline void inspect_string(const std::string& key, const std::string& value, GgufCapabilities& caps) {
+    const std::string k = to_lower(key);
+    const std::string v = to_lower(value);
+    const std::string combined = k + "\n" + v;
+
+    if (contains(k, "vision") || contains(k, "image") || contains(k, "mmproj") || contains(k, "clip.vision")) {
+        caps.vision = true;
+    }
+
+    if (contains(v, "vision") || contains(v, "image") || contains(v, "mmproj") ||
+        contains(v, "multimodal") || contains(v, "multi-modal") ||
+        contains(v, "qwen2vl") || contains(v, "qwen2_5_vl") || contains(v, "qwen3vl") ||
+        contains(v, "mllama") || contains(v, "llava") || contains(v, "pixtral") ||
+        contains(v, "paligemma")) {
+        caps.vision = true;
+    }
+
+    if ((contains(k, "chat_template") || contains(k, "tool")) &&
+        (contains(combined, "tool_call") || contains(combined, "tool-call") ||
+         contains(combined, "function_call") || contains(combined, "function-call") ||
+         contains(combined, "<tool") || contains(combined, "</tool") ||
+         contains(combined, " tools") || contains(combined, "\"tools\"") ||
+         contains(combined, "'tools'"))) {
+        caps.tool_calling = true;
+    }
+}
+
+inline bool skip_value(std::istream& in, uint32_t type);
+
+inline bool read_or_skip_array(std::istream& in, const std::string& key, GgufCapabilities& caps) {
+    uint32_t elem_type = 0;
+    uint64_t count = 0;
+    if (!read_le(in, elem_type) || !read_le(in, count)) return false;
+
+    if (elem_type == 8) {
+        for (uint64_t i = 0; i < count; ++i) {
+            std::string value;
+            if (!read_string(in, value)) return false;
+            inspect_string(key, value, caps);
+        }
+        return true;
+    }
+
+    if (elem_type == 9) return false;
+    uint64_t elem_size = scalar_size(elem_type);
+    if (elem_size == 0) return false;
+    if (count > std::numeric_limits<uint64_t>::max() / elem_size) return false;
+    return skip_bytes(in, count * elem_size);
+}
+
+inline bool skip_value(std::istream& in, uint32_t type) {
+    if (type == 8) {
+        std::string ignored;
+        return read_string(in, ignored);
+    }
+    if (type == 9) {
+        GgufCapabilities ignored_caps;
+        return read_or_skip_array(in, "", ignored_caps);
+    }
+    uint64_t size = scalar_size(type);
+    return size > 0 && skip_bytes(in, size);
+}
+
+}  // namespace gguf_capabilities_detail
+
+inline GgufCapabilities read_gguf_capabilities(std::istream& in) {
+    using namespace gguf_capabilities_detail;
+
+    GgufCapabilities caps;
+    char magic[4] = {};
+    in.read(magic, sizeof(magic));
+    if (!in || std::memcmp(magic, "GGUF", 4) != 0) return caps;
+
+    uint32_t version = 0;
+    uint64_t tensor_count = 0;
+    uint64_t kv_count = 0;
+    if (!read_le(in, version) || !read_le(in, tensor_count) || !read_le(in, kv_count)) return caps;
+    (void)version;
+    (void)tensor_count;
+
+    for (uint64_t i = 0; i < kv_count; ++i) {
+        std::string key;
+        uint32_t type = 0;
+        if (!read_string(in, key) || !read_le(in, type)) break;
+        inspect_string(key, "", caps);
+
+        if (type == 8) {
+            std::string value;
+            if (!read_string(in, value)) break;
+            inspect_string(key, value, caps);
+        } else if (type == 9) {
+            if (!read_or_skip_array(in, key, caps)) break;
+        } else if (!skip_value(in, type)) {
+            break;
+        }
+
+        if (caps.vision && caps.tool_calling) break;
+    }
+
+    return caps;
+}
+
+inline bool add_label_once(std::vector<std::string>& labels, const std::string& label) {
+    if (std::find(labels.begin(), labels.end(), label) != labels.end()) return false;
+    labels.push_back(label);
+    return true;
+}
+
+inline bool apply_gguf_capability_labels(std::vector<std::string>& labels, const GgufCapabilities& caps) {
+    bool changed = false;
+    if (caps.vision) changed = add_label_once(labels, "vision") || changed;
+    if (caps.tool_calling) changed = add_label_once(labels, "tool-calling") || changed;
+    return changed;
+}
+
+}  // namespace lemon

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -1,5 +1,4 @@
 #include "lemon/hf_variants.h"
-#include "lemon/gguf_capabilities.h"
 
 #include <algorithm>
 #include <cctype>
@@ -79,7 +78,9 @@ int quant_priority(const std::string& q) {
 }
 
 void add_label(std::vector<std::string>& labels, const std::string& label) {
-    add_label_once(labels, label);
+    if (std::find(labels.begin(), labels.end(), label) == labels.end()) {
+        labels.push_back(label);
+    }
 }
 
 }  // namespace
@@ -290,9 +291,6 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
 
     // Suggested labels.
     std::vector<std::string> labels;
-    // Keep /pull/variants lightweight: this endpoint is called repeatedly while
-    // users type in the model search UI, so do not fetch or parse GGUF bytes here.
-    // Runtime labels from GGUF metadata are applied after the model is downloaded.
     if (!vset.mmproj_files.empty()) add_label(labels, "vision");
     {
         std::string id_lower = to_lower(checkpoint);

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -7,7 +7,6 @@
 #include <map>
 #include <regex>
 #include <stdexcept>
-#include <sstream>
 #include <unordered_map>
 
 #include "lemon/utils/http_client.h"
@@ -77,28 +76,6 @@ int quant_priority(const std::string& q) {
     };
     auto it = priority.find(q);
     return it == priority.end() ? 100 : it->second;
-}
-
-GgufCapabilities fetch_remote_gguf_capabilities(
-    const std::string& checkpoint,
-    const std::string& filename,
-    const std::map<std::string, std::string>& base_headers) {
-    if (filename.empty()) return {};
-
-    auto headers = base_headers;
-    headers["Accept-Encoding"] = "identity";
-    headers["Range"] = "bytes=0-4194303";
-
-    try {
-        std::string url = "https://huggingface.co/" + checkpoint + "/resolve/main/" + filename;
-        auto response = HttpClient::get(url, headers);
-        if (response.status_code != 206 && response.status_code != 200) return {};
-
-        std::istringstream in(response.body, std::ios::binary);
-        return read_gguf_capabilities(in);
-    } catch (...) {
-        return {};
-    }
 }
 
 void add_label(std::vector<std::string>& labels, const std::string& label) {
@@ -313,12 +290,10 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
 
     // Suggested labels.
     std::vector<std::string> labels;
+    // Keep /pull/variants lightweight: this endpoint is called repeatedly while
+    // users type in the model search UI, so do not fetch or parse GGUF bytes here.
+    // Runtime labels from GGUF metadata are applied after the model is downloaded.
     if (!vset.mmproj_files.empty()) add_label(labels, "vision");
-    if (!vset.variants.empty()) {
-        apply_gguf_capability_labels(
-            labels,
-            fetch_remote_gguf_capabilities(checkpoint, vset.variants.front().primary_file, headers));
-    }
     {
         std::string id_lower = to_lower(checkpoint);
         if (id_lower.find("embed") != std::string::npos) add_label(labels, "embeddings");

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -1,4 +1,5 @@
 #include "lemon/hf_variants.h"
+#include "lemon/gguf_capabilities.h"
 
 #include <algorithm>
 #include <cctype>
@@ -6,6 +7,7 @@
 #include <map>
 #include <regex>
 #include <stdexcept>
+#include <sstream>
 #include <unordered_map>
 
 #include "lemon/utils/http_client.h"
@@ -75,6 +77,32 @@ int quant_priority(const std::string& q) {
     };
     auto it = priority.find(q);
     return it == priority.end() ? 100 : it->second;
+}
+
+GgufCapabilities fetch_remote_gguf_capabilities(
+    const std::string& checkpoint,
+    const std::string& filename,
+    const std::map<std::string, std::string>& base_headers) {
+    if (filename.empty()) return {};
+
+    auto headers = base_headers;
+    headers["Accept-Encoding"] = "identity";
+    headers["Range"] = "bytes=0-4194303";
+
+    try {
+        std::string url = "https://huggingface.co/" + checkpoint + "/resolve/main/" + filename;
+        auto response = HttpClient::get(url, headers);
+        if (response.status_code != 206 && response.status_code != 200) return {};
+
+        std::istringstream in(response.body, std::ios::binary);
+        return read_gguf_capabilities(in);
+    } catch (...) {
+        return {};
+    }
+}
+
+void add_label(std::vector<std::string>& labels, const std::string& label) {
+    add_label_once(labels, label);
 }
 
 }  // namespace
@@ -285,11 +313,16 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
 
     // Suggested labels.
     std::vector<std::string> labels;
-    if (!vset.mmproj_files.empty()) labels.push_back("vision");
+    if (!vset.mmproj_files.empty()) add_label(labels, "vision");
+    if (!vset.variants.empty()) {
+        apply_gguf_capability_labels(
+            labels,
+            fetch_remote_gguf_capabilities(checkpoint, vset.variants.front().primary_file, headers));
+    }
     {
         std::string id_lower = to_lower(checkpoint);
-        if (id_lower.find("embed") != std::string::npos) labels.push_back("embeddings");
-        if (id_lower.find("rerank") != std::string::npos) labels.push_back("reranking");
+        if (id_lower.find("embed") != std::string::npos) add_label(labels, "embeddings");
+        if (id_lower.find("rerank") != std::string::npos) add_label(labels, "reranking");
     }
 
     nlohmann::json out;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -344,9 +344,15 @@ static void populate_static_max_context_window(ModelInfo& info) {
         if (!gguf_path.empty() && ends_with_ignore_case(gguf_path, ".gguf") && safe_exists(path_from_utf8(gguf_path))) {
             info.max_context_window = read_gguf_context_length(gguf_path);
 
-            std::ifstream in(path_from_utf8(gguf_path), std::ios::binary);
-            if (in && apply_gguf_capability_labels(info.labels, read_gguf_capabilities(in))) {
-                info.type = get_model_type_from_labels(info.labels);
+            // GGUF vision/tool metadata are LLM capabilities. Do not apply
+            // them to embedding/reranking models, otherwise labels such as
+            // tool-calling would reclassify the model away from its endpoint
+            // type and break /embeddings or /rerank.
+            if (info.type == ModelType::LLM) {
+                std::ifstream in(path_from_utf8(gguf_path), std::ios::binary);
+                if (in) {
+                    apply_gguf_capability_labels(info.labels, read_gguf_capabilities(in));
+                }
             }
         }
     } else if (info.recipe == "flm") {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1,6 +1,7 @@
 #include <lemon/model_manager.h>
 #include <lemon/runtime_config.h>
 #include <lemon/hf_variants.h>
+#include <lemon/gguf_capabilities.h>
 #include <lemon/utils/json_utils.h>
 #include <lemon/utils/http_client.h>
 #include <lemon/utils/process_manager.h>
@@ -342,6 +343,11 @@ static void populate_static_max_context_window(ModelInfo& info) {
         std::string gguf_path = info.resolved_path();
         if (!gguf_path.empty() && ends_with_ignore_case(gguf_path, ".gguf") && safe_exists(path_from_utf8(gguf_path))) {
             info.max_context_window = read_gguf_context_length(gguf_path);
+
+            std::ifstream in(path_from_utf8(gguf_path), std::ios::binary);
+            if (in && apply_gguf_capability_labels(info.labels, read_gguf_capabilities(in))) {
+                info.type = get_model_type_from_labels(info.labels);
+            }
         }
     } else if (info.recipe == "flm") {
         info.max_context_window = read_flm_max_context_window(info);


### PR DESCRIPTION
## Summary

- Detect GGUF model capabilities from metadata and automatically add `vision` / `tool-calling` labels
- Apply inferred labels to custom `user.` models and local/internal `extra.` models
- Pre-fill the Vision checkbox when adding compatible Hugging Face GGUF models while keeping user override possible

## Testing

- Tested with Hugging Face GGUF models via the add-model flow
- Verified inferred labels are added automatically after install
- Verified Vision checkbox is pre-filled for detected vision models and can still be changed manually

Closes #1979