### PR TITLE
ci: keep Windows inference cache outside workspace

### DIFF
--- a/.github/actions/cleanup-ci-paths-windows/action.yml
+++ b/.github/actions/cleanup-ci-paths-windows/action.yml
@@ -1,0 +1,110 @@
+name: Cleanup Windows CI paths
+
+description: Remove Windows CI directories using long-path-safe deletion.
+
+inputs:
+  paths:
+    description: Newline-separated list of paths to remove, or roots to prune when prune-children-older-than-days is set.
+    required: true
+  expected-root:
+    description: Optional root that every deleted path must be under.
+    required: false
+    default: ''
+  prune-children-older-than-days:
+    description: Optional age threshold. When set, delete child directories under each path that are older than this many days instead of deleting the paths themselves.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Cleanup Windows CI paths
+      shell: powershell
+      env:
+        CLEANUP_PATHS: ${{ inputs.paths }}
+        EXPECTED_ROOT: ${{ inputs.expected-root }}
+        PRUNE_CHILDREN_OLDER_THAN_DAYS: ${{ inputs.prune-children-older-than-days }}
+      run: |
+        $ErrorActionPreference = "Continue"
+
+        function Get-NormalizedFullPath {
+          param([string]$Path)
+          return [System.IO.Path]::GetFullPath($Path)
+        }
+
+        function Test-PathUnderRoot {
+          param(
+            [string]$Path,
+            [string]$ExpectedRoot
+          )
+
+          if (-not $ExpectedRoot) { return $true }
+          if (-not $Path) { return $false }
+
+          $fullPath = Get-NormalizedFullPath $Path
+          $fullRoot = Get-NormalizedFullPath $ExpectedRoot
+
+          if (-not $fullPath.EndsWith("\")) { $fullPath = "$fullPath\" }
+          if (-not $fullRoot.EndsWith("\")) { $fullRoot = "$fullRoot\" }
+
+          return $fullPath.StartsWith($fullRoot, [System.StringComparison]::OrdinalIgnoreCase)
+        }
+
+        function Remove-LongPathTree {
+          param([string]$Path)
+
+          if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return }
+
+          $fullPath = Get-NormalizedFullPath $Path
+          if (-not (Test-PathUnderRoot -Path $fullPath -ExpectedRoot $env:EXPECTED_ROOT)) {
+            Write-Host "Skipping cleanup outside expected root: $fullPath" -ForegroundColor Yellow
+            return
+          }
+
+          if ($fullPath.StartsWith("\\")) {
+            $longPath = "\\?\UNC\" + $fullPath.Substring(2)
+          } else {
+            $longPath = "\\?\" + $fullPath
+          }
+
+          Write-Host "Removing path: $fullPath" -ForegroundColor Yellow
+          cmd /c rmdir /s /q "$longPath" 2>$null
+          if (Test-Path -LiteralPath $Path) {
+            Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
+          }
+        }
+
+        $paths = @($env:CLEANUP_PATHS -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+        if ($paths.Count -eq 0) {
+          Write-Host "No paths provided for cleanup."
+          exit 0
+        }
+
+        $pruneDays = $null
+        if ($env:PRUNE_CHILDREN_OLDER_THAN_DAYS) {
+          try {
+            $pruneDays = [int]$env:PRUNE_CHILDREN_OLDER_THAN_DAYS
+          } catch {
+            Write-Host "Invalid prune-children-older-than-days value: $env:PRUNE_CHILDREN_OLDER_THAN_DAYS" -ForegroundColor Red
+            exit 1
+          }
+        }
+
+        if ($null -ne $pruneDays) {
+          $cutoff = (Get-Date).AddDays(-$pruneDays)
+          foreach ($root in $paths) {
+            if (-not (Test-Path -LiteralPath $root)) { continue }
+            if (-not (Test-PathUnderRoot -Path $root -ExpectedRoot $env:EXPECTED_ROOT)) {
+              Write-Host "Skipping prune root outside expected root: $root" -ForegroundColor Yellow
+              continue
+            }
+
+            Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue |
+              Where-Object { $_.LastWriteTime -lt $cutoff } |
+              ForEach-Object { Remove-LongPathTree $_.FullName }
+          }
+        } else {
+          foreach ($path in $paths) {
+            Remove-LongPathTree $path
+          }
+        }

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1051,15 +1051,59 @@ jobs:
           $extraArgs = "${{ matrix.extra_args }}" -split " " | Where-Object { $_ }
           $backends = "${{ matrix.backends }}" -split " " | Where-Object { $_ }
 
+          function Invoke-TestBackend {
+            param(
+              [string]$Backend,
+              [int]$MaxAttempts = 1
+            )
+
+            for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+              Write-Host "Running test/${{ matrix.script }} ${{ matrix.extra_args }} --backend $Backend (attempt $attempt/$MaxAttempts)" -ForegroundColor Cyan
+              & $venvPython test/${{ matrix.script }} @extraArgs --backend $Backend --cli-binary $serverExe
+              $testExitCode = $LASTEXITCODE
+
+              if ($testExitCode -eq 0) {
+                return
+              }
+
+              if ($attempt -lt $MaxAttempts) {
+                Write-Host "::warning title=Retrying transient backend test::test/${{ matrix.script }} --backend $Backend failed with exit code $testExitCode; cleaning sd-server state and retrying."
+
+                Get-Process sd-server -ErrorAction SilentlyContinue |
+                  Stop-Process -Force -ErrorAction SilentlyContinue
+                Start-Sleep -Seconds 20
+
+                try {
+                  Invoke-RestMethod `
+                    -Uri "http://localhost:13305/api/v1/unload" `
+                    -Method Post `
+                    -ContentType "application/json" `
+                    -Body "{}" `
+                    -TimeoutSec 30 | Out-Null
+                } catch {
+                  Write-Host "Unload before retry failed or server had no model loaded: $_" -ForegroundColor Yellow
+                }
+
+                Start-Sleep -Seconds 10
+                continue
+              }
+
+              exit $testExitCode
+            }
+          }
+
           if ($backends.Count -eq 0) {
             Write-Host "Running test/${{ matrix.script }} ${{ matrix.extra_args }}" -ForegroundColor Cyan
             & $venvPython test/${{ matrix.script }} @extraArgs --cli-binary $serverExe
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           } else {
             foreach ($backend in $backends) {
-              Write-Host "Running test/${{ matrix.script }} ${{ matrix.extra_args }} --backend $backend" -ForegroundColor Cyan
-              & $venvPython test/${{ matrix.script }} @extraArgs --backend $backend --cli-binary $serverExe
-              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              $maxAttempts = 1
+              if ("${{ matrix.name }}" -eq "stable-diffusion" -and $backend -eq "rocm") {
+                $maxAttempts = 3
+              }
+
+              Invoke-TestBackend -Backend $backend -MaxAttempts $maxAttempts
             }
           }
 

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1922,19 +1922,44 @@ jobs:
       - uses: actions/checkout@v5
 
       # ---- Windows Setup ----
-      - name: Setup (Windows)
+      - name: Setup short Windows CI paths
         if: runner.os == 'Windows'
         shell: powershell
         run: |
-          $cwd = (Get-Item .).FullName
-          echo "HF_HOME=$cwd\hf-cache" >> $Env:GITHUB_ENV
-          echo "LEMONADE_INSTALL_PATH=$cwd\lemonade_server_install" >> $Env:GITHUB_ENV
+          $ErrorActionPreference = "Stop"
+
+          $ciRoot = "C:\lemonade-ci"
+          $matrixName = "${{ matrix.os }}" -replace '[^A-Za-z0-9_.-]', '-'
+          $runKey = "${{ github.run_id }}-${{ github.run_attempt }}-$matrixName"
+
+          $hfHome = Join-Path $ciRoot "hf"
+          $cacheDir = Join-Path (Join-Path $ciRoot "cache") $matrixName
+          $installPath = Join-Path (Join-Path $ciRoot "install") $runKey
+          $tmpDir = Join-Path (Join-Path $ciRoot "tmp") $runKey
+
+          foreach ($path in @($ciRoot, $hfHome, $cacheDir, $installPath, $tmpDir)) {
+            New-Item -ItemType Directory -Force -Path $path | Out-Null
+          }
+
+          # Keep runtime/cache/install/temp paths outside $GITHUB_WORKSPACE.
+          # This mirrors the .exe inference job and avoids workspace cleanup/long-path failures.
+          echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
+          echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
+          echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
+          echo "LEMONADE_CI_ROOT=$ciRoot" >> $Env:GITHUB_ENV
+          echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
+          echo "TMP=$tmpDir" >> $Env:GITHUB_ENV
+
+          Write-Host "HF_HOME=$hfHome" -ForegroundColor Gray
+          Write-Host "LEMONADE_CACHE_DIR=$cacheDir" -ForegroundColor Gray
+          Write-Host "LEMONADE_INSTALL_PATH=$installPath" -ForegroundColor Gray
+          Write-Host "TEMP/TMP=$tmpDir" -ForegroundColor Gray
 
       - name: Install Lemonade Server (Windows)
         if: runner.os == 'Windows'
         uses: ./.github/actions/install-lemonade-server-msi
         with:
-          install-path: ${{ env.LEMONADE_INSTALL_PATH }}
+          install-path: C:\lemonade-ci\install\${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.os }}
 
       - name: Set paths (Windows)
         if: runner.os == 'Windows'
@@ -2134,17 +2159,40 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup (Windows)
+      - name: Setup short Windows CI paths
         shell: powershell
         run: |
-          $cwd = (Get-Item .).FullName
-          echo "HF_HOME=$cwd\hf-cache" >> $Env:GITHUB_ENV
-          echo "LEMONADE_INSTALL_PATH=$cwd\lemonade_server_install" >> $Env:GITHUB_ENV
+          $ErrorActionPreference = "Stop"
+
+          $ciRoot = "C:\lemonade-ci"
+          $runKey = "${{ github.run_id }}-${{ github.run_attempt }}-apikey-windows-latest"
+
+          $hfHome = Join-Path $ciRoot "hf"
+          $cacheDir = Join-Path (Join-Path $ciRoot "cache") "apikey-windows-latest"
+          $installPath = Join-Path (Join-Path $ciRoot "install") $runKey
+          $tmpDir = Join-Path (Join-Path $ciRoot "tmp") $runKey
+
+          foreach ($path in @($ciRoot, $hfHome, $cacheDir, $installPath, $tmpDir)) {
+            New-Item -ItemType Directory -Force -Path $path | Out-Null
+          }
+
+          # Keep runtime/cache/install/temp paths outside $GITHUB_WORKSPACE.
+          echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
+          echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
+          echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
+          echo "LEMONADE_CI_ROOT=$ciRoot" >> $Env:GITHUB_ENV
+          echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
+          echo "TMP=$tmpDir" >> $Env:GITHUB_ENV
+
+          Write-Host "HF_HOME=$hfHome" -ForegroundColor Gray
+          Write-Host "LEMONADE_CACHE_DIR=$cacheDir" -ForegroundColor Gray
+          Write-Host "LEMONADE_INSTALL_PATH=$installPath" -ForegroundColor Gray
+          Write-Host "TEMP/TMP=$tmpDir" -ForegroundColor Gray
 
       - name: Install Lemonade Server (Windows)
         uses: ./.github/actions/install-lemonade-server-msi
         with:
-          install-path: ${{ env.LEMONADE_INSTALL_PATH }}
+          install-path: C:\lemonade-ci\install\${{ github.run_id }}-${{ github.run_attempt }}-apikey-windows-latest
 
       - name: Set paths (Windows)
         shell: powershell

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -881,25 +881,142 @@ jobs:
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
-      LEMONADE_CACHE_DIR: ".\\ci-cache"
       PYTHONIOENCODING: utf-8
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
+      - name: Prepare Windows runner for long paths and stale workspace caches
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          Write-Host "Enabling Git long path support before checkout..." -ForegroundColor Cyan
+          git config --global core.longpaths true
+
+          try {
+            New-ItemProperty `
+              -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" `
+              -Name "LongPathsEnabled" `
+              -Value 1 `
+              -PropertyType DWord `
+              -Force `
+              -ErrorAction Stop | Out-Null
+            Write-Host "Windows long paths enabled in registry." -ForegroundColor Green
+          } catch {
+            Write-Host "Could not set Windows long-path registry flag; continuing with Git core.longpaths=true: $_" -ForegroundColor Yellow
+          }
+
+          function Remove-LongPathTree {
+            param([string]$Path)
+            if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return }
+
+            $fullPath = [System.IO.Path]::GetFullPath($Path)
+            if ($fullPath.StartsWith("\\")) {
+              $longPath = "\\?\UNC\" + $fullPath.Substring(2)
+            } else {
+              $longPath = "\\?\" + $fullPath
+            }
+
+            Write-Host "Removing stale path: $fullPath" -ForegroundColor Yellow
+            cmd /c rmdir /s /q "$longPath" 2>$null
+            if (Test-Path -LiteralPath $Path) {
+              Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
+            }
+          }
+
+          # These legacy locations were inside the repository workspace and could
+          # make actions/checkout fail to clean/reset the repository on Windows,
+          # especially after TheRock created very deep bin/ci-cache/bin/therock trees.
+          if ($env:GITHUB_WORKSPACE) {
+            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "ci-cache")
+            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "hf-cache")
+            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "lemonade_server_install")
+          }
+
       - uses: actions/checkout@v5
+        with:
+          clean: true
+          fetch-depth: 0
+
+      - name: Set Windows CI cache and install paths
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          function Remove-LongPathTree {
+            param([string]$Path)
+            if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return }
+
+            $fullPath = [System.IO.Path]::GetFullPath($Path)
+            if ($fullPath.StartsWith("\\")) {
+              $longPath = "\\?\UNC\" + $fullPath.Substring(2)
+            } else {
+              $longPath = "\\?\" + $fullPath
+            }
+
+            Write-Host "Removing stale path: $fullPath" -ForegroundColor Yellow
+            cmd /c rmdir /s /q "$longPath" 2>$null
+            if (Test-Path -LiteralPath $Path) {
+              Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
+            }
+          }
+
+          $matrixName = "${{ matrix.name }}" -replace '[^A-Za-z0-9_.-]', '-'
+          $runKey = "${{ github.run_id }}-${{ github.run_attempt }}-$matrixName"
+
+          # Keep all heavyweight runtime state outside $GITHUB_WORKSPACE. This
+          # prevents actions/checkout from trying to clean TheRock/backend caches
+          # and keeps paths short enough for Windows self-hosted runners.
+          $ciRoot = "C:\lemonade-ci"
+          $cacheRoot = Join-Path $ciRoot "cache"
+          $installRoot = Join-Path $ciRoot "install"
+          $tmpRoot = Join-Path $ciRoot "tmp"
+
+          $hfHome = Join-Path $ciRoot "hf"
+          $cacheDir = Join-Path $cacheRoot $matrixName
+          $therockCache = Join-Path $cacheDir "bin\therock"
+          $installPath = Join-Path $installRoot $runKey
+          $tmpDir = Join-Path $tmpRoot $runKey
+
+          foreach ($path in @($ciRoot, $hfHome, $cacheDir, $therockCache, $installPath, $tmpDir)) {
+            New-Item -ItemType Directory -Force -Path $path | Out-Null
+          }
+
+          # Remove the legacy in-workspace locations again after checkout in case
+          # they were restored by a previous failed checkout attempt.
+          if ($env:GITHUB_WORKSPACE) {
+            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "ci-cache")
+            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "hf-cache")
+            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "lemonade_server_install")
+          }
+
+          # Prune old transient installs/tmp dirs from previous runs. Do not wipe
+          # cacheRoot here; preserving backend/model caches is intentional.
+          foreach ($root in @($installRoot, $tmpRoot)) {
+            if (Test-Path -LiteralPath $root) {
+              Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue |
+                Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-2) } |
+                ForEach-Object { Remove-LongPathTree $_.FullName }
+            }
+          }
+
+          # Persistent HF cache outside the workspace so models survive across
+          # jobs; Lemonade backend/TheRock cache also stays outside the workspace.
+          echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
+          echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
+          echo "THEROCK_CACHE_DIR=$therockCache" >> $Env:GITHUB_ENV
+          echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
+          echo "LEMONADE_CI_ROOT=$ciRoot" >> $Env:GITHUB_ENV
+          echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
+          echo "TMP=$tmpDir" >> $Env:GITHUB_ENV
+
+          Write-Host "HF_HOME=$hfHome" -ForegroundColor Gray
+          Write-Host "LEMONADE_CACHE_DIR=$cacheDir" -ForegroundColor Gray
+          Write-Host "THEROCK_CACHE_DIR=$therockCache" -ForegroundColor Gray
+          Write-Host "LEMONADE_INSTALL_PATH=$installPath" -ForegroundColor Gray
+          Write-Host "TEMP/TMP=$tmpDir" -ForegroundColor Gray
 
       - name: Cleanup processes
         uses: ./.github/actions/cleanup-processes-windows
