### PR TITLE
Fix(cli): Lemonade backends now shows only supported backends . Added --all  option to show all backends.

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -35,7 +35,7 @@ The `lemonade` CLI is the primary tool for interacting with Lemonade Server from
 |---------------------|-------------------------------------|
 | `status`            | Check if server can be reached. If it is, prints server information. Use `--json` for machine-readable output. |
 | `logs`              | Open server logs in the web UI. |
-| `backends`          | List available recipes and backends. Use `install` or `uninstall` to manage backends. |
+| `backends`          | List supported recipes and backends or list all available recipes and backends with `--all`. Use `install` or `uninstall` to manage backends. |
 | `cloud`             | Manage cloud OpenAI-compatible providers. See command options [below](#options-for-cloud). |
 | `scan`              | Scan for network beacons on the local network. See command options [below](#options-for-scan). |
 
@@ -432,30 +432,35 @@ lemonade export Qwen3-0.6B-GGUF --output model.json && cat model.json
 
 ## Options for backends
 
-The `backends` command lists available recipes and their backends. Use the `install` and `uninstall` subcommands to manage them:
+The `backends` command lists supported recipes and their backends. Use `--all` to list all available backends or use the `install` and `uninstall` subcommands to manage them:
 
 ```bash
 lemonade backends
+lemonade backends --all
 lemonade backends install SPEC [--force]
 lemonade backends uninstall SPEC
 ```
 
 | Command | Description |
 |--------|-------------|
-| `lemonade backends` | List available recipes and backends |
+| `lemonade backends` | List supported recipes and backends |
+| `lemonade backends --all` | List all available recipes and backends |
 | `lemonade backends install SPEC` | Install a backend. Format: `recipe:backend` (e.g., `llamacpp:vulkan`) |
 | `lemonade backends uninstall SPEC` | Uninstall a backend. Format: `recipe:backend` (e.g., `llamacpp:cpu`) |
 | `lemonade backends install SPEC --force` | Bypass hardware filtering and attempt the install anyway |
 
 **Notes:**
-- Available backends depend on your system and the recipe
-- Use `lemonade backends` to list all available recipes and backends
+- Supported backends depend on your system and the recipe
+- Use `lemonade backends --all` to list all available recipes and backends
 
 **Examples:**
 
 ```bash
-# List all available recipes and backends
+# List supported recipes and backends
 lemonade backends
+
+# List all available recipes and backends
+lemonade backends --all
 
 # Install Vulkan backend for llamacpp
 lemonade backends install llamacpp:vulkan

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -801,7 +801,7 @@ nlohmann::json LemonadeClient::get_model_info(const std::string& model_name) con
     }
 }
 
-int LemonadeClient::list_recipes(bool backends_supported) const {
+int LemonadeClient::list_recipes(bool show_all) const {
     try {
         std::string response = make_request("/api/v1/system-info");
         auto json_response = json::parse(response);
@@ -875,7 +875,7 @@ int LemonadeClient::list_recipes(bool backends_supported) const {
                         info_col = "-";
                     }
                     std::string action_col = backend.action.empty() ? "-" : backend.action;
-                    if (!backends_supported  || status_str != "unsupported") {
+                    if (show_all || status_str != "unsupported") {
                         std::cout << std::left << std::setw(20) << recipe_col
                                 << std::setw(12) << backend.name
                                 << std::setw(16) << status_str

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -801,7 +801,7 @@ nlohmann::json LemonadeClient::get_model_info(const std::string& model_name) con
     }
 }
 
-int LemonadeClient::list_recipes() const {
+int LemonadeClient::list_recipes(bool backends_supported) const {
     try {
         std::string response = make_request("/api/v1/system-info");
         auto json_response = json::parse(response);
@@ -862,7 +862,7 @@ int LemonadeClient::list_recipes() const {
                           << std::setw(46) << "No backend definitions"
                           << "-" << std::endl;
             } else {
-                for (const auto& backend : recipe.backends) {
+                for (const auto& backend : recipe.backends) {                    
                     std::string recipe_col = first_backend ? recipe.name : "";
                     std::string status_str = backend.state.empty() ? "unsupported" : backend.state;
 
@@ -875,14 +875,15 @@ int LemonadeClient::list_recipes() const {
                         info_col = "-";
                     }
                     std::string action_col = backend.action.empty() ? "-" : backend.action;
+                    if (!backends_supported  || status_str != "unsupported") {
+                        std::cout << std::left << std::setw(20) << recipe_col
+                                << std::setw(12) << backend.name
+                                << std::setw(16) << status_str
+                                << std::setw(46) << info_col
+                                << " " << action_col << std::endl;
 
-                    std::cout << std::left << std::setw(20) << recipe_col
-                              << std::setw(12) << backend.name
-                              << std::setw(16) << status_str
-                              << std::setw(46) << info_col
-                              << " " << action_col << std::endl;
-
-                    first_backend = false;
+                        first_backend = false;
+                    }
                 }
             }
         }

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -856,11 +856,13 @@ int LemonadeClient::list_recipes(bool show_all) const {
             bool first_backend = true;
 
             if (recipe.backends.empty()) {
-                std::cout << std::left << std::setw(20) << recipe.name
-                          << std::setw(12) << "-"
-                          << std::setw(16) << "unsupported"
-                          << std::setw(46) << "No backend definitions"
-                          << "-" << std::endl;
+                if (show_all) {
+                    std::cout << std::left << std::setw(20) << recipe.name
+                            << std::setw(12) << "-"
+                            << std::setw(16) << "unsupported"
+                            << std::setw(46) << "No backend definitions"
+                            << "-" << std::endl;
+                }
             } else {
                 for (const auto& backend : recipe.backends) {                    
                     std::string recipe_col = first_backend ? recipe.name : "";

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -155,7 +155,7 @@ struct CliConfig {
     nlohmann::json recipe_options;
     bool save_options = false;
     std::string backend_spec;  // Format: "recipe:backend"
-    bool backends_supported = false;
+    bool backends_showall = false;
     bool force = false;
     std::string output_file;
     bool downloaded = false;
@@ -509,7 +509,7 @@ static int handle_backends_command(lemonade::LemonadeClient& client,
         return result;
     }
 
-    return client.list_recipes(config.backends_supported);
+    return client.list_recipes(config.backends_showall);
 }
 
 static std::vector<lemon_cli::AgentModelEntry> fetch_llm_models_for_sync(
@@ -1135,9 +1135,9 @@ int main(int argc, char* argv[]) {
     CLI::App* chat_cmd = app.add_subcommand("chat", "Open an interactive chat REPL in the terminal")->group("Quick start");
 
     // Server commands
-    CLI::App* backends_cmd = app.add_subcommand("backends", "List available recipes and backends.")->group("Server");
+    CLI::App* backends_cmd = app.add_subcommand("backends", "List supported recipes and backends. Use --all to show all backends")->group("Server");
     backends_cmd->alias("recipes");
-    backends_cmd->add_flag("--supported", config.backends_supported, "Show only supported backends");
+    backends_cmd->add_flag("--all", config.backends_showall, "Show all backends");
     CLI::App* backends_install_cmd = backends_cmd->add_subcommand("install", "Install a backend")->group("Subcommands");
     CLI::App* backends_uninstall_cmd = backends_cmd->add_subcommand("uninstall", "Uninstall a backend")->group("Subcommands");
     CLI::App* status_cmd = app.add_subcommand("status", "Check server status")->group("Server");

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -155,6 +155,7 @@ struct CliConfig {
     nlohmann::json recipe_options;
     bool save_options = false;
     std::string backend_spec;  // Format: "recipe:backend"
+    bool backends_supported = false;
     bool force = false;
     std::string output_file;
     bool downloaded = false;
@@ -508,7 +509,7 @@ static int handle_backends_command(lemonade::LemonadeClient& client,
         return result;
     }
 
-    return client.list_recipes();
+    return client.list_recipes(config.backends_supported);
 }
 
 static std::vector<lemon_cli::AgentModelEntry> fetch_llm_models_for_sync(
@@ -1134,8 +1135,9 @@ int main(int argc, char* argv[]) {
     CLI::App* chat_cmd = app.add_subcommand("chat", "Open an interactive chat REPL in the terminal")->group("Quick start");
 
     // Server commands
-    CLI::App* backends_cmd = app.add_subcommand("backends", "List available recipes and backends")->group("Server");
+    CLI::App* backends_cmd = app.add_subcommand("backends", "List available recipes and backends.")->group("Server");
     backends_cmd->alias("recipes");
+    backends_cmd->add_flag("--supported", config.backends_supported, "Show only supported backends");
     CLI::App* backends_install_cmd = backends_cmd->add_subcommand("install", "Install a backend")->group("Subcommands");
     CLI::App* backends_uninstall_cmd = backends_cmd->add_subcommand("uninstall", "Uninstall a backend")->group("Subcommands");
     CLI::App* status_cmd = app.add_subcommand("status", "Check server status")->group("Server");

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -93,7 +93,7 @@ public:
     std::vector<ModelInfo> get_models(bool show_all) const;
 
     // Recipe/backend commands
-    int list_recipes(bool backends_supported) const;
+    int list_recipes(bool show_all = false) const;
     int install_backend(const std::string& recipe, const std::string& backend, bool force = false);
     int uninstall_backend(const std::string& recipe, const std::string& backend);
 

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -93,7 +93,7 @@ public:
     std::vector<ModelInfo> get_models(bool show_all) const;
 
     // Recipe/backend commands
-    int list_recipes() const;
+    int list_recipes(bool backends_supported) const;
     int install_backend(const std::string& recipe, const std::string& backend, bool force = false);
     int uninstall_backend(const std::string& recipe, const std::string& backend);
 


### PR DESCRIPTION

On lemonade cli , the `lemonade backends` now shows only the supported backends and recipes.

There is a new option  `lemonade backends --all` to show all available recipes and backends.
