### PR TITLE
fix: remove load options environment variable support from lemonade CLI

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -2020,7 +2020,7 @@ jobs:
           HF_HOME: ${{ env.HF_HOME }}
         run: |
           set -e
-          $VENV_PYTHON test/server_cli2.py --cli-binary "$CLI_BINARY"
+          $VENV_PYTHON test/server_cli2.py --cli-binary "$CLI_BINARY" --api-key "$LEMONADE_API_KEY"
 
       - name: Capture and upload server logs
         if: always()

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -226,21 +226,21 @@ json RecipeOptions::get_option(const std::string& opt) const {
 #ifdef LEMONADE_CLI
 // CLI_OPTIONS used only by the lemonade CLI client for add_cli_options
 static const json CLI_OPTIONS = {
-    {"--ctx-size", {{"option_name", "ctx_size"}, {"type_name", "SIZE"}, {"envname", "LEMONADE_CTX_SIZE"}, {"help", "Context size for the model"}, {"group", "General Options"}}},
-    {"--merge-args", {{"option_name", "merge_args"}, {"type_name", "BOOL"}, {"envname", "LEMONADE_MERGE_ARGS"}, {"help", "Merge global and model arguments when loading the model"}, {"group", "General Options"}}},
-    {"--llamacpp", {{"option_name", "llamacpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_LLAMACPP"}, {"help", "LlamaCpp backend to use"}, {"group", "Llama.cpp Backend Options"}}},
-    {"--llamacpp-device", {{"option_name", "llamacpp_device"}, {"type_name", "DEVICES"}, {"envname", "LEMONADE_LLAMACPP_DEVICE"}, {"help", "Comma-separated list of accelerator devices to use (e.g. Vulkan0)"}, {"group", "Llama.cpp Backend Options"}}},
-    {"--llamacpp-args", {{"option_name", "llamacpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_LLAMACPP_ARGS"}, {"help", "Custom arguments to pass to llama-server"}, {"group", "Llama.cpp Backend Options"}}},
-    {"--sdcpp", {{"option_name", "sd-cpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_SDCPP"}, {"help", "SD.cpp backend to use"}, {"group", "Stable Diffusion Options"}}},
-    {"--sdcpp-args", {{"option_name", "sdcpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_SDCPP_ARGS"}, {"help", "Custom arguments to pass to sd-server (must not conflict with managed args)"}, {"group", "Stable Diffusion Options"}}},
-    {"--whispercpp", {{"option_name", "whispercpp_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_WHISPERCPP"}, {"help", "WhisperCpp backend to use"}, {"group", "Whisper.cpp Options"}}},
-    {"--whispercpp-args", {{"option_name", "whispercpp_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_WHISPERCPP_ARGS"}, {"help", "Custom arguments to pass to whisper-server"}, {"group", "Whisper.cpp Options"}}},
-    {"--moonshine-args", {{"option_name", "moonshine_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_MOONSHINE_ARGS"}, {"help", "Custom arguments to pass to moonshine-server"}}},
-    {"--vllm", {{"option_name", "vllm_backend"}, {"type_name", "BACKEND"}, {"envname", "LEMONADE_VLLM"}, {"help", "vLLM backend to use"}, {"group", "vLLM Options"}}},
-    {"--vllm-args", {{"option_name", "vllm_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_VLLM_ARGS"}, {"help", "Custom arguments to pass to vllm-server"}, {"group", "vLLM Options"}}},
+    {"--ctx-size", {{"option_name", "ctx_size"}, {"type_name", "SIZE"}, {"help", "Context size for the model"}, {"group", "General Options"}}},
+    {"--merge-args", {{"option_name", "merge_args"}, {"type_name", "BOOL"}, {"help", "Merge global and model arguments when loading the model"}, {"group", "General Options"}}},
+    {"--llamacpp", {{"option_name", "llamacpp_backend"}, {"type_name", "BACKEND"}, {"help", "LlamaCpp backend to use"}, {"group", "Llama.cpp Backend Options"}}},
+    {"--llamacpp-device", {{"option_name", "llamacpp_device"}, {"type_name", "DEVICES"}, {"help", "Comma-separated list of accelerator devices to use (e.g. Vulkan0)"}, {"group", "Llama.cpp Backend Options"}}},
+    {"--llamacpp-args", {{"option_name", "llamacpp_args"}, {"type_name", "ARGS"}, {"help", "Custom arguments to pass to llama-server"}, {"group", "Llama.cpp Backend Options"}}},
+    {"--sdcpp", {{"option_name", "sd-cpp_backend"}, {"type_name", "BACKEND"}, {"help", "SD.cpp backend to use"}, {"group", "Stable Diffusion Options"}}},
+    {"--sdcpp-args", {{"option_name", "sdcpp_args"}, {"type_name", "ARGS"}, {"help", "Custom arguments to pass to sd-server (must not conflict with managed args)"}, {"group", "Stable Diffusion Options"}}},
+    {"--whispercpp", {{"option_name", "whispercpp_backend"}, {"type_name", "BACKEND"}, {"help", "WhisperCpp backend to use"}, {"group", "Whisper.cpp Options"}}},
+    {"--whispercpp-args", {{"option_name", "whispercpp_args"}, {"type_name", "ARGS"}, {"help", "Custom arguments to pass to whisper-server"}, {"group", "Whisper.cpp Options"}}},
+    {"--moonshine-args", {{"option_name", "moonshine_args"}, {"type_name", "ARGS"}, {"help", "Custom arguments to pass to moonshine-server"}}},
+    {"--vllm", {{"option_name", "vllm_backend"}, {"type_name", "BACKEND"}, {"help", "vLLM backend to use"}, {"group", "vLLM Options"}}},
+    {"--vllm-args", {{"option_name", "vllm_args"}, {"type_name", "ARGS"}, {"help", "Custom arguments to pass to vllm-server"}, {"group", "vLLM Options"}}},
     // Note: Image gen params (--steps, --cfg-scale, --width, --height) removed — recipe-level only.
     // Runtime options (--diffusion-fa, --offload-to-cpu) go through --sdcpp-args.
-    {"--flm-args", {{"option_name", "flm_args"}, {"type_name", "ARGS"}, {"envname", "LEMONADE_FLM_ARGS"}, {"help", "Custom arguments to pass to flm serve"}, {"group", "FastFlowLM Options"}}}
+    {"--flm-args", {{"option_name", "flm_args"}, {"type_name", "ARGS"}, {"help", "Custom arguments to pass to flm serve"}, {"group", "FastFlowLM Options"}}}
 };
 
 void RecipeOptions::add_cli_options(CLI::App& app, json& storage) {
@@ -263,7 +263,6 @@ void RecipeOptions::add_cli_options(CLI::App& app, json& storage) {
             o->default_val(defval);
         }
 
-        o->envname(opt["envname"]);
         o->type_name(opt["type_name"]);
         o->group(opt.value("group", "Options"));
     }

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -125,6 +125,7 @@ def _resolve_hf_cache_root(repo_cache_dirs, checkpoint_specs=None):
 # Global configuration
 _config = {
     "cli_binary": None,
+    "cli_api_key": None,
 }
 
 IS_WINDOWS = platform.system() == "Windows"
@@ -145,10 +146,17 @@ def parse_cli_args():
         default=get_default_cli_binary(),
         help="Path to lemonade CLI binary (default: CMake build output)",
     )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="API key to pass to all CLI invocations (for servers requiring auth)",
