### PR TITLE
security: validate URL scheme in openExternal handler

### DIFF
--- a/src/app/src/renderer/tauriShim.ts
+++ b/src/app/src/renderer/tauriShim.ts
@@ -113,7 +113,14 @@ async function installTauriApi(): Promise<void> {
       await writeText(String(text));
     },
     openExternal: (url: string) => {
-      openUrl(url).catch((e) => console.warn('openExternal', e));
+      try {
+        const u = new URL(url);
+        if (u.protocol === 'http:' || u.protocol === 'https:') {
+          openUrl(u.href).catch((e) => console.warn('openExternal', e));
+        }
+      } catch {
+        // Ignore invalid URLs
+      }
     },
 
     getSettings: () => invoke('get_app_settings'),


### PR DESCRIPTION
Only allow http:// and https:// schemes in window.api.openExternal(). This prevents attackers from injecting dangerous schemes like file://, \\unc, smb://, search-ms:, ms-msdt:, etc. that Windows ShellExecute would execute.

Attack surface includes: prompt-injected LLM output in markdown links, XSS, compromised npm dependencies, or malicious content from lemonade-server.ai iframe. Validation is applied at the Tauri layer (URL parsing + scheme check) to catch injection before it reaches the platform opener plugin.