### PR TITLE
fix(cuda): NVIDIA Blackwell/PRIME detection and CUDA device fixes on Linux

### DIFF
--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -535,10 +535,6 @@ void LlamaCppServer::load(const std::string& model_name,
         const char* existing_prime = std::getenv("__NV_PRIME_RENDER_OFFLOAD");
         if (!existing_prime || existing_prime[0] == '\0') {
             env_vars.push_back({"__NV_PRIME_RENDER_OFFLOAD", "1"});
-            const char* existing_provider = std::getenv("__NV_PRIME_RENDER_OFFLOAD_PROVIDER");
-            if (!existing_provider || existing_provider[0] == '\0') {
-                env_vars.push_back({"__NV_PRIME_RENDER_OFFLOAD_PROVIDER", "NVIDIA-G0"});
-            }
             LOG(INFO, "LlamaCpp") << "Setting __NV_PRIME_RENDER_OFFLOAD=1 for PRIME Offload compatibility" << std::endl;
         }
 #endif

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -535,7 +535,10 @@ void LlamaCppServer::load(const std::string& model_name,
         const char* existing_prime = std::getenv("__NV_PRIME_RENDER_OFFLOAD");
         if (!existing_prime || existing_prime[0] == '\0') {
             env_vars.push_back({"__NV_PRIME_RENDER_OFFLOAD", "1"});
-            env_vars.push_back({"__NV_PRIME_RENDER_OFFLOAD_PROVIDER", "NVIDIA-G0"});
+            const char* existing_provider = std::getenv("__NV_PRIME_RENDER_OFFLOAD_PROVIDER");
+            if (!existing_provider || existing_provider[0] == '\0') {
+                env_vars.push_back({"__NV_PRIME_RENDER_OFFLOAD_PROVIDER", "NVIDIA-G0"});
+            }
             LOG(INFO, "LlamaCpp") << "Setting __NV_PRIME_RENDER_OFFLOAD=1 for PRIME Offload compatibility" << std::endl;
         }
 #endif

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -525,6 +525,20 @@ void LlamaCppServer::load(const std::string& model_name,
                     << std::endl;
             }
         }
+
+#ifdef __linux__
+        // On NVIDIA Optimus/PRIME laptops in On-Demand mode the dGPU is only
+        // activated for applications that opt in via __NV_PRIME_RENDER_OFFLOAD.
+        // Without this, CUDA reports "no CUDA-capable device is detected" even
+        // though the kernel module is loaded and /proc/driver/nvidia/gpus exists.
+        // Setting the variable is harmless on non-Optimus (single-GPU) systems.
+        const char* existing_prime = std::getenv("__NV_PRIME_RENDER_OFFLOAD");
+        if (!existing_prime || existing_prime[0] == '\0') {
+            env_vars.push_back({"__NV_PRIME_RENDER_OFFLOAD", "1"});
+            env_vars.push_back({"__NV_PRIME_RENDER_OFFLOAD_PROVIDER", "NVIDIA-G0"});
+            LOG(INFO, "LlamaCpp") << "Setting __NV_PRIME_RENDER_OFFLOAD=1 for PRIME Offload compatibility" << std::endl;
+        }
+#endif
     }
 
 #ifdef __APPLE__

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2131,11 +2131,11 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
                         std::string name = gpu.value("name", "unknown");
                         std::string family = gpu.value("family", "");
                         std::string cc = gpu.value("compute_capability", "");
-                        LOG(INFO, "ModelManager") << "  - NVIDIA GPU: " << name;
-                        if (!cc.empty()) LOG(INFO, "ModelManager") << " (compute " << cc << ", " << (family.empty() ? "unsupported arch" : family) << ")";
-                        else if (!family.empty()) LOG(INFO, "ModelManager") << " (" << family << ")";
-                        else LOG(INFO, "ModelManager") << " (arch unknown — nvidia-smi may have failed)";
-                        LOG(INFO, "ModelManager") << std::endl;
+                        std::string suffix;
+                        if (!cc.empty()) suffix = " (compute " + cc + ", " + (family.empty() ? "unsupported arch" : family) + ")";
+                        else if (!family.empty()) suffix = " (" + family + ")";
+                        else suffix = " (arch unknown -- nvidia-smi may have failed)";
+                        LOG(INFO, "ModelManager") << "  - NVIDIA GPU: " << name << suffix << std::endl;
                     } else if (gpu.contains("error")) {
                         LOG(INFO, "ModelManager") << "  - NVIDIA GPU: detection error: " << gpu["error"].get<std::string>() << std::endl;
                     }

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2089,6 +2089,29 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
         if (largest_mem_pool_gb > 0.0) {
             LOG(INFO, "ModelManager") << "  - Largest memory pool: " << std::fixed << std::setprecision(1) << largest_mem_pool_gb << std::endl;
         }
