### PR TITLE
fix(windows): use ProcessManager::run_command for 7z extraction instead of system() Fixes #2313

### DIFF
--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -185,7 +185,8 @@ namespace lemon::backends {
         std::string output;
         int result = lemon::utils::ProcessManager::run_command(command, output, 300);
         if (result != 0) {
-            LOG(ERROR, backend_name) << "Extraction failed with code: " << result << std::endl;
+            LOG(ERROR, backend_name) << "Extraction failed with code: " << result
+                                     << (output.empty() ? "" : " - " + output) << std::endl;
             return false;
         }
         return true;

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -182,7 +182,8 @@ namespace lemon::backends {
         LOG(ERROR, backend_name) << "Error: .7z backend archives are only expected on Windows. Linux CUDA assets should be .tar.xz." << std::endl;
         return false;
 #endif
-        int result = system(command.c_str());
+        std::string output;
+        int result = lemon::utils::ProcessManager::run_command(command, output, 300);
         if (result != 0) {
             LOG(ERROR, backend_name) << "Extraction failed with code: " << result << std::endl;
             return false;


### PR DESCRIPTION
  **Summary**

  - On Windows, system() called from a SUBSYSTEM:WINDOWS process causes a brief console/progress window to flash during 7z extraction. Replaces it with ProcessManager::run_command(), which uses CreateProcess with CREATE_NO_WINDOW to suppress that window while still capturing output and exit codes.

  **Test plan**

  - [x] Trigger a backend installation that extracts a .7z archive on Windows
  - [x] Confirm no console/progress window appears during extraction
  - [x] Confirm extraction completes successfully and the backend loads

Fixes #2313 