### PR TITLE
Fix FLM runtime version check false negative due to missing XRT lib

### DIFF
--- a/data/lemond-user.service.in
+++ b/data/lemond-user.service.in
@@ -7,6 +7,7 @@ After=network-online.target
 Type=simple
 WorkingDirectory=%h
 EnvironmentFile=-%E/lemonade/conf.d/*.conf
+Environment=LD_LIBRARY_PATH=/opt/xilinx/xrt/lib:/opt/xilinx/xrt/lib64
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/lemond
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure

--- a/data/lemond.service.in
+++ b/data/lemond.service.in
@@ -18,6 +18,7 @@ WorkingDirectory=%S/lemonade
 #   LEMONADE_API_KEY         — require API-key auth on all routes
 #   LEMONADE_ADMIN_API_KEY   — API-key specific to internal routes
 EnvironmentFile=-/etc/lemonade/conf.d/*.conf
+Environment=LD_LIBRARY_PATH=/opt/xilinx/xrt/lib:/opt/xilinx/xrt/lib64
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/lemond
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure


### PR DESCRIPTION
FLM runtime version detection regression was somewhere around v10.2 / #1475, I believe...

This fixes the issue when testing locally on Fedora43, FLM v0.9.43, building ` lemonade-server-10.8.0.x86_64.rpm`, enabling the unit service, and checking flm backend status at the localhost port 13305