### PR TITLE
fix: properly detect zombie backend processes in is_running()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1720,3 +1720,34 @@ if(EXISTS "${_GGUF_CAPS_TEST_SRC}")
     include(CTest)
     add_test(NAME GgufCapabilitiesTest COMMAND test_gguf_capabilities)
 endif()
+
+# ProcessManager non-mutating is_running() test (POSIX).
+set(_PM_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_process_manager.cpp"
+)
+set(_PM_TEST_LIBS
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/utils/process_manager.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/utils/platform/process_unix.cpp"
+)
+
+list(GET _PM_TEST_LIBS 0 _pm_lib0)
+list(GET _PM_TEST_LIBS 1 _pm_lib1)
+if(EXISTS "${_PM_TEST_SRC}" AND EXISTS "${_pm_lib0}" AND EXISTS "${_pm_lib1}")
+    add_executable(test_process_manager
+        test/cpp/test_process_manager.cpp
+        src/cpp/server/utils/process_manager.cpp
+        src/cpp/server/utils/platform/process_unix.cpp
+    )
+    target_include_directories(test_process_manager PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    if(UNIX)
+        target_link_libraries(test_process_manager PRIVATE pthread)
+        target_link_options(test_process_manager PRIVATE -pthread)
+    endif()
+
+    # Enable testing and register the test with CTest
+    include(CTest)
+    add_test(NAME ProcessManagerTest COMMAND test_process_manager)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1721,33 +1721,33 @@ if(EXISTS "${_GGUF_CAPS_TEST_SRC}")
     add_test(NAME GgufCapabilitiesTest COMMAND test_gguf_capabilities)
 endif()
 
-# ProcessManager non-mutating is_running() test (POSIX).
-set(_PM_TEST_SRC
-    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_process_manager.cpp"
-)
-set(_PM_TEST_LIBS
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/utils/process_manager.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/utils/platform/process_unix.cpp"
-)
+# ProcessManager non-mutating is_running() test (Linux /proc-specific).
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(_PM_TEST_SRC
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_process_manager.cpp"
+    )
+    set(_PM_TEST_LIBS
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/utils/process_manager.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/utils/platform/process_unix.cpp"
+    )
 
-list(GET _PM_TEST_LIBS 0 _pm_lib0)
-list(GET _PM_TEST_LIBS 1 _pm_lib1)
-if(EXISTS "${_PM_TEST_SRC}" AND EXISTS "${_pm_lib0}" AND EXISTS "${_pm_lib1}")
-    add_executable(test_process_manager
-        test/cpp/test_process_manager.cpp
-        src/cpp/server/utils/process_manager.cpp
-        src/cpp/server/utils/platform/process_unix.cpp
-    )
-    target_include_directories(test_process_manager PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
-        ${CMAKE_CURRENT_BINARY_DIR}/include
-    )
-    if(UNIX)
+    list(GET _PM_TEST_LIBS 0 _pm_lib0)
+    list(GET _PM_TEST_LIBS 1 _pm_lib1)
+    if(EXISTS "${_PM_TEST_SRC}" AND EXISTS "${_pm_lib0}" AND EXISTS "${_pm_lib1}")
+        add_executable(test_process_manager
+            test/cpp/test_process_manager.cpp
+            src/cpp/server/utils/process_manager.cpp
+            src/cpp/server/utils/platform/process_unix.cpp
+        )
+        target_include_directories(test_process_manager PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+            ${CMAKE_CURRENT_BINARY_DIR}/include
+        )
         target_link_libraries(test_process_manager PRIVATE pthread)
         target_link_options(test_process_manager PRIVATE -pthread)
-    endif()
 
-    # Enable testing and register the test with CTest
-    include(CTest)
-    add_test(NAME ProcessManagerTest COMMAND test_process_manager)
+        # Enable testing and register the test with CTest
+        include(CTest)
+        add_test(NAME ProcessManagerTest COMMAND test_process_manager)
+    endif()
 endif()

--- a/src/cpp/server/utils/platform/process_unix.cpp
+++ b/src/cpp/server/utils/platform/process_unix.cpp
@@ -86,10 +86,6 @@ static void preserve_capabilities_for_exec() {
 #endif
 
 #ifdef __linux__
-// Check whether a process is a zombie by reading /proc/<pid>/stat.
-// Returns true if the process exists and is in zombie ('Z') state,
-// false otherwise (including if the proc entry doesn't exist).
-// This is non-mutating — it does not reap the child.
 static bool is_zombie_by_proc(pid_t pid) {
     char path[64];
     std::snprintf(path, sizeof(path), "/proc/%d/stat", pid);

--- a/src/cpp/server/utils/platform/process_unix.cpp
+++ b/src/cpp/server/utils/platform/process_unix.cpp
@@ -370,6 +370,16 @@ bool UnixProcessPlatform::is_running(ProcessHandle handle) {
     }
 #endif
 
+    // Reap any zombie before falling back to kill(). kill(pid,0) returns
+    // success for zombies (PID still in kernel table) so we must try to wait
+    // on the child first.
+    int status = 0;
+    pid_t result = waitpid(handle.pid, &status, WNOHANG);
+    if (result > 0) {
+        // Process has exited (including zombie) — reap it and report dead.
+        return false;
+    }
+
     errno = 0;
     return ::kill(handle.pid, 0) == 0 || errno == EPERM;
 }

--- a/src/cpp/server/utils/platform/process_unix.cpp
+++ b/src/cpp/server/utils/platform/process_unix.cpp
@@ -21,6 +21,9 @@
 
 #ifdef __linux__
 #include <sys/prctl.h>
+#include <fstream>
+#include <sstream>
+#include <cstdio>
 #endif
 
 #ifdef HAVE_LIBCAP
@@ -79,6 +82,45 @@ static void preserve_capabilities_for_exec() {
     }
 
     cap_free(caps);
+}
+#endif
+
+#ifdef __linux__
+// Check whether a process is a zombie by reading /proc/<pid>/stat.
+// Returns true if the process exists and is in zombie ('Z') state,
+// false otherwise (including if the proc entry doesn't exist).
+// This is non-mutating — it does not reap the child.
+static bool is_zombie_by_proc(pid_t pid) {
+    char path[64];
+    std::snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        return false;
+    }
+    std::string line;
+    if (!std::getline(f, line)) {
+        return false;
+    }
+    // /proc/<pid>/stat format: pid (comm) field3 field4 ...
+    // The comm field is enclosed in parentheses and may contain spaces,
+    // so we find both delimiters to correctly skip to the field list.
+    auto open_paren = line.find('(');
+    if (open_paren == std::string::npos) {
+        return false;
+    }
+    auto close_paren = line.rfind(')');
+    if (close_paren == std::string::npos || close_paren <= open_paren) {
+        return false;
+    }
+    // Everything after the closing ')' is the remaining fields.
+    // Field 1 after ')' is the process state character.
+    std::string rest = line.substr(close_paren + 1);
+    std::istringstream iss(rest);
+    char state;
+    if (!(iss >> state)) {
+        return false;
+    }
+    return state == 'Z';
 }
 #endif
 
