### PR TITLE
fix(llamacpp): bump cuda/rocm-stable to b9581

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -2,9 +2,9 @@
   "comment": "This configuration file controls which llama.cpp, whisper.cpp, sd.cpp, ryzenai-llm, and FLM versions are downloaded for each backend. You can modify these values to pin specific versions without rebuilding the application.",
   "llamacpp": {
     "vulkan": "b9550",
-    "rocm-stable": "b9549",
+    "rocm-stable": "b9581",
     "rocm-nightly": "b1290",
-    "cuda": "b9549",
+    "cuda": "b9581",
     "metal": "b9550",
     "cpu": "b9550"
   },


### PR DESCRIPTION
## Summary

Fixes #2163

b9549 was missing 8 CUDA artifacts:
- All 7 Windows CUDA builds (`windows-cuda-sm_*-x64.7z`)
- `ubuntu-cuda-sm_90-x64.tar.xz`

b9581 has the complete set of 25 expected artifacts.

## Changes
- `rocm-stable`: `b9549` → `b9581`
- `cuda`: `b9549` → `b9581`