### PR TITLE
ci: add repo-manager workflow

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1020,47 +1020,47 @@ jobs:
             script: server_llm.py
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan rocm"
-            runner: [Windows, vulkan, rocm]
+            runner: [Windows, vulkan, rocm, lemon-prod]
           - name: omni
             script: server_omni.py
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan"
-            runner: [Windows, vulkan, stx-halo]
+            runner: [Windows, vulkan, stx-halo, lemon-prod]
           - name: ryzenai
             script: server_llm.py
             extra_args: "--wrapped-server ryzenai"
             backends: "cpu hybrid npu"
-            runner: [Windows, xdna2]
+            runner: [Windows, xdna2, lemon-prod]
           - name: flm
             script: server_llm.py
             extra_args: "--wrapped-server flm"
             backends: "npu"
-            runner: [Windows, xdna2]
+            runner: [Windows, xdna2, lemon-prod]
           - name: whisper
             script: server_whisper.py
             extra_args: "--wrapped-server whispercpp"
             backends: "cpu npu rocm"
-            runner: [Windows, stx-halo]
+            runner: [Windows, stx-halo, lemon-prod]
           - name: flm-whisper
             script: server_whisper.py
             extra_args: "--wrapped-server flm"
             backends: "npu"
-            runner: [Windows, xdna2]
+            runner: [Windows, xdna2, lemon-prod]
           - name: moonshine
             script: server_moonshine.py
             extra_args: "--wrapped-server moonshine"
             backends: "cpu"
-            runner: [self-hosted, Windows]
+            runner: [self-hosted, Windows, lemon-prod]
           - name: stable-diffusion
             script: server_sd.py
             extra_args: ""
             backends: "cpu rocm vulkan"
-            runner: [Windows, rocm, vulkan]
+            runner: [Windows, rocm, vulkan, lemon-prod]
           - name: text-to-speech
             script: server_tts.py
             extra_args: ""
             backends: ""
