### PR TITLE
docs: specify DEB generator for Linux package

### DIFF
--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -230,7 +230,7 @@ Creates `lemonade-server-minimal.msi` which:
 
 ```bash
 cd build
-cpack
+cpack -G DEB
 ```
 
 **Package Output:**


### PR DESCRIPTION
## Summary

This PR updates the Linux .deb packaging instructions to explicitly use:

```bash
cpack -G DEB
```

instead of:

```bash
cpack
```

## Background

When I tried to build a Debian package by following the current documentation, `cpack` alone did not generate a `.deb` package in my environment.

Because this section is specifically for Debian/Ubuntu `.deb` packages, I think explicitly specifying the DEB generator makes the instruction clearer and avoids relying on CPack's default generator behavior.

I hope this helps other users who may run into the same issue.