-
-      - name: Set environment variables
-        shell: PowerShell
-        run: |
-          # Persistent HF cache outside the workspace so models survive across
-          # jobs — the checkout clean wipes untracked workspace files (#2103)
-          $hfHome = Join-Path $Env:USERPROFILE ".cache\lemonade-ci\huggingface"
-          New-Item -ItemType Directory -Force -Path $hfHome | Out-Null
-          echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
-          $cwd = (Get-Item .\).FullName
-          echo "LEMONADE_INSTALL_PATH=$cwd\lemonade_server_install" >> $Env:GITHUB_ENV
 
       - name: Install and Verify Lemonade Server
         uses: ./.github/actions/install-lemonade-server-msi
@@ -952,9 +1069,86 @@ jobs:
         with:
           artifact-name: server-logs-exe-${{ matrix.name }}
 
-      - name: Cleanup
+      - name: Cleanup processes
         if: always()
         uses: ./.github/actions/cleanup-processes-windows
+
+      - name: Cleanup transient Windows CI directories
+        if: always()
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          function Remove-LongPathTree {
+            param([string]$Path)
+            if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return }
+
+            $fullPath = [System.IO.Path]::GetFullPath($Path)
+            if ($fullPath.StartsWith("\\")) {
+              $longPath = "\\?\UNC\" + $fullPath.Substring(2)
+            } else {
+              $longPath = "\\?\" + $fullPath
+            }
+
+            Write-Host "Removing path: $fullPath" -ForegroundColor Yellow
+            cmd /c rmdir /s /q "$longPath" 2>$null
+            if (Test-Path -LiteralPath $Path) {
+              Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
+            }
+          }
+
+          function Test-PathUnderRoot {
+            param(
+              [string]$Path,
+              [string]$ExpectedRoot
+            )
+
+            if (-not $Path -or -not $ExpectedRoot) { return $false }
+
+            $fullPath = [System.IO.Path]::GetFullPath($Path)
+            $fullRoot = [System.IO.Path]::GetFullPath($ExpectedRoot)
+
+            if (-not $fullPath.EndsWith("\")) { $fullPath = "$fullPath\" }
+            if (-not $fullRoot.EndsWith("\")) { $fullRoot = "$fullRoot\" }
+
+            return $fullPath.StartsWith($fullRoot, [System.StringComparison]::OrdinalIgnoreCase)
+          }
+
+          function Remove-CiPath {
+            param(
+              [string]$Path,
+              [string]$ExpectedRoot
+            )
+
+            if (-not $Path) { return }
+
+            if (-not (Test-PathUnderRoot -Path $Path -ExpectedRoot $ExpectedRoot)) {
+              Write-Host "Skipping cleanup outside expected CI root: $Path" -ForegroundColor Yellow
+              return
+            }
+
+            Remove-LongPathTree $Path
+          }
+
+          Remove-CiPath $env:LEMONADE_INSTALL_PATH "C:\lemonade-ci\install"
+          Remove-CiPath $env:TEMP "C:\lemonade-ci\tmp"
+
+          # Remove legacy in-workspace directories that caused checkout cleanup
+          # failures on self-hosted Windows runners.
+          if ($env:GITHUB_WORKSPACE) {
+            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "ci-cache")
+            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "hf-cache")
+            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "lemonade_server_install")
+          }
+
+          # Keep persistent cache dirs, but remove old transient run dirs.
+          foreach ($root in @("C:\lemonade-ci\install", "C:\lemonade-ci\tmp")) {
+            if (Test-Path -LiteralPath $root) {
+              Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue |
+                Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-2) } |
+                ForEach-Object { Remove-LongPathTree $_.FullName }
+            }
+          }
 
   test-deb-inference:
     name: Test .deb - ${{ matrix.name }}

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -959,18 +959,17 @@ jobs:
 
           $hfHome = Join-Path $ciRoot "hf"
           $cacheDir = Join-Path $cacheRoot $matrixName
