### PR TITLE
fix(security): prevent path traversal in /web-app/ route

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1511,6 +1511,11 @@ jobs:
         shell: bash
         run: .venv/bin/python test/server_endpoints.py --cli-binary lemonade
 
+      - name: Test web-app path traversal
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        shell: bash
+        run: .venv/bin/python test/server_webapp.py --cli-binary lemonade
+
       - name: Test ollama
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         shell: bash
@@ -1624,6 +1629,11 @@ jobs:
         if: ${{ !cancelled() && steps.setup.outcome == 'success' && !(runner.os == 'macOS' && needs.build-lemonade-macos-dmg.outputs.has_signing != 'true') }}
         shell: bash
         run: $VENV_PYTHON test/server_endpoints.py --cli-binary "$CLI_BINARY"
+
+      - name: Test web-app path traversal
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' && !(runner.os == 'macOS' && needs.build-lemonade-macos-dmg.outputs.has_signing != 'true') }}
+        shell: bash
+        run: $VENV_PYTHON test/server_webapp.py --cli-binary "$CLI_BINARY"
 
       - name: Test ollama
         if: ${{ !cancelled() && steps.setup.outcome == 'success' && !(runner.os == 'macOS' && needs.build-lemonade-macos-dmg.outputs.has_signing != 'true') }}

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -497,6 +497,20 @@ jobs:
           .venv/bin/python test/server_endpoints.py --cli-binary ./build/lemonade
           echo "Endpoint tests PASSED!"
 