+        if (system_info.contains("devices") && system_info["devices"].contains("nvidia_gpu")) {
+            const auto& nvidia_gpus = system_info["devices"]["nvidia_gpu"];
+            if (nvidia_gpus.is_array()) {
+                for (const auto& gpu : nvidia_gpus) {
+                    if (gpu.value("available", false)) {
+                        std::string name = gpu.value("name", "unknown");
+                        std::string family = gpu.value("family", "");
+                        std::string cc = gpu.value("compute_capability", "");
+                        LOG(INFO, "ModelManager") << "  - NVIDIA GPU: " << name;
+                        if (!cc.empty()) LOG(INFO, "ModelManager") << " (compute " << cc << ", " << (family.empty() ? "unsupported arch" : family) << ")";
+                        else if (!family.empty()) LOG(INFO, "ModelManager") << " (" << family << ")";
+                        else LOG(INFO, "ModelManager") << " (arch unknown — nvidia-smi may have failed)";
+                        LOG(INFO, "ModelManager") << std::endl;
+                    } else if (gpu.contains("error")) {
+                        LOG(INFO, "ModelManager") << "  - NVIDIA GPU: detection error: " << gpu["error"].get<std::string>() << std::endl;
+                    }
+                }
+                if (system_info["devices"].contains("nvidia_gpu_error")) {
+                    LOG(INFO, "ModelManager") << "  - NVIDIA GPU: detection error: "
+                        << system_info["devices"]["nvidia_gpu_error"].get<std::string>() << std::endl;
+                }
+            }
+        }
         debug_printed = true;
     }
 

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2123,6 +2123,29 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
         if (largest_mem_pool_gb > 0.0) {
             LOG(INFO, "ModelManager") << "  - Largest memory pool: " << std::fixed << std::setprecision(1) << largest_mem_pool_gb << std::endl;
         }
+        if (system_info.contains("devices") && system_info["devices"].contains("nvidia_gpu")) {
+            const auto& nvidia_gpus = system_info["devices"]["nvidia_gpu"];
+            if (nvidia_gpus.is_array()) {
+                for (const auto& gpu : nvidia_gpus) {
+                    if (gpu.value("available", false)) {
+                        std::string name = gpu.value("name", "unknown");
+                        std::string family = gpu.value("family", "");
+                        std::string cc = gpu.value("compute_capability", "");
+                        LOG(INFO, "ModelManager") << "  - NVIDIA GPU: " << name;
+                        if (!cc.empty()) LOG(INFO, "ModelManager") << " (compute " << cc << ", " << (family.empty() ? "unsupported arch" : family) << ")";
+                        else if (!family.empty()) LOG(INFO, "ModelManager") << " (" << family << ")";
+                        else LOG(INFO, "ModelManager") << " (arch unknown — nvidia-smi may have failed)";
+                        LOG(INFO, "ModelManager") << std::endl;
+                    } else if (gpu.contains("error")) {
+                        LOG(INFO, "ModelManager") << "  - NVIDIA GPU: detection error: " << gpu["error"].get<std::string>() << std::endl;
+                    }
+                }
+                if (system_info["devices"].contains("nvidia_gpu_error")) {
+                    LOG(INFO, "ModelManager") << "  - NVIDIA GPU: detection error: "
+                        << system_info["devices"]["nvidia_gpu_error"].get<std::string>() << std::endl;
+                }
+            }
+        }
         debug_printed = true;
     }
 

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -3047,6 +3047,55 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
         return gpus;
     }
 