-          $therockCache = Join-Path $cacheDir "bin\therock"
           $installPath = Join-Path $installRoot $runKey
           $tmpDir = Join-Path $tmpRoot $runKey
 
-          foreach ($path in @($ciRoot, $hfHome, $cacheDir, $therockCache, $installPath, $tmpDir)) {
+          foreach ($path in @($ciRoot, $hfHome, $cacheDir, $installPath, $tmpDir)) {
             New-Item -ItemType Directory -Force -Path $path | Out-Null
           }
           # Persistent HF cache outside the workspace so models survive across
-          # jobs; Lemonade backend/TheRock cache also stays outside the workspace.
+          # jobs; the Lemonade backend/TheRock cache lives under LEMONADE_CACHE_DIR
+          # (bin\therock), so it also stays outside the workspace.
           echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
           echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
-          echo "THEROCK_CACHE_DIR=$therockCache" >> $Env:GITHUB_ENV
           echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
           # Set both Windows temp aliases: different tools read either TEMP or TMP.
           echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
@@ -978,7 +977,6 @@ jobs:
 
           Write-Host "HF_HOME=$hfHome" -ForegroundColor Gray
           Write-Host "LEMONADE_CACHE_DIR=$cacheDir" -ForegroundColor Gray
-          Write-Host "THEROCK_CACHE_DIR=$therockCache" -ForegroundColor Gray
           Write-Host "LEMONADE_INSTALL_PATH=$installPath" -ForegroundColor Gray
           Write-Host "TEMP/TMP=$tmpDir" -ForegroundColor Gray
 

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -889,6 +889,11 @@ jobs:
         run: |
           $ErrorActionPreference = "Continue"
 
+          # Local composite actions are unavailable before actions/checkout,
+          # so this minimal long-path-safe cleanup stays inline. It removes
+          # stale workspace cache/install dirs that can otherwise make
+          # checkout clean/reset fail on persistent self-hosted Windows runners.
+
           Write-Host "Enabling Git long path support before checkout..." -ForegroundColor Cyan
           git config --global core.longpaths true
 
@@ -941,25 +946,6 @@ jobs:
         shell: PowerShell
         run: |
           $ErrorActionPreference = "Stop"
-
-          function Remove-LongPathTree {
-            param([string]$Path)
-            if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return }
-
-            $fullPath = [System.IO.Path]::GetFullPath($Path)
-            if ($fullPath.StartsWith("\\")) {
-              $longPath = "\\?\UNC\" + $fullPath.Substring(2)
-            } else {
-              $longPath = "\\?\" + $fullPath
-            }
-
-            Write-Host "Removing stale path: $fullPath" -ForegroundColor Yellow
-            cmd /c rmdir /s /q "$longPath" 2>$null
-            if (Test-Path -LiteralPath $Path) {
-              Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
-            }
-          }
-
           $matrixName = "${{ matrix.name }}" -replace '[^A-Za-z0-9_.-]', '-'
           $runKey = "${{ github.run_id }}-${{ github.run_attempt }}-$matrixName"
 
