### PR TITLE
Fix spurious model re-downloads: make client pulls cache-first by default

### DIFF
--- a/src/app/src/renderer/App.tsx
+++ b/src/app/src/renderer/App.tsx
@@ -369,9 +369,13 @@ const AppContent: React.FC = () => {
       : undefined;
     // An Omni collection whose components are all present needs no download —
     // only its definition gets registered. registrationOnly skips the Download
-    // Manager/progress flow for that case.
+    // Manager/progress flow for that case. Require at least one component:
+    // every() is vacuously true for an empty array, which would otherwise let a
+    // malformed collection (missing/empty components) take the no-download path.
     const collectionFullyDownloaded = requestBody.recipe === 'collection.omni' &&
-      (collectionComponents ?? []).every((component) =>
+      collectionComponents !== undefined &&
+      collectionComponents.length > 0 &&
+      collectionComponents.every((component) =>
         isModelEffectivelyDownloaded(component, modelsData[component], modelsData)
       );
 

--- a/src/app/src/renderer/App.tsx
+++ b/src/app/src/renderer/App.tsx
@@ -12,7 +12,6 @@ import { ModelsProvider, useModels } from './hooks/useModels';
 import { SystemProvider } from './hooks/useSystem';
 import { DEFAULT_LAYOUT_SETTINGS } from './utils/appSettings';
 import { downloadTracker } from './utils/downloadTracker';
-import { serverFetch } from './utils/serverConfig';
 import CustomCollectionPanel from './components/CustomCollectionPanel';
 import { ToastContainer, useToast } from './Toast';
 import { pullModel, type ModelRegistrationData } from './utils/backendInstaller';
@@ -368,30 +367,19 @@ const AppContent: React.FC = () => {
     const collectionComponents = Array.isArray(requestBody.components)
       ? requestBody.components
       : undefined;
-    const collectionNeedsDownload = requestBody.recipe === 'collection.omni' &&
-      (collectionComponents ?? []).some((component) =>
-        !isModelEffectivelyDownloaded(component, modelsData[component], modelsData)
+    // An Omni collection whose components are all present needs no download —
+    // only its definition gets registered. registrationOnly skips the Download
+    // Manager/progress flow for that case.
+    const collectionFullyDownloaded = requestBody.recipe === 'collection.omni' &&
+      (collectionComponents ?? []).every((component) =>
+        isModelEffectivelyDownloaded(component, modelsData[component], modelsData)
       );
-
-    if (requestBody.recipe === 'collection.omni' && !collectionNeedsDownload) {
-      const response = await serverFetch('/pull', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...requestBody, stream: false, subscribe: false }),
-        cache: 'no-store',
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(errorText || response.statusText);
-      }
-      return;
-    }
 
     await pullModel(requestBody.model_name, {
       registrationData: requestBody as ModelRegistrationData,
       collectionComponents,
       declaredSizeGB: typeof requestBody.size === 'number' ? requestBody.size : undefined,
+      registrationOnly: collectionFullyDownloaded,
     });
   };
 

--- a/src/app/src/renderer/utils/backendInstaller.ts
+++ b/src/app/src/renderer/utils/backendInstaller.ts
@@ -484,8 +484,42 @@ export async function pullModel(
     /** Declared model size in GB from the registry, used as the download
      *  total when the server can't emit a cumulative size (e.g. FLM pull). */
     declaredSizeGB?: number;
+    /** Force a Hugging Face update check even when the model is already
+     *  cached. Defaults to false (cache-first): an already-downloaded model is
+     *  reused without contacting Hugging Face. Only explicit "update" actions
+     *  should set this to true. */
+    upgrade?: boolean;
+    /** Persist a model/collection definition without downloading anything.
+     *  Used when all required files are already present (e.g. saving an Omni
+     *  collection whose components are downloaded): the server registers the
+     *  record and transfers no bytes, so there is no progress to show. */
+    registrationOnly?: boolean;
   }
 ): Promise<void> {
+  // Registration-only fast path: persist the definition with a synchronous,
+  // non-streaming pull. No Download Manager entry or SSE progress, because
+  // nothing is downloaded. Stays cache-first unless the caller opts into upgrade.
+  if (options?.registrationOnly) {
+    const requestBody: Record<string, unknown> = {
+      model_name: modelName,
+      ...(options.registrationData ?? {}),
+      stream: false,
+      subscribe: false,
+      do_not_upgrade: options.upgrade !== true,
+    };
+    const response = await serverFetch('/pull', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestBody),
+      cache: 'no-store',
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || response.statusText);
+    }
+    return;
+  }
+
   const showInDownloadManager = options?.showInDownloadManager ?? true;
   const abortController = new AbortController();
   const declaredTotalBytes = options?.declaredSizeGB
