### PR TITLE
Fix copy-to-clipboard buttons silently failing in web-app over HTTP

### DIFF
--- a/src/app/src/renderer/utils/clipboardUtils.ts
+++ b/src/app/src/renderer/utils/clipboardUtils.ts
@@ -1,23 +1,31 @@
-function legacyCopy(text: string): Promise<void> {
+function legacyCopy(text: string): void {
   const ta = document.createElement('textarea');
-  ta.value = text;
+  ta.value = String(text);
+  ta.setAttribute('readonly', '');
   ta.style.position = 'fixed';
-  ta.style.opacity = '0';
-  ta.style.pointerEvents = 'none';
+  ta.style.left = '-9999px';
   document.body.appendChild(ta);
-  ta.select();
-  document.execCommand('copy');
-  document.body.removeChild(ta);
-  return Promise.resolve();
+  try {
+    ta.select();
+    if (!document.execCommand('copy')) {
+      throw new Error('Legacy clipboard copy failed');
+    }
+  } finally {
+    document.body.removeChild(ta);
+  }
 }
 
 export async function writeClipboard(text: string): Promise<void> {
   if (window.api?.writeClipboard) {
     return window.api.writeClipboard(text);
   }
-  try {
-    return await navigator.clipboard.writeText(text);
-  } catch {
-    legacyCopy(text);
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Ignore clipboard errors and fall back to legacy method
+    }
   }
+  legacyCopy(text);
 }

--- a/src/app/src/renderer/utils/clipboardUtils.ts
+++ b/src/app/src/renderer/utils/clipboardUtils.ts
@@ -1,7 +1,23 @@
+function legacyCopy(text: string): Promise<void> {
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.style.position = 'fixed';
+  ta.style.opacity = '0';
+  ta.style.pointerEvents = 'none';
+  document.body.appendChild(ta);
+  ta.select();
+  document.execCommand('copy');
+  document.body.removeChild(ta);
+  return Promise.resolve();
+}
+
 export async function writeClipboard(text: string): Promise<void> {
   if (window.api?.writeClipboard) {
-    await window.api.writeClipboard(text);
-  } else {
-    await navigator.clipboard.writeText(text);
+    return window.api.writeClipboard(text);
+  }
+  try {
+    return await navigator.clipboard.writeText(text);
+  } catch {
+    legacyCopy(text);
   }
 }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -838,17 +838,26 @@ window.api = {
     },
     restartApp: () => window.location.reload(),
     writeClipboard: async (text) => {
+        if (navigator.clipboard) {
+            try {
+                await navigator.clipboard.writeText(text);
+                return;
+            } catch {
+                // Ignore clipboard errors and fall back to legacy method
+            }
+        }
+        const ta = document.createElement('textarea');
+        ta.value = String(text);
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'fixed';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
         try {
-            await navigator.clipboard.writeText(text);
-        } catch {
-            const ta = document.createElement('textarea');
-            ta.value = text;
-            ta.style.position = 'fixed';
-            ta.style.opacity = '0';
-            ta.style.pointerEvents = 'none';
-            document.body.appendChild(ta);
             ta.select();
-            document.execCommand('copy');
+            if (!document.execCommand('copy')) {
+                throw new Error('Legacy clipboard copy failed');
+            }
+        } finally {
             document.body.removeChild(ta);
         }
     }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -836,7 +836,22 @@ window.api = {
         const settings = await window.api.getSettings();
         return settings.apiKey?.value || '';
     },
-    restartApp: () => window.location.reload()
+    restartApp: () => window.location.reload(),
+    writeClipboard: async (text) => {
+        try {
+            await navigator.clipboard.writeText(text);
+        } catch {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.style.position = 'fixed';
+            ta.style.opacity = '0';
+            ta.style.pointerEvents = 'none';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+        }
+    }
 };
 </script>
 )";


### PR DESCRIPTION
Closes #2259

**Problem:** Copy-to-clipboard buttons in the web-app silently fail when served via `lemond`'s HTTP server (non-HTTPS). `navigator.clipboard.writeText()` requires a secure context (HTTPS/localhost) and throws without user-visible feedback on plain HTTP.

The `window.api` mock injected by `server.cpp` lacked a `writeClipboard` method, so `clipboardUtils.ts` fell through to `navigator.clipboard.writeText()` - which fails in non-secure contexts. This affected all three copy buttons:

- "Copy model name" in Model Options modal
- "Copy code block" in chat messages  
- "Copy action" in Backend manager

**Fix (2 files):**

1. **`src/cpp/server/server.cpp`** - Added `writeClipboard` to the injected `window.api` mock. It tries the modern Clipboard API first, with a fallback to `document.execCommand('copy')` via a hidden `<textarea>` (best-effort fallback, no HTTPS required).

2. **`src/app/src/renderer/utils/clipboardUtils.ts`** - Added the same `execCommand` fallback for any context where `window.api?.writeClipboard` is unavailable (defense in depth).

**Root cause:** The `writeClipboard` mock existed in the old Electron version (commit `7d8804d8`) but was never ported to the C++ mock injected by `server.cpp` when the app migrated from Electron to Tauri (`77220b9b`).