### PR TITLE
fix(ui): polish capability badges and reasoning timing

### DIFF
--- a/prototype/ui-redesign/src/api.ts
+++ b/prototype/ui-redesign/src/api.ts
@@ -142,12 +142,14 @@ export interface ChatCompletionStats {
   ttft: string | null;
   tokens: number;
   reasoningTokens: number;
+  reasoningElapsedMs: number | null;
 }
 
 export interface LiveStreamStats {
   tps: number;
   tokens: number;
   reasoningTokens: number;
+  reasoningElapsedMs: number | null;
   elapsed: number;
   ttft: number | null;
 }
@@ -1047,6 +1049,33 @@ class LemonadeAPI {
     let firstTokenTime: number | null = null;
     let tokenCount = 0;
     let reasoningTokenCount = 0;
+    let reasoningStartTime: number | null = null;
+    let reasoningEndTime: number | null = null;
+    let reasoningClosed = false;
+
+    const reasoningElapsedMs = (now: number): number | null => {
+      if (reasoningStartTime == null) return null;
+      return Math.max(0, (reasoningEndTime ?? now) - reasoningStartTime);
+    };
+
+    const buildDoneStats = (now: number, full: string, reasoning: string, respId: string | null): ChatCompletionStats => {
+      if (reasoningStartTime != null && !reasoningClosed) {
+        reasoningEndTime = now;
+        reasoningClosed = true;
+      }
+      const decodeTime = firstTokenTime ? (now - firstTokenTime) / 1000 : 0;
+      const totalTokens = tokenCount + reasoningTokenCount;
+      return {
+        content: full,
+        reasoning,
+        id: respId,
+        tps: totalTokens > 0 && decodeTime > 0 ? (totalTokens / decodeTime).toFixed(1) : '0',
+        ttft: firstTokenTime ? (firstTokenTime - t0).toFixed(0) : null,
+        tokens: tokenCount,
+        reasoningTokens: reasoningTokenCount,
+        reasoningElapsedMs: reasoningElapsedMs(now),
+      };
+    };
 
     const emitStats = () => {
       const now = performance.now();
@@ -1058,6 +1087,7 @@ class LemonadeAPI {
         tps: total > 0 && decodeTime > 0 ? total / decodeTime : 0,
         tokens: tokenCount,
         reasoningTokens: reasoningTokenCount,
+        reasoningElapsedMs: reasoningElapsedMs(now),
         elapsed,
         ttft: firstTokenTime ? firstTokenTime - t0 : null,
       });
@@ -1102,11 +1132,7 @@ class LemonadeAPI {
               return;
             }
             const now = performance.now();
-            const decodeTime = firstTokenTime ? (now - firstTokenTime) / 1000 : 0;
-            const totalTokens = tokenCount + reasoningTokenCount;
-            const tps = totalTokens > 0 && decodeTime > 0 ? (totalTokens / decodeTime).toFixed(1) : '0';
-            const ttft = firstTokenTime ? (firstTokenTime - t0).toFixed(0) : null;
-            onDone?.({ content: full, reasoning, id: respId, tps, ttft, tokens: tokenCount, reasoningTokens: reasoningTokenCount });
+            onDone?.(buildDoneStats(now, full, reasoning, respId));
             return;
           }
           try {
@@ -1121,13 +1147,22 @@ class LemonadeAPI {
             const delta = chunk.choices?.[0]?.delta;
             // Handle reasoning/thinking tokens (Qwen3.5, etc.)
             if (delta?.reasoning_content) {
-              if (!firstTokenTime) firstTokenTime = performance.now();
+              const now = performance.now();
+              if (!firstTokenTime) firstTokenTime = now;
+              if (reasoningStartTime == null) reasoningStartTime = now;
+              reasoningEndTime = now;
+              reasoningClosed = false;
               reasoningTokenCount++;
               reasoning += delta.reasoning_content;
               onReasoning?.(delta.reasoning_content, reasoning);
             }
             if (delta?.content) {
-              if (!firstTokenTime) firstTokenTime = performance.now();
+              const now = performance.now();
+              if (!firstTokenTime) firstTokenTime = now;
+              if (reasoningStartTime != null && !reasoningClosed) {
+                reasoningEndTime = now;
+                reasoningClosed = true;
+              }
               tokenCount++;
               full += delta.content;
               onToken?.(delta.content, full);
@@ -1158,11 +1193,7 @@ class LemonadeAPI {
         onToolCalls?.(Array.from(pendingToolCalls.values()));
       } else {
         const now = performance.now();
-        const decodeTime = firstTokenTime ? (now - firstTokenTime) / 1000 : 0;
-        const totalTokens = tokenCount + reasoningTokenCount;
-        const tps = totalTokens > 0 && decodeTime > 0 ? (totalTokens / decodeTime).toFixed(1) : '0';
-        const ttft = firstTokenTime ? (firstTokenTime - t0).toFixed(0) : null;
-        onDone?.({ content: full, reasoning, id: respId, tps, ttft, tokens: tokenCount, reasoningTokens: reasoningTokenCount });
+        onDone?.(buildDoneStats(now, full, reasoning, respId));
       }
     } catch (err) {
       clearInterval(statsInterval);

--- a/prototype/ui-redesign/src/components/ChatView.tsx
+++ b/prototype/ui-redesign/src/components/ChatView.tsx
@@ -187,6 +187,27 @@ function isPersistableAssistantMessage(m: Message): boolean {
   return !(m.isError || /^Error:/i.test(m.content));
 }
 
+
+function formatDurationMs(ms: number | null | undefined): string | null {
+  if (!Number.isFinite(Number(ms)) || Number(ms) <= 0) return null;
+  const value = Number(ms);
+  if (value < 1000) return `${Math.round(value)}ms`;
+  const seconds = value / 1000;
+  if (seconds < 10) return `${seconds.toFixed(2)}s`;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = Math.round(seconds % 60);
+  return `${minutes}m ${remainder}s`;
+}
+
+function reasoningSummary(stats: Pick<ChatCompletionStats, 'reasoningTokens' | 'reasoningElapsedMs'> | null | undefined): string {
+  const parts: string[] = [];
+  if (stats?.reasoningTokens) parts.push(`${stats.reasoningTokens} tokens`);
+  const duration = formatDurationMs(stats?.reasoningElapsedMs);
+  if (duration) parts.push(duration);
+  return parts.length ? ` · ${parts.join(' · ')}` : '';
+}
+
 function timeAgo(ts: number): string {
   const diff = Date.now() - ts;
   if (diff < 60000) return 'just now';
@@ -2270,7 +2291,7 @@ const MessageBubble: React.FC<{ message: Message; activeModel: ModelSnapshot | n
             open={thinkingOpen}
             onToggle={e => setThinkingOpen((e.target as HTMLDetailsElement).open)}
           >
-            <summary>Reasoning {message.stats?.reasoningTokens ? `· ${message.stats.reasoningTokens} tokens` : ''}</summary>
+            <summary>Reasoning{reasoningSummary(message.stats)}</summary>
             <div className="message__thinking-content">
               <MarkdownMessage content={message.thinking} />
             </div>

--- a/prototype/ui-redesign/src/components/Icon.tsx
+++ b/prototype/ui-redesign/src/components/Icon.tsx
@@ -9,7 +9,7 @@ export type IconName =
   | 'reranking' | 'model' | 'globe' | 'file' | 'code' | 'vision' | 'logs'
   | 'search' | 'edit' | 'download' | 'play' | 'plug' | 'box' | 'alert' | 'clock'
   | 'citrus' | 'scale' | 'gem' | 'gauge' | 'timer' | 'pen-line' | 'library'
-  | 'hard-drive' | 'sliders-horizontal';
+  | 'hard-drive' | 'sliders-horizontal' | 'flame' | 'wrench' | 'brain' | 'rocket';
 
 interface IconProps {
   name: IconName;
@@ -68,6 +68,10 @@ export const Icon: React.FC<IconProps> = ({ name, size = 16, className, title })
       case 'library': return <><path d="M4 19.5V5a2 2 0 012-2h12v16H6a2 2 0 00-2 2" /><path d="M8 7h6" /><path d="M8 11h6" /><path d="M8 15h4" /></>;
       case 'hard-drive': return <><path d="M4 12l2-7h12l2 7" /><rect x="4" y="12" width="16" height="8" rx="2" /><path d="M7 16h.01" /><path d="M17 16h.01" /></>;
       case 'sliders-horizontal': return <><path d="M4 6h7" /><path d="M15 6h5" /><circle cx="13" cy="6" r="2" /><path d="M4 12h3" /><path d="M11 12h9" /><circle cx="9" cy="12" r="2" /><path d="M4 18h10" /><path d="M18 18h2" /><circle cx="16" cy="18" r="2" /></>;
+      case 'flame': return <><path d="M8.5 14.5A4 4 0 0012 21a5.5 5.5 0 005.5-5.5c0-3.5-2.5-5.2-3.1-8.5-1.5 1.1-2.2 2.4-2.4 4.2C10.6 9.8 10.2 7.4 10.5 5 8.2 6.6 6.5 9.2 6.5 12.5c0 .8.3 1.5.7 2.1" /><path d="M12 21a2.7 2.7 0 002.7-2.7c0-1.4-.8-2.3-1.7-3.3-.2 1-.7 1.7-1.3 2.2-.6-.8-.8-1.7-.7-2.6-1 .8-1.7 2-1.7 3.3A2.7 2.7 0 0012 21z" /></>;
+      case 'wrench': return <><path d="M14.7 6.3a4 4 0 01-5 5L4.5 16.5a2.1 2.1 0 103 3l5.2-5.2a4 4 0 005-5l-2.5 2.5-3-3 2.5-2.5z" /></>;
+      case 'brain': return <><path d="M9 4a3 3 0 00-3 3v.4A3.5 3.5 0 003.5 11 3.5 3.5 0 006 14.4V17a3 3 0 003 3" /><path d="M15 4a3 3 0 013 3v.4a3.5 3.5 0 012.5 3.6 3.5 3.5 0 01-2.5 3.4V17a3 3 0 01-3 3" /><path d="M9 4v16M15 4v16M9 8h2M13 8h2M9 12h2M13 12h2M9 16h2M13 16h2" /></>;
+      case 'rocket': return <><path d="M5 19c1.5-.4 2.8-1.2 3.8-2.2" /><path d="M15 14l-5-5c1.8-3.2 4.8-5.3 9-6 0 4.2-2 7.2-5.2 9" /><path d="M9 15l-3 3" /><path d="M14 9h.01" /><path d="M7 11l-3 1 2-4 4-2" /><path d="M13 17l-1 3 4-2 2-4" /></>;
       default: return <><rect x="5" y="5" width="14" height="14" rx="3" /><path d="M9 9h6v6H9z" /></>;
     }
   })();
@@ -80,9 +84,15 @@ export const Icon: React.FC<IconProps> = ({ name, size = 16, className, title })
   );
 };
 
-export function capabilityIconName(capability: ModelCapability | 'all' | 'vision' | 'code' | 'transcription'): IconName {
+export type CapabilityIconTarget = ModelCapability | 'all' | 'vision' | 'code' | 'transcription' | 'popular' | 'tools' | 'reasoning' | 'mtp';
+
+export function capabilityIconName(capability: CapabilityIconTarget): IconName {
   switch (capability) {
     case 'all': return 'globe';
+    case 'popular': return 'flame';
+    case 'tools': return 'wrench';
+    case 'reasoning': return 'brain';
+    case 'mtp': return 'rocket';
     case 'chat': return 'chat';
     case 'omni': return 'omni';
     case 'image': return 'image';
@@ -97,7 +107,7 @@ export function capabilityIconName(capability: ModelCapability | 'all' | 'vision
   }
 }
 
-export const CapabilityIcon: React.FC<{ capability: ModelCapability | 'all' | 'vision' | 'code' | 'transcription'; size?: number; className?: string; title?: string }> = ({ capability, size, className, title }) => (
+export const CapabilityIcon: React.FC<{ capability: CapabilityIconTarget; size?: number; className?: string; title?: string }> = ({ capability, size, className, title }) => (
   <Icon name={capabilityIconName(capability)} size={size} className={className} title={title} />
 );
 

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -143,27 +143,121 @@ function modelType(m: ModelInfo): string {
 
 function labelDisplay(label: string): string {
   const map: Record<string, string> = {
+    'chat': 'Chat',
+    'llm': 'Chat',
     'tool-calling': 'Tools',
+    'tools': 'Tools',
     'vision': 'Vision',
+    'image-input': 'Vision',
+    'vlm': 'VLM',
     'omni': 'Omni',
     'multimodal': 'Multimodal',
+    'multi-modal': 'Multimodal',
     'vision-language': 'Vision Language',
     'reasoning': 'Reasoning',
     'coding': 'Code',
+    'code': 'Code',
     'hot': 'Popular',
+    'popular': 'Popular',
     'mtp': 'MTP',
+    'embedding': 'Embedding',
     'embeddings': 'Embeddings',
+    'reranker': 'Reranking',
     'reranking': 'Reranking',
+    'audio': 'Audio',
+    'asr': 'ASR',
+    'stt': 'STT',
+    'speech-to-text': 'Speech to Text',
     'transcription': 'Transcription',
     'realtime-transcription': 'Realtime',
     'chat-transcription': 'Chat ASR',
     'tts': 'TTS',
+    'speech': 'Speech',
+    'text-to-speech': 'Text to Speech',
     'image': 'Image',
+    'image-generation': 'Image',
+    'diffusion': 'Image',
     'edit': 'Edit',
+    'image-edit': 'Edit',
+    'image-editing': 'Edit',
     'upscaling': 'Upscale',
     'custom': 'Custom',
   };
-  return map[label] || label;
+  const key = String(label || '').toLowerCase();
+  return map[key] || label;
+}
+
+type CapabilityIconTarget = ModelCapability | 'all' | 'vision' | 'code' | 'transcription' | 'popular' | 'tools' | 'reasoning' | 'mtp';
+
+function iconForCapabilityLabel(label: string): CapabilityIconTarget {
+  const key = String(label || '').toLowerCase().trim();
+  if (['all'].includes(key)) return 'all';
+  if (['hot', 'popular'].includes(key)) return 'popular';
+  if (['tool-calling', 'tools'].includes(key)) return 'tools';
+  if (['reasoning'].includes(key)) return 'reasoning';
+  if (['mtp'].includes(key)) return 'mtp';
+  if (['chat', 'llm'].includes(key)) return 'chat';
+  if (['omni', 'multimodal', 'multi-modal'].includes(key)) return 'omni';
+  if (['vision', 'image-input', 'vlm', 'vision-language'].includes(key)) return 'vision';
+  if (['coding', 'code'].includes(key)) return 'code';
+  if (['image', 'image-generation', 'diffusion', 'edit', 'image-edit', 'image-editing', 'upscaling'].includes(key)) return 'image';
+  if (['audio', 'transcription', 'realtime-transcription', 'chat-transcription', 'asr', 'stt', 'speech-to-text'].includes(key)) return 'transcription';
+  if (['tts', 'speech', 'text-to-speech'].includes(key)) return 'tts';
+  if (['embedding', 'embeddings'].includes(key)) return 'embedding';
+  if (['reranking', 'reranker', 'rerank'].includes(key)) return 'reranking';
+  return 'unknown';
+}
+
+function labelFromCapability(capability: ModelCapability): string | null {
+  switch (capability) {
+    case 'chat': return 'chat';
+    case 'omni': return 'omni';
+    case 'image': return 'image';
+    case 'audio': return 'transcription';
+    case 'tts': return 'tts';
+    case 'embedding': return 'embedding';
+    case 'reranking': return 'reranking';
+    default: return null;
+  }
+}
+
+function findModelInfoByDisplayName(models: ModelInfo[], name: string): ModelInfo | null {
+  const needle = String(name || '').trim().toLowerCase();
+  if (!needle) return null;
+  return models.find(model => modelName(model).toLowerCase() === needle
+    || String(model.display_name || '').trim().toLowerCase() === needle
+    || String(model.id || '').trim().toLowerCase() === needle) || null;
+}
+
+function capabilityLabelsForModel(model: ModelInfo | null | undefined, allModels: ModelInfo[]): string[] {
+  const labels: string[] = [];
+  const addLabel = (raw: unknown) => {
+    const label = String(raw || '').trim().toLowerCase();
+    if (!label || ['llamacpp', 'custom'].includes(label)) return;
+    labels.push(label);
+  };
+
+  modelLabels(model).forEach(addLabel);
+
+  if (model && isCollectionModel(model)) {
+    for (const componentName of getCollectionComponents(model)) {
+      const component = findModelInfoByDisplayName(allModels, componentName);
+      if (component) {
+        modelLabels(component).forEach(addLabel);
+        addLabel(labelFromCapability(capabilityFromModelInfo(component)));
+      }
+    }
+  }
+
+  if (model) addLabel(labelFromCapability(capabilityFromModelInfo(model)));
+
+  const unique = new Map<string, string>();
+  for (const label of labels) {
+    const display = labelDisplay(label);
+    const key = display.toLowerCase();
+    if (!unique.has(key)) unique.set(key, label);
+  }
+  return [...unique.values()];
 }
 
 function hfUrl(checkpoint: string): string | null {
@@ -1299,15 +1393,19 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   /* ── Render helpers ──────────────────────────────────────── */
 
   const renderLabels = (labels: string[]) => {
-    const normalizedLabels = labels.map(label => String(label).trim()).filter(Boolean);
+    const normalizedLabels = labels.map(label => String(label).trim().toLowerCase()).filter(Boolean);
     if (normalizedLabels.length === 0) return null;
-    // Filter out the 'llamacpp' label since it's redundant with recipe
-    const displayLabels = normalizedLabels.filter(l => l !== 'llamacpp' && l !== 'custom');
+    const displayLabels = [...new Map(normalizedLabels
+      .filter(l => l !== 'llamacpp' && l !== 'custom')
+      .map(l => [labelDisplay(l).toLowerCase(), l] as const)).values()];
     if (displayLabels.length === 0) return null;
     return (
       <div className="row__labels">
         {displayLabels.map(l => (
-          <span key={l} className="row__label">{labelDisplay(l)}</span>
+          <span key={l} className="row__label row__label--with-icon">
+            <CapabilityIcon capability={iconForCapabilityLabel(l)} size={10} />
+            {labelDisplay(l)}
+          </span>
         ))}
       </div>
     );
@@ -1327,6 +1425,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     const showContext = Boolean(displayCtx);
     const compositeModels = Array.isArray((m as any).composite_models) ? (m as any).composite_models : [];
     const collectionComponents = getCollectionComponents(m);
+    const detailCapabilityLabels = capabilityLabelsForModel(m, allModels);
     const url = hfUrl(checkpoint);
     const exportData = {
       ...m,
@@ -1364,12 +1463,15 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
                 <span className="detail__value">{contextLabel(displayCtx!)} tokens</span>
               </div>
             )}
-            {modelLabels(m).length > 0 && (
+            {detailCapabilityLabels.length > 0 && (
               <div className="detail__field">
                 <span className="detail__label">Capabilities</span>
                 <div className="detail__caps">
-                  {modelLabels(m).filter(l => l !== 'llamacpp').map(l => (
-                    <span key={l} className="detail__cap">{labelDisplay(l)}</span>
+                  {detailCapabilityLabels.map(l => (
+                    <span key={l} className="detail__cap detail__cap--with-icon">
+                      <CapabilityIcon capability={iconForCapabilityLabel(l)} size={12} />
+                      {labelDisplay(l)}
+                    </span>
                   ))}
                 </div>
               </div>
@@ -1550,7 +1652,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
                 {m.size ? ` · ${formatSize(m.size)}` : ''}
                 {rowCtx ? ` · ${contextLabel(rowCtx)} ctx` : ''}
               </span>
-              {renderLabels(modelLabels(m))}
+              {renderLabels(capabilityLabelsForModel(m, allModels))}
               <span className="row__preset-pill"><PresetIcon preset={activePreset} /> {activePreset.name}</span>
             </div>
           </div>
@@ -1575,7 +1677,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
                   onClick={(e) => { e.stopPropagation(); handleLoad(m); }}
                   disabled={isLoading}
                 >
-                  {isLoading ? 'Loading…' : <> <Icon name="play" size={13} /> Load</>}
+                  {isLoading ? 'Loading…' : <><Icon name="play" size={13} /> Load</>}
                 </button>
                 <button
                   className="row__action row__action--delete"

--- a/prototype/ui-redesign/src/components/PresetManager.tsx
+++ b/prototype/ui-redesign/src/components/PresetManager.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import api, { LoadedModel, ModelInfo } from '../api';
-import { capabilityIcon } from '../modelCapabilities';
 import {
   CAPABILITY_LABELS,
   DEFAULT_PRESET,
@@ -22,7 +21,7 @@ import {
   saveApplied,
   saveUserPresets,
 } from '../presetStore';
-import { PresetIcon } from './Icon';
+import { CapabilityIcon, PresetIcon } from './Icon';
 
 const ENGINE_LABELS: Record<PresetRecipe, string> = {
   auto: 'Auto — server decides',
@@ -247,7 +246,7 @@ function hasManualArgs(preset: Pick<Preset, 'recipe_options'>): boolean {
 
 const CapabilityChip: React.FC<{ cap: Capability; small?: boolean; on?: boolean; off?: boolean }> = ({ cap, small, on, off }) => (
   <span className={`cap-chip ${capChipClass(cap)}${small ? ' cap-chip--sm' : ''}${on ? ' is-on' : ''}${off ? ' is-off' : ''}`}>
-    <span className="cap-chip__icon" aria-hidden="true">{capabilityIcon(cap)}</span>
+    <span className="cap-chip__icon" aria-hidden="true"><CapabilityIcon capability={cap} size={12} /></span>
     {CAPABILITY_LABELS[cap] || cap}
   </span>
 );

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -6231,4 +6231,30 @@ input, textarea {
   .composer__model-button {
     max-width: 55vw;
   }
+/* Fix model action icon vertical alignment and bind capability icons to labels. */
+.row__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  line-height: 1;
+}
+
+.row__action svg {
+  display: block;
+  flex: 0 0 auto;
+}
+
+.row__label--with-icon,
+.detail__cap--with-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.row__label--with-icon svg,
+.detail__cap--with-icon svg,
+.cap-chip__icon svg {
+  display: block;
+  flex: 0 0 auto;
 }

--- a/prototype/ui-redesign/src/tools/lemonadeTools.ts
+++ b/prototype/ui-redesign/src/tools/lemonadeTools.ts
@@ -3,6 +3,8 @@
  * Exposes lemonade server management as OpenAI-compatible function calling tools.
  */
 import api, { searchHuggingFace, HFModelResult, PullVariantsResult } from '../api';
+import { allStoredPresets, isCompatible, loadApplied, saveApplied, type Preset } from '../presetStore';
+import { getCollectionComponents, isCollectionModel } from '../features/collections/collectionModels';
 
 /* ── Tool schemas (OpenAI function calling format) ─────────────── */
 
@@ -51,7 +53,7 @@ export const LEMONADE_TOOLS: ToolFunction[] = [
     type: 'function',
     function: {
       name: 'load_model',
-      description: 'Load a downloaded/local model into the server for inference. Use this when the user asks to load/start/use a model. A recipe defines the inference backend: llamacpp (GPU/CPU via llama.cpp — backends: vulkan, rocm, metal, cpu), flm (NPU via FastFlowLM), ryzenai-llm (hybrid NPU). Combined forms like "llamacpp-vulkan" or "llamacpp-cpu" select a backend. If the user asks for CPU, pass backend/device=cpu. If multiple recipes are available and the user did not choose, call get_model_info and ask_question first.',
+      description: 'Load a downloaded/local model into the server for inference. Use this when the user asks to load/start/use a model. It can also assign a preset before loading via preset, preset_id, or preset_name. A recipe defines the inference backend: llamacpp (GPU/CPU via llama.cpp — backends: vulkan, rocm, metal, cpu), flm (NPU via FastFlowLM), ryzenai-llm (hybrid NPU). Combined forms like "llamacpp-vulkan" or "llamacpp-cpu" select a backend. If the user asks for CPU, pass backend/device=cpu. If multiple recipes are available and the user did not choose, call get_model_info and ask_question first.',
       parameters: {
         type: 'object',
         properties: {
@@ -61,6 +63,9 @@ export const LEMONADE_TOOLS: ToolFunction[] = [
           device: { type: 'string', description: 'Alias for backend. Examples: "cpu", "gpu", "npu".' },
           n_ctx: { type: 'number', description: 'Context window size (e.g. 4096, 8192, 32768). Higher uses more memory.' },
           n_gpu_layers: { type: 'number', description: 'Number of layers to offload to GPU. Higher = faster but uses more VRAM.' },
+          preset: { type: 'string', description: 'Optional preset id or preset name to assign to this model before loading. Examples: Default, Balanced, Quality, Fast, Creative, Long Context, Code, Sharp, Quick.' },
+          preset_id: { type: 'string', description: 'Optional exact preset id to assign before loading.' },
+          preset_name: { type: 'string', description: 'Optional exact preset name to assign before loading.' },
         },
         required: ['model_name'],
       },
@@ -212,6 +217,25 @@ function asString(value: unknown): string {
 function asNumber(value: unknown): number | undefined {
   const number = Number(value);
   return Number.isFinite(number) ? number : undefined;
+}
+
+function presetSpecifier(args: Record<string, unknown>): string {
+  return asString(args.preset_id) || asString(args.preset_name) || asString(args.preset);
+}
+
+function resolvePreset(specifier: string): Preset | null {
+  const needle = specifier.trim().toLowerCase();
+  if (!needle) return null;
+  const presets = allStoredPresets();
+  return presets.find(preset => preset.id.toLowerCase() === needle)
+    || presets.find(preset => preset.name.toLowerCase() === needle)
+    || presets.find(preset => preset.name.toLowerCase().includes(needle))
+    || null;
+}
+
+function applyPresetBinding(model: string, preset: Preset): void {
+  const current = loadApplied();
+  saveApplied({ ...current, [model]: preset.id });
 }
 
 function modelName(model: AnyModel | null | undefined): string {
@@ -615,6 +639,23 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
         const detail = await api.modelDetail(modelName(resolved)).catch(() => resolved);
         const loadedItem = loadedFor(resolved, loaded);
         const summary = modelSummary(detail as AnyModel, loadedItem);
+        const detailComponentNames = getCollectionComponents(detail as any);
+        const componentNames = detailComponentNames.length > 0 ? detailComponentNames : getCollectionComponents(resolved as any);
+        const componentSummaries: Array<Record<string, unknown>> = await Promise.all(componentNames.map(async componentName => {
+          const component = resolveModel(data.data as AnyModel[], loaded, componentName);
+          const componentLoaded = component
+            ? loadedFor(component, loaded)
+            : loaded.find(item => asString(item.model_name).toLowerCase() === componentName.toLowerCase()) || null;
+          const componentDetail = component ? await api.modelDetail(modelName(component)).catch(() => component) : { id: componentName, name: componentName };
+          return {
+            ...modelSummary(componentDetail as AnyModel, componentLoaded),
+            raw_name: modelName(componentDetail as AnyModel) || componentName,
+            downloaded: isDownloaded(componentDetail as AnyModel),
+            loaded: Boolean(componentLoaded),
+            checkpoint: (componentDetail as AnyModel).checkpoint,
+          };
+        }));
+        const componentCapabilities = Array.from(new Set(componentSummaries.map(component => String(component.capability || '')).filter(Boolean)));
         const result = {
           ...summary,
           raw_name: modelName(detail as AnyModel),
@@ -623,7 +664,12 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
           checkpoint: (detail as AnyModel).checkpoint,
           context_window: (detail as AnyModel).max_context_window || (detail as AnyModel).context_length || (detail as AnyModel).n_ctx,
           recipe_options: extractRecipeBackendOptions(detail as AnyModel),
-          answer_instruction: 'Answer the user with the model status, capability, size/context, checkpoint, and recipe/backend options. If they asked to load it, call load_model next.',
+          is_collection: isCollectionModel(detail as any) || componentSummaries.length > 0,
+          collection_components: componentSummaries.length > 0 ? componentSummaries : undefined,
+          collection_capabilities: componentCapabilities.length > 0 ? componentCapabilities : undefined,
+          answer_instruction: componentSummaries.length > 0
+            ? 'Answer the user with the collection status and list every involved component model with each component capability/status. If they asked to load it, call load_model next.'
+            : 'Answer the user with the model status, capability, size/context, checkpoint, and recipe/backend options. If they asked to load it, call load_model next.',
         };
         const display = [
           `${summary.name || summary.id} — ${summary.status}, ${summary.capability}`,
@@ -631,6 +677,7 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
           result.context_window ? `Context: ${result.context_window}` : '',
           result.checkpoint ? `Checkpoint: ${result.checkpoint}` : '',
           Array.isArray(summary.recipes) && summary.recipes.length ? `Recipes: ${summary.recipes.join(', ')}` : '',
+          componentSummaries.length ? `Components:\n${componentSummaries.map(component => `- ${component.name || component.id} — ${component.status}, ${component.capability}`).join('\n')}` : '',
         ].filter(Boolean).join('\n');
         return toolPayload(call, result, display || 'Model info retrieved');
       }
@@ -643,6 +690,28 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
         const targetModelName = resolved ? modelName(resolved) : asString(args.model_name);
         if (!targetModelName) {
           return toolPayload(call, { error: 'Missing model_name. Use list_models with a query to resolve a downloaded model first.' }, 'Error: missing model name', true);
+        }
+        const requestedPreset = presetSpecifier(args);
+        let appliedPreset: Preset | null = null;
+        if (requestedPreset) {
+          appliedPreset = resolvePreset(requestedPreset);
+          if (!appliedPreset) {
+            const choices = allStoredPresets().map(preset => `${preset.name} (${preset.id})`).slice(0, 12);
+            return toolPayload(call, {
+              error: `Preset not found: ${requestedPreset}`,
+              available_presets: choices,
+              answer_instruction: 'Tell the user the requested preset was not found and ask them to choose one of the available presets.',
+            }, `Preset not found: ${requestedPreset}`, true);
+          }
+          if (resolved && !isCompatible(appliedPreset, resolved as any)) {
+            return toolPayload(call, {
+              error: `Preset ${appliedPreset.name} is not compatible with ${targetModelName}`,
+              preset: { id: appliedPreset.id, name: appliedPreset.name, applies_to: appliedPreset.applies_to },
+              model: modelSummary(resolved, loadedFor(resolved, loaded)),
+              answer_instruction: 'Tell the user the preset is incompatible with the selected model and ask for a compatible preset.',
+            }, `Preset ${appliedPreset.name} is not compatible with ${targetModelName}`, true);
+          }
+          applyPresetBinding(targetModelName, appliedPreset);
         }
         const opts: Record<string, unknown> = {};
         const recipeArg = typeof args.recipe === 'string' ? args.recipe.trim().toLowerCase() : '';
@@ -679,11 +748,15 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
         const result = {
           status: 'loaded',
           model: targetModelName,
+          preset: appliedPreset ? { id: appliedPreset.id, name: appliedPreset.name, applies_to: appliedPreset.applies_to } : undefined,
           options: opts,
           response,
-          answer_instruction: 'Tell the user the model was loaded, including the model name and selected recipe/backend if any.',
+          answer_instruction: appliedPreset
+            ? 'Tell the user the preset was assigned and the model was loaded, including the model name and selected recipe/backend if any.'
+            : 'Tell the user the model was loaded, including the model name and selected recipe/backend if any.',
         };
-        return toolPayload(call, result, `Loaded ${targetModelName}${Object.keys(opts).length ? ` with ${shortJson(opts, 120)}` : ''}`);
+        const presetText = appliedPreset ? ` using preset ${appliedPreset.name}` : '';
+        return toolPayload(call, result, `Loaded ${targetModelName}${presetText}${Object.keys(opts).length ? ` with ${shortJson(opts, 120)}` : ''}`);
       }
 
       case 'unload_model': {


### PR DESCRIPTION
Visual fixes, reasoning time displayed and tool capabilities improved

- map capability badges to requested icons: Popular = flame, Tools = wrench, Reasoning = brain, MTP = rocket
- show thinking duration next to reasoning token count once reasoning is complete
- keep prior model-row, preset-capability, omni-collection, and Lemonade tool fixes included
- fixed all/chat/iamge icons in presets
- centered position for some icons
- load_model allows also presets, get_model_info can get collection components

Validation:

npm test
16 passes 7 skipped

Checked the changes manual with firefox