### PR TITLE
Fix: eviction_engine does not run  nvidia-smi on AMD configs anymore and some testing problems fixed.

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -4075,30 +4075,31 @@ double SystemInfo::get_global_vram_usage_pct() {
 
     // NVIDIA: one query returns used + total for the first GPU.
     {
-        std::string output;
-        int rc = lemon::utils::ProcessManager::run_command(
-            "nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits",
-            output, 5);
-        if (rc == 0 && !output.empty()) {
-            std::istringstream iss(output);
-            std::string line;
-            if (std::getline(iss, line)) {
-                size_t comma = line.find(',');
-                if (comma != std::string::npos) {
-                    try {
-                        double used = std::stod(line.substr(0, comma));
-                        double total = std::stod(line.substr(comma + 1));
-                        if (total > 0.0) {
-                            return used / total;
+        if (!get_cuda_arch().empty()) {
+            std::string output;
+            int rc = lemon::utils::ProcessManager::run_command(
+                "nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits",
+                output, 5);
+            if (rc == 0 && !output.empty()) {
+                std::istringstream iss(output);
+                std::string line;
+                if (std::getline(iss, line)) {
+                    size_t comma = line.find(',');
+                    if (comma != std::string::npos) {
+                        try {
+                            double used = std::stod(line.substr(0, comma));
+                            double total = std::stod(line.substr(comma + 1));
+                            if (total > 0.0) {
+                                return used / total;
+                            }
+                        } catch (...) {
+                            // fall through to other sources
                         }
-                    } catch (...) {
-                        // fall through to other sources
                     }
                 }
             }
         }
     }
-
 #ifdef __linux__
     // AMD (and other DRM GPUs): read used/total from sysfs, taking the busiest card.
     try {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -4087,7 +4087,7 @@ double SystemInfo::get_global_vram_usage_pct() {
 
     // NVIDIA: one query returns used + total for the first GPU.
     {
-        if (!get_cuda_arch().empty()) {
+        if (!find_executable_in_path("nvidia-smi").empty()) {
             std::string output;
             int rc = lemon::utils::ProcessManager::run_command(
                 "nvidia-smi --query-gpu=memory.used,memory.total --format=csv,noheader,nounits",

--- a/test/server_eviction.py
+++ b/test/server_eviction.py
@@ -6,6 +6,7 @@ import time
 from utils.server_base import ServerTestBase, pull_model_with_retry
 from utils.test_models import (
     ENDPOINT_TEST_MODEL,
+    SECOND_TEST_MODEL_EVICTION,
     TIMEOUT_MODEL_OPERATION,
     TIMEOUT_DEFAULT,
 )
@@ -19,7 +20,7 @@ class EvictionTests(ServerTestBase):
 
     _model_pulled = False
     _model2_pulled = False
-    MODEL2 = "Phi-4-mini-instruct-GGUF"
+    MODEL2 = SECOND_TEST_MODEL_EVICTION
 
     @classmethod
     def setUpClass(cls):
@@ -187,14 +188,14 @@ class EvictionTests(ServerTestBase):
 
         requests.post(
             f"{self.base_url.replace('/api/v1', '')}/internal/set",
-            json={"auto_evict": True, "auto_evict_threshold_pct": 0.90},
+            json={"auto_evict": True, "auto_evict_threshold_pct": 0.90, "max_models_loaded" : 2},
             headers=headers,
         )
 
         # Protected model loaded first (older) but with a large weight factor.
         requests.post(
             f"{self.base_url}/load",
-            json={"model_name": ENDPOINT_TEST_MODEL, "evict_weight_factor": 1000.0, "max_models_loaded" : 2},
+            json={"model_name": ENDPOINT_TEST_MODEL, "evict_weight_factor": 1000.0},
             timeout=TIMEOUT_MODEL_OPERATION,
         )
         time.sleep(2)

--- a/test/server_eviction.py
+++ b/test/server_eviction.py
@@ -188,7 +188,7 @@ class EvictionTests(ServerTestBase):
 
         requests.post(
             f"{self.base_url.replace('/api/v1', '')}/internal/set",
-            json={"auto_evict": True, "auto_evict_threshold_pct": 0.90, "max_models_loaded" : 2},
+            json={"auto_evict": True, "auto_evict_threshold_pct": 0.90, "max_loaded_models" : 2},
             headers=headers,
         )
 

--- a/test/server_eviction.py
+++ b/test/server_eviction.py
@@ -19,7 +19,7 @@ class EvictionTests(ServerTestBase):
 
     _model_pulled = False
     _model2_pulled = False
-    MODEL2 = "phi-3-mini-4k-instruct-q4"
+    MODEL2 = "Phi-4-mini-instruct-GGUF"
 
     @classmethod
     def setUpClass(cls):
@@ -83,7 +83,7 @@ class EvictionTests(ServerTestBase):
 
         requests.post(
             f"{self.base_url.replace('/api/v1', '')}/internal/set",
-            json={"auto_evict": True, "auto_evict_threshold_pct": 0.90},
+            json={"auto_evict": True, "auto_evict_threshold_pct": 0.90,"max_loaded_models": 2},
             headers=headers,
         )
 
@@ -194,7 +194,7 @@ class EvictionTests(ServerTestBase):
         # Protected model loaded first (older) but with a large weight factor.
         requests.post(
             f"{self.base_url}/load",
-            json={"model_name": ENDPOINT_TEST_MODEL, "evict_weight_factor": 1000.0},
+            json={"model_name": ENDPOINT_TEST_MODEL, "evict_weight_factor": 1000.0, "max_models_loaded" : 2},
             timeout=TIMEOUT_MODEL_OPERATION,
         )
         time.sleep(2)
@@ -203,6 +203,7 @@ class EvictionTests(ServerTestBase):
             json={"model_name": self.MODEL2},
             timeout=TIMEOUT_MODEL_OPERATION,
         )
+        time.sleep(2)
 
         self._simulate_vram_pressure(0.95)
 

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -196,6 +196,9 @@ TOOL_CALLING_MODEL = "Qwen3-4B-Instruct-2507-GGUF"
 # Secondary model for multi-model testing (small, fast to load)
 MULTI_MODEL_SECONDARY = "Tiny-Test-Model-GGUF"
 
+# Secondary model for eviction testing
+SECOND_TEST_MODEL_EVICTION = "Phi-4-mini-instruct-GGUF"
+
 # Tertiary model for LRU eviction testing
 MULTI_MODEL_TERTIARY = "Qwen3-0.6B-GGUF"
 


### PR DESCRIPTION
Hi!

I found some bugs on eviction engine.

First, my config is all AMD hardware and when I launched lemonade I saw this line repeated all time:

sh 1: nvidia-smi not found.

looking  at code, I saw at system_info.cpp  funtion  double SystemInfo::get_global_vram_usage_pct()  that it was always executing the call to nvidia-smi program so if somebody had amd config, it will not find this program.

<img width="1703" height="718" alt="image" src="https://github.com/user-attachments/assets/57872408-7a0f-475b-8462-f7e6fdb60e8a" />

I fixed  making a get_cuda_arch().empty()) call to  check if you have some nvidia arch on your config.  If so.. it launches the code.

Second, I tryed the server_eviction.py tests. but I found some errors.

- The Script loads a test model  phi-3-mini-4k-instruct-q4 that did not exists on lemonade so it failed. I changed by equivalent  Phi-4-mini-instruct-GGUF.
- The tests usually loaded 2 models but it did not changed the by default config so the server always had  max_models_loaded = 1 and failed when the second model was loaded.
- Finally at  def test_weight_factor_protects_model(self): test , i found  that it loads  the first model (with weight), sleeps 2 seconds and loads the second one. It always failed and unloaded the one with weight. Looking the code and doing some manual testing I found that when it loaded the second model, the first model was about 3 seconds at server and the seconds 3 ms. So the 1000 value of weight did not difference. The solution I thought was do another sleep after the  second model load and when I executed i found it passed the test!! it unload the second one .

<img width="1003" height="487" alt="image" src="https://github.com/user-attachments/assets/6f44d456-3d45-4596-b4ce-145547b27b42" />

I hope these changes help.