### PR TITLE
docs(cli): correct launch note - LEMONADE_* recipe env vars no longer honored

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -528,7 +528,7 @@ Codex-only option:
 - `--api-key` is propagated to the launched agent process.
 - For `codex`, launch now injects a Lemonade model provider by default so host/port settings are honored.
 - `--provider` is accepted only by `lemonade launch codex` and is passed directly to Codex as `model_provider`; provider resolution/errors are handled by Codex.
-- Existing `LEMONADE_*` recipe env vars such as `LEMONADE_CTX_SIZE` are still honored by `launch`.
+- `LEMONADE_*` recipe env vars such as `LEMONADE_CTX_SIZE` are no longer honored (by `launch` or any command). Set recipe options ahead of time with `lemonade load <model> --ctx-size ... --save-options`, or with `lemonade config set`.
 - `--agent-args` is parsed and appended to the launched agent command.
 - Supported agents: `claude`, `codex`, `opencode`, `pi`
 - `opencode` uses an auto-managed config file at `~/.config/opencode/opencode.json`.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -528,7 +528,7 @@ Codex-only option:
 - `--api-key` is propagated to the launched agent process.
 - For `codex`, launch now injects a Lemonade model provider by default so host/port settings are honored.
 - `--provider` is accepted only by `lemonade launch codex` and is passed directly to Codex as `model_provider`; provider resolution/errors are handled by Codex.
-- `LEMONADE_*` recipe env vars such as `LEMONADE_CTX_SIZE` are no longer honored (by `launch` or any command). Set recipe options ahead of time with `lemonade load <model> --ctx-size ... --save-options`, or with `lemonade config set`.
+- To customize recipe options (e.g. context size) for the launched model, configure them ahead of time with `lemonade load <model> --ctx-size ... --save-options`, or with `lemonade config set`.
 - `--agent-args` is parsed and appended to the launched agent command.
 - Supported agents: `claude`, `codex`, `opencode`, `pi`
 - `opencode` uses an auto-managed config file at `~/.config/opencode/opencode.json`.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -528,7 +528,7 @@ Codex-only option:
 - `--api-key` is propagated to the launched agent process.
 - For `codex`, launch now injects a Lemonade model provider by default so host/port settings are honored.
 - `--provider` is accepted only by `lemonade launch codex` and is passed directly to Codex as `model_provider`; provider resolution/errors are handled by Codex.
-- To customize recipe options (e.g. context size) for the launched model, configure them ahead of time with `lemonade load <model> --ctx-size ... --save-options`, or with `lemonade config set`.
+- To customize recipe options (e.g. context size) for the launched model, configure them ahead of time with `lemonade load <model> ... --save-options`, or with `lemonade config set`.
 - `--agent-args` is parsed and appended to the launched agent command.
 - Supported agents: `claude`, `codex`, `opencode`, `pi`
 - `opencode` uses an auto-managed config file at `~/.config/opencode/opencode.json`.


### PR DESCRIPTION
## Problem

PR #2185 removed environment-variable support for recipe options from the lemonade CLI (`LEMONADE_CTX_SIZE`, `LEMONADE_LLAMACPP*`, `LEMONADE_SDCPP*`, `LEMONADE_WHISPERCPP*`, `LEMONADE_VLLM*`, `LEMONADE_FLM_ARGS`, `LEMONADE_MERGE_ARGS`, `LEMONADE_MOONSHINE*`). That change also dropped the env-var binding from `launch` (it even removed the test that asserted `launch` honored `LEMONADE_CTX_SIZE`).

But `docs/guide/cli.md` still claimed the opposite:

> - Existing `LEMONADE_*` recipe env vars such as `LEMONADE_CTX_SIZE` are still honored by `launch`.

This directly contradicts the breaking change and misleads exactly the users who need migration guidance. The CLI test suite doesn't catch it (`test_900` only checks the docs for `--ctx-size`/`--use-recipe` strings, not this sentence).

## Fix

Update the launch note to state the env vars are no longer honored and point to the replacement paths:

> - `LEMONADE_*` recipe env vars such as `LEMONADE_CTX_SIZE` are no longer honored (by `launch` or any command). Set recipe options ahead of time with `lemonade load <model> --ctx-size ... --save-options`, or with `lemonade config set`.

## Verification

- Built `lemonade`/`lemond` from source and confirmed at runtime that `LEMONADE_CTX_SIZE` is ignored on load (env set to a distinctive value → loaded model used the auto-determined ctx size, not the env value), while `--ctx-size` and `lemonade config set` work as the replacement paths.
- Grepped `docs/` to confirm line 531 was the only remaining stale `LEMONADE_*` recipe-env claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