@@ -980,32 +966,13 @@ jobs:
           foreach ($path in @($ciRoot, $hfHome, $cacheDir, $therockCache, $installPath, $tmpDir)) {
             New-Item -ItemType Directory -Force -Path $path | Out-Null
           }
-
-          # Remove the legacy in-workspace locations again after checkout in case
-          # they were restored by a previous failed checkout attempt.
-          if ($env:GITHUB_WORKSPACE) {
-            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "ci-cache")
-            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "hf-cache")
-            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "lemonade_server_install")
-          }
-
-          # Prune old transient installs/tmp dirs from previous runs. Do not wipe
-          # cacheRoot here; preserving backend/model caches is intentional.
-          foreach ($root in @($installRoot, $tmpRoot)) {
-            if (Test-Path -LiteralPath $root) {
-              Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue |
-                Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-2) } |
-                ForEach-Object { Remove-LongPathTree $_.FullName }
-            }
-          }
-
           # Persistent HF cache outside the workspace so models survive across
           # jobs; Lemonade backend/TheRock cache also stays outside the workspace.
           echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
           echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
           echo "THEROCK_CACHE_DIR=$therockCache" >> $Env:GITHUB_ENV
           echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
-          echo "LEMONADE_CI_ROOT=$ciRoot" >> $Env:GITHUB_ENV
+          # Set both Windows temp aliases: different tools read either TEMP or TMP.
           echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
           echo "TMP=$tmpDir" >> $Env:GITHUB_ENV
 
