### PR TITLE
fix(ui): audit follow-up — tool-loop hang guard, load errors, preset wiring, capability unification

### DIFF
--- a/prototype/ui-redesign/src/components/ChatView.tsx
+++ b/prototype/ui-redesign/src/components/ChatView.tsx
@@ -292,15 +292,17 @@ function partialImageSettingsFromSource(source?: Record<string, unknown> | null)
   return next;
 }
 
-function imageDefaultsForModel(loadedModel: LoadedModel | null, modelInfo: ModelInfo | null): ImageGenerationSettings {
+function imageDefaultsForModel(loadedModel: LoadedModel | null, modelInfo: ModelInfo | null, activePresetRecipeOptions?: Record<string, unknown> | null): ImageGenerationSettings {
   const modelImageDefaults = partialImageSettingsFromSource(modelInfo?.image_defaults as Record<string, unknown> | undefined);
   const modelRecipeOptions = partialImageSettingsFromSource(modelInfo?.recipe_options as Record<string, unknown> | undefined);
   const loadedRecipeOptions = partialImageSettingsFromSource(loadedModel?.recipe_options);
+  const presetDefaults = partialImageSettingsFromSource(activePresetRecipeOptions);
   return {
     ...DEFAULT_IMAGE_SETTINGS,
     ...modelImageDefaults,
     ...modelRecipeOptions,
     ...loadedRecipeOptions,
+    ...presetDefaults,
   };
 }
 
@@ -634,8 +636,12 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel, loadedModels, onModel
   );
 
   const defaultImageSettings = useMemo(
-    () => imageDefaultsForModel(currentLoadedModel, currentKnownModelInfo),
-    [currentLoadedModel, currentKnownModelInfo],
+    () => imageDefaultsForModel(
+      currentLoadedModel,
+      currentKnownModelInfo,
+      currentCapability === 'image' ? (currentPreset?.recipe_options as Record<string, unknown> | undefined) : undefined,
+    ),
+    [currentLoadedModel, currentKnownModelInfo, currentPreset, currentCapability],
   );
   const defaultImageSettingsKey = useMemo(() => JSON.stringify(defaultImageSettings), [defaultImageSettings]);
 
@@ -728,7 +734,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel, loadedModels, onModel
     return filtered.slice(0, 80);
   }, [capabilityForLoaded, knownModelInfos, modelPickerQuery, selectableModels]);
 
-  const modeSupportsChatCompletions = currentLoadedModel ? canUseChatCompletions(currentLoadedModel) : (currentCapability === 'chat' || currentCapability === 'omni');
+  const modeSupportsChatCompletions = currentCapability === 'chat' || currentCapability === 'omni';
   const modeSupportsTools = modeSupportsChatCompletions;
   const canUseAudioInput = currentCapability === 'omni' || currentCapability === 'audio' || supportsRealtimeAudio;
 

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -582,6 +582,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   const [connectionStatus, setConnectionStatus] = useState(api.status);
   const [modelsLoading, setModelsLoading] = useState(api.isConnected && api.allModels.length === 0);
   const [loadingModel, setLoadingModel] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<{ modelName: string; message: string } | null>(null);
   const [pulling, setPulling] = useState<Record<string, number>>({});  // model → percent
   const pullAbortRef = useRef<Record<string, AbortController>>({});
   const [expandedModel, setExpandedModel] = useState<string | null>(null);
@@ -850,6 +851,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   const handleLoad = async (model: ModelInfo) => {
     if (loadingModel) return;
     const name = modelName(model);
+    setLoadError(null);
     setLoadingModel(name);
     try {
       await loadModelRuntime(model);
@@ -857,6 +859,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
       onModelSelect(name);
     } catch (err) {
       console.error('Load failed:', err);
+      const message = friendlyErrorMessage(err);
+      setLoadError({ modelName: name, message });
+      window.setTimeout(() => setLoadError(prev => prev?.modelName === name ? null : prev), 6000);
     }
     setLoadingModel(null);
   };
@@ -956,6 +961,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
           onModelSelect(name);
         } catch (err) {
           console.error('Load after pull failed:', err);
+          const message = friendlyErrorMessage(err);
+          setLoadError({ modelName: name, message });
+          window.setTimeout(() => setLoadError(prev => prev?.modelName === name ? null : prev), 6000);
         }
         setLoadingModel(null);
       },
@@ -1601,6 +1609,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         </div>
 
         {expandedModel === name && renderModelDetail(m)}
+        {loadError?.modelName === name && (
+          <div className="row__load-error">
+            <Icon name="alert" size={13} /> {loadError.message}
+          </div>
+        )}
       </div>
     );
   };