+    )
 
     args = parser.parse_args()
 
     _config["cli_binary"] = args.cli_binary
+    _config["cli_api_key"] = args.api_key
 
     return args
 
@@ -156,6 +164,9 @@ def parse_cli_args():
 def run_cli_command(args, timeout=60, check=False, env=None, input_text=None):
     """
     Run a CLI command and return the result.
+
+    If --api-key was provided to the test runner, it is automatically prepended
+    to every CLI invocation so commands work against a server requiring auth.
 
     Args:
         args: List of command arguments (without the binary)
@@ -167,6 +178,9 @@ def run_cli_command(args, timeout=60, check=False, env=None, input_text=None):
     Returns:
         subprocess.CompletedProcess result
     """
+    cli_args = list(args)
+    if _config["cli_api_key"]:
+        cli_args = ["--api-key", _config["cli_api_key"]] + cli_args
     cli_binary = get_cli_binary()
     if os.path.isabs(cli_binary):
         resolved_cli_binary = cli_binary
@@ -1425,65 +1439,6 @@ sys.exit(0)
             self.assertIn("never", argv)
             self.assertIn("--custom", argv)
             self.assertIn("a b", argv)
-
-    def test_102i_launch_recipe_env_var_bindings_preserved(self):
-        """Launch should continue honoring hidden recipe env vars like LEMONADE_CTX_SIZE."""
-        if IS_WINDOWS:
-            self.skipTest(WINDOWS_LAUNCH_STUB_SKIP_REASON)
-
-        with tempfile.TemporaryDirectory(prefix="lemonade-launch-stub-") as temp_dir:
-            capture_path = os.path.join(temp_dir, "claude_capture_ctx_env.json")
-            self._write_fake_agent(temp_dir, "claude", capture_path)
-            env = self._build_stubbed_agent_env(temp_dir)
-            env["LEMONADE_CTX_SIZE"] = "2048"
-
-            result = run_cli_command(
-                [
-                    "launch",
-                    "claude",
-                    "--model",
-                    ENDPOINT_TEST_MODEL,
-                ],
-                timeout=TIMEOUT_DEFAULT,
-                env=env,
-            )
-
-            self.assertEqual(result.returncode, 0)
-            self.assertTrue(
-                os.path.exists(capture_path),
-                "Fake claude binary was not executed",
-            )
-
-            deadline = time.time() + TIMEOUT_MODEL_OPERATION
-            loaded_model = None
-            while time.time() < deadline:
-                response = requests.get(
-                    f"http://127.0.0.1:{PORT}/api/v1/health",
-                    headers=_auth_headers(),
-                    timeout=TIMEOUT_DEFAULT,
-                )
-                self.assertEqual(response.status_code, 200)
-                health_data = response.json()
-                loaded_model = next(
-                    (
-                        model
-                        for model in health_data.get("all_models_loaded", [])
-                        if model.get("model_name") == ENDPOINT_TEST_MODEL
-                    ),
-                    None,
-                )
-                recipe_options = (loaded_model or {}).get("recipe_options", {})
-                if recipe_options.get("ctx_size") == 2048:
-                    break
-                time.sleep(1)
-
-            self.assertIsNotNone(
-                loaded_model, f"Model {ENDPOINT_TEST_MODEL} should be loaded"
-            )
-            self.assertEqual(
-                loaded_model.get("recipe_options", {}).get("ctx_size"),
-                2048,
-            )
 
     def test_103_launch_explicit_model_with_repo_flags_is_deterministic(self):
         """Explicit model should skip import flow even when repo flags are present."""


### PR DESCRIPTION
Drop LEMONADE_CTX_SIZE, LEMONADE_MERGE_ARGS, LEMONADE_LLAMACPP*, LEMONADE_SDCPP*, LEMONADE_WHISPERCPP*, LEMONADE_VLLM*, and LEMONADE_FLM_ARGS from recipe options.

Fixes #2158