@@ -1014,6 +981,25 @@ jobs:
           Write-Host "THEROCK_CACHE_DIR=$therockCache" -ForegroundColor Gray
           Write-Host "LEMONADE_INSTALL_PATH=$installPath" -ForegroundColor Gray
           Write-Host "TEMP/TMP=$tmpDir" -ForegroundColor Gray
+
+
+      - name: Cleanup legacy workspace cache dirs
+        uses: ./.github/actions/cleanup-ci-paths-windows
+        with:
+          paths: |
+            ${{ github.workspace }}\ci-cache
+            ${{ github.workspace }}\hf-cache
+            ${{ github.workspace }}\lemonade_server_install
+          expected-root: ${{ github.workspace }}
+
+      - name: Prune old transient Windows CI directories
+        uses: ./.github/actions/cleanup-ci-paths-windows
+        with:
+          paths: |
+            C:\lemonade-ci\install
+            C:\lemonade-ci\tmp
+          expected-root: C:\lemonade-ci
+          prune-children-older-than-days: '2'
 
       - name: Cleanup processes
         uses: ./.github/actions/cleanup-processes-windows
@@ -1117,82 +1103,35 @@ jobs:
         if: always()
         uses: ./.github/actions/cleanup-processes-windows
 
-      - name: Cleanup transient Windows CI directories
+      - name: Cleanup current Windows CI directories
         if: always()
