### PR TITLE
fix(ui): mobile/responsive layout for phones (480px breakpoint)

### DIFF
--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -756,6 +756,9 @@ input, textarea {
   border-collapse: collapse;
   margin: var(--space-3) 0;
   font-size: var(--text-sm);
+  max-width: 100%;
+  display: block;
+  overflow-x: auto;
 }
 
 .message__content th, .message__content td {
@@ -3664,6 +3667,68 @@ input, textarea {
   .matrix th, .matrix td { padding: var(--space-3); }
 }
 
+/* ---------- 480px — phone --------------------------------- */
+@media (max-width: 480px) {
+
+  /* ── Nav: allow horizontal scroll so all 7 items remain
+        reachable without overflowing the titlebar ── */
+  .titlebar__nav {
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-width: none;           /* Firefox */
+    -webkit-overflow-scrolling: touch;
+  }
+  .titlebar__nav::-webkit-scrollbar { display: none; }
+  /* Prevent buttons from shrinking — they must stay full-width */
+  .titlebar__nav button { flex-shrink: 0; }
+
+  /* ── Tighten titlebar brand area ── */
+  .titlebar { gap: var(--space-1); padding: 0 var(--space-2); }
+
+  /* ── Composer: increase send/stop to 44 px touch targets ── */
+  .composer__send,
+  .composer__stop {
+    width: 44px;
+    height: 44px;
+    flex-shrink: 0;
+  }
+
+  /* ── Composer toolbar: allow wrapping on very narrow screens ── */
+  .composer__toolbar {
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  /* ── Composer: tighten padding so the bar uses full width ── */
+  .composer { padding: var(--space-2) var(--space-3) var(--space-3); }
+
+  /* ── ModelManager: tighten head/body padding ── */
+  .manager__head { padding: var(--space-4) var(--space-3) var(--space-3); }
+  .manager__body { padding: var(--space-3) var(--space-3) var(--space-6); }
+
+  /* ── PresetManager: tighten similarly ── */
+  .recipes__head { padding: var(--space-4) var(--space-3) var(--space-3); }
+  .recipes__body { padding: var(--space-3) var(--space-3) var(--space-6); }
+
+  /* ── BackendManager: tighten ── */
+  .backends__head { padding: var(--space-4) var(--space-3) var(--space-3); }
+
+  /* ── Connect view: reduce horizontal padding on phone ── */
+  .connect { padding: 0 var(--space-4); }
+
+  /* ── Slide-over: full-width on phone ── */
+  .slideover { width: 100vw; max-width: 100vw; }
+
+  /* ── Hero greeting: tighten vertical space ── */
+  .hero { padding: var(--space-6) 0 var(--space-4); }
+
+  /* ── Filter chips: allow wrapping in ModelManager toolbar ── */
+  .manager__filters { flex-wrap: wrap; }
+
+  /* ── Chat inner: use smaller padding ── */
+  .chat__inner { padding: var(--space-4) var(--space-3); }
+}
+
 /* ─────────────────────────────────────────────────────────
    DASHBOARD v2
    ───────────────────────────────────────────────────────── */
@@ -4751,6 +4816,11 @@ input, textarea {
   .logs-line { padding: 1px var(--space-2); }
   .logs-line__time { width: 70px; font-size: 0.7rem; }
   .logs-line__tag { display: none; }
+}
+
+@media (max-width: 480px) {
+  .logs-toolbar__left, .logs-toolbar__right { gap: var(--space-2); }
+  .logs-line__time { width: 56px; }
 }
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -6143,5 +6213,22 @@ input, textarea {
 
   .composer__model-button {
     max-width: 72vw;
+  }
+}
+
+@media (max-width: 480px) {
+  /* With-logs layout: collapse rail on phone */
+  .chat--with-logs,
+  .chat--with-logs.rail-expanded {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "main"
+      "logs"
+      "composer";
+  }
+
+  /* Composer model button: tighter on phone */
+  .composer__model-button {
+    max-width: 55vw;
   }
 }

--- a/prototype/ui-redesign/src/styles/tokens.css
+++ b/prototype/ui-redesign/src/styles/tokens.css
@@ -122,6 +122,18 @@
   --composer-min:       96px;
   --max-content-width:  860px;
   --slide-over-width:   420px;
+
+  /* ---------- Responsive breakpoints ----------
+   * Note: CSS custom properties cannot be used inside @media queries.
+   * These values are documented here for reference; use the raw px
+   * values in media query expressions.
+   *   @media (max-width: 480px)  → phone
+   *   @media (max-width: 768px)  → tablet (already used throughout)
+   *   @media (max-width: 1024px) → desktop narrow
+   */
+  --breakpoint-mobile:  480px;
+  --breakpoint-tablet:  768px;
+  --breakpoint-desktop: 1024px;
 }
 
 /* ---------- Light theme overrides ---------- */


### PR DESCRIPTION
Adds responsive layout for phones. Targets the `squished` rendering Kyle saw on mobile during demo testing.

## Root cause
No phone-specific breakpoint existed. The 7-item titlebar nav (chat / models / presets / backends / dashboard / logs / connect) needs ~425px at minimum width — wider than 360–414px phones. Combined with no phone-specific layout adjustments, content overflowed and cramped.

Viewport meta tag was already correct in `index.html`.

## Changes

### `tokens.css`
Added documented breakpoint tokens:
- `--breakpoint-mobile: 480px` (phone)
- `--breakpoint-tablet: 768px` (tablet)  
- `--breakpoint-desktop: 1024px` (desktop narrow)

### `styles.css`
New `@media (max-width: 480px)` block with 10 fixes:

1. **Nav becomes horizontal-scroll** — all 7 items reachable via swipe, no overflow
2. **Send/Stop buttons → 44px** (iOS HIG touch target minimum, was 36px)
3. **Composer toolbar wraps** instead of overflowing
4. **Panel padding tightened** on ModelManager, PresetManager, BackendManager, ConnectView
5. **Slide-over goes 100vw** on phone (native-feeling drawer)
6. **Hero section compressed** vertically
7. **Chat-with-logs grid** collapses to single column
8. **Log viewer toolbar** tightened, timestamp column narrowed

Plus a global (all viewport sizes) fix:
- **Markdown tables** get `display: block; overflow-x: auto` to prevent message content from forcing the page wider.

## Verification
- `npm run build` exits 0, no new errors
- Live-tested on Kyle's phone via dev server at `192.168.3.35:8080` with HMR

## Out of scope (deferred)

- **Nav button height** still ~21px — full fix needs icon-only view or bottom tab bar pattern in `App.tsx` (React change). For now, scrollable nav makes everything reachable.
- `icon-btn` and `titlebar__theme-toggle` remain 32px (secondary controls, lower urgency)
- Bottom tab bar would be the ideal long-term phone nav pattern

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
