### PR TITLE
Add a `--add-system-info` flag to `lemonade bench`

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -656,6 +656,7 @@ lemonade bench [options] MODEL_NAME [MODEL_NAME ...]
 | `--output FILE` | Write results to file (in addition to stdout) | — |
 | `--compare FILE` | Compare results against a previously saved JSON file | — |
 | `--auto-pull` | Automatically pull the model if not downloaded | False |
+| `--add-system-info` | Include output from the system-info endpoint in the JSON file, for CPU/GPU type, and backend version. | False |
 | `--no-memory` | Disable VRAM/RAM tracking | Tracking enabled |
 | `--no-reload` | Skip model reload between scenarios (faster, but prompt cache may skew results) | Model reloaded |
 | `--llamacpp-args ARGS` | Custom args for llama-server (e.g. `"-b 2048 -ub 1024"`). Repeat for multiple arg sets. | — |
@@ -732,6 +733,9 @@ code-short          46.1    44.3    47.8    168.9   162.3   175.4   1.2
 With `--json`, results are emitted as structured JSON. Use `--output FILE` to save them for later comparison with `--compare`.
 The top-level JSON always includes a `models` array, even for single-model runs, so downstream tooling can handle a single schema for all benchmark results.
 Each scenario includes `duration_ms` stats (`mean`, `min`, `max`, `p50`, `p95`) representing end-to-end request time per run.
+
+If `--add-system-info` is given, the output from `/v1/system-info` will be included at the top level of the JSON file. This
+information includes, among other things, CPU and GPU types, and backend versions.
 
 ### Comparison Mode
 

--- a/src/cpp/cli/bench.cpp
+++ b/src/cpp/cli/bench.cpp
@@ -1124,6 +1124,18 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
 
     const std::string command_timestamp = get_timestamp_iso();
 
+    json system_info = json::object();
+    if (config.add_system_info) {
+        try {
+            std::string response = client.make_request("/v1/system-info", "GET", "", "", 10000, 10000);
+            system_info = json::parse(response);
+        } catch (const std::exception& e) {
+            std::cerr << "Error: Failed to fetch /v1/system-info for benchmark output: "
+                      << e.what() << std::endl;
+            return 1;
+        }
+    }
+
     // Preflight: ensure all requested models are available before any benchmark starts.
     // If --auto-pull is enabled, pull missing/not-downloaded models during this phase.
     std::map<std::string, json> model_info_by_name;
