### PR TITLE
auto update and validate sd-cpp

### DIFF
--- a/.github/scripts/update_sdcpp_versions.py
+++ b/.github/scripts/update_sdcpp_versions.py
@@ -18,7 +18,7 @@ from typing import Iterable
 
 SDCPP_RELEASE_RE = re.compile(r"^master-[0-9]+-[0-9a-f]{7,40}$")
 DEFAULT_BACKENDS = ("cpu", "vulkan", "rocm-stable", "metal", "cuda")
-FORBIDDEN_BACKENDS = {"rocm-nightly", "rocm-nighly"}
+FORBIDDEN_BACKENDS = {"rocm-nightly"}
 
 
 def parse_csv(value: str) -> list[str]:

--- a/.github/scripts/update_sdcpp_versions.py
+++ b/.github/scripts/update_sdcpp_versions.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Update Lemonade's pinned stable-diffusion.cpp backend versions.
+
+The stable-diffusion.cpp release tags used by Lemonade look like
+``master-684-138da14``. This updater is intentionally narrow: it updates only
+existing sd-cpp backend keys in backend_versions.json, rejects nightly aliases,
+and does not create new keys.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Iterable
+
+
+SDCPP_RELEASE_RE = re.compile(r"^master-[0-9]+-[0-9a-f]{7,40}$")
+DEFAULT_BACKENDS = ("cpu", "vulkan", "rocm-stable", "metal", "cuda")
+FORBIDDEN_BACKENDS = {"rocm-nightly", "rocm-nighly"}
+
+
+def parse_csv(value: str) -> list[str]:
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    if not items:
+        raise argparse.ArgumentTypeError("backend list must not be empty")
+    return items
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--release",
+        required=True,
+        help="stable-diffusion.cpp release tag, e.g. master-684-138da14",
+    )
+    parser.add_argument(
+        "--path",
+        default="src/cpp/resources/backend_versions.json",
+        help="Path to backend_versions.json",
+    )
+    parser.add_argument(
+        "--backends",
+        type=parse_csv,
+        default=list(DEFAULT_BACKENDS),
+        help=(
+            "Comma-separated existing sd-cpp backend keys to update. "
+            "Default: cpu,vulkan,rocm-stable,metal,cuda. rocm-nightly is rejected."
+        ),
+    )
+    return parser.parse_args()
+
+
+def validate_backends(requested: Iterable[str], section: dict[str, object]) -> list[str]:
+    keys: list[str] = []
+    seen: set[str] = set()
+    for key in requested:
+        if key in seen:
+            continue
+        seen.add(key)
+        if key in FORBIDDEN_BACKENDS:
+            raise SystemExit("Refusing to update or create sd-cpp.rocm-nightly")
+        if key not in section:
+            raise SystemExit(
+                f"Refusing to create missing sd-cpp.{key}; only existing backend keys may be updated."
+            )
+        value = section[key]
+        if not isinstance(value, str):
+            raise SystemExit(f"sd-cpp.{key} must be a string in backend_versions.json")
+        keys.append(key)
+    return keys
+
+
+def main() -> int:
+    args = parse_args()
+    release = args.release.strip()
+    if not SDCPP_RELEASE_RE.match(release):
+        raise SystemExit(
+            f"Invalid stable-diffusion.cpp release tag '{release}'. "
+            "Expected format like master-684-138da14."
+        )
+
+    path = Path(args.path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if "sd-cpp" not in data or not isinstance(data["sd-cpp"], dict):
+        raise SystemExit("backend_versions.json is missing an sd-cpp object")
+
+    section: dict[str, object] = data["sd-cpp"]
+    backends = validate_backends(args.backends, section)
+
+    old = {key: section[key] for key in backends}
+    for key in backends:
+        section[key] = release
+
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    print("Updated sd-cpp backend versions:")
+    for key in backends:
+        print(f"  sd-cpp.{key}: {old[key]} -> {release}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -37,6 +37,7 @@ env:
   HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
   LITE_MODE: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.lite == true) }}
   SDCPP_REPO: leejet/stable-diffusion.cpp
+  SDCPP_CUDA_REPO: lemonade-sdk/stable-diffusion.cpp
   # Update only existing sd-cpp pins. Do not add/touch rocm-nightly.
   SDCPP_UPDATE_BACKENDS: cpu,vulkan,rocm-stable,metal,cuda
   SDCPP_TEST_PROMPT: "A small glass of lemonade on a clean table, product photo, high detail"
@@ -115,6 +116,17 @@ jobs:
           gh api repos/${SDCPP_REPO}/releases/tags/${RELEASE} --jq '.assets[].name' | sort > assets.txt
           cat assets.txt
 
+          # CUDA validation is disabled until a CUDA runner exists. Keep the CUDA
+          # asset probe non-blocking, but use the real CUDA artifact names from
+          # lemonade-sdk/stable-diffusion.cpp: windows-cuda and ubuntu-cuda.
+          if gh api repos/${SDCPP_CUDA_REPO}/releases/tags/${RELEASE} --jq '.assets[].name' | sort > cuda-assets.txt 2>/dev/null; then
+            echo "CUDA release assets from ${SDCPP_CUDA_REPO}:"
+            cat cuda-assets.txt
+          else
+            echo "::notice::No matching CUDA release found in ${SDCPP_CUDA_REPO} for ${RELEASE}; CUDA validation is disabled for this workflow run."
+            : > cuda-assets.txt
+          fi
+
           python3 <<'PY'
           import os
           import re
@@ -123,6 +135,7 @@ jobs:
 
           short = os.environ['SHORT_RELEASE']
           assets = set(Path('assets.txt').read_text(encoding='utf-8').splitlines())
