### PR TITLE
ci: wire HF_TOKEN into linux distro builds; drop Fedora

### DIFF
--- a/.github/workflows/linux_distro_builds.yml
+++ b/.github/workflows/linux_distro_builds.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}
+    env:
+      HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
 
     strategy:
       fail-fast: false
@@ -43,9 +45,6 @@ jobs:
             python: python
           - distro: Debian
             image: debian:trixie
-            python: python3
-          - distro: Fedora
-            image: fedora:latest
             python: python3
           - distro: openSUSE
             image: opensuse/tumbleweed:latest


### PR DESCRIPTION
The purpose of this PR is to reduce the amount of CI failures from distro builds getting rate limited by HF.

Applies `HF_TOKEN` to `.github/workflows/linux_distro_builds.yml`, following the same pattern #2105 used for `cpp_server_build_test_release.yml`.

Also removes the **Fedora** distro from the build matrix (Arch, Debian, and openSUSE remain). The Fedora build was not needed in this workflow since we have 2 Fedora builds in the main release workflow.