### PR TITLE
Fix ROCm whisper-server startup: add TheRock lib dir to LD_LIBRARY_PATH

### DIFF
--- a/src/cpp/server/backends/whisper_server.cpp
+++ b/src/cpp/server/backends/whisper_server.cpp
@@ -301,6 +301,19 @@ void WhisperServer::load(const std::string& model_name,
     // set LD_LIBRARY_PATH to include executable directory
     std::string lib_path = exe_dir.string();
 
+    // ROCm whisper-server needs the TheRock ROCm libs (libamd_comgr.so.3, etc.)
+    // on LD_LIBRARY_PATH, exactly as llamacpp_server.cpp and sd_server.cpp do.
+    // Without this it aborts at startup (dlopen libamd_comgr.so.3) on gfx1151.
+    if (whispercpp_backend == "rocm") {
+        std::string rocm_arch = SystemInfo::get_rocm_arch();
+        if (!rocm_arch.empty()) {
+            std::string therock_lib = BackendUtils::get_therock_lib_path(rocm_arch);
+            if (!therock_lib.empty()) {
+                lib_path = therock_lib + ":" + lib_path;
+            }
+        }
+    }
+
     const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
     if (existing_ld_path && strlen(existing_ld_path) > 0) {
         lib_path = lib_path + ":" + std::string(existing_ld_path);


### PR DESCRIPTION
Fixes #2292.

`WhisperServer` was the only ROCm backend launcher not prepending the TheRock ROCm library directory to `LD_LIBRARY_PATH`, so the rocm `whisper-server` aborted at startup (exit 134) failing to `dlopen libamd_comgr.so.3`. This mirrors the existing logic in `sd_server.cpp` and `llamacpp_server.cpp`, gated on the rocm backend.

```cpp
// src/cpp/server/backends/whisper_server.cpp, in WhisperServer::load (#ifndef _WIN32 block)
    std::string lib_path = exe_dir.string();

    // ROCm whisper-server needs the TheRock ROCm libs (libamd_comgr.so.3, etc.)
    // on LD_LIBRARY_PATH, exactly as llamacpp_server.cpp and sd_server.cpp do.
    // Without this it aborts at startup (dlopen libamd_comgr.so.3) on gfx1151.
    if (whispercpp_backend == "rocm") {
        std::string rocm_arch = SystemInfo::get_rocm_arch();
        if (!rocm_arch.empty()) {
            std::string therock_lib = BackendUtils::get_therock_lib_path(rocm_arch);
            if (!therock_lib.empty()) {
                lib_path = therock_lib + ":" + lib_path;
            }
        }
    }
```

Note: the gate uses the raw `whispercpp_backend == "rocm"` option value, not the `resolved_backend == "rocm-stable"` form used by llamacpp/sd_server. This is intentional -- whisper has no resolve step and uses the literal `"rocm"` string throughout (see the download path in `get_install_params`).

## Testing

Built `lemond` from the v10.8.0 tag (the patched file is byte-identical on `main`) in `build-environment:ubuntu24.04`, then ran it on a gfx1151 (Radeon 8060S, Strix Halo) host with `whispercpp.backend=rocm`:

- The rocm `whisper-server` now boots: `(WhisperServer) Using backend: rocm` -> `whisper-server is ready!`
- `POST /api/v1/load {"model_name":"Whisper-Base"}` -> `status: success`
- `POST /api/v1/audio/transcriptions` -> returns transcribed text

Causation control on the same bundled rocm `whisper-server` binary:

- exe-dir-only `LD_LIBRARY_PATH` (pre-patch): `implib-gen: libamd_comgr.so.3: failed to load library ... Aborted (core dumped)`
- TheRock dir prepended (this patch): `found 1 ROCm devices ... Radeon 8060S Graphics, gfx1151`, then runs.
