### PR TITLE
feat: implement safe model pinning to prevent auto-eviction

### DIFF
--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -430,6 +430,7 @@ Explicitly load a registered model into memory. This is useful to ensure that th
 | Parameter | Required | Applies to | Description |
 |-----------|----------|------------|-------------|
 | `model_name` | Yes | All | [Lemonade Server model name](https://lemonade-server.ai/models.html) to load. |
+| `pinned` | No | All | Boolean. If true, pins the loaded model to prevent LRU eviction. Defaults to `false`. |
 | `save_options` | No | All | Boolean. If true, saves recipe options to `recipe_options.json`. Any previously stored value for `model_name` is replaced. |
 | `ctx_size` | No | llamacpp, flm, ryzenai-llm | Context size for the model. Overrides the default value. |
 | `llamacpp_backend` | No | llamacpp | LlamaCpp backend to use (`vulkan`, `rocm`, `metal` or `cpu`). |
@@ -599,6 +600,8 @@ Error response (model not found):
 
 In case of an error, the status will be `error` and the message will contain the error message.
 
+
+
 ## `GET /v1/health`
 <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
 
@@ -629,6 +632,7 @@ curl http://localhost:13305/v1/health
       "last_use": 1732123456.789,
       "type": "llm",
       "device": "gpu npu",
+      "pinned": true,
       "recipe": "ryzenai-llm",
       "pid": 12345,
       "recipe_options": {
@@ -642,6 +646,7 @@ curl http://localhost:13305/v1/health
       "last_use": 1732123450.123,
       "type": "embedding",
       "device": "gpu",
+      "pinned": false,
       "recipe": "llamacpp",
       "pid": 12346,
       "recipe_options": {
@@ -652,6 +657,14 @@ curl http://localhost:13305/v1/health
       "backend_url": "http://127.0.0.1:8002/v1"
     }
   ],
+  "pinned_models": {
+    "transcription":0,
+    "embedding":0,
+    "image":0,
+    "llm":1,
+    "reranking":0,
+    "tts":0
+  },
   "max_models": {
     "transcription":1,
     "embedding":1,
@@ -674,10 +687,12 @@ curl http://localhost:13305/v1/health
   - `last_use` - Unix timestamp of last access (load or inference)
   - `type` - Model type: `"llm"`, `"embedding"`, `"reranking"`, `"transcription"`, `"image"`, or `"tts"`
   - `device` - Space-separated device list: `"cpu"`, `"gpu"`, `"npu"`, or combinations like `"gpu npu"`
+  - `pinned` - Boolean indicating if the model is currently pinned to prevent auto-eviction
   - `backend_url` - URL of the backend server process handling this model (useful for debugging)
   - `pid` - The Process ID (PID) of the backend engine handling this model
   - `recipe` - Backend/device recipe used to load the model (e.g., `"ryzenai-llm"`, `"llamacpp"`, `"flm"`)
   - `recipe_options` - Options used to load the model (e.g., `"ctx_size"`, `"llamacpp_backend"`, `"llamacpp_args"`, `"whispercpp_args"`)
+- `pinned_models` - Counts of pinned models currently loaded in memory per model type (e.g., `llm`, `embedding`, etc.)
 - `max_models` - Maximum number of models that can be loaded simultaneously per type (set via `max_loaded_models` in [Server Configuration](../guide/configuration/README.md)):
   - `llm` - Maximum LLM/chat models
   - `embedding` - Maximum embedding models

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -590,7 +590,7 @@ A GUI application for desktop users that exposes the server via a system tray ic
 The `lemonade` client communicates with `lemond` server via HTTP:
 - **Model operations:** `/api/v1/models`, `/api/v1/pull`, `/api/v1/delete`
 - **Model control:** `/api/v1/load`, `/api/v1/unload`
-- **Server management:** `/api/v1/health`, `/internal/shutdown`, `/internal/set`, `/internal/config`, `/internal/cleanup-cache`
+- **Server management:** `/api/v1/health`, `/internal/shutdown`, `/internal/set`, `/internal/config`, `/internal/cleanup-cache`, `/internal/pin`
 - **Inference:** `/api/v1/chat/completions`, `/api/v1/completions`, `/api/v1/audio/transcriptions`
 
 The client automatically:
@@ -625,6 +625,7 @@ Internal endpoints accept connections from any address, so first-party clients o
 | `POST` | `/internal/set` | Unified config setter (see below) |
 | `GET`  | `/internal/config` | Returns the full runtime config snapshot |
 | `POST` | `/internal/cleanup-cache` | Cleans up orphaned files in the Hugging Face cache |
+| `POST` | `/internal/pin` | Pin or unpin a loaded model |
 
 #### `POST /internal/set`
 

--- a/docs/embeddable/runtime.md
+++ b/docs/embeddable/runtime.md
@@ -10,6 +10,7 @@ Contents:
 - [Runtime Settings Management](#runtime-settings-management)
   - [`GET /internal/config`](#get-internalconfig)
   - [`POST /internal/set`](#post-internalset)
+  - [`POST /internal/pin`](#post-internalpin)
 
 ## Launching
 
@@ -113,6 +114,7 @@ Your app can manage its `lemond` instance at runtime by using `/internal` endpoi
 |--------|------|-------------|
 | `POST` | `/internal/set` | Unified config setter (see below) |
 | `GET`  | `/internal/config` | Returns the full runtime config snapshot |
+| `POST` | `/internal/pin` | Pin or unpin a loaded model (prevents auto-eviction) |
 
 The settings defined in `config.json` can all be changed at runtime without restarting `lemond` with the `/internal/set` endpoint. See the [Configuration Guide](../guide/configuration/README.md) for details on all settings.
 
@@ -184,3 +186,40 @@ Accepts a JSON object with one or more keys to update atomically. Returns `{"sta
       -H "Content-Type: application/json" \
       -d '{"ctx_size": 8192, "max_loaded_models": 3, "log_level": "debug"}'
     ```
+
+#### `POST /internal/pin`
+
+Pin or unpin a loaded model in memory. Pinned models are excluded from the Least Recently Used (LRU) eviction policy.
+
+**Parameters:**
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `model_name` | Yes | Name of the loaded model to pin or unpin. |
+| `pinned` | Yes | Boolean. Set to `true` to pin the model, or `false` to unpin it. |
+
+**Example:**
+=== "Windows (cmd.exe)"
+
+    ```cmd
+    curl -X POST http://localhost:8000/internal/pin ^
+      -H "Content-Type: application/json" ^
+      -d "{\"model_name\": \"Qwen3-0.6B-GGUF\", \"pinned\": true}"
+    ```
+
+=== "Linux (bash)"
+
+    ```bash
+    curl -X POST http://localhost:8000/internal/pin \
+      -H "Content-Type: application/json" \
+      -d '{"model_name": "Qwen3-0.6B-GGUF", "pinned": true}'
+    ```
+
+**Response format:**
+```json
+{
+  "status": "success",
+  "model_name": "Qwen3-0.6B-GGUF",
+  "pinned": true
+}
+```

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -49,6 +49,8 @@ The `lemonade` CLI is the primary tool for interacting with Lemonade Server from
 | `delete MODEL_NAME` | Delete a model and its files from local storage. |
 | `load MODEL_NAME`   | Load a model for inference. See command options [below](#options-for-load). |
 | `unload [MODEL_NAME]` | Unload a model. If no model name is provided, unload all loaded models. |
+| `pin MODEL_NAME`    | Pin a loaded model to prevent auto-eviction. See options [below](#options-for-pin-and-unpin). |
+| `unpin MODEL_NAME`  | Unpin a loaded model to allow auto-eviction. See options [below](#options-for-pin-and-unpin). |
 | `export MODEL_NAME` | Export model information to JSON format. See command options [below](#options-for-export). |
 
 ### Benchmarking
@@ -303,11 +305,21 @@ lemonade import model-with-id-alias.json
 
 ## Options for load
 
-The `load` command loads a model into memory for inference. It supports recipe-specific options that are passed to the backend server:
+The `load` command loads a model into memory for inference. It supports both general options and recipe-specific options that are passed to the backend server:
 
 ```bash
 lemonade load MODEL_NAME [options]
 ```
+
+### General Options
+
+The following options apply to all model loads:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--pinned` | Pin the model in memory to prevent auto-eviction under capacity limits. | `false` |
+| `--save-options` | Persist the supplied recipe options in `recipe_options.json` for future loads. | `false` |
+| `--merge-args` / `--no-merge-args` | Merge global and model arguments when loading the model (if `false`, per-model replaces global entirely). | `true` |
 
 ### Recipe-Specific Options
 
@@ -350,13 +362,10 @@ The following options are available depending on the recipe being used:
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--whispercpp BACKEND` | WhisperCpp backend to use | Auto-detected |
-| `--merge-args` / `--no-merge-args` | Merge global and model arguments when loading the model | `true` |
 
 **Notes:**
-- Use `--save-options` to persist your configuration for the model
 - Unspecified options will use the backend's default values
 - Backend options (`--llamacpp`, `--sdcpp`, `--whispercpp`) are auto-detected based on system capabilities
-- `--merge-args` controls whether `*_args` from global config are merged with per-model args (default: merge). Use `--no-merge-args` to replace global args entirely with per-model args.
 
 **Examples:**
 
@@ -381,6 +390,25 @@ lemonade load Qwen3-0.6B-GGUF --no-merge-args --llamacpp-args "--flash-attn on"
 
 # Load an image generation model with custom settings
 lemonade load Z-Image-Turbo --sdcpp rocm --steps 8 --cfg-scale 1 --width 1024 --height 1024
+```
+
+## Options for pin and unpin
+
+The `pin` and `unpin` commands dynamically modify the pinned status of a currently loaded model. Pinned models are excluded from Least Recently Used (LRU) eviction.
+
+```bash
+lemonade pin MODEL_NAME
+lemonade unpin MODEL_NAME
+```
+
+**Examples:**
+
+```bash
+# Pin a loaded model to prevent it from being auto-evicted
+lemonade pin Qwen3-0.6B-GGUF
+
+# Unpin a model to allow it to be evicted when slots are full
+lemonade unpin Qwen3-0.6B-GGUF
 ```
 
 ## Options for run

--- a/docs/guide/configuration/multi-model.md
+++ b/docs/guide/configuration/multi-model.md
@@ -78,6 +78,26 @@ These can be set per model on `/api/v1/load` (or globally where noted):
 | `evict_idle_timeout` | per-model | `300` | Seconds idle before full eviction |
 | `evict_weight_factor` | per-model | `1.0` | Eviction-protection weight (higher = more protected) |
 
+## Model Pinning
+
+To prevent frequently used models from being auto-evicted by the LRU policy, you can "pin" them in memory. Pinned models are excluded from the eviction candidate search.
+
+### Pinning Behavior
+
+- **Load-time Pinning:** You can request a model to be pinned when loading it by passing the `--pinned` flag in the CLI:
+  ```bash
+  lemonade load Qwen3-0.6B-GGUF --pinned
+  ```
+  Or by setting `"pinned": true` in the POST request body to `/api/v1/load`.
+- **Dynamic Pinning/Unpinning:** Toggles the pinned status of a currently loaded model dynamically without needing a reload:
+  ```bash
+  lemonade pin Qwen3-0.6B-GGUF
+  lemonade unpin Qwen3-0.6B-GGUF
+  ```
+  Or via a POST request to `/internal/pin`.
+- **Pre-emptive Warnings:** The CLI checks `/api/v1/health` before loading a new model. If all slots for that model type are occupied by pinned models, the CLI will output a pre-emptive warning alerting you that loading will fail.
+- **Capacity Failures:** If all loaded models of a type are pinned and a request to load another model of that type is received, the load request fails with a `409 Conflict` HTTP status containing a `slots_pinned_error` code. You must unpin or unload at least one model of that type to free up a slot.
+
 ## Per-Model Settings
 
 Each model can be loaded with custom settings (context size, llamacpp backend, llamacpp args) via the `/api/v1/load` endpoint. These per-model settings override the default values set via CLI arguments or environment variables. See the [`/api/v1/load` endpoint documentation](../../api/lemonade.md#post-v1load) for details.

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -18,7 +18,7 @@ import BackendManager from './BackendManager';
 import ConnectedBackendRow from './components/ConnectedBackendRow';
 import MarketplacePanel, { MarketplaceCategory } from './MarketplacePanel';
 import { RECIPE_DISPLAY_NAMES } from './utils/recipeNames';
-import { EjectIcon } from './components/Icons';
+import { EjectIcon, PinIcon } from './components/Icons';
 import { getCollectionComponents, isCollectionFullyDownloaded, isCollectionModel, isModelEffectivelyDownloaded, isModelEffectivelyLoaded } from './utils/collectionModels';
 import { getCollectionDisplayName, isCollectionEditableAsCustom } from './utils/customCollections';
 
@@ -356,6 +356,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ isContentVisible, onContent
   const [showFilterPanel, setShowFilterPanel] = useState(false);
 const [searchQuery, setSearchQuery] = useState('');
   const [loadedModels, setLoadedModels] = useState<Set<string>>(new Set());
+  const [pinnedModels, setPinnedModels] = useState<Set<string>>(new Set());
   const [loadingModels, setLoadingModels] = useState<Set<string>>(new Set());
   const [hoveredModel, setHoveredModel] = useState<string | null>(null);
   const [optionsModel, setOptionsModel] = useState<string | null>(null);
@@ -390,6 +391,14 @@ const [searchQuery, setSearchQuery] = useState('');
         );
         setLoadedModels(loadedModelNames);
 
+        // Extract pinned models from the all_models_loaded array
+        const pinnedModelNames = new Set<string>(
+          data.all_models_loaded
+            .filter((model: any) => model.pinned === true)
+            .map((model: any) => model.model_name)
+        );
+        setPinnedModels(pinnedModelNames);
+
         // Remove loaded models from loading state
         setLoadingModels(prev => {
           const newSet = new Set(prev);
@@ -398,9 +407,11 @@ const [searchQuery, setSearchQuery] = useState('');
         });
       } else {
         setLoadedModels(new Set());
+        setPinnedModels(new Set());
       }
     } catch (error) {
       setLoadedModels(new Set());
+      setPinnedModels(new Set());
       console.error('Failed to fetch current loaded model:', error);
     }
   }, []);
@@ -1234,6 +1245,22 @@ const [searchQuery, setSearchQuery] = useState('');
     }
   };
 
+  const handleTogglePin = async (modelName: string, pin: boolean) => {
+    try {
+      const response = await serverFetch('/internal/pin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model_name: modelName, pinned: pin })
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to pin model: ${response.statusText}`);
+      }
+      await fetchCurrentLoadedModel();
+    } catch (error) {
+      showError(`Failed to update pin: ${error instanceof Error ? error.message : 'Unknown'}`);
+    }
+  };
+
   const hasActiveDownloadForModel = (modelName: string): boolean => {
     const relatedNames = new Set<string>([modelName]);
     const info = modelsData[modelName];
@@ -1869,9 +1896,18 @@ const [searchQuery, setSearchQuery] = useState('');
                       <span className="loaded-model-name" title={modelName}>{getModelDisplayName(modelName)}</span>
                     </div>
                     {!isLoading && (
-                      <button className="model-action-btn unload-btn active-model-eject-button" onClick={() => handleUnloadModel(modelName)} title="Eject model">
-                        <EjectIcon />
-                      </button>
+                      <div className="active-model-actions">
+                        <button
+                          className={`model-action-btn pin-btn ${pinnedModels.has(modelName) ? 'pinned' : ''}`}
+                          onClick={() => handleTogglePin(modelName, !pinnedModels.has(modelName))}
+                          title={pinnedModels.has(modelName) ? "Unpin model" : "Pin model"}
+                        >
+                          <PinIcon fill={pinnedModels.has(modelName) ? 'currentColor' : 'none'} />
+                        </button>
+                        <button className="model-action-btn unload-btn active-model-eject-button" onClick={() => handleUnloadModel(modelName)} title="Eject model">
+                          <EjectIcon />
+                        </button>
+                      </div>
                     )}
                   </div>
                 ))}

--- a/src/app/src/renderer/components/Icons.tsx
+++ b/src/app/src/renderer/components/Icons.tsx
@@ -264,3 +264,10 @@ export const MicrophoneIcon: React.FC<{ active?: boolean }> = ({ active = false 
     />
   </svg>
 );
+
+export const PinIcon: React.FC<{ size?: number; fill?: string }> = ({ size = 14, fill = 'none' }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill={fill} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <line x1="12" y1="17" x2="12" y2="22" />
+    <path d="M5 17h14v-1.76a2 2 0 0 0-.44-1.24l-2.78-3.48A2 2 0 0 1 15 9.28V5a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v4.28a2 2 0 0 1-.78 1.24l-2.78 3.48a2 2 0 0 0-.44 1.24Z" />
+  </svg>
+);

--- a/src/app/src/renderer/recipes/recipeOptionsConfig.ts
+++ b/src/app/src/renderer/recipes/recipeOptionsConfig.ts
@@ -37,6 +37,7 @@ export interface LlamaOptions {
   llamacppBackend: StringOption;
   llamacppArgs: StringOption;
   mergeArgs: BooleanOption;
+  pinned: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -45,6 +46,7 @@ export interface WhisperOptions {
   whispercppBackend: StringOption;
   whispercppArgs: StringOption;
   mergeArgs: BooleanOption;
+  pinned: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -52,6 +54,7 @@ export interface MoonshineOptions {
   recipe: 'moonshine';
   moonshineArgs: StringOption;
   mergeArgs: BooleanOption;
+  pinned: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -59,6 +62,7 @@ export interface FlmOptions {
   recipe: 'flm';
   ctxSize: NumericOption;
   mergeArgs: BooleanOption;
+  pinned: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -67,6 +71,7 @@ export type RyzenAIRecipe = 'ryzenai-llm';
 export interface RyzenAIOptions {
   recipe: RyzenAIRecipe;
   ctxSize: NumericOption;
+  pinned: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -78,6 +83,7 @@ export interface StableDiffusionOptions {
   width: NumericOption;
   height: NumericOption;
   mergeArgs: BooleanOption;
+  pinned: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -87,6 +93,7 @@ export interface VLLMOptions {
   vllmBackend: StringOption;
   vllmArgs: StringOption;
   mergeArgs: BooleanOption;
+  pinned: BooleanOption;
   saveOptions: BooleanOption;
 }
 
@@ -273,6 +280,14 @@ export const OPTION_DEFINITIONS: Record<string, OptionDef> = {
     label: 'Save Options',
     description: 'Save these options in lemonade server for future loads',
   },
+
+  // Pin model option
+  pinned: {
+    type: 'boolean',
+    default: false,
+    label: 'Pin Model',
+    description: 'Pin this model to prevent it from being auto-evicted',
+  },
 };
 
 // =============================================================================
@@ -286,13 +301,13 @@ export type RecipeName = 'llamacpp' | 'whispercpp' | 'moonshine' | 'flm' | 'ryze
  * This mirrors the C++ get_keys_for_recipe() function in recipe_options.cpp
  */
 export const RECIPE_OPTIONS_MAP: Record<RecipeName, string[]> = {
-  'llamacpp': ['ctxSize', 'llamacppBackend', 'llamacppArgs', 'mergeArgs', 'saveOptions'],
-  'whispercpp': ['whispercppBackend', 'whispercppArgs', 'mergeArgs', 'saveOptions'],
-  'moonshine': ['moonshineArgs', 'mergeArgs', 'saveOptions'],
-  'flm': ['ctxSize', 'mergeArgs', 'saveOptions'],
-  'ryzenai-llm': ['ctxSize', 'saveOptions'],
-  'sd-cpp': ['sdcppBackend', 'steps', 'cfgScale', 'width', 'height', 'mergeArgs', 'saveOptions'],
-  'vllm': ['ctxSize', 'vllmBackend', 'vllmArgs', 'mergeArgs', 'saveOptions'],
+  'llamacpp': ['ctxSize', 'llamacppBackend', 'llamacppArgs', 'mergeArgs', 'pinned', 'saveOptions'],
+  'whispercpp': ['whispercppBackend', 'whispercppArgs', 'mergeArgs', 'pinned', 'saveOptions'],
+  'moonshine': ['moonshineArgs', 'mergeArgs', 'pinned', 'saveOptions'],
+  'flm': ['ctxSize', 'mergeArgs', 'pinned', 'saveOptions'],
+  'ryzenai-llm': ['ctxSize', 'pinned', 'saveOptions'],
+  'sd-cpp': ['sdcppBackend', 'steps', 'cfgScale', 'width', 'height', 'mergeArgs', 'pinned', 'saveOptions'],
+  'vllm': ['ctxSize', 'vllmBackend', 'vllmArgs', 'mergeArgs', 'pinned', 'saveOptions'],
 };
 
 /**

--- a/src/app/src/renderer/utils/serverConfig.ts
+++ b/src/app/src/renderer/utils/serverConfig.ts
@@ -320,7 +320,9 @@ class ServerConfig {
 
     const fullUrl = endpoint.startsWith('http')
       ? endpoint
-      : `${this.getApiBaseUrl()}${endpoint.startsWith('/') ? endpoint : `/${endpoint}`}`;
+      : endpoint.startsWith('/internal/')
+        ? `${this.getServerBaseUrl()}${endpoint}`
+        : `${this.getApiBaseUrl()}${endpoint.startsWith('/') ? endpoint : `/${endpoint}`}`;
 
     const options = { ...opts };
 

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -1495,7 +1495,7 @@ footer {
 
 .loaded-model-info {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 22px;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     gap: 8px;
     margin-bottom: 0;
@@ -1602,6 +1602,27 @@ footer {
     flex-shrink: 0;
     width: 14px;
     height: 14px;
+}
+
+.active-model-actions {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    margin-right: 2px;
+}
+
+.active-model-actions svg {
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+}
+
+.model-action-btn.pin-btn.pinned {
+    color: var(--info-color);
+}
+
+.model-action-btn.pin-btn:hover {
+    color: var(--info-color);
 }
 
 .downloaded-filter {

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -283,8 +283,13 @@ int LemonadeClient::status(int display_port) const {
             for (const auto& model : json_response["all_models_loaded"]) {
                 if (!model.is_object()) continue;
 
+                std::string model_name = model.value("model_name", "-");
+                if (model.value("pinned", false)) {
+                    model_name += " (pinned)";
+                }
+
                 std::cout << std::left
-                          << std::setw(30) << model.value("model_name", "-")
+                          << std::setw(30) << model_name
                           << std::setw(10) << model.value("type", "-")
                           << std::setw(10) << model.value("device", "-")
                           << std::setw(14) << model.value("recipe", "-")
@@ -737,13 +742,16 @@ int LemonadeClient::cleanup_cache(bool dry_run) const {
     }
 }
 
-int LemonadeClient::load_model(const std::string& model_name, const nlohmann::json& recipe_options, bool save_options) const {
+int LemonadeClient::load_model(const std::string& model_name, const nlohmann::json& recipe_options, bool save_options, std::optional<bool> pinned) const {
     std::cout << "Loading model: " << model_name << std::endl;
 
     try {
         json request_body = recipe_options;
         request_body["model_name"] = model_name;
         request_body["save_options"] = save_options;
+        if (pinned.has_value()) {
+            request_body["pinned"] = pinned.value();
+        }
 
         // since load can trigger a pull but doesn't send the related streaming events, we want long read timeouts.
         make_request("/api/v1/load", "POST", request_body.dump(), "application/json", LONG_TIMEOUT_MS, LONG_TIMEOUT_MS);
@@ -756,6 +764,18 @@ int LemonadeClient::load_model(const std::string& model_name, const nlohmann::js
         return 1;
     } catch (const std::exception& e) {
         std::cerr << "Error loading model: " << e.what() << std::endl;
+        return 1;
+    }
+}
+
+int LemonadeClient::pin_model(const std::string& model_name, bool pinned) const {
+    try {
+        json request_body = {{"model_name", model_name}, {"pinned", pinned}};
+        make_request("/internal/pin", "POST", request_body.dump(), "application/json");
+        std::cout << "Model " << (pinned ? "pinned" : "unpinned") << " successfully!" << std::endl;
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
         return 1;
     }
 }

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -27,6 +27,7 @@
 #include <functional>
 #include <map>
 #include <vector>
+#include <optional>
 
 #ifdef _WIN32
     #include <winsock2.h>
@@ -154,6 +155,7 @@ struct CliConfig {
     std::vector<std::string> components;
     nlohmann::json recipe_options;
     bool save_options = false;
+    std::optional<bool> pinned = std::nullopt;
     std::string backend_spec;  // Format: "recipe:backend"
     bool force = false;
     std::string output_file;
@@ -434,13 +436,37 @@ static int handle_load_command(lemonade::LemonadeClient& client, const CliConfig
         return 1;
     }
 
-    // Check if model is downloaded
-    if (!model_info.contains("downloaded") || !model_info["downloaded"].is_boolean()) {
-        std::cerr << "Error: Failed to determine download status for model '" << config.model << "'" << std::endl;
-        return 1;
+    // Pre-emptive capacity check
+    std::vector<std::string> labels;
+    if (model_info.contains("labels") && model_info["labels"].is_array()) {
+        for (const auto& label : model_info["labels"]) {
+            labels.push_back(label.get<std::string>());
+        }
+    }
+    lemon::ModelType model_type = lemon::get_model_type_from_labels(labels);
+    std::string type_str = lemon::model_type_to_string(model_type);
+
+    try {
+        std::string health_str = client.make_request("/api/v1/health", "GET", "", "", 2000, 2000);
+        auto health_json = nlohmann::json::parse(health_str);
+        if (health_json.contains("max_models") && health_json.contains("pinned_models")) {
+            auto max_models = health_json["max_models"];
+            auto pinned_models = health_json["pinned_models"];
+            int max = max_models.value(type_str, -1);
+            int pinned_count = pinned_models.value(type_str, 0);
+            if (max != -1 && pinned_count >= max) {
+                std::cerr << "Warning: All slots (" << max << ") for model type '" << type_str
+                          << "' are occupied by pinned models. Loading will fail." << std::endl;
+            }
+        }
+    } catch (...) {
+        // Ignore errors checking health status pre-emptively
     }
 
-    bool is_downloaded = model_info["downloaded"].get<bool>();
+    bool is_downloaded = false;
+    if (model_info.contains("downloaded") && model_info["downloaded"].is_boolean()) {
+        is_downloaded = model_info["downloaded"].get<bool>();
+    }
 
     if (!is_downloaded) {
         std::cout << "Model '" << config.model << "' is not downloaded. Pulling..." << std::endl;
@@ -455,7 +481,7 @@ static int handle_load_command(lemonade::LemonadeClient& client, const CliConfig
     }
 
     // Proceed with loading the model
-    return client.load_model(config.model, config.recipe_options, config.save_options);
+    return client.load_model(config.model, config.recipe_options, config.save_options, config.pinned);
 }
 
 static int handle_chat_command(lemonade::LemonadeClient& client, const CliConfig& config) {
@@ -1156,6 +1182,8 @@ int main(int argc, char* argv[]) {
     CLI::App* delete_cmd = app.add_subcommand("delete", "Delete a model")->group("Model management");
     CLI::App* load_cmd = app.add_subcommand("load", "Load a model")->group("Model management");
     CLI::App* unload_cmd = app.add_subcommand("unload", "Unload a model (or all models)")->group("Model management");
+    CLI::App* pin_cmd = app.add_subcommand("pin", "Pin a loaded model to prevent eviction")->group("Model management");
+    CLI::App* unpin_cmd = app.add_subcommand("unpin", "Unpin a loaded model")->group("Model management");
     CLI::App* import_cmd = app.add_subcommand("import", "Import a model from JSON file")->group("Model management");
     CLI::App* export_cmd = app.add_subcommand("export", "Export model information to JSON")->group("Model management");
     CLI::App* cleanup_cmd = app.add_subcommand("cleanup-cache", "Clean up orphaned files in HuggingFace cache")->group("Model management");
@@ -1241,14 +1269,18 @@ int main(int argc, char* argv[]) {
     delete_cmd->add_option("model", config.model, "Model name to delete")->required()->type_name("MODEL");
 
     // Load options
+    static bool load_pinned_flag = false;
     load_cmd->add_option("model", config.model, "Model name to load")->required()->type_name("MODEL");
     lemon::RecipeOptions::add_cli_options(*load_cmd, config.recipe_options);
     load_cmd->add_flag("--save-options", config.save_options, "Save model options for future loads");
+    load_cmd->add_flag("--pinned", load_pinned_flag, "Pin the model to prevent auto-eviction");
 
     // Run options (same as load)
+    static bool run_pinned_flag = false;
     run_cmd->add_option("model", config.model, "Model name to run")->type_name("MODEL");
     lemon::RecipeOptions::add_cli_options(*run_cmd, config.recipe_options);
     run_cmd->add_flag("--save-options", config.save_options, "Save model options for future runs");
+    run_cmd->add_flag("--pinned", run_pinned_flag, "Pin the model to prevent auto-eviction");
     run_cmd->add_flag("--chat-cli", config.chat_cli,
         "After loading, open an interactive chat REPL in the terminal instead of the browser");
 
@@ -1262,6 +1294,10 @@ int main(int argc, char* argv[]) {
 
     // Unload options
     unload_cmd->add_option("model", config.model, "Model name to unload")->type_name("MODEL");
+
+    // Pin/unpin options
+    pin_cmd->add_option("model", config.model, "Model name to pin")->required()->type_name("MODEL");
+    unpin_cmd->add_option("model", config.model, "Model name to unpin")->required()->type_name("MODEL");
 
     // Export options
     export_cmd->add_option("model", config.model, "Model name to export")->type_name("MODEL")->required();
@@ -1323,6 +1359,20 @@ int main(int argc, char* argv[]) {
             return 1;
         }
         return app.exit(e);
+    }
+
+    if (load_cmd->count() > 0) {
+        if (load_cmd->count("--pinned") > 0) {
+            config.pinned = load_pinned_flag;
+        } else {
+            config.pinned = std::nullopt;
+        }
+    } else if (run_cmd->count() > 0) {
+        if (run_cmd->count("--pinned") > 0) {
+            config.pinned = run_pinned_flag;
+        } else {
+            config.pinned = std::nullopt;
+        }
     }
     config.codex_use_user_config = (codex_provider_opt != nullptr && codex_provider_opt->count() > 0);
 
@@ -1391,6 +1441,10 @@ int main(int argc, char* argv[]) {
         return handle_load_command(client, config);
     } else if (unload_cmd->count() > 0) {
         return client.unload_model(config.model);
+    } else if (pin_cmd->count() > 0) {
+        return client.pin_model(config.model, true);
+    } else if (unpin_cmd->count() > 0) {
+        return client.pin_model(config.model, false);
     } else if (export_cmd->count() > 0) {
         return handle_export_command(client, config);
     } else if (backends_cmd->count() > 0) {

--- a/src/cpp/include/lemon/error_types.h
+++ b/src/cpp/include/lemon/error_types.h
@@ -20,6 +20,7 @@ namespace ErrorType {
     constexpr const char* PROCESS_ERROR = "process_error";
     constexpr const char* FILE_ERROR = "file_error";
     constexpr const char* INTERNAL_ERROR = "internal_error";
+    constexpr const char* SLOTS_PINNED = "slots_pinned_error";
 }
 
 // Base exception class for all Lemon errors
@@ -54,6 +55,13 @@ public:
     ModelNotLoadedException(const std::string& details = "")
         : LemonException("No model loaded" + (details.empty() ? "" : ": " + details),
                         ErrorType::MODEL_NOT_LOADED) {}
+};
+
+class SlotsPinnedException : public LemonException {
+public:
+    SlotsPinnedException(const std::string& model_type, const std::string& details = "")
+        : LemonException("All loaded models of type " + model_type + " are pinned. Unload a model first." + (details.empty() ? "" : " " + details),
+                        ErrorType::SLOTS_PINNED) {}
 };
 
 class BackendException : public LemonException {

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <vector>
+#include <optional>
 #include <nlohmann/json.hpp>
 #include <httplib.h>
 #include "wrapped_server.h"
@@ -65,7 +66,8 @@ public:
                     const ModelInfo& model_info,
                     RecipeOptions options,
                     bool do_not_upgrade = true,
-                    bool allow_reload_on_option_change = false);
+                    bool allow_reload_on_option_change = false,
+                    std::optional<bool> pinned = std::nullopt);
 
     void unload_model(const std::string& model_name = "");  // Empty = unload all
 
@@ -75,6 +77,12 @@ public:
     json get_all_loaded_models() const;
 
     json get_max_model_limits() const;
+
+    // Get pinned model counts per type
+    json get_pinned_model_counts() const;
+
+    // Pin or unpin a model
+    void set_model_pinned(const std::string& model_name, bool pinned);
 
     bool is_model_loaded() const;
 
@@ -154,6 +162,7 @@ private:
     bool reload_model_after_watchdog_reset(const std::string& requested_model, const RecipeOptions& options);
     bool is_watchdog_reset_response(const json& response) const;
     int count_servers_by_type(ModelType type) const;
+    int count_pinned_servers_by_type(ModelType type) const;
     WrappedServer* find_lru_server_by_type(ModelType type) const;
     bool has_npu_server() const;
     WrappedServer* find_npu_server() const;

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -103,6 +103,7 @@ private:
     void handle_pull_variants(const httplib::Request& req, httplib::Response& res);
     void handle_load(const httplib::Request& req, httplib::Response& res);
     void handle_unload(const httplib::Request& req, httplib::Response& res);
+    void handle_pin(const httplib::Request& req, httplib::Response& res);
     void handle_delete(const httplib::Request& req, httplib::Response& res);
     void handle_cleanup_cache(const httplib::Request& req, httplib::Response& res);
 

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -117,6 +117,10 @@ public:
         return load_duration_ms_;
     }
 
+    // Pinned status for eviction prevention
+    bool is_pinned() const { return pinned_; }
+    void set_pinned(bool pinned) { pinned_ = pinned; }
+
     // Acquire model for inference, safely recovering from DOWNSIZING/EVICTING if necessary.
     // Blocks if LOADING.
     //
@@ -437,6 +441,7 @@ protected:
     // from being unloaded/destroyed while the engine holds a raw pointer to it.
     bool maintenance_in_progress_;
     long load_duration_ms_;
+    bool pinned_ = false;
 
 private:
     void begin_backend_request(BackendRequestKind kind);

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <cstdint>
 #include <chrono>
+#include <optional>
 #include <nlohmann/json.hpp>
 
 // Forward declaration for httplib
@@ -83,7 +84,8 @@ public:
     // should pass upgrade=true to force an HF update check.
     int pull_model(const nlohmann::json& model_data, const std::string& display_name = "", bool upgrade = false);
     int delete_model(const std::string& model_name) const;
-    int load_model(const std::string& model_name, const nlohmann::json& recipe_options, bool save_options = false) const;
+    int load_model(const std::string& model_name, const nlohmann::json& recipe_options, bool save_options = false, std::optional<bool> pinned = std::nullopt) const;
+    int pin_model(const std::string& model_name, bool pinned) const;
     int unload_model(const std::string& model_name) const;
     nlohmann::json get_model_info(const std::string& model_name) const;
     int launch_model(const std::string& model_name, const nlohmann::json& recipe_options, const std::string& agent);

--- a/src/cpp/server/eviction_engine.cpp
+++ b/src/cpp/server/eviction_engine.cpp
@@ -69,6 +69,9 @@ void EvictionEngine::evaluate_servers(double current_vram_pct) {
             WrappedServer* server = server_ptr.get();
             if (!server) continue;
 
+            // Pinned models must never be auto-evicted or downsized
+            if (server->is_pinned()) continue;
+
             // Check auto_evict config
             bool auto_evict = RuntimeConfig::global()->auto_evict();
             auto recipe_opts = server->get_recipe_options().to_json();
@@ -173,4 +176,3 @@ void EvictionEngine::evaluate_servers(double current_vram_pct) {
 }
 
 } // namespace lemon
-

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -44,7 +44,8 @@ static const json DEFAULTS = {
     {"auto_evict", nullptr},          // nullptr means fallback to global config
     {"evict_idle_timeout", 300},      // Default hard idle timeout (5 mins)
     {"downsize_idle_timeout", 60},    // Default soft idle timeout (1 min)
-    {"evict_weight_factor", 1.0}      // Eviction-protection weight (higher = more protected)
+    {"evict_weight_factor", 1.0},     // Eviction-protection weight (higher = more protected)
+    {"pinned", false}
 };
 
 
@@ -84,18 +85,19 @@ static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
     } else if (recipe == "vllm") {
         keys = {"ctx_size", "vllm_backend", "vllm_args", "merge_args"};
     }
-    
+
     // Add auto-eviction options for all recipes
     keys.push_back("auto_evict");
     keys.push_back("evict_idle_timeout");
     keys.push_back("downsize_idle_timeout");
     keys.push_back("evict_weight_factor");
+    keys.push_back("pinned");
 
     return keys;
 }
 
 static bool is_empty_option(json option) {
-    return option.is_null() || 
+    return option.is_null() ||
            (option.is_number() && (option == -1)) ||
            (option.is_string() && (option == "" || option == "auto"));
 }

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -125,7 +125,15 @@ bool Router::reload_model_after_watchdog_reset(const std::string& requested_mode
         LOG(WARNING, "Router") << "Reloading model after backend watchdog reset: "
                                 << requested_model << std::endl;
         auto info = model_manager_->get_model_info(requested_model);
-        load_model(requested_model, info, options, true, false);
+        bool was_pinned = false;
+        {
+            std::lock_guard<std::mutex> lock(load_mutex_);
+            auto* existing = find_server_by_model_name(requested_model);
+            if (existing) {
+                was_pinned = existing->is_pinned();
+            }
+        }
+        load_model(requested_model, info, options, true, false, was_pinned);
         return true;
     } catch (const std::exception& e) {
         LOG(ERROR, "Router") << "Automatic reload after watchdog reset failed for "
@@ -160,6 +168,9 @@ WrappedServer* Router::find_lru_server_by_type(ModelType type) const {
             continue;
         }
         if (server->is_backend_alive() && server->get_model_type() == type) {
+            if (server->is_pinned()) {
+                continue;
+            }
             if (!lru || server->get_last_access_time() < lru->get_last_access_time()) {
                 lru = server.get();
             }
@@ -336,7 +347,8 @@ void Router::load_model(const std::string& model_name,
                        const ModelInfo& model_info,
                        RecipeOptions options,
                        bool do_not_upgrade,
-                       bool allow_reload_on_option_change) {
+                       bool allow_reload_on_option_change,
+                       std::optional<bool> pinned) {
     const std::string canonical_model_name = resolve_model_name(model_name);
     const std::string backend_option = model_info.recipe + "_backend";
 
@@ -370,6 +382,16 @@ void Router::load_model(const std::string& model_name,
             << ", device: " << device_type_to_string(model_info.device) << ")" << std::endl;
 
     try {
+        WrappedServer* existing_pre = find_server_by_model_name(canonical_model_name);
+        bool final_pinned = false;
+        if (pinned.has_value()) {
+            final_pinned = pinned.value();
+        } else if (existing_pre) {
+            final_pinned = existing_pre->is_pinned();
+        } else {
+            final_pinned = (effective_options.get_option("pinned").is_boolean() && effective_options.get_option("pinned").get<bool>());
+        }
+
         prune_unavailable_servers_locked();
 
         // Check if model is already loaded. Watchdog-reset or otherwise dead
@@ -390,7 +412,8 @@ void Router::load_model(const std::string& model_name,
                 evict_server(existing);
                 // Fall through to create and load with new options
             } else {
-                LOG(INFO, "Router") << "Model already loaded, updating access time" << std::endl;
+                LOG(INFO, "Router") << "Model already loaded, updating access time and pinned status" << std::endl;
+                existing->set_pinned(final_pinned);
                 existing->update_access_time();
                 is_loading_ = false;
                 load_cv_.notify_all();
@@ -457,6 +480,10 @@ void Router::load_model(const std::string& model_name,
                           << model_type_to_string(model_type)
                           << ", evicting LRU: " << lru->get_model_name() << std::endl;
                 evict_server(lru);
+            } else {
+                is_loading_ = false;
+                load_cv_.notify_all();
+                throw SlotsPinnedException(model_type_to_string(model_type));
             }
         }
 
@@ -465,6 +492,7 @@ void Router::load_model(const std::string& model_name,
 
         // Set model metadata
         new_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
+        new_server->set_pinned(final_pinned);
         new_server->update_access_time();
 
         // CRITICAL: Release lock before slow backend startup
@@ -533,6 +561,7 @@ void Router::load_model(const std::string& model_name,
             // Create new server for retry
             std::unique_ptr<WrappedServer> retry_server = create_backend_server(model_info);
             retry_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
+            retry_server->set_pinned(final_pinned);
             retry_server->update_access_time();
 
             lock.unlock();
@@ -656,6 +685,7 @@ json Router::get_all_loaded_models() const {
         if (!watchdog_reason.empty()) {
             model_info["watchdog_reset_reason"] = watchdog_reason;
         }
+        model_info["pinned"] = server->is_pinned();
         RecipeOptions recipe_options =  server->get_recipe_options();
         model_info["recipe"] = recipe_options.get_recipe();
         model_info["recipe_options"] = recipe_options.to_json();
@@ -1402,6 +1432,40 @@ void Router::responses_stream(const std::string& request_body, httplib::DataSink
                 record_prompt_tokens_for_model(identity, input_tokens);
             });
     });
+}
+
+int Router::count_pinned_servers_by_type(ModelType type) const {
+    int count = 0;
+    for (const auto& server : loaded_servers_) {
+        if (server->get_recipe_options().get_recipe() == "cloud") {
+            continue;
+        }
+        if (server->is_backend_alive() && server->get_model_type() == type && server->is_pinned()) {
+            count++;
+        }
+    }
+    return count;
+}
+
+json Router::get_pinned_model_counts() const {
+    std::lock_guard<std::mutex> lock(load_mutex_);
+    return {
+        {"llm", count_pinned_servers_by_type(ModelType::LLM)},
+        {"embedding", count_pinned_servers_by_type(ModelType::EMBEDDING)},
+        {"reranking", count_pinned_servers_by_type(ModelType::RERANKING)},
+        {"transcription", count_pinned_servers_by_type(ModelType::TRANSCRIPTION)},
+        {"image", count_pinned_servers_by_type(ModelType::IMAGE)},
+        {"tts", count_pinned_servers_by_type(ModelType::TTS)}
+    };
+}
+
+void Router::set_model_pinned(const std::string& model_name, bool pinned) {
+    std::lock_guard<std::mutex> lock(load_mutex_);
+    WrappedServer* server = find_server_by_model_name(model_name);
+    if (!server) {
+        throw std::runtime_error("Model not loaded: " + model_name);
+    }
+    server->set_pinned(pinned);
 }
 
 } // namespace lemon

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1,4 +1,5 @@
 #include "lemon/server.h"
+#include <optional>
 #include "lemon/collection_orchestrator.h"
 #include "lemon/hf_variants.h"
 #include "lemon/config_file.h"
@@ -173,6 +174,16 @@ void set_error_response(const json& response, httplib::Response& res,
                         int default_status_code = 500) {
     res.status = get_error_status_code(response, default_status_code);
     res.set_content(response.dump(), "application/json");
+}
+
+int get_http_status_from_error(const std::string& error_code) {
+    if (error_code == "slots_pinned_error") {
+        return 409;
+    } else if (error_code == "model_load_error") {
+        return 500;
+    } else {
+        return 404;
+    }
 }
 
 bool is_quiet_polling_path(const std::string& path) {
@@ -619,6 +630,10 @@ void Server::setup_routes(httplib::Server &web_server) {
     // Internal shutdown endpoint (not part of public API)
     web_server.Post("/internal/shutdown", [this](const httplib::Request& req, httplib::Response& res) {
         handle_shutdown(req, res);
+    });
+
+    web_server.Post("/internal/pin", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_pin(req, res);
     });
 
     // Unified config endpoints (not part of public API)
@@ -1480,7 +1495,18 @@ nlohmann::json Server::create_model_error(const std::string& requested_model, co
         return error_response;
     }
 
-    // Case 3: Model exists and is available, but failed to load (engine error)
+    // Case 3: Model exists and is available, but failed to load (engine error or pinned slots constraint)
+    if (exception_msg.find("are pinned") != std::string::npos) {
+        error_response["error"] = {
+            {"message", exception_msg},
+            {"type", "slots_pinned_error"},
+            {"param", "model"},
+            {"code", "slots_pinned_error"},
+            {"requested_model", requested_model}
+        };
+        return error_response;
+    }
+
     // Return the actual exception message so the user knows what went wrong
     std::string message = "Failed to load model '" + requested_model + "': " + exception_msg;
 
@@ -1602,6 +1628,9 @@ void Server::handle_health(const httplib::Request& req, httplib::Response& res) 
 
     // Add max model limits
     response["max_models"] = router_->get_max_model_limits();
+
+    // Add pinned model counts
+    response["pinned_models"] = router_->get_pinned_model_counts();
 
     // Add WebSocket server port for realtime API and log streaming
     if (websocket_server_ && websocket_server_->is_running()) {
@@ -1750,7 +1779,7 @@ void Server::handle_collection_chat_completions(const nlohmann::json& request_js
                              << "': " << e.what() << std::endl;
         auto error_response = create_model_error(collection_info.model_name, e.what());
         std::string error_code = error_response["error"]["code"].get<std::string>();
-        res.status = (error_code == "model_load_error") ? 500 : 404;
+        res.status = get_http_status_from_error(error_code);
         res.set_content(error_response.dump(), "application/json");
         return;
     }
@@ -1842,11 +1871,7 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 auto error_response = create_model_error(requested_model, e.what());
                 // Set appropriate status code based on error type
                 std::string error_code = error_response["error"]["code"].get<std::string>();
-                if (error_code == "model_load_error") {
-                    res.status = 500;  // Internal server error - model exists but failed to load
-                } else {
-                    res.status = 404;  // Not found - model doesn't exist or is filtered out
-                }
+                res.status = get_http_status_from_error(error_code);
                 res.set_content(error_response.dump(), "application/json");
                 return;
             }
@@ -2052,11 +2077,7 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
                 auto error_response = create_model_error(requested_model, e.what());
                 // Set appropriate status code based on error type
                 std::string error_code = error_response["error"]["code"].get<std::string>();
-                if (error_code == "model_load_error") {
-                    res.status = 500;  // Internal server error - model exists but failed to load
-                } else {
-                    res.status = 404;  // Not found - model doesn't exist or is filtered out
-                }
+                res.status = get_http_status_from_error(error_code);
                 res.set_content(error_response.dump(), "application/json");
                 return;
             }
@@ -2235,7 +2256,7 @@ void Server::handle_embeddings(const httplib::Request& req, httplib::Response& r
                 LOG(ERROR, "Server") << "Failed to load model: " << e.what() << std::endl;
                 auto error_response = create_model_error(requested_model, e.what());
                 std::string error_code = error_response["error"]["code"].get<std::string>();
-                res.status = (error_code == "model_load_error") ? 500 : 404;
+                res.status = get_http_status_from_error(error_code);
                 res.set_content(error_response.dump(), "application/json");
                 return;
             }
@@ -2271,7 +2292,7 @@ void Server::handle_reranking(const httplib::Request& req, httplib::Response& re
                 LOG(ERROR, "Server") << "Failed to load model: " << e.what() << std::endl;
                 auto error_response = create_model_error(requested_model, e.what());
                 std::string error_code = error_response["error"]["code"].get<std::string>();
-                res.status = (error_code == "model_load_error") ? 500 : 404;
+                res.status = get_http_status_from_error(error_code);
                 res.set_content(error_response.dump(), "application/json");
                 return;
             }
@@ -2500,7 +2521,7 @@ void Server::handle_audio_transcriptions(const httplib::Request& req, httplib::R
                 LOG(ERROR, "Server") << "Failed to load audio model: " << e.what() << std::endl;
                 auto error_response = create_model_error(requested_model, e.what());
                 std::string error_code = error_response["error"]["code"].get<std::string>();
-                res.status = (error_code == "model_load_error") ? 500 : 404;
+                res.status = get_http_status_from_error(error_code);
                 res.set_content(error_response.dump(), "application/json");
                 return;
             }
@@ -2548,7 +2569,7 @@ void Server::handle_audio_speech(const httplib::Request& req, httplib::Response&
                 LOG(ERROR, "Server") << "Failed to load text-to-speech model: " << e.what() << std::endl;
                 auto error_response = create_model_error(requested_model, e.what());
                 std::string error_code = error_response["error"]["code"].get<std::string>();
-                res.status = (error_code == "model_load_error") ? 500 : 404;
+                res.status = get_http_status_from_error(error_code);
                 res.set_content(error_response.dump(), "application/json");
                 return;
             }
@@ -2679,7 +2700,7 @@ void Server::handle_image_generations(const httplib::Request& req, httplib::Resp
             LOG(ERROR, "Server") << "Failed to load image model: " << e.what() << std::endl;
             auto error_response = create_model_error(requested_model, e.what());
             std::string error_code = error_response["error"]["code"].get<std::string>();
-            res.status = (error_code == "model_load_error") ? 500 : 404;
+            res.status = get_http_status_from_error(error_code);
             res.set_content(error_response.dump(), "application/json");
             return;
         }
@@ -2781,7 +2802,7 @@ bool Server::load_image_model(const nlohmann::json& request_json, httplib::Respo
         LOG(ERROR, "Server") << "Failed to load image model: " << e.what() << std::endl;
         auto error_response = create_model_error(requested_model, e.what());
         std::string error_code = error_response["error"]["code"].get<std::string>();
-        res.status = (error_code == "model_load_error") ? 500 : 404;
+        res.status = get_http_status_from_error(error_code);
         res.set_content(error_response.dump(), "application/json");
         return false;
     }
@@ -3176,7 +3197,7 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
                 LOG(ERROR, "Server") << "Failed to load model: " << e.what() << std::endl;
                 auto error_response = create_model_error(requested_model, e.what());
                 std::string error_code = error_response["error"]["code"].get<std::string>();
-                res.status = (error_code == "model_load_error") ? 500 : 404;
+                res.status = get_http_status_from_error(error_code);
                 res.set_content(error_response.dump(), "application/json");
                 return;
             }
@@ -3443,6 +3464,10 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
         // Extract optional per-model settings (defaults to -1 / empty = use Router defaults)
         RecipeOptions options = RecipeOptions(info.recipe, request_json);
         bool save_options = request_json.value("save_options", false);
+        std::optional<bool> pinned_opt = std::nullopt;
+        if (request_json.contains("pinned") && request_json["pinned"].is_boolean()) {
+            pinned_opt = request_json["pinned"].get<bool>();
+        }
 
         LOG(INFO, "Server") << "Ensuring model loaded: " << model_name;
         LOG(INFO, "Server") << " " << options.to_log_string(false);
@@ -3478,7 +3503,8 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
             // if already loaded with matching options, reload only if options
             // differ)
             router_->load_model(model_name, info, options, true,
-                                /*allow_reload_on_option_change=*/true);
+                                /*allow_reload_on_option_change=*/true,
+                                pinned_opt);
 
             // Return success response
             nlohmann::json response = {
@@ -3497,7 +3523,7 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
         if (!model_name.empty()) {
             auto error_response = create_model_error(model_name, e.what());
             std::string error_code = error_response["error"]["code"].get<std::string>();
-            res.status = (error_code == "model_load_error") ? 500 : 404;
+            res.status = get_http_status_from_error(error_code);
             res.set_content(error_response.dump(), "application/json");
         } else {
             // JSON parsing failed before we got model_name - return generic error
@@ -3565,6 +3591,64 @@ void Server::handle_unload(const httplib::Request& req, httplib::Response& res) 
         }
 
         nlohmann::json error = {{"error", e.what()}};
+        res.set_content(error.dump(), "application/json");
+    }
+}
+
+void Server::handle_pin(const httplib::Request& req, httplib::Response& res) {
+    try {
+        nlohmann::json request_json;
+        try {
+            request_json = nlohmann::json::parse(req.body);
+        } catch (const std::exception& parse_err) {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", {
+                {"message", "Invalid JSON body: " + std::string(parse_err.what())},
+                {"type", "invalid_request_error"}
+            }}}.dump(), "application/json");
+            return;
+        }
+
+        if (!request_json.contains("model") && !request_json.contains("model_name")) {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", {
+                {"message", "Parameter 'model' or 'model_name' is required"},
+                {"type", "invalid_request_error"}
+            }}}.dump(), "application/json");
+            return;
+        }
+
+        if (!request_json.contains("pinned") || !request_json["pinned"].is_boolean()) {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", {
+                {"message", "Parameter 'pinned' is required and must be a boolean"},
+                {"type", "invalid_request_error"}
+            }}}.dump(), "application/json");
+            return;
+        }
+
+        std::string model_name = request_json.contains("model") ?
+            request_json["model"].get<std::string>() :
+            request_json["model_name"].get<std::string>();
+        bool pinned = request_json["pinned"].get<bool>();
+
+        std::string canonical_name = model_manager_->resolve_model_name(model_name);
+        router_->set_model_pinned(canonical_name, pinned);
+
+        nlohmann::json response = {
+            {"status", "success"},
+            {"model_name", model_name},
+            {"pinned", pinned}
+        };
+        res.status = 200;
+        res.set_content(response.dump(), "application/json");
+    } catch (const std::exception& e) {
+        LOG(ERROR, "Server") << "Pin/unpin failed: " << e.what() << std::endl;
+        res.status = 400;
+        nlohmann::json error = {{"error", {
+            {"message", e.what()},
+            {"type", "invalid_request_error"}
+        }}};
         res.set_content(error.dump(), "application/json");
     }
 }

