### PR TITLE
fix(kokoro): correct ESPEAK_DATA_PATH construction

### DIFF
--- a/src/cpp/server/backends/kokoro_server.cpp
+++ b/src/cpp/server/backends/kokoro_server.cpp
@@ -100,7 +100,7 @@ void KokoroServer::load(const std::string& model_name, const ModelInfo& model_in
 
     std::vector<std::pair<std::string, std::string>> env_vars;
     fs::path exe_dir = fs::path(exe_path).parent_path();
-    env_vars.push_back({"ESPEAK_DATA_PATH", exe_dir.string() + "espeak-ng-data"});
+    env_vars.push_back({"ESPEAK_DATA_PATH", (exe_dir / "espeak-ng-data").string()});
 #ifndef _WIN32
     std::string lib_path = exe_dir.string();
     // Preserve existing LD_LIBRARY_PATH if it exists


### PR DESCRIPTION
## Summary

Addresses the malformed `ESPEAK_DATA_PATH` setup reported in #1925.

## Changes

- Construct `ESPEAK_DATA_PATH` with `fs::path` joining instead of string concatenation.
- Prevent paths such as `.../cpuespeak-ng-data`; the expected path is `.../cpu/espeak-ng-data`.

## Testing

- `cmake --build --preset windows --target lemond`
- `python test/server_tts.py` (6 tests passed against the compiled `lemond`)

## Note

This corrects the malformed root data path. The language-alias packaging behavior discussed for British/French voices is separate and is not addressed here.