### PR TITLE
fix: avoid HF user model name collisions act only when they occur

### DIFF
--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -1085,16 +1085,52 @@ const [searchQuery, setSearchQuery] = useState('');
     return `${modelId}:${quantObj?.quantization ?? selectedFilename}`;
   }, [hfSelectedQuantizations]);
 
-  const resolveHfModelName = useCallback((modelId: string, backend: DetectedBackend): string => {
-    const suggestedName = backend.suggestedName || modelId.split('/').pop() || modelId;
-    if (backend.recipe !== 'llamacpp') return suggestedName;
+  const resolveHfModelName = useCallback((modelId: string, backend: DetectedBackend, checkpoint?: string): string => {
+    const getOwnerSuffixName = (modelName: string): string => {
+      const owner = modelId.split('/')[0]?.trim();
+      if (!owner) return modelName;
+      const safeOwner = owner.replace(/[^A-Za-z0-9_.-]+/g, '-').replace(/^-+|-+$/g, '');
+      return safeOwner ? `${modelName}-${safeOwner}` : modelName;
+    };
+    const lookupModelInfo = (modelName: string): ModelInfo | undefined => {
+      return modelsData[`user.${modelName}`] ?? modelsData[modelName];
+    };
 
-    const selectedFilename = hfSelectedQuantizations[modelId];
-    if (!selectedFilename) return suggestedName;
-    const quantObj = backend.quantizations?.find(q => q.filename === selectedFilename);
-    const variantName = quantObj?.quantization ?? selectedFilename;
-    return `${suggestedName}-${variantName}`;
-  }, [hfSelectedQuantizations]);
+    const matchesCheckpoint = (info: ModelInfo | undefined): boolean => {
+      if (!info || !checkpoint) return false;
+      return info.checkpoint === checkpoint || info.checkpoints?.main === checkpoint;
+    };
+
+    const suggestedName = backend.suggestedName || modelId.split('/').pop() || modelId;
+    let defaultName = suggestedName;
+
+    if (backend.recipe === 'llamacpp') {
+      const selectedFilename = hfSelectedQuantizations[modelId];
+      if (selectedFilename) {
+        const quantObj = backend.quantizations?.find(q => q.filename === selectedFilename);
+        const variantName = quantObj?.quantization ?? selectedFilename;
+        defaultName = `${suggestedName}-${variantName}`;
+      }
+    }
+
+    if (!checkpoint) return defaultName;
+
+    const existingDefault = lookupModelInfo(defaultName);
+    if (!existingDefault || matchesCheckpoint(existingDefault)) {
+      return defaultName;
+    }
+
+    const fallbackBase = getOwnerSuffixName(defaultName);
+    let candidate = fallbackBase;
+    let suffix = 2;
+    let existingCandidate = lookupModelInfo(candidate);
+    while (existingCandidate && !matchesCheckpoint(existingCandidate)) {
+      candidate = `${fallbackBase}-${suffix}`;
+      suffix += 1;
+      existingCandidate = lookupModelInfo(candidate);
+    }
+    return candidate;
+  }, [hfSelectedQuantizations, modelsData]);
 
   const handleInstallHFModel = useCallback((hfModel: HFModelInfo) => {
     const backend = hfModelBackends[hfModel.id];
@@ -1102,7 +1138,7 @@ const [searchQuery, setSearchQuery] = useState('');
     const checkpoint = backend.recipe === 'llamacpp'
       ? resolveGgufCheckpoint(hfModel.id, backend)
       : hfModel.id;
-    const modelName = `user.${resolveHfModelName(hfModel.id, backend)}`;
+    const modelName = `user.${resolveHfModelName(hfModel.id, backend, checkpoint)}`;
     const labels = new Set(backend.suggestedLabels ?? []);
     const mmproj = backend.mmprojFiles?.[0];
     if (mmproj) labels.add('vision');
@@ -2036,7 +2072,7 @@ const [searchQuery, setSearchQuery] = useState('');
                                   window.dispatchEvent(new CustomEvent('openAddModel', {
                                     detail: {
                                       initialValues: {
-                                        name: resolveHfModelName(hfModel.id, backend),
+                                        name: resolveHfModelName(hfModel.id, backend, checkpoint),
                                         checkpoint,
                                         recipe: backend.recipe,
                                         mmprojOptions: backend.mmprojFiles,

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -258,13 +258,15 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
     }
     for (const auto& kv : file_sizes) total_repo_size += kv.second;
 
-    // Suggested name = component after the last '/'.
+    // Keep the Hugging Face namespace in the suggested name so repos with the
+    // same leaf name but different owners do not collide in user_models.json.
+    // Example:
+    //   LiquidAI/LFM2.5-8B-A1B-GGUF:Q8_0
+    //   unsloth/LFM2.5-8B-A1B-GGUF:Q8_0
+    // become distinct user model names instead of both becoming
+    // LFM2.5-8B-A1B-GGUF-Q8_0.
     std::string suggested_name = checkpoint;
-    {
-        size_t slash = checkpoint.find_last_of('/');
-        if (slash != std::string::npos) suggested_name = checkpoint.substr(slash + 1);
-    }
-
+    
     // ONNX RyzenAI branch: synthesize a 1-element variant set.
     if (!has_gguf && has_onnx && has_genai_config) {
         nlohmann::json vj;

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -258,15 +258,13 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
     }
     for (const auto& kv : file_sizes) total_repo_size += kv.second;
 
-    // Keep the Hugging Face namespace in the suggested name so repos with the
-    // same leaf name but different owners do not collide in user_models.json.
-    // Example:
-    //   LiquidAI/LFM2.5-8B-A1B-GGUF:Q8_0
-    //   unsloth/LFM2.5-8B-A1B-GGUF:Q8_0
-    // become distinct user model names instead of both becoming
-    // LFM2.5-8B-A1B-GGUF-Q8_0.
+    // Suggested name = component after the last '/'.
     std::string suggested_name = checkpoint;
-    
+    {
+        size_t slash = checkpoint.find_last_of('/');
+        if (slash != std::string::npos) suggested_name = checkpoint.substr(slash + 1);
+    }
+
     // ONNX RyzenAI branch: synthesize a 1-element variant set.
     if (!has_gguf && has_onnx && has_genai_config) {
         nlohmann::json vj;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1412,6 +1412,58 @@ static void parse_components(ModelInfo& info, const json& model_json) {
     }
 }
 
+static std::string join_conflict_parts(const std::vector<std::string>& parts) {
+    std::string result;
+    for (size_t i = 0; i < parts.size(); ++i) {
+        if (i > 0) result += "; ";
+        result += parts[i];
+    }
+    return result;
+}
+
+static std::string describe_registration_conflict(const ModelInfo& existing,
+                                                  const json& requested) {
+    std::vector<std::string> diffs;
+
+    auto add_diff = [&diffs](const std::string& field,
+                             const std::string& current_value,
+                             const std::string& requested_value) {
+        if (!requested_value.empty() && requested_value != current_value) {
+            diffs.push_back(field + " (existing='" + current_value +
+                            "', requested='" + requested_value + "')");
+        }
+    };
+
+    std::string requested_main;
+    if (requested.contains("checkpoints") && requested["checkpoints"].is_object()) {
+        requested_main = requested["checkpoints"].value("main", std::string());
+        for (const auto& [role, value] : requested["checkpoints"].items()) {
+            if (!value.is_string()) continue;
+            add_diff("checkpoint[" + role + "]",
+                     existing.checkpoint(role),
+                     value.get<std::string>());
+        }
+    } else {
+        requested_main = requested.value("checkpoint", std::string());
+        add_diff("checkpoint", existing.checkpoint(), requested_main);
+    }
+
+    const std::string requested_recipe = requested.value("recipe", std::string());
+    add_diff("recipe", existing.recipe, requested_recipe);
+
+    const std::string requested_mmproj = requested.value("mmproj", std::string());
+    if (!requested_mmproj.empty()) {
+        const std::string main_for_mmproj = requested_main.empty()
+            ? existing.checkpoint()
+            : requested_main;
+        add_diff("mmproj",
+                 existing.checkpoint("mmproj"),
+                 legacy_mmproj_to_checkpoint(main_for_mmproj, requested_mmproj));
+    }
+
+    return join_conflict_parts(diffs);
+}
+
 // Check if all components of a collection model are downloaded.
 static bool check_component_downloaded(const ModelInfo& info,
                                         const std::map<std::string, ModelInfo>& model_map) {
@@ -2887,10 +2939,12 @@ void ModelManager::download_model(const std::string& model_name,
             LOG(INFO, "ModelManager") << "Registering new user model: " << model_name << std::endl;
         }
     } else {
-        // Model is registered - if checkpoint not provided, look up from registry
-        // otherwise overwrite registration. Collections have no checkpoint, so
-        // the "components in request" flag distinguishes a real overwrite from
-        // a cascade pull that should reuse the registered components.
+        // Model is registered - if checkpoint not provided, look up from registry.
+        // If checkpoint/recipe are provided, allow an idempotent re-pull of the
+        // same registration but never silently replace a user model with a
+        // different HF checkpoint. Silent replacement is what made a previously
+        // installed GGUF variant disappear when another variant reused the same
+        // generated user.* name.
         bool is_collection_overwrite = is_model_collection_recipe(actual_recipe) &&
                                         model_data.contains("components");
         if (is_collection_overwrite) {
@@ -2905,7 +2959,20 @@ void ModelManager::download_model(const std::string& model_name,
             actual_checkpoint = info.checkpoint();
             actual_recipe = info.recipe;
         } else {
-            model_registered = false;
+            auto info = get_model_info(model_name);
+            std::string conflict = describe_registration_conflict(info, model_data);
+            if (!conflict.empty()) {
+                throw std::runtime_error(
+                    "Model '" + model_name + "' is already registered with different "
+                    "model metadata: " + conflict + ". Choose a different model name "
+                    "for this Hugging Face checkpoint."
+                );
+            }
+            if (actual_recipe.empty()) {
+                actual_recipe = info.recipe;
+            } else {
+                model_registered = false;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes Hugging Face user model name collisions without changing the normal happy-path model names.

Previously, two HF pulls could resolve to the same `user.*` model name and the later pull could silently overwrite the existing `user_models.json` registration. This could make the first model or GGUF variant disappear from Lemonade, even if the files were still present in the Hugging Face cache.

This PR keeps the default short model name unchanged, e.g.

`LFM2.5-8B-A1B-GGUF-Q8_0`

and only falls back to an owner-qualified name when that default already exists with a different checkpoint. The owner is appended as a suffix so the family/model name remains at the front for UI grouping, e.g.

`LFM2.5-8B-A1B-GGUF-Q8_0`
`LFM2.5-8B-A1B-GGUF-Q8_0-unsloth`

The server also prevents silent re-registration of an existing `user.*` model with different checkpoint metadata. In that case, the caller must choose a different model name, or delete the existing user model before registering a replacement.

## Why

This keeps the happy path unchanged while fixing the real collision bug. It avoids breaking existing HF “Use this model” flows and prevents users from accidentally losing access to an already installed model or GGUF variant.

## Testing

* Verified that pulling/registering the same generated model name with a different checkpoint no longer silently overwrites the old registration.
* Verified that two HF repositories with the same leaf repo name are registered as separate user models.
* Verified that two GGUF variants from the same repository remain separately visible and usable.
* Verified that normal single-model pulls still use the short default name.

Closes #2053
