### PR TITLE
ci: add engine::moonshine to auto-labeling

### DIFF
--- a/.github/scripts/auto_label.py
+++ b/.github/scripts/auto_label.py
@@ -48,6 +48,7 @@ Engine — apply AT MOST ONE total. This is a hard rule: even if multiple seem r
 - engine::whispercpp — whisper.cpp; audio transcription
 - engine::sd         — stable-diffusion.cpp; image generation/edit/variations
 - engine::kokoro     — Kokoro TTS
+- engine::moonshine  — Moonshine; fast on-device audio transcription (ASR)
 
 Area — apply AT MOST ONE total. Same hard rule as engines. Skip if not clearly in one area:
 - area::cli       — `lemonade` CLI client (src/cpp/cli)
@@ -177,6 +178,7 @@ KNOWN_LABELS = {
     "engine::whispercpp",
     "engine::sd",
     "engine::kokoro",
+    "engine::moonshine",
     "area::cli",
     "area::installer",
     "area::api",


### PR DESCRIPTION
## Summary
Adds the `engine::moonshine` label (Moonshine on-device ASR / audio transcription) to the auto-labeling workflow so issues and PRs about the Moonshine backend get classified.

Two changes in `.github/scripts/auto_label.py`:
- Added `engine::moonshine` to the **Engine** section of the LLM classification prompt, with a one-line description.
- Added `engine::moonshine` to the `KNOWN_LABELS` validation set so the model's output isn't filtered out as unknown.

The existing "apply AT MOST ONE engine::" constraint applies automatically — `engine::` is already in `AT_MOST_ONE_PREFIXES`. No change needed to `auto-label.yml`.

## Note
The `engine::moonshine` GitHub label must exist in the repo for `gh issue edit --add-label` to succeed (the script doesn't create labels). Create it if it doesn't already exist:
```
gh label create "engine::moonshine"
```
Closes #2197 
🤖 Generated with [Claude Code](https://claude.com/claude-code)