### PR TITLE
fix: re-download missing checkpoint files automatically (no restart needed)

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2889,6 +2889,12 @@ bool ModelManager::is_model_downloaded(const std::string& model_name) {
         : model_name;
     auto it = models_cache_.find(canonical_name);
     if (it != models_cache_.end()) {
+        if (it->second.downloaded) {
+            bool still_complete = are_required_checkpoints_complete(it->second);
+            if (!still_complete) {
+                it->second.downloaded = false;
+            }
+        }
         return it->second.downloaded;
     }
     return false;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3451,10 +3451,10 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
             model_manager_->save_model_options(info);
         }
 
-        // Download model if needed (first-time use). Collections have no
+        // Download model if needed (first-time use or missing files). Collections have no
         // checkpoint of their own, so skip the generic HF download path here
         // and let the per-component branch below cascade any missing pieces.
-        if (!info.downloaded && !is_collection_recipe(info.recipe)) {
+        if (!model_manager_->is_model_downloaded(model_name) && !is_collection_recipe(info.recipe)) {
             LOG(INFO, "Server") << "Model not downloaded, downloading..." << std::endl;
             model_manager_->download_registered_model(info);
             info = model_manager_->get_model_info(model_name);


### PR DESCRIPTION
If a model checkpoint file (e.g. `mmproj-F16.gguf` for vision models) is deleted from the HuggingFace cache while `lemond` is running, the server fails with a 500 error and requires a full restart to recover. The `.downloaded` flag was computed once in `build_cache()` at startup and never re-verified.

**Root cause:**

- `is_model_downloaded()` returned the cached boolean without checking actual file existence
- The `/load` endpoint handler read `info.downloaded` directly from cache, bypassing even the cached `is_model_downloaded()` check

**Changes:**

1. `model_manager.cpp` - `is_model_downloaded()` now re-verifies file existence on disk when the cached flag is `true`. Only the requested model's checkpoints are checked (1-2 `stat()` calls), not the entire registry. If files are missing, the cache is updated accordingly.

2. `server.cpp` - The `/load` endpoint now uses `model_manager_->is_model_downloaded()` instead of the stale `info.downloaded` field, matching the behavior of the inference auto-load path.

Both auto-load (chat/completions) and explicit `/load` now correctly detect missing files, trigger re-download for only the missing checkpoints (existing ones are skipped), and retry loading - without dropping other loaded models or active connections.

Fixes #2234