+    // Secondary: /proc/driver/nvidia/gpus/*/information — readable whenever the
+    // nvidia kernel module is loaded, even when the GPU is in Optimus power-save
+    // mode and nvidia-smi fails. Provides the full model name and GPU UUID, which
+    // is enough for identify_cuda_arch_from_name() to determine the sm_XX family.
+    // (No compute_capability here; family is resolved from the name.)
+    LOG(WARNING, "SystemInfo") << "nvidia-smi detection failed; "
+        << "falling back to /proc/driver/nvidia/gpus" << std::endl;
+    {
+        fs::path gpus_dir = "/proc/driver/nvidia/gpus";
+        std::error_code ec;
+        if (fs::exists(gpus_dir, ec) && fs::is_directory(gpus_dir, ec)) {
+            std::string driver_version = get_nvidia_driver_version();
+            double vram = get_nvidia_vram();
+            int ordinal = 0;
+            for (const auto& entry : fs::directory_iterator(gpus_dir, ec)) {
+                fs::path info_path = entry.path() / "information";
+                std::ifstream info_file(info_path);
+                if (!info_file.is_open()) continue;
+
+                std::string model;
+                std::string uuid;
+                std::string line;
+                while (std::getline(info_file, line)) {
+                    if (line.rfind("Model:", 0) == 0) {
+                        model = line.substr(6);
+                        size_t s = model.find_first_not_of(" \t");
+                        if (s != std::string::npos) model = model.substr(s);
+                    } else if (line.rfind("GPU UUID:", 0) == 0) {
+                        uuid = line.substr(9);
+                        size_t s = uuid.find_first_not_of(" \t");
+                        if (s != std::string::npos) uuid = uuid.substr(s);
+                    }
+                }
+
+                if (!model.empty()) {
+                    GPUInfo gpu;
+                    gpu.index          = ordinal++;
+                    gpu.name           = model;
+                    gpu.uuid           = uuid;
+                    gpu.available      = true;
+                    gpu.driver_version = driver_version;
+                    if (vram > 0.0) gpu.vram_gb = vram;
+                    gpus.push_back(gpu);
+                }
+            }
+            if (!gpus.empty()) return gpus;
+        }
+    }
+
     // Fallback: lspci (for systems where nvidia-smi is unavailable)
     FILE* pipe = popen("lspci 2>/dev/null | grep -iE 'vga|3d|display'", "r");
     if (!pipe) {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1775,12 +1775,14 @@ std::string identify_cuda_arch_from_name(const std::string& device_name) {
     }
 
     // Compact table: {sm_XX, {substrings that identify the architecture}}.
-    // Listed highest-to-lowest; first match wins.
+    // More-specific entries must come before broader ones; first match wins.
+    // sm_100 is listed first as a belt-and-suspenders fallback (the early guard
+    // above already returns before this table is reached for B100/B200).
     static const std::vector<std::pair<std::string, std::vector<std::string>>> TABLE = {
+        {"sm_100", {"b100", "b200"}},
         {"sm_120", {"blackwell", "rtx 50", "rtx50", "5090", "5080", "5070", "5060",
                     "rtx pro 6000", "rtx pro 5000", "rtx pro 4500", "rtx pro 4000",
                     "rtx pro 3500", "rtx pro 3000", "rtx pro 2000", "rtx pro 1000"}},
-        {"sm_100", {"b100", "b200"}},
         {"sm_90",  {"h100", "h200"}},
         {"sm_89",  {"rtx 40", "rtx40", "4090", "4080", "4070", "4060", "l40", " l4"}},
         {"sm_80",  {"a100"}},

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1769,7 +1769,9 @@ std::string identify_cuda_arch_from_name(const std::string& device_name) {
     // Compact table: {sm_XX, {substrings that identify the architecture}}.
     // Listed highest-to-lowest; first match wins.
     static const std::vector<std::pair<std::string, std::vector<std::string>>> TABLE = {
-        {"sm_120", {"rtx 50", "rtx50", "5090", "5080", "5070", "5060"}},
+        {"sm_120", {"blackwell", "rtx 50", "rtx50", "5090", "5080", "5070", "5060",
+                    "rtx pro 6000", "rtx pro 5000", "rtx pro 4500", "rtx pro 4000",
+                    "rtx pro 3500", "rtx pro 3000", "rtx pro 2000", "rtx pro 1000"}},
         {"sm_100", {"b100", "b200"}},
         {"sm_90",  {"h100", "h200"}},
         {"sm_89",  {"rtx 40", "rtx40", "4090", "4080", "4070", "4060", "l40", " l4"}},

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -3054,15 +3054,13 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
     // mode and nvidia-smi fails. Provides the full model name and GPU UUID, which
     // is enough for identify_cuda_arch_from_name() to determine the sm_XX family.
     // (No compute_capability here; family is resolved from the name.)
-    LOG(WARNING, "SystemInfo") << "nvidia-smi detection failed; "
-        << "falling back to /proc/driver/nvidia/gpus" << std::endl;
     {
         fs::path gpus_dir = "/proc/driver/nvidia/gpus";
         std::error_code ec;
         if (fs::exists(gpus_dir, ec) && fs::is_directory(gpus_dir, ec)) {
+            LOG(WARNING, "SystemInfo") << "nvidia-smi detection failed; falling back to /proc/driver/nvidia/gpus" << std::endl;
             std::string driver_version = get_nvidia_driver_version();
             double vram = get_nvidia_vram();
-            int ordinal = 0;
             for (const auto& entry : fs::directory_iterator(gpus_dir, ec)) {
                 fs::path info_path = entry.path() / "information";
                 std::ifstream info_file(info_path);
@@ -3085,7 +3083,6 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
 
                 if (!model.empty()) {
                     GPUInfo gpu;
-                    gpu.index          = ordinal++;
                     gpu.name           = model;
                     gpu.uuid           = uuid;
                     gpu.available      = true;

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1766,6 +1766,14 @@ std::string identify_cuda_arch_from_name(const std::string& device_name) {
     }
     if (!is_nvidia) return "";
 
+    // Data-center Blackwell (B100/B200) is compute capability 10.0 (sm_100),
+    // not 12.0 (sm_120) like the consumer/workstation Blackwell parts below.
+    // Resolve it explicitly first so the generic "blackwell" keyword in the
+    // sm_120 row doesn't misclassify a name like "NVIDIA B200 (Blackwell)".
+    if (n.find("b100") != std::string::npos || n.find("b200") != std::string::npos) {
+        return "sm_100";
+    }
+
     // Compact table: {sm_XX, {substrings that identify the architecture}}.
     // Listed highest-to-lowest; first match wins.
     static const std::vector<std::pair<std::string, std::vector<std::string>>> TABLE = {
@@ -3060,7 +3068,9 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
         if (fs::exists(gpus_dir, ec) && fs::is_directory(gpus_dir, ec)) {
             LOG(WARNING, "SystemInfo") << "nvidia-smi detection failed; falling back to /proc/driver/nvidia/gpus" << std::endl;
             std::string driver_version = get_nvidia_driver_version();
-            double vram = get_nvidia_vram();
+            // VRAM is intentionally left unset here: get_nvidia_vram() reads a
+            // single memory.total value, which would be wrong if applied to
+            // every GPU on a multi-GPU system. /proc has no per-GPU memory.
             for (const auto& entry : fs::directory_iterator(gpus_dir, ec)) {
                 fs::path info_path = entry.path() / "information";
                 std::ifstream info_file(info_path);
@@ -3087,7 +3097,6 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
                     gpu.uuid           = uuid;
                     gpu.available      = true;
                     gpu.driver_version = driver_version;
-                    if (vram > 0.0) gpu.vram_gb = vram;
                     gpus.push_back(gpu);
                 }
             }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -3081,13 +3081,9 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
                 std::string line;
                 while (std::getline(info_file, line)) {
                     if (line.rfind("Model:", 0) == 0) {
-                        model = line.substr(6);
-                        size_t s = model.find_first_not_of(" \t");
-                        if (s != std::string::npos) model = model.substr(s);
+                        model = trim_copy(line.substr(6));
                     } else if (line.rfind("GPU UUID:", 0) == 0) {
-                        uuid = line.substr(9);
-                        size_t s = uuid.find_first_not_of(" \t");
-                        if (s != std::string::npos) uuid = uuid.substr(s);
+                        uuid = trim_copy(line.substr(9));
                     }
                 }
 

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -2209,6 +2209,12 @@ std::string SystemInfo::get_cuda_visible_devices_for_arch(const std::string& arc
     // CUDA runtime ordinals and nvidia-smi/NVML indices can differ on mixed systems.
     // Passing a numeric nvidia-smi index can therefore accidentally expose the wrong GPU
     // (e.g. selecting sm_120 but making an sm_89 RTX 4090 visible as CUDA0).
+    //
+    // Only restrict CUDA_VISIBLE_DEVICES when there are mixed architectures that need
+    // hiding. If every available NVIDIA GPU matches the target arch, returning empty
+    // string lets the CUDA runtime enumerate them all without UUID filtering — which
+    // avoids driver-level UUID mismatches seen on some single-arch systems (e.g. RTX 50
+    // Blackwell where UUID-based filtering can cause "no CUDA-capable device detected").
     std::vector<std::string> devices_to_expose;
     if (arch.empty()) {
         return "";
@@ -2225,6 +2231,7 @@ std::string SystemInfo::get_cuda_visible_devices_for_arch(const std::string& arc
             return "";
         }
 
+        bool has_other_arch = false;
         int ordinal = 0;
         for (const auto& gpu : devices["nvidia_gpu"]) {
             if (!gpu.value("available", false)) {
@@ -2241,8 +2248,15 @@ std::string SystemInfo::get_cuda_visible_devices_for_arch(const std::string& arc
                     // than UUIDs because numeric CUDA ordinals can differ from nvidia-smi indices.
                     devices_to_expose.push_back(std::to_string(ordinal));
                 }
+            } else {
+                has_other_arch = true;
             }
             ordinal++;
+        }
+
+        // No mixed architectures — no need to restrict CUDA_VISIBLE_DEVICES.
+        if (!has_other_arch) {
+            return "";
         }
     } catch (...) {
         devices_to_expose.clear();

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -3049,6 +3049,55 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
         return gpus;
     }
 
+    // Secondary: /proc/driver/nvidia/gpus/*/information — readable whenever the
+    // nvidia kernel module is loaded, even when the GPU is in Optimus power-save
+    // mode and nvidia-smi fails. Provides the full model name and GPU UUID, which
+    // is enough for identify_cuda_arch_from_name() to determine the sm_XX family.
+    // (No compute_capability here; family is resolved from the name.)
+    LOG(WARNING, "SystemInfo") << "nvidia-smi detection failed; "
+        << "falling back to /proc/driver/nvidia/gpus" << std::endl;
+    {
+        fs::path gpus_dir = "/proc/driver/nvidia/gpus";
+        std::error_code ec;
+        if (fs::exists(gpus_dir, ec) && fs::is_directory(gpus_dir, ec)) {
+            std::string driver_version = get_nvidia_driver_version();
+            double vram = get_nvidia_vram();
+            int ordinal = 0;
+            for (const auto& entry : fs::directory_iterator(gpus_dir, ec)) {
+                fs::path info_path = entry.path() / "information";
+                std::ifstream info_file(info_path);
+                if (!info_file.is_open()) continue;
+
+                std::string model;
+                std::string uuid;
+                std::string line;
+                while (std::getline(info_file, line)) {
+                    if (line.rfind("Model:", 0) == 0) {
+                        model = line.substr(6);
+                        size_t s = model.find_first_not_of(" \t");
+                        if (s != std::string::npos) model = model.substr(s);
+                    } else if (line.rfind("GPU UUID:", 0) == 0) {
+                        uuid = line.substr(9);
+                        size_t s = uuid.find_first_not_of(" \t");
+                        if (s != std::string::npos) uuid = uuid.substr(s);
+                    }
+                }
+
+                if (!model.empty()) {
+                    GPUInfo gpu;
+                    gpu.index          = ordinal++;
+                    gpu.name           = model;
+                    gpu.uuid           = uuid;
+                    gpu.available      = true;
+                    gpu.driver_version = driver_version;
+                    if (vram > 0.0) gpu.vram_gb = vram;
+                    gpus.push_back(gpu);
+                }
+            }
+            if (!gpus.empty()) return gpus;
+        }
+    }
+
     // Fallback: lspci (for systems where nvidia-smi is unavailable)
     FILE* pipe = popen("lspci 2>/dev/null | grep -iE 'vga|3d|display'", "r");
     if (!pipe) {

--- a/test/test_cuda_arch_mapping.py
+++ b/test/test_cuda_arch_mapping.py
@@ -79,8 +79,6 @@ _NAME_ARCH_TABLE = [
         ],
         "sm_120",
     ),
-    # Blackwell DC (sm_100)
-    (["b100", "b200"], "sm_100"),
     # Hopper (sm_90)
     (["h100", "h200"], "sm_90"),
     # Ada Lovelace (sm_89)
@@ -228,6 +226,31 @@ class TestIdentifyCudaArchFromName(unittest.TestCase):
             ("NVIDIA B200", "sm_100"),
             ("NVIDIA B200 (Blackwell)", "sm_100"),
             ("NVIDIA B100", "sm_100"),
+        ]
+        for name, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(identify_cuda_arch_from_name(name), expected)
+
+    def test_blackwell_consumer(self):
+        # Generic "Blackwell" keyword and RTX PRO Blackwell → sm_120
+        cases = [
+            ("NVIDIA GeForce RTX 5080", "sm_120"),
+            ("NVIDIA RTX PRO 3000 Blackwell Generation Laptop GPU", "sm_120"),
+            ("NVIDIA RTX PRO 6000 Blackwell", "sm_120"),
+            ("NVIDIA RTX PRO 4000 Blackwell", "sm_120"),
+        ]
+        for name, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(identify_cuda_arch_from_name(name), expected)
+
+    def test_blackwell_datacenter_guard(self):
+        # B100/B200 must resolve to sm_100 even when "Blackwell" appears in the name
+        cases = [
+            ("NVIDIA B100", "sm_100"),
+            ("NVIDIA B200", "sm_100"),
+            ("NVIDIA B100 Blackwell", "sm_100"),
+            ("NVIDIA B200 Blackwell", "sm_100"),
+            ("NVIDIA B200 (Blackwell)", "sm_100"),
         ]
         for name, expected in cases:
             with self.subTest(name=name):

--- a/test/test_cuda_arch_mapping.py
+++ b/test/test_cuda_arch_mapping.py
@@ -49,17 +49,44 @@ def compute_cap_to_sm(compute_cap: str) -> str:
 # Python replica of system_info.cpp::identify_cuda_arch_from_name() (compact)
 # ---------------------------------------------------------------------------
 
+# Data-center Blackwell (B100/B200) is compute capability 10.0 (sm_100), not
+# 12.0 (sm_120) like the consumer/workstation Blackwell parts. These are matched
+# before the generic "blackwell" keyword below so a name like
+# "NVIDIA B200 (Blackwell)" still resolves to sm_100. Mirrors the C++ pre-check.
+_DC_BLACKWELL = ["b100", "b200"]
+
 _NAME_ARCH_TABLE = [
+    # Blackwell consumer/workstation (sm_120). The generic "blackwell" keyword
+    # covers current and future RTX 50 / RTX PRO Blackwell GPUs; explicit model
+    # numbers cover names that do not include "Blackwell".
+    (
+        [
+            "blackwell",
+            "rtx 50",
+            "rtx50",
+            "5090",
+            "5080",
+            "5070",
+            "5060",
+            "rtx pro 6000",
+            "rtx pro 5000",
+            "rtx pro 4500",
+            "rtx pro 4000",
+            "rtx pro 3500",
+            "rtx pro 3000",
+            "rtx pro 2000",
+            "rtx pro 1000",
+        ],
+        "sm_120",
+    ),
     # Blackwell DC (sm_100)
     (["b100", "b200"], "sm_100"),
     # Hopper (sm_90)
     (["h100", "h200"], "sm_90"),
-    # Ampere DC (sm_80)
-    (["a100"], "sm_80"),
-    # Blackwell consumer (sm_120)
-    (["rtx 50", "rtx50", "5090", "5080", "5070", "5060"], "sm_120"),
     # Ada Lovelace (sm_89)
     (["rtx 40", "rtx40", "4090", "4080", "4070", "4060", "l40", " l4"], "sm_89"),
+    # Ampere DC (sm_80)
+    (["a100"], "sm_80"),
     # Ampere consumer/pro (sm_86)
     (
         [
@@ -122,10 +149,12 @@ def identify_cuda_arch_from_name(device_name: str) -> str:
         "b100",
         "b200",
         "l40",
-        "l4",
     ]
     if not any(kw in name for kw in nvidia_ids):
         return ""
+    # Data-center Blackwell first, before the generic "blackwell" keyword.
+    if any(kw in name for kw in _DC_BLACKWELL):
+        return "sm_100"
     for keywords, sm in _NAME_ARCH_TABLE:
         if any(kw in name for kw in keywords):
             return sm
@@ -189,6 +218,16 @@ class TestIdentifyCudaArchFromName(unittest.TestCase):
             ("NVIDIA A100-SXM4-80GB", "sm_80"),
             ("NVIDIA A10", "sm_86"),
             ("NVIDIA A40", "sm_86"),
+            # RTX PRO Blackwell (sm_120) — both the generic "Blackwell" keyword
+            # and the explicit RTX PRO model numbers must resolve to sm_120.
+            ("NVIDIA RTX PRO 3000 Blackwell Generation Laptop GPU", "sm_120"),
+            ("NVIDIA RTX PRO 6000 Blackwell", "sm_120"),
+            ("NVIDIA RTX PRO 1000", "sm_120"),
+            # Data-center Blackwell (sm_100) must NOT be misclassified as sm_120
+            # even when the name contains "Blackwell".
+            ("NVIDIA B200", "sm_100"),
+            ("NVIDIA B200 (Blackwell)", "sm_100"),
+            ("NVIDIA B100", "sm_100"),
         ]
         for name, expected in cases:
             with self.subTest(name=name):


### PR DESCRIPTION
## Summary

Fixes CUDA backend failures on Linux with NVIDIA Blackwell (RTX 50 / RTX PRO) GPUs, particularly on Optimus/PRIME Offload laptops. Tested on a ThinkPad P16 Gen 3 with an NVIDIA RTX PRO 3000 Blackwell Generation Laptop GPU.

Four independent fixes are included:

- **Skip `CUDA_VISIBLE_DEVICES` restriction on single-arch systems** — The existing code unconditionally set `CUDA_VISIBLE_DEVICES` to the GPU UUID to hide incompatible GPUs on mixed-arch systems. On single-architecture systems (e.g. only sm_120 GPUs), this UUID-based filtering broke CUDA initialization ("no CUDA-capable device is detected") due to driver-level UUID mismatches. The restriction is now only applied when there are actually mixed GPU architectures present.

- **Detect NVIDIA GPU via `/proc/driver/nvidia/gpus` when `nvidia-smi` fails** — On Optimus laptops in On-Demand/PRIME power-save mode, `nvidia-smi` can fail silently while the kernel module is still loaded. The `lspci` fallback doesn't know the PCI IDs for brand-new Blackwell cards, leaving the GPU undetected. A new intermediate fallback reads `/proc/driver/nvidia/gpus/*/information` (maintained by the kernel module) to get the full model name and UUID. Also adds a `[Warn]` log when nvidia-smi detection fails, and expands the ModelManager startup log to show detected NVIDIA GPUs.

- **Add Blackwell arch detection for RTX PRO and generic Blackwell GPUs** — The `/proc` fallback returns names like `"NVIDIA RTX PRO 3000 Blackwell Generation Laptop GPU"` which didn't match any sm_120 keyword. Adds `"blackwell"` as a top-level keyword for sm_120 (covers all current and future Blackwell GPUs) plus explicit RTX PRO Blackwell model numbers (1000–6000).

- **Set `__NV_PRIME_RENDER_OFFLOAD=1` for CUDA on Linux PRIME Offload systems** — On Optimus laptops in On-Demand mode, the dGPU only activates for applications that opt in via `__NV_PRIME_RENDER_OFFLOAD=1`. Without this, CUDA reports "no CUDA-capable device is detected" even though the driver is loaded. NVIDIA documents this requirement for CUDA compute on PRIME systems. The variable is a no-op on non-Optimus systems.

## Test plan

- [x] Build and run on Linux with NVIDIA Blackwell GPU (RTX 50 series or RTX PRO Blackwell)
- [ ] Verify `lemonade recipes` shows `llamacpp cuda installable` (not `unsupported`) on Blackwell systems
- [ ] Verify CUDA backend loads and runs inference successfully
- [ ] Verify no regression on non-NVIDIA or non-Optimus systems (CUDA_VISIBLE_DEVICES and PRIME vars are no-ops)
- [ ] Verify on mixed-arch NVIDIA systems (e.g. RTX 40 + RTX 50) that CUDA_VISIBLE_DEVICES restriction still applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)