### PR TITLE
Downgrade metal version from v1.8.5 to v1.8.4

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -13,7 +13,7 @@
     "vulkan": "v1.8.4",
     "rocm": "v1.8.4",
     "npu": "v1.8.4",
-    "metal": "v1.8.5"
+    "metal": "v1.8.4"
   },
   "sd-cpp": {
     "cpu": "master-672-1f9ee88",


### PR DESCRIPTION
This is the PR needed to get CI running again.

The version was updated since there was a fix with v1.8.5 available at that time - but this is not available anymore since the full update for all backends failed for the NPU.

Therefore a temporarily downgrade is needed and fastest solution.