### PR TITLE
fix: resolve shared-repo GGUF variants orphaned by refs/main advance

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1528,160 +1528,216 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
             return files;
         };
 
-        std::vector<std::string> all_gguf_files = collect_gguf_files(active_hf_snapshot_path(model_cache_path_fs));
-        if (all_gguf_files.empty()) {
-            // Backward-compatible fallback for caches without refs/main and for
-            // partially migrated/manual HF cache layouts.
-            all_gguf_files = collect_gguf_files(model_cache_path_fs);
-        }
+        // Resolve the requested GGUF variant within a candidate list of files.
+        // Returns the matched absolute path, or "" if this candidate set does not
+        // contain the variant. Factored into a lambda so the search can be retried
+        // against a broader set of snapshots (see #2300 below) without duplicating
+        // the matching logic.
+        auto resolve_gguf_variant =
+            [&](const std::vector<std::string>& gguf_files) -> std::string {
+            if (gguf_files.empty()) {
+                return "";
+            }
 
-        if (all_gguf_files.empty()) {
-            return model_cache_path;  // Return directory if no GGUF found
-        }
+            // Case 0: Wildcard (*) - return first file (llama-server will auto-load shards)
+            if (variant == "*") {
+                return gguf_files[0];
+            }
 
-        // Sort files for consistent ordering (important for sharded models)
-        std::sort(all_gguf_files.begin(), all_gguf_files.end());
+            // Case 1: Empty variant - return first file
+            if (variant.empty()) {
+                return gguf_files[0];
+            }
 
-        // Case 0: Wildcard (*) - return first file (llama-server will auto-load shards)
-        if (variant == "*") {
-            return all_gguf_files[0];
-        }
+            // Case 2: Exact filename match (variant ends with .gguf)
+            if (variant.find(".gguf") != std::string::npos) {
+                for (const auto& filepath : gguf_files) {
+                    std::string filename = path_from_utf8(filepath).filename().string();
+                    if (filename == variant) {
+                        return filepath;
+                    }
+                }
+                return "";  // Exact variant not found in this candidate set
+            }
 
-        // Case 1: Empty variant - return first file
-        if (variant.empty()) {
-            return all_gguf_files[0];
-        }
+            // Case 3: Files ending with {variant}.gguf (case insensitive)
+            std::string variant_lower = variant;
+            std::transform(variant_lower.begin(), variant_lower.end(), variant_lower.begin(), ::tolower);
+            std::string suffix = variant_lower + ".gguf";
 
-        // Case 2: Exact filename match (variant ends with .gguf)
-        if (variant.find(".gguf") != std::string::npos) {
-            for (const auto& filepath : all_gguf_files) {
+            std::vector<std::string> matching_files;
+            for (const auto& filepath : gguf_files) {
                 std::string filename = path_from_utf8(filepath).filename().string();
-                if (filename == variant) {
+                std::string filename_lower = filename;
+                std::transform(filename_lower.begin(), filename_lower.end(), filename_lower.begin(), ::tolower);
+
+                if (filename_lower.size() >= suffix.size() &&
+                    filename_lower.substr(filename_lower.size() - suffix.size()) == suffix) {
+                    matching_files.push_back(filepath);
+                }
+            }
+
+            if (!matching_files.empty()) {
+                return matching_files[0];
+            }
+
+            // Case 4: Folder-based sharding (files in variant/ folder)
+            std::string folder_prefix_lower = variant_lower + "/";
+
+            for (const auto& filepath : gguf_files) {
+                // Get relative path from model cache path
+                std::string relative_path = path_to_utf8(
+                    path_from_utf8(filepath).lexically_relative(model_cache_path_fs));
+                std::string relative_lower = relative_path;
+                // Normalize path separators and case so folder-variant matching works cross-platform.
+                std::transform(relative_lower.begin(), relative_lower.end(), relative_lower.begin(), ::tolower);
+                std::replace(relative_lower.begin(), relative_lower.end(), '\\', '/');
+
+                if (relative_lower.find(folder_prefix_lower) != std::string::npos) {
                     return filepath;
                 }
             }
-            return "";  // Exact variant not found — signal not downloaded
-        }
 
-        // Case 3: Files ending with {variant}.gguf (case insensitive)
-        std::string variant_lower = variant;
-        std::transform(variant_lower.begin(), variant_lower.end(), variant_lower.begin(), ::tolower);
-        std::string suffix = variant_lower + ".gguf";
+            // Case 5: Local quant-token fallback.
+            //
+            // Keep the existing resolver cases above as the primary logic: exact
+            // filenames, suffix matches, and folder-based sharding are more
+            // specific and preserve the CHECKPOINT:VARIANT contract.
+            //
+            // Some GGUF repositories name files with the quant token in the middle,
+            // for example:
+            //   Qwen3.6-27B-MTP-IMAT-IQ4_XS-Q8nextn.gguf
+            // for variant:
+            //   IQ4_XS
+            // That file does not end with IQ4_XS.gguf, so mirror the downloader's
+            // GGUF variant enumeration over the files that are already present in
+            // the local HF cache before declaring the model missing.
+            //
+            // HF cache paths have an extra snapshots/<revision>/ prefix that is not
+            // part of the repository-relative filename. Strip it before calling
+            // enumerate_gguf_variants(); otherwise the enumerator treats
+            // "snapshots" as a top-level sharded-folder variant and never extracts
+            // the quant token from the actual GGUF filename.
+            std::vector<std::string> relative_gguf_files;
+            std::map<std::string, std::string> absolute_by_relative;
+            auto repo_relative_from_cache_relative = [](std::string rel) {
+                std::replace(rel.begin(), rel.end(), '\\', '/');
 
-        std::vector<std::string> matching_files;
-        for (const auto& filepath : all_gguf_files) {
-            std::string filename = path_from_utf8(filepath).filename().string();
-            std::string filename_lower = filename;
-            std::transform(filename_lower.begin(), filename_lower.end(), filename_lower.begin(), ::tolower);
+                static const std::string snapshots_prefix = "snapshots/";
+                if (rel.rfind(snapshots_prefix, 0) == 0) {
+                    size_t revision_end = rel.find('/', snapshots_prefix.size());
+                    if (revision_end != std::string::npos && revision_end + 1 < rel.size()) {
+                        rel = rel.substr(revision_end + 1);
+                    }
+                }
 
-            if (filename_lower.size() >= suffix.size() &&
-                filename_lower.substr(filename_lower.size() - suffix.size()) == suffix) {
-                matching_files.push_back(filepath);
-            }
-        }
+                return rel;
+            };
 
-        if (!matching_files.empty()) {
-            return matching_files[0];
-        }
+            for (const auto& filepath : gguf_files) {
+                std::string relative_path = path_to_utf8(
+                    path_from_utf8(filepath).lexically_relative(model_cache_path_fs));
+                relative_path = repo_relative_from_cache_relative(relative_path);
 
-        // Case 4: Folder-based sharding (files in variant/ folder)
-        std::string folder_prefix_lower = variant_lower + "/";
-
-        for (const auto& filepath : all_gguf_files) {
-            // Get relative path from model cache path
-            std::string relative_path = path_to_utf8(
-                path_from_utf8(filepath).lexically_relative(model_cache_path_fs));
-            std::string relative_lower = relative_path;
-            // Normalize path separators and case so folder-variant matching works cross-platform.
-            std::transform(relative_lower.begin(), relative_lower.end(), relative_lower.begin(), ::tolower);
-            std::replace(relative_lower.begin(), relative_lower.end(), '\\', '/');
-
-            if (relative_lower.find(folder_prefix_lower) != std::string::npos) {
-                return filepath;
-            }
-        }
-
-        // Case 5: Local quant-token fallback.
-        //
-        // Keep the existing resolver cases above as the primary logic: exact
-        // filenames, suffix matches, and folder-based sharding are more
-        // specific and preserve the CHECKPOINT:VARIANT contract.
-        //
-        // Some GGUF repositories name files with the quant token in the middle,
-        // for example:
-        //   Qwen3.6-27B-MTP-IMAT-IQ4_XS-Q8nextn.gguf
-        // for variant:
-        //   IQ4_XS
-        // That file does not end with IQ4_XS.gguf, so mirror the downloader's
-        // GGUF variant enumeration over the files that are already present in
-        // the local HF cache before declaring the model missing.
-        //
-        // HF cache paths have an extra snapshots/<revision>/ prefix that is not
-        // part of the repository-relative filename. Strip it before calling
-        // enumerate_gguf_variants(); otherwise the enumerator treats
-        // "snapshots" as a top-level sharded-folder variant and never extracts
-        // the quant token from the actual GGUF filename.
-        std::vector<std::string> relative_gguf_files;
-        std::map<std::string, std::string> absolute_by_relative;
-        auto repo_relative_from_cache_relative = [](std::string rel) {
-            std::replace(rel.begin(), rel.end(), '\\', '/');
-
-            static const std::string snapshots_prefix = "snapshots/";
-            if (rel.rfind(snapshots_prefix, 0) == 0) {
-                size_t revision_end = rel.find('/', snapshots_prefix.size());
-                if (revision_end != std::string::npos && revision_end + 1 < rel.size()) {
-                    rel = rel.substr(revision_end + 1);
+                // Multiple HF snapshots can contain the same repo-relative file.
+                // Keep the first absolute path from the sorted gguf_files list
+                // so duplicates do not create false ambiguity.
+                if (absolute_by_relative.emplace(relative_path, filepath).second) {
+                    relative_gguf_files.push_back(relative_path);
                 }
             }
 
-            return rel;
+            std::vector<std::string> enumerated_matches;
+            auto local_variants = lemon::enumerate_gguf_variants(relative_gguf_files);
+            for (const auto& local_variant : local_variants.variants) {
+                if (to_lower(local_variant.name) != variant_lower) {
+                    continue;
+                }
+
+                auto it = absolute_by_relative.find(local_variant.primary_file);
+                if (it != absolute_by_relative.end()) {
+                    enumerated_matches.push_back(it->second);
+                }
+            }
+
+            if (enumerated_matches.size() == 1) {
+                LOG(INFO, "ModelManager")
+                    << "Resolved local GGUF variant '" << variant
+                    << "' via quant-token fallback: " << enumerated_matches[0] << std::endl;
+                return enumerated_matches[0];
+            }
+
+            if (enumerated_matches.size() > 1) {
+                LOG(WARNING, "ModelManager")
+                    << "Multiple local GGUF files matched variant '" << variant
+                    << "' via quant-token fallback; refusing to guess" << std::endl;
+                return "";
+            }
+
+            // No match in this candidate set. Do not fall back to another
+            // quantization in the same Hugging Face repo; otherwise a custom
+            // download with a different quant can make a built-in model appear
+            // downloaded and allow deleting the wrong file.
+            return "";
         };
 
-        for (const auto& filepath : all_gguf_files) {
-            std::string relative_path = path_to_utf8(
-                path_from_utf8(filepath).lexically_relative(model_cache_path_fs));
-            relative_path = repo_relative_from_cache_relative(relative_path);
+        // Prefer the active refs/main snapshot so that when upstream only changed
+        // README/metadata Lemonade keeps using the previous snapshot's artifacts.
+        // (Sorted for consistent ordering, important for sharded models.)
+        std::vector<std::string> active_gguf_files =
+            collect_gguf_files(active_hf_snapshot_path(model_cache_path_fs));
+        std::sort(active_gguf_files.begin(), active_gguf_files.end());
 
-            // Multiple HF snapshots can contain the same repo-relative file.
-            // Keep the first absolute path from the sorted all_gguf_files list
-            // so duplicates do not create false ambiguity.
-            if (absolute_by_relative.emplace(relative_path, filepath).second) {
-                relative_gguf_files.push_back(relative_path);
+        // Whole-repo-cache candidates spanning every snapshot, populated on demand.
+        std::vector<std::string> all_cache_gguf_files;
+        bool all_cache_collected = false;
+        auto whole_cache_gguf_files = [&]() -> const std::vector<std::string>& {
+            if (!all_cache_collected) {
+                all_cache_gguf_files = collect_gguf_files(model_cache_path_fs);
+                std::sort(all_cache_gguf_files.begin(), all_cache_gguf_files.end());
+                all_cache_collected = true;
+            }
+            return all_cache_gguf_files;
+        };
+
+        if (active_gguf_files.empty() && whole_cache_gguf_files().empty()) {
+            return model_cache_path;  // Return directory if no GGUF found anywhere
+        }
+
+        std::string resolved_path = resolve_gguf_variant(active_gguf_files);
+
+        // #2300: a sibling variant that shares this HF repo can live in a snapshot
+        // other than the one refs/main points at. refs/main advances to the
+        // snapshot of whichever variant was pulled or updated last, leaving the
+        // other variants' symlinks behind in earlier snapshots; after a restart the
+        // refs/main-only search above then reports them as missing. If the active
+        // snapshot did not contain the requested variant, broaden the search to
+        // every snapshot in this repo's cache before declaring it missing. Blobs are
+        // content-addressed and shared, so reading an older snapshot is safe, and
+        // resolving against the active snapshot first preserves the CHECKPOINT:VARIANT
+        // contract (a different quant is never substituted while the exact one exists).
+        //
+        // The whole-cache set is a superset of the active set (it recurses the repo
+        // cache, which contains the active snapshot dir), so the two are equal only
+        // when refs/main's snapshot is the sole snapshot holding GGUFs — in which case
+        // the broader search is identical and skipped. Comparing the (sorted) sets,
+        // rather than just their sizes, makes that intent explicit and stays correct
+        // even if that superset relationship ever changes.
+        //
+        // When more than one inactive snapshot holds the requested variant, the
+        // existing first-by-sorted-path dedup (see Case 5) picks one deterministically;
+        // every such copy is a valid GGUF of that quant, so this is safe for the
+        // resolve/downloaded-status purpose. Preferring the newest snapshot per variant
+        // would need per-variant snapshot state the HF cache does not record today and
+        // is left as a follow-up (out of scope for this fix).
+        if (resolved_path.empty()) {
+            const std::vector<std::string>& all_files = whole_cache_gguf_files();
+            if (all_files != active_gguf_files) {
+                resolved_path = resolve_gguf_variant(all_files);
             }
         }
 
-        std::vector<std::string> enumerated_matches;
-        auto local_variants = lemon::enumerate_gguf_variants(relative_gguf_files);
-        for (const auto& local_variant : local_variants.variants) {
-            if (to_lower(local_variant.name) != variant_lower) {
-                continue;
-            }
-
-            auto it = absolute_by_relative.find(local_variant.primary_file);
-            if (it != absolute_by_relative.end()) {
-                enumerated_matches.push_back(it->second);
-            }
-        }
-
-        if (enumerated_matches.size() == 1) {
-            LOG(INFO, "ModelManager")
-                << "Resolved local GGUF variant '" << variant
-                << "' via quant-token fallback: " << enumerated_matches[0] << std::endl;
-            return enumerated_matches[0];
-        }
-
-        if (enumerated_matches.size() > 1) {
-            LOG(WARNING, "ModelManager")
-                << "Multiple local GGUF files matched variant '" << variant
-                << "' via quant-token fallback; refusing to guess" << std::endl;
-            return "";
-        }
-
-        // No match found for the requested GGUF variant. Do not fall back to
-        // another quantization in the same Hugging Face repo; otherwise a
-        // custom download with a different quant can make a built-in model
-        // appear downloaded and allow deleting the wrong file.
-        return "";
+        return resolved_path;
     }
 
     // Everything else

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -40,6 +40,9 @@ from utils.server_base import (
 from utils.test_models import (
     PORT,
     ENDPOINT_TEST_MODEL,
+    SHARED_REPO_MODEL_A_NAME,
+    SHARED_REPO_MODEL_A_CHECKPOINT,
+    SHARED_REPO_MODEL_B_NAME,
     SHARED_REPO_MODEL_B_CHECKPOINT,
     TIMEOUT_MODEL_OPERATION,
     TIMEOUT_DEFAULT,
@@ -3258,6 +3261,155 @@ class EndpointTests(ServerTestBase):
             f"[OK] Valid checkpoint returned {len(variants)} variant(s): "
             f"{[v['name'] for v in variants]}"
         )
+
+    def test_034_shared_repo_variant_resolves_after_refs_main_advances(self):
+        """Regression for #2300: two models sharing one HF repo with different
+        quants must both stay resolvable after refs/main advances past one of them.
+
+        HF refs/main is a single sticky per-repo pointer (advanced only on a
+        successful pull). When a sibling variant is pulled/updated, refs/main moves
+        to a snapshot that contains only that variant; the other variant stays in
+        the previous snapshot, so refs/main no longer covers both. On the next
+        models-cache build (i.e. after a lemond restart) the GGUF resolver, which
+        searches only the refs/main snapshot, then reports the variant not covered
+        by refs/main as not downloaded even though its file is still cached. The fix
+        broadens the resolver to fall back to all snapshots when the active one
+        lacks the requested variant.
+
+        Repro without waiting for a real upstream commit: pull both variants (they
+        land in one snapshot under the current commit), then move one variant into a
+        fresh snapshot and repoint refs/main at it, so the two variants live in
+        different snapshots. The models cache is then rebuilt by pulling an
+        unrelated model from a *different* repo (re-pulling a shared-repo model would
+        query HF and repair refs/main, masking the bug).
+        """
+        a_name = SHARED_REPO_MODEL_A_NAME
+        b_name = SHARED_REPO_MODEL_B_NAME
+        repo_id, a_file = SHARED_REPO_MODEL_A_CHECKPOINT.split(":", 1)
+        b_file = SHARED_REPO_MODEL_B_CHECKPOINT.split(":", 1)[1]
+        repo_cache_dir = "models--" + repo_id.replace("/", "--")
+        throwaway = f"user.OrphanRebuild-{uuid.uuid4().hex[:8]}"
+
+        def _pull(model_name, checkpoint):
+            r = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": model_name,
+                    "recipe": "llamacpp",
+                    "checkpoints": {"main": checkpoint},
+                    "stream": False,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(r.status_code, 200, r.text)
+
+        def _delete(model_name):
+            # Best-effort cleanup; ignore status so one failure does not mask others.
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": model_name},
+                    timeout=TIMEOUT_MODEL_OPERATION,
+                )
+            except requests.RequestException:
+                pass
+
+        def _downloaded(model_name):
+            # GET /models/{id} -> get_model_info() -> build_cache(), so this re-runs
+            # the on-disk resolver against the staged cache state.
+            r = requests.get(
+                f"{self.base_url}/models/{model_name}", timeout=TIMEOUT_DEFAULT
+            )
+            self.assertEqual(r.status_code, 200, r.text)
+            return r.json().get("downloaded", False)
+
+        try:
+            # 1. Pull both variants of the shared repo. With a single upstream commit
+            #    both files land in the same snapshots/<commit>/ directory.
+            _pull(a_name, SHARED_REPO_MODEL_A_CHECKPOINT)
+            _pull(b_name, SHARED_REPO_MODEL_B_CHECKPOINT)
+            self.assertTrue(_downloaded(a_name), "Variant A should download")
+            self.assertTrue(_downloaded(b_name), "Variant B should download")
+
+            # Locate the server's real HF cache (handles config models_dir overrides
+            # and packaged servers running under a different user/HOME).
+            cache_root = self._server_hf_cache_root(repo_cache_dir)
+            if cache_root is None:
+                self.skipTest(
+                    "Cannot locate the server's HF cache from the test process; "
+                    "the shared-repo resolution path needs on-disk snapshot access."
+                )
+
+            repo_dir = os.path.join(cache_root, repo_cache_dir)
+            snapshots_dir = os.path.join(repo_dir, "snapshots")
+            refs_main = os.path.join(repo_dir, "refs", "main")
+
+            with open(refs_main, encoding="utf-8") as f:
+                cur_rev = f.read().strip()
+            cur_snapshot = os.path.join(snapshots_dir, cur_rev)
+            a_in_cur = os.path.join(cur_snapshot, a_file)
+            b_in_cur = os.path.join(cur_snapshot, b_file)
+            if not (os.path.exists(a_in_cur) and os.path.exists(b_in_cur)):
+                self.skipTest(
+                    "Shared-repo variants are not co-located in the active snapshot "
+                    "(upstream layout changed); cannot stage the orphan."
+                )
+
+            # 2. Simulate an upstream commit being pulled for one variant: move B
+            #    into a fresh snapshot and advance refs/main to it. This mirrors what
+            #    a real pull does — only the freshly pulled file lands in the new
+            #    snapshot, so the two variants no longer share one snapshot and
+            #    refs/main no longer covers both of them. (The repo here stores real
+            #    files in the snapshot dirs, so the file is relocated directly.)
+            new_rev = "0" * 40
+            new_snapshot = os.path.join(snapshots_dir, new_rev)
+            os.makedirs(new_snapshot, exist_ok=True)
+            os.rename(b_in_cur, os.path.join(new_snapshot, b_file))
+            os.makedirs(os.path.dirname(refs_main), exist_ok=True)
+            with open(refs_main, "w", encoding="utf-8") as f:
+                f.write(new_rev)
+
+            # Sanity: each variant now lives in a different snapshot, and refs/main
+            # points at the one that holds only B.
+            self.assertTrue(
+                os.path.exists(os.path.join(new_snapshot, b_file)),
+                "Setup error: B must be in the new refs/main snapshot",
+            )
+            self.assertFalse(
+                os.path.exists(os.path.join(new_snapshot, a_file)),
+                "Setup error: A must not be in the new refs/main snapshot",
+            )
+            self.assertTrue(
+                os.path.exists(a_in_cur),
+                "Setup error: A must remain in the previous snapshot",
+            )
+
+            # 3. Force a models-cache rebuild without touching the shared repo (this
+            #    is what a lemond restart would do). Pulling an unrelated model from a
+            #    different repo invalidates the cache so the resolver re-runs.
+            _pull(throwaway, USER_MODEL_MAIN_CHECKPOINT)
+
+            # 4. #2300: both variants are still physically cached (one in each
+            #    snapshot), so both must resolve as downloaded. Before the fix the
+            #    resolver searched only the refs/main snapshot, so the variant not
+            #    covered by refs/main was reported missing.
+            self.assertTrue(
+                _downloaded(b_name),
+                "#2300: variant B must remain downloaded after refs/main advances "
+                "(its file is still cached, in the new snapshot)",
+            )
+            self.assertTrue(
+                _downloaded(a_name),
+                "#2300: variant A must remain downloaded after refs/main advances "
+                "(its file is still cached, in the previous snapshot)",
+            )
+            print(
+                "[OK] #2300 shared-repo variants both resolve after refs/main advance"
+            )
+        finally:
+            _delete(a_name)
+            _delete(b_name)
+            _delete(throwaway)
 
 
 if __name__ == "__main__":

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -230,7 +230,9 @@ USER_MODEL_TE_CHECKPOINT = (
 # Using a file not at repo top-level
 USER_MODEL_VAE_CHECKPOINT = "Comfy-Org/z_image:split_files/vae/ae.safetensors"
 
-# Models for shared-repo dependency testing (same repo, different quants)
+# Models for shared-repo dependency testing (same repo, different quants).
+# Also used by server_endpoints.py::test_034 (shared-repo variant resolution after a
+# refs/main advance); keep both quants pointing at the same repo if these change.
 SHARED_REPO_MODEL_A_NAME = "user.SharedRepo-TestA"
 SHARED_REPO_MODEL_A_CHECKPOINT = (
     "unsloth/SmolLM2-135M-Instruct-GGUF:SmolLM2-135M-Instruct-Q2_K.gguf"


### PR DESCRIPTION
## Problem

`refs/main` in a Hugging Face repo cache is a single sticky pointer (advanced only on a successful pull). When two models share one HF repo with different quants, pulling or updating one variant advances `refs/main` to a snapshot that contains only that variant — the sibling variant's file stays behind in the previous snapshot.

The llamacpp main-GGUF resolver (`ModelManager::resolve_model_path`) collected candidate GGUFs from the `refs/main` snapshot only, with a whole-cache fallback that fired solely when that snapshot had *zero* GGUFs. So after the next models-cache build (e.g. a `lemond` restart), the sibling variant — present, but not under `refs/main` — was reported as not downloaded even though its file is still cached. Fixes #2300.

## Fix

Factor the variant-matching cases into a `resolve_gguf_variant` lambda. Try the active `refs/main` snapshot first; only if that misses, broaden the search to every snapshot in the repo cache before declaring the variant missing.

- **Active snapshot first** preserves the `CHECKPOINT:VARIANT` contract — a different quant is never substituted while the exact one exists under `refs/main`.
- Blobs are content-addressed and shared across snapshots, so reading an older snapshot's copy is safe.
- The whole-cache walk is **lazy** (only runs on a miss), so the hot path is unchanged.
- The auxiliary-checkpoint resolver already had this all-snapshots fallback; this brings the main GGUF path in line.

The C++ diff is mostly reindentation of the existing cases into the lambda — each case's matching behaviour is unchanged.

## Test

`test_034` (`server_endpoints.py`): pulls two quants sharing a repo, moves one into a fresh snapshot and advances `refs/main`, forces a models-cache rebuild (via an unrelated throwaway pull — re-pulling a shared-repo model would query HF and repair `refs/main`, masking the bug), then asserts both variants stay resolvable. Fails on `main`, passes with this change.

## Validation

Exercised on real hardware:

- **lemonade:** 10.8.0 (imac-built dev `.deb` carrying this branch; not a release)
- **OS / kernel:** Ubuntu 26.04 LTS · `7.0.0-22-generic` · glibc 2.43 · amd64
- **GPU:** AMD Radeon RX 7900 XT (Navi 31 `[1002:744c]`, gfx1100, RDNA3, 24 GB)
- **Backend:** none — `test_034` and `test_030`–`test_033` exercise GGUF cache/path resolution and the pull-variants API; no model is loaded, so no inference backend or ROCm runtime is invoked.

`test_034` fails on an unpatched build and passes with this change; the existing `test_030`–`test_033` pull-variant tests remain green.
