### PR TITLE
fix: Prevent the Rosetta prompt on macOS installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1325,6 +1325,10 @@ if(APPLE)
     set(CPACK_PACKAGE_NAME "Lemonade")
     set(CPACK_PRODUCTBUILD_IDENTIFIER "com.lemonade.server")
 
+    # Declare the package arm64-only so the macOS Installer does not assume our
+    # postflight script needs x86_64 and prompt to install Rosetta on Apple Silicon.
+    set(CPACK_APPLE_PKG_INSTALLER_CONTENT "<hostArchitectures><hostArchitecture>arm64</hostArchitecture></hostArchitectures>")
+
     set(CPACK_PRODUCTBUILD_DOMAIN "system")
 
     if(INSTALLER_IDENTITY)


### PR DESCRIPTION
This should solve #2290, at least in theory, I can't know for sure as my CI is failing on the whisper metal inference test for some reason. Creating as draft for now.