### PR TITLE
ci: set HF_HOME before starting hosted Linux server

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1445,6 +1445,7 @@ jobs:
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
+      HF_HOME: ${{ github.workspace }}/hf-cache
       PYTHONIOENCODING: utf-8
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       LEMONADE_VERSION: ${{ needs.build-lemonade-deb.outputs.version }}
@@ -1468,15 +1469,15 @@ jobs:
           .venv/bin/pip install --upgrade pip
           .venv/bin/pip install -r test/requirements.txt
 
-      - name: Set environment
+      - name: Prepare HF cache
         id: setup
         shell: bash
         run: |
-          # HF_HOME must be set before install-lemonade-deb starts lemond.
-          # Values written to GITHUB_ENV are available to later steps/actions.
-          HF_HOME="$PWD/hf-cache"
+          set -e
+          # HF_HOME is job-level env so install-lemonade-deb and the lemond
+          # process it starts inherit the same cache path.
           mkdir -p "$HF_HOME"
-          echo "HF_HOME=$HF_HOME" >> "$GITHUB_ENV"
+          echo "HF_HOME=$HF_HOME"
 
       - name: Install Lemonade (.deb)
         uses: ./.github/actions/install-lemonade-deb

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1468,16 +1468,20 @@ jobs:
           .venv/bin/pip install --upgrade pip
           .venv/bin/pip install -r test/requirements.txt
 
-      - name: Install Lemonade (.deb)
-        uses: ./.github/actions/install-lemonade-deb
-        with:
-          version: ${{ env.LEMONADE_VERSION }}
-
       - name: Set environment
         id: setup
         shell: bash
         run: |
-          echo "HF_HOME=$PWD/hf-cache" >> $GITHUB_ENV
+          # HF_HOME must be set before install-lemonade-deb starts lemond.
+          # Values written to GITHUB_ENV are available to later steps/actions.
+          HF_HOME="$PWD/hf-cache"
+          mkdir -p "$HF_HOME"
+          echo "HF_HOME=$HF_HOME" >> "$GITHUB_ENV"
+
+      - name: Install Lemonade (.deb)
+        uses: ./.github/actions/install-lemonade-deb
+        with:
+          version: ${{ env.LEMONADE_VERSION }}
 
       # All test scripts run in one job so they share a single setup and model
       # cache (issue #2103). Each step runs even if an earlier test failed


### PR DESCRIPTION
## Summary

Move the hosted Linux HF_HOME setup before the .deb install action starts `lemond`.

## Why

The .deb install action starts the server as part of installation. In the consolidated hosted Linux job, HF_HOME was being written to $GITHUB_ENV only after that action completed, so the running `lemond` process did not inherit the intended job-local HF cache path.

This meant model downloads from the server process could still use the default cache location instead of the shared per-job `hf-cache`.

## Changes

- Move the `Set environment` step before `Install Lemonade (.deb)`.
- Create the `hf-cache` directory before server startup.
- Keep the existing step id so later test-step gating remains unchanged.

## Scope

This is a small follow-up to the CI consolidation work. It does not change test coverage, model selection, or server code.