### PR TITLE
Generate an artifact for Debian 13

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -105,6 +105,7 @@ runs:
           echo "|------------------|-----------|"
           echo "| **Windows** | [lemonade.msi](https://github.com/$REPO/releases/download/$TAG_NAME/lemonade.msi) |"
           echo "| **Ubuntu 24.04+** | [Launchpad PPA](https://launchpad.net/~lemonade-team/+archive/ubuntu/stable) |"
+          echo "| **Debian 13** | [lemonade-server_${VERSION}-debian13_amd64.deb](https://github.com/$REPO/releases/download/$TAG_NAME/lemonade-server_${VERSION}-debian13_amd64.deb) |"
           echo "| **Fedora 43** | [lemonade-server-${VERSION}-fc43.x86_64.rpm](https://github.com/$REPO/releases/download/$TAG_NAME/lemonade-server-${VERSION}-fc43.x86_64.rpm) |"
           echo "| **Fedora 44** | [lemonade-server-${VERSION}-fc44.x86_64.rpm](https://github.com/$REPO/releases/download/$TAG_NAME/lemonade-server-${VERSION}-fc44.x86_64.rpm) |"
           echo "| **macOS** | [Lemonade-${VERSION}-Darwin.pkg](https://github.com/$REPO/releases/download/$TAG_NAME/Lemonade-${VERSION}-Darwin.pkg) |"

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -277,6 +277,74 @@ jobs:
           path: ${{ steps.build_deb.outputs.output-dir }}/*.deb
           retention-days: 7
 
+  build-lemonade-debian13:
+    name: Build Lemonade .deb Package (Debian 13)
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+    container:
+      image: debian:stable
+    steps:
+      - name: Enable Trixie backports
+        run: |
+          echo "deb http://deb.debian.org/debian trixie-backports main" > /etc/apt/sources.list.d/trixie-backports.list
+      - name: Install git
+        run: |
+          set -e
+          apt-get update
+          apt-get install -y git
+      - name: Install from backports
+        run: |
+          set -e
+          apt-get install -y -t trixie-backports libcpp-httplib-dev node-markdown-it-texmath
+
+      - uses: actions/checkout@v5
+        with:
+          clean: true
+          fetch-depth: 0
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory $(pwd)
+
+      - name: Prepare Debian build
+        id: get_version
+        uses: ./.github/actions/prepare-debian-build
+        with:
+          release: '13'
+          codename: 'trixie'
+
+      - name: Build Debian package
+        id: build_deb
+        uses: ./.github/actions/build-debian-package
+        with:
+          package-type: binary
+          deb-version: ${{ steps.get_version.outputs.version }}
+
+      - name: Rename server .deb for release
+        id: rename
+        shell: bash
+        run: |
+          set -e
+          VERSION="${{ steps.get_version.outputs.version }}"
+          OUTPUT_DIR="${{ steps.build_deb.outputs.output-dir }}"
+          SRC=$(ls "$OUTPUT_DIR"/lemonade-server_*_amd64.deb | head -n1)
+          if [ -z "$SRC" ]; then
+            echo "ERROR: server .deb not found in $OUTPUT_DIR"
+            ls -la "$OUTPUT_DIR"
+            exit 1
+          fi
+          DEST="$OUTPUT_DIR/lemonade-server_${VERSION}-debian13_amd64.deb"
+          mv "$SRC" "$DEST"
+          echo "Renamed $SRC -> $DEST"
+          echo "deb-path=$DEST" >> $GITHUB_OUTPUT
+
+      - name: Upload .deb package
+        uses: actions/upload-artifact@v7
+        with:
+          name: lemonade-debian13
+          path: ${{ steps.rename.outputs.deb-path }}
+          retention-days: 7
+
   build-lemonade-rpm:
     name: Build Lemonade .rpm - Fedora ${{ matrix.fedora-version }}
     runs-on: ubuntu-latest
@@ -2040,6 +2108,7 @@ jobs:
     needs:
       - sign-msi-installers
       - build-lemonade-rpm
+      - build-lemonade-debian13
       - build-lemonade-macos-dmg
       - build-lemonade-embeddable-linux
       - build-lemonade-embeddable-windows
@@ -2069,6 +2138,12 @@ jobs:
           pattern: lemonade-rpm-fedora-*
           path: .
           merge-multiple: true
+
+      - name: Download Lemonade .deb (Debian 13)
+        uses: actions/download-artifact@v7
+        with:
+          name: lemonade-debian13
+          path: .
 
       - name: Download Lemonade macOS .pkg Package
         uses: actions/download-artifact@v7
@@ -2100,6 +2175,7 @@ jobs:
           ls -lh lemonade-server-minimal.msi
           ls -lh lemonade.msi
           ls -lh lemonade-server-*.x86_64.rpm
+          ls -lh lemonade-server_${LEMONADE_VERSION}-debian13_amd64.deb
           ls -lh *.pkg
           ls -lh lemonade-embeddable-${LEMONADE_VERSION}-ubuntu-x64.tar.gz
           ls -lh lemonade-embeddable-${LEMONADE_VERSION}-windows-x64.zip
@@ -2122,6 +2198,7 @@ jobs:
             lemonade-server-minimal.msi
             lemonade.msi
             lemonade-server-*.x86_64.rpm
+            lemonade-server_${{ env.LEMONADE_VERSION }}-debian13_amd64.deb
             *.pkg
             lemonade-embeddable-${{ env.LEMONADE_VERSION }}-ubuntu-x64.tar.gz
             lemonade-embeddable-${{ env.LEMONADE_VERSION }}-windows-x64.zip

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -345,6 +345,66 @@ jobs:
           path: ${{ steps.rename.outputs.deb-path }}
           retention-days: 7
 
+  test-lemonade-debian13-smoke:
+    name: Smoke test .deb (Debian 13)
+    runs-on: ubuntu-latest
+    needs: build-lemonade-debian13
+    container:
+      image: debian:trixie
+    env:
+      LEMONADE_VERSION: ${{ needs.build-lemonade-debian13.outputs.version }}
+    steps:
+      - name: Download Lemonade .deb Package
+        uses: actions/download-artifact@v7
+        with:
+          name: lemonade-debian13
+          path: .
+
+      - name: Install and smoke test
+        shell: bash
+        run: |
+          set -e
+          DEB_FILE=$(ls lemonade-server_*-debian13_amd64.deb 2>/dev/null | head -n1)
+          if [ -z "$DEB_FILE" ]; then
+            echo "ERROR: .deb file not found"
+            ls -la *.deb 2>/dev/null || echo "No .deb files found in current directory"
+            exit 1
+          fi
+          echo "Debian 13 version: $(cat /etc/os-release | grep PRETTY_NAME)"
+          echo "Testing artifact: $DEB_FILE"
+
+          echo "deb http://deb.debian.org/debian trixie-backports main" > /etc/apt/sources.list.d/trixie-backports.list
+          apt-get update
+          apt-get install -y curl
+          apt-get install -y -t trixie-backports ./"$DEB_FILE"
+
+          /usr/bin/lemond --version
+          /usr/bin/lemonade --version
+          echo "Package installed successfully"
+
+          mkdir -p "$RUNNER_TEMP/xdg-runtime"
+          chmod 700 "$RUNNER_TEMP/xdg-runtime"
+          export XDG_RUNTIME_DIR="$RUNNER_TEMP/xdg-runtime"
+          /usr/bin/lemond "$(pwd)" > "$RUNNER_TEMP/lemonade-server.log" 2>&1 &
+          SERVER_PID=$!
+          echo "Server started (PID $SERVER_PID)"
+
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:13305/live > /dev/null 2>&1; then
+              echo "Server is running and healthy on port 13305"
+              break
+            fi
+            if ! kill -0 $SERVER_PID 2>/dev/null; then
+              echo "ERROR: Server process exited prematurely"
+              echo "=== Server log ==="
+              cat "$RUNNER_TEMP/lemonade-server.log" 2>/dev/null || echo "(no log)"
+              exit 1
+            fi
+            echo "Waiting for server... ($i/30)"
+            sleep 2
+          done
+          kill $SERVER_PID 2>/dev/null || true
+
   build-lemonade-rpm:
     name: Build Lemonade .rpm - Fedora ${{ matrix.fedora-version }}
     runs-on: ubuntu-latest
@@ -2109,6 +2169,7 @@ jobs:
       - sign-msi-installers
       - build-lemonade-rpm
       - build-lemonade-debian13
+      - test-lemonade-debian13-smoke
       - build-lemonade-macos-dmg
       - build-lemonade-embeddable-linux
       - build-lemonade-embeddable-windows

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -283,7 +283,7 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     container:
-      image: debian:stable
+      image: debian:trixie
     steps:
       - name: Enable Trixie backports
         run: |

--- a/.github/workflows/linux_distro_builds.yml
+++ b/.github/workflows/linux_distro_builds.yml
@@ -43,9 +43,6 @@ jobs:
           - distro: Arch
             image: archlinux:latest
             python: python
-          - distro: Debian
-            image: debian:trixie
-            python: python3
           - distro: openSUSE
             image: opensuse/tumbleweed:latest
             python: python3

--- a/docs/guide/install/README.md
+++ b/docs/guide/install/README.md
@@ -14,7 +14,7 @@ Lemonade is available on a broad range of platforms.
 
     [Fedora instructions](./fedora.md).
 
-    Debian Trixie+: [build from source](../../dev/getting-started.md).
+    [Debian instructions](./debian.md).
 
 === "Docker"
 

--- a/docs/guide/install/debian.md
+++ b/docs/guide/install/debian.md
@@ -1,0 +1,24 @@
+## Debian Installation
+
+Lemonade is built for Debian 13 (Trixie).
+
+Get the `.deb` from the [latest release](https://github.com/lemonade-sdk/lemonade/releases):
+`lemonade-server_<version>-debian13_amd64.deb`
+
+```bash
+sudo apt install ./lemonade-server_*-debian13_amd64.deb
+```
+
+Enable and start the service:
+
+```bash
+sudo systemctl enable --now lemond
+```
+
+Check that it's running:
+
+```bash
+sudo systemctl --no-pager status lemond
+```
+
+Once the service is running, open [http://localhost:13305](http://localhost:13305) in your browser.

--- a/docs/index.html
+++ b/docs/index.html
@@ -440,8 +440,22 @@
             }
             break;
           case 'debian':
-            html = '<a class="gs-download-link" href="https://github.com/lemonade-sdk/lemonade/blob/main/docs/dev/getting-started.md#building-from-source" target="_blank" rel="noopener">' +
-              '<span class="material-symbols-outlined">open_in_new</span> Build from source</a>';
+            if (v) {
+              var deb = 'lemonade-server_' + v + '-debian13_amd64.deb';
+              html = gsConsoleHtml([
+                'wget https://github.com/lemonade-sdk/lemonade/releases/latest/download/' + deb,
+                'sudo apt install ./' + deb
+              ]) +
+              '<div style="margin-top:16px;">' +
+                gsConsoleHtml([
+                  'sudo systemctl enable --now lemond',
+                  'sudo systemctl --no-pager status lemond'
+                ]) +
+              '</div>';
+            } else {
+              html = '<a class="gs-download-link" href="https://github.com/lemonade-sdk/lemonade/releases/latest">' +
+                '<span class="material-symbols-outlined">open_in_new</span> View latest release</a>';
+            }
             break;
         }
         el.innerHTML = html;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - Ubuntu: guide/install/ubuntu.md
       - Arch: guide/install/arch.md
       - Fedora: guide/install/fedora.md
+      - Debian: guide/install/debian.md
       - Docker: guide/install/docker.md
     - Local Server Concepts: guide/concepts.md
     - CLI: guide/cli.md


### PR DESCRIPTION
We don't have PPAs in Debian (although there is debusine - so that might be worth looking at later).

Currently the artifact gets made on Github and added to the release.
As we already have this build happening on Debian 13 remove the other build doing a similar role.
