### PR TITLE
Fix macOS auto-tune memory detection (unified memory)

### DIFF
--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -133,12 +133,18 @@ inline double get_available_memory_gb(DeviceType device_type) {
             }
         }
 
-        // Metal (macOS — unified memory, reported via get_amd_igpu_device on macOS)
-        auto amd_igpu_mac = si->get_amd_igpu_device();
-        if (amd_igpu_mac.available && amd_igpu_mac.vram_gb > 0) {
-            double available = std::max(0.0, amd_igpu_mac.vram_gb - used_gb);
-            LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (Metal) total="
-                                   << std::fixed << std::setprecision(2) << amd_igpu_mac.vram_gb
+        // Metal (macOS — Apple Silicon unified memory). CPU and GPU share one pool:
+        //   vram_gb    = Metal's recommended GPU working-set budget (a soft ceiling)
+        //   virtual_gb = total unified RAM
+        // Available to the GPU = the free unified RAM (total − used), capped at the
+        // working-set budget so we don't push the system into swap.
+        auto apple = si->get_apple_silicon_device();
+        if (apple.available && apple.vram_gb > 0) {
+            double free_unified = std::max(0.0, apple.virtual_gb - used_gb);
+            double available = std::min(apple.vram_gb, free_unified);
+            LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (Metal) budget="
+                                   << std::fixed << std::setprecision(2) << apple.vram_gb
+                                   << " GB, unified=" << apple.virtual_gb
                                    << " GB, used=" << used_gb
                                    << " GB → " << available << " GB available"  << " ";
             return available;
@@ -146,6 +152,18 @@ inline double get_available_memory_gb(DeviceType device_type) {
     }
 
     // CPU / NPU: use system RAM
+    // Apple Silicon: the full unified-memory pool (total physical RAM) is reported
+    // as virtual_gb on the Apple Silicon device.
+    auto apple = si->get_apple_silicon_device();
+    if (apple.available && apple.virtual_gb > 0) {
+        double available = std::max(0.0, apple.virtual_gb - used_gb);
+        LOG(DEBUG, "AutoTune") << "get_available_memory_gb: CPU/NPU (Apple Silicon unified) total="
+                               << std::fixed << std::setprecision(2) << apple.virtual_gb
+                               << " GB, used=" << used_gb
+                               << " GB → " << available << " GB available"  << " ";
+        return available;
+    }
+
     // On unified-memory systems (APU), the iGPU vram_gb + virtual_gb approximates system RAM
     auto amd_igpu = si->get_amd_igpu_device();
     if (amd_igpu.available && amd_igpu.vram_gb > 0) {

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -66,6 +66,10 @@ public:
     virtual std::vector<GPUInfo> get_nvidia_gpu_devices() = 0;
     virtual NPUInfo get_npu_device() = 0;
 
+    // Apple Silicon unified-memory GPU. Only meaningful on macOS; the base
+    // implementation reports "unavailable" so non-Apple platforms need no stub.
+    virtual GPUInfo get_apple_silicon_device() { return GPUInfo{}; }
+
     // Common methods (can be overridden for detailed platform info)
     virtual std::string get_os_version();
 
@@ -207,6 +211,7 @@ public:
     std::vector<GPUInfo> get_amd_dgpu_devices() override;
     std::vector<GPUInfo> get_nvidia_gpu_devices() override;
     NPUInfo get_npu_device() override;
+    GPUInfo get_apple_silicon_device() override;
 
     // Override to add macOS-specific fields
     json get_system_info_dict() override;

--- a/src/cpp/server/macos_system_info.mm
+++ b/src/cpp/server/macos_system_info.mm
@@ -63,6 +63,43 @@ std::vector<GPUInfo> MacOSSystemInfo::detect_metal_gpus() {
         return {}; // or return empty vector
     }
 }
+
+// Apple Silicon presents a single unified-memory pool shared by CPU and GPU.
+// Report it as a GPUInfo so auto-tune can treat it like any other GPU device:
+//   vram_gb     = Metal's recommended GPU working-set budget (recommendedMaxWorkingSetSize)
+//   virtual_gb  = total physical RAM (hw.memsize), the rest of the unified pool
+GPUInfo MacOSSystemInfo::get_apple_silicon_device() {
+    GPUInfo gpu;
+
+    // Total unified memory (physical RAM).
+    uint64_t mem_bytes = 0;
+    size_t size = sizeof(mem_bytes);
+    double total_ram_gb = 0.0;
+    if (sysctlbyname("hw.memsize", &mem_bytes, &size, nullptr, 0) == 0 && mem_bytes > 0) {
+        total_ram_gb = mem_bytes / (1024.0 * 1024.0 * 1024.0);
+    }
+
+    // Metal's advertised GPU working-set budget (a conservative slice of unified memory).
+    std::vector<GPUInfo> metal_gpus = detect_metal_gpus();
+    if (!metal_gpus.empty() && metal_gpus[0].available) {
+        gpu = metal_gpus[0];
+        gpu.virtual_gb = total_ram_gb;
+        return gpu;
+    }
+
+    // No Metal device (e.g. very old macOS): fall back to reporting RAM only.
+    if (total_ram_gb > 0.0) {
+        gpu.available = true;
+        gpu.name = "Apple Silicon (unified memory)";
+        gpu.vram_gb = total_ram_gb;
+        gpu.virtual_gb = total_ram_gb;
+        return gpu;
+    }
+
+    gpu.available = false;
+    gpu.error = "Could not determine Apple Silicon unified memory";
+    return gpu;
+}
 } // namespace lemon
 
 #endif // __APPLE__

--- a/src/cpp/server/platform/metrics_macos.cpp
+++ b/src/cpp/server/platform/metrics_macos.cpp
@@ -1,6 +1,9 @@
 #include <lemon/system_metrics_platform.h>
 #include <sys/types.h>
 #include <sys/sysctl.h>
+#include <mach/mach.h>
+#include <mach/mach_host.h>
+#include <mach/vm_statistics.h>
 #include <cmath>
 
 namespace lemon {
@@ -20,14 +23,30 @@ public:
     }
 
     double get_memory_usage_gb() override {
-        int64_t physical_memory = 0;
-        size_t length = sizeof(physical_memory);
-        if (sysctlbyname("hw.memsize", &physical_memory, &length, nullptr, 0) == 0) {
-            // For now, just report total memory since getting free memory is complex on macOS
-            double total_gb = physical_memory / (1024.0 * 1024.0 * 1024.0);
-            return std::round(total_gb * 10.0) / 10.0;
+        // Report RAM currently in use (not total). On macOS this approximates
+        // Activity Monitor's "Memory Used": (active + wired + compressed) pages.
+        // Inactive/free/purgeable pages are reclaimable and counted as available.
+        mach_port_t host = mach_host_self();
+
+        vm_size_t page_size = 0;
+        if (host_page_size(host, &page_size) != KERN_SUCCESS || page_size == 0) {
+            return 0.0;
         }
-        return 0.0;
+
+        vm_statistics64_data_t vm_stats;
+        mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+        if (host_statistics64(host, HOST_VM_INFO64,
+                              reinterpret_cast<host_info64_t>(&vm_stats),
+                              &count) != KERN_SUCCESS) {
+            return 0.0;
+        }
+
+        uint64_t used_pages = static_cast<uint64_t>(vm_stats.active_count) +
+                              static_cast<uint64_t>(vm_stats.wire_count) +
+                              static_cast<uint64_t>(vm_stats.compressor_page_count);
+        double used_gb = (used_pages * static_cast<double>(page_size)) /
+                         (1024.0 * 1024.0 * 1024.0);
+        return std::round(used_gb * 10.0) / 10.0;
     }
 
     double get_gpu_usage() override {

--- a/src/cpp/server/platform/metrics_macos.cpp
+++ b/src/cpp/server/platform/metrics_macos.cpp
@@ -30,6 +30,7 @@ public:
 
         vm_size_t page_size = 0;
         if (host_page_size(host, &page_size) != KERN_SUCCESS || page_size == 0) {
+            mach_port_deallocate(mach_task_self(), host);
             return 0.0;
         }
 
@@ -38,8 +39,11 @@ public:
         if (host_statistics64(host, HOST_VM_INFO64,
                               reinterpret_cast<host_info64_t>(&vm_stats),
                               &count) != KERN_SUCCESS) {
+            mach_port_deallocate(mach_task_self(), host);
             return 0.0;
         }
+
+        mach_port_deallocate(mach_task_self(), host);
 
         uint64_t used_pages = static_cast<uint64_t>(vm_stats.active_count) +
                               static_cast<uint64_t>(vm_stats.wire_count) +


### PR DESCRIPTION
## Problem

On Apple Silicon, auto-tune resolved **every** model's context to the 4096 fallback (`resolve_auto_ctx_size: memory undetectable, returning 4096`) — e.g. a 4B model on a 24 GB MacBook got only 4k context. Yet `system-info` reported 24 GB correctly and the model-list RAM filter worked fine.

## Root cause

The working features and auto-tune use **different memory paths**, and only auto-tune's was unimplemented on macOS. Two gaps:

1. **No unified-memory accessor.** `get_available_memory_gb()` only consults the AMD/NVIDIA device accessors, which are stubs on macOS, so it fell through to `return 0.0` → 4096.
2. **`get_memory_usage_gb()` returned *total* RAM, not *used*.** So even with #1 fixed, `available = total − used = 0`. The comment admitted it: *"just report total memory since getting free memory is complex on macOS."*

## Fix

- **`system_info.h`** — add `virtual GPUInfo get_apple_silicon_device()` to the base `SystemInfo` (default reports "unavailable" so Windows/Linux need no stub), overridden in `MacOSSystemInfo`. Fits the existing per-platform device-accessor pattern.
- **`macos_system_info.mm`** — implement it: `vram_gb` = Metal's `recommendedMaxWorkingSetSize` (GPU working-set budget), `virtual_gb` = total `hw.memsize` (unified pool). Reuses the existing `detect_metal_gpus()`.
- **`auto_tune.h`** — Metal branch computes `min(GPU budget, free unified RAM)`; CPU/NPU branch uses total unified RAM. Both subtract used memory.
- **`metrics_macos.cpp`** — `get_memory_usage_gb()` now reports real used memory via mach `host_statistics64` (`active + wired + compressed` pages), matching the used-memory semantics already on Windows/Linux. This also corrects the `/stats` `memory_gb` field and the Prometheus `lemonade_memory_used_gb` gauge.

## Verification

Linked a driver against the full server core and ran on an M4 Pro / 24 GB machine:

```
apple_silicon_device: available=1 name="Apple M4 Pro" vram_gb=17.76 virtual_gb=24.00
get_available_memory_gb(GPU)=10.90   # was 0.00
get_available_memory_gb(CPU)=10.90   # was 0.00
```

Used ≈ 13 GB cross-checks against `vm_stat`. A 4B model now sees ~11 GB of headroom, so auto-tune resolves context well above the 4096 floor.

## Note

"Used" is approximated as `active + wired + compressed` (≈ Activity Monitor's "Memory Used"), treating inactive/purgeable as reclaimable. Including `inactive` for a more conservative count is a one-line change if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)