### PR TITLE
fix(vLLM): make startup timeout adjustable, increased global_timeout

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -24,7 +24,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
   "port": 13305,
   "host": "localhost",
   "log_level": "info",
-  "global_timeout": 300,
+  "global_timeout": 600,
   "max_loaded_models": 1,
   "no_broadcast": false,
   "extra_models_dir": "",
@@ -88,7 +88,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
 | `port` | int | 13305 | Port number for the HTTP server |
 | `host` | string | "localhost" | Address to bind for connections |
 | `log_level` | string | "info" | Logging level (trace, debug, info, warning, error, fatal, none) |
-| `global_timeout` | int | 300 | Timeout in seconds for HTTP, inference, and readiness checks |
+| `global_timeout` | int | 600 | Timeout in seconds for HTTP, inference, and readiness checks |
 | `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
 | `no_broadcast` | bool | false | Disable UDP broadcasting for server discovery |
 | `extra_models_dir` | string | "" | Secondary directory to scan for GGUF model files |

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -4,7 +4,7 @@
   "host": "localhost",
   "websocket_port": "auto",
   "log_level": "info",
-  "global_timeout": 300,
+  "global_timeout": 600,
   "max_loaded_models": 1,
   "no_broadcast": false,
   "extra_models_dir": "",

--- a/src/cpp/server/backends/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm_server.cpp
@@ -209,7 +209,7 @@ void VLLMServer::load(const std::string& model_name,
     process_handle_ = ProcessManager::start_process(executable, args, "", inherit_output, true, env_vars);
 
     // vLLM can take longer to start (loading model, compiling kernels)
-    if (!wait_for_ready("/health", 600)) {
+    if (!wait_for_ready("/health", HttpClient::get_default_timeout())) {
         ProcessManager::stop_process(process_handle_);
         process_handle_ = {nullptr, 0};
         std::string err = "vllm-server failed to start within timeout";

--- a/test/server_env_vars.py
+++ b/test/server_env_vars.py
@@ -422,7 +422,7 @@ class TestDefaults(unittest.TestCase):
         self.assertEqual(self.snapshot["log_level"], "info")
 
     def test_default_global_timeout(self):
-        self.assertEqual(self.snapshot["global_timeout"], 300)
+        self.assertEqual(self.snapshot["global_timeout"], 600)
 
     def test_default_max_loaded_models(self):
         self.assertEqual(self.snapshot["max_loaded_models"], 1)


### PR DESCRIPTION
## Summary

- Use the configurable global timeout for vLLM server readiness checks instead of a hardcoded startup timeout of 600 s
- Set the default `global_timeout` to 600 s.

vLLM model loading can take longer than the hard-coded 600-second default, depending on model size and hardware.
To avoid a timeout removal global_timeout is used to introduce the option for adaption.
A user would expect eliminating a timeout error with increasing global_timeout - this patch ensures that behavior.

A 600-second timeout has been used for vLLM and the default global_timeout is increased to that level - a level that was in use also before and is considered acceptable based on prior discussion, while still keeping a bounded startup timeout.

## Testing

- Verified that vLLM startup/readiness now uses the configured global_timeout.
- Verified `global_timeout=600` can be set and used for longer vLLM load times.