### PR TITLE
port(ui-redesign): add model pinning UI and tests to next-gen redesign prototype

### DIFF
--- a/prototype/ui-redesign/src/api.ts
+++ b/prototype/ui-redesign/src/api.ts
@@ -57,6 +57,7 @@ function normalizeLoadedModel(model: unknown): LoadedModel | null {
     type: String(model.type || 'unknown').toLowerCase(),
     last_use: Number(model.last_use || Date.now()),
     recipe_options: isObject(model.recipe_options) ? model.recipe_options : undefined,
+    pinned: Boolean(model.pinned),
   };
 }
 
@@ -118,6 +119,7 @@ export interface LoadedModel {
   type: string;
   last_use: number;
   recipe_options?: Record<string, unknown>;
+  pinned?: boolean;
 }
 
 export interface ModelInfo {
@@ -675,6 +677,15 @@ class LemonadeAPI {
   async unloadModel(modelName?: string): Promise<unknown> {
     const body = modelName ? { model_name: modelName } : {};
     const result = await this._json('/api/v1/unload', { method: 'POST', body });
+    this._notifyModelsChanged();
+    return result;
+  }
+
+  async pinModel(modelName: string, pinned: boolean): Promise<unknown> {
+    const result = await this._json('/internal/pin', {
+      method: 'POST',
+      body: { model_name: modelName, pinned },
+    });
     this._notifyModelsChanged();
     return result;
   }

--- a/prototype/ui-redesign/src/components/Icon.tsx
+++ b/prototype/ui-redesign/src/components/Icon.tsx
@@ -9,7 +9,7 @@ export type IconName =
   | 'reranking' | 'model' | 'globe' | 'file' | 'code' | 'vision' | 'logs'
   | 'search' | 'edit' | 'download' | 'play' | 'plug' | 'box' | 'alert' | 'clock'
   | 'citrus' | 'scale' | 'gem' | 'gauge' | 'timer' | 'pen-line' | 'library'
-  | 'hard-drive' | 'sliders-horizontal';
+  | 'hard-drive' | 'sliders-horizontal' | 'pin';
 
 interface IconProps {
   name: IconName;
@@ -67,7 +67,8 @@ export const Icon: React.FC<IconProps> = ({ name, size = 16, className, title })
       case 'pen-line': return <><path d="M4 20h4l11-11a2.1 2.1 0 00-3-3L5 17v3z" /><path d="M14 7l3 3" /><path d="M3 22h18" /></>;
       case 'library': return <><path d="M4 19.5V5a2 2 0 012-2h12v16H6a2 2 0 00-2 2" /><path d="M8 7h6" /><path d="M8 11h6" /><path d="M8 15h4" /></>;
       case 'hard-drive': return <><path d="M4 12l2-7h12l2 7" /><rect x="4" y="12" width="16" height="8" rx="2" /><path d="M7 16h.01" /><path d="M17 16h.01" /></>;
-      case 'sliders-horizontal': return <><path d="M4 6h7" /><path d="M15 6h5" /><circle cx="13" cy="6" r="2" /><path d="M4 12h3" /><path d="M11 12h9" /><circle cx="9" cy="12" r="2" /><path d="M4 18h10" /><path d="M18 18h2" /><circle cx="16" cy="18" r="2" /></>;
+       case 'sliders-horizontal': return <><path d="M4 6h7" /><path d="M15 6h5" /><circle cx="13" cy="6" r="2" /><path d="M4 12h3" /><path d="M11 12h9" /><circle cx="9" cy="12" r="2" /><path d="M4 18h10" /><path d="M18 18h2" /><circle cx="16" cy="18" r="2" /></>;
+      case 'pin': return <><line x1="12" y1="17" x2="12" y2="22" /><path d="M5 17h14v-1.76a2 2 0 0 0-.44-1.24l-2.78-3.48A2 2 0 0 1 15 9.28V5a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v4.28a2 2 0 0 1-.78 1.24l-2.78 3.48a2 2 0 0 0-.44 1.24Z" /></>;
       default: return <><rect x="5" y="5" width="14" height="14" rx="3" /><path d="M9 9h6v6H9z" /></>;
     }
   })();

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -1475,6 +1475,22 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
               </button>
             )}
             <button
