### PR TITLE
ci(repo-manager): automatic repo-manager fully operational

### DIFF
--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -7,6 +7,11 @@ on:
       - 'release-v*'
   workflow_dispatch:
 
+# One run at a time; a new push cancels any queued or in-progress run.
+concurrency:
+  group: repo-manager
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: read
@@ -15,6 +20,7 @@ permissions:
 jobs:
   repo-manager:
     runs-on: [self-hosted, linux, repo-manager]
+    timeout-minutes: 30
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -27,6 +33,8 @@ jobs:
         run: |
           git config --global user.name "Lemonade Bot"
           git config --global user.email "lemonade@amd.com"
+          # repo-manager clones lemonade into /opt/lemonade-manager/.repo-manager/checkout
+          # as root during initial setup; mark it safe for the runner user.
           git config --global --add safe.directory /opt/lemonade-manager/.repo-manager/checkout
           gh auth setup-git
 
@@ -34,5 +42,8 @@ jobs:
         run: rm -rf /opt/lemonade-manager/.repo-manager/pages
 
       - name: Run repo-manager
+        # /opt/lemonade-manager is the pre-existing repo-manager config/DB directory
+        # that targets lemonade-sdk/lemonade. It is separate from $GITHUB_WORKSPACE
+        # (the checked-out repo), which repo-manager reads via the gh CLI.
         working-directory: /opt/lemonade-manager
         run: repo-manager all

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -23,8 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Mark lemonade-manager as git safe directory
-        run: git config --global --add safe.directory /opt/lemonade-manager/.repo-manager/checkout
+      - name: Configure git identity and safe directories
+        run: |
+          git config --global user.name "Lemonade Bot"
+          git config --global user.email "lemonade@amd.com"
+          git config --global --add safe.directory /opt/lemonade-manager/.repo-manager/checkout
 
       - name: Run repo-manager
         working-directory: /opt/lemonade-manager

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  issues: read
+  issues: write
 
 jobs:
   repo-manager:

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Mark lemonade-manager as git safe directory
+        run: git config --global --add safe.directory /opt/lemonade-manager/.repo-manager/checkout
+
       - name: Run repo-manager
         working-directory: /opt/lemonade-manager
         run: repo-manager all

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -28,6 +28,7 @@ jobs:
           git config --global user.name "Lemonade Bot"
           git config --global user.email "lemonade@amd.com"
           git config --global --add safe.directory /opt/lemonade-manager/.repo-manager/checkout
+          gh auth setup-git
 
       - name: Clean stale repo-manager state
         run: rm -rf /opt/lemonade-manager/.repo-manager/pages

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: read
   issues: write
 

--- a/.github/workflows/repo-manager.yml
+++ b/.github/workflows/repo-manager.yml
@@ -29,6 +29,9 @@ jobs:
           git config --global user.email "lemonade@amd.com"
           git config --global --add safe.directory /opt/lemonade-manager/.repo-manager/checkout
 
+      - name: Clean stale repo-manager state
+        run: rm -rf /opt/lemonade-manager/.repo-manager/pages
+
       - name: Run repo-manager
         working-directory: /opt/lemonade-manager
         run: repo-manager all

--- a/docs/dev/self-hosted-runners.md
+++ b/docs/dev/self-hosted-runners.md
@@ -27,9 +27,9 @@ Workflows target self-hosted runners by the labels the runner carries. We use tw
 
 | Label | Meaning |
 |-------|---------|
-| `lemon-prod` | Runner is a production lemonade-sdk runner. **Every self-hosted runner job must include this label.** It acts as a hard gate that prevents jobs from landing on non-lemonade machines (e.g. personal developer boxes or special-purpose runners like `repo-manager`) that happen to share capability labels. |
+| `lemon-prod` | Runner is a production lemonade-sdk runner. **Every production self-hosted runner job must include this label.** It acts as a hard gate that prevents jobs from landing on non-lemonade machines (e.g. personal developer boxes) that happen to share capability labels. Special-purpose runners (e.g. `repo-manager`) use their own dedicated labels and intentionally omit `lemon-prod`. |
 