@@ -537,6 +571,11 @@ export async function pullModel(
     if (options?.registrationData) {
       Object.assign(requestBody, options.registrationData);
     }
+
+    // Cache-first by default: an already-downloaded model is reused instead of
+    // triggering a Hugging Face update check (and a possible full re-download).
+    // Set after registrationData so the helper's decision is authoritative.
+    requestBody.do_not_upgrade = options?.upgrade !== true;
 
     const response = await serverFetch('/pull', {
       method: 'POST',

--- a/src/app/src/renderer/utils/backendInstaller.ts
+++ b/src/app/src/renderer/utils/backendInstaller.ts
@@ -470,7 +470,10 @@ export async function deleteModel(modelName: string): Promise<void> {
  * - Download Manager progress tracking (always on by default)
  * - Pause/cancel from Download Manager UI (throws DownloadAbortError)
  * - Custom model registration data
- * - Dispatches `modelsUpdated` event on success
+ *
+ * The streaming download path dispatches `modelsUpdated` on success. The
+ * `registrationOnly` fast path does not — it transfers no bytes, so its
+ * callers are responsible for refreshing the models context.
  *
  * @throws DownloadAbortError if the user pauses or cancels via Download Manager
  * @throws Error on download failure

--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -276,7 +276,7 @@ int hf_pull_flow(lemonade::LemonadeClient& client,
 
         std::cout << "Pulling " << checkpoint
                   << " as " << suggested_name << std::endl;
-        return client.pull_model(pull_body, suggested_name);
+        return client.pull_model(pull_body, suggested_name, /*upgrade=*/true);
     }
 
     // Resolve variant by case-insensitive name match.
@@ -339,7 +339,7 @@ int hf_pull_flow(lemonade::LemonadeClient& client,
     std::cout << "Pulling " << pull_body["checkpoint"].get<std::string>()
               << " as " << model_name << std::endl;
 
-    return client.pull_model(pull_body, model_name);
+    return client.pull_model(pull_body, model_name, /*upgrade=*/true);
 }
 
 }  // namespace lemon_cli

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -531,7 +531,7 @@ static bool parse_sse_progress(const std::string& event_data, StreamingRequestSt
     }
 }
 
-int LemonadeClient::pull_model(const json& model_data, const std::string& display_name) {
+int LemonadeClient::pull_model(const json& model_data, const std::string& display_name, bool upgrade) {
     try {
         // Validate that model field exists in model_data
         if (!model_data.contains("model_name") || !model_data["model_name"].is_string()) {
@@ -545,6 +545,14 @@ int LemonadeClient::pull_model(const json& model_data, const std::string& displa
 
         json request_body = model_data;
         request_body["stream"] = true;
+
+        // Cache-first by default: an already-downloaded model is reused instead
+        // of triggering a Hugging Face update check (and a possible full
+        // re-download). Only the explicit `lemonade pull` update flow opts into
+        // an upgrade. An explicit field already in model_data wins.
+        if (!request_body.contains("do_not_upgrade")) {
+            request_body["do_not_upgrade"] = !upgrade;
+        }
 
         std::string body = request_body.dump();
 

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -289,7 +289,8 @@ static int handle_manual_pull_command(lemonade::LemonadeClient& client, const Cl
         model_data["labels"] = config.labels;
     }
 
-    return client.pull_model(model_data);
+    // Explicit `lemonade pull`: opt into an upgrade (Hugging Face update check).
+    return client.pull_model(model_data, "", /*upgrade=*/true);
 }
 
 static bool has_manual_pull_options(const CliConfig& config) {
@@ -334,7 +335,8 @@ static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig
 
     nlohmann::json model_data;
     model_data["model_name"] = config.model;
-    return client.pull_model(model_data);
+    // Explicit `lemonade pull`: opt into an upgrade (Hugging Face update check).
+    return client.pull_model(model_data, "", /*upgrade=*/true);
 }
 
 static int handle_export_command(lemonade::LemonadeClient& client, const CliConfig& config) {

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -77,7 +77,11 @@ public:
 
     // Model management commands
     int list_models(bool show_all, const std::string& name_filter = "") const;
-    int pull_model(const nlohmann::json& model_data, const std::string& display_name = "");
+    // Pulls/registers a model. By default the pull is cache-first
+    // (do_not_upgrade=true): an already-downloaded model is reused without
+    // contacting Hugging Face. Only the explicit `lemonade pull` update flow
+    // should pass upgrade=true to force an HF update check.
+    int pull_model(const nlohmann::json& model_data, const std::string& display_name = "", bool upgrade = false);
     int delete_model(const std::string& model_name) const;
     int load_model(const std::string& model_name, const nlohmann::json& recipe_options, bool save_options = false) const;
     int unload_model(const std::string& model_name) const;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2676,17 +2676,13 @@ void ModelManager::download_model(const std::string& model_name,
         }
     }
 
-    // CRITICAL: If do_not_upgrade=true AND model is already downloaded, skip entirely
-    // This prevents unnecessary HuggingFace API queries when we just want to use cached models
-    // The do_not_upgrade flag means:
-    //   - Load/inference endpoints: Don't check HuggingFace for updates (use cache if available)
-    //   - Pull endpoint: Always check HuggingFace for latest version (do_not_upgrade=false)
-    if (do_not_upgrade && is_model_downloaded(model_name)) {
-        LOG(INFO, "ModelManager") << "Model already downloaded and do_not_upgrade=true, using cached version" << std::endl;
-        return;
-    }
-
-    // Register user models to user_models.json
+    // Persist registration and recipe options BEFORE the cache-first shortcut
+    // below. A registration/import/overwrite that targets an already-downloaded
+    // model must still update user_models.json and recipe_options.json. The
+    // do_not_upgrade fast return only skips the Hugging Face download/update
+    // check — it must never skip the metadata the caller asked us to record,
+    // otherwise an import that reports success would silently leave the old
+    // checkpoints/options in place.
     if (is_user_model_name(model_name) && !model_registered) {
         register_user_model(model_name, model_data);
     }
@@ -2704,6 +2700,17 @@ void ModelManager::download_model(const std::string& model_name,
         }
         model_info.recipe_options = RecipeOptions(model_info.recipe, merged);
         save_model_options(model_info);
+    }
+
+    // CRITICAL: If do_not_upgrade=true AND model is already downloaded, skip the
+    // download/HF update check. Registration and recipe options were already
+    // persisted above, so an import/overwrite still takes effect on disk.
+    // The do_not_upgrade flag means:
+    //   - Load/inference endpoints: Don't check HuggingFace for updates (use cache if available)
+    //   - Pull endpoint: Always check HuggingFace for latest version (do_not_upgrade=false)
+    if (do_not_upgrade && is_model_downloaded(model_name)) {
+        LOG(INFO, "ModelManager") << "Model already downloaded and do_not_upgrade=true, using cached version" << std::endl;
+        return;
     }
 
     download_registered_model(model_info, do_not_upgrade, progress_callback);


### PR DESCRIPTION
## Problem

Users hit unexpected, large re-downloads of models that are already cached.

Root cause is client-side: **every** CLI and GUI request to `/pull` omits `do_not_upgrade`, so the server defaults it to `false` (`server.cpp`) and always queries Hugging Face. The server only reuses the cached copy when `do_not_upgrade && is_model_downloaded()` (`model_manager.cpp`). With the flag false, any pull contacts HF, and an upstream commit — even a README-only change — turns that into a full re-download.

The documented contract already says *"Load/inference endpoints: Don't check HuggingFace for updates (use cache if available)"* — the clients just never honored it.

## Fix

Invert the default at the **single pull chokepoint in each client** so the unsafe "upgrade" behavior requires an explicit opt-in. A future caller that reaches for the helper gets cache-first behavior unless it consciously asks for an HF update.

**CLI** (`src/cpp/cli/`)
- `LemonadeClient::pull_model` gains `bool upgrade=false`; sets `do_not_upgrade = !upgrade` on the body.
- Only explicit `lemonade pull` / HF-checkpoint flows pass `upgrade=true` (`main.cpp`, `hf_pull.cpp`).
- `load`/`run`, `bench --auto-pull`, and recipe import inherit the safe default — no per-caller change.

**GUI** (`src/app/src/renderer/`)
- `pullModel` gains an `upgrade?: boolean` option and always sets `requestBody.do_not_upgrade = options?.upgrade !== true`.
- The one `/pull` body built outside `pullModel` (the Omni collection re-save in `App.tsx`) now also sends `do_not_upgrade: true`.

No behavior change for genuine downloads: the server short-circuit only fires when the model is actually downloaded, so absent models still download normally.

## Verification

Built CLI + server; renderer type-checks clean. End-to-end against an isolated `lemond` with the model already cached:

| Path | Result |
|---|---|
| `/pull` with `do_not_upgrade=true` (new default) | `Model already downloaded … using cached version` — no manifest, no HF contact |
| `/pull` with `do_not_upgrade=false` (old behavior) | `Using commit hash…` + `Created download manifest` — round-trips to HF |
| `lemonade load <cached model>` | loads with **zero** HF-contact log lines |