### PR TITLE
fix(server): fall back to installed llama.cpp binary when "latest" release lookup fails

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -275,8 +275,9 @@ jobs:
           set -e
           cmake --preset default
           cmake --build --preset default --target test_directory_watcher
+          cmake --build --preset default --target test_latest_version_fallback
           cd build
-          ctest --output-on-failure -R DirectoryWatcher
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -534,8 +535,9 @@ jobs:
         shell: bash
         run: |
           cmake --build --preset default --target test_directory_watcher
+          cmake --build --preset default --target test_latest_version_fallback
           cd build
-          ctest --output-on-failure -R DirectoryWatcher
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1720,3 +1720,23 @@ if(EXISTS "${_GGUF_CAPS_TEST_SRC}")
     include(CTest)
     add_test(NAME GgufCapabilitiesTest COMMAND test_gguf_capabilities)
 endif()
+
+# Pure version-resolution policy test (lemon::resolve_latest_pin). Header-only
+# logic, so the test links nothing beyond the standard library — regression
+# coverage for #2265 (fall back to the installed binary when the GitHub
+# "latest" lookup fails).
+set(_LATEST_FALLBACK_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_latest_version_fallback.cpp"
+)
+if(EXISTS "${_LATEST_FALLBACK_TEST_SRC}")
+    add_executable(test_latest_version_fallback
+        test/cpp/test_latest_version_fallback.cpp
+    )
+    target_include_directories(test_latest_version_fallback PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+
+    include(CTest)
+    add_test(NAME LatestVersionFallbackTest COMMAND test_latest_version_fallback)
+endif()

--- a/src/cpp/include/lemon/backend_manager.h
+++ b/src/cpp/include/lemon/backend_manager.h
@@ -82,10 +82,12 @@ private:
 
     // Resolve the user's *_bin config value for a (recipe, backend) into a
     // concrete release tag. Falls back to `pinned_version` for "" / "builtin"
-    // / path-syntax values. For "latest", queries GitHub (cached). For any
+    // / path-syntax values. For "latest", queries GitHub (cached); if the
+    // lookup fails (e.g. HTTP 504) or is skipped (offline), falls back to the
+    // installed version.txt so an already-installed binary still loads. For any
     // other value, returns the value verbatim as a release tag.
-    // Throws on failure for "latest" when offline/no_fetch_executables block
-    // resolution and no installed version.txt exists.
+    // Throws on failure for "latest" only when the lookup cannot be satisfied
+    // (offline or GitHub error) AND no installed version.txt exists.
     std::string resolve_user_version(const std::string& recipe,
                                      const std::string& resolved_backend,
                                      const std::string& pinned_version,

--- a/src/cpp/include/lemon/backend_version_policy.h
+++ b/src/cpp/include/lemon/backend_version_policy.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <string>
+
+// Pure decision logic for resolving a user's "latest" *_bin config pin into a
+// concrete release tag. Kept free of I/O (no network, no filesystem, no global
+// config) so the policy can be unit-tested in isolation; callers gather the
+// inputs (live GitHub lookup result + installed version.txt) and apply the
+// result. See resolve_user_version() in backend_manager.cpp.
+namespace lemon {
+
+struct LatestPinResolution {
+    // Concrete release tag to use. Empty only when resolution failed, in which
+    // case `error` explains why.
+    std::string version;
+    // Human-readable reason the pin could not be resolved; empty on success.
+    std::string error;
+    // True when `version` came from the installed binary rather than a live
+    // GitHub lookup (so the caller can log a "falling back" warning).
+    bool used_installed_fallback = false;
+};
+
+// Resolve a "latest" pin.
+//
+//   offline           — true when the caller is in offline mode and so did not
+//                        attempt the live lookup; when true the GitHub result
+//                        is ignored. Every other reason the live tag is absent
+//                        (HTTP 504, network error, no_fetch_executables, etc.)
+//                        is conveyed by an empty `fetched_latest`, not this flag.
+//   fetched_latest     — tag returned by the live GitHub lookup; empty when the
+//                        lookup failed (e.g. HTTP 504, network error) or was
+//                        skipped.
+//   installed_version  — contents of the installed version.txt for this
+//                        (recipe, backend); empty when nothing is installed.
+//
+// Policy: prefer a freshly-fetched tag; otherwise fall back to the binary
+// already installed so a transient GitHub failure (or offline mode) does not
+// block loading a model that is otherwise ready. Only when neither is available
+// does resolution fail.
+inline LatestPinResolution resolve_latest_pin(const std::string& recipe,
+                                              const std::string& backend,
+                                              bool offline,
+                                              const std::string& fetched_latest,
+                                              const std::string& installed_version) {
+    if (!offline && !fetched_latest.empty()) {
+        return {fetched_latest, "", false};
+    }
+    if (!installed_version.empty()) {
+        return {installed_version, "", true};
+    }
+    const std::string why = offline
+        ? "offline mode and no installed version found"
+        : "GitHub lookup failed and no installed version found";
+    return {"", "Cannot resolve 'latest' for " + recipe + ":" + backend + ": " + why, false};
+}
+
+} // namespace lemon

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -1,4 +1,5 @@
 #include "lemon/backend_manager.h"
+#include "lemon/backend_version_policy.h"
 #include "lemon/backends/backend_utils.h"
 #include "lemon/runtime_config.h"
 #include "lemon/system_info.h"
@@ -369,24 +370,40 @@ std::string BackendManager::resolve_user_version(const std::string& recipe,
     // any UI/metadata callers that still touch this code path.
     if (utils::looks_like_path(raw)) return pinned_version;
 
-    // "latest" → ask GitHub. If offline and a previously-installed version is
-    // recorded, reuse it instead of failing.
+    // "latest" → ask GitHub for the newest release. The lookup can be skipped
+    // (offline) or fail (e.g. HTTP 504, network error); in either case fall back
+    // to the binary already installed rather than refusing to load a model that
+    // is otherwise ready. Only when nothing is installed do we surface an error.
     if (raw == "latest") {
-        if (cfg->offline()) {
-            std::string install_dir = backends::BackendUtils::get_install_directory(
-                recipe, resolved_backend);
-            std::string cached = read_version_file(fs::path(install_dir) / "version.txt");
-            if (!cached.empty()) {
+        const bool offline = cfg->offline();
+        // A non-throwing lookup so a transient GitHub failure becomes a fallback
+        // rather than an exception. Skipped entirely when offline.
+        std::string fetched = offline
+            ? std::string()
+            : fetch_latest_github_tag(repo, /*throw_on_failure=*/false);
+
+        // The install directory is not version-scoped, so version.txt always
+        // reflects the most recently installed binary for this (recipe, backend).
+        std::string install_dir = backends::BackendUtils::get_install_directory(
+            recipe, resolved_backend);
+        std::string installed = read_version_file(fs::path(install_dir) / "version.txt");
+
+        LatestPinResolution resolution =
+            resolve_latest_pin(recipe, resolved_backend, offline, fetched, installed);
+        if (!resolution.version.empty()) {
+            if (resolution.used_installed_fallback && offline) {
                 LOG(WARNING, "BackendManager") << "offline: reusing installed " << recipe
                                                << ":" << resolved_backend << " version "
-                                               << cached << " for 'latest'" << std::endl;
-                return cached;
+                                               << resolution.version << " for 'latest'" << std::endl;
+            } else if (resolution.used_installed_fallback) {
+                LOG(WARNING, "BackendManager") << "could not resolve 'latest' for " << recipe
+                                               << ":" << resolved_backend
+                                               << "; falling back to installed version "
+                                               << resolution.version << std::endl;
             }
-            throw std::runtime_error(
-                "Cannot resolve 'latest' for " + recipe + ":" + resolved_backend
-                + ": offline mode and no installed version found");
+            return resolution.version;
         }
-        return fetch_latest_github_tag(repo, /*throw_on_failure=*/true);
+        throw std::runtime_error(resolution.error);
     }
 
     // Otherwise: a bare upstream release tag (e.g. "b8664"). Pass through.

--- a/test/cpp/test_latest_version_fallback.cpp
+++ b/test/cpp/test_latest_version_fallback.cpp
@@ -1,0 +1,109 @@
+// Standalone unit tests for lemon::resolve_latest_pin() — the pure policy that
+// decides how a "latest" *_bin config pin resolves to a concrete release tag
+// when the live GitHub lookup succeeds, fails (e.g. HTTP 504), or is skipped
+// (offline). Regression coverage for lemonade-sdk/lemonade#2265: a transient
+// GitHub failure must fall back to the installed binary instead of refusing to
+// load a model that is otherwise ready.
+//
+// Checks use an explicit pass/fail counter (not assert()) so the test stays
+// effective under the Release build the CI `default` preset uses, where
+// -DNDEBUG would compile assert() to a no-op.
+//
+// Compile with:
+//   g++ -std=c++17 -I src/cpp/include \
+//       test/cpp/test_latest_version_fallback.cpp -o latest_version_fallback_test
+//
+// Run with:
+//   ./latest_version_fallback_test
+
+#include <cstdio>
+#include <string>
+
+#include <lemon/backend_version_policy.h>
+
+using lemon::LatestPinResolution;
+using lemon::resolve_latest_pin;
+
+struct TestResult {
+    int passed = 0;
+    int failed = 0;
+
+    void check(bool cond, const std::string& name) {
+        if (cond) {
+            printf("[PASS] %s\n", name.c_str());
+            ++passed;
+        } else {
+            printf("[FAIL] %s\n", name.c_str());
+            ++failed;
+        }
+    }
+};
+
+int main() {
+    TestResult r;
+    const std::string recipe = "llamacpp";
+    const std::string backend = "vulkan";
+
+    printf("=== resolve_latest_pin() Unit Tests ===\n\n");
+
+    // Online, GitHub lookup succeeds → use the freshly-fetched tag (no fallback).
+    {
+        LatestPinResolution res = resolve_latest_pin(recipe, backend, /*offline=*/false,
+                                                     /*fetched_latest=*/"b9700",
+                                                     /*installed_version=*/"b9632");
+        r.check(res.version == "b9700", "online ok: uses fetched tag");
+        r.check(res.error.empty(), "online ok: no error");
+        r.check(!res.used_installed_fallback, "online ok: not a fallback");
+    }
+
+    // Online, GitHub lookup FAILS, a binary is installed → fall back to the
+    // installed version (the #2265 fix). Must not produce an error.
+    {
+        LatestPinResolution res = resolve_latest_pin(recipe, backend, /*offline=*/false,
+                                                     /*fetched_latest=*/"",
+                                                     /*installed_version=*/"b9632");
+        r.check(res.version == "b9632", "online failed + installed: falls back to installed (#2265)");
+        r.check(res.error.empty(), "online failed + installed: no error");
+        r.check(res.used_installed_fallback, "online failed + installed: flagged as fallback");
+    }
+
+    // Online, GitHub lookup FAILS, nothing installed → unresolvable, with a
+    // message that names the GitHub failure (not offline).
+    {
+        LatestPinResolution res = resolve_latest_pin(recipe, backend, /*offline=*/false,
+                                                     /*fetched_latest=*/"",
+                                                     /*installed_version=*/"");
+        r.check(res.version.empty(), "online failed + none: no version");
+        r.check(res.error.find("GitHub lookup failed") != std::string::npos,
+                "online failed + none: error names GitHub failure");
+        r.check(res.error.find("llamacpp:vulkan") != std::string::npos,
+                "online failed + none: error names recipe:backend");
+        r.check(!res.used_installed_fallback, "online failed + none: not a fallback");
+    }
+
+    // Offline, a binary is installed → reuse it (the live result is ignored even
+    // if somehow non-empty).
+    {
+        LatestPinResolution res = resolve_latest_pin(recipe, backend, /*offline=*/true,
+                                                     /*fetched_latest=*/"b9700",
+                                                     /*installed_version=*/"b9632");
+        r.check(res.version == "b9632", "offline + installed: reuses installed, ignores fetched");
+        r.check(res.error.empty(), "offline + installed: no error");
+        r.check(res.used_installed_fallback, "offline + installed: flagged as fallback");
+    }
+
+    // Offline, nothing installed → unresolvable, with the offline-specific
+    // message.
+    {
+        LatestPinResolution res = resolve_latest_pin(recipe, backend, /*offline=*/true,
+                                                     /*fetched_latest=*/"",
+                                                     /*installed_version=*/"");
+        r.check(res.version.empty(), "offline + none: no version");
+        r.check(res.error.find("offline mode") != std::string::npos,
+                "offline + none: error names offline mode");
+        r.check(!res.used_installed_fallback, "offline + none: not a fallback");
+    }
+
+    printf("\n%d/%d checks passed\n", r.passed, r.passed + r.failed);
+    return r.failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
Fixes #2265.

When a backend's `*_bin` is pinned to `latest`, loading a model resolves the newest release tag from GitHub. If that lookup fails (e.g. HTTP 504) or is otherwise unreachable, resolution **threw** and the model refused to load — even though a perfectly usable binary was already installed.

This makes the live-failure path behave like the existing **offline** path: fall back to the version recorded in the installed binary's `version.txt`, load with a warning, and only error when *neither* a live tag *nor* an installed binary is available.

## Root cause
`LlamaCppServer::load()` → `install_backend()` → `get_install_params()` → `resolve_user_version()`. For `*_bin="latest"`, that last call did `fetch_latest_github_tag(repo, throw_on_failure=true)`; a transient GitHub failure propagated up as `model_load_error` before the already-installed binary was ever considered.

## Fix
- In the `"latest"` branch, do a **non-throwing** lookup; on an empty result fall back to the installed `version.txt`. The install dir isn't version-scoped, so it always reflects the on-disk binary — `install_from_github` then sees a version match and skips re-download, so the fallback needs no network.
- The selection rule is extracted into a pure, I/O-free helper `lemon::resolve_latest_pin()` so it's unit-testable in isolation.

**Behavioral scope:** `resolve_user_version()` is shared, so this fallback now applies to **every `*_bin=latest` backend** (llamacpp, whisper, sd, kokoro, …), not just `llamacpp:vulkan`. The failure mode is generic to `latest`, so this is intended. Pinned / `builtin` / path / bare-tag values and unrelated load errors are unchanged.

## Testing
- **New C++ unit test** (`test/cpp/test_latest_version_fallback.cpp`) covering the full decision table (online ok / online failed / offline × with/without an installed binary), wired into CMake + CI alongside `test_directory_watcher`. It uses explicit pass/fail accounting rather than `assert()` (which the Release build's `-DNDEBUG` would compile to a no-op) so it actually guards in CI.
- **Verified on real hardware** (Radeon RX 7900 XT, gfx1100, Vulkan): forced the GitHub `latest` lookup to fail with an already-installed `b9632` binary.
  - Before: `model_load_error: Failed to query GitHub for latest release of ggml-org/llama.cpp`.
  - After: `could not resolve 'latest' for llamacpp:vulkan; falling back to installed version b9632` → model loads and serves a completion.

_Touches `CMakeLists.txt` and the two CI `Run C++ unit tests` steps purely to gate the new regression test._