-        shell: PowerShell
-        run: |
-          $ErrorActionPreference = "Continue"
+        uses: ./.github/actions/cleanup-ci-paths-windows
+        with:
+          paths: |
+            ${{ env.LEMONADE_INSTALL_PATH }}
+            ${{ env.TEMP }}
+          expected-root: C:\lemonade-ci
 
-          function Remove-LongPathTree {
-            param([string]$Path)
-            if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return }
+      - name: Cleanup legacy workspace cache dirs
+        if: always()
+        uses: ./.github/actions/cleanup-ci-paths-windows
+        with:
+          paths: |
+            ${{ github.workspace }}\ci-cache
+            ${{ github.workspace }}\hf-cache
+            ${{ github.workspace }}\lemonade_server_install
+          expected-root: ${{ github.workspace }}
 
-            $fullPath = [System.IO.Path]::GetFullPath($Path)
-            if ($fullPath.StartsWith("\\")) {
-              $longPath = "\\?\UNC\" + $fullPath.Substring(2)
-            } else {
-              $longPath = "\\?\" + $fullPath
-            }
+      - name: Prune old transient Windows CI directories
+        if: always()
+        uses: ./.github/actions/cleanup-ci-paths-windows
+        with:
+          paths: |
+            C:\lemonade-ci\install
+            C:\lemonade-ci\tmp
+          expected-root: C:\lemonade-ci
+          prune-children-older-than-days: '2'
 
