### PR TITLE
fix: refuse to start a second lemond when the port is already in use (#2255)

### DIFF
--- a/.github/actions/install-lemonade-deb/action.yml
+++ b/.github/actions/install-lemonade-deb/action.yml
@@ -125,6 +125,16 @@ runs:
         chmod 700 "$RUNNER_TEMP/xdg-runtime"
         echo "XDG_RUNTIME_DIR=$RUNNER_TEMP/xdg-runtime" >> "$GITHUB_ENV"
         export XDG_RUNTIME_DIR="$RUNNER_TEMP/xdg-runtime"
+
+        # On self-hosted runners a previous run's lemond (or its TIME_WAIT
+        # socket) can still hold port 13305, which lemond now refuses to bind
+        # over. Free the port before starting so we don't exit as a duplicate.
+        if command -v fuser >/dev/null 2>&1; then
+          fuser -k 13305/tcp 2>/dev/null || true
+        fi
+        pkill -9 -x lemond 2>/dev/null || true
+        sleep 1
+
         "$SERVER_BIN" "$CACHE_DIR" > "$LOG_FILE" 2>&1 &
         SERVER_PID=$!
 

--- a/.github/actions/install-lemonade-deb/action.yml
+++ b/.github/actions/install-lemonade-deb/action.yml
@@ -126,14 +126,58 @@ runs:
         echo "XDG_RUNTIME_DIR=$RUNNER_TEMP/xdg-runtime" >> "$GITHUB_ENV"
         export XDG_RUNTIME_DIR="$RUNNER_TEMP/xdg-runtime"
 
-        # On self-hosted runners a previous run's lemond (or its TIME_WAIT
-        # socket) can still hold port 13305, which lemond now refuses to bind
-        # over. Free the port before starting so we don't exit as a duplicate.
-        if command -v fuser >/dev/null 2>&1; then
-          fuser -k 13305/tcp 2>/dev/null || true
+        # On these single-tenant self-hosted runners a previous run's lemond can
+        # still hold port 13305, which lemond now refuses to bind over (it exits
+        # as a duplicate). Free the port authoritatively before starting: kill
+        # any lemond, then kill whatever still holds the port (escalating with
+        # sudo if available), and wait until the port is actually free instead of
+        # assuming a fixed delay is enough.
+        SUDO=""
+        if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+          SUDO="sudo"
         fi
-        pkill -9 -x lemond 2>/dev/null || true
-        sleep 1
+
+        free_port_13305() {
+          # Kill known lemonade processes by name.
+          $SUDO pkill -9 -x lemond 2>/dev/null || true
+          $SUDO pkill -9 -f LemonadeServer 2>/dev/null || true
+          # Kill whatever is bound to the port, by PID, via the first tool present.
+          if command -v fuser >/dev/null 2>&1; then
+            $SUDO fuser -k 13305/tcp 2>/dev/null || true
+          fi
+          if command -v lsof >/dev/null 2>&1; then
+            local pids
+            pids=$(lsof -t -iTCP:13305 -sTCP:LISTEN 2>/dev/null || true)
+            [ -n "$pids" ] && $SUDO kill -9 $pids 2>/dev/null || true
+          fi
+        }
+
+        # Returns 0 when nothing is LISTENING on 13305.
+        port_is_free() {
+          if command -v ss >/dev/null 2>&1; then
+            ! ss -ltn 2>/dev/null | grep -q ':13305 '
+          elif command -v lsof >/dev/null 2>&1; then
+            [ -z "$(lsof -t -iTCP:13305 -sTCP:LISTEN 2>/dev/null || true)" ]
+          else
+            ! (netstat -ltn 2>/dev/null | grep -q ':13305 ')
+          fi
+        }
+
+        for attempt in $(seq 1 10); do
+          if port_is_free; then
+            break
+          fi
+          echo "Port 13305 still in use (attempt $attempt) - freeing it..."
+          free_port_13305
+          sleep 1
+        done
+        if ! port_is_free; then
+          echo "ERROR: Port 13305 is still held after cleanup. Current listeners:"
+          (command -v ss >/dev/null 2>&1 && $SUDO ss -ltnp 2>/dev/null | grep ':13305 ') \
+            || (command -v lsof >/dev/null 2>&1 && $SUDO lsof -iTCP:13305 -sTCP:LISTEN 2>/dev/null) \
+            || true
+          exit 1
+        fi
 
         "$SERVER_BIN" "$CACHE_DIR" > "$LOG_FILE" 2>&1 &
         SERVER_PID=$!

--- a/.github/actions/install-lemonade-deb/action.yml
+++ b/.github/actions/install-lemonade-deb/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Whether to download the artifact (set to false if already downloaded)'
     required: false
     default: 'true'
+  port:
+    description: "Port to start lemond on. Use 'auto' to pick a free port (needed on shared self-hosted runners where the default port may be taken)."
+    required: false
+    default: '13305'
 
 outputs:
   bin-path:
@@ -126,79 +130,72 @@ runs:
         echo "XDG_RUNTIME_DIR=$RUNNER_TEMP/xdg-runtime" >> "$GITHUB_ENV"
         export XDG_RUNTIME_DIR="$RUNNER_TEMP/xdg-runtime"
 
-        # On these single-tenant self-hosted runners a previous run's lemond can
-        # still hold port 13305, which lemond now refuses to bind over (it exits
-        # as a duplicate). Free the port authoritatively before starting: kill
-        # any lemond, then kill whatever still holds the port (escalating with
-        # sudo if available), and wait until the port is actually free instead of
-        # assuming a fixed delay is enough.
-        SUDO=""
-        if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
-          SUDO="sudo"
-        fi
+        # With port=auto, start on a job-unique free port instead of the default
+        # 13305. Non-containerized self-hosted jobs share the host network, so a
+        # concurrent job may already hold 13305 — and lemond now refuses to bind
+        # an in-use port. The resolved port is exported so the test harness
+        # (LEMONADE_TEST_PORT) and the lemonade CLI (LEMONADE_PORT) target it.
+        REQUESTED_PORT="${{ inputs.port }}"
 
-        free_port_13305() {
-          # Kill known lemonade processes by name.
-          $SUDO pkill -9 -x lemond 2>/dev/null || true
-          $SUDO pkill -9 -f LemonadeServer 2>/dev/null || true
-          # Kill whatever is bound to the port, by PID, via the first tool present.
-          if command -v fuser >/dev/null 2>&1; then
-            $SUDO fuser -k 13305/tcp 2>/dev/null || true
+        # Print a free TCP port (loopback). Prefer an OS-assigned ephemeral port
+        # via python3; fall back to a random high port checked with ss.
+        pick_free_port() {
+          if command -v python3 >/dev/null 2>&1; then
+            python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' && return 0
           fi
-          if command -v lsof >/dev/null 2>&1; then
-            local pids
-            pids=$(lsof -t -iTCP:13305 -sTCP:LISTEN 2>/dev/null || true)
-            [ -n "$pids" ] && $SUDO kill -9 $pids 2>/dev/null || true
-          fi
+          for _ in $(seq 1 50); do
+            local p=$(( (RANDOM % 20000) + 20000 ))
+            if ! ss -ltn 2>/dev/null | grep -q ":$p "; then
+              echo "$p"; return 0
+            fi
+          done
+          return 1
         }
 
-        # Returns 0 when nothing is LISTENING on 13305.
-        port_is_free() {
-          if command -v ss >/dev/null 2>&1; then
-            ! ss -ltn 2>/dev/null | grep -q ':13305 '
-          elif command -v lsof >/dev/null 2>&1; then
-            [ -z "$(lsof -t -iTCP:13305 -sTCP:LISTEN 2>/dev/null || true)" ]
+        # Start lemond; with auto, retry on a fresh port if the chosen one got
+        # taken in the race between picking and binding.
+        started=0
+        for start_attempt in $(seq 1 5); do
+          if [ "$REQUESTED_PORT" = "auto" ]; then
+            PORT=$(pick_free_port) || { echo "ERROR: could not find a free port"; exit 1; }
           else
-            ! (netstat -ltn 2>/dev/null | grep -q ':13305 ')
+            PORT="$REQUESTED_PORT"
           fi
-        }
+          echo "Attempt $start_attempt: starting lemond on 127.0.0.1:$PORT..."
+          "$SERVER_BIN" "$CACHE_DIR" --port "$PORT" > "$LOG_FILE" 2>&1 &
+          SERVER_PID=$!
 
-        for attempt in $(seq 1 10); do
-          if port_is_free; then
+          for i in $(seq 1 30); do
+            if curl -sf "http://127.0.0.1:$PORT/live" > /dev/null 2>&1; then
+              echo "Server is running and healthy on port $PORT (PID $SERVER_PID)"
+              echo "LEMONADE_TEST_PORT=$PORT" >> "$GITHUB_ENV"
+              echo "LEMONADE_PORT=$PORT" >> "$GITHUB_ENV"
+              started=1
+              break
+            fi
+            if ! kill -0 $SERVER_PID 2>/dev/null; then
+              echo "Server (PID $SERVER_PID) exited prematurely on port $PORT"
+              echo "=== Server log ==="
+              cat "$LOG_FILE" 2>/dev/null || echo "(no log file)"
+              break
+            fi
+            echo "Waiting for server... ($i/30)"
+            sleep 2
+          done
+
+          [ "$started" = "1" ] && break
+          # Only an auto port is worth retrying (a fixed port won't change).
+          if [ "$REQUESTED_PORT" != "auto" ]; then
             break
           fi
-          echo "Port 13305 still in use (attempt $attempt) - freeing it..."
-          free_port_13305
+          echo "Start attempt $start_attempt failed; retrying on a new port..."
+          kill -9 $SERVER_PID 2>/dev/null || true
           sleep 1
         done
-        if ! port_is_free; then
-          echo "ERROR: Port 13305 is still held after cleanup. Current listeners:"
-          (command -v ss >/dev/null 2>&1 && $SUDO ss -ltnp 2>/dev/null | grep ':13305 ') \
-            || (command -v lsof >/dev/null 2>&1 && $SUDO lsof -iTCP:13305 -sTCP:LISTEN 2>/dev/null) \
-            || true
+
+        if [ "$started" != "1" ]; then
+          echo "ERROR: server failed to start after multiple attempts"
+          echo "=== Server log (last 50 lines) ==="
+          tail -50 "$LOG_FILE" 2>/dev/null || echo "(no log file)"
           exit 1
         fi
-
-        "$SERVER_BIN" "$CACHE_DIR" > "$LOG_FILE" 2>&1 &
-        SERVER_PID=$!
-
-        echo "Waiting for server to be ready (PID $SERVER_PID)..."
-        for i in $(seq 1 30); do
-          if curl -sf http://127.0.0.1:13305/live > /dev/null 2>&1; then
-            echo "Server is running and healthy"
-            exit 0
-          fi
-          # Check if process is still alive
-          if ! kill -0 $SERVER_PID 2>/dev/null; then
-            echo "ERROR: Server process (PID $SERVER_PID) exited prematurely"
-            echo "=== Server log ==="
-            cat "$LOG_FILE" 2>/dev/null || echo "(no log file)"
-            exit 1
-          fi
-          echo "Waiting for server... ($i/30)"
-          sleep 2
-        done
-        echo "ERROR: Server did not start within 60 seconds"
-        echo "=== Server log (last 50 lines) ==="
-        tail -50 "$LOG_FILE" 2>/dev/null || echo "(no log file)"
-        exit 1

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1411,6 +1411,10 @@ jobs:
         uses: ./.github/actions/install-lemonade-deb
         with:
           version: ${{ env.LEMONADE_VERSION }}
+          # These jobs run directly on shared self-hosted runners (no container
+          # network isolation), so the default port can be held by a concurrent
+          # job. Use a job-unique free port to avoid the collision.
+          port: auto
 
       - name: Setup Python and virtual environment
         uses: ./.github/actions/setup-venv

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -145,15 +145,57 @@ jobs:
           echo "XDG_RUNTIME_DIR=$RUNNER_TEMP/xdg-runtime" >> "$GITHUB_ENV"
           export XDG_RUNTIME_DIR="$RUNNER_TEMP/xdg-runtime"
 
-          ./build/lemond "$CACHE_DIR" --port 13305 --host 127.0.0.1 \
-            > "$LOGS_DIR/lemond.stdout.log" 2> "$LOGS_DIR/lemond.stderr.log" &
-          LEMOND_PID=$!
-          echo "Started lemond PID $LEMOND_PID"
+          # This validate job runs on a shared self-hosted runner, so the default
+          # port 13305 may already be held by another job. lemond now refuses to
+          # bind an in-use port, so start on a job-unique free port and pass it to
+          # validate_vllm.py and the shutdown call.
+          pick_free_port() {
+            if command -v python3 >/dev/null 2>&1; then
+              python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' && return 0
+            fi
+            for _ in $(seq 1 50); do
+              local p=$(( (RANDOM % 20000) + 20000 ))
+              if ! ss -ltn 2>/dev/null | grep -q ":$p "; then echo "$p"; return 0; fi
+            done
+            return 1
+          }
+
+          LEMOND_PID=""
+          started=0
+          for start_attempt in $(seq 1 5); do
+            PORT=$(pick_free_port) || { echo "ERROR: could not find a free port"; exit 1; }
+            echo "Attempt $start_attempt: starting lemond on 127.0.0.1:$PORT..."
+            ./build/lemond "$CACHE_DIR" --port "$PORT" --host 127.0.0.1 \
+              > "$LOGS_DIR/lemond.stdout.log" 2> "$LOGS_DIR/lemond.stderr.log" &
+            LEMOND_PID=$!
+            for i in $(seq 1 30); do
+              if curl -sf "http://127.0.0.1:$PORT/api/v1/health" > /dev/null 2>&1; then
+                echo "lemond is healthy on port $PORT (PID $LEMOND_PID)"
+                started=1
+                break
+              fi
+              if ! kill -0 "$LEMOND_PID" 2>/dev/null; then
+                echo "lemond (PID $LEMOND_PID) exited prematurely on port $PORT"
+                cat "$LOGS_DIR/lemond.stderr.log" 2>/dev/null || true
+                break
+              fi
+              sleep 2
+            done
+            [ "$started" = "1" ] && break
+            echo "Start attempt $start_attempt failed; retrying on a new port..."
+            kill -9 "$LEMOND_PID" 2>/dev/null || true
+            sleep 1
+          done
+          if [ "$started" != "1" ]; then
+            echo "ERROR: lemond failed to start after multiple attempts"
+            exit 1
+          fi
 
           EXIT_CODE=0
           VALIDATION_ARGS=(
             test/validate_vllm.py
             --backend rocm
+            --port "$PORT"
             --output vllm_validation_rocm.json
             --logs-dir "$LOGS_DIR"
           )
@@ -164,7 +206,7 @@ jobs:
           .venv/bin/python "${VALIDATION_ARGS[@]}" || EXIT_CODE=$?
 
           # Shut the server down cleanly so logs flush.
-          curl -sf -X POST http://127.0.0.1:13305/internal/shutdown || true
+          curl -sf -X POST "http://127.0.0.1:$PORT/internal/shutdown" || true
           sleep 2
           kill $LEMOND_PID 2>/dev/null || true
 

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -51,6 +51,11 @@ public:
     // Get server status
     bool is_running() const;
 
+    // True if run() returned because startup could not proceed (e.g. the
+    // configured port was already in use by another lemond instance). Lets
+    // main() report a clear failure and exit non-zero.
+    bool startup_failed() const;
+
 private:
     std::string resolve_host_to_ip(int ai_family, const std::string& host);
     void setup_routes(httplib::Server &web_server);
@@ -259,6 +264,7 @@ private:
     std::map<std::string, std::shared_ptr<DownloadJob>> download_jobs_;
 
     bool running_;
+    bool startup_failed_ = false;
     std::atomic<bool> shutdown_requested_{false};
     std::atomic<bool> rebind_requested_{false};
     std::atomic<bool> metrics_access_logged_{false};

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -51,9 +51,8 @@ public:
     // Get server status
     bool is_running() const;
 
-    // True if run() returned because startup could not proceed (e.g. the
-    // configured port was already in use by another lemond instance). Lets
-    // main() report a clear failure and exit non-zero.
+    // True if run() aborted startup (e.g. the port was already in use), so
+    // main() can report failure and exit non-zero.
     bool startup_failed() const;
 
 private:

--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -142,6 +142,15 @@ int main(int argc, char** argv) {
         server.run();
         g_server_instance = nullptr;
 
+        // If startup failed (e.g. the port was already in use by another lemond
+        // instance), exit non-zero immediately. Use std::_Exit to skip the
+        // Server/Router destructors
+        if (server.startup_failed()) {
+            std::cout.flush();
+            std::cerr.flush();
+            std::_Exit(1);
+        }
+
         return 0;
 
     } catch (const std::exception& e) {

--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -142,9 +142,8 @@ int main(int argc, char** argv) {
         server.run();
         g_server_instance = nullptr;
 
-        // If startup failed (e.g. the port was already in use by another lemond
-        // instance), exit non-zero immediately. Use std::_Exit to skip the
-        // Server/Router destructors
+        // Startup aborted (e.g. port already in use): exit non-zero now and skip
+        // destructors, whose teardown logging would bury the error message.
         if (server.startup_failed()) {
             std::cout.flush();
             std::cerr.flush();

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -16,6 +16,7 @@
 #include "lemon/system_info.h"
 #include "lemon/version.h"
 #include <cctype>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <iomanip>
@@ -1170,22 +1171,31 @@ void Server::setup_http_logger(httplib::Server &web_server) {
     });
 }
 
-// Preflight bind probe: returns true if we can exclusively bind host_ip:port
-// (i.e. the port is free), false if it is already in use. This deliberately
-// does NOT set SO_REUSEADDR/SO_REUSEPORT (and uses SO_EXCLUSIVEADDRUSE on
-// Windows) so that a port already held by another process is reported as
-// unavailable rather than silently shared. The socket is closed immediately;
-// the real listeners bind moments later.
+// Preflight bind probe: returns true if we can bind host_ip:port (i.e. the port
+// is free), false if it is already actively held by another listener. The probe
+// MUST use the same socket options as the real listeners (see
+// exclusive_socket_options in setup_http_servers): SO_EXCLUSIVEADDRUSE on
+// Windows, and SO_REUSEADDR (but NOT SO_REUSEPORT) on POSIX. This keeps the
+// probe's result identical to what the real bind would do, in particular it
+// must still succeed over a socket left in TIME_WAIT by a just-exited server
+// (common during fast restarts and under systemd Restart=), while failing
+// against another instance that is actively listening. The socket is closed
+// immediately; the real listeners bind moments later.
 static bool port_is_available(int family, const std::string& host_ip, int port) {
     socket_t sock = socket(family, SOCK_STREAM, IPPROTO_TCP);
     if (sock == INVALID_SOCKET) {
         // Can't probe — don't block startup; the real bind path will report any error.
         return true;
     }
-#ifdef _WIN32
     int opt = 1;
+#ifdef _WIN32
     setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
                reinterpret_cast<const char*>(&opt), sizeof(opt));
+#else
+    // Match the real listener: allow rebinding a TIME_WAIT socket so a fast
+    // restart isn't falsely reported as "port in use". Do NOT set SO_REUSEPORT,
+    // so an actively-listening duplicate still makes this bind fail.
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 #endif
 
     bool available = false;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -39,6 +39,8 @@
 #else
     #include <sys/types.h>
     #include <sys/socket.h>
+    #include <netinet/in.h>  // sockaddr_in / sockaddr_in6
+    #include <arpa/inet.h>   // inet_pton, htons
     #include <netdb.h>  // Crucial for getaddrinfo and addrinfo struct
     #include <unistd.h>
 #endif
@@ -292,6 +294,30 @@ void Server::setup_http_servers() {
     };
     http_front_ = std::make_unique<UpgradableFrontServer>(http_server_.get(), upgrade_handler);
     http_front_v6_ = std::make_unique<UpgradableFrontServer>(http_server_v6_.get(), upgrade_handler);
+
+    // Bind exclusively so a second lemond instance on the same host:port fails
+    // to bind (instead of silently sharing the port).
+    // (cpp-httplib's default_socket_options sets SO_REUSEPORT (POSIX) / SO_REUSEADDR (Windows),
+    // both of which let a duplicate instance bind the same port: on Linux/macOS
+    // the kernel load-balances connections across both servers and on Windows
+    // the second socket can hijack the port.)
+    // Overriding these options makes the duplicate bind fail with EADDRINUSE.
+    auto exclusive_socket_options = [](socket_t sock) {
+        int opt = 1;
+#ifdef _WIN32
+        // On Windows, SO_REUSEADDR=1 (httplib's default) allows a second socket
+        // to take over the port. SO_EXCLUSIVEADDRUSE enforces true exclusivity.
+        setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
+                   reinterpret_cast<const char*>(&opt), sizeof(opt));
+#else
+        // Keep SO_REUSEADDR (so a quick restart isn't blocked by a TIME_WAIT
+        // socket) but deliberately do NOT set SO_REUSEPORT, which would let a
+        // second instance share the port.
+        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+#endif
+    };
+    http_front_->set_socket_options(exclusive_socket_options);
+    http_front_v6_->set_socket_options(exclusive_socket_options);
 
     // CRITICAL: Enable multi-threading so the server can handle concurrent requests
     // Without this, the server is single-threaded and blocks on long operations
@@ -1144,6 +1170,61 @@ void Server::setup_http_logger(httplib::Server &web_server) {
     });
 }
 
