### PR TITLE
security: replace deny-list with allow-list for backend arguments

### DIFF
--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -389,17 +389,44 @@ void LlamaCppServer::load(const std::string& model_name,
     LOG(DEBUG, "LlamaCpp") << "ngl set to " << gpu_layers << std::endl;
     push_arg(args, reserved_flags, "-ngl", gpu_layers, std::vector<std::string>{"--gpu-layers", "--n-gpu-layers"});
 
-    // Validate and append custom arguments
+    // Validate and append custom arguments using allow-list only
     if (!llamacpp_args.empty()) {
-        std::string validation_error = validate_custom_args(llamacpp_args, reserved_flags);
-        if (!validation_error.empty()) {
-            throw std::invalid_argument(
-                "Invalid custom llama-server arguments:\n" + validation_error
-            );
-        }
+        static const std::set<std::string> kAllowedFlags = {
+            "--threads", "-t",
+            "--ctx-size", "-c",
+            "--batch-size", "-b",
+            "--ubatch-size", "-ub",
+            "--n-gpu-layers", "-ngl",
+            "--flash-attn",
+            "--temp",
+            "--top-k",
+            "--top-p",
+            "--min-p",
+            "--repeat-penalty",
+            "--frequency-penalty",
+            "--presence-penalty",
+            "--mirostat",
+            "--mirostat-tau",
+            "--mirostat-eta",
+            "--seed",
+            "--penalize-nl"
+        };
 
         LOG(DEBUG, "LlamaCpp") << "Adding custom arguments: " << llamacpp_args << std::endl;
         std::vector<std::string> custom_args_vec = parse_custom_args(llamacpp_args);
+
+        for (const auto& token : custom_args_vec) {
+            std::string flag = token;
+            size_t eq_pos = token.find('=');
+            if (eq_pos != std::string::npos) {
+                flag = token.substr(0, eq_pos);
+            }
+
+            if (!flag.empty() && flag[0] == '-' && kAllowedFlags.find(flag) == kAllowedFlags.end()) {
+                throw std::invalid_argument("llamacpp.args: flag not in allow-list: " + flag);
+            }
+        }
+
         args.insert(args.end(), custom_args_vec.begin(), custom_args_vec.end());
     }
 

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -222,15 +222,28 @@ void SDServer::load(const std::string& model_name,
     };
 
     if (!sdcpp_args.empty()) {
-        std::string validation_error = validate_custom_args(sdcpp_args, reserved_flags);
-        if (!validation_error.empty()) {
-            throw std::invalid_argument(
-                "Invalid custom sd-server arguments:\n" + validation_error
-            );
-        }
+        static const std::set<std::string> kAllowedFlags = {
+            "--threads", "-t",
+            "--mode",
+            "--schedule",
+            "--sampling-method"
+        };
 
         LOG(DEBUG, "SDServer") << "Adding custom arguments: " << sdcpp_args << std::endl;
         std::vector<std::string> custom_args_vec = parse_custom_args(sdcpp_args);
+
+        for (const auto& token : custom_args_vec) {
+            std::string flag = token;
+            size_t eq_pos = token.find('=');
+            if (eq_pos != std::string::npos) {
+                flag = token.substr(0, eq_pos);
+            }
+
+            if (!flag.empty() && flag[0] == '-' && kAllowedFlags.find(flag) == kAllowedFlags.end()) {
+                throw std::invalid_argument("sdcpp.args: flag not in allow-list: " + flag);
+            }
+        }
+
         args.insert(args.end(), custom_args_vec.begin(), custom_args_vec.end());
     }
 

--- a/src/cpp/server/backends/whisper_server.cpp
+++ b/src/cpp/server/backends/whisper_server.cpp
@@ -252,15 +252,27 @@ void WhisperServer::load(const std::string& model_name,
     };
 
     if (!whispercpp_args.empty()) {
-        std::string validation_error = validate_custom_args(whispercpp_args, reserved_flags);
-        if (!validation_error.empty()) {
-            throw std::invalid_argument(
-                "Invalid custom whisper-server arguments:\n" + validation_error
-            );
-        }
+        static const std::set<std::string> kAllowedFlags = {
+            "--threads", "-t",
+            "--processor",
+            "--gpu-device"
+        };
 
         LOG(DEBUG, "WhisperServer") << "Adding custom arguments: " << whispercpp_args << std::endl;
         std::vector<std::string> custom_args_vec = parse_custom_args(whispercpp_args);
+
+        for (const auto& token : custom_args_vec) {
+            std::string flag = token;
+            size_t eq_pos = token.find('=');
+            if (eq_pos != std::string::npos) {
+                flag = token.substr(0, eq_pos);
+            }
+
+            if (!flag.empty() && flag[0] == '-' && kAllowedFlags.find(flag) == kAllowedFlags.end()) {
+                throw std::invalid_argument("whispercpp.args: flag not in allow-list: " + flag);
+            }
+        }
+
         args.insert(args.end(), custom_args_vec.begin(), custom_args_vec.end());
     }
 


### PR DESCRIPTION
HTTP-reachable config keys (llamacpp.args, whispercpp.args, sdcpp.args) were validated using only a deny-list of reserved flags. This allowed attackers to inject dangerous flags like --path (serve arbitrary directory), --log-file (write to arbitrary path), -lua-init, -grammar-file, etc. leading to arbitrary file read/write and RCE as the lemonade process UID (root on macOS daemon).

Replace deny-list validation with strict allow-list of safe tuning flags:
- llamacpp.args: allows only --threads, --ctx-size, --batch-size, --n-gpu-layers, tuning parameters (temp, top-k, top-p, etc.), and sampling options
- whispercpp.args: allows only --threads and device selection
- sdcpp.args: allows only --threads and inference tuning