### PR TITLE
Update URL for CUDA backend for llama.cpp (llamacpp:cuda)

### DIFF
--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -34,7 +34,7 @@ Lemonade uses [llama.cpp](https://github.com/ggerganov/llama.cpp) as its primary
 - **Hardware**: NVIDIA GPUs with Compute Capability 7.5+ (Turing, Ampere, Ada, Hopper, Blackwell)
 - **Use Case**: NVIDIA GPU-optimized inference
 - **Performance**: Optimized for NVIDIA hardware, typically outperforms Vulkan on supported GPUs
-- **Source**: Per-architecture builds from [Phqen1x/llama.cpp-builds](https://github.com/Phqen1x/llama.cpp-builds)
+- **Source**: Per-architecture builds from [lemonade-sdk/llama.cpp](https://github.com/lemonade-sdk/llama.cpp)
 - **Binaries**: Compute-capability-specific builds (sm_75, sm_80, sm_86, sm_89, sm_90, sm_100, sm_120)
 - **Runtime**: Bundled CUDA runtime libraries (no system-wide CUDA toolkit installation required)
 - **Notes**: On Windows, .7z extraction requires the bsdtar bundled with Windows 11 22H2+. On Linux, the build is shipped as .tar.xz and extracts with the system `tar`.

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -4,7 +4,7 @@
     "vulkan": "b9253",
     "rocm-stable": "b9247",
     "rocm-nightly": "b1274",
-    "cuda": "b1016",
+    "cuda": "b9436",
     "metal": "b9253",
     "cpu": "b9253"
   },

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -104,7 +104,7 @@ namespace lemon::backends {
         fs::create_directories(dest_dir);
         LOG(DEBUG, backend_name) << "Extracting tarball to " << dest_dir << std::endl;
         // Use the auto-detect form `-xf` (instead of `-xzf`) so we transparently
-        // handle .tar.gz, .tar.xz, .tar.bz2, etc. — the Phqen1x/llamacpp-cuda
+        // handle .tar.gz, .tar.xz, .tar.bz2, etc. — the lemonade-sdk/llama.cpp
         // Linux release ships .tar.xz.
 #ifdef _WIN32
         if (!is_native_tar_available()) {
@@ -165,7 +165,7 @@ namespace lemon::backends {
             }
         }
         // Note: do NOT use --strip-components=1 here. The CUDA .7z archives from
-        // Phqen1x/llama.cpp-builds have no top-level directory — files sit at the
+        // lemonade-sdk/llama.cpp have no top-level directory — files sit at the
         // archive root. Stripping would discard every entry and produce an empty dir.
         command = get_native_tar_path() + " -xf \"" + archive_path + "\" -C \"" + dest_dir + "\"";
 #else

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -188,14 +188,14 @@ InstallParams LlamaCppServer::get_install_params(const std::string& backend, con
         throw std::runtime_error("ROCm stable llamacpp is currently supported on Windows and Linux only");
 #endif
     } else if (resolved_backend == "cuda") {
-        params.repo = "Phqen1x/llama.cpp-builds";
+        params.repo = "lemonade-sdk/llama.cpp";
         std::string target_arch = SystemInfo::get_cuda_arch();
         if (target_arch.empty()) {
             throw std::runtime_error(
                 SystemInfo::get_unsupported_backend_error("llamacpp", "cuda")
             );
         }
-        // Phqen1x/llama.cpp-builds releases publish per-Compute-Capability binaries
+        // lemonade-sdk/llama.cpp releases publish per-Compute-Capability binaries
         // and embed the build tag in the asset filename, e.g.
         // llama-b1011-ubuntu-cuda-sm_120-x64.tar.xz.
 #ifdef _WIN32

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -72,7 +72,7 @@ const std::vector<std::string> NVIDIA_DISCRETE_GPU_KEYWORDS = {
     "a100", "a40", "a30", "a10", "a6000", "a5000", "a4000", "a2000"
 };
 
-// CUDA Compute Capability targets that the Phqen1x/llama.cpp-builds release pipeline
+// CUDA Compute Capability targets that the lemonade-sdk/llama.cpp release pipeline
 // publishes binaries for. Each entry is a literal `sm_XX` token that appears in the
 // release asset filename (e.g. llama-ubuntu-cuda-sm_86-x64.tar.xz).
 // Empty string means "no CUDA binary for this compute capability" — skip for


### PR DESCRIPTION
## Summary

Updates the URL for downloading the CUDA backend, depends on https://github.com/lemonade-sdk/llama.cpp/pull/5