### PR TITLE
feat(server): persist model pin status and auto-load pinned models on boot

### DIFF
--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -402,6 +402,7 @@ private:
     void evict_if_committed(const std::string& model_name);
     std::unique_ptr<WrappedServer> create_backend_server(const ModelInfo& model_info);
     std::string resolve_model_name(const std::string& model_name) const;
+    void persist_pinned_state(const std::string& model_name, bool pinned);
     ModelTelemetryIdentity get_telemetry_identity(WrappedServer* server) const;
     void record_request_telemetry_for_model(const ModelTelemetryIdentity& identity,
                                             const StreamingProxy::TelemetryData& telemetry);

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -220,6 +220,8 @@ private:
     void handle_jobs_resume(const httplib::Request& req, httplib::Response& res);
     void handle_jobs_delete(const httplib::Request& req, httplib::Response& res);
 
+    void load_pinned_models_async();
+
     // Backend management endpoint handlers
     void handle_install(const httplib::Request& req, httplib::Response& res);
     void handle_install_dry_run(const httplib::Request& req, httplib::Response& res);
@@ -371,6 +373,11 @@ private:
     };
     std::vector<SyncTaskThread> background_sync_threads_;
     std::mutex background_sync_mutex_;
+
+    std::thread pinned_models_autoload_thread_;
+
+    std::mutex shutdown_mutex_;
+    std::condition_variable shutdown_cv_;
 
 
     // Routed servers (all routes/handlers; never listen) and the main-port

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -618,6 +618,10 @@ void Router::evict_server(WrappedServer* server, int timeout_seconds) {
     if (!server) return;
 
     std::string model_name = server->get_model_name();
+    if (server->is_pinned()) {
+        LOG(WARNING, "Router") << "Evicting pinned model: " << model_name
+                               << " (due to NPU exclusivity or capacity limits)" << std::endl;
+    }
     LOG(INFO, "Router") << "Evicting model: " << model_name << std::endl;
 
     // Wait for any ongoing inference to complete. For watchdog-reset/dead
@@ -902,6 +906,9 @@ void Router::load_model(const std::string& model_name,
                 existing->update_access_time();
                 is_loading_ = false;
                 load_cv_.notify_all();
+                if (pinned.has_value()) {
+                    persist_pinned_state(canonical_model_name, pinned.value());
+                }
                 return;
             }
         }
