### PR TITLE
test: retry transient model pull setup failures

### DIFF
--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -24,6 +24,7 @@ import glob
 import json
 import os
 import platform
+import re
 import requests
 import shutil
 import subprocess
@@ -199,6 +200,62 @@ def run_cli_command(args, timeout=60, check=False, env=None, input_text=None):
         )
 
     return result
+
+
+def _is_transient_cli_pull_failure(result):
+    """Return True when a failed CLI pull looks like a transient server/HF issue."""
+    if result.returncode == 0:
+        return False
+
+    output = f"{result.stdout or ''}\n{result.stderr or ''}".lower()
+    transient_statuses = {408, 409, 429, 500, 502, 503, 504}
+    observed_statuses = {
+        int(match)
+        for match in re.findall(r"(?:status\s*[:=]|http\s*)(\d{3})", output)
+    }
+
+    if observed_statuses.intersection(transient_statuses):
+        return True
+
+    return (
+        "too many requests" in output
+        or "rate limit" in output
+        or "temporarily unavailable" in output
+        or "connection reset" in output
+        or "connection aborted" in output
+        or "connection refused" in output
+        or "timed out" in output
+        or "timeout" in output
+    )
+
+
+def run_cli_pull_command_with_retry(args, timeout=TIMEOUT_MODEL_OPERATION, attempts=3):
+    """Run a CLI pull command with bounded retry for transient setup failures.
+
+    The command still has to succeed with exit code 0. This only retries failures
+    that look transient, such as HF rate limits or temporary server/network errors.
+    """
+    last_result = None
+
+    for attempt in range(1, attempts + 1):
+        if attempt > 1:
+            time.sleep(min(30, 2 ** (attempt - 1)))
+
+        result = run_cli_command(args, timeout=timeout)
+        if result.returncode == 0:
+            return result
+
+        last_result = result
+        if _is_transient_cli_pull_failure(result) and attempt < attempts:
+            print(
+                f"Transient CLI pull failure, attempt {attempt}/{attempts}. "
+                "Retrying..."
+            )
+            continue
+
+        break
+
+    return last_result
 
 
 class PersistentServerCLIClientTests(unittest.TestCase):
@@ -575,7 +632,7 @@ sys.exit(0)
 
     def test_050_pull_with_checkpoint(self):
         """Test pull command with --checkpoint option."""