--- a/test/server_eviction.py
+++ b/test/server_eviction.py
@@ -4,7 +4,11 @@ import unittest
 import requests
 import time
 from utils.server_base import ServerTestBase, pull_model_with_retry
-from utils.test_models import ENDPOINT_TEST_MODEL, TIMEOUT_MODEL_OPERATION, TIMEOUT_DEFAULT
+from utils.test_models import (
+    ENDPOINT_TEST_MODEL,
+    TIMEOUT_MODEL_OPERATION,
+    TIMEOUT_DEFAULT,
+)
 
 EVICTION_POLL_INTERVAL = 0.5
 EVICTION_POLL_TIMEOUT = 10
@@ -41,7 +45,9 @@ class EvictionTests(ServerTestBase):
                 return model
         return None
 
-    def _wait_for_model_status(self, model_name, target_statuses, timeout=EVICTION_POLL_TIMEOUT):
+    def _wait_for_model_status(
+        self, model_name, target_statuses, timeout=EVICTION_POLL_TIMEOUT
+    ):
         """Poll until the model reaches one of the target statuses, or timeout."""
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
@@ -59,12 +65,14 @@ class EvictionTests(ServerTestBase):
             headers["Authorization"] = f"Bearer {admin_key}"
 
         response = requests.post(
-            f"{self.base_url}/internal/simulate-vram-pressure",
+            f"{self.base_url.replace('/api/v1', '')}/internal/simulate-vram-pressure",
             json={"pct": pct},
             headers=headers,
             timeout=TIMEOUT_DEFAULT,
         )
