### PR TITLE
fix(server): translate model names before checking if they are downloaded (#2014)

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1250,7 +1250,7 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
                 return filepath;
             }
         }
-        
+
         // Case 5: Local quant-token fallback.
         //
         // Keep the existing resolver cases above as the primary logic: exact
@@ -2424,7 +2424,9 @@ bool ModelManager::is_model_downloaded(const std::string& model_name) {
 
     // O(1) lookup - download status is in cache
     std::lock_guard<std::mutex> lock(models_cache_mutex_);
-    auto it = models_cache_.find(model_name);
+    auto alias_it = public_model_aliases_.find(model_name);
+    std::string canonical_name = alias_it != public_model_aliases_.end() ? alias_it->second : model_name;
+    auto it = models_cache_.find(canonical_name);
     if (it != models_cache_.end()) {
         return it->second.downloaded;
     }

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1837,88 +1837,29 @@ class EndpointTests(ServerTestBase):
             self._set_extra_models_dir(prior_dir)
             shutil.rmtree(extra_dir, ignore_errors=True)
 
-    def test_021r_openai_chat_extra_models_dir(self):
-        """OpenAI chat completions resolves bare names to extra.* models and avoids HF downloads."""
-        bare = "dummy-extra-chat-model"
-        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_chat_")
-        self._write_root_stub_gguf(extra_dir, f"{bare}.gguf")
-
-        prior_dir = self._set_extra_models_dir(extra_dir)
-        try:
-            # 1. Verify the native API correctly reports the bare name as downloaded
-            model_info = requests.get(f"{self.base_url}/models/{bare}").json()
-            self.assertTrue(
-                model_info.get("downloaded"), "Model should be reported as downloaded"
-            )
-
-            # 2. Verify the OpenAI endpoint attempts to load the local stub
-            payload = {
-                "model": bare,
-                "messages": [{"role": "user", "content": "hello"}],
-            }
-            resp = requests.post(
-                f"http://localhost:{PORT}/v1/chat/completions",
-                json=payload,
-                timeout=TIMEOUT_DEFAULT,
-            )
-
-            # Check for standard OpenAI error structure instead of raw text
-            self.assertEqual(resp.status_code, 500)
-            error_data = resp.json().get("error", {})
-            self.assertIn("Failed to load model", error_data.get("message", ""))
-
-            print(
-                f"[OK] OpenAI chat completion resolves extra_models_dir alias: {bare}"
-            )
-        finally:
-            self._set_extra_models_dir(prior_dir)
-            shutil.rmtree(extra_dir, ignore_errors=True)
-
-    def test_021s_openai_chat_name_collision(self):
-        """OpenAI chat uses canonical resolution precedence when built-in and extra.* collide."""
-        # Use a known built-in model name
+    def test_021r_openai_chat_extra_models_precedence(self):
+        """Regression test for #2014: OpenAI API resolves aliases to local files, shadowing built-ins."""
+        # Use a built-in model name to prove precedence and alias resolution simultaneously
         bare = ENDPOINT_TEST_MODEL
-        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_collision_")
-
-        # Create a stub extra model with the exact same name
+        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_regression_")
         self._write_root_stub_gguf(extra_dir, f"{bare}.gguf")
 
         prior_dir = self._set_extra_models_dir(extra_dir)
         try:
-            # We already know from test_021h that extra.* wins precedence over builtin.*
-            # We want to ensure that /v1/chat/completions respects this by attempting
-            # to load the (stubbed) extra model instead of the real builtin.
-
-            # 1. Verify the native API correctly reports the bare name as downloaded
-            model_info = requests.get(f"{self.base_url}/models/{bare}").json()
-            self.assertTrue(
-                model_info.get("downloaded"), "Model should be reported as downloaded"
-            )
-
-            # 2. Verify the OpenAI endpoint attempts to load the local stub
-            payload = {
-                "model": bare,
-                "messages": [{"role": "user", "content": "hello"}],
-            }
+            # 500 (Failed to load) proves it resolved to our local stub instead of the real built-in.
+            payload = {"model": bare, "messages": [{"role": "user", "content": "hi"}]}
             resp = requests.post(
                 f"http://localhost:{PORT}/v1/chat/completions",
                 json=payload,
                 timeout=TIMEOUT_DEFAULT,
             )
 
-            # The extra model is a 0-byte stub, so loading will fail with 500.
-            # If it fell back to the builtin, it would either succeed (200) or
-            # trigger a download (401/404 if not pulled).
-            # The 500 proves the OpenAI endpoint resolved to the extra.* model.
-
-            # Check for standard OpenAI error structure instead of raw text
             self.assertEqual(resp.status_code, 500)
-            error_data = resp.json().get("error", {})
-            self.assertIn("Failed to load model", error_data.get("message", ""))
-
-            print(
-                f"[OK] OpenAI chat completion resolves collision to extra_models_dir: {bare}"
+            self.assertIn(
+                "Failed to load model", resp.json().get("error", {}).get("message", "")
             )
+
+            print(f"[OK] OpenAI API correctly resolves local shadowing for: {bare}")
         finally:
             self._set_extra_models_dir(prior_dir)
             shutil.rmtree(extra_dir, ignore_errors=True)

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1837,6 +1837,78 @@ class EndpointTests(ServerTestBase):
             self._set_extra_models_dir(prior_dir)
             shutil.rmtree(extra_dir, ignore_errors=True)
 
+    def test_021j_openai_chat_extra_models_dir(self):
+        """OpenAI chat completions resolves bare names to extra.* models and avoids HF downloads."""
+        bare = "dummy-extra-chat-model"
+        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_chat_")
+        self._write_root_stub_gguf(extra_dir, f"{bare}.gguf")
+
+        prior_dir = self._set_extra_models_dir(extra_dir)
+        try:
+            # Send a chat completion request for the bare name
+            payload = {
+                "model": bare,
+                "messages": [{"role": "user", "content": "hello"}],
+            }
+            resp = requests.post(
+                f"http://localhost:{PORT}/v1/chat/completions",
+                json=payload,
+                timeout=TIMEOUT_DEFAULT,
+            )
+
+            # Since it's a stub 0-byte GGUF, we expect the backend load to fail (500),
+            # NOT a 404/401 indicating a Hugging Face download attempt.
+            self.assertEqual(resp.status_code, 500)
+            self.assertIn("Failed to load model", resp.text)
+            self.assertNotIn("Hugging Face API", resp.text)
+
+            print(
+                f"[OK] OpenAI chat completion resolves extra_models_dir alias: {bare}"
+            )
+        finally:
+            self._set_extra_models_dir(prior_dir)
+            shutil.rmtree(extra_dir, ignore_errors=True)
+
+    def test_021k_openai_chat_name_collision(self):
+        """OpenAI chat uses canonical resolution precedence when built-in and extra.* collide."""
+        # Use a known built-in model name
+        bare = ENDPOINT_TEST_MODEL
+        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_collision_")
+
+        # Create a stub extra model with the exact same name
+        self._write_root_stub_gguf(extra_dir, f"{bare}.gguf")
+
+        prior_dir = self._set_extra_models_dir(extra_dir)
+        try:
+            # We already know from test_021h that extra.* wins precedence over builtin.*
+            # We want to ensure that /v1/chat/completions respects this by attempting
+            # to load the (stubbed) extra model instead of the real builtin.
+
+            payload = {
+                "model": bare,
+                "messages": [{"role": "user", "content": "hello"}],
+            }
+            resp = requests.post(
+                f"http://localhost:{PORT}/v1/chat/completions",
+                json=payload,
+                timeout=TIMEOUT_DEFAULT,
+            )
+
+            # The extra model is a 0-byte stub, so loading will fail with 500.
+            # If it fell back to the builtin, it would either succeed (200) or
+            # trigger a download (401/404 if not pulled).
+            # The 500 proves the OpenAI endpoint resolved to the extra.* model.
+            self.assertEqual(resp.status_code, 500)
+            self.assertIn("Failed to load model", resp.text)
+            self.assertNotIn("Hugging Face API", resp.text)
+
+            print(
+                f"[OK] OpenAI chat completion resolves collision to extra_models_dir: {bare}"
+            )
+        finally:
+            self._set_extra_models_dir(prior_dir)
+            shutil.rmtree(extra_dir, ignore_errors=True)
+
     def _get_test_backend(self):
         """Get a lightweight test backend based on platform."""
         import sys

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1837,7 +1837,7 @@ class EndpointTests(ServerTestBase):
             self._set_extra_models_dir(prior_dir)
             shutil.rmtree(extra_dir, ignore_errors=True)
 
-    def test_021j_openai_chat_extra_models_dir(self):
+    def test_021r_openai_chat_extra_models_dir(self):
         """OpenAI chat completions resolves bare names to extra.* models and avoids HF downloads."""
         bare = "dummy-extra-chat-model"
         extra_dir = tempfile.mkdtemp(prefix="lemon_extra_chat_")
@@ -1845,7 +1845,13 @@ class EndpointTests(ServerTestBase):
 
         prior_dir = self._set_extra_models_dir(extra_dir)
         try:
-            # Send a chat completion request for the bare name
+            # 1. Verify the native API correctly reports the bare name as downloaded
+            model_info = requests.get(f"{self.base_url}/models/{bare}").json()
+            self.assertTrue(
+                model_info.get("downloaded"), "Model should be reported as downloaded"
+            )
+
+            # 2. Verify the OpenAI endpoint attempts to load the local stub
             payload = {
                 "model": bare,
                 "messages": [{"role": "user", "content": "hello"}],
@@ -1856,11 +1862,10 @@ class EndpointTests(ServerTestBase):
                 timeout=TIMEOUT_DEFAULT,
             )
 
-            # Since it's a stub 0-byte GGUF, we expect the backend load to fail (500),
-            # NOT a 404/401 indicating a Hugging Face download attempt.
+            # Check for standard OpenAI error structure instead of raw text
             self.assertEqual(resp.status_code, 500)
-            self.assertIn("Failed to load model", resp.text)
-            self.assertNotIn("Hugging Face API", resp.text)
+            error_data = resp.json().get("error", {})
+            self.assertIn("Failed to load model", error_data.get("message", ""))
 
             print(
                 f"[OK] OpenAI chat completion resolves extra_models_dir alias: {bare}"
@@ -1869,7 +1874,7 @@ class EndpointTests(ServerTestBase):
             self._set_extra_models_dir(prior_dir)
             shutil.rmtree(extra_dir, ignore_errors=True)
 
-    def test_021k_openai_chat_name_collision(self):
+    def test_021s_openai_chat_name_collision(self):
         """OpenAI chat uses canonical resolution precedence when built-in and extra.* collide."""
         # Use a known built-in model name
         bare = ENDPOINT_TEST_MODEL
@@ -1884,6 +1889,13 @@ class EndpointTests(ServerTestBase):
             # We want to ensure that /v1/chat/completions respects this by attempting
             # to load the (stubbed) extra model instead of the real builtin.
 
+            # 1. Verify the native API correctly reports the bare name as downloaded
+            model_info = requests.get(f"{self.base_url}/models/{bare}").json()
+            self.assertTrue(
+                model_info.get("downloaded"), "Model should be reported as downloaded"
+            )
+
+            # 2. Verify the OpenAI endpoint attempts to load the local stub
             payload = {
                 "model": bare,
                 "messages": [{"role": "user", "content": "hello"}],
@@ -1898,9 +1910,11 @@ class EndpointTests(ServerTestBase):
             # If it fell back to the builtin, it would either succeed (200) or
             # trigger a download (401/404 if not pulled).
             # The 500 proves the OpenAI endpoint resolved to the extra.* model.
+
+            # Check for standard OpenAI error structure instead of raw text
             self.assertEqual(resp.status_code, 500)
-            self.assertIn("Failed to load model", resp.text)
-            self.assertNotIn("Hugging Face API", resp.text)
+            error_data = resp.json().get("error", {})
+            self.assertIn("Failed to load model", error_data.get("message", ""))
 
             print(
                 f"[OK] OpenAI chat completion resolves collision to extra_models_dir: {bare}"


### PR DESCRIPTION
# OpenAI API cannot load models from `extra_models_dir`

## Description

When Lemonade is used as an OpenAI-compatible server, client apps can see models from `extra_models_dir`, but they cannot load them.

When a client selects one of these models, Lemonade treats it as missing and tries to download it from Hugging Face instead of loading the local model file.

Using the `extra.` prefix does not fix the issue.

## Platform

Windows

## Lemonade Version

10.6.0

## Steps to Reproduce

1. Enable `extra_models_dir`.
2. Add a model to `extra_models_dir`.
3. Start Lemonade Server.
4. Connect an OpenAI-compatible client, such as AnythingLLM, a custom script, or the POML VS Code extension.
5. Select the model from `extra_models_dir`.
6. Send a chat completion request.

## Expected Behavior

Lemonade loads the local model from `extra_models_dir`.

## Actual Behavior

Lemonade treats the model as missing and tries to download it from Hugging Face.

Example log message:

```text
Model not cached, downloading from Hugging Face
```

If the download fails, the client eventually times out.
