### PR TITLE
ci: support tagging releases from a release branch

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -95,17 +95,17 @@ runs:
         # Extract unique contributors from the changelog (exclude bots)
         CONTRIBUTORS=$(echo "$AUTO_NOTES" | grep -oE '@[a-zA-Z0-9_-]+' | grep -ivE '^@(copilot|claude)$' | sort -u | tr '\n' ' ' | sed 's/ /, /g' | sed 's/, $//' || echo "")
 
-        # Search for the vNext release notes issue to extract Headline and Breaking Changes
+        # Search for the release notes issue by exact title (e.g. "v10.8.0 release notes")
         RELEASE_NOTES_ISSUE_BODY=$(gh issue list --repo "$REPO" \
-          --label documentation \
-          --search "release notes in:title" \
-          --json title,body --limit 10 \
-          | jq -r '[.[] | select(.body | test("kind.*release_notes"))] | .[0].body' 2>/dev/null || echo "")
+          --state open \
+          --search "\"$TAG_NAME release notes\" in:title" \
+          --json body --limit 1 \
+          | jq -r '.[0].body // ""' 2>/dev/null || echo "")
 
         HEADLINE_SECTION=""
         BREAKING_CHANGES_SECTION=""
 
-        if [ -n "$RELEASE_NOTES_ISSUE_BODY" ] && [ "$RELEASE_NOTES_ISSUE_BODY" != "null" ]; then
+        if [ -n "$RELEASE_NOTES_ISSUE_BODY" ]; then
           echo "Found release notes issue, extracting Headline and Breaking Changes..."
           HEADLINE_SECTION=$(echo "$RELEASE_NOTES_ISSUE_BODY" | \
             awk '/^## Headline/{found=1} found && /^## / && !/^## Headline/{found=0} found{print}')

--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -95,8 +95,39 @@ runs:
         # Extract unique contributors from the changelog (exclude bots)
         CONTRIBUTORS=$(echo "$AUTO_NOTES" | grep -oE '@[a-zA-Z0-9_-]+' | grep -ivE '^@(copilot|claude)$' | sort -u | tr '\n' ' ' | sed 's/ /, /g' | sed 's/, $//' || echo "")
 
+        # Search for the vNext release notes issue to extract Headline and Breaking Changes
+        RELEASE_NOTES_ISSUE_BODY=$(gh issue list --repo "$REPO" \
+          --label documentation \
+          --search "release notes in:title" \
+          --json title,body --limit 10 \
+          | jq -r '[.[] | select(.body | test("kind.*release_notes"))] | .[0].body' 2>/dev/null || echo "")
+
+        HEADLINE_SECTION=""
+        BREAKING_CHANGES_SECTION=""
+
+        if [ -n "$RELEASE_NOTES_ISSUE_BODY" ] && [ "$RELEASE_NOTES_ISSUE_BODY" != "null" ]; then
+          echo "Found release notes issue, extracting Headline and Breaking Changes..."
+          HEADLINE_SECTION=$(echo "$RELEASE_NOTES_ISSUE_BODY" | \
+            awk '/^## Headline/{found=1} found && /^## / && !/^## Headline/{found=0} found{print}')
+          BREAKING_CHANGES_SECTION=$(echo "$RELEASE_NOTES_ISSUE_BODY" | \
+            awk '/^## Breaking Changes/{found=1} found && /^## / && !/^## Breaking Changes/{found=0} found{print}')
+        else
+          echo "No release notes issue found; Headline and Breaking Changes will need to be added manually."
+        fi
+
         # Build the release notes file
         RELEASE_NOTES_FILE="release_notes.md"
+
+        {
+          if [ -n "$HEADLINE_SECTION" ]; then
+            echo "$HEADLINE_SECTION"
+            echo ""
+          fi
+          if [ -n "$BREAKING_CHANGES_SECTION" ]; then
+            echo "$BREAKING_CHANGES_SECTION"
+            echo ""
+          fi
+        } > "$RELEASE_NOTES_FILE"
 
         {
           echo "## Lemonade Server"
@@ -124,7 +155,7 @@ runs:
           echo ""
           echo "---"
           echo ""
-        } > "$RELEASE_NOTES_FILE"
+        } >> "$RELEASE_NOTES_FILE"
 
         # Build What's Changed section with thank you and collapsible details
         if [ -n "$WHATS_CHANGED_CONTENT" ]; then

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -2,7 +2,7 @@ name: C++ Server Build, Test, and Release 🚀
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release-v*"]
     tags:
       - v*
   pull_request:

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -31,13 +31,14 @@ jobs:
           run: |
             git config --global user.name "Lemonade Bot"
             git config --global user.email "lemonade@amd.com"
