### PR TITLE
fix(gpu): support wildcards in GPU detection logic

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -652,12 +652,24 @@ static std::string read_version_file(const fs::path& version_file);
 static std::string get_expected_backend_version(const std::string& recipe, const std::string& backend);
 
 // Check if device matches constraints (empty constraint set = all families allowed)
+// A trailing 'X' in an allowed family acts as a wildcard (e.g. "gfx110X" matches "gfx1103").
 static bool device_matches_constraint(const std::string& device_family,
                                        const std::set<std::string>& allowed_families) {
     if (allowed_families.empty()) {
         return true;  // Empty = all families allowed
     }
-    return allowed_families.count(device_family) > 0;
+    if (allowed_families.count(device_family) > 0) {
+        return true;
+    }
+    for (const auto& af : allowed_families) {
+        if (af.size() > 1 && af.back() == 'X') {
+            std::string prefix = af.substr(0, af.size() - 1);
+            if (device_family.compare(0, prefix.size(), prefix) == 0) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 // Generic installation check

--- a/test/test_device_family_matching.py
+++ b/test/test_device_family_matching.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+CPU-runnable unit tests for device family matching logic (device_matches_constraint).
+
+These tests replicate the C++ logic for matching a device family against a set of
+allowed families, including support for wildcard 'X' at the end of a family name.
+"""
+
+import unittest
+
+# ---------------------------------------------------------------------------
+# Python replica of system_info.cpp::device_matches_constraint()
+# ---------------------------------------------------------------------------
+
+def device_matches_constraint(device_family: str, allowed_families: set) -> bool:
+    if not allowed_families:
+        return True  # Empty = all families allowed
+
+    if device_family in allowed_families:
+        return True
+
+    for af in allowed_families:
+        if len(af) > 1 and af.endswith('X'):
+            prefix = af[:-1]
+            if device_family.startswith(prefix):
+                return True
+
+    return False
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestDeviceFamilyMatching(unittest.TestCase):
+    def test_wildcard_matching(self):
+        # gfx1103 should match gfx110X
+        self.assertTrue(device_matches_constraint("gfx1103", {"gfx110X"}))
+        # gfx1201 should match gfx120X
+        self.assertTrue(device_matches_constraint("gfx1201", {"gfx120X"}))
+
+    def test_exact_matching(self):
+        # gfx1151 should match gfx1151
+        self.assertTrue(device_matches_constraint("gfx1151", {"gfx1151"}))
+        # gfx1152 should match gfx1152
+        self.assertTrue(device_matches_constraint("gfx1152", {"gfx1152"}))
+
+    def test_non_matching(self):
+        # gfx1151 should NOT match gfx110X
+        self.assertFalse(device_matches_constraint("gfx1151", {"gfx110X"}))
+
+    def test_empty_allowed_families(self):
+        # Empty allowed_families should match everything
+        self.assertTrue(device_matches_constraint("gfx1151", set()))
+
+    def test_multiple_allowed_families(self):
+        # Should match if any in the set match
+        self.assertTrue(device_matches_constraint("gfx1103", {"gfx103X", "gfx110X"}))
+        self.assertTrue(device_matches_constraint("gfx1201", {"gfx110X", "gfx120X"}))
+        self.assertFalse(device_matches_constraint("gfx1151", {"gfx103X", "gfx110X"}))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This patch fixes ROCm detection for me for the GPUs covered by wildcard strings.

The identify_rocm_arch_from_name() function converts KFD gfx_target_version values (e.g. 110003, 120001) into specific family strings like gfx1103 and gfx1201. However, the RECIPE_DEFS table uses X-suffixed wildcards (gfx110X, gfx120X) to represent entire architecture families.

device_matches_constraint() did an exact string comparison, so gfx1103 != gfx110X and gfx1201 != gfx120X, causing valid AMD GPUs (RDNA3/RDNA4) detected via KFD sysfs to be reported as "Unsupported GPU" for ROCm backends.

Fix device_matches_constraint() to treat a trailing X in allowed family strings as a prefix wildcard match.