### PR TITLE
ci: harden Linux cleanup for self-hosted runners

### DIFF
--- a/.github/actions/cleanup-processes-linux/action.yml
+++ b/.github/actions/cleanup-processes-linux/action.yml
@@ -377,7 +377,7 @@ runs:
 
             # CI Linux runners are expected to provide ss. Avoid tool probing here;
             # if the runner image is missing ss, the cleanup log should show that directly.
-            ss -H -ltnp "sport = :$port" 2>/dev/null \
+            ss -H -ltnp "sport = :$port" \
                 | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p'
         }
 
@@ -572,4 +572,4 @@ runs:
 
         # Always succeed. Cleanup problems should be warnings, not CI blockers.
         exit 0
-        
+

--- a/.github/actions/cleanup-processes-linux/action.yml
+++ b/.github/actions/cleanup-processes-linux/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Clean up Lemonade-related processes
       shell: bash
       run: |
-        # GitHub runs bash composite steps with error handling enabled.
+        # GitHub composite steps may run with strict error handling.
         # Cleanup must be best-effort and must never fail the real test job.
         set +e
 
@@ -18,8 +18,14 @@ runs:
         TEMP_ROOT="${RUNNER_TEMP:-/tmp}"
         CURRENT_PID="$$"
 
+        # Default: safest behavior for shared self-hosted runners.
+        # Set LEMONADE_CLEANUP_ALLOW_UNSCOPED_TARGETS=1 only on dedicated CI hosts
+        # if you intentionally want to kill unscoped Lemonade-like listeners.
+        ALLOW_UNSCOPED_TARGETS="${LEMONADE_CLEANUP_ALLOW_UNSCOPED_TARGETS:-0}"
+
         echo "Workspace root: $WORKSPACE_ROOT"
         echo "Runner temp:    $TEMP_ROOT"
+        echo "Allow unscoped target kills: $ALLOW_UNSCOPED_TARGETS"
 
         read_pid_cmdline() {
             local pid="$1"
@@ -39,8 +45,10 @@ runs:
                 return 0
             fi
 
+            # Keep this intentionally narrow. Do not match "actions-runner"
+            # broadly because normal job workspaces often live under that path.
             case "$cmdline" in
-                *cleanup-processes-linux*|*actions-runner*|*Runner.Listener*|*Runner.Worker*)
+                *Runner.Listener*|*Runner.Worker*)
                     return 0
                     ;;
             esac
@@ -52,7 +60,25 @@ runs:
             local cmdline="$1"
 
             case "$cmdline" in
-                *lemonade*|*lemond*|*llama*|*stable-diffusion*|*whisper*|*tts*|*server_llm.py*|*server_sd.py*|*server_tts.py*|*server_whisper.py*)
+                *lemonade*|*lemond*)
+                    return 0
+                    ;;
+                *llama-server*|*llama-cli*|*llama-bench*|*llamacpp*)
+                    return 0
+                    ;;
+                *sd-server*|*stable-diffusion*|*server_sd.py*)
+                    return 0
+                    ;;
+                *whisper-server*|*whispercpp*|*server_whisper.py*)
+                    return 0
+                    ;;
+                *flm*|*fastflowlm*|*server_llm.py*)
+                    return 0
+                    ;;
+                *kokoro-server*|*kokoros*|*tts-server*|*server_tts.py*)
+                    return 0
+                    ;;
+                *vllm-server*)
                     return 0
                     ;;
             esac
@@ -82,9 +108,31 @@ runs:
             return 1
         }
 
+        terminate_pid() {
+            local pid="$1"
+            local reason="$2"
+            local cmdline="$3"
+
+            echo "  Terminating PID $pid ($reason): $cmdline"
+            kill "$pid" 2>/dev/null || true
+
+            for _ in 1 2 3 4 5; do
+                if [ ! -d "/proc/$pid" ]; then
+                    return 0
+                fi
+                sleep 0.3
+            done
+
+            if [ -d "/proc/$pid" ]; then
+                echo "  Force-killing PID $pid ($reason): $cmdline"
+                kill -9 "$pid" 2>/dev/null || true
+            fi
+        }
+
         kill_pid_if_safe() {
             local pid="$1"
             local reason="$2"
+            local policy="${3:-require_scope}"
             local cmdline
 
             if [ -z "$pid" ] || [ ! -d "/proc/$pid" ]; then
@@ -101,12 +149,29 @@ runs:
                 return 0
             fi
 
-            if is_target_like_process "$cmdline" || is_scoped_to_this_job "$pid" "$cmdline"; then
-                echo "  Killing PID $pid ($reason): $cmdline"
-                kill -9 "$pid" 2>/dev/null || true
-            else
-                echo "  Skipping unscoped non-target PID $pid ($reason): $cmdline"
-            fi
+            case "$policy" in
+                require_scope)
+                    if is_scoped_to_this_job "$pid" "$cmdline"; then
+                        terminate_pid "$pid" "$reason" "$cmdline"
+                    else
+                        echo "  Skipping unscoped PID $pid ($reason): $cmdline"
+                    fi
+                    ;;
+
+                require_scope_or_allowed_target)
+                    if is_scoped_to_this_job "$pid" "$cmdline"; then
+                        terminate_pid "$pid" "$reason" "$cmdline"
+                    elif is_target_like_process "$cmdline" && [ "$ALLOW_UNSCOPED_TARGETS" = "1" ]; then
+                        terminate_pid "$pid" "$reason; unscoped target allowed" "$cmdline"
+                    else
+                        echo "  Skipping unscoped PID $pid ($reason): $cmdline"
+                    fi
+                    ;;
+
+                *)
+                    echo "  Unknown cleanup policy '$policy'; skipping PID $pid"
+                    ;;
+            esac
         }
 
         kill_exact_name() {
@@ -114,7 +179,7 @@ runs:
             local pids
 
             echo ""
-            echo "Killing exact process name: $name"
+            echo "Checking exact process name: $name"
 
             pids="$(pgrep -x "$name" 2>/dev/null || true)"
             if [ -z "$pids" ]; then
@@ -123,7 +188,7 @@ runs:
             fi
 
             for pid in $pids; do
-                kill_pid_if_safe "$pid" "exact name $name"
+                kill_pid_if_safe "$pid" "exact name $name" "require_scope"
             done
         }
 
@@ -161,10 +226,10 @@ runs:
             fi
 
             for pid in $pids; do
-                kill_pid_if_safe "$pid" "TCP port $port listener"
+                kill_pid_if_safe "$pid" "TCP port $port listener" "require_scope_or_allowed_target"
             done
 
-            sleep 0.3
+            sleep 0.5
 
             if command -v ss >/dev/null 2>&1; then
                 if ss -ltnp "sport = :$port" 2>/dev/null | grep -q ":$port"; then
@@ -205,7 +270,7 @@ runs:
                 fi
 
                 if is_target_like_process "$cmdline" && is_scoped_to_this_job "$pid" "$cmdline"; then
-                    kill_pid_if_safe "$pid" "workspace-scoped target"
+                    kill_pid_if_safe "$pid" "workspace-scoped target" "require_scope"
                     killed_any="true"
                 fi
             done
@@ -223,17 +288,19 @@ runs:
             local lines
 
             if command -v pgrep >/dev/null 2>&1; then
