### PR TITLE
fix(rocm): accept wildcard GPU arch families in TheRock install gate (#2093 follow-up)

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -46,7 +46,10 @@
       "gfx1033",
       "gfx1034",
       "gfx1035",
-      "gfx1036"
+      "gfx1036",
+      "gfx103X",
+      "gfx110X",
+      "gfx120X"
     ],
     "url_mapping": {
       "gfx908": "gfx90X-dcgpu",


### PR DESCRIPTION
## Problem (release-relevant)

PR #2093 ("Enable TheRock ROCm install on Windows for Radeon RX GPUs") was **squash-merged from the wrong tree state** — it captured `da8e5325` and dropped the author's follow-up fix `0b164e80` ("Undo breakage from dropping ROCM_ARCH_MAPPING"). That fix is on neither `main` nor `release-v10.8.0`.

As a result, the released `therock.architectures` gate is incomplete and the PR's headline feature is broken for the GPUs it targets:

- On Windows, `SystemInfo::get_rocm_arch()` resolves Radeon RX dGPUs from their marketing name to a **wildcard family**: `gfx103X` (RDNA2), `gfx110X` (RDNA3), `gfx120X` (RDNA4).
- `therock.architectures` in `backend_versions.json` lists **only exact ISAs** (`gfx1100`, `gfx1030`, …) — none of the wildcards.
- `will_install_therock()` does an exact string compare against that array, so a wildcard return never matches → **TheRock is skipped → ROCm is silently never installed** for RDNA2/3/4 RX dGPUs.
- `therock.url_mapping` already contains the wildcard keys, so only the gate array was wrong.

(Same arch-vs-config gap class as the whisper `gfx103X` issue fixed in #2274.)

## Fix

Add `gfx103X` / `gfx110X` / `gfx120X` to `therock.architectures` so the install gate matches what `get_rocm_arch()` actually returns.

This is deliberately the **minimal** fix — it does **not** touch `get_rocm_arch()`.
