### PR TITLE
Separate local and available model list output

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -145,7 +145,7 @@ lemonade export Qwen3-0.6B-GGUF --output model-info.json
 
 ## Options for list
 
-The `list` command displays available models. By default, it shows all models. Use the `--downloaded` flag to filter for downloaded models only:
+The `list` command displays all models. By default, the output is partitioned into **Local** (downloaded) and **Available for Download** sections. You can restrict the output to only local models by passing the `--downloaded` flag:
 
 ```bash
 lemonade list [options]

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -387,27 +387,54 @@ int LemonadeClient::list_models(bool show_all, const std::string& name_filter) c
             return 0;
         }
 
-        std::cout << std::left << std::setw(40) << "Model Name"
-                  << std::setw(12) << "Downloaded"
-                  << "Details" << std::endl;
-        std::cout << std::string(100, '-') << std::endl;
+        // Helper lambda to print a formatted table of models.
+        auto print_model_table = [](const std::vector<ModelInfo>& models) {
+            std::cout << std::left << std::setw(40) << "Model Name"
+                      << std::setw(12) << "Downloaded"
+                      << "Details" << std::endl;
+            std::cout << std::string(100, '-') << std::endl;
 
-        // Model Name is the API id emitted verbatim by `/v1/models`. For each
-        // bare name, the precedence-winning source (registered > imported >
-        // builtin) shows as the bare name; any shadowed sources show as their
-        // canonical id (user.NAME / extra.NAME / builtin.NAME). Either form is
-        // valid input to `lemonade load`, `lemonade delete`, etc., so the
-        // column is always copy-paste-safe.
-        for (const auto& model : models) {
-            std::string downloaded = model.downloaded ? "Yes" : "No";
-            std::string details = model.recipe.empty() ? "-" : model.recipe;
+            // Model Name is the API id emitted verbatim by `/v1/models`. For each
+            // bare name, the precedence-winning source (registered > imported >
+            // builtin) shows as the bare name; any shadowed sources show as their
+            // canonical id (user.NAME / extra.NAME / builtin.NAME). Either form is
+            // valid input to `lemonade load`, `lemonade delete`, etc., so the
+            // column is always copy-paste-safe.
+            for (const auto& model : models) {
+                std::string downloaded = model.downloaded ? "Yes" : "No";
+                std::string details = model.recipe.empty() ? "-" : model.recipe;
 
-            std::cout << std::left << std::setw(40) << model.id
-                      << std::setw(12) << downloaded
-                      << details << std::endl;
+                std::cout << std::left << std::setw(40) << model.id
+                          << std::setw(12) << downloaded
+                          << details << std::endl;
+            }
+
+            std::cout << std::string(100, '-') << std::endl;
+        };
+
+        if (!show_all) {
+            print_model_table(models);
+            return 0;
         }
 
-        std::cout << std::string(100, '-') << std::endl;
+        std::vector<ModelInfo> local_models;
+        std::vector<ModelInfo> available_models;
+        for (const auto& model : models) {
+            if (model.downloaded) {
+                local_models.push_back(model);
+            } else {
+                available_models.push_back(model);
+            }
+        }
+
+        std::cout << "Local" << std::endl;
+        print_model_table(local_models);
+
+        std::cout << std::endl;
+
+        std::cout << "Available for Download" << std::endl;
+        print_model_table(available_models);
+
         return 0;
 
     } catch (const HttpError& e) {

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -428,12 +428,20 @@ int LemonadeClient::list_models(bool show_all, const std::string& name_filter) c
         }
 
         std::cout << "Local" << std::endl;
-        print_model_table(local_models);
+        if (local_models.empty()) {
+            std::cout << "No local models downloaded." << std::endl;
+        } else {
+            print_model_table(local_models);
+        }
 
         std::cout << std::endl;
 
         std::cout << "Available for Download" << std::endl;
-        print_model_table(available_models);
+        if (available_models.empty()) {
+            std::cout << "No models available for download." << std::endl;
+        } else {
+            print_model_table(available_models);
+        }
 
         return 0;
 

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -383,7 +383,7 @@ int LemonadeClient::list_models(bool show_all, const std::string& name_filter) c
             });
 
         if (models.empty()) {
-            std::cout << "No models available" << std::endl;
+            std::cout << (show_all ? "No models available" : "No local models downloaded.") << std::endl;
             return 0;
         }
 

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -1067,7 +1067,7 @@ int main(int argc, char* argv[]) {
     config_set_cmd->fallthrough(false);
 
     // Model commands
-    CLI::App* list_cmd = app.add_subcommand("list", "List available models")->group("Model management");
+    CLI::App* list_cmd = app.add_subcommand("list", "List available models. Use --downloaded to show only local models.")->group("Model management");
     CLI::App* pull_cmd = app.add_subcommand("pull",
         "Pull/download a model by registered name or Hugging Face checkpoint")->group("Model management");
     CLI::App* delete_cmd = app.add_subcommand("delete", "Delete a model")->group("Model management");

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -420,11 +420,17 @@ sys.exit(0)
         output_lines = output.splitlines()
         self.assertNotIn("Local", output_lines)
         self.assertNotIn("Available for Download", output_lines)
-        self.assertIn("Model Name", output)
-        self.assertIn("Downloaded", output)
-        self.assertIn("Details", output)
 
-        downloaded_models = self._parse_model_table(output)
+        # A fresh cache has no local models yet, so --downloaded may return
+        # the empty local-state message instead of a table.
+        if "No local models downloaded." in output:
+            downloaded_models = []
+        else:
+            self.assertIn("Model Name", output)
+            self.assertIn("Downloaded", output)
+            self.assertIn("Details", output)
+            downloaded_models = self._parse_model_table(output)
+
         for m in downloaded_models:
             self.assertTrue(
                 m["downloaded"],

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -28,6 +28,10 @@ import requests
 import shutil
 import subprocess
 import sys
+
+if sys.platform == "win32":
+    sys.stdout.reconfigure(errors="replace")
+    sys.stderr.reconfigure(errors="replace")
 import tempfile
 import time
 import unittest
@@ -342,12 +346,25 @@ sys.exit(0)
         result = self.assertCommandSucceeds(["list"])
         output = result.stdout + result.stderr
         print(f"List output: {output}")
+        output_lines = output.splitlines()
+        self.assertIn("Local", output_lines)
+        self.assertIn("Available for Download", output_lines)
+        self.assertLess(
+            output_lines.index("Local"),
+            output_lines.index("Available for Download"),
+        )
 
     def test_021_list_downloaded_flag(self):
         """Test list --downloaded flag."""
         result = self.assertCommandSucceeds(["list", "--downloaded"])
         output = result.stdout + result.stderr
         print(f"List --downloaded output: {output}")
+        output_lines = output.splitlines()
+        self.assertNotIn("Local", output_lines)
+        self.assertNotIn("Available for Download", output_lines)
+        self.assertIn("Model Name", output)
+        self.assertIn("Downloaded", output)
+        self.assertIn("Details", output)
 
     # =============================================================================
     # Export Tests

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -28,10 +28,6 @@ import requests
 import shutil
 import subprocess
 import sys
-
-if sys.platform == "win32":
-    sys.stdout.reconfigure(errors="replace")
-    sys.stderr.reconfigure(errors="replace")
 import tempfile
 import time
 import unittest
@@ -341,6 +337,41 @@ sys.exit(0)
     # List Tests
     # =============================================================================
 
+    def _section_between(self, output, start_header, end_header=None):
+        lines = output.splitlines()
+        self.assertIn(start_header, lines)
+
+        start = lines.index(start_header) + 1
+        end = (
+            lines.index(end_header)
+            if end_header and end_header in lines
+            else len(lines)
+        )
+
+        return "\n".join(lines[start:end])
+
+    def _parse_model_table(self, section_text):
+        parsed_models = []
+        for line in section_text.splitlines():
+            line = line.strip()
+            if (
+                not line
+                or line.startswith("Model Name")
+                or line.startswith("---")
+                or "No local models" in line
+                or "No models available" in line
+            ):
+                continue
+            parts = line.split()
+            if len(parts) >= 2:
+                name = parts[0]
+                downloaded = parts[1] == "Yes"
+                details = parts[2] if len(parts) > 2 else ""
+                parsed_models.append(
+                    {"name": name, "downloaded": downloaded, "details": details}
+                )
+        return parsed_models
+
     def test_020_list(self):
         """Test list command."""
         result = self.assertCommandSucceeds(["list"])
@@ -354,8 +385,35 @@ sys.exit(0)
             output_lines.index("Available for Download"),
         )
 
+        local_section = self._section_between(output, "Local", "Available for Download")
+        available_section = self._section_between(output, "Available for Download")
+
+        local_models = self._parse_model_table(local_section)
+        available_models = self._parse_model_table(available_section)
+
+        if not local_models:
+            self.assertIn("No local models downloaded.", local_section)
+        else:
+            for m in local_models:
+                self.assertTrue(
+                    m["downloaded"],
+                    f"Model {m['name']} in Local section should be downloaded (Yes)",
+                )
+
+        for m in available_models:
+            self.assertFalse(
+                m["downloaded"],
+                f"Model {m['name']} in Available for Download section should not be downloaded (No)",
+            )
+
     def test_021_list_downloaded_flag(self):
         """Test list --downloaded flag."""
+        # Get all models from the full list to know what's available vs downloaded
+        all_result = self.assertCommandSucceeds(["list"])
+        all_output = all_result.stdout + all_result.stderr
+        available_section = self._section_between(all_output, "Available for Download")
+        available_models = self._parse_model_table(available_section)
+
         result = self.assertCommandSucceeds(["list", "--downloaded"])
         output = result.stdout + result.stderr
         print(f"List --downloaded output: {output}")
@@ -365,6 +423,25 @@ sys.exit(0)
         self.assertIn("Model Name", output)
         self.assertIn("Downloaded", output)
         self.assertIn("Details", output)
+
+        downloaded_models = self._parse_model_table(output)
+        for m in downloaded_models:
+            self.assertTrue(
+                m["downloaded"],
+                f"Model {m['name']} in --downloaded list should be downloaded (Yes)",
+            )
+
+        non_downloaded_names = [
+            m["name"] for m in available_models if not m["downloaded"]
+        ]
+        if non_downloaded_names:
+            downloaded_names = [m["name"] for m in downloaded_models]
+            for name in non_downloaded_names:
+                self.assertNotIn(
+                    name,
+                    downloaded_names,
+                    f"Non-downloaded model {name} should not be in --downloaded list",
+                )
 
     # =============================================================================
     # Export Tests


### PR DESCRIPTION
## Background

`lemonade list` used to show local and not-yet-downloaded models in one table. That made the output harder to scan, especially for new users.

This change keeps the command simple but separates the output into two sections:

- `Local`
- `Available for Download`

`lemonade list --downloaded` still prints one flat table, so existing scripts and users who rely on that output are not affected.

## Changes

- Added sectioned output for the default `lemonade list` command.
- Kept the original table printing logic in one helper.
- Kept `lemonade list --downloaded` as a single flat table.
- Updated CLI help text for `list`.
- Added test assertions for the new section headers and the old `--downloaded` behavior.
- Updated `docs/guide/cli.md` to explain the new default output.

## Testing

```powershell
python -m py_compile test\server_cli2.py
```

## Documentation

`docs/guide/cli.md` now says that `lemonade list` shows two sections by default:

- `Local` for downloaded models
- `Available for Download` for models that can be pulled

It also keeps the existing guidance that `--downloaded` restricts the output to local models.

Fixes #2080
