### PR TITLE
add instructions to start/enable lemond on Fedora based distros

### DIFF
--- a/docs/guide/install/fedora.md
+++ b/docs/guide/install/fedora.md
@@ -2,7 +2,34 @@
 
 Lemonade is built for Fedora 43 and 44.
 
-1. Get the RPM for your version from the [latest release](https://github.com/lemonade-sdk/lemonade/releases):
-   - Fedora 43: `lemonade-server-<version>-fc43.x86_64.rpm`
-   - Fedora 44: `lemonade-server-<version>-fc44.x86_64.rpm`
-2. `sudo dnf install ./DOWNLOADED_FILE`
+=== "Fedora 43"
+
+    Get the RPM from the [latest release](https://github.com/lemonade-sdk/lemonade/releases):
+    `lemonade-server-<version>-fc43.x86_64.rpm`
+
+    ```bash
+    sudo dnf install ./lemonade-server-*-fc43.x86_64.rpm
+    ```
+
+=== "Fedora 44"
+
+    Get the RPM from the [latest release](https://github.com/lemonade-sdk/lemonade/releases):
+    `lemonade-server-<version>-fc44.x86_64.rpm`
+
+    ```bash
+    sudo dnf install ./lemonade-server-*-fc44.x86_64.rpm
+    ```
+
+Enable and start the service:
+
+```bash
+sudo systemctl enable --now lemond
+```
+
+Check that it's running:
+
+```bash
+sudo systemctl status lemond
+```
+
+Once the service is running, open [http://localhost:13305](http://localhost:13305) in your browser.

--- a/docs/guide/install/fedora.md
+++ b/docs/guide/install/fedora.md
@@ -29,7 +29,7 @@ sudo systemctl enable --now lemond
 Check that it's running:
 
 ```bash
-sudo systemctl status lemond
+sudo systemctl --no-pager status lemond
 ```
 
 Once the service is running, open [http://localhost:13305](http://localhost:13305) in your browser.

--- a/docs/index.html
+++ b/docs/index.html
@@ -431,7 +431,7 @@
               '<div style="margin-top:16px;">' +
                 gsConsoleHtml([
                   'sudo systemctl enable --now lemond',
-                  'sudo systemctl status lemond'
+                  'sudo systemctl --no-pager status lemond'
                 ]) +
               '</div>';
             } else {

--- a/docs/index.html
+++ b/docs/index.html
@@ -412,16 +412,28 @@
             if (v) {
               var rpm43 = 'lemonade-server-' + v + '-fc43.x86_64.rpm';
               var rpm44 = 'lemonade-server-' + v + '-fc44.x86_64.rpm';
-              html = '<p class="gs-fedora-label">Fedora 43</p>' +
+              html = '<div style="display:flex;gap:12px;">' +
+                '<div style="flex:1;">' +
+                  '<p class="gs-fedora-label">Fedora 43</p>' +
+                  gsConsoleHtml([
+                    'wget https://github.com/lemonade-sdk/lemonade/releases/latest/download/' + rpm43,
+                    'sudo dnf install ./' + rpm43
+                  ]) +
+                '</div>' +
+                '<div style="flex:1;">' +
+                  '<p class="gs-fedora-label">Fedora 44</p>' +
+                  gsConsoleHtml([
+                    'wget https://github.com/lemonade-sdk/lemonade/releases/latest/download/' + rpm44,
+                    'sudo dnf install ./' + rpm44
+                  ]) +
+                '</div>' +
+              '</div>' +
+              '<div style="margin-top:16px;">' +
                 gsConsoleHtml([
-                  'wget https://github.com/lemonade-sdk/lemonade/releases/latest/download/' + rpm43,
-                  'sudo dnf install ./' + rpm43
+                  'sudo systemctl enable --now lemond',
+                  'sudo systemctl status lemond'
                 ]) +
-                '<p class="gs-fedora-label">Fedora 44</p>' +
-                gsConsoleHtml([
-                  'wget https://github.com/lemonade-sdk/lemonade/releases/latest/download/' + rpm44,
-                  'sudo dnf install ./' + rpm44
-                ]);
+              '</div>';
             } else {
               html = '<a class="gs-download-link" href="https://github.com/lemonade-sdk/lemonade/releases/latest">' +
                 '<span class="material-symbols-outlined">open_in_new</span> View latest release</a>';


### PR DESCRIPTION
### Refs #1930

## Changes
- added instructions to enable and start lemond.service on the website docs

I'll add another PR that fully addresses #1947 later