+              className={`row__action row__action--pin${m.pinned ? ' row__action--pinned' : ''}`}
+              onClick={async (e) => {
+                e.stopPropagation();
+                try {
+                  await api.pinModel(m.model_name, !m.pinned);
+                  await refresh();
+                } catch (err) {
+                  console.error('Failed to pin/unpin model:', err);
+                }
+              }}
+              disabled={loadingModel === m.model_name}
+              title={m.pinned ? 'Unpin model' : 'Pin model to prevent eviction'}
+            >
+              <Icon name="pin" size={13} /> {m.pinned ? 'Pinned' : 'Pin'}
+            </button>
+            <button
               className="row__action row__action--unload"
               onClick={(e) => { e.stopPropagation(); handleUnload(m); }}
               disabled={loadingModel === m.model_name}

--- a/prototype/ui-redesign/src/components/PresetManager.tsx
+++ b/prototype/ui-redesign/src/components/PresetManager.tsx
@@ -699,6 +699,7 @@ const SlideoverContent: React.FC<{
   const [topP, setTopP] = useState(sp.top_p ?? 0.9);
   const [topK, setTopK] = useState(sp.top_k ?? 40);
   const [repeatPenalty, setRepeatPenalty] = useState(sp.repeat_penalty ?? 1.05);
+  const [pinned, setPinned] = useState(ro.pinned ?? false);
   const [saved, setSaved] = useState(false);
 
   useEffect(() => {
@@ -722,6 +723,7 @@ const SlideoverContent: React.FC<{
     setTopP(nextSp.top_p ?? 0.9);
     setTopK(nextSp.top_k ?? 40);
     setRepeatPenalty(nextSp.repeat_penalty ?? 1.05);
+    setPinned(nextRo.pinned ?? false);
     setSaved(false);
   }, [preset, autoRuns]);
 
@@ -745,13 +747,13 @@ const SlideoverContent: React.FC<{
       description,
       applies_to: normalizePresetCapabilities(preset.id, appliesTo),
       engine_hint: engineHint,
-      recipe_options: buildRecipeOptions(appliesTo, ctxSize, steps, cfgScale, imgWidth, imgHeight, llamacppBackend, llamacppDevice, llamacppArgs, sdcppArgs),
+      recipe_options: buildRecipeOptions(appliesTo, ctxSize, steps, cfgScale, imgWidth, imgHeight, llamacppBackend, llamacppDevice, llamacppArgs, sdcppArgs, pinned),
       sampling: buildSampling(appliesTo, temperature, topP, topK, repeatPenalty),
       starter: false,
       auto_opt_enabled: !manualArgsActive,
       auto_opt_run_id: manualArgsActive ? null : (autoOptRunId || autoRuns[0]?.id || null),
     };
-  }, [isReadOnly, preset, name, description, appliesTo, engineHint, ctxSize, steps, cfgScale, imgWidth, imgHeight, llamacppBackend, llamacppDevice, llamacppArgs, sdcppArgs, temperature, topP, topK, repeatPenalty, manualArgsActive, autoOptRunId, autoRuns]);
+  }, [isReadOnly, preset, name, description, appliesTo, engineHint, ctxSize, steps, cfgScale, imgWidth, imgHeight, llamacppBackend, llamacppDevice, llamacppArgs, sdcppArgs, temperature, topP, topK, repeatPenalty, pinned, manualArgsActive, autoOptRunId, autoRuns]);
 
   const selectedModel = models.find(m => modelName(m) === applyTarget);
   const selectedModelContextLimit = contextLimitForModel(selectedModel);
