### PR TITLE
test: pre-warm ROCm (TheRock) runtime before rocm-backend tests

### DIFF
--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -339,6 +339,7 @@ def ensure_rocm_runtime():
         response = requests.post(
             f"http://localhost:{PORT}/api/v1/install",
             json={"recipe": recipe, "backend": "rocm", "stream": False},
+            headers=_auth_headers(),
             timeout=TIMEOUT_ROCM_INSTALL,
         )
         response.raise_for_status()

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -45,6 +45,7 @@ from .test_models import (
     STANDARD_MESSAGES,
     TIMEOUT_MODEL_OPERATION,
     TIMEOUT_DEFAULT,
+    TIMEOUT_ROCM_INSTALL,
     get_default_cli_binary,
 )
 
@@ -300,6 +301,56 @@ def _build_runtime_config(additional_server_args=None):
     return config
 
 
+# Recipes whose "rocm" backend resolves to the rocm-stable channel and therefore
+# trigger a TheRock runtime download on a cold cache (see will_install_therock in
+# backend_manager.cpp). Other rocm consumers (vllm, llamacpp rocm-nightly) bundle
+# their own runtime and do not need this.
+_THEROCK_RECIPES = ("llamacpp", "sd-cpp")
+
+
+def ensure_rocm_runtime():
+    """
+    Pre-warm the ROCm (TheRock) runtime before running rocm-backend tests.
+
+    On a cold cache, loading a rocm-stable model triggers a ~4.5 GB TheRock
+    download inside the first inference request, which can exceed the tighter
+    per-request inference timeout. Doing it here, as an explicit setup step with
+    a generous timeout, keeps that cost out of the test body and surfaces a
+    download/runtime failure as a clear, distinct setup error rather than a
+    confusing inference timeout.
+
+    No-op unless the active backend is "rocm" and the recipe is one that uses
+    the TheRock runtime. Idempotent: the server skips the download when TheRock
+    is already installed, so this is a fast check on a warm cache.
+    """
+    if _config.get("backend") != "rocm":
+        return
+    recipe = _config.get("wrapped_server")
+    if recipe not in _THEROCK_RECIPES:
+        return
+    if requests is None:
+        raise RuntimeError(
+            "ROCM_INSTALL_FAILED: the `requests` package is required to pre-warm "
+            "the ROCm (TheRock) runtime; install it with `pip install requests`."
+        )
+
+    print(f"\n=== Ensuring ROCm (TheRock) runtime for {recipe}:rocm ===")
+    try:
+        response = requests.post(
+            f"http://localhost:{PORT}/api/v1/install",
+            json={"recipe": recipe, "backend": "rocm", "stream": False},
+            timeout=TIMEOUT_ROCM_INSTALL,
+        )
+        response.raise_for_status()
+    except Exception as e:
+        raise RuntimeError(
+            f"ROCM_INSTALL_FAILED: ROCm runtime (TheRock) install failed for "
+            f"{recipe}:rocm. This is an environment/setup failure, not a test "
+            f"failure. Detail: {e}"
+        ) from e
+    print(f"ROCm (TheRock) runtime ready for {recipe}:rocm")
+
+
 class ServerTestBase(unittest.TestCase):
     """
     Base class for server tests.
@@ -340,6 +391,10 @@ class ServerTestBase(unittest.TestCase):
                 "(e.g., install the package or run lemond manually)." % PORT
             )
         print("Server is reachable on port %d" % PORT)
+
+        # Pre-warm the ROCm (TheRock) runtime so its cold-cache download does not
+        # blow the per-request inference timeout inside the first test.
+        ensure_rocm_runtime()
 
         # Build and apply runtime config from CLI args + class-level args
         runtime_config = _build_runtime_config(cls.additional_server_args)

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -140,6 +140,11 @@ TIMEOUT_MODEL_OPERATION = 500
 # For requests that don't download a model (health, unload, stats, etc.)
 TIMEOUT_DEFAULT = 60
 
+# For pre-warming the ROCm (TheRock) runtime, which downloads a ~4.5 GB tarball
+# on a cold cache. Generous so a slow/interrupted download does not blow the
+# tighter per-request inference timeout above.
+TIMEOUT_ROCM_INSTALL = 1800
+
 # Standard test messages for chat completions
 STANDARD_MESSAGES = [
     {"role": "system", "content": "You are a helpful assistant."},


### PR DESCRIPTION
## Problem

The Windows `.exe` `stable-diffusion` and `llamacpp` rocm inference tests fail intermittently on a **cold TheRock cache**. The first rocm-stable model load downloads a ~4.5 GB TheRock tarball *inside the first inference request*, which can exceed the per-request inference timeout (`TIMEOUT_MODEL_OPERATION = 500s`) and surfaces as a confusing `ReadTimeout` rather than an install failure.

This is the cold-cache follow-up to the cache-out-of-workspace fix (#2148): that keeps the cache warm across runs, but a fresh runner / TheRock version bump / eviction still pays the cold download under the test's request timeout.

## Change

Add a shared `ensure_rocm_runtime()` helper, called from `ServerTestBase.setUpClass()`, that pre-installs the runtime via `POST /api/v1/install` with a generous `TIMEOUT_ROCM_INSTALL = 1800s`:

- **Gated** on `backend == "rocm"` and recipe ∈ `{llamacpp, sd-cpp}` — exactly the C++ `will_install_therock` condition. No-op for vulkan/cpu/npu, ryzenai/flm/whisper, rocm-nightly, and vLLM.
- **Idempotent** — the server skips the download when TheRock is already installed, so it's a fast check on a warm cache.
- **Distinct failure** — on non-2xx (500 install exception / 400 unsupported) or timeout, raises `ROCM_INSTALL_FAILED`, so a runtime/download problem reports as a setup error, not an inference test failure.

Moves the cold download out of the test body's 500s window into an explicit setup step with an appropriate budget.