### PR TITLE
Drop support for `flm_args`

### DIFF
--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -657,7 +657,6 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 | `cfg_scale` | number |
 | `width` | int (positive) |
 | `height` | int (positive) |
-| `flm_args` | string |
 
 **Example:**
 ```bash

--- a/docs/embeddable/runtime.md
+++ b/docs/embeddable/runtime.md
@@ -167,7 +167,6 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
 | `cfg_scale` | number |
 | `width` | int (positive) |
 | `height` | int (positive) |
-| `flm_args` | string |
 
 **Example:**
 === "Windows (cmd.exe)"

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -327,7 +327,6 @@ The following options are available depending on the recipe being used:
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--ctx-size SIZE` | Context size for the model | `4096` |
-| `--flm-args ARGS` | Custom arguments to pass to flm serve (e.g., `"--socket 20 --q-len 15"`) | `""` |
 
 #### RyzenAI LLM (`ryzenai-llm` recipe)
 
@@ -659,7 +658,6 @@ lemonade bench [options] MODEL_NAME [MODEL_NAME ...]
 | `--no-memory` | Disable VRAM/RAM tracking | Tracking enabled |
 | `--no-reload` | Skip model reload between scenarios (faster, but prompt cache may skew results) | Model reloaded |
 | `--llamacpp-args ARGS` | Custom args for llama-server (e.g. `"-b 2048 -ub 1024"`). Repeat for multiple arg sets. | — |
