### PR TITLE
docs: fix Debian 13 installation docs for issue #2299

### DIFF
--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -239,8 +239,9 @@ Creates `lemonade-server_<VERSION>_amd64.deb` (e.g., `lemonade-server_9.0.3_amd6
 - Installs to `/opt/bin/` (executables)
 - Installs resources to `/opt/share/lemonade-server/`
 - Creates desktop entry in `/opt/share/applications/`
-- Declares dependencies: `libcurl4`, `libssl3`, `libz1`, `unzip`, `fonts-katex`
-- Recommends: `ffmpeg` for whisper.cpp audio resampling and/or transcoding, plus a Chromium-compatible browser for `lemonade-web-app`
+- Declares dependencies: `libcurl4`, `libssl3`, `libz1`, `unzip`, `fonts-katex`, `libcpp-httplib0.41`
+- Recommends: `ffmpeg` for whisper.cpp audio resampling and/or transcoding, `libxrt-npu2` for NPU acceleration,
+  plus a Chromium-compatible browser for `lemonade-web-app`
 - Package size: ~2.2 MB (clean, runtime-only package)
 - Includes postinst script that creates writable `/opt/share/lemonade-server/llama/` directory
 

--- a/docs/guide/install/README.md
+++ b/docs/guide/install/README.md
@@ -16,6 +16,9 @@ Lemonade is available on a broad range of platforms.
 
     [Debian instructions](./debian.md).
 
+    > **Note:** Debian 13 requires the [Debian Backports](https://backports.debian.org/) repository
+    > for `libcpp-httplib0.41` (Debian 13 ships only `libcpp-httplib0.18`).
+
 === "Docker"
 
     [Docker instructions](./docker.md).

--- a/docs/guide/install/debian.md
+++ b/docs/guide/install/debian.md
@@ -2,12 +2,26 @@
 
 Lemonade is built for Debian 13 (Trixie).
 
-Get the `.deb` from the [latest release](https://github.com/lemonade-sdk/lemonade/releases):
-`lemonade-server_<version>-debian13_amd64.deb`
+=== "Prerequisites"
 
-```bash
-sudo apt install ./lemonade-server_*-debian13_amd64.deb
-```
+    Lemonade depends on **`libcpp-httplib0.41`** which is not available in Debian 13's
+    default repositories (it ships `libcpp-httplib0.18` only). You must enable the
+    [Debian Backports](https://backports.debian.org/) repository first:
+
+    ```bash
+    # Add the backports repository
+    echo "deb http://deb.debian.org/debian trixie-backports main" | sudo tee /etc/apt/sources.list.d/backports.list
+    sudo apt update
+    ```
+
+=== "Installation"
+
+    Get the `.deb` from the [latest release](https://github.com/lemonade-sdk/lemonade/releases):
+    `lemonade-server_<version>-debian13_amd64.deb`
+
+    ```bash
+    sudo apt install ./lemonade-server_*-debian13_amd64.deb
+    ```
 
 Enable and start the service:
 


### PR DESCRIPTION
- Add Debian Backports prerequisite to debian.md (libcpp-httplib0.41 not
  available in Debian 13 default repos, only 0.18)
- Add Backports note to install README for quick reference
- Update dev docs dependency list to include libcpp-httplib0.41 and
  libxrt-npu2 which were missing