+          cuda_assets = set(Path('cuda-assets.txt').read_text(encoding='utf-8').splitlines())
 
           checks = {
               'cpu': [
@@ -140,10 +153,6 @@ jobs:
               'metal': [
                   rf'^sd-{re.escape(short)}-bin-Darwin-macOS-[^/]+-arm64\.zip$',
               ],
-              'cuda': [
-                  rf'^sd-{re.escape(short)}-bin-win-cuda12-x64\.zip$',
-                  rf'^sd-{re.escape(short)}-windows-cuda-.+-x64\.zip$',
-              ],
           }
 
           missing = []
@@ -151,8 +160,12 @@ jobs:
               if not any(re.match(pattern, asset) for pattern in patterns for asset in assets):
                   missing.append(f"{backend}: {' OR '.join(patterns)}")
 
-          if 'cuda' not in missing and any(asset == 'cudart-sd-bin-win-cu12-x64.zip' for asset in assets):
-              print('Found CUDA runtime asset: cudart-sd-bin-win-cu12-x64.zip')
+          cuda_patterns = [
+              rf'^sd-{re.escape(short)}-windows-cuda-sm_[0-9]+-x64\.zip$',
+              rf'^sd-{re.escape(short)}-ubuntu-cuda-sm_[0-9]+-x64\.tar\.xz$',
+          ]
+          if cuda_assets and not any(re.match(pattern, asset) for pattern in cuda_patterns for asset in cuda_assets):
+              missing.append(f"cuda: {' OR '.join(cuda_patterns)}")
 
           if missing:
               print('Missing expected release assets:', file=sys.stderr)
@@ -223,6 +236,8 @@ jobs:
           - label: cpu
             backend: cpu
             channel: ""
+            # No dedicated CPU runner label exists; run CPU validation on the
+            # existing Windows 128GB Vulkan host with the sd-cpp CPU backend.
             runner: [self-hosted, Windows, 128gb, vulkan]
           - label: vulkan
             backend: vulkan
@@ -233,8 +248,8 @@ jobs:
             channel: stable
             runner: [self-hosted, Windows, 128gb, rocm]
           # CUDA validation is prepared but disabled until a CUDA runner is available.
-          # The updater still pins sd-cpp.cuda and the release asset check still verifies
-          # CUDA artifacts. Re-enable this block once the runner exists.
+          # The updater still pins sd-cpp.cuda and the release step probes CUDA
+          # artifact names. Re-enable this block once the runner exists.
           # - label: cuda
           #   backend: cuda
           #   channel: ""
@@ -251,7 +266,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: sdcpp-build
-          path: build
+          path: .
 
       - name: Verify binaries
         shell: PowerShell
@@ -418,47 +433,52 @@ jobs:
                   row["artifact"] = f"sdcpp-validation-{label}"
                   rows.append(row)
 
+          summary = {}
+          for row in rows:
+              label = row.get("label")
+              item = summary.setdefault(
+                  label,
+                  {"total": 0, "passed": 0, "elapsed": 0.0, "missing": False},
+              )
+              if row.get("missing"):
+                  item["missing"] = True
+                  continue
+              item["total"] += 1
+              if row.get("pass"):
+                  item["passed"] += 1
+              try:
+                  item["elapsed"] += float(row.get("elapsed_s", 0) or 0)
+              except (TypeError, ValueError):
+                  pass
+
           lines = [
-              "## Auto-update stable-diffusion.cpp backends",
+              f"This updates the existing `sd-cpp` backend pins to `{release}`.",
               "",
-              f"- **stable-diffusion.cpp**: `{release}` (`{short_release}` assets)",
-              f"- Updated existing `sd-cpp` pins: `{update_backends}`",
-              "- `sd-cpp.rocm-nightly` is intentionally not created or updated.",
-              "- Release asset inventory was checked before validation.",
-              "",
-              "## Deterministic validation evidence",
+              "Validated with the same prompt and seed on each available runner:",
               "",
               f"- Prompt: `{prompt or os.environ.get('SDCPP_TEST_PROMPT', '')}`",
-              "- Seed: `12345`",
-              "- Steps: `4`",
+              "- Seed / steps: `12345` / `4`",
+              "- Models: `SD-Turbo-GGUF`, `Flux-2-Klein-4B`",
               "- Sizes: `512x256`, `1024x1024`",
-              "- Models: `SD-Turbo-GGUF` and `Flux-2-Klein-4B`",
-              "- Timing column is end-to-end request wall-clock time and can include first-use model download/load.",
               "",
-              "| Runner | Model | Size | Result | PNG bytes | Time | Artifact image path |",
-              "|---|---|---:|---|---:|---:|---|",
+              "| Backend | Result | Total time | Evidence |",
+              "|---|---:|---:|---|",
           ]
 
-          for row in rows:
-              if row.get("missing"):
-                  lines.append(f"| {row['label']} | - | - | MISSING | - | - | - |")
+          for label in labels:
+              item = summary.get(label, {"missing": True, "total": 0, "passed": 0, "elapsed": 0.0})
+              if item.get("missing") and item.get("total", 0) == 0:
+                  lines.append(f"| {label} | missing | - | `sdcpp-validation-{label}` |")
                   continue
-              status = "PASS" if row.get("pass") else "FAIL"
-              error = row.get("error")
-              if error:
-                  status = f"{status}: {str(error)[:120].replace('|', '/')}"
-              lines.append(
-                  f"| {row.get('label', '')} | {row.get('model', '')} | {row.get('size', '')} | "
-                  f"{status} | {row.get('bytes', '-')} | {row.get('elapsed_s', '-')}s | "
-                  f"`{row.get('image_path', '')}` |"
-              )
+              result = f"{item['passed']}/{item['total']} images"
+              elapsed = f"{item['elapsed']:.1f}s"
+              lines.append(f"| {label} | {result} | {elapsed} | `sdcpp-validation-{label}` |")
 
           lines += [
               "",
-              "Generated PNGs and JSON summaries are attached to the workflow artifacts for visual inspection.",
-              "",
-              "---",
-              "*Auto-generated by validate_sdcpp workflow.*",
+              "The workflow artifacts contain the generated PNGs plus per-image timings.",
+              "CUDA is pinned, but CUDA validation is disabled until a matching runner is available.",
+              "`sd-cpp.rocm-nightly` is not touched.",
           ]
 
           Path("pr_body.md").write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -223,7 +223,7 @@ jobs:
           - label: cpu
             backend: cpu
             channel: ""
-            runner: [self-hosted, Windows, 128gb, cpu]
+            runner: [self-hosted, Windows, 128gb, vulkan]
           - label: vulkan
             backend: vulkan
             channel: ""
@@ -232,10 +232,13 @@ jobs:
             backend: rocm
             channel: stable
             runner: [self-hosted, Windows, 128gb, rocm]
-          - label: cuda
-            backend: cuda
-            channel: ""
-            runner: [self-hosted, Windows, 128gb, cuda]
+          # CUDA validation is prepared but disabled until a CUDA runner is available.
+          # The updater still pins sd-cpp.cuda and the release asset check still verifies
+          # CUDA artifacts. Re-enable this block once the runner exists.
+          # - label: cuda
+          #   backend: cuda
+          #   channel: ""
+          #   runner: [self-hosted, Windows, 128gb, cuda]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -400,7 +403,7 @@ jobs:
           release = os.environ["SDCPP_RELEASE"]
           short_release = os.environ["SDCPP_SHORT_RELEASE"]
           update_backends = os.environ["SDCPP_UPDATE_BACKENDS"]
-          labels = ["cpu", "vulkan", "rocm-stable", "cuda"]
+          labels = ["cpu", "vulkan", "rocm-stable"]
 
           rows = []
           prompt = None

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -38,8 +38,8 @@ env:
   LITE_MODE: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.lite == true) }}
   SDCPP_REPO: leejet/stable-diffusion.cpp
   SDCPP_CUDA_REPO: lemonade-sdk/stable-diffusion.cpp
