### PR TITLE
Add support for additional draft checkpoint

### DIFF
--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -690,13 +690,65 @@
     },
     "Gemma-4-12B-it-GGUF": {
         "checkpoint": "unsloth/gemma-4-12b-it-GGUF:Q4_K_M",
+        "mmproj": "mmproj-F16.gguf",
         "recipe": "llamacpp",
         "suggested": true,
         "labels": [
             "tool-calling",
+            "vision",
             "llamacpp"
         ],
-        "size": 7.12
+        "size": 7.29
+    },
+    "Gemma-4-26B-A4B-it-MTP-GGUF": {
+        "checkpoints": {
+            "main": "unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M",
+            "draft": "unsloth/gemma-4-26B-A4B-it-GGUF:mtp-gemma-4-26B-A4B-it.gguf",
+            "mmproj": "unsloth/gemma-4-26B-A4B-it-GGUF:mmproj-F16.gguf"
+        },
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "hot",
+            "tool-calling",
+            "vision",
+            "llamacpp",
+            "mtp"
+        ],
+        "size": 18.5
+    },
+    "Gemma-4-31B-it-MTP-GGUF": {
+        "checkpoints": {
+            "main": "unsloth/gemma-4-31B-it-GGUF:Q4_K_M",
+            "draft": "unsloth/gemma-4-31B-it-GGUF:mtp-gemma-4-31B-it.gguf",
+            "mmproj": "unsloth/gemma-4-31B-it-GGUF:mmproj-F16.gguf"
+        },
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "hot",
+            "tool-calling",
+            "vision",
+            "llamacpp",
+            "mtp"
+        ],
+        "size": 20.0
+    },
+    "Gemma-4-12B-it-MTP-GGUF": {
+        "checkpoints": {
+            "main": "unsloth/gemma-4-12b-it-GGUF:Q4_K_M",
+            "draft": "unsloth/gemma-4-12b-it-GGUF:mtp-gemma-4-12b-it.gguf",
+            "mmproj": "unsloth/gemma-4-12b-it-GGUF:mmproj-F16.gguf"
+        },
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "tool-calling",
+            "llamacpp",
+            "vision",
+            "mtp"
+        ],
+        "size": 7.75
     },
     "Gemma-4-E4B-it-GGUF": {
         "checkpoint": "unsloth/gemma-4-E4B-it-GGUF:Q4_K_M",

--- a/src/cpp/server/backends/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp_server.cpp
@@ -294,8 +294,9 @@ void LlamaCppServer::load(const std::string& model_name,
         LOG(DEBUG, "LlamaCpp") << "Using GGUF: " << gguf_path << std::endl;
     }
 
-    // Get mmproj path for vision models
+    // Get mmproj path for vision models and drafter path for mtp or other drafting strategies
     std::string mmproj_path = model_info.resolved_path("mmproj");
+    std::string draft_path = model_info.resolved_path("draft");
 
     // Choose port
     port_ = choose_port();
@@ -352,6 +353,12 @@ void LlamaCppServer::load(const std::string& model_name,
         }
     }
     push_reserved(reserved_flags, "--mmproj", std::vector<std::string>{"-mm", "-mmu", "--mmproj-url", "--no-mmproj", "--mmproj-auto", "--no-mmproj-auto", "--mmproj-offload", "--no-mmproj-offload"});
+
+    // Add draft model if present
+    if (!draft_path.empty()) {
+        push_arg(args, reserved_flags, "--model-draft", draft_path);
+    }
+    push_reserved(reserved_flags, "--model-draft", std::vector<std::string>{"-md", "--spec-draft-model"});
 
     // Use legacy reasoning formatting
     push_overridable_arg(args, llamacpp_args, "--reasoning-format", "auto");


### PR DESCRIPTION
- Added support for `draft` checkpoint in llamacpp recipe. This allows downloading a drafter model (MTP, EAGLE3, etc) alongside the main model. Works well with the existing `mtp` label and with manually specifying MTP/drafting options
- Added Gemma4 MTP models that use this mechanism.