### PR TITLE
fix(moonshine): return 400 on invalid audio

### DIFF
--- a/src/cpp/server/backends/moonshine_server.cpp
+++ b/src/cpp/server/backends/moonshine_server.cpp
@@ -295,8 +295,35 @@ json MoonshineServer::forward_multipart_audio_data(const std::string& audio_data
     LOG(DEBUG, "MoonshineServer") << "Response status: " << res.status_code << std::endl;
 
     if (res.status_code != 200) {
-        throw std::runtime_error("moonshine-server returned status " +
-                                std::to_string(res.status_code) + ": " + res.body);
+        std::string err_msg = res.body;
+        std::string err_type = "audio_processing_error";
+        int status_code = res.status_code;
+
+        try {
+            json error_json = json::parse(res.body);
+            if (error_json.contains("error")) {
+                if (error_json["error"].is_string()) {
+                    err_msg = error_json["error"].get<std::string>();
+                } else if (error_json["error"].is_object() && error_json["error"].contains("message")) {
+                    err_msg = error_json["error"]["message"].get<std::string>();
+                }
+            }
+        } catch (...) {
+            // Keep res.body as raw error message
+        }
+
+        if (status_code == 400 || (status_code == 500 && err_msg.find("Not a valid RIFF file") != std::string::npos)) {
+            status_code = 400;
+            err_type = "invalid_request_error";
+        }
+
+        return json{
+            {"error", {
+                {"message", "Transcription failed: " + err_msg},
+                {"type", err_type},
+                {"status_code", status_code}
+            }}
+        };
     }
 
     try {
@@ -322,7 +349,8 @@ json MoonshineServer::audio_transcriptions(const json& request) {
         return json{
             {"error", {
                 {"message", std::string("Transcription failed: ") + e.what()},
-                {"type", "audio_processing_error"}
+                {"type", "audio_processing_error"},
+                {"status_code", 500}
             }}
         };
     }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2578,7 +2578,8 @@ void Server::handle_audio_transcriptions(const httplib::Request& req, httplib::R
 
         // Check for error in response
         if (response.contains("error")) {
-            res.status = 500;
+            set_error_response(response, res, 500);
+            return;
         }
 
         res.set_content(response.dump(), "application/json");

--- a/test/server_moonshine.py
+++ b/test/server_moonshine.py
@@ -49,14 +49,17 @@ class MoonshineTests(ServerTestBase):
         import math
 
         n_samples = int(duration_sec * sample_rate)
-        tmp_path = os.path.join(tempfile.gettempdir(), "moonshine_test_audio.wav")
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            tmp_path = tmp.name
 
         with wave.open(tmp_path, "w") as wf:
             wf.setnchannels(1)
             wf.setsampwidth(2)
             wf.setframerate(sample_rate)
             for i in range(n_samples):
-                sample = int(math.sin(2 * math.pi * 440 * i / sample_rate) * 0.3 * 32767)
+                sample = int(
+                    math.sin(2 * math.pi * 440 * i / sample_rate) * 0.3 * 32767
+                )
                 wf.writeframes(struct.pack("<h", sample))
 
         return tmp_path
@@ -85,7 +88,9 @@ class MoonshineTests(ServerTestBase):
                 data = {"model": model_name, "response_format": "json"}
                 resp = requests.post(url, files=files, data=data, timeout=60)
 
-            self.assertEqual(resp.status_code, 200, f"Transcription failed: {resp.text}")
+            self.assertEqual(
+                resp.status_code, 200, f"Transcription failed: {resp.text}"
+            )
 
             result = resp.json()
             self.assertIn("text", result)
@@ -145,10 +150,14 @@ class MoonshineTests(ServerTestBase):
                 frames_per_chunk = rate * chunk_ms // 1000
 
                 async with websockets.connect(ws_url) as ws:
-                    await ws.send(jsonlib.dumps({
-                        "type": "session.update",
-                        "session": {"model": model_name},
-                    }))
+                    await ws.send(
+                        jsonlib.dumps(
+                            {
+                                "type": "session.update",
+                                "session": {"model": model_name},
+                            }
+                        )
+                    )
 
                     async def reader():
                         nonlocal final_text
@@ -171,39 +180,49 @@ class MoonshineTests(ServerTestBase):
                         # continue for the audio that follows
                         for _ in range(3):
                             frames = wf.readframes(frames_per_chunk)
-                            await ws.send(jsonlib.dumps({
-                                "type": "input_audio_buffer.append",
-                                "audio": base64.b64encode(frames).decode(),
-                            }))
+                            await ws.send(
+                                jsonlib.dumps(
+                                    {
+                                        "type": "input_audio_buffer.append",
+                                        "audio": base64.b64encode(frames).decode(),
+                                    }
+                                )
+                            )
                             await asyncio.sleep(chunk_ms / 1000)
                         wf.rewind()
-                        await ws.send(jsonlib.dumps(
-                            {"type": "input_audio_buffer.clear"}
-                        ))
+                        await ws.send(
+                            jsonlib.dumps({"type": "input_audio_buffer.clear"})
+                        )
                         await asyncio.sleep(0.5)
 
                     while True:
                         frames = wf.readframes(frames_per_chunk)
                         if not frames:
                             break
-                        await ws.send(jsonlib.dumps({
-                            "type": "input_audio_buffer.append",
-                            "audio": base64.b64encode(frames).decode(),
-                        }))
+                        await ws.send(
+                            jsonlib.dumps(
+                                {
+                                    "type": "input_audio_buffer.append",
+                                    "audio": base64.b64encode(frames).decode(),
+                                }
+                            )
+                        )
                         await asyncio.sleep(chunk_ms / 1000)
 
                     # Trailing silence lets the streaming model close the line
                     silence = b"\x00\x00" * frames_per_chunk
                     for _ in range(15):
-                        await ws.send(jsonlib.dumps({
-                            "type": "input_audio_buffer.append",
-                            "audio": base64.b64encode(silence).decode(),
-                        }))
+                        await ws.send(
+                            jsonlib.dumps(
+                                {
+                                    "type": "input_audio_buffer.append",
+                                    "audio": base64.b64encode(silence).decode(),
+                                }
+                            )
+                        )
                         await asyncio.sleep(chunk_ms / 1000)
 
-                    await ws.send(jsonlib.dumps(
-                        {"type": "input_audio_buffer.commit"}
-                    ))
+                    await ws.send(jsonlib.dumps({"type": "input_audio_buffer.commit"}))
                     await asyncio.sleep(3)
                     rtask.cancel()
             return events, final_text
@@ -281,10 +300,10 @@ class MoonshineTests(ServerTestBase):
 
         # Find the moonshine-server subprocess PID
         import subprocess
+
         try:
             output = subprocess.check_output(
-                ["pgrep", "-f", "moonshine-server"],
-                text=True
+                ["pgrep", "-f", "moonshine-server"], text=True
             ).strip()
             if not output:
                 self.skipTest("moonshine-server process not found")
@@ -295,13 +314,94 @@ class MoonshineTests(ServerTestBase):
                     if line.startswith("Threads:"):
                         thread_count = int(line.split()[1])
                         self.assertLessEqual(
-                            thread_count, 10,
-                            f"moonshine-server spawned {thread_count} threads (expected <= 10)"
+                            thread_count,
+                            10,
+                            f"moonshine-server spawned {thread_count} threads (expected <= 10)",
                         )
                         print(f"[MoonshineTest] Thread count: {thread_count}")
                         break
         except Exception as e:
             self.skipTest(f"Could not check thread count: {e}")
+
+    @skip_if_unsupported("transcription")
+    def test_moonshine_invalid_file_transcription(self):
+        """Test that transcribing an invalid/unsupported file returns a 400 Bad Request."""
+        model_name = _get_moonshine_model()
+        if not model_name or "Moonshine" not in model_name:
+            self.skipTest("No Moonshine model configured for testing")
+
+        self._load_model(model_name)
+
+        # Create an invalid WAV file (just some text content) using NamedTemporaryFile
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            tmp.write(b"This is not a valid RIFF/WAV file.")
+            tmp_path = tmp.name
+
+        try:
+            url = f"http://127.0.0.1:{PORT}/v1/audio/transcriptions"
+            with open(tmp_path, "rb") as f:
+                files = {"file": ("test.wav", f, "audio/wav")}
+                data = {"model": model_name, "response_format": "json"}
+                resp = requests.post(url, files=files, data=data, timeout=60)
+
+            # We expect a 400 Bad Request
+            self.assertEqual(
+                resp.status_code,
+                400,
+                f"Expected 400 but got {resp.status_code}: {resp.text}",
+            )
+
+            result = resp.json()
+            self.assertIn("error", result)
+            self.assertIn("message", result["error"])
+            self.assertEqual(result["error"]["type"], "invalid_request_error")
+
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    @skip_if_unsupported("transcription")
+    def test_moonshine_unsupported_ogg_transcription(self):
+        """Test that transcribing a valid but unsupported Ogg audio file returns a 400 Bad Request."""
+        model_name = _get_moonshine_model()
+        if not model_name or "Moonshine" not in model_name:
+            self.skipTest("No Moonshine model configured for testing")
+
+        self._load_model(model_name)
+
+        import base64
+
+        # A tiny valid silent Ogg file fixture (180 bytes)
+        ogg_data = base64.b64decode(
+            "T2dnUwACAAAAAAAAAAAyzN3NAAAAAGFf2X8BM39GTEFDAQAAAWZMYUMAAAAiEgASAAAAAAAkFQrEQPAAAAAAAAAAAAAAAAAAAAAAAAAAAE9nZ1MAAAAAAAAAAAAAMszdzQEAAAD5LKCSATeEAAAzDQAAAExhdmY1NS40OC4xMDABAAAAGgAAAGVuY29kZXI9TGF2YzU1LjY5LjEwMCBmbGFjT2dnUwAEARIAAAAAAAAyzN3NAgAAAKWVljkCDAD/+GkIAAAdAAABICI="
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as tmp:
+            tmp.write(ogg_data)
+            tmp_path = tmp.name
+
+        try:
+            url = f"http://127.0.0.1:{PORT}/v1/audio/transcriptions"
+            with open(tmp_path, "rb") as f:
+                files = {"file": ("test.ogg", f, "audio/ogg")}
+                data = {"model": model_name, "response_format": "json"}
+                resp = requests.post(url, files=files, data=data, timeout=60)
+
+            # Ogg is unsupported by Moonshine, so it must return 400 Bad Request
+            self.assertEqual(
+                resp.status_code,
+                400,
+                f"Expected 400 but got {resp.status_code}: {resp.text}",
+            )
+
+            result = resp.json()
+            self.assertIn("error", result)
+            self.assertIn("message", result["error"])
+            self.assertEqual(result["error"]["type"], "invalid_request_error")
+
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
 
 
 if __name__ == "__main__":

--- a/tools/moonshine-server/main.py
+++ b/tools/moonshine-server/main.py
@@ -58,38 +58,41 @@ except ImportError as e:
     ) from e
 
 
-def convert_tokenizer_json_to_bin(tokenizer_json_path: str, tokenizer_bin_path: str) -> None:
+def convert_tokenizer_json_to_bin(
+    tokenizer_json_path: str, tokenizer_bin_path: str
+) -> None:
     """Convert a HuggingFace tokenizer.json to moonshine's tokenizer.bin format."""
     import json
-    with open(tokenizer_json_path, 'r', encoding='utf-8') as f:
+
+    with open(tokenizer_json_path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
-    model = data.get('model', {})
-    vocab = model.get('vocab', {})
+    model = data.get("model", {})
+    vocab = model.get("vocab", {})
     if not vocab:
         raise ValueError(f"No vocabulary found in {tokenizer_json_path}")
 
     vocab_size = len(vocab)
-    tokens = [b''] * vocab_size
+    tokens = [b""] * vocab_size
     for token_str, token_id in vocab.items():
         if token_id < vocab_size:
-            tokens[token_id] = token_str.encode('utf-8')
+            tokens[token_id] = token_str.encode("utf-8")
 
-    added_tokens = data.get('added_tokens', [])
+    added_tokens = data.get("added_tokens", [])
     for added in added_tokens:
-        token_id = added.get('id')
-        content = added.get('content', '')
+        token_id = added.get("id")
+        content = added.get("content", "")
         if token_id is not None and token_id < len(tokens):
-            tokens[token_id] = content.encode('utf-8')
+            tokens[token_id] = content.encode("utf-8")
         elif token_id is not None and token_id >= len(tokens):
-            tokens.extend([b''] * (token_id - len(tokens) + 1))
-            tokens[token_id] = content.encode('utf-8')
+            tokens.extend([b""] * (token_id - len(tokens) + 1))
+            tokens[token_id] = content.encode("utf-8")
 
-    with open(tokenizer_bin_path, 'wb') as f:
+    with open(tokenizer_bin_path, "wb") as f:
         for token_bytes in tokens:
             length = len(token_bytes)
             if length == 0:
-                f.write(b'\x00')
+                f.write(b"\x00")
             elif length < 128:
                 f.write(bytes([length]))
                 f.write(token_bytes)
@@ -103,15 +106,19 @@ def convert_tokenizer_json_to_bin(tokenizer_json_path: str, tokenizer_bin_path: 
 def ensure_tokenizer_bin(model_path: str) -> None:
     """Ensure tokenizer.bin exists in model_path, converting from tokenizer.json if needed."""
     import os
-    bin_path = os.path.join(model_path, 'tokenizer.bin')
+
+    bin_path = os.path.join(model_path, "tokenizer.bin")
     if os.path.exists(bin_path):
         return
-    json_path = os.path.join(model_path, 'tokenizer.json')
+    json_path = os.path.join(model_path, "tokenizer.json")
     if not os.path.exists(json_path):
         raise FileNotFoundError(
             f"Neither tokenizer.bin nor tokenizer.json found in {model_path}"
         )
-    print(f"[moonshine-server] Converting tokenizer.json -> tokenizer.bin ...", file=sys.stderr)
+    print(
+        f"[moonshine-server] Converting tokenizer.json -> tokenizer.bin ...",
+        file=sys.stderr,
+    )
     convert_tokenizer_json_to_bin(json_path, bin_path)
     print(f"[moonshine-server] Wrote {bin_path}", file=sys.stderr)
 
@@ -119,6 +126,7 @@ def ensure_tokenizer_bin(model_path: str) -> None:
 def load_model(model_path: str, model_arch: int):
     """Lazy import and load moonshine model."""
     from moonshine_voice import Transcriber, ModelArch
+
     ensure_tokenizer_bin(model_path)
     arch = ModelArch(model_arch)
     return Transcriber(model_path=model_path, model_arch=arch)
@@ -141,6 +149,7 @@ def _generate_id(prefix: str = "sess_", length: int = 24) -> str:
 
 class _EventSender:
     """Abstract base for sending events to a client."""
+
     def send(self, msg: dict):
         raise NotImplementedError
 
@@ -159,8 +168,7 @@ class WebSocketEventSender(_EventSender):
             return
         try:
             asyncio.run_coroutine_threadsafe(
-                self.websocket.send(json.dumps(msg)),
-                self.loop
+                self.websocket.send(json.dumps(msg)), self.loop
             )
         except Exception:
             self._closed = True
@@ -239,10 +247,12 @@ class StreamingListener(TranscriptEventListener):
             return
         text = event.line.text or ""
         self._current_text = text
-        self.sender.send({
-            "type": "conversation.item.input_audio_transcription.delta",
-            "delta": text,
-        })
+        self.sender.send(
+            {
+                "type": "conversation.item.input_audio_transcription.delta",
+                "delta": text,
+            }
+        )
 
     def on_line_completed(self, event):
         if self._suppress_line:
@@ -254,10 +264,12 @@ class StreamingListener(TranscriptEventListener):
         # stop event before the final transcript, mirroring the OpenAI ordering
         # (speech_stopped -> transcription.completed).
         self.sender.send({"type": "input_audio_buffer.speech_stopped"})
-        self.sender.send({
-            "type": "conversation.item.input_audio_transcription.completed",
-            "transcript": text,
-        })
+        self.sender.send(
+            {
+                "type": "conversation.item.input_audio_transcription.completed",
+                "transcript": text,
+            }
+        )
         self._current_text = ""
 
 
@@ -335,10 +347,12 @@ async def _handle_streaming_session(reader, sender: _EventSender, transcriber_fa
                     # No finalizer available — synthesize the final transcript
                     # from the last interim so the client is never left waiting.
                     sender.send({"type": "input_audio_buffer.speech_stopped"})
-                    sender.send({
-                        "type": "conversation.item.input_audio_transcription.completed",
-                        "transcript": listener._current_text,
-                    })
+                    sender.send(
+                        {
+                            "type": "conversation.item.input_audio_transcription.completed",
+                            "transcript": listener._current_text,
+                        }
+                    )
                     listener._current_text = ""
 
             elif msg_type == "session.update":
@@ -363,15 +377,14 @@ async def websocket_handler(websocket, transcriber_factory):
     loop = asyncio.get_running_loop()
 
     sender = WebSocketEventSender(loop, websocket)
-    sender.send({
-        "type": "session.created",
-        "session": {"id": session_id}
-    })
+    sender.send({"type": "session.created", "session": {"id": session_id}})
 
     await _handle_streaming_session(websocket, sender, transcriber_factory)
 
 
-async def tcp_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter, transcriber_factory):
+async def tcp_handler(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter, transcriber_factory
+):
     """Handle a single TCP connection for line-delimited JSON streaming."""
     sender = TcpEventSender(writer)
     await _handle_streaming_session(reader, sender, transcriber_factory)
@@ -452,7 +465,9 @@ def get_handler(transcriber, tcp_ready=None):
                     ".flac": ".flac",
                     ".webm": ".webm",
                 }
-                client_ext = os.path.splitext(file_item.filename or "audio.wav")[1].lower()
+                client_ext = os.path.splitext(file_item.filename or "audio.wav")[
+                    1
+                ].lower()
                 ext = allowed_exts.get(client_ext, ".wav")
                 with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
                     tmp.write(audio_bytes)
@@ -460,7 +475,12 @@ def get_handler(transcriber, tcp_ready=None):
 
                 try:
                     from moonshine_voice import load_wav_file
-                    audio_data, sample_rate = load_wav_file(tmp_path)
+
+                    try:
+                        audio_data, sample_rate = load_wav_file(tmp_path)
+                    except Exception as e:
+                        self._error(400, f"Invalid audio file: {str(e)}")
+                        return
                 finally:
                     try:
                         os.unlink(tmp_path)
@@ -468,7 +488,9 @@ def get_handler(transcriber, tcp_ready=None):
                         pass
 
                 # Transcribe
-                result = transcriber.transcribe_without_streaming(audio_data, sample_rate)
+                result = transcriber.transcribe_without_streaming(
+                    audio_data, sample_rate
+                )
 
                 # Build OpenAI-compatible response
                 text = " ".join(line.text for line in result.lines)
@@ -537,16 +559,22 @@ def _fmt_timestamp(seconds: float, vtt: bool = False) -> str:
 
 def run_websocket_server(host: str, port: int, transcriber_factory):
     """Run the WebSocket server in a dedicated asyncio event loop (thread target)."""
+
     async def _serve():
         async def _handler(websocket):
             await websocket_handler(websocket, transcriber_factory)
 
         # Suppress websockets library logging noise
         import logging
+
         logging.getLogger("websockets").setLevel(logging.WARNING)
 
         async with websockets.serve(_handler, host, port):
-            print(f"[moonshine-server] WebSocket listening on ws://{host}:{port}", file=sys.stderr, flush=True)
+            print(
+                f"[moonshine-server] WebSocket listening on ws://{host}:{port}",
+                file=sys.stderr,
+                flush=True,
+            )
             await asyncio.Future()  # Run forever
 
     loop = asyncio.new_event_loop()
@@ -556,12 +584,16 @@ def run_websocket_server(host: str, port: int, transcriber_factory):
 
 def run_tcp_server(host: str, port: int, transcriber_factory, ready_event=None):
     """Run the TCP line-delimited JSON server in a dedicated asyncio event loop (thread target)."""
+
     async def _serve():
         server = await asyncio.start_server(
-            lambda r, w: tcp_handler(r, w, transcriber_factory),
-            host, port
+            lambda r, w: tcp_handler(r, w, transcriber_factory), host, port
         )
-        print(f"[moonshine-server] TCP listening on {host}:{port}", file=sys.stderr, flush=True)
+        print(
+            f"[moonshine-server] TCP listening on {host}:{port}",
+            file=sys.stderr,
+            flush=True,
+        )
         if ready_event is not None:
             ready_event.set()
         async with server:
@@ -573,12 +605,29 @@ def run_tcp_server(host: str, port: int, transcriber_factory, ready_event=None):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Moonshine HTTP + WebSocket + TCP server for Lemonade")
+    parser = argparse.ArgumentParser(
+        description="Moonshine HTTP + WebSocket + TCP server for Lemonade"
+    )
     parser.add_argument("--model-path", required=True, help="Path to model directory")
-    parser.add_argument("--model-arch", type=int, default=5, help="Model architecture enum value (default: 5)")
+    parser.add_argument(
+        "--model-arch",
+        type=int,
+        default=5,
+        help="Model architecture enum value (default: 5)",
+    )
     parser.add_argument("--port", type=int, default=8080, help="HTTP server port")
-    parser.add_argument("--ws-port", type=int, default=None, help="WebSocket server port (default: HTTP port + 1)")
-    parser.add_argument("--tcp-port", type=int, default=None, help="TCP line-delimited JSON port (default: HTTP port + 2)")
+    parser.add_argument(
+        "--ws-port",
+        type=int,
+        default=None,
+        help="WebSocket server port (default: HTTP port + 1)",
+    )
+    parser.add_argument(
+        "--tcp-port",
+        type=int,
+        default=None,
+        help="TCP line-delimited JSON port (default: HTTP port + 2)",
+    )
     args = parser.parse_args()
 
     ws_port = args.ws_port if args.ws_port is not None else args.port + 1
@@ -586,9 +635,15 @@ def main():
 
     model_path = args.model_path
 
-    print(f"[moonshine-server] Loading model from {model_path} (arch={args.model_arch})...", file=sys.stderr)
+    print(
+        f"[moonshine-server] Loading model from {model_path} (arch={args.model_arch})...",
+        file=sys.stderr,
+    )
     transcriber = load_model(model_path, args.model_arch)
-    print(f"[moonshine-server] Model loaded. HTTP={args.port} WS={ws_port} TCP={tcp_port}", file=sys.stderr)
+    print(
+        f"[moonshine-server] Model loaded. HTTP={args.port} WS={ws_port} TCP={tcp_port}",
+        file=sys.stderr,
+    )
 
     # Share the loaded transcriber across connections; each streaming session
     # gets its own stream via create_stream(). Loading a fresh model per


### PR DESCRIPTION
Return 400 Bad Request instead of 500 when audio format is invalid. Add integration test coverage for WAV RIFF errors and unsupported OGG.