### PR TITLE
Feature - Default model fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,6 +596,7 @@ set(SOURCES_CORE
     src/cpp/server/system_info.cpp
     src/cpp/server/recipe_options.cpp
     src/cpp/server/runtime_config.cpp
+    src/cpp/server/model_resolution.cpp
     src/cpp/server/logging_config.cpp
     src/cpp/server/log_stream.cpp
     src/cpp/server/prometheus_metrics.cpp

--- a/src/app/src/renderer/SettingsPanel.tsx
+++ b/src/app/src/renderer/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 import { ChevronRight } from './components/Icons';
 import {
   AppSettings,
@@ -12,6 +12,8 @@ import {
 import ConnectionSettings from './tabs/ConnectionSettings';
 import TTSSettings from './tabs/TTSSettings';
 import LLMChatSettings from './tabs/LLMChatSettings';
+import { useModels } from './hooks/useModels';
+import { fetchDefaultModel, saveDefaultModel } from './utils/serverRuntimeConfig';
 
 interface SettingsPanelProps {
   isVisible: boolean;
@@ -47,8 +49,17 @@ const numericSettingsConfig: Array<{
 
 const SettingsPanel: React.FC<SettingsPanelProps> = ({ isVisible, searchQuery = '' }) => {
   const [settings, setSettings] = useState<AppSettings>(createDefaultSettings());
+  const [defaultModel, setDefaultModel] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const { downloadedModels } = useModels();
+  const defaultModelOptions = useMemo(() => {
+    const optionSet = new Set(downloadedModels.map((model) => model.id));
+    if (defaultModel) {
+      optionSet.add(defaultModel);
+    }
+    return Array.from(optionSet).sort((a, b) => a.localeCompare(b));
+  }, [downloadedModels, defaultModel]);
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
     new Set(['connection_settings', 'llm_chat_settings', 'tts_settings'])
   );
@@ -72,6 +83,15 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ isVisible, searchQuery = 
         const stored = await window.api.getSettings();
         if (isMounted) {
           setSettings(mergeWithDefaultSettings(stored));
+        }
+
+        try {
+          const configuredDefaultModel = await fetchDefaultModel();
+          if (isMounted) {
+            setDefaultModel(configuredDefaultModel);
+          }
+        } catch (error) {
+          console.error('Failed to load default model setting:', error);
         }
       } catch (error) {
         console.error('Failed to load settings:', error);
@@ -197,17 +217,18 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ isVisible, searchQuery = 
 
   const handleReset = () => {
     setSettings(createDefaultSettings());
+    setDefaultModel('');
   };
 
   const handleSave = async () => {
-    if (!window.api?.saveSettings) {
-      return;
-    }
-
     setIsSaving(true);
     try {
-      const saved = await window.api.saveSettings(settings);
-      setSettings(mergeWithDefaultSettings(saved));
+      if (window.api?.saveSettings) {
+        const saved = await window.api.saveSettings(settings);
+        setSettings(mergeWithDefaultSettings(saved));
+      }
+
+      await saveDefaultModel(defaultModel);
     } catch (error) {
       console.error('Failed to save settings:', error);
       alert('Failed to save settings. Please try again.');
@@ -247,9 +268,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ isVisible, searchQuery = 
       id: 'llm_chat_settings',
       label: 'LLM',
       keywords: [
-        'llm', 'chat', 'temperature', 'top k', 'top p', 'repeat penalty', 'thinking', 'collapse thinking'
+        'llm', 'chat', 'default model', 'temperature', 'top k', 'top p', 'repeat penalty', 'thinking', 'collapse thinking'
       ],
-      settingCount: 6,
+      settingCount: 7,
     },
     {
       id: 'tts_settings',
@@ -282,6 +303,9 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({ isVisible, searchQuery = 
         return <LLMChatSettings
           settings={settings}
           numericSettingsConfig={numericSettingsConfig}
+          defaultModel={defaultModel}
+          defaultModelOptions={defaultModelOptions}
+          onDefaultModelChange={setDefaultModel}
           onBooleanChangeFunc={handleBooleanChange}
           onNumericChangeFunc={handleNumericChange}
           onResetFunc={handleResetField}

--- a/src/app/src/renderer/tabs/LLMChatSettings.tsx
+++ b/src/app/src/renderer/tabs/LLMChatSettings.tsx
@@ -8,17 +8,49 @@ interface NumericSettingConfig {
   description: string
 }
 
-interface  LLMChatSettingsProps {
+interface LLMChatSettingsProps {
   settings: AppSettings,
   numericSettingsConfig: NumericSettingConfig[];
+  defaultModel: string;
+  defaultModelOptions: string[];
+  onDefaultModelChange: (model: string) => void;
   onBooleanChangeFunc: (key: string | any, value: boolean) => void;
   onNumericChangeFunc: (key: NumericSettingKey, rawValue: number) => void;
   onResetFunc: (key: any) => void
 }
 
-const LLMChatSettings: React.FC<LLMChatSettingsProps> = ({settings, numericSettingsConfig, onBooleanChangeFunc, onNumericChangeFunc, onResetFunc}) => {
+const LLMChatSettings: React.FC<LLMChatSettingsProps> = ({
+  settings,
+  numericSettingsConfig,
+  defaultModel,
+  defaultModelOptions,
+  onDefaultModelChange,
+  onBooleanChangeFunc,
+  onNumericChangeFunc,
+  onResetFunc,
+}) => {
   return (
     <div className="settings-section-container">
+      <div className="settings-section">
+        <div className="settings-label-row">
+          <label className="settings-label">
+            <span className="settings-label-text">Default Model</span>
+            <span className="settings-description">
+              When a request names an unknown model, Lemonade uses this fallback. Choose None to return an error instead.
+            </span>
+          </label>
+        </div>
+        <select
+          className="settings-text-input"
+          value={defaultModel}
+          onChange={(e) => onDefaultModelChange(e.target.value)}
+        >
+          <option value="">None</option>
+          {defaultModelOptions.map((modelId) => (
+            <option key={modelId} value={modelId}>{modelId}</option>
+          ))}
+        </select>
+      </div>
       {numericSettingsConfig.map((config: NumericSettingConfig) => (
         <NumericSetting
           settings={settings}

--- a/src/app/src/renderer/utils/serverRuntimeConfig.ts
+++ b/src/app/src/renderer/utils/serverRuntimeConfig.ts
@@ -1,0 +1,39 @@
+import { serverFetch } from './serverConfig';
+
+export async function fetchRuntimeConfig(): Promise<Record<string, unknown>> {
+  const response = await serverFetch('/internal/config');
+  if (!response.ok) {
+    throw new Error(`Failed to load server config (${response.status})`);
+  }
+  return response.json();
+}
+
+export async function updateRuntimeConfig(changes: Record<string, unknown>): Promise<void> {
+  const response = await serverFetch('/internal/set', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(changes),
+  });
+
+  if (!response.ok) {
+    let message = `Failed to update server config (${response.status})`;
+    try {
+      const body: unknown = await response.json();
+      if (typeof body === 'object' && body !== null && typeof (body as { error?: unknown }).error === 'string') {
+        message = (body as { error: string }).error;
+      }
+    } catch {
+      // ignore parse errors
+    }
+    throw new Error(message);
+  }
+}
+
+export async function fetchDefaultModel(): Promise<string> {
+  const config = await fetchRuntimeConfig();
+  return typeof config.default_model === 'string' ? config.default_model : '';
+}
+
+export async function saveDefaultModel(model: string): Promise<void> {
+  await updateRuntimeConfig({ default_model: model });
+}

--- a/src/cpp/include/lemon/model_resolution.h
+++ b/src/cpp/include/lemon/model_resolution.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace lemon {
+
+class ModelManager;
+
+/// When `requested` is registered, returns it unchanged. Otherwise, if
+/// `default_model` is configured in config.json and that model exists,
+/// returns the default. If no fallback applies, returns `requested` as-is
+/// (caller should check existence before loading).
+std::string resolve_model_with_default(const std::string& requested,
+                                       ModelManager* model_manager);
+
+} // namespace lemon

--- a/src/cpp/include/lemon/ollama_api.h
+++ b/src/cpp/include/lemon/ollama_api.h
@@ -41,7 +41,7 @@ private:
     void register_anthropic_routes(httplib::Server& server, const std::shared_ptr<OllamaApi>& self);
 
     // Helpers
-    void auto_load_model(const std::string& model);
+    std::string auto_load_model(const std::string& model);
     std::string normalize_model_name(const std::string& name);
     json build_ollama_model_entry(const std::string& id, const ModelInfo& info);
     json convert_openai_chat_to_ollama(const json& openai_response, const std::string& model);

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -40,6 +40,8 @@ public:
     bool offline() const;
     bool no_fetch_executables() const;
     bool disable_model_filtering() const;
+    /// Fallback model when a requested name is not registered. Empty means disabled.
+    std::string default_model() const;
     bool enable_dgpu_gtt() const;
     std::string rocm_channel() const;
     std::string rocm_channel_for_recipe(const std::string& recipe) const;

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -13,6 +13,7 @@
   "offline": false,
   "no_fetch_executables": false,
   "disable_model_filtering": false,
+  "default_model": "",
   "enable_dgpu_gtt": false,
   "rocm_channel": "stable",
   "llamacpp": {

--- a/src/cpp/server/anthropic_api.cpp
+++ b/src/cpp/server/anthropic_api.cpp
@@ -889,7 +889,7 @@ void OllamaApi::handle_anthropic_messages(const httplib::Request& req, httplib::
         auto openai_req = convert_anthropic_to_openai_chat(request_json, warnings);
 
         try {
-            auto_load_model(model);
+            model = auto_load_model(model);
         } catch (const std::exception&) {
             res.status = 404;
             json error = {
@@ -902,6 +902,8 @@ void OllamaApi::handle_anthropic_messages(const httplib::Request& req, httplib::
             res.set_content(error.dump(), "application/json");
             return;
         }
+
+        openai_req["model"] = model;
 
         bool stream = openai_req.value("stream", false);
         if (!warnings.empty()) {

--- a/src/cpp/server/model_resolution.cpp
+++ b/src/cpp/server/model_resolution.cpp
@@ -1,0 +1,28 @@
+#include "lemon/model_resolution.h"
+
+#include "lemon/model_manager.h"
+#include "lemon/runtime_config.h"
+#include "lemon/utils/aixlog.hpp"
+
+namespace lemon {
+
+std::string resolve_model_with_default(const std::string& requested,
+                                       ModelManager* model_manager) {
+    if (model_manager && model_manager->model_exists(requested)) {
+        return requested;
+    }
+
+    if (auto* cfg = RuntimeConfig::global()) {
+        const std::string fallback = cfg->default_model();
+        if (!fallback.empty() && model_manager && model_manager->model_exists(fallback)) {
+            LOG(INFO, "ModelResolution")
+                << "Model '" << requested << "' not found, using default model '"
+                << fallback << "'" << std::endl;
+            return fallback;
+        }
+    }
+
+    return requested;
+}
+
+} // namespace lemon

--- a/src/cpp/server/ollama_api.cpp
+++ b/src/cpp/server/ollama_api.cpp
@@ -1,4 +1,5 @@
 #include "lemon/ollama_api.h"
+#include "lemon/model_resolution.h"
 #include "lemon/model_types.h"
 #include <iostream>
 #include <lemon/utils/aixlog.hpp>
@@ -223,30 +224,32 @@ std::string OllamaApi::normalize_model_name(const std::string& name) {
 // ============================================================================
 // auto-load model if needed (mirrors Server::auto_load_model_if_needed)
 // ============================================================================
-void OllamaApi::auto_load_model(const std::string& model) {
+std::string OllamaApi::auto_load_model(const std::string& model) {
     std::string name = normalize_model_name(model);
+    std::string effective = resolve_model_with_default(name, model_manager_);
 
-    if (router_->is_model_loaded(name)) {
-        return;
+    if (router_->is_model_loaded(effective)) {
+        return effective;
     }
 
-    LOG(INFO, "OllamaApi") << "Auto-loading model: " << name << std::endl;
+    LOG(INFO, "OllamaApi") << "Auto-loading model: " << effective << std::endl;
 
-    if (!model_manager_->model_exists(name)) {
+    if (!model_manager_->model_exists(effective)) {
         throw std::runtime_error("model '" + name + "' not found");
     }
 
-    auto info = model_manager_->get_model_info(name);
+    auto info = model_manager_->get_model_info(effective);
 
     // Download if not cached
-    if (info.recipe != "flm" && !model_manager_->is_model_downloaded(name)) {
+    if (info.recipe != "flm" && !model_manager_->is_model_downloaded(effective)) {
         LOG(INFO, "OllamaApi") << "Model not cached, downloading..." << std::endl;
         model_manager_->download_registered_model(info, true);
-        info = model_manager_->get_model_info(name);
+        info = model_manager_->get_model_info(effective);
     }
 
-    router_->load_model(name, info, RecipeOptions(info.recipe, json::object()), true);
-    LOG(INFO, "OllamaApi") << "Model loaded: " << name << std::endl;
+    router_->load_model(effective, info, RecipeOptions(info.recipe, json::object()), true);
+    LOG(INFO, "OllamaApi") << "Model loaded: " << effective << std::endl;
+    return effective;
 }
 
 // build Ollama model entry from ModelInfo
@@ -702,7 +705,7 @@ void OllamaApi::handle_chat(const httplib::Request& req, httplib::Response& res)
 
         // Auto-load the model
         try {
-            auto_load_model(model);
+            model = auto_load_model(model);
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found, try pulling it first"}};
@@ -715,6 +718,7 @@ void OllamaApi::handle_chat(const httplib::Request& req, httplib::Response& res)
 
         // Convert to OpenAI format
         auto openai_req = convert_ollama_to_openai_chat(request_json);
+        openai_req["model"] = model;
 
         bool has_tools = request_json.contains("tools") &&
                          request_json["tools"].is_array() &&
@@ -834,7 +838,7 @@ void OllamaApi::handle_generate(const httplib::Request& req, httplib::Response& 
         }
 
         try {
-            auto_load_model(model);
+            model = auto_load_model(model);
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found, try pulling it first"}};
@@ -855,6 +859,7 @@ void OllamaApi::handle_generate(const httplib::Request& req, httplib::Response& 
         bool stream = request_json.value("stream", true);  // Ollama defaults to streaming
 
         auto openai_req = convert_ollama_to_openai_completion(request_json);
+        openai_req["model"] = model;
 
         if (stream) {
             LOG(INFO, "OllamaApi") << "POST /api/generate - Streaming (model: " << model << ")" << std::endl;
@@ -1264,7 +1269,7 @@ void OllamaApi::handle_embed(const httplib::Request& req, httplib::Response& res
         }
 
         try {
-            auto_load_model(model);
+            model = auto_load_model(model);
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found"}};
@@ -1331,7 +1336,7 @@ void OllamaApi::handle_embeddings(const httplib::Request& req, httplib::Response
         }
 
         try {
-            auto_load_model(model);
+            model = auto_load_model(model);
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found"}};

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -231,6 +231,14 @@ bool RuntimeConfig::disable_model_filtering() const {
     return config_["disable_model_filtering"].get<bool>();
 }
 
+std::string RuntimeConfig::default_model() const {
+    std::shared_lock lock(mutex_);
+    if (config_.contains("default_model") && config_["default_model"].is_string()) {
+        return config_["default_model"].get<std::string>();
+    }
+    return "";
+}
+
 bool RuntimeConfig::enable_dgpu_gtt() const {
     std::shared_lock lock(mutex_);
     return config_["enable_dgpu_gtt"].get<bool>();
@@ -404,6 +412,10 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
     } else if (key == "extra_models_dir" || key == "models_dir") {
         if (!value.is_string()) {
             throw std::invalid_argument("'" + key + "' must be a string");
+        }
+    } else if (key == "default_model") {
+        if (!value.is_string()) {
+            throw std::invalid_argument("'default_model' must be a string");
         }
     } else if (key == "no_broadcast" || key == "offline" ||
                key == "no_fetch_executables" ||

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -4,6 +4,7 @@
 #include "lemon/hf_variants.h"
 #include "lemon/config_file.h"
 #include "lemon/mcp_server.h"
+#include "lemon/model_resolution.h"
 #include "lemon/ollama_api.h"
 #include "lemon/backends/cloud_server.h"
 #include "lemon/backends/sd_server.h"
@@ -1547,21 +1548,23 @@ nlohmann::json Server::create_model_error(const std::string& requested_model, co
 //
 // Note: Only the /pull endpoint checks HuggingFace for updates (do_not_upgrade=false)
 void Server::auto_load_model_if_needed(const std::string& requested_model) {
+    std::string model = resolve_model_with_default(requested_model, model_manager_.get());
+
     // Check if this specific model is already loaded (multi-model aware)
-    if (router_->is_model_loaded(requested_model)) {
-        LOG(INFO, "Server") << "Model already loaded: " << requested_model << std::endl;
+    if (router_->is_model_loaded(model)) {
+        LOG(INFO, "Server") << "Model already loaded: " << model << std::endl;
         return;
     }
 
     // Log the auto-loading action
-    LOG(INFO, "Server") << "Auto-loading model: " << requested_model << std::endl;
+    LOG(INFO, "Server") << "Auto-loading model: " << model << std::endl;
 
     // Get model info
-    if (!model_manager_->model_exists(requested_model)) {
+    if (!model_manager_->model_exists(model)) {
         throw std::runtime_error("Model not found: " + requested_model);
     }
 
-    auto info = model_manager_->get_model_info(requested_model);
+    auto info = model_manager_->get_model_info(model);
 
     // Collections have no backend of their own — load each component instead.
     if (is_collection_recipe(info.recipe)) {
@@ -1575,22 +1578,22 @@ void Server::auto_load_model_if_needed(const std::string& requested_model) {
     //   - If model is NOT downloaded: Download it from HuggingFace
     //   - If model IS downloaded: Skip HuggingFace API check entirely (use cached version)
     // Only the /pull endpoint should check for updates (uses do_not_upgrade=false)
-    if (info.recipe != "flm" && !model_manager_->is_model_downloaded(requested_model)) {
+    if (info.recipe != "flm" && !model_manager_->is_model_downloaded(model)) {
         LOG(INFO, "Server") << "Model not cached, downloading from Hugging Face..." << std::endl;
         LOG(INFO, "Server") << "This may take several minutes for large models." << std::endl;
         model_manager_->download_registered_model(info, true);
-        LOG(INFO, "Server") << "Model download complete: " << requested_model << std::endl;
+        LOG(INFO, "Server") << "Model download complete: " << model << std::endl;
 
         // CRITICAL: Refresh model info after download to get correct resolved_path
         // The resolved_path is computed based on filesystem, so we need fresh info now that files exist
-        info = model_manager_->get_model_info(requested_model);
+        info = model_manager_->get_model_info(model);
     }
 
     // Load model with do_not_upgrade=true
     // For FLM models: FastFlowLMServer will handle download internally if needed
     // For non-FLM models: Model should already be cached at this point
-    router_->load_model(requested_model, info, RecipeOptions(info.recipe, json::object()), true);
-    LOG(INFO, "Server") << "Model loaded successfully: " << requested_model << std::endl;
+    router_->load_model(model, info, RecipeOptions(info.recipe, json::object()), true);
+    LOG(INFO, "Server") << "Model loaded successfully: " << model << std::endl;
 }
 
 void Server::ensure_collection_loaded(const ModelInfo& info) {

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -24,6 +24,7 @@ except ImportError:
 from utils.server_base import (
     ServerTestBase,
     run_server_tests,
+    set_server_config,
 )
 from utils.test_models import (
     PORT,
@@ -389,6 +390,28 @@ class OllamaTests(ServerTestBase):
             timeout=TIMEOUT_DEFAULT,
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_012b_chat_falls_back_to_default_model(self):
+        """Test /api/chat uses configured default_model when request model is unknown."""
+        self.ensure_model_pulled()
+        set_server_config({"default_model": ENDPOINT_TEST_MODEL})
+        try:
+            response = requests.post(
+                f"{OLLAMA_BASE_URL}/api/chat",
+                json={
+                    "model": "gemma3:12b",
+                    "messages": [{"role": "user", "content": "Say hello"}],
+                    "stream": False,
+                    "options": {"num_predict": 10},
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(response.status_code, 200, response.text)
+            data = response.json()
+            self.assertEqual(data["model"], ENDPOINT_TEST_MODEL)
+            self.assertTrue(data["done"])
+        finally:
+            set_server_config({"default_model": ""})
 
     def test_013_chat_with_latest_suffix(self):
         """Test /api/chat strips :latest suffix from model name."""


### PR DESCRIPTION
This commit introduces a default model setting that allows the chat API to fall back to a configured model when an unknown model is requested. The implementation includes updates to the SettingsPanel for managing the default model, enhancements in the LLMChatSettings component to select the default model, and modifications in the server logic to utilize the default model during chat requests. Additionally, unit tests are added to verify the fallback functionality.