### PR TITLE
Support `image[]` parameter for `/v1/images/edits`

### DIFF
--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -677,7 +677,7 @@ Image Editing API. You provide a source image and a text prompt describing the d
 | Parameter | Required | Description | Status |
 |-----------|----------|-------------|--------|
 | `model` | Yes | The Stable Diffusion model to use (e.g., `Flux-2-Klein-4B`, `SD-Turbo`). | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
-| `image` | Yes | The source image file to edit (PNG). Sent as a file in multipart/form-data. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
+| `image` / `image[]` | Yes | The source image file to edit (PNG). Sent as a file in multipart/form-data. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `prompt` | Yes | A text description of the desired edit. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `mask` | No | An optional mask image (PNG). White areas indicate regions to edit; black areas are preserved. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `size` | No | The size of the output image. Format: `WIDTHxHEIGHT` (e.g., `512x512`). Default: `512x512`. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2805,7 +2805,7 @@ bool Server::parse_n_from_form(const httplib::Request& req, httplib::Response& r
 
 bool Server::extract_image_from_form(const httplib::Request& req, httplib::Response& res, nlohmann::json& out) {
     for (const auto& file_pair : req.form.files) {
-        if (file_pair.first == "image") {
+        if (file_pair.first == "image" || file_pair.first == "image[]") {
             const auto& file = file_pair.second;
             out["image_data"] = utils::JsonUtils::base64_encode(file.content);
             out["image_filename"] = file.filename;

--- a/test/server_sd.py
+++ b/test/server_sd.py
@@ -664,6 +664,40 @@ class StableDiffusionTests(ServerTestBase):
         )
         print(f"[OK] Upscale successful ({len(decoded)} bytes)")
 
+    def test_021_image_edit_array_field(self):
+        """Test basic image edit using array parameter syntax."""
+        png_bytes = create_minimal_png(256, 256)
+        print(f"[INFO] Sending image edit request with model {SD_MODEL}")
+
+        response = requests.post(
+            f"{self.base_url}/images/edits",
+            files={"image[]": ("test.png", io.BytesIO(png_bytes), "image/png")},
+            data={
+                "model": SD_MODEL,
+                "prompt": "A red circle",
+                "size": "256x256",
+                "n": "1",
+                "response_format": "b64_json",
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Image edit failed with status {response.status_code}: {response.text}",
+        )
+
+        result = response.json()
+        self.assertIn("data", result, "Response should contain 'data' field")
+        self.assertGreater(
+            len(result["data"]), 0, "Data should have at least one image"
+        )
+        b64_data = result["data"][0]["b64_json"]
+        decoded = base64.b64decode(b64_data)
+        self.assertTrue(decoded[:4] == b"\x89PNG", "Result should be a valid PNG")
+        print(f"[OK] Image edit successful ({len(decoded)} bytes)")
+
 
 if __name__ == "__main__":
     run_server_tests(


### PR DESCRIPTION
Some clients may send the image to be edited to the image edit API using the conventional (but not strictly standard) `[]` suffix to indicate an array of field values in the form, meaning the actual form field name will be `image[]` instead of `image`. [OpenAI has an example accepting this](https://developers.openai.com/api/reference/resources/images/methods/edit), and [Open WebUI does this explicitly](https://github.com/open-webui/open-webui/blob/3660bc00fd807deced3400a63bfa6db47811a3bb/backend/open_webui/routers/images.py#L899).

To make the Lemonade equivalent endpoint more compliant and compatible, it should also accept the image using this naming syntax, even if it currently does not support more than one image, because some clients always use this naming even when sending only one image to be edited.

Fixes https://github.com/lemonade-sdk/lemonade/issues/1963