### PR TITLE
add cuda to llama.cpp auto updater

### DIFF
--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -106,6 +106,7 @@ jobs:
           Write-Host "Updating llamacpp rocm-stable to $rocmStable" -ForegroundColor Cyan
           $old = $data.llamacpp.'rocm-stable'
           $data.llamacpp.'rocm-stable' = $rocmStable
+          $data.llamacpp.'cuda' = $rocmStable
           Write-Host "  llamacpp.rocm-stable: $old -> $rocmStable"
 
           $data | ConvertTo-Json -Depth 10 | Set-Content $path -Encoding UTF8
@@ -307,6 +308,7 @@ jobs:
           data['llamacpp']['vulkan'] = llamacpp
           data['llamacpp']['cpu'] = llamacpp
           data['llamacpp']['metal'] = llamacpp
+          data['llamacpp']['cuda'] = rocm_stable
           data['llamacpp']['rocm-stable'] = rocm_stable
           data['llamacpp']['rocm-nightly'] = rocm_nightly
           with open(path, 'w') as f:


### PR DESCRIPTION
Add `llamacpp:cuda` to the llama.cpp auto-upgrade workflow.

Closes #2150

## Changes

- Update CUDA to use the same `lemonade-sdk/llama.cpp` release as `rocm-stable`
- Keep build-time and PR-generation backend version updates consistent