### PR TITLE
ci(windows): migrate Windows builds to Visual Studio 2026

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -133,9 +133,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: build/_deps
-          key: fetchcontent-windows-${{ hashFiles('CMakeLists.txt') }}
+          # vs2026 marker: VS 2022-built _deps are generator-incompatible with the
+          # VS 2026 configure, so they must not be restored across the toolchain bump.
+          key: fetchcontent-windows-vs2026-${{ hashFiles('CMakeLists.txt') }}
           restore-keys: |
-            fetchcontent-windows-
+            fetchcontent-windows-vs2026-
 
       - name: Run setup.ps1 to configure environment
         shell: PowerShell
@@ -151,8 +153,10 @@ jobs:
           Write-Host "Building C++ server, Tauri app, web app, and MSI installers..." -ForegroundColor Cyan
 
           # Single build command: wix_installers depends on all C++ targets,
-          # tauri-app, and web-app via CMake dependency graph
-          cmake --build --preset windows --target wix_installers
+          # tauri-app, and web-app via CMake dependency graph.
+          # Build by directory (not --preset) so we follow whichever generator
+          # setup.ps1 auto-detected for the installed Visual Studio version.
+          cmake --build build --config Release --target wix_installers
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           # Verify outputs
@@ -778,18 +782,20 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/_deps
-          key: fetchcontent-windows-embeddable-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: fetchcontent-windows-embeddable-
+          # vs2026 marker: see installer job — VS 2022-built _deps cannot be
+          # reused by the VS 2026 configure.
+          key: fetchcontent-windows-embeddable-vs2026-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: fetchcontent-windows-embeddable-vs2026-
 
       - name: Build embeddable archive
         shell: PowerShell
         run: |
           $ErrorActionPreference = "Stop"
 
-          cmake --preset windows -DBUILD_WEB_APP=OFF
+          cmake --preset vs18 -DBUILD_WEB_APP=OFF
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-          cmake --build --preset windows --target embeddable
+          cmake --build build --config Release --target embeddable
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           $archive = "build\lemonade-embeddable-$($env:LEMONADE_VERSION)-windows-x64.zip"

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -117,7 +117,7 @@ jobs:
           $ErrorActionPreference = "Stop"
           Write-Host "Building Lemonade server binaries..." -ForegroundColor Cyan
           if (Test-Path "build") { Remove-Item -Recurse -Force "build" }
-          cmake --preset windows
+          cmake --preset vs18
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cmake --build build --config Release
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
## Problem

The `windows-latest` GitHub runner image dropped Visual Studio 2022 in favor of **VS 2026**, breaking every Windows C++ job across all open PRs (e.g. #2196). This is an environment change, not a code regression — which is why it hit all PRs at once.

Two distinct failures resulted:

1. **Installer job** — `setup.ps1` auto-detects the installed VS and selected the `vs18` preset (VS 2026 generator), but the restored `fetchcontent-windows-*` cache held `_deps` built with **VS 2022**. The mismatch fails the configure inside FetchContent:
   ```
   CMake Error: generator : Visual Studio 18 2026
   Does not match the generator used previously: Visual Studio 17 2022
   -- Configuring incomplete, errors occurred!
   ```
   Because configure never finished, `wix_installers.vcxproj` was never generated:
   ```
   MSBUILD : error MSB1009: Project file does not exist.
   Switch: wix_installers.vcxproj
   ```

2. **Embeddable-Windows & validate_llamacpp jobs** — these hardcode `cmake --preset windows` (the VS 2022 generator), which the VS-2026-only runner cannot satisfy:
   ```
   CMake Error at CMakeLists.txt:8 (project):
     Generator Visual Studio 17 2022 could not find any instance of Visual Studio.
   ```

## Fix

- **Re-key both Windows FetchContent caches** with a `vs2026` marker so the stale VS 2022 `_deps` are not restored into a VS 2026 configure. (The old caches simply go cold and repopulate fresh — no manual deletion needed.)
- **Installer build step** now uses `cmake --build build --config Release` (generator-agnostic) so it follows whatever generator `setup.ps1` auto-detected, rather than re-hardcoding a preset that can disagree — this avoids reintroducing the same mismatch class on future toolchain bumps.
- **Pin the embeddable-windows and validate_llamacpp configures** to the `vs18` preset (these jobs run their own configure and don't go through `setup.ps1`).

`setup.ps1` is intentionally **left unchanged** so local builds keep auto-detecting the installed Visual Studio version (and it does not need to export any GitHub env vars).

## Note

This pins CI to VS 2026. If `windows-latest` later rolls to VS 2027, the hardcoded-`vs18` jobs and the cache key will need the same bump again; the installer job is future-proof on that axis since it rides `setup.ps1`'s detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)