### PR TITLE
fix(nvidia/snap): CUDA GPU detection under snap strict confinement

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -37,11 +37,6 @@
 #endif
 
 #ifdef __linux__
-#include <unistd.h>
-#include <dlfcn.h>
-#endif
-
-#ifdef __linux__
 #include <dlfcn.h>
 #include <sys/ioctl.h>
 #include <fcntl.h>
@@ -2430,10 +2425,14 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
         std::string cmd = std::string(smi) + smi_query;
         FILE* pipe = popen(cmd.c_str(), "r");
         if (!pipe) continue;
+        std::string candidate;
         char buffer[512];
-        while (fgets(buffer, sizeof(buffer), pipe) != nullptr) output += buffer;
-        pclose(pipe);
-        if (!output.empty()) break;
+        while (fgets(buffer, sizeof(buffer), pipe) != nullptr) candidate += buffer;
+        int rc = pclose(pipe);
+        if (rc == 0 && !candidate.empty()) {
+            output = candidate;
+            break;
+        }
     }
     if (output.empty()) return result;
 #endif
@@ -2571,14 +2570,14 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_nvml() {
             char name_buf[NVML_DEVICE_NAME_BUFFER_SIZE] = {};
             if (nvmlGetName(dev, name_buf, sizeof(name_buf)) != NVML_SUCCESS) continue;
 
-            int major = 0, minor = 0;
-            if (nvmlGetCC(dev, &major, &minor) != NVML_SUCCESS) continue;
-
             NvidiaSmiGpuInfo info;
             info.index          = static_cast<int>(i);
             info.name           = name_buf;
-            info.compute_cap    = std::to_string(major) + "." + std::to_string(minor);
             info.driver_version = driver_version;
+
+            int major = 0, minor = 0;
+            if (nvmlGetCC(dev, &major, &minor) == NVML_SUCCESS)
+                info.compute_cap = std::to_string(major) + "." + std::to_string(minor);
 
             if (nvmlGetMem) {
                 NvmlMemory mem{};
@@ -3176,16 +3175,40 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
         return gpus;
     }
 
-    // Secondary: /proc/driver/nvidia/gpus/*/information — readable whenever the
+    // Secondary: NVML via dlopen — libnvidia-ml.so.1 communicates with the NVIDIA
+    // kernel module through /dev/nvidiactl (allowed by the snap opengl interface)
+    // rather than /proc/driver/nvidia/, so it works under snap strict confinement.
+    // Returns full name, compute capability, and per-GPU VRAM — same quality as nvidia-smi.
+    {
+        auto nvml_gpus = query_nvidia_nvml();
+        if (!nvml_gpus.empty()) {
+            LOG(WARNING, "SystemInfo") << "nvidia-smi detection failed; NVML library fallback succeeded" << std::endl;
+            for (const auto& nvml : nvml_gpus) {
+                GPUInfo gpu;
+                gpu.index              = nvml.index;
+                gpu.name               = nvml.name;
+                gpu.available          = true;
+                gpu.compute_capability = nvml.compute_cap;
+                gpu.driver_version     = nvml.driver_version.empty()
+                    ? get_nvidia_driver_version() : nvml.driver_version;
+                if (gpu.driver_version.empty()) gpu.driver_version = "Unknown";
+                gpu.vram_gb            = nvml.vram_gb;
+                gpus.push_back(gpu);
+            }
+            return gpus;
+        }
+    }
+
+    // Tertiary: /proc/driver/nvidia/gpus/*/information — readable whenever the
     // nvidia kernel module is loaded, even when the GPU is in Optimus power-save
-    // mode and nvidia-smi fails. Provides the full model name and GPU UUID, which
-    // is enough for identify_cuda_arch_from_name() to determine the sm_XX family.
-    // (No compute_capability here; family is resolved from the name.)
+    // mode and NVML/nvidia-smi fail. Provides the full model name and GPU UUID,
+    // which is enough for identify_cuda_arch_from_name() to determine the sm_XX
+    // family. (No compute_capability here; family is resolved from the name.)
     {
         fs::path gpus_dir = "/proc/driver/nvidia/gpus";
         std::error_code ec;
         if (fs::exists(gpus_dir, ec) && fs::is_directory(gpus_dir, ec)) {
-            LOG(WARNING, "SystemInfo") << "nvidia-smi detection failed; falling back to /proc/driver/nvidia/gpus" << std::endl;
+            LOG(WARNING, "SystemInfo") << "nvidia-smi/NVML detection failed; falling back to /proc/driver/nvidia/gpus" << std::endl;
             std::string driver_version = get_nvidia_driver_version();
             // VRAM is intentionally left unset here: get_nvidia_vram() reads a
             // single memory.total value, which would be wrong if applied to
@@ -3216,30 +3239,6 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
                 }
             }
             if (!gpus.empty()) return gpus;
-        }
-    }
-
-    // Fallback: NVML via dlopen — libnvidia-ml.so.1 communicates with the NVIDIA
-    // kernel module through /dev/nvidiactl (allowed by the snap opengl interface)
-    // rather than /proc/driver/nvidia/, so it works under snap strict confinement.
-    // Returns full name and compute capability, same quality as nvidia-smi.
-    {
-        auto nvml_gpus = query_nvidia_nvml();
-        if (!nvml_gpus.empty()) {
-            LOG(WARNING, "SystemInfo") << "nvidia-smi detection failed; NVML library fallback succeeded" << std::endl;
-            for (const auto& nvml : nvml_gpus) {
-                GPUInfo gpu;
-                gpu.index             = nvml.index;
-                gpu.name              = nvml.name;
-                gpu.available         = true;
-                gpu.compute_capability = nvml.compute_cap;
-                gpu.driver_version    = nvml.driver_version.empty()
-                    ? get_nvidia_driver_version() : nvml.driver_version;
-                if (gpu.driver_version.empty()) gpu.driver_version = "Unknown";
-                gpu.vram_gb           = nvml.vram_gb;
-                gpus.push_back(gpu);
-            }
-            return gpus;
         }
     }
 
