### PR TITLE
ci: drop src/cpp from distro build triggers

### DIFF
--- a/.github/workflows/linux_distro_builds.yml
+++ b/.github/workflows/linux_distro_builds.yml
@@ -9,7 +9,6 @@ on:
       - "**/CMakeLists.txt"
       - "CMakePresets.json"
       - "cmake/**"
-      - "src/cpp/**"
       - "setup.sh"
       - "test/server_cli2.py"
       - "test/server_endpoints.py"


### PR DESCRIPTION
\Removes `"src/cpp/**"` from the `pull_request` path filters in `.github/workflows/linux_distro_builds.yml`, so changes to C++ source no longer trigger the Linux distro builds.

IMO we should not need to trigger on C++ changes, since the distro builds should only have true negative results if we change the dependencies or tests.

LMK if you think this is true @fl0rianr.