### PR TITLE
Map LEMONADE_WHISPERCPP_VULKAN_{BIN,ARGS} env vars for parity

### DIFF
--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -211,8 +211,10 @@ static const EnvMapping env_mappings[] = {
     {"LEMONADE_WHISPERCPP_ARGS",         "whispercpp", "args"},
     {"LEMONADE_WHISPERCPP_CPU_ARGS",     "whispercpp", "cpu_args"},
     {"LEMONADE_WHISPERCPP_NPU_ARGS",     "whispercpp", "npu_args"},
+    {"LEMONADE_WHISPERCPP_VULKAN_ARGS",  "whispercpp", "vulkan_args"},
     {"LEMONADE_WHISPERCPP_CPU_BIN",      "whispercpp", "cpu_bin"},
     {"LEMONADE_WHISPERCPP_NPU_BIN",      "whispercpp", "npu_bin"},
+    {"LEMONADE_WHISPERCPP_VULKAN_BIN",   "whispercpp", "vulkan_bin"},
     // sdcpp
     {"LEMONADE_SDCPP",                   "sdcpp", "backend"},
     {"LEMONADE_SDCPP_ARGS",              "sdcpp", "args"},


### PR DESCRIPTION
Map `LEMONADE_WHISPERCPP_VULKAN_BIN` / `LEMONADE_WHISPERCPP_VULKAN_ARGS`

## Problem

whisper.cpp has a working `vulkan` backend (`WhisperServer::get_install_params` handles `backend == "vulkan"` on Linux), and the generic config plumbing already reads its overrides:

- the binary from config key `whispercpp.vulkan_bin` (`BackendUtils::build_bin_config_key`)
- the args from `whispercpp.vulkan_args` (`RuntimeConfig` reads `whispercpp.<backend>_args`)

But the env-var migration table maps only whispercpp `cpu`/`npu` bin and args — not `vulkan`. So the vulkan whisper binary and args can only be set by hand-editing `config.json`, unlike `llamacpp` and `sd-cpp`, which both expose `*_VULKAN_BIN` and `*_VULKAN_ARGS`.

## Fix

Add the two missing rows to `env_mappings[]` for parity:

```cpp
{"LEMONADE_WHISPERCPP_VULKAN_ARGS",  "whispercpp", "vulkan_args"},
{"LEMONADE_WHISPERCPP_VULKAN_BIN",   "whispercpp", "vulkan_bin"},
```

Pure data-table extension following the existing `cpu`/`npu` rows; both keys are already consumed by the runtime, so no other code changes are needed. This lets the vulkan whisper backend be configured via environment like every other backend.