-                lines="$(pgrep -af "lemond|lemonade|llama|stable-diffusion|whisper|tts|server_llm.py|server_sd.py|server_tts.py|server_whisper.py" 2>/dev/null \
-                    | grep -v "cleanup-processes-linux" \
-                    | grep -v "Runner.Worker" \
-                    | grep -v "Runner.Listener" || true)"
+                lines="$(
+                    pgrep -af "lemond|lemonade|llama-server|llama-cli|llama-bench|llamacpp|sd-server|stable-diffusion|whisper-server|whispercpp|flm|fastflowlm|kokoro-server|kokoros|tts-server|vllm-server|server_llm.py|server_sd.py|server_tts.py|server_whisper.py" 2>/dev/null \
+                        | grep -v "cleanup-processes-linux" \
+                        | grep -v "Runner.Worker" \
+                        | grep -v "Runner.Listener" || true
+                )"
                 if [ -n "$lines" ]; then
                     echo "$lines"
                     found="true"
                 fi
             else
                 ps aux \
-                    | grep -E "lemond|lemonade|llama|stable-diffusion|whisper|tts|server_llm.py|server_sd.py|server_tts.py|server_whisper.py" \
+                    | grep -E "lemond|lemonade|llama-server|llama-cli|llama-bench|llamacpp|sd-server|stable-diffusion|whisper-server|whispercpp|flm|fastflowlm|kokoro-server|kokoros|tts-server|vllm-server|server_llm.py|server_sd.py|server_tts.py|server_whisper.py" \
                     | grep -v grep \
                     | grep -v "cleanup-processes-linux" || true
             fi
@@ -255,9 +322,14 @@ runs:
             llama-server \
             llama-cli \
             llama-bench \
+            sd-server \
             stable-diffusion \
             whisper-server \
-            tts-server; do
+            flm \
+            kokoro-server \
+            kokoros \
+            tts-server \
+            vllm-server; do
             kill_exact_name "$proc_name"
         done
 

--- a/.github/actions/cleanup-processes-linux/action.yml
+++ b/.github/actions/cleanup-processes-linux/action.yml
@@ -1,5 +1,5 @@
 name: 'Cleanup Processes (Linux)'
-description: 'Best-effort cleanup of Lemonade, backend, and occupied CI ports on Linux'
+description: 'Best-effort safe cleanup of Lemonade-owned Linux CI processes and ports'
 runs:
   using: "composite"
   steps:
@@ -15,21 +15,45 @@ runs:
         echo "========================================"
 
         WORKSPACE_ROOT="${GITHUB_WORKSPACE:-$PWD}"
-        TEMP_ROOT="${RUNNER_TEMP:-/tmp}"
+        TEMP_ROOT="${RUNNER_TEMP:-}"
+        RUNTIME_ROOT="${XDG_RUNTIME_DIR:-}"
         CURRENT_PID="$$"
 
-        # Default: safest behavior for shared self-hosted runners.
-        # Set LEMONADE_CLEANUP_ALLOW_UNSCOPED_TARGETS=1 only on dedicated CI hosts
-        # if you intentionally want to kill unscoped Lemonade-like listeners.
+        # Safe default for shared self-hosted runners: never kill unscoped processes.
+        # Set LEMONADE_CLEANUP_ALLOW_UNSCOPED_TARGETS=1 only on dedicated CI hosts.
         ALLOW_UNSCOPED_TARGETS="${LEMONADE_CLEANUP_ALLOW_UNSCOPED_TARGETS:-0}"
 
-        echo "Workspace root: $WORKSPACE_ROOT"
-        echo "Runner temp:    $TEMP_ROOT"
-        echo "Allow unscoped target kills: $ALLOW_UNSCOPED_TARGETS"
+        # Keep the cleanup backend-agnostic. New backends should not need changes here
+        # unless they introduce additional long-lived CI ports or opt-out of normal CI env.
+        CLEANUP_PORTS="${LEMONADE_CLEANUP_PORTS:-13305 9001}"
+
+        # Used only for diagnostics and the final fallback scan. Ownership checks are the
+        # safety boundary; this hint is not enough by itself unless explicitly allowed.
+        PROCESS_HINT_REGEX="${LEMONADE_CLEANUP_PROCESS_HINT_REGEX:-lemond|lemonade|llama|llamacpp|server_[[:alnum:]_-]+\.py|wrapped-server|stable-diffusion|sd-server|server_sd\.py|whisper|fastflowlm|(^|[[:space:]/_-])flm([[:space:]]|$)|kokoro|tts-server|server_tts\.py|vllm}"
+
+        echo "Workspace root:        $WORKSPACE_ROOT"
+        if [ -n "$TEMP_ROOT" ]; then
+            echo "Runner temp:           $TEMP_ROOT"
+        else
+            echo "Runner temp:           <unset>"
+        fi
+        if [ -n "$RUNTIME_ROOT" ]; then
+            echo "XDG runtime dir:       $RUNTIME_ROOT"
+        else
+            echo "XDG runtime dir:       <unset>"
+        fi
+        echo "Configured CI ports:   $CLEANUP_PORTS"
+        echo "Allow unscoped kills:  $ALLOW_UNSCOPED_TARGETS"
+        echo "Remove install dir:    ${LEMONADE_CLEANUP_REMOVE_INSTALL_DIR:-auto}"
 
         read_pid_cmdline() {
             local pid="$1"
             tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null
+        }
+
+        read_pid_environ_lines() {
+            local pid="$1"
+            tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null
         }
 
         read_pid_cwd() {
@@ -37,18 +61,26 @@ runs:
             readlink "/proc/$pid/cwd" 2>/dev/null || true
         }
 
