### PR TITLE
Remove sd-cpp cuda Windows support from compatibility tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td><code>cuda</code></td>
       <td>NVIDIA GPUs (Turing or newer)**</td>
-      <td>Windows, Linux</td>
+      <td>Linux</td>
     </tr>
     <tr>
       <td><code>cpu</code></td>

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -502,8 +502,8 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
         }},
     }},
 
-    // stable-diffusion.cpp - CUDA backend for NVIDIA GPUs (Windows/Linux)
-    {"sd-cpp", "cuda", {"windows", "linux"}, {
+    // stable-diffusion.cpp - CUDA backend for NVIDIA GPUs (Linux)
+    {"sd-cpp", "cuda", {"linux"}, {
         {"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120"}},
     }},
 


### PR DESCRIPTION
## What

sd-cpp's CUDA backend is not supported on Windows. This drops Windows from the sd-cpp/cuda row in:

- `src/cpp/server/system_info.cpp` — recipe compatibility table (`{"sd-cpp", "cuda", {"linux"}, ...}`)
- `README.md` — Supported Configurations table (OS column now `Linux`)

Both now reflect Linux-only support.

## Note

`src/cpp/server/backends/sd_server.cpp` still contains a `_WIN32` branch that builds a `sd-...-windows-cuda-...-x64.zip` filename. With the compatibility table now Linux-only, that branch is effectively unreachable in normal flow. It was left untouched to keep this PR scoped to the compatibility tables — happy to remove it in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)