-| `--flm-args ARGS` | Custom args for flm serve. Repeat for multiple. | — |
 | `--vllm-args ARGS` | Custom args for vllm-server. Repeat for multiple. | — |
 
 **Preflight behavior:**

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -435,7 +435,7 @@ When loading a model, settings are resolved in this order (highest to lowest pri
 2. Per-model values from `recipe_options.json`
 3. Global configuration values, see [Server Configuration](./README.md)
 
-**`*_args` merge behavior:** For options ending in `_args` (e.g., `llamacpp_args`, `whispercpp_args`, `sdcpp_args`, `flm_args`, `vllm_args`), the CLI/API arguments are **merged** rather than replaced. The merge works at the flag level with higher priority settings taking priority.
+**`*_args` merge behavior:** For options ending in `_args` (e.g., `llamacpp_args`, `whispercpp_args`, `sdcpp_args`, `vllm_args`), the CLI/API arguments are **merged** rather than replaced. The merge works at the flag level with higher priority settings taking priority.
 
 For full details, see the [load endpoint documentation](../../api/lemonade.md#post-v1load).
 

--- a/src/cpp/cli/bench.cpp
+++ b/src/cpp/cli/bench.cpp
@@ -390,7 +390,6 @@ std::vector<BackendDiscovery> discover_backends(lemonade::LemonadeClient& client
 // Map recipe name to the recipe_options key for custom args
 static const std::map<std::string, std::string> RECIPE_ARGS_KEY = {
     {"llamacpp", "llamacpp_args"},
-    {"flm", "flm_args"},
     {"vllm", "vllm_args"},
     {"sd-cpp", "sdcpp_args"},
     {"whispercpp", "whispercpp_args"},
@@ -1501,9 +1500,6 @@ CLI::App* register_bench_command(CLI::App& parent,
     cmd->add_option("--llamacpp-args", opts.llamacpp_args, "Custom args for llama-server (e.g. \"-b 2048 -ub 1024\"). Repeat for multiple.")
         ->type_name("ARGS")
         ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
-    cmd->add_option("--flm-args", opts.flm_args, "Custom args for flm serve. Repeat for multiple.")
-        ->type_name("ARGS")
-        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     cmd->add_option("--vllm-args", opts.vllm_args, "Custom args for vllm-server. Repeat for multiple.")
         ->type_name("ARGS")
         ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
@@ -1535,7 +1531,6 @@ BenchConfig build_bench_config(const std::string& output_file,
     config.scenario_names = cli.scenario_names;
     // Populate backend-specific args map (only non-empty values)
     if (!cli.llamacpp_args.empty()) config.backend_args["llamacpp"] = cli.llamacpp_args;
-    if (!cli.flm_args.empty()) config.backend_args["flm"] = cli.flm_args;
     if (!cli.vllm_args.empty()) config.backend_args["vllm"] = cli.vllm_args;
     if (!cli.sdcpp_args.empty()) config.backend_args["sd-cpp"] = cli.sdcpp_args;
     if (!cli.whispercpp_args.empty()) config.backend_args["whispercpp"] = cli.whispercpp_args;

--- a/src/cpp/include/lemon_cli/bench.h
+++ b/src/cpp/include/lemon_cli/bench.h
@@ -168,7 +168,6 @@ struct BenchCliOptions {
     std::string compare_file;
     // Backend-specific custom args (repeatable for multiple comparisons)
     std::vector<std::string> llamacpp_args;
-    std::vector<std::string> flm_args;
     std::vector<std::string> vllm_args;
     std::vector<std::string> sdcpp_args;
     std::vector<std::string> whispercpp_args;
@@ -193,7 +192,7 @@ struct BenchConfig {
     bool memory_tracking = true;
     bool reload = true;  // unload+reload model between runs to clear prompt cache
     std::string compare_file;
-    // Backend-specific custom args (keyed by recipe name: "llamacpp", "flm", "vllm", "sd-cpp", "whispercpp")
+    // Backend-specific custom args (keyed by recipe name: "llamacpp", "vllm", "sd-cpp", "whispercpp")
     // Each recipe can have multiple arg sets; all combinations are benchmarked.
     std::map<std::string, std::vector<std::string>> backend_args;
 };

--- a/src/cpp/server/backends/fastflowlm_server.cpp
+++ b/src/cpp/server/backends/fastflowlm_server.cpp
@@ -11,7 +11,6 @@
 #include <cstdlib>
 #include <thread>
 #include <chrono>
-#include <sstream>
 #include <fstream>
 #include <algorithm>
 #include <lemon/utils/aixlog.hpp>
@@ -154,13 +153,8 @@ void FastFlowLMServer::load(const std::string& model_name,
 
     // Get FLM-specific options from RecipeOptions
     int ctx_size = options.get_option("ctx_size");
-    std::string flm_args = options.get_option("flm_args");
 
-    std::cout << "[FastFlowLM] Options: ctx_size=" << ctx_size;
-    if (!flm_args.empty()) {
-        std::cout << ", flm_args=\"" << flm_args << "\"";
-    }
-    std::cout << std::endl;
+    std::cout << "[FastFlowLM] Options: ctx_size=" << ctx_size << std::endl;
     // Note: checkpoint_ is set by Router via set_model_metadata() before load() is called
     // We use checkpoint_ (base class field) for FLM API calls
 
@@ -214,15 +208,6 @@ void FastFlowLMServer::load(const std::string& model_name,
             "--host", "127.0.0.1",
             "--quiet"
         };
-    }
-
-    // Parse and append custom flm_args if provided
-    if (!flm_args.empty()) {
-        std::istringstream iss(flm_args);
-        std::string token;
-        while (iss >> token) {
-            args.push_back(token);
-        }
     }
 
     LOG(INFO, "FastFlowLM") << "Starting flm-server..." << std::endl;

--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -145,4 +145,5 @@ void ConfigFile::save(const std::string& cache_dir, const json& config) {
     }
 }
 
+
 } // namespace lemon

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -32,8 +32,6 @@ static const json DEFAULTS = {
     {"height", 512},
     {"sampling_method", ""},
     {"flow_shift", 0.0},
-    // FLM-specific options
-    {"flm_args", ""},       // Custom arguments to pass to flm serve
     // vLLM-specific options
     {"vllm_backend", ""},  // "" means auto-detect
     {"vllm_args", ""},     // Custom arguments to pass to vllm-server
@@ -58,7 +56,6 @@ static const std::map<std::string, std::string> OPTION_TO_CLI_FLAG = {
     {"whispercpp_backend", "--whispercpp"},
     {"whispercpp_args", "--whispercpp-args"},
     {"moonshine_args", "--moonshine-args"},
-    {"flm_args", "--flm-args"},
     {"vllm_backend", "--vllm"},
     {"vllm_args", "--vllm-args"}
 };
@@ -71,7 +68,7 @@ static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
     } else if (recipe == "moonshine") {
         return {"moonshine_args", "merge_args"};
     } else if (recipe == "flm") {
-        return {"ctx_size", "flm_args", "merge_args"};
+        return {"ctx_size", "merge_args"};
     } else if (recipe == "ryzenai-llm") {
         return {"ctx_size"};
     } else if (recipe == "sd-cpp") {
@@ -244,7 +241,6 @@ static const json CLI_OPTIONS = {
     {"--vllm-args", {{"option_name", "vllm_args"}, {"type_name", "ARGS"}, {"help", "Custom arguments to pass to vllm-server"}, {"group", "vLLM Options"}}},
     // Note: Image gen params (--steps, --cfg-scale, --width, --height) removed — recipe-level only.
     // Runtime options (--diffusion-fa, --offload-to-cpu) go through --sdcpp-args.
-    {"--flm-args", {{"option_name", "flm_args"}, {"type_name", "ARGS"}, {"help", "Custom arguments to pass to flm serve"}, {"group", "FastFlowLM Options"}}}
 };
 
 void RecipeOptions::add_cli_options(CLI::App& app, json& storage) {

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -333,11 +333,6 @@ json RuntimeConfig::recipe_options(const std::string& backend) const {
         if (sd.contains("height")) result["height"] = sd["height"];
     }
 
-    if (config_.contains("flm")) {
-        const auto& flm = config_["flm"];
-        if (flm.contains("args")) result["flm_args"] = flm["args"];
-    }
-
     if (config_.contains("vllm")) {
         const auto& vl = config_["vllm"];
         if (vl.contains("backend")) result["vllm_backend"] = resolve_auto(vl["backend"]);

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -2036,7 +2036,6 @@ class CLIHelpDocsConsistencyTests(unittest.TestCase):
         """Run/load help should keep every recipe flag under the intended group."""
         expected_groups = {
             "General Options:": ["--ctx-size", "--merge-args"],
-            "FastFlowLM Options:": ["--flm-args"],
             "Llama.cpp Backend Options:": [
                 "--llamacpp",
                 "--llamacpp-device",
@@ -2110,7 +2109,6 @@ class CLIHelpDocsConsistencyTests(unittest.TestCase):
         self.assertNotIn("--ctx-size", claude_help)
         self.assertNotIn("LEMONADE_CTX_SIZE", claude_help)
         self.assertNotIn("--llamacpp", claude_help)
-        self.assertNotIn("--flm-args", claude_help)
 
         opencode_result = run_cli_command(
             ["launch", "opencode", "--help"], timeout=TIMEOUT_DEFAULT


### PR DESCRIPTION
Arguments are passed without validation into `flm` which can cause unintended arguments to override behavior in `flm`.

There are two options to solve this:
1. Drop all flm argument support
2. Whitelist individual arguments that should be passed down.

This aims for the former.