@@ -3276,8 +3275,8 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
                 gpu.name           = device_id.empty()
                     ? "NVIDIA GPU"
                     : "NVIDIA GPU [" + device_id + "]";
-                double vram = get_nvidia_vram();
-                if (vram > 0.0) gpu.vram_gb = vram;
+                // VRAM intentionally left unset: get_nvidia_vram() shells out to
+                // nvidia-smi, which we already know is unavailable at this point.
                 gpus.push_back(gpu);
             }
             if (!gpus.empty()) return gpus;

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -2546,7 +2546,7 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_nvml() {
     auto nvmlGetDriver = (fn_GetDriver)load("nvmlSystemGetDriverVersion");
 
     if (!nvmlInit || !nvmlShutdown || !nvmlGetCount || !nvmlGetHandle ||
-        !nvmlGetName || !nvmlGetCC) {
+        !nvmlGetName) {
         dlclose(handle);
         return result;
     }
@@ -2576,7 +2576,7 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_nvml() {
             info.driver_version = driver_version;
 
             int major = 0, minor = 0;
-            if (nvmlGetCC(dev, &major, &minor) == NVML_SUCCESS)
+            if (nvmlGetCC && nvmlGetCC(dev, &major, &minor) == NVML_SUCCESS)
                 info.compute_cap = std::to_string(major) + "." + std::to_string(minor);
 
             if (nvmlGetMem) {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -3191,6 +3191,7 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
             for (const auto& nvml : nvml_gpus) {
                 GPUInfo gpu;
                 gpu.index              = nvml.index;
+                gpu.uuid               = nvml.uuid;
                 gpu.name               = nvml.name;
                 gpu.available          = true;
                 gpu.compute_capability = nvml.compute_cap;

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -2253,10 +2253,8 @@ std::string SystemInfo::get_cuda_visible_devices_for_arch(const std::string& arc
         }
 
         bool has_other_arch = false;
-        int ordinal = 0;
         for (const auto& gpu : devices["nvidia_gpu"]) {
             if (!gpu.value("available", false)) {
-                ordinal++;
                 continue;
             }
 
@@ -2264,15 +2262,14 @@ std::string SystemInfo::get_cuda_visible_devices_for_arch(const std::string& arc
                 std::string uuid = gpu.value("uuid", "");
                 if (!uuid.empty()) {
                     devices_to_expose.push_back(uuid);
-                } else {
-                    // Fallback only for detection paths that lack UUIDs. This is less robust
-                    // than UUIDs because numeric CUDA ordinals can differ from nvidia-smi indices.
-                    devices_to_expose.push_back(std::to_string(ordinal));
                 }
+                // If UUID is missing we skip this GPU rather than falling back to a numeric
+                // ordinal — ordinals are unreliable on mixed-arch systems and can expose the
+                // wrong GPU, causing "no kernel image available" crashes like the RTX 5090 +
+                // RTX 4090 case. Returning "" (no restriction) is safer than a wrong ordinal.
             } else {
                 has_other_arch = true;
             }
-            ordinal++;
         }
 
         // No mixed architectures — no need to restrict CUDA_VISIBLE_DEVICES.
@@ -2524,6 +2521,7 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_nvml() {
     using fn_GetCount   = nvmlReturn_t (*)(unsigned int*);
     using fn_GetHandle  = nvmlReturn_t (*)(unsigned int, nvmlDevice_t*);
     using fn_GetName    = nvmlReturn_t (*)(nvmlDevice_t, char*, unsigned int);
+    using fn_GetUUID    = nvmlReturn_t (*)(nvmlDevice_t, char*, unsigned int);
     using fn_GetCC      = nvmlReturn_t (*)(nvmlDevice_t, int*, int*);
     using fn_GetMem     = nvmlReturn_t (*)(nvmlDevice_t, NvmlMemory*);
     using fn_GetDriver  = nvmlReturn_t (*)(char*, unsigned int);
@@ -2541,6 +2539,7 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_nvml() {
     if (!nvmlGetHandle)
         nvmlGetHandle = (fn_GetHandle)load("nvmlDeviceGetHandleByIndex");
     auto nvmlGetName   = (fn_GetName)load("nvmlDeviceGetName");
+    auto nvmlGetUUID   = (fn_GetUUID)load("nvmlDeviceGetUUID");
     auto nvmlGetCC     = (fn_GetCC)load("nvmlDeviceGetCudaComputeCapability");
     auto nvmlGetMem    = (fn_GetMem)load("nvmlDeviceGetMemoryInfo");
     auto nvmlGetDriver = (fn_GetDriver)load("nvmlSystemGetDriverVersion");
@@ -2574,6 +2573,12 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_nvml() {
             info.index          = static_cast<int>(i);
             info.name           = name_buf;
             info.driver_version = driver_version;
+
+            if (nvmlGetUUID) {
+                char uuid_buf[96] = {};
+                if (nvmlGetUUID(dev, uuid_buf, sizeof(uuid_buf)) == NVML_SUCCESS)
+                    info.uuid = uuid_buf;
+            }
 
             int major = 0, minor = 0;
             if (nvmlGetCC && nvmlGetCC(dev, &major, &minor) == NVML_SUCCESS)

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -38,6 +38,7 @@
 
 #ifdef __linux__
 #include <unistd.h>
+#include <dlfcn.h>
 #endif
 
 #ifdef __linux__
@@ -2422,13 +2423,18 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
         output, 10);
     if (rc != 0 || output.empty()) return result;
 #else
-    FILE* pipe = popen(
-        "nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total "
-        "--format=csv,noheader,nounits 2>/dev/null", "r");
-    if (!pipe) return result;
-    char buffer[512];
-    while (fgets(buffer, sizeof(buffer), pipe) != nullptr) output += buffer;
-    pclose(pipe);
+    static const char* smi_query =
+        " --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total"
+        " --format=csv,noheader,nounits 2>/dev/null";
+    for (const char* smi : {"nvidia-smi", "/usr/bin/nvidia-smi"}) {
+        std::string cmd = std::string(smi) + smi_query;
+        FILE* pipe = popen(cmd.c_str(), "r");
+        if (!pipe) continue;
+        char buffer[512];
+        while (fgets(buffer, sizeof(buffer), pipe) != nullptr) output += buffer;
+        pclose(pipe);
+        if (!output.empty()) break;
+    }
     if (output.empty()) return result;
 #endif
 
@@ -2491,6 +2497,104 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
     }
     return result;
 }
+
+#ifdef __linux__
+// Query GPU info via NVML (libnvidia-ml.so.1) using dlopen so no link-time
+// dependency is required.  NVML communicates with the NVIDIA kernel module
+// through /dev/nvidiactl (allowed by the snap opengl interface) rather than
+// through /proc/driver/nvidia/, making it the correct fallback when nvidia-smi
+// fails due to AppArmor restrictions in snap strict confinement.
+static std::vector<NvidiaSmiGpuInfo> query_nvidia_nvml() {
+    std::vector<NvidiaSmiGpuInfo> result;
+
+    void* handle = dlopen("libnvidia-ml.so.1", RTLD_NOW | RTLD_LOCAL);
+    if (!handle)
+        handle = dlopen("/usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1", RTLD_NOW | RTLD_LOCAL);
+    if (!handle)
+        return result;
+
+    // Minimal NVML ABI surface — only what we actually call.
+    using nvmlDevice_t = void*;
+    using nvmlReturn_t = int;
+    constexpr nvmlReturn_t NVML_SUCCESS = 0;
+    constexpr unsigned int NVML_DEVICE_NAME_BUFFER_SIZE = 96;
+    struct NvmlMemory { unsigned long long total, free, used; };
+
+    using fn_Init       = nvmlReturn_t (*)(void);
+    using fn_Shutdown   = nvmlReturn_t (*)(void);
+    using fn_GetCount   = nvmlReturn_t (*)(unsigned int*);
+    using fn_GetHandle  = nvmlReturn_t (*)(unsigned int, nvmlDevice_t*);
+    using fn_GetName    = nvmlReturn_t (*)(nvmlDevice_t, char*, unsigned int);
+    using fn_GetCC      = nvmlReturn_t (*)(nvmlDevice_t, int*, int*);
+    using fn_GetMem     = nvmlReturn_t (*)(nvmlDevice_t, NvmlMemory*);
+    using fn_GetDriver  = nvmlReturn_t (*)(char*, unsigned int);
+
+    auto load = [&](const char* sym) { return dlsym(handle, sym); };
+
+    auto nvmlInit    = (fn_Init)load("nvmlInit_v2");
+    if (!nvmlInit)
+        nvmlInit = (fn_Init)load("nvmlInit");
+    auto nvmlShutdown = (fn_Shutdown)load("nvmlShutdown");
+    auto nvmlGetCount = (fn_GetCount)load("nvmlDeviceGetCount_v2");
+    if (!nvmlGetCount)
+        nvmlGetCount = (fn_GetCount)load("nvmlDeviceGetCount");
+    auto nvmlGetHandle = (fn_GetHandle)load("nvmlDeviceGetHandleByIndex_v2");
+    if (!nvmlGetHandle)
+        nvmlGetHandle = (fn_GetHandle)load("nvmlDeviceGetHandleByIndex");
+    auto nvmlGetName   = (fn_GetName)load("nvmlDeviceGetName");
+    auto nvmlGetCC     = (fn_GetCC)load("nvmlDeviceGetCudaComputeCapability");
+    auto nvmlGetMem    = (fn_GetMem)load("nvmlDeviceGetMemoryInfo");
+    auto nvmlGetDriver = (fn_GetDriver)load("nvmlSystemGetDriverVersion");
+
+    if (!nvmlInit || !nvmlShutdown || !nvmlGetCount || !nvmlGetHandle ||
+        !nvmlGetName || !nvmlGetCC) {
+        dlclose(handle);
+        return result;
+    }
+
+    if (nvmlInit() != NVML_SUCCESS) {
+        dlclose(handle);
+        return result;
+    }
+
+    char driver_buf[64] = {};
+    std::string driver_version;
+    if (nvmlGetDriver && nvmlGetDriver(driver_buf, sizeof(driver_buf)) == NVML_SUCCESS)
+        driver_version = driver_buf;
+
+    unsigned int count = 0;
+    if (nvmlGetCount(&count) == NVML_SUCCESS) {
+        for (unsigned int i = 0; i < count; i++) {
+            nvmlDevice_t dev = nullptr;
+            if (nvmlGetHandle(i, &dev) != NVML_SUCCESS) continue;
+
+            char name_buf[NVML_DEVICE_NAME_BUFFER_SIZE] = {};
+            if (nvmlGetName(dev, name_buf, sizeof(name_buf)) != NVML_SUCCESS) continue;
+
+            int major = 0, minor = 0;
+            if (nvmlGetCC(dev, &major, &minor) != NVML_SUCCESS) continue;
+
+            NvidiaSmiGpuInfo info;
+            info.index          = static_cast<int>(i);
+            info.name           = name_buf;
+            info.compute_cap    = std::to_string(major) + "." + std::to_string(minor);
+            info.driver_version = driver_version;
+
+            if (nvmlGetMem) {
+                NvmlMemory mem{};
+                if (nvmlGetMem(dev, &mem) == NVML_SUCCESS)
+                    info.vram_gb = static_cast<double>(mem.total) / (1024.0 * 1024.0 * 1024.0);
+            }
+
+            result.push_back(info);
+        }
+    }
+
+    nvmlShutdown();
+    dlclose(handle);
+    return result;
+}
+#endif
 
 // ============================================================================
 // Windows implementation
@@ -3115,6 +3219,71 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
         }
     }
 
+    // Fallback: NVML via dlopen — libnvidia-ml.so.1 communicates with the NVIDIA
+    // kernel module through /dev/nvidiactl (allowed by the snap opengl interface)
+    // rather than /proc/driver/nvidia/, so it works under snap strict confinement.
+    // Returns full name and compute capability, same quality as nvidia-smi.
+    {
+        auto nvml_gpus = query_nvidia_nvml();
+        if (!nvml_gpus.empty()) {
+            LOG(WARNING, "SystemInfo") << "nvidia-smi detection failed; NVML library fallback succeeded" << std::endl;
+            for (const auto& nvml : nvml_gpus) {
+                GPUInfo gpu;
+                gpu.index             = nvml.index;
+                gpu.name              = nvml.name;
+                gpu.available         = true;
+                gpu.compute_capability = nvml.compute_cap;
+                gpu.driver_version    = nvml.driver_version.empty()
+                    ? get_nvidia_driver_version() : nvml.driver_version;
+                if (gpu.driver_version.empty()) gpu.driver_version = "Unknown";
+                gpu.vram_gb           = nvml.vram_gb;
+                gpus.push_back(gpu);
+            }
+            return gpus;
+        }
+    }
+
+    // Fallback: /sys/class/drm — readable via hardware-observe; works in snap strict
+    // confinement where /proc/driver/nvidia/ access is restricted.  Provides GPU
+    // presence and device IDs but not human-readable names, so name defaults to a
+    // placeholder that downstream callers can refine.
+    {
+        fs::path drm_path = "/sys/class/drm";
+        std::error_code ec;
+        if (fs::exists(drm_path, ec) && fs::is_directory(drm_path, ec)) {
+            std::string driver_version = get_nvidia_driver_version();
+            for (const auto& entry : fs::directory_iterator(drm_path, ec)) {
+                std::string card_name = entry.path().filename().string();
+                // Only top-level card* entries; skip connectors (contain '-').
+                if (card_name.rfind("card", 0) != 0 || card_name.find('-') != std::string::npos)
+                    continue;
+
+                fs::path vendor_path = entry.path() / "device" / "vendor";
+                std::ifstream vendor_file(vendor_path);
+                if (!vendor_file.is_open()) continue;
+                std::string vendor_str;
+                std::getline(vendor_file, vendor_str);
+                if (vendor_str != "0x10de") continue;  // NVIDIA PCI vendor ID
+
+                std::string device_id;
+                fs::path device_path = entry.path() / "device" / "device";
+                std::ifstream device_file(device_path);
+                if (device_file.is_open()) std::getline(device_file, device_id);
+
+                GPUInfo gpu;
+                gpu.available      = true;
+                gpu.driver_version = driver_version.empty() ? "Unknown" : driver_version;
+                gpu.name           = device_id.empty()
+                    ? "NVIDIA GPU"
+                    : "NVIDIA GPU [" + device_id + "]";
+                double vram = get_nvidia_vram();
+                if (vram > 0.0) gpu.vram_gb = vram;
+                gpus.push_back(gpu);
+            }
+            if (!gpus.empty()) return gpus;
+        }
+    }
+
     // Fallback: lspci (for systems where nvidia-smi is unavailable)
     FILE* pipe = popen("lspci 2>/dev/null | grep -iE 'vga|3d|display'", "r");
     if (!pipe) {
@@ -3382,6 +3551,18 @@ std::string LinuxSystemInfo::get_nvidia_driver_version() {
             }
         }
         pclose(pipe);
+    }
+
+    // Fallback: /sys/module/nvidia/version — accessible via hardware-observe interface
+    // and does not require /proc/driver/nvidia/ access.
+    {
+        std::ifstream sysfile("/sys/module/nvidia/version");
+        if (sysfile.is_open()) {
+            std::string version;
+            if (std::getline(sysfile, version) && !version.empty()) {
+                return version;
+            }
+        }
     }
 
     // Fallback: Try /proc/driver/nvidia/version


### PR DESCRIPTION
## Summary

- Try `/usr/bin/nvidia-smi` explicitly since `nvidia-smi` may not be in `PATH` under snap strict confinement
- Add `/sys/module/nvidia/version` fallback for driver version detection (readable via `hardware-observe` interface)
- Add NVML `dlopen` fallback that queries `libnvidia-ml.so.1` directly — NVML communicates via `/dev/nvidiactl` (permitted by the `opengl` interface) rather than `/proc/driver/nvidia/` (blocked by AppArmor), and returns full GPU name and compute capability

Fallback chain after this change:
1. `nvidia-smi` (PATH + `/usr/bin/` explicit)
2. NVML via `dlopen` (snap-friendly, full data)
3. `/proc/driver/nvidia/gpus/` (non-snap)
4. `/sys/class/drm` vendor scan (presence only)
5. `lspci`

## Test plan

- [ ] Build and install the snap with `opengl` and `hardware-observe` interfaces connected
- [ ] Confirm `lemonade list` shows NVIDIA GPU models (previously showed "arch unknown")
- [ ] Confirm `lemonade run` works with a CUDA-capable model (e.g. a llama.cpp Vulkan/CUDA model)
- [ ] On a non-snap install, confirm GPU detection still works via the existing nvidia-smi path

🤖 Generated with [Claude Code](https://claude.com/claude-code)