### PR TITLE
fix(ui): connect log stream on main HTTP port instead of dedicated WebSocket port

### DIFF
--- a/src/app/src/renderer/utils/logWebSocketClient.ts
+++ b/src/app/src/renderer/utils/logWebSocketClient.ts
@@ -1,4 +1,4 @@
-import { buildWebSocketUrl, serverFetch } from './serverConfig';
+import { buildWebSocketUrl } from './serverConfig';
 
 export interface LogEntry {
   seq: number;
@@ -24,18 +24,7 @@ export async function connectLogStream(
   afterSeq: number | null,
   callbacks: LogStreamCallbacks,
 ): Promise<LogStreamHandle> {
-  // Get websocket port from health endpoint
-  const healthResponse = await serverFetch('/health');
-  if (!healthResponse.ok) {
-    throw new Error(`Failed to fetch health: ${healthResponse.status}`);
-  }
-  const health = await healthResponse.json();
-  const wsPort = health.websocket_port;
-  if (typeof wsPort !== 'number') {
-    throw new Error('Server did not advertise a websocket port');
-  }
-
-  const wsUrl = buildWebSocketUrl('/logs/stream', wsPort);
+  const wsUrl = buildWebSocketUrl('/logs/stream');
   const socket = new WebSocket(wsUrl);
 
   socket.addEventListener('open', () => {


### PR DESCRIPTION
## Description

Fixes the log viewer failing to connect when Lemonade is accessed through a reverse proxy.

### Root Cause

`connectLogStream()` in `src/app/src/renderer/utils/logWebSocketClient.ts` always fetched `websocket_port` from `/health` and connected to the dedicated WebSocket port. Behind a reverse proxy that only exposes the main HTTP port (e.g. 443), this port is unreachable.

### Fix

Connect to `/logs/stream` on the main HTTP port by removing the `wsPort` argument from `buildWebSocketUrl()`. The main port already accepts WebSocket upgrades for `/logs/stream` via `UpgradableFrontServer` (`upgradable_http_server.h:112`), so no server-side changes are needed.

### Testing

Tested locally using lemond on 0.0.0.0:13305 with Mikrotik Reverse Proxy - log stream connects and receives entries successfully.

### Related Issue

Closes #2190