### PR TITLE
fix: align moonshine backend lifecycle with watchdog

### DIFF
--- a/src/cpp/server/backends/moonshine_server.cpp
+++ b/src/cpp/server/backends/moonshine_server.cpp
@@ -162,7 +162,7 @@ void MoonshineServer::load(const std::string& model_name,
 
     // Launch the subprocess
     bool inherit_output = (log_level_ == "info") || is_debug();
-    process_handle_ = utils::ProcessManager::start_process(
+    ProcessHandle started_handle = utils::ProcessManager::start_process(
         executable,
         args,
         "",     // working_dir
@@ -170,12 +170,13 @@ void MoonshineServer::load(const std::string& model_name,
         false,  // filter_health_logs
         env_vars
     );
+    set_process_handle(started_handle);
 
-    if (process_handle_.pid == 0) {
+    if (!has_process_handle(started_handle)) {
         throw std::runtime_error("Failed to start moonshine-server process");
     }
 
-    LOG(INFO, "MoonshineServer") << "Process started with PID: " << process_handle_.pid << std::endl;
+    LOG(INFO, "MoonshineServer") << "Process started with PID: " << started_handle.pid << std::endl;
 
     // Wait for server to be ready
     if (!wait_for_ready("/health")) {
@@ -187,13 +188,13 @@ void MoonshineServer::load(const std::string& model_name,
 }
 
 void MoonshineServer::unload() {
-    if (process_handle_.pid != 0) {
-        LOG(INFO, "MoonshineServer") << "Stopping server (PID: " << process_handle_.pid << ")" << std::endl;
-        utils::ProcessManager::stop_process(process_handle_);
-        process_handle_ = {nullptr, 0};
-        port_ = 0;
-        tcp_port_ = 0;
+    stop_backend_watchdog();
+    const ProcessHandle handle = consume_process_handle_for_cleanup();
+    if (has_process_handle(handle)) {
+        LOG(INFO, "MoonshineServer") << "Stopping server (PID: " << handle.pid << ")" << std::endl;
+        utils::ProcessManager::stop_process(handle);
     }
+    tcp_port_ = 0;
 }
 
 std::string MoonshineServer::get_streaming_address() {
@@ -286,7 +287,7 @@ json MoonshineServer::forward_multipart_audio_data(const std::string& audio_data
         fields.push_back(prompt_field);
     }
 
-    const std::string url = "http://127.0.0.1:" + std::to_string(port_) + "/inference";
+    const std::string url = "http://127.0.0.1:" + std::to_string(get_backend_port()) + "/inference";
     LOG(DEBUG, "MoonshineServer") << "Sending multipart request to " << url << " (direct data)" << std::endl;
 
     auto res = utils::HttpClient::post_multipart(url, fields, 0);


### PR DESCRIPTION
## Summary

Follow-up to #2028.

moonshine was added recently and after the backend watchdog work and still used direct
process_handle_ / port_  access. This aligns it with the shared
WrappedServer lifecycle used by the other wrapped backends.

## What changed

- Use set_process_handle() / has_process_handle() when starting Moonshine
- Stop the backend watchdog before unload
- Use consume_process_handle_for_cleanup() during cleanup
- Use get_backend_port() for multipart forwarding
- Reset the Moonshine TCP streaming port on unload

## Testing

- Testet moonshine functions and checked parity with the analogous WhisperServer watchdog