### PR TITLE
Add model folders to Settings UI

### DIFF
--- a/docs/embeddable/models.md
+++ b/docs/embeddable/models.md
@@ -5,12 +5,12 @@ This guide covers how `lemond` discovers, exposes, and bundles models in an embe
 Contents:
 
 - [Model Organization](#model-organization)
-    - [Sharing Models With Other Apps](#sharing-models-with-other-apps)
-    - [Private Models](#private-models)
-    - [Importing Models to `lemond`](#importing-models-to-lemond)
+  - [Sharing Models With Other Apps](#sharing-models-with-other-apps)
+  - [Private Models](#private-models)
+  - [Importing Models to `lemond`](#importing-models-to-lemond)
 - [Customization](#customization)
-    - [Changing the Built-In Models List](#changing-the-built-in-models-list)
-    - [Per-Model Load Options](#per-model-load-options)
+  - [Changing the Built-In Models List](#changing-the-built-in-models-list)
+  - [Per-Model Load Options](#per-model-load-options)
 - [Bundling Models](#bundling-models)
 
 ## Model Organization
@@ -81,6 +81,7 @@ models--unsloth--Qwen3-0.6B-GGUF
 You may want to share models within your app if `lemond` is not your only inference provider for GGUF LLMs.
 
 There is also a scenario where `lemond`'s Hugging Face Hub-based `pull` methodology is not able to obtain the models you need, for example:
+
 - Hugging Face Hub is blocked in your users' locality.
 - Your GGUF files are not on Hugging Face Hub.
 

--- a/docs/embeddable/models.md
+++ b/docs/embeddable/models.md
@@ -144,10 +144,10 @@ You can test whether it worked like this:
 Which should return:
 
 ```
-extra.my_custom_model.gguf              Yes         llamacpp
+my_custom_model.gguf                    Yes         llamacpp
 ```
 
-> Note: models imported via `extra_models_dir` will have the `extra.` prefix in the `list` command and `/v1/models` endpoint.
+> Note: imported models keep their bare filename in the `list` command and `/v1/models` endpoint. The `extra.` prefix is only added when the bare name would conflict with an already-registered model — in that case both can coexist (e.g. `Qwen3-Coder-30B-A3B-Instruct-GGUF` and `extra.Qwen3-Coder-30B-A3B-Instruct-GGUF`).
 
 > Tip: `extra_models_dir` can be a relative path to any location within your app's package, or any absolute path on your user's system. It searches recursively and can import many GGUFs from a single directory tree.
 

--- a/docs/embeddable/models.md
+++ b/docs/embeddable/models.md
@@ -20,6 +20,8 @@ Contents:
 - `models_dir` is the primary model store, where `lemond` will `pull` models to.
 - `extra_models_dir` is a search path for GGUF LLMs that can be imported into `lemond`.
 
+> Tip: in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings &rarr; Server**.
+
 ### Sharing Models With Other Apps
 
 The default value for `models_dir` is `"auto"`, which means "respect my user's `HF_HOME` and `HF_HUB_CACHE` environment variables, in accordance with the Hugging Face Hub standard." If those environment variables are not set, it defaults to `~/.cache/huggingface/hub`.

--- a/docs/embeddable/models.md
+++ b/docs/embeddable/models.md
@@ -5,12 +5,12 @@ This guide covers how `lemond` discovers, exposes, and bundles models in an embe
 Contents:
 
 - [Model Organization](#model-organization)
-  - [Sharing Models With Other Apps](#sharing-models-with-other-apps)
-  - [Private Models](#private-models)
-  - [Importing Models to `lemond`](#importing-models-to-lemond)
+    - [Sharing Models With Other Apps](#sharing-models-with-other-apps)
+    - [Private Models](#private-models)
+    - [Importing Models to `lemond`](#importing-models-to-lemond)
 - [Customization](#customization)
-  - [Changing the Built-In Models List](#changing-the-built-in-models-list)
-  - [Per-Model Load Options](#per-model-load-options)
+    - [Changing the Built-In Models List](#changing-the-built-in-models-list)
+    - [Per-Model Load Options](#per-model-load-options)
 - [Bundling Models](#bundling-models)
 
 ## Model Organization
@@ -81,7 +81,6 @@ models--unsloth--Qwen3-0.6B-GGUF
 You may want to share models within your app if `lemond` is not your only inference provider for GGUF LLMs.
 
 There is also a scenario where `lemond`'s Hugging Face Hub-based `pull` methodology is not able to obtain the models you need, for example:
-
 - Hugging Face Hub is blocked in your users' locality.
 - Your GGUF files are not on Hugging Face Hub.
 

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -41,7 +41,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
     "vulkan_args": "",
     "rocm_args": "",
     "cpu_args": "",
-    "device": "",
+	"device": "",
     "prefer_system": false,
     "rocm_bin": "builtin",
     "vulkan_bin": "builtin",
@@ -70,7 +70,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
     "vulkan_bin": "builtin"
   },
   "flm": {
-    "args": ""
+    "args": "",
   },
   "ryzenai": {
     "server_bin": "builtin"
@@ -83,22 +83,22 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
 
 ### Settings Reference
 
-| Key                       | Type   | Default     | Description                                                                                                    |
-| ------------------------- | ------ | ----------- | -------------------------------------------------------------------------------------------------------------- |
-| `port`                    | int    | 13305       | Port number for the HTTP server                                                                                |
-| `host`                    | string | "localhost" | Address to bind for connections                                                                                |
-| `log_level`               | string | "info"      | Logging level (trace, debug, info, warning, error, fatal, none)                                                |
-| `global_timeout`          | int    | 300         | Timeout in seconds for HTTP, inference, and readiness checks                                                   |
-| `max_loaded_models`       | int    | 1           | Max models per type slot. Use -1 for unlimited                                                                 |
-| `no_broadcast`            | bool   | false       | Disable UDP broadcasting for server discovery                                                                  |
-| `extra_models_dir`        | string | ""          | Secondary directory to scan for GGUF model files                                                               |
-| `models_dir`              | string | "auto"      | Directory for cached model files. "auto" follows HF_HUB_CACHE / HF_HOME / platform default                     |
-| `ctx_size`                | int    | 4096        | Default context size for LLM models                                                                            |
-| `offline`                 | bool   | false       | Skip model downloads                                                                                           |
-| `no_fetch_executables`    | bool   | false       | Prevent downloading backend executable artifacts; backends must already be installed or use the system backend |
-| `disable_model_filtering` | bool   | false       | Show all models regardless of hardware capabilities                                                            |
-| `enable_dgpu_gtt`         | bool   | false       | Include GTT for hardware-based model filtering                                                                 |
-| `rocm_channel`            | string | "stable"    | ROCm backend channel: "stable" (default) or "nightly". See [llama.cpp Backend](./llamacpp.md) for details      |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `port` | int | 13305 | Port number for the HTTP server |
+| `host` | string | "localhost" | Address to bind for connections |
+| `log_level` | string | "info" | Logging level (trace, debug, info, warning, error, fatal, none) |
+| `global_timeout` | int | 300 | Timeout in seconds for HTTP, inference, and readiness checks |
+| `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
+| `no_broadcast` | bool | false | Disable UDP broadcasting for server discovery |
+| `extra_models_dir` | string | "" | Secondary directory to scan for GGUF model files |
+| `models_dir` | string | "auto" | Directory for cached model files. "auto" follows HF_HUB_CACHE / HF_HOME / platform default |
+| `ctx_size` | int | 4096 | Default context size for LLM models |
+| `offline` | bool | false | Skip model downloads |
+| `no_fetch_executables` | bool | false | Prevent downloading backend executable artifacts; backends must already be installed or use the system backend |
+| `disable_model_filtering` | bool | false | Show all models regardless of hardware capabilities |
+| `enable_dgpu_gtt` | bool | false | Include GTT for hardware-based model filtering |
+| `rocm_channel` | string | "stable" | ROCm backend channel: "stable" (default) or "nightly". See [llama.cpp Backend](./llamacpp.md) for details |
 
 > Tip: in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings &rarr; Server**.
 
@@ -155,13 +155,13 @@ Backend-specific settings are nested under their backend name:
 
 Every `*_bin` key (e.g. `llamacpp.vulkan_bin`, `whispercpp.cpu_bin`, `sdcpp.rocm_bin`) accepts the same set of values:
 
-| Value                         | Meaning                                                                                                                                                                                                                   |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"builtin"` _(default)_       | Use the version of the upstream backend that lemonade pins in its release. Recommended for most users — these versions are tested with this lemonade build.                                                               |
-| `""`                          | Same as `"builtin"`.                                                                                                                                                                                                      |
-| `"latest"`                    | Resolve to the most-recent upstream GitHub release on first install or first status query for that backend, then install on demand. The resolved tag is recorded in `<lemonade-home>/bin/<recipe>/<backend>/version.txt`. |
-| `"b8664"` / `"v1.8.2"` / etc. | A specific upstream release tag. Lemonade downloads that exact version from GitHub.                                                                                                                                       |
-| `"/path/to/bin"`              | A directory you populated yourself (e.g. a local build). Lemonade uses the executable inside this directory and never downloads. The path must exist when set.                                                            |
+| Value | Meaning |
+|---|---|
+| `"builtin"` *(default)* | Use the version of the upstream backend that lemonade pins in its release. Recommended for most users — these versions are tested with this lemonade build. |
+| `""` | Same as `"builtin"`. |
+| `"latest"` | Resolve to the most-recent upstream GitHub release on first install or first status query for that backend, then install on demand. The resolved tag is recorded in `<lemonade-home>/bin/<recipe>/<backend>/version.txt`. |
+| `"b8664"` / `"v1.8.2"` / etc. | A specific upstream release tag. Lemonade downloads that exact version from GitHub. |
+| `"/path/to/bin"` | A directory you populated yourself (e.g. a local build). Lemonade uses the executable inside this directory and never downloads. The path must exist when set. |
 
 > Note: the `latest` setting is experimental.
 
@@ -196,7 +196,7 @@ Changing a `*_bin` value applies live: lemonade unloads any model currently usin
 The `lemonade backends` listing surfaces two upgrade signals for backends pinned to `"latest"`:
 
 - **`update_available`** — A newer upstream release exists than what's installed. The backend keeps running on the installed version; the listed `action` is the install command to apply the upgrade when you're ready.
-- **`update_required`** — The installed version is _older_ than the version lemonade ships in this release. This forces an upgrade prompt because running below the lemonade-shipped baseline is not supported.
+- **`update_required`** — The installed version is *older* than the version lemonade ships in this release. This forces an upgrade prompt because running below the lemonade-shipped baseline is not supported.
 
 Backends pinned to a specific tag (e.g. `b8664`) do not get either signal — they're treated as an explicit user choice.
 
@@ -276,12 +276,12 @@ The `LEMONADE_ADMIN_API_KEY` environment variable provides elevated access to bo
 
 **Authentication Hierarchy:**
 
-| Scenario            | `LEMONADE_API_KEY` | `LEMONADE_ADMIN_API_KEY` | Internal Endpoints | Regular API Endpoints |
-| ------------------- | ------------------ | ------------------------ | ------------------ | --------------------- |
-| No keys set         | (not set)          | (not set)                | No auth required   | No auth required      |
-| Only API key        | "secret"           | (not set)                | Requires key       | Requires key          |
-| Only admin key      | (not set)          | "admin"                  | Requires admin key | No auth required      |
-| Both keys different | "regular"          | "admin"                  | Requires admin key | Either key accepted   |
+| Scenario | `LEMONADE_API_KEY` | `LEMONADE_ADMIN_API_KEY` | Internal Endpoints | Regular API Endpoints |
+|----------|-------------------|--------------------------|-------------------|----------------------|
+| No keys set | (not set) | (not set) | No auth required | No auth required |
+| Only API key | "secret" | (not set) | Requires key | Requires key |
+| Only admin key | (not set) | "admin" | Requires admin key | No auth required |
+| Both keys different | "regular" | "admin" | Requires admin key | Either key accepted |
 
 **Client Behavior:** Clients (CLI, tray app) automatically prefer `LEMONADE_ADMIN_API_KEY` if set, otherwise fall back to `LEMONADE_API_KEY`.
 

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -100,6 +100,8 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
 | `enable_dgpu_gtt` | bool | false | Include GTT for hardware-based model filtering |
 | `rocm_channel` | string | "stable" | ROCm backend channel: "stable" (default) or "nightly". See [llama.cpp Backend](./llamacpp.md) for details |
 
+> Tip: in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings &rarr; Server**.
+
 ### Backend Configuration
 
 Backend-specific settings are nested under their backend name:

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -41,7 +41,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
     "vulkan_args": "",
     "rocm_args": "",
     "cpu_args": "",
-	"device": "",
+    "device": "",
     "prefer_system": false,
     "rocm_bin": "builtin",
     "vulkan_bin": "builtin",
@@ -70,7 +70,7 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
     "vulkan_bin": "builtin"
   },
   "flm": {
-    "args": "",
+    "args": ""
   },
   "ryzenai": {
     "server_bin": "builtin"
@@ -83,22 +83,22 @@ If you are using a standalone `lemond` exectable, the default location is `~/.ca
 
 ### Settings Reference
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `port` | int | 13305 | Port number for the HTTP server |
-| `host` | string | "localhost" | Address to bind for connections |
-| `log_level` | string | "info" | Logging level (trace, debug, info, warning, error, fatal, none) |
-| `global_timeout` | int | 300 | Timeout in seconds for HTTP, inference, and readiness checks |
-| `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
-| `no_broadcast` | bool | false | Disable UDP broadcasting for server discovery |
-| `extra_models_dir` | string | "" | Secondary directory to scan for GGUF model files |
-| `models_dir` | string | "auto" | Directory for cached model files. "auto" follows HF_HUB_CACHE / HF_HOME / platform default |
-| `ctx_size` | int | 4096 | Default context size for LLM models |
-| `offline` | bool | false | Skip model downloads |
-| `no_fetch_executables` | bool | false | Prevent downloading backend executable artifacts; backends must already be installed or use the system backend |
-| `disable_model_filtering` | bool | false | Show all models regardless of hardware capabilities |
-| `enable_dgpu_gtt` | bool | false | Include GTT for hardware-based model filtering |
-| `rocm_channel` | string | "stable" | ROCm backend channel: "stable" (default) or "nightly". See [llama.cpp Backend](./llamacpp.md) for details |
+| Key                       | Type   | Default     | Description                                                                                                    |
+| ------------------------- | ------ | ----------- | -------------------------------------------------------------------------------------------------------------- |
+| `port`                    | int    | 13305       | Port number for the HTTP server                                                                                |
+| `host`                    | string | "localhost" | Address to bind for connections                                                                                |
+| `log_level`               | string | "info"      | Logging level (trace, debug, info, warning, error, fatal, none)                                                |
+| `global_timeout`          | int    | 300         | Timeout in seconds for HTTP, inference, and readiness checks                                                   |
+| `max_loaded_models`       | int    | 1           | Max models per type slot. Use -1 for unlimited                                                                 |
+| `no_broadcast`            | bool   | false       | Disable UDP broadcasting for server discovery                                                                  |
+| `extra_models_dir`        | string | ""          | Secondary directory to scan for GGUF model files                                                               |
+| `models_dir`              | string | "auto"      | Directory for cached model files. "auto" follows HF_HUB_CACHE / HF_HOME / platform default                     |
+| `ctx_size`                | int    | 4096        | Default context size for LLM models                                                                            |
+| `offline`                 | bool   | false       | Skip model downloads                                                                                           |
+| `no_fetch_executables`    | bool   | false       | Prevent downloading backend executable artifacts; backends must already be installed or use the system backend |
+| `disable_model_filtering` | bool   | false       | Show all models regardless of hardware capabilities                                                            |
+| `enable_dgpu_gtt`         | bool   | false       | Include GTT for hardware-based model filtering                                                                 |
+| `rocm_channel`            | string | "stable"    | ROCm backend channel: "stable" (default) or "nightly". See [llama.cpp Backend](./llamacpp.md) for details      |
 
 > Tip: in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings &rarr; Server**.
 
@@ -155,13 +155,13 @@ Backend-specific settings are nested under their backend name:
 
 Every `*_bin` key (e.g. `llamacpp.vulkan_bin`, `whispercpp.cpu_bin`, `sdcpp.rocm_bin`) accepts the same set of values:
 
-| Value | Meaning |
-|---|---|
-| `"builtin"` *(default)* | Use the version of the upstream backend that lemonade pins in its release. Recommended for most users — these versions are tested with this lemonade build. |
-| `""` | Same as `"builtin"`. |
-| `"latest"` | Resolve to the most-recent upstream GitHub release on first install or first status query for that backend, then install on demand. The resolved tag is recorded in `<lemonade-home>/bin/<recipe>/<backend>/version.txt`. |
-| `"b8664"` / `"v1.8.2"` / etc. | A specific upstream release tag. Lemonade downloads that exact version from GitHub. |
-| `"/path/to/bin"` | A directory you populated yourself (e.g. a local build). Lemonade uses the executable inside this directory and never downloads. The path must exist when set. |
+| Value                         | Meaning                                                                                                                                                                                                                   |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"builtin"` _(default)_       | Use the version of the upstream backend that lemonade pins in its release. Recommended for most users — these versions are tested with this lemonade build.                                                               |
+| `""`                          | Same as `"builtin"`.                                                                                                                                                                                                      |
+| `"latest"`                    | Resolve to the most-recent upstream GitHub release on first install or first status query for that backend, then install on demand. The resolved tag is recorded in `<lemonade-home>/bin/<recipe>/<backend>/version.txt`. |
+| `"b8664"` / `"v1.8.2"` / etc. | A specific upstream release tag. Lemonade downloads that exact version from GitHub.                                                                                                                                       |
+| `"/path/to/bin"`              | A directory you populated yourself (e.g. a local build). Lemonade uses the executable inside this directory and never downloads. The path must exist when set.                                                            |
 
 > Note: the `latest` setting is experimental.
 
@@ -196,7 +196,7 @@ Changing a `*_bin` value applies live: lemonade unloads any model currently usin
 The `lemonade backends` listing surfaces two upgrade signals for backends pinned to `"latest"`:
 
 - **`update_available`** — A newer upstream release exists than what's installed. The backend keeps running on the installed version; the listed `action` is the install command to apply the upgrade when you're ready.
-- **`update_required`** — The installed version is *older* than the version lemonade ships in this release. This forces an upgrade prompt because running below the lemonade-shipped baseline is not supported.
+- **`update_required`** — The installed version is _older_ than the version lemonade ships in this release. This forces an upgrade prompt because running below the lemonade-shipped baseline is not supported.
 
 Backends pinned to a specific tag (e.g. `b8664`) do not get either signal — they're treated as an explicit user choice.
 
@@ -276,12 +276,12 @@ The `LEMONADE_ADMIN_API_KEY` environment variable provides elevated access to bo
 
 **Authentication Hierarchy:**
 
-| Scenario | `LEMONADE_API_KEY` | `LEMONADE_ADMIN_API_KEY` | Internal Endpoints | Regular API Endpoints |
-|----------|-------------------|--------------------------|-------------------|----------------------|
-| No keys set | (not set) | (not set) | No auth required | No auth required |
-| Only API key | "secret" | (not set) | Requires key | Requires key |
-| Only admin key | (not set) | "admin" | Requires admin key | No auth required |
-| Both keys different | "regular" | "admin" | Requires admin key | Either key accepted |
+| Scenario            | `LEMONADE_API_KEY` | `LEMONADE_ADMIN_API_KEY` | Internal Endpoints | Regular API Endpoints |
+| ------------------- | ------------------ | ------------------------ | ------------------ | --------------------- |
+| No keys set         | (not set)          | (not set)                | No auth required   | No auth required      |
+| Only API key        | "secret"           | (not set)                | Requires key       | Requires key          |
+| Only admin key      | (not set)          | "admin"                  | Requires admin key | No auth required      |
+| Both keys different | "regular"          | "admin"                  | Requires admin key | Either key accepted   |
 
 **Client Behavior:** Clients (CLI, tray app) automatically prefer `LEMONADE_ADMIN_API_KEY` if set, otherwise fall back to `LEMONADE_API_KEY`.
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -4,226 +4,232 @@
 
 ### 1. **What is Lemonade and what does it include?**
 
-Lemonade is an open-source local LLM solution that: - Gets you started in minutes with one-click installers. - Auto-configures optimized inference engines for your PC. - Provides a convenient app to get set up and test out LLMs. - Provides LLMs through the OpenAI API standard, enabling apps on your PC to access them.
+   Lemonade is an open-source local LLM solution that:
+      - Gets you started in minutes with one-click installers.
+      - Auto-configures optimized inference engines for your PC.
+      - Provides a convenient app to get set up and test out LLMs.
+      - Provides LLMs through the OpenAI API standard, enabling apps on your PC to access them.
 
 ### 2. **What are the use cases for different audiences?**
 
-- **LLM Enthusiasts**: LLMs on your GPU or NPU with minimal setup, and connect to great apps listed [here](https://lemonade-server.ai/docs/server/apps/).
-- **Developers**: Integrate LLMs into apps using standard APIs with no device-specific code. See the [Server Integration Guide](https://lemonade-server.ai/docs/server/server_integration/).
-- **Agent Developers**: Use [GAIA](https://github.com/amd/gaia) to quickly develop local-first agents.
+   - **LLM Enthusiasts**: LLMs on your GPU or NPU with minimal setup, and connect to great apps listed [here](https://lemonade-server.ai/docs/server/apps/).
+   - **Developers**: Integrate LLMs into apps using standard APIs with no device-specific code. See the [Server Integration Guide](https://lemonade-server.ai/docs/server/server_integration/
+   ).
+   - **Agent Developers**: Use [GAIA](https://github.com/amd/gaia) to quickly develop local-first agents.
 
 ## Installation & Compatibility
 
 ### 1. **How do I install Lemonade SDK or Server?**
 
-Visit https://lemonade-server.ai/install_options.html and click the options that apply to you.
+   Visit https://lemonade-server.ai/install_options.html and click the options that apply to you.
 
 ### 2. **Which devices are supported?**
 
-👉 [Supported Configurations](https://github.com/lemonade-sdk/lemonade?tab=readme-ov-file#supported-configurations)
+   👉 [Supported Configurations](https://github.com/lemonade-sdk/lemonade?tab=readme-ov-file#supported-configurations)
 
-For more information on AMD Ryzen AI NPU Support, see the section [Hybrid/NPU](#hybrid-and-npu-questions).
+   For more information on AMD Ryzen AI NPU Support, see the section [Hybrid/NPU](#hybrid-and-npu-questions).
 
 ### 3. **Is Linux supported? What about macOS?**
 
-Yes, both Linux and macOS are supported!
+   Yes, both Linux and macOS are supported!
 
-- **Linux**: Visit https://lemonade-server.ai/install_options.html#linux for installation instructions.
-- **macOS**: A macOS installer (.pkg) is available for Apple Silicon Macs. Visit https://lemonade-server.ai/install_options.html#macos to download. macOS support uses the llama.cpp backend with Metal acceleration.
+   - **Linux**: Visit https://lemonade-server.ai/install_options.html#linux for installation instructions.
+   - **macOS**: A macOS installer (.pkg) is available for Apple Silicon Macs. Visit https://lemonade-server.ai/install_options.html#macos to download. macOS support uses the llama.cpp backend with Metal acceleration.
 
-Visit the [Supported Configurations](https://github.com/lemonade-sdk/lemonade?tab=readme-ov-file#supported-configurations) section to see the support matrix for CPU, GPU, and NPU.
+   Visit the [Supported Configurations](https://github.com/lemonade-sdk/lemonade?tab=readme-ov-file#supported-configurations) section to see the support matrix for CPU, GPU, and NPU.
 
 ### 4. **How do I uninstall Lemonade Server? (Windows)**
 
-To uninstall Lemonade Server, use the Windows Add/Remove Programs menu.
+   To uninstall Lemonade Server, use the Windows Add/Remove Programs menu.
 
-**Optional: Remove cached files**
-
-- Open File Explorer and navigate to `%USERPROFILE%\.cache`
-- Delete the `lemonade` folder if it exists
-- To remove downloaded models, delete the `huggingface` folder
+   **Optional: Remove cached files**
+   - Open File Explorer and navigate to `%USERPROFILE%\.cache`
+   - Delete the `lemonade` folder if it exists
+   - To remove downloaded models, delete the `huggingface` folder
 
 ## Models
 
 ### 1. **Where are models stored and how do I change that?**
 
-Lemonade uses three model locations:
+   Lemonade uses three model locations:
 
-**Primary: Hugging Face Cache**
+   **Primary: Hugging Face Cache**
 
-Models downloaded through Lemonade are stored using the Hugging Face Hub specification. By default, models are located at `~/.cache/huggingface/hub/`, where `~` is your home directory.
+   Models downloaded through Lemonade are stored using the Hugging Face Hub specification. By default, models are located at `~/.cache/huggingface/hub/`, where `~` is your home directory.
 
-For example, `Qwen/Qwen2.5-0.5B` is stored at `~/.cache/huggingface/hub/models--Qwen--Qwen2.5-0.5B`.
+   For example, `Qwen/Qwen2.5-0.5B` is stored at `~/.cache/huggingface/hub/models--Qwen--Qwen2.5-0.5B`.
 
-You can change this location by setting the `HF_HOME` env var, which will store your models in `$HF_HOME/hub` (e.g., `$HF_HOME/hub/models--Qwen--Qwen2.5-0.5B`). Alternatively, you can set `HF_HUB_CACHE` and your models will be in `$HF_HUB_CACHE` (e.g., `$HF_HUB_CACHE/models--Qwen--Qwen2.5-0.5B`).
+   You can change this location by setting the `HF_HOME` env var, which will store your models in `$HF_HOME/hub` (e.g., `$HF_HOME/hub/models--Qwen--Qwen2.5-0.5B`). Alternatively, you can set `HF_HUB_CACHE` and your models will be in `$HF_HUB_CACHE` (e.g., `$HF_HUB_CACHE/models--Qwen--Qwen2.5-0.5B`).
 
-You can use the official Hugging Face Hub utility (`pip install huggingface-hub`) to manage models outside of Lemonade, e.g., `hf cache ls` will print all models and their sizes.
+   You can use the official Hugging Face Hub utility (`pip install huggingface-hub`) to manage models outside of Lemonade, e.g., `hf cache ls` will print all models and their sizes.
 
-**Secondary: Extra Models Directory (GGUF)**
+   **Secondary: Extra Models Directory (GGUF)**
 
-Lemonade Server can discover GGUF models from a secondary directory using the `extra_models_dir` option, enabling compatibility with llama.cpp and LM Studio model caches. Suggested paths:
+   Lemonade Server can discover GGUF models from a secondary directory using the `extra_models_dir` option, enabling compatibility with llama.cpp and LM Studio model caches. Suggested paths:
 
-- **Windows:**
-  - LM Studio: `C:\Users\You\.lmstudio\models`
-  - llamacpp: `%LOCALAPPDATA%\llama.cpp` (e.g., `C:\Users\You\AppData\Local\llama.cpp`)
-- **Linux:** `~/.cache/llama.cpp`
+   - **Windows:**
+       - LM Studio: `C:\Users\You\.lmstudio\models`
+       - llamacpp: `%LOCALAPPDATA%\llama.cpp` (e.g., `C:\Users\You\AppData\Local\llama.cpp`)
+   - **Linux:** `~/.cache/llama.cpp`
 
-Set `extra_models_dir` (see [Server Configuration](./configuration/README.md)):
+   Set `extra_models_dir` (see [Server Configuration](./configuration/README.md)):
 
-```bash
-lemonade config set extra_models_dir="/home/you/.cache/llama.cpp"
-```
+   ```bash
+   lemonade config set extra_models_dir="/home/you/.cache/llama.cpp"
+   ```
 
-> Tip: in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings &rarr; Server**.
+   > Tip: in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings &rarr; Server**.
 
-Any `.gguf` files found in this directory (including subdirectories) will automatically appear in Lemonade's model list under their bare filename. If a bare name would collide with an already-registered model, the imported entry is shown with an `extra.` prefix so both can coexist.
+   Any `.gguf` files found in this directory (including subdirectories) will automatically appear in Lemonade's model list in the `custom` category.
 
-**FastFlowLM**
+   **FastFlowLM**
 
-FastFlowLM (FLM) has its own model management system. When you first install FLM the install wizard asks for a model directory, which is then saved to the `FLM_MODEL_PATH` environment variable on your system PATH. Models are stored in that directory. If you change the variable's value, newly downloaded models will be stored on the new path, but your prior models will still be at the prior path.
+   FastFlowLM (FLM) has its own model management system. When you first install FLM the install wizard asks for a model directory, which is then saved to the `FLM_MODEL_PATH` environment variable on your system PATH. Models are stored in that directory. If you change the variable's value, newly downloaded models will be stored on the new path, but your prior models will still be at the prior path.
 
 ### 2. **What models are supported?**
 
-Lemonade supports a wide range of LLMs including LLaMA, DeepSeek, Qwen, Gemma, Phi, gpt-oss, LFM, and many more. Most GGUF models can also be added to Lemonade Server by users using the Model Manager interface in the app or the `pull` command on the CLI.
+   Lemonade supports a wide range of LLMs including LLaMA, DeepSeek, Qwen, Gemma, Phi, gpt-oss, LFM, and many more. Most GGUF models can also be added to Lemonade Server by users using the Model Manager interface in the app or the `pull` command on the CLI.
 
-👉 [Supported Models List](https://lemonade-server.ai/models.html)
-👉 [pull command](https://lemonade-server.ai/docs/lemonade-cli/#options-for-pull)
+   👉 [Supported Models List](https://lemonade-server.ai/models.html)
+   👉 [pull command](https://lemonade-server.ai/docs/lemonade-cli/#options-for-pull)
 
 ### 3. **How do I know what size model will work with my setup?**
 
-Model compatibility depends on your system's RAM, VRAM, and NPU availability. **The actual file size varies significantly between models** due to different quantization techniques and architectures.
+   Model compatibility depends on your system's RAM, VRAM, and NPU availability. **The actual file size varies significantly between models** due to different quantization techniques and architectures.
 
-**To check if a model will work:**
-
-1.  Visit the model's Hugging Face page (e.g., [`amd/Qwen2.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Qwen2.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid)).
-2.  Check the "Files and versions" tab to see the actual download size.
-3.  Add ~2-4 GB overhead for KV cache, activations, and runtime memory.
-4.  Ensure your system has sufficient RAM/VRAM.
+   **To check if a model will work:**
+   1. Visit the model's Hugging Face page (e.g., [`amd/Qwen2.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Qwen2.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid)).
+   2. Check the "Files and versions" tab to see the actual download size.
+   3. Add ~2-4 GB overhead for KV cache, activations, and runtime memory.
+   4. Ensure your system has sufficient RAM/VRAM.
 
 ### 4. **I'm looking for a model, but it's not listed in the Model Manager.**
 
-If a model isn't listed, it may not be compatible with your PC due to device or RAM limitations, or we just haven't added it to the `server_models.json` file yet.
+   If a model isn't listed, it may not be compatible with your PC due to device or RAM limitations, or we just haven't added it to the `server_models.json` file yet.
 
-You can:
+   You can:
 
-- Add a custom model manually via the app's "Add a Model" interface or the [CLI pull command](https://lemonade-server.ai/docs/lemonade-cli/#options-for-pull). For advanced manual configuration, see the [Custom Model Configuration Guide](https://lemonade-server.ai/docs/server/custom-models/).
-- Use a pull request to add the model to the built-in `server_models.json` file.
-- Request support by opening a [GitHub issue](https://github.com/lemonade-sdk/lemonade/issues).
+   - Add a custom model manually via the app's "Add a Model" interface or the [CLI pull command](https://lemonade-server.ai/docs/lemonade-cli/#options-for-pull). For advanced manual configuration, see the [Custom Model Configuration Guide](https://lemonade-server.ai/docs/server/custom-models/).
+   - Use a pull request to add the model to the built-in `server_models.json` file.
+   - Request support by opening a [GitHub issue](https://github.com/lemonade-sdk/lemonade/issues).
 
-If you are sure that a model should be listed, but you aren't seeing it, you can `lemonade config set disable_model_filtering=true` in to show all models supported by Lemonade on any PC configuration. But please note, this can show models that definitely won't work on your system.
+   If you are sure that a model should be listed, but you aren't seeing it, you can `lemonade config set disable_model_filtering=true` in to show all models supported by Lemonade on any PC configuration. But please note, this can show models that definitely won't work on your system.
 
-Alternatively if you are attempting to use GTT on your dGPU then you can `lemonade config set enable_dgpu_gtt=true` to filter using the combined memory pool. Please note ROCM does not support splitting memory across multiple pools, vulkan is likely required for this usecase.
+   Alternatively if you are attempting to use GTT on your dGPU then you can `lemonade config set enable_dgpu_gtt=true` to filter using the combined memory pool. Please note ROCM does not support splitting memory across multiple pools, vulkan is likely required for this usecase.
 
 ### 5. **Is there a script or tool to convert models to Ryzen AI NPU format?**
 
-Yes, there's a guide on preparing your models for Ryzen AI NPU:
+   Yes, there's a guide on preparing your models for Ryzen AI NPU:
 
-👉 [Model Preparation Guide](https://ryzenai.docs.amd.com/en/latest/oga_model_prepare.html)
+   👉 [Model Preparation Guide](https://ryzenai.docs.amd.com/en/latest/oga_model_prepare.html)
 
 ### 6. **What's the difference between GGUF and ONNX models?**
 
-- **GGUF**: Used with llama.cpp backend, supports CPU, and GPU via Vulkan or ROCm.
-- **ONNX**: Used with OnnxRuntime GenAI, supports NPU and NPU+iGPU Hybrid execution.
+   - **GGUF**: Used with llama.cpp backend, supports CPU, and GPU via Vulkan or ROCm.
+   - **ONNX**: Used with OnnxRuntime GenAI, supports NPU and NPU+iGPU Hybrid execution.
 
 ## Inference Behavior & Performance
 
 ### 1. **Can Lemonade print out stats like tokens per second?**
 
-Yes! Lemonade Server exposes a `/stats` endpoint that returns performance metrics from the most recent completion request:
+   Yes! Lemonade Server exposes a `/stats` endpoint that returns performance metrics from the most recent completion request:
 
-```bash
-curl http://localhost:13305/api/v1/stats
-```
+   ```bash
+   curl http://localhost:13305/api/v1/stats
+   ```
 
-Or, use `lemonade config set log_level=debug` to enable debug logging, or `lemonade logs` to view logs.
+   Or, use `lemonade config set log_level=debug` to enable debug logging, or `lemonade logs` to view logs.
 
 ### 2. **How does Lemonade's performance compare to llama.cpp?**
 
-Lemonade supports llama.cpp as a backend, so performance is similar when using the same model and quantization.
+   Lemonade supports llama.cpp as a backend, so performance is similar when using the same model and quantization.
 
 ### 3. **How can ROCm performance be improved for my use case?**
 
-File a detailed issue on TheRock repo for support: https://github.com/ROCm/TheRock
+   File a detailed issue on TheRock repo for support: https://github.com/ROCm/TheRock
 
 ### 4. **How should dedicated GPU RAM be allocated on Strix Halo**
 
-**Linux**
+   **Linux**
 
-Please see the official AMD guidance [here](https://rocm.docs.amd.com/en/latest/how-to/system-optimization/strixhalo.html).
+   Please see the official AMD guidance [here](https://rocm.docs.amd.com/en/latest/how-to/system-optimization/strixhalo.html).
 
-**Windows**
+   **Windows**
 
-Strix Halo PCs can have up to 128 GB of unified RAM and Windows allows the user to allocate a portion of this to dedicated GPU RAM.
+   Strix Halo PCs can have up to 128 GB of unified RAM and Windows allows the user to allocate a portion of this to dedicated GPU RAM.
 
-We suggest setting dedicated GPU RAM to `64/64 (auto)`.
+   We suggest setting dedicated GPU RAM to `64/64 (auto)`.
 
-> Note: On Windows, the GPU can access both unified RAM and dedicated GPU RAM, but the CPU is blocked from accessing dedicated GPU RAM. For this reason, allocating too much dedicated GPU RAM can interfere with model loading, which requires the CPU to access a substantial amount unified RAM.
+   > Note: On Windows, the GPU can access both unified RAM and dedicated GPU RAM, but the CPU is blocked from accessing dedicated GPU RAM. For this reason, allocating too much dedicated GPU RAM can interfere with model loading, which requires the CPU to access a substantial amount unified RAM.
+
 
 ## Hybrid and NPU Questions
 
 ### 1. **Does LLM inference with the NPU only work on Windows?**
 
-Today, NPU-only inference on Linux is available via FastFlowLM, see the guide [here](https://lemonade-server.ai/flm_npu_linux.html).
+   Today, NPU-only inference on Linux is available via FastFlowLM, see the guide [here](https://lemonade-server.ai/flm_npu_linux.html).
 
-At the moment, Ryzen AI SW's implementation of NPU and hybrid inference is currently supported only on Windows.
+   At the moment, Ryzen AI SW's implementation of NPU and hybrid inference is currently supported only on Windows.
 
 ### 2. **I loaded a hybrid model, but the NPU is barely active. Is that expected?**
 
-Yes. In hybrid mode:
+   Yes. In hybrid mode:
 
-- The NPU handles prompt processing.
-- The GPU handles token generation.
-- If your prompt is short, the NPU finishes quickly. Try a longer prompt to see more NPU activity.
+   - The NPU handles prompt processing.
+   - The GPU handles token generation.
+   - If your prompt is short, the NPU finishes quickly. Try a longer prompt to see more NPU activity.
 
 ### 3. **Does Lemonade work on older AMD processors or non-Ryzen AI systems?**
 
-Yes! Lemonade supports multiple execution modes:
+   Yes! Lemonade supports multiple execution modes:
 
-- **AMD Ryzen 7000/8000/200 series**: GPU acceleration via llama.cpp + Vulkan backend
-- **AMD Ryzen AI MAX+ (Strix Halo) on Linux**: in addition to the above, the experimental `vllm:rocm` backend is supported on gfx1151 (see [vLLM configuration](configuration/vllm.md))
-- **Systems with Radeon GPUs**: Yes
-- **Any x86 CPU**: Yes
-- **Intel/NVIDIA systems**: CPU inference, with GPU support via the llama.cpp + Vulkan backend
+   - **AMD Ryzen 7000/8000/200 series**: GPU acceleration via llama.cpp + Vulkan backend
+   - **AMD Ryzen AI MAX+ (Strix Halo) on Linux**: in addition to the above, the experimental `vllm:rocm` backend is supported on gfx1151 (see [vLLM configuration](configuration/vllm.md))
+   - **Systems with Radeon GPUs**: Yes
+   - **Any x86 CPU**: Yes
+   - **Intel/NVIDIA systems**: CPU inference, with GPU support via the llama.cpp + Vulkan backend
 
-While you won't get NPU acceleration on non-Ryzen AI 300 systems, you can still benefit from GPU acceleration and the OpenAI-compatible API.
+   While you won't get NPU acceleration on non-Ryzen AI 300 systems, you can still benefit from GPU acceleration and the OpenAI-compatible API.
 
 ### 4. **Is the NPU on the AMD Ryzen AI 7000/8000/200 series going to be supported for LLM inference?**
 
-No inference engine providers have plans to support NPUs prior to Ryzen AI 300-series, but you can still request this by filing an issue on their respective GitHubs: - Ryzen AI SW: https://github.com/amd/ryzenai-sw - FastFlowLM: https://github.com/FastFlowLM/FastFlowLM
+   No inference engine providers have plans to support NPUs prior to Ryzen AI 300-series, but you can still request this by filing an issue on their respective GitHubs:
+      - Ryzen AI SW: https://github.com/amd/ryzenai-sw
+      - FastFlowLM: https://github.com/FastFlowLM/FastFlowLM
 
 ### 5. **How do I know what model architectures are supported by the NPU?**
 
-AMD publishes pre-quantized and optimized models in their Hugging Face collections:
+   AMD publishes pre-quantized and optimized models in their Hugging Face collections:
 
-- [Ryzen AI NPU Models](https://huggingface.co/collections/amd/ryzenai-15-llm-npu-models-6859846d7c13f81298990db0)
-- [Ryzen AI Hybrid Models](https://huggingface.co/collections/amd/ryzenai-15-llm-hybrid-models-6859a64b421b5c27e1e53899)
+   - [Ryzen AI NPU Models](https://huggingface.co/collections/amd/ryzenai-15-llm-npu-models-6859846d7c13f81298990db0)
+   - [Ryzen AI Hybrid Models](https://huggingface.co/collections/amd/ryzenai-15-llm-hybrid-models-6859a64b421b5c27e1e53899)
 
-To find the architecture of a specific model, click on any model in these collections and look for the "Base model" field, which will show you the underlying architecture (e.g., Llama, Qwen, Phi).
+   To find the architecture of a specific model, click on any model in these collections and look for the "Base model" field, which will show you the underlying architecture (e.g., Llama, Qwen, Phi).
 
 ### 6. **How can I get better performance from the NPU?**
 
-Make sure that you've put the NPU in "Turbo" mode to get the best results. This is done by opening a terminal window and running the following commands:
+   Make sure that you've put the NPU in "Turbo" mode to get the best results. This is done by opening a terminal window and running the following commands:
 
-```cmd
-cd C:\Windows\System32\AMD
-.\xrt-smi configure --pmode turbo
-```
+   ```cmd
+   cd C:\Windows\System32\AMD
+   .\xrt-smi configure --pmode turbo
+   ```
 
 ## Remote Access
 
 ### 1. **How do I run Lemonade Server on one PC and access it from another?**
 
-Lemonade supports running the server on one machine while using the app from another machine on the same network.
+   Lemonade supports running the server on one machine while using the app from another machine on the same network.
 
-For detailed instructions and security considerations, see [Remote Server Connection](./configuration/README.md#remote-server-connection).
+   For detailed instructions and security considerations, see [Remote Server Connection](./configuration/README.md#remote-server-connection).
 
 ## Customization
 
 ### 1. **How do I use my own llama.cpp or whisper.cpp binaries?**
 
-Lemonade Server allows you to use custom `llama-server` or `whisper-server` binaries instead of the bundled ones by setting environment variables to the full path of your binary.
+   Lemonade Server allows you to use custom `llama-server` or `whisper-server` binaries instead of the bundled ones by setting environment variables to the full path of your binary.
 
-👉 [Custom Backend Binaries](./configuration/README.md)
+   👉 [Custom Backend Binaries](./configuration/README.md)
 
 ## TTS
 
@@ -257,16 +263,16 @@ Some voices are not supported yet. If you manually enter a voice name instead of
 
 ### 1. **What if I encounter installation or runtime errors?**
 
-Check the Lemonade Server logs via the App or tray icon. Common issues include model compatibility or outdated versions.
+   Check the Lemonade Server logs via the App or tray icon. Common issues include model compatibility or outdated versions.
 
-👉 [Open an Issue on GitHub](https://github.com/lemonade-sdk/lemonade/issues)
+   👉 [Open an Issue on GitHub](https://github.com/lemonade-sdk/lemonade/issues)
 
 ### 2. **Lemonade is missing a feature I really want. What should I do?**
 
-Open a feature request on GitHub. We're actively shaping the roadmap based on user feedback.
+   Open a feature request on GitHub. We're actively shaping the roadmap based on user feedback.
 
 ### 3. **Do you plan to share a roadmap?**
 
-Yes! Check out the project README:
+   Yes! Check out the project README:
 
-👉 [Lemonade Roadmap](https://github.com/lemonade-sdk/lemonade#project-roadmap)
+   👉 [Lemonade Roadmap](https://github.com/lemonade-sdk/lemonade#project-roadmap)

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -4,232 +4,226 @@
 
 ### 1. **What is Lemonade and what does it include?**
 
-   Lemonade is an open-source local LLM solution that:
-      - Gets you started in minutes with one-click installers.
-      - Auto-configures optimized inference engines for your PC.
-      - Provides a convenient app to get set up and test out LLMs.
-      - Provides LLMs through the OpenAI API standard, enabling apps on your PC to access them.
+Lemonade is an open-source local LLM solution that: - Gets you started in minutes with one-click installers. - Auto-configures optimized inference engines for your PC. - Provides a convenient app to get set up and test out LLMs. - Provides LLMs through the OpenAI API standard, enabling apps on your PC to access them.
 
 ### 2. **What are the use cases for different audiences?**
 
-   - **LLM Enthusiasts**: LLMs on your GPU or NPU with minimal setup, and connect to great apps listed [here](https://lemonade-server.ai/docs/server/apps/).
-   - **Developers**: Integrate LLMs into apps using standard APIs with no device-specific code. See the [Server Integration Guide](https://lemonade-server.ai/docs/server/server_integration/
-   ).
-   - **Agent Developers**: Use [GAIA](https://github.com/amd/gaia) to quickly develop local-first agents.
+- **LLM Enthusiasts**: LLMs on your GPU or NPU with minimal setup, and connect to great apps listed [here](https://lemonade-server.ai/docs/server/apps/).
+- **Developers**: Integrate LLMs into apps using standard APIs with no device-specific code. See the [Server Integration Guide](https://lemonade-server.ai/docs/server/server_integration/).
+- **Agent Developers**: Use [GAIA](https://github.com/amd/gaia) to quickly develop local-first agents.
 
 ## Installation & Compatibility
 
 ### 1. **How do I install Lemonade SDK or Server?**
 
-   Visit https://lemonade-server.ai/install_options.html and click the options that apply to you.
+Visit https://lemonade-server.ai/install_options.html and click the options that apply to you.
 
 ### 2. **Which devices are supported?**
 
-   👉 [Supported Configurations](https://github.com/lemonade-sdk/lemonade?tab=readme-ov-file#supported-configurations)
+👉 [Supported Configurations](https://github.com/lemonade-sdk/lemonade?tab=readme-ov-file#supported-configurations)
 
-   For more information on AMD Ryzen AI NPU Support, see the section [Hybrid/NPU](#hybrid-and-npu-questions).
+For more information on AMD Ryzen AI NPU Support, see the section [Hybrid/NPU](#hybrid-and-npu-questions).
 
 ### 3. **Is Linux supported? What about macOS?**
 
-   Yes, both Linux and macOS are supported!
+Yes, both Linux and macOS are supported!
 
-   - **Linux**: Visit https://lemonade-server.ai/install_options.html#linux for installation instructions.
-   - **macOS**: A macOS installer (.pkg) is available for Apple Silicon Macs. Visit https://lemonade-server.ai/install_options.html#macos to download. macOS support uses the llama.cpp backend with Metal acceleration.
+- **Linux**: Visit https://lemonade-server.ai/install_options.html#linux for installation instructions.
+- **macOS**: A macOS installer (.pkg) is available for Apple Silicon Macs. Visit https://lemonade-server.ai/install_options.html#macos to download. macOS support uses the llama.cpp backend with Metal acceleration.
 
-   Visit the [Supported Configurations](https://github.com/lemonade-sdk/lemonade?tab=readme-ov-file#supported-configurations) section to see the support matrix for CPU, GPU, and NPU.
+Visit the [Supported Configurations](https://github.com/lemonade-sdk/lemonade?tab=readme-ov-file#supported-configurations) section to see the support matrix for CPU, GPU, and NPU.
 
 ### 4. **How do I uninstall Lemonade Server? (Windows)**
 
-   To uninstall Lemonade Server, use the Windows Add/Remove Programs menu.
+To uninstall Lemonade Server, use the Windows Add/Remove Programs menu.
 
-   **Optional: Remove cached files**
-   - Open File Explorer and navigate to `%USERPROFILE%\.cache`
-   - Delete the `lemonade` folder if it exists
-   - To remove downloaded models, delete the `huggingface` folder
+**Optional: Remove cached files**
+
+- Open File Explorer and navigate to `%USERPROFILE%\.cache`
+- Delete the `lemonade` folder if it exists
+- To remove downloaded models, delete the `huggingface` folder
 
 ## Models
 
 ### 1. **Where are models stored and how do I change that?**
 
-   Lemonade uses three model locations:
+Lemonade uses three model locations:
 
-   **Primary: Hugging Face Cache**
+**Primary: Hugging Face Cache**
 
-   Models downloaded through Lemonade are stored using the Hugging Face Hub specification. By default, models are located at `~/.cache/huggingface/hub/`, where `~` is your home directory.
+Models downloaded through Lemonade are stored using the Hugging Face Hub specification. By default, models are located at `~/.cache/huggingface/hub/`, where `~` is your home directory.
 
-   For example, `Qwen/Qwen2.5-0.5B` is stored at `~/.cache/huggingface/hub/models--Qwen--Qwen2.5-0.5B`.
+For example, `Qwen/Qwen2.5-0.5B` is stored at `~/.cache/huggingface/hub/models--Qwen--Qwen2.5-0.5B`.
 
-   You can change this location by setting the `HF_HOME` env var, which will store your models in `$HF_HOME/hub` (e.g., `$HF_HOME/hub/models--Qwen--Qwen2.5-0.5B`). Alternatively, you can set `HF_HUB_CACHE` and your models will be in `$HF_HUB_CACHE` (e.g., `$HF_HUB_CACHE/models--Qwen--Qwen2.5-0.5B`).
+You can change this location by setting the `HF_HOME` env var, which will store your models in `$HF_HOME/hub` (e.g., `$HF_HOME/hub/models--Qwen--Qwen2.5-0.5B`). Alternatively, you can set `HF_HUB_CACHE` and your models will be in `$HF_HUB_CACHE` (e.g., `$HF_HUB_CACHE/models--Qwen--Qwen2.5-0.5B`).
 
-   You can use the official Hugging Face Hub utility (`pip install huggingface-hub`) to manage models outside of Lemonade, e.g., `hf cache ls` will print all models and their sizes.
+You can use the official Hugging Face Hub utility (`pip install huggingface-hub`) to manage models outside of Lemonade, e.g., `hf cache ls` will print all models and their sizes.
 
-   **Secondary: Extra Models Directory (GGUF)**
+**Secondary: Extra Models Directory (GGUF)**
 
-   Lemonade Server can discover GGUF models from a secondary directory using the `extra_models_dir` option, enabling compatibility with llama.cpp and LM Studio model caches. Suggested paths:
+Lemonade Server can discover GGUF models from a secondary directory using the `extra_models_dir` option, enabling compatibility with llama.cpp and LM Studio model caches. Suggested paths:
 
-   - **Windows:**
-       - LM Studio: `C:\Users\You\.lmstudio\models`
-       - llamacpp: `%LOCALAPPDATA%\llama.cpp` (e.g., `C:\Users\You\AppData\Local\llama.cpp`)
-   - **Linux:** `~/.cache/llama.cpp`
+- **Windows:**
+  - LM Studio: `C:\Users\You\.lmstudio\models`
+  - llamacpp: `%LOCALAPPDATA%\llama.cpp` (e.g., `C:\Users\You\AppData\Local\llama.cpp`)
+- **Linux:** `~/.cache/llama.cpp`
 
-   Set `extra_models_dir` (see [Server Configuration](./configuration/README.md)):
+Set `extra_models_dir` (see [Server Configuration](./configuration/README.md)):
 
-   ```bash
-   lemonade config set extra_models_dir="/home/you/.cache/llama.cpp"
-   ```
+```bash
+lemonade config set extra_models_dir="/home/you/.cache/llama.cpp"
+```
 
-   > Tip: in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings &rarr; Server**.
+> Tip: in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings &rarr; Server**.
 
-   Any `.gguf` files found in this directory (including subdirectories) will automatically appear in Lemonade's model list in the `custom` category.
+Any `.gguf` files found in this directory (including subdirectories) will automatically appear in Lemonade's model list in the `custom` category.
 
-   **FastFlowLM**
+**FastFlowLM**
 
-   FastFlowLM (FLM) has its own model management system. When you first install FLM the install wizard asks for a model directory, which is then saved to the `FLM_MODEL_PATH` environment variable on your system PATH. Models are stored in that directory. If you change the variable's value, newly downloaded models will be stored on the new path, but your prior models will still be at the prior path.
+FastFlowLM (FLM) has its own model management system. When you first install FLM the install wizard asks for a model directory, which is then saved to the `FLM_MODEL_PATH` environment variable on your system PATH. Models are stored in that directory. If you change the variable's value, newly downloaded models will be stored on the new path, but your prior models will still be at the prior path.
 
 ### 2. **What models are supported?**
 
-   Lemonade supports a wide range of LLMs including LLaMA, DeepSeek, Qwen, Gemma, Phi, gpt-oss, LFM, and many more. Most GGUF models can also be added to Lemonade Server by users using the Model Manager interface in the app or the `pull` command on the CLI.
+Lemonade supports a wide range of LLMs including LLaMA, DeepSeek, Qwen, Gemma, Phi, gpt-oss, LFM, and many more. Most GGUF models can also be added to Lemonade Server by users using the Model Manager interface in the app or the `pull` command on the CLI.
 
-   👉 [Supported Models List](https://lemonade-server.ai/models.html)
-   👉 [pull command](https://lemonade-server.ai/docs/lemonade-cli/#options-for-pull)
+👉 [Supported Models List](https://lemonade-server.ai/models.html)
+👉 [pull command](https://lemonade-server.ai/docs/lemonade-cli/#options-for-pull)
 
 ### 3. **How do I know what size model will work with my setup?**
 
-   Model compatibility depends on your system's RAM, VRAM, and NPU availability. **The actual file size varies significantly between models** due to different quantization techniques and architectures.
+Model compatibility depends on your system's RAM, VRAM, and NPU availability. **The actual file size varies significantly between models** due to different quantization techniques and architectures.
 
-   **To check if a model will work:**
-   1. Visit the model's Hugging Face page (e.g., [`amd/Qwen2.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Qwen2.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid)).
-   2. Check the "Files and versions" tab to see the actual download size.
-   3. Add ~2-4 GB overhead for KV cache, activations, and runtime memory.
-   4. Ensure your system has sufficient RAM/VRAM.
+**To check if a model will work:**
+
+1.  Visit the model's Hugging Face page (e.g., [`amd/Qwen2.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid`](https://huggingface.co/amd/Qwen2.5-7B-Chat-awq-g128-int4-asym-fp16-onnx-hybrid)).
+2.  Check the "Files and versions" tab to see the actual download size.
+3.  Add ~2-4 GB overhead for KV cache, activations, and runtime memory.
+4.  Ensure your system has sufficient RAM/VRAM.
 
 ### 4. **I'm looking for a model, but it's not listed in the Model Manager.**
 
-   If a model isn't listed, it may not be compatible with your PC due to device or RAM limitations, or we just haven't added it to the `server_models.json` file yet.
+If a model isn't listed, it may not be compatible with your PC due to device or RAM limitations, or we just haven't added it to the `server_models.json` file yet.
 
-   You can:
+You can:
 
-   - Add a custom model manually via the app's "Add a Model" interface or the [CLI pull command](https://lemonade-server.ai/docs/lemonade-cli/#options-for-pull). For advanced manual configuration, see the [Custom Model Configuration Guide](https://lemonade-server.ai/docs/server/custom-models/).
-   - Use a pull request to add the model to the built-in `server_models.json` file.
-   - Request support by opening a [GitHub issue](https://github.com/lemonade-sdk/lemonade/issues).
+- Add a custom model manually via the app's "Add a Model" interface or the [CLI pull command](https://lemonade-server.ai/docs/lemonade-cli/#options-for-pull). For advanced manual configuration, see the [Custom Model Configuration Guide](https://lemonade-server.ai/docs/server/custom-models/).
+- Use a pull request to add the model to the built-in `server_models.json` file.
+- Request support by opening a [GitHub issue](https://github.com/lemonade-sdk/lemonade/issues).
 
-   If you are sure that a model should be listed, but you aren't seeing it, you can `lemonade config set disable_model_filtering=true` in to show all models supported by Lemonade on any PC configuration. But please note, this can show models that definitely won't work on your system.
+If you are sure that a model should be listed, but you aren't seeing it, you can `lemonade config set disable_model_filtering=true` in to show all models supported by Lemonade on any PC configuration. But please note, this can show models that definitely won't work on your system.
 
-   Alternatively if you are attempting to use GTT on your dGPU then you can `lemonade config set enable_dgpu_gtt=true` to filter using the combined memory pool. Please note ROCM does not support splitting memory across multiple pools, vulkan is likely required for this usecase.
+Alternatively if you are attempting to use GTT on your dGPU then you can `lemonade config set enable_dgpu_gtt=true` to filter using the combined memory pool. Please note ROCM does not support splitting memory across multiple pools, vulkan is likely required for this usecase.
 
 ### 5. **Is there a script or tool to convert models to Ryzen AI NPU format?**
 
-   Yes, there's a guide on preparing your models for Ryzen AI NPU:
+Yes, there's a guide on preparing your models for Ryzen AI NPU:
 
-   👉 [Model Preparation Guide](https://ryzenai.docs.amd.com/en/latest/oga_model_prepare.html)
+👉 [Model Preparation Guide](https://ryzenai.docs.amd.com/en/latest/oga_model_prepare.html)
 
 ### 6. **What's the difference between GGUF and ONNX models?**
 
-   - **GGUF**: Used with llama.cpp backend, supports CPU, and GPU via Vulkan or ROCm.
-   - **ONNX**: Used with OnnxRuntime GenAI, supports NPU and NPU+iGPU Hybrid execution.
+- **GGUF**: Used with llama.cpp backend, supports CPU, and GPU via Vulkan or ROCm.
+- **ONNX**: Used with OnnxRuntime GenAI, supports NPU and NPU+iGPU Hybrid execution.
 
 ## Inference Behavior & Performance
 
 ### 1. **Can Lemonade print out stats like tokens per second?**
 
-   Yes! Lemonade Server exposes a `/stats` endpoint that returns performance metrics from the most recent completion request:
+Yes! Lemonade Server exposes a `/stats` endpoint that returns performance metrics from the most recent completion request:
 
-   ```bash
-   curl http://localhost:13305/api/v1/stats
-   ```
+```bash
+curl http://localhost:13305/api/v1/stats
+```
 
-   Or, use `lemonade config set log_level=debug` to enable debug logging, or `lemonade logs` to view logs.
+Or, use `lemonade config set log_level=debug` to enable debug logging, or `lemonade logs` to view logs.
 
 ### 2. **How does Lemonade's performance compare to llama.cpp?**
 
-   Lemonade supports llama.cpp as a backend, so performance is similar when using the same model and quantization.
+Lemonade supports llama.cpp as a backend, so performance is similar when using the same model and quantization.
 
 ### 3. **How can ROCm performance be improved for my use case?**
 
-   File a detailed issue on TheRock repo for support: https://github.com/ROCm/TheRock
+File a detailed issue on TheRock repo for support: https://github.com/ROCm/TheRock
 
 ### 4. **How should dedicated GPU RAM be allocated on Strix Halo**
 
-   **Linux**
+**Linux**
 
-   Please see the official AMD guidance [here](https://rocm.docs.amd.com/en/latest/how-to/system-optimization/strixhalo.html).
+Please see the official AMD guidance [here](https://rocm.docs.amd.com/en/latest/how-to/system-optimization/strixhalo.html).
 
-   **Windows**
+**Windows**
 
-   Strix Halo PCs can have up to 128 GB of unified RAM and Windows allows the user to allocate a portion of this to dedicated GPU RAM.
+Strix Halo PCs can have up to 128 GB of unified RAM and Windows allows the user to allocate a portion of this to dedicated GPU RAM.
 
-   We suggest setting dedicated GPU RAM to `64/64 (auto)`.
+We suggest setting dedicated GPU RAM to `64/64 (auto)`.
 
-   > Note: On Windows, the GPU can access both unified RAM and dedicated GPU RAM, but the CPU is blocked from accessing dedicated GPU RAM. For this reason, allocating too much dedicated GPU RAM can interfere with model loading, which requires the CPU to access a substantial amount unified RAM.
-
+> Note: On Windows, the GPU can access both unified RAM and dedicated GPU RAM, but the CPU is blocked from accessing dedicated GPU RAM. For this reason, allocating too much dedicated GPU RAM can interfere with model loading, which requires the CPU to access a substantial amount unified RAM.
 
 ## Hybrid and NPU Questions
 
 ### 1. **Does LLM inference with the NPU only work on Windows?**
 
-   Today, NPU-only inference on Linux is available via FastFlowLM, see the guide [here](https://lemonade-server.ai/flm_npu_linux.html).
+Today, NPU-only inference on Linux is available via FastFlowLM, see the guide [here](https://lemonade-server.ai/flm_npu_linux.html).
 
-   At the moment, Ryzen AI SW's implementation of NPU and hybrid inference is currently supported only on Windows.
+At the moment, Ryzen AI SW's implementation of NPU and hybrid inference is currently supported only on Windows.
 
 ### 2. **I loaded a hybrid model, but the NPU is barely active. Is that expected?**
 
-   Yes. In hybrid mode:
+Yes. In hybrid mode:
 
-   - The NPU handles prompt processing.
-   - The GPU handles token generation.
-   - If your prompt is short, the NPU finishes quickly. Try a longer prompt to see more NPU activity.
+- The NPU handles prompt processing.
+- The GPU handles token generation.
+- If your prompt is short, the NPU finishes quickly. Try a longer prompt to see more NPU activity.
 
 ### 3. **Does Lemonade work on older AMD processors or non-Ryzen AI systems?**
 
-   Yes! Lemonade supports multiple execution modes:
+Yes! Lemonade supports multiple execution modes:
 
-   - **AMD Ryzen 7000/8000/200 series**: GPU acceleration via llama.cpp + Vulkan backend
-   - **AMD Ryzen AI MAX+ (Strix Halo) on Linux**: in addition to the above, the experimental `vllm:rocm` backend is supported on gfx1151 (see [vLLM configuration](configuration/vllm.md))
-   - **Systems with Radeon GPUs**: Yes
-   - **Any x86 CPU**: Yes
-   - **Intel/NVIDIA systems**: CPU inference, with GPU support via the llama.cpp + Vulkan backend
+- **AMD Ryzen 7000/8000/200 series**: GPU acceleration via llama.cpp + Vulkan backend
+- **AMD Ryzen AI MAX+ (Strix Halo) on Linux**: in addition to the above, the experimental `vllm:rocm` backend is supported on gfx1151 (see [vLLM configuration](configuration/vllm.md))
+- **Systems with Radeon GPUs**: Yes
+- **Any x86 CPU**: Yes
+- **Intel/NVIDIA systems**: CPU inference, with GPU support via the llama.cpp + Vulkan backend
 
-   While you won't get NPU acceleration on non-Ryzen AI 300 systems, you can still benefit from GPU acceleration and the OpenAI-compatible API.
+While you won't get NPU acceleration on non-Ryzen AI 300 systems, you can still benefit from GPU acceleration and the OpenAI-compatible API.
 
 ### 4. **Is the NPU on the AMD Ryzen AI 7000/8000/200 series going to be supported for LLM inference?**
 
-   No inference engine providers have plans to support NPUs prior to Ryzen AI 300-series, but you can still request this by filing an issue on their respective GitHubs:
-      - Ryzen AI SW: https://github.com/amd/ryzenai-sw
-      - FastFlowLM: https://github.com/FastFlowLM/FastFlowLM
+No inference engine providers have plans to support NPUs prior to Ryzen AI 300-series, but you can still request this by filing an issue on their respective GitHubs: - Ryzen AI SW: https://github.com/amd/ryzenai-sw - FastFlowLM: https://github.com/FastFlowLM/FastFlowLM
 
 ### 5. **How do I know what model architectures are supported by the NPU?**
 
-   AMD publishes pre-quantized and optimized models in their Hugging Face collections:
+AMD publishes pre-quantized and optimized models in their Hugging Face collections:
 
-   - [Ryzen AI NPU Models](https://huggingface.co/collections/amd/ryzenai-15-llm-npu-models-6859846d7c13f81298990db0)
-   - [Ryzen AI Hybrid Models](https://huggingface.co/collections/amd/ryzenai-15-llm-hybrid-models-6859a64b421b5c27e1e53899)
+- [Ryzen AI NPU Models](https://huggingface.co/collections/amd/ryzenai-15-llm-npu-models-6859846d7c13f81298990db0)
+- [Ryzen AI Hybrid Models](https://huggingface.co/collections/amd/ryzenai-15-llm-hybrid-models-6859a64b421b5c27e1e53899)
 
-   To find the architecture of a specific model, click on any model in these collections and look for the "Base model" field, which will show you the underlying architecture (e.g., Llama, Qwen, Phi).
+To find the architecture of a specific model, click on any model in these collections and look for the "Base model" field, which will show you the underlying architecture (e.g., Llama, Qwen, Phi).
 
 ### 6. **How can I get better performance from the NPU?**
 
-   Make sure that you've put the NPU in "Turbo" mode to get the best results. This is done by opening a terminal window and running the following commands:
+Make sure that you've put the NPU in "Turbo" mode to get the best results. This is done by opening a terminal window and running the following commands:
 
-   ```cmd
-   cd C:\Windows\System32\AMD
-   .\xrt-smi configure --pmode turbo
-   ```
+```cmd
+cd C:\Windows\System32\AMD
+.\xrt-smi configure --pmode turbo
+```
 
 ## Remote Access
 
 ### 1. **How do I run Lemonade Server on one PC and access it from another?**
 
-   Lemonade supports running the server on one machine while using the app from another machine on the same network.
+Lemonade supports running the server on one machine while using the app from another machine on the same network.
 
-   For detailed instructions and security considerations, see [Remote Server Connection](./configuration/README.md#remote-server-connection).
+For detailed instructions and security considerations, see [Remote Server Connection](./configuration/README.md#remote-server-connection).
 
 ## Customization
 
 ### 1. **How do I use my own llama.cpp or whisper.cpp binaries?**
 
-   Lemonade Server allows you to use custom `llama-server` or `whisper-server` binaries instead of the bundled ones by setting environment variables to the full path of your binary.
+Lemonade Server allows you to use custom `llama-server` or `whisper-server` binaries instead of the bundled ones by setting environment variables to the full path of your binary.
 
-   👉 [Custom Backend Binaries](./configuration/README.md)
+👉 [Custom Backend Binaries](./configuration/README.md)
 
 ## TTS
 
@@ -263,16 +257,16 @@ Some voices are not supported yet. If you manually enter a voice name instead of
 
 ### 1. **What if I encounter installation or runtime errors?**
 
-   Check the Lemonade Server logs via the App or tray icon. Common issues include model compatibility or outdated versions.
+Check the Lemonade Server logs via the App or tray icon. Common issues include model compatibility or outdated versions.
 
-   👉 [Open an Issue on GitHub](https://github.com/lemonade-sdk/lemonade/issues)
+👉 [Open an Issue on GitHub](https://github.com/lemonade-sdk/lemonade/issues)
 
 ### 2. **Lemonade is missing a feature I really want. What should I do?**
 
-   Open a feature request on GitHub. We're actively shaping the roadmap based on user feedback.
+Open a feature request on GitHub. We're actively shaping the roadmap based on user feedback.
 
 ### 3. **Do you plan to share a roadmap?**
 
-   Yes! Check out the project README:
+Yes! Check out the project README:
 
-   👉 [Lemonade Roadmap](https://github.com/lemonade-sdk/lemonade#project-roadmap)
+👉 [Lemonade Roadmap](https://github.com/lemonade-sdk/lemonade#project-roadmap)

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -78,6 +78,8 @@
    lemonade config set extra_models_dir="/home/you/.cache/llama.cpp"
    ```
 
+   > Tip: in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings &rarr; Server**.
+
    Any `.gguf` files found in this directory (including subdirectories) will automatically appear in Lemonade's model list in the `custom` category.
 
    **FastFlowLM**

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -76,7 +76,7 @@ lemonade config set extra_models_dir="/home/you/.cache/llama.cpp"
 
 > Tip: in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings &rarr; Server**.
 
-Any `.gguf` files found in this directory (including subdirectories) will automatically appear in Lemonade's model list in the `custom` category.
+Any `.gguf` files found in this directory (including subdirectories) will automatically appear in Lemonade's model list under their bare filename. If a bare name would collide with an already-registered model, the imported entry is shown with an `extra.` prefix so both can coexist.
 
 **FastFlowLM**
 

--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -7,11 +7,12 @@
     "": {
       "name": "lemonade-app",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
         "@tauri-apps/plugin-deep-link": "^2.0.0",
+        "@tauri-apps/plugin-dialog": "^2.0.0",
         "@tauri-apps/plugin-opener": "^2.0.0",
         "@types/markdown-it": "^14.1.2",
         "highlight.js": "^11.11.1",
@@ -669,9 +670,10 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
+      "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/tauri"
@@ -896,6 +898,15 @@
       "integrity": "sha512-Cd2Cs960MGuGONeIwxOPx9wqwedetAHOGlwK5boJ/SMTfAtAyfErpfVPEn+EJzgXsJun8EKzsEumHjr+64V4fw==",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.0.0",
+        "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
         "@tauri-apps/plugin-deep-link": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",
@@ -23,7 +23,7 @@
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
-        "@tauri-apps/cli": "^2.0.0",
+        "@tauri-apps/cli": "^2.11.2",
         "@types/katex": "^0.16.7",
         "@types/node": "^20.10.5",
         "@types/react": "^19.2.2",
@@ -680,10 +680,11 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.10.1.tgz",
-      "integrity": "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz",
+      "integrity": "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==",
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "bin": {
         "tauri": "tauri.js"
       },
@@ -695,27 +696,28 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.10.1",
-        "@tauri-apps/cli-darwin-x64": "2.10.1",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-arm64-musl": "2.10.1",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-gnu": "2.10.1",
-        "@tauri-apps/cli-linux-x64-musl": "2.10.1",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.10.1",
-        "@tauri-apps/cli-win32-x64-msvc": "2.10.1"
+        "@tauri-apps/cli-darwin-arm64": "2.11.2",
+        "@tauri-apps/cli-darwin-x64": "2.11.2",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.2",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.2",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.2",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.2",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.2"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
-      "integrity": "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz",
+      "integrity": "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -725,13 +727,14 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
-      "integrity": "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz",
+      "integrity": "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -741,13 +744,14 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
-      "integrity": "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz",
+      "integrity": "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -757,13 +761,17 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
-      "integrity": "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz",
+      "integrity": "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -773,13 +781,17 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
-      "integrity": "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz",
+      "integrity": "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -789,13 +801,17 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
-      "integrity": "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz",
+      "integrity": "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -805,13 +821,17 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
-      "integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz",
+      "integrity": "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -821,13 +841,17 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
-      "integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz",
+      "integrity": "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -837,13 +861,14 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
-      "integrity": "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz",
+      "integrity": "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "win32"
@@ -853,13 +878,14 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
-      "integrity": "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz",
+      "integrity": "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "win32"
@@ -869,13 +895,14 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.10.1.tgz",
-      "integrity": "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz",
+      "integrity": "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "win32"

--- a/src/app/package-lock.json
+++ b/src/app/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
         "@tauri-apps/plugin-deep-link": "^2.0.0",
-        "@tauri-apps/plugin-dialog": "^2.0.0",
+        "@tauri-apps/plugin-dialog": "~2.2.2",
         "@tauri-apps/plugin-opener": "^2.0.0",
         "@types/markdown-it": "^14.1.2",
         "highlight.js": "^11.11.1",
@@ -23,7 +23,7 @@
         "react-dom": "^19.2.0"
       },
       "devDependencies": {
-        "@tauri-apps/cli": "^2.11.2",
+        "@tauri-apps/cli": "^2.0.0",
         "@types/katex": "^0.16.7",
         "@types/node": "^20.10.5",
         "@types/react": "^19.2.2",
@@ -670,21 +670,19 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
-      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
-      "license": "Apache-2.0 OR MIT",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/tauri"
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz",
-      "integrity": "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.10.1.tgz",
+      "integrity": "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g==",
       "dev": true,
-      "license": "Apache-2.0 OR MIT",
       "bin": {
         "tauri": "tauri.js"
       },
@@ -696,28 +694,27 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.11.2",
-        "@tauri-apps/cli-darwin-x64": "2.11.2",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.11.2",
-        "@tauri-apps/cli-linux-arm64-musl": "2.11.2",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2",
-        "@tauri-apps/cli-linux-x64-gnu": "2.11.2",
-        "@tauri-apps/cli-linux-x64-musl": "2.11.2",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.11.2",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.11.2",
-        "@tauri-apps/cli-win32-x64-msvc": "2.11.2"
+        "@tauri-apps/cli-darwin-arm64": "2.10.1",
+        "@tauri-apps/cli-darwin-x64": "2.10.1",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.10.1",
+        "@tauri-apps/cli-linux-arm64-musl": "2.10.1",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1",
+        "@tauri-apps/cli-linux-x64-gnu": "2.10.1",
+        "@tauri-apps/cli-linux-x64-musl": "2.10.1",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.10.1",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.10.1",
+        "@tauri-apps/cli-win32-x64-msvc": "2.10.1"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz",
-      "integrity": "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.10.1.tgz",
+      "integrity": "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -727,14 +724,13 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz",
-      "integrity": "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.10.1.tgz",
+      "integrity": "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -744,14 +740,13 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz",
-      "integrity": "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.10.1.tgz",
+      "integrity": "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -761,17 +756,13 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz",
-      "integrity": "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.10.1.tgz",
+      "integrity": "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -781,17 +772,13 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz",
-      "integrity": "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.10.1.tgz",
+      "integrity": "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -801,17 +788,13 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz",
-      "integrity": "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.10.1.tgz",
+      "integrity": "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -821,17 +804,13 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz",
-      "integrity": "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.10.1.tgz",
+      "integrity": "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -841,17 +820,13 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz",
-      "integrity": "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.10.1.tgz",
+      "integrity": "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "linux"
@@ -861,14 +836,13 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz",
-      "integrity": "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.10.1.tgz",
+      "integrity": "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "win32"
@@ -878,14 +852,13 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz",
-      "integrity": "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.10.1.tgz",
+      "integrity": "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "win32"
@@ -895,14 +868,13 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz",
-      "integrity": "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.10.1.tgz",
+      "integrity": "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
         "win32"
@@ -928,12 +900,12 @@
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
-      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.2.2.tgz",
+      "integrity": "sha512-Pm9qnXQq8ZVhAMFSEPwxvh+nWb2mk7LASVlNEHYaksHvcz8P6+ElR5U5dNL9Ofrm+uwhh1/gYKWswK8JJJAh6A==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.11.0"
+        "@tauri-apps/api": "^2.0.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@tauri-apps/cli": "^2.11.2",
+    "@tauri-apps/cli": "^2.0.0",
     "@types/katex": "^0.16.7",
     "@types/node": "^20.10.5",
     "@types/react": "^19.2.2",
@@ -39,10 +39,10 @@
     "webpack-dev-server": "^5.2.3"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
     "@tauri-apps/plugin-deep-link": "^2.0.0",
-    "@tauri-apps/plugin-dialog": "^2.0.0",
+    "@tauri-apps/plugin-dialog": "~2.2.2",
     "@tauri-apps/plugin-opener": "^2.0.0",
     "@types/markdown-it": "^14.1.2",
     "highlight.js": "^11.11.1",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -42,6 +42,7 @@
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
     "@tauri-apps/plugin-deep-link": "^2.0.0",
+    "@tauri-apps/plugin-dialog": "^2.0.0",
     "@tauri-apps/plugin-opener": "^2.0.0",
     "@types/markdown-it": "^14.1.2",
     "highlight.js": "^11.11.1",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -22,7 +22,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@tauri-apps/cli": "^2.0.0",
+    "@tauri-apps/cli": "^2.11.2",
     "@types/katex": "^0.16.7",
     "@types/node": "^20.10.5",
     "@types/react": "^19.2.2",
@@ -39,7 +39,7 @@
     "webpack-dev-server": "^5.2.3"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.0.0",
+    "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.0.0",
     "@tauri-apps/plugin-deep-link": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/src/app/src-tauri/Cargo.lock
+++ b/src/app/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -116,6 +116,27 @@ dependencies = [
  "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.4",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
 ]
 
 [[package]]
@@ -734,19 +755,13 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.8.0"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "quote",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -780,17 +795,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "dbus"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -886,7 +890,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -910,6 +914,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
 ]
 
 [[package]]
@@ -988,21 +1001,6 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
-
-[[package]]
-name = "dtor"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -1110,7 +1108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2305,15 +2303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,9 +2450,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.19.2"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
+checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2474,7 +2463,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png 0.18.1",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2494,6 +2483,12 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -2587,27 +2582,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-cloud-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2629,38 +2603,6 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-core-image"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-location"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
-dependencies = [
- "objc2",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-text"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
- "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2721,27 +2663,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
  "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
  "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-location",
- "objc2-core-text",
- "objc2-foundation",
- "objc2-quartz-core",
- "objc2-user-notifications",
-]
-
-[[package]]
-name = "objc2-user-notifications"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
-dependencies = [
- "objc2",
  "objc2-foundation",
 ]
 
@@ -2816,7 +2739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2922,6 +2845,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -3018,6 +2942,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3345,6 +3282,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +3312,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3380,6 +3337,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3522,10 +3488,11 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.16.0"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
 dependencies = [
+ "ashpd",
  "block2",
  "dispatch2",
  "glib-sys",
@@ -3541,7 +3508,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3579,7 +3546,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3647,6 +3614,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3932,7 +3905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4112,16 +4085,15 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.35.3"
+version = "0.34.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
+checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
- "dbus",
  "dispatch2",
  "dlopen2",
  "dpi",
@@ -4132,14 +4104,13 @@ dependencies = [
  "libc",
  "log",
  "ndk",
+ "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
- "objc2-ui-kit",
  "once_cell",
  "parking_lot",
- "percent-encoding",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -4169,9 +4140,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.2"
+version = "2.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
+checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4222,9 +4193,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.2"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
+checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4238,14 +4209,15 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
+ "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.2"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
+checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4270,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.2"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
+checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4337,9 +4309,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+checksum = "a33318fe222fc2a612961de8b0419e2982767f213f54a4d3a21b0d7b85c41df8"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -4416,9 +4388,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.2"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
+checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
 dependencies = [
  "cookie",
  "dpi",
@@ -4441,9 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.2"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
+checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
  "http",
@@ -4467,15 +4439,14 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
+checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
- "dom_query",
  "dunce",
  "glob",
  "html5ever 0.29.1",
@@ -4485,8 +4456,7 @@ dependencies = [
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.13.1",
- "plist",
+ "phf 0.11.3",
  "proc-macro2",
  "quote",
  "regex",
@@ -4498,7 +4468,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "toml 0.9.12+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -4526,7 +4496,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4668,6 +4638,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -4893,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.23.1"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
+checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -4907,7 +4878,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png 0.18.1",
+ "png 0.17.16",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -4950,7 +4921,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5259,6 +5230,7 @@ dependencies = [
  "cc",
  "downcast-rs",
  "rustix",
+ "scoped-tls",
  "smallvec",
  "wayland-sys",
 ]
@@ -5317,6 +5289,8 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
+ "dlib",
+ "log",
  "pkg-config",
 ]
 
@@ -5450,7 +5424,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6081,9 +6055,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.55.1"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
+checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
 dependencies = [
  "base64 0.22.1",
  "block2",
@@ -6209,6 +6183,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_repr",
+ "tokio",
  "tracing",
  "uds_windows",
  "uuid",
@@ -6349,6 +6324,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",

--- a/src/app/src-tauri/Cargo.lock
+++ b/src/app/src-tauri/Cargo.lock
@@ -2232,6 +2232,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-deep-link",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-single-instance",
  "tokio",
@@ -2597,6 +2598,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3426,6 +3428,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,6 +4242,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4556,6 +4624,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]

--- a/src/app/src-tauri/Cargo.lock
+++ b/src/app/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -734,13 +734,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.117",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -774,6 +780,17 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -869,7 +886,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -971,6 +988,21 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -1078,7 +1110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2273,6 +2305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2433,7 +2474,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -2453,12 +2494,6 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -2552,6 +2587,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2573,6 +2629,38 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2633,8 +2721,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2709,7 +2816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2815,7 +2922,6 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -2912,19 +3018,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3486,7 +3579,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3839,7 +3932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4019,15 +4112,16 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.8"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
+ "dbus",
  "dispatch2",
  "dlopen2",
  "dpi",
@@ -4038,13 +4132,14 @@ dependencies = [
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -4074,9 +4169,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4127,9 +4222,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.6"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
+checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4143,15 +4238,14 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.5"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
+checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4176,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.5"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
+checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4322,9 +4416,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
 dependencies = [
  "cookie",
  "dpi",
@@ -4347,9 +4441,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
@@ -4373,14 +4467,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.3"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
  "html5ever 0.29.1",
@@ -4390,7 +4485,8 @@ dependencies = [
  "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf 0.13.1",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -4402,7 +4498,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -4430,7 +4526,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4797,9 +4893,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -4811,7 +4907,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -4854,7 +4950,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5354,7 +5450,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5985,9 +6081,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.54.4"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src/app/src-tauri/Cargo.toml
+++ b/src/app/src-tauri/Cargo.toml
@@ -18,12 +18,12 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2.11", features = ["protocol-asset", "image-ico"] }
+tauri = { version = "2", features = ["protocol-asset", "image-ico"] }
 tauri-plugin-opener = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-deep-link = "2"
-tauri-plugin-dialog = "2"
+tauri-plugin-dialog = "~2.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/src/app/src-tauri/Cargo.toml
+++ b/src/app/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset", "image-ico"] }
+tauri = { version = "2.11", features = ["protocol-asset", "image-ico"] }
 tauri-plugin-opener = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-single-instance = "2"

--- a/src/app/src-tauri/Cargo.toml
+++ b/src/app/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-deep-link = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/src/app/src-tauri/capabilities/default.json
+++ b/src/app/src-tauri/capabilities/default.json
@@ -26,6 +26,7 @@
     "opener:allow-open-url",
     "clipboard-manager:default",
     "clipboard-manager:allow-write-text",
-    "deep-link:default"
+    "deep-link:default",
+    "dialog:allow-open"
   ]
 }

--- a/src/app/src-tauri/src/lib.rs
+++ b/src/app/src-tauri/src/lib.rs
@@ -91,6 +91,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             let app_handle = app.handle().clone();
 

--- a/src/app/src/renderer/SettingsPanel.tsx
+++ b/src/app/src/renderer/SettingsPanel.tsx
@@ -10,6 +10,7 @@ import {
   DEFAULT_TTS_SETTINGS,
 } from './utils/appSettings';
 import ConnectionSettings from './tabs/ConnectionSettings';
+import ServerSettings from './tabs/ServerSettings';
 import TTSSettings from './tabs/TTSSettings';
 import LLMChatSettings from './tabs/LLMChatSettings';
 
@@ -50,7 +51,7 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ isVisible, searchQuery = 
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
-    new Set(['connection_settings', 'llm_chat_settings', 'tts_settings'])
+    new Set(['connection_settings', 'server_settings', 'llm_chat_settings', 'tts_settings'])
   );
 
   useEffect(() => {
@@ -252,6 +253,15 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ isVisible, searchQuery = 
       settingCount: 6,
     },
     {
+      id: 'server_settings',
+      label: 'Server',
+      keywords: [
+        'server', 'models', 'model', 'folder', 'directory', 'download', 'models dir',
+        'models_dir', 'extra models', 'extra_models_dir', 'storage', 'cache', 'huggingface'
+      ],
+      settingCount: 1,
+    },
+    {
       id: 'tts_settings',
       label: 'Speech',
       keywords: [
@@ -278,6 +288,8 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ isVisible, searchQuery = 
           onValueChangeFunc={handleTextInputChange}
           onResetFunc={handleResetField}
         />;
+      case 'server_settings':
+        return <ServerSettings />;
       case 'llm_chat_settings':
         return <LLMChatSettings
           settings={settings}

--- a/src/app/src/renderer/SettingsPanel.tsx
+++ b/src/app/src/renderer/SettingsPanel.tsx
@@ -257,9 +257,10 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ isVisible, searchQuery = 
       label: 'Server',
       keywords: [
         'server', 'models', 'model', 'folder', 'directory', 'download', 'models dir',
-        'models_dir', 'extra models', 'extra_models_dir', 'storage', 'cache', 'huggingface'
+        'models_dir', 'extra models', 'extra_models_dir', 'extra', 'gguf', 'import',
+        'storage', 'cache', 'huggingface'
       ],
-      settingCount: 1,
+      settingCount: 2,
     },
     {
       id: 'tts_settings',

--- a/src/app/src/renderer/tabs/ServerSettings.tsx
+++ b/src/app/src/renderer/tabs/ServerSettings.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import { open } from '@tauri-apps/plugin-dialog';
 import {
+  RuntimeConfigUpdateResult,
+  clearExtraModelsDir,
   getRuntimeConfig,
-  setModelsDir,
-  resetModelsDir,
   isModelsDirAuto,
   MODELS_DIR_AUTO_SENTINEL,
+  resetModelsDir,
+  setExtraModelsDir,
+  setModelsDir,
 } from '../utils/serverRuntimeConfig';
 
 type Status =
@@ -16,13 +19,115 @@ type Status =
   | { kind: 'error'; message: string }
   | { kind: 'saved' };
 
+interface DirectoryFieldProps {
+  label: string;
+  description: ReactNode;
+  placeholder: string;
+  dialogTitle: string;
+  // Current server-persisted value. The field considers itself "at default"
+  // — and disables Reset — when `isDefault(serverValue)` returns true.
+  serverValue: string;
+  isDefault: (value: string) => boolean;
+  // Disable browse/inputs when the parent is busy or auth has failed.
+  disabled: boolean;
+  // Apply a user-typed or user-picked value. The parent handles status updates
+  // and re-fetches config afterward.
+  onApply: (value: string) => Promise<void>;
+  // Reset to the field's default (which differs between models_dir and
+  // extra_models_dir, so it stays a callback rather than a sentinel here).
+  onReset: () => Promise<void>;
+}
+
+const DirectoryField: React.FC<DirectoryFieldProps> = ({
+  label,
+  description,
+  placeholder,
+  dialogTitle,
+  serverValue,
+  isDefault,
+  disabled,
+  onApply,
+  onReset,
+}) => {
+  // Local draft tracks what the user has typed but not yet applied. We re-sync
+  // it from `serverValue` whenever the parent reloads, so the input always
+  // reflects the server after a save.
+  const [draft, setDraft] = useState(serverValue);
+  useEffect(() => {
+    setDraft(serverValue);
+  }, [serverValue]);
+
+  const handleBrowse = async () => {
+    // Seed the picker with the current path when it's a real directory; for
+    // the default sentinel (or empty), let the OS pick the start location.
+    const defaultPath = isDefault(draft) ? undefined : draft || undefined;
+    const selected = await open({
+      directory: true,
+      multiple: false,
+      defaultPath,
+      title: dialogTitle,
+    });
+    if (typeof selected === 'string' && selected.length > 0) {
+      setDraft(selected);
+      await onApply(selected);
+    }
+  };
+
+  const isDirty = draft.trim() !== serverValue;
+  const atDefault = isDefault(serverValue);
+
+  return (
+    <div className={`settings-section ${atDefault ? 'settings-section-default' : ''}`}>
+      <div className="settings-label-row">
+        <label className="settings-label">
+          <span className="settings-label-text">{label}</span>
+          <span className="settings-description">{description}</span>
+        </label>
+        <button
+          type="button"
+          className="settings-field-reset"
+          onClick={() => { void onReset(); }}
+          disabled={disabled || atDefault}
+        >
+          Reset
+        </button>
+      </div>
+      <div className="settings-path-row">
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          className="settings-text-input"
+          placeholder={placeholder}
+          title={label}
+          disabled={disabled}
+        />
+        <button
+          type="button"
+          className="settings-field-reset"
+          onClick={() => { void handleBrowse(); }}
+          disabled={disabled}
+        >
+          Browse…
+        </button>
+        <button
+          type="button"
+          className="settings-field-reset"
+          onClick={() => { void onApply(draft.trim()); }}
+          disabled={disabled || !isDirty}
+        >
+          Apply
+        </button>
+      </div>
+    </div>
+  );
+};
+
 const ServerSettings: React.FC = () => {
-  // models_dir is server-wide config — it does NOT live in AppSettings.
-  // We hold a local draft of the text input plus the last-known server value
-  // so the Reset/Apply buttons can do the right thing.
+  // Server-wide config does NOT live in AppSettings. We mirror the last-known
+  // server values here and rewrite them via the helpers in serverRuntimeConfig.
   const [serverModelsDir, setServerModelsDir] = useState<string>(MODELS_DIR_AUTO_SENTINEL);
-  const [draftModelsDir, setDraftModelsDir] = useState<string>(MODELS_DIR_AUTO_SENTINEL);
-  const [extraModelsDir, setExtraModelsDir] = useState<string>('');
+  const [serverExtraModelsDir, setServerExtraModelsDir] = useState<string>('');
   const [status, setStatus] = useState<Status>({ kind: 'loading' });
 
   const loadConfig = useCallback(async () => {
@@ -30,8 +135,7 @@ const ServerSettings: React.FC = () => {
     const result = await getRuntimeConfig();
     if (result.kind === 'ok') {
       setServerModelsDir(result.modelsDir);
-      setDraftModelsDir(result.modelsDir);
-      setExtraModelsDir(result.extraModelsDir);
+      setServerExtraModelsDir(result.extraModelsDir);
       setStatus({ kind: 'ready' });
     } else if (result.kind === 'unauthorized') {
       setStatus({ kind: 'unauthorized' });
@@ -41,22 +145,17 @@ const ServerSettings: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    loadConfig();
+    void loadConfig();
   }, [loadConfig]);
 
-  const applyValue = async (path: string) => {
-    setStatus({ kind: 'saving' });
-    const result = path === MODELS_DIR_AUTO_SENTINEL || isModelsDirAuto(path)
-      ? await resetModelsDir()
-      : await setModelsDir(path);
+  const finishApply = async (result: RuntimeConfigUpdateResult) => {
     if (result.kind === 'ok') {
       setStatus({ kind: 'saved' });
       // Re-read so we display whatever the server actually persisted.
       const fresh = await getRuntimeConfig();
       if (fresh.kind === 'ok') {
         setServerModelsDir(fresh.modelsDir);
-        setDraftModelsDir(fresh.modelsDir);
-        setExtraModelsDir(fresh.extraModelsDir);
+        setServerExtraModelsDir(fresh.extraModelsDir);
       }
     } else if (result.kind === 'unauthorized') {
       setStatus({ kind: 'unauthorized' });
@@ -65,125 +164,88 @@ const ServerSettings: React.FC = () => {
     }
   };
 
-  const handleBrowse = async () => {
-    try {
-      // Seed the picker with the current path when it's a real directory; for
-      // the `"auto"` sentinel, let the OS default the starting location.
-      const defaultPath = isModelsDirAuto(draftModelsDir) ? undefined : draftModelsDir;
-      const selected = await open({
-        directory: true,
-        multiple: false,
-        defaultPath,
-        title: 'Choose model download folder',
-      });
-      if (typeof selected === 'string' && selected.length > 0) {
-        setDraftModelsDir(selected);
-        await applyValue(selected);
-      }
-    } catch (error) {
-      setStatus({
-        kind: 'error',
-        message: error instanceof Error ? error.message : String(error),
-      });
-    }
+  const applyModelsDir = async (value: string) => {
+    setStatus({ kind: 'saving' });
+    const result = value === MODELS_DIR_AUTO_SENTINEL || isModelsDirAuto(value)
+      ? await resetModelsDir()
+      : await setModelsDir(value);
+    await finishApply(result);
   };
 
-  const handleApply = () => applyValue(draftModelsDir.trim());
-  const handleReset = () => applyValue(MODELS_DIR_AUTO_SENTINEL);
+  const applyExtraModelsDir = async (value: string) => {
+    setStatus({ kind: 'saving' });
+    const result = value === ''
+      ? await clearExtraModelsDir()
+      : await setExtraModelsDir(value);
+    await finishApply(result);
+  };
 
-  const isAuto = isModelsDirAuto(serverModelsDir);
-  const isDirty = draftModelsDir.trim() !== serverModelsDir;
   const isBusy = status.kind === 'loading' || status.kind === 'saving';
+  const isUnauthorized = status.kind === 'unauthorized';
+  const fieldsDisabled = isBusy || isUnauthorized;
 
   return (
     <div className="settings-section-container">
-      <div className={`settings-section ${isAuto ? 'settings-section-default' : ''}`}>
-        <div className="settings-label-row">
-          <label className="settings-label">
-            <span className="settings-label-text">Model download folder</span>
-            <span className="settings-description">
-              Where the server downloads and stores models. Use <code>auto</code> to follow
-              the Hugging Face cache (<code>~/.cache/huggingface/hub</code>). This is a server-wide
-              setting — changes apply to every client connected to this server.
-            </span>
-          </label>
-          <button
-            type="button"
-            className="settings-field-reset"
-            onClick={handleReset}
-            disabled={isBusy || isAuto}
-          >
-            Reset
-          </button>
-        </div>
-        <div className="settings-path-row">
-          <input
-            type="text"
-            value={draftModelsDir}
-            onChange={(e) => setDraftModelsDir(e.target.value)}
-            className="settings-text-input"
-            placeholder="auto"
-            title="Model download folder"
-            disabled={isBusy || status.kind === 'unauthorized'}
-          />
-          <button
-            type="button"
-            className="settings-field-reset"
-            onClick={handleBrowse}
-            disabled={isBusy || status.kind === 'unauthorized'}
-          >
-            Browse…
-          </button>
-          <button
-            type="button"
-            className="settings-field-reset"
-            onClick={handleApply}
-            disabled={isBusy || !isDirty || status.kind === 'unauthorized'}
-          >
-            Apply
-          </button>
-        </div>
+      <DirectoryField
+        label="Model download folder"
+        description={
+          <>
+            Where the server downloads and stores models pulled from Hugging Face. Use{' '}
+            <code>auto</code> to follow the Hugging Face cache
+            (<code>~/.cache/huggingface/hub</code>). This is a server-wide setting — changes
+            apply to every client connected to this server. Loose GGUF files placed in this
+            folder are <em>not</em> detected; for that, use the Extra models folder below.
+          </>
+        }
+        placeholder="auto"
+        dialogTitle="Choose model download folder"
+        serverValue={serverModelsDir}
+        isDefault={isModelsDirAuto}
+        disabled={fieldsDisabled}
+        onApply={applyModelsDir}
+        onReset={() => applyModelsDir(MODELS_DIR_AUTO_SENTINEL)}
+      />
 
-        {status.kind === 'loading' && (
-          <div className="settings-description">Loading current value…</div>
-        )}
-        {status.kind === 'saving' && (
-          <div className="settings-description">Saving…</div>
-        )}
-        {status.kind === 'saved' && (
-          <div className="settings-description">Saved. Server is using the new folder.</div>
-        )}
-        {status.kind === 'unauthorized' && (
-          <div className="settings-description">
-            The server rejected the request. Editing server configuration requires the
-            admin API key (<code>LEMONADE_ADMIN_API_KEY</code>). Set it on the server and
-            in Connection → API Key, then reload.
-          </div>
-        )}
-        {status.kind === 'error' && (
-          <div className="settings-description">Could not read or update the setting: {status.message}</div>
-        )}
-      </div>
+      <DirectoryField
+        label="Extra models folder"
+        description={
+          <>
+            An additional folder the server recursively scans for loose <code>.gguf</code>{' '}
+            files. Imported models appear in the model list with the <code>extra.</code>{' '}
+            prefix. Leave empty to disable. Tip: after changing this, refresh Model Manager
+            to see imported models.
+          </>
+        }
+        placeholder="(none — feature disabled)"
+        dialogTitle="Choose extra models folder"
+        serverValue={serverExtraModelsDir}
+        isDefault={(value) => value.trim() === ''}
+        disabled={fieldsDisabled}
+        onApply={applyExtraModelsDir}
+        onReset={() => applyExtraModelsDir('')}
+      />
 
-      {/* <div className="settings-section settings-section-default">
-        <div className="settings-label-row">
-          <label className="settings-label">
-            <span className="settings-label-text">Extra models folder (read-only)</span>
-            <span className="settings-description">
-              Additional path the server searches recursively for GGUF files. Configure
-              with <code>lemonade config set extra_models_dir=...</code>.
-            </span>
-          </label>
+      {status.kind === 'loading' && (
+        <div className="settings-description">Loading current values…</div>
+      )}
+      {status.kind === 'saving' && (
+        <div className="settings-description">Saving…</div>
+      )}
+      {status.kind === 'saved' && (
+        <div className="settings-description">Saved. Server is using the new value.</div>
+      )}
+      {status.kind === 'unauthorized' && (
+        <div className="settings-description">
+          The server rejected the request. Editing server configuration requires the
+          admin API key (<code>LEMONADE_ADMIN_API_KEY</code>). Set it on the server and
+          in Connection → API Key, then reload.
         </div>
-        <input
-          type="text"
-          value={extraModelsDir || '(not set)'}
-          readOnly
-          className="settings-text-input"
-          title="Extra models folder"
-          placeholder="(not set)"
-        />
-      </div> */}
+      )}
+      {status.kind === 'error' && (
+        <div className="settings-description">
+          Could not read or update the setting: {status.message}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/src/renderer/tabs/ServerSettings.tsx
+++ b/src/app/src/renderer/tabs/ServerSettings.tsx
@@ -36,6 +36,9 @@ interface DirectoryFieldProps {
   // Reset to the field's default (which differs between models_dir and
   // extra_models_dir, so it stays a callback rather than a sentinel here).
   onReset: () => Promise<void>;
+  // Surface dialog/plugin failures to the parent so they appear in the shared
+  // status row instead of becoming unhandled promise rejections.
+  onError: (message: string) => void;
 }
 
 const DirectoryField: React.FC<DirectoryFieldProps> = ({
@@ -48,6 +51,7 @@ const DirectoryField: React.FC<DirectoryFieldProps> = ({
   disabled,
   onApply,
   onReset,
+  onError,
 }) => {
   // Local draft tracks what the user has typed but not yet applied. We re-sync
   // it from `serverValue` whenever the parent reloads, so the input always
@@ -61,15 +65,20 @@ const DirectoryField: React.FC<DirectoryFieldProps> = ({
     // Seed the picker with the current path when it's a real directory; for
     // the default sentinel (or empty), let the OS pick the start location.
     const defaultPath = isDefault(draft) ? undefined : draft || undefined;
-    const selected = await open({
-      directory: true,
-      multiple: false,
-      defaultPath,
-      title: dialogTitle,
-    });
-    if (typeof selected === 'string' && selected.length > 0) {
-      setDraft(selected);
-      await onApply(selected);
+    try {
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        defaultPath,
+        title: dialogTitle,
+      });
+      // A null return means the user cancelled the dialog — not an error.
+      if (typeof selected === 'string' && selected.length > 0) {
+        setDraft(selected);
+        await onApply(selected);
+      }
+    } catch (error) {
+      onError(error instanceof Error ? error.message : String(error));
     }
   };
 
@@ -149,18 +158,34 @@ const ServerSettings: React.FC = () => {
   }, [loadConfig]);
 
   const finishApply = async (result: RuntimeConfigUpdateResult) => {
-    if (result.kind === 'ok') {
-      setStatus({ kind: 'saved' });
-      // Re-read so we display whatever the server actually persisted.
-      const fresh = await getRuntimeConfig();
-      if (fresh.kind === 'ok') {
-        setServerModelsDir(fresh.modelsDir);
-        setServerExtraModelsDir(fresh.extraModelsDir);
+    if (result.kind !== 'ok') {
+      if (result.kind === 'unauthorized') {
+        setStatus({ kind: 'unauthorized' });
+      } else {
+        setStatus({ kind: 'error', message: result.message });
       }
-    } else if (result.kind === 'unauthorized') {
-      setStatus({ kind: 'unauthorized' });
+      return;
+    }
+    // Write succeeded — re-read BEFORE claiming "Saved" so we never show
+    // "Saved" alongside stale values if the refresh itself fails.
+    const fresh = await getRuntimeConfig();
+    if (fresh.kind === 'ok') {
+      setServerModelsDir(fresh.modelsDir);
+      setServerExtraModelsDir(fresh.extraModelsDir);
+      setStatus({ kind: 'saved' });
+    } else if (fresh.kind === 'unauthorized') {
+      // Write went through but we lost read access on the follow-up; surface
+      // that explicitly rather than implying the displayed values are current.
+      setStatus({
+        kind: 'error',
+        message:
+          'Saved, but could not re-read the configuration (admin authorization required). Displayed values may be stale.',
+      });
     } else {
-      setStatus({ kind: 'error', message: result.message });
+      setStatus({
+        kind: 'error',
+        message: `Saved, but could not re-read the configuration: ${fresh.message}. Displayed values may be stale.`,
+      });
     }
   };
 
@@ -184,6 +209,10 @@ const ServerSettings: React.FC = () => {
   const isUnauthorized = status.kind === 'unauthorized';
   const fieldsDisabled = isBusy || isUnauthorized;
 
+  const handleFieldError = (message: string) => {
+    setStatus({ kind: 'error', message });
+  };
+
   return (
     <div className="settings-section-container">
       <DirectoryField
@@ -204,6 +233,7 @@ const ServerSettings: React.FC = () => {
         disabled={fieldsDisabled}
         onApply={applyModelsDir}
         onReset={() => applyModelsDir(MODELS_DIR_AUTO_SENTINEL)}
+        onError={handleFieldError}
       />
 
       <DirectoryField
@@ -224,6 +254,7 @@ const ServerSettings: React.FC = () => {
         disabled={fieldsDisabled}
         onApply={applyExtraModelsDir}
         onReset={() => applyExtraModelsDir('')}
+        onError={handleFieldError}
       />
 
       {status.kind === 'loading' && (

--- a/src/app/src/renderer/tabs/ServerSettings.tsx
+++ b/src/app/src/renderer/tabs/ServerSettings.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { open } from '@tauri-apps/plugin-dialog';
+import {
+  getRuntimeConfig,
+  setModelsDir,
+  resetModelsDir,
+  isModelsDirAuto,
+  MODELS_DIR_AUTO_SENTINEL,
+} from '../utils/serverRuntimeConfig';
+
+type Status =
+  | { kind: 'loading' }
+  | { kind: 'ready' }
+  | { kind: 'saving' }
+  | { kind: 'unauthorized' }
+  | { kind: 'error'; message: string }
+  | { kind: 'saved' };
+
+const ServerSettings: React.FC = () => {
+  // models_dir is server-wide config — it does NOT live in AppSettings.
+  // We hold a local draft of the text input plus the last-known server value
+  // so the Reset/Apply buttons can do the right thing.
+  const [serverModelsDir, setServerModelsDir] = useState<string>(MODELS_DIR_AUTO_SENTINEL);
+  const [draftModelsDir, setDraftModelsDir] = useState<string>(MODELS_DIR_AUTO_SENTINEL);
+  const [extraModelsDir, setExtraModelsDir] = useState<string>('');
+  const [status, setStatus] = useState<Status>({ kind: 'loading' });
+
+  const loadConfig = useCallback(async () => {
+    setStatus({ kind: 'loading' });
+    const result = await getRuntimeConfig();
+    if (result.kind === 'ok') {
+      setServerModelsDir(result.modelsDir);
+      setDraftModelsDir(result.modelsDir);
+      setExtraModelsDir(result.extraModelsDir);
+      setStatus({ kind: 'ready' });
+    } else if (result.kind === 'unauthorized') {
+      setStatus({ kind: 'unauthorized' });
+    } else {
+      setStatus({ kind: 'error', message: result.message });
+    }
+  }, []);
+
+  useEffect(() => {
+    loadConfig();
+  }, [loadConfig]);
+
+  const applyValue = async (path: string) => {
+    setStatus({ kind: 'saving' });
+    const result = path === MODELS_DIR_AUTO_SENTINEL || isModelsDirAuto(path)
+      ? await resetModelsDir()
+      : await setModelsDir(path);
+    if (result.kind === 'ok') {
+      setStatus({ kind: 'saved' });
+      // Re-read so we display whatever the server actually persisted.
+      const fresh = await getRuntimeConfig();
+      if (fresh.kind === 'ok') {
+        setServerModelsDir(fresh.modelsDir);
+        setDraftModelsDir(fresh.modelsDir);
+        setExtraModelsDir(fresh.extraModelsDir);
+      }
+    } else if (result.kind === 'unauthorized') {
+      setStatus({ kind: 'unauthorized' });
+    } else {
+      setStatus({ kind: 'error', message: result.message });
+    }
+  };
+
+  const handleBrowse = async () => {
+    try {
+      // Seed the picker with the current path when it's a real directory; for
+      // the `"auto"` sentinel, let the OS default the starting location.
+      const defaultPath = isModelsDirAuto(draftModelsDir) ? undefined : draftModelsDir;
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        defaultPath,
+        title: 'Choose model download folder',
+      });
+      if (typeof selected === 'string' && selected.length > 0) {
+        setDraftModelsDir(selected);
+        await applyValue(selected);
+      }
+    } catch (error) {
+      setStatus({
+        kind: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  const handleApply = () => applyValue(draftModelsDir.trim());
+  const handleReset = () => applyValue(MODELS_DIR_AUTO_SENTINEL);
+
+  const isAuto = isModelsDirAuto(serverModelsDir);
+  const isDirty = draftModelsDir.trim() !== serverModelsDir;
+  const isBusy = status.kind === 'loading' || status.kind === 'saving';
+
+  return (
+    <div className="settings-section-container">
+      <div className={`settings-section ${isAuto ? 'settings-section-default' : ''}`}>
+        <div className="settings-label-row">
+          <label className="settings-label">
+            <span className="settings-label-text">Model download folder</span>
+            <span className="settings-description">
+              Where the server downloads and stores models. Use <code>auto</code> to follow
+              the Hugging Face cache (<code>~/.cache/huggingface/hub</code>). This is a server-wide
+              setting — changes apply to every client connected to this server.
+            </span>
+          </label>
+          <button
+            type="button"
+            className="settings-field-reset"
+            onClick={handleReset}
+            disabled={isBusy || isAuto}
+          >
+            Reset
+          </button>
+        </div>
+        <div className="settings-path-row">
+          <input
+            type="text"
+            value={draftModelsDir}
+            onChange={(e) => setDraftModelsDir(e.target.value)}
+            className="settings-text-input"
+            placeholder="auto"
+            title="Model download folder"
+            disabled={isBusy || status.kind === 'unauthorized'}
+          />
+          <button
+            type="button"
+            className="settings-field-reset"
+            onClick={handleBrowse}
+            disabled={isBusy || status.kind === 'unauthorized'}
+          >
+            Browse…
+          </button>
+          <button
+            type="button"
+            className="settings-field-reset"
+            onClick={handleApply}
+            disabled={isBusy || !isDirty || status.kind === 'unauthorized'}
+          >
+            Apply
+          </button>
+        </div>
+
+        {status.kind === 'loading' && (
+          <div className="settings-description">Loading current value…</div>
+        )}
+        {status.kind === 'saving' && (
+          <div className="settings-description">Saving…</div>
+        )}
+        {status.kind === 'saved' && (
+          <div className="settings-description">Saved. Server is using the new folder.</div>
+        )}
+        {status.kind === 'unauthorized' && (
+          <div className="settings-description">
+            The server rejected the request. Editing server configuration requires the
+            admin API key (<code>LEMONADE_ADMIN_API_KEY</code>). Set it on the server and
+            in Connection → API Key, then reload.
+          </div>
+        )}
+        {status.kind === 'error' && (
+          <div className="settings-description">Could not read or update the setting: {status.message}</div>
+        )}
+      </div>
+
+      {/* <div className="settings-section settings-section-default">
+        <div className="settings-label-row">
+          <label className="settings-label">
+            <span className="settings-label-text">Extra models folder (read-only)</span>
+            <span className="settings-description">
+              Additional path the server searches recursively for GGUF files. Configure
+              with <code>lemonade config set extra_models_dir=...</code>.
+            </span>
+          </label>
+        </div>
+        <input
+          type="text"
+          value={extraModelsDir || '(not set)'}
+          readOnly
+          className="settings-text-input"
+          title="Extra models folder"
+          placeholder="(not set)"
+        />
+      </div> */}
+    </div>
+  );
+};
+
+export default ServerSettings;

--- a/src/app/src/renderer/tabs/ServerSettings.tsx
+++ b/src/app/src/renderer/tabs/ServerSettings.tsx
@@ -211,9 +211,10 @@ const ServerSettings: React.FC = () => {
         description={
           <>
             An additional folder the server recursively scans for loose <code>.gguf</code>{' '}
-            files. Imported models appear in the model list with the <code>extra.</code>{' '}
-            prefix. Leave empty to disable. Tip: after changing this, refresh Model Manager
-            to see imported models.
+            files. Imported models appear in Model Manager under their bare filename; the{' '}
+            <code>extra.</code> prefix is only added when the bare name would conflict with an
+            already-registered model. Leave empty to disable. Tip: after changing this, refresh
+            Model Manager to see imported models.
           </>
         }
         placeholder="(none — feature disabled)"

--- a/src/app/src/renderer/tabs/ServerSettings.tsx
+++ b/src/app/src/renderer/tabs/ServerSettings.tsx
@@ -40,6 +40,10 @@ interface DirectoryFieldProps {
   // Surface dialog/plugin failures to the parent so they appear in the shared
   // status row instead of becoming unhandled promise rejections.
   onError: (message: string) => void;
+  // Optional extended help text shown in a CSS-only hover popover anchored to
+  // an info (i) icon at the bottom-left of the field. Use this for detail that
+  // would otherwise crowd the short inline description.
+  tooltip?: ReactNode;
 }
 
 const DirectoryField: React.FC<DirectoryFieldProps> = ({
@@ -53,6 +57,7 @@ const DirectoryField: React.FC<DirectoryFieldProps> = ({
   onApply,
   onReset,
   onError,
+  tooltip,
 }) => {
   // Local draft tracks what the user has typed but not yet applied. We re-sync
   // it from `serverValue` whenever the parent reloads, so the input always
@@ -109,8 +114,28 @@ const DirectoryField: React.FC<DirectoryFieldProps> = ({
         title={label}
         disabled={disabled}
       />
-      <div className="settings-path-actions">
-        <button
+      <div className="settings-path-actions">{tooltip ? (
+          <span
+            className="settings-info-tooltip"
+            tabIndex={0}
+            role="button"
+            aria-label="More information"
+          >
+            <svg
+              className="settings-info-tooltip-icon"
+              viewBox="0 0 16 16"
+              width="16"
+              height="16"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" strokeWidth="1.25" />
+              <circle cx="8" cy="4.5" r="0.95" fill="currentColor" />
+              <rect x="7.25" y="6.75" width="1.5" height="5.25" rx="0.6" fill="currentColor" />
+            </svg>
+            <span className="settings-info-tooltip-bubble" role="tooltip">{tooltip}</span>
+          </span>
+        ) : null}        <button
           type="button"
           className="settings-field-reset"
           onClick={() => { void handleBrowse(); }}
@@ -243,6 +268,16 @@ const ServerSettings: React.FC = () => {
         onApply={applyModelsDir}
         onReset={() => applyModelsDir(MODELS_DIR_AUTO_SENTINEL)}
         onError={handleFieldError}
+        tooltip={
+          <>
+            Use <code>auto</code> to follow the Hugging Face cache
+            (<code>~/.cache/huggingface/hub</code>, or <code>HF_HOME</code> /
+            <code>HF_HUB_CACHE</code> if set). This is a server-wide setting —
+            changes apply to every client connected to this server. Loose
+            <code>.gguf</code> files placed in this folder are <em>not</em> detected;
+            for that, use the Extra Models Folder.
+          </>
+        }
       />
 
       <DirectoryField
@@ -261,6 +296,14 @@ const ServerSettings: React.FC = () => {
         onApply={applyExtraModelsDir}
         onReset={() => applyExtraModelsDir('')}
         onError={handleFieldError}
+        tooltip={
+          <>
+            Imported models appear in Model Manager under their bare filename;
+            the <code>extra.</code> prefix is only added when the bare name would
+            conflict with an already-registered model. Leave empty to disable.
+            Tip: after changing this, refresh Model Manager to see imported models.
+          </>
+        }
       />
 
       {status.kind === 'loading' && (

--- a/src/app/src/renderer/tabs/ServerSettings.tsx
+++ b/src/app/src/renderer/tabs/ServerSettings.tsx
@@ -87,12 +87,9 @@ const DirectoryField: React.FC<DirectoryFieldProps> = ({
   const atDefault = isDefault(serverValue);
 
   return (
-    <div className={`settings-section ${atDefault ? 'settings-section-default' : ''}`}>
+    <div className={`settings-section settings-directory-field ${atDefault ? 'settings-section-default' : ''}`}>
       <div className="settings-label-row">
-        <label className="settings-label">
-          <span className="settings-label-text">{label}</span>
-          <span className="settings-description">{description}</span>
-        </label>
+        <span className="settings-label-text">{label}</span>
         <button
           type="button"
           className="settings-field-reset"
@@ -102,23 +99,24 @@ const DirectoryField: React.FC<DirectoryFieldProps> = ({
           Reset
         </button>
       </div>
-      <div className="settings-path-row">
-        <input
-          type="text"
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          className="settings-text-input"
-          placeholder={placeholder}
-          title={label}
-          disabled={disabled}
-        />
+      <div className="settings-description">{description}</div>
+      <input
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        className="settings-text-input"
+        placeholder={placeholder}
+        title={label}
+        disabled={disabled}
+      />
+      <div className="settings-path-actions">
         <button
           type="button"
           className="settings-field-reset"
           onClick={() => { void handleBrowse(); }}
           disabled={disabled}
         >
-          Browse…
+          Browse
         </button>
         <button
           type="button"
@@ -231,14 +229,10 @@ const ServerSettings: React.FC = () => {
   return (
     <div className="settings-section-container">
       <DirectoryField
-        label="Model download folder"
+        label="Model Download Folder"
         description={
           <>
-            Where the server downloads and stores models pulled from Hugging Face. Use{' '}
-            <code>auto</code> to follow the Hugging Face cache
-            (<code>~/.cache/huggingface/hub</code>). This is a server-wide setting — changes
-            apply to every client connected to this server. Loose GGUF files placed in this
-            folder are <em>not</em> detected; for that, use the Extra models folder below.
+            Where the server downloads and stores models pulled from Hugging Face. 
           </>
         }
         placeholder="auto"
@@ -252,14 +246,11 @@ const ServerSettings: React.FC = () => {
       />
 
       <DirectoryField
-        label="Extra models folder"
+        label="Extra Models Folder"
         description={
           <>
             An additional folder the server recursively scans for loose <code>.gguf</code>{' '}
-            files. Imported models appear in Model Manager under their bare filename; the{' '}
-            <code>extra.</code> prefix is only added when the bare name would conflict with an
-            already-registered model. Leave empty to disable. Tip: after changing this, refresh
-            Model Manager to see imported models.
+            files.
           </>
         }
         placeholder="(none — feature disabled)"

--- a/src/app/src/renderer/tabs/ServerSettings.tsx
+++ b/src/app/src/renderer/tabs/ServerSettings.tsx
@@ -16,6 +16,7 @@ type Status =
   | { kind: 'ready' }
   | { kind: 'saving' }
   | { kind: 'unauthorized' }
+  | { kind: 'forbidden_remote' }
   | { kind: 'error'; message: string }
   | { kind: 'saved' };
 
@@ -148,6 +149,8 @@ const ServerSettings: React.FC = () => {
       setStatus({ kind: 'ready' });
     } else if (result.kind === 'unauthorized') {
       setStatus({ kind: 'unauthorized' });
+    } else if (result.kind === 'forbidden_remote') {
+      setStatus({ kind: 'forbidden_remote' });
     } else {
       setStatus({ kind: 'error', message: result.message });
     }
@@ -161,6 +164,8 @@ const ServerSettings: React.FC = () => {
     if (result.kind !== 'ok') {
       if (result.kind === 'unauthorized') {
         setStatus({ kind: 'unauthorized' });
+      } else if (result.kind === 'forbidden_remote') {
+        setStatus({ kind: 'forbidden_remote' });
       } else {
         setStatus({ kind: 'error', message: result.message });
       }
@@ -180,6 +185,12 @@ const ServerSettings: React.FC = () => {
         kind: 'error',
         message:
           'Saved, but could not re-read the configuration (admin authorization required). Displayed values may be stale.',
+      });
+    } else if (fresh.kind === 'forbidden_remote') {
+      setStatus({
+        kind: 'error',
+        message:
+          'Saved, but could not re-read the configuration (server restricts /internal/* to local clients). Displayed values may be stale.',
       });
     } else {
       setStatus({
@@ -207,7 +218,11 @@ const ServerSettings: React.FC = () => {
 
   const isBusy = status.kind === 'loading' || status.kind === 'saving';
   const isUnauthorized = status.kind === 'unauthorized';
-  const fieldsDisabled = isBusy || isUnauthorized;
+  const isForbiddenRemote = status.kind === 'forbidden_remote';
+  // We keep the inputs visible in every state so the user can see what is
+  // configured (e.g. on a remote server they can still read the values they
+  // typed), but we disable editing whenever the server will reject the write.
+  const fieldsDisabled = isBusy || isUnauthorized || isForbiddenRemote;
 
   const handleFieldError = (message: string) => {
     setStatus({ kind: 'error', message });
@@ -268,9 +283,19 @@ const ServerSettings: React.FC = () => {
       )}
       {status.kind === 'unauthorized' && (
         <div className="settings-description">
-          The server rejected the request. Editing server configuration requires the
-          admin API key (<code>LEMONADE_ADMIN_API_KEY</code>). Set it on the server and
-          in Connection → API Key, then reload.
+          The server rejected the request with HTTP 401. Editing server configuration
+          requires the admin API key (<code>LEMONADE_ADMIN_API_KEY</code>). Set it on
+          the server and in Connection → API Key, then reload.
+        </div>
+      )}
+      {status.kind === 'forbidden_remote' && (
+        <div className="settings-description">
+          This server restricts <code>/internal/*</code> endpoints to local clients
+          (HTTP 403), so server-wide configuration cannot be edited from a remote
+          desktop app. To change <code>models_dir</code> or <code>extra_models_dir</code>,
+          run the desktop app (or <code>lemonade config set</code>) on the same machine
+          as <code>lemond</code>. Setting <code>LEMONADE_ADMIN_API_KEY</code> will not
+          unlock this from a remote client.
         </div>
       )}
       {status.kind === 'error' && (

--- a/src/app/src/renderer/utils/serverRuntimeConfig.ts
+++ b/src/app/src/renderer/utils/serverRuntimeConfig.ts
@@ -128,8 +128,9 @@ export function resetModelsDir(): Promise<RuntimeConfigUpdateResult> {
 /**
  * Set `extra_models_dir` to an absolute path on the server's machine. The
  * server recursively scans this directory for loose `.gguf` files and exposes
- * them under the `extra.` prefix. Pass an empty string to disable the feature
- * (use `clearExtraModelsDir` for clarity).
+ * them under their bare filename (an `extra.` prefix is added only when the
+ * bare name would collide with an already-registered model). Pass an empty
+ * string to disable the feature (use `clearExtraModelsDir` for clarity).
  */
 export function setExtraModelsDir(path: string): Promise<RuntimeConfigUpdateResult> {
   return postInternalSet({ extra_models_dir: path });

--- a/src/app/src/renderer/utils/serverRuntimeConfig.ts
+++ b/src/app/src/renderer/utils/serverRuntimeConfig.ts
@@ -125,8 +125,30 @@ export function resetModelsDir(): Promise<RuntimeConfigUpdateResult> {
   return postInternalSet({ models_dir: MODELS_DIR_AUTO });
 }
 
+/**
+ * Set `extra_models_dir` to an absolute path on the server's machine. The
+ * server recursively scans this directory for loose `.gguf` files and exposes
+ * them under the `extra.` prefix. Pass an empty string to disable the feature
+ * (use `clearExtraModelsDir` for clarity).
+ */
+export function setExtraModelsDir(path: string): Promise<RuntimeConfigUpdateResult> {
+  return postInternalSet({ extra_models_dir: path });
+}
+
+/**
+ * Clear `extra_models_dir` (writes the empty-string default), disabling the
+ * loose-GGUF discovery feature. See `docs/embeddable/models.md`.
+ */
+export function clearExtraModelsDir(): Promise<RuntimeConfigUpdateResult> {
+  return postInternalSet({ extra_models_dir: '' });
+}
+
 export const MODELS_DIR_AUTO_SENTINEL = MODELS_DIR_AUTO;
 
 export function isModelsDirAuto(value: string): boolean {
   return value.trim().toLowerCase() === MODELS_DIR_AUTO;
+}
+
+export function isExtraModelsDirEnabled(value: string): boolean {
+  return value.trim() !== '';
 }

--- a/src/app/src/renderer/utils/serverRuntimeConfig.ts
+++ b/src/app/src/renderer/utils/serverRuntimeConfig.ts
@@ -25,11 +25,13 @@ const MODELS_DIR_AUTO = 'auto';
 export type RuntimeConfigStatus =
   | { kind: 'ok'; modelsDir: string; extraModelsDir: string }
   | { kind: 'unauthorized' }
+  | { kind: 'forbidden_remote' }
   | { kind: 'error'; message: string };
 
 export type RuntimeConfigUpdateResult =
   | { kind: 'ok' }
   | { kind: 'unauthorized' }
+  | { kind: 'forbidden_remote' }
   | { kind: 'error'; message: string };
 
 function buildInternalUrl(path: string): string {
@@ -43,10 +45,17 @@ function authHeaders(): Record<string, string> {
 }
 
 function classifyHttpError(status: number, body: string): RuntimeConfigStatus & RuntimeConfigUpdateResult {
-  if (status === 401 || status === 403) {
-    // /internal/* may require LEMONADE_ADMIN_API_KEY rather than the regular
-    // LEMONADE_API_KEY; surface that distinctly so callers can guide the user.
+  if (status === 401) {
+    // Missing/invalid credentials. /internal/* requires LEMONADE_ADMIN_API_KEY
+    // (rather than the regular LEMONADE_API_KEY) when auth is enabled.
     return { kind: 'unauthorized' } as RuntimeConfigStatus & RuntimeConfigUpdateResult;
+  }
+  if (status === 403) {
+    // /internal/* endpoints are restricted to loopback on the server side. A
+    // 403 means the request reached lemond but was rejected as non-local —
+    // setting LEMONADE_ADMIN_API_KEY will not help. Callers should explain
+    // this is a remote-server limitation, not an auth problem.
+    return { kind: 'forbidden_remote' } as RuntimeConfigStatus & RuntimeConfigUpdateResult;
   }
   return {
     kind: 'error',
@@ -57,8 +66,10 @@ function classifyHttpError(status: number, body: string): RuntimeConfigStatus & 
 /**
  * Fetch the current runtime configuration from lemond.
  *
- * Returns `{ kind: 'unauthorized' }` when the server rejects the request for
- * auth reasons; the UI should explain that admin-level access is required.
+ * Returns `{ kind: 'unauthorized' }` on HTTP 401 (the admin API key is missing
+ * or invalid) and `{ kind: 'forbidden_remote' }` on HTTP 403 (lemond restricts
+ * `/internal/*` to loopback, so a remote client cannot read or write
+ * server-wide config). The UI should surface these distinctly.
  */
 export async function getRuntimeConfig(): Promise<RuntimeConfigStatus> {
   await serverConfig.waitForInit();

--- a/src/app/src/renderer/utils/serverRuntimeConfig.ts
+++ b/src/app/src/renderer/utils/serverRuntimeConfig.ts
@@ -1,0 +1,132 @@
+/**
+ * Helpers for reading and writing lemond's server-wide runtime configuration
+ * (config.json) from the renderer.
+ *
+ * Server-wide config (e.g. `models_dir`) is fundamentally different from the
+ * per-client preferences stored in `app_settings.json`: it is shared by every
+ * client connected to the same `lemond` instance and therefore MUST NOT be
+ * mirrored into `AppSettings`. This module talks directly to lemond over HTTP,
+ * mirroring the pattern used for `/health` and `/system-stats` (see
+ * `StatusBar.tsx`, `AboutModal.tsx`, and the comment in `tauriShim.ts`).
+ *
+ * Endpoints used:
+ *   GET  /internal/config           → full config JSON snapshot
+ *   POST /internal/set              → { key: value, ... } partial update
+ *
+ * These live at the server root, not under `/api/v1`, so we build absolute
+ * URLs from `serverConfig.getServerBaseUrl()` rather than calling
+ * `serverConfig.fetch()` (which auto-prefixes `/api/v1`).
+ */
+
+import { serverConfig } from './serverConfig';
+
+const MODELS_DIR_AUTO = 'auto';
+
+export type RuntimeConfigStatus =
+  | { kind: 'ok'; modelsDir: string; extraModelsDir: string }
+  | { kind: 'unauthorized' }
+  | { kind: 'error'; message: string };
+
+export type RuntimeConfigUpdateResult =
+  | { kind: 'ok' }
+  | { kind: 'unauthorized' }
+  | { kind: 'error'; message: string };
+
+function buildInternalUrl(path: string): string {
+  const base = serverConfig.getServerBaseUrl().replace(/\/+$/, '');
+  return `${base}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+function authHeaders(): Record<string, string> {
+  const key = serverConfig.getAPIKey();
+  return key ? { Authorization: `Bearer ${key}` } : {};
+}
+
+function classifyHttpError(status: number, body: string): RuntimeConfigStatus & RuntimeConfigUpdateResult {
+  if (status === 401 || status === 403) {
+    // /internal/* may require LEMONADE_ADMIN_API_KEY rather than the regular
+    // LEMONADE_API_KEY; surface that distinctly so callers can guide the user.
+    return { kind: 'unauthorized' } as RuntimeConfigStatus & RuntimeConfigUpdateResult;
+  }
+  return {
+    kind: 'error',
+    message: `Server returned ${status}${body ? `: ${body.slice(0, 200)}` : ''}`,
+  } as RuntimeConfigStatus & RuntimeConfigUpdateResult;
+}
+
+/**
+ * Fetch the current runtime configuration from lemond.
+ *
+ * Returns `{ kind: 'unauthorized' }` when the server rejects the request for
+ * auth reasons; the UI should explain that admin-level access is required.
+ */
+export async function getRuntimeConfig(): Promise<RuntimeConfigStatus> {
+  await serverConfig.waitForInit();
+  try {
+    const response = await fetch(buildInternalUrl('/internal/config'), {
+      headers: authHeaders(),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      return classifyHttpError(response.status, text) as RuntimeConfigStatus;
+    }
+    const data = await response.json();
+    const modelsDir = typeof data?.models_dir === 'string' ? data.models_dir : MODELS_DIR_AUTO;
+    const extraModelsDir = typeof data?.extra_models_dir === 'string' ? data.extra_models_dir : '';
+    return { kind: 'ok', modelsDir, extraModelsDir };
+  } catch (error) {
+    return {
+      kind: 'error',
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function postInternalSet(body: Record<string, unknown>): Promise<RuntimeConfigUpdateResult> {
+  await serverConfig.waitForInit();
+  try {
+    const response = await fetch(buildInternalUrl('/internal/set'), {
+      method: 'POST',
+      headers: {
+        ...authHeaders(),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      return classifyHttpError(response.status, text) as RuntimeConfigUpdateResult;
+    }
+    return { kind: 'ok' };
+  } catch (error) {
+    return {
+      kind: 'error',
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Set `models_dir` to an absolute path on the server's machine.
+ *
+ * The server applies the change immediately and invalidates its model cache;
+ * no restart is required. Callers should refresh any model listing afterward.
+ */
+export function setModelsDir(path: string): Promise<RuntimeConfigUpdateResult> {
+  return postInternalSet({ models_dir: path });
+}
+
+/**
+ * Reset `models_dir` to the `"auto"` sentinel, which makes lemond honor the
+ * user's `HF_HOME` / `HF_HUB_CACHE` env vars (defaulting to
+ * `~/.cache/huggingface/hub`). See `docs/embeddable/models.md`.
+ */
+export function resetModelsDir(): Promise<RuntimeConfigUpdateResult> {
+  return postInternalSet({ models_dir: MODELS_DIR_AUTO });
+}
+
+export const MODELS_DIR_AUTO_SENTINEL = MODELS_DIR_AUTO;
+
+export function isModelsDirAuto(value: string): boolean {
+  return value.trim().toLowerCase() === MODELS_DIR_AUTO;
+}

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -5253,6 +5253,16 @@ input::-webkit-calendar-picker-indicator {
     text-align: left;
 }
 
+.settings-path-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.settings-path-row .settings-text-input {
+    flex: 1;
+}
+
 .settings-checkbox-label {
     display: flex;
     align-items: flex-start;

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -5274,6 +5274,61 @@ input::-webkit-calendar-picker-indicator {
     display: flex;
     gap: 8px;
     justify-content: flex-end;
+    align-items: center;
+}
+
+/* Info icon + CSS-only hover/focus tooltip used by directory fields. Pure CSS,
+   no JS or new dependencies. Pushed to the left so action buttons stay right-
+   aligned via margin-right: auto. */
+.settings-info-tooltip {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: auto;
+    width: 12px;
+    height: 12px;
+    color: var(--text-secondary);
+    cursor: help;
+    outline: none;
+}
+
+.settings-info-tooltip-icon {
+    display: block;
+}
+
+.settings-info-tooltip:hover .settings-info-tooltip-icon,
+.settings-info-tooltip:focus-visible .settings-info-tooltip-icon {
+    color: var(--text-primary);
+}
+
+.settings-info-tooltip-bubble {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 0;
+    z-index: 10;
+    min-width: 220px;
+    max-width: 320px;
+    padding: 8px 10px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    font-size: 0.7rem;
+    line-height: 1.4;
+    text-align: left;
+    white-space: normal;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+    pointer-events: none;
+}
+
+.settings-info-tooltip:hover .settings-info-tooltip-bubble,
+.settings-info-tooltip:focus-visible .settings-info-tooltip-bubble {
+    opacity: 1;
+    visibility: visible;
 }
 
 .settings-checkbox-label {

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -5263,6 +5263,19 @@ input::-webkit-calendar-picker-indicator {
     flex: 1;
 }
 
+/* Directory-picker rows (Settings -> Server). Stacks label/Reset, description,
+   text input, and action buttons vertically so the path field can use the full
+   width of the settings panel. */
+.settings-directory-field .settings-text-input {
+    width: 100%;
+}
+
+.settings-directory-field .settings-path-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
 .settings-checkbox-label {
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
## Summary

Adds a new **Settings → Server** panel in the desktop app for editing two server-wide config keys that previously required the CLI:

- `models_dir` — where the server downloads HF models (default: `auto`).
- `extra_models_dir` — recursive search path for loose `.gguf` files (default: empty / disabled).

Each field has a text input, a native folder picker (**Browse…**), **Apply**, and **Reset** (which restores the field's own default — `auto` for `models_dir`, empty for `extra_models_dir`). Status messages distinguish:

- **401** — admin API key missing/invalid (fixable by setting `LEMONADE_ADMIN_API_KEY`).
- **403** — `/internal/*` is loopback-only; the change must be made on the server machine (the admin key cannot unlock this from a remote client).
- Dialog/plugin failures, surfaced through the shared error row instead of becoming unhandled promise rejections.

<img width="1437" height="899" alt="image" src="https://github.com/user-attachments/assets/22e1289b-fa74-445a-a502-eb308a645c03"/>

## Architecture notes

- These keys are **server-wide config**, not per-client preferences, so they are *not* added to `AppSettings` / `app_settings.json` (per AGENTS.md invariant #11). The renderer reads/writes them directly via `GET /internal/config` and `POST /internal/set`, mirroring the existing direct-fetch pattern used for `/health` and `/system-stats`.
- New helper module `src/app/src/renderer/utils/serverRuntimeConfig.ts` encapsulates the HTTP calls and classifies HTTP errors into `unauthorized` (401), `forbidden_remote` (403), and generic `error` variants.
- `ServerSettings.tsx` factors a small `<DirectoryField>` sub-component shared by both rows. The panel stays visible (read-only) in unauthorized / forbidden_remote states so users can still see the configured values and an explanation of why editing is disabled.
- After a successful write, the panel re-reads the config *before* transitioning to "Saved", so a failed refresh never leaves stale values labelled as saved.
- No server-side C++ changes — `handle_config_set` in `src/cpp/server/server.cpp` already handles both keys and invalidates the model cache, so changes take effect immediately.

## Dependencies added

| Layer | Package | Version | Reason |
|---|---|---|---|
| npm (runtime) | `@tauri-apps/plugin-dialog` | `~2.2.2` | Native folder picker for the **Browse…** button |
| Rust (Tauri) | `tauri-plugin-dialog` | `~2.2` | Host-side plugin registration |
| Capability | `dialog:allow-open` | — | Tauri permission allowlist entry |

These versions are deliberately pinned to the last plugin-dialog releases compatible with `@tauri-apps/api ^2.0.0` and `tauri ^2` respectively (plugin-dialog 2.3.0 raised both floors). This keeps `tauri`, `@tauri-apps/api`, `@tauri-apps/cli`, `tao`, `wry`, `tauri-runtime`, `muda`, and `tray-icon` at main's versions; the `Cargo.lock` diff is purely additive (0 removals). A cosmetic Tauri Rust/JS version-mismatch warning is the trade-off; a follow-up dependency PR can bump them all together.

## Docs

- Added a consistent one-line tip ("in the Lemonade desktop app, `models_dir` and `extra_models_dir` can also be set under **Settings → Server**") to `docs/embeddable/models.md`, `docs/guide/configuration/README.md`, and `docs/guide/faq.md`.
- Corrected the description of how imported models appear in the model list in `docs/embeddable/models.md` (plus the in-app description and the helper module's doc comment): imported models are shown under their **bare filename**; the `extra.` prefix is only added when the bare name would conflict with an already-registered model. The previous wording implied the prefix was always applied.

## Verification

- `npm run build:renderer:prod` passes (no new warnings).
- `cargo check` against the Tauri host passes.
- Manually verified: picking a folder via Browse persists to the server, Reset returns to `auto` / empty, and a loose `.gguf` dropped into the extra folder appears under its bare filename in Model Manager.
- Unauthorized path (401) verified by hitting `/internal/*` without admin auth — UI displays the admin-key guidance.

## AI NOTE
AI was used to assist in creating this update, but the code was manually reviewed and verified before submission.