### PR TITLE
docs(release): update release process for repo-manager automation

### DIFF
--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -6,13 +6,15 @@ This guide documents the end-to-end process of releasing Lemonade.
 
 Lemonade has built its brand on quality and ease-of-use. Do not release a new Lemonade version if this is compromised in any way.
 
-The repo-manager workflow runs automatically on every push to `main` or a release branch and publishes a live release dashboard at [https://lemonade-server.ai/repo-manager](https://lemonade-server.ai/repo-manager). Use this as your primary source of truth for whether the release is ready to ship. It also maintains three GitHub issues for the upcoming release (described in the steps below); these are updated automatically on each push.
+The repo-manager workflow runs automatically on every push to `main` or a release branch and publishes a live release dashboard at [https://lemonade-server.ai/repo-manager](https://lemonade-server.ai/repo-manager). Use to assess whether the release is ready to ship. It also maintains three GitHub issues for the upcoming release (described in the steps below); these are updated automatically on each push.
 
 ## Release Cadence
 
 Lemonade operates on a weekly release cadence, with new releases coming out each Wednesday morning. Each release is managed by a core maintainer on a rotating basis.
 
 It is highly recommended that any PR targeting a particular release be in a highly-reviewed state by Monday morning on the week of that release. Maintainers reserve the right to postpone merging any PR until after the release, in order to prioritize quality.
+
+We suggest creating the release branch on the Tuesday before the release to provide time for testing before the Wednesday release.
 
 ## Step 1: Update the Version
 
@@ -46,7 +48,7 @@ Once the branch is pushed, repo-manager will automatically create three GitHub i
 - **`vX.Y.Z release notes`** — Headline and Breaking Changes sections pre-populated from the commit history. Review and edit before tagging; the release action pulls directly from this issue.
 - **`vX.Y.Z announcement`** — a full Discord announcement draft with per-feature sections and contributor shoutouts. Review and edit before posting.
 
-All three issues are re-synced automatically on every subsequent push to the release branch.
+All three issues are re-synced automatically on every subsequent push to the release branch. If you leave comments on those issues the system will take your feedback into account when regenerating the issue content.
 
 ### Managing the Release Branch
 
@@ -158,6 +160,31 @@ Open the **`vX.Y.Z announcement`** GitHub issue. Repo-manager has drafted a full
 - Major and Minor releases: `@everyone`
 - Patch releases: `@release`
 
+The auto-generated announcement uses people's github usernames for shoutouts. Please try to translate those to Discord usernames to the best of your ability before posting.
+
 ## Step 8: Social Media
 
 Not required, but it is always good to promote the new release online.
+
+### Reddit
+
+There are two kinds of Reddit posts we typically do. It's ok to do both for a single release, but in that case post one on Wednesday and one 2+ days later.
+
+**Release Update**
+
+Covers the entire release. This can be similar to the announcement posted on Discord, but:
+- Be sure to remove Discord-specific artifacts like `@everyone`.
+- Add context for people who are not Lemonade users.
+- Add call-to-action (CTA) content to the bottom. Typically a link to the GitHub, a link to the Discord, and some request such as giving feedback on a plan or trying something out.
+
+Example of a successful Reddit release updates:
+- Major update: https://www.reddit.com/r/LocalLLaMA/comments/1rsucvk/lemonade_v10_linux_npu_support_and_chock_full_of/
+- Minor update: https://www.reddit.com/r/LocalLLaMA/comments/1u26wkb/lemonade_v107_release_and_project_organization/
+
+**Feature Update**
+
+Covers a specific feature in-depth. Always include a graphical asset to draw people in.
+
+Examples of successful Reddit feature posts:
+- https://www.reddit.com/r/LocalLLaMA/comments/1t7g70j/vllm_rocm_has_been_added_to_lemonade_as_an/
+- https://www.reddit.com/r/LocalLLaMA/comments/1u37q7u/having_some_fun_with_lmxomni52bhalo_in_open_webui/

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -4,7 +4,9 @@ This guide documents the end-to-end process of releasing Lemonade.
 
 ## Quality
 
-Lemonade has built its brand on quality and ease-of-use. Do not release a new Lemonade version if this is compromised in any way. Carefully monitor the state of the upcoming release using [https://lemonade-server.ai/repo-manager](https://lemonade-server.ai/repo-manager).
+Lemonade has built its brand on quality and ease-of-use. Do not release a new Lemonade version if this is compromised in any way.
+
+The repo-manager workflow runs automatically on every push to `main` or a release branch and publishes a live release dashboard at [https://lemonade-server.ai/repo-manager](https://lemonade-server.ai/repo-manager). Use this as your primary source of truth for whether the release is ready to ship. It also maintains three GitHub issues for the upcoming release (described in the steps below); these are updated automatically on each push.
 
 ## Release Cadence
 
@@ -38,6 +40,14 @@ git checkout -b release-vX.Y.Z
 git push origin release-vX.Y.Z
 ```
 
+Once the branch is pushed, repo-manager will automatically create three GitHub issues for this release:
+
+- **`Release vX.Y.Z final checklist`** — a prioritized (P1/P2/P3) checklist of things to verify before shipping, with a machine-generated verdict (`Ready` / `Needs Attention`). Work through the P1 items before tagging.
+- **`vX.Y.Z release notes`** — Headline and Breaking Changes sections pre-populated from the commit history. Review and edit before tagging; the release action pulls directly from this issue.
+- **`vX.Y.Z announcement`** — a full Discord announcement draft with per-feature sections and contributor shoutouts. Review and edit before posting.
+
+All three issues are re-synced automatically on every subsequent push to the release branch.
+
 ### Managing the Release Branch
 
 Two situations arise while the release branch is open:
@@ -69,6 +79,8 @@ git push origin main   # requires admin "bypass branch protections" permission
 Confirm with the team before pushing directly to `main`.
 
 ## Step 3: Push a Tag
+
+Before tagging, check the **`Release vX.Y.Z final checklist`** issue. All P1 items should be resolved and the verdict should read `Ready`.
 
 Lemonade releases are automatically created by the [cpp_server_build_test_release.yml workflow](https://github.com/lemonade-sdk/lemonade/blob/main/.github/workflows/cpp_server_build_test_release.yml) final step, which is triggered by pushing a tag that matches the `v*` pattern. The tag must match the pattern `v<major>.<minor>.<patch>`, i.e., the value from CMakeLists.txt with a leading `v`.
 
@@ -120,9 +132,9 @@ git push origin vX.Y.Z --force
 
 ## Step 6: Update the Release Notes
 
-The release action auto-generates release notes that include the **Headline** and **Breaking Changes** sections pulled from the open GitHub issue titled `vX.Y.Z release notes` (exact match on the tag name, e.g. `v10.8.0 release notes`). The result looks like this: https://github.com/lemonade-sdk/lemonade/releases/tag/v10.7.0
+Open the **`vX.Y.Z release notes`** GitHub issue. Repo-manager has pre-populated the **Headline** and **Breaking Changes** sections from the commit history. Review and edit them — the release action pulls these sections directly from this issue to build the GitHub release page.
 
-You may need to manually edit the release to:
+You may also need to manually edit the GitHub release after it publishes to:
 - add co-author contributors who were missing
 - add deprecation notices
 - add/remove links to release artifacts that we forgot to update in the release workflow.
@@ -141,21 +153,10 @@ Bulleted list with one item per breaking change. Keep it concise, and link to a 
 
 ## Step 7: Discord Announcement
 
-Each release gets a post in `#announcements` on the Lemonade Discord.
+Open the **`vX.Y.Z announcement`** GitHub issue. Repo-manager has drafted a full announcement with per-feature sections and contributor shoutouts. Review it, make any edits, and post it in `#announcements` on the Lemonade Discord.
 
 - Major and Minor releases: `@everyone`
 - Patch releases: `@release`
-
-This announcement should create excitement for the release and give shout outs to everyone who contributed
-
-Suggested structure:
-- Introduction sentence
-- News (if any)
-- Breaking changes: copied from release notes
-- One section per headline from the release notes, with 1-2 sentences explaining it.
-- Additional Improvements section with a bulleted list, one bullet per notable contribution
-
-Try to find an appealing narrative arc for the release, and implement it by combining contributions into sections/bullets. For example, if there were 3 contributions by 3 authors for LMX models, say "Authors X, Y, and Z teamed up to improve in LMX..."
 
 ## Step 8: Social Media
 


### PR DESCRIPTION
Updates `docs/dev/release.md` to reflect that repo-manager now automates a significant chunk of the release process.

**What changed:**

- **Quality section** — clarifies that lemonade-server.ai/repo-manager is auto-updated on every push to `main` or a release branch, not manually maintained.
- **Step 2 (Create Release Branch)** — adds a description of the three GitHub issues repo-manager auto-creates when the branch is first pushed: the final checklist (with P1/P2/P3 items and a readiness verdict), the release notes issue (Headline + Breaking Changes pre-filled), and the announcement draft.
- **Step 3 (Push Tag)** — adds a prompt to check the checklist issue verdict before tagging.
- **Step 6 (Release Notes)** — reframes this as "review and edit what repo-manager drafted" rather than "write from scratch"; clarifies that the release action pulls directly from the issue.
- **Step 7 (Discord)** — same reframe: open the announcement issue, review/edit the auto-drafted text, post it.
- Added new social media guidance.