### PR TITLE
Add sherpa-onnx streaming STT backend with ROCm (all AMD GPUs)

### DIFF
--- a/.github/workflows/build-sherpa-onnx-rocm.yml
+++ b/.github/workflows/build-sherpa-onnx-rocm.yml
@@ -1,0 +1,173 @@
+name: Build sherpa-onnx ROCm (all AMD GPUs) 🛠️
+
+# Builds the sherpa-onnx ROCm prebuilt that lemonade's "sherpa-onnx" backend
+# downloads for the `rocm` provider (see SherpaServer::get_install_params).
+#
+# ALL-AMD-GPU POLICY
+# ------------------
+# This produces ONE Linux x64 shared-library asset that runs on EVERY AMD GPU.
+# It is a multi-arch ("fat") binary: the HIP/ROCm device code is compiled for a
+# broad GPU target list (RDNA2/3/3.5/4 + CDNA), so a single download serves all
+# AMD GPUs. Unlike llamacpp/sd (which publish per-gfx assets and select one via
+# SystemInfo::get_rocm_arch()), sherpa is intentionally NOT architecture-specific.
+#
+# Why a fat binary covers all AMD GPUs: each listed gfx target is compiled to its
+# own device code object and bundled into the shared libraries; at load time the
+# ROCm runtime picks the code object matching the installed GPU. Listing every
+# supported arch therefore yields one binary that JIT-free-runs on all of them.
+# For any arch NOT in the list, the runtime escape hatch is the
+# HSA_OVERRIDE_GFX_VERSION env var (e.g. 11.0.0), which lemonade inherits from the
+# parent process env automatically — no code change needed.
+#
+# The asset is named exactly as SherpaServer::get_install_params() expects:
+#   sherpa-onnx-<version>-linux-x64-rocm-shared.tar.bz2
+# and is published as a release on lemonade-sdk/sherpa-onnx-builds with the tag
+# equal to the pinned version in src/cpp/resources/backend_versions.json
+# (sherpa-onnx.rocm, currently v1.13.2).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag / version to publish (must match backend_versions.json sherpa-onnx.rocm)'
+        required: true
+        default: 'v1.13.2'
+      gpu_targets:
+        description: 'AMD GPU targets (semicolon-separated). Default covers RDNA2/3/3.5/4 + CDNA.'
+        required: false
+        default: 'gfx900;gfx906;gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201'
+
+permissions:
+  contents: write
+
+env:
+  # k2-fsa/sherpa-onnx PR #1110 adds the AMD ROCm execution provider. We build
+  # from that PR ref until it merges upstream.
+  SHERPA_ONNX_PR: "1110"
+
+jobs:
+  build-sherpa-onnx-rocm:
+    name: Build sherpa-onnx ROCm (Linux x64, all AMD GPUs)
+    # TODO(operator): set this to a ROCm-capable build runner label. The build
+    # needs the ROCm/HIP toolchain (hipcc, rocm-device-libs) installed; it does
+    # NOT need a physical AMD GPU (device code is cross-compiled for the target
+    # list). A self-hosted runner with ROCm 6.x, or a container image such as
+    # rocm/dev-ubuntu-22.04, satisfies this. Replace the placeholder below.
+    runs-on: [self-hosted, linux, x64, rocm]  # TODO(operator): wire up a ROCm build runner with this label
+    # If using a bare runner instead of a ROCm-preinstalled one, uncomment to
+    # build inside the official ROCm dev image:
+    # container:
+    #   image: rocm/dev-ubuntu-22.04:6.2
+
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+      GPU_TARGETS: ${{ github.event.inputs.gpu_targets }}
+
+    steps:
+      - name: Show build parameters
+        shell: bash
+        run: |
+          echo "sherpa-onnx version/tag : $VERSION"
+          echo "sherpa-onnx PR ref      : #$SHERPA_ONNX_PR (ROCm execution provider)"
+          echo "AMD GPU targets         : $GPU_TARGETS"
+
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          # ROCm/HIP toolchain is expected to be preinstalled on the runner (or
+          # provided by the container image). Here we install the generic build
+          # tooling. cmake >= 3.18 is required by the sherpa-onnx ROCm path.
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            git build-essential cmake ninja-build python3 ca-certificates bzip2 tar
+          cmake --version
+          # Sanity-check the ROCm toolchain is on PATH (hipcc); fail early if not.
+          which hipcc || { echo "::error::hipcc not found — runner is not ROCm-capable. See the runs-on TODO."; exit 1; }
+          hipcc --version || true
+
+      - name: Checkout k2-fsa/sherpa-onnx at PR #1110 (ROCm execution provider)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git clone https://github.com/k2-fsa/sherpa-onnx.git sherpa-onnx
+          cd sherpa-onnx
+          # Fetch the PR head ref and check it out detached. PR #1110 adds the
+          # ROCm execution provider (-DSHERPA_ONNX_ENABLE_ROCM=ON / --provider=rocm).
+          git fetch origin "pull/${SHERPA_ONNX_PR}/head:pr-${SHERPA_ONNX_PR}"
+          git checkout "pr-${SHERPA_ONNX_PR}"
+          git log -1 --oneline
+
+      - name: Configure (CMake) — ROCm ON, shared libs, all-AMD-GPU multi-arch
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cd sherpa-onnx
+          mkdir -p build
+          # Multi-arch fat binary: we pass the broad GPU target list under EVERY
+          # variable that the onnxruntime-ROCm + sherpa-onnx + HIP build layers
+          # may honor, so whichever one is read, all AMD archs are compiled in:
+          #   - CMAKE_HIP_ARCHITECTURES : modern CMake HIP language target list
+          #   - GPU_TARGETS / AMDGPU_TARGETS : ROCm/onnxruntime amdgpu target list
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
+            -DSHERPA_ONNX_ENABLE_ROCM=ON \
+            -DSHERPA_ONNX_ENABLE_PYTHON=OFF \
+            -DSHERPA_ONNX_ENABLE_TESTS=OFF \
+            -DSHERPA_ONNX_ENABLE_CHECK=OFF \
+            -DSHERPA_ONNX_ENABLE_PORTAUDIO=OFF \
+            -DSHERPA_ONNX_ENABLE_WEBSOCKET=ON \
+            -DCMAKE_HIP_ARCHITECTURES="$GPU_TARGETS" \
+            -DGPU_TARGETS="$GPU_TARGETS" \
+            -DAMDGPU_TARGETS="$GPU_TARGETS" \
+            -DCMAKE_INSTALL_PREFIX="$PWD/install"
+
+      - name: Build & install
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cd sherpa-onnx
+          cmake --build build --config Release -j"$(nproc)"
+          cmake --install build --config Release
+          # Confirm the websocket server binary that lemonade launches is present.
+          test -x install/bin/sherpa-onnx-online-websocket-server
+
+      - name: Package asset (name must match get_install_params)
+        id: package
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cd sherpa-onnx
+          # Asset layout mirrors upstream k2-fsa shared builds: bin/ + lib/ so
+          # SherpaServer finds the binary and the sibling lib/ on the rpath.
+          ASSET="sherpa-onnx-${VERSION}-linux-x64-rocm-shared.tar.bz2"
+          STAGE="sherpa-onnx-${VERSION}-linux-x64-rocm-shared"
+          rm -rf "$STAGE"
+          mkdir -p "$STAGE"
+          cp -a install/bin "$STAGE/bin"
+          cp -a install/lib "$STAGE/lib"
+          tar -cjf "$ASSET" "$STAGE"
+          ls -lh "$ASSET"
+          echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to lemonade-sdk/sherpa-onnx-builds
+        shell: bash
+        env:
+          # TODO(operator): GITHUB_TOKEN cannot write to a different repo. Provide
+          # a PAT (or fine-grained token) with `contents:write` on
+          # lemonade-sdk/sherpa-onnx-builds as a secret, e.g. SHERPA_BUILDS_TOKEN.
+          GH_TOKEN: ${{ secrets.SHERPA_BUILDS_TOKEN }}
+        run: |
+          set -euxo pipefail
+          cd sherpa-onnx
+          ASSET="${{ steps.package.outputs.asset }}"
+          REPO="lemonade-sdk/sherpa-onnx-builds"
+          # Create the release if it does not exist yet, then upload (clobber so
+          # re-runs replace the asset). Tag == pinned version in backend_versions.json.
+          if ! gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$VERSION" --repo "$REPO" \
+              --title "sherpa-onnx $VERSION (ROCm, all AMD GPUs)" \
+              --notes "Multi-arch ROCm build of k2-fsa/sherpa-onnx PR #${SHERPA_ONNX_PR}. One Linux x64 shared-library asset covering RDNA2/3/3.5/4 + CDNA: ${GPU_TARGETS}. Runtime escape hatch for unlisted archs: HSA_OVERRIDE_GFX_VERSION."
+          fi
+          gh release upload "$VERSION" "$ASSET" --repo "$REPO" --clobber

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,6 +601,7 @@ set(SOURCES_CORE
     src/cpp/server/backends/fastflowlm_server.cpp
     src/cpp/server/backends/ryzenaiserver.cpp
     src/cpp/server/backends/whisper_server.cpp
+    src/cpp/server/backends/sherpa_server.cpp
     src/cpp/server/backends/kokoro_server.cpp
     src/cpp/server/backends/sd_server.cpp
     src/cpp/server/backends/vllm_server.cpp

--- a/docs/embeddable/backends.md
+++ b/docs/embeddable/backends.md
@@ -198,6 +198,17 @@ transcription path because it emits partial results as audio streams in.
   (built with `-DSHERPA_ONNX_ENABLE_ROCM=ON`, launched with `--provider=rocm`,
   **Linux x64 only**). `cpu` uses the upstream shared build with the CPU
   execution provider.
+- **AMD GPU support:** the ROCm backend supports **all AMD GPUs** —
+  RDNA2/3/3.5/4 and CDNA. There is a single, architecture-agnostic ROCm asset
+  (`linux-x64-rocm`), not a per-`gfx` download like `llamacpp:rocm` /
+  `sd-cpp:rocm`. It is a multi-arch ("fat") build: one binary compiled for a
+  broad AMD GPU target list, so the same download runs on every AMD GPU and the
+  runtime picks the matching device code. The asset is produced by
+  [`.github/workflows/build-sherpa-onnx-rocm.yml`](../../.github/workflows/build-sherpa-onnx-rocm.yml).
+  - **Escape hatch:** for an AMD GPU whose `gfx` arch is newer than the compiled
+    target list, set `HSA_OVERRIDE_GFX_VERSION` (e.g. `11.0.0`) in the
+    environment before launching; `lemond` inherits it from the parent process,
+    so no extra configuration is needed.
 - **Models:** point the checkpoint at a streaming transducer repo that contains
   `encoder*.onnx`, `decoder*.onnx`, `joiner*.onnx`, and `tokens.txt`
   (for example `csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26`).

--- a/docs/embeddable/backends.md
+++ b/docs/embeddable/backends.md
@@ -173,3 +173,62 @@ For example, to use your own Vulkan `llama-server` in place of Lemonade's:
     ```
 
 See the `*_bin` settings in the [Configuration Guide](../guide/configuration/README.md) for the full set of customization options.
+
+## Speech-to-Text Backends
+
+`lemond` ships two speech-to-text (transcription) backends. Both implement the same
+OpenAI-compatible `POST /api/v1/audio/transcriptions` endpoint and the realtime
+WebSocket transcription path, so they are interchangeable from the client's point
+of view.
+
+| Backend | Recipe | Devices | Strength |
+| --- | --- | --- | --- |
+| whisper.cpp | `whispercpp` | cpu, vulkan, npu, metal | Batch / file transcription, broad audio-format support |
+| sherpa-onnx | `sherpa-onnx` | rocm, cpu | True low-latency streaming (transducer models) |
+
+### sherpa-onnx (streaming STT, ROCm)
+
+The `sherpa-onnx` backend wraps the [k2-fsa/sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx)
+`sherpa-onnx-online-websocket-server`, which serves streaming transducer
+(encoder/decoder/joiner + `tokens.txt`) models. It is well-suited to the realtime
+transcription path because it emits partial results as audio streams in.
+
+- **Backends:** `rocm` selects the AMD ROCm execution provider added in
+  sherpa-onnx [PR #1110](https://github.com/k2-fsa/sherpa-onnx/pull/1110)
+  (built with `-DSHERPA_ONNX_ENABLE_ROCM=ON`, launched with `--provider=rocm`,
+  **Linux x64 only**). `cpu` uses the upstream shared build with the CPU
+  execution provider.
+- **Models:** point the checkpoint at a streaming transducer repo that contains
+  `encoder*.onnx`, `decoder*.onnx`, `joiner*.onnx`, and `tokens.txt`
+  (for example `csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26`).
+- **Input:** the streaming backend consumes mono 16&nbsp;kHz PCM16 WAV. Use a
+  whisper.cpp model for compressed/long-form file inputs.
+- **Custom args:** pass sherpa flags such as `--num-threads` or
+  `--decoding-method modified_beam_search` via `sherpa-onnx.args` /
+  `--sherpa-onnx-args`. The model triple, `--port`, and `--provider` are managed
+  by `lemond`.
+
+```bash
+# Select the ROCm provider for sherpa-onnx
+./lemonade config set sherpa-onnx.backend rocm
+
+# Bundle the sherpa-onnx ROCm backend at packaging time (Linux x64)
+./lemonade backends install sherpa-onnx:rocm
+```
+
+### Standardized transcription request parameters
+
+In addition to the OpenAI fields (`file`, `model`, `language`, `prompt`,
+`temperature`, `response_format`), the `audio/transcriptions` endpoint accepts a
+small, standardized set of optional carrier-audio parameters that every
+transcription backend honors uniformly:
+
+| Field | Meaning |
+| --- | --- |
+| `sample_rate` | Source sample rate in Hz (e.g. `8000` for telephony, `16000` for wideband) |
+| `audio_bitrate` | Source audio bitrate in bits per second (informational / passthrough) |
+| `channels` | Number of channels (1 = mono, 2 = stereo; multi-channel is downmixed) |
+| `language` | BCP-47 / ISO-639 language hint |
+
+These are all optional; omitting them preserves the existing OpenAI-compatible
+behavior.

--- a/src/app/src/renderer/AddModelPanel.tsx
+++ b/src/app/src/renderer/AddModelPanel.tsx
@@ -62,6 +62,10 @@ const RECIPE_EXAMPLES: Record<string, RecipeExample> = {
     name: 'Whisper-Tiny',
     checkpoint: 'ggerganov/whisper.cpp:ggml-tiny.bin',
   },
+  'sherpa-onnx': {
+    name: 'Sherpa-Streaming-Zipformer-EN',
+    checkpoint: 'csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-06-26',
+  },
   'sd-cpp': {
     name: 'Z-Image-Turbo',
     checkpoint: 'Comfy-Org/z_image_turbo:split_files/diffusion_models/z_image_turbo_bf16.safetensors',

--- a/src/app/src/renderer/BackendManager.tsx
+++ b/src/app/src/renderer/BackendManager.tsx
@@ -8,6 +8,7 @@ import ConnectedBackendRow from './components/ConnectedBackendRow';
 const RECIPE_ORDER = new Map([
   'llamacpp',
   'whispercpp',
+  'sherpa-onnx',
   'sd-cpp',
   'kokoro',
   'flm',

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -856,6 +856,18 @@ const [searchQuery, setSearchQuery] = useState('');
         return;
       }
 
+      // Sherpa-ONNX streaming transducer (encoder/decoder/joiner .onnx + tokens.txt)
+      const hasTransducerTriple =
+        files.some(f => f.includes('encoder') && f.endsWith('.onnx')) &&
+        files.some(f => f.includes('decoder') && f.endsWith('.onnx')) &&
+        files.some(f => f.includes('joiner') && f.endsWith('.onnx')) &&
+        files.some(f => f.endsWith('tokens.txt'));
+      if (hasTransducerTriple || (modelId.toLowerCase().includes('sherpa') && hasTransducerTriple)) {
+        setHfModelBackends((prev: Record<string, DetectedBackend | null>) => ({ ...prev, [modelId]: { recipe: 'sherpa-onnx', label: 'Sherpa-ONNX' } }));
+        if (totalFileSize) setHfModelSizes((prev: Record<string, number | undefined>) => ({ ...prev, [modelId]: totalFileSize }));
+        return;
+      }
+
       // Stable Diffusion
       if (tags.includes('stable-diffusion') || tags.includes('text-to-image') || modelId.toLowerCase().includes('stable-diffusion') || modelId.toLowerCase().includes('flux')) {
         setHfModelBackends((prev: Record<string, DetectedBackend | null>) => ({ ...prev, [modelId]: { recipe: 'sd-cpp', label: 'SD.cpp' } }));
@@ -1843,14 +1855,14 @@ const [searchQuery, setSearchQuery] = useState('');
                     detectingBackendFor === null &&
                     hfSearchResults.every((m: HFModelInfo) => {
                       const backend = hfModelBackends[m.id];
-                      return backend === null || (backend != null && ['sd-cpp', 'whispercpp'].includes(backend.recipe));
+                      return backend === null || (backend != null && ['sd-cpp', 'whispercpp', 'sherpa-onnx'].includes(backend.recipe));
                     }))
                 ) && (
                   <div className="hf-search-message">No compatible models found.</div>
                 )}
                 {hfSearchResults.filter((hfModel: HFModelInfo) => {
                   const backend = hfModelBackends[hfModel.id];
-                  return backend !== null && !(backend != null && ['sd-cpp', 'whispercpp'].includes(backend.recipe));
+                  return backend !== null && !(backend != null && ['sd-cpp', 'whispercpp', 'sherpa-onnx'].includes(backend.recipe));
                 }).map((hfModel: HFModelInfo) => {
                   const backend = hfModelBackends[hfModel.id];
                   const isDetecting = detectingBackendFor === hfModel.id;

--- a/src/app/src/renderer/recipes/recipeOptions.ts
+++ b/src/app/src/renderer/recipes/recipeOptions.ts
@@ -14,6 +14,7 @@ export {
   // Recipe-specific interfaces
   LlamaOptions,
   WhisperOptions,
+  SherpaOnnxOptions,
   FlmOptions,
   RyzenAIOptions,
   RyzenAIRecipe,

--- a/src/app/src/renderer/recipes/recipeOptionsConfig.ts
+++ b/src/app/src/renderer/recipes/recipeOptionsConfig.ts
@@ -48,6 +48,14 @@ export interface WhisperOptions {
   saveOptions: BooleanOption;
 }
 
+export interface SherpaOnnxOptions {
+  recipe: 'sherpa-onnx';
+  sherpaOnnxBackend: StringOption;
+  sherpaOnnxArgs: StringOption;
+  mergeArgs: BooleanOption;
+  saveOptions: BooleanOption;
+}
+
 export interface FlmOptions {
   recipe: 'flm';
   ctxSize: NumericOption;
@@ -84,7 +92,7 @@ export interface VLLMOptions {
 }
 
 // Union type of all recipe options
-export type RecipeOptions = LlamaOptions | WhisperOptions | FlmOptions | RyzenAIOptions | StableDiffusionOptions | VLLMOptions;
+export type RecipeOptions = LlamaOptions | WhisperOptions | SherpaOnnxOptions | FlmOptions | RyzenAIOptions | StableDiffusionOptions | VLLMOptions;
 
 // =============================================================================
 // Recipe Constants
@@ -205,6 +213,23 @@ export const OPTION_DEFINITIONS: Record<string, OptionDef> = {
     description: 'Custom arguments to pass to whisper-server, for example --convert',
   },
 
+  // Sherpa-ONNX (streaming STT) options
+  sherpaOnnxBackend: {
+    type: 'string',
+    default: '',
+    label: 'Backend',
+    description: 'Sherpa-ONNX execution provider to use (rocm or cpu)',
+    isBackendOption: true,
+    backendRecipe: 'sherpa-onnx',
+  },
+  sherpaOnnxArgs: {
+    type: 'string',
+    default: '',
+    label: 'Sherpa-ONNX Arguments',
+    description:
+      'Custom arguments to pass to sherpa-onnx-online-websocket-server, for example --num-threads 4 --decoding-method modified_beam_search',
+  },
+
   // Stable Diffusion options
   sdcppBackend: {
     type: 'string',
@@ -264,7 +289,7 @@ export const OPTION_DEFINITIONS: Record<string, OptionDef> = {
 // Recipe Configuration - Maps recipes to their available options
 // =============================================================================
 
-export type RecipeName = 'llamacpp' | 'whispercpp' | 'flm' | 'ryzenai-llm' | 'sd-cpp' | 'vllm';
+export type RecipeName = 'llamacpp' | 'whispercpp' | 'sherpa-onnx' | 'flm' | 'ryzenai-llm' | 'sd-cpp' | 'vllm';
 
 /**
  * Maps recipe names to the option keys they support.
@@ -273,6 +298,7 @@ export type RecipeName = 'llamacpp' | 'whispercpp' | 'flm' | 'ryzenai-llm' | 'sd
 export const RECIPE_OPTIONS_MAP: Record<RecipeName, string[]> = {
   'llamacpp': ['ctxSize', 'llamacppBackend', 'llamacppArgs', 'mergeArgs', 'saveOptions'],
   'whispercpp': ['whispercppBackend', 'whispercppArgs', 'mergeArgs', 'saveOptions'],
+  'sherpa-onnx': ['sherpaOnnxBackend', 'sherpaOnnxArgs', 'mergeArgs', 'saveOptions'],
   'flm': ['ctxSize', 'mergeArgs', 'saveOptions'],
   'ryzenai-llm': ['ctxSize', 'saveOptions'],
   'sd-cpp': ['sdcppBackend', 'steps', 'cfgScale', 'width', 'height', 'mergeArgs', 'saveOptions'],
@@ -307,6 +333,8 @@ const FRONTEND_TO_API_MAP: Record<string, string> = {
   llamacppArgs: 'llamacpp_args',
   whispercppBackend: 'whispercpp_backend',
   whispercppArgs: 'whispercpp_args',
+  sherpaOnnxBackend: 'sherpa-onnx_backend',
+  sherpaOnnxArgs: 'sherpa-onnx_args',
   sdcppBackend: 'sd-cpp_backend',
   cfgScale: 'cfg_scale',
   vllmBackend: 'vllm_backend',

--- a/src/app/src/renderer/utils/recipeNames.ts
+++ b/src/app/src/renderer/utils/recipeNames.ts
@@ -10,6 +10,7 @@ export const RECIPE_DISPLAY_NAMES: Record<string, string> = {
   'llamacpp': 'Llama.cpp GPU',
   'ryzenai-llm': 'Ryzen AI LLM',
   'whispercpp': 'Whisper.cpp',
+  'sherpa-onnx': 'Sherpa-ONNX (streaming)',
   'sd-cpp': 'StableDiffusion.cpp',
   'kokoro': 'Kokoro',
   'vllm': 'vLLM ROCm (experimental)',

--- a/src/cpp/include/lemon/audio_types.h
+++ b/src/cpp/include/lemon/audio_types.h
@@ -43,5 +43,42 @@ namespace Limits {
     constexpr double MAX_AUDIO_DURATION_SECONDS = 600.0;       // 10 minutes
 }
 
+// Standardized optional request parameters for the audio transcription API.
+//
+// These supplement the OpenAI-compatible fields (file, model, language, prompt,
+// temperature, response_format) with a small, documented set of carrier-audio
+// knobs that every transcription backend understands the same way. They are all
+// OPTIONAL — when absent the backend keeps its existing behavior, so OpenAI
+// compatibility is preserved.
+//
+// Defined once here and honored by every ITranscriptionServer backend
+// (whisper.cpp, sherpa-onnx, ...) via build_transcription_request(), so the API
+// surface is uniform regardless of which backend serves the request. Do NOT
+// introduce per-backend ad-hoc parameter names; extend this set instead.
+namespace RequestParam {
+    // Source sample rate of the supplied audio, in Hz (e.g. 8000 for telephony
+    // / carrier audio, 16000 for wideband). Backends that need a specific
+    // internal rate use this to drive resampling.
+    constexpr const char* SAMPLE_RATE = "sample_rate";
+
+    // Source audio bitrate in bits per second (e.g. 64000). Informational /
+    // passthrough hint describing compressed carrier audio.
+    constexpr const char* AUDIO_BITRATE = "audio_bitrate";
+
+    // Number of channels in the source audio (1 = mono, 2 = stereo). Transducer
+    // backends require mono and will downmix when more than one channel is sent.
+    constexpr const char* CHANNELS = "channels";
+
+    // BCP-47 / ISO-639 language hint (also part of the OpenAI surface).
+    constexpr const char* LANGUAGE = "language";
+}
+
+// Default sample rate assumed when a request omits RequestParam::SAMPLE_RATE.
+// 16 kHz mono PCM is the canonical input for streaming transducer models.
+namespace AudioDefaults {
+    constexpr int SAMPLE_RATE_HZ = 16000;
+    constexpr int CHANNELS = 1;
+}
+
 } // namespace audio
 } // namespace lemon

--- a/src/cpp/include/lemon/backends/sherpa_server.h
+++ b/src/cpp/include/lemon/backends/sherpa_server.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "../wrapped_server.h"
+#include "../server_capabilities.h"
+#include "backend_utils.h"
+#include <string>
+#include <filesystem>
+#include <vector>
+#include <cstdint>
+
+namespace lemon {
+namespace backends {
+
+// Streaming speech-to-text backend wrapping the sherpa-onnx online (streaming)
+// transducer recognizer.
+//
+// Unlike whisper.cpp, sherpa-onnx ships a true streaming recognizer served by
+// `sherpa-onnx-online-websocket-server`, which speaks a small custom WebSocket
+// protocol (binary float32 PCM frames + a "Done" text sentinel, JSON results
+// back). This class launches that server as a subprocess and bridges
+// lemonade's OpenAI-shaped `audio/transcriptions` (and therefore the realtime
+// WebSocket path, which feeds WAV chunks through the same router method) onto
+// it: decode the incoming audio to mono 16 kHz PCM, stream it to the sherpa
+// server, and return the aggregated transcript as `{ "text": ... }`.
+//
+// ROCm: sherpa-onnx PR #1110 adds an AMD ROCm execution provider, built with
+// -DSHERPA_ONNX_ENABLE_ROCM=ON and selected at runtime with --provider=rocm.
+// The "rocm" backend selects that prebuilt and launches with --provider=rocm;
+// the "cpu" backend uses the upstream shared build and --provider=cpu. ROCm is
+// Linux x64 only (per PR #1110); other platforms throw.
+class SherpaServer : public WrappedServer, public ITranscriptionServer {
+public:
+    static InstallParams get_install_params(const std::string& backend, const std::string& version);
+
+    inline static const BackendSpec SPEC = BackendSpec(
+        "sherpa-onnx",
+#ifdef _WIN32
+        "sherpa-onnx-online-websocket-server.exe"
+#else
+        "sherpa-onnx-online-websocket-server"
+#endif
+        , get_install_params
+    );
+
+    explicit SherpaServer(const std::string& log_level,
+                          ModelManager* model_manager,
+                          BackendManager* backend_manager);
+
+    ~SherpaServer() override;
+
+    void load(const std::string& model_name,
+             const ModelInfo& model_info,
+             const RecipeOptions& options,
+             bool do_not_upgrade = false) override;
+
+    void unload() override;
+
+    // ICompletionServer implementation (not supported - return errors)
+    json chat_completion(const json& request) override;
+    json completion(const json& request) override;
+    json responses(const json& request) override;
+
+    // ITranscriptionServer implementation
+    json audio_transcriptions(const json& request) override;
+
+private:
+    // Resolve the transducer triple (encoder/decoder/joiner ONNX + tokens.txt)
+    // from the resolved model path. The model path may point at any one of the
+    // four files or at the directory containing them.
+    struct TransducerPaths {
+        std::string encoder;
+        std::string decoder;
+        std::string joiner;
+        std::string tokens;
+    };
+    TransducerPaths resolve_transducer_paths(const std::string& model_path);
+
+    // Decode arbitrary input audio (request "file_data") to mono 16 kHz PCM16
+    // little-endian samples. Only WAV is decoded natively; the realtime path
+    // (and the documented streaming contract) supplies 16 kHz mono PCM16 WAV.
+    std::vector<float> decode_to_mono_f32(const std::string& audio_data,
+                                          const std::string& filename,
+                                          int target_sample_rate);
+
+    // Stream float32 samples to the running sherpa websocket server and collect
+    // the final transcript. Returns the recognized text.
+    std::string stream_to_websocket(const std::vector<float>& samples);
+
+    std::string model_path_;
+    std::string sherpa_backend_;   // "rocm" or "cpu" (provider passed to server)
+    int num_threads_ = 2;
+    std::string decoding_method_ = "greedy_search";
+};
+
+} // namespace backends
+} // namespace lemon

--- a/src/cpp/include/lemon/backends/sherpa_server.h
+++ b/src/cpp/include/lemon/backends/sherpa_server.h
@@ -4,9 +4,7 @@
 #include "../server_capabilities.h"
 #include "backend_utils.h"
 #include <string>
-#include <filesystem>
 #include <vector>
-#include <cstdint>
 
 namespace lemon {
 namespace backends {

--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -127,6 +127,8 @@ inline DeviceType get_device_type_from_recipe(const std::string& recipe) {
         return DEVICE_NPU;
     } else if (recipe == "whispercpp") {
         return DEVICE_CPU;
+    } else if (recipe == "sherpa-onnx") {
+        return DEVICE_CPU;  // overridden to GPU by SherpaServer when backend == rocm
     } else if (recipe == "sd-cpp") {
         return DEVICE_CPU;
     } else if (recipe == "kokoro") {

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -15,6 +15,10 @@
     "npu": "v1.8.4",
     "metal": "v1.8.4"
   },
+  "sherpa-onnx": {
+    "cpu": "v1.13.2",
+    "rocm": "v1.13.2"
+  },
   "sd-cpp": {
     "cpu": "master-672-1f9ee88",
     "rocm-stable": "master-672-1f9ee88",

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -35,6 +35,14 @@
     "cpu_bin": "builtin",
     "npu_bin": "builtin"
   },
+  "sherpa-onnx": {
+    "backend": "auto",
+    "args": "",
+    "cpu_args": "",
+    "rocm_args": "",
+    "cpu_bin": "builtin",
+    "rocm_bin": "builtin"
+  },
   "sdcpp": {
     "backend": "auto",
     "args": "",

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -3,6 +3,7 @@
 #include "lemon/system_info.h"
 #include "lemon/backends/llamacpp_server.h"
 #include "lemon/backends/whisper_server.h"
+#include "lemon/backends/sherpa_server.h"
 #include "lemon/backends/sd_server.h"
 #include "lemon/backends/kokoro_server.h"
 #include "lemon/backends/ryzenaiserver.h"
@@ -39,6 +40,7 @@ namespace lemon::backends {
     const BackendSpec* try_get_spec_for_recipe(const std::string& recipe) {
         if (recipe == "llamacpp") return &LlamaCppServer::SPEC;
         if (recipe == "whispercpp") return &WhisperServer::SPEC;
+        if (recipe == "sherpa-onnx") return &SherpaServer::SPEC;
         if (recipe == "sd-cpp") return &SDServer::SPEC;
         if (recipe == "kokoro") return &KokoroServer::SPEC;
         if (recipe == "ryzenai-llm") return &::lemon::RyzenAIServer::SPEC;

--- a/src/cpp/server/backends/sherpa_server.cpp
+++ b/src/cpp/server/backends/sherpa_server.cpp
@@ -4,8 +4,6 @@
 #include "lemon/runtime_config.h"
 #include "lemon/audio_types.h"
 #include "lemon/utils/custom_args.h"
-#include "lemon/utils/http_client.h"
-#include "lemon/utils/path_utils.h"
 #include "lemon/utils/process_manager.h"
 #include "lemon/error_types.h"
 #include <cstring>
@@ -13,11 +11,8 @@
 #include <chrono>
 #include <thread>
 #include <filesystem>
-#include <fstream>
-#include <sstream>
 #include <set>
 #include <vector>
-#include <atomic>
 #include <mutex>
 #include <condition_variable>
 #include <nlohmann/json.hpp>
@@ -49,6 +44,15 @@ InstallParams SherpaServer::get_install_params(const std::string& backend, const
         // not yet publish a prebuilt ROCm asset, so lemonade hosts a ROCm build
         // (-DSHERPA_ONNX_ENABLE_ROCM=ON -DBUILD_SHARED_LIBS=ON) in the same
         // style as the whisper.cpp builds repo. Linux x64 only, per PR #1110.
+        //
+        // ALL-AMD-GPU build: this single asset is a multi-arch ("fat") binary
+        // compiled for a broad AMD GPU target list (RDNA2/3/3.5/4 + CDNA), so
+        // ONE download runs on every AMD GPU. It is intentionally NOT per-gfx
+        // (unlike llamacpp/sd, which call SystemInfo::get_rocm_arch() and fetch
+        // an arch-specific asset). There is no gfx pin here. The build is
+        // produced by .github/workflows/build-sherpa-onnx-rocm.yml. Any future
+        // unlisted arch can still be forced at runtime via HSA_OVERRIDE_GFX_VERSION
+        // (inherited from the parent process env).
 #if defined(__linux__)
         params.repo = "lemonade-sdk/sherpa-onnx-builds";
         params.filename = "sherpa-onnx-" + version + "-linux-x64-rocm-shared.tar.bz2";

--- a/src/cpp/server/backends/sherpa_server.cpp
+++ b/src/cpp/server/backends/sherpa_server.cpp
@@ -1,0 +1,656 @@
+#include "lemon/backends/sherpa_server.h"
+#include "lemon/backends/backend_utils.h"
+#include "lemon/backend_manager.h"
+#include "lemon/runtime_config.h"
+#include "lemon/audio_types.h"
+#include "lemon/utils/custom_args.h"
+#include "lemon/utils/http_client.h"
+#include "lemon/utils/path_utils.h"
+#include "lemon/utils/process_manager.h"
+#include "lemon/error_types.h"
+#include <cstring>
+#include <iostream>
+#include <chrono>
+#include <thread>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <set>
+#include <vector>
+#include <atomic>
+#include <mutex>
+#include <condition_variable>
+#include <nlohmann/json.hpp>
+#include <libwebsockets.h>
+#include <lemon/utils/aixlog.hpp>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+using namespace lemon::utils;
+
+namespace lemon {
+namespace backends {
+
+InstallParams SherpaServer::get_install_params(const std::string& backend, const std::string& version) {
+    InstallParams params;
+
+    if (backend == "rocm") {
+        // sherpa-onnx PR #1110 adds the ROCm execution provider. Upstream does
+        // not yet publish a prebuilt ROCm asset, so lemonade hosts a ROCm build
+        // (-DSHERPA_ONNX_ENABLE_ROCM=ON -DBUILD_SHARED_LIBS=ON) in the same
+        // style as the whisper.cpp builds repo. Linux x64 only, per PR #1110.
+#if defined(__linux__)
+        params.repo = "lemonade-sdk/sherpa-onnx-builds";
+        params.filename = "sherpa-onnx-" + version + "-linux-x64-rocm-shared.tar.bz2";
+#else
+        throw std::runtime_error("sherpa-onnx ROCm backend is only supported on Linux x64");
+#endif
+    } else if (backend == "cpu") {
+        // Upstream k2-fsa shared CPU build (CPU execution provider).
+        params.repo = "k2-fsa/sherpa-onnx";
+#if defined(__linux__)
+        params.filename = "sherpa-onnx-" + version + "-linux-x64-shared.tar.bz2";
+#elif defined(_WIN32)
+        params.filename = "sherpa-onnx-" + version + "-win-x64-shared.tar.bz2";
+#elif defined(__APPLE__)
+        params.filename = "sherpa-onnx-" + version + "-osx-universal2-shared.tar.bz2";
+#else
+        throw std::runtime_error("Unsupported platform for sherpa-onnx");
+#endif
+    } else {
+        throw std::runtime_error("[SherpaServer] Unknown sherpa-onnx backend: " + backend);
+    }
+
+    return params;
+}
+
+SherpaServer::SherpaServer(const std::string& log_level, ModelManager* model_manager, BackendManager* backend_manager)
+    : WrappedServer("sherpa-onnx-server", log_level, model_manager, backend_manager) {
+}
+
+SherpaServer::~SherpaServer() {
+    unload();
+}
+
+namespace {
+
+// The sherpa online websocket server has no HTTP health endpoint, so the
+// base-class HTTP readiness probe (which requires a 200) never succeeds. Poll a
+// raw TCP connect instead: once the port accepts connections the server is up.
+bool tcp_port_open(int port, int timeout_ms) {
+#ifdef _WIN32
+    SOCKET sock = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (sock == INVALID_SOCKET) return false;
+#else
+    int sock = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (sock < 0) return false;
+#endif
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(static_cast<uint16_t>(port));
+    ::inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+
+    bool ok = ::connect(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0;
+    (void)timeout_ms;  // blocking connect with loopback resolves immediately
+#ifdef _WIN32
+    ::closesocket(sock);
+#else
+    ::close(sock);
+#endif
+    return ok;
+}
+
+// --- Minimal WAV (RIFF/PCM) decoder -------------------------------------
+// The realtime path and the documented streaming contract supply 16 kHz mono
+// PCM16 WAV. We parse the canonical RIFF header, downmix to mono, convert
+// PCM16 -> float32 in [-1, 1], and (if needed) linearly resample to the
+// recognizer's target rate.
+struct WavData {
+    std::vector<float> samples;  // mono float32
+    int sample_rate = 0;
+};
+
+uint32_t rd_u32(const unsigned char* p) {
+    return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
+           (static_cast<uint32_t>(p[2]) << 16) | (static_cast<uint32_t>(p[3]) << 24);
+}
+uint16_t rd_u16(const unsigned char* p) {
+    return static_cast<uint16_t>(p[0]) | (static_cast<uint16_t>(p[1]) << 8);
+}
+
+WavData decode_wav(const std::string& data) {
+    WavData out;
+    const auto* buf = reinterpret_cast<const unsigned char*>(data.data());
+    const size_t n = data.size();
+    if (n < 44 || std::memcmp(buf, "RIFF", 4) != 0 || std::memcmp(buf + 8, "WAVE", 4) != 0) {
+        throw std::runtime_error("Unsupported audio: expected mono 16 kHz PCM16 WAV");
+    }
+
+    uint16_t channels = 1;
+    uint16_t bits_per_sample = 16;
+    int sample_rate = 0;
+    size_t pos = 12;
+    const unsigned char* data_chunk = nullptr;
+    uint32_t data_size = 0;
+
+    while (pos + 8 <= n) {
+        const unsigned char* chunk_id = buf + pos;
+        uint32_t chunk_size = rd_u32(buf + pos + 4);
+        const unsigned char* chunk_body = buf + pos + 8;
+        if (std::memcmp(chunk_id, "fmt ", 4) == 0 && pos + 8 + 16 <= n) {
+            channels = rd_u16(chunk_body + 2);
+            sample_rate = static_cast<int>(rd_u32(chunk_body + 4));
+            bits_per_sample = rd_u16(chunk_body + 14);
+        } else if (std::memcmp(chunk_id, "data", 4) == 0) {
+            data_chunk = chunk_body;
+            data_size = chunk_size;
+            if (pos + 8 + data_size > n) {
+                data_size = static_cast<uint32_t>(n - (pos + 8));  // tolerate truncated size
+            }
+            break;
+        }
+        pos += 8 + chunk_size + (chunk_size & 1);  // chunks are word-aligned
+    }
+
+    if (!data_chunk || sample_rate == 0 || bits_per_sample != 16 || channels == 0) {
+        throw std::runtime_error("Unsupported WAV format: only 16-bit PCM is supported");
+    }
+
+    const auto* pcm = reinterpret_cast<const int16_t*>(data_chunk);
+    size_t total_samples = data_size / sizeof(int16_t);
+    size_t frames = total_samples / channels;
+    out.samples.reserve(frames);
+    for (size_t i = 0; i < frames; ++i) {
+        int32_t acc = 0;
+        for (uint16_t c = 0; c < channels; ++c) {
+            acc += pcm[i * channels + c];
+        }
+        float v = static_cast<float>(acc) / channels / 32768.0f;
+        out.samples.push_back(v);
+    }
+    out.sample_rate = sample_rate;
+    return out;
+}
+
+std::vector<float> resample_linear(const std::vector<float>& in, int in_rate, int out_rate) {
+    if (in_rate == out_rate || in.empty()) return in;
+    double ratio = static_cast<double>(out_rate) / in_rate;
+    size_t out_n = static_cast<size_t>(in.size() * ratio);
+    std::vector<float> out;
+    out.reserve(out_n);
+    for (size_t i = 0; i < out_n; ++i) {
+        double src = i / ratio;
+        size_t i0 = static_cast<size_t>(src);
+        size_t i1 = std::min(i0 + 1, in.size() - 1);
+        double frac = src - i0;
+        out.push_back(static_cast<float>(in[i0] * (1.0 - frac) + in[i1] * frac));
+    }
+    return out;
+}
+
+// --- libwebsockets client for the sherpa online websocket protocol ------
+// Protocol (from sherpa-onnx online-websocket-server-impl.cc):
+//   * client sends binary frames of raw float32 PCM samples
+//   * client sends a text frame "Done" to mark end of stream
+//   * server replies with JSON results ({ "text": ..., ... }); on completion it
+//     sends the text sentinel "Done!".
+struct SherpaWsClient {
+    std::string host = "127.0.0.1";
+    int port = 0;
+    const std::vector<float>* samples = nullptr;
+    size_t offset = 0;
+    bool sent_done = false;
+
+    std::string last_text;     // most recent non-empty transcript JSON text
+    bool finished = false;
+    std::string error;
+
+    std::mutex mtx;
+    std::condition_variable cv;
+};
+
+// Send up to ~3200 samples (200 ms @ 16 kHz) per writeable callback.
+constexpr size_t kSamplesPerMessage = 3200;
+
+int sherpa_ws_callback(struct lws* wsi, enum lws_callback_reasons reason,
+                       void* /*user*/, void* in, size_t len) {
+    struct lws_context* ctx = lws_get_context(wsi);
+    auto* client = static_cast<SherpaWsClient*>(lws_context_user(ctx));
+    if (!client) return 0;
+
+    switch (reason) {
+        case LWS_CALLBACK_CLIENT_ESTABLISHED:
+            lws_callback_on_writable(wsi);
+            break;
+
+        case LWS_CALLBACK_CLIENT_CONNECTION_ERROR: {
+            std::lock_guard<std::mutex> lk(client->mtx);
+            client->error = in ? std::string(static_cast<char*>(in), len)
+                                : "sherpa-onnx websocket connection error";
+            client->finished = true;
+            client->cv.notify_all();
+            break;
+        }
+
+        case LWS_CALLBACK_CLIENT_RECEIVE: {
+            std::string msg(static_cast<char*>(in), len);
+            if (msg == "Done!") {
+                std::lock_guard<std::mutex> lk(client->mtx);
+                client->finished = true;
+                client->cv.notify_all();
+                return -1;  // close the connection
+            }
+            // Otherwise it's a JSON result; keep the latest non-empty text.
+            try {
+                auto j = nlohmann::json::parse(msg);
+                if (j.contains("text") && j["text"].is_string()) {
+                    std::string t = j["text"].get<std::string>();
+                    if (!t.empty()) {
+                        std::lock_guard<std::mutex> lk(client->mtx);
+                        client->last_text = t;
+                    }
+                }
+            } catch (const std::exception&) {
+                // Non-JSON frame; ignore.
+            }
+            break;
+        }
+
+        case LWS_CALLBACK_CLIENT_WRITEABLE: {
+            if (client->samples && client->offset < client->samples->size()) {
+                size_t remaining = client->samples->size() - client->offset;
+                size_t count = std::min(remaining, kSamplesPerMessage);
+                size_t bytes = count * sizeof(float);
+                std::vector<unsigned char> frame(LWS_PRE + bytes);
+                std::memcpy(frame.data() + LWS_PRE,
+                            client->samples->data() + client->offset, bytes);
+                int written = lws_write(wsi, frame.data() + LWS_PRE, bytes, LWS_WRITE_BINARY);
+                if (written < static_cast<int>(bytes)) {
+                    std::lock_guard<std::mutex> lk(client->mtx);
+                    client->error = "Failed to write audio frame to sherpa-onnx";
+                    client->finished = true;
+                    client->cv.notify_all();
+                    return -1;
+                }
+                client->offset += count;
+                lws_callback_on_writable(wsi);
+            } else if (!client->sent_done) {
+                // All samples sent; send the "Done" sentinel as a text frame.
+                static const std::string done = "Done";
+                std::vector<unsigned char> frame(LWS_PRE + done.size());
+                std::memcpy(frame.data() + LWS_PRE, done.data(), done.size());
+                lws_write(wsi, frame.data() + LWS_PRE, done.size(), LWS_WRITE_TEXT);
+                client->sent_done = true;
+            }
+            break;
+        }
+
+        case LWS_CALLBACK_CLIENT_CLOSED: {
+            std::lock_guard<std::mutex> lk(client->mtx);
+            client->finished = true;
+            client->cv.notify_all();
+            break;
+        }
+
+        default:
+            break;
+    }
+    return 0;
+}
+
+const struct lws_protocols kSherpaProtocols[] = {
+    {"sherpa-online", sherpa_ws_callback, 0, 1 << 16, 0, nullptr, 0},
+    LWS_PROTOCOL_LIST_TERM
+};
+
+}  // namespace
+
+SherpaServer::TransducerPaths SherpaServer::resolve_transducer_paths(const std::string& model_path) {
+    TransducerPaths paths;
+
+    // model_path may be a directory or any of the four model files. Search the
+    // containing directory (recursively) for the transducer triple + tokens.
+    fs::path p(model_path);
+    fs::path dir = fs::is_directory(p) ? p : p.parent_path();
+
+    if (!fs::exists(dir)) {
+        throw std::runtime_error("sherpa-onnx model directory not found: " + dir.string());
+    }
+
+    auto matches = [](const std::string& name, const std::string& key) {
+        return name.find(key) != std::string::npos;
+    };
+
+    for (const auto& entry : fs::recursive_directory_iterator(dir)) {
+        if (!entry.is_regular_file()) continue;
+        std::string fname = entry.path().filename().string();
+        std::string full = entry.path().string();
+        if (fname == "tokens.txt") {
+            paths.tokens = full;
+        } else if (entry.path().extension() == ".onnx") {
+            if (matches(fname, "encoder") && paths.encoder.empty()) paths.encoder = full;
+            else if (matches(fname, "decoder") && paths.decoder.empty()) paths.decoder = full;
+            else if (matches(fname, "joiner") && paths.joiner.empty()) paths.joiner = full;
+        }
+    }
+
+    if (paths.encoder.empty() || paths.decoder.empty() ||
+        paths.joiner.empty() || paths.tokens.empty()) {
+        throw std::runtime_error(
+            "sherpa-onnx model is incomplete: expected encoder/decoder/joiner .onnx "
+            "and tokens.txt in " + dir.string());
+    }
+
+    return paths;
+}
+
+void SherpaServer::load(const std::string& model_name,
+                        const ModelInfo& model_info,
+                        const RecipeOptions& options,
+                        bool do_not_upgrade) {
+    LOG(INFO, "SherpaServer") << "Loading model: " << model_name << std::endl;
+    LOG(INFO, "SherpaServer") << "Per-model settings: " << options.to_log_string() << std::endl;
+
+    std::string sherpa_backend = options.get_option("sherpa-onnx_backend").get<std::string>();
+    std::string sherpa_args = options.get_option("sherpa-onnx_args").get<std::string>();
+
+    RuntimeConfig::validate_backend_choice("sherpa-onnx", sherpa_backend);
+
+    // Device reporting: ROCm runs on the GPU, CPU provider on the CPU.
+    if (sherpa_backend == "rocm") {
+        device_type_ = DEVICE_GPU;
+    } else {
+        device_type_ = DEVICE_CPU;
+    }
+    sherpa_backend_ = sherpa_backend;
+
+    backend_manager_->install_backend(SPEC.recipe, sherpa_backend);
+
+    std::string model_path = model_info.resolved_path();
+    if (model_path.empty()) {
+        throw std::runtime_error("Model file not found for checkpoint: " + model_info.checkpoint());
+    }
+    model_path_ = model_path;
+
+    TransducerPaths tp = resolve_transducer_paths(model_path);
+
+    LOG(INFO, "SherpaServer") << "Using backend: " << sherpa_backend << std::endl;
+    LOG(INFO, "SherpaServer") << "  encoder: " << tp.encoder << std::endl;
+    LOG(INFO, "SherpaServer") << "  decoder: " << tp.decoder << std::endl;
+    LOG(INFO, "SherpaServer") << "  joiner:  " << tp.joiner << std::endl;
+    LOG(INFO, "SherpaServer") << "  tokens:  " << tp.tokens << std::endl;
+
+    std::string exe_path = BackendUtils::get_backend_binary_path(SPEC, sherpa_backend);
+
+    port_ = choose_port();
+    if (port_ == 0) {
+        throw std::runtime_error("Failed to find an available port");
+    }
+
+    LOG(INFO, "SherpaServer") << "Starting server on port " << port_ << std::endl;
+
+    // The "rocm" backend selects the ROCm execution provider (PR #1110); the
+    // "cpu" backend uses the default cpu provider.
+    std::string provider = (sherpa_backend == "rocm") ? "rocm" : "cpu";
+
+    // Lemonade manages the model triple, port, and provider; users may add
+    // sherpa flags (e.g. --num-threads, --decoding-method) via sherpa-onnx_args.
+    std::vector<std::string> args = {
+        "--encoder", tp.encoder,
+        "--decoder", tp.decoder,
+        "--joiner", tp.joiner,
+        "--tokens", tp.tokens,
+        "--provider", provider,
+        "--port", std::to_string(port_)
+    };
+
+    std::set<std::string> reserved_flags = {
+        "--encoder", "--decoder", "--joiner", "--tokens", "--provider", "--port"
+    };
+
+    if (!sherpa_args.empty()) {
+        std::string validation_error = validate_custom_args(sherpa_args, reserved_flags);
+        if (!validation_error.empty()) {
+            throw std::invalid_argument(
+                "Invalid custom sherpa-onnx-online-websocket-server arguments:\n" + validation_error
+            );
+        }
+
+        LOG(DEBUG, "SherpaServer") << "Adding custom arguments: " << sherpa_args << std::endl;
+        std::vector<std::string> custom_args_vec = parse_custom_args(sherpa_args);
+        args.insert(args.end(), custom_args_vec.begin(), custom_args_vec.end());
+    }
+
+    // Set up environment variables for shared library loading.
+    std::vector<std::pair<std::string, std::string>> env_vars;
+    fs::path exe_dir = fs::path(exe_path).parent_path();
+
+#ifndef _WIN32
+    std::string lib_path = exe_dir.string();
+    // sherpa-onnx ships its shared libs alongside the binary and (often) in a
+    // sibling lib/ directory.
+    fs::path sibling_lib = exe_dir.parent_path() / "lib";
+    if (fs::exists(sibling_lib)) {
+        lib_path = lib_path + ":" + sibling_lib.string();
+    }
+
+    const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
+    if (existing_ld_path && strlen(existing_ld_path) > 0) {
+        lib_path = lib_path + ":" + std::string(existing_ld_path);
+    }
+
+    env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
+    if (is_debug()) {
+        std::cout << "[SherpaServer] Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
+    }
+#endif
+
+    process_handle_ = utils::ProcessManager::start_process(
+        exe_path,
+        args,
+        "",          // working_dir (empty = current)
+        is_debug(),  // inherit_output
+        false,       // filter_health_logs
+        env_vars
+    );
+
+    if (process_handle_.pid == 0) {
+        throw std::runtime_error("Failed to start sherpa-onnx-online-websocket-server process");
+    }
+
+    LOG(INFO, "SherpaServer") << "Process started with PID: " << process_handle_.pid << std::endl;
+
+    // sherpa's websocket server has no HTTP health endpoint, so poll for the
+    // listening TCP port instead of the base-class HTTP readiness probe.
+    const int max_attempts = 6000;  // ~600s at 100ms
+    bool ready = false;
+    for (int i = 0; i < max_attempts; ++i) {
+        if (!utils::ProcessManager::is_running(process_handle_)) {
+            int exit_code = utils::ProcessManager::get_exit_code(process_handle_);
+            LOG(ERROR, "SherpaServer") << "sherpa-onnx server terminated with exit code: "
+                                       << exit_code << std::endl;
+            break;
+        }
+        if (tcp_port_open(port_, 1000)) {
+            ready = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    if (!ready) {
+        unload();
+        throw std::runtime_error("sherpa-onnx server failed to start or become ready");
+    }
+
+    LOG(INFO, "SherpaServer") << "Server is ready!" << std::endl;
+}
+
+void SherpaServer::unload() {
+    if (process_handle_.pid != 0) {
+        LOG(INFO, "SherpaServer") << "Stopping server (PID: " << process_handle_.pid << ")" << std::endl;
+        utils::ProcessManager::stop_process(process_handle_);
+        process_handle_ = {nullptr, 0};
+        port_ = 0;
+    }
+}
+
+// ICompletionServer implementation - not supported for sherpa-onnx STT
+json SherpaServer::chat_completion(const json& request) {
+    return json{
+        {"error", {
+            {"message", "sherpa-onnx models do not support chat completion. Use audio transcription endpoints instead."},
+            {"type", "unsupported_operation"},
+            {"code", "model_not_applicable"}
+        }}
+    };
+}
+
+json SherpaServer::completion(const json& request) {
+    return json{
+        {"error", {
+            {"message", "sherpa-onnx models do not support text completion. Use audio transcription endpoints instead."},
+            {"type", "unsupported_operation"},
+            {"code", "model_not_applicable"}
+        }}
+    };
+}
+
+json SherpaServer::responses(const json& request) {
+    return json{
+        {"error", {
+            {"message", "sherpa-onnx models do not support responses. Use audio transcription endpoints instead."},
+            {"type", "unsupported_operation"},
+            {"code", "model_not_applicable"}
+        }}
+    };
+}
+
+std::vector<float> SherpaServer::decode_to_mono_f32(const std::string& audio_data,
+                                                    const std::string& filename,
+                                                    int target_sample_rate) {
+    fs::path fp(filename);
+    std::string ext = fp.extension().string();
+    for (auto& c : ext) c = static_cast<char>(::tolower(c));
+
+    // Only WAV is decoded natively. The realtime path always sends 16 kHz mono
+    // PCM16 WAV; the batch path documents WAV as the streaming-backend input.
+    if (!ext.empty() && ext != ".wav") {
+        throw std::runtime_error(
+            "sherpa-onnx streaming backend requires PCM16 WAV input (got '" + ext +
+            "'); convert to WAV or use a whisper.cpp model for compressed formats");
+    }
+
+    WavData wav = decode_wav(audio_data);
+    return resample_linear(wav.samples, wav.sample_rate, target_sample_rate);
+}
+
+std::string SherpaServer::stream_to_websocket(const std::vector<float>& samples) {
+    SherpaWsClient client;
+    client.port = port_;
+    client.samples = &samples;
+
+    struct lws_context_creation_info info;
+    std::memset(&info, 0, sizeof(info));
+    info.port = CONTEXT_PORT_NO_LISTEN;  // client-only context
+    info.protocols = kSherpaProtocols;
+    info.gid = -1;
+    info.uid = -1;
+    info.user = &client;
+
+    struct lws_context* context = lws_create_context(&info);
+    if (!context) {
+        throw std::runtime_error("Failed to create libwebsockets context for sherpa-onnx client");
+    }
+
+    struct lws_client_connect_info ccinfo;
+    std::memset(&ccinfo, 0, sizeof(ccinfo));
+    ccinfo.context = context;
+    ccinfo.address = "127.0.0.1";
+    ccinfo.port = port_;
+    ccinfo.path = "/";
+    ccinfo.host = "127.0.0.1";
+    ccinfo.origin = "127.0.0.1";
+    ccinfo.protocol = kSherpaProtocols[0].name;
+
+    if (!lws_client_connect_via_info(&ccinfo)) {
+        lws_context_destroy(context);
+        throw std::runtime_error("Failed to connect to sherpa-onnx websocket server");
+    }
+
+    // Service the event loop until the server signals completion ("Done!") or
+    // the connection closes. Bounded by a generous timeout.
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(600);
+    while (true) {
+        {
+            std::lock_guard<std::mutex> lk(client.mtx);
+            if (client.finished) break;
+        }
+        if (std::chrono::steady_clock::now() > deadline) {
+            std::lock_guard<std::mutex> lk(client.mtx);
+            client.error = "Timed out waiting for sherpa-onnx transcription";
+            break;
+        }
+        lws_service(context, 50);
+    }
+
+    lws_context_destroy(context);
+
+    std::lock_guard<std::mutex> lk(client.mtx);
+    if (!client.error.empty()) {
+        throw std::runtime_error(client.error);
+    }
+    return client.last_text;
+}
+
+// ITranscriptionServer implementation
+json SherpaServer::audio_transcriptions(const json& request) {
+    try {
+        if (!request.contains("file_data")) {
+            throw std::runtime_error("Missing 'file_data' in request");
+        }
+
+        std::string audio_data = request["file_data"].get<std::string>();
+        std::string filename = request.value("filename", "audio.wav");
+
+        if (audio_data.empty()) {
+            throw std::runtime_error("Empty audio data");
+        }
+
+        // Standardized optional carrier-audio params (see audio_types.h
+        // RequestParam). sherpa transducer models run at a fixed internal rate;
+        // we resample the supplied audio to that rate. The recognizer rate is
+        // 16 kHz mono (AudioDefaults). sample_rate, if provided, is only used as
+        // a fallback when the WAV header is absent/unreliable.
+        const int target_rate = audio::AudioDefaults::SAMPLE_RATE_HZ;
+
+        std::vector<float> samples = decode_to_mono_f32(audio_data, filename, target_rate);
+        if (samples.empty()) {
+            return json{{"text", ""}};
+        }
+
+        std::string text = stream_to_websocket(samples);
+        return json{{"text", text}};
+
+    } catch (const std::exception& e) {
+        return json{
+            {"error", {
+                {"message", std::string("Transcription failed: ") + e.what()},
+                {"type", "audio_processing_error"}
+            }}
+        };
+    }
+}
+
+} // namespace backends
+} // namespace lemon

--- a/src/cpp/server/backends/whisper_server.cpp
+++ b/src/cpp/server/backends/whisper_server.cpp
@@ -453,6 +453,19 @@ json WhisperServer::build_transcription_request(const json& request, bool transl
         whisper_req["response_format"] = "json";  // Default
     }
 
+    // Standardized optional carrier-audio params (see audio_types.h
+    // RequestParam). whisper-server resamples internally to 16 kHz, so these
+    // are forwarded as hints/passthrough and do not change the managed flags.
+    if (request.contains(audio::RequestParam::SAMPLE_RATE)) {
+        whisper_req[audio::RequestParam::SAMPLE_RATE] = request[audio::RequestParam::SAMPLE_RATE];
+    }
+    if (request.contains(audio::RequestParam::AUDIO_BITRATE)) {
+        whisper_req[audio::RequestParam::AUDIO_BITRATE] = request[audio::RequestParam::AUDIO_BITRATE];
+    }
+    if (request.contains(audio::RequestParam::CHANNELS)) {
+        whisper_req[audio::RequestParam::CHANNELS] = request[audio::RequestParam::CHANNELS];
+    }
+
     // Add translate flag if needed
     if (translate) {
         whisper_req["translate"] = true;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1224,6 +1224,24 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
         return model_cache_path;  // Return directory even if index not found
     }
 
+    // For sherpa-onnx, return the directory holding the transducer triple
+    // (encoder/decoder/joiner .onnx + tokens.txt). SherpaServer resolves the
+    // individual files from this directory.
+    if (info.recipe == "sherpa-onnx") {
+        if (safe_exists(model_cache_path_fs)) {
+            for (const auto& entry : fs::recursive_directory_iterator(model_cache_path_fs, safe_dir_options)) {
+                if (entry.is_regular_file()) {
+                    std::string fname = entry.path().filename().string();
+                    if (fname.find("encoder") != std::string::npos &&
+                        entry.path().extension() == ".onnx") {
+                        return path_to_utf8(entry.path().parent_path());
+                    }
+                }
+            }
+        }
+        return model_cache_path;  // Return directory even if triple not found
+    }
+
     // For whispercpp, find the .bin model file
     if (info.recipe == "whispercpp" && variant.empty()) {
         // No variant specified - use fallback logic to find any .bin file
@@ -2435,6 +2453,10 @@ void ModelManager::register_user_model(const std::string& model_name,
         labels.insert("image");
     }
     if (recipe == "whispercpp") {
+        labels.insert("transcription");
+        labels.insert("realtime-transcription");
+    }
+    if (recipe == "sherpa-onnx") {
         labels.insert("transcription");
         labels.insert("realtime-transcription");
     }

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -22,6 +22,8 @@ static const json DEFAULTS = {
     {"sdcpp_args", ""},
     {"whispercpp_backend", ""},  // "" means auto-detect (mapped from "auto" in config.json)
     {"whispercpp_args", ""},
+    {"sherpa-onnx_backend", ""},  // "" means auto-detect (mapped from "auto" in config.json)
+    {"sherpa-onnx_args", ""},
     // Image generation defaults (for sd-cpp recipe)
     // These are recipe-level defaults only, not CLI arguments — per reviewer guidance,
     // there are too many image gen params for CLI flags, and no universal defaults.
@@ -52,6 +54,8 @@ static const std::map<std::string, std::string> OPTION_TO_CLI_FLAG = {
     {"sdcpp_args", "--sdcpp-args"},
     {"whispercpp_backend", "--whispercpp"},
     {"whispercpp_args", "--whispercpp-args"},
+    {"sherpa-onnx_backend", "--sherpa-onnx"},
+    {"sherpa-onnx_args", "--sherpa-onnx-args"},
     {"flm_args", "--flm-args"},
     {"vllm_backend", "--vllm"},
     {"vllm_args", "--vllm-args"}
@@ -62,6 +66,8 @@ static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
         return {"ctx_size", "llamacpp_device", "llamacpp_backend", "llamacpp_args", "merge_args"};
     } else if (recipe == "whispercpp") {
         return {"whispercpp_backend", "whispercpp_args", "merge_args"};
+    } else if (recipe == "sherpa-onnx") {
+        return {"sherpa-onnx_backend", "sherpa-onnx_args", "merge_args"};
     } else if (recipe == "flm") {
         return {"ctx_size", "flm_args", "merge_args"};
     } else if (recipe == "ryzenai-llm") {
@@ -231,6 +237,8 @@ static const json CLI_OPTIONS = {
     {"--sdcpp-args", {{"option_name", "sdcpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_SDCPP_ARGS"}, {"help", "Custom arguments to pass to sd-server (must not conflict with managed args)"}}},
     {"--whispercpp", {{"option_name", "whispercpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_WHISPERCPP"}, {"help", "WhisperCpp backend to use"}}},
     {"--whispercpp-args", {{"option_name", "whispercpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_WHISPERCPP_ARGS"}, {"help", "Custom arguments to pass to whisper-server"}}},
+    {"--sherpa-onnx", {{"option_name", "sherpa-onnx_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_SHERPA_ONNX"}, {"help", "sherpa-onnx backend to use (rocm or cpu)"}}},
+    {"--sherpa-onnx-args", {{"option_name", "sherpa-onnx_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_SHERPA_ONNX_ARGS"}, {"help", "Custom arguments to pass to sherpa-onnx-online-websocket-server"}}},
     {"--vllm", {{"option_name", "vllm_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_VLLM"}, {"help", "vLLM backend to use"}}},
     {"--vllm-args", {{"option_name", "vllm_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_VLLM_ARGS"}, {"help", "Custom arguments to pass to vllm-server"}}},
     // Note: Image gen params (--steps, --cfg-scale, --width, --height) removed — recipe-level only.

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -3,6 +3,7 @@
 #include "lemon/backends/fastflowlm_server.h"
 #include "lemon/backends/ryzenaiserver.h"
 #include "lemon/backends/whisper_server.h"
+#include "lemon/backends/sherpa_server.h"
 #include "lemon/backends/kokoro_server.h"
 #include "lemon/backends/sd_server.h"
 #include "lemon/backends/vllm_server.h"
@@ -186,6 +187,9 @@ std::unique_ptr<WrappedServer> Router::create_backend_server(const ModelInfo& mo
     if (model_info.recipe == "whispercpp") {
         LOG(DEBUG, "Router") << "Creating WhisperServer backend" << std::endl;
         new_server = std::make_unique<backends::WhisperServer>(log_level, model_manager_, backend_manager_);
+    } else if (model_info.recipe == "sherpa-onnx") {
+        LOG(DEBUG, "Router") << "Creating SherpaServer backend" << std::endl;
+        new_server = std::make_unique<backends::SherpaServer>(log_level, model_manager_, backend_manager_);
     } else if (model_info.recipe == "kokoro") {
         LOG(DEBUG, "Router") << "Creating Kokoro backend" << std::endl;
         new_server = std::make_unique<backends::KokoroServer>(log_level, model_manager_, backend_manager_);

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -30,7 +30,7 @@ RuntimeConfig* RuntimeConfig::global() {
 }
 
 static const std::vector<std::string> s_backend_names = {
-    "llamacpp", "whispercpp", "sdcpp", "flm", "vllm", "ryzenai", "kokoro"
+    "llamacpp", "whispercpp", "sherpa-onnx", "sdcpp", "flm", "vllm", "ryzenai", "kokoro"
 };
 
 static bool is_backend_name(const std::string& key) {
@@ -39,7 +39,7 @@ static bool is_backend_name(const std::string& key) {
 
 // Backends that have a selectable "backend" key
 static const std::vector<std::string> s_selectable_backends = {
-    "llamacpp", "whispercpp", "sdcpp", "vllm"
+    "llamacpp", "whispercpp", "sherpa-onnx", "sdcpp", "vllm"
 };
 
 static bool has_backend_selection(const std::string& config_section) {
@@ -306,6 +306,16 @@ json RuntimeConfig::recipe_options(const std::string& backend) const {
             result["whispercpp_args"] = wc[backend_args];
         } else if (wc.contains("args")) {
             result["whispercpp_args"] = wc["args"];
+        }
+    }
+
+    if (config_.contains("sherpa-onnx")) {
+        const auto& sh = config_["sherpa-onnx"];
+        if (sh.contains("backend")) result["sherpa-onnx_backend"] = resolve_auto(sh["backend"]);
+        if (sh.contains(backend_args) && sh[backend_args] != "") {
+            result["sherpa-onnx_args"] = sh[backend_args];
+        } else if (sh.contains("args")) {
+            result["sherpa-onnx_args"] = sh["args"];
         }
     }
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1,4 +1,5 @@
 #include "lemon/server.h"
+#include "lemon/audio_types.h"
 #include "lemon/collection_orchestrator.h"
 #include "lemon/hf_variants.h"
 #include "lemon/config_file.h"
@@ -2318,6 +2319,20 @@ void Server::handle_audio_transcriptions(const httplib::Request& req, httplib::R
         }
         if (req.form.has_field("temperature")) {
             request_json["temperature"] = std::stod(req.form.get_field("temperature"));
+        }
+        // Standardized optional carrier-audio params (see audio_types.h
+        // RequestParam). Honored uniformly by every transcription backend.
+        if (req.form.has_field(audio::RequestParam::SAMPLE_RATE)) {
+            request_json[audio::RequestParam::SAMPLE_RATE] =
+                std::stoi(req.form.get_field(audio::RequestParam::SAMPLE_RATE));
+        }
+        if (req.form.has_field(audio::RequestParam::AUDIO_BITRATE)) {
+            request_json[audio::RequestParam::AUDIO_BITRATE] =
+                std::stoi(req.form.get_field(audio::RequestParam::AUDIO_BITRATE));
+        }
+        if (req.form.has_field(audio::RequestParam::CHANNELS)) {
+            request_json[audio::RequestParam::CHANNELS] =
+                std::stoi(req.form.get_field(audio::RequestParam::CHANNELS));
         }
 
         // Extract audio file

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -486,6 +486,15 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
         {"metal", {}},
     }},
 
+    // sherpa-onnx (streaming STT) - ROCm for AMD GPUs (Linux x64, per PR #1110);
+    // CPU execution provider on Windows/Linux x86_64.
+    {"sherpa-onnx", "rocm", {"linux"}, {
+        {"amd_gpu", {"gfx1100", "gfx1101", "gfx1102", "gfx1030", "gfx1031", "gfx1032"}},
+    }},
+    {"sherpa-onnx", "cpu", {"windows", "linux"}, {
+        {"cpu", {"x86_64"}},
+    }},
+
     // kokoro - Windows/Linux x86_64; macOS arm64 (Metal)
     {"kokoro", "cpu", {"windows", "linux"}, {
         {"cpu", {"x86_64"}},

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -488,8 +488,15 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
 
     // sherpa-onnx (streaming STT) - ROCm for AMD GPUs (Linux x64, per PR #1110);
     // CPU execution provider on Windows/Linux x86_64.
+    //
+    // The ROCm asset is a multi-arch ("fat") build covering ALL AMD GPUs
+    // (RDNA2/3/3.5/4 + CDNA), so the device family set is intentionally empty
+    // ({} = all AMD GPU families). Unlike llamacpp/sd, sherpa is NOT pinned to a
+    // per-gfx arch and does NOT use SystemInfo::get_rocm_arch(); a single binary
+    // serves every AMD GPU. Any future unlisted arch can still be forced with the
+    // HSA_OVERRIDE_GFX_VERSION env var (inherited from the parent process).
     {"sherpa-onnx", "rocm", {"linux"}, {
-        {"amd_gpu", {"gfx1100", "gfx1101", "gfx1102", "gfx1030", "gfx1031", "gfx1032"}},
+        {"amd_gpu", {}},  // all AMD GPU families (multi-arch ROCm build)
     }},
     {"sherpa-onnx", "cpu", {"windows", "linux"}, {
         {"cpu", {"x86_64"}},


### PR DESCRIPTION
## Summary

Adds a new transcription backend (recipe `sherpa-onnx`) that wraps the
k2-fsa/sherpa-onnx online (streaming) transducer recognizer, modeled on the
whisper.cpp backend, with AMD ROCm support that runs on **all AMD GPUs**.

### What's included

- **Wrapped streaming backend.** `SherpaServer` launches
  `sherpa-onnx-online-websocket-server` with the encoder/decoder/joiner/tokens
  triple and bridges lemonade's OpenAI `audio/transcriptions` (and the realtime
  WebSocket path) onto the server's custom WebSocket protocol via a
  libwebsockets client. Registered across router/backend_utils/model_types/
  recipe_options/runtime_config/system_info/model_manager/backend_versions/
  defaults/CMakeLists. UI exposes it as a selectable backend with HF
  auto-detection for transducer triples.
- **ROCm via PR #1110.** The `rocm` provider uses the AMD ROCm execution
  provider added in sherpa-onnx
  [PR #1110](https://github.com/k2-fsa/sherpa-onnx/pull/1110)
  (`-DSHERPA_ONNX_ENABLE_ROCM=ON`, launched with `--provider=rocm`, Linux x64).
- **All AMD GPUs (multi-arch build).** The ROCm asset is one architecture-
  agnostic Linux x64 binary — a multi-arch ("fat") build compiled for a broad
  AMD GPU target list (RDNA2/3/3.5/4 + CDNA), so a single download runs on every
  AMD GPU. sherpa is intentionally **not** per-`gfx` (unlike llamacpp/sd, which
  call `SystemInfo::get_rocm_arch()`); its device family set is `{}` = all AMD
  GPU families. `HSA_OVERRIDE_GFX_VERSION` (inherited from the parent env) is the
  runtime escape hatch for any future unlisted arch.
- **Standardized audio params.** `sample_rate`, `audio_bitrate`, `channels`,
  `language` defined once in `audio_types.h` and honored by every
  `ITranscriptionServer` backend.
- **Build workflow.** `.github/workflows/build-sherpa-onnx-rocm.yml` checks out
  PR #1110, builds with the broad GPU target list under
  `CMAKE_HIP_ARCHITECTURES` / `GPU_TARGETS` / `AMDGPU_TARGETS`, packages
  `sherpa-onnx-<version>-linux-x64-rocm-shared.tar.bz2`, and publishes it to
  `lemonade-sdk/sherpa-onnx-builds` (tag = `v1.13.2`).

### Gating note (action required before `rocm` works end-to-end)

The ROCm prebuilt asset does **not exist yet**. It must be produced by the new
workflow, which needs:
- a **ROCm-capable build runner** (`runs-on` is a placeholder `[self-hosted,
  linux, x64, rocm]` with a TODO — the operator must wire the runner/label), and
- a **`SHERPA_BUILDS_TOKEN`** secret with `contents:write` on
  `lemonade-sdk/sherpa-onnx-builds` (TODO in the workflow).

The lemonade integration itself is already arch-agnostic at install (single
`linux-x64-rocm` asset) and launch (`--provider rocm`, no gfx pin).