### PR TITLE
Return HTTP 400 for malformed request JSON

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2026,6 +2026,16 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
             }
         }
 
+    } catch (const nlohmann::json::parse_error& e) {
+        // Empty or malformed JSON body is a client error (400), not a server fault (500).
+        LOG(WARNING, "Server") << "Invalid JSON in request body: " << e.what() << std::endl;
+        res.status = 400;
+        nlohmann::json error = {{"error", {
+            {"message", std::string("Invalid JSON in request body: ") + e.what()},
+            {"type", "invalid_request_error"},
+            {"code", "invalid_request"}
+        }}};
+        res.set_content(error.dump(), "application/json");
     } catch (const std::exception& e) {
         LOG(ERROR, "Server") << "Chat completion failed: " << e.what() << std::endl;
         res.status = 500;
@@ -3365,6 +3375,16 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             res.set_content(response.dump(), "application/json");
         }
 
+    } catch (const nlohmann::json::parse_error& e) {
+        // Empty or malformed JSON body is a client error (400), not a server fault (500).
+        LOG(WARNING, "Server") << "Invalid JSON in request body: " << e.what() << std::endl;
+        res.status = 400;
+        nlohmann::json error = {{"error", {
+            {"message", std::string("Invalid JSON in request body: ") + e.what()},
+            {"type", "invalid_request_error"},
+            {"code", "invalid_request"}
+        }}};
+        res.set_content(error.dump(), "application/json");
     } catch (const lemon::UnknownModelError& e) {
         LOG(ERROR, "Server") << "ERROR in handle_pull: " << e.what() << std::endl;
         res.status = 400;
@@ -3626,6 +3646,16 @@ void Server::handle_delete(const httplib::Request& req, httplib::Response& res) 
             }
         }
 
+    } catch (const nlohmann::json::parse_error& e) {
+        // Empty or malformed JSON body is a client error (400), not a server fault (500).
+        LOG(WARNING, "Server") << "Invalid JSON in request body: " << e.what() << std::endl;
+        res.status = 400;
+        nlohmann::json error = {{"error", {
+            {"message", std::string("Invalid JSON in request body: ") + e.what()},
+            {"type", "invalid_request_error"},
+            {"code", "invalid_request"}
+        }}};
+        res.set_content(error.dump(), "application/json");
     } catch (const std::exception& e) {
         LOG(ERROR, "Server") << "ERROR in handle_delete: " << e.what() << std::endl;
 

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -150,6 +150,32 @@ class EndpointTests(ServerTestBase):
 
         session.close()
 
+    def test_000a_malformed_json_body_returns_400(self):
+        """Empty or malformed JSON bodies must return 400, not 500 (issue #2231)."""
+        # POST endpoints that parse a JSON request body.
+        endpoints = ["chat/completions", "pull", "load", "delete"]
+        bad_bodies = [
+            ("", "empty body"),
+            ("not json", "malformed JSON"),
+            ("{", "truncated JSON"),
+        ]
+        for endpoint in endpoints:
+            url = f"{self.base_url}/{endpoint}"
+            for body, label in bad_bodies:
+                response = requests.post(
+                    url,
+                    data=body,
+                    headers={"Content-Type": "application/json"},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                self.assertEqual(
+                    response.status_code,
+                    400,
+                    f"{endpoint} with {label} returned "
+                    f"{response.status_code}, expected 400",
+                )
+        print("[OK] malformed/empty JSON bodies return 400")
+
     def test_001_live_endpoint(self):
         """Test the /live endpoint for load balancer health checks."""
         response = requests.get(


### PR DESCRIPTION
## Original Issue

Some API endpoints returned HTTP 500 Internal Server Error for malformed request JSON like `not json` or `{`.

That should be HTTP 400 Bad Request because the request body is invalid. HTTP 500 suggests a server malfunction, while this case is malformed request data.

## Summary

Return HTTP 400 when JSON parsing fails in:
- `chat/completions`
- `pull`
- `delete`

`load` already returned HTTP 400 for this case, so it was unchanged.

Add regression coverage for:
- empty body
- `not json`
- `{`

across:
- `chat/completions`
- `pull`
- `load`
- `delete`

## Example

POST /api/v1/pull
Body: not json

Before: HTTP 500 Internal Server Error
After: HTTP 400 Bad Request

## Testing

- Built `lemond.exe`
- Manually verified all 12 endpoint/body combinations returned HTTP 400 Bad Request

Fixes #2231