### PR TITLE
devcontainers - Create the python env and install reqs to allow python test execution

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,7 +26,14 @@ ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+RUN chown -R vscode:vscode ${VIRTUAL_ENV}
+
 WORKDIR /usr/src/app
 
 # Copy the Project Root into the container
 COPY . .
+
+# We create XDG_RUNTIME ENV VAR.
+RUN mkdir -p /run/lemonade
+RUN chown vscode:vscode /run/lemonade
+ENV XDG_RUNTIME_DIR=/run/lemonade

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     python3 \
-    python3-pip \
+    python3-pip \los
     python3-dev \
     python3-venv \
     python3-setuptools \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN if [ "${REINSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     python3 \
-    python3-pip \los
+    python3-pip \
     python3-dev \
     python3-venv \
     python3-setuptools \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
 				"ms-vscode.cpptools-extension-pack" // (Optional) Adds CMake & Themes
 			]
 		}
-	}
+	}, 
+	"postCreateCommand": "/opt/venv/bin/pip install -r ./test/requirements.txt"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 				"ms-vscode.cpptools-extension-pack" // (Optional) Adds CMake & Themes
 			]
 		}
-	}, 
+	},
 	"postCreateCommand": "/opt/venv/bin/pip install -r ./test/requirements.txt"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.


### PR DESCRIPTION
Hello,

I have changed the files of .devcontainer to install the python env and pip dependencies on deploy  so now when you finish deploying your devcontainer you can call the test with 

/opt/venv/bin/python3 ./test/server_cli2.py

Do not forget to run lemond before testing! :)

<img width="1144" height="411" alt="image" src="https://github.com/user-attachments/assets/219a85e9-89c3-4f90-a745-b70c456d869a" />



NOTE: I have configured the env var  => XDG_RUNTIME_DIR=/run/lemonade because the previous deploy always failed and I had to define it. Now it will define on create container.