### PR TITLE
cli: group run/load recipe options

### DIFF
--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -222,20 +222,20 @@ json RecipeOptions::get_option(const std::string& opt) const {
 #ifdef LEMONADE_CLI
 // CLI_OPTIONS used only by the lemonade CLI client for add_cli_options
 static const json CLI_OPTIONS = {
-    {"--ctx-size", {{"option_name", "ctx_size"}, {"type_name", "SIZE"}, {"envname", "LEMONADE_CTX_SIZE"}, {"help", "Context size for the model"}}},
-    {"--merge-args", {{"option_name", "merge_args"}, {"type_name", "BOOL"}, {"envname", "LEMONADE_MERGE_ARGS"}, {"help", "Merge global and model arguments when loading the model"}}},
-    {"--llamacpp", {{"option_name", "llamacpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_LLAMACPP"}, {"help", "LlamaCpp backend to use"}}},
-    {"--llamacpp-device", {{"option_name", "llamacpp_device"}, {"type_name", "DEVICES"}, {"envname", "LEMONADE_LLAMACPP_DEVICE"}, {"help", "Comma-separated list of accelerator devices to use (e.g. Vulkan0)"}}},
-    {"--llamacpp-args", {{"option_name", "llamacpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_LLAMACPP_ARGS"}, {"help", "Custom arguments to pass to llama-server"}}},
-    {"--sdcpp", {{"option_name", "sd-cpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_SDCPP"}, {"help", "SD.cpp backend to use"}}},
-    {"--sdcpp-args", {{"option_name", "sdcpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_SDCPP_ARGS"}, {"help", "Custom arguments to pass to sd-server (must not conflict with managed args)"}}},
-    {"--whispercpp", {{"option_name", "whispercpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_WHISPERCPP"}, {"help", "WhisperCpp backend to use"}}},
-    {"--whispercpp-args", {{"option_name", "whispercpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_WHISPERCPP_ARGS"}, {"help", "Custom arguments to pass to whisper-server"}}},
-    {"--vllm", {{"option_name", "vllm_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_VLLM"}, {"help", "vLLM backend to use"}}},
-    {"--vllm-args", {{"option_name", "vllm_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_VLLM_ARGS"}, {"help", "Custom arguments to pass to vllm-server"}}},
+    {"--ctx-size", {{"option_name", "ctx_size"}, {"type_name", "SIZE"}, {"envname", "LEMONADE_CTX_SIZE"}, {"help", "Context size for the model"}, {"group", "General Options"}}},
+    {"--merge-args", {{"option_name", "merge_args"}, {"type_name", "BOOL"}, {"envname", "LEMONADE_MERGE_ARGS"}, {"help", "Merge global and model arguments when loading the model"}, {"group", "General Options"}}},
+    {"--llamacpp", {{"option_name", "llamacpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_LLAMACPP"}, {"help", "LlamaCpp backend to use"}, {"group", "Llama.cpp Backend Options"}}},
+    {"--llamacpp-device", {{"option_name", "llamacpp_device"}, {"type_name", "DEVICES"}, {"envname", "LEMONADE_LLAMACPP_DEVICE"}, {"help", "Comma-separated list of accelerator devices to use (e.g. Vulkan0)"}, {"group", "Llama.cpp Backend Options"}}},
+    {"--llamacpp-args", {{"option_name", "llamacpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_LLAMACPP_ARGS"}, {"help", "Custom arguments to pass to llama-server"}, {"group", "Llama.cpp Backend Options"}}},
+    {"--sdcpp", {{"option_name", "sd-cpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_SDCPP"}, {"help", "SD.cpp backend to use"}, {"group", "Stable Diffusion Options"}}},
+    {"--sdcpp-args", {{"option_name", "sdcpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_SDCPP_ARGS"}, {"help", "Custom arguments to pass to sd-server (must not conflict with managed args)"}, {"group", "Stable Diffusion Options"}}},
+    {"--whispercpp", {{"option_name", "whispercpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_WHISPERCPP"}, {"help", "WhisperCpp backend to use"}, {"group", "Whisper.cpp Options"}}},
+    {"--whispercpp-args", {{"option_name", "whispercpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_WHISPERCPP_ARGS"}, {"help", "Custom arguments to pass to whisper-server"}, {"group", "Whisper.cpp Options"}}},
+    {"--vllm", {{"option_name", "vllm_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_VLLM"}, {"help", "vLLM backend to use"}, {"group", "vLLM Options"}}},
+    {"--vllm-args", {{"option_name", "vllm_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_VLLM_ARGS"}, {"help", "Custom arguments to pass to vllm-server"}, {"group", "vLLM Options"}}},
     // Note: Image gen params (--steps, --cfg-scale, --width, --height) removed — recipe-level only.
     // Runtime options (--diffusion-fa, --offload-to-cpu) go through --sdcpp-args.
-    {"--flm-args", {{"option_name", "flm_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_FLM_ARGS"}, {"help", "Custom arguments to pass to flm serve"}}}
+    {"--flm-args", {{"option_name", "flm_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_FLM_ARGS"}, {"help", "Custom arguments to pass to flm serve"}, {"group", "FastFlowLM Options"}}}
 };
 
 void RecipeOptions::add_cli_options(CLI::App& app, json& storage) {
@@ -260,6 +260,7 @@ void RecipeOptions::add_cli_options(CLI::App& app, json& storage) {
 
         o->envname(opt["envname"]);
         o->type_name(opt["type_name"]);
+        o->group(opt.value("group", "Options"));
     }
 }
 #endif

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -2042,6 +2042,42 @@ sys.exit(0)
 class CLIHelpDocsConsistencyTests(unittest.TestCase):
     """Lightweight checks that compare CLI help semantics with docs text."""
 
+    def test_899_run_load_recipe_options_are_grouped(self):
+        """Run/load help should keep every recipe flag under the intended group."""
+        expected_groups = [
+            "General Options:",
+            "Llama.cpp Backend Options:",
+            "Stable Diffusion Options:",
+            "Whisper.cpp Options:",
+            "vLLM Options:",
+            "FastFlowLM Options:",
+        ]
+        expected_flags = [
+            "--ctx-size",
+            "--merge-args",
+            "--llamacpp",
+            "--llamacpp-device",
+            "--llamacpp-args",
+            "--sdcpp",
+            "--sdcpp-args",
+            "--whispercpp",
+            "--whispercpp-args",
+            "--vllm",
+            "--vllm-args",
+            "--flm-args",
+        ]
+
+        for command in ("run", "load"):
+            with self.subTest(command=command):
+                result = run_cli_command([command, "--help"], timeout=TIMEOUT_DEFAULT)
+                self.assertEqual(result.returncode, 0)
+
+                help_output = result.stdout + result.stderr
+                for group in expected_groups:
+                    self.assertIn(group, help_output)
+                for flag in expected_flags:
+                    self.assertIn(flag, help_output)
+
     def test_900_launch_docs_match_help_text(self):
         """The launch model-selection wording in docs should match actual CLI behavior/help."""
         result = run_cli_command(["launch", "--help"], timeout=TIMEOUT_DEFAULT)

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -2044,28 +2044,18 @@ class CLIHelpDocsConsistencyTests(unittest.TestCase):
 
     def test_899_run_load_recipe_options_are_grouped(self):
         """Run/load help should keep every recipe flag under the intended group."""
-        expected_groups = [
-            "General Options:",
-            "Llama.cpp Backend Options:",
-            "Stable Diffusion Options:",
-            "Whisper.cpp Options:",
-            "vLLM Options:",
-            "FastFlowLM Options:",
-        ]
-        expected_flags = [
-            "--ctx-size",
-            "--merge-args",
-            "--llamacpp",
-            "--llamacpp-device",
-            "--llamacpp-args",
-            "--sdcpp",
-            "--sdcpp-args",
-            "--whispercpp",
-            "--whispercpp-args",
-            "--vllm",
-            "--vllm-args",
-            "--flm-args",
-        ]
+        expected_groups = {
+            "General Options:": ["--ctx-size", "--merge-args"],
+            "FastFlowLM Options:": ["--flm-args"],
+            "Llama.cpp Backend Options:": [
+                "--llamacpp",
+                "--llamacpp-device",
+                "--llamacpp-args",
+            ],
+            "Stable Diffusion Options:": ["--sdcpp", "--sdcpp-args"],
+            "vLLM Options:": ["--vllm", "--vllm-args"],
+            "Whisper.cpp Options:": ["--whispercpp", "--whispercpp-args"],
+        }
 
         for command in ("run", "load"):
             with self.subTest(command=command):
@@ -2073,10 +2063,35 @@ class CLIHelpDocsConsistencyTests(unittest.TestCase):
                 self.assertEqual(result.returncode, 0)
 
                 help_output = result.stdout + result.stderr
-                for group in expected_groups:
-                    self.assertIn(group, help_output)
-                for flag in expected_flags:
-                    self.assertIn(flag, help_output)
+                group_positions = {
+                    group: help_output.find(group) for group in expected_groups
+                }
+                for group, position in group_positions.items():
+                    self.assertNotEqual(position, -1, f"Missing help group: {group}")
+
+                ordered_groups = sorted(
+                    group_positions.items(), key=lambda item: item[1]
+                )
+                for index, (group, start) in enumerate(ordered_groups):
+                    end = (
+                        ordered_groups[index + 1][1]
+                        if index + 1 < len(ordered_groups)
+                        else len(help_output)
+                    )
+                    section = help_output[start:end]
+
+                    for flag in expected_groups[group]:
+                        self.assertTrue(
+                            any(
+                                line.strip().startswith(flag)
+                                and (
+                                    len(line.strip()) == len(flag)
+                                    or line.strip()[len(flag)] in " ,"
+                                )
+                                for line in section.splitlines()
+                            ),
+                            f"{flag} missing from {group} in `{command} --help`",
+                        )
 
     def test_900_launch_docs_match_help_text(self):
         """The launch model-selection wording in docs should match actual CLI behavior/help."""


### PR DESCRIPTION
Groups the existing run/load recipe flags by backend in the CLI help output so they're easier to scan. No new flags are added.

Tests:
- cmake --build build --config Debug --target lemonade
- CLIHelpDocsConsistencyTests.test_899_run_load_recipe_options_are_grouped
- CLIHelpDocsConsistencyTests.test_900_launch_docs_match_help_text

Partially addresses #1066