-            Write-Host "Removing path: $fullPath" -ForegroundColor Yellow
-            cmd /c rmdir /s /q "$longPath" 2>$null
-            if (Test-Path -LiteralPath $Path) {
-              Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction SilentlyContinue
-            }
-          }
-
-          function Test-PathUnderRoot {
-            param(
-              [string]$Path,
-              [string]$ExpectedRoot
-            )
-
-            if (-not $Path -or -not $ExpectedRoot) { return $false }
-
-            $fullPath = [System.IO.Path]::GetFullPath($Path)
-            $fullRoot = [System.IO.Path]::GetFullPath($ExpectedRoot)
-
-            if (-not $fullPath.EndsWith("\")) { $fullPath = "$fullPath\" }
-            if (-not $fullRoot.EndsWith("\")) { $fullRoot = "$fullRoot\" }
-
-            return $fullPath.StartsWith($fullRoot, [System.StringComparison]::OrdinalIgnoreCase)
-          }
-
-          function Remove-CiPath {
-            param(
-              [string]$Path,
-              [string]$ExpectedRoot
-            )
-
-            if (-not $Path) { return }
-
-            if (-not (Test-PathUnderRoot -Path $Path -ExpectedRoot $ExpectedRoot)) {
-              Write-Host "Skipping cleanup outside expected CI root: $Path" -ForegroundColor Yellow
-              return
-            }
-
-            Remove-LongPathTree $Path
-          }
-
-          Remove-CiPath $env:LEMONADE_INSTALL_PATH "C:\lemonade-ci\install"
-          Remove-CiPath $env:TEMP "C:\lemonade-ci\tmp"
-
-          # Remove legacy in-workspace directories that caused checkout cleanup
-          # failures on self-hosted Windows runners.
-          if ($env:GITHUB_WORKSPACE) {
-            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "ci-cache")
-            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "hf-cache")
-            Remove-LongPathTree (Join-Path $env:GITHUB_WORKSPACE "lemonade_server_install")
-          }
-
-          # Keep persistent cache dirs, but remove old transient run dirs.
-          foreach ($root in @("C:\lemonade-ci\install", "C:\lemonade-ci\tmp")) {
-            if (Test-Path -LiteralPath $root) {
-              Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue |
-                Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-2) } |
-                ForEach-Object { Remove-LongPathTree $_.FullName }
-            }
-          }
 
   test-deb-inference:
     name: Test .deb - ${{ matrix.name }}
