### PR TITLE
feat(config): honor LEMONADE_DEFAULTS_PATH for non-FHS installs

### DIFF
--- a/src/cpp/server/config_file.cpp
+++ b/src/cpp/server/config_file.cpp
@@ -2,6 +2,7 @@
 #include "lemon/utils/json_utils.h"
 #include "lemon/utils/path_utils.h"
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 
@@ -36,6 +37,12 @@ json ConfigFile::get_defaults() {
         defaults = utils::JsonUtils::merge(defaults, load_json_file(distro_defaults));
     }
 #endif
+
+    // Packagers on non-FHS distros (Nix, Guix) can't write the /usr/share
+    // file above; this seeds the same defaults from any path.
+    if (const char* env = std::getenv("LEMONADE_DEFAULTS_PATH"); env && *env && fs::exists(env)) {
+        defaults = utils::JsonUtils::merge(defaults, load_json_file(env));
+    }
 
     return defaults;
 }


### PR DESCRIPTION
**What** — `get_defaults()` merges `/usr/share/lemonade/defaults.json` so distro packagers can seed default config (e.g. backend `*_bin` paths). Non-FHS distros such as Nix and Guix cannot write under `/usr/share`. This adds a `LEMONADE_DEFAULTS_PATH` env var that merges a `defaults.json` from an arbitrary path, at the same precedence as the `/usr/share` file (below the user `config.json`).

**Why** — Packaging Lemonade for NixOS: v10.7.0 removing the `*_bin` env→config migration left no declarative way to point lemonade at nix-store backend binaries. `/usr/share/lemonade/defaults.json` is the intended hook but is not writable on non-FHS systems. This mirrors the `LEMONADE_GGML_HIP_PATH` escape hatch from #2044.

**Change** — 6-line addition in `get_defaults()` plus `#include <cstdlib>`. Cross-platform (outside the `#ifndef _WIN32` block) so Windows packagers can use it too.

**Testing** — Built `lemond` with this change and ran it with `LEMONADE_DEFAULTS_PATH` set; the merged config picked up the supplied values (verified the resulting `config.json`, and `lemonade backends` showing a path-overridden backend as `installed`).