### PR TITLE
ci: grant pull-requests:read to triage dashboard workflow

### DIFF
--- a/.github/workflows/triage-dashboard.yml
+++ b/.github/workflows/triage-dashboard.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       contents: read
       issues: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

The deployed triage dashboard (https://lemonade-sdk.github.io/lemonade-triage/) reports **0 PRs** even though the repo has dozens of open PRs.

## Root cause

`triage_dashboard.py` fetches `/repos/{repo}/issues?state=open`. GitHub's REST issues endpoint returns **both** issues and pull requests (PRs are issues in GitHub's data model), and the script distinguishes them via the `pull_request` field.

However, the workflow's scoped `GITHUB_TOKEN` was granted only `issues: read`. When the token lacks `pull-requests: read`, GitHub **silently filters pull requests out** of the `/issues` response. So:

- **Local** runs (full personal `gh` auth) → PRs included ✅
- **CI** runs (scoped `GITHUB_TOKEN`) → PRs stripped → `0 PRs` ❌

## Fix

Add `pull-requests: read` to the workflow's `permissions` block. No change needed to `triage_dashboard.py` — it already handles PRs correctly. The next scheduled run will regenerate the deployed dashboard with PRs included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)