### PR TITLE
speech: Avoid duplicate Content-Type headers

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2261,8 +2261,6 @@ void Server::handle_audio_speech(const httplib::Request& req, httplib::Response&
         // Log the HTTP request
         LOG(INFO, "Server") << "POST /api/v1/audio/speech" << std::endl;
 
-        res.set_header("Content-Type", mime_type);
-
         auto audio_source = [this, request_json](size_t offset, httplib::DataSink& sink) {
             // For chunked responses, offset tracks bytes sent so far
             // We only want to stream once when offset is 0


### PR DESCRIPTION
## Issue

Lemonade's `api/speech` endpoint sends duplicate `Content-Type` headers and things like python's `aiohttp` raise exceptions and fail on things like Open WebUI.

Before patch Open WebUI fails with an exception:

    aiohttp.client_exceptions.ClientResponseError: 400, message="Duplicate 'Content-Type' header found.", url='http://127.0.0.1:13305/v1/audio/speech'

Manually test:

    > xh -h POST http://127.0.0.1:13305/api/v1/audio/speech model=kokoro-v1 input=test
    HTTP/1.1 200 OK
    Access-Control-Allow-Headers: Content-Type, Authorization
    Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
    Access-Control-Allow-Origin: *
    Content-Type: audio/mpeg
    Content-Type: audio/mpeg
    Keep-Alive: timeout=5, max=100

This seems related to: https://github.com/lemonade-sdk/lemonade/pull/1573

## Fix

Drop the duplicate header.

With patch:

    > xh -h POST http://127.0.0.1:13305/api/v1/audio/speech model=kokoro-v1 input=fixed
    HTTP/1.1 200 OK
    Access-Control-Allow-Headers: Content-Type, Authorization
    Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
    Access-Control-Allow-Origin: *
    Content-Type: audio/mpeg
    Keep-Alive: timeout=5, max=100