@@ -1099,6 +1106,10 @@ void Router::load_model(const std::string& model_name,
 
             LOG(INFO, "Router") << "Model loaded successfully. Total loaded: "
                       << loaded_servers_.size() << std::endl;
+
+            if (pinned.has_value()) {
+                persist_pinned_state(canonical_model_name, pinned.value());
+            }
         } else {
             // ERROR HANDLING (from spec: Error Handling section)
             // Check if error is "file not found" (exception to nuclear policy)
@@ -1185,6 +1196,10 @@ void Router::load_model(const std::string& model_name,
                 load_cv_.notify_all();
 
                 LOG(DEBUG, "Router") << "Retry successful in " << retry_duration_ms << "ms!" << std::endl;
+
+                if (pinned.has_value()) {
+                    persist_pinned_state(canonical_model_name, pinned.value());
+                }
             } catch (const std::exception& retry_error) {
                 retry_server->set_load_cancel_flag(nullptr);
                 lock.lock();
@@ -2967,6 +2982,25 @@ void Router::set_model_pinned(const std::string& model_name, bool pinned) {
         throw std::runtime_error("Model not loaded: " + model_name);
     }
     server->set_pinned(pinned);
+    persist_pinned_state(model_name, pinned);
+}
+
+void Router::persist_pinned_state(const std::string& model_name, bool pinned) {
+    try {
+        ModelInfo info = model_manager_->get_model_info(model_name);
+        bool already_pinned = false;
+        json p_opt = info.recipe_options.get_option("pinned");
+        if (p_opt.is_boolean()) {
+            already_pinned = p_opt.get<bool>();
+        }
+        if (pinned == already_pinned) {
+            return; // Avoid redundant write
+        }
+        info.recipe_options.set_option("pinned", pinned);
+        model_manager_->save_model_options(info);
+    } catch (const std::exception& e) {
+        LOG(WARNING, "Router") << "Failed to persist pinned state for model " << model_name << ": " << e.what() << std::endl;
+    }
 }
 
 } // namespace lemon

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -830,6 +830,9 @@ Server::~Server() {
     if (model_cache_warmup_thread_.joinable()) {
         model_cache_warmup_thread_.join();
     }
+    if (pinned_models_autoload_thread_.joinable()) {
+        pinned_models_autoload_thread_.join();
+    }
 
     std::lock_guard<std::mutex> lock(background_sync_mutex_);
     for (auto& entry : background_sync_threads_) {
@@ -2198,6 +2201,9 @@ void Server::run() {
                         << "or hostname that resolves to RFC1918 IPv4." << std::endl;
         }
 
+        // Load pinned models gracefully in the background on boot
+        load_pinned_models_async();
+
         // Wait for listener threads, but check periodically for shutdown or rebind signals.
         // The threads are blocked in listen_after_bind(), which only returns when
         // the server is stopped or an error occurs.
@@ -2270,7 +2276,11 @@ bool Server::should_shutdown() const {
 }
 
 void Server::set_shutdown_requested(bool requested) {
-    shutdown_requested_.store(requested);
+    {
+        std::lock_guard<std::mutex> lock(shutdown_mutex_);
+        shutdown_requested_.store(requested);
+    }
+    shutdown_cv_.notify_all();
 }
 
 bool Server::is_running() const {
@@ -2287,6 +2297,20 @@ void Server::stop() {
         udp_beacon_.stopBroadcasting();
         stop_http_listeners();
         running_ = false;
+
+        {
+            std::lock_guard<std::mutex> lock(shutdown_mutex_);
+            shutdown_requested_.store(true);
+        }
+        shutdown_cv_.notify_all();
+
+        // Join the background pinned models autoload thread.
+        // Note: If a model is currently mid-load inside the thread, this call
+        // will block/stall until that specific backend load completes.
+        if (pinned_models_autoload_thread_.joinable()) {
+            pinned_models_autoload_thread_.join();
+        }
+
         shutdown_requested_ = false;  // Reset for potential future use
 
         if (websocket_server_) {
@@ -2315,6 +2339,10 @@ void Server::stop() {
 
     if (model_cache_warmup_thread_.joinable()) {
         model_cache_warmup_thread_.join();
+    }
+
+    if (pinned_models_autoload_thread_.joinable()) {
+        pinned_models_autoload_thread_.join();
     }
 
     {
@@ -8266,6 +8294,53 @@ void Server::enrich_recipes(json& recipes) {
             } catch (...) {}
         }
     }
+}
+
+void Server::load_pinned_models_async() {
+    if (pinned_models_autoload_thread_.joinable()) {
+        return;
+    }
+    pinned_models_autoload_thread_ = std::thread([this]() {
+        try {
+            // Brief interruptible sleep to defer log interleaving, allowing startup logs and
+            // listener addresses to print fully before background model loading output begins.
+            {
+                std::unique_lock<std::mutex> lock(shutdown_mutex_);
+                if (shutdown_cv_.wait_for(lock, std::chrono::milliseconds(100), [this]() { return shutdown_requested_.load(); })) {
+                    return;
+                }
+            }
+
+            LOG(INFO, "Server") << "Checking for pinned models to auto-load..." << std::endl;
+            auto models = model_manager_->get_supported_models();
+            for (const auto& [name, info] : models) {
+                if (shutdown_requested_.load()) {
+                    break;
+                }
+
+                bool is_pinned = info.recipe_options.get_option("pinned").is_boolean() &&
+                                 info.recipe_options.get_option("pinned").get<bool>();
+
+                if (is_pinned) {
+                    LOG(INFO, "Server") << "Auto-loading pinned model: " << name << std::endl;
+                    try {
+                        router_->load_model(name, info, info.recipe_options, true, false, true);
+                        LOG(INFO, "Server") << "Successfully auto-loaded pinned model: " << name << std::endl;
+                    } catch (const std::exception& e) {
+                        LOG(ERROR, "Server") << "Failed to auto-load pinned model '" << name << "': " << e.what() << std::endl;
+                    }
+                }
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING, "Server") << "Error during pinned models auto-load: " << e.what() << std::endl;
+        }
+
+        // KEEP THREAD ALIVE to prevent Linux PR_SET_PDEATHSIG from killing child processes.
+        // On Linux, the parent task is the specific thread that spawned the child.
+        // If this thread exits, the kernel sends SIGTERM to the spawned llama-servers.
+        std::unique_lock<std::mutex> lock(shutdown_mutex_);
+        shutdown_cv_.wait(lock, [this]() { return shutdown_requested_.load(); });
+    });
 }
 
 } // namespace lemon

--- a/test/server_pinning.py
+++ b/test/server_pinning.py
@@ -1,7 +1,13 @@
+import json
 import os
+import shutil
 import signal
+import socket
+import subprocess
+import tempfile
 import time
 import unittest
+import psutil
 import requests
 from utils.capabilities import (
     get_current_config,
@@ -13,6 +19,7 @@ from utils.test_models import (
     ENDPOINT_TEST_MODEL,
     TIMEOUT_MODEL_OPERATION,
     TIMEOUT_DEFAULT,
+    get_default_lemond_binary,
 )
 
 EVICTION_POLL_INTERVAL = 0.5
@@ -27,6 +34,12 @@ def _headers():
     if admin_key:
         headers["Authorization"] = f"Bearer {admin_key}"
     return headers
+
+
+def find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
 
 
 class PinningTests(ServerTestBase):
@@ -97,7 +110,10 @@ class PinningTests(ServerTestBase):
                 f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
             ).json()
             for model in last_health.get("all_models_loaded", []):
-                if model.get("model_name") == model_name and model.get("loaded", True):
+                if (
+                    model.get("model_name") == model_name
+                    and model.get("loaded") is True
+                ):
                     return model
             time.sleep(POLL_SECONDS)
         self.fail(
@@ -386,6 +402,177 @@ class PinningTests(ServerTestBase):
             info.get("pinned"),
             "Model should be unpinned by explicit load with pinned=False",
         )
+
+    def test_pinned_model_persists_and_autoloads_on_restart(self):
+        """A pinned model's pinned status persists in recipe_options.json and is autoloaded on boot."""
+        # Create a temp directory for cache/config
+        tmp_dir = tempfile.mkdtemp()
+        port = find_free_port()
+        lemond_bin = get_default_lemond_binary()
+
+        server_proc = None
+        log1 = open(os.path.join(tmp_dir, "lemond1.log"), "w")
+        log2 = open(os.path.join(tmp_dir, "lemond2.log"), "w")
+        try:
+            # 1. Start lemond on custom port with temp directory
+            env = os.environ.copy()
+            # Link to the existing models directory so we don't have to re-download the model
+            real_config = requests.get(
+                f"{self.base_url.replace('/api/v1', '')}/internal/config",
+                headers=_headers(),
+            ).json()
+            models_dir = real_config.get("models_dir", "")
+
+            # Write a custom config.json to the temp dir to use the same models directory
+            config_json_path = os.path.join(tmp_dir, "config.json")
+            with open(config_json_path, "w") as f:
+                json.dump({"models_dir": models_dir}, f)
+
+            # Start the server
+            server_proc = subprocess.Popen(
+                [lemond_bin, tmp_dir, "--port", str(port)],
+                stdout=log1,
+                stderr=log1,
+                text=True,
+                env=env,
+            )
+
+            # Wait for server to be ready
+            url = f"http://localhost:{port}/api/v1"
+            for _ in range(30):
+                try:
+                    requests.get(f"{url}/models", timeout=1)
+                    break
+                except Exception:
+                    time.sleep(1)
+                if server_proc.poll() is not None:
+                    self.fail("Server process died early during start")
+            else:
+                self.fail("Server timed out starting up")
+
+            # 2. Pin model via /internal/pin
+            # First, load the model unpinned
+            response = requests.post(
+                f"{url}/load",
+                json={"model_name": ENDPOINT_TEST_MODEL, "pinned": False},
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(response.status_code, 200)
+
+            # Pin it via the /pin endpoint to test dynamic pin persistence
+            response = requests.post(
+                f"http://localhost:{port}/internal/pin",
+                json={"model_name": ENDPOINT_TEST_MODEL, "pinned": True},
+                headers=_headers(),
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(response.status_code, 200)
+
+            # Verify the model is loaded and is pinned in registry/options
+            models_response = requests.get(
+                f"{url}/models", timeout=TIMEOUT_DEFAULT
+            ).json()
+            model_info = None
+            for m in models_response.get("data", []):
+                if m.get("id") == ENDPOINT_TEST_MODEL:
+                    model_info = m
+                    break
+            self.assertIsNotNone(model_info)
+            self.assertTrue(model_info.get("recipe_options", {}).get("pinned"))
+
+            # 3. Kill server and its children to prevent orphaned backends
+            try:
+                parent = psutil.Process(server_proc.pid)
+                children = parent.children(recursive=True)
+            except psutil.NoSuchProcess:
+                children = []
+
+            server_proc.terminate()
+            try:
+                server_proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                server_proc.kill()
+                server_proc.wait()
+            server_proc = None
+
+            for child in children:
+                try:
+                    child.kill()
+                except psutil.NoSuchProcess:
+                    pass
+
+            # 4. Restart server on a different port to avoid TIME_WAIT / EADDRINUSE conflicts
+            port2 = find_free_port()
+            url2 = f"http://localhost:{port2}/api/v1"
+            server_proc = subprocess.Popen(
+                [lemond_bin, tmp_dir, "--port", str(port2)],
+                stdout=log2,
+                stderr=log2,
+                text=True,
+                env=env,
+            )
+
+            # Wait for server to be ready
+            for _ in range(30):
+                try:
+                    requests.get(f"{url2}/models", timeout=1)
+                    break
+                except Exception:
+                    time.sleep(1)
+            else:
+                self.fail("Server timed out starting up after restart")
+
+            # 5. Check if the model is automatically loaded in the background
+            loaded = False
+            for _ in range(30):
+                health = requests.get(f"{url2}/health", timeout=TIMEOUT_DEFAULT).json()
+                for m in health.get("all_models_loaded", []):
+                    if (
+                        m.get("model_name") == ENDPOINT_TEST_MODEL
+                        and m.get("loaded") is True
+                    ):
+                        loaded = True
+                        break
+                if loaded:
+                    break
+                time.sleep(1)
+
+            if not loaded:
+                # Read and print log files for debugging
+                log1.close()
+                log2.close()
+                with open(os.path.join(tmp_dir, "lemond1.log"), "r") as f:
+                    print(f"\n--- lemond1.log ---\n{f.read()}")
+                with open(os.path.join(tmp_dir, "lemond2.log"), "r") as f:
+                    print(f"\n--- lemond2.log ---\n{f.read()}")
+
+            self.assertTrue(loaded, "Pinned model did not autoload on server restart")
+
+        except Exception as e:
+            # Read and print log files for debugging
+            log1.close()
+            log2.close()
+            try:
+                with open(os.path.join(tmp_dir, "lemond1.log"), "r") as f:
+                    print(f"\n--- lemond1.log ---\n{f.read()}")
+            except Exception:
+                pass
+            try:
+                with open(os.path.join(tmp_dir, "lemond2.log"), "r") as f:
+                    print(f"\n--- lemond2.log ---\n{f.read()}")
+            except Exception:
+                pass
+            raise e
+        finally:
+            log1.close()
+            log2.close()
+            if server_proc:
+                server_proc.terminate()
+                try:
+                    server_proc.wait(timeout=3)
+                except Exception:
+                    server_proc.kill()
+            shutil.rmtree(tmp_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Persist model pin status in `recipe_options.json` and automatically load pinned models in the background on server boot.

When a model is pinned (either during explicit load via `{"pinned": true}` or via `/internal/pin`), its pinned status is persisted to disk under `config_dir`. Upon server restart, `lemond` scans for pinned models and loads them asynchronously in the background so essential models remain available without manual reload.

* Persists pin state only after successful load or pin modification (preventing persistence of failing models).
* Avoids redundant disk writes when pin status is unchanged.
* Spawns an asynchronous autoload thread during boot and keeps the thread alive until shutdown to ensure Linux `PR_SET_PDEATHSIG` does not kill child inference backends.
* Logs warnings when a pinned model is evicted due to NPU exclusivity or capacity limits.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
* `ctest --test-dir build -L cpp-ci --output-on-failure` (59/59 unit tests passed).
* `python3 docs/tools/gen_backend_boilerplate.py --check` (verified zero drift).
* `test/server_pinning.py::test_pinned_model_persists_and_autoloads_on_restart` validates dynamic pinning, disk persistence in `recipe_options.json`, server restart, and background autoloading.

## Documentation

- [x] Documentation is not affected by this change.
- [ ] Documentation is affected and has been updated.
- [ ] Documentation is affected but will be handled in a separate PR or issue.

## Breaking Changes

- [ ] This PR introduces breaking changes.
- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [ ] I did not use AI tools for this PR.

If AI tools were used:
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.
