### PR TITLE
fix(server): prevent SIGPIPE crash in macOS DirectoryWatcher on kevent failure

### DIFF
--- a/src/cpp/server/directory_watcher.cpp
+++ b/src/cpp/server/directory_watcher.cpp
@@ -298,6 +298,13 @@ private:
         fcntl(stop_pipe_fds[0], F_SETFL, flags | O_NONBLOCK);
         flags = fcntl(stop_pipe_fds[1], F_GETFL);
         fcntl(stop_pipe_fds[1], F_SETFL, flags | O_NONBLOCK);
+        // Suppress SIGPIPE on the write end: if the read end is closed due to a
+        // race between stop() and run_loop cleanup, write() returns EPIPE instead
+        // of raising SIGPIPE and killing the process.
+        {
+            int nosig = 1;
+            fcntl(stop_pipe_fds[1], F_SETNOSIGPIPE, nosig);
+        }
         stop_pipe_read_ = stop_pipe_fds[0]; // read end for kqueue/drain
         stop_pipe_write_ = stop_pipe_fds[1]; // write end for signaling
 
@@ -318,11 +325,14 @@ private:
 
         struct kevent change_events[2] = { ev_dir, ev_stop };
         if (kevent(kq_, change_events, 2, nullptr, 0, nullptr) < 0) {
+            // Zero pipe members BEFORE any close so a concurrent stop() sees
+            // -1 and skips the pipe write, preventing SIGPIPE if the read end
+            // is closed while stop_pipe_write_ still looks valid.
+            stop_pipe_read_ = -1;
+            stop_pipe_write_ = -1;
             ::close(stop_pipe_fds[0]);
             ::close(stop_pipe_fds[1]);
             ::close(dir_fd_);
-            stop_pipe_read_ = -1;
-            stop_pipe_write_ = -1;
             dir_fd_ = -1;
             ::close(kq_);
             kq_ = -1;


### PR DESCRIPTION
## Summary

- Zero `stop_pipe_read_` and `stop_pipe_write_` **before** any `::close()` in the `kevent()` registration failure path so a concurrent `stop()` call sees `-1` and skips the pipe write, preventing SIGPIPE when the read end is already closed.
- Apply `F_SETNOSIGPIPE` to the pipe write end at creation so any write that races through after the read end is closed returns `EPIPE` instead of raising `SIGPIPE` and killing the process.

## Root cause

On `macos-15-arm64` CI runners, `kevent()` registration appears to fail consistently (likely sandbox restrictions on `EVFILT_VNODE`), triggering the early-return path on every `DirectoryWatcherTest` run. In that path, the original code closed `stop_pipe_fds[0]` (read end) before setting `stop_pipe_write_ = -1`. The `DirectoryWatcher` destructor calls `stop()` concurrently, which checks `stop_pipe_write_ >= 0` and writes to the write fd — but the read end is already gone → SIGPIPE → process killed.

## Test plan

- [ ] `DirectoryWatcherTest` passes on `macos-15-arm64` CI runner (was consistently crashing with SIGPIPE before this fix)
- [ ] No behaviour change on Linux or Windows (the edited code is inside `#ifdef __APPLE__`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)