### PR TITLE
fix: stop refreshing models on download progress

### DIFF
--- a/src/app/src/renderer/App.tsx
+++ b/src/app/src/renderer/App.tsx
@@ -169,7 +169,6 @@ const AppContent: React.FC = () => {
     const handleDownloadSignal = (e: any) => {
       const downloads = Array.isArray(e.detail?.downloads) ? e.detail.downloads : downloadTracker.getActiveDownloads();
       openIfActive(downloads);
-      void refreshModels();
     };
 
     const handleChatDownloadComplete = () => {


### PR DESCRIPTION
closes #1986

Removes an unnecessary model refresh. No risk. 