-        self.assertEqual(response.status_code, 200, f"Simulate VRAM failed: {response.text}")
+        self.assertEqual(
+            response.status_code, 200, f"Simulate VRAM failed: {response.text}"
+        )
 
     def test_eviction_vram_pressure(self):
         """VRAM pressure evicts the least-recently-used model."""
@@ -74,7 +82,7 @@ class EvictionTests(ServerTestBase):
             headers["Authorization"] = f"Bearer {admin_key}"
 
         requests.post(
-            f"{self.base_url}/internal/set",
+            f"{self.base_url.replace('/api/v1', '')}/internal/set",
             json={"auto_evict": True, "auto_evict_threshold_pct": 0.90},
             headers=headers,
         )
@@ -146,7 +154,9 @@ class EvictionTests(ServerTestBase):
         )
 
         # Let it slip into the downsized (degraded) tier
-        info = self._wait_for_model_status(ENDPOINT_TEST_MODEL, {"downsized"}, timeout=15)
+        info = self._wait_for_model_status(
+            ENDPOINT_TEST_MODEL, {"downsized"}, timeout=15
+        )
         self.assertIsNotNone(info)
         self.assertEqual(info.get("status"), "downsized")
 
@@ -162,7 +172,9 @@ class EvictionTests(ServerTestBase):
 
         # After serving, the model should be resident again (ready/in_use), not downsized.
         info_after = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
