### PR TITLE
Allow LEMONADE_GGML_HIP_PATH to locate the HIP plugin on non-FHS installs

### DIFF
--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -53,6 +53,13 @@ Lemonade uses [llama.cpp](https://github.com/ggerganov/llama.cpp) as its primary
 - **Performance**: Depends on build configuration
 - **Installation**: Requires manual installation of `llama-server` in system PATH
 - **Notes**: Not enabled by default; set `LEMONADE_LLAMACPP_PREFER_SYSTEM=true` in config
+- **HIP plugin on non-standard paths**: When an AMD GPU is present, the system backend needs the GGML HIP plugin (`libggml-hip.so`). Lemonade looks for it in the standard system library paths. If your distribution or package manager installs it elsewhere (e.g. NixOS, a custom prefix, or a manual build), set `LEMONADE_GGML_HIP_PATH` to the full path of the plugin so the backend is reported as available:
+
+  ```bash
+  export LEMONADE_GGML_HIP_PATH=/opt/rocm/lib/libggml-hip.so
+  ```
+
+  The filename must look like `libggml-hip*.so*` (versioned sonames such as `libggml-hip.so.0` are accepted). This Linux-only variable is used solely to detect plugin availability; it is not forwarded to the GGML loader, so it does not change where llama.cpp actually loads the plugin from.
 
 ## ROCm Channel Configuration
 

--- a/src/cpp/server/utils/path_utils.cpp
+++ b/src/cpp/server/utils/path_utils.cpp
@@ -269,6 +269,11 @@ std::string find_executable_in_path(const std::string& executable_name) {
 
 bool is_ggml_hip_plugin_available() {
 #ifdef __linux__
+    // Allow distros/packagers that install outside the FHS paths below
+    // (e.g. NixOS, custom prefixes) to point directly at libggml-hip.so.
+    if (const char* env = std::getenv("LEMONADE_GGML_HIP_PATH"); env && *env && fs::is_regular_file(env)) {
+        return true;
+    }
     // On Linux x86_64, check common system library paths for the HIP plugin
     std::vector<std::string> possible_paths = {
         // Debian/Ubuntu multiarch path (most common)

--- a/src/cpp/server/utils/path_utils.cpp
+++ b/src/cpp/server/utils/path_utils.cpp
@@ -1,6 +1,8 @@
 #include <lemon/utils/path_utils.h>
 #include <lemon/utils/json_utils.h>
 #include <lemon/utils/process_manager.h>
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <vector>
 #include <string>
@@ -271,8 +273,24 @@ bool is_ggml_hip_plugin_available() {
 #ifdef __linux__
     // Allow distros/packagers that install outside the FHS paths below
     // (e.g. NixOS, custom prefixes) to point directly at libggml-hip.so.
-    if (const char* env = std::getenv("LEMONADE_GGML_HIP_PATH"); env && *env && fs::is_regular_file(env)) {
-        return true;
+    if (const char* env = std::getenv("LEMONADE_GGML_HIP_PATH"); env && *env) {
+        // Require the basename to look like the HIP plugin (libggml-hip*.so*,
+        // case-insensitive, versioned sonames allowed). This is a sanity check,
+        // not a security boundary: the path is not forwarded to ggml's loader,
+        // so we cannot verify it is actually loadable. It only guards against an
+        // accidental override pointing at an unrelated existing file.
+        std::string name = fs::path(env).filename().string();
+        std::transform(name.begin(), name.end(), name.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        const bool name_matches = name.rfind("libggml-hip", 0) == 0 &&
+                                  name.find(".so") != std::string::npos;
+        // LEMONADE_GGML_HIP_PATH is user-controlled, so use the non-throwing
+        // filesystem overload: an odd or malformed path resolves to "not a
+        // regular file" (ec set) instead of raising a filesystem_error.
+        std::error_code hip_path_ec;
+        if (name_matches && fs::is_regular_file(env, hip_path_ec)) {
+            return true;
+        }
     }
     // On Linux x86_64, check common system library paths for the HIP plugin
     std::vector<std::string> possible_paths = {

--- a/test/cpp/test_ggml_hip_path.cpp
+++ b/test/cpp/test_ggml_hip_path.cpp
@@ -1,0 +1,128 @@
+// Standalone test for lemon::utils::is_ggml_hip_plugin_available().
+// Compile with: g++ -std=c++17 -I src/cpp/include \
+//                   test/cpp/test_ggml_hip_path.cpp \
+//                   src/cpp/server/utils/path_utils.cpp \
+//                   src/cpp/server/utils/json_utils.cpp \
+//                   src/cpp/server/utils/process_manager.cpp -o hip_path_test
+
+#include <cassert>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include <lemon/utils/path_utils.h>
+
+#ifdef __linux__
+#include <unistd.h>
+#endif
+
+// Regression tests for the LEMONADE_GGML_HIP_PATH override consumed by
+// lemon::utils::is_ggml_hip_plugin_available(). The override lets non-FHS
+// installs (NixOS, custom prefixes) point directly at libggml-hip.so.
+//
+// The override is Linux-only, and because the path is user-controlled the
+// implementation must (a) match a libggml-hip*.so* basename and (b) use the
+// non-throwing std::filesystem overload so an odd path reports "unavailable"
+// instead of raising filesystem_error.
+
+namespace fs = std::filesystem;
+using lemon::utils::is_ggml_hip_plugin_available;
+
+namespace {
+
+void set_hip_path(const std::string& value) {
+    setenv("LEMONADE_GGML_HIP_PATH", value.c_str(), /*overwrite=*/1);
+}
+
+void clear_hip_path() { unsetenv("LEMONADE_GGML_HIP_PATH"); }
+
+}  // namespace
+
+int main() {
+#ifndef __linux__
+    // The override has no effect off Linux; the function always returns false.
+    clear_hip_path();
+    assert(!is_ggml_hip_plugin_available());
+    std::cout << "[skip] LEMONADE_GGML_HIP_PATH override is Linux-only"
+              << std::endl;
+    return 0;
+#else
+    clear_hip_path();
+    // If the host already has a system HIP plugin at an FHS path, the negative
+    // cases below would still report "available" through the FHS fallback, so
+    // those assertions can't isolate the override. Detect that and skip them.
+    const bool baseline_available = is_ggml_hip_plugin_available();
+
+    fs::path tmp =
+        fs::temp_directory_path() / ("lemon_hip_test_" + std::to_string(getpid()));
+    fs::create_directories(tmp);
+    const auto write_stub = [](const fs::path& p) {
+        std::ofstream(p) << "stub";
+    };
+
+    const fs::path valid_so = tmp / "libggml-hip.so";
+    const fs::path versioned_so = tmp / "libggml-hip.so.0";
+    const fs::path upper_so = tmp / "LIBGGML-HIP.SO";
+    const fs::path wrong_name = tmp / "libsomethingelse.so";
+    const fs::path not_a_lib = tmp / "notes.txt";
+    write_stub(valid_so);
+    write_stub(versioned_so);
+    write_stub(upper_so);
+    write_stub(wrong_name);
+    write_stub(not_a_lib);
+
+    set_hip_path(valid_so.string());
+    assert(is_ggml_hip_plugin_available());
+    std::cout << "[ok] valid libggml-hip.so override -> available" << std::endl;
+
+    set_hip_path(versioned_so.string());
+    assert(is_ggml_hip_plugin_available());
+    std::cout << "[ok] versioned libggml-hip.so.0 override -> available"
+              << std::endl;
+
+    set_hip_path(upper_so.string());
+    assert(is_ggml_hip_plugin_available());
+    std::cout << "[ok] case-insensitive basename override -> available"
+              << std::endl;
+
+    if (!baseline_available) {
+        set_hip_path((tmp / "missing" / "libggml-hip.so").string());
+        assert(!is_ggml_hip_plugin_available());
+        std::cout << "[ok] missing override path -> not available" << std::endl;
+
+        set_hip_path(tmp.string());
+        assert(!is_ggml_hip_plugin_available());
+        std::cout << "[ok] directory override -> not available" << std::endl;
+
+        set_hip_path(wrong_name.string());
+        assert(!is_ggml_hip_plugin_available());
+        std::cout << "[ok] wrong-name file override -> not available"
+                  << std::endl;
+
+        set_hip_path(not_a_lib.string());
+        assert(!is_ggml_hip_plugin_available());
+        std::cout << "[ok] non-.so file override -> not available" << std::endl;
+
+        // Using an existing file as a path component yields ENOTDIR, which the
+        // throwing is_regular_file() overload would turn into a filesystem_error
+        // (crashing this test). The non-throwing overload must just report
+        // "not available". The basename still matches, isolating the behavior.
+        set_hip_path((valid_so / "libggml-hip.so").string());
+        assert(!is_ggml_hip_plugin_available());
+        std::cout << "[ok] non-directory path component -> not available "
+                     "(no throw)"
+                  << std::endl;
+    } else {
+        std::cout << "[skip] host has a system HIP plugin; negative override "
+                     "cases are not distinguishable"
+                  << std::endl;
+    }
+
+    clear_hip_path();
+    fs::remove_all(tmp);
+    std::cout << "All ggml_hip_path tests passed" << std::endl;
+    return 0;
+#endif
+}

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -453,6 +453,83 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
         self.assertIn("system", backends)
         self.assertEqual(backends["system"]["state"], "installed")
 
+    def _require_system_backend_blocked_by_hip_plugin(self):
+        """Skip unless the running server reports the 'system' llamacpp backend
+        as blocked by a missing HIP plugin.
+
+        LEMONADE_GGML_HIP_PATH only affects is_ggml_hip_plugin_available(),
+        which system_info.cpp consults solely for the 'system' backend, only
+        when an AMD GPU is present (/sys/class/kfd) and llama-server is in PATH.
+        Its only observable effect is the system backend's "HIP plugin
+        libggml-hip.so not installed" message. Callers must add llama-server to
+        PATH and start the server before calling this.
+        """
+        system = self._get_llamacpp_backends().get("system", {})
+        if "HIP plugin" not in system.get("message", ""):
+            self.skipTest(
+                "Requires an AMD GPU without an FHS-installed HIP plugin; "
+                f"system backend reported: {system}"
+            )
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"), "System backend only supported on Linux"
+    )
+    def test_005a_hip_path_override_satisfies_hip_plugin_check(self):
+        """A valid LEMONADE_GGML_HIP_PATH satisfies the HIP-plugin check that
+        otherwise blocks the 'system' backend on AMD GPU hosts."""
+        if not os.path.exists("/sys/class/kfd"):
+            self.skipTest("Requires an AMD GPU (/sys/class/kfd present)")
+        self._add_dummy_llama_server_to_path()
+
+        # Baseline: without the override the system backend is blocked by a
+        # missing HIP plugin, otherwise the override has nothing to satisfy.
+        _start_server()
+        self._require_system_backend_blocked_by_hip_plugin()
+        _stop_server()
+
+        valid_so = os.path.join(self.temp_bin_dir, "libggml-hip.so")
+        with open(valid_so, "w", encoding="utf-8") as handle:
+            handle.write("stub")
+
+        # _start_server() launches lemond with os.environ.copy(), so set the
+        # override in this process's environment and clean it up afterwards.
+        self.addCleanup(os.environ.pop, "LEMONADE_GGML_HIP_PATH", None)
+        os.environ["LEMONADE_GGML_HIP_PATH"] = valid_so
+        _start_server()
+        system = self._get_llamacpp_backends().get("system", {})
+        self.assertNotIn("HIP plugin", system.get("message", ""), system)
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"), "System backend only supported on Linux"
+    )
+    def test_005b_hip_path_override_invalid_is_ignored(self):
+        """An invalid LEMONADE_GGML_HIP_PATH (nonexistent file or directory) is
+        ignored: the 'system' backend stays blocked by the missing HIP plugin."""
+        if not os.path.exists("/sys/class/kfd"):
+            self.skipTest("Requires an AMD GPU (/sys/class/kfd present)")
+        self._add_dummy_llama_server_to_path()
+
+        _start_server()
+        self._require_system_backend_blocked_by_hip_plugin()
+        _stop_server()
+
+        self.addCleanup(os.environ.pop, "LEMONADE_GGML_HIP_PATH", None)
+
+        # Nonexistent file: the override is ignored.
+        os.environ["LEMONADE_GGML_HIP_PATH"] = os.path.join(
+            self.temp_bin_dir, "missing", "libggml-hip.so"
+        )
+        _start_server()
+        system = self._get_llamacpp_backends().get("system", {})
+        self.assertIn("HIP plugin", system.get("message", ""), system)
+        _stop_server()
+
+        # A directory is not a regular file and must also be ignored.
+        os.environ["LEMONADE_GGML_HIP_PATH"] = self.temp_bin_dir
+        _start_server()
+        system = self._get_llamacpp_backends().get("system", {})
+        self.assertIn("HIP plugin", system.get("message", ""), system)
+
     @unittest.skipUnless(
         sys.platform.startswith("linux"), "System backend only supported on Linux"
     )


### PR DESCRIPTION
Allow `LEMONADE_GGML_HIP_PATH` to locate `libggml-hip.so` on non-FHS installs

## Problem

`is_ggml_hip_plugin_available()` probes only a fixed set of FHS paths for `libggml-hip.so`:

```
/usr/lib/x86_64-linux-gnu/ggml/backends0/libggml-hip.so   (Debian/Ubuntu)
/usr/lib/libggml-hip.so                                   (Arch AUR)
/usr/lib/ggml/backends0/libggml-hip.so
/usr/lib64/ggml/backends0/libggml-hip.so
```

On distros/packaging that install the plugin elsewhere — NixOS, Guix, custom prefixes, relocatable installs — the `system` llamacpp recipe is reported as `HIP plugin libggml-hip.so not installed` on any machine with an AMD GPU (`/sys/class/kfd` present), even when a perfectly good `libggml-hip.so` exists. There is currently no way to override the lookup.

## Fix

Add a `LEMONADE_GGML_HIP_PATH` environment variable that points directly at the plugin file. When it is set and names a regular file, the plugin is considered available; otherwise the existing FHS probe runs unchanged.

- Default behavior on Debian/Ubuntu/Arch is **identical** (the env var is opt-in).
- `fs::is_regular_file` follows symlinks, so a symlink into a store/prefix resolves correctly, and a stale path or directory does **not** falsely pass the gate.
- Scoped inside the existing `#ifdef __linux__`; non-Linux builds are unaffected.

## Test

Built `lemonade` from source on NixOS where `libggml-hip.so` lives under the Nix store. Before: `system` + ROCm shows as not installed. After: `LEMONADE_GGML_HIP_PATH=/nix/store/.../lib/libggml-hip.so` makes the `system` recipe report installed and ROCm acceleration works.