-        - name: Capture main branch commit hash
+        - name: Capture release commit hash
           run: |
-            echo "MAIN_COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+            echo "RELEASE_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+            echo "RELEASE_COMMIT_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
         - name: Merge into website branch
           run: |
             git checkout website
-            git merge origin/main -X theirs
+            git merge $RELEASE_COMMIT -X theirs
         - name: Update README with marketplace apps
           run: |
             venvPython=".venv/bin/python"
@@ -52,6 +53,6 @@ jobs:
             if git diff --staged --quiet; then
               echo "No changes to commit, skipping commit step"
             else
-              git commit -m "Update website for: ${MAIN_COMMIT_HASH}"
+              git commit -m "Update website for: ${RELEASE_COMMIT_SHORT}"
             fi
             git push

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -38,7 +38,7 @@ jobs:
         - name: Merge into website branch
           run: |
             git checkout website
-            git merge $RELEASE_COMMIT -X theirs
+            git merge "$RELEASE_COMMIT" -X theirs
         - name: Update README with marketplace apps
           run: |
             venvPython=".venv/bin/python"

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -120,7 +120,7 @@ git push origin vX.Y.Z --force
 
 ## Step 6: Update the Release Notes
 
-The release action auto-generates release notes that include the **Headline** and **Breaking Changes** sections pulled from the vNext release notes issue (the one tracked under the `documentation` label with `kind: release_notes` in its body). The result looks like this: https://github.com/lemonade-sdk/lemonade/releases/tag/v10.7.0
+The release action auto-generates release notes that include the **Headline** and **Breaking Changes** sections pulled from the open GitHub issue titled `vX.Y.Z release notes` (exact match on the tag name, e.g. `v10.8.0 release notes`). The result looks like this: https://github.com/lemonade-sdk/lemonade/releases/tag/v10.7.0
 
 You may need to manually edit the release to:
 - add co-author contributors who were missing

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -27,25 +27,66 @@ Decide the new version number using these criteria:
 - `patch` release: release only contains fixes or less-visible features.
     - `patch` releases are rare, and typically only happen if a serious bug needs to be fixed right after a `major`/`minor` release.
 
