### PR TITLE
Fix downloaded status for multi-checkpoint models

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1250,7 +1250,7 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
                 return filepath;
             }
         }
-        
+
         // Case 5: Local quant-token fallback.
         //
         // Keep the existing resolver cases above as the primary logic: exact
@@ -1500,6 +1500,50 @@ static bool check_component_downloaded(const ModelInfo& info,
     return true;
 }
 
+static bool has_partial_files(const fs::path& dir) {
+    std::error_code ec;
+    if (!safe_is_directory(dir)) return false;
+    // Non-recursive scan for .partial markers to confirm folder integrity
+    for (const auto& entry : fs::directory_iterator(dir, ec)) {
+        if (entry.path().extension() == ".partial") {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool is_checkpoint_path_complete(const std::string& path_str) {
+    if (path_str.empty()) return false;
+
+    fs::path resolved(path_str);
+    if (!safe_exists(resolved)) return false;
+
+    // A manifest or .partial file indicates an interrupted multi-file download
+    fs::path marker_dir = safe_is_directory(resolved) ? resolved : resolved.parent_path();
+    if (safe_exists(marker_dir / ".download_manifest.json")) return false;
+
+    if (safe_is_directory(resolved)) {
+        if (has_partial_files(marker_dir)) return false;
+    } else if (safe_exists(path_from_utf8(path_str + ".partial"))) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Returns true if all files required by the model recipe are present and complete.
+ * Note: npu_cache is skipped as it is managed lazily by the flm-npu backend.
+ */
+static bool are_required_checkpoints_complete(const ModelInfo& info) {
+    for (const auto& [type, _] : info.checkpoints) {
+        if (type == "npu_cache") continue;
+
+        if (!is_checkpoint_path_complete(info.resolved_path(type))) return false;
+    }
+    return true;
+}
+
 void ModelManager::build_cache() {
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
 
@@ -1640,43 +1684,7 @@ void ModelManager::build_cache() {
         } else if (info.recipe == "flm") {
             info.downloaded = flm_set.count(info.checkpoint()) > 0;
         } else {
-            // Check if model file/dir exists
-            bool file_exists = !info.resolved_path().empty() && safe_exists(info.resolved_path());
-
-            if (file_exists) {
-                // Also check for incomplete downloads:
-                // 1. Check for .download_manifest.json in snapshot directory
-                // 2. Check for any .partial files
-                fs::path resolved(info.resolved_path());
-
-                // For directories (OGA models), check within the directory
-                // For files (GGUF models), check in parent directory
-                fs::path snapshot_dir = safe_is_directory(resolved) ? resolved : resolved.parent_path();
-
-                // Check for manifest (indicates incomplete multi-file download)
-                fs::path manifest_path = snapshot_dir / ".download_manifest.json";
-                bool has_manifest = safe_exists(manifest_path);
-
-                // Check for .partial files
-                bool has_partial = false;
-                if (safe_is_directory(resolved)) {
-                    // For directories, scan for any .partial files inside
-                    std::error_code ec;
-                    for (const auto& entry : fs::directory_iterator(snapshot_dir, ec)) {
-                        if (entry.path().extension() == ".partial") {
-                            has_partial = true;
-                            break;
-                        }
-                    }
-                } else {
-                    // For files, check if the specific file has a .partial version
-                    has_partial = safe_exists(info.resolved_path() + ".partial");
-                }
-
-                info.downloaded = !has_manifest && !has_partial;
-            } else {
-                info.downloaded = false;
-            }
+            info.downloaded = are_required_checkpoints_complete(info);
         }
 
         if (info.downloaded) {
@@ -1779,33 +1787,7 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
         auto flm_models = get_flm_installed_models();
         info.downloaded = std::find(flm_models.begin(), flm_models.end(), info.checkpoint()) != flm_models.end();
     } else {
-        bool file_exists = !info.resolved_path().empty() && safe_exists(info.resolved_path());
-
-        if (file_exists) {
-            // Check for incomplete downloads
-            fs::path resolved(info.resolved_path());
-            fs::path snapshot_dir = safe_is_directory(resolved) ? resolved : resolved.parent_path();
-
-            fs::path manifest_path = snapshot_dir / ".download_manifest.json";
-            bool has_manifest = safe_exists(manifest_path);
-
-            bool has_partial = false;
-            if (safe_is_directory(resolved)) {
-                std::error_code ec;
-                for (const auto& entry : fs::directory_iterator(snapshot_dir, ec)) {
-                    if (entry.path().extension() == ".partial") {
-                        has_partial = true;
-                        break;
-                    }
-                }
-            } else {
-                has_partial = safe_exists(info.resolved_path() + ".partial");
-            }
-
-            info.downloaded = !has_manifest && !has_partial;
-        } else {
-            info.downloaded = false;
-        }
+        info.downloaded = are_required_checkpoints_complete(info);
     }
 
     populate_static_max_context_window(info);

--- a/test/test_multi_checkpoint_completeness.py
+++ b/test/test_multi_checkpoint_completeness.py
@@ -1,0 +1,273 @@
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+import requests
+
+from utils.test_models import get_default_lemond_binary, get_default_cli_binary
+
+
+class TestMultiCheckpointCompleteness(unittest.TestCase):
+    """
+    Integration tests for multi-checkpoint download integrity.
+
+    These tests verify that models requiring multiple files (e.g., Image Gen with VAEs)
+    are only marked as 'Downloaded' when all required components are 100% present.
+
+    Operation:
+    - Creates a temporary workspace for each test case.
+    - Simulates 'broken' or 'partial' downloads by creating fake files and marker files
+      (.partial, .download_manifest.json) on disk.
+    - Launches the 'lemond' server and uses the 'lemonade' CLI to verify the
+      reported download status matches expectations.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.lemond_bin = get_default_lemond_binary()
+        self.cli_bin = get_default_cli_binary()
+        self.port = 13306
+        self.server_proc = None
+        self.server_stdout = ""
+        self.server_stderr = ""
+
+    def tearDown(self):
+        self.stop_server()
+        shutil.rmtree(self.tmp_dir)
+
+    def start_server(self, capture_output=False):
+        self.stop_server()
+        env = os.environ.copy()
+        # Ensure it doesn't use the real HF cache
+        env["HF_HUB_CACHE"] = os.path.join(self.tmp_dir, "hf")
+        os.makedirs(env["HF_HUB_CACHE"], exist_ok=True)
+
+        stdout = subprocess.PIPE if capture_output else subprocess.DEVNULL
+        stderr = subprocess.PIPE if capture_output else subprocess.DEVNULL
+
+        self.server_proc = subprocess.Popen(
+            [self.lemond_bin, self.tmp_dir, "--port", str(self.port)],
+            stdout=stdout,
+            stderr=stderr,
+            text=True,
+            env=env,
+        )
+        for i in range(30):
+            try:
+                requests.get(f"http://localhost:{self.port}/api/v1/models", timeout=1)
+                break
+            except:
+                time.sleep(1)
+        else:
+            self.fail("Server timed out")
+
+    def stop_server(self):
+        if self.server_proc:
+            self.server_proc.terminate()
+            try:
+                stdout, stderr = self.server_proc.communicate(timeout=5)
+                self.server_stdout = stdout if stdout else ""
+                self.server_stderr = stderr if stderr else ""
+            except:
+                self.server_proc.kill()
+                stdout, stderr = self.server_proc.communicate()
+                self.server_stdout = stdout if stdout else ""
+                self.server_stderr = stderr if stderr else ""
+            self.server_proc = None
+
+    def test_multi_checkpoint_completeness(self):
+        model_id = "multi-test"
+        path1 = os.path.join(self.tmp_dir, "model1.gguf")
+        path2 = os.path.join(self.tmp_dir, "model2.gguf")
+
+        user_models = {
+            model_id: {
+                "checkpoints": {"main": path1, "vae": path2},
+                "recipe": "llamacpp",
+                "source": "local_path",
+            }
+        }
+
+        with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
+            json.dump(user_models, f)
+
+        # 1. No files
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("No", [l for l in res.stdout.splitlines() if model_id in l][0])
+
+        # 2. One file
+        with open(path1, "w") as f:
+            f.write("fake")
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("No", [l for l in res.stdout.splitlines() if model_id in l][0])
+
+        # 3. Two files
+        with open(path2, "w") as f:
+            f.write("fake")
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("Yes", [l for l in res.stdout.splitlines() if model_id in l][0])
+
+        # 4. Partial file
+        partial = path1 + ".partial"
+        with open(partial, "w") as f:
+            f.write("partial")
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("No", [l for l in res.stdout.splitlines() if model_id in l][0])
+        os.remove(partial)
+
+        # 5. HF Marker logic
+        # We'll use a fake HF repo structure
+        hf_model_id = "hf-test"
+        repo = "org/repo"
+        # models--org--repo/snapshots/main/model.gguf
+        repo_dir = os.path.join(self.tmp_dir, "hf", "models--org--repo")
+        snapshot_dir = os.path.join(repo_dir, "snapshots", "main")
+        os.makedirs(snapshot_dir, exist_ok=True)
+        gguf_path = os.path.join(snapshot_dir, "model.gguf")
+        with open(gguf_path, "w") as f:
+            f.write("fake")
+
+        # Register it
+        with open(os.path.join(self.tmp_dir, "user_models.json"), "r") as f:
+            user_models = json.load(f)
+        user_models[hf_model_id] = {
+            "checkpoint": f"{repo}:model.gguf",
+            "recipe": "llamacpp",
+        }
+        with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
+            json.dump(user_models, f)
+
+        # Should be Yes initially
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn(
+            "Yes", [l for l in res.stdout.splitlines() if hf_model_id in l][0]
+        )
+
+        # Add manifest at snapshot root
+        manifest = os.path.join(snapshot_dir, ".download_manifest.json")
+        with open(manifest, "w") as f:
+            f.write("{}")
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("No", [l for l in res.stdout.splitlines() if hf_model_id in l][0])
+
+    def test_collection_status_with_incomplete_component(self):
+        # Status-regression coverage for the collection fan-out skip predicate.
+        # If a component is missing an auxiliary checkpoint, it must not be
+        # reported as downloaded; collection pull uses that downloaded status
+        # to decide whether a component can be skipped.
+        comp_id = "comp-multi"
+        coll_id = "coll-test"
+        path1 = os.path.join(self.tmp_dir, "model1.gguf")
+        path2 = os.path.join(self.tmp_dir, "model2.gguf")
+
+        user_models = {
+            comp_id: {
+                "checkpoints": {"main": path1, "vae": path2},
+                "recipe": "llamacpp",
+                "source": "local_path",
+            },
+            coll_id: {"components": [comp_id], "recipe": "collection.omni"},
+        }
+
+        with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
+            json.dump(user_models, f)
+
+        # 1. Component incomplete (only 1 file)
+        with open(path1, "w") as f:
+            f.write("fake")
+
+        # Start server and capture output to verify fan-out logs
+        self.start_server(capture_output=True)
+
+        # 2. Run 'pull' on the collection.
+        # The pull subprocess return code is intentionally not asserted here
+        # because the fake local-path component may fail later. This test
+        # only asserts that collection fan-out reaches the incomplete component,
+        # not that the full pull succeeds.
+        subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "pull", coll_id],
+            capture_output=True,
+            text=True,
+        )
+
+        # Stop server to flush logs
+        self.stop_server()
+
+        # Check server logs for the fan-out decision
+        log_output = self.server_stdout + self.server_stderr
+        self.assertIn(f"Downloading component: {comp_id}", log_output)
+
+    def test_single_checkpoint_guard(self):
+        # Ensure standard models still work normally
+        model_id = "single-test"
+        path = os.path.join(self.tmp_dir, "single.gguf")
+
+        user_models = {
+            model_id: {
+                "checkpoint": path,
+                "recipe": "llamacpp",
+                "source": "local_path",
+            }
+        }
+
+        with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
+            json.dump(user_models, f)
+
+        # Downloaded
+        with open(path, "w") as f:
+            f.write("fake")
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("Yes", [l for l in res.stdout.splitlines() if model_id in l][0])
+
+        # Partial
+        with open(path + ".partial", "w") as f:
+            f.write("fake")
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("No", [l for l in res.stdout.splitlines() if model_id in l][0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1958.

This PR fixes how Lemonade decides whether a model is downloaded.

Before this change, a model could be marked as downloaded when only the main checkpoint existed. That was wrong for models that also need extra files like `vae` or `mmproj`. In that case, `pull` could skip the model even though some required files were still missing.

## What changed

The changes unify how Lemonade calculates a model's downloaded status:
- **Verified completeness:** Every required checkpoint is now checked (skipping lazy `npu_cache`).
- **Unified logic:** Reused the same check in both cache initialization and single-model updates.
- **Preserved markers:** Kept the existing detection for `.partial` and `.download_manifest.json` files.

Incomplete download markers are checked the same way as before: file checkpoints check their parent directory for `.download_manifest.json` and their own `.partial` marker; directory checkpoints check the directory itself.

## Tests

Added coverage for:

- a multi-checkpoint model with the main checkpoint present but an auxiliary checkpoint missing;
- collection pull fan-out, making sure an incomplete component is reached instead of skipped;
- single-checkpoint models, to make sure existing behavior still works.

## Scope

This PR only changes downloaded-status detection. It does not change the downloader, model deletion, cache cleanup, GGUF shard handling, or path resolution.

<details>
<summary>Review context</summary>

The original issue was that downloaded status only checked the main model file. That made multi-checkpoint models look complete even when auxiliary files were missing.

During review, the scope was narrowed to avoid changing the downloader or cache cleanup paths. The final approach keeps the fix focused on downloaded-status calculation:

- extract the existing completeness check into a small helper;
- apply it to every required checkpoint;
- skip only lazy `npu_cache`;
- use that result in `build_cache()` and `add_model_to_cache()`.

The marker-check wording was also updated. The implementation does not claim to check the Hugging Face snapshot root directly. It keeps the existing local behavior: file checkpoints check their parent directory and specific `.partial` marker; directory checkpoints check the directory itself.

</details>
