### PR TITLE
fix: emit collection components under public model names

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -582,13 +582,18 @@ void Server::setup_static_files(httplib::Server &web_server) {
         // Convert map to JSON
         json filtered_models = json::object();
         for (const auto& [model_name, info] : models_map) {
+            std::vector<std::string> public_components;
+            public_components.reserve(info.components.size());
+            for (const auto& component : info.components) {
+                public_components.push_back(model_manager_->get_public_model_name(component));
+            }
             filtered_models[model_name] = {
                 {"model_name", model_name},
                 {"checkpoint", info.checkpoint()},
                 {"recipe", info.recipe},
                 {"labels", info.labels},
                 {"suggested", info.suggested},
-                {"components", info.components},
+                {"components", public_components},
                 {"mmproj", info.mmproj()}
             };
 
@@ -1412,6 +1417,11 @@ void Server::handle_models(const httplib::Request& req, httplib::Response& res) 
 }
 
 nlohmann::json Server::model_info_to_json(const std::string& model_id, const ModelInfo& info) {
+    std::vector<std::string> public_components;
+    public_components.reserve(info.components.size());
+    for (const auto& component : info.components) {
+        public_components.push_back(model_manager_->get_public_model_name(component));
+    }
     nlohmann::json model_json = {
         {"id", model_id},
         {"object", "model"},
@@ -1423,7 +1433,7 @@ nlohmann::json Server::model_info_to_json(const std::string& model_id, const Mod
         {"downloaded", info.downloaded},
         {"suggested", info.suggested},
         {"labels", info.labels},
-        {"components", info.components},
+        {"components", public_components},
         {"recipe_options", info.recipe_options.to_json()},
     };
 

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1524,6 +1524,8 @@ class EndpointTests(ServerTestBase):
         overwrite the stored entry, not silently reuse the old components."""
         suffix = uuid.uuid4().hex[:8]
         extra_component = f"user.RepullExtra-{suffix}"
+        # Unique user.<name> entries surface under the bare public alias on the wire.
+        extra_component_alias = extra_component[5:]
         collection_name = f"user.RepullColl-{suffix}"
         try:
             extra_pull = requests.post(
@@ -1576,7 +1578,7 @@ class EndpointTests(ServerTestBase):
             self.assertIsNotNone(entry)
             self.assertEqual(
                 sorted(entry.get("components", [])),
-                sorted([ENDPOINT_TEST_MODEL, extra_component]),
+                sorted([ENDPOINT_TEST_MODEL, extra_component_alias]),
                 "Re-pull must persist the new components list",
             )
             print("[OK] Collection re-pull overwrote components")

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1403,9 +1403,11 @@ class EndpointTests(ServerTestBase):
         print("[OK] Self-reference rejected with 400")
 
     def test_021p_collection_components_canonicalized(self):
-        """Component names passed as public aliases must be stored in canonical
-        form so downstream cache-key lookups
-        (check_component_downloaded / update_model_in_cache) match."""
+        """Client may register a collection using a component's public alias.
+        Storage must canonicalize so downstream cache-key lookups
+        (check_component_downloaded / update_model_in_cache) match; the wire
+        format then re-emits components under their public names for
+        consistency with the `id` field."""
         suffix = uuid.uuid4().hex[:8]
         component_canonical = f"user.AliasComp-{suffix}"
         # Unique user.<name> entries surface under the bare public alias.
@@ -1452,14 +1454,17 @@ class EndpointTests(ServerTestBase):
             self.assertIsNotNone(entry)
             self.assertEqual(
                 entry.get("components"),
-                [component_canonical],
-                "Aliased component must be stored canonically",
+                [component_alias],
+                "Wire-format components must use public names (same namespace as `id`)",
             )
+            # `downloaded` can only be True if the internal cache-key lookup
+            # found the component under its canonical name — this is the real
+            # proof that storage canonicalized the aliased input.
             self.assertTrue(
                 entry.get("downloaded"),
-                "Cache-key lookups must find the canonical component",
+                "Cache-key lookups must find the canonically-stored component",
             )
-            print("[OK] Aliased component canonicalized at registration")
+            print("[OK] Aliased component canonicalized in storage, public on wire")
         finally:
             for name in (collection_name, component_canonical):
                 try:


### PR DESCRIPTION
## Summary
- Custom omni collections that include a user-registered component (e.g. a `user.X` model) were misrendered in the desktop/web app: the collection showed as "not downloaded", the download button did nothing, and the Planner LLM dropdown was empty.
- Root cause was a wire-format inconsistency in `/api/v1/models`. The `id` field uses the public (bare) model name, but the `components` array was emitted verbatim from internal storage, where user components are stored canonically with the `user.` prefix. Renderer-side exact-name lookups against the public model map (`isCollectionFullyDownloaded`, `inferComponentsFromList`, etc.) missed those entries.
- Fix: translate each entry in `info.components` through `ModelManager::get_public_model_name` at the two JSON emission sites in `server.cpp` so `components` lives in the same namespace as `id` and every other model-name field on the wire.

Internal storage, cache lookups, and the download/load fan-out paths are unchanged — they continue to operate on canonical `user.X` names. The input path (`POST /api/v1/pull` of a collection) already canonicalizes incoming names via `resolve_model_name`, so the round-trip stays symmetric whether a client posts back bare or canonical component names.

## Test plan
- [x] Restart `lemond` and confirm `/api/v1/models?show_all=true` for a custom collection that references a user-registered component emits the component under its bare public name in the `components` array (matching the component's own `id`).
- [x] In the desktop app, open the affected custom omni collection — confirm it now shows as downloaded, the Planner LLM dropdown is pre-populated with the user component, and the Edit/Download flows behave normally.
- [x] Verify collections built entirely from built-in components (e.g. `LMX-Omni-5.5B-Lite`, `MyOmniModel`) are unchanged.
- [x] Re-save an edited custom collection and confirm round-trip storage still produces a canonical `user.X` entry in `user_models.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)