@@ -820,6 +822,19 @@ const SlideoverContent: React.FC<{
               <strong>No preset overrides</strong>
               <span>Lemonade uses the selected model's current defaults for sampling, context and image generation.</span>
               <span className="preset-param-lines">{presetParamPreviewLines(preset).map(line => <span key={line}>{line}</span>)}</span>
+            </div>
+          )}
+          {!isDefaultEmptyPreset && (
+            <div className="field">
+              <label className="backends__toggle">
+                <input
+                  type="checkbox"
+                  checked={pinned}
+                  disabled={isReadOnly}
+                  onChange={e => setPinned(e.target.checked)}
+                />
+                <span>Pin model (prevent eviction)</span>
+              </label>
             </div>
           )}
           {!isDefaultEmptyPreset && hasChat && (
@@ -927,6 +942,7 @@ function buildRecipeOptions(
   llamacppDevice: string,
   llamacppArgs: string,
   sdcppArgs: string,
+  pinned: boolean,
 ): RecipeOptions {
   const opts: RecipeOptions = {};
   const hasAll = appliesTo.includes('all');
@@ -944,6 +960,9 @@ function buildRecipeOptions(
     opts.width = imgWidth;
     opts.height = imgHeight;
     if (sdcppArgs) opts.sdcpp_args = sdcppArgs;
+  }
+  if (pinned) {
+    opts.pinned = true;
   }
   return opts;
 }

--- a/prototype/ui-redesign/src/presetStore.ts
+++ b/prototype/ui-redesign/src/presetStore.ts
@@ -26,6 +26,7 @@ export interface RecipeOptions {
   vllm_args?: string;
   flm_args?: string;
   merge_args?: boolean;
+  pinned?: boolean;
 }
 
 export interface SamplingParams {
@@ -439,25 +440,34 @@ function pickRecipeOptions(options: RecipeOptions, keys: Array<keyof RecipeOptio
 export function recipeOptionsForCapability(options: RecipeOptions, capability: ModelCapability | 'all' | 'vision' | 'code' | 'transcription'): RecipeOptions {
   if (!options || Object.keys(options).length === 0) return {};
 
+  const baseOpts = pickRecipeOptions(options, ['pinned']);
+  let capOpts: RecipeOptions = {};
+
   switch (capability) {
     case 'image':
-      return pickRecipeOptions(options, ['steps', 'cfg_scale', 'width', 'height', 'sampling_method', 'flow_shift', 'sdcpp_args', 'merge_args']);
+      capOpts = pickRecipeOptions(options, ['steps', 'cfg_scale', 'width', 'height', 'sampling_method', 'flow_shift', 'sdcpp_args', 'merge_args']);
+      break;
     case 'audio':
     case 'transcription':
-      return pickRecipeOptions(options, ['whispercpp_backend', 'whispercpp_args', 'moonshine_backend', 'moonshine_args', 'merge_args']);
+      capOpts = pickRecipeOptions(options, ['whispercpp_backend', 'whispercpp_args', 'moonshine_backend', 'moonshine_args', 'merge_args']);
+      break;
     case 'tts':
-      return pickRecipeOptions(options, ['merge_args']);
+      capOpts = pickRecipeOptions(options, ['merge_args']);
+      break;
     case 'embedding':
     case 'reranking':
     case 'chat':
     case 'omni':
     case 'vision':
     case 'code':
-      return pickRecipeOptions(options, ['ctx_size', 'llamacpp_backend', 'llamacpp_device', 'llamacpp_args', 'flm_args', 'vllm_backend', 'vllm_args', 'merge_args']);
+      capOpts = pickRecipeOptions(options, ['ctx_size', 'llamacpp_backend', 'llamacpp_device', 'llamacpp_args', 'flm_args', 'vllm_backend', 'vllm_args', 'merge_args']);
+      break;
     case 'all':
     default:
       return { ...options };
   }
+
+  return { ...baseOpts, ...capOpts };
 }
 
 export function recipeOptionsForModel(modelName: string, model?: ModelInfo | null): RecipeOptions | undefined {

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -1901,6 +1901,31 @@ input, textarea {
   border-color: var(--border-strong);
 }
 
+.row__action--pin {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-subtle);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.row__action--pin:hover {
+  background: var(--surface-3);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+
+.row__action--pinned {
+  background: var(--info-soft) !important;
+  color: var(--info) !important;
+  border-color: color-mix(in srgb, var(--info) 45%, transparent) !important;
+}
+
+.row__action--pinned svg {
+  fill: currentColor;
+}
+
 .row__action--delete {
   background: transparent;
   color: var(--text-tertiary);

--- a/prototype/ui-redesign/tests/features.spec.ts
+++ b/prototype/ui-redesign/tests/features.spec.ts
@@ -918,4 +918,137 @@ test.describe('Lemonade UI — Feature Parity', () => {
 
     await page.screenshot({ path: 'screenshots/22-backends-update.png', fullPage: true });
   });
+
+  test('23 — Model Pinning UI interaction', async ({ page }) => {
+    let pinnedState = false;
+    let pinCallBody: any = null;
+
+    // Mock models endpoint
+    await page.route('**/api/v1/models**', async route => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        data: [
+          { id: 'llama-chat', name: 'llama-chat', labels: ['llm'], recipe: 'llamacpp' },
+        ],
+      }),
+    }));
+
+    // Mock health endpoint to dynamically return the pinned state
+    await page.route('**/api/v1/health', async route => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'ok',
+          version: '1.0.0',
+          model_loaded: 'llama-chat',
+          websocket_port: 9000,
+          all_models_loaded: [
+            {
+              model_name: 'llama-chat',
+              checkpoint: 'llama-chat',
+              recipe: 'llamacpp-llm',
+              device: 'gpu',
+              backend_url: 'http://127.0.0.1:1234',
+              pid: 12345,
+              type: 'llm',
+              last_use: 1718462400000,
+              pinned: pinnedState
+            }
+          ],
+          max_models: {}
+        }),
+      });
+    });
+
+    // Mock pin endpoint
+    await page.route('**/internal/pin', async route => {
+      const request = route.request();
+      if (request.method() === 'POST') {
+        pinCallBody = request.postDataJSON();
+        pinnedState = pinCallBody.pinned;
+      }
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok' }),
+      });
+    });
+
+    // Clear preset storage
+    await page.addInitScript(() => {
+      localStorage.removeItem('lemonade_user_presets');
+      localStorage.removeItem('lemonade_applied_presets');
+    });
+
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+
+    // 1. Check Model manager loaded models UI
+    // Navigate to Models
+    await page.locator('.titlebar__nav').getByText('Models').click();
+    await page.waitForSelector('.manager');
+
+    // Wait for the running model row to appear
+    const pinBtn = page.locator('.row__action--pin');
+    await expect(pinBtn).toBeVisible();
+    await expect(pinBtn).toContainText('Pin');
+    await expect(pinBtn).not.toHaveClass(/row__action--pinned/);
+
+    // Click the Pin button and wait for the pin request/response
+    const pinPromise = page.waitForResponse(response =>
+      response.url().includes('/internal/pin') && response.request().method() === 'POST'
+    );
+    await pinBtn.click();
+    const pinResponse = await pinPromise;
+    expect(pinResponse.request().postDataJSON()).toEqual({ model_name: 'llama-chat', pinned: true });
+
+    // The button class/text should update dynamically because of the refresh call
+    await expect(pinBtn).toHaveClass(/row__action--pinned/);
+    await expect(pinBtn).toContainText('Pinned');
+
+    // Click it again to unpin and wait for request/response
+    const unpinPromise = page.waitForResponse(response =>
+      response.url().includes('/internal/pin') && response.request().method() === 'POST'
+    );
+    await pinBtn.click();
+    const unpinResponse = await unpinPromise;
+    expect(unpinResponse.request().postDataJSON()).toEqual({ model_name: 'llama-chat', pinned: false });
+    await expect(pinBtn).not.toHaveClass(/row__action--pinned/);
+    await expect(pinBtn).toContainText('Pin');
+
+    // 2. Check Presets "Pin model" checkbox UI
+    // Navigate to Presets
+    await page.locator('.titlebar__nav').getByText('Presets').click();
+    await page.waitForSelector('.recipes');
+
+    // Click "+ New Preset" button
+    await page.locator('.recipes__actions').getByText('New Preset').click();
+    await page.waitForSelector('.slideover.is-open');
+
+    // "Pin model (prevent eviction)" checkbox should be visible and not checked
+    const pinCheckbox = page.locator('.slideover .backends__toggle input[type="checkbox"]');
+    await expect(pinCheckbox).toBeVisible();
+    await expect(pinCheckbox).not.toBeChecked();
+
+    // Toggle it on
+    await pinCheckbox.check();
+    await expect(pinCheckbox).toBeChecked();
+
+    // Save the preset
+    await page.locator('.slideover__foot').getByText('Save').click();
+
+    // Apply the preset to llama-chat
+    await page.locator('[data-recipe-apply-target]').selectOption('llama-chat');
+    await page.locator('.slideover .btn--primary').getByText('Apply').click();
+    await expect(page.locator('.preset-success')).toContainText('Will apply on next load');
+
+    // Close the slideover
+    await page.locator('.slideover__close').click();
+
+    // Verify the preset is added under 'Your presets' list
+    const userPresetCard = page.locator('[data-recipe-grid="yours"] .recipe-card');
+    await expect(userPresetCard).toBeVisible();
+    await expect(userPresetCard.locator('.recipe-card__name')).toContainText('New Preset');
+
+    await page.screenshot({ path: 'screenshots/23-model-pinning.png', fullPage: true });
+  });
 });


### PR DESCRIPTION
This is a companion PR to #2226 forward-poring model pinning UI to the new ui. The functionality used by these changes depend on #2226 being merged.

<img width="2466" height="856" alt="Screenshot From 2026-06-15 16-50-03" src="https://github.com/user-attachments/assets/39287702-c2ee-4919-a6c6-6bc17f7b5926" />