-        is_protected_process() {
+        read_pid_exe() {
             local pid="$1"
-            local cmdline="$2"
+            readlink "/proc/$pid/exe" 2>/dev/null || true
+        }
 
-            if [ "$pid" = "$CURRENT_PID" ]; then
-                return 0
+        read_pid_ppid() {
+            local pid="$1"
+            awk '/^PPid:/ { print $2; exit }' "/proc/$pid/status" 2>/dev/null
+        }
+
+        path_under_root() {
+            local path="$1"
+            local root="$2"
+
+            if [ -z "$path" ] || [ -z "$root" ]; then
+                return 1
             fi
 
-            # Keep this intentionally narrow. Do not match "actions-runner"
-            # broadly because normal job workspaces often live under that path.
-            case "$cmdline" in
-                *Runner.Listener*|*Runner.Worker*)
+            case "$path" in
+                "$root"|"$root"/*)
                     return 0
                     ;;
             esac
@@ -56,29 +88,87 @@ runs:
             return 1
         }
 
-        is_target_like_process() {
+        cmdline_contains_root() {
             local cmdline="$1"
+            local root="$2"
+
+            if [ -z "$cmdline" ] || [ -z "$root" ]; then
+                return 1
+            fi
 
             case "$cmdline" in
-                *lemonade*|*lemond*)
+                *"$root"*)
                     return 0
                     ;;
-                *llama-server*|*llama-cli*|*llama-bench*|*llamacpp*)
+            esac
+
+            return 1
+        }
+
+        has_env_line() {
+            local pid="$1"
+            local expected="$2"
+
+            read_pid_environ_lines "$pid" | grep -Fx -- "$expected" >/dev/null 2>&1
+        }
+
+        has_current_run_env() {
+            local pid="$1"
+
+            if [ -z "${GITHUB_RUN_ID:-}" ]; then
+                return 1
+            fi
+
+            has_env_line "$pid" "GITHUB_RUN_ID=$GITHUB_RUN_ID"
+        }
+
+        has_lemonade_ci_env() {
+            local pid="$1"
+
+            has_env_line "$pid" "LEMONADE_CI_MODE=True" || \
+                has_env_line "$pid" "LEMONADE_CI_MODE=true" || \
+                has_env_line "$pid" "LEMONADE_CI_MODE=1"
+        }
+
+        pid_is_current_ancestor() {
+            local candidate="$1"
+            local pid="$CURRENT_PID"
+
+            while [ -n "$pid" ] && [ "$pid" != "0" ]; do
+                if [ "$candidate" = "$pid" ]; then
                     return 0
-                    ;;
-                *sd-server*|*stable-diffusion*|*server_sd.py*)
+                fi
+                pid="$(read_pid_ppid "$pid")"
+            done
+
+            return 1
+        }
+
+        pid_is_current_descendant() {
+            local pid="$1"
+
+            while [ -n "$pid" ] && [ "$pid" != "0" ]; do
+                if [ "$pid" = "$CURRENT_PID" ]; then
                     return 0
-                    ;;
-                *whisper-server*|*whispercpp*|*server_whisper.py*)
-                    return 0
-                    ;;
-                *flm*|*fastflowlm*|*server_llm.py*)
-                    return 0
-                    ;;
-                *kokoro-server*|*kokoros*|*tts-server*|*server_tts.py*)
-                    return 0
-                    ;;
-                *vllm-server*)
+                fi
+                pid="$(read_pid_ppid "$pid")"
+            done
+
+            return 1
+        }
+
+        is_protected_process() {
+            local pid="$1"
+            local cmdline="$2"
+
+            if pid_is_current_ancestor "$pid" || pid_is_current_descendant "$pid"; then
+                return 0
+            fi
+
+            # Keep this intentionally narrow. Do not match "actions-runner" broadly
+            # because normal job workspaces often live under that path.
+            case "$cmdline" in
+                *Runner.Listener*|*Runner.Worker*)
                     return 0
                     ;;
             esac
@@ -90,22 +180,72 @@ runs:
             local pid="$1"
             local cmdline="$2"
             local cwd
+            local exe
+
+            if has_current_run_env "$pid"; then
+                return 0
+            fi
+
+            if cmdline_contains_root "$cmdline" "$WORKSPACE_ROOT" || \
+                cmdline_contains_root "$cmdline" "$TEMP_ROOT" || \
+                cmdline_contains_root "$cmdline" "$RUNTIME_ROOT"; then
+                return 0
+            fi
 
             cwd="$(read_pid_cwd "$pid")"
+            if path_under_root "$cwd" "$WORKSPACE_ROOT" || \
+                path_under_root "$cwd" "$TEMP_ROOT" || \
+                path_under_root "$cwd" "$RUNTIME_ROOT"; then
+                return 0
+            fi
 
-            case "$cmdline" in
-                *"$WORKSPACE_ROOT"*|*"$TEMP_ROOT"*)
-                    return 0
-                    ;;
-            esac
-
-            case "$cwd" in
-                "$WORKSPACE_ROOT"|"$WORKSPACE_ROOT"/*|"$TEMP_ROOT"|"$TEMP_ROOT"/*)
-                    return 0
-                    ;;
-            esac
+            exe="$(read_pid_exe "$pid")"
+            if path_under_root "$exe" "$WORKSPACE_ROOT" || \
+                path_under_root "$exe" "$TEMP_ROOT" || \
+                path_under_root "$exe" "$RUNTIME_ROOT"; then
+                return 0
+            fi
 
             return 1
+        }
+
+        has_process_hint() {
+            local cmdline="$1"
+
+            printf '%s\n' "$cmdline" | grep -Eiq -- "$PROCESS_HINT_REGEX"
+        }
+
+        is_lemonade_ci_process() {
+            local pid="$1"
+            local cmdline="$2"
+
+            # Strongest ownership signal: the process belongs to this exact
+            # GitHub Actions run. This catches child backend processes even when
+            # their command line does not include a Lemonade-specific path or name.
+            if has_current_run_env "$pid"; then
+                return 0
+            fi
+
+            # LEMONADE_CI_MODE is workflow-level and can be inherited by unrelated
+            # jobs on the same self-hosted runner. Treat it as ownership only when
+            # an independent path/cwd/exe signal also scopes the process to this job.
+            if has_lemonade_ci_env "$pid" && is_scoped_to_this_job "$pid" "$cmdline"; then
+                return 0
+            fi
+
+            # Fallback for older leftovers: require both scope evidence and a Lemonade-ish
+            # command hint. The hint alone is never enough in safe mode.
+            if is_scoped_to_this_job "$pid" "$cmdline" && has_process_hint "$cmdline"; then
+                return 0
+            fi
+
+            return 1
+        }
+
+        pid_exists() {
+            local pid="$1"
+
+            [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
         }
 
         terminate_pid() {
@@ -113,29 +253,41 @@ runs:
             local reason="$2"
             local cmdline="$3"
 
-            echo "  Terminating PID $pid ($reason): $cmdline"
-            kill "$pid" 2>/dev/null || true
+            echo "  Sending SIGTERM to PID $pid ($reason): $cmdline"
+            kill -TERM "$pid" 2>/dev/null || true
 
             for _ in 1 2 3 4 5; do
-                if [ ! -d "/proc/$pid" ]; then
+                if ! pid_exists "$pid"; then
+                    echo "  PID $pid exited after SIGTERM"
                     return 0
                 fi
                 sleep 0.3
             done
 
-            if [ -d "/proc/$pid" ]; then
-                echo "  Force-killing PID $pid ($reason): $cmdline"
-                kill -9 "$pid" 2>/dev/null || true
+            if pid_exists "$pid"; then
+                echo "  Sending SIGKILL to PID $pid ($reason): $cmdline"
+                kill -KILL "$pid" 2>/dev/null || true
+            fi
+
+            sleep 0.3
+            if pid_exists "$pid"; then
+                echo "  WARNING: PID $pid is still present after SIGKILL"
+            else
+                echo "  PID $pid exited after SIGKILL"
             fi
         }
 
-        kill_pid_if_safe() {
+        cleanup_pid() {
             local pid="$1"
             local reason="$2"
-            local policy="${3:-require_scope}"
+            local policy="${3:-safe}"
             local cmdline
 
-            if [ -z "$pid" ] || [ ! -d "/proc/$pid" ]; then
+            if ! echo "$pid" | grep -Eq '^[0-9]+$'; then
+                return 0
+            fi
+
+            if ! pid_exists "$pid" || [ ! -d "/proc/$pid" ]; then
                 return 0
             fi
 
@@ -149,46 +301,66 @@ runs:
                 return 0
             fi
 
-            case "$policy" in
-                require_scope)
-                    if is_scoped_to_this_job "$pid" "$cmdline"; then
-                        terminate_pid "$pid" "$reason" "$cmdline"
-                    else
-                        echo "  Skipping unscoped PID $pid ($reason): $cmdline"
-                    fi
-                    ;;
+            if is_lemonade_ci_process "$pid" "$cmdline"; then
+                terminate_pid "$pid" "$reason" "$cmdline"
+                return 0
+            fi
 
-                require_scope_or_allowed_target)
-                    if is_scoped_to_this_job "$pid" "$cmdline"; then
-                        terminate_pid "$pid" "$reason" "$cmdline"
-                    elif is_target_like_process "$cmdline" && [ "$ALLOW_UNSCOPED_TARGETS" = "1" ]; then
-                        terminate_pid "$pid" "$reason; unscoped target allowed" "$cmdline"
-                    else
-                        echo "  Skipping unscoped PID $pid ($reason): $cmdline"
-                    fi
-                    ;;
+            # Known CI port cleanup may also remove listeners that are clearly scoped
+            # to this job, even when their command line has no Lemonade-specific hint.
+            if [ "$policy" = "allow_unscoped" ] && is_scoped_to_this_job "$pid" "$cmdline"; then
+                terminate_pid "$pid" "$reason; scoped to current job" "$cmdline"
+                return 0
+            fi
 
-                *)
-                    echo "  Unknown cleanup policy '$policy'; skipping PID $pid"
-                    ;;
-            esac
+            if [ "$policy" = "allow_unscoped" ] && [ "$ALLOW_UNSCOPED_TARGETS" = "1" ] && has_process_hint "$cmdline"; then
+                terminate_pid "$pid" "$reason; unscoped target allowed" "$cmdline"
+                return 0
+            fi
+
+            if [ "$policy" = "allow_unscoped" ] && [ "$ALLOW_UNSCOPED_TARGETS" = "1" ]; then
+                echo "  Skipping unscoped non-target PID $pid ($reason), even though unscoped cleanup is enabled: $cmdline"
+                return 0
+            fi
+
+            echo "  Skipping unscoped PID $pid ($reason): $cmdline"
         }
 
-        kill_exact_name() {
-            local name="$1"
+        collect_pid_file_pids() {
+            local file
+
+            if [ -n "$TEMP_ROOT" ]; then
+                for file in "$TEMP_ROOT"/lemonade*.pid "$TEMP_ROOT"/lemond*.pid; do
+                    if [ -f "$file" ]; then
+                        sed -n 's/^[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$file" 2>/dev/null
+                    fi
+                done
+            fi
+
+            if [ -n "$RUNTIME_ROOT" ]; then
+                for file in "$RUNTIME_ROOT"/lemonade/lemonade*.pid; do
+                    if [ -f "$file" ]; then
+                        sed -n 's/^[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$file" 2>/dev/null
+                    fi
+                done
+            fi
+        }
+
+        cleanup_pid_files() {
             local pids
+            local pid
 
             echo ""
-            echo "Checking exact process name: $name"
+            echo "Step 1: PID-file cleanup"
 
-            pids="$(pgrep -x "$name" 2>/dev/null || true)"
+            pids="$(collect_pid_file_pids | grep -E '^[0-9]+$' | sort -u || true)"
             if [ -z "$pids" ]; then
-                echo "  No $name processes found"
+                echo "  No Lemonade PID files found"
                 return 0
             fi
 
             for pid in $pids; do
-                kill_pid_if_safe "$pid" "exact name $name" "require_scope"
+                cleanup_pid "$pid" "Lemonade PID file" "safe"
             done
         }
 
@@ -209,24 +381,22 @@ runs:
             fi
         }
 
-        kill_port_listener() {
+        cleanup_port_listener() {
             local port="$1"
             local pids
+            local pid
 
             echo ""
-            echo "Cleaning TCP port $port..."
+            echo "Step 2: TCP port $port cleanup"
 
             pids="$(port_listener_pids "$port" | grep -E '^[0-9]+$' | sort -u || true)"
             if [ -z "$pids" ]; then
                 echo "  No listener PID found for TCP port $port"
-                if command -v ss >/dev/null 2>&1; then
-                    ss -ltnp "sport = :$port" 2>/dev/null || true
-                fi
                 return 0
             fi
 
             for pid in $pids; do
-                kill_pid_if_safe "$pid" "TCP port $port listener" "require_scope_or_allowed_target"
+                cleanup_pid "$pid" "TCP port $port listener" "allow_unscoped"
             done
 
             sleep 0.5
@@ -241,17 +411,19 @@ runs:
             fi
         }
 
-        kill_workspace_related_processes() {
+        cleanup_owned_processes() {
+            local proc_dir
+            local pid
+            local cmdline
+            local found="false"
+
             echo ""
-            echo "Killing Lemonade/backend processes scoped to this workspace or runner temp..."
+            echo "Step 3: owned Lemonade CI process cleanup"
 
             if [ ! -d /proc ]; then
-                echo "  /proc not available; skipping workspace-scoped process cleanup"
+                echo "  /proc not available; skipping process scan"
                 return 0
             fi
-
-            local killed_any="false"
-            local proc_dir pid cmdline
 
             for proc_dir in /proc/[0-9]*; do
                 pid="$(basename "$proc_dir")"
@@ -269,14 +441,14 @@ runs:
                     continue
                 fi
 
-                if is_target_like_process "$cmdline" && is_scoped_to_this_job "$pid" "$cmdline"; then
-                    kill_pid_if_safe "$pid" "workspace-scoped target" "require_scope"
-                    killed_any="true"
+                if is_lemonade_ci_process "$pid" "$cmdline"; then
+                    cleanup_pid "$pid" "owned Lemonade CI process" "safe"
+                    found="true"
                 fi
             done
 
-            if [ "$killed_any" = "false" ]; then
-                echo "  No scoped Lemonade/backend processes found"
+            if [ "$found" = "false" ]; then
+                echo "  No owned Lemonade CI processes found"
             fi
         }
 
@@ -289,7 +461,7 @@ runs:
 
             if command -v pgrep >/dev/null 2>&1; then
                 lines="$(
-                    pgrep -af "lemond|lemonade|llama-server|llama-cli|llama-bench|llamacpp|sd-server|stable-diffusion|whisper-server|whispercpp|flm|fastflowlm|kokoro-server|kokoros|tts-server|vllm-server|server_llm.py|server_sd.py|server_tts.py|server_whisper.py" 2>/dev/null \
+                    pgrep -af "$PROCESS_HINT_REGEX" 2>/dev/null \
                         | grep -v "cleanup-processes-linux" \
                         | grep -v "Runner.Worker" \
                         | grep -v "Runner.Listener" || true
@@ -299,10 +471,16 @@ runs:
                     found="true"
                 fi
             else
-                ps aux \
-                    | grep -E "lemond|lemonade|llama-server|llama-cli|llama-bench|llamacpp|sd-server|stable-diffusion|whisper-server|whispercpp|flm|fastflowlm|kokoro-server|kokoros|tts-server|vllm-server|server_llm.py|server_sd.py|server_tts.py|server_whisper.py" \
-                    | grep -v grep \
-                    | grep -v "cleanup-processes-linux" || true
+                lines="$(
+                    ps aux 2>/dev/null \
+                        | grep -Ei "$PROCESS_HINT_REGEX" \
+                        | grep -v grep \
+                        | grep -v "cleanup-processes-linux" || true
+                )"
+                if [ -n "$lines" ]; then
+                    echo "$lines"
+                    found="true"
+                fi
             fi
 
             if [ "$found" = "true" ]; then
@@ -312,76 +490,95 @@ runs:
             fi
         }
 
-        echo ""
-        echo "Step 1: exact known process names"
-        for proc_name in \
-            lemond \
-            lemonade \
-            lemonade-server \
-            lemonade-tray \
-            llama-server \
-            llama-cli \
-            llama-bench \
-            sd-server \
-            stable-diffusion \
-            whisper-server \
-            flm \
-            kokoro-server \
-            kokoros \
-            tts-server \
-            vllm-server; do
-            kill_exact_name "$proc_name"
+        cleanup_runtime_files() {
+            local tmp_root="${RUNNER_TEMP:-$PWD}"
+
+            echo ""
+            echo "Cleaning up Lemonade lock, PID, and log files..."
+
+            rm -f "$tmp_root"/lemonade*.lock 2>/dev/null || true
+            rm -f "$tmp_root"/lemonade*.pid 2>/dev/null || true
+            rm -f "$tmp_root"/lemond*.pid 2>/dev/null || true
+            rm -f "$tmp_root"/lemonade*.log 2>/dev/null || true
+            rm -f "$tmp_root"/lemonade-server*.log 2>/dev/null || true
+            rm -f "$tmp_root"/lemond*.log 2>/dev/null || true
+
+            if [ -n "$RUNTIME_ROOT" ]; then
+                rm -f "$RUNTIME_ROOT"/lemonade/lemonade*.lock 2>/dev/null || true
+                rm -f "$RUNTIME_ROOT"/lemonade/lemonade*.pid 2>/dev/null || true
+                rm -f "$RUNTIME_ROOT"/lemonade/lemonade*.log 2>/dev/null || true
+            fi
+
+            echo "Runtime files cleaned."
+        }
+
+        should_remove_installation_dir() {
+            case "${LEMONADE_CLEANUP_REMOVE_INSTALL_DIR:-auto}" in
+                1|true|True|TRUE|yes|Yes|YES)
+                    return 0
+                    ;;
+                0|false|False|FALSE|no|No|NO)
+                    return 1
+                    ;;
+                auto|"")
+                    # Safe default: remove only when HOME is explicitly scoped to this
+                    # job. This preserves persistent user-level installs on shared
+                    # self-hosted runners, while still cleaning ephemeral CI homes.
+                    path_under_root "${HOME:-}" "$WORKSPACE_ROOT" || \
+                        path_under_root "${HOME:-}" "$TEMP_ROOT" || \
+                        path_under_root "${HOME:-}" "$RUNTIME_ROOT"
+                    return $?
+                    ;;
+                *)
+                    echo "  Unknown LEMONADE_CLEANUP_REMOVE_INSTALL_DIR value '${LEMONADE_CLEANUP_REMOVE_INSTALL_DIR}'; preserving install directory"
+                    return 1
+                    ;;
+            esac
+        }
+
+        cleanup_installation_dir() {
+            local install_dir="${HOME:-}/.local/share/lemonade-server"
+
+            echo ""
+            echo "Cleaning up Lemonade installation directories..."
+
+            if [ -z "${HOME:-}" ]; then
+                echo "  HOME is unset; skipping install directory cleanup"
+                return 0
+            fi
+
+            if [ ! -d "$install_dir" ]; then
+                echo "No lemonade-server directory found in ~/.local/share/"
+                return 0
+            fi
+
+            if should_remove_installation_dir; then
+                rm -rf "$install_dir" 2>/dev/null || true
+                echo "Removed: $install_dir"
+            else
+                echo "Preserved: $install_dir"
+                echo "  Set LEMONADE_CLEANUP_REMOVE_INSTALL_DIR=1 to remove persistent install directories on dedicated runners."
+            fi
+        }
+
+        cleanup_pid_files
+
+        for port in $CLEANUP_PORTS; do
+            if echo "$port" | grep -Eq '^[0-9]+$'; then
+                cleanup_port_listener "$port"
+            else
+                echo "Skipping invalid port value: $port"
+            fi
         done
 
-        echo ""
-        echo "Step 2: workspace-scoped process cleanup"
-        kill_workspace_related_processes
-
-        echo ""
-        echo "Step 3: Lemonade CI port cleanup"
-        # Main Lemonade HTTP API port
-        kill_port_listener 13305
-
-        # Common Lemonade/WebSocket/test helper port
-        kill_port_listener 9001
+        cleanup_owned_processes
 
         # Give killed processes a moment to exit and release sockets.
         sleep 2
 
         show_remaining_targets
-
-        echo ""
-        echo "Cleaning up lock and PID files..."
-        TMP_ROOT="${RUNNER_TEMP:-$PWD}"
-        rm -f "$TMP_ROOT"/lemonade*.lock 2>/dev/null || true
-        rm -f "$TMP_ROOT"/lemonade*.pid 2>/dev/null || true
-        rm -f "$TMP_ROOT"/lemond.pid 2>/dev/null || true
-
-        if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
-            rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.lock 2>/dev/null || true
-            rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.pid 2>/dev/null || true
-        fi
-        echo "Lock and PID files cleaned."
-
-        echo ""
-        echo "Cleaning up log files..."
-        rm -f "$TMP_ROOT"/lemonade*.log 2>/dev/null || true
-        rm -f "$TMP_ROOT"/lemonade-server*.log 2>/dev/null || true
-        rm -f "$TMP_ROOT"/lemond*.log 2>/dev/null || true
-
-        if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
-            rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.log 2>/dev/null || true
-        fi
-        echo "Log files cleaned."
-
-        echo ""
-        echo "Cleaning up Lemonade installation directories..."
-        if [ -d "$HOME/.local/share/lemonade-server" ]; then
-            rm -rf "$HOME/.local/share/lemonade-server" 2>/dev/null || true
-            echo "Removed: $HOME/.local/share/lemonade-server"
-        else
-            echo "No lemonade-server directory found in ~/.local/share/"
-        fi
+        cleanup_runtime_files
+        cleanup_installation_dir
 
         echo ""
         echo "========================================"

--- a/.github/actions/cleanup-processes-linux/action.yml
+++ b/.github/actions/cleanup-processes-linux/action.yml
@@ -1,88 +1,282 @@
 name: 'Cleanup Processes (Linux)'
-description: 'Kill all lemonade, Python, and llama-server processes on Linux'
+description: 'Best-effort cleanup of Lemonade, backend, and occupied CI ports on Linux'
 runs:
   using: "composite"
   steps:
-    - name: Kill zombie processes
+    - name: Clean up Lemonade-related processes
       shell: bash
       run: |
+        # GitHub runs bash composite steps with error handling enabled.
+        # Cleanup must be best-effort and must never fail the real test job.
+        set +e
+
         echo "========================================"
-        echo "Cleaning up processes on Linux..."
+        echo "Cleaning up Lemonade-related processes on Linux..."
         echo "========================================"
 
-        # Kill processes aggressively by pattern
-        kill_by_pattern() {
-            local pattern=$1
-            local description=$2
+        WORKSPACE_ROOT="${GITHUB_WORKSPACE:-$PWD}"
+        TEMP_ROOT="${RUNNER_TEMP:-/tmp}"
+        CURRENT_PID="$$"
 
-            echo ""
-            echo "Killing $description processes..."
+        echo "Workspace root: $WORKSPACE_ROOT"
+        echo "Runner temp:    $TEMP_ROOT"
 
-            # Find and kill in one shot with SIGKILL
-            pkill -9 -f "$pattern" 2>/dev/null && echo "  Killed processes matching: $pattern" || echo "  No $description processes found"
+        read_pid_cmdline() {
+            local pid="$1"
+            tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null
         }
 
-        # Kill by exact name (even more aggressive)
-        kill_by_exact_name() {
-            local name=$1
+        read_pid_cwd() {
+            local pid="$1"
+            readlink "/proc/$pid/cwd" 2>/dev/null || true
+        }
 
-            if pgrep -x "$name" > /dev/null 2>&1; then
-                echo "Killing $name (exact match)..."
-                pkill -9 -x "$name"
-                sleep 0.5
-                # Verify it's dead
-                if pgrep -x "$name" > /dev/null 2>&1; then
-                    echo "  WARNING: $name still running after kill!"
+        is_protected_process() {
+            local pid="$1"
+            local cmdline="$2"
+
+            if [ "$pid" = "$CURRENT_PID" ]; then
+                return 0
+            fi
+
+            case "$cmdline" in
+                *cleanup-processes-linux*|*actions-runner*|*Runner.Listener*|*Runner.Worker*)
+                    return 0
+                    ;;
+            esac
+
+            return 1
+        }
+
+        is_target_like_process() {
+            local cmdline="$1"
+
+            case "$cmdline" in
+                *lemonade*|*lemond*|*llama*|*stable-diffusion*|*whisper*|*tts*|*server_llm.py*|*server_sd.py*|*server_tts.py*|*server_whisper.py*)
+                    return 0
+                    ;;
+            esac
+
+            return 1
+        }
+
+        is_scoped_to_this_job() {
+            local pid="$1"
+            local cmdline="$2"
+            local cwd
+
+            cwd="$(read_pid_cwd "$pid")"
+
+            case "$cmdline" in
+                *"$WORKSPACE_ROOT"*|*"$TEMP_ROOT"*)
+                    return 0
+                    ;;
+            esac
+
+            case "$cwd" in
+                "$WORKSPACE_ROOT"|"$WORKSPACE_ROOT"/*|"$TEMP_ROOT"|"$TEMP_ROOT"/*)
+                    return 0
+                    ;;
+            esac
+
+            return 1
+        }
+
+        kill_pid_if_safe() {
+            local pid="$1"
+            local reason="$2"
+            local cmdline
+
+            if [ -z "$pid" ] || [ ! -d "/proc/$pid" ]; then
+                return 0
+            fi
+
+            cmdline="$(read_pid_cmdline "$pid")"
+            if [ -z "$cmdline" ]; then
+                return 0
+            fi
+
+            if is_protected_process "$pid" "$cmdline"; then
+                echo "  Skipping protected PID $pid: $cmdline"
+                return 0
+            fi
+
+            if is_target_like_process "$cmdline" || is_scoped_to_this_job "$pid" "$cmdline"; then
+                echo "  Killing PID $pid ($reason): $cmdline"
+                kill -9 "$pid" 2>/dev/null || true
+            else
+                echo "  Skipping unscoped non-target PID $pid ($reason): $cmdline"
+            fi
+        }
+
+        kill_exact_name() {
+            local name="$1"
+            local pids
+
+            echo ""
+            echo "Killing exact process name: $name"
+
+            pids="$(pgrep -x "$name" 2>/dev/null || true)"
+            if [ -z "$pids" ]; then
+                echo "  No $name processes found"
+                return 0
+            fi
+
+            for pid in $pids; do
+                kill_pid_if_safe "$pid" "exact name $name"
+            done
+        }
+
+        port_listener_pids() {
+            local port="$1"
+
+            if command -v lsof >/dev/null 2>&1; then
+                lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true
+            fi
+
+            if command -v fuser >/dev/null 2>&1; then
+                fuser -n tcp "$port" 2>/dev/null | tr ' ' '\n' || true
+            fi
+
+            if command -v ss >/dev/null 2>&1; then
+                ss -H -ltnp "sport = :$port" 2>/dev/null \
+                    | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' || true
+            fi
+        }
+
+        kill_port_listener() {
+            local port="$1"
+            local pids
+
+            echo ""
+            echo "Cleaning TCP port $port..."
+
+            pids="$(port_listener_pids "$port" | grep -E '^[0-9]+$' | sort -u || true)"
+            if [ -z "$pids" ]; then
+                echo "  No listener PID found for TCP port $port"
+                if command -v ss >/dev/null 2>&1; then
+                    ss -ltnp "sport = :$port" 2>/dev/null || true
+                fi
+                return 0
+            fi
+
+            for pid in $pids; do
+                kill_pid_if_safe "$pid" "TCP port $port listener"
+            done
+
+            sleep 0.3
+
+            if command -v ss >/dev/null 2>&1; then
+                if ss -ltnp "sport = :$port" 2>/dev/null | grep -q ":$port"; then
+                    echo "  WARNING: TCP port $port still appears occupied"
+                    ss -ltnp "sport = :$port" 2>/dev/null || true
                 else
-                    echo "  Successfully killed $name"
+                    echo "  TCP port $port is free"
                 fi
             fi
         }
 
-        # Kill llama processes
-        kill_by_pattern "llama-server" "llama-server"
-        kill_by_pattern "llama-cli" "llama-cli"
-        kill_by_pattern "llama-bench" "llama-bench"
+        kill_workspace_related_processes() {
+            echo ""
+            echo "Killing Lemonade/backend processes scoped to this workspace or runner temp..."
 
-        # Kill everything lemonade-related
-        kill_by_pattern "lemonade" "lemonade"
+            if [ ! -d /proc ]; then
+                echo "  /proc not available; skipping workspace-scoped process cleanup"
+                return 0
+            fi
 
-        # Kill Python processes (this is aggressive - be careful!)
-        kill_by_pattern "python" "Python"
+            local killed_any="false"
+            local proc_dir pid cmdline
 
-        # Additional pass: kill by exact process names
+            for proc_dir in /proc/[0-9]*; do
+                pid="$(basename "$proc_dir")"
+
+                if [ ! -r "$proc_dir/cmdline" ]; then
+                    continue
+                fi
+
+                cmdline="$(read_pid_cmdline "$pid")"
+                if [ -z "$cmdline" ]; then
+                    continue
+                fi
+
+                if is_protected_process "$pid" "$cmdline"; then
+                    continue
+                fi
+
+                if is_target_like_process "$cmdline" && is_scoped_to_this_job "$pid" "$cmdline"; then
+                    kill_pid_if_safe "$pid" "workspace-scoped target"
+                    killed_any="true"
+                fi
+            done
+
+            if [ "$killed_any" = "false" ]; then
+                echo "  No scoped Lemonade/backend processes found"
+            fi
+        }
+
+        show_remaining_targets() {
+            echo ""
+            echo "=== Remaining target process check ==="
+
+            local found="false"
+            local lines
+
+            if command -v pgrep >/dev/null 2>&1; then
+                lines="$(pgrep -af "lemond|lemonade|llama|stable-diffusion|whisper|tts|server_llm.py|server_sd.py|server_tts.py|server_whisper.py" 2>/dev/null \
+                    | grep -v "cleanup-processes-linux" \
+                    | grep -v "Runner.Worker" \
+                    | grep -v "Runner.Listener" || true)"
+                if [ -n "$lines" ]; then
+                    echo "$lines"
+                    found="true"
+                fi
+            else
+                ps aux \
+                    | grep -E "lemond|lemonade|llama|stable-diffusion|whisper|tts|server_llm.py|server_sd.py|server_tts.py|server_whisper.py" \
+                    | grep -v grep \
+                    | grep -v "cleanup-processes-linux" || true
+            fi
+
+            if [ "$found" = "true" ]; then
+                echo "WARNING: Some target-like processes may still exist. Cleanup is best-effort only."
+            else
+                echo "No remaining target-like processes found"
+            fi
+        }
+
         echo ""
-        echo "Second pass: killing by exact name..."
-        for proc_name in lemond lemonade-tray llama-server llama-cli llama-bench; do
-            kill_by_exact_name "$proc_name"
+        echo "Step 1: exact known process names"
+        for proc_name in \
+            lemond \
+            lemonade \
+            lemonade-server \
+            lemonade-tray \
+            llama-server \
+            llama-cli \
+            llama-bench \
+            stable-diffusion \
+            whisper-server \
+            tts-server; do
+            kill_exact_name "$proc_name"
         done
 
-        # Wait for processes to die
+        echo ""
+        echo "Step 2: workspace-scoped process cleanup"
+        kill_workspace_related_processes
+
+        echo ""
+        echo "Step 3: Lemonade CI port cleanup"
+        # Main Lemonade HTTP API port
+        kill_port_listener 13305
+
+        # Common Lemonade/WebSocket/test helper port
+        kill_port_listener 9001
+
+        # Give killed processes a moment to exit and release sockets.
         sleep 2
 
-        # FINAL VERIFICATION - show what's still alive
-        echo ""
-        echo "=== Verification: checking for remaining processes ==="
-        if pgrep -f "lemonade|llama" > /dev/null 2>&1; then
-            echo "WARNING: Some processes still alive:"
-            ps aux | grep -E "lemonade|llama" | grep -v grep | grep -v "cleanup-processes" || true
-
-            # NUCLEAR OPTION: Kill them with extreme prejudice
-            echo "Using nuclear option..."
-            pkill -9 -f "llama" 2>/dev/null || true
-            pkill -9 -f "lemonade" 2>/dev/null || true
-            sleep 1
-
-            # Check again
-            if pgrep -f "lemonade|llama" > /dev/null 2>&1; then
-                echo "ERROR: Processes STILL alive after nuclear option!"
-                ps aux | grep -E "lemonade|llama" | grep -v grep || true
-            else
-                echo "Nuclear option successful"
-            fi
-        else
-            echo "All target processes terminated successfully"
-        fi
+        show_remaining_targets
 
         echo ""
         echo "Cleaning up lock and PID files..."
@@ -90,26 +284,26 @@ runs:
         rm -f "$TMP_ROOT"/lemonade*.lock 2>/dev/null || true
         rm -f "$TMP_ROOT"/lemonade*.pid 2>/dev/null || true
         rm -f "$TMP_ROOT"/lemond.pid 2>/dev/null || true
+
         if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
-          rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.lock 2>/dev/null || true
-          rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.pid 2>/dev/null || true
+            rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.lock 2>/dev/null || true
+            rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.pid 2>/dev/null || true
         fi
         echo "Lock and PID files cleaned."
 
-        # Clean up log files
         echo ""
         echo "Cleaning up log files..."
         rm -f "$TMP_ROOT"/lemonade*.log 2>/dev/null || true
         rm -f "$TMP_ROOT"/lemonade-server*.log 2>/dev/null || true
         rm -f "$TMP_ROOT"/lemond*.log 2>/dev/null || true
+
         if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
-          rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.log 2>/dev/null || true
+            rm -f "${XDG_RUNTIME_DIR}/lemonade/lemonade"*.log 2>/dev/null || true
         fi
         echo "Log files cleaned."
 
-        # Clean up installation directories
         echo ""
-        echo "Cleaning up lemonade installation directories..."
+        echo "Cleaning up Lemonade installation directories..."
         if [ -d "$HOME/.local/share/lemonade-server" ]; then
             rm -rf "$HOME/.local/share/lemonade-server" 2>/dev/null || true
             echo "Removed: $HOME/.local/share/lemonade-server"
@@ -121,3 +315,6 @@ runs:
         echo "========================================"
         echo "Process cleanup complete!"
         echo "========================================"
+
+        # Always succeed. Cleanup problems should be warnings, not CI blockers.
+        exit 0

--- a/.github/actions/cleanup-processes-linux/action.yml
+++ b/.github/actions/cleanup-processes-linux/action.yml
@@ -22,6 +22,7 @@ runs:
         # Safe default for shared self-hosted runners: never kill unscoped processes.
         # Set LEMONADE_CLEANUP_ALLOW_UNSCOPED_TARGETS=1 only on dedicated CI hosts.
         ALLOW_UNSCOPED_TARGETS="${LEMONADE_CLEANUP_ALLOW_UNSCOPED_TARGETS:-0}"
+        FORCE_KILL="${LEMONADE_CLEANUP_FORCE_KILL:-0}"
 
         # Keep the cleanup backend-agnostic. New backends should not need changes here
         # unless they introduce additional long-lived CI ports or opt-out of normal CI env.
@@ -44,6 +45,7 @@ runs:
         fi
         echo "Configured CI ports:   $CLEANUP_PORTS"
         echo "Allow unscoped kills:  $ALLOW_UNSCOPED_TARGETS"
+        echo "Force-kill fallback:   $FORCE_KILL"
         echo "Remove install dir:    ${LEMONADE_CLEANUP_REMOVE_INSTALL_DIR:-auto}"
 
         read_pid_cmdline() {
@@ -58,12 +60,12 @@ runs:
 
         read_pid_cwd() {
             local pid="$1"
-            readlink "/proc/$pid/cwd" 2>/dev/null || true
+            readlink "/proc/$pid/cwd" 2>/dev/null
         }
 
         read_pid_exe() {
             local pid="$1"
-            readlink "/proc/$pid/exe" 2>/dev/null || true
+            readlink "/proc/$pid/exe" 2>/dev/null
         }
 
         read_pid_ppid() {
@@ -254,26 +256,32 @@ runs:
             local cmdline="$3"
 
             echo "  Sending SIGTERM to PID $pid ($reason): $cmdline"
-            kill -TERM "$pid" 2>/dev/null || true
+            kill -TERM "$pid" 2>/dev/null
 
-            for _ in 1 2 3 4 5; do
+            for _ in 1 2 3 4 5 6 7 8 9 10; do
                 if ! pid_exists "$pid"; then
                     echo "  PID $pid exited after SIGTERM"
                     return 0
                 fi
-                sleep 0.3
+                sleep 0.5
             done
 
-            if pid_exists "$pid"; then
-                echo "  Sending SIGKILL to PID $pid ($reason): $cmdline"
-                kill -KILL "$pid" 2>/dev/null || true
+            if ! pid_exists "$pid"; then
+                echo "  PID $pid exited after SIGTERM"
+                return 0
             fi
 
-            sleep 0.3
-            if pid_exists "$pid"; then
-                echo "  WARNING: PID $pid is still present after SIGKILL"
+            if [ "$FORCE_KILL" = "1" ]; then
+                echo "  Sending SIGKILL to PID $pid ($reason; force-kill fallback enabled): $cmdline"
+                kill -KILL "$pid" 2>/dev/null
+                sleep 0.3
+                if pid_exists "$pid"; then
+                    echo "  WARNING: PID $pid is still present after SIGKILL"
+                else
+                    echo "  PID $pid exited after SIGKILL"
+                fi
             else
-                echo "  PID $pid exited after SIGKILL"
+                echo "  WARNING: PID $pid did not exit after SIGTERM; leaving it running because LEMONADE_CLEANUP_FORCE_KILL is not enabled"
             fi
         }
 
@@ -353,7 +361,7 @@ runs:
             echo ""
             echo "Step 1: PID-file cleanup"
 
-            pids="$(collect_pid_file_pids | grep -E '^[0-9]+$' | sort -u || true)"
+            pids="$(collect_pid_file_pids | grep -E '^[0-9]+$' | sort -u)"
             if [ -z "$pids" ]; then
                 echo "  No Lemonade PID files found"
                 return 0
@@ -367,18 +375,10 @@ runs:
         port_listener_pids() {
             local port="$1"
 
-            if command -v lsof >/dev/null 2>&1; then
-                lsof -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null || true
-            fi
-
-            if command -v fuser >/dev/null 2>&1; then
-                fuser -n tcp "$port" 2>/dev/null | tr ' ' '\n' || true
-            fi
-
-            if command -v ss >/dev/null 2>&1; then
-                ss -H -ltnp "sport = :$port" 2>/dev/null \
-                    | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p' || true
-            fi
+            # CI Linux runners are expected to provide ss. Avoid tool probing here;
+            # if the runner image is missing ss, the cleanup log should show that directly.
+            ss -H -ltnp "sport = :$port" 2>/dev/null \
+                | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p'
         }
 
         cleanup_port_listener() {
@@ -389,7 +389,7 @@ runs:
             echo ""
             echo "Step 2: TCP port $port cleanup"
 
-            pids="$(port_listener_pids "$port" | grep -E '^[0-9]+$' | sort -u || true)"
+            pids="$(port_listener_pids "$port" | grep -E '^[0-9]+$' | sort -u)"
             if [ -z "$pids" ]; then
                 echo "  No listener PID found for TCP port $port"
                 return 0
@@ -401,13 +401,11 @@ runs:
 
             sleep 0.5
 
-            if command -v ss >/dev/null 2>&1; then
-                if ss -ltnp "sport = :$port" 2>/dev/null | grep -q ":$port"; then
-                    echo "  WARNING: TCP port $port still appears occupied"
-                    ss -ltnp "sport = :$port" 2>/dev/null || true
-                else
-                    echo "  TCP port $port is free"
-                fi
+            if ss -ltnp "sport = :$port" | grep -q ":$port"; then
+                echo "  WARNING: TCP port $port still appears occupied"
+                ss -ltnp "sport = :$port"
+            else
+                echo "  TCP port $port is free"
             fi
         }
 
@@ -459,28 +457,15 @@ runs:
             local found="false"
             local lines
 
-            if command -v pgrep >/dev/null 2>&1; then
-                lines="$(
-                    pgrep -af "$PROCESS_HINT_REGEX" 2>/dev/null \
-                        | grep -v "cleanup-processes-linux" \
-                        | grep -v "Runner.Worker" \
-                        | grep -v "Runner.Listener" || true
-                )"
-                if [ -n "$lines" ]; then
-                    echo "$lines"
-                    found="true"
-                fi
-            else
-                lines="$(
-                    ps aux 2>/dev/null \
-                        | grep -Ei "$PROCESS_HINT_REGEX" \
-                        | grep -v grep \
-                        | grep -v "cleanup-processes-linux" || true
-                )"
-                if [ -n "$lines" ]; then
-                    echo "$lines"
-                    found="true"
-                fi
+            lines="$(
+                pgrep -af "$PROCESS_HINT_REGEX" 2>/dev/null \
+                    | grep -v "cleanup-processes-linux" \
+                    | grep -v "Runner.Worker" \
+                    | grep -v "Runner.Listener"
+            )"
+            if [ -n "$lines" ]; then
+                echo "$lines"
+                found="true"
             fi
 
             if [ "$found" = "true" ]; then
@@ -496,17 +481,17 @@ runs:
             echo ""
             echo "Cleaning up Lemonade lock, PID, and log files..."
 
-            rm -f "$tmp_root"/lemonade*.lock 2>/dev/null || true
-            rm -f "$tmp_root"/lemonade*.pid 2>/dev/null || true
-            rm -f "$tmp_root"/lemond*.pid 2>/dev/null || true
-            rm -f "$tmp_root"/lemonade*.log 2>/dev/null || true
-            rm -f "$tmp_root"/lemonade-server*.log 2>/dev/null || true
-            rm -f "$tmp_root"/lemond*.log 2>/dev/null || true
+            rm -f "$tmp_root"/lemonade*.lock 2>/dev/null
+            rm -f "$tmp_root"/lemonade*.pid 2>/dev/null
+            rm -f "$tmp_root"/lemond*.pid 2>/dev/null
+            rm -f "$tmp_root"/lemonade*.log 2>/dev/null
+            rm -f "$tmp_root"/lemonade-server*.log 2>/dev/null
+            rm -f "$tmp_root"/lemond*.log 2>/dev/null
 
             if [ -n "$RUNTIME_ROOT" ]; then
-                rm -f "$RUNTIME_ROOT"/lemonade/lemonade*.lock 2>/dev/null || true
-                rm -f "$RUNTIME_ROOT"/lemonade/lemonade*.pid 2>/dev/null || true
-                rm -f "$RUNTIME_ROOT"/lemonade/lemonade*.log 2>/dev/null || true
+                rm -f "$RUNTIME_ROOT"/lemonade/lemonade*.lock 2>/dev/null
+                rm -f "$RUNTIME_ROOT"/lemonade/lemonade*.pid 2>/dev/null
+                rm -f "$RUNTIME_ROOT"/lemonade/lemonade*.log 2>/dev/null
             fi
 
             echo "Runtime files cleaned."
@@ -553,7 +538,7 @@ runs:
             fi
 
             if should_remove_installation_dir; then
-                rm -rf "$install_dir" 2>/dev/null || true
+                rm -rf "$install_dir" 2>/dev/null
                 echo "Removed: $install_dir"
             else
                 echo "Preserved: $install_dir"
@@ -587,3 +572,4 @@ runs:
 
         # Always succeed. Cleanup problems should be warnings, not CI blockers.
         exit 0
+        

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -163,9 +163,13 @@ jobs:
           .venv/bin/python "${VALIDATION_ARGS[@]}" || EXIT_CODE=$?
 
           # Shut the server down cleanly so logs flush.
-          curl -sf -X POST http://127.0.0.1:13305/internal/shutdown || true
+          if ! curl -sf -X POST http://127.0.0.1:13305/internal/shutdown; then
+            echo "lemond shutdown endpoint did not respond; continuing cleanup"
+          fi
           sleep 2
-          kill "$LEMOND_PID" 2>/dev/null || true
+          if ! kill "$LEMOND_PID" 2>/dev/null; then
+            echo "lemond PID $LEMOND_PID is already stopped"
+          fi
 
           exit $EXIT_CODE
 
@@ -308,4 +312,4 @@ jobs:
             --body-file pr_body.md \
             --base main \
             --head "$BRANCH"
-            
+

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -188,10 +188,10 @@ jobs:
 
       - name: Cleanup
         if: always()
-        run: |
-          pkill -9 -f lemond 2>/dev/null || true
-          pkill -9 -f "vllm" 2>/dev/null || true
-          pkill -9 -f "resource_tracker" 2>/dev/null || true
+        uses: ./.github/actions/cleanup-processes-linux
+        env:
+          # Keep this workflow-specific hint narrow; ownership checks in the action remain the safety boundary.
+          LEMONADE_CLEANUP_PROCESS_HINT_REGEX: 'lemond|lemonade|vllm|resource_tracker'
 
   # ========================================================================
   # Create PR if validation passed (schedule or workflow_dispatch only)

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -165,7 +165,7 @@ jobs:
           # Shut the server down cleanly so logs flush.
           curl -sf -X POST http://127.0.0.1:13305/internal/shutdown || true
           sleep 2
-          kill $LEMOND_PID 2>/dev/null || true
+          kill "$LEMOND_PID" 2>/dev/null || true
 
           exit $EXIT_CODE
 
@@ -308,3 +308,4 @@ jobs:
             --body-file pr_body.md \
             --base main \
             --head "$BRANCH"
+            


### PR DESCRIPTION
## Summary

This hardens the Linux cleanup action for self-hosted runners by making process cleanup best-effort, scoped, and less destructive.

The previous cleanup logic used broad `pkill -9 -f` patterns, including a generic Python kill and a final broad llama|lemonade fallback. That can be unsafe on shared or long-lived self-hosted runners because it may terminate unrelated jobs or persistent runner-side processes.

This PR replaces that behavior with a safer cleanup flow:

- never fail the real CI job because cleanup is best-effort
- avoid broad generic Python process kills
- protect GitHub runner processes and the current cleanup process tree
- resolve listener PIDs for known Lemonade CI ports before killing anything
- only kill processes that are scoped to the current workspace, runner temp/runtime dir, or current GitHub Actions run
- keep unscoped kills opt-in via LEMONADE_CLEANUP_ALLOW_UNSCOPED_TARGETS=1 for dedicated CI hosts
- centralize cleanup behavior so backend workflows do not need their own ad-hoc `pkill` blocks (see vLLM)

## Why this is larger than the old cleanup script

Most of the added lines are guardrails, diagnostics, and explicit ownership checks. The old implementation was short because it was intentionally aggressive; the new implementation is longer because it avoids killing unrelated processes on self-hosted runners.

This should be easy to maintain despite the larger diff because the policy is now explicit:

- **safe by default** for shared runners
- **configurable** for dedicated runners
- **backend-agnostic** through process hints and port configuration
- **centralized** in one reusable cleanup action instead of repeated workflow-specific cleanup snippets

## Notes

Cleanup remains best-effort. If a process cannot be safely associated with the current job, the action logs it and leaves it alone rather than risking termination of unrelated work.