### PR TITLE
CI: Limit distro builds to relevant changes

### DIFF
--- a/.github/workflows/linux_distro_builds.yml
+++ b/.github/workflows/linux_distro_builds.yml
@@ -4,7 +4,20 @@ on:
   push:
     branches: ["main"]
   pull_request:
-  merge_group:
+    paths:
+      - "CMakeLists.txt"
+      - "**/CMakeLists.txt"
+      - "CMakePresets.json"
+      - "cmake/**"
+      - "src/cpp/**"
+      - "setup.sh"
+      - "test/server_cli2.py"
+      - "test/server_endpoints.py"
+      - "test/requirements.txt"
+      - "test/utils/**"
+      - ".github/workflows/linux_distro_builds.yml"
+      - ".github/actions/capture-server-logs/**"
+      - "!**/*.md"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Reduce unnecessary Linux distro build CI runs by limiting PR triggers to build-related changes.

## Changes

* Keep Linux distro builds running on push to main.
* Keep workflow_dispatch so maintainers can run the workflow manually.
* Limit PR-triggered distro builds to relevant files, see lines changed

## Why

The distro build workflow is useful for validating Linux distribution compatibility, but it rarely catches legitimate issues on unrelated PRs and can produce false negatives.

This keeps the signal where it matters while avoiding CI noise for docs-only or unrelated changes.
