### PR TITLE
fix: bump macOS sd.cpp metal version and macOS release number

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -18,7 +18,7 @@
   "sd-cpp": {
     "cpu": "master-616-cde20d5",
     "rocm-stable": "master-616-cde20d5",
-    "metal": "master-616-cde20d5"
+    "metal": "master-655-29ab511"
   },
   "therock": {
     "version": "7.13.0",

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -93,7 +93,7 @@ InstallParams SDServer::get_install_params(const std::string& backend, const std
 
     if (resolved_backend == "metal") {
 #if defined(__APPLE__)
-        params.filename = "sd-" + short_version + "-bin-Darwin-macOS-15.7.4-arm64.zip";
+        params.filename = "sd-" + short_version + "-bin-Darwin-macOS-15.7.7-arm64.zip";
 #endif
     } else if (is_rocm_backend(resolved_backend)) {
         std::string target_arch = SystemInfo::get_rocm_arch();


### PR DESCRIPTION
Bump the macOS sd.cpp metal backend to the new upstream release: `master-616-cde20d5` → `master-655-29ab511`, and update the macOS release number from 15.7.4 to 15.7.7.