### PR TITLE
fix: remove references to env vars dropped in #2106

### DIFF
--- a/examples/llm-debate.html
+++ b/examples/llm-debate.html
@@ -831,8 +831,8 @@
             <h3 style="color: var(--accent-red);">⚠️ Not Enough Model Slots</h3>
             <p id="errorPopupMessage" style="color: var(--text-secondary); margin-bottom: 1rem;"></p>
             <p style="color: var(--text-secondary); font-size: 0.85rem;">
-                Update config.json to increase model slots:<br>
-                <code id="errorPopupCommand">"max_loaded_models": 9</code>
+                Run this command to increase model slots:<br>
+                <code id="errorPopupCommand">lemonade config set max_loaded_models=9</code>
             </p>
             <button class="got-it-btn" style="background: linear-gradient(135deg, var(--accent-red) 0%, #dc2626 100%);" onclick="document.getElementById('errorPopup').style.display='none'">Got it!</button>
         </div>
@@ -1177,7 +1177,7 @@
             const command = document.getElementById('errorPopupCommand');
 
             message.textContent = `You selected ${selectedCount} models, but the server only has ${maxSlots} LLM slot${maxSlots === 1 ? '' : 's'} available.`;
-            command.textContent = `Set LEMONADE_MAX_LOADED_MODELS=${selectedCount} and restart the server`;
+            command.textContent = `lemonade config set max_loaded_models=${selectedCount}`;
             popup.style.display = 'flex';
         }
 

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2232,7 +2232,7 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
 
     if (enable_dgpu_gtt)
     {
-      LOG(INFO, "ModelManager") << "LEMONADE_ENABLE_DGPU_GTT has been set to true." << std::endl
+      LOG(INFO, "ModelManager") << "enable_dgpu_gtt has been set to true." << std::endl
                 << "     Models are being filtered assuming GTT memory." << std::endl
                 << "     Using GTT on a dGPU will have a significant performance impact." << std::endl;
     }


### PR DESCRIPTION
## Summary

PR #2106 dropped the environment-variable → `config.json` migration code, so several `LEMONADE_*` env vars no longer have any effect. A sweep of the repo (docs, examples, Docker examples, tests, CI) turned up two user-facing spots that still referenced removed env vars:

- **`examples/llm-debate.html`** — the "not enough model slots" popup instructed users to `Set LEMONADE_MAX_LOADED_MODELS=N and restart the server`. That env var was removed in #2106. Replaced with the actionable `lemonade config set max_loaded_models=N` (matches the surrounding "increase model slots" copy). No restart wording: the router reads `config_->max_loaded_models()` on every load, so the new value applies on the next model load.
- **`src/cpp/server/model_manager.cpp`** — a startup log line still named the removed `LEMONADE_ENABLE_DGPU_GTT` env var (the value now comes from `config.json` via `cfg->enable_dgpu_gtt()`). Reworded to the config key `enable_dgpu_gtt`.

## Notes on what was *not* changed

Many removed env var *names* (`LEMONADE_HOST`, `LEMONADE_PORT`, `LEMONADE_CTX_SIZE`, `LEMONADE_LLAMACPP*`, `LEMONADE_SDCPP*`, `LEMONADE_WHISPERCPP*`, `LEMONADE_FLM_ARGS`) are still wired into the `lemonade` CLI client via CLI11 `->envname()`, so they remain functional and their doc references are correct. The Docker docs/Dockerfiles were already cleaned by #2106. Only truly-dead references were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)