### PR TITLE
test: cover embeddings missing model error

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -132,6 +132,20 @@ int get_error_status_code(const json& response, int default_status_code = 500) {
         }
     }
 
+    if (error.contains("type") && error["type"].is_string()) {
+        const std::string type = error["type"].get<std::string>();
+
+        if (type == ErrorType::INVALID_REQUEST ||
+            type == "invalid_request_error" ||
+            type == ErrorType::UNSUPPORTED_OPERATION) {
+            return 400;
+        }
+
+        if (type == ErrorType::MODEL_NOT_LOADED) {
+            return 404;
+        }
+    }
+
     return default_status_code;
 }
 
@@ -3451,6 +3465,11 @@ void Server::handle_embeddings(const httplib::Request& req, httplib::Response& r
 
         // Call router's embeddings method
         auto response = router_->embeddings(request_json);
+        if (response.contains("error")) {
+            set_error_response(response, res);
+            return;
+        }
+
         res.set_content(response.dump(), "application/json");
 
     } catch (const std::exception& e) {

--- a/test/server_llm.py
+++ b/test/server_llm.py
@@ -566,6 +566,27 @@ class LLMTests(ServerTestBase):
         self.assertGreater(len(response.data[0].embedding), 0)
         print(f"Embedding dimension: {len(response.data[0].embedding)}")
 
+    @skip_if_unsupported("embeddings")
+    def test_015b_embeddings_missing_model_returns_400(self):
+        """Test embeddings request without model returns a helpful 400 error."""
+        # Ensure the server cannot satisfy a missing-model request from a
+        # previously loaded model left behind by another test.
+        requests.post(f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT)
+
+        response = requests.post(
+            f"{self.base_url}/embeddings",
+            json={
+                "input": "Hello, how are you today?",
+                "encoding_format": "float",
+            },
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        error = response.json().get("error", "")
+        self.assertIn("model", error.lower())
+        self.assertIn("No model loaded", error)
+
     @skip_if_unsupported("embeddings_batch")
     def test_016_embeddings_array_of_strings(self):
         """Test embeddings with array of strings."""

--- a/test/server_llm.py
+++ b/test/server_llm.py
@@ -569,9 +569,10 @@ class LLMTests(ServerTestBase):
     @skip_if_unsupported("embeddings")
     def test_015b_embeddings_missing_model_returns_400(self):
         """Test embeddings request without model returns a helpful 400 error."""
-        # Ensure the server cannot satisfy a missing-model request from a
-        # previously loaded model left behind by another test.
-        requests.post(f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT)
+        headers = {}
+        api_key = os.environ.get("LEMONADE_API_KEY")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
 
         response = requests.post(
             f"{self.base_url}/embeddings",
@@ -579,13 +580,19 @@ class LLMTests(ServerTestBase):
                 "input": "Hello, how are you today?",
                 "encoding_format": "float",
             },
+            headers=headers,
             timeout=TIMEOUT_DEFAULT,
         )
 
-        self.assertEqual(response.status_code, 400)
-        error = response.json().get("error", "")
-        self.assertIn("model", error.lower())
-        self.assertIn("No model loaded", error)
+        self.assertEqual(response.status_code, 400, response.text)
+
+        error = response.json().get("error")
+        self.assertIsInstance(error, dict, response.text)
+        self.assertEqual(error.get("type"), "invalid_request")
+        self.assertIn(
+            "no model specified",
+            error.get("message", "").lower(),
+        )
 
     @skip_if_unsupported("embeddings_batch")
     def test_016_embeddings_array_of_strings(self):


### PR DESCRIPTION
## Summary
- add coverage for embeddings requests without model
- restore HTTP 400 for the structured invalid_request returned by the router
- map Lemon error types to the appropriate HTTP status in the shared error response helper

**Updated:**
The original test coverage exposed a regression on current main: the router correctly returns a structured invalid_request when model is missing, but handle_embeddings was returning that error body without propagating the corresponding HTTP status.

closes #2040 

## Testing

Before the server fix, the regression test fails as expected:

```text
test_015b_embeddings_missing_model_returns_400
AssertionError: 200 != 400
```

After applying the server fix and rebuilding/restarting the server:

```text
test_015b_embeddings_missing_model_returns_400 ... ok
```

The test also verifies that the response contains:

```json
{
  "error": {
    "type": "invalid_request",
    "message": "...No model specified..."
  }
}
```

This negative-path test does not require a model load or inference.