-  # Update only existing sd-cpp pins. Do not add/touch rocm-nightly.
-  SDCPP_UPDATE_BACKENDS: cpu,vulkan,rocm-stable,metal,cuda
+  # Base sd-cpp pins to update. CUDA is added only when matching CUDA assets exist.
+  SDCPP_BASE_UPDATE_BACKENDS: cpu,vulkan,rocm-stable,metal
   SDCPP_TEST_PROMPT: "A small glass of lemonade on a clean table, product photo, high detail"
   SDCPP_TEST_SEED: "12345"
   SDCPP_TEST_STEPS: "4"
@@ -57,6 +57,7 @@ jobs:
       release: ${{ steps.release.outputs.release }}
       short_release: ${{ steps.release.outputs.short_release }}
       is_update_run: ${{ steps.release.outputs.is_update_run }}
+      update_backends: ${{ steps.assets.outputs.update_backends }}
     steps:
       - uses: actions/checkout@v5
 
@@ -106,6 +107,7 @@ jobs:
           echo "Using stable-diffusion.cpp release: $RELEASE ($SHORT_RELEASE)"
 
       - name: Verify upstream release has expected backend assets
+        id: assets
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -174,6 +176,14 @@ jobs:
               sys.exit(1)
           PY
 
+          if [ -s cuda-assets.txt ]; then
+            UPDATE_BACKENDS="${SDCPP_BASE_UPDATE_BACKENDS},cuda"
+          else
+            UPDATE_BACKENDS="${SDCPP_BASE_UPDATE_BACKENDS}"
+          fi
+          echo "update_backends=${UPDATE_BACKENDS}" >> "$GITHUB_OUTPUT"
+          echo "Will update sd-cpp backend pins: ${UPDATE_BACKENDS}"
+
   build:
     name: Build Lemonade with sd-cpp pin
     needs: discover-release
@@ -192,7 +202,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           python .github/scripts/update_sdcpp_versions.py `
             --release "${{ needs.discover-release.outputs.release }}" `
-            --backends "${{ env.SDCPP_UPDATE_BACKENDS }}"
+            --backends "${{ needs.discover-release.outputs.update_backends }}"
 
       - name: Build C++ Server with CMake
         shell: PowerShell
@@ -401,14 +411,14 @@ jobs:
         run: |
           python3 .github/scripts/update_sdcpp_versions.py \
             --release "${{ needs.discover-release.outputs.release }}" \
-            --backends "${{ env.SDCPP_UPDATE_BACKENDS }}"
+            --backends "${{ needs.discover-release.outputs.update_backends }}"
 
       - name: Generate PR body
         shell: bash
         env:
           SDCPP_RELEASE: ${{ needs.discover-release.outputs.release }}
           SDCPP_SHORT_RELEASE: ${{ needs.discover-release.outputs.short_release }}
-          SDCPP_UPDATE_BACKENDS: ${{ env.SDCPP_UPDATE_BACKENDS }}
+          SDCPP_UPDATE_BACKENDS: ${{ needs.discover-release.outputs.update_backends }}
         run: |
           python3 <<'PY'
           import json
@@ -418,7 +428,9 @@ jobs:
           release = os.environ["SDCPP_RELEASE"]
           short_release = os.environ["SDCPP_SHORT_RELEASE"]
           update_backends = os.environ["SDCPP_UPDATE_BACKENDS"]
+          updated = [item.strip() for item in update_backends.split(",") if item.strip()]
           labels = ["cpu", "vulkan", "rocm-stable"]
+          unvalidated = [backend for backend in updated if backend not in labels]
 
           rows = []
           prompt = None
