### PR TITLE
auto-label: teach prompt about area::ci + test coverage ≠ documentation

### DIFF
--- a/.github/scripts/auto_label.py
+++ b/.github/scripts/auto_label.py
@@ -54,6 +54,7 @@ Area — apply AT MOST ONE total. Same hard rule as engines. Skip if not clearly
 - area::installer — Windows MSI, macOS DMG, Debian / RPM packaging
 - area::api       — HTTP REST API surface, route handlers, Ollama/Anthropic/OpenAI compat
 - area::tray      — system tray app (LemonadeServer.exe, lemonade-tray)
+- area::ci        — CI / GitHub Actions workflows, self-hosted runner infrastructure, test infrastructure (e.g. fixtures, harness, CI cleanup)
 
 Runtime — apply AT MOST ONE total. Same hard rule. Skip if the item is not specific to a particular GPU/compute runtime. Runtime labels complement engine labels — e.g., a Vulkan-only llama.cpp bug gets both `engine::llamacpp` and `runtime::vulkan`:
 - runtime::vulkan — Vulkan path (typically llama.cpp on AMD/Intel/Nvidia GPUs)
@@ -77,6 +78,12 @@ Rules:
   endpoint, or mention multiple components — that's not enough to apply
   `area::cli`, `area::api`, `audio`, etc. Apply those only when the bug
   or feature is in that surface itself.
+- `documentation` is for human-readable docs only — READMEs, user
+  guides, installation instructions, doc-comments. Items about test
+  coverage, missing tests, test infrastructure, or test harness
+  changes are `enhancement` (or `bug` if the test itself is broken),
+  NEVER `documentation`. Same goes for items about adding examples
+  to the test suite vs adding examples to a user guide.
 - Be conservative. If unclear, omit the label. It is much better to
   under-label than to mislabel.
 - Skip labels the item already has.
@@ -167,6 +174,7 @@ KNOWN_LABELS = {
     "area::installer",
     "area::api",
     "area::tray",
+    "area::ci",
     "runtime::vulkan",
     "runtime::rocm",
     "runtime::cuda",


### PR DESCRIPTION
Follow-up to #2076.

After running the first backfill of open items via #2076's workflow, two small gaps showed up in the prompt:

## 1. CI / infrastructure items had no label

Four open items (#2116, #2037, #1960, plus one more on the website side) were about CI workflows, runner cleanup, or test infrastructure. None of `area::cli`, `area::installer`, `area::api`, `area::tray` fit, so the model returned `(none)`.

This PR:
- Adds `area::ci` to the `Area` block of `SYSTEM_PROMPT` with explicit coverage for: CI / GitHub Actions workflows, self-hosted runner infrastructure, and test infrastructure (fixtures, harness, CI cleanup).
- Adds `"area::ci"` to `KNOWN_LABELS` so the parser admits it. The `area::ci` label already exists on the repo (created out-of-band during the backfill triage).
- Verified the at-most-one-`area::` rule still applies: `area::ci, area::api` → just `area::ci` passes through; `area::ci` against an existing `area::*` is dropped.

## 2. `documentation` was over-applied to test-coverage items

The model labeled #2032 and #2040 with `documentation` even though they were a quality bug and a test-coverage gap respectively. The connection seems to be the model treating "documents the missing coverage" or "missing test docs" loosely.

This PR adds an explicit rule to the prompt:

> `documentation` is for human-readable docs only — READMEs, user guides, installation instructions, doc-comments. Items about test coverage, missing tests, test infrastructure, or test harness changes are `enhancement` (or `bug` if the test itself is broken), NEVER `documentation`.

## Test plan / rollout

What this PR exercises automatically vs what needs a manual nudge (h/t @fl0rianr for catching that the original wording was wrong):

| Trigger | LLM runs? | Re-labels existing `(none)` items? |
|---|---|---|
| `issues.opened` / `pull_request_target.opened` | ✓ | Only for *new* items going forward |
| `issue_comment.created` | ✗ priority-only | No |
| `schedule` daily cron | ✗ priority-only | No |
| `workflow_dispatch -f mode=all` | ✓ | **Yes** — the post-merge action |

- [x] Local parser verification — 5 cases covering `area::ci` admission, at-most-one-`area::` enforcement, and co-occurrence with engine + type labels.
- [ ] **After merge**, dispatch a fresh backfill with `gh workflow run auto-label.yml -f dry_run=true -f mode=all` to preview re-classification of items currently at `(none)`. The backfill filter already excludes items with `engine::/area::`, so this only touches items that the previous backfill skipped.
- [ ] After review of the dry-run decisions, dispatch with `-f dry_run=false -f mode=all` to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)