### PR TITLE
fix(windows): set safe cwd for backend child processes

### DIFF
--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -560,7 +560,7 @@ void LlamaCppServer::load(const std::string& model_name,
     // Keep llama-server output visible at info log level.
     // Use a dedicated temp working directory so backend/Vulkan relative writes do
     // not inherit a protected launcher directory on Windows.
-    fs::path working_dir = fs::path(utils::get_runtime_dir()) / "lemonade" / "llamacpp" / llamacpp_backend;
+    fs::path working_dir = fs::temp_directory_path() / "lemonade" / "llamacpp" / llamacpp_backend;
     std::error_code working_dir_ec;
     fs::create_directories(working_dir, working_dir_ec);
     if (working_dir_ec) {

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -299,6 +299,16 @@ void LlamaCppServer::load(const std::string& model_name,
     // Get mmproj path for vision models
     std::string mmproj_path = model_info.resolved_path("mmproj");
 
+#ifdef _WIN32
+    // Child CWD changes on Windows require absolute file paths.
+    if (!gguf_path.empty()) {
+        gguf_path = path_to_utf8(fs::absolute(fs::path(gguf_path)));
+    }
+    if (!mmproj_path.empty()) {
+        mmproj_path = path_to_utf8(fs::absolute(fs::path(mmproj_path)));
+    }
+#endif
+
     // Choose port
     port_ = choose_port();
 
@@ -560,7 +570,6 @@ void LlamaCppServer::load(const std::string& model_name,
     std::string process_executable = executable;
     std::string working_dir;
 #ifdef _WIN32
-    // Avoid inheriting a protected launcher cwd while preserving backend-relative files.
     fs::path executable_path = fs::absolute(fs::path(executable));
     process_executable = path_to_utf8(executable_path);
     working_dir = path_to_utf8(executable_path.parent_path());

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <system_error>
 #include <iostream>
 #include <lemon/utils/aixlog.hpp>
 #include <set>
@@ -557,8 +558,20 @@ void LlamaCppServer::load(const std::string& model_name,
 
     // Start process (inherit output if debug logging enabled, filter health check spam)
     // Keep llama-server output visible at info log level.
+    // Use a dedicated temp working directory so backend/Vulkan relative writes do
+    // not inherit a protected launcher directory on Windows.
+    fs::path working_dir = fs::path(utils::get_runtime_dir()) / "lemonade" / "llamacpp" / llamacpp_backend;
+    std::error_code working_dir_ec;
+    fs::create_directories(working_dir, working_dir_ec);
+    if (working_dir_ec) {
+        throw std::runtime_error("Failed to create llama-server working directory '" +
+                                 utils::path_to_utf8(working_dir) + "': " +
+                                 working_dir_ec.message());
+    }
+
     bool inherit_llama_output = (log_level_ == "info") || is_debug();
-    set_process_handle(ProcessManager::start_process(executable, args, "", inherit_llama_output, true, env_vars));
+    set_process_handle(ProcessManager::start_process(
+        executable, args, utils::path_to_utf8(working_dir), inherit_llama_output, true, env_vars));
 
     // Wait for server to be ready
     if (!wait_for_ready("/health")) {

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -12,7 +12,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
-#include <system_error>
 #include <iostream>
 #include <lemon/utils/aixlog.hpp>
 #include <set>
@@ -558,20 +557,18 @@ void LlamaCppServer::load(const std::string& model_name,
 
     // Start process (inherit output if debug logging enabled, filter health check spam)
     // Keep llama-server output visible at info log level.
-    // Use a dedicated temp working directory so backend/Vulkan relative writes do
-    // not inherit a protected launcher directory on Windows.
-    fs::path working_dir = fs::temp_directory_path() / "lemonade" / "llamacpp" / llamacpp_backend;
-    std::error_code working_dir_ec;
-    fs::create_directories(working_dir, working_dir_ec);
-    if (working_dir_ec) {
-        throw std::runtime_error("Failed to create llama-server working directory '" +
-                                 utils::path_to_utf8(working_dir) + "': " +
-                                 working_dir_ec.message());
-    }
+    std::string process_executable = executable;
+    std::string working_dir;
+#ifdef _WIN32
+    // Avoid inheriting a protected launcher cwd while preserving backend-relative files.
+    fs::path executable_path = fs::absolute(fs::path(executable));
+    process_executable = path_to_utf8(executable_path);
+    working_dir = path_to_utf8(executable_path.parent_path());
+#endif
 
     bool inherit_llama_output = (log_level_ == "info") || is_debug();
     set_process_handle(ProcessManager::start_process(
-        executable, args, utils::path_to_utf8(working_dir), inherit_llama_output, true, env_vars));
+        process_executable, args, working_dir, inherit_llama_output, true, env_vars));
 
     // Wait for server to be ready
     if (!wait_for_ready("/health")) {

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -299,16 +299,6 @@ void LlamaCppServer::load(const std::string& model_name,
     // Get mmproj path for vision models
     std::string mmproj_path = model_info.resolved_path("mmproj");
 
-#ifdef _WIN32
-    // Child CWD changes on Windows require absolute file paths.
-    if (!gguf_path.empty()) {
-        gguf_path = path_to_utf8(fs::absolute(fs::path(gguf_path)));
-    }
-    if (!mmproj_path.empty()) {
-        mmproj_path = path_to_utf8(fs::absolute(fs::path(mmproj_path)));
-    }
-#endif
-
     // Choose port
     port_ = choose_port();
 
@@ -480,7 +470,7 @@ void LlamaCppServer::load(const std::string& model_name,
             if (!rocm_arch.empty()) {
                 std::string therock_bin = BackendUtils::get_therock_lib_path(rocm_arch);
                 if (!therock_bin.empty()) {
-                    new_path = therock_bin;
+                    new_path = path_to_utf8(fs::absolute(path_from_utf8(therock_bin)));
                 }
             }
         }
@@ -502,15 +492,15 @@ void LlamaCppServer::load(const std::string& model_name,
         // CUDA Windows builds bundle cudart64_*.dll, cublas64_*.dll, etc. next to
         // llama-server.exe. Prepend the executable directory to PATH so the loader
         // resolves them before any system-wide CUDA install.
-        fs::path exe_dir = fs::path(executable).parent_path();
-        std::string new_path = exe_dir.string();
+        fs::path exe_dir = fs::absolute(fs::path(executable)).parent_path();
+        std::string new_path = path_to_utf8(exe_dir);
 
         const char* existing_path = std::getenv("PATH");
         if (existing_path && strlen(existing_path) > 0) {
             new_path += ";" + std::string(existing_path);
         }
         env_vars.push_back({"PATH", new_path});
-        LOG(DEBUG, "LlamaCpp") << "Prepending CUDA exe dir to PATH: " << exe_dir.string() << std::endl;
+        LOG(DEBUG, "LlamaCpp") << "Prepending CUDA exe dir to PATH: " << path_to_utf8(exe_dir) << std::endl;
     }
 #endif
 
@@ -570,6 +560,7 @@ void LlamaCppServer::load(const std::string& model_name,
     std::string process_executable = executable;
     std::string working_dir;
 #ifdef _WIN32
+    // Avoid inheriting a protected launcher cwd while keeping Linux/macOS behavior unchanged.
     fs::path executable_path = fs::absolute(fs::path(executable));
     process_executable = path_to_utf8(executable_path);
     working_dir = path_to_utf8(executable_path.parent_path());

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -12,6 +12,7 @@
 #include <httplib.h>
 #include <iostream>
 #include <filesystem>
+#include <system_error>
 #include <fstream>
 #include <chrono>
 #include <random>
@@ -362,11 +363,22 @@ void SDServer::load(const std::string& model_name,
         BackendUtils::apply_cuda_env_vars(env_vars, "SDServer");
     }
 
-    // Launch the server process
+    // Launch the server process from a dedicated temp working directory so
+    // backend/Vulkan relative writes do not inherit a protected launcher
+    // directory on Windows.
+    fs::path working_dir = fs::path(utils::get_runtime_dir()) / "lemonade" / "sd-cpp" / resolved_backend;
+    std::error_code working_dir_ec;
+    fs::create_directories(working_dir, working_dir_ec);
+    if (working_dir_ec) {
+        throw std::runtime_error("Failed to create sd-server working directory '" +
+                                 utils::path_to_utf8(working_dir) + "': " +
+                                 working_dir_ec.message());
+    }
+
     ProcessHandle started_handle = utils::ProcessManager::start_process(
         exe_path,
         args,
-        "",     // working_dir (empty = current)
+        utils::path_to_utf8(working_dir),
         is_debug(),  // inherit_output
         false,  // filter_health_logs
         env_vars

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -229,6 +229,17 @@ void SDServer::load(const std::string& model_name,
         throw std::runtime_error("Model file does not exist: " + model_path);
     }
 
+#ifdef _WIN32
+    // Child CWD changes on Windows require absolute file paths.
+    model_path = path_to_utf8(fs::absolute(fs::path(model_path)));
+    if (!llm_path.empty()) {
+        llm_path = path_to_utf8(fs::absolute(fs::path(llm_path)));
+    }
+    if (!vae_path.empty()) {
+        vae_path = path_to_utf8(fs::absolute(fs::path(vae_path)));
+    }
+#endif
+
     LOG(DEBUG, "SDServer") << "Using model: " << model_path << std::endl;
 
     // Get sd-server executable path
@@ -366,7 +377,6 @@ void SDServer::load(const std::string& model_name,
     std::string process_exe_path = exe_path;
     std::string working_dir;
 #ifdef _WIN32
-    // Avoid inheriting a protected launcher cwd while preserving backend-relative files.
     fs::path executable_path = fs::absolute(fs::path(exe_path));
     process_exe_path = path_to_utf8(executable_path);
     working_dir = path_to_utf8(executable_path.parent_path());

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -229,17 +229,6 @@ void SDServer::load(const std::string& model_name,
         throw std::runtime_error("Model file does not exist: " + model_path);
     }
 
-#ifdef _WIN32
-    // Child CWD changes on Windows require absolute file paths.
-    model_path = path_to_utf8(fs::absolute(fs::path(model_path)));
-    if (!llm_path.empty()) {
-        llm_path = path_to_utf8(fs::absolute(fs::path(llm_path)));
-    }
-    if (!vae_path.empty()) {
-        vae_path = path_to_utf8(fs::absolute(fs::path(vae_path)));
-    }
-#endif
-
     LOG(DEBUG, "SDServer") << "Using model: " << model_path << std::endl;
 
     // Get sd-server executable path
@@ -307,6 +296,10 @@ void SDServer::load(const std::string& model_name,
     // Set up environment variables
     std::vector<std::pair<std::string, std::string>> env_vars;
     fs::path exe_dir = fs::path(exe_path).parent_path();
+#ifdef _WIN32
+    fs::path executable_path = fs::absolute(fs::path(exe_path));
+    exe_dir = executable_path.parent_path();
+#endif
 
 #ifndef _WIN32
     // For Linux, always set LD_LIBRARY_PATH to include executable directory
@@ -335,14 +328,14 @@ void SDServer::load(const std::string& model_name,
     if (is_rocm_backend(resolved_backend)) {
         // Add executable directory to PATH for ROCm runtime DLLs
         // This allows the sd-server.exe to find required HIP/ROCm libraries at runtime
-        std::string new_path = exe_dir.string();
+        std::string new_path = path_to_utf8(exe_dir);
 
         if (resolved_backend == "rocm-stable") {
             std::string rocm_arch = SystemInfo::get_rocm_arch();
             if (!rocm_arch.empty()) {
                 std::string therock_bin = BackendUtils::get_therock_lib_path(rocm_arch);
                 if (!therock_bin.empty()) {
-                    new_path = therock_bin + ";" + new_path;
+                    new_path = path_to_utf8(fs::absolute(path_from_utf8(therock_bin))) + ";" + new_path;
                 }
             }
         }
@@ -353,19 +346,19 @@ void SDServer::load(const std::string& model_name,
         }
         env_vars.push_back({"PATH", new_path});
 
-        LOG(INFO, "SDServer") << "ROCm backend: added " << exe_dir.string() << " to PATH" << std::endl;
+        LOG(INFO, "SDServer") << "ROCm backend: added " << path_to_utf8(exe_dir) << " to PATH" << std::endl;
     } else if (is_cuda_backend(resolved_backend)) {
         // CUDA Windows builds bundle cudart64_*.dll, cublas64_*.dll, etc. next to
         // sd-server.exe. Prepend the executable directory to PATH so the loader
         // resolves them before any system-wide CUDA install.
-        std::string new_path = exe_dir.string();
+        std::string new_path = path_to_utf8(exe_dir);
 
         const char* existing_path = std::getenv("PATH");
         if (existing_path && strlen(existing_path) > 0) {
             new_path += ";" + std::string(existing_path);
         }
         env_vars.push_back({"PATH", new_path});
-        LOG(DEBUG, "SDServer") << "Prepending CUDA exe dir to PATH: " << exe_dir.string() << std::endl;
+        LOG(DEBUG, "SDServer") << "Prepending CUDA exe dir to PATH: " << path_to_utf8(exe_dir) << std::endl;
     }
 #endif
 
@@ -377,7 +370,6 @@ void SDServer::load(const std::string& model_name,
     std::string process_exe_path = exe_path;
     std::string working_dir;
 #ifdef _WIN32
-    fs::path executable_path = fs::absolute(fs::path(exe_path));
     process_exe_path = path_to_utf8(executable_path);
     working_dir = path_to_utf8(executable_path.parent_path());
 #endif

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -12,7 +12,6 @@
 #include <httplib.h>
 #include <iostream>
 #include <filesystem>
-#include <system_error>
 #include <fstream>
 #include <chrono>
 #include <random>
@@ -363,22 +362,20 @@ void SDServer::load(const std::string& model_name,
         BackendUtils::apply_cuda_env_vars(env_vars, "SDServer");
     }
 
-    // Launch the server process from a dedicated temp working directory so
-    // backend/Vulkan relative writes do not inherit a protected launcher
-    // directory on Windows.
-    fs::path working_dir = fs::temp_directory_path() / "lemonade" / "sd-cpp" / resolved_backend;
-    std::error_code working_dir_ec;
-    fs::create_directories(working_dir, working_dir_ec);
-    if (working_dir_ec) {
-        throw std::runtime_error("Failed to create sd-server working directory '" +
-                                 utils::path_to_utf8(working_dir) + "': " +
-                                 working_dir_ec.message());
-    }
+    // Launch the server process
+    std::string process_exe_path = exe_path;
+    std::string working_dir;
+#ifdef _WIN32
+    // Avoid inheriting a protected launcher cwd while preserving backend-relative files.
+    fs::path executable_path = fs::absolute(fs::path(exe_path));
+    process_exe_path = path_to_utf8(executable_path);
+    working_dir = path_to_utf8(executable_path.parent_path());
+#endif
 
     ProcessHandle started_handle = utils::ProcessManager::start_process(
-        exe_path,
+        process_exe_path,
         args,
-        utils::path_to_utf8(working_dir),
+        working_dir,
         is_debug(),  // inherit_output
         false,  // filter_health_logs
         env_vars

--- a/src/cpp/server/backends/sd_server.cpp
+++ b/src/cpp/server/backends/sd_server.cpp
@@ -366,7 +366,7 @@ void SDServer::load(const std::string& model_name,
     // Launch the server process from a dedicated temp working directory so
     // backend/Vulkan relative writes do not inherit a protected launcher
     // directory on Windows.
-    fs::path working_dir = fs::path(utils::get_runtime_dir()) / "lemonade" / "sd-cpp" / resolved_backend;
+    fs::path working_dir = fs::temp_directory_path() / "lemonade" / "sd-cpp" / resolved_backend;
     std::error_code working_dir_ec;
     fs::create_directories(working_dir, working_dir_ec);
     if (working_dir_ec) {


### PR DESCRIPTION
## Summary

This is a small follow-up to #2184 for a separate Windows filesystem issue.
Fixes #2218.

#2184 addressed the HuggingFace cache symlink / create_directories path. This PR addresses the child-process side: llama-server and sd-server were started with an empty working directory, so on Windows they inherited Lemonade's current working directory.

For Vulkan backends, that can trigger Windows Controlled Folder Access / protected-folder blocks if the backend, Vulkan runtime, driver, or shader/pipeline cache performs relative writes.

## Changes

* Set an explicit Windows-only backend working directory before starting llama-server
* Set an explicit Windows-only backend working directory before starting sd-server
* Use absolute Windows backend runtime paths so relative cache/runtime paths keep working after the cwd change
* Keep the change intentionally small and local to backend process launch