-        result = run_cli_command(
+        result = run_cli_pull_command_with_retry(
             [
                 "pull",
                 USER_MODEL_NAME,
@@ -591,7 +648,7 @@ sys.exit(0)
 
     def test_051_pull_with_labels(self):
         """Test pull command with --label option."""
-        result = run_cli_command(
+        result = run_cli_pull_command_with_retry(
             [
                 "pull",
                 USER_MODEL_NAME,
@@ -634,7 +691,7 @@ sys.exit(0)
 
     def test_053_pull_with_multiple_checkpoints(self):
         """Test pull command with multiple checkpoints (e.g., main + mmproj)."""
-        result = run_cli_command(
+        result = run_cli_pull_command_with_retry(
             [
                 "pull",
                 USER_MODEL_NAME,
@@ -653,9 +710,14 @@ sys.exit(0)
 
     def test_054_pull_registered_name(self):
         """Test pull command with a registered model name (no flags)."""
-        result = self.assertCommandSucceeds(
+        result = run_cli_pull_command_with_retry(
             ["pull", ENDPOINT_TEST_MODEL],
             timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Command failed with exit code {result.returncode}: {result.stderr}",
         )
         output = result.stdout.lower() + result.stderr.lower()
         self.assertFalse(
@@ -669,7 +731,7 @@ sys.exit(0)
         # Unique user.<name> entries surface under the bare public name.
         public_name = collection_name[5:]
         try:
-            result = self.assertCommandSucceeds(
+            result = run_cli_pull_command_with_retry(
                 [
                     "pull",
                     collection_name,
@@ -679,6 +741,11 @@ sys.exit(0)
                     ENDPOINT_TEST_MODEL,
                 ],
                 timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"Command failed with exit code {result.returncode}: {result.stderr}",
             )
             output = result.stdout.lower() + result.stderr.lower()
             self.assertFalse(

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -33,6 +33,7 @@ from utils.server_base import (
     ServerTestBase,
     run_server_tests,
     OpenAI,
+    pull_model_with_retry,
 )
 from utils.test_models import (
     PORT,
@@ -68,16 +69,9 @@ class EndpointTests(ServerTestBase):
             return
 
         print(f"\n[SETUP] Ensuring {ENDPOINT_TEST_MODEL} is pulled...")
-        response = requests.post(
-            f"http://localhost:{PORT}/api/v1/pull",
-            json={"model_name": ENDPOINT_TEST_MODEL},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        if response.status_code == 200:
-            print(f"[SETUP] {ENDPOINT_TEST_MODEL} is ready")
-            cls._model_pulled = True
-        else:
-            print(f"[SETUP] Warning: pull returned {response.status_code}")
+        pull_model_with_retry(ENDPOINT_TEST_MODEL)
+        print(f"[SETUP] {ENDPOINT_TEST_MODEL} is ready")
+        cls._model_pulled = True
 
     def setUp(self):
         """Set up each test."""

--- a/test/server_omni.py
+++ b/test/server_omni.py
@@ -33,6 +33,7 @@ from utils.server_base import (
     run_server_tests,
     requests,
     PORT,
+    pull_model_with_retry,
 )
 from utils.capabilities import (
     skip_if_unsupported,
@@ -102,16 +103,9 @@ class OmniTests(ServerTestBase):
 
         model = get_test_model("omni")
         print(f"\n[SETUP] Ensuring {model} and its components are pulled...")
-        response = requests.post(
-            f"http://localhost:{PORT}/api/v1/pull",
-            json={"model_name": model},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        if response.status_code == 200:
-            print(f"[SETUP] {model} is ready")
-            cls._model_pulled = True
-        else:
-            print(f"[SETUP] Warning: pull returned {response.status_code}")
+        pull_model_with_retry(model)
+        print(f"[SETUP] {model} is ready")
+        cls._model_pulled = True
 
     @staticmethod
     def _solid_color_png_data_uri(r, g, b, size=256):

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -26,6 +26,7 @@ from utils.server_base import (
     get_cli_binary,
     parse_args,
     PORT,
+    pull_model_with_retry,
     set_server_config,
     wait_for_server,
 )
@@ -325,15 +326,7 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
         if cls._model_pulled:
             return
 
-        response = requests.post(
-            f"http://localhost:{PORT}/api/v1/pull",
-            json={"model_name": ENDPOINT_TEST_MODEL},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        if response.status_code != 200:
-            raise AssertionError(
-                f"Expected 200 from /api/v1/pull, got {response.status_code}"
-            )
+        pull_model_with_retry(ENDPOINT_TEST_MODEL)
         cls._model_pulled = True
 
     @unittest.skipUnless(

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -184,24 +184,39 @@ def unload_all_models(port=PORT):
     return response
 
 
+def _is_transient_pull_status(status_code):
+    return status_code in {408, 409, 429, 500, 502, 503, 504}
+
+
 def pull_model_with_retry(model_name, attempts=3, port=PORT):
     """Pull a model with bounded retry for transient setup failures.
 
-    Test setup should tolerate one-off transient 5xx failures, but persistent
+    Test setup should tolerate one-off transient pull failures, but persistent
     failures and permanent client errors should still fail with useful details.
     """
     last_status = None
     last_body = ""
+    last_error = None
 
     for attempt in range(1, attempts + 1):
         if attempt > 1:
-            time.sleep(2 * attempt)
+            time.sleep(min(30, 2 ** (attempt - 1)))
 
-        response = requests.post(
-            f"http://localhost:{port}/api/v1/pull",
-            json={"model_name": model_name},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
+        try:
+            response = requests.post(
+                f"http://localhost:{port}/api/v1/pull",
+                json={"model_name": model_name},
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+        except requests.RequestException as exc:
+            last_error = exc
+            if attempt < attempts:
+                print(
+                    f"Transient /pull setup request failure for {model_name}: "
+                    f"{exc} (attempt {attempt}/{attempts}). Retrying..."
+                )
+                continue
+            break
 
         if response.status_code == 200:
             return response
@@ -209,7 +224,7 @@ def pull_model_with_retry(model_name, attempts=3, port=PORT):
         last_status = response.status_code
         last_body = response.text[:1000]
 
-        if response.status_code >= 500 and attempt < attempts:
+        if _is_transient_pull_status(response.status_code) and attempt < attempts:
             print(
                 f"Transient /pull setup failure for {model_name}: "
                 f"status={response.status_code}, attempt={attempt}/{attempts}. "
@@ -218,6 +233,12 @@ def pull_model_with_retry(model_name, attempts=3, port=PORT):
             continue
 
         break
+
+    if last_error is not None and last_status is None:
+        raise AssertionError(
+            f"Expected 200 from /api/v1/pull for {model_name} after "
+            f"{attempts} attempt(s), last request failed with: {last_error}"
+        )
 
     raise AssertionError(
         f"Expected 200 from /api/v1/pull for {model_name} after "

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -184,6 +184,47 @@ def unload_all_models(port=PORT):
     return response
 
 
+def pull_model_with_retry(model_name, attempts=3, port=PORT):
+    """Pull a model with bounded retry for transient setup failures.
+
+    Test setup should tolerate one-off transient 5xx failures, but persistent
+    failures and permanent client errors should still fail with useful details.
+    """
+    last_status = None
+    last_body = ""
+
+    for attempt in range(1, attempts + 1):
+        if attempt > 1:
+            time.sleep(2 * attempt)
+
+        response = requests.post(
+            f"http://localhost:{port}/api/v1/pull",
+            json={"model_name": model_name},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        if response.status_code == 200:
+            return response
+
+        last_status = response.status_code
+        last_body = response.text[:1000]
+
+        if response.status_code >= 500 and attempt < attempts:
+            print(
+                f"Transient /pull setup failure for {model_name}: "
+                f"status={response.status_code}, attempt={attempt}/{attempts}. "
+                "Retrying..."
+            )
+            continue
+
+        break
+
+    raise AssertionError(
+        f"Expected 200 from /api/v1/pull for {model_name} after "
+        f"{attempts} attempt(s), got {last_status}. Body: {last_body}"
+    )
+
+
 def _build_runtime_config(additional_server_args=None):
     """
     Translate CLI args (--wrapped-server, --backend, additional_server_args)
@@ -413,6 +454,7 @@ __all__ = [
     "wait_for_server",
     "set_server_config",
     "unload_all_models",
+    "pull_model_with_retry",
     "run_server_tests",
     "OpenAI",
     "AsyncOpenAI",


### PR DESCRIPTION
## Summary

Retry transient model /pull setup failures in server tests.

## Why

Several tests use /api/v1/pull only as setup before checking unrelated behavior. A one-off transient 5xx from /pull could fail the test before the actual assertion was exercised.

## Changes

- Add shared `pull_model_with_retry()` test helper.
- Retry transient 5xx pull setup failures with bounded backoff.
- Use the helper in endpoint, omni, and llama.cpp system backend tests.
- Keep permanent errors and persistent failures visible with status/body details.

## Scope

This does not relax the actual test assertions. It only makes model-pull setup more resilient to transient server/download failures.