### PR TITLE
Fix Problem with  .devcontainer. It did not copy .devcontainer/reinstall-cmake.sh when building container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ build
 
 # Dev & CI tooling
 .devcontainer
+!.devcontainer/reinstall-cmake.sh
 .pylintrc
 
 # Docs

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -13,7 +13,7 @@
     "vulkan": "v1.8.4",
     "rocm": "v1.8.4",
     "npu": "v1.8.4",
-    "metal": "v1.8.5"
+    "metal": "v1.8.4"
   },
   "sd-cpp": {
     "cpu": "master-672-1f9ee88",


### PR DESCRIPTION
Hello,

I saw the lemonade repo had a .devcontainer so  I tryed the visual code devcontainer feature on my ubuntu 24.04  , visual code 1.124.2.

I tryed but i saw visual code throw an error when it tryed to build container

<img width="1412" height="894" alt="image" src="https://github.com/user-attachments/assets/2bb452ba-21e0-4a40-9be3-20affb03fe70" />

It failed when it tryed to copy .devcontainer/reinstall-cmake.sh . I investigate and i saw that inside .dockerignore there is a 
.devcontainer line that  is guilty :)

I added below :

!.devcontainer/reinstall-cmake.sh 

so it will let to copy the script . I tryed and finally worked!

<img width="936" height="883" alt="image" src="https://github.com/user-attachments/assets/3f5fc6b1-d3b6-46e6-aa8e-0a318b8b50a0" />

