### PR TITLE
Fix light theme persistence

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -12,7 +12,8 @@
     "build": "tauri build",
     "build:nobundle": "tauri build --no-bundle",
     "build:mac": "tauri build --bundles app",
-    "test:custom-collections": "node ../../test/app/customCollections.test.cjs"
+    "test:custom-collections": "node ../../test/app/customCollections.test.cjs",
+    "test:app-settings": "node ../../test/app/appSettings.test.cjs"
   },
   "keywords": [
     "tauri",

--- a/src/app/src-tauri/src/settings.rs
+++ b/src/app/src-tauri/src/settings.rs
@@ -26,8 +26,17 @@ fn default_repeat_penalty() -> f64 {
     1.1
 }
 
+fn default_theme() -> String {
+    "dark".to_string()
+}
+
+fn is_valid_theme(v: &str) -> bool {
+    matches!(v, "dark" | "light")
+}
+
 fn default_layout() -> LayoutSettings {
     LayoutSettings {
+        theme: default_theme(),
         is_chat_visible: true,
         is_model_manager_visible: true,
         left_panel_view: "models".to_string(),
@@ -83,6 +92,8 @@ pub struct TypedSetting {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LayoutSettings {
+    #[serde(default = "default_theme")]
+    pub theme: String,
     pub is_chat_visible: bool,
     pub is_model_manager_visible: bool,
     // Renderer-side type is a string union: 'models' | 'marketplace' | 'backends' | 'settings'.
@@ -262,6 +273,12 @@ pub(crate) fn sanitize_app_settings(incoming: &Value) -> AppSettings {
                 *slot = v;
             }
         };
+        if let Some(theme) = raw_layout.get("theme").and_then(Value::as_str) {
+            if is_valid_theme(theme) {
+                s.layout.theme = theme.to_string();
+            }
+        }
+
         set_bool("isChatVisible", &mut s.layout.is_chat_visible);
         set_bool("isModelManagerVisible", &mut s.layout.is_model_manager_visible);
         set_bool("isLogsVisible", &mut s.layout.is_logs_visible);
@@ -405,6 +422,7 @@ mod tests {
                 "enableUserTTS": { "value": true, "useDefault": false },
             },
             "layout": {
+                "theme": "light",
                 "isChatVisible": true,
                 "isModelManagerVisible": true,
                 "leftPanelView": "marketplace",
@@ -437,6 +455,11 @@ mod tests {
             Some("marketplace"),
             "leftPanelView round-trip"
         );
+        assert_eq!(
+            layout.get("theme").and_then(|v| v.as_str()),
+            Some("light"),
+            "theme round-trip"
+        );
         assert!(
             !layout.contains_key("isMarketplaceVisible"),
             "stale isMarketplaceVisible field leaked"
@@ -456,5 +479,14 @@ mod tests {
         });
         let sanitized = sanitize_app_settings(&incoming);
         assert_eq!(sanitized.layout.left_panel_view, "models", "fell back to default");
+    }
+
+    #[test]
+    fn theme_rejects_unknown_values() {
+        let incoming = json!({
+            "layout": { "theme": "neon-pink" }
+        });
+        let sanitized = sanitize_app_settings(&incoming);
+        assert_eq!(sanitized.layout.theme, "dark", "fell back to default");
     }
 }

--- a/src/app/src/renderer/utils/appSettings.ts
+++ b/src/app/src/renderer/utils/appSettings.ts
@@ -236,6 +236,9 @@ export const mergeWithDefaultSettings = (incoming?: Partial<AppSettings>): AppSe
   // Merge layout settings
   const rawLayout = incoming.layout;
   if (rawLayout && typeof rawLayout === 'object') {
+    if (rawLayout.theme === 'dark' || rawLayout.theme === 'light') {
+      defaults.layout.theme = rawLayout.theme;
+    }
     // Merge boolean visibility settings
     if (typeof rawLayout.isChatVisible === 'boolean') {
       defaults.layout.isChatVisible = rawLayout.isChatVisible;

--- a/test/app/appSettings.test.cjs
+++ b/test/app/appSettings.test.cjs
@@ -1,0 +1,85 @@
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith('npm_') || key === 'INIT_CWD') {
+    delete process.env[key];
+  }
+}
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const appRoot = path.resolve(__dirname, '..', '..', 'src', 'app');
+let ts;
+try {
+  ts = require(path.join(appRoot, 'node_modules', 'typescript'));
+} catch (_) {
+  ts = require('typescript');
+}
+
+const originalTsLoader = require.extensions['.ts'];
+
+require.extensions['.ts'] = function loadTypeScript(module, filename) {
+  const source = fs.readFileSync(filename, 'utf8');
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      module: ts.ModuleKind.CommonJS,
+      moduleResolution: ts.ModuleResolutionKind.NodeJs,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: filename,
+  }).outputText;
+  module._compile(output, filename);
+};
+
+const appSettingsPath = path.join(appRoot, 'src', 'renderer', 'utils', 'appSettings.ts');
+const { mergeWithDefaultSettings } = require(appSettingsPath);
+
+if (originalTsLoader) {
+  require.extensions['.ts'] = originalTsLoader;
+} else {
+  delete require.extensions['.ts'];
+}
+
+const tests = [];
+
+function defineTest(name, fn) {
+  tests.push({ name, fn });
+}
+
+defineTest('mergeWithDefaultSettings preserves light theme', () => {
+  const settings = mergeWithDefaultSettings({
+    layout: {
+      theme: 'light',
+    },
+  });
+
+  assert.equal(settings.layout.theme, 'light');
+});
+
+defineTest('mergeWithDefaultSettings rejects invalid theme', () => {
+  const settings = mergeWithDefaultSettings({
+    layout: {
+      theme: 'neon-pink',
+    },
+  });
+
+  assert.equal(settings.layout.theme, 'dark');
+});
+
+let failures = 0;
+
+for (const { name, fn } of tests) {
+  try {
+    fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    failures += 1;
+    console.error(`not ok - ${name}`);
+    console.error(error);
+  }
+}
+
+if (failures > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Fixes #2120.

This change keeps the selected Light theme after refresh or reopen.

The app was already saving a `theme` value, but the settings load/save code did not keep that value when it rebuilt the settings object. This caused the app to fall back to the default Dark theme.

This PR preserves valid theme values: `dark` and `light`.

Tests:
- npm run build:renderer