@@ -1312,6 +1324,9 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         if (config.json_output) {
             json output;
             output["timestamp"] = command_timestamp;
+            if (config.add_system_info) {
+                output["system-info"] = system_info;
+            }
             output["models"] = json::array();
             for (const auto& model_result : by_model) {
                 output["models"].push_back(
@@ -1334,6 +1349,9 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             if (!config.output_file.empty()) {
                 json output;
                 output["timestamp"] = command_timestamp;
+                if (config.add_system_info) {
+                    output["system-info"] = system_info;
+                }
                 output["models"] = json::array();
                 for (const auto& model_result : by_model) {
                     output["models"].push_back(
@@ -1416,6 +1434,9 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             json output;
 
             output["timestamp"] = command_timestamp;
+            if (config.add_system_info) {
+                output["system-info"] = system_info;
+            }
             output["compare_file"] = config.compare_file;
             if (!previous_timestamp.empty()) {
                 output["previous_timestamp"] = previous_timestamp;
@@ -1496,6 +1517,8 @@ CLI::App* register_bench_command(CLI::App& parent,
     cmd->add_option("--output", output_file, "Write results to file (in addition to stdout)")->type_name("FILE");
     cmd->add_option("--compare", opts.compare_file, "Compare results against a previously saved JSON file")->type_name("FILE");
     cmd->add_flag("--auto-pull", opts.auto_pull, "Automatically pull the model if not downloaded");
+    cmd->add_flag("--add-system-info", opts.add_system_info,
+        "Include system information to benchmark JSON");
     cmd->add_flag("--no-memory", opts.no_memory, "Disable VRAM/RAM tracking");
     cmd->add_flag("--no-reload", opts.no_reload, "Skip model reload between scenarios (faster but prompt cache may skew results)");
     cmd->add_option("--llamacpp-args", opts.llamacpp_args, "Custom args for llama-server (e.g. \"-b 2048 -ub 1024\"). Repeat for multiple.")
@@ -1529,6 +1552,7 @@ BenchConfig build_bench_config(const std::string& output_file,
     config.scenario_file = cli.scenario_file;
     config.scenario_dir = cli.scenario_dir;
     config.auto_pull = cli.auto_pull;
+    config.add_system_info = cli.add_system_info;
     config.memory_tracking = !cli.no_memory;
     config.reload = !cli.no_reload;
     config.compare_file = cli.compare_file;

--- a/src/cpp/include/lemon_cli/bench.h
+++ b/src/cpp/include/lemon_cli/bench.h
@@ -163,6 +163,7 @@ struct BenchCliOptions {
     std::string scenario_dir;
     bool json_output = false;
     bool auto_pull = false;
+    bool add_system_info = false;
     bool no_memory = false;
     bool no_reload = false;  // disable reload between runs
     std::string compare_file;
@@ -190,6 +191,7 @@ struct BenchConfig {
     std::string scenario_file;
     std::string scenario_dir;
     bool auto_pull = false;
+    bool add_system_info = false;
     bool memory_tracking = true;
     bool reload = true;  // unload+reload model between runs to clear prompt cache
     std::string compare_file;


### PR DESCRIPTION
Presence or absence of system info doesn't break comparison mode. No one would have expected that running on batteries can make a laptop slower. Not enabled by default for privacy reasons, but the system information section is correctly populated or remains absent depending on the state of the flag

```
$ ./lemonade bench --add-system-info --output quick-bench.json Bonsai-1.7B-gguf
...

<unplugged laptop from AC power>
$ ./lemonade bench  --output quick-bench2.json --compare quick-bench.json Bonsai-1.7B-gguf
...

Model set comparison
====================================================================================================
Current models (1):  Bonsai-1.7B-gguf
Previous models (1): Bonsai-1.7B-gguf
Matched: Bonsai-1.7B-gguf
New:     -
Removed: -

Benchmark: Bonsai-1.7B-gguf
====================================================================================================

Backend: llamacpp/rocm (ctx=4096)
----------------------------------------------------------------------------------------------------
Scenario            TTFT    min     max     TPS     min     max     VRAM (GB)
----------------------------------------------------------------------------------------------------
chat-short          146.0   143.9   149.1   84.8    80.6    87.5    2.0
chat-long-output    168.2   161.4   172.8   83.4    82.9    83.9    2.0
code-short          148.2   143.7   151.3   85.1    84.5    85.4    2.0
code-explain        295.6   292.8   300.5   83.2    82.4    83.9    1.9
code-debug          551.8   547.9   555.8   80.3    79.5    81.0    1.9

Backend: llamacpp/vulkan (ctx=4096)
----------------------------------------------------------------------------------------------------
Scenario            TTFT    min     max     TPS     min     max     VRAM (GB)
----------------------------------------------------------------------------------------------------
chat-short          143.8   138.8   147.1   95.3    94.1    97.1    1.8
chat-long-output    182.5   179.5   184.3   89.5    88.7    90.0    1.8
code-short          149.5   145.8   151.7   92.3    92.0    92.8    1.8
code-explain        421.0   418.4   422.9   89.0    88.2    89.5    1.8
code-debug          700.1   694.3   706.8   86.6    86.2    87.0    1.8

(*Nf = N failed runs excluded from stats)

Comparison: Bonsai-1.7B-gguf
Previous: quick-bench.json (2026-06-14T12:02:35Z)
Current:  2026-06-14T12:09:16Z
====================================================================================================

Backend: llamacpp/rocm (ctx=4096)
--------------------------------------------------------------------------------
Scenario              TTFT change   TPS change    VRAM change     Status
--------------------------------------------------------------------------------
chat-short            +69.5%        -19.9%        +0.0 GB         (matched)
chat-long-output      +65.2%        -17.5%        +0.0 GB         (matched)
code-short            +71.8%        -17.8%        +0.0 GB         (matched)
code-explain          +39.4%        -17.1%        -0.0 GB         (matched)
code-debug            +31.1%        -17.1%        -0.0 GB         (matched)

Backend: llamacpp/vulkan (ctx=4096)
--------------------------------------------------------------------------------
Scenario              TTFT change   TPS change    VRAM change     Status
--------------------------------------------------------------------------------
chat-short            +72.9%        -24.7%        -0.0 GB         (matched)
chat-long-output      +64.3%        -23.5%        -0.0 GB         (matched)
code-short            +73.5%        -23.8%        -0.0 GB         (matched)
code-explain          +38.4%        -23.2%        -0.0 GB         (matched)
code-debug            +32.1%        -23.0%        -0.1 GB         (matched)

Legend: TTFT change > 0 means slower (worse). TPS change > 0 means faster (better).
Status: matched = compared against previous, new = no previous data, removed = not in current run, failed = all runs errored, prev_failed = previous run errored
```

Co-authored-by: copilot, GPT-5.3-Codex