-            runner: [self-hosted, Windows]
+            runner: [self-hosted, Windows, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
@@ -1328,37 +1328,37 @@ jobs:
             script: server_llm.py
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan rocm"
-            runner: [Linux, vulkan, rocm]
+            runner: [Linux, vulkan, rocm, lemon-prod]
           - name: omni
             script: server_omni.py
             extra_args: "--wrapped-server llamacpp"
             backends: "vulkan"
-            runner: [Linux, vulkan, stx-halo]
+            runner: [Linux, vulkan, stx-halo, lemon-prod]
           - name: stable-diffusion
             script: server_sd.py
             extra_args: ""
             backends: "cpu rocm vulkan"
-            runner: [Linux, vulkan, rocm]
+            runner: [Linux, vulkan, rocm, lemon-prod]
           - name: whisper
             script: server_whisper.py
             extra_args: "--wrapped-server whispercpp"
             backends: "cpu vulkan rocm"
-            runner: [Linux, rocm, xdna2]
+            runner: [Linux, rocm, xdna2, lemon-prod]
           - name: moonshine
             script: server_moonshine.py
             extra_args: "--wrapped-server moonshine"
             backends: "cpu"
-            runner: [self-hosted, Linux]
+            runner: [self-hosted, Linux, lemon-prod]
           - name: flm
             script: server_llm.py
             extra_args: "--wrapped-server flm"
             backends: "npu"
-            runner: [Linux, xdna2]
+            runner: [Linux, xdna2, lemon-prod]
           - name: text-to-speech
             script: server_tts.py
             extra_args: ""
             backends: ""
-            runner: [self-hosted, Linux]
+            runner: [self-hosted, Linux, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   repo-manager:
-    runs-on: [self-hosted, linux, repo-manager]
+    runs-on: [self-hosted, linux, repo-manager, lemon-prod]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -1,0 +1,27 @@
+name: Repo Manager
+
+on:
+  push:
+    branches:
+      - main
+      - 'release-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  repo-manager:
+    runs-on: [self-hosted, linux, repo-manager]
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run repo-manager
+        run: repo-manager all

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   repo-manager:
-    runs-on: [self-hosted, linux, repo-manager, lemon-prod]
+    runs-on: [self-hosted, linux, repo-manager]
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -24,4 +24,5 @@ jobs:
           fetch-depth: 0
 
       - name: Run repo-manager
+        working-directory: /home/jfowers/lemonade-manager
         run: repo-manager all

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -24,5 +24,5 @@ jobs:
           fetch-depth: 0
 
       - name: Run repo-manager
-        working-directory: /home/jfowers/lemonade-manager
+        working-directory: /opt/lemonade-manager
         run: repo-manager all

--- a/.github/workflows/runner_heartbeat.yml
+++ b/.github/workflows/runner_heartbeat.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         runner: ${{ fromJSON(needs.setup.outputs.runners) }}
       fail-fast: false  # Continue even if one runner fails
-    runs-on: [self-hosted, "${{ matrix.runner }}"]
+    runs-on: [self-hosted, "${{ matrix.runner }}", lemon-prod]
     # Fail fast if no runner is available to pick up this job, instead of
     # waiting indefinitely in the queue.
     timeout-minutes: 10

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -149,13 +149,13 @@ jobs:
       matrix:
         include:
           - backend: vulkan
-            runner: [self-hosted, Windows, 128gb, vulkan]
+            runner: [self-hosted, Windows, 128gb, vulkan, lemon-prod]
           - backend: rocm
             channel: stable
-            runner: [self-hosted, Windows, 128gb, rocm]
+            runner: [self-hosted, Windows, 128gb, rocm, lemon-prod]
           - backend: rocm
             channel: nightly
-            runner: [self-hosted, Windows, 128gb, rocm]
+            runner: [self-hosted, Windows, 128gb, rocm, lemon-prod]
           # CUDA validation is prepared but intentionally disabled until an
           # NVIDIA self-hosted runner is available. To enable it, uncomment this
           # matrix entry.

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -103,7 +103,7 @@ jobs:
     name: Validate vllm (rocm)
     needs: [get-latest-releases, build]
     if: always() && needs.build.result == 'success'
-    runs-on: [self-hosted, stx-halo, Linux]
+    runs-on: [self-hosted, stx-halo, Linux, lemon-prod]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/docs/dev/self-hosted-runners.md
+++ b/docs/dev/self-hosted-runners.md
@@ -23,6 +23,14 @@ You can read about all this here: [GitHub: About self-hosted runners](https://do
 
 Workflows target self-hosted runners by the labels the runner carries. We use two kinds of labels:
 
+### Pool membership label
+
+| Label | Meaning |
+|-------|---------|
+| `lemon-prod` | Runner is a production lemonade-sdk runner. **Every self-hosted runner job must include this label.** It acts as a hard gate that prevents jobs from landing on non-lemonade machines (e.g. personal developer boxes or special-purpose runners like `repo-manager`) that happen to share capability labels. |
+
+Without `lemon-prod`, a job that requests only `[self-hosted, Linux]` could run on *any* self-hosted Linux machine registered to the org. All production runners carry this label; runners that are not part of the production inference pool must not have it.
+
 ### Capability labels
 
 These describe *what a runner can do*. A workflow should request only the capability labels it actually needs.
@@ -34,7 +42,7 @@ These describe *what a runner can do*. A workflow should request only the capabi
 | `cuda` | Runner can execute CUDA GPU workloads | TBD |
 | `xdna2` | Runner has a Ryzen AI 300/400 series NPU | `ryzenai` backend, `flm` (FastFlowLM) backend |
 
-A job that exercises more than one backend should request all the labels it needs (e.g., `[Windows, vulkan, rocm]` for a test that runs both Vulkan and ROCm cases). GitHub Actions requires the runner to carry *every* label in the `runs-on` list.
+A job that exercises more than one backend should request all the labels it needs (e.g., `[Windows, vulkan, rocm, lemon-prod]` for a test that runs both Vulkan and ROCm cases). GitHub Actions requires the runner to carry *every* label in the `runs-on` list.
 
 CPU-only jobs should target GitHub-hosted runners when possible.
 
@@ -56,8 +64,8 @@ Capability and hardware labels must be present on each runner for the workflow t
 
 | Hardware | Labels to apply |
 |----------|-----------------|
-| Ryzen AI 300-series laptop (NPU + Vulkan iGPU + ROCm iGPU) | `xdna2`, `vulkan`, `rocm` |
-| Strix Halo | `xdna2`, `rocm`, `stx-halo` |
+| Ryzen AI 300-series laptop (NPU + Vulkan iGPU + ROCm iGPU) | `lemon-prod`, `xdna2`, `vulkan`, `rocm` |
+| Strix Halo | `lemon-prod`, `xdna2`, `rocm`, `stx-halo` |
 
 ## New Runner Setup
 
@@ -85,7 +93,7 @@ These steps will place your machine into the production pool.
     - When running `./config.cmd` in step 2, make the following choices:
          - Name of the runner group = `stx`
          - For the runner name, call it `NAME-TYPE-NUMBER`, where NAME is your alias and NUMBER would tell you this is the Nth machine of TYPE you've added. TYPE examples include `stx`, `stx-halo`, `phx`, etc.
-         - Apply capability labels (`xdna2`, `vulkan`, `rocm`, etc. and any hardware labels like `stx-halo`).
+         - Apply `lemon-prod` plus any capability labels (`xdna2`, `vulkan`, `rocm`, etc.) and hardware labels like `stx-halo`.
          - Accept the default for the work folder
          - You want the runner to function as a service (respond Y)
          - User account to use for the service = `NT AUTHORITY\SYSTEM` (not the default of `NT AUTHORITY\NETWORK SERVICE`)
@@ -130,8 +138,8 @@ Also, if someone else's laptop is misbehaving and causing Actions to fail unexpe
 There are three options:
 
 Option 1, which is available to anyone in the `lemonade-sdk` org: remove the runner's capability labels.
-- Workflows target runners by requesting capability labels like `xdna2`, `vulkan`, and `rocm` (see [Runner Labels](#runner-labels)). Removing every capability label from a runner will drain it completely — no workflow will match.
-- To drain the runner for only one backend (e.g., take it out of ROCm jobs but keep it available for NPU jobs), remove just that one capability label.
+- Workflows target runners by requesting capability labels like `xdna2`, `vulkan`, and `rocm` (see [Runner Labels](#runner-labels)). Removing every capability label **including `lemon-prod`** from a runner will drain it completely — no workflow will match.
+- To drain the runner for only one backend (e.g., take it out of ROCm jobs but keep it available for NPU jobs), remove just that one capability label (leave `lemon-prod` in place).
 - Go to the [runners page](https://github.com/organizations/lemonade-sdk/settings/actions/runners), click the specific runner in question, click the gear icon in the Labels section, and uncheck the capability labels you want to drain.
 - To reverse this action later, go back to the [runners page](https://github.com/organizations/lemonade-sdk/settings/actions/runners), click the gear icon, and re-check the labels you removed.
 
@@ -156,7 +164,7 @@ Here are some general guidelines to observe when creating or modifying workflows
 - Place a 🌩️ emoji in the name of all of your self-host workflows, so that PR reviewers can see at a glance which workflows are using self-hosted resources.
     - Example: `name: Test Lemonade on NPU and Hybrid with OGA environment 🌩️`
 - Avoid triggering your workflow before anyone has had a chance to review it against these guidelines. To avoid triggers, do not include `on: pull request:` in your workflow until after a reviewer has signed off.
-- Request only the capability labels your job actually needs (see [Runner Labels](#runner-labels)). For example, `runs-on: [Windows, xdna2]` for NPU work, `runs-on: [Linux, vulkan, rocm]` for a job that exercises both GPU backends. Do not ask for `xdna2` or a GPU capability if your job is CPU-only — use `[self-hosted, Windows]` / `[self-hosted, Linux]`, or move the step to a GitHub-hosted runner like `runs-on: windows-latest` when possible.
+- **Always include `lemon-prod`** in every self-hosted `runs-on` list (see [Pool membership label](#pool-membership-label)). For example, `runs-on: [Windows, xdna2, lemon-prod]` for NPU work, `runs-on: [Linux, vulkan, rocm, lemon-prod]` for a job that exercises both GPU backends. CPU-only self-hosted jobs use `[self-hosted, Windows, lemon-prod]` / `[self-hosted, Linux, lemon-prod]`, but prefer GitHub-hosted runners (`windows-latest`, `ubuntu-latest`) for CPU-only work when possible.
 - Be very considerate about installing software on to the runners:
     - Installing software into the CWD (e.g., a path of `.\`) is always ok, because that will end up in `C:\actions-runner\_work\REPO`, which is always wiped between tests.
     - Installing software into `AppData`, `Program Files`, etc. is not advisable because that software will persist across tests. See the [setup](#new-runner-setup) section to see which software is already expected on the system.

--- a/docs/dev/self-hosted-runners.md
+++ b/docs/dev/self-hosted-runners.md
@@ -138,8 +138,8 @@ Also, if someone else's laptop is misbehaving and causing Actions to fail unexpe
 There are three options:
 
 Option 1, which is available to anyone in the `lemonade-sdk` org: remove the runner's capability labels.
-- Workflows target runners by requesting capability labels like `xdna2`, `vulkan`, and `rocm` (see [Runner Labels](#runner-labels)). Removing every capability label **including `lemon-prod`** from a runner will drain it completely — no workflow will match.
-- To drain the runner for only one backend (e.g., take it out of ROCm jobs but keep it available for NPU jobs), remove just that one capability label (leave `lemon-prod` in place).
+- Removing `lemon-prod` from a runner will drain it completely — no production workflow will match, regardless of what other capability labels it carries.
+- To drain the runner for only one backend (e.g., take it out of ROCm jobs but keep it available for NPU jobs), remove just that capability label (e.g. `rocm`) while leaving `lemon-prod` in place.
 - Go to the [runners page](https://github.com/organizations/lemonade-sdk/settings/actions/runners), click the specific runner in question, click the gear icon in the Labels section, and uncheck the capability labels you want to drain.
 - To reverse this action later, go back to the [runners page](https://github.com/organizations/lemonade-sdk/settings/actions/runners), click the gear icon, and re-check the labels you removed.
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/repo-manager.yml` to run `repo-manager all` automatically
- Triggers on push to `main` or any `release-v*` branch, plus manual dispatch
- Targets the dedicated `[self-hosted, linux, repo-manager]` runner where `repo-manager` and Pi are pre-installed
- Permissions scoped to read-only (`contents`, `pull-requests`, `issues`) — sufficient for `gh` CLI analysis

## Pre-merge setup

Before merging, make `repo-manager` available on the runner's PATH (one-time):
```bash
# Option A: symlink
ln -s /path/to/repo-manager-venv/bin/repo-manager ~/.local/bin/repo-manager

# Option B: add venv bin to PATH in ~/.bashrc / ~/.profile
export PATH="/path/to/repo-manager-venv/bin:$PATH"
```

## Test plan

- [ ] Complete runner PATH setup above
- [ ] Push a commit to `main` → "Repo Manager" job appears and succeeds in Actions
- [ ] Use "Run workflow" button → manual dispatch works
- [ ] Push to a `release-v*` branch → workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)