### PR TITLE
fix(whisper): drop gfx103X from rocm whisper supported archs

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -450,7 +450,9 @@ static const std::vector<RecipeBackendDef> RECIPE_DEFS = {
         {"amd_npu", {"XDNA2"}},
     }},
     {"whispercpp", "rocm", {"windows", "linux"}, {
-        {"amd_gpu", {"gfx1150", "gfx1151", "gfx103X", "gfx110X", "gfx120X"}},
+        // gfx103X omitted: lemonade-sdk/whisper.cpp-rocm publishes no gfx103X
+        // ROCm whisper build, so advertising it would yield a 404 on install.
+        {"amd_gpu", {"gfx1150", "gfx1151", "gfx110X", "gfx120X"}},
     }},
     {"whispercpp", "vulkan", {"windows", "linux"}, {
         {"cpu", {"x86_64"}},


### PR DESCRIPTION
## Problem

PR #2188 migrated whisper.cpp downloads to `lemonade-sdk/whisper.cpp-rocm` and advertised the new ROCm whisper backend for `gfx103X`:

```cpp
{whispercpp, rocm, {windows, linux}, {
    {amd_gpu, {gfx1150, gfx1151, gfx103X, gfx110X, gfx120X}},
}},
```

However, the `whisper.cpp-rocm` release publishes **no `gfx103X` whisper build** — only `gfx1150`, `gfx1151`, `gfx110X`, and `gfx120X` (verified for tag `v1.8.4` on both Windows and Linux).

As a result, a `gfx103X` (RDNA2, e.g. Radeon RX 6000 series) device would see `whispercpp:rocm` reported as **installable** via `/system-info`, then hit a **404** when fetching `whisper-{version}-{os}-rocm-gfx103X.{zip,tar.gz}`.

## Fix

Remove `gfx103X` from the `whispercpp`/`rocm` `RECIPE_DEFS` entry so the advertised architectures match the assets actually published. This mirrors the `vllm`/`rocm` entry, which already omits `gfx103X`.

## Verification

- Built `lemond` from source (release branch build) with the change — compiles cleanly.
- Confirmed on a Strix Halo (`gfx1151`, Radeon 8060S) device that `whispercpp:rocm` still resolves to `whisper-v1.8.4-windows-rocm-gfx1151.zip` and is unaffected.
- Full end-to-end ROCm whisper transcription (download → install → load → transcribe on `ROCm0`) verified working on `gfx1151` separately.
- `gfx103X` removal can't be exercised on this hardware; it is a list/asset consistency fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)