-## Step 2: Push a Tag
+## Step 2: Create the Release Branch
+
+Each release is developed and tagged from a dedicated release branch, not from `main`. Create the branch from the tip of `main` once the release is ready to stabilize:
+
+```bash
+git checkout main
+git pull
+git checkout -b release-vX.Y.Z
+git push origin release-vX.Y.Z
+```
+
+### Managing the Release Branch
+
+Two situations arise while the release branch is open:
+
+**Backport a fix from `main` to the release branch** (most common — a fix merged to main that should also land in this release):
+
+```bash
+# Find the squash-merge commit SHA on main
+git log main --oneline | head -10
+
+git checkout release-vX.Y.Z
+git cherry-pick <commit-sha>
+git push origin release-vX.Y.Z
+```
+
+The release branch has no squash-merge PR requirement, so a direct push works fine.
+
+**Forward-port a commit from the release branch back to `main`** (rare — a fix made directly on the release branch that was never on main):
+
+Because `main` requires squash merges for PRs, **do not use a PR** — it would collapse the cherry-picked commit into a squash commit, destroying authorship and history. Push directly with an admin bypass instead:
+
+```bash
+git checkout main
+git pull
+git cherry-pick <commit-sha-from-release-branch>
+git push origin main   # requires admin "bypass branch protections" permission
+```
+
+Confirm with the team before pushing directly to `main`.
+
+## Step 3: Push a Tag
 
 Lemonade releases are automatically created by the [cpp_server_build_test_release.yml workflow](https://github.com/lemonade-sdk/lemonade/blob/main/.github/workflows/cpp_server_build_test_release.yml) final step, which is triggered by pushing a tag that matches the `v*` pattern. The tag must match the pattern `v<major>.<minor>.<patch>`, i.e., the value from CMakeLists.txt with a leading `v`.
 
-Let's say you're releasing v10.7.0, this will trigger the release action:
+Let's say you're releasing v10.8.0, this will trigger the release action:
 
-```
+```bash
 # Make sure you are tagging the right commit!
-git checkout main
+git checkout release-v10.8.0
 git pull
 
-git tag v10.7.0
+git tag v10.8.0
 
-git push origin v10.7.0
+git push origin v10.8.0
 ```
 
 Example action from v10.7.0: https://github.com/lemonade-sdk/lemonade/actions/runs/27283434473/job/80590025966
 
-## Step 3: Windows Signing
+## Step 4: Windows Signing
 
 Lemonade .msi artifacts are signed by SignPath.io under their SignPath Foundation program. Thank you SignPath!
 
@@ -61,21 +102,27 @@ You can view the signing request here: https://app.signpath.io/Web/8103545b-7814
 
 You must click the link, sign in, and press `Approve`.
 
-## Step 4: Release Action Finishes
+## Step 5: Release Action Finishes
 
 Wait for the `cpp_server_build_test_release.yml` action to complete successfully. Sometimes it doesn't, because of a false negative on a test or because we renamed a workflow step or release artifact and forgot to update the release step.
 
 If it fails, ideally you can press "rerun" on the job and get success.
 
-If you need to fix the code, first push the fix to `main` branch. Then tag the head of main with the release tag and force push it to origin.
+If you need to fix the code, push the fix to the release branch. Then move the tag to the new head and force push it to origin:
 
-## Step 5: Update the Release Notes
+```bash
+git checkout release-vX.Y.Z
+# ... make fix, commit ...
+git push origin release-vX.Y.Z
+git tag -f vX.Y.Z
+git push origin vX.Y.Z --force
+```
 
-The release action auto-generates a set of release notes that looks like this: https://github.com/lemonade-sdk/lemonade/releases/tag/v10.7.0
+## Step 6: Update the Release Notes
 
-Notably, two sections are not auto-generated: the headline and breaking changes.
+The release action auto-generates release notes that include the **Headline** and **Breaking Changes** sections pulled from the vNext release notes issue (the one tracked under the `documentation` label with `kind: release_notes` in its body). The result looks like this: https://github.com/lemonade-sdk/lemonade/releases/tag/v10.7.0
 
-You may also need to edit the release to:
+You may need to manually edit the release to:
 - add co-author contributors who were missing
 - add deprecation notices
 - add/remove links to release artifacts that we forgot to update in the release workflow.
@@ -84,15 +131,15 @@ DO NOT add or replace release artifacts, as this would break the chain of custod
 
 ### Headline
 
-The headline section must start with `## Headline` and contain a single-depth bulleted list, because https://lemonade-server.ai looks for this pattern.
+The headline section starts with `## Headline` and contains a single-depth bulleted list. The website at https://lemonade-server.ai parses this section, so the format must be preserved.
 
-The list should be the 3-5 most noteworthy aspects of the release that you would want users to know about. Keep these concise and do not include meta info like shoutouts. Headlines must also not include any special formatting or links.
+The list should be the 3-5 most noteworthy aspects of the release. Keep items concise; no special formatting or links, no shoutouts.
 
 ### Breaking Changes
 
 Bulleted list with one item per breaking change. Keep it concise, and link to a wiki article for migration if more details are needed.
 
-## Step 6: Discord Announcement
+## Step 7: Discord Announcement
 
 Each release gets a post in `#announcements` on the Lemonade Discord.
 
@@ -110,6 +157,6 @@ Suggested structure:
 
 Try to find an appealing narrative arc for the release, and implement it by combining contributions into sections/bullets. For example, if there were 3 contributions by 3 authors for LMX models, say "Authors X, Y, and Z teamed up to improve in LMX..."
 
-## Step 7: Social Media
+## Step 8: Social Media
 
 Not required, but it is always good to promote the new release online.


### PR DESCRIPTION
## Summary

- **`publish-website.yml`**: Replace hardcoded `git merge origin/main` with `git merge $RELEASE_COMMIT` (the SHA of the triggering commit) so the website deploys correctly when the tag is on a release branch.
- **`cpp_server_build_test_release.yml`**: Add `release-v*` to the branch CI trigger so builds and tests run on every push to a release branch, not only on `main` and tag pushes.
- **`generate-release-notes/action.yml`**: Auto-populate `## Headline` and `## Breaking Changes` from the vNext release notes GitHub issue (label `documentation`, body contains `kind: release_notes`) and prepend them before the download table. Gracefully skips if no issue is found.
- **`docs/dev/release.md`**: Rewrite to document the release branch workflow — how to create the branch, cherry-pick fixes in both directions (with admin-bypass note for forward-porting to `main`), updated step numbering (now 8 steps), and recovery instructions that use the release branch instead of `main`.