### PR TITLE
fix: harden markdown link handling against prompt injection

### DIFF
--- a/src/app/src/renderer/MarkdownMessage.tsx
+++ b/src/app/src/renderer/MarkdownMessage.tsx
@@ -127,6 +127,15 @@ const MarkdownMessage: React.FC<MarkdownMessageProps> = ({ content, isComplete =
     const container = containerRef.current;
     if (!container) return;
 
+    const isSafeUrl = (url: string): boolean => {
+      try {
+        const parsed = new URL(url, 'https://example.com/');
+        return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+      } catch {
+        return false;
+      }
+    };
+
     // Add click handlers for links to open in external browser
     const handleLinkClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement;
@@ -139,7 +148,7 @@ const MarkdownMessage: React.FC<MarkdownMessageProps> = ({ content, isComplete =
             window.dispatchEvent(new CustomEvent('open-external-content', { detail: { url: href } }));
             return;
           }
-          if (window.api) {
+          if (window.api && isSafeUrl(href)) {
             window.api.openExternal(href);
           }
         }


### PR DESCRIPTION
Validate URL schemes in MarkdownMessage renderer before dispatching to openExternal IPC. Only http:// and https:// links are now passed to the main process; file://, smb://, javascript:, and other schemes are blocked.

This prevents prompt-injection payloads in LLM responses from triggering native code execution via attacker-controlled link schemes.

- Add isSafeUrl() validator in link click handler
- Allow only http/https protocols for external links