### PR TITLE
ci / test: fix the 409 CI error

### DIFF
--- a/test/server_streaming_errors.py
+++ b/test/server_streaming_errors.py
@@ -73,16 +73,20 @@ class StreamingErrorTests(ServerTestBase):
             if attempt > 1:
                 time.sleep(2 * attempt)
 
-            # Start each attempt from a clean loaded-model state. Ignore unload
-            # failures here; the following /load response is the real setup signal.
-            try:
-                requests.post(
-                    f"http://localhost:{PORT}/api/v1/unload",
-                    json={},
-                    timeout=TIMEOUT_DEFAULT,
-                )
-            except requests.RequestException as exc:
-                print(f"Warning: unload before load attempt {attempt} failed: {exc}")
+                # On retries, recover from a potentially bad setup state before
+                # loading again. The first attempt intentionally avoids /unload
+                # so an already-loaded model can remain a cheap /load no-op.
+                try:
+                    requests.post(
+                        f"http://localhost:{PORT}/api/v1/unload",
+                        json={},
+                        timeout=TIMEOUT_DEFAULT,
+                    )
+                except requests.RequestException as exc:
+                    print(
+                        f"Warning: unload before load retry attempt {attempt} "
+                        f"failed: {exc}"
+                    )
 
             load_resp = requests.post(
                 f"http://localhost:{PORT}/api/v1/load",
@@ -91,7 +95,7 @@ class StreamingErrorTests(ServerTestBase):
             )
 
             if load_resp.status_code in [200, 409]:
-                return load_resp
+                return
 
             last_status = load_resp.status_code
             last_body = load_resp.text[:1000]
@@ -100,7 +104,7 @@ class StreamingErrorTests(ServerTestBase):
                 print(
                     f"Transient /load setup failure for {ENDPOINT_TEST_MODEL}: "
                     f"status={load_resp.status_code}, attempt={attempt}/{attempts}. "
-                    "Retrying after clean unload..."
+                    "Retrying after unload recovery..."
                 )
                 continue
 

--- a/test/server_streaming_errors.py
+++ b/test/server_streaming_errors.py
@@ -9,6 +9,8 @@ Usage:
     python server_streaming_errors.py --cli-binary /path/to/lemonade
 """
 
+import time
+
 import requests
 
 from utils.server_base import ServerTestBase, run_server_tests
@@ -57,6 +59,58 @@ class StreamingErrorTests(ServerTestBase):
             self.fail(f"Stream not properly terminated (sink.done() missing?): {exc}")
         return lines
 
+    def _ensure_test_model_loaded(self, attempts=3):
+        """Load ENDPOINT_TEST_MODEL with bounded retry for transient setup failures.
+
+        These tests are about streaming response termination, not /load reliability.
+        A transient 5xx during setup gets a clean retry; persistent failures still
+        fail the test with the response status/body for diagnosis.
+        """
+        last_status = None
+        last_body = ""
+
+        for attempt in range(1, attempts + 1):
+            if attempt > 1:
+                time.sleep(2 * attempt)
+
+            # Start each attempt from a clean loaded-model state. Ignore unload
+            # failures here; the following /load response is the real setup signal.
+            try:
+                requests.post(
+                    f"http://localhost:{PORT}/api/v1/unload",
+                    json={},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except requests.RequestException as exc:
+                print(f"Warning: unload before load attempt {attempt} failed: {exc}")
+
+            load_resp = requests.post(
+                f"http://localhost:{PORT}/api/v1/load",
+                json={"model_name": ENDPOINT_TEST_MODEL},
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+
+            if load_resp.status_code in [200, 409]:
+                return load_resp
+
+            last_status = load_resp.status_code
+            last_body = load_resp.text[:1000]
+
+            if load_resp.status_code >= 500 and attempt < attempts:
+                print(
+                    f"Transient /load setup failure for {ENDPOINT_TEST_MODEL}: "
+                    f"status={load_resp.status_code}, attempt={attempt}/{attempts}. "
+                    "Retrying after clean unload..."
+                )
+                continue
+
+            break
+
+        self.fail(
+            f"Failed to load {ENDPOINT_TEST_MODEL} for streaming-error test setup "
+            f"after {attempts} attempt(s). Last status={last_status}, body={last_body}"
+        )
+
     def test_001_nonexistent_model_stream_terminates_cleanly(self):
         """Streaming request for a model not in the catalog terminates cleanly."""
         response = self._post_streaming("NonExistentModel-XYZ-DoesNotExist-12345")
@@ -91,12 +145,7 @@ class StreamingErrorTests(ServerTestBase):
         HTTP response, llama.cpp returns 400 (prompt exceeds n_ctx), and without
         the fix sink.done() is never called, leaving the stream open.
         """
-        load_resp = requests.post(
-            f"http://localhost:{PORT}/api/v1/load",
-            json={"model_name": ENDPOINT_TEST_MODEL},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        self.assertIn(load_resp.status_code, [200, 409])
+        self._ensure_test_model_loaded()
 
         # ~5 000 tokens — well above the 2048-token context of Tiny-Test-Model-GGUF
         overflow_prompt = "The quick brown fox jumps over the lazy dog. " * 600
@@ -111,6 +160,8 @@ class StreamingErrorTests(ServerTestBase):
 
     def test_005_streaming_with_many_tools_terminates_cleanly(self):
         """Streaming with 15 tools terminates cleanly (original bug report scenario)."""
+        self._ensure_test_model_loaded()
+
         many_tools = [
             {
                 "type": "function",
@@ -151,12 +202,7 @@ class StreamingErrorTests(ServerTestBase):
 
     def test_006_successful_stream_includes_done_marker(self):
         """Successful streaming response includes [DONE] and terminates cleanly."""
-        load_resp = requests.post(
-            f"http://localhost:{PORT}/api/v1/load",
-            json={"model_name": ENDPOINT_TEST_MODEL},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        self.assertIn(load_resp.status_code, [200, 409])
+        self._ensure_test_model_loaded()
 
         response = self._post_streaming(
             ENDPOINT_TEST_MODEL,


### PR DESCRIPTION
## Summary

Make server_streaming_errors.py more resilient to transient /load setup failures.

## Why

The streaming error tests are meant to verify that streaming responses terminate cleanly. A transient 5xx from the setup /load call could fail the test before the actual streaming behavior was exercised.

## Changes

* Add a small helper to load ENDPOINT_TEST_MODEL with bounded retry.
* Treat 200 and 409 setup responses as already-loaded / successfully-loaded states.
* Retry transient 5xx setup failures with /unload recovery before retry attempts.
* Avoid forcing /unload on the first attempt so an already-loaded model can remain a cheap /load no-op.
* Keep persistent failures visible with status code and response body.
* Use the helper in the streaming tests that require the model to be loaded.

## Scope

This does not relax the streaming assertions. The tests still fail if the stream does not terminate cleanly or if a successful stream does not include [DONE].