+// Preflight bind probe: returns true if we can exclusively bind host_ip:port
+// (i.e. the port is free), false if it is already in use. This deliberately
+// does NOT set SO_REUSEADDR/SO_REUSEPORT (and uses SO_EXCLUSIVEADDRUSE on
+// Windows) so that a port already held by another process is reported as
+// unavailable rather than silently shared. The socket is closed immediately;
+// the real listeners bind moments later.
+static bool port_is_available(int family, const std::string& host_ip, int port) {
+    socket_t sock = socket(family, SOCK_STREAM, IPPROTO_TCP);
+    if (sock == INVALID_SOCKET) {
+        // Can't probe — don't block startup; the real bind path will report any error.
+        return true;
+    }
+#ifdef _WIN32
+    int opt = 1;
+    setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
+               reinterpret_cast<const char*>(&opt), sizeof(opt));
+#endif
+
+    bool available = false;
+    if (family == AF_INET) {
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(static_cast<uint16_t>(port));
+        if (inet_pton(AF_INET, host_ip.c_str(), &addr.sin_addr) != 1) {
+#ifdef _WIN32
+            closesocket(sock);
+#else
+            close(sock);
+#endif
+            return true;  // Couldn't parse address — let the real bind path decide.
+        }
+        available = bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0;
+    } else {
+        sockaddr_in6 addr{};
+        addr.sin6_family = AF_INET6;
+        addr.sin6_port = htons(static_cast<uint16_t>(port));
+        if (inet_pton(AF_INET6, host_ip.c_str(), &addr.sin6_addr) != 1) {
+#ifdef _WIN32
+            closesocket(sock);
+#else
+            close(sock);
+#endif
+            return true;
+        }
+        available = bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0;
+    }
+
+#ifdef _WIN32
+    closesocket(sock);
+#else
+    close(sock);
+#endif
+    return available;
+}
+
 void Server::run() {
     std::string host = config_->host();
     LOG(INFO, "Server") << "Starting HTTP server on " << host << ":" << port_ << std::endl;
@@ -1157,6 +1238,35 @@ void Server::run() {
     if (ipv4.empty() && ipv6.empty()) {
         throw std::runtime_error("Failed to resolve host '" + host + "' to any address. "
                                  "Cannot start server.");
+    }
+
+    // Preflight: fail fast and loudly if the port is already taken (most often
+    // because another lemond is already running). Without this, startup would
+    // proceed far enough to start the WebSocket server, begin UDP broadcasting,
+    // and finish model-cache warmup before the bind failure surfaces deep in the
+    // run loop below — burying the real cause under unrelated shutdown logs.
+    {
+        std::string in_use_ip;
+        if (!ipv4.empty() && !port_is_available(AF_INET, ipv4, port_)) {
+            in_use_ip = ipv4;
+        } else if (!ipv6.empty() && !port_is_available(AF_INET6, ipv6, port_)) {
+            in_use_ip = ipv6;
+        }
+        if (!in_use_ip.empty()) {
+            // Write straight to stderr (unbuffered) so the message is reliably
+            // visible in the user's terminal, then also log it for the log file.
+            std::cerr << "[Server] ERROR: Port " << port_ << " on " << in_use_ip
+                      << " is already in use. Another Lemonade server (lemond) is "
+                         "most likely already running on this port. This instance "
+                         "will now exit." << std::endl;
+            std::cerr.flush();
+            LOG(ERROR, "Server") << "Port " << port_ << " on " << in_use_ip
+                << " is already in use. Another Lemonade server (lemond) is most "
+                   "likely already running on this port. This instance will now "
+                   "exit." << std::endl;
+            startup_failed_ = true;
+            return;
+        }
     }
 
     // Operators binding beyond loopback should secure the server with an API
@@ -1286,9 +1396,22 @@ void Server::run() {
         // Wait for listener threads, but check periodically for shutdown or rebind signals.
         // The threads are blocked in listen_after_bind(), which only returns when
         // the server is stopped or an error occurs.
+        //
+        // Also stop waiting if a listener thread failed to bind (e.g. the port is
+        // already in use by another lemond instance). A thread that returned early
+        // after a failed bind is still joinable(), so without the listener_start_failed
+        // check this loop would spin forever and never reach the error-reporting code below
         while ((http_v4_thread_.joinable() || http_v6_thread_.joinable()) &&
-               !shutdown_requested_.load() && !rebind_requested_.load()) {
+               !shutdown_requested_.load() && !rebind_requested_.load() &&
+               !listener_start_failed.load()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+
+        // If a listener failed to start (e.g. duplicate instance on the same
+        // port), stop() any sibling listener that did bind so its thread can
+        // unblock from listen_after_bind() before we join below.
+        if (listener_start_failed.load() && !shutdown_requested_.load() && !rebind_requested_.load()) {
+            stop();
         }
 
         // If shutdown was requested while the server was running, stop it now
@@ -1332,6 +1455,8 @@ void Server::run() {
             }
             std::cerr << "[Server] Another Lemonade router/server instance is already running on "
                       << config_->host() << ":" << port_ << ". Duplicate instance now exiting." << std::endl;
+            LOG(ERROR, "Server") << "Another Lemonade router/server instance is already running on "
+                      << config_->host() << ":" << port_ << ". Duplicate instance now exiting." << std::endl;
             stop();
             break;
         }
@@ -1362,6 +1487,10 @@ void Server::set_shutdown_requested(bool requested) {
 
 bool Server::is_running() const {
     return running_;
+}
+
+bool Server::startup_failed() const {
+    return startup_failed_;
 }
 
 void Server::stop() {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -308,16 +308,10 @@ void Server::setup_http_servers() {
     http_front_ = std::make_unique<UpgradableFrontServer>(http_server_.get(), upgrade_handler);
     http_front_v6_ = std::make_unique<UpgradableFrontServer>(http_server_v6_.get(), upgrade_handler);
 
-    // Note: the real listeners intentionally keep cpp-httplib's default socket
-    // options (SO_REUSEPORT on POSIX / SO_REUSEADDR on Windows). Those defaults
-    // are required for correct dual-stack binding: httplib binds IPv6 with
-    // IPV6_V6ONLY=0 (see CPPHTTPLIB_IPV6_V6ONLY), so the IPv6 wildcard "::"
-    // overlaps the already-bound IPv4 wildcard "0.0.0.0"; only SO_REUSEPORT lets
-    // those two wildcard sockets coexist on the same port. Duplicate-instance
-    // detection is handled up front by port_is_available() in run(), which probes
-    // with an exclusive (non-SO_REUSEPORT) socket and refuses to start if another
-    // server is already listening — so we must NOT make the real listeners
-    // exclusive here, or a normal dual-stack startup would fail to bind IPv6.
+    // Keep cpp-httplib's default socket options here. httplib binds IPv6 with
+    // IPV6_V6ONLY=0, so "::" overlaps the IPv4 wildcard "0.0.0.0" and only the
+    // default SO_REUSEPORT lets the two coexist. Duplicate detection is done by
+    // port_is_available() in run(), not by making these listeners exclusive.
 
     // CRITICAL: Enable multi-threading so the server can handle concurrent requests
     // Without this, the server is single-threaded and blocks on long operations
@@ -1187,70 +1181,49 @@ void Server::setup_http_logger(httplib::Server &web_server) {
     });
 }
 
-// Preflight bind probe: returns true if we can bind host_ip:port (i.e. the port
-// is free), false if it is already actively held by another listener (another
-// lemond). The probe binds an *exclusive* socket — SO_EXCLUSIVEADDRUSE on
-// Windows, and SO_REUSEADDR WITHOUT SO_REUSEPORT on POSIX — so that:
-//   - it fails if another instance is actively listening (the real listeners
-//     keep httplib's SO_REUSEPORT default, and a non-SO_REUSEPORT bind against a
-//     SO_REUSEPORT holder still returns EADDRINUSE), and
-//   - it still succeeds over a socket left in TIME_WAIT by a just-exited server
-//     (common during fast restarts and under systemd Restart=), thanks to
-//     SO_REUSEADDR.
-// Each address family is probed on its own short-lived socket that is closed
-// before the next, so the IPv4 and IPv6 probes never overlap. The socket is
-// closed immediately; the real listeners bind moments later.
+// Probe whether host_ip:port can be bound (i.e. the port is free). Uses an
+// exclusive socket (SO_EXCLUSIVEADDRUSE on Windows; SO_REUSEADDR but NOT
+// SO_REUSEPORT on POSIX) so an actively-listening duplicate is detected, while a
+// socket left in TIME_WAIT by a just-exited server is still bindable.
 static bool port_is_available(int family, const std::string& host_ip, int port) {
     socket_t sock = socket(family, SOCK_STREAM, IPPROTO_TCP);
     if (sock == INVALID_SOCKET) {
-        // Can't probe — don't block startup; the real bind path will report any error.
-        return true;
+        return true;  // Can't probe; let the real bind path report any error.
     }
+    auto close_sock = [&]() {
+#ifdef _WIN32
+        closesocket(sock);
+#else
+        close(sock);
+#endif
+    };
+
     int opt = 1;
 #ifdef _WIN32
     setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
                reinterpret_cast<const char*>(&opt), sizeof(opt));
 #else
-    // Match the real listener: allow rebinding a TIME_WAIT socket so a fast
-    // restart isn't falsely reported as "port in use". Do NOT set SO_REUSEPORT,
-    // so an actively-listening duplicate still makes this bind fail.
     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 #endif
 
-    bool available = false;
+    sockaddr_storage ss{};
+    socklen_t len;
     if (family == AF_INET) {
-        sockaddr_in addr{};
-        addr.sin_family = AF_INET;
-        addr.sin_port = htons(static_cast<uint16_t>(port));
-        if (inet_pton(AF_INET, host_ip.c_str(), &addr.sin_addr) != 1) {
-#ifdef _WIN32
-            closesocket(sock);
-#else
-            close(sock);
-#endif
-            return true;  // Couldn't parse address — let the real bind path decide.
-        }
-        available = bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0;
+        auto* a = reinterpret_cast<sockaddr_in*>(&ss);
+        a->sin_family = AF_INET;
+        a->sin_port = htons(static_cast<uint16_t>(port));
+        if (inet_pton(AF_INET, host_ip.c_str(), &a->sin_addr) != 1) { close_sock(); return true; }
+        len = sizeof(sockaddr_in);
     } else {
-        sockaddr_in6 addr{};
-        addr.sin6_family = AF_INET6;
-        addr.sin6_port = htons(static_cast<uint16_t>(port));
-        if (inet_pton(AF_INET6, host_ip.c_str(), &addr.sin6_addr) != 1) {
-#ifdef _WIN32
-            closesocket(sock);
-#else
-            close(sock);
-#endif
-            return true;
-        }
-        available = bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0;
+        auto* a = reinterpret_cast<sockaddr_in6*>(&ss);
+        a->sin6_family = AF_INET6;
+        a->sin6_port = htons(static_cast<uint16_t>(port));
+        if (inet_pton(AF_INET6, host_ip.c_str(), &a->sin6_addr) != 1) { close_sock(); return true; }
+        len = sizeof(sockaddr_in6);
     }
 
-#ifdef _WIN32
-    closesocket(sock);
-#else
-    close(sock);
-#endif
+    bool available = bind(sock, reinterpret_cast<sockaddr*>(&ss), len) == 0;
+    close_sock();
     return available;
 }
 
@@ -1269,11 +1242,8 @@ void Server::run() {
                                  "Cannot start server.");
     }
 
-    // Preflight: fail fast and loudly if the port is already taken (most often
-    // because another lemond is already running). Without this, startup would
-    // proceed far enough to start the WebSocket server, begin UDP broadcasting,
-    // and finish model-cache warmup before the bind failure surfaces deep in the
-    // run loop below — burying the real cause under unrelated shutdown logs.
+    // Fail fast if the port is already taken (usually another lemond). Detecting
+    // it here keeps the error from being buried under later startup logs.
     {
         std::string in_use_ip;
         if (!ipv4.empty() && !port_is_available(AF_INET, ipv4, port_)) {
@@ -1282,17 +1252,11 @@ void Server::run() {
             in_use_ip = ipv6;
         }
         if (!in_use_ip.empty()) {
-            // Write straight to stderr (unbuffered) so the message is reliably
-            // visible in the user's terminal, then also log it for the log file.
-            std::cerr << "[Server] ERROR: Port " << port_ << " on " << in_use_ip
-                      << " is already in use. Another Lemonade server (lemond) is "
-                         "most likely already running on this port. This instance "
-                         "will now exit." << std::endl;
-            std::cerr.flush();
-            LOG(ERROR, "Server") << "Port " << port_ << " on " << in_use_ip
-                << " is already in use. Another Lemonade server (lemond) is most "
-                   "likely already running on this port. This instance will now "
-                   "exit." << std::endl;
+            std::string msg = "Port " + std::to_string(port_) + " on " + in_use_ip +
+                " is already in use. Another Lemonade server (lemond) is likely "
+                "already running on this port. This instance will now exit.";
+            std::cerr << "[Server] ERROR: " << msg << std::endl;  // terminal visibility
+            LOG(ERROR, "Server") << msg << std::endl;
             startup_failed_ = true;
             return;
         }
@@ -1425,28 +1389,9 @@ void Server::run() {
         // Wait for listener threads, but check periodically for shutdown or rebind signals.
         // The threads are blocked in listen_after_bind(), which only returns when
         // the server is stopped or an error occurs.
-        //
-        // Also stop waiting if EVERY listener failed to bind (total failure, e.g.
-        // the port is held by something we can't share with). A thread that
-        // returned early after a failed bind is still joinable(), so without this
-        // check the loop would spin forever and never reach the error-reporting
-        // code below. We must only treat this as fatal when NOTHING bound: on a
-        // dual-stack host one family can legitimately fail (e.g. the IPv6 wildcard
-        // overlapping the IPv4 wildcard) while the other serves fine, and tearing
-        // the server down in that case would kill a working listener.
         while ((http_v4_thread_.joinable() || http_v6_thread_.joinable()) &&
-               !shutdown_requested_.load() && !rebind_requested_.load() &&
-               !(listener_start_failed.load() && !listener_started.load())) {
+               !shutdown_requested_.load() && !rebind_requested_.load()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        }
-
-        // If NO listener started (total bind failure), stop() so any thread that
-        // is mid-teardown unblocks before we join below, then fall through to the
-        // error-reporting block. A partial failure (one family bound, the other
-        // did not) is intentionally left running on the working family.
-        if (listener_start_failed.load() && !listener_started.load() &&
-            !shutdown_requested_.load() && !rebind_requested_.load()) {
-            stop();
         }
 
         // If shutdown was requested while the server was running, stop it now
@@ -1489,8 +1434,6 @@ void Server::run() {
                 break;
             }
             std::cerr << "[Server] Another Lemonade router/server instance is already running on "
-                      << config_->host() << ":" << port_ << ". Duplicate instance now exiting." << std::endl;
-            LOG(ERROR, "Server") << "Another Lemonade router/server instance is already running on "
                       << config_->host() << ":" << port_ << ". Duplicate instance now exiting." << std::endl;
             stop();
             break;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -308,29 +308,16 @@ void Server::setup_http_servers() {
     http_front_ = std::make_unique<UpgradableFrontServer>(http_server_.get(), upgrade_handler);
     http_front_v6_ = std::make_unique<UpgradableFrontServer>(http_server_v6_.get(), upgrade_handler);
 
-    // Bind exclusively so a second lemond instance on the same host:port fails
-    // to bind (instead of silently sharing the port).
-    // (cpp-httplib's default_socket_options sets SO_REUSEPORT (POSIX) / SO_REUSEADDR (Windows),
-    // both of which let a duplicate instance bind the same port: on Linux/macOS
-    // the kernel load-balances connections across both servers and on Windows
-    // the second socket can hijack the port.)
-    // Overriding these options makes the duplicate bind fail with EADDRINUSE.
-    auto exclusive_socket_options = [](socket_t sock) {
-        int opt = 1;
-#ifdef _WIN32
-        // On Windows, SO_REUSEADDR=1 (httplib's default) allows a second socket
-        // to take over the port. SO_EXCLUSIVEADDRUSE enforces true exclusivity.
-        setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE,
-                   reinterpret_cast<const char*>(&opt), sizeof(opt));
-#else
-        // Keep SO_REUSEADDR (so a quick restart isn't blocked by a TIME_WAIT
-        // socket) but deliberately do NOT set SO_REUSEPORT, which would let a
-        // second instance share the port.
-        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-#endif
-    };
-    http_front_->set_socket_options(exclusive_socket_options);
-    http_front_v6_->set_socket_options(exclusive_socket_options);
+    // Note: the real listeners intentionally keep cpp-httplib's default socket
+    // options (SO_REUSEPORT on POSIX / SO_REUSEADDR on Windows). Those defaults
+    // are required for correct dual-stack binding: httplib binds IPv6 with
+    // IPV6_V6ONLY=0 (see CPPHTTPLIB_IPV6_V6ONLY), so the IPv6 wildcard "::"
+    // overlaps the already-bound IPv4 wildcard "0.0.0.0"; only SO_REUSEPORT lets
+    // those two wildcard sockets coexist on the same port. Duplicate-instance
+    // detection is handled up front by port_is_available() in run(), which probes
+    // with an exclusive (non-SO_REUSEPORT) socket and refuses to start if another
+    // server is already listening — so we must NOT make the real listeners
+    // exclusive here, or a normal dual-stack startup would fail to bind IPv6.
 
     // CRITICAL: Enable multi-threading so the server can handle concurrent requests
     // Without this, the server is single-threaded and blocks on long operations
@@ -1201,15 +1188,18 @@ void Server::setup_http_logger(httplib::Server &web_server) {
 }
 
 // Preflight bind probe: returns true if we can bind host_ip:port (i.e. the port
-// is free), false if it is already actively held by another listener. The probe
-// MUST use the same socket options as the real listeners (see
-// exclusive_socket_options in setup_http_servers): SO_EXCLUSIVEADDRUSE on
-// Windows, and SO_REUSEADDR (but NOT SO_REUSEPORT) on POSIX. This keeps the
-// probe's result identical to what the real bind would do, in particular it
-// must still succeed over a socket left in TIME_WAIT by a just-exited server
-// (common during fast restarts and under systemd Restart=), while failing
-// against another instance that is actively listening. The socket is closed
-// immediately; the real listeners bind moments later.
+// is free), false if it is already actively held by another listener (another
+// lemond). The probe binds an *exclusive* socket — SO_EXCLUSIVEADDRUSE on
+// Windows, and SO_REUSEADDR WITHOUT SO_REUSEPORT on POSIX — so that:
+//   - it fails if another instance is actively listening (the real listeners
+//     keep httplib's SO_REUSEPORT default, and a non-SO_REUSEPORT bind against a
+//     SO_REUSEPORT holder still returns EADDRINUSE), and
+//   - it still succeeds over a socket left in TIME_WAIT by a just-exited server
+//     (common during fast restarts and under systemd Restart=), thanks to
+//     SO_REUSEADDR.
+// Each address family is probed on its own short-lived socket that is closed
+// before the next, so the IPv4 and IPv6 probes never overlap. The socket is
+// closed immediately; the real listeners bind moments later.
 static bool port_is_available(int family, const std::string& host_ip, int port) {
     socket_t sock = socket(family, SOCK_STREAM, IPPROTO_TCP);
     if (sock == INVALID_SOCKET) {
@@ -1436,20 +1426,26 @@ void Server::run() {
         // The threads are blocked in listen_after_bind(), which only returns when
         // the server is stopped or an error occurs.
         //
-        // Also stop waiting if a listener thread failed to bind (e.g. the port is
-        // already in use by another lemond instance). A thread that returned early
-        // after a failed bind is still joinable(), so without the listener_start_failed
-        // check this loop would spin forever and never reach the error-reporting code below
+        // Also stop waiting if EVERY listener failed to bind (total failure, e.g.
+        // the port is held by something we can't share with). A thread that
+        // returned early after a failed bind is still joinable(), so without this
+        // check the loop would spin forever and never reach the error-reporting
+        // code below. We must only treat this as fatal when NOTHING bound: on a
+        // dual-stack host one family can legitimately fail (e.g. the IPv6 wildcard
+        // overlapping the IPv4 wildcard) while the other serves fine, and tearing
+        // the server down in that case would kill a working listener.
         while ((http_v4_thread_.joinable() || http_v6_thread_.joinable()) &&
                !shutdown_requested_.load() && !rebind_requested_.load() &&
-               !listener_start_failed.load()) {
+               !(listener_start_failed.load() && !listener_started.load())) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
 
-        // If a listener failed to start (e.g. duplicate instance on the same
-        // port), stop() any sibling listener that did bind so its thread can
-        // unblock from listen_after_bind() before we join below.
-        if (listener_start_failed.load() && !shutdown_requested_.load() && !rebind_requested_.load()) {
+        // If NO listener started (total bind failure), stop() so any thread that
+        // is mid-teardown unblocks before we join below, then fall through to the
+        // error-reporting block. A partial failure (one family bound, the other
+        // did not) is intentionally left running on the working family.
+        if (listener_start_failed.load() && !listener_started.load() &&
+            !shutdown_requested_.load() && !rebind_requested_.load()) {
             stop();
         }
 

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -23,6 +23,9 @@ Usage:
 import json
 import os
 import platform
+import socket
+import subprocess
+import time
 import unittest
 import shutil
 import tempfile
@@ -40,6 +43,7 @@ from utils.server_base import (
 from utils.test_models import (
     PORT,
     ENDPOINT_TEST_MODEL,
+    get_default_lemond_binary,
     SHARED_REPO_MODEL_B_CHECKPOINT,
     TIMEOUT_MODEL_OPERATION,
     TIMEOUT_DEFAULT,
@@ -50,6 +54,47 @@ from utils.test_models import (
     get_hf_cache_dir,
     get_hf_cache_dir_candidates,
 )
+
+
+def _resolve_lemond_binary():
+    """Locate the lemond daemon binary for the duplicate-port test.
+
+    Prefers the binary built alongside this checkout; falls back to whatever is
+    on PATH. Returns None if neither exists so the test can skip cleanly rather
+    than fail on a machine without a built daemon.
+    """
+    candidate = get_default_lemond_binary()
+    if candidate and os.path.exists(candidate):
+        return candidate
+    return shutil.which("lemond")
+
+
+def _pick_free_port():
+    """Return an unused TCP port assigned by the OS on the IPv4 loopback.
+
+    Binding to port 0 lets the kernel pick a free port; we read it back and
+    close the socket immediately. Both lemond instances in the duplicate-port
+    test target this port, which is independent of the suite's server on PORT.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+def _lemond_health_ok(port, headers):
+    """True if lemond answers a 200 on /api/v1/health at the given port."""
+    try:
+        response = requests.get(
+            f"http://localhost:{port}/api/v1/health",
+            headers=headers,
+            timeout=2,
+        )
+        return response.status_code == 200
+    except requests.RequestException:
+        return False
 
 
 class EndpointTests(ServerTestBase):
@@ -3258,6 +3303,115 @@ class EndpointTests(ServerTestBase):
             f"[OK] Valid checkpoint returned {len(variants)} variant(s): "
             f"{[v['name'] for v in variants]}"
         )
+
+    def test_034_second_lemond_on_busy_port_exits_nonzero(self):
+        """A second lemond on an in-use port must refuse to start and exit non-zero.
+
+        Regression test for the duplicate-port guard: lemond preflight-probes the
+        listen port and if another server already holds it, prints a clear error
+        to stderr and exits non-zero instead of silently failing to bind. This
+        test starts a real lemond on a fresh port, launches a second lemond on the
+        same port, and asserts the second one (a) exits non-zero, (b) reports the
+        port is already in use, and (c) leaves the first server healthy.
+        """
+        lemond_binary = _resolve_lemond_binary()
+        if not lemond_binary:
+            self.skipTest("lemond binary not found (build it or add it to PATH)")
+
+        headers = {}
+        api_key = os.environ.get("LEMONADE_API_KEY")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        port = _pick_free_port()
+        cache_dir = tempfile.mkdtemp(prefix="lemond_dupport_")
+        first_log_path = os.path.join(cache_dir, "first_lemond.log")
+        cmd = [lemond_binary, cache_dir, "--port", str(port)]
+
+        first = None
+        second = None
+        try:
+            # --- Start the first lemond and wait until it is healthy ---
+            with open(first_log_path, "w", encoding="utf-8") as first_log:
+                first = subprocess.Popen(
+                    cmd,
+                    stdout=first_log,
+                    stderr=subprocess.STDOUT,
+                    env=os.environ.copy(),
+                )
+
+            deadline = time.time() + 60
+            first_healthy = False
+            while time.time() < deadline:
+                if first.poll() is not None:
+                    break  # exited early; surface the log below
+                if _lemond_health_ok(port, headers):
+                    first_healthy = True
+                    break
+                time.sleep(1)
+
+            if not first_healthy:
+                with open(first_log_path, "r", encoding="utf-8", errors="replace") as f:
+                    log = f.read()
+                self.fail(
+                    f"First lemond never became healthy on port {port}.\n"
+                    f"=== lemond log ===\n{log}"
+                )
+
+            # --- Start the second lemond on the SAME port; it must refuse ---
+            second = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=os.environ.copy(),
+            )
+            try:
+                out, err = second.communicate(timeout=30)
+            except subprocess.TimeoutExpired:
+                second.kill()
+                out, err = second.communicate()
+                self.fail(
+                    "Second lemond did not exit; it should fail fast on the "
+                    f"in-use port {port}."
+                )
+
+            combined = f"{out or ''}\n{err or ''}"
+
+            self.assertNotEqual(
+                second.returncode,
+                0,
+                "Second lemond on an in-use port must exit non-zero, "
+                f"got exit code 0.\n=== output ===\n{combined}",
+            )
+            self.assertIn(
+                "already in use",
+                combined.lower(),
+                "Second lemond should report the port is already in use.\n"
+                f"=== output ===\n{combined}",
+            )
+
+            # --- The original server must still be healthy ---
+            self.assertTrue(
+                _lemond_health_ok(port, headers),
+                "First lemond should remain healthy after the duplicate was "
+                "rejected.",
+            )
+
+            print(
+                f"[OK] Second lemond on in-use port {port} exited "
+                f"{second.returncode} and first server stayed healthy"
+            )
+        finally:
+            for proc in (second, first):
+                if proc is not None and proc.poll() is None:
+                    proc.terminate()
+                    try:
+                        proc.wait(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        proc.kill()
+                        proc.wait(timeout=10)
+            shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -63,6 +63,17 @@ def get_arg(flag, default):
     return default
 
 
+# lemond detects the system llama-server version by running
+# `llama-server --version` and reading one line of stdout (see
+# SystemInfo::get_system_llamacpp_version in src/cpp/server/system_info.cpp).
+# The real binary prints a version line and exits immediately. We must mirror
+# that: otherwise the probe blocks forever on our long-lived HTTP server and
+# /internal/set hangs until the client times out.
+if "--version" in sys.argv or "--help" in sys.argv:
+    print("version: 9999 (mock)")
+    sys.exit(0)
+
+
 class ReusableHTTPServer(ThreadingHTTPServer):
     allow_reuse_address = True
 
@@ -406,7 +417,7 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
         if cls._model_pulled:
             return
 
-        pull_model_with_retry(ENDPOINT_TEST_MODEL)
+        pull_model_with_retry(ENDPOINT_TEST_MODEL, port=PORT)
         cls._model_pulled = True
 
     @unittest.skipUnless(

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -28,7 +28,6 @@ from utils.server_base import (
     PORT,
     pull_model_with_retry,
     set_server_config,
-    wait_for_server,
 )
 from utils.test_models import (
     ENDPOINT_TEST_MODEL,
@@ -167,59 +166,11 @@ def _is_server_running(port=PORT):
         return False
 
 
-def _port_bindable(family, ip, port):
-    """Probe whether (ip, port) can be bound. Mirrors lemond's port_is_available
-    check: uses SO_REUSEADDR (POSIX) / SO_EXCLUSIVEADDRUSE (Windows) so a socket
-    in TIME_WAIT is still treated as free, while an actively-bound listener is
-    detected as busy.
-    """
-    sock = socket.socket(family, socket.SOCK_STREAM)
-    try:
-        if os.name == "nt":
-            # Best-effort: SO_EXCLUSIVEADDRUSE matches the lemond probe but is
-            # only present on Windows.
-            try:
-                sock.setsockopt(
-                    socket.SOL_SOCKET, getattr(socket, "SO_EXCLUSIVEADDRUSE", 0), 1
-                )
-            except (AttributeError, OSError):
-                pass
-        else:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        try:
-            sock.bind((ip, port))
-            return True
-        except OSError:
-            return False
-    finally:
-        sock.close()
-
-
-def _port_is_free(port=PORT):
-    """True only when the port is bindable on both 127.0.0.1 and ::1.
-
-    lemond binds IPv4 and IPv6 separately and refuses to start if either is
-    already in use. A liveness probe via socket.create_connection() can return
-    False (connect refused) while an old lemond's IPv6 listen socket is still
-    bound, so we explicitly verify both families are free.
-    """
-    if not _port_bindable(socket.AF_INET, "127.0.0.1", port):
-        return False
-    if socket.has_ipv6:
-        try:
-            if not _port_bindable(socket.AF_INET6, "::1", port):
-                return False
-        except OSError:
-            # IPv6 stack unavailable — IPv4 result is sufficient.
-            pass
-    return True
-
-
 def _wait_for_server_stop(port=PORT, timeout=30):
-    """Wait for the server to stop and the port to become bindable again."""
+    """Wait for the server's HTTP endpoint to stop accepting connections."""
     start_time = time.time()
     while time.time() - start_time < timeout:
-        if not _is_server_running(port) and _port_is_free(port):
+        if not _is_server_running(port):
             return True
         time.sleep(1)
     return False
@@ -237,58 +188,123 @@ def _get_lemond_binary():
     return shutil.which("lemond") or "lemond"
 
 
+def _pick_free_port():
+    """Return an unused TCP port assigned by the OS on the IPv4 loopback.
+
+    Each lemond instance this test starts uses a fresh OS-assigned port. That
+    sidesteps a TCP rebind hazard: lemond (the server) initiates the close on
+    shutdown, so its accepted socket on the listen port lingers in FIN_WAIT2 /
+    TIME_WAIT. Once the process is gone that socket is orphaned and, on Linux,
+    can keep the port un-bindable for up to ~60s even with SO_REUSEADDR. Because
+    this test restarts lemond many times in quick succession, reusing one fixed
+    port makes startup flaky in CI; a fresh port is always immediately bindable.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
 def _stop_server():
-    """Stop the server via /internal/shutdown."""
+    """Stop the currently-running server via /internal/shutdown."""
     try:
         requests.post(
             f"http://localhost:{PORT}/internal/shutdown",
             headers=_auth_headers(),
             timeout=5,
         )
-        _wait_for_server_stop()
+        _wait_for_server_stop(PORT)
     except Exception as e:
         print(f"Warning: Failed to stop server: {e}")
 
 
+def _server_healthy(port=PORT):
+    """True if lemond answers a health check on the port."""
+    try:
+        response = requests.get(
+            f"http://localhost:{port}/api/v1/health",
+            headers=_auth_headers(),
+            timeout=2,
+        )
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
 def _start_server(wrapped_server=None, backend=None, config_updates=None):
-    """Start lemond and wait for it to be ready."""
+    """Start a fresh lemond on a new OS-assigned port and wait until ready.
+
+    Each call binds a brand-new port (see _pick_free_port) and republishes it as
+    the module-level ``PORT`` so the rest of the test talks to the current
+    instance. Binding a fresh port every time means the rapid restarts this test
+    performs never contend for a port still held in a lingering TCP teardown
+    state by a previously stopped instance.
+    """
+    global PORT
+
     lemond_binary = _get_lemond_binary()
     cache_dir = LlamaCppSystemBackendTests.cache_dir
-    cmd = [lemond_binary, cache_dir, "--port", str(PORT)]
 
-    # lemond refuses to start if the port is already in use, and its shutdown
-    # has a multi-second teardown that can keep the listen socket open briefly
-    # after the HTTP endpoint stops responding. Make sure the port is fully
-    # released before launching so a stop->start in quick succession doesn't
-    # race the previous instance.
+    # Stop the instance we previously started, if any, so it releases its
+    # resources before we launch the next one.
     if _is_server_running(PORT):
         _stop_server()
-    if not _wait_for_server_stop(PORT, timeout=30):
-        raise RuntimeError(f"Port {PORT} still in use; cannot start lemond")
 
     # Redirect output to a log file rather than a PIPE: lemond runs with
     # debug logging here, and an undrained PIPE can fill its buffer and block
     # the process before it opens the port. The log is printed on failure.
-    log_path = os.path.join(tempfile.gettempdir(), f"lemond_test_{PORT}.log")
-    log_file = open(log_path, "w", encoding="utf-8")
-    subprocess.Popen(
-        cmd,
-        stdout=log_file,
-        stderr=subprocess.STDOUT,
-        env=os.environ.copy(),
-    )
+    log_path = os.path.join(tempfile.gettempdir(), "lemond_test.log")
+    last_log = ""
 
-    try:
-        wait_for_server(timeout=60)
-    except TimeoutError:
-        log_file.flush()
+    proc = None
+    started = False
+    max_attempts = 5
+    for _attempt in range(1, max_attempts + 1):
+        port = _pick_free_port()
+        PORT = port
+        cmd = [lemond_binary, cache_dir, "--port", str(port)]
+
+        with open(log_path, "w", encoding="utf-8") as log_file:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                env=os.environ.copy(),
+            )
+
+        # Wait for this instance to become healthy, bailing early if it exits
+        # so we can retry on a fresh port.
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                break  # lemond exited early -> retry on a new port
+            if _server_healthy(port):
+                started = True
+                break
+            time.sleep(1)
+
+        if started:
+            break
+
+        # This attempt failed: clean up before retrying on a new port.
+        try:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=10)
+        except Exception:
+            pass
         try:
             with open(log_path, "r", encoding="utf-8", errors="replace") as f:
-                print("=== lemond startup log ===")
-                print(f.read())
+                last_log = f.read()
         except OSError:
-            pass
-        raise
+            last_log = ""
+
+    if not started:
+        print("=== lemond startup log (last attempt) ===")
+        print(last_log)
+        raise RuntimeError(f"lemond failed to start after {max_attempts} attempts")
 
     runtime_config = {}
     if wrapped_server == "llamacpp" and backend:

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -167,11 +167,59 @@ def _is_server_running(port=PORT):
         return False
 
 
+def _port_bindable(family, ip, port):
+    """Probe whether (ip, port) can be bound. Mirrors lemond's port_is_available
+    check: uses SO_REUSEADDR (POSIX) / SO_EXCLUSIVEADDRUSE (Windows) so a socket
+    in TIME_WAIT is still treated as free, while an actively-bound listener is
+    detected as busy.
+    """
+    sock = socket.socket(family, socket.SOCK_STREAM)
+    try:
+        if os.name == "nt":
+            # Best-effort: SO_EXCLUSIVEADDRUSE matches the lemond probe but is
+            # only present on Windows.
+            try:
+                sock.setsockopt(
+                    socket.SOL_SOCKET, getattr(socket, "SO_EXCLUSIVEADDRUSE", 0), 1
+                )
+            except (AttributeError, OSError):
+                pass
+        else:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((ip, port))
+            return True
+        except OSError:
+            return False
+    finally:
+        sock.close()
+
+
+def _port_is_free(port=PORT):
+    """True only when the port is bindable on both 127.0.0.1 and ::1.
+
+    lemond binds IPv4 and IPv6 separately and refuses to start if either is
+    already in use. A liveness probe via socket.create_connection() can return
+    False (connect refused) while an old lemond's IPv6 listen socket is still
+    bound, so we explicitly verify both families are free.
+    """
+    if not _port_bindable(socket.AF_INET, "127.0.0.1", port):
+        return False
+    if socket.has_ipv6:
+        try:
+            if not _port_bindable(socket.AF_INET6, "::1", port):
+                return False
+        except OSError:
+            # IPv6 stack unavailable — IPv4 result is sufficient.
+            pass
+    return True
+
+
 def _wait_for_server_stop(port=PORT, timeout=30):
-    """Wait for server to stop."""
+    """Wait for the server to stop and the port to become bindable again."""
     start_time = time.time()
     while time.time() - start_time < timeout:
-        if not _is_server_running(port):
+        if not _is_server_running(port) and _port_is_free(port):
             return True
         time.sleep(1)
     return False

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -208,23 +208,39 @@ def _start_server(wrapped_server=None, backend=None, config_updates=None):
     cache_dir = LlamaCppSystemBackendTests.cache_dir
     cmd = [lemond_binary, cache_dir, "--port", str(PORT)]
 
-    if sys.platform == "win32":
-        subprocess.Popen(
-            cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            env=os.environ.copy(),
-        )
-    else:
-        subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            env=os.environ.copy(),
-        )
+    # lemond refuses to start if the port is already in use, and its shutdown
+    # has a multi-second teardown that can keep the listen socket open briefly
+    # after the HTTP endpoint stops responding. Make sure the port is fully
+    # released before launching so a stop->start in quick succession doesn't
+    # race the previous instance.
+    if _is_server_running(PORT):
+        _stop_server()
+    if not _wait_for_server_stop(PORT, timeout=30):
+        raise RuntimeError(f"Port {PORT} still in use; cannot start lemond")
 
-    wait_for_server(timeout=60)
+    # Redirect output to a log file rather than a PIPE: lemond runs with
+    # debug logging here, and an undrained PIPE can fill its buffer and block
+    # the process before it opens the port. The log is printed on failure.
+    log_path = os.path.join(tempfile.gettempdir(), f"lemond_test_{PORT}.log")
+    log_file = open(log_path, "w", encoding="utf-8")
+    subprocess.Popen(
+        cmd,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        env=os.environ.copy(),
+    )
+
+    try:
+        wait_for_server(timeout=60)
+    except TimeoutError:
+        log_file.flush()
+        try:
+            with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+                print("=== lemond startup log ===")
+                print(f.read())
+        except OSError:
+            pass
+        raise
 
     runtime_config = {}
     if wrapped_server == "llamacpp" and backend:


### PR DESCRIPTION
## Summary

Fixes #2255

Starting a second `lemond` on a port that's already in use (e.g. 13305) used to silently succeed. The second instance now detects the conflict, prints error and exits with a non-zero code.

## Root cause

The front HTTP listeners inherited cpp-httplib's `default_socket_options`, which enable address/port reuse:

- **Linux/macOS** → `SO_REUSEPORT`: multiple sockets may bind the same `host:port` and the kernel **load-balances** connections across them.
- **Windows** → `SO_REUSEADDR`: the second socket can **hijack** the port.

Because the bind appeared to succeed, the existing duplicate-instance guard in the run loop never fired and the process kept running as a confusing second listener.

## Changes

### Server (core fix)

1. **Exclusive bind**: A duplicate bind now fails with `EADDRINUSE`.

2. **Early, readable failure**: Added a preflight bind probe at the top of `Server::run()` that detects an in-use port *before* the WebSocket server starts.

3. **Fast exit**:  On a port conflict, will write to `stderr` and exit immediately via `std::_Exit(1)` (gated by a new `startup_failed()` flag), skipping the multi-second destructor teardown so the error stays as the last visible line and the process returns a non-zero exit code for scripting.

Files: `src/cpp/server/server.cpp`, `src/cpp/include/lemon/server.h`, `src/cpp/server/main.cpp`.

### CI pipeline (required by the stricter bind)

Making `lemond` refuse an in-use port means the **non-containerized self-hosted** jobs could now hard-fail: they share the host network, so a concurrent job may already hold the default port 13305.

- **`.github/actions/install-lemonade-deb`**: new optional `port` input  (default `13305`, or `auto`). In `auto` mode it picks a free loopback port, retries on a fresh port if it loses the pick→bind race, and exports `LEMONADE_PORT` / `LEMONADE_TEST_PORT` so the downstream test steps and the `lemonade` CLI target the resolved port.
- **`.github/workflows/cpp_server_build_test_release.yml`**: the self-hosted jobs now pass `port: auto` to the action. (The containerized `test-cli-endpoints-linux` job keeps the default port — it has network isolation.)

### Tests (required by the stricter bind)

`test/test_llamacpp_system_backend.py` repeatedly stops and restarts `lemond`. With the stricter bind, two latent problems became real failures:

1. **Fresh port per instance** To allow immediate rebind when `lemond` shuts down
2. **Mock `llama-server` handles `--version`** Setting the `system` backend makes  `lemond` run `llama-server --version` to read its version. The test's fake  `llama-server` didn't handle `--version` and instead ran forever, so that call  hung. It now prints a version and exits, like the real binary. (This only  started failing once the fresh-port change above stopped accidentally hiding it.)
3. **Pull targets the live port** One test helper was still pointing at the old fixed port; it now uses the current instance's port.

## Behavior

Before: 
the second instance kept running and competed for requests.

After:
```
[Server] ERROR: Port 13305 on 127.0.0.1 is already in use. Another Lemonade server (lemond) is likely already running on this port. This instance will now exit.
```

(The reported IP is whichever of the resolved IPv4/IPv6 loopback addresses is in use.)

## Testing

- Built `lemond` on Windows (MSVC).
- Started instance 1 on port 13305 (confirmed listening).
- Started instance 2 on the same port → prints the error above as the final
  line and exits with code 1; instance 1 keeps serving uninterrupted.