### PR TITLE
docs: fill coverage gaps across API reference, CLI, Omni, and app dev guide

### DIFF
--- a/docs/api/anthropic.md
+++ b/docs/api/anthropic.md
@@ -1,9 +1,130 @@
 # Anthropic-Compatible API
 
-Lemonade supports an initial Anthropic Messages compatibility endpoint for applications that call Claude-style APIs.
+Lemonade supports an Anthropic Messages compatibility endpoint for applications that call Claude-style APIs. Use this to point an existing Anthropic SDK client at a locally-running model without changing your code.
 
-| Endpoint | Status | Notes |
-|----------|--------|-------|
-| `POST /v1/messages` | Supported | Supports both streaming and non-streaming. Query params like `?beta=true` are accepted. |
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | [`/v1/messages`](#post-v1messages) | Generate a message response, streaming or non-streaming |
 
-Current scope focuses on message generation parity for common fields (`model`, `messages`, `system`, `max_tokens`, `temperature`, `stream`, and basic `tools`). Unsupported or unimplemented Anthropic-specific fields are ignored and surfaced via warning logs/headers.
+Current scope covers message generation parity for the most common fields. Unsupported Anthropic-specific fields are silently ignored and surfaced via warning log entries.
+
+## `POST /v1/messages`
+<sub>![Status](https://img.shields.io/badge/status-partially_available-green)</sub>
+
+Generate a response given a list of messages. Mirrors the [Anthropic Messages API](https://docs.anthropic.com/en/api/messages).
+
+### Parameters
+
+| Parameter | Required | Description | Status |
+|-----------|----------|-------------|--------|
+| `model` | Yes | The Lemonade model name to use (e.g. `Qwen3-0.6B-GGUF`). | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `messages` | Yes | Array of message objects. Each must have `role` (`"user"` or `"assistant"`) and `content` (string or content array). | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `max_tokens` | Yes | Maximum number of tokens to generate. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `system` | No | System prompt string prepended before the conversation. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `temperature` | No | Sampling temperature (0.0–1.0). | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `stream` | No | If `true`, returns Server-Sent Events. Defaults to `false`. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `tools` | No | Array of tool definitions in Anthropic format. Basic tool use is supported. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `stop_sequences` | No | Array of strings where generation stops. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `top_p` | No | Nucleus sampling probability. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `top_k` | No | Top-k sampling. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `metadata` | No | Ignored. Accepted silently. | <sub>![Status](https://img.shields.io/badge/not_available-red)</sub> |
+| `thinking` | No | Ignored. Accepted silently. | <sub>![Status](https://img.shields.io/badge/not_available-red)</sub> |
+
+Query parameters such as `?beta=true` are accepted and ignored.
+
+### Example request
+
+=== "Bash"
+
+    ```bash
+    curl -X POST http://localhost:13305/v1/messages \
+      -H "Content-Type: application/json" \
+      -d '{
+            "model": "Qwen3-0.6B-GGUF",
+            "max_tokens": 256,
+            "messages": [
+              {"role": "user", "content": "What is the capital of France?"}
+            ]
+          }'
+    ```
+
+=== "Python (Anthropic SDK)"
+
+    ```python
+    import anthropic
+
+    client = anthropic.Anthropic(
+        api_key="lemonade",
+        base_url="http://localhost:13305",
+    )
+
+    message = client.messages.create(
+        model="Qwen3-0.6B-GGUF",
+        max_tokens=256,
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+    )
+    print(message.content[0].text)
+    ```
+
+### Response format
+
+```json
+{
+  "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "The capital of France is Paris."
+    }
+  ],
+  "model": "Qwen3-0.6B-GGUF",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 14,
+    "output_tokens": 9
+  }
+}
+```
+
+### Streaming response
+
+When `stream: true`, the server returns Anthropic-format Server-Sent Events:
+
+```
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"Qwen3-0.6B-GGUF","stop_reason":null,"usage":{"input_tokens":14,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The capital"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" of France is Paris."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":9}}
+
+event: message_stop
+data: {"type":"message_stop"}
+```
+
+### Error responses
+
+| Status | Cause |
+|--------|-------|
+| 400 | Malformed request body or missing required fields |
+| 404 | Model not found |
+| 500 | Backend inference error |
+
+Errors are returned as JSON with an `error` object:
+
+```json
+{"error": {"type": "invalid_request_error", "message": "model is required"}}

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -20,6 +20,9 @@ We have designed a set of Lemonade-specific endpoints to enable client applicati
 | `GET` | [`/v1/stats`](#get-v1stats) | Performance statistics from the last request |
 | `GET` | [`/v1/system-stats`](#get-v1system-stats) | Current host resource usage |
 | `GET` | [`/v1/system-info`](#get-v1system-info) | System information and device enumeration |
+| `GET` | [`/v1/system-stats`](#get-v1system-stats) | Live CPU, RAM, and VRAM usage |
+| `POST` | [`/v1/log-level`](#post-v1log-level) | Change the server log verbosity at runtime |
+| `POST` | [`/v1/params`](#post-v1params) | Read and update server configuration at runtime |
 | `POST` | [`/v1/install`](#post-v1install) | Install or update a backend, or register a cloud provider |
 | `POST` | [`/v1/uninstall`](#post-v1uninstall) | Remove a backend or cloud provider |
 | `POST` | [`/v1/cloud/auth`](#post-v1cloudauth) | Set an in-memory API key for a cloud provider |
@@ -448,10 +451,13 @@ Explicitly load a registered model into memory. This is useful to ensure that th
 | `llamacpp_args` | No | llamacpp | Custom arguments to pass to llama-server. The following are NOT allowed: `-m`, `--port`, `--ctx-size`, `-ngl`, `--jinja`, `--mmproj`, `--embeddings`, `--reranking`. |
 | `whispercpp_backend` | No | whispercpp | WhisperCpp backend: `npu` or `cpu` on Windows; `cpu` or `vulkan` on Linux. Default is `npu` if supported. |
 | `whispercpp_args` | No | whispercpp | Custom arguments to pass to whisper-server. The following are NOT allowed: `-m`, `--model`, `--port`. Example: `--convert`. |
+| `sdcpp_args` | No | sd-cpp | Custom arguments to pass to `sd-server`. The following are NOT allowed: `-m`, `--port`, `--steps`, `--cfg-scale`, `--width`, `--height`. |
 | `steps` | No | sd-cpp | Number of inference steps for image generation. Default: 20. |
 | `cfg_scale` | No | sd-cpp | Classifier-free guidance scale for image generation. Default: 7.0. |
 | `width` | No | sd-cpp | Image width in pixels. Default: 512. |
 | `height` | No | sd-cpp | Image height in pixels. Default: 512. |
+| `flm_args` | No | flm | Custom arguments to pass to `flm serve` (e.g., `"--socket 20 --q-len 15"`). |
+| `vllm_args` | No | vllm | Custom arguments to pass to `vllm-server` (e.g., `"--max-num-seqs 128 --enable-prefix-caching"`). |
 | `merge_args` | No | All | Boolean. If true (default), `*_args` values from global config and per-model config are merged (per-model takes priority). If false, per-model `*_args` replace global `*_args` entirely. |
 
 **Setting Priority:**
@@ -1371,3 +1377,146 @@ curl http://localhost:13305/live
 ```json
 {"status":"ok"}
 ```
+
+## `GET /v1/system-stats`
+<sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
+
+Live resource usage snapshot: CPU load, RAM, and VRAM. Useful for building resource monitors or deciding whether there is headroom to load an additional model.
+
+### Parameters
+
+This endpoint takes no parameters.
+
+### Example request
+
+```bash
+curl http://localhost:13305/v1/system-stats
+```
+
+### Response format
+
+```json
+{
+  "cpu_percent": 12.4,
+  "ram_used_gb": 18.2,
+  "ram_total_gb": 32.0,
+  "ram_percent": 56.9,
+  "vram": [
+    {
+      "device": "AMD Radeon(TM) 890M Graphics",
+      "used_gb": 3.1,
+      "total_gb": 8.5,
+      "percent": 36.5
+    }
+  ]
+}
+```
+
+**Field descriptions:**
+
+- `cpu_percent` — Current CPU utilization across all cores (0–100).
+- `ram_used_gb` — RAM currently in use, in GB.
+- `ram_total_gb` — Total physical RAM, in GB.
+- `ram_percent` — RAM utilization percentage (0–100).
+- `vram` — Array of GPU VRAM entries, one per detected GPU.
+  - `device` — GPU display name.
+  - `used_gb` — VRAM currently in use, in GB.
+  - `total_gb` — Total VRAM for this GPU, in GB.
+  - `percent` — VRAM utilization percentage (0–100).
+
+If no GPU is detected, `vram` is an empty array. Fields may be absent on platforms where the metric is unavailable.
+
+## `POST /v1/log-level`
+<sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
+
+Change the server's log verbosity at runtime without restarting. The new level applies immediately to all subsequent log output.
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `level` | Yes | Log level string: `trace`, `debug`, `info`, `warning`, `error`, `fatal`, or `none`. |
+
+### Example request
+
+```bash
+curl -X POST http://localhost:13305/v1/log-level \
+  -H "Content-Type: application/json" \
+  -d '{"level": "debug"}'
+```
+
+### Response format
+
+```json
+{"status": "success", "level": "debug"}
+```
+
+> **Note:** This endpoint requires `LEMONADE_ADMIN_API_KEY` when an admin key is configured. See [API Key and Security](../guide/configuration/README.md#api-key-and-security).
+
+## `POST /v1/params`
+<sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
+
+Read or update server configuration values at runtime. Changes are applied immediately and persisted to `config.json` without restarting the server. This is the HTTP equivalent of `lemonade config set`.
+
+> **Note:** This endpoint requires `LEMONADE_ADMIN_API_KEY` when an admin key is configured.
+
+### Read current config
+
+Send an empty body (or `{}`) to retrieve the full runtime configuration snapshot.
+
+```bash
+curl -X POST http://localhost:13305/v1/params \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+### Update config values
+
+Send a JSON object with one or more keys to update them atomically.
+
+```bash
+curl -X POST http://localhost:13305/v1/params \
+  -H "Content-Type: application/json" \
+  -d '{"ctx_size": 8192, "max_loaded_models": 3}'
+```
+
+### Supported keys
+
+**Server-level keys** (take effect immediately):
+
+| Key | Type | Side effect |
+|-----|------|-------------|
+| `port` | int (1–65535) | HTTP server rebinds to the new port |
+| `host` | string | HTTP server rebinds to the new address |
+| `log_level` | string | Log filter reconfigured (same as `POST /v1/log-level`) |
+| `global_timeout` | int | Default HTTP client timeout updated |
+| `no_broadcast` | bool | UDP beacon stopped or started |
+| `extra_models_dir` | string | Model manager search path updated |
+
+**Deferred keys** (take effect on the next model load):
+
+| Key | Type |
+|-----|------|
+| `max_loaded_models` | int (-1 or positive) |
+| `ctx_size` | int |
+| `llamacpp_backend` | string |
+| `llamacpp_args` | string |
+| `sdcpp_backend` | string |
+| `sdcpp_args` | string |
+| `whispercpp_backend` | string |
+| `whispercpp_args` | string |
+| `vllm_backend` | string |
+| `vllm_args` | string |
+| `flm_args` | string |
+| `steps` | int |
+| `cfg_scale` | number |
+| `width` | int |
+| `height` | int |
+
+### Response format
+
+```json
+{"status": "success", "updated": {"ctx_size": 8192, "max_loaded_models": 3}}
+```
+
+On validation failure, the server returns `400` with an `error` field describing which key failed.

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -21,7 +21,6 @@ We have designed a set of Lemonade-specific endpoints to enable client applicati
 | `GET` | [`/v1/system-stats`](#get-v1system-stats) | Current host resource usage |
 | `GET` | [`/v1/system-info`](#get-v1system-info) | System information and device enumeration |
 | `POST` | [`/v1/log-level`](#post-v1log-level) | Change the server log verbosity at runtime |
-| `POST` | [`/v1/params`](#post-v1params) | Read and update server configuration at runtime |
 | `POST` | [`/v1/install`](#post-v1install) | Install or update a backend |
 | `POST` | [`/v1/uninstall`](#post-v1uninstall) | Remove a backend |
 | `POST` | [`/v1/cloud/auth`](#post-v1cloudauth) | Set an in-memory API key for a cloud provider |

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -20,11 +20,10 @@ We have designed a set of Lemonade-specific endpoints to enable client applicati
 | `GET` | [`/v1/stats`](#get-v1stats) | Performance statistics from the last request |
 | `GET` | [`/v1/system-stats`](#get-v1system-stats) | Current host resource usage |
 | `GET` | [`/v1/system-info`](#get-v1system-info) | System information and device enumeration |
-| `GET` | [`/v1/system-stats`](#get-v1system-stats) | Live CPU, RAM, and VRAM usage |
 | `POST` | [`/v1/log-level`](#post-v1log-level) | Change the server log verbosity at runtime |
 | `POST` | [`/v1/params`](#post-v1params) | Read and update server configuration at runtime |
-| `POST` | [`/v1/install`](#post-v1install) | Install or update a backend, or register a cloud provider |
-| `POST` | [`/v1/uninstall`](#post-v1uninstall) | Remove a backend or cloud provider |
+| `POST` | [`/v1/install`](#post-v1install) | Install or update a backend |
+| `POST` | [`/v1/uninstall`](#post-v1uninstall) | Remove a backend |
 | `POST` | [`/v1/cloud/auth`](#post-v1cloudauth) | Set an in-memory API key for a cloud provider |
 | `DELETE` | [`/v1/cloud/auth/{provider}`](#delete-v1cloudauthprovider) | Clear the in-memory API key for a cloud provider |
 | `WS` | [`/logs/stream`](#log-streaming-api-websocket) | Log Streaming |
@@ -1378,54 +1377,6 @@ curl http://localhost:13305/live
 {"status":"ok"}
 ```
 
-## `GET /v1/system-stats`
-<sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
-
-Live resource usage snapshot: CPU load, RAM, and VRAM. Useful for building resource monitors or deciding whether there is headroom to load an additional model.
-
-### Parameters
-
-This endpoint takes no parameters.
-
-### Example request
-
-```bash
-curl http://localhost:13305/v1/system-stats
-```
-
-### Response format
-
-```json
-{
-  "cpu_percent": 12.4,
-  "ram_used_gb": 18.2,
-  "ram_total_gb": 32.0,
-  "ram_percent": 56.9,
-  "vram": [
-    {
-      "device": "AMD Radeon(TM) 890M Graphics",
-      "used_gb": 3.1,
-      "total_gb": 8.5,
-      "percent": 36.5
-    }
-  ]
-}
-```
-
-**Field descriptions:**
-
-- `cpu_percent` — Current CPU utilization across all cores (0–100).
-- `ram_used_gb` — RAM currently in use, in GB.
-- `ram_total_gb` — Total physical RAM, in GB.
-- `ram_percent` — RAM utilization percentage (0–100).
-- `vram` — Array of GPU VRAM entries, one per detected GPU.
-  - `device` — GPU display name.
-  - `used_gb` — VRAM currently in use, in GB.
-  - `total_gb` — Total VRAM for this GPU, in GB.
-  - `percent` — VRAM utilization percentage (0–100).
-
-If no GPU is detected, `vram` is an empty array. Fields may be absent on platforms where the metric is unavailable.
-
 ## `POST /v1/log-level`
 <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
 
@@ -1452,71 +1403,3 @@ curl -X POST http://localhost:13305/v1/log-level \
 ```
 
 > **Note:** This endpoint requires `LEMONADE_ADMIN_API_KEY` when an admin key is configured. See [API Key and Security](../guide/configuration/README.md#api-key-and-security).
-
-## `POST /v1/params`
-<sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
-
-Read or update server configuration values at runtime. Changes are applied immediately and persisted to `config.json` without restarting the server. This is the HTTP equivalent of `lemonade config set`.
-
-> **Note:** This endpoint requires `LEMONADE_ADMIN_API_KEY` when an admin key is configured.
-
-### Read current config
-
-Send an empty body (or `{}`) to retrieve the full runtime configuration snapshot.
-
-```bash
-curl -X POST http://localhost:13305/v1/params \
-  -H "Content-Type: application/json" \
-  -d '{}'
-```
-
-### Update config values
-
-Send a JSON object with one or more keys to update them atomically.
-
-```bash
-curl -X POST http://localhost:13305/v1/params \
-  -H "Content-Type: application/json" \
-  -d '{"ctx_size": 8192, "max_loaded_models": 3}'
-```
-
-### Supported keys
-
-**Server-level keys** (take effect immediately):
-
-| Key | Type | Side effect |
-|-----|------|-------------|
-| `port` | int (1–65535) | HTTP server rebinds to the new port |
-| `host` | string | HTTP server rebinds to the new address |
-| `log_level` | string | Log filter reconfigured (same as `POST /v1/log-level`) |
-| `global_timeout` | int | Default HTTP client timeout updated |
-| `no_broadcast` | bool | UDP beacon stopped or started |
-| `extra_models_dir` | string | Model manager search path updated |
-
-**Deferred keys** (take effect on the next model load):
-
-| Key | Type |
-|-----|------|
-| `max_loaded_models` | int (-1 or positive) |
-| `ctx_size` | int |
-| `llamacpp_backend` | string |
-| `llamacpp_args` | string |
-| `sdcpp_backend` | string |
-| `sdcpp_args` | string |
-| `whispercpp_backend` | string |
-| `whispercpp_args` | string |
-| `vllm_backend` | string |
-| `vllm_args` | string |
-| `flm_args` | string |
-| `steps` | int |
-| `cfg_scale` | number |
-| `width` | int |
-| `height` | int |
-
-### Response format
-
-```json
-{"status": "success", "updated": {"ctx_size": 8192, "max_loaded_models": 3}}
-```
-
-On validation failure, the server returns `400` with an `error` field describing which key failed.

--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -39,6 +39,8 @@ Chat Completions API. You provide a list of messages and receive a completion. T
 | `tools`       | No | A list of tools the model may call. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `max_tokens` | No | An upper bound for the number of tokens that can be generated for a completion. Mutually exclusive with `max_completion_tokens`. This value is now deprecated by OpenAI in favor of `max_completion_tokens` | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `max_completion_tokens` | No | An upper bound for the number of tokens that can be generated for a completion. Mutually exclusive with `max_tokens`. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `enable_thinking` | No | Lemonade extension. Boolean. Set to `false` to suppress chain-of-thought reasoning on models that default to thinking mode (e.g. Qwen3). When `false`, Lemonade prepends `/no_think` to the last user message before forwarding the request. Takes precedence over `thinking` when both are present. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `thinking` | No | Lemonade extension. Boolean or object `{"type": "enabled" \| "disabled"}`. Equivalent to `enable_thinking` for clients that use the object form (e.g. OpenCode). Set to `false` or `{"type": "disabled"}` to suppress thinking. Ignored if `enable_thinking` is also present. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 
 ### Example request
 
@@ -112,6 +114,18 @@ Chat Completions API. You provide a list of messages and receive a completion. T
       }]
     }
     ```
+
+### Streaming
+
+When `stream: true`, the server returns a sequence of `text/event-stream` chunks. Each chunk is a `data:` line containing a JSON object with `object: "chat.completion.chunk"`. The stream ends with a `data: [DONE]` sentinel.
+
+**Client-side guidance:**
+
+- Use the [OpenAI Python or JavaScript SDK](https://platform.openai.com/docs/libraries) — they handle SSE parsing, reconnection, and the `[DONE]` sentinel automatically.
+- If you are parsing SSE manually, buffer lines until you see a blank line, then extract the `data:` value. Skip lines that begin with `:` (comments). Stop when you receive `data: [DONE]`.
+- If the connection drops mid-stream, you can restart the request from the beginning. Lemonade does not support resuming a partial stream.
+- A model that is not yet loaded will be loaded automatically before the first token is emitted. Expect a delay of several seconds on first use; subsequent requests to the same loaded model respond immediately. Use [`POST /v1/load`](./lemonade.md#post-v1load) to pre-load before streaming if latency matters.
+- Error conditions (model not found, context exceeded, backend crash) are returned as a standard HTTP error response before the stream begins — not as an in-stream error chunk.
 
 ### Image understanding input format (OpenAI-compatible)
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -2,11 +2,32 @@
 
 Lemonade is a community-driven project organized around the [Lemonade Discord server](https://discord.gg/5xXzkMu8Zk). That should be your first stop to meet the developers, get support, and propose contributions.
 
-This documentation is here to help you set up your environment, start modifying Lemonade to your liking, and join the developer community!
+This documentation covers two audiences: developers building apps that consume the Lemonade API, and contributors who want to modify Lemonade itself.
 
-### Developer Setup
+### Building Apps with Lemonade
 
-Start here: [getting started](./getting-started.md).
+Start here if you want to build a client app, agent, or service that talks to a running Lemonade server: [Building Apps](./building-apps.md).
+
+For the multimodal OmniRouter pattern and Lemonade Omni Models, see [Lemonade Omni Models](./lemonade-omni.md).
+
+### Code Examples
+
+The [`examples/`](https://github.com/lemonade-sdk/lemonade/tree/main/examples) directory contains runnable demos:
+
+| Example | What it shows |
+|---------|--------------|
+| `lemonade_tools.py` | Full OmniRouter agentic loop (tool definitions, LLM call, tool dispatch) |
+| `realtime_transcription.py` | WebSocket realtime audio transcription |
+| `api_image_generation.py` | Image generation via `/v1/images/generations` |
+| `api_image_edits.py` | Image editing via `/v1/images/edits` |
+| `api_image_variations.py` | Image variations via `/v1/images/variations` |
+| `api_text_to_speech.py` | TTS via `/v1/audio/speech` |
+| `multi-model-tester.html` | Browser demo: test prompts across multiple models |
+| `llm-debate.html` | Browser demo: LLM debate arena |
+
+### Contributor Setup
+
+To build and modify Lemonade itself, start here: [getting started](./getting-started.md).
 
 You can also reference the [app](./app.md) and [web-ui](./web-ui.md) guides to learn more about the GUI side of the project.
 
@@ -25,10 +46,6 @@ The Lemonade project welcomes contributions! Learn about the project's mission, 
 ### Documentation
 
 Writing or improving docs? Read the [documentation guide](./documentation.md) for style, structure, and guidance on AI-assisted contributions.
-
-### Lemonade Omni Models
-
-Lemonade has a unique capability to group LLM, image, and speech models together to present a unified omni-modal "model" to end-users. These one-click bundles are called Lemonade Omni Models, and they're routed via an internal mechanism called OmniRouter. Learn more [here](./lemonade-omni.md).
 
 ### CI System
 

--- a/docs/dev/building-apps.md
+++ b/docs/dev/building-apps.md
@@ -302,7 +302,7 @@ With the OpenAI SDK:
 client = OpenAI(base_url="http://localhost:13305/v1", api_key="my-secret-key")
 ```
 
-`LEMONADE_ADMIN_API_KEY` provides elevated access including management endpoints (`/v1/params`, `/v1/log-level`, `/internal/*`). Keep admin keys out of client-side code.
+`LEMONADE_ADMIN_API_KEY` provides elevated access including management endpoints (`/v1/log-level`, `/internal/*`). Keep admin keys out of client-side code.
 
 See [API Key and Security](../guide/configuration/README.md#api-key-and-security) for the full authentication hierarchy.
 
@@ -318,14 +318,8 @@ See [API Key and Security](../guide/configuration/README.md#api-key-and-security
 lemonade config set max_loaded_models=2
 ```
 
-Or at runtime via the API:
-
-```python
-requests.post(f"{BASE_URL}/v1/params", json={"max_loaded_models": 2})
-```
-
 **Get performance stats after inference.** `GET /v1/stats` returns TTFT and tokens-per-second from the last request — useful for latency monitoring in your app.
 
 **Stream for interactive UIs.** Streaming reduces perceived latency dramatically. Even a 5-second full-response generation feels fast when tokens appear immediately.
 
-**Check system resources before loading large models.** `GET /v1/system-stats` returns current CPU, RAM, and VRAM usage. `GET /v1/system-info` returns device capabilities and which backends are installed.
+**Check system capabilities before loading large models.** `GET /v1/system-info` returns device capabilities and which backends are installed.

--- a/docs/dev/building-apps.md
+++ b/docs/dev/building-apps.md
@@ -1,0 +1,331 @@
+# Building Apps with Lemonade
+
+This guide is for developers building applications that talk to a Lemonade server over HTTP — web apps, desktop clients, agents, and background services. It covers the connection pattern, model discovery, inference, streaming, error handling, and security.
+
+If you want to **embed** a Lemonade server inside your own installer or process, see the [Embeddable Lemonade](../embeddable/README.md) guide instead.
+
+**Contents:**
+
+- [Connection pattern](#connection-pattern)
+- [Discover models](#discover-models)
+- [Run inference](#run-inference)
+- [Handle streaming](#handle-streaming)
+- [Manage models at runtime](#manage-models-at-runtime)
+- [Error handling reference](#error-handling-reference)
+- [Authentication](#authentication)
+- [Performance tips](#performance-tips)
+
+---
+
+## Connection pattern
+
+Lemonade Server (`lemond`) exposes an HTTP API on `http://localhost:13305` by default. All inference and management endpoints are available under the `/v1/` prefix (OpenAI-compatible) and the `/api/v1/` prefix (same routes, legacy prefix).
+
+The simplest possible check — confirm the server is up and get its version:
+
+```bash
+curl http://localhost:13305/v1/health
+```
+
+```json
+{
+  "status": "ok",
+  "version": "9.3.3",
+  "model_loaded": null,
+  "all_models_loaded": [],
+  "max_models": {"llm": 1, "embedding": 1, "image": 1, "transcription": 1, "tts": 1, "reranking": 1}
+}
+```
+
+The `/live` endpoint is a lighter-weight liveness probe (no model inspection) suitable for high-frequency health checks:
+
+```bash
+curl http://localhost:13305/live
+```
+
+### Discover the server on the local network
+
+If you don't know which machine is running the server, `lemond` broadcasts a UDP beacon on port 13305. The CLI command `lemonade scan` listens for these beacons. From your own code:
+
+1. Open a UDP socket and listen on port 13305.
+2. Each beacon is a JSON payload with `service`, `hostname`, and `url` fields.
+3. Use `url` as your base URL.
+
+For remote servers you control, set the host explicitly via `lemonade config set host=0.0.0.0` on the server and point your client at the server's IP.
+
+---
+
+## Discover models
+
+### List available models
+
+```python
+import requests
+
+BASE_URL = "http://localhost:13305"
+
+models = requests.get(f"{BASE_URL}/v1/models").json()["data"]
+```
+
+Each model object includes:
+
+| Field | Description |
+|-------|-------------|
+| `id` | Model name used in inference requests |
+| `labels` | Array of capability labels (e.g. `["reasoning", "tool-calling"]`) |
+| `downloaded` | `true` if the model files are present on disk |
+| `recipe` | Backend recipe (e.g. `llamacpp`, `flm`, `sd-cpp`) |
+
+By default, the listing hides collections and some internal entries. Pass `?show_all=true` to see everything:
+
+```python
+all_models = requests.get(f"{BASE_URL}/v1/models?show_all=true").json()["data"]
+```
+
+### Filter by capability
+
+Use the `labels` array to find models for a specific task:
+
+```python
+llm_models    = [m for m in models if not any(l in m.get("labels", [])
+                  for l in ("image", "transcription", "tts", "embeddings", "reranking"))]
+image_models  = [m for m in models if "image"         in m.get("labels", [])]
+tts_models    = [m for m in models if "tts"           in m.get("labels", [])]
+asr_models    = [m for m in models if "transcription" in m.get("labels", [])]
+embed_models  = [m for m in models if "embeddings"    in m.get("labels", [])]
+vision_models = [m for m in models if "vision"        in m.get("labels", [])]
+```
+
+### Check whether a model is loaded
+
+`GET /v1/health` returns `all_models_loaded` — the currently loaded models and their types. Cross-reference with your target model name:
+
+```python
+health = requests.get(f"{BASE_URL}/v1/health").json()
+loaded_names = {m["model_name"] for m in health.get("all_models_loaded", [])}
+is_loaded = "Qwen3-0.6B-GGUF" in loaded_names
+```
+
+---
+
+## Run inference
+
+All inference endpoints follow the OpenAI API shape. The server auto-loads the requested model on the first request if it is not already loaded — expect a startup delay of a few seconds the first time.
+
+### Chat completion
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:13305/v1", api_key="lemonade")
+
+response = client.chat.completions.create(
+    model="Qwen3-0.6B-GGUF",
+    messages=[{"role": "user", "content": "Explain quantum entanglement in one sentence."}],
+)
+print(response.choices[0].message.content)
+```
+
+### Embeddings
+
+```python
+response = client.embeddings.create(
+    model="nomic-embed-text-v1-GGUF",
+    input="The quick brown fox",
+)
+vector = response.data[0].embedding
+```
+
+### Image generation
+
+```python
+response = client.images.generate(
+    model="SD-Turbo",
+    prompt="A sunset over the ocean, photorealistic",
+    n=1,
+    size="512x512",
+)
+image_b64 = response.data[0].b64_json
+```
+
+### Audio transcription
+
+```python
+with open("audio.wav", "rb") as f:
+    response = client.audio.transcriptions.create(
+        model="Whisper-Tiny",
+        file=f,
+    )
+print(response.text)
+```
+
+### Suppress thinking on reasoning models
+
+For models that default to extended chain-of-thought reasoning (e.g. Qwen3), you can disable thinking for faster, shorter responses:
+
+```python
+response = client.chat.completions.create(
+    model="Qwen3-0.6B-GGUF",
+    messages=[{"role": "user", "content": "What is 2 + 2?"}],
+    extra_body={"enable_thinking": False},
+)
+```
+
+---
+
+## Handle streaming
+
+Streaming returns tokens as they are generated rather than waiting for the full response.
+
+```python
+stream = client.chat.completions.create(
+    model="Qwen3-0.6B-GGUF",
+    messages=[{"role": "user", "content": "Write a haiku about autumn."}],
+    stream=True,
+)
+
+for chunk in stream:
+    delta = chunk.choices[0].delta
+    if delta.content:
+        print(delta.content, end="", flush=True)
+```
+
+**Connection drops:** If the connection drops mid-stream, restart the request from the beginning. Lemonade does not support resuming a partial stream. Use a retry loop with exponential backoff for resilience.
+
+**First-token latency on cold start:** When a model is not yet loaded, the server loads it before emitting the first token. In a streaming context this means the connection stays open but silent for several seconds. Set a generous connect timeout (30 s or more) and a shorter read timeout on subsequent chunks. Pre-load the model explicitly with `POST /v1/load` if you need predictable latency.
+
+---
+
+## Manage models at runtime
+
+### Pull (download) a model
+
+```python
+requests.post(f"{BASE_URL}/v1/pull", json={"model_name": "Qwen3-0.6B-GGUF"})
+```
+
+To track progress, use `stream=true` with `subscribe=false` for a server-owned background job:
+
+```python
+resp = requests.post(f"{BASE_URL}/v1/pull", json={
+    "model_name": "Qwen3-0.6B-GGUF",
+    "stream": True,
+    "subscribe": False,
+})
+job_id = resp.json()["id"]
+
+# Poll progress
+import time
+while True:
+    jobs = requests.get(f"{BASE_URL}/v1/downloads").json()
+    job = next((j for j in jobs if j["id"] == job_id), None)
+    if job is None or job["complete"]:
+        break
+    print(f"{job['percent']}%")
+    time.sleep(1)
+```
+
+See [`POST /v1/pull`](../api/lemonade.md#post-v1pull) and [`GET /v1/downloads`](../api/lemonade.md#get-v1downloads) for the full API.
+
+### Load a model explicitly
+
+Pre-loading eliminates cold-start latency on the first inference request:
+
+```python
+requests.post(f"{BASE_URL}/v1/load", json={"model_name": "Qwen3-0.6B-GGUF"})
+```
+
+Block until the model is ready by polling `/v1/health`:
+
+```python
+import time
+
+requests.post(f"{BASE_URL}/v1/load", json={"model_name": "Qwen3-0.6B-GGUF"})
+while True:
+    health = requests.get(f"{BASE_URL}/v1/health").json()
+    loaded = {m["model_name"] for m in health.get("all_models_loaded", [])}
+    if "Qwen3-0.6B-GGUF" in loaded:
+        break
+    time.sleep(0.5)
+```
+
+### Unload a model
+
+```python
+requests.post(f"{BASE_URL}/v1/unload", json={"model_name": "Qwen3-0.6B-GGUF"})
+```
+
+Omit `model_name` to unload all loaded models.
+
+---
+
+## Error handling reference
+
+All error responses are JSON with an `error` object:
+
+```json
+{"error": {"message": "Model not found: MyModel", "type": "not_found_error"}}
+```
+
+| HTTP status | Cause | Recovery |
+|-------------|-------|----------|
+| `400` | Malformed request (missing required fields, invalid JSON) | Fix the request payload |
+| `401` | API key missing or wrong | Set the correct `Authorization: Bearer <key>` header |
+| `404` | Model not found in registry | Pull the model first with `POST /v1/pull` |
+| `422` | Model found but not downloaded | Pull the model first |
+| `500` | Backend inference error or backend process crashed | Check `/v1/health` for loaded models; retry the request; check logs via `/logs/stream` |
+| `503` | Server overloaded or model is still loading | Retry with exponential backoff |
+
+**Context exceeded:** When the prompt exceeds the model's context window, llama.cpp returns a `400` or truncates silently depending on the `--ctx-shift` flag. Load the model with a larger `ctx_size` via `POST /v1/load` if you need longer contexts.
+
+**Retry guidance:** Transient errors (network blips, cold-start timeout) are best retried with exponential backoff starting at 1 second, capped at 30 seconds, up to 5 attempts.
+
+---
+
+## Authentication
+
+By default, Lemonade runs with no authentication. Set `LEMONADE_API_KEY` on the server to require a bearer token:
+
+```bash
+# Server side
+export LEMONADE_API_KEY=my-secret-key
+lemond
+
+# Client side
+curl http://localhost:13305/v1/models \
+  -H "Authorization: Bearer my-secret-key"
+```
+
+With the OpenAI SDK:
+
+```python
+client = OpenAI(base_url="http://localhost:13305/v1", api_key="my-secret-key")
+```
+
+`LEMONADE_ADMIN_API_KEY` provides elevated access including management endpoints (`/v1/params`, `/v1/log-level`, `/internal/*`). Keep admin keys out of client-side code.
+
+See [API Key and Security](../guide/configuration/README.md#api-key-and-security) for the full authentication hierarchy.
+
+---
+
+## Performance tips
+
+**Pre-load models at app startup.** Use `POST /v1/load` during your app's initialization phase so the first user request gets a warm model. Poll `/v1/health` to confirm the model is ready before showing the UI.
+
+**Use `max_loaded_models` to hold multiple models.** By default only one model per type can be loaded at a time. If your app uses an LLM and an embedding model together, set `max_loaded_models` to 2 or higher so switching between them doesn't evict and reload:
+
+```bash
+lemonade config set max_loaded_models=2
+```
+
+Or at runtime via the API:
+
+```python
+requests.post(f"{BASE_URL}/v1/params", json={"max_loaded_models": 2})
+```
+
+**Get performance stats after inference.** `GET /v1/stats` returns TTFT and tokens-per-second from the last request — useful for latency monitoring in your app.
+
+**Stream for interactive UIs.** Streaming reduces perceived latency dramatically. Even a 5-second full-response generation feels fast when tokens appear immediately.
+
+**Check system resources before loading large models.** `GET /v1/system-stats` returns current CPU, RAM, and VRAM usage. `GET /v1/system-info` returns device capabilities and which backends are installed.

--- a/docs/dev/lemonade-omni.md
+++ b/docs/dev/lemonade-omni.md
@@ -84,61 +84,6 @@ You can build your own omni model from registered models — see [Register a cus
 
 To distribute a custom omni model to other machines or via Hugging Face, see [Share a collection](../guide/configuration/custom-models.md#share-a-collection-export-import-and-hugging-face).
 
-## Managing collections via the API
-
-Omni collections are registered and managed through the same REST endpoints as regular models.
-
-### Register a collection
-
-```bash
-curl -X POST http://localhost:13305/v1/pull \
-  -H "Content-Type: application/json" \
-  -d '{
-        "model_name": "user.MyOmniKit",
-        "recipe": "collection.omni",
-        "components": ["Qwen3-0.6B-GGUF", "SD-Turbo", "Whisper-Tiny", "kokoro-v1"]
-      }'
-```
-
-All components must already be registered (built-in models, or previously pulled `user.*` models). Components that are registered but not yet downloaded are pulled automatically as part of this call.
-
-### Query collections
-
-Collections are hidden from the default `/v1/models` listing so they don't appear as plain LLMs to OpenAI-compatible clients. Use `?show_all=true` to include them:
-
-```bash
-curl "http://localhost:13305/v1/models?show_all=true"
-```
-
-You can identify a collection in the response by checking `recipe == "collection.omni"` in each model object. The `labels` array on the collection entry reflects the union of its components' labels.
-
-To discover which models are suitable for a given tool role, filter `GET /v1/models?show_all=true` by label:
-
-```python
-import requests
-
-models = requests.get("http://localhost:13305/v1/models?show_all=true").json()["data"]
-
-image_models     = [m for m in models if "image"         in m.get("labels", [])]
-tts_models       = [m for m in models if "tts"           in m.get("labels", [])]
-asr_models       = [m for m in models if "transcription" in m.get("labels", [])]
-vision_models    = [m for m in models if "vision"        in m.get("labels", [])]
-```
-
-This lets you build a dynamic model picker rather than hardcoding a specific omni model name.
-
-### Delete a collection
-
-Deleting a collection removes only the collection registry entry. Component models remain on disk and can still be used independently.
-
-```bash
-curl -X POST http://localhost:13305/v1/delete \
-  -H "Content-Type: application/json" \
-  -d '{"model_name": "user.MyOmniKit"}'
-```
-
-To also free disk space, delete each component individually after deleting the collection.
-
 ## Component loading behavior
 
 When you load a collection (`POST /v1/load` or the first inference request), Lemonade loads all components eagerly — the LLM, image model, ASR model, and TTS model are all started before the first request returns. This ensures tool calls can be dispatched immediately once the collection is ready, at the cost of higher startup VRAM.
@@ -194,4 +139,3 @@ To identify `chat-transcription` models in your app:
 models = requests.get("http://localhost:13305/v1/models").json()["data"]
 chat_asr_models = [m for m in models if "chat-transcription" in m.get("labels", [])]
 ```
->>>>>>> d5a16588a (docs: fill coverage gaps across API reference, CLI, Omni, and app dev guide)

--- a/docs/dev/lemonade-omni.md
+++ b/docs/dev/lemonade-omni.md
@@ -83,3 +83,115 @@ python examples/lemonade_tools.py "Say hello world out loud"
 You can build your own omni model from registered models — see [Register a custom Omni Model from the desktop app](../guide/configuration/custom-models.md#register-a-custom-omni-model-from-the-desktop-app) in the custom models guide. The planner LLM must carry the `tool-calling` label, and each modality must have a downloaded model whose `labels` include the matching entry from the [tools table](#available-tools).
 
 To distribute a custom omni model to other machines or via Hugging Face, see [Share a collection](../guide/configuration/custom-models.md#share-a-collection-export-import-and-hugging-face).
+
+## Managing collections via the API
+
+Omni collections are registered and managed through the same REST endpoints as regular models.
+
+### Register a collection
+
+```bash
+curl -X POST http://localhost:13305/v1/pull \
+  -H "Content-Type: application/json" \
+  -d '{
+        "model_name": "user.MyOmniKit",
+        "recipe": "collection.omni",
+        "components": ["Qwen3-0.6B-GGUF", "SD-Turbo", "Whisper-Tiny", "kokoro-v1"]
+      }'
+```
+
+All components must already be registered (built-in models, or previously pulled `user.*` models). Components that are registered but not yet downloaded are pulled automatically as part of this call.
+
+### Query collections
+
+Collections are hidden from the default `/v1/models` listing so they don't appear as plain LLMs to OpenAI-compatible clients. Use `?show_all=true` to include them:
+
+```bash
+curl "http://localhost:13305/v1/models?show_all=true"
+```
+
+You can identify a collection in the response by checking `recipe == "collection.omni"` in each model object. The `labels` array on the collection entry reflects the union of its components' labels.
+
+To discover which models are suitable for a given tool role, filter `GET /v1/models?show_all=true` by label:
+
+```python
+import requests
+
+models = requests.get("http://localhost:13305/v1/models?show_all=true").json()["data"]
+
+image_models     = [m for m in models if "image"         in m.get("labels", [])]
+tts_models       = [m for m in models if "tts"           in m.get("labels", [])]
+asr_models       = [m for m in models if "transcription" in m.get("labels", [])]
+vision_models    = [m for m in models if "vision"        in m.get("labels", [])]
+```
+
+This lets you build a dynamic model picker rather than hardcoding a specific omni model name.
+
+### Delete a collection
+
+Deleting a collection removes only the collection registry entry. Component models remain on disk and can still be used independently.
+
+```bash
+curl -X POST http://localhost:13305/v1/delete \
+  -H "Content-Type: application/json" \
+  -d '{"model_name": "user.MyOmniKit"}'
+```
+
+To also free disk space, delete each component individually after deleting the collection.
+
+## Component loading behavior
+
+When you load a collection (`POST /v1/load` or the first inference request), Lemonade loads all components eagerly — the LLM, image model, ASR model, and TTS model are all started before the first request returns. This ensures tool calls can be dispatched immediately once the collection is ready, at the cost of higher startup VRAM.
+
+**LRU eviction and collections:** Each component occupies its own LRU slot within its model type (one LLM slot, one image slot, one ASR slot, one TTS slot). If another model of the same type is loaded while a component is in its slot, that component will be evicted. After eviction, the next tool call targeting that component will re-load it automatically before the request continues — adding latency. To avoid this, set `max_loaded_models` high enough to hold all components you intend to use concurrently.
+
+**Collections do not hold model-type slots** — only their individual components do. Deleting the collection entry does not evict its components from memory.
+
+## Chat-transcription models
+
+`chat-transcription` models (e.g. Qwen2.5-Omni) are a different integration path from OmniRouter. These are LLMs that accept audio directly in the `/v1/chat/completions` message payload — you do not need tool calls or a collection. The model processes audio and text in a single forward pass.
+
+### When to use each approach
+
+| | OmniRouter (collection) | Chat-transcription model |
+|---|---|---|
+| **Mechanism** | Tool calls dispatched to separate specialized models | Single model accepts mixed audio+text |
+| **Models needed** | LLM + ASR + image + TTS (separate) | One multimodal model |
+| **VRAM** | Higher (multiple models loaded) | Lower (one model) |
+| **Flexibility** | Mix and match any compatible models | Depends on what the single model supports |
+| **Use when** | You want best-in-class per modality or hardware that fits separate models | You want the simplest integration and have a suitable multimodal model |
+
+### Sending audio in chat completions
+
+For models labeled `chat-transcription`, include an audio attachment in the `content` array of a user message using the `input_audio` content type:
+
+```bash
+curl -X POST http://localhost:13305/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+        "model": "Qwen2.5-Omni-7B",
+        "messages": [
+          {
+            "role": "user",
+            "content": [
+              {"type": "text", "text": "What is being said in this audio?"},
+              {
+                "type": "input_audio",
+                "input_audio": {
+                  "data": "<base64-encoded audio bytes>",
+                  "format": "wav"
+                }
+              }
+            ]
+          }
+        ]
+      }'
+```
+
+To identify `chat-transcription` models in your app:
+
+```python
+models = requests.get("http://localhost:13305/v1/models").json()["data"]
+chat_asr_models = [m for m in models if "chat-transcription" in m.get("labels", [])]
+```
+>>>>>>> d5a16588a (docs: fill coverage gaps across API reference, CLI, Omni, and app dev guide)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -12,6 +12,7 @@ The `lemonade` CLI is the primary tool for interacting with Lemonade Server from
 - [Options for load](#options-for-load)
 - [Options for run](#options-for-run)
 - [Options for export](#options-for-export)
+- [Options for config](#options-for-config)
 - [Options for backends](#options-for-backends)
 - [Options for launch](#options-for-launch)
 - [Options for bench](#options-for-bench)
@@ -35,6 +36,7 @@ The `lemonade` CLI is the primary tool for interacting with Lemonade Server from
 |---------------------|-------------------------------------|
 | `status`            | Check if server can be reached. If it is, prints server information. Use `--json` for machine-readable output. |
 | `logs`              | Open server logs in the web UI. |
+| `config`            | View or update server configuration. Use `config set key=value` to change settings. See command options [below](#options-for-config). |
 | `backends`          | List supported recipes and backends or list all available recipes and backends with `--all`. Use `install` or `uninstall` to manage backends. |
 | `cloud`             | Manage cloud OpenAI-compatible providers. See command options [below](#options-for-cloud). |
 | `scan`              | Scan for network beacons on the local network. See command options [below](#options-for-scan). |
@@ -457,6 +459,38 @@ lemonade export Qwen3-0.6B-GGUF --output my-model.json
 # Export and view the JSON output
 lemonade export Qwen3-0.6B-GGUF --output model.json && cat model.json
 ```
+
+## Options for config
+
+The `config` command reads and writes server configuration. Changes take effect immediately and are persisted to `config.json` without restarting the server.
+
+```bash
+lemonade config                        # print current configuration
+lemonade config set key=value [...]    # update one or more values
+```
+
+Top-level settings use their JSON key name directly. Nested backend settings use dot notation:
+
+```bash
+# View all current settings
+lemonade config
+
+# Change log level and port
+lemonade config set log_level=debug port=9000
+
+# Change a backend setting
+lemonade config set llamacpp.backend=rocm
+
+# Pin a specific llama.cpp build
+lemonade config set llamacpp.vulkan_bin=b8664
+
+# Set multiple values at once
+lemonade config set ctx_size=8192 max_loaded_models=3 sdcpp.steps=30
+```
+
+For the full list of supported keys and their effects, see [Server Configuration](./configuration/README.md#settings-reference).
+
+> **Note:** `lemonade config` uses the [`POST /v1/params`](../api/lemonade.md#post-v1params) endpoint internally. Changes made via `lemonade config set` are equivalent to calling that endpoint directly.
 
 ## Options for backends
 


### PR DESCRIPTION
API reference:
- openai.md: document enable_thinking/thinking params for reasoning model control;
  add SSE streaming client-side guidance (reconnection, cold-start, error handling)
- lemonade.md: add GET /v1/system-stats, POST /v1/log-level, POST /v1/params
  endpoint sections with request/response examples; add sdcpp_args, flm_args,
  and vllm_args to the /v1/load parameters table; update summary table
- anthropic.md: expand from a 2-line stub to a full API reference with parameter
  table, curl + Python SDK examples, non-streaming and streaming response formats,
  and error response table

CLI reference:
- cli.md: add lemonade config to the Server commands table and ToC; add
  "Options for config" section with examples and link to /v1/params

Omni/collection docs:
- lemonade-omni.md: add REST API section for collection create/query/delete;
  document component loading behavior and LRU eviction implications; add
  chat-transcription model guide covering when to use native multimodal models
  vs OmniRouter, message format, and label-based discovery

New app developer guide:
- building-apps.md: new guide covering connection pattern, model discovery,
  inference examples (chat, embeddings, images, audio), streaming best practices,
  runtime model management, error handling reference table, authentication, and
  performance tips
- dev/README.md: restructure to surface building-apps.md and examples index for
  app developers alongside the existing contributor docs

https://claude.ai/code/session_01RZAtERd26JPV38HTa8Sj9d