### PR TITLE
fix(backends): stage and verify backend install before removing the working binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1740,3 +1740,22 @@ if(EXISTS "${_LATEST_FALLBACK_TEST_SRC}")
     include(CTest)
     add_test(NAME LatestVersionFallbackTest COMMAND test_latest_version_fallback)
 endif()
+
+# Backend install atomicity (staging + verified atomic swap).
+# Header-only unit under test, so no extra source files are required.
+set(_INSTALL_ATOMICITY_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_install_atomicity.cpp"
+)
+if(EXISTS "${_INSTALL_ATOMICITY_TEST_SRC}")
+    add_executable(test_install_atomicity
+        test/cpp/test_install_atomicity.cpp
+    )
+    target_include_directories(test_install_atomicity PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+
+    # Enable testing and register the test with CTest
+    include(CTest)
+    add_test(NAME InstallAtomicityTest COMMAND test_install_atomicity)
+endif()

--- a/src/cpp/include/lemon/backends/install_staging.h
+++ b/src/cpp/include/lemon/backends/install_staging.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+// Header-only, dependency-light staging/atomic-swap helpers for backend
+// installation. Kept free of the heavier backend_utils.cpp dependencies so the
+// crash-safety invariant can be unit-tested in isolation (test/cpp/test_install_atomicity.cpp).
+namespace lemon::backends {
+
+    /**
+     * Recursively search `dir` for a regular file named `binary_name` (or
+     * `binary_name + ".exe"` on Windows). Returns the full path, or "" if not
+     * found or `dir` does not exist.
+     */
+    inline std::string find_executable_in_dir(const std::string& dir,
+                                              const std::string& binary_name) {
+        namespace fs = std::filesystem;
+        if (!fs::exists(dir)) {
+            return "";
+        }
+#ifdef _WIN32
+        const std::string binary_name_exe = binary_name + ".exe";
+#endif
+        for (const fs::directory_entry& dir_entry : fs::recursive_directory_iterator(dir)) {
+            if (dir_entry.is_regular_file()) {
+                const auto& fname = dir_entry.path().filename();
+                if (fname == binary_name
+#ifdef _WIN32
+                    || fname == binary_name_exe
+#endif
+                ) {
+                    return dir_entry.path().string();
+                }
+            }
+        }
+        return "";
+    }
+
+    /**
+     * Atomically promote a fully-prepared staging directory to `install_dir`.
+     *
+     * Verifies that `staging_dir` contains `binary_name` before touching the
+     * currently-installed copy. The caller MUST create `staging_dir` as a
+     * sibling of `install_dir` so the renames stay on one filesystem.
+     *
+     * The promotion keeps a recoverable copy of the previous install at all
+     * times so a failed swap can never lose both installs:
+     *   1. move the existing install aside to `install_dir + ".old"`;
+     *   2. rename `staging_dir` into `install_dir`;
+     *   3. only then delete the `.old` backup.
+     * If step 2 fails the `.old` backup is rolled back into place, restoring the
+     * previously-working install.
+     *
+     * Outcomes:
+     *   - returns the path to the installed executable on success;
+     *   - returns "" when `staging_dir` does not contain `binary_name` (nothing
+     *     was promoted; `staging_dir` is removed, `install_dir` is untouched);
+     *   - throws std::runtime_error when the filesystem swap itself fails — the
+     *     previous install is left in place (or rolled back), and `staging_dir`
+     *     is left for the caller to clean up. This is distinct from the "" case
+     *     so the caller can report an accurate error.
+     */
+    inline std::string commit_staged_install(const std::string& staging_dir,
+                                             const std::string& install_dir,
+                                             const std::string& binary_name) {
+        namespace fs = std::filesystem;
+
+        // Verify the freshly-staged tree actually contains the backend
+        // executable before we touch the currently-installed copy.
+        std::string staged_exe = find_executable_in_dir(staging_dir, binary_name);
+        if (staged_exe.empty()) {
+            std::error_code ec;
+            fs::remove_all(staging_dir, ec);  // drop the bad staging tree; keep install_dir
+            return "";
+        }
+
+        const std::string backup_dir = install_dir + ".old";
+        std::error_code ec;
+        fs::remove_all(backup_dir, ec);  // clear any stale backup from a prior aborted swap
+
+        // Move the existing install aside (if any) so it survives a failed
+        // promotion. We never remove it outright — it is renamed to .old and
+        // only deleted once the new tree is verified in place.
+        const bool had_install = fs::exists(install_dir);
+        if (had_install) {
+            fs::rename(install_dir, backup_dir, ec);
+            if (ec) {
+                // Could not move the existing install aside; leave it untouched.
+                throw std::runtime_error(
+                    "backend install swap failed: could not back up existing install at "
+                    + install_dir + " (" + ec.message() + ")");
+            }
+        }
+
+        // Promote the staged tree into place.
+        fs::rename(staging_dir, install_dir, ec);
+        if (ec) {
+            // Promotion failed. Roll the backup back so the previously-working
+            // install is restored rather than lost.
+            if (had_install) {
+                std::error_code rollback_ec;
+                fs::rename(backup_dir, install_dir, rollback_ec);
+            }
+            throw std::runtime_error(
+                "backend install swap failed: could not promote staged install to "
+                + install_dir + " (" + ec.message() + ")");
+        }
+
+        // New install is in place; drop the backup.
+        fs::remove_all(backup_dir, ec);
+
+        return find_executable_in_dir(install_dir, binary_name);
+    }
+
+}  // namespace lemon::backends

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -1,4 +1,5 @@
 #include "lemon/backends/backend_utils.h"
+#include "lemon/backends/install_staging.h"
 #include "lemon/runtime_config.h"
 #include "lemon/system_info.h"
 #include "lemon/backends/llamacpp_server.h"
@@ -24,6 +25,7 @@
 #include <iostream>
 #include <lemon/utils/aixlog.hpp>
 #include <algorithm>
+#include <system_error>
 #include <vector>
 #include <nlohmann/json.hpp>
 
@@ -259,27 +261,9 @@ namespace lemon::backends {
     }
 
     std::string BackendUtils::find_executable_in_install_dir(const std::string& install_dir, const std::string& binary_name) {
-        if (fs::exists(install_dir)) {
-            // On Windows, executables have a .exe extension that may not be in binary_name
-#ifdef _WIN32
-            const std::string binary_name_exe = binary_name + ".exe";
-#endif
-            // This could be optimized with a cache but saving a few milliseconds every few minutes/hours is not going to do much
-            for (const fs::directory_entry& dir_entry : fs::recursive_directory_iterator(install_dir)) {
-                if (dir_entry.is_regular_file()) {
-                    const auto& fname = dir_entry.path().filename();
-                    if (fname == binary_name
-#ifdef _WIN32
-                        || fname == binary_name_exe
-#endif
-                    ) {
-                        return dir_entry.path().string();
-                    }
-                }
-            }
-        }
-
-        return "";
+        // Delegates to the header-only helper so the executable-lookup logic has
+        // a single source of truth shared with commit_staged_install().
+        return find_executable_in_dir(install_dir, binary_name);
     }
 
     std::string BackendUtils::get_backend_binary_path(const BackendSpec& spec, const std::string& backend) {
@@ -405,7 +389,11 @@ namespace lemon::backends {
                     LOG(INFO, spec.log_name()) << "Upgrading " << spec.binary << " from " << installed_version
                             << " to " << expected_version << std::endl;
                     needs_install = true;
-                    fs::remove_all(install_dir);
+                    // NOTE: do NOT remove install_dir here. The existing working
+                    // binary is kept in place until the replacement has been
+                    // downloaded, extracted, and verified; the atomic swap below
+                    // (commit_staged_install) handles removal so an interrupted
+                    // download cannot leave the backend with no usable binary.
                 }
             } else if (!needs_install && !expected_version.empty()) {
                 // If the executable exists but version.txt is missing, SystemInfo
@@ -415,7 +403,7 @@ namespace lemon::backends {
                 LOG(INFO, spec.log_name()) << "Installed executable is missing version.txt; reinstalling "
                         << spec.binary << " version " << expected_version << std::endl;
                 needs_install = true;
-                fs::remove_all(install_dir);
+                // See note above: removal is deferred to the verified atomic swap.
             }
         }
 
@@ -423,11 +411,37 @@ namespace lemon::backends {
             LOG(INFO, spec.log_name()) << "Installing " << spec.binary << " (version: "
                     << expected_version << ")" << std::endl;
 
-            // Create install directory
-            fs::create_directories(install_dir);
+            // Stage the new install in a sibling directory so the currently
+            // installed (working) binary is left untouched until the download is
+            // complete, extracted, and verified. Only then is staging atomically
+            // swapped into place (see commit_staged_install below), so a slow or
+            // interrupted download never destroys a working binary.
+            const std::string staging_dir = install_dir + ".staging";
+            std::error_code staging_ec;
+            fs::remove_all(staging_dir, staging_ec);  // clear any leftover from a prior aborted install
+            fs::remove_all(install_dir + ".old", staging_ec);  // and any orphaned swap backup
+            // If a stale staging tree could not be cleared (e.g. a locked file on
+            // Windows), fail rather than extracting into it — a leftover binary
+            // could otherwise satisfy verification and get promoted as a stale or
+            // mixed install over the working one.
+            if (fs::exists(staging_dir)) {
+                throw std::runtime_error("Could not clear stale staging directory: " + staging_dir);
+            }
+            fs::create_directories(staging_dir);
 
-            std::string url = "https://github.com/" + repo + "/releases/download/" +
-                            expected_version + "/" + filename;
+            // Remove the staging tree on any early exit (exception) before the
+            // swap, so a failed download/extraction never leaves a half-built
+            // tree behind for the next attempt to trip over.
+            struct StagingGuard {
+                const std::string& dir;
+                bool active = true;
+                ~StagingGuard() {
+                    if (active) {
+                        std::error_code ec;
+                        fs::remove_all(dir, ec);
+                    }
+                }
+            } staging_guard{staging_dir};
 
             // Download archive to cache directory.
             // Preserve the actual filename (sanitised for use in a path) so that
@@ -443,6 +457,19 @@ namespace lemon::backends {
             std::string zip_path = (cache_dir / (zip_name + "_" + expected_version + "_" + safe_filename)).string();
 
             LOG(DEBUG, spec.log_name()) << "Downloading to: " << zip_path << std::endl;
+
+            // Remove the downloaded archive on ANY exit from here on — success
+            // OR exception, including a throw from commit_staged_install() below
+            // (a swap/rename failure) — so the cache archive is never leaked.
+            // Mirrors StagingGuard above; replaces the per-throw fs::remove(zip_path)
+            // calls that did not cover the commit_staged_install throw path.
+            struct ZipGuard {
+                const std::string& path;
+                ~ZipGuard() {
+                    std::error_code ec;
+                    fs::remove(path, ec);
+                }
+            } zip_guard{zip_path};
 
             const std::string base_download_url = "https://github.com/" + repo + "/releases/download/" +
                                                   expected_version + "/";
@@ -587,7 +614,6 @@ namespace lemon::backends {
                     if (!part_result.success) {
                         combined.close();
                         fs::remove(part_path);
-                        fs::remove(zip_path);
                         throw std::runtime_error("Failed to download " + part_filename + " from: " + part_url +
                                                  " - " + part_result.error_message);
                     }
@@ -612,28 +638,44 @@ namespace lemon::backends {
             LOG(DEBUG, spec.log_name()) << "Downloaded archive file size: "
                     << (file_size / 1024 / 1024) << " MB" << std::endl;
 
-            // Extract
-            if (!extract_archive(zip_path, install_dir, spec.log_name())) {
-                fs::remove(zip_path);
-                fs::remove_all(install_dir);
+            // Extract into the staging directory (NOT install_dir) so a failed
+            // extraction cannot destroy the currently-installed binary. The
+            // staging guard removes the partial tree when we throw.
+            if (!extract_archive(zip_path, staging_dir, spec.log_name())) {
                 throw std::runtime_error("Failed to extract archive: " + zip_path);
             }
 
-            // Verify extraction
-            exe_path = find_executable_in_install_dir(install_dir, spec.binary);
-            if (exe_path.empty()) {
-                LOG(ERROR, spec.log_name()) << "Extraction completed but executable not found" << std::endl;
-                fs::remove(zip_path);
-                fs::remove_all(install_dir);
-                throw std::runtime_error("Extraction failed: executable not found");
+            // Save version info into the staging tree so it travels with the
+            // atomic swap below. Fail cleanly on a write error rather than
+            // promoting a backend with no version.txt (which would make the next
+            // status check force an unnecessary reinstall).
+            {
+                const std::string staged_version_file = (fs::path(staging_dir) / "version.txt").string();
+                std::ofstream vf(staged_version_file);
+                vf << expected_version;
+                vf.flush();
+                if (!vf.good()) {
+                    throw std::runtime_error("Failed to write version file: " + staged_version_file);
+                }
             }
 
-            LOG(DEBUG, spec.log_name()) << "Executable verified at: " << exe_path << std::endl;
+            // Verify the staged tree contains the executable, then atomically
+            // swap it into place. commit_staged_install keeps a recoverable .old
+            // backup across the swap: it removes the staging tree and leaves
+            // install_dir untouched on verification failure (returns ""), and on
+            // a swap (rename) failure it rolls the backup back and throws — so a
+            // botched download/extraction/swap never destroys the working binary.
+            exe_path = commit_staged_install(staging_dir, install_dir, spec.binary);
+            if (exe_path.empty()) {
+                LOG(ERROR, spec.log_name()) << "Extraction completed but executable not found" << std::endl;
+                throw std::runtime_error("Extraction failed: executable not found");
+            }
+            // Swap succeeded: staging was consumed by the rename, so disarm the
+            // guard (its cleanup would now be a no-op, but disarm to make intent
+            // explicit and skip a pointless filesystem call).
+            staging_guard.active = false;
 
-            // Save version info
-            std::ofstream vf(version_file);
-            vf << expected_version;
-            vf.close();
+            LOG(DEBUG, spec.log_name()) << "Executable verified at: " << exe_path << std::endl;
 
     #ifndef _WIN32
             // Make all binaries in bin/ executable (tar may lose permissions)
@@ -651,8 +693,7 @@ namespace lemon::backends {
             chmod(exe_path.c_str(), 0755);
     #endif
 
-            // Delete ZIP file
-            fs::remove(zip_path);
+            // (The downloaded archive is removed by zip_guard on scope exit.)
 
             // Send completion event now that installation is fully done.
             // For split archives the combined on-disk size is only known after

--- a/test/cpp/test_install_atomicity.cpp
+++ b/test/cpp/test_install_atomicity.cpp
@@ -1,0 +1,187 @@
+// Standalone test for lemon::backends::commit_staged_install.
+//
+// Guards the crash-safety invariant for backend installation: a failed or
+// incomplete install (interrupted download, truncated/garbage archive, wrong
+// contents) must NEVER destroy a previously-working binary. The fix stages the
+// new install in a sibling directory and only swaps it into place once the
+// executable is verified present; before the fix, install_from_github removed
+// the working install_dir up front, so a failed download left no usable binary.
+//
+// Compile with:
+//   g++ -std=c++17 -I src/cpp/include test/cpp/test_install_atomicity.cpp -o install_atomicity_test
+//   cl /std:c++17 /EHsc /I src/cpp/include test/cpp/test_install_atomicity.cpp
+
+#include "lemon/backends/install_staging.h"
+
+#include <cstdio>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+
+namespace fs = std::filesystem;
+using lemon::backends::commit_staged_install;
+
+struct TestResult {
+    int passed = 0;
+    int failed = 0;
+
+    void check(bool cond, const std::string& name) {
+        if (cond) {
+            printf("[PASS] %s\n", name.c_str());
+            ++passed;
+        } else {
+            printf("[FAIL] %s\n", name.c_str());
+            ++failed;
+        }
+    }
+};
+
+// Unique temp directory for one sub-test, so runs don't collide.
+static fs::path make_temp_root(const std::string& tag) {
+    static int counter = 0;
+    fs::path root = fs::temp_directory_path() / ("install_atomicity_test_" + tag + "_");
+    root += std::to_string(std::hash<std::string>{}(
+        std::to_string(std::time(nullptr)) + tag + std::to_string(counter++)));
+    fs::create_directories(root);
+    return root;
+}
+
+static void write_file(const fs::path& p, const std::string& contents) {
+    fs::create_directories(p.parent_path());
+    std::ofstream f(p);
+    f << contents;
+}
+
+static std::string read_file(const fs::path& p) {
+    std::ifstream f(p);
+    std::string s((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    return s;
+}
+
+// 1) Happy path: a valid staging tree replaces the old install atomically.
+static void test_successful_swap(TestResult& r) {
+    fs::path root = make_temp_root("ok");
+    fs::path install_dir = root / "llamacpp";
+    fs::path staging_dir = root / "llamacpp.staging";  // sibling, as the installer creates it
+    const std::string binary = "llama-server";
+
+    // Old working install with a sentinel "version".
+    write_file(install_dir / "bin" / binary, "OLD");
+    write_file(install_dir / "version.txt", "v1");
+
+    // New staged install (executable found recursively under bin/).
+    write_file(staging_dir / "bin" / binary, "NEW");
+    write_file(staging_dir / "version.txt", "v2");
+
+    std::string exe = commit_staged_install(staging_dir.string(), install_dir.string(), binary);
+
+    r.check(!exe.empty(), "successful swap returns installed exe path");
+    r.check(fs::exists(install_dir / "bin" / binary), "installed executable present after swap");
+    r.check(read_file(install_dir / "bin" / binary) == "NEW", "installed binary is the NEW one");
+    r.check(read_file(install_dir / "version.txt") == "v2", "version.txt is the staged one");
+    r.check(!fs::exists(staging_dir), "staging dir consumed by the rename");
+    r.check(!fs::exists(install_dir.string() + ".old"), "no .old backup left after a successful swap");
+
+    fs::remove_all(root);
+}
+
+// 2) REGRESSION GUARD: a staging tree without the executable must NOT destroy
+//    the existing working install.
+static void test_failed_install_preserves_working_binary(TestResult& r) {
+    fs::path root = make_temp_root("fail");
+    fs::path install_dir = root / "llamacpp";
+    fs::path staging_dir = root / "llamacpp.staging";
+    const std::string binary = "llama-server";
+
+    // Old working install.
+    write_file(install_dir / "bin" / binary, "OLD");
+    write_file(install_dir / "version.txt", "v1");
+
+    // Botched staging: extracted something, but the expected executable is
+    // missing (e.g. truncated/garbage archive, wrong asset).
+    write_file(staging_dir / "README.txt", "partial");
+
+    std::string exe = commit_staged_install(staging_dir.string(), install_dir.string(), binary);
+
+    r.check(exe.empty(), "failed verification returns empty");
+    r.check(fs::exists(install_dir / "bin" / binary), "OLD working binary still present");
+    r.check(read_file(install_dir / "bin" / binary) == "OLD", "OLD binary contents intact");
+    r.check(read_file(install_dir / "version.txt") == "v1", "OLD version.txt intact");
+    r.check(!fs::exists(staging_dir), "bad staging dir cleaned up");
+
+    fs::remove_all(root);
+}
+
+// 3) Fresh install: no prior install_dir exists.
+static void test_fresh_install(TestResult& r) {
+    fs::path root = make_temp_root("fresh");
+    fs::path install_dir = root / "llamacpp";
+    fs::path staging_dir = root / "llamacpp.staging";
+    const std::string binary = "llama-server";
+
+    write_file(staging_dir / "bin" / binary, "NEW");
+
+    std::string exe = commit_staged_install(staging_dir.string(), install_dir.string(), binary);
+
+    r.check(!exe.empty(), "fresh install returns exe path");
+    r.check(fs::exists(install_dir / "bin" / binary), "fresh install places executable");
+    r.check(!fs::exists(staging_dir), "staging consumed on fresh install");
+
+    fs::remove_all(root);
+}
+
+// 4) REGRESSION GUARD (POSIX): if the filesystem swap itself fails, the working
+//    install must survive and the failure must be reported (thrown), not
+//    silently swallowed. We force the backup rename to fail by making the parent
+//    directory read-only, which blocks creating install_dir + ".old".
+//    Windows permission semantics differ, so this is gated to POSIX.
+#ifndef _WIN32
+static void test_swap_failure_preserves_working_binary(TestResult& r) {
+    fs::path root = make_temp_root("swapfail");
+    fs::path install_dir = root / "llamacpp";
+    fs::path staging_dir = root / "llamacpp.staging";
+    const std::string binary = "llama-server";
+
+    write_file(install_dir / "bin" / binary, "OLD");
+    write_file(staging_dir / "bin" / binary, "NEW");
+
+    // Make the parent read-only so the .old backup rename fails.
+    fs::permissions(root, fs::perms::owner_read | fs::perms::owner_exec,
+                    fs::perm_options::replace);
+
+    bool threw = false;
+    std::string exe;
+    try {
+        exe = commit_staged_install(staging_dir.string(), install_dir.string(), binary);
+    } catch (const std::exception&) {
+        threw = true;
+    }
+
+    // Restore write permission so we can inspect / clean up.
+    fs::permissions(root, fs::perms::owner_all, fs::perm_options::replace);
+
+    r.check(threw, "swap failure throws (distinct from the verify-fail empty return)");
+    r.check(fs::exists(install_dir / "bin" / binary), "OLD working binary survives a failed swap");
+    r.check(read_file(install_dir / "bin" / binary) == "OLD", "OLD binary contents intact after failed swap");
+
+    fs::permissions(root, fs::perms::owner_all, fs::perm_options::replace);
+    fs::remove_all(root);
+}
+#endif
+
+int main() {
+    TestResult r;
+    printf("=== commit_staged_install atomicity tests ===\n");
+    test_successful_swap(r);
+    test_failed_install_preserves_working_binary(r);
+    test_fresh_install(r);
+#ifndef _WIN32
+    test_swap_failure_preserves_working_binary(r);
+#endif
+    printf("\n%d passed, %d failed\n", r.passed, r.failed);
+    return r.failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## What

Makes backend (re)installation crash-safe. `BackendUtils::install_from_github` no longer deletes the working binary before the replacement is downloaded and verified.

Closes #2312.

## Why

On a version-mismatch / missing-`version.txt` reinstall, `install_from_github` called `fs::remove_all(install_dir)` **up front** — before downloading the new release asset. If that download then failed (slow/unreliable link, going offline mid-flight, a transient GitHub 5xx), the backend was left with **no usable binary**: the old one was already gone and the new one never arrived.

Surfaced by @ckuethe on #2279 ("not remove and replace the llama binary until the download is verified to be complete" — slow links, e.g. on an airplane). #2279 handled the latest-version *lookup* failure; this is the complementary *download* robustness case.

## The fix

Stage → verify → atomic swap:

1. Download + extract into a sibling `install_dir + ".staging"` directory — the working install is untouched.
2. Verify the expected executable is present in staging.
3. Promote with a recoverable backup that never leaves the backend with nothing:
   - rename the existing install aside to `install_dir + ".old"`,
   - rename staging into `install_dir`,
   - delete `.old` only once the new tree is in place;
   - if the promotion rename fails, roll `.old` back.

Additional hardening (from review):
- A RAII guard removes the staging tree on **any** pre-swap failure (download/probe/extract), so no half-built tree is left behind.
- Stale staging that can't be cleared is treated as fatal, so a leftover binary can never be promoted as a mixed install.
- The staged `version.txt` write is checked.
- The swap helper throws a distinct error on a *swap* failure (vs. the empty-return "executable not found" case), so the caller reports an accurate message.

The staging/swap logic is a small header-only helper (`lemon/backends/install_staging.h`) so it can be unit-tested without the heavier `backend_utils.cpp` dependencies; `find_executable_in_install_dir` now delegates to it (single source of truth).

## Testing

New ctest **`InstallAtomicityTest`** (`test/cpp/test_install_atomicity.cpp`), network-free, covering: successful swap (no `.old`/`.staging` left behind), **regression guard** — a staging tree missing the executable leaves the old working binary + `version.txt` byte-for-byte intact, fresh install, and (POSIX) a **failed filesystem swap** preserves the working binary and throws.

RED→GREEN verified: the regression assertions fail against the pre-fix `remove-before-verify` ordering and pass against the fix.

### Validation environment

This is a pure `std::filesystem` change with no inference path exercised, so **backend = none** (no model load, no ROCm/Vulkan). The unit test runs on every platform via CI ctest.

| Field | Value |
|-------|-------|
| Change type | backend install/filesystem logic — **no inference, backend=none** |
| Local | Ubuntu 26.04 (resolute), full `cmake --build` clean, `lemond` links, `ctest` 3/3 green |
| ai3 | Ubuntu 26.04 LTS (resolute), kernel `7.0.0-22-generic`, glibc 2.43, g++ 15.2.0 — `InstallAtomicityTest` 17/17 pass, clean `-Wall -Wextra` |
| Tests | `test/cpp/test_install_atomicity.cpp` (ctest `InstallAtomicityTest`) |

## Scope / follow-up

`install_therock` (the ROCm tarball path) has the same `remove_all`-before-download shape and would benefit from the same staging approach, but is left out of scope to keep this PR focused — happy to follow up in a separate PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