-Without `lemon-prod`, a job that requests only `[self-hosted, Linux]` could run on *any* self-hosted Linux machine registered to the org. All production runners carry this label; runners that are not part of the production inference pool must not have it.
+Without `lemon-prod`, a job that requests only `[self-hosted, Linux]` could run on *any* self-hosted Linux machine registered to the org. All production inference runners carry this label; special-purpose runners that are not part of the production pool must not have it.
 
 ### Capability labels
 
@@ -164,7 +164,7 @@ Here are some general guidelines to observe when creating or modifying workflows
 - Place a 🌩️ emoji in the name of all of your self-host workflows, so that PR reviewers can see at a glance which workflows are using self-hosted resources.
     - Example: `name: Test Lemonade on NPU and Hybrid with OGA environment 🌩️`
 - Avoid triggering your workflow before anyone has had a chance to review it against these guidelines. To avoid triggers, do not include `on: pull request:` in your workflow until after a reviewer has signed off.
-- **Always include `lemon-prod`** in every self-hosted `runs-on` list (see [Pool membership label](#pool-membership-label)). For example, `runs-on: [Windows, xdna2, lemon-prod]` for NPU work, `runs-on: [Linux, vulkan, rocm, lemon-prod]` for a job that exercises both GPU backends. CPU-only self-hosted jobs use `[self-hosted, Windows, lemon-prod]` / `[self-hosted, Linux, lemon-prod]`, but prefer GitHub-hosted runners (`windows-latest`, `ubuntu-latest`) for CPU-only work when possible.
+- **Always include `lemon-prod`** in every *production* self-hosted `runs-on` list (see [Pool membership label](#pool-membership-label)). For example, `runs-on: [Windows, xdna2, lemon-prod]` for NPU work, `runs-on: [Linux, vulkan, rocm, lemon-prod]` for a job that exercises both GPU backends. CPU-only self-hosted jobs use `[self-hosted, Windows, lemon-prod]` / `[self-hosted, Linux, lemon-prod]`, but prefer GitHub-hosted runners (`windows-latest`, `ubuntu-latest`) for CPU-only work when possible. Special-purpose runners with their own dedicated labels (e.g. `[self-hosted, linux, repo-manager]`) are the exception and should not include `lemon-prod`.
 - Be very considerate about installing software on to the runners:
     - Installing software into the CWD (e.g., a path of `.\`) is always ok, because that will end up in `C:\actions-runner\_work\REPO`, which is always wiped between tests.
     - Installing software into `AppData`, `Program Files`, etc. is not advisable because that software will persist across tests. See the [setup](#new-runner-setup) section to see which software is already expected on the system.


### PR DESCRIPTION
Closes https://github.com/lemonade-sdk/lemonade/issues/2277

Fixes runtime errors discovered when running the workflow added in #2276.

The workflow runs `repo-manager all` on the dedicated `repo-manager` self-hosted runner, using `/opt/lemonade-manager` as its working directory (the pre-existing repo-manager config/DB that targets this repo). The checkout step gives repo-manager access to the full git history; the actual analysis goes through the `gh` CLI, not the workspace directly.

**Permissions fixed:**
- `contents: write` — publish-pages pushes commits to the pages repo
- `issues: write` — sync updates GitHub issues

**Runner setup:**
- `gh auth setup-git` — wires `gh` as git's HTTPS credential helper so the pages repo clone authenticates via `GH_TOKEN` instead of hanging on a username prompt
- Git identity configured globally so publish-pages commits don't fail with "unable to auto-detect email address"
- `safe.directory` added for `/opt/lemonade-manager/.repo-manager/checkout` (owned by root from initial setup)
- Pages checkout wiped before each run to prevent stale state from a partially-completed prior run blocking the next one

**Reliability (per review feedback in #2277):**
- `concurrency: cancel-in-progress: true` — a new push cancels any queued or in-progress run
- `timeout-minutes: 30` — bounds hung runs
- Docs updated: `lemon-prod` is required for *production* self-hosted jobs; special-purpose runners like `repo-manager` intentionally omit it