@@ -454,6 +466,10 @@ jobs:
           lines = [
               f"This updates the existing `sd-cpp` backend pins to `{release}`.",
               "",
+              f"- Updated pins: `{', '.join(updated)}`",
+              f"- Validated backends: `{', '.join(labels)}`",
+              "- Updated but not validated here: " + (f"`{', '.join(unvalidated)}`" if unvalidated else "none"),
+              "",
               "Validated with the same prompt and seed on each available runner:",
               "",
               f"- Prompt: `{prompt or os.environ.get('SDCPP_TEST_PROMPT', '')}`",
@@ -477,7 +493,8 @@ jobs:
           lines += [
               "",
               "The workflow artifacts contain the generated PNGs plus per-image timings.",
-              "CUDA is pinned, but CUDA validation is disabled until a matching runner is available.",
+              "CUDA is only pinned when matching CUDA assets exist; CUDA validation remains disabled until a matching runner is available.",
+              "Metal is pinned when updated, but not validated in this workflow because there is no macOS matrix leg.",
               "`sd-cpp.rocm-nightly` is not touched.",
           ]
 

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -158,15 +158,17 @@ jobs:
 
           missing = []
           for backend, patterns in checks.items():
-              if not any(re.match(pattern, asset) for pattern in patterns for asset in assets):
-                  missing.append(f"{backend}: {' OR '.join(patterns)}")
-
+              for pattern in patterns:
+                  if not any(re.match(pattern, asset) for asset in assets):
+                      missing.append(f"{backend}: {pattern}")
           cuda_patterns = [
               rf'^sd-{re.escape(short)}-windows-cuda-sm_[0-9]+-x64\.zip$',
               rf'^sd-{re.escape(short)}-ubuntu-cuda-sm_[0-9]+-x64\.tar\.xz$',
           ]
-          if cuda_assets and not any(re.match(pattern, asset) for pattern in cuda_patterns for asset in cuda_assets):
-              missing.append(f"cuda: {' OR '.join(cuda_patterns)}")
+          if cuda_assets:
+              for pattern in cuda_patterns:
+                  if not any(re.match(pattern, asset) for asset in cuda_assets):
+                      missing.append(f"cuda: {pattern}")
 
           if missing:
               print('Missing expected release assets:', file=sys.stderr)

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -1,0 +1,496 @@
+name: Validate New stable-diffusion.cpp Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "Optional upstream tag, e.g. master-684-138da14. Empty = latest."
+        required: false
+        type: string
+      lite:
+        description: "Smoke test only: first model at 512x256. Full update PRs should leave this off."
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - ".github/workflows/validate_sdcpp.yml"
+      - ".github/scripts/update_sdcpp_versions.py"
+      - "test/validate_sdcpp.py"
+      - "src/cpp/resources/backend_versions.json"
+      - "src/cpp/resources/server_models.json"
+      - "src/cpp/server/backends/sd_server.cpp"
+      - "src/cpp/server/backend_manager.cpp"
+      - "src/cpp/server/runtime_config.cpp"
+      - "src/cpp/server/system_info.cpp"
+  schedule:
+    # Sunday at 17:20 UTC, staggered after the llama.cpp auto-update workflow.
+    - cron: "20 17 * * 0"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  LEMONADE_DISABLE_SYSTEMD_JOURNAL: "1"
+  LEMONADE_CI_MODE: "True"
+  PYTHONIOENCODING: utf-8
+  HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
+  LITE_MODE: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.lite == true) }}
+  SDCPP_REPO: leejet/stable-diffusion.cpp
+  # Update only existing sd-cpp pins. Do not add/touch rocm-nightly.
+  SDCPP_UPDATE_BACKENDS: cpu,vulkan,rocm-stable,metal,cuda
+  SDCPP_TEST_PROMPT: "A small glass of lemonade on a clean table, product photo, high detail"
+  SDCPP_TEST_SEED: "12345"
+  SDCPP_TEST_STEPS: "4"
+  LEMONADE_VALIDATE_SD_TIMEOUT: "7200"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  discover-release:
+    name: Discover stable-diffusion.cpp release
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.release.outputs.release }}
+      short_release: ${{ steps.release.outputs.short_release }}
+      is_update_run: ${{ steps.release.outputs.is_update_run }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve release tag
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.release || '' }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$INPUT_RELEASE" ]; then
+            RELEASE="$INPUT_RELEASE"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            RELEASE=$(python3 - <<'PY'
+          import json
+          with open('src/cpp/resources/backend_versions.json', encoding='utf-8') as f:
+              data = json.load(f)
+          print(data['sd-cpp']['cpu'])
+          PY
+          )
+          else
+            RELEASE=$(gh api repos/${SDCPP_REPO}/releases/latest --jq '.tag_name')
+          fi
+
+          if ! [[ "$RELEASE" =~ ^master-[0-9]+-[0-9a-f]{7,40}$ ]]; then
+            echo "Invalid stable-diffusion.cpp release tag: $RELEASE" >&2
+            exit 1
+          fi
+
+          SHORT_RELEASE=$(python3 - <<PY
+          release = "$RELEASE"
+          parts = release.split('-', 2)
+          print(parts[0] + '-' + parts[2])
+          PY
+          )
+
+          echo "release=$RELEASE" >> "$GITHUB_OUTPUT"
+          echo "short_release=$SHORT_RELEASE" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "is_update_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_update_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Using stable-diffusion.cpp release: $RELEASE ($SHORT_RELEASE)"
+
+      - name: Verify upstream release has expected backend assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE: ${{ steps.release.outputs.release }}
+          SHORT_RELEASE: ${{ steps.release.outputs.short_release }}
+        run: |
+          set -euo pipefail
+          gh api repos/${SDCPP_REPO}/releases/tags/${RELEASE} --jq '.assets[].name' | sort > assets.txt
+          cat assets.txt
+
+          python3 <<'PY'
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          short = os.environ['SHORT_RELEASE']
+          assets = set(Path('assets.txt').read_text(encoding='utf-8').splitlines())
+
+          checks = {
+              'cpu': [
+                  rf'^sd-{re.escape(short)}-bin-win-avx2-x64\.zip$',
+                  rf'^sd-{re.escape(short)}-bin-Linux-Ubuntu-24\.04-x86_64\.zip$',
+              ],
+              'vulkan': [
+                  rf'^sd-{re.escape(short)}-bin-win-vulkan-x64\.zip$',
+                  rf'^sd-{re.escape(short)}-bin-Linux-Ubuntu-24\.04-x86_64-vulkan\.zip$',
+              ],
+              'rocm-stable': [
+                  rf'^sd-{re.escape(short)}-bin-win-rocm-[0-9][^/]*-x64\.zip$',
+                  rf'^sd-{re.escape(short)}-bin-Linux-Ubuntu-24\.04-x86_64-rocm-[0-9][^/]*\.zip$',
+              ],
+              'metal': [
+                  rf'^sd-{re.escape(short)}-bin-Darwin-macOS-[^/]+-arm64\.zip$',
+              ],
+              'cuda': [
+                  rf'^sd-{re.escape(short)}-bin-win-cuda12-x64\.zip$',
+                  rf'^sd-{re.escape(short)}-windows-cuda-.+-x64\.zip$',
+              ],
+          }
+
+          missing = []
+          for backend, patterns in checks.items():
+              if not any(re.match(pattern, asset) for pattern in patterns for asset in assets):
+                  missing.append(f"{backend}: {' OR '.join(patterns)}")
+
+          if 'cuda' not in missing and any(asset == 'cudart-sd-bin-win-cu12-x64.zip' for asset in assets):
+              print('Found CUDA runtime asset: cudart-sd-bin-win-cu12-x64.zip')
+
+          if missing:
+              print('Missing expected release assets:', file=sys.stderr)
+              for item in missing:
+                  print(f'  - {item}', file=sys.stderr)
+              sys.exit(1)
+          PY
+
+  build:
+    name: Build Lemonade with sd-cpp pin
+    needs: discover-release
+    if: always() && !failure() && !cancelled()
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          clean: true
+          fetch-depth: 0
+
+      - name: Update backend_versions.json for validation
+        if: needs.discover-release.outputs.is_update_run == 'true'
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Stop"
+          python .github/scripts/update_sdcpp_versions.py `
+            --release "${{ needs.discover-release.outputs.release }}" `
+            --backends "${{ env.SDCPP_UPDATE_BACKENDS }}"
+
+      - name: Build C++ Server with CMake
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Stop"
+          Write-Host "Building Lemonade server binaries..." -ForegroundColor Cyan
+          if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
+          cmake --preset windows
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cmake --build build --config Release --target lemond lemonade
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (-not (Test-Path "build\Release\lemond.exe")) {
+              Write-Host "ERROR: lemond.exe not found!" -ForegroundColor Red
+              exit 1
+          }
+          if (-not (Test-Path "build\Release\lemonade.exe")) {
+              Write-Host "ERROR: lemonade.exe not found!" -ForegroundColor Red
+              exit 1
+          }
+          Write-Host "Build successful!" -ForegroundColor Green
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdcpp-build
+          path: |
+            build/Release/
+            build/resources/
+          retention-days: 7
+
+  validate:
+    name: Validate ${{ matrix.label }}
+    needs: [discover-release, build]
+    if: always() && needs.build.result == 'success'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 420
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: cpu
+            backend: cpu
+            channel: ""
+            runner: [self-hosted, Windows, 128gb, cpu]
+          - label: vulkan
+            backend: vulkan
+            channel: ""
+            runner: [self-hosted, Windows, 128gb, vulkan]
+          - label: rocm-stable
+            backend: rocm
+            channel: stable
+            runner: [self-hosted, Windows, 128gb, rocm]
+          - label: cuda
+            backend: cuda
+            channel: ""
+            runner: [self-hosted, Windows, 128gb, cuda]
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          clean: true
+
+      - name: Cleanup processes
+        uses: ./.github/actions/cleanup-processes-windows
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: sdcpp-build
+          path: build
+
+      - name: Verify binaries
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $lemondExe = "build\Release\lemond.exe"
+          $lemonadeExe = "build\Release\lemonade.exe"
+          if (-not (Test-Path $lemondExe)) {
+              Write-Host "ERROR: lemond.exe not found!" -ForegroundColor Red
+              Get-ChildItem -Recurse build | Select-Object FullName
+              exit 1
+          }
+          if (-not (Test-Path $lemonadeExe)) {
+              Write-Host "ERROR: lemonade.exe not found!" -ForegroundColor Red
+              Get-ChildItem -Recurse build | Select-Object FullName
+              exit 1
+          }
+          & $lemondExe --version
+          & $lemonadeExe --version
+          Write-Host "Binaries verified!" -ForegroundColor Green
+
+      - name: Setup Python and virtual environment
+        uses: ./.github/actions/setup-venv
+        with:
+          venv-name: '.venv'
+          python-version: '3.10'
+          requirements-file: 'test/requirements.txt'
+
+      - name: Run validation with lemond
+        shell: PowerShell
+        env:
+          HF_TOKEN: ${{ env.HF_TOKEN }}
+          LEMONADE_VALIDATE_SD_PROMPT: ${{ env.SDCPP_TEST_PROMPT }}
+          LEMONADE_VALIDATE_SD_STEPS: ${{ env.SDCPP_TEST_STEPS }}
+          LEMONADE_VALIDATE_SD_TIMEOUT: ${{ env.LEMONADE_VALIDATE_SD_TIMEOUT }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $lemondExe = (Resolve-Path "build\Release\lemond.exe").Path
+          $backend = "${{ matrix.backend }}"
+          $channel = "${{ matrix.channel }}"
+          $label = "${{ matrix.label }}"
+          $logsDir = "server-logs-$label"
+          $cacheDir = Join-Path $PWD "ci-cache-$label"
+          $venvPython = ".\.venv\Scripts\python.exe"
+
+          New-Item -ItemType Directory -Force -Path $logsDir | Out-Null
+          New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
+
+          $stdoutLog = Join-Path $PWD "$logsDir\lemond.stdout.log"
+          $stderrLog = Join-Path $PWD "$logsDir\lemond.stderr.log"
+
+          $proc = Start-Process `
+            -FilePath $lemondExe `
+            -ArgumentList @($cacheDir, "--port", "13305", "--host", "127.0.0.1") `
+            -RedirectStandardOutput $stdoutLog `
+            -RedirectStandardError $stderrLog `
+            -PassThru
+
+          Write-Host "Started lemond PID $($proc.Id)" -ForegroundColor Cyan
+
+          try {
+            $validationArgs = @(
+              "test/validate_sdcpp.py",
+              "--backend", $backend,
+              "--seed", "${{ env.SDCPP_TEST_SEED }}",
+              "--size", "512x256",
+              "--size", "1024x1024",
+              "--output", "sdcpp_validation_$label.json",
+              "--images-dir", "sdcpp-images-$label"
+            )
+            if ($channel) {
+              $validationArgs += "--channel"
+              $validationArgs += $channel
+            }
+            if ("${{ env.LITE_MODE }}" -eq "true") {
+              $validationArgs += "--lite"
+            }
+
+            & $venvPython @validationArgs
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          } finally {
+            try {
+              Invoke-WebRequest -Uri "http://127.0.0.1:13305/internal/shutdown" `
+                -Method POST -TimeoutSec 10 | Out-Null
+              Start-Sleep -Seconds 2
+            } catch {
+              Write-Host "lemond shutdown not reachable; relying on cleanup step." -ForegroundColor Yellow
+            }
+          }
+
+      - name: Upload validation evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdcpp-validation-${{ matrix.label }}
+          path: |
+            sdcpp_validation_${{ matrix.label }}.json
+            sdcpp-images-${{ matrix.label }}/
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Upload server logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdcpp-server-logs-${{ matrix.label }}
+          path: server-logs-${{ matrix.label }}/
+          retention-days: 30
+          if-no-files-found: ignore
+
+      - name: Cleanup
+        if: always()
+        uses: ./.github/actions/cleanup-processes-windows
+
+  create-pr:
+    name: Create update PR
+    needs: [discover-release, validate]
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      needs.validate.result == 'success'
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download validation evidence
+        uses: actions/download-artifact@v7
+        with:
+          pattern: sdcpp-validation-*
+          merge-multiple: true
+
+      - name: Update backend_versions.json
+        run: |
+          python3 .github/scripts/update_sdcpp_versions.py \
+            --release "${{ needs.discover-release.outputs.release }}" \
+            --backends "${{ env.SDCPP_UPDATE_BACKENDS }}"
+
+      - name: Generate PR body
+        shell: bash
+        env:
+          SDCPP_RELEASE: ${{ needs.discover-release.outputs.release }}
+          SDCPP_SHORT_RELEASE: ${{ needs.discover-release.outputs.short_release }}
+          SDCPP_UPDATE_BACKENDS: ${{ env.SDCPP_UPDATE_BACKENDS }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          release = os.environ["SDCPP_RELEASE"]
+          short_release = os.environ["SDCPP_SHORT_RELEASE"]
+          update_backends = os.environ["SDCPP_UPDATE_BACKENDS"]
+          labels = ["cpu", "vulkan", "rocm-stable", "cuda"]
+
+          rows = []
+          prompt = None
+          for label in labels:
+              path = Path(f"sdcpp_validation_{label}.json")
+              if not path.exists():
+                  rows.append({"label": label, "missing": True})
+                  continue
+              for row in json.loads(path.read_text(encoding="utf-8")):
+                  if prompt is None and row.get("prompt"):
+                      prompt = row["prompt"]
+                  row["artifact"] = f"sdcpp-validation-{label}"
+                  rows.append(row)
+
+          lines = [
+              "## Auto-update stable-diffusion.cpp backends",
+              "",
+              f"- **stable-diffusion.cpp**: `{release}` (`{short_release}` assets)",
+              f"- Updated existing `sd-cpp` pins: `{update_backends}`",
+              "- `sd-cpp.rocm-nightly` is intentionally not created or updated.",
+              "- Release asset inventory was checked before validation.",
+              "",
+              "## Deterministic validation evidence",
+              "",
+              f"- Prompt: `{prompt or os.environ.get('SDCPP_TEST_PROMPT', '')}`",
+              "- Seed: `12345`",
+              "- Steps: `4`",
+              "- Sizes: `512x256`, `1024x1024`",
+              "- Models: `SD-Turbo-GGUF` and `Flux-2-Klein-4B`",
+              "- Timing column is end-to-end request wall-clock time and can include first-use model download/load.",
+              "",
+              "| Runner | Model | Size | Result | PNG bytes | Time | Artifact image path |",
+              "|---|---|---:|---|---:|---:|---|",
+          ]
+
+          for row in rows:
+              if row.get("missing"):
+                  lines.append(f"| {row['label']} | - | - | MISSING | - | - | - |")
+                  continue
+              status = "PASS" if row.get("pass") else "FAIL"
+              error = row.get("error")
+              if error:
+                  status = f"{status}: {str(error)[:120].replace('|', '/')}"
+              lines.append(
+                  f"| {row.get('label', '')} | {row.get('model', '')} | {row.get('size', '')} | "
+                  f"{status} | {row.get('bytes', '-')} | {row.get('elapsed_s', '-')}s | "
+                  f"`{row.get('image_path', '')}` |"
+              )
+
+          lines += [
+              "",
+              "Generated PNGs and JSON summaries are attached to the workflow artifacts for visual inspection.",
+              "",
+              "---",
+              "*Auto-generated by validate_sdcpp workflow.*",
+          ]
+
+          Path("pr_body.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+          PY
+
+      - name: Create Pull Request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SDCPP_RELEASE: ${{ needs.discover-release.outputs.release }}
+        run: |
+          set -euo pipefail
+          BRANCH="auto/sdcpp-update-${SDCPP_RELEASE}"
+
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists for branch $BRANCH. Skipping."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet src/cpp/resources/backend_versions.json; then
+            echo "backend_versions.json is unchanged; nothing to update."
+            exit 0
+          fi
+
+          git checkout -B "$BRANCH"
+          git add src/cpp/resources/backend_versions.json
+          git commit -m "Update stable-diffusion.cpp to ${SDCPP_RELEASE}"
+          git push --force-with-lease origin "$BRANCH"
+
+          gh pr create \
+            --title "Update stable-diffusion.cpp to ${SDCPP_RELEASE}" \
+            --body-file pr_body.md \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -27,8 +27,7 @@ on:
     - cron: "20 17 * * 0"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   LEMONADE_DISABLE_SYSTEMD_JOURNAL: "1"
@@ -210,7 +209,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           Write-Host "Building Lemonade server binaries..." -ForegroundColor Cyan
           if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
-          cmake --preset windows
+          cmake --preset vs18
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cmake --build build --config Release --target lemond lemonade
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -395,6 +394,9 @@ jobs:
     name: Create update PR
     needs: [discover-release, validate]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: >-
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       needs.validate.result == 'success'

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -275,7 +275,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: sdcpp-build
-          path: .
+          path: build
 
       - name: Verify binaries
         shell: PowerShell

--- a/test/validate_sdcpp.py
+++ b/test/validate_sdcpp.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Validate Lemonade stable-diffusion.cpp image generation.
+
+Expected server state: ``lemond`` is already running. This script switches
+Lemonade to the requested sd-cpp backend, then generates deterministic PNGs for
+all requested model/size combinations. It records enough evidence for reviewers:
+model, backend, prompt, seed, size, generated PNG path, byte size, and elapsed
+wall-clock time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import struct
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+DEFAULT_PORT = int(os.environ.get("LEMONADE_PORT", "13305"))
+DEFAULT_TIMEOUT = int(os.environ.get("LEMONADE_VALIDATE_SD_TIMEOUT", "3600"))
+DEFAULT_STEPS = int(os.environ.get("LEMONADE_VALIDATE_SD_STEPS", "4"))
+DEFAULT_PROMPT = os.environ.get(
+    "LEMONADE_VALIDATE_SD_PROMPT",
+    "A small glass of lemonade on a clean table, product photo, high detail",
+)
+DEFAULT_MODELS = ("SD-Turbo-GGUF", "Flux-2-Klein-4B")
+DEFAULT_SIZES = ("512x256", "1024x1024")
+
+
+def parse_size(value: str) -> tuple[int, int]:
+    try:
+        width_s, height_s = value.lower().split("x", 1)
+        width = int(width_s)
+        height = int(height_s)
+    except Exception as exc:  # noqa: BLE001 - argparse shows the clean message
+        raise argparse.ArgumentTypeError(
+            f"Invalid size '{value}'. Expected WIDTHxHEIGHT, e.g. 512x256."
+        ) from exc
+    if width <= 0 or height <= 0:
+        raise argparse.ArgumentTypeError("Image dimensions must be positive.")
+    return width, height
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", required=True, choices=["cpu", "vulkan", "rocm", "cuda"])
+    parser.add_argument("--channel", choices=["stable"], default=None)
+    parser.add_argument(
+        "--model",
+        action="append",
+        default=None,
+        help=(
+            "Model to validate. May be repeated. "
+            "Default: SD-Turbo-GGUF and Flux-2-Klein-4B."
+        ),
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--steps", type=int, default=DEFAULT_STEPS)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--seed", type=int, default=12345)
+    parser.add_argument(
+        "--size",
+        action="append",
+        type=parse_size,
+        default=None,
+        help="Image size to validate. May be repeated. Default: 512x256 and 1024x1024.",
+    )
+    parser.add_argument(
+        "--lite",
+        action="store_true",
+        help="Only run the first model at the first size; intended for PR smoke checks.",
+    )
+    parser.add_argument("--output", default="sdcpp_validation.json")
+    parser.add_argument("--images-dir", default="sdcpp-validation-images")
+    return parser.parse_args()
+
+
+def wait_for_server(base_url: str, timeout_s: int = 120) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f"{base_url}/live", timeout=5)
+            if response.status_code == 200:
+                return
+            last_error = f"HTTP {response.status_code}: {response.text[:200]}"
+        except requests.RequestException as exc:
+            last_error = str(exc)
+        time.sleep(2)
+    raise RuntimeError(f"lemond did not become ready within {timeout_s}s: {last_error}")
+
+
+def post_json(url: str, payload: dict[str, Any], timeout: int) -> requests.Response:
+    return requests.post(url, json=payload, timeout=timeout)
+
+
+def configure_backend(base_url: str, backend: str, channel: str | None) -> None:
+    config: dict[str, Any] = {"sdcpp": {"backend": backend}}
+    if backend == "rocm":
+        config["rocm_channel"] = channel or "stable"
+
+    response = post_json(f"{base_url}/internal/set", config, timeout=60)
+    response.raise_for_status()
+
+    # Keep matrix legs isolated even when a previous run left a model loaded.
+    unload = post_json(f"{base_url}/api/v1/unload", {}, timeout=60)
+    if unload.status_code not in {200, 404}:
+        unload.raise_for_status()
+
+
+def png_dimensions(data: bytes) -> tuple[int, int]:
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError("decoded image is not a PNG")
+    if data[12:16] != b"IHDR":
+        raise ValueError("PNG IHDR chunk not found at expected offset")
+    return struct.unpack(">II", data[16:24])
+
+
+def generate_image(
+    api_base_url: str,
+    model: str,
+    prompt: str,
+    size: tuple[int, int],
+    steps: int,
+    seed: int,
+    timeout: int,
+) -> tuple[bytes, dict[str, Any]]:
+    width, height = size
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "size": f"{width}x{height}",
+        "steps": steps,
+        "seed": seed,
+        "n": 1,
+        "response_format": "b64_json",
+    }
+    response = post_json(f"{api_base_url}/images/generations", payload, timeout=timeout)
+    if response.status_code != 200:
+        raise RuntimeError(
+            f"image generation failed for {model} {width}x{height}: "
+            f"HTTP {response.status_code}: {response.text[:1000]}"
+        )
+    result = response.json()
+    image_b64 = result["data"][0]["b64_json"]
+    return base64.b64decode(image_b64), result
+
+
+def safe_slug(value: str) -> str:
+    allowed = []
+    for char in value.lower():
+        if char.isalnum():
+            allowed.append(char)
+        elif char in {"-", "_", "."}:
+            allowed.append(char)
+        else:
+            allowed.append("-")
+    return "".join(allowed).strip("-")
+
+
+def safe_label(backend: str, channel: str | None) -> str:
+    if backend == "rocm":
+        return f"rocm-{channel or 'stable'}"
+    return backend
+
+
+def main() -> int:
+    args = parse_args()
+    sizes = args.size or [parse_size(value) for value in DEFAULT_SIZES]
+    models = args.model or list(DEFAULT_MODELS)
+    if args.lite:
+        sizes = sizes[:1]
+        models = models[:1]
+
+    base_url = f"http://{args.host}:{args.port}"
+    api_base_url = f"{base_url}/api/v1"
+    label = safe_label(args.backend, args.channel)
+    images_dir = Path(args.images_dir)
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict[str, Any]] = []
+    overall_pass = True
+
+    print(f"[INFO] Waiting for Lemonade server at {base_url}")
+    wait_for_server(base_url)
+    print(f"[INFO] Configuring sd-cpp backend={args.backend} channel={args.channel or ''}")
+    configure_backend(base_url, args.backend, args.channel)
+
+    for model in models:
+        for width, height in sizes:
+            started = time.monotonic()
+            record: dict[str, Any] = {
+                "backend": args.backend,
+                "channel": args.channel,
+                "label": label,
+                "model": model,
+                "prompt": args.prompt,
+                "size": f"{width}x{height}",
+                "steps": args.steps,
+                "seed": args.seed,
+                "pass": False,
+            }
+            try:
+                print(f"[INFO] Generating {model} {width}x{height} on {label}")
+                image, response_json = generate_image(
+                    api_base_url=api_base_url,
+                    model=model,
+                    prompt=args.prompt,
+                    size=(width, height),
+                    steps=args.steps,
+                    seed=args.seed,
+                    timeout=args.timeout,
+                )
+                actual_width, actual_height = png_dimensions(image)
+                if (actual_width, actual_height) != (width, height):
+                    raise AssertionError(
+                        f"PNG dimensions are {actual_width}x{actual_height}, expected {width}x{height}"
+                    )
+                image_path = images_dir / f"sdcpp-{label}-{safe_slug(model)}-{width}x{height}.png"
+                image_path.write_bytes(image)
+                record.update(
+                    {
+                        "pass": True,
+                        "bytes": len(image),
+                        "width": actual_width,
+                        "height": actual_height,
+                        "image_path": str(image_path),
+                        "elapsed_s": round(time.monotonic() - started, 3),
+                        "created": response_json.get("created"),
+                    }
+                )
+                print(
+                    f"[OK] {model} {width}x{height}: wrote {image_path} "
+                    f"({len(image)} bytes, {record['elapsed_s']}s)"
+                )
+            except Exception as exc:  # noqa: BLE001 - keep JSON on all failures
+                overall_pass = False
+                record.update(
+                    {
+                        "error": str(exc),
+                        "elapsed_s": round(time.monotonic() - started, 3),
+                    }
+                )
+                print(f"[FAIL] {model} {width}x{height}: {exc}", file=sys.stderr)
+            results.append(record)
+
+    output_path = Path(args.output)
+    output_path.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    print(f"[INFO] Wrote validation summary to {output_path}")
+    return 0 if overall_pass else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/validate_sdcpp.py
+++ b/test/validate_sdcpp.py
@@ -53,9 +53,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--backend",
         required=True,