-        self.assertIsNotNone(info_after, "Model should still be loaded after the request")
+        self.assertIsNotNone(
+            info_after, "Model should still be loaded after the request"
+        )
         self.assertIn(info_after.get("status"), ("ready", "in_use"))
 
     def test_weight_factor_protects_model(self):
@@ -174,7 +186,7 @@ class EvictionTests(ServerTestBase):
             headers["Authorization"] = f"Bearer {admin_key}"
 
         requests.post(
-            f"{self.base_url}/internal/set",
+            f"{self.base_url.replace('/api/v1', '')}/internal/set",
             json={"auto_evict": True, "auto_evict_threshold_pct": 0.90},
             headers=headers,
         )
@@ -218,7 +230,7 @@ class EvictionTests(ServerTestBase):
         # Very short downsize timeout so the engine is constantly trying to
         # downsize the model while we churn it underneath.
         requests.post(
-            f"{self.base_url}/internal/set",
+            f"{self.base_url.replace('/api/v1', '')}/internal/set",
             json={"auto_evict": True},
             headers=headers,
         )

--- a/test/server_pinning.py
+++ b/test/server_pinning.py
@@ -1,0 +1,397 @@
+import os
+import signal
+import time
+import unittest
+import requests
+from utils.capabilities import (
+    get_current_config,
+    set_current_config,
+    skip_if_unsupported,
+)
+from utils.server_base import ServerTestBase, run_server_tests, pull_model_with_retry
+from utils.test_models import (
+    ENDPOINT_TEST_MODEL,
+    TIMEOUT_MODEL_OPERATION,
+    TIMEOUT_DEFAULT,
+)
+
+EVICTION_POLL_INTERVAL = 0.5
+EVICTION_POLL_TIMEOUT = 10
+WATCHDOG_WAIT_SECONDS = 30
+POLL_SECONDS = 0.5
+
+
+def _headers():
+    admin_key = os.environ.get("LEMONADE_ADMIN_API_KEY", "")
+    headers = {}
+    if admin_key:
+        headers["Authorization"] = f"Bearer {admin_key}"
+    return headers
+
+
+class PinningTests(ServerTestBase):
+    """Integration tests for model pinning capabilities."""
+
+    _model_pulled = False
+    _model2_pulled = False
+    MODEL2 = "Qwen3-0.6B-GGUF"
+
+    @classmethod
+    def setUpClass(cls):
+        wrapped_server, backend, modality = get_current_config()
+        if wrapped_server is None:
+            set_current_config(
+                os.environ.get("LEMONADE_TEST_WRAPPED_SERVER", "llamacpp"),
+                os.environ.get("LEMONADE_TEST_BACKEND"),
+                "llm",
+            )
+        super().setUpClass()
+        if not cls._model_pulled:
+            print(f"\n[SETUP] Ensuring {ENDPOINT_TEST_MODEL} is pulled...")
+            pull_model_with_retry(ENDPOINT_TEST_MODEL)
+            cls._model_pulled = True
+
+        if not cls._model2_pulled:
+            print(f"\n[SETUP] Ensuring {cls.MODEL2} is pulled...")
+            pull_model_with_retry(cls.MODEL2)
+            cls._model2_pulled = True
+
+    def setUp(self):
+        super().setUp()
+        requests.post(f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT)
+        requests.post(
+            f"{self.base_url.replace('/api/v1', '')}/internal/set",
+            json={
+                "max_loaded_models": 2,
+                "auto_evict": False,
+                "auto_evict_threshold_pct": 0.85,
+            },
+            headers=_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+    def _get_loaded_model_info(self, model_name):
+        health = requests.get(f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT).json()
+        for model in health.get("all_models_loaded", []):
+            if model["model_name"] == model_name:
+                return model
+        return None
+
+    def _wait_for_model_status(
+        self, model_name, target_statuses, timeout=EVICTION_POLL_TIMEOUT
+    ):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            info = self._get_loaded_model_info(model_name)
+            status = info.get("status") if info else None
+            if status in target_statuses or (None in target_statuses and info is None):
+                return info
+            time.sleep(EVICTION_POLL_INTERVAL)
+        return self._get_loaded_model_info(model_name)
+
+    def _wait_for_loaded_model(self, model_name, timeout=WATCHDOG_WAIT_SECONDS):
+        deadline = time.time() + timeout
+        last_health = None
+        while time.time() < deadline:
+            last_health = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            ).json()
+            for model in last_health.get("all_models_loaded", []):
+                if model.get("model_name") == model_name and model.get("loaded", True):
+                    return model
+            time.sleep(POLL_SECONDS)
+        self.fail(
+            f"Timed out waiting for {model_name!r} to be loaded. Last health={last_health}"
+        )
+
+    def _simulate_vram_pressure(self, pct):
+        response = requests.post(
+            f"{self.base_url.replace('/api/v1', '')}/internal/simulate-vram-pressure",
+            json={"pct": pct},
+            headers=_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            response.status_code, 200, f"Simulate VRAM failed: {response.text}"
+        )
+
+    def test_pinning_lru_eviction_protection(self):
+        """Pinned models are protected from LRU eviction under capacity slot limits."""
+        # Set max loaded models to 1
+        requests.post(
+            f"{self.base_url.replace('/api/v1', '')}/internal/set",
+            json={"max_loaded_models": 1},
+            headers=_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        # 1. Load model 1 pinned
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": ENDPOINT_TEST_MODEL, "pinned": True},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # 2. Try loading model 2. Since max_loaded_models is 1 and model 1 is pinned, this must fail.
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": self.MODEL2},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "slots_pinned_error")
+
+        # 3. Unpin model 1
+        response = requests.post(
+            f"{self.internal_url}/pin",
+            json={"model_name": ENDPOINT_TEST_MODEL, "pinned": False},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json().get("pinned"))
+
+        # 4. Try loading model 2 again. Now it should succeed and evict model 1.
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": self.MODEL2},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Verify model 1 is evicted and model 2 is loaded
+        self.assertIsNone(self._get_loaded_model_info(ENDPOINT_TEST_MODEL))
+        self.assertIsNotNone(self._get_loaded_model_info(self.MODEL2))
+
+    def test_eviction_engine_skips_pinned_models(self):
+        """The EvictionEngine ignores pinned models during idle and VRAM pressure checks."""
+        requests.post(
+            f"{self.base_url.replace('/api/v1', '')}/internal/set",
+            json={"auto_evict": True, "auto_evict_threshold_pct": 0.90},
+            headers=_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        # 1. Load model 1 (pinned)
+        requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": ENDPOINT_TEST_MODEL, "pinned": True},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        # Sleep briefly so ENDPOINT_TEST_MODEL is older
+        time.sleep(2)
+
+        # 2. Load model 2 (unpinned)
+        requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": self.MODEL2, "pinned": False},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self.assertIsNotNone(self._get_loaded_model_info(ENDPOINT_TEST_MODEL))
+        self.assertIsNotNone(self._get_loaded_model_info(self.MODEL2))
+
+        # 3. Simulate VRAM pressure
+        self._simulate_vram_pressure(0.95)
+
+        # Model 2 (unpinned, newer) should be evicted because model 1 (pinned, older) is protected.
+        info2 = self._wait_for_model_status(self.MODEL2, {None, "evicting", "unloaded"})
+        evicted2 = info2 is None or info2.get("status") in ("evicting", "unloaded")
+        self.assertTrue(
+            evicted2, "Unpinned model should be evicted under VRAM pressure"
+        )
+        self.assertIsNotNone(
+            self._get_loaded_model_info(ENDPOINT_TEST_MODEL),
+            "Pinned model must remain loaded",
+        )
+
+    def test_pinned_model_bypasses_idle_timeout_downsize(self):
+        """Pinned models are not downsized by the EvictionEngine idle timer."""
+        requests.post(
+            f"{self.base_url}/load",
+            json={
+                "model_name": ENDPOINT_TEST_MODEL,
+                "pinned": True,
+                "auto_evict": True,
+                "downsize_idle_timeout": 2,
+                "evict_idle_timeout": 300,
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        info = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertIsNotNone(info)
+        self.assertEqual(info.get("status"), "ready")
+
+        # Wait to span the idle timeout check (which runs every 5s)
+        time.sleep(8)
+
+        # Pinned model should still be in 'ready' status, NOT 'downsized'
+        info_after = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertIsNotNone(info_after)
+        self.assertEqual(info_after.get("status"), "ready")
+
+    @unittest.skipIf(os.name == "nt", "POSIX signal tests skipped on Windows")
+    def test_watchdog_reload_preserves_pin_state(self):
+        """Watchdog reloads preserve the pinning status of the crashed backend."""
+        # 1. Load model pinned
+        entry = self._get_loaded_model_info(self.MODEL2)
+        if entry is None:
+            response = requests.post(
+                f"{self.base_url}/load",
+                json={"model_name": self.MODEL2, "pinned": True},
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(response.status_code, 200)
+            entry = self._wait_for_loaded_model(self.MODEL2)
+        else:
+            # Pin it dynamically
+            requests.post(
+                f"{self.internal_url}/pin",
+                json={"model_name": self.MODEL2, "pinned": True},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            entry = self._wait_for_loaded_model(self.MODEL2)
+
+        self.assertTrue(entry.get("pinned"), f"Model must be pinned initially: {entry}")
+        old_pid = int(entry["pid"])
+
+        # 2. Kill backend process
+        os.kill(old_pid, signal.SIGKILL)
+
+        # 3. Request completion to trigger watchdog reload
+        client = self.get_openai_client()
+        completion = client.chat.completions.create(
+            model=self.MODEL2,
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=8,
+        )
+        self.assertTrue(completion.choices)
+
+        # 4. Check status and ensure fresh pid and retained pin
+        entry_after = self._wait_for_loaded_model(self.MODEL2)
+        new_pid = int(entry_after["pid"])
+        self.assertNotEqual(old_pid, new_pid)
+        self.assertTrue(
+            entry_after.get("pinned"),
+            "Pinned flag must be preserved after watchdog reload",
+        )
+
+    def test_pin_api_validation(self):
+        """The /pin endpoint rejects invalid requests with HTTP 400 and structured JSON errors."""
+        # 1. Invalid JSON
+        response = requests.post(f"{self.internal_url}/pin", data="{invalid json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid JSON body", response.json()["error"]["message"])
+        self.assertEqual(response.json()["error"]["type"], "invalid_request_error")
+
+        # 2. Missing model/model_name
+        response = requests.post(f"{self.internal_url}/pin", json={"pinned": True})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Parameter 'model' or 'model_name' is required",
+            response.json()["error"]["message"],
+        )
+        self.assertEqual(response.json()["error"]["type"], "invalid_request_error")
+
+        # 3. Missing pinned
+        response = requests.post(
+            f"{self.internal_url}/pin", json={"model": ENDPOINT_TEST_MODEL}
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Parameter 'pinned' is required and must be a boolean",
+            response.json()["error"]["message"],
+        )
+        self.assertEqual(response.json()["error"]["type"], "invalid_request_error")
+
+        # 4. Non-boolean pinned
+        response = requests.post(
+            f"{self.internal_url}/pin",
+            json={"model": ENDPOINT_TEST_MODEL, "pinned": "true"},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(
+            "Parameter 'pinned' is required and must be a boolean",
+            response.json()["error"]["message"],
+        )
+        self.assertEqual(response.json()["error"]["type"], "invalid_request_error")
+
+    def test_pinning_idempotency(self):
+        """A subsequent load without explicit pin intent must preserve the pinned status of a model."""
+        # 1. Load/pin model
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": ENDPOINT_TEST_MODEL, "pinned": True},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        info = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertIsNotNone(info)
+        self.assertTrue(info.get("pinned"), "Model should be pinned initially")
+
+        # 2. Call load again without explicit pin intent (pinned omitted)
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # 3. Verify it remains pinned
+        info = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertIsNotNone(info)
+        self.assertTrue(
+            info.get("pinned"),
+            "Model should remain pinned after load without pin intent",
+        )
+
+        # 4. Explicitly unpin (either via /internal/pin or load with pinned=False)
+        # Let's test /internal/pin first
+        response = requests.post(
+            f"{self.internal_url}/pin",
+            json={"model_name": ENDPOINT_TEST_MODEL, "pinned": False},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Verify it becomes unpinned
+        info = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertIsNotNone(info)
+        self.assertFalse(info.get("pinned"), "Model should be unpinned dynamically")
+
+        # 5. Let's also test load with pinned=False explicitly unpins an already pinned model
+        # Pin it again
+        requests.post(
+            f"{self.internal_url}/pin",
+            json={"model_name": ENDPOINT_TEST_MODEL, "pinned": True},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        info = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertTrue(info.get("pinned"))
+
+        # Explicitly load with pinned=False
+        response = requests.post(
+            f"{self.base_url}/load",
+            json={"model_name": ENDPOINT_TEST_MODEL, "pinned": False},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Verify it becomes unpinned
+        info = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
+        self.assertIsNotNone(info)
+        self.assertFalse(
+            info.get("pinned"),
+            "Model should be unpinned by explicit load with pinned=False",
+        )
+
+
+if __name__ == "__main__":
+    run_server_tests(
+        PinningTests,
+        description="MODEL PINNING CAPABILITY TESTS",
+        modality="llm",
+        default_wrapped_server="llamacpp",
+    )

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -368,6 +368,7 @@ class ServerTestBase(unittest.TestCase):
         print(f"\n=== Starting test: {self._testMethodName} ===")
 
         self.base_url = f"http://localhost:{PORT}/api/v1"
+        self.internal_url = f"http://localhost:{PORT}/internal"
         self.messages = STANDARD_MESSAGES.copy()
 
     def tearDown(self):


### PR DESCRIPTION
- Exclude pinned models from the LRU auto-eviction policy.
- Fail loads with 400 Bad Request (slots_pinned_error) when all slots are pinned.
- Register /api/v1/pin endpoint to dynamically toggle pin states.
- Expose pinned status in /health response and lemonade status outputs.
- Add lemonade pin/unpin CLI subcommands and --pinned options.
- Check slots capacity pre-emptively on CLI load commands.
- Support Pin Model load checkbox and sidebar dynamic toggle buttons in the desktop app and web UI.