### PR TITLE
Fix CUDA backend on NVIDIA GB10 (sm_121) arm64

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -4,7 +4,7 @@
     "vulkan": "b9585",
     "rocm-stable": "b9586",
     "rocm-nightly": "b1292",
-    "cuda": "b9586",
+    "cuda": "b9602",
     "metal": "b9585",
     "cpu": "b9585"
   },
@@ -19,7 +19,7 @@
     "cpu": "master-672-1f9ee88",
     "rocm-stable": "master-672-1f9ee88",
     "vulkan": "master-672-1f9ee88",
-    "cuda": "master-672-b638fe9",
+    "cuda": "master-685-db48014",
     "metal": "master-672-1f9ee88"
   },
   "therock": {

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -201,7 +201,11 @@ InstallParams LlamaCppServer::get_install_params(const std::string& backend, con
 #ifdef _WIN32
         params.filename = "llama-" + version + "-windows-cuda-" + target_arch + "-x64.7z";
 #elif defined(__linux__)
+#if defined(__aarch64__)
+        params.filename = "llama-" + version + "-ubuntu-cuda-" + target_arch + "-arm64.tar.xz";
+#else
         params.filename = "llama-" + version + "-ubuntu-cuda-" + target_arch + "-x64.tar.xz";
+#endif
 #else
         throw std::runtime_error("CUDA llamacpp is currently supported on Windows and Linux only");
 #endif

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -151,7 +151,11 @@ InstallParams SDServer::get_install_params(const std::string& backend, const std
 #ifdef _WIN32
         params.filename = "sd-" + short_version + "-windows-cuda-" + target_arch + "-x64.zip";
 #elif defined(__linux__)
+#if defined(__aarch64__)
+        params.filename = "sd-" + short_version + "-ubuntu-cuda-" + target_arch + "-arm64.tar.xz";
+#else
         params.filename = "sd-" + short_version + "-ubuntu-cuda-" + target_arch + "-x64.tar.xz";
+#endif
 #else
         throw std::runtime_error("CUDA sd.cpp is currently supported on Windows and Linux only");
 #endif

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -659,6 +659,7 @@ std::string identify_rocm_arch_from_name(const std::string& device_name);
 std::string identify_cuda_arch_from_name(const std::string& device_name);
 std::string identify_npu_arch();
 static std::string compute_cap_to_sm(const std::string& compute_cap);
+static std::string normalize_cuda_arch(const std::string& arch);
 static std::string read_version_file(const fs::path& version_file);
 static std::string get_expected_backend_version(const std::string& recipe, const std::string& backend);
 
@@ -1138,7 +1139,10 @@ json SystemInfo::build_recipes_info(const json& devices) {
         for (const auto& gpu : devices["nvidia_gpu"]) {
             if (gpu.value("available", false)) {
                 std::string name = gpu.value("name", "");
-                std::string family = gpu.value("family", "");
+                // Normalize to the nearest supported arch so that GPUs with
+                // unsupported minor revisions (e.g. sm_121 GB10 -> sm_120)
+                // still match the BACKEND_AVAILABILITY constraint set.
+                std::string family = normalize_cuda_arch(gpu.value("family", ""));
                 if (!name.empty()) {
                     detected_devices.push_back({
                         "nvidia_gpu",
@@ -2133,10 +2137,37 @@ static int cuda_sm_value(const std::string& arch) {
     }
 }
 
+// Maps an sm_XX token to the nearest supported binary target.
+// If the arch is directly in CUDA_SUPPORTED_ARCHS, returns it unchanged.
+// Otherwise finds the highest supported arch that is <= the detected arch,
+// enabling forward-compatible GPUs (e.g. sm_121 GB10 -> sm_120 binary).
+// Returns "" if no suitable match exists.
+static std::string normalize_cuda_arch(const std::string& arch) {
+    if (arch.empty()) return "";
+    if (CUDA_SUPPORTED_ARCHS.count(arch)) return arch;
+
+    int detected_val = cuda_sm_value(arch);
+    if (detected_val <= 0) return "";
+
+    std::string best;
+    int best_val = 0;
+    for (const auto& supported : CUDA_SUPPORTED_ARCHS) {
+        int val = cuda_sm_value(supported);
+        if (val <= detected_val && val > best_val) {
+            best_val = val;
+            best = supported;
+        }
+    }
+    return best;
+}
+
 static std::string cuda_arch_from_gpu_json(const json& gpu) {
     std::string family = gpu.value("family", "");
-    if (!family.empty() && CUDA_SUPPORTED_ARCHS.count(family)) {
-        return family;
+    if (!family.empty()) {
+        std::string normalized = normalize_cuda_arch(family);
+        if (!normalized.empty()) {
+            return normalized;
+        }
     }
 
     std::string name = gpu.value("name", "");

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -82,6 +82,7 @@ const std::set<std::string> CUDA_SUPPORTED_ARCHS = {
     "sm_90",   // Hopper       (H100, H200)
     "sm_100",  // Blackwell DC (B100, B200)
     "sm_120",  // Blackwell    (RTX 50)
+    "sm_121",  // Blackwell    (GB10 / Thor SoC)
 };
 
 // ROCm architecture mapping - maps specific gfx architectures to their family (download target).
@@ -459,7 +460,7 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
         {"metal", {}},
     }},
     {"llamacpp", "cuda", {"windows", "linux"}, {
-        {"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120"}},
+        {"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120", "sm_121"}},
     }},
     {"llamacpp", "vulkan", {"windows", "linux"}, {
         {"cpu", {"x86_64", "arm64"}},
@@ -504,7 +505,7 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
 
     // stable-diffusion.cpp - CUDA backend for NVIDIA GPUs (Linux)
     {"sd-cpp", "cuda", {"linux"}, {
-        {"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120"}},
+        {"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120", "sm_121"}},
     }},
 
     // stable-diffusion.cpp - Vulkan backend (Windows/Linux x86_64)
@@ -571,6 +572,7 @@ static const std::map<std::string, std::string> DEVICE_FAMILY_NAMES = {
     {"sm_90",  "NVIDIA H100 / H200 (Hopper)"},
     {"sm_100", "NVIDIA B100 / B200 (Blackwell)"},
     {"sm_120", "GeForce RTX 50 series (Blackwell)"},
+    {"sm_121", "NVIDIA GB10 (Blackwell)"},
 
     // NPU architectures
     {"XDNA2", "AMD XDNA 2"},
@@ -1772,7 +1774,7 @@ std::string identify_cuda_arch_from_name(const std::string& device_name) {
     // Quick guard: require at least one NVIDIA identifier substring
     static const std::vector<std::string> NVIDIA_IDS = {
         "nvidia", "geforce", "rtx", "gtx", "quadro", "tesla", "titan",
-        "a100", "a40", "a30", "a10", "h100", "h200", "b100", "b200", "l40",
+        "a100", "a40", "a30", "a10", "h100", "h200", "b100", "b200", "l40", "gb10",
     };
     bool is_nvidia = false;
     for (const auto& id : NVIDIA_IDS) {
@@ -1793,6 +1795,7 @@ std::string identify_cuda_arch_from_name(const std::string& device_name) {
     // sm_100 is listed first as a belt-and-suspenders fallback (the early guard
     // above already returns before this table is reached for B100/B200).
     static const std::vector<std::pair<std::string, std::vector<std::string>>> TABLE = {
+        {"sm_121", {"gb10"}},
         {"sm_100", {"b100", "b200"}},
         {"sm_120", {"blackwell", "rtx 50", "rtx50", "5090", "5080", "5070", "5060",
                     "rtx pro 6000", "rtx pro 5000", "rtx pro 4500", "rtx pro 4000",

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -659,7 +659,6 @@ std::string identify_rocm_arch_from_name(const std::string& device_name);
 std::string identify_cuda_arch_from_name(const std::string& device_name);
 std::string identify_npu_arch();
 static std::string compute_cap_to_sm(const std::string& compute_cap);
-static std::string normalize_cuda_arch(const std::string& arch);
 static std::string read_version_file(const fs::path& version_file);
 static std::string get_expected_backend_version(const std::string& recipe, const std::string& backend);
 
@@ -1139,10 +1138,7 @@ json SystemInfo::build_recipes_info(const json& devices) {
         for (const auto& gpu : devices["nvidia_gpu"]) {
             if (gpu.value("available", false)) {
                 std::string name = gpu.value("name", "");
-                // Normalize to the nearest supported arch so that GPUs with
-                // unsupported minor revisions (e.g. sm_121 GB10 -> sm_120)
-                // still match the BACKEND_AVAILABILITY constraint set.
-                std::string family = normalize_cuda_arch(gpu.value("family", ""));
+                std::string family = gpu.value("family", "");
                 if (!name.empty()) {
                     detected_devices.push_back({
                         "nvidia_gpu",
@@ -2137,37 +2133,10 @@ static int cuda_sm_value(const std::string& arch) {
     }
 }
 
-// Maps an sm_XX token to the nearest supported binary target.
-// If the arch is directly in CUDA_SUPPORTED_ARCHS, returns it unchanged.
-// Otherwise finds the highest supported arch that is <= the detected arch,
-// enabling forward-compatible GPUs (e.g. sm_121 GB10 -> sm_120 binary).
-// Returns "" if no suitable match exists.
-static std::string normalize_cuda_arch(const std::string& arch) {
-    if (arch.empty()) return "";
-    if (CUDA_SUPPORTED_ARCHS.count(arch)) return arch;
-
-    int detected_val = cuda_sm_value(arch);
-    if (detected_val <= 0) return "";
-
-    std::string best;
-    int best_val = 0;
-    for (const auto& supported : CUDA_SUPPORTED_ARCHS) {
-        int val = cuda_sm_value(supported);
-        if (val <= detected_val && val > best_val) {
-            best_val = val;
-            best = supported;
-        }
-    }
-    return best;
-}
-
 static std::string cuda_arch_from_gpu_json(const json& gpu) {
     std::string family = gpu.value("family", "");
-    if (!family.empty()) {
-        std::string normalized = normalize_cuda_arch(family);
-        if (!normalized.empty()) {
-            return normalized;
-        }
+    if (!family.empty() && CUDA_SUPPORTED_ARCHS.count(family)) {
+        return family;
     }
 
     std::string name = gpu.value("name", "");

--- a/test/test_cuda_arch_mapping.py
+++ b/test/test_cuda_arch_mapping.py
@@ -150,6 +150,7 @@ def identify_cuda_arch_from_name(device_name: str) -> str:
         "b100",
         "b200",
         "l40",
+        "gb10",
     ]
     if not any(kw in name for kw in nvidia_ids):
         return ""
@@ -221,6 +222,7 @@ class TestIdentifyCudaArchFromName(unittest.TestCase):
             ("NVIDIA A10", "sm_86"),
             ("NVIDIA A40", "sm_86"),
             ("NVIDIA GB10", "sm_121"),
+            ("GB10", "sm_121"),
             # RTX PRO Blackwell (sm_120) — both the generic "Blackwell" keyword
             # and the explicit RTX PRO model numbers must resolve to sm_120.
             ("NVIDIA RTX PRO 3000 Blackwell Generation Laptop GPU", "sm_120"),

--- a/test/test_cuda_arch_mapping.py
+++ b/test/test_cuda_arch_mapping.py
@@ -126,6 +126,41 @@ _NAME_ARCH_TABLE = [
 ]
 
 
+def cuda_sm_value(arch: str) -> int:
+    """Convert sm_XX token to integer value for comparison."""
+    if len(arch) <= 3 or not arch.startswith("sm_"):
+        return 0
+    try:
+        return int(arch[3:])
+    except ValueError:
+        return 0
+
+
+def normalize_cuda_arch(arch: str) -> str:
+    """
+    Map an sm_XX token to the nearest supported binary target.
+    If the arch is directly in CUDA_SUPPORTED_ARCHS, returns it unchanged.
+    Otherwise finds the highest supported arch <= the detected arch,
+    enabling forward-compatible GPUs (e.g. sm_121 GB10 -> sm_120 binary).
+    Returns "" if no suitable match exists.
+    """
+    if not arch:
+        return ""
+    if arch in CUDA_SUPPORTED_ARCHS:
+        return arch
+    detected_val = cuda_sm_value(arch)
+    if detected_val <= 0:
+        return ""
+    best = ""
+    best_val = 0
+    for supported in CUDA_SUPPORTED_ARCHS:
+        val = cuda_sm_value(supported)
+        if val <= detected_val and val > best_val:
+            best_val = val
+            best = supported
+    return best
+
+
 def identify_cuda_arch_from_name(device_name: str) -> str:
     """Compact fallback: infer sm_XX from GPU marketing name."""
     name = device_name.lower()
@@ -202,6 +237,39 @@ class TestComputeCapToSm(unittest.TestCase):
             self.assertNotIn(
                 sm, CUDA_SUPPORTED_ARCHS, f"{cap} -> {sm} unexpectedly in supported set"
             )
+
+    def test_gb10_compute_cap(self):
+        # NVIDIA GB10 (Thor SoC) reports compute capability 12.1
+        self.assertEqual(compute_cap_to_sm("12.1"), "sm_121")
+
+
+class TestNormalizeCudaArch(unittest.TestCase):
+    def test_supported_arch_passthrough(self):
+        for arch in CUDA_SUPPORTED_ARCHS:
+            with self.subTest(arch=arch):
+                self.assertEqual(normalize_cuda_arch(arch), arch)
+
+    def test_gb10_fallback(self):
+        # GB10 (sm_121) should fall back to sm_120 (nearest supported Blackwell binary)
+        self.assertEqual(normalize_cuda_arch("sm_121"), "sm_120")
+
+    def test_fallback_to_best_supported(self):
+        # sm_121 -> sm_120, not sm_100 or sm_89
+        result = normalize_cuda_arch("sm_121")
+        self.assertEqual(result, "sm_120")
+
+    def test_unsupported_old_arch_returns_empty(self):
+        # sm_50 (Maxwell) is below all supported arches — no fallback
+        self.assertEqual(normalize_cuda_arch("sm_50"), "")
+        self.assertEqual(normalize_cuda_arch("sm_60"), "")
+        self.assertEqual(normalize_cuda_arch("sm_70"), "")
+
+    def test_empty_returns_empty(self):
+        self.assertEqual(normalize_cuda_arch(""), "")
+
+    def test_invalid_returns_empty(self):
+        self.assertEqual(normalize_cuda_arch("invalid"), "")
+        self.assertEqual(normalize_cuda_arch("sm_"), "")
 
 
 class TestIdentifyCudaArchFromName(unittest.TestCase):

--- a/test/test_cuda_arch_mapping.py
+++ b/test/test_cuda_arch_mapping.py
@@ -24,6 +24,7 @@ CUDA_SUPPORTED_ARCHS = {
     "sm_90",  # Hopper
     "sm_100",  # Blackwell DC
     "sm_120",  # Blackwell consumer
+    "sm_121",  # Blackwell GB10 / Thor SoC
 }
 
 
@@ -56,6 +57,8 @@ def compute_cap_to_sm(compute_cap: str) -> str:
 _DC_BLACKWELL = ["b100", "b200"]
 
 _NAME_ARCH_TABLE = [
+    # GB10 Thor SoC (sm_121)
+    (["gb10"], "sm_121"),
     # Blackwell consumer/workstation (sm_120). The generic "blackwell" keyword
     # covers current and future RTX 50 / RTX PRO Blackwell GPUs; explicit model
     # numbers cover names that do not include "Blackwell".
@@ -174,6 +177,7 @@ class TestComputeCapToSm(unittest.TestCase):
             ("9.0", "sm_90"),
             ("10.0", "sm_100"),
             ("12.0", "sm_120"),
+            ("12.1", "sm_121"),
         ]
         for cap, expected in cases:
             with self.subTest(cap=cap):
@@ -190,7 +194,7 @@ class TestComputeCapToSm(unittest.TestCase):
                 self.assertEqual(compute_cap_to_sm(bad), "")
 
     def test_supported_arch_membership(self):
-        for cap in ["7.5", "8.0", "8.6", "8.9", "9.0", "10.0", "12.0"]:
+        for cap in ["7.5", "8.0", "8.6", "8.9", "9.0", "10.0", "12.0", "12.1"]:
             sm = compute_cap_to_sm(cap)
             self.assertIn(
                 sm, CUDA_SUPPORTED_ARCHS, f"{cap} -> {sm} not in supported set"
@@ -216,6 +220,7 @@ class TestIdentifyCudaArchFromName(unittest.TestCase):
             ("NVIDIA A100-SXM4-80GB", "sm_80"),
             ("NVIDIA A10", "sm_86"),
             ("NVIDIA A40", "sm_86"),
+            ("NVIDIA GB10", "sm_121"),
             # RTX PRO Blackwell (sm_120) — both the generic "Blackwell" keyword
             # and the explicit RTX PRO model numbers must resolve to sm_120.
             ("NVIDIA RTX PRO 3000 Blackwell Generation Laptop GPU", "sm_120"),

--- a/test/test_cuda_arch_mapping.py
+++ b/test/test_cuda_arch_mapping.py
@@ -126,41 +126,6 @@ _NAME_ARCH_TABLE = [
 ]
 
 
-def cuda_sm_value(arch: str) -> int:
-    """Convert sm_XX token to integer value for comparison."""
-    if len(arch) <= 3 or not arch.startswith("sm_"):
-        return 0
-    try:
-        return int(arch[3:])
-    except ValueError:
-        return 0
-
-
-def normalize_cuda_arch(arch: str) -> str:
-    """
-    Map an sm_XX token to the nearest supported binary target.
-    If the arch is directly in CUDA_SUPPORTED_ARCHS, returns it unchanged.
-    Otherwise finds the highest supported arch <= the detected arch,
-    enabling forward-compatible GPUs (e.g. sm_121 GB10 -> sm_120 binary).
-    Returns "" if no suitable match exists.
-    """
-    if not arch:
-        return ""
-    if arch in CUDA_SUPPORTED_ARCHS:
-        return arch
-    detected_val = cuda_sm_value(arch)
-    if detected_val <= 0:
-        return ""
-    best = ""
-    best_val = 0
-    for supported in CUDA_SUPPORTED_ARCHS:
-        val = cuda_sm_value(supported)
-        if val <= detected_val and val > best_val:
-            best_val = val
-            best = supported
-    return best
-
-
 def identify_cuda_arch_from_name(device_name: str) -> str:
     """Compact fallback: infer sm_XX from GPU marketing name."""
     name = device_name.lower()
@@ -237,39 +202,6 @@ class TestComputeCapToSm(unittest.TestCase):
             self.assertNotIn(
                 sm, CUDA_SUPPORTED_ARCHS, f"{cap} -> {sm} unexpectedly in supported set"
             )
-
-    def test_gb10_compute_cap(self):
-        # NVIDIA GB10 (Thor SoC) reports compute capability 12.1
-        self.assertEqual(compute_cap_to_sm("12.1"), "sm_121")
-
-
-class TestNormalizeCudaArch(unittest.TestCase):
-    def test_supported_arch_passthrough(self):
-        for arch in CUDA_SUPPORTED_ARCHS:
-            with self.subTest(arch=arch):
-                self.assertEqual(normalize_cuda_arch(arch), arch)
-
-    def test_gb10_fallback(self):
-        # GB10 (sm_121) should fall back to sm_120 (nearest supported Blackwell binary)
-        self.assertEqual(normalize_cuda_arch("sm_121"), "sm_120")
-
-    def test_fallback_to_best_supported(self):
-        # sm_121 -> sm_120, not sm_100 or sm_89
-        result = normalize_cuda_arch("sm_121")
-        self.assertEqual(result, "sm_120")
-
-    def test_unsupported_old_arch_returns_empty(self):
-        # sm_50 (Maxwell) is below all supported arches — no fallback
-        self.assertEqual(normalize_cuda_arch("sm_50"), "")
-        self.assertEqual(normalize_cuda_arch("sm_60"), "")
-        self.assertEqual(normalize_cuda_arch("sm_70"), "")
-
-    def test_empty_returns_empty(self):
-        self.assertEqual(normalize_cuda_arch(""), "")
-
-    def test_invalid_returns_empty(self):
-        self.assertEqual(normalize_cuda_arch("invalid"), "")
-        self.assertEqual(normalize_cuda_arch("sm_"), "")
 
 
 class TestIdentifyCudaArchFromName(unittest.TestCase):


### PR DESCRIPTION
## Problem

On NVIDIA GB10 (compute 12.1, sm_121) arm64 devices, the CUDA backend was not presented as an available option even though the GPU was correctly detected. Two bugs:

1. `sm_121` was not in `CUDA_SUPPORTED_ARCHS`, so the availability filter rejected it and no CUDA models were shown
2. The CUDA Linux download filename was hardcoded as `x64` even on aarch64, so installing would fetch the wrong binary

## Changes

**`src/cpp/server/system_info.cpp`**
- Add `sm_121` to `CUDA_SUPPORTED_ARCHS`
- Add `sm_121` to `BACKEND_AVAILABILITY` for llamacpp and sd-cpp cuda
- Add `sm_121` to `ARCH_DESCRIPTIONS`
- Add `gb10` keyword to `identify_cuda_arch_from_name()` name table (before the generic `blackwell` row) for name-based fallback detection
- Add `gb10` to the NVIDIA_IDS guard list

**`src/cpp/server/backends/llamacpp_server.cpp`**
- Add `__aarch64__` guard for the CUDA Linux filename so it resolves to `arm64.tar.xz` instead of `x64.tar.xz` on ARM64 hosts (releases already ship both variants)

**`test/test_cuda_arch_mapping.py`**
- Add `sm_121` to `CUDA_SUPPORTED_ARCHS` replica
- Add `12.1` compute cap mapping test
- Add GB10 name detection test case