@@ -1946,7 +1885,7 @@ jobs:
           echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
           echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
           echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
-          echo "LEMONADE_CI_ROOT=$ciRoot" >> $Env:GITHUB_ENV
+          # Set both Windows temp aliases: different tools read either TEMP or TMP.
           echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
           echo "TMP=$tmpDir" >> $Env:GITHUB_ENV
 
@@ -1959,7 +1898,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: ./.github/actions/install-lemonade-server-msi
         with:
-          install-path: C:\lemonade-ci\install\${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.os }}
+          install-path: ${{ env.LEMONADE_INSTALL_PATH }}
 
       - name: Set paths (Windows)
         if: runner.os == 'Windows'
@@ -2180,7 +2119,7 @@ jobs:
           echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
           echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
           echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
-          echo "LEMONADE_CI_ROOT=$ciRoot" >> $Env:GITHUB_ENV
+          # Set both Windows temp aliases: different tools read either TEMP or TMP.
           echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
           echo "TMP=$tmpDir" >> $Env:GITHUB_ENV
 
@@ -2192,7 +2131,7 @@ jobs:
       - name: Install Lemonade Server (Windows)
         uses: ./.github/actions/install-lemonade-server-msi
         with:
-          install-path: C:\lemonade-ci\install\${{ github.run_id }}-${{ github.run_attempt }}-apikey-windows-latest
+          install-path: ${{ env.LEMONADE_INSTALL_PATH }}
 
       - name: Set paths (Windows)
         shell: powershell


### PR DESCRIPTION
Summary:

- Moves Windows .exe inference job runtime/cache/install/temp paths out of the GitHub workspace and into short `C:\lemonade-ci\...` paths.
- Enables Git long-path support before checkout and cleans stale in-workspace cache/install directories before and after checkout.
- Keeps persistent Lemonade/Hugging Face/TheRock cache state outside the workspace while pruning old transient install/tmp run directories.

Is intended to **fix** a large amount of **CI failures** and validation will be done with this real world testing here.