+      - name: Run web-app path traversal tests (unsigned path)
+        if: steps.check_signing.outputs.has_signing != 'true'
+        shell: bash
+        env:
+          LEMONADE_CI_MODE: "True"
+          PYTHONIOENCODING: utf-8
+          HF_HOME: ${{ github.workspace }}/hf-cache
+          GGML_METAL_NO_RESIDENCY: "1"
+        run: |
+          set -e
+          echo "Running web-app path traversal tests..."
+          .venv/bin/python test/server_webapp.py --cli-binary ./build/lemonade
+          echo "Web-app tests PASSED!"
+
       - name: Run Ollama API tests (unsigned path)
         if: steps.check_signing.outputs.has_signing != 'true'
         shell: bash

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -760,10 +760,49 @@ window.api = {
         // Serve all static assets from the web app directory (JS, CSS, fonts, assets, etc.)
         // Handle both root-level assets and /web-app/ prefixed paths for backwards compatibility
         auto serve_web_app_asset = [web_app_dir](const httplib::Request& req, httplib::Response& res, const std::string& file_path) {
-            std::string full_path = web_app_dir + "/" + file_path;
+            std::error_code ec;
+            namespace fs = std::filesystem;
+
+            auto base = fs::weakly_canonical(fs::path(web_app_dir), ec);
+            if (ec) {
+                res.status = 500;
+                res.set_content("Internal server error", "text/plain");
+                return;
+            }
+
+            auto candidate = fs::weakly_canonical(base / file_path, ec);
+            if (ec) {
+                // Path doesn't exist or cannot be canonicalized
+                res.status = 404;
+                res.set_content("File not found", "text/plain");
+                return;
+            }
+
+            // Verify the resolved path is confined under the base directory.
+            // Use std::filesystem::relative (not string prefix) so it works
+            // correctly on Windows where path separators differ.
+            auto relative = fs::relative(candidate, base, ec);
+            if (ec || relative.empty() || relative.is_absolute()) {
+                // empty = candidate == base (directory, not a file)
+                // is_absolute = somehow escaped (shouldn't happen after canonicalization)
+                res.status = 403;
+                res.set_content("Forbidden", "text/plain");
+                return;
+            }
+            // Belt-and-suspenders: reject if any path component is ".."
+            // (weakly_canonical should have resolved it, but this catches
+            // edge cases on exotic filesystems). Check components, not
+            // substrings, so legitimate filenames like "my..file.js" are allowed.
+            for (const auto& part : relative) {
+                if (part == "..") {
+                    res.status = 403;
+                    res.set_content("Forbidden", "text/plain");
+                    return;
+                }
+            }
 
             // Serve the file
-            std::ifstream file(full_path, std::ios::binary);
+            std::ifstream file(candidate, std::ios::binary);
             if (!file.is_open()) {
                 res.status = 404;
                 res.set_content("File not found", "text/plain");

--- a/test/server_webapp.py
+++ b/test/server_webapp.py
@@ -1,0 +1,215 @@
+"""
+Regression tests for the /web-app/ static asset route.
+
+Tests the path-traversal security fix:
+- Normal assets return 200
+- Encoded traversal attempts are rejected with 403
+- Nonexistent assets return 404
+- Windows validation note (string-prefix check was broken on Windows)
+
+Requires a running server (started by the installer or manually).
+No inference backends are needed.
+
+Usage:
+    python server_webapp.py
+"""
+
+import os
+import sys
+import unittest
+import requests
+
+from utils.server_base import (
+    ServerTestBase,
+    run_server_tests,
+    parse_args,
+    PORT,
+    TIMEOUT_DEFAULT,
+)
+
+
+class WebAppAssetTests(ServerTestBase):
+    """Tests for web-app static asset serving and path-traversal prevention."""
+
+    additional_server_args = []
+
+    @classmethod
+    def setUpClass(cls):
+        """Verify server is reachable. Do NOT pull any models."""
+        super().setUpClass()
+
+    def _is_webapp_available(self):
+        """Check if the server has a web-app directory compiled in."""
+        resp = requests.get(f"http://localhost:{PORT}/", timeout=TIMEOUT_DEFAULT)
+        return resp.status_code == 200 and "<!doctype" in resp.text[:4096].lower()
+
+    def test_001_normal_js_asset_returns_200(self):
+        """A normal web-app JS asset should return 200."""
+        if not self._is_webapp_available():
+            self.skipTest("Web app not available on this server")
+
+        # renderer.bundle.js is a standard web-app asset
+        resp = requests.get(
+            f"http://localhost:{PORT}/renderer.bundle.js", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("text/javascript", resp.headers.get("Content-Type", ""))
+        self.assertGreater(
+            len(resp.content), 0, "renderer.bundle.js should not be empty"
+        )
+        print("[OK] renderer.bundle.js returned 200 with correct content-type")
+
+    def test_002_normal_css_asset_returns_200(self):
+        """A normal web-app CSS asset should return 200."""
+        if not self._is_webapp_available():
+            self.skipTest("Web app not available on this server")
+
+        # SVG assets are always present in the web-app build
+        resp = requests.get(
+            f"http://localhost:{PORT}/ecd3a2194d527cfbf0bc.svg",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("image/svg+xml", resp.headers.get("Content-Type", ""))
+        self.assertGreater(len(resp.content), 0, "SVG asset should not be empty")
+        print("[OK] SVG asset returned 200 with correct content-type")
+
+    def test_003_web_app_prefix_asset_returns_200(self):
+        """A /web-app/ prefixed asset should return 200 (backwards compat)."""
+        if not self._is_webapp_available():
+            self.skipTest("Web app not available on this server")
+
+        resp = requests.get(
+            f"http://localhost:{PORT}/web-app/renderer.bundle.js",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertGreater(len(resp.content), 0)
+        print("[OK] /web-app/ prefixed path returned 200")
+
+    def test_004_url_encoded_traversal_rejected(self):
+        """
+        URL-encoded path traversal (..%2f) should return 403 specifically.
+
+        Uses backend_versions.json as a known existing file outside web-app.
+        If the traversal check is broken, this would return 200 with the file content.
+        """
+        if not self._is_webapp_available():
+            self.skipTest("Web app not available on this server")
+
+        # Try to access src/cpp/resources/backend_versions.json via traversal
+        # From web-app directory: ../../resources/backend_versions.json
+        # %2f = /, %2e = .
+        resp = requests.get(
+            f"http://localhost:{PORT}/web-app/..%2f..%2fresources%2fbackend_versions.json",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        # Must return 403 Forbidden, not 200 (file leaked) or 404 (file not found)
+        self.assertEqual(
+            resp.status_code,
+            403,
+            f"Encoded traversal to existing file should return 403, got {resp.status_code}",
+        )
+        print("[OK] URL-encoded traversal to backend_versions.json returned 403")
+
+    def test_005_double_encoded_traversal_rejected(self):
+        """Double-encoded traversal should be rejected with 403."""
+        if not self._is_webapp_available():
+            self.skipTest("Web app not available on this server")
+
+        # %252e = %2e (literal %2e), %252f = %2f (literal %2f)
+        # Some proxies double-decode, so this tests defense-in-depth
+        resp = requests.get(
+            f"http://localhost:{PORT}/web-app/%252e%252e%252f%252e%252e%252fetc%252fpasswd",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        # This should either be 403 (traversal blocked) or 404 (file not found)
+        # It should NOT be 200 (file leaked)
+        self.assertNotEqual(
+            resp.status_code, 200, "Double-encoded traversal should not return 200"
+        )
+        print(f"[OK] Double-encoded traversal returned {resp.status_code} (not 200)")
+
+    def test_006_backslash_traversal_rejected(self):
+        """Backslash-based traversal should be rejected with 403 on all platforms."""
+        if not self._is_webapp_available():
+            self.skipTest("Web app not available on this server")
+
+        # Some clients send backslashes as path separators
+        resp = requests.get(
+            f"http://localhost:{PORT}/web-app/..%5c..%5c..%5cetc%5cpasswd",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        # Should be 403 (traversal blocked) or 404 (not found)
+        self.assertNotEqual(
+            resp.status_code, 200, "Backslash traversal should not return 200"
+        )
+        print(f"[OK] Backslash traversal returned {resp.status_code} (not 200)")
+
+    def test_007_nonexistent_asset_returns_404(self):
+        """A nonexistent asset should return 404."""
+        if not self._is_webapp_available():
+            self.skipTest("Web app not available on this server")
+
+        resp = requests.get(
+            f"http://localhost:{PORT}/nonexistent-file-xyz123.js",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(resp.status_code, 404)
+        print("[OK] Nonexistent asset returned 404")
+
+    def test_008_legitimate_filename_with_dots_allowed(self):
+        """
+        Legitimate filenames containing ".." as a substring should be allowed.
+
+        This verifies we're checking path components, not substring matching.
+        The old implementation using rel_str.find("..") would incorrectly
+        reject filenames like "my..test..file.js".
+        """
+        if not self._is_webapp_available():
+            self.skipTest("Web app not available on this server")
+
+        resp = requests.get(
+            f"http://localhost:{PORT}/web-app/my..test..file.js",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        # Should return 404 (file doesn't exist), not 403 (forbidden)
+        self.assertEqual(
+            resp.status_code,
+            404,
+            f"Filename with .. substring should return 404 (not found), not 403 (forbidden). Got {resp.status_code}",
+        )
+        print("[OK] Filename with .. substring returned 404 (not 403)")
+
+    def test_009_windows_validation_note(self):
+        """
+        Windows path-separator validation note.
+
+        The old string-prefix check compared candidate.string() against
+        base.string() + "/" which is broken on Windows because
+        std::filesystem::path::string() uses backslashes (e.g.
+        C:\\web-app\\renderer.bundle.js won't start with C:\\web-app/).
+
+        The fix uses std::filesystem::relative(candidate, base) which
+        is platform-agnostic and works correctly on Windows, Linux, and macOS.
+
+        Windows validation checklist (run manually on a Windows build):
+        1. Build with: cmake --build --preset windows --target web-app
+        2. Start lemond
+        3. Verify: curl http://localhost:13305/renderer.bundle.js -> 200
+        4. Verify: curl http://localhost:13305/web-app/..%2f..%2f..%2fetc%2fpasswd -> 403
+        5. Verify: curl http://localhost:13305/nonexistent.js -> 404
+        """
+        self.skipTest("Windows validation must be done manually on a Windows build")
+
+
+def main():
+    parse_args()
+    run_server_tests(
+        WebAppAssetTests,
+        description="WEB APP ASSET & SECURITY TESTS",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/server_webapp.py
+++ b/test/server_webapp.py
@@ -59,22 +59,7 @@ class WebAppAssetTests(ServerTestBase):
         )
         print("[OK] renderer.bundle.js returned 200 with correct content-type")
 
-    def test_002_normal_svg_asset_returns_200(self):
-        """A normal web-app SVG asset should return 200."""
-        if not self._is_webapp_available():
-            self.skipTest("Web app not available on this server")
-
-        # SVG assets are always present in the web-app build
-        resp = requests.get(
-            f"http://localhost:{PORT}/ecd3a2194d527cfbf0bc.svg",
-            timeout=TIMEOUT_DEFAULT,
-        )
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("image/svg+xml", resp.headers.get("Content-Type", ""))
-        self.assertGreater(len(resp.content), 0, "SVG asset should not be empty")
-        print("[OK] SVG asset returned 200 with correct content-type")
-
-    def test_003_web_app_prefix_asset_returns_200(self):
+    def test_002_web_app_prefix_asset_returns_200(self):
         """A /web-app/ prefixed asset should return 200 (backwards compat)."""
         if not self._is_webapp_available():
             self.skipTest("Web app not available on this server")
@@ -87,7 +72,7 @@ class WebAppAssetTests(ServerTestBase):
         self.assertGreater(len(resp.content), 0)
         print("[OK] /web-app/ prefixed path returned 200")
 
-    def test_004_url_encoded_traversal_rejected(self):
+    def test_003_url_encoded_traversal_rejected(self):
         """
         URL-encoded path traversal (..%2f) should return 403 specifically.
 
@@ -112,7 +97,7 @@ class WebAppAssetTests(ServerTestBase):
         )
         print("[OK] URL-encoded traversal to backend_versions.json returned 403")
 
-    def test_005_double_encoded_traversal_rejected(self):
+    def test_004_double_encoded_traversal_rejected(self):
         """Double-encoded traversal should be rejected with 403."""
         if not self._is_webapp_available():
             self.skipTest("Web app not available on this server")
@@ -130,7 +115,7 @@ class WebAppAssetTests(ServerTestBase):
         )
         print(f"[OK] Double-encoded traversal returned {resp.status_code} (not 200)")
 
-    def test_006_backslash_traversal_rejected(self):
+    def test_005_backslash_traversal_rejected(self):
         """Backslash-based traversal should be rejected with 403 on all platforms."""
         if not self._is_webapp_available():
             self.skipTest("Web app not available on this server")
@@ -146,7 +131,7 @@ class WebAppAssetTests(ServerTestBase):
         )
         print(f"[OK] Backslash traversal returned {resp.status_code} (not 200)")
 
-    def test_007_nonexistent_asset_returns_404(self):
+    def test_006_nonexistent_asset_returns_404(self):
         """A nonexistent asset should return 404."""
         if not self._is_webapp_available():
             self.skipTest("Web app not available on this server")
@@ -158,7 +143,7 @@ class WebAppAssetTests(ServerTestBase):
         self.assertEqual(resp.status_code, 404)
         print("[OK] Nonexistent asset returned 404")
 
-    def test_008_legitimate_filename_with_dots_allowed(self):
+    def test_007_legitimate_filename_with_dots_allowed(self):
         """
         Legitimate filenames containing ".." as a substring should be allowed.
 
@@ -181,7 +166,7 @@ class WebAppAssetTests(ServerTestBase):
         )
         print("[OK] Filename with .. substring returned 404 (not 403)")
 
-    def test_009_windows_validation_note(self):
+    def test_008_windows_validation_note(self):
         """
         Windows path-separator validation note.
 

--- a/test/server_webapp.py
+++ b/test/server_webapp.py
@@ -59,8 +59,8 @@ class WebAppAssetTests(ServerTestBase):
         )
         print("[OK] renderer.bundle.js returned 200 with correct content-type")
 
-    def test_002_normal_css_asset_returns_200(self):
-        """A normal web-app CSS asset should return 200."""
+    def test_002_normal_svg_asset_returns_200(self):
+        """A normal web-app SVG asset should return 200."""
         if not self._is_webapp_available():
             self.skipTest("Web app not available on this server")
 


### PR DESCRIPTION
The /web-app/(.+) route concatenated the regex capture directly onto web_app_dir with no canonicalization or .. filtering. cpp-httplib URL-decodes %2f → / and %2e → . before regex matching, allowing GET /web-app/..%2f..%2f..%2fetc%2fpasswd to read arbitrary files.

Add path canonicalization via std::filesystem::weakly_canonical and verify the resolved path is confined under web_app_dir before opening. Reject any path that escapes the base directory with 403 Forbidden.