### PR TITLE
fix(ui): visual reload of cloud provider text

### DIFF
--- a/src/app/src/renderer/CloudProvidersSection.tsx
+++ b/src/app/src/renderer/CloudProvidersSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { serverConfig } from './utils/serverConfig';
 import { useModels } from './hooks/useModels';
@@ -403,6 +403,12 @@ const CloudProvidersSection: React.FC<CloudProvidersSectionProps> = ({ searchQue
     { mode: 'install' } | { mode: 'edit'; row: CloudProviderRow } | null
   >(null);
 
+  // To avoid frequent, visually visiable reloads
+  const showErrorRef = useRef(showError);
+  useEffect(() => {
+    showErrorRef.current = showError;
+  }, [showError]);
+
   // Install / uninstall / edit on a cloud provider can change the set of
   // models visible in /v1/models (discovery adds the provider's chat-capable
   // ids, eviction removes them). The Backends tab doesn't re-fetch the
@@ -416,11 +422,11 @@ const CloudProvidersSection: React.FC<CloudProvidersSectionProps> = ({ searchQue
       const rows = await fetchCloudProviders();
       setProviders(rows);
     } catch (err) {
-      showError(`Failed to load cloud providers: ${err instanceof Error ? err.message : String(err)}`);
+      showErrorRef.current(`Failed to load cloud providers: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setIsLoading(false);
     }
-  }, [showError]);
+  }, []);
 
   const reloadAll = useCallback(async () => {
     await reload();


### PR DESCRIPTION
Issue:

<img width="335" height="72" alt="image" src="https://github.com/user-attachments/assets/2fe65c38-f7d6-4a76-9b58-5b8f8f35274f" />

In this newly added section (under backends), the text blinks noticeable every 5s (roughly).

This small fix solves this.