### PR TITLE
Fix download speed and ETA display at very low speeds

### DIFF
--- a/src/app/src/renderer/DownloadManager.tsx
+++ b/src/app/src/renderer/DownloadManager.tsx
@@ -121,10 +121,13 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
   }, [isVisible]);
 
   const formatBytes = (bytes: number): string => {
-    if (bytes === 0) return '0 B';
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
     const k = 1024;
-    const sizes = ['B', 'KB', 'MB', 'GB'];
-    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
+    const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.min(
+      Math.max(Math.floor(Math.log(bytes) / Math.log(k)), 0),
+      sizes.length - 1,
+    );
     return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
   };
 
@@ -136,6 +139,8 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
   };
 
   const formatSpeed = (bytesPerSecond: number): string => {
+    if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) return '--';
+    if (bytesPerSecond < 1) return '<1 B/s';
     return `${formatBytes(bytesPerSecond)}/s`;
   };
 
@@ -166,7 +171,7 @@ const DownloadManager: React.FC<DownloadManagerProps> = ({ isVisible, onClose })
     }
 
     const speed = calculateSpeed(download);
-    if (speed === 0) return '--';
+    if (!Number.isFinite(speed) || speed < 1) return '--';
 
     const remainingBytes = download.bytesTotal - download.bytesDownloaded;
 


### PR DESCRIPTION
## Summary

Fix misleading download metrics when the smoothed download speed drops below 1 B/s near the end of a download.

Previously, formatBytes() could compute a negative unit index for sub-byte values, which caused the speed display to render as undefined/s. The ETA calculation also continued using near-zero speeds, producing extremely large and unhelpful remaining-time estimates.

This change:
- makes formatBytes() robust for non-finite, zero, and negative values
- clamps the byte unit index on both ends
- displays `<1 B/s` for positive sub-byte speeds
- suppresses ETA when speed is non-finite or below 1 B/s