### PR TITLE
vllm: rename built-in models with -FP16- suffix

### DIFF
--- a/docs/guide/configuration/vllm.md
+++ b/docs/guide/configuration/vllm.md
@@ -35,7 +35,9 @@ The install fetches a per-GPU-target release (e.g. `…-gfx1151`, `…-gfx1150`)
 
 ## Use
 
-Models registered with the `vllm` recipe in [`server_models.json`](https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/resources/server_models.json) load automatically on first request. To register your own:
+Models registered with the `vllm` recipe in [`server_models.json`](https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/resources/server_models.json) load automatically on first request. Built-in `vllm` entries serve the upstream Hugging Face weights as-is in **FP16** — there is no quantization step in the load path — so their model IDs carry an explicit `-FP16-` segment (e.g. `Qwen3.5-4B-FP16-vLLM`). This mirrors the `-Hybrid` / `-CPU` suffix convention used by `ryzenai-llm` and makes the data type obvious next to `llamacpp` (GGUF, typically Q4_K_M) and `flm` (4-bit) entries in the same list. Pointing a `user.*` `vllm` registration at a pre-quantized checkpoint (FP8, AWQ, GPTQ, etc.) is still supported.
+
+To register your own:
 
 ```bash
 lemonade pull user.MyModel \

--- a/docs/news/vllm-rocm.html
+++ b/docs/news/vllm-rocm.html
@@ -90,7 +90,7 @@ sudo apt install lemonade-server
 
 # Install and run the vLLM ROCm backend
 lemonade backends install vllm:rocm
-lemonade run Qwen3.5-0.8B-vLLM</code></pre>
+lemonade run Qwen3.5-0.8B-FP16-vLLM</code></pre>
           </div>
 
           <p>The vLLM backend download is large and can take a while. The first model download also takes a few minutes, and first-time users should confirm the Linux kernel prerequisites before installing the backend.</p>

--- a/src/app/src/renderer/AddModelPanel.tsx
+++ b/src/app/src/renderer/AddModelPanel.tsx
@@ -73,7 +73,7 @@ const RECIPE_EXAMPLES: Record<string, RecipeExample> = {
     checkpoint: 'mikkoph/kokoro-onnx',
   },
   'vllm': {
-    name: 'Qwen3.5-0.8B-vLLM',
+    name: 'Qwen3.5-0.8B-FP16-vLLM',
     checkpoint: 'Qwen/Qwen3.5-0.8B',
   },
 };

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1567,7 +1567,7 @@
         ],
         "size": 0.017
     },
-    "Qwen3.5-0.8B-vLLM": {
+    "Qwen3.5-0.8B-FP16-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-0.8B",
         "recipe": "vllm",
         "suggested": true,
@@ -1576,7 +1576,7 @@
         ],
         "size": 1.77
     },
-    "Qwen3.5-2B-vLLM": {
+    "Qwen3.5-2B-FP16-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-2B",
         "recipe": "vllm",
         "suggested": true,
@@ -1585,7 +1585,7 @@
         ],
         "size": 4.57
     },
-    "Qwen3.5-4B-vLLM": {
+    "Qwen3.5-4B-FP16-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-4B",
         "recipe": "vllm",
         "suggested": true,
@@ -1595,7 +1595,7 @@
         ],
         "size": 9.34
     },
-    "Qwen3.5-9B-vLLM": {
+    "Qwen3.5-9B-FP16-vLLM": {
         "checkpoint": "Qwen/Qwen3.5-9B",
         "recipe": "vllm",
         "suggested": true,


### PR DESCRIPTION
## Summary
- Rename the four built-in `vllm` entries in `server_models.json` to embed `-FP16-` in the model ID — e.g. `Qwen3.5-4B-vLLM` → `Qwen3.5-4B-FP16-vLLM`. This matches the `-Hybrid` / `-CPU` suffix convention already used by `ryzenai-llm` and makes the data type obvious next to `llamacpp` (Q4_K_M) and `flm` (4-bit) entries in the same list.
- Update the one `Qwen3.5-0.8B-vLLM` placeholder in `AddModelPanel.tsx` (Add Model panel example) and the quickstart in `docs/news/vllm-rocm.html` so existing references stay correct.
- Add a short paragraph to `docs/guide/configuration/vllm.md` documenting the naming convention and noting that pointing a `user.*` `vllm` registration at a pre-quantized checkpoint (FP8, AWQ, GPTQ, …) is still supported.

> **Heads-up — breaking change to public model IDs.** Existing pulls/downloads under the old `Qwen3.5-*-vLLM` names will no longer match a built-in registry entry. vLLM is still flagged experimental, so this is the cheapest time to do this; deferring it would mean shipping a deprecation alias later.

Closes #1826.

## Test plan
- [ ] `lemonade list` shows the renamed entries: `Qwen3.5-0.8B-FP16-vLLM`, `Qwen3.5-2B-FP16-vLLM`, `Qwen3.5-4B-FP16-vLLM`, `Qwen3.5-9B-FP16-vLLM`.
- [ ] `lemonade run Qwen3.5-4B-FP16-vLLM` loads, downloads if needed, and serves chat completions as before.
- [ ] `GET /api/v1/models` returns the renamed IDs.
- [ ] Add Model panel in the desktop app shows the new placeholder name when recipe is set to `vllm`.
- [ ] Docs site renders the new paragraph in `docs/guide/configuration/vllm.md` cleanly; quickstart on the vllm-rocm blog page is consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)