### PR TITLE
fix(cli): lemonade launch claude fails to launch on Windows, throws Error 193

### DIFF
--- a/src/cpp/cli/agent_launcher.cpp
+++ b/src/cpp/cli/agent_launcher.cpp
@@ -97,10 +97,13 @@ void configure_claude_agent(const std::string& base_url,
                             AgentConfig& config) {
     const std::string resolved_api_key = api_key.empty() ? kDefaultAgentApiKey : api_key;
 
-    config.binary_name = "claude";
 #ifdef _WIN32
-    config.binary_alternatives = {"claude.cmd", "claude.exe"};
+    // npm puts a Unix shell script named just "claude" next to claude.cmd.
+    // Windows cannot run the shell script, so look for .cmd/.exe first.
+    config.binary_name = "claude.cmd";
+    config.binary_alternatives = {"claude.exe", "claude"};
 #else
+    config.binary_name = "claude";
     config.binary_alternatives = {};
 #endif
     config.fallback_paths = {

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -1232,6 +1232,42 @@ sys.exit(0)
                 payload["env"]["ANTHROPIC_BASE_URL"], f"http://localhost:{PORT}"
             )
 
+    def test_115_launch_claude_windows_prefers_cmd_over_npm_shim(self):
+        """On Windows, launch must run claude.cmd, not npm's extensionless shell script."""
+        if not IS_WINDOWS:
+            self.skipTest(
+                "Windows-only: npm shim vs .cmd resolution does not apply on Unix"
+            )
+
+        with tempfile.TemporaryDirectory(prefix="lemonade-launch-stub-") as temp_dir:
+            capture_path = os.path.join(temp_dir, "claude_cmd_capture.txt")
+
+            # Recreate what 'npm install -g' leaves on PATH: a Unix shell
+            # script named just "claude" next to claude.cmd. Windows cannot
+            # run the shell script, so the launcher must pick the .cmd.
+            with open(os.path.join(temp_dir, "claude"), "w", encoding="utf-8") as f:
+                f.write('#!/bin/sh\nexec node "$(dirname "$0")/claude.js" "$@"\n')
+            with open(os.path.join(temp_dir, "claude.cmd"), "w", encoding="utf-8") as f:
+                f.write(f'@echo off\necho fake-agent-ok> "{capture_path}"\nexit /b 0\n')
+
+            env = self._build_stubbed_agent_env(temp_dir)
+            result = run_cli_command(
+                ["launch", "claude", "--model", ENDPOINT_TEST_MODEL],
+                timeout=TIMEOUT_DEFAULT,
+                env=env,
+            )
+
+            self.assertEqual(
+                result.returncode,
+                0,
+                "launch failed; the extensionless npm shim was likely picked "
+                "instead of claude.cmd (Error 193)",
+            )
+            self.assertTrue(
+                os.path.exists(capture_path),
+                "claude.cmd was not executed",
+            )
+
     def test_102c_launch_codex_provider_default(self):
         """Codex launch -p should select default provider without injecting provider config."""
         if IS_WINDOWS:


### PR DESCRIPTION
## Summary

On Windows, \lemonade launch claude\ fails instantly with Error 193 (\%1 is not a valid Win32 application\) and the agent never starts.

\
pm install -g\ creates three launchers in \%APPDATA%\\npm\: a Unix shell script named just \claude\, plus \claude.cmd\ and \claude.ps1\. The CLI searched for the bare name \claude\ first, found the shell script, and Windows cannot run shell scripts, so the launch failed before the agent started.

## Fix

Look for \claude.cmd\ / \claude.exe\ before the bare name, the same way the opencode config already does. On Windows the search order is now \claude.cmd\ -> \claude.exe\ -> \claude\. Linux and macOS are unchanged.

## Testing

- New Windows-only test \	est_115_launch_claude_windows_prefers_cmd_over_npm_shim\ recreates the npm layout (a shell script named \claude\ next to \claude.cmd\ on PATH) and runs \lemonade launch claude\. It fails with Error 193 on the old code and passes with the fix.
- Built the \lemonade\ CLI with the \windows\ preset (VS 2022); compiles cleanly.
- Manual check: \
pm install -g @anthropic-ai/claude-code\, then \lemonade launch claude\ starts normally.

## Notes

Fixes #2211. On Windows, the ctx_size issue from #2063 is also present once the launcher works, but that is out of scope for this PR and is being addressed separately.