### PR TITLE
cli: use long read timeout for pull and install streams

### DIFF
--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -629,7 +629,7 @@ int LemonadeClient::pull_model(const json& model_data, const std::string& displa
             } else {
                 parse_sse_progress(event_data, state);
             }
-        }, LONG_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
+        }, LONG_TIMEOUT_MS, LONG_TIMEOUT_MS);
 
         if (!state.success) {
             // Wire-protocol constant; server-side definition and contract live in
@@ -926,7 +926,7 @@ int LemonadeClient::install_backend(const std::string& recipe, const std::string
             } else {
                 parse_sse_progress(event_data, state);
             }
-        }, LONG_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
+        }, LONG_TIMEOUT_MS, LONG_TIMEOUT_MS);
         if (!state.success) {
             if (!state.error_message.empty()) {
                 throw std::runtime_error(state.error_message);


### PR DESCRIPTION
#### Problem
When pulling large models (e.g., 25GB+ GGUF files), the server performs a synchronous hash verification immediately after the download completes. During this hashing step, the server is busy and does not send any progress updates over the SSE (Server-Sent Events) connection. 

Because the CLI client has a hardcoded 30-second socket read timeout (`DEFAULT_READ_TIMEOUT_MS`), it times out and aborts the connection during this hashing phase, which in turn causes the server to cancel the download of any remaining files (e.g., `config.json`). A similar issue can occur when installing larger backends.

#### Solution
Modified both the `/api/v1/pull` and `/api/v1/install` streaming requests in the C++ CLI client to use `LONG_TIMEOUT_MS` (24 hours) for their socket read timeout instead of the default 30 seconds. This ensures the connection is not prematurely severed during heavy disk I/O verification or archive extraction phases.