@@ -370,15 +412,11 @@ bool UnixProcessPlatform::is_running(ProcessHandle handle) {
     }
 #endif
 
-    // Reap any zombie before falling back to kill(). kill(pid,0) returns
-    // success for zombies (PID still in kernel table) so we must try to wait
-    // on the child first.
-    int status = 0;
-    pid_t result = waitpid(handle.pid, &status, WNOHANG);
-    if (result > 0) {
-        // Process has exited (including zombie) — reap it and report dead.
+#ifdef __linux__
+    if (is_zombie_by_proc(handle.pid)) {
         return false;
     }
+#endif
 
     errno = 0;
     return ::kill(handle.pid, 0) == 0 || errno == EPERM;

--- a/test/cpp/test_process_manager.cpp
+++ b/test/cpp/test_process_manager.cpp
@@ -1,0 +1,218 @@
+// Standalone test for ProcessManager::is_running() non-mutating contract on POSIX.
+//
+// Verifies:
+//  1. is_running() returns true for a running process
+//  2. is_running() returns false for an exited process WITHOUT reaping it
+//  3. reap_process() retrieves the real exit code after is_running() returned false
+//
+// Compile:
+//   g++ -std=c++17 -I src/cpp/include test/cpp/test_process_manager.cpp \
+//       src/cpp/server/utils/process_manager.cpp \
+//       src/cpp/server/utils/platform/process_unix.cpp \
+//       -pthread -o test_process_manager
+//
+// Run:
+//   ./test_process_manager
+
+#include <lemon/utils/process_manager.h>
+#include <lemon/utils/process_platform.h>
+
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <thread>
+#include <chrono>
+
+#ifdef __linux__
+#include <fstream>
+#include <sstream>
+#endif
+
+using lemon::utils::ProcessHandle;
+using lemon::utils::ProcessManager;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+// Spawn a child via fork() that exits with a known code.
+// Returns the child PID (or -1 on failure).
+static pid_t spawn_child(int exit_code) {
+    pid_t pid = fork();
+    if (pid < 0) {
+        return -1;
+    }
+    if (pid == 0) {
+        _exit(exit_code);
+    }
+    return pid;
+}
+
+// Create a ProcessHandle from a raw PID.
+static ProcessHandle make_handle(pid_t pid) {
+    ProcessHandle h;
+    h.handle = nullptr;
+    h.pid = static_cast<int>(pid);
+    return h;
+}
+
+// Wait for a child to exit without reaping it.
+// Uses waitid(WNOWAIT) on platforms that support it, or /proc/<pid>/stat on Linux.
+// Returns the child PID when it has exited (is a zombie), or -1 on timeout.
+static pid_t wait_for_exit_no_reap(pid_t child, int timeout_ms = 5000) {
+    auto start = std::chrono::steady_clock::now();
+    while (true) {
+#ifdef WNOWAIT
+        siginfo_t info;
+        std::memset(&info, 0, sizeof(info));
+        if (waitid(P_PID, static_cast<id_t>(child), &info, WEXITED | WNOHANG | WNOWAIT) == 0) {
+            if (info.si_pid != 0) {
+                return child;
+            }
+        }
+#endif
+#ifdef __linux__
+        {
+            char path[64];
+            std::snprintf(path, sizeof(path), "/proc/%d/stat", child);
+            std::ifstream f(path);
+            if (f.is_open()) {
+                std::string line;
+                if (std::getline(f, line)) {
+                    auto open_paren = line.find('(');
+                    if (open_paren != std::string::npos) {
+                        auto close_paren = line.rfind(')');
+                        if (close_paren != std::string::npos && close_paren > open_paren) {
+                            std::string rest = line.substr(close_paren + 1);
+                            std::istringstream iss(rest);
+                            char state;
+                            if (iss >> state && state == 'Z') {
+                                return child;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+#endif
+        // Fallback: try waitpid with WNOHANG. If the child has already
+        // been reaped by something else (or we lost the race), return -1
+        // to indicate we couldn't verify the exit without consuming it.
+        int status = 0;
+        pid_t r = waitpid(child, &status, WNOHANG);
+        if (r == child) {
+            return -1;
+        }
+        auto now = std::chrono::steady_clock::now();
+        if (std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count() > timeout_ms) {
+            return -1;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+
+int main() {
+    // --- Test: is_running() returns false for an exited child ---
+    {
+        pid_t child = spawn_child(42);
+        check("spawn_child returns valid PID", child > 0);
+
+        // Wait for the child to exit without reaping it.
+        pid_t exited = wait_for_exit_no_reap(child);
+        check("child exited (detected without reap)", exited > 0);
+
+        if (exited > 0) {
+            ProcessHandle h = make_handle(exited);
+
+            // is_running() must NOT reap the child — it should just report
+            // that the process is no longer running.
+            bool running = ProcessManager::is_running(h);
+            check("is_running() returns false for exited child", !running);
+
+            // reap_process() should retrieve the real exit code (42).
+            int exit_code = ProcessManager::reap_process(h);
+            check("reap_process() returns real exit code 42", exit_code == 42);
+        } else {
+            // wait_for_exit_no_reap timed out — child already exited, so it's
+            // a zombie. Clean it up to avoid leaking zombies.
+            int status = 0;
+            waitpid(child, &status, 0);
+        }
+    }
+
+    // --- Test: is_running() returns false for PID 0 ---
+    {
+        ProcessHandle h = make_handle(0);
+        check("is_running() returns false for PID 0", !ProcessManager::is_running(h));
+    }
+
+    // --- Test: is_running() returns false for negative PID ---
+    {
+        ProcessHandle h = make_handle(-1);
+        check("is_running() returns false for negative PID", !ProcessManager::is_running(h));
+    }
+
+    // --- Test: is_running() returns false for a non-existent PID ---
+    {
+        // Use a PID that almost certainly doesn't exist.
+        ProcessHandle h = make_handle(999999);
+        check("is_running() returns false for non-existent PID", !ProcessManager::is_running(h));
+    }
+
+    // --- Test: is_running() returns true for a running process ---
+    {
+        pid_t child = fork();
+        check("fork succeeds", child >= 0);
+
+        if (child > 0) {
+            ProcessHandle h = make_handle(child);
+            check("is_running() returns true for running child", ProcessManager::is_running(h));
+
+            // Clean up: kill the child and reap.
+            kill(child, SIGKILL);
+            int status = 0;
+            waitpid(child, &status, 0);
+        } else if (child == 0) {
+            // Parent will SIGKILL us — just sleep forever.
+            while (true) {
+                sleep(1);
+            }
+        }
+    }
+
+    // --- Test: reap_process() returns -1 for a still-running process ---
+    {
+        pid_t child = fork();
+        check("fork for reap test", child >= 0);
+
+        if (child > 0) {
+            ProcessHandle h = make_handle(child);
+            // Give the child a moment to start.
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+            int rc = ProcessManager::reap_process(h);
+            check("reap_process() returns -1 for running process", rc == -1);
+
+            // Clean up.
+            kill(child, SIGKILL);
+            int status = 0;
+            waitpid(child, &status, 0);
+        } else if (child == 0) {
+            while (true) {
+                sleep(1);
+            }
+        }
+    }
+
+    if (g_failures == 0) {
+        std::printf("\nAll process_manager tests passed\n");
+        return 0;
+    }
+    std::printf("\n%d process_manager test(s) FAILED\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
# Bug: Zombie backend process not detected by watchdog, no automatic restart

## Summary

When the llama-server backend is killed by the Linux OOM killer, it becomes a zombie process (`<defunct>`). The lemond watchdog fails to detect this zombie as "exited" because `is_running()` uses `kill(pid, 0)` as its fallback check, which returns success for zombie processes. As a result, the backend remains in a dead/zombie state indefinitely and is never automatically restarted.

## Environment

- **lemond version:** 10.6.0
- **OS:** Linux (Ubuntu, AMD ROCm / Strix Halo)
- **Container:** Docker (`restart: unless-stopped`)
- **Backend:** llamacpp (vulkan)

## Reproduction Steps

1. Run lemond with a large model that requires significant RAM (e.g., Qwen3.6-35B-A3B with 256k context)
2. Send a prompt long enough to trigger OOM (the llama-server process uses ~91GB+ RAM)
3. The Linux OOM killer terminates the llama-server process
4. The process becomes a zombie (`[llama-server] <defunct>`)
5. lemond does not detect the exit — the zombie persists indefinitely
6. All subsequent requests fail with `CURL error: Couldn't connect to server`
7. No automatic restart occurs

## Expected Behavior

The watchdog should detect that the backend process has exited (including zombie state) and either:
- Automatically restart the backend, or
- At minimum, clean up the zombie and report the backend as unavailable so a retry can trigger a reload

## Actual Behavior

The zombie process persists. `is_running()` returns `true` for the zombie, so:
- The watchdog never calls `request_backend_reset_from_watchdog()`
- The process handle and port are never consumed/cleaned up
- All new requests fail with connection errors
- The only recovery is to manually kill the zombie or restart the container

## Root Cause

In `src/cpp/server/utils/platform/process_unix.cpp`, the `is_running()` function:

```cpp
bool UnixProcessPlatform::is_running(ProcessHandle handle) {
    if (handle.pid <= 0) {
        return false;
    }

#ifdef WNOWAIT
    siginfo_t info;
    std::memset(&info, 0, sizeof(info));
    if (waitid(P_PID, static_cast<id_t>(handle.pid), &info, WEXITED | WNOHANG | WNOWAIT) == 0) {
        return info.si_pid == 0;
    }

    if (errno == ECHILD) {
        return false;
    }
#endif

    // BUG: kill(pid, 0) returns 0 for zombies (PID still in kernel table)
    errno = 0;
    return ::kill(handle.pid, 0) == 0 || errno == EPERM;
}
```

The `waitid()` with `WNOWAIT` detects exited children non-mutatingly when available, but on platforms without `WNOWAIT` (or when `waitid()` fails for reasons other than `ECHILD`), the `kill(pid, 0)` fallback is reached. `kill(pid, 0)` returns 0 (success) for zombie processes because the PID still exists in the kernel's process table, making `is_running()` incorrectly report the zombie as "running."

## Fix Applied

The fix uses a Linux-specific `/proc/<pid>/stat` check to detect zombie processes **without reaping them** (preserving the non-mutating contract of `is_running()`).

### `is_zombie_by_proc()` helper (`process_unix.cpp:93-124`)

```cpp
#ifdef __linux__
static bool is_zombie_by_proc(pid_t pid) {
    char path[64];
    std::snprintf(path, sizeof(path), "/proc/%d/stat", pid);
    std::ifstream f(path);
    if (!f.is_open()) {
        return false;
    }
    std::string line;
    if (!std::getline(f, line)) {
        return false;
    }
    // /proc/<pid>/stat format: pid (comm) field3 field4 ...
    // The comm field may contain spaces, so find both parentheses.
    auto open_paren = line.find('(');
    if (open_paren == std::string::npos) {
        return false;
    }
    auto close_paren = line.rfind(')');
    if (close_paren == std::string::npos || close_paren <= open_paren) {
        return false;
    }
    // Field 1 after ')' is the process state character.
    std::string rest = line.substr(close_paren + 1);
    std::istringstream iss(rest);
    char state;
    if (!(iss >> state)) {
        return false;
    }
    return state == 'Z';
}
#endif
```

### Updated `is_running()` (`process_unix.cpp:398-423`)

```cpp
bool UnixProcessPlatform::is_running(ProcessHandle handle) {
    if (handle.pid <= 0) {
        return false;
    }

#ifdef WNOWAIT
    siginfo_t info;
    std::memset(&info, 0, sizeof(info));
    if (waitid(P_PID, static_cast<id_t>(handle.pid), &info, WEXITED | WNOHANG | WNOWAIT) == 0) {
        return info.si_pid == 0;
    }

    if (errno == ECHILD) {
        return false;
    }
#endif

#ifdef __linux__
    if (is_zombie_by_proc(handle.pid)) {
        return false;
    }
#endif

    errno = 0;
    return ::kill(handle.pid, 0) == 0 || errno == EPERM;
}
```

### Design decisions

- **Non-mutating `is_running()`**: The fix deliberately avoids `waitpid()` with `WNOHANG` because reaping inside `is_running()` would break the contract — `reap_process()` needs to retrieve the actual exit code later. The `/proc/<pid>/stat` approach detects zombies purely by reading the state character, without consuming the child.
- **Platform scoped**: The `/proc` check is `#ifdef __linux__` only. macOS and other Unix platforms rely on the `WNOWAIT` path (available on Linux and some BSDs) or fall through to `kill(pid, 0)`.
- **Defense in depth**: The detection order is: (1) `waitid(WNOWAIT)` for portable non-mutating exit detection, (2) `/proc/<pid>/stat` for Linux zombie detection, (3) `kill(pid, 0)` as a final fallback for "does the PID exist."

### Tests added (`test/cpp/test_process_manager.cpp`)

A standalone C++ test verifies the non-mutating contract:

| Test | What it verifies |
|------|-----------------|
| `is_running() returns false for exited child` | Spawns a child, waits for exit without reaping, confirms `is_running()` returns false without consuming the zombie |
| `reap_process() returns real exit code 42` | After `is_running()` returned false, `reap_process()` retrieves the actual exit code |
| `is_running() returns false for PID 0 / negative / non-existent` | Edge cases for invalid PIDs |
| `is_running() returns true for running process` | Confirms live processes are still detected |
| `reap_process() returns -1 for running process` | Confirms reaping a live process is a no-op |

### CMake integration

Test target `test_process_manager` is conditionally built on Linux only (`CMakeLists.txt`), compiling the test alongside the process manager source files.

## Impact

- **Severity:** High — causes complete service outage until manual intervention
- **Frequency:** Occurs whenever the backend is OOM-killed or otherwise terminated externally
- **Recovery:** With the fix applied, zombies are detected and the watchdog can trigger backend restart
- **Affected backends:** All backends managed through `WrappedServer` (llamacpp, vllm, sd_server, etc.)

## Workaround (pre-fix)

Manually kill the zombie process and restart the container:

```bash
docker exec lemonade-256k kill -9 <zombie_pid>
docker restart lemonade-256k
```

Or set `LEMONADE_BACKEND_WATCHDOG=0` and rely on request-time detection (though this also has the zombie detection issue).

## Logs

```
$ dmesg | grep -i oom
oom-kill:constraint=CONSTRAINT_NONE,...,task=llama-server,pid=3659732
Out of memory: Killed process 3659732 (llama-server) total-vm:135423044kB, anon-rss:95329868kB

$ docker exec lemonade-256k ps aux
root          43  8.3  0.0      0     0 ?        Z    03:13   7:25 [llama-server] <defunct>

$ docker logs --tail 5 lemonade-256k
2026-06-18 03:39:38.924 [Error] (HttpClient) Stream ended with: Transferred a partial file
2026-06-18 03:39:39.867 [Error] (HttpClient) CURL error: Couldn't connect to server
2026-06-18 03:39:39.870 [Error] (WrappedServer) Streaming request failed: CURL error: Couldn't connect to server
```

The zombie persists indefinitely with no watchdog activity after the crash.