### PR TITLE
test(gguf): add unit tests for MTP / capability label detection (#2176)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1701,3 +1701,22 @@ if(EXISTS "${_DIR_WATCHER_TEST_SRC}" AND EXISTS "${_DIR_WATCHER_LIB_SRC}")
     include(CTest)
     add_test(NAME DirectoryWatcherTest COMMAND test_directory_watcher)
 endif()
+
+# GGUF capability detection (MTP / vision / tool-calling label logic).
+# Header-only unit under test, so no extra source files are required.
+set(_GGUF_CAPS_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_gguf_capabilities.cpp"
+)
+if(EXISTS "${_GGUF_CAPS_TEST_SRC}")
+    add_executable(test_gguf_capabilities
+        test/cpp/test_gguf_capabilities.cpp
+    )
+    target_include_directories(test_gguf_capabilities PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+
+    # Enable testing and register the test with CTest
+    include(CTest)
+    add_test(NAME GgufCapabilitiesTest COMMAND test_gguf_capabilities)
+endif()

--- a/test/cpp/test_gguf_capabilities.cpp
+++ b/test/cpp/test_gguf_capabilities.cpp
@@ -1,0 +1,147 @@
+// Standalone test for lemon GGUF capability detection (src/cpp/include/lemon/gguf_capabilities.h).
+// Focus: the MTP (Multi-Token Prediction) label path added in PR #2176, plus the
+// sibling vision / tool-calling detection that lives in the same header.
+//
+// Note on scope: the raw MTP *trigger* (scanning GGUF KV metadata for
+// `nextn_predict_layers` and matching llama.cpp MTP/MAD tensor names) lives in
+// model_manager.cpp and requires a parsed GGUF file. That sets
+// GgufCapabilities::mtp. This test covers the header-level contract that turns
+// that flag into the user-visible "mtp" model label (apply_gguf_capability_labels)
+// and the dedup helper (add_label_once), which is the regression-prone seam.
+//
+// Compile with: cl /std:c++17 /EHsc /I src/cpp/include test/cpp/test_gguf_capabilities.cpp
+// or:          g++ -std=c++17 -I src/cpp/include test/cpp/test_gguf_capabilities.cpp -o gguf_caps_test
+
+#include "lemon/gguf_capabilities.h"
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using lemon::GgufCapabilities;
+using lemon::add_label_once;
+using lemon::apply_gguf_capability_labels;
+using lemon::inspect_gguf_string;
+
+static int g_failures = 0;
+
+static bool has_label(const std::vector<std::string>& labels, const std::string& label) {
+    return std::find(labels.begin(), labels.end(), label) != labels.end();
+}
+
+static int count_label(const std::vector<std::string>& labels, const std::string& label) {
+    int n = 0;
+    for (const auto& l : labels) {
+        if (l == label) ++n;
+    }
+    return n;
+}
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+int main() {
+    // --- MTP label application -------------------------------------------------
+
+    // mtp flag set -> "mtp" label added, and the function reports a change.
+    {
+        GgufCapabilities caps;
+        caps.mtp = true;
+        std::vector<std::string> labels;
+        bool changed = apply_gguf_capability_labels(labels, caps);
+        check("mtp=true adds 'mtp' label", has_label(labels, "mtp"));
+        check("mtp=true reports changed=true", changed);
+        check("mtp=true adds exactly one 'mtp'", count_label(labels, "mtp") == 1);
+    }
+
+    // mtp flag unset -> no "mtp" label, no change.
+    {
+        GgufCapabilities caps;  // all false by default
+        std::vector<std::string> labels;
+        bool changed = apply_gguf_capability_labels(labels, caps);
+        check("mtp=false does not add 'mtp'", !has_label(labels, "mtp"));
+        check("all-false reports changed=false", !changed);
+        check("all-false leaves labels empty", labels.empty());
+    }
+
+    // Idempotency: applying twice must not duplicate, and the second call is a no-op.
+    {
+        GgufCapabilities caps;
+        caps.mtp = true;
+        std::vector<std::string> labels;
+        apply_gguf_capability_labels(labels, caps);
+        bool changed_second = apply_gguf_capability_labels(labels, caps);
+        check("re-applying mtp does not duplicate", count_label(labels, "mtp") == 1);
+        check("re-applying mtp reports changed=false", !changed_second);
+    }
+
+    // Pre-existing "mtp" label is preserved without duplication.
+    {
+        GgufCapabilities caps;
+        caps.mtp = true;
+        std::vector<std::string> labels = {"reasoning", "mtp"};
+        bool changed = apply_gguf_capability_labels(labels, caps);
+        check("pre-existing 'mtp' not duplicated", count_label(labels, "mtp") == 1);
+        check("pre-existing 'mtp' reports changed=false", !changed);
+        check("pre-existing unrelated label preserved", has_label(labels, "reasoning"));
+    }
+
+    // --- add_label_once helper -------------------------------------------------
+    {
+        std::vector<std::string> labels;
+        bool first = add_label_once(labels, "mtp");
+        bool second = add_label_once(labels, "mtp");
+        check("add_label_once first insert returns true", first);
+        check("add_label_once second insert returns false", !second);
+        check("add_label_once keeps a single copy", count_label(labels, "mtp") == 1);
+    }
+
+    // --- MTP combines with the other capabilities ------------------------------
+    {
+        GgufCapabilities caps;
+        caps.vision = true;
+        caps.tool_calling = true;
+        caps.mtp = true;
+        std::vector<std::string> labels;
+        bool changed = apply_gguf_capability_labels(labels, caps);
+        check("vision+tool_calling+mtp adds all three",
+              has_label(labels, "vision") && has_label(labels, "tool-calling") &&
+                  has_label(labels, "mtp"));
+        check("combined apply reports changed=true", changed);
+    }
+
+    // --- inspect_gguf_string does NOT infer mtp (it is detected upstream) -------
+    // mtp must come from the KV/tensor scan in model_manager.cpp, never from a
+    // metadata-string heuristic, so a value mentioning "mtp" must not flip it.
+    {
+        GgufCapabilities caps;
+        inspect_gguf_string("general.name", "some-model-mtp-v1", caps);
+        check("inspect_gguf_string never sets mtp", !caps.mtp);
+    }
+
+    // Guard the sibling detection in the same header so this file fully covers it.
+    {
+        GgufCapabilities caps;
+        inspect_gguf_string("general.architecture", "qwen3vl", caps);
+        check("inspect_gguf_string detects vision", caps.vision);
+    }
+    {
+        GgufCapabilities caps;
+        inspect_gguf_string("tokenizer.chat_template", "{% if tools %}<tool_call>", caps);
+        check("inspect_gguf_string detects tool-calling", caps.tool_calling);
+    }
+    {
+        GgufCapabilities caps;
+        // A non-stable key must not trigger vision even with a matching value.
+        inspect_gguf_string("some.random.key", "this is a vision image model", caps);
+        check("inspect_gguf_string ignores non-stable vision key", !caps.vision);
+    }
+
+    if (g_failures == 0) {
+        std::printf("\nAll gguf_capabilities tests passed\n");
+        return 0;
+    }
+    std::printf("\n%d gguf_capabilities test(s) FAILED\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
## Problem

PR #2176 added auto-detection of the **MTP (Multi-Token Prediction)** capability for GGUF models — it scans KV metadata for `nextn_predict_layers` and llama.cpp MTP/MAD tensor names, then applies an `mtp` model label so llama-server uses draft-mtp speculation. It shipped with **no automated tests**, so the detection/labeling logic is unguarded against regressions (the open maintainer to-do from the v10.8.0 review).

## Change

Add `test/cpp/test_gguf_capabilities.cpp` and register it with CTest as `GgufCapabilitiesTest`, mirroring the existing `test_directory_watcher` wiring. `gguf_capabilities.h` is header-only, so the test compiles against just the header (no extra sources).

### Coverage (20 cases, all passing)
- `apply_gguf_capability_labels`: `"mtp"` added **iff** `caps.mtp`, with the correct `changed` return.
- `add_label_once` dedup + idempotency: re-applying is a no-op and never duplicates the label.
- Pre-existing labels preserved; `mtp` correctly combines with `vision` / `tool-calling`.
- `inspect_gguf_string` **never** infers `mtp` from a metadata string (mtp must originate from the upstream KV/tensor scan, not a heuristic).
- The sibling `vision` / `tool-calling` detection in the same header is covered too (incl. the non-stable-key negative case).

### Scope note
The raw MTP *trigger* (the KV `nextn_predict_layers` check + tensor-name matching) lives in `model_manager.cpp` and requires a parsed GGUF file, so it's out of scope for a header-level unit test. This test guards the header's capability→label contract, which is the regression-prone seam that PR #2176 introduced.

## Verification
Built and ran locally (`cmake --build --preset vs18 --target test_gguf_capabilities`):
```
All gguf_capabilities tests passed   (20/20, exit 0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