--- a/prototype/ui-redesign/src/hooks/useChatStreaming.ts
+++ b/prototype/ui-redesign/src/hooks/useChatStreaming.ts
@@ -184,83 +184,102 @@ export function useChatStreaming(
             setLiveStats(prev => ({ ...prev, [convoId]: stats }));
           },
           onToolCalls: async (toolCalls) => {
-            toolRound++;
-            if (toolRound > MAX_TOOL_ROUNDS) {
-              onError(convoId, 'Too many tool call rounds — stopping to prevent loops.');
-              cleanup(convoId);
-              resolve();
-              return;
-            }
-
-            // Show tool status in the stream and add running entries
-            const toolNames = toolCalls.map(tc => tc.function.name).join(', ');
-            const runningEntries: ToolCallEntry[] = toolCalls.map(tc => {
-              let argsStr = '';
-              try { const a = JSON.parse(tc.function.arguments || '{}'); argsStr = Object.entries(a).map(([k,v]) => `${k}: ${v}`).join(', '); } catch {}
-              return { name: tc.function.name, args: argsStr, rawArgs: tc.function.arguments, result: '', status: 'running' as const };
-            });
-            allToolCalls.push(...runningEntries);
-            setActiveStreams(prev => ({
-              ...prev,
-              [convoId]: { ...(prev[convoId] || { content: '', thinking: '', toolCalls: [] }), toolStatus: `Calling ${toolNames}…`, toolCalls: [...allToolCalls] },
-            }));
-
-            // Append the assistant's tool_calls message
-            fullMessages = [
-              ...fullMessages,
-              { role: 'assistant' as const, content: '', tool_calls: toolCalls },
-            ];
-
-            // Execute all tool calls in parallel
-            const results = await Promise.all(
-              toolCalls.map(tc => runtime!.execute(tc as ToolCall))
-            );
-
-            // Update entries with results
-            for (let j = 0; j < runningEntries.length; j++) {
-              const r = results[j];
-              const entry = runningEntries[j];
-              entry.artifacts = r.artifacts;
-              if (r.displayResult) {
-                entry.result = r.displayResult;
-                entry.status = r.error ? 'error' : 'done';
-                continue;
+            try {
+              toolRound++;
+              if (toolRound > MAX_TOOL_ROUNDS) {
+                onError(convoId, 'Too many tool call rounds — stopping to prevent loops.');
+                cleanup(convoId);
+                resolve();
+                return;
               }
-              try {
-                const parsed = JSON.parse(r.content);
-                entry.result = parsed.error ? `Error: ${parsed.error}` : summarizeResult(entry.name, parsed);
-                entry.status = parsed.error ? 'error' : 'done';
-              } catch {
-                entry.result = r.content.slice(0, 200);
-                entry.status = r.error ? 'error' : 'done';
-              }
-            }
 
-            // Append tool results, then remind the model to produce a real final
-            // answer (or call a narrower tool) instead of echoing a broad count.
-            for (const result of results) {
+              // Show tool status in the stream and add running entries
+              const toolNames = toolCalls.map(tc => tc.function.name).join(', ');
+              const runningEntries: ToolCallEntry[] = toolCalls.map(tc => {
+                let argsStr = '';
+                try { const a = JSON.parse(tc.function.arguments || '{}'); argsStr = Object.entries(a).map(([k,v]) => `${k}: ${v}`).join(', '); } catch {}
+                return { name: tc.function.name, args: argsStr, rawArgs: tc.function.arguments, result: '', status: 'running' as const };
+              });
+              allToolCalls.push(...runningEntries);
+              setActiveStreams(prev => ({
+                ...prev,
+                [convoId]: { ...(prev[convoId] || { content: '', thinking: '', toolCalls: [] }), toolStatus: `Calling ${toolNames}…`, toolCalls: [...allToolCalls] },
+              }));
+
+              // Append the assistant's tool_calls message
               fullMessages = [
                 ...fullMessages,
-                { role: 'tool' as const, content: result.content, tool_call_id: result.tool_call_id },
+                { role: 'assistant' as const, content: '', tool_calls: toolCalls },
               ];
-            }
-            fullMessages = [
-              ...fullMessages,
-              { role: 'user' as const, content: TOOL_FOLLOWUP_PROMPT },
-            ];
 
-            // Clear tool status, keep accumulated tool call entries
-            setActiveStreams(prev => ({
-              ...prev,
-              [convoId]: { ...(prev[convoId] || { content: '', thinking: '', toolCalls: [] }), toolStatus: undefined, toolCalls: [...allToolCalls] },
-            }));
+              // Execute all tool calls in parallel
+              const results = await Promise.all(
+                toolCalls.map(tc => runtime!.execute(tc as ToolCall))
+              );
 
-            // Re-run completion with tool results
-            try {
-              await runCompletion();
+              // Update entries with results
+              for (let j = 0; j < runningEntries.length; j++) {
+                const r = results[j];
+                const entry = runningEntries[j];
+                entry.artifacts = r.artifacts;
+                if (r.displayResult) {
+                  entry.result = r.displayResult;
+                  entry.status = r.error ? 'error' : 'done';
+                  continue;
+                }
+                try {
+                  const parsed = JSON.parse(r.content);
+                  entry.result = parsed.error ? `Error: ${parsed.error}` : summarizeResult(entry.name, parsed);
+                  entry.status = parsed.error ? 'error' : 'done';
+                } catch {
+                  entry.result = r.content.slice(0, 200);
+                  entry.status = r.error ? 'error' : 'done';
+                }
+              }
+
+              // Append tool results, then remind the model to produce a real final
+              // answer (or call a narrower tool) instead of echoing a broad count.
+              for (const result of results) {
+                fullMessages = [
+                  ...fullMessages,
+                  { role: 'tool' as const, content: result.content, tool_call_id: result.tool_call_id },
+                ];
+              }
+              fullMessages = [
+                ...fullMessages,
+                { role: 'user' as const, content: TOOL_FOLLOWUP_PROMPT },
+              ];
+
+              // Clear tool status, keep accumulated tool call entries
+              setActiveStreams(prev => ({
+                ...prev,
+                [convoId]: { ...(prev[convoId] || { content: '', thinking: '', toolCalls: [] }), toolStatus: undefined, toolCalls: [...allToolCalls] },
+              }));
+
+              // Re-run completion with tool results
+              try {
+                await runCompletion();
+                resolve();
+              } catch (err) {
+                reject(err);
+              }
+            } catch (err: unknown) {
+              // Mark any still-running tool call entries as errored so the user sees what happened.
+              const msg = err instanceof Error ? err.message : String(err);
+              for (const entry of allToolCalls) {
+                if (entry.status === 'running') {
+                  entry.result = `Error: ${msg}`;
+                  entry.status = 'error';
+                }
+              }
+              setActiveStreams(prev => ({
+                ...prev,
+                [convoId]: { ...(prev[convoId] || { content: '', thinking: '', toolCalls: [] }), toolStatus: undefined, toolCalls: [...allToolCalls] },
+              }));
+              delete tokenBufferRef.current[convoId];
+              onError(convoId, `Tool execution failed: ${msg}`);
+              cleanup(convoId);
               resolve();
-            } catch (err) {
-              reject(err);
             }
           },
           onDone: (stats) => {

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -1926,6 +1926,17 @@ input, textarea {
 
 /* ── Model Detail (expanded) ──────────────────────────────── */
 
+.row__load-error {
+  padding: var(--space-2) var(--space-5);
+  font-size: var(--text-xs);
+  color: var(--danger);
+  background: var(--danger-soft);
+  border-top: 1px solid rgba(217, 122, 108, 0.24);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .row__detail {
   padding: var(--space-4) var(--space-5);
   border-top: 1px solid var(--border-subtle);


### PR DESCRIPTION
Implements the top 4 actionable items from Mattingly's fresh audit of the prototype at HEAD `af66ea14`.

## Fixes

### P0 — Tool-loop hang guard
**`prototype/ui-redesign/src/hooks/useChatStreaming.ts`**
Wrapped the async `onToolCalls` body in try/catch so an unexpected executor throw cleanly settles the outer stream Promise instead of hanging forever. Pending tool entries are marked errored, `onError` fires, `cleanup`/`resolve` are called.

### P1 — Surface load errors in ModelManager
**`ModelManager.tsx` + `styles.css`**
Added `loadError` state set in `handleLoad` and `handlePullAndLoad` catch blocks via `friendlyErrorMessage`. Renders `.row__load-error` inline near the affected model row using existing `--danger`/`--danger-soft` tokens. Replaces silent `console.error`.

### P1 — Wire preset values into image composer
**`ChatView.tsx`**
`imageDefaultsForModel` now accepts the active preset's `recipe_options` as a third (highest-priority) source. Existing `imageSettingsTouchedRef` guard prevents clobbering user edits. Applying `Sharp` (30 steps / cfg 8.0) now actually shows in the composer instead of staying at default 20/7.

### P1 — Unify `modeSupportsChatCompletions`
**`ChatView.tsx:731`**
Replaced the `currentLoadedModel ? canUseChatCompletions(...) : ...` branch with `currentCapability === 'chat' || currentCapability === 'omni'`. Custom models with no recipe field now get the tools toggle correctly enabled (`currentCapability` is already enriched via the snapshot system).

## Verification

- `npm run build` exits 0 (3 pre-existing bundle-size warnings, no errors)
- All four touched files re-read end-to-end
- No changes to `src/cpp/`, no new dependencies, no changes to `src/app/` or `src/web-app/`

## Out of scope (deferred)

Audit also flagged: `ScriptProcessorNode` deprecation in `useAudioCapture` (needs AudioWorklet migration, ~30-50 lines + worklet file), `modelSupportsImageEdit` hardcoded name patterns, ChatView size (101KB — needs component extraction), legacy `lemonade_use_tools` migration, `transpileOnly: true` masking `as any` type holes. Tracked in audit decision note.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