-        choices=["cpu", "vulkan", "rocm", "cuda", "metal"],
+        choices=["cpu", "vulkan", "rocm", "cuda"],
     )
-    parser.add_argument("--channel", choices=["stable", "nightly"], default=None)
+    parser.add_argument("--channel", choices=["stable"], default=None)
     parser.add_argument(
         "--model",
         action="append",

--- a/test/validate_sdcpp.py
+++ b/test/validate_sdcpp.py
@@ -51,7 +51,7 @@ def parse_size(value: str) -> tuple[int, int]:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--backend", required=True, choices=["cpu", "vulkan", "rocm", "cuda"])
-    parser.add_argument("--channel", choices=["stable"], default=None)
+    parser.add_argument("--channel", choices=["stable", "nightly"], default=None)
     parser.add_argument(
         "--model",
         action="append",

--- a/test/validate_sdcpp.py
+++ b/test/validate_sdcpp.py
@@ -50,7 +50,11 @@ def parse_size(value: str) -> tuple[int, int]:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--backend", required=True, choices=["cpu", "vulkan", "rocm", "cuda"])
+    parser.add_argument(
+        "--backend",
+        required=True,
+        choices=["cpu", "vulkan", "rocm", "cuda", "metal"],
+    )
     parser.add_argument("--channel", choices=["stable", "nightly"], default=None)
     parser.add_argument(
         "--model",


### PR DESCRIPTION
This updates the existing sd-cp backend pins to <release>.

Validated with the same prompt and seed on each available runner:

- Prompt: <prompt>
- Seed / steps: 12345 / 4
- Models: SD-Turbo-GGUF, Flux-2-Klein-4B
- Sizes: 512x256, 1024x1024

| Backend | Result | Total time | Evidence |
|---|---:|---:|---|
| cpu | 4/4 images | ...s | sdcpp-validation-cpu |
| vulkan | 4/4 images | ...s | sdcpp-validation-vulkan |
| rocm-stable | 4/4 images | ...s | sdcpp-validation-rocm-stable |

The workflow artifacts contain the generated PNGs plus per-image timings.