### PR TITLE
Better auto context size estimate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1787,3 +1787,22 @@ if(EXISTS "${_INSTALL_ATOMICITY_TEST_SRC}")
     include(CTest)
     add_test(NAME InstallAtomicityTest COMMAND test_install_atomicity)
 endif()
+
+# Auto-tune: GGUF array storage, scalar derivation, weighted KV cache computation.
+# Covers head_count_kv_per_layer, sliding_window_pattern, SWA precise weighted sum,
+# full_attention_interval exact count, and scalar fallback paths.
+set(_AUTO_TUNE_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_auto_tune.cpp"
+)
+if(EXISTS "${_AUTO_TUNE_TEST_SRC}")
+    add_executable(test_auto_tune
+        test/cpp/test_auto_tune.cpp
+    )
+    target_include_directories(test_auto_tune PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+
+    include(CTest)
+    add_test(NAME AutoTuneTest COMMAND test_auto_tune)
+endif()

--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -98,7 +98,7 @@ inline double get_available_memory_gb(DeviceType device_type) {
         if (amd_igpu.available && amd_igpu.vram_gb > 0) {
             // iGPU total = dedicated VRAM + GTT (system memory pool accessible by GPU)
             double total_gb = amd_igpu.vram_gb + amd_igpu.virtual_gb;
-            double available = std::max(0.0, total_gb - used_gb);
+            double available = (std::max)(0.0, total_gb - used_gb);
             LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (AMD iGPU) total="
                                    << std::fixed << std::setprecision(2) << total_gb
                                    << " GB (vram=" << amd_igpu.vram_gb
@@ -111,7 +111,7 @@ inline double get_available_memory_gb(DeviceType device_type) {
         auto amd_dgpus = si->get_amd_dgpu_devices();
         for (const auto& gpu : amd_dgpus) {
             if (gpu.available && gpu.vram_gb > 0) {
-                double available = std::max(0.0, gpu.vram_gb - used_gb);
+                double available = (std::max)(0.0, gpu.vram_gb - used_gb);
                 LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (AMD dGPU) total="
                                        << std::fixed << std::setprecision(2) << gpu.vram_gb
                                        << " GB, used=" << used_gb
@@ -124,7 +124,7 @@ inline double get_available_memory_gb(DeviceType device_type) {
         auto nvidia_gpus = si->get_nvidia_gpu_devices();
         for (const auto& gpu : nvidia_gpus) {
             if (gpu.available && gpu.vram_gb > 0) {
-                double available = std::max(0.0, gpu.vram_gb - used_gb);
+                double available = (std::max)(0.0, gpu.vram_gb - used_gb);
                 LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (NVIDIA) total="
                                        << std::fixed << std::setprecision(2) << gpu.vram_gb
                                        << " GB, used=" << used_gb
@@ -140,8 +140,8 @@ inline double get_available_memory_gb(DeviceType device_type) {
         // working-set budget so we don't push the system into swap.
         auto apple = si->get_apple_silicon_device();
         if (apple.available && apple.vram_gb > 0) {
-            double free_unified = std::max(0.0, apple.virtual_gb - used_gb);
-            double available = std::min(apple.vram_gb, free_unified);
+            double free_unified = (std::max)(0.0, apple.virtual_gb - used_gb);
+            double available = (std::min)(apple.vram_gb, free_unified);
             LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (Metal) budget="
                                    << std::fixed << std::setprecision(2) << apple.vram_gb
                                    << " GB, unified=" << apple.virtual_gb
@@ -156,7 +156,7 @@ inline double get_available_memory_gb(DeviceType device_type) {
     // as virtual_gb on the Apple Silicon device.
     auto apple = si->get_apple_silicon_device();
     if (apple.available && apple.virtual_gb > 0) {
-        double available = std::max(0.0, apple.virtual_gb - used_gb);
+        double available = (std::max)(0.0, apple.virtual_gb - used_gb);
         LOG(DEBUG, "AutoTune") << "get_available_memory_gb: CPU/NPU (Apple Silicon unified) total="
                                << std::fixed << std::setprecision(2) << apple.virtual_gb
                                << " GB, used=" << used_gb
@@ -168,7 +168,7 @@ inline double get_available_memory_gb(DeviceType device_type) {
     auto amd_igpu = si->get_amd_igpu_device();
     if (amd_igpu.available && amd_igpu.vram_gb > 0) {
         double total_gb = amd_igpu.vram_gb + amd_igpu.virtual_gb;
-        double available = std::max(0.0, total_gb - used_gb);
+        double available = (std::max)(0.0, total_gb - used_gb);
         LOG(DEBUG, "AutoTune") << "get_available_memory_gb: CPU/NPU (AMD iGPU proxy) total="
                                << std::fixed << std::setprecision(2) << total_gb
                                << " GB, used=" << used_gb
@@ -180,7 +180,7 @@ inline double get_available_memory_gb(DeviceType device_type) {
     auto amd_dgpus = si->get_amd_dgpu_devices();
     for (const auto& gpu : amd_dgpus) {
         if (gpu.available && gpu.virtual_gb > 0) {
-            double available = std::max(0.0, gpu.virtual_gb - used_gb);
+            double available = (std::max)(0.0, gpu.virtual_gb - used_gb);
             LOG(DEBUG, "AutoTune") << "get_available_memory_gb: CPU/NPU (AMD dGPU GTT proxy) total="
                                    << std::fixed << std::setprecision(2) << gpu.virtual_gb
                                    << " GB, used=" << used_gb
@@ -247,7 +247,7 @@ inline int64_t compute_auto_context_size(const ModelInfo& model_info,
 
     // Available memory for KV cache = total - used - model weights
     // (used is already subtracted in get_available_memory_gb)
-    double model_weight_gb = std::max(0.0, model_info.size);
+    double model_weight_gb = (std::max)(0.0, model_info.size);
     double available_for_kv_gb = available_memory_gb - model_weight_gb;
 
     if (available_for_kv_gb <= 0) {

--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -192,56 +192,6 @@ inline double get_available_memory_gb(DeviceType device_type) {
     LOG(DEBUG, "AutoTune") << "get_available_memory_gb: could not determine memory, returning 0.0";
     return 0.0;  // Could not determine
 }
-
-/**
- * Compute the maximum context window that fits in available memory based on
- * GGUF architecture metadata.
- *
- * Base formula (standard MHA/GQA):
- *   kv_bytes_per_token = head_count_kv × key_length × 2[F16] × 2[K+V]
- *   (head_count_kv is total KV heads across all blocks)
- *
- * Architecture-specific scaling factors reduce this for models that compress
- * their KV cache.  Rules are driven by GGUF metadata, not architecture names:
- *   - SWA with reduced dims: factor = 1 - swa_ratio + swa_ratio × (key_swa / key)
- *   - Hybrid SSM-attention: factor = 1 / full_attention_interval
- *   - Neither detected: factor = 1.0 (conservative)
- *
- *   max_ctx = floor((available_memory_gb × 1024³ - weights) / kv_bytes_per_token)
- *   ctx_size = min(model_max_context_window, max_ctx)
- *
- * When GGUF metadata is unavailable, estimates kv_bytes_per_token from model size.
- * For embedding models, the result is floored at EMBEDDING_CTX_SIZE.
- *
- * @param model_info       Model metadata including GGUF architecture fields
- * @param available_memory_gb  Total memory available for the model (VRAM or system RAM)
- * @param is_embedding     Whether this is an embedding model (applies minimum floor)
- * @return Resolved context size, or AUTO_CTX_FALLBACK if computation fails
- */
-static double compute_kv_cache_scaling_factor(const GgufMetadata& gguf) {
-    // SWA with reduced dimensions: some layers store smaller key/value vectors.
-    // Detected by sliding_window_pattern (→ swa_layer_count) and key_length_swa < key_length.
-    // Approximation assumes KV heads are distributed proportionally across layers.
-    if (gguf.swa_layer_count > 0 &&
-        gguf.block_count > 0 &&
-        gguf.key_length_swa > 0 && gguf.key_length > 0 &&
-        gguf.key_length_swa < gguf.key_length) {
-        double swa_ratio = static_cast<double>(gguf.swa_layer_count) /
-                           static_cast<double>(gguf.block_count);
-        double dim_ratio = static_cast<double>(gguf.key_length_swa) /
-                           static_cast<double>(gguf.key_length);
-        double factor = 1.0 - swa_ratio + swa_ratio * dim_ratio;
-        return std::max(0.1, factor);
-    }
-
-    // Hybrid SSM-attention: only 1 every `full_attention_interval` layers grows KV cache;
-    // the rest use SSM recurrent state (constant memory regardless of context length).
-    if (gguf.full_attention_interval > 1) {
-        return 1.0 / static_cast<double>(gguf.full_attention_interval);
-    }
-
-    return 1.0;  // Standard MHA/GQA — no scaling
-}
 inline int64_t compute_auto_context_size(const ModelInfo& model_info,
                                           double available_memory_gb,
                                           bool is_embedding = false) {
@@ -262,16 +212,28 @@ inline int64_t compute_auto_context_size(const ModelInfo& model_info,
     int64_t key_length = model_info.gguf.key_length;
 
     if (block_count > 0 && head_count_kv > 0 && key_length > 0) {
-        // Base formula: total_kv_heads × head_dim × 2[F16] × 2[K+V]
-        // head_count_kv is already the total across all blocks
-        kv_cache_scale = compute_kv_cache_scaling_factor(model_info.gguf);
-        kv_bytes_per_token = static_cast<double>(head_count_kv)
-                            * static_cast<double>(key_length)
-                            * 2.0  // F16 = 2 bytes per element
-                            * 2.0  // K cache + V cache
-                            * kv_cache_scale;
+        kv_bytes_per_token = compute_weighted_kv_cache_bytes_per_token(
+            model_info.gguf, &kv_cache_scale);
         if (kv_cache_scale < 1.0) {
             estimated = true;  // mark as architecture-adjusted
+        }
+        // Log precise SWA head breakdown when raw arrays are available
+        if (model_info.gguf.key_length_swa > 0 &&
+            model_info.gguf.key_length_swa < model_info.gguf.key_length &&
+            !model_info.gguf.head_count_kv_per_layer.empty() &&
+            !model_info.gguf.sliding_window_pattern.empty()) {
+            int64_t swa_heads = 0, full_heads = 0;
+            for (size_t i = 0; i < model_info.gguf.head_count_kv_per_layer.size(); ++i) {
+                if (model_info.gguf.sliding_window_pattern[i])
+                    swa_heads += model_info.gguf.head_count_kv_per_layer[i];
+                else
+                    full_heads += model_info.gguf.head_count_kv_per_layer[i];
+            }
+            if (swa_heads > 0 || full_heads > 0) {
+                LOG(DEBUG, "AutoTune") << "  SWA head breakdown: swa_heads="
+                                       << swa_heads << ", full_heads="
+                                       << full_heads << " ";
+            }
         }
     } else {
         // GGUF metadata missing — estimate from model size

--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -218,10 +218,12 @@ inline int64_t compute_auto_context_size(const ModelInfo& model_info,
             estimated = true;  // mark as architecture-adjusted
         }
         // Log precise SWA head breakdown when raw arrays are available
+        // (and both arrays have matching lengths so per-layer indexing is safe)
         if (model_info.gguf.key_length_swa > 0 &&
             model_info.gguf.key_length_swa < model_info.gguf.key_length &&
             !model_info.gguf.head_count_kv_per_layer.empty() &&
-            !model_info.gguf.sliding_window_pattern.empty()) {
+            !model_info.gguf.sliding_window_pattern.empty() &&
+            model_info.gguf.head_count_kv_per_layer.size() == model_info.gguf.sliding_window_pattern.size()) {
             int64_t swa_heads = 0, full_heads = 0;
             for (size_t i = 0; i < model_info.gguf.head_count_kv_per_layer.size(); ++i) {
                 if (model_info.gguf.sliding_window_pattern[i])

--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -198,9 +198,11 @@ inline double get_available_memory_gb(DeviceType device_type) {
  * GGUF architecture metadata.
  *
  * Formula (from auto-tune schema):
- *   kv_bytes_per_token = block_count × head_count_kv × key_length × 2[F16] × 2[K+V]
+ *   kv_bytes_per_token = head_count_kv × key_length × 2[F16] × 2[K+V]
  *   max_ctx = floor((available_memory_gb × 1024³ - weights) / kv_bytes_per_token)
  *   ctx_size = min(model_max_context_window, max_ctx)
+ *
+ * head_count_kv is the total KV head count across all blocks (pre-computed in GGUF reader).
  *
  * When GGUF metadata is unavailable, estimates kv_bytes_per_token from model size.
  * For embedding models, the result is floored at EMBEDDING_CTX_SIZE.
@@ -224,14 +226,14 @@ inline int64_t compute_auto_context_size(const ModelInfo& model_info,
     bool estimated = false;
 
     // Try exact GGUF metadata first
-    int64_t block_count = model_info.gguf_block_count;
-    int64_t head_count_kv = model_info.gguf_head_count_kv;
-    int64_t key_length = model_info.gguf_key_length;
+    int64_t block_count = model_info.gguf.block_count;
+    int64_t head_count_kv = model_info.gguf.head_count_kv;
+    int64_t key_length = model_info.gguf.key_length;
 
     if (block_count > 0 && head_count_kv > 0 && key_length > 0) {
-        // Exact formula: layers × kv_heads × head_dim × 2[F16] × 2[K+V]
-        kv_bytes_per_token = static_cast<double>(block_count)
-                            * static_cast<double>(head_count_kv)
+        // Exact formula: total_kv_heads × head_dim × 2[F16] × 2[K+V]
+        // head_count_kv is already the total across all blocks
+        kv_bytes_per_token = static_cast<double>(head_count_kv)
                             * static_cast<double>(key_length)
                             * 2.0  // F16 = 2 bytes per element
                             * 2.0; // K cache + V cache

--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -197,12 +197,18 @@ inline double get_available_memory_gb(DeviceType device_type) {
  * Compute the maximum context window that fits in available memory based on
  * GGUF architecture metadata.
  *
- * Formula (from auto-tune schema):
+ * Base formula (standard MHA/GQA):
  *   kv_bytes_per_token = head_count_kv × key_length × 2[F16] × 2[K+V]
+ *   (head_count_kv is total KV heads across all blocks)
+ *
+ * Architecture-specific scaling factors reduce this for models that compress
+ * their KV cache.  Rules are driven by GGUF metadata, not architecture names:
+ *   - SWA with reduced dims: factor = 1 - swa_ratio + swa_ratio × (key_swa / key)
+ *   - Hybrid SSM-attention: factor = 1 / full_attention_interval
+ *   - Neither detected: factor = 1.0 (conservative)
+ *
  *   max_ctx = floor((available_memory_gb × 1024³ - weights) / kv_bytes_per_token)
  *   ctx_size = min(model_max_context_window, max_ctx)
- *
- * head_count_kv is the total KV head count across all blocks (pre-computed in GGUF reader).
  *
  * When GGUF metadata is unavailable, estimates kv_bytes_per_token from model size.
  * For embedding models, the result is floored at EMBEDDING_CTX_SIZE.
@@ -212,6 +218,30 @@ inline double get_available_memory_gb(DeviceType device_type) {
  * @param is_embedding     Whether this is an embedding model (applies minimum floor)
  * @return Resolved context size, or AUTO_CTX_FALLBACK if computation fails
  */
+static double compute_kv_cache_scaling_factor(const GgufMetadata& gguf) {
+    // SWA with reduced dimensions: some layers store smaller key/value vectors.
+    // Detected by sliding_window_pattern (→ swa_layer_count) and key_length_swa < key_length.
+    // Approximation assumes KV heads are distributed proportionally across layers.
+    if (gguf.swa_layer_count > 0 &&
+        gguf.block_count > 0 &&
+        gguf.key_length_swa > 0 && gguf.key_length > 0 &&
+        gguf.key_length_swa < gguf.key_length) {
+        double swa_ratio = static_cast<double>(gguf.swa_layer_count) /
+                           static_cast<double>(gguf.block_count);
+        double dim_ratio = static_cast<double>(gguf.key_length_swa) /
+                           static_cast<double>(gguf.key_length);
+        double factor = 1.0 - swa_ratio + swa_ratio * dim_ratio;
+        return std::max(0.1, factor);
+    }
+
+    // Hybrid SSM-attention: only 1 every `full_attention_interval` layers grows KV cache;
+    // the rest use SSM recurrent state (constant memory regardless of context length).
+    if (gguf.full_attention_interval > 1) {
+        return 1.0 / static_cast<double>(gguf.full_attention_interval);
+    }
+
+    return 1.0;  // Standard MHA/GQA — no scaling
+}
 inline int64_t compute_auto_context_size(const ModelInfo& model_info,
                                           double available_memory_gb,
                                           bool is_embedding = false) {
@@ -223,6 +253,7 @@ inline int64_t compute_auto_context_size(const ModelInfo& model_info,
 
     // KV cache bytes per token
     double kv_bytes_per_token = 0;
+    double kv_cache_scale = 1.0;
     bool estimated = false;
 
     // Try exact GGUF metadata first
@@ -231,12 +262,17 @@ inline int64_t compute_auto_context_size(const ModelInfo& model_info,
     int64_t key_length = model_info.gguf.key_length;
 
     if (block_count > 0 && head_count_kv > 0 && key_length > 0) {
-        // Exact formula: total_kv_heads × head_dim × 2[F16] × 2[K+V]
+        // Base formula: total_kv_heads × head_dim × 2[F16] × 2[K+V]
         // head_count_kv is already the total across all blocks
+        kv_cache_scale = compute_kv_cache_scaling_factor(model_info.gguf);
         kv_bytes_per_token = static_cast<double>(head_count_kv)
                             * static_cast<double>(key_length)
                             * 2.0  // F16 = 2 bytes per element
-                            * 2.0; // K cache + V cache
+                            * 2.0  // K cache + V cache
+                            * kv_cache_scale;
+        if (kv_cache_scale < 1.0) {
+            estimated = true;  // mark as architecture-adjusted
+        }
     } else {
         // GGUF metadata missing — estimate from model size
         kv_bytes_per_token = estimate_kv_bytes_per_token_from_model_size(model_info.size);
@@ -285,8 +321,11 @@ inline int64_t compute_auto_context_size(const ModelInfo& model_info,
     }
 
     LOG(DEBUG, "AutoTune") << "compute_auto_context_size: " << model_info.model_name
-                           << " — GGUF: blocks=" << block_count << ", kv_heads=" << head_count_kv
+                           << " — GGUF: " << model_info.gguf.architecture
+                           << ", blocks=" << block_count << ", kv_heads=" << head_count_kv
                            << ", key_len=" << key_length
+                           << ", swa_layers=" << model_info.gguf.swa_layer_count
+                           << ", scale=" << std::fixed << std::setprecision(2) << kv_cache_scale
                            << " | kv_cache=" << std::fixed << std::setprecision(2)
                            << (kv_bytes_per_token / (1024.0 * 1024.0)) << " MB/token"
                            << (estimated ? " (est)" : "")

--- a/src/cpp/include/lemon/gguf_reader.h
+++ b/src/cpp/include/lemon/gguf_reader.h
@@ -12,7 +12,6 @@
 #include <cstring>
 #include <fstream>
 #include <ios>
-#include <limits>
 #include <string>
 #include <lemon/gguf_capabilities.h>
 #include <lemon/utils/path_utils.h>
@@ -55,7 +54,7 @@ static bool read_gguf_string(std::istream& in, std::string& value) {
 }
 
 static bool skip_gguf_bytes(std::istream& in, uint64_t bytes) {
-    if (bytes > static_cast<uint64_t>(std::numeric_limits<std::streamoff>::max())) return false;
+    if (bytes > INT64_MAX) return false;
     in.seekg(static_cast<std::streamoff>(bytes), std::ios::cur);
     return static_cast<bool>(in);
 }
@@ -96,7 +95,7 @@ static bool read_gguf_integer_value(std::istream& in, uint32_t type, int64_t& va
         case 10: {
             uint64_t v = 0;
             if (!read_gguf_le(in, v)) return false;
-            if (v > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) return false;
+            if (v > INT64_MAX) return false;
             value = static_cast<int64_t>(v);
             return true;
         }
@@ -128,7 +127,7 @@ static bool skip_gguf_value(std::istream& in, uint32_t type) {
         if (elem_type == 9) return false;
         uint64_t elem_size = gguf_scalar_size(elem_type);
         if (elem_size == 0) return false;
-        if (count > std::numeric_limits<uint64_t>::max() / elem_size) return false;
+        if (count > INT64_MAX / elem_size) return false;
         return skip_gguf_bytes(in, count * elem_size);
     }
 

--- a/src/cpp/include/lemon/gguf_reader.h
+++ b/src/cpp/include/lemon/gguf_reader.h
@@ -466,7 +466,7 @@ inline double compute_weighted_kv_cache_bytes_per_token(const GgufMetadata& gguf
         double dim_ratio = static_cast<double>(key_length_swa)
                          / static_cast<double>(key_length);
         factor = 1.0 - swa_ratio + swa_ratio * dim_ratio;
-        factor = std::max(0.1, factor);
+        factor = (std::max)(0.1, factor);
     }
 
     if (scale_out) *scale_out = factor;

--- a/src/cpp/include/lemon/gguf_reader.h
+++ b/src/cpp/include/lemon/gguf_reader.h
@@ -28,8 +28,11 @@ struct GgufMetadata {
     int64_t context_length = 0;
     int64_t block_count = 0;
     int64_t embedding_length = 0;
-    int64_t head_count_kv = 0;
+    int64_t head_count_kv = 0;    // total across all blocks (summed from array, or scalar × block_count)
     int64_t key_length = 0;
+    int64_t key_length_swa = 0;   // SWA-reduced key length (Gemma4, etc.)
+    int64_t swa_layer_count = 0;  // layers with sliding-window attention
+    int64_t full_attention_interval = 0; // every Nth layer does full attention (Qwen SSM)
     GgufCapabilities caps;
 };
 
@@ -149,8 +152,22 @@ inline bool ends_with_ignore_case(const std::string& str, const std::string& suf
     return to_lower(str.substr(str.length() - suffix.length())) == to_lower(suffix);
 }
 
+inline bool starts_with_ignore_case(const std::string& str, const std::string& prefix) {
+    if (prefix.length() > str.length()) return false;
+    return to_lower(str.substr(0, prefix.length())) == to_lower(prefix);
+}
+
 inline bool contains_ignore_case(const std::string& str, const std::string& substr) {
     return to_lower(str).find(to_lower(substr)) != std::string::npos;
+}
+
+inline bool has_gguf_magic(const std::string& path) {
+    std::ifstream in(utils::path_from_utf8(path), std::ios::binary);
+    if (!in.is_open()) return false;
+    char magic[4] = {};
+    in.read(magic, sizeof(magic));
+    return in.gcount() == static_cast<std::streamsize>(sizeof(magic)) &&
+           std::memcmp(magic, "GGUF", 4) == 0;
 }
 
 } // namespace gguf_reader_detail
@@ -254,6 +271,41 @@ inline bool read_gguf_metadata(GgufMetadata& out, const std::string& path) {
                     out.key_length = value;
                 continue;
             }
+            if (key == out.architecture + ".attention.key_length_swa") {
+                int64_t value = 0;
+                if (read_gguf_integer_value(in, type, value) && value > 0)
+                    out.key_length_swa = value;
+                continue;
+            }
+            if (key == out.architecture + ".full_attention_interval") {
+                int64_t value = 0;
+                if (read_gguf_integer_value(in, type, value) && value > 0)
+                    out.full_attention_interval = value;
+                continue;
+            }
+        }
+
+        // sliding_window_pattern: bool array, one entry per layer.
+        // Count true entries → swa_layer_count.  Match by suffix so we don't
+        // need the architecture prefix (key shape: arch.attention.sliding_window_pattern).
+        if (key.size() > std::strlen(".sliding_window_pattern")
+             && gguf_reader_detail::ends_with_ignore_case(key, ".sliding_window_pattern") && type == 9) {
+            uint32_t elem_type = 0;
+            uint64_t count = 0;
+            if (read_gguf_le(in, elem_type) && read_gguf_le(in, count)) {
+                if (elem_type == 7) {  // BOOL
+                    for (uint64_t j = 0; j < count; ++j) {
+                        uint8_t v = 0;
+                        if (read_gguf_le(in, v) && v)
+                            out.swa_layer_count++;
+                    }
+                } else if (elem_type != 9) {
+                    uint64_t elem_size = gguf_scalar_size(elem_type);
+                    if (elem_size > 0)
+                        skip_gguf_bytes(in, count * elem_size);
+                }
+            }
+            continue;
         }
 
         // Capability detection (vision, tool-calling, MTP)

--- a/src/cpp/include/lemon/gguf_reader.h
+++ b/src/cpp/include/lemon/gguf_reader.h
@@ -430,7 +430,8 @@ inline double compute_weighted_kv_cache_bytes_per_token(const GgufMetadata& gguf
     // ── SWA or standard MHA/GQA ──────────────────────────────────────
     bool has_swa = (key_length_swa > 0 && key_length_swa < key_length);
 
-    if (has_swa && !gguf.head_count_kv_per_layer.empty() && !gguf.sliding_window_pattern.empty()) {
+    if (has_swa && !gguf.head_count_kv_per_layer.empty() && !gguf.sliding_window_pattern.empty()
+        && gguf.head_count_kv_per_layer.size() == gguf.sliding_window_pattern.size()) {
         // Precise per-layer weighted sum using raw arrays.
         // Each layer contributes: heads[layer] × key_len[layer] × 2[F16] × 2[K+V]
         // where key_len[layer] = key_length_swa if SWA, key_length otherwise.

--- a/src/cpp/include/lemon/gguf_reader.h
+++ b/src/cpp/include/lemon/gguf_reader.h
@@ -8,11 +8,13 @@
 /// MTP).  All helpers are static — no stateful reader class is needed because
 /// the header is read sequentially in one shot.
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <ios>
 #include <string>
+#include <vector>
 #include <lemon/gguf_capabilities.h>
 #include <lemon/utils/path_utils.h>
 
@@ -22,17 +24,33 @@ namespace lemon {
 ///
 /// Stored inside ModelInfo for llama.cpp models so that auto-tune and other
 /// subsystems can estimate KV-cache pressure and clamp context size.
+///
+/// Arrays that vary per-block (head_count_kv_per_layer, sliding_window_pattern)
+/// are stored as-is so that downstream code can perform precise per-layer
+/// computations (e.g. distinguishing SWA-layer head counts from full-layer
+/// head counts).  Scalar convenience fields (head_count_kv, swa_layer_count)
+/// are derived from the raw arrays after the header pass completes.
 struct GgufMetadata {
     std::string architecture;
     int64_t context_length = 0;
     int64_t block_count = 0;
     int64_t embedding_length = 0;
-    int64_t head_count_kv = 0;    // total across all blocks (summed from array, or scalar × block_count)
+    int64_t head_count_kv = 0;       // total across all blocks (derived)
     int64_t key_length = 0;
-    int64_t key_length_swa = 0;   // SWA-reduced key length (Gemma4, etc.)
-    int64_t swa_layer_count = 0;  // layers with sliding-window attention
+    int64_t key_length_swa = 0;      // SWA-reduced key length (Gemma4, etc.)
+    int64_t swa_layer_count = 0;     // layers with sliding-window attention (derived)
     int64_t full_attention_interval = 0; // every Nth layer does full attention (Qwen SSM)
     GgufCapabilities caps;
+
+    // ── Raw per-layer arrays (stored as read from GGUF) ───────────────
+    // Populated when the GGUF field is an array.  Empty when the field is
+    // a scalar (in which case the scalar is repeated for every block).
+    std::vector<int64_t> head_count_kv_per_layer;
+    std::vector<bool> sliding_window_pattern;
+
+    // Transient scalar held when head_count_kv GGUF field is a scalar.
+    // Converted to head_count_kv_per_layer in post-loop validation.
+    int64_t head_count_kv_scalar = 0;
 };
 
 // ── Low-level binary readers ──────────────────────────────────────────
@@ -244,23 +262,22 @@ inline bool read_gguf_metadata(GgufMetadata& out, const std::string& path) {
             }
             if (key == out.architecture + ".attention.head_count_kv") {
                 if (type == 9) {
-                    // Array of integers: one entry per block — sum to get total KV heads
+                    // Array of integers: one entry per block — store raw values
                     uint32_t elem_type = 0;
                     uint64_t count = 0;
                     if (read_gguf_le(in, elem_type) && read_gguf_le(in, count)) {
-                        int64_t total = 0;
+                        out.head_count_kv_per_layer.resize(static_cast<size_t>(count));
                         for (uint64_t j = 0; j < count; ++j) {
                             int64_t v = 0;
-                            if (read_gguf_integer_value(in, elem_type, v) && v > 0)
-                                total += v;
+                            if (read_gguf_integer_value(in, elem_type, v))
+                                out.head_count_kv_per_layer[j] = v;
                         }
-                        out.head_count_kv = total;
                     }
                 } else {
-                    // Scalar: per-block count, multiply by block_count for total
+                    // Scalar: per-block count, stored transiently for later
                     int64_t value = 0;
                     if (read_gguf_integer_value(in, type, value) && value > 0)
-                        out.head_count_kv = value * out.block_count;
+                        out.head_count_kv_scalar = value;
                 }
                 continue;
             }
@@ -285,18 +302,20 @@ inline bool read_gguf_metadata(GgufMetadata& out, const std::string& path) {
         }
 
         // sliding_window_pattern: bool array, one entry per layer.
-        // Count true entries → swa_layer_count.  Match by suffix so we don't
-        // need the architecture prefix (key shape: arch.attention.sliding_window_pattern).
+        // Store raw values so downstream code can correlate with per-layer
+        // head counts and key lengths.  Match by suffix so we don't need the
+        // architecture prefix (key shape: arch.attention.sliding_window_pattern).
         if (key.size() > std::strlen(".sliding_window_pattern")
              && gguf_reader_detail::ends_with_ignore_case(key, ".sliding_window_pattern") && type == 9) {
             uint32_t elem_type = 0;
             uint64_t count = 0;
             if (read_gguf_le(in, elem_type) && read_gguf_le(in, count)) {
                 if (elem_type == 7) {  // BOOL
+                    out.sliding_window_pattern.resize(static_cast<size_t>(count));
                     for (uint64_t j = 0; j < count; ++j) {
                         uint8_t v = 0;
-                        if (read_gguf_le(in, v) && v)
-                            out.swa_layer_count++;
+                        if (read_gguf_le(in, v))
+                            out.sliding_window_pattern[j] = (v != 0);
                     }
                 } else if (elem_type != 9) {
                     uint64_t elem_size = gguf_scalar_size(elem_type);
@@ -348,7 +367,115 @@ inline bool read_gguf_metadata(GgufMetadata& out, const std::string& path) {
     if (out.context_length == 0 && pending_context_length > 0) {
         out.context_length = pending_context_length;
     }
+
+    // ── Derive scalar convenience fields from raw arrays ──────────────
+    // head_count_kv: total KV heads across all blocks
+    if (!out.head_count_kv_per_layer.empty()) {
+        for (int64_t v : out.head_count_kv_per_layer)
+            out.head_count_kv += v;
+    } else if (out.head_count_kv_scalar > 0 && out.block_count > 0) {
+        out.head_count_kv = out.head_count_kv_scalar * out.block_count;
+        // Also populate the per-layer array for uniform scalar case
+        out.head_count_kv_per_layer.assign(out.block_count, out.head_count_kv_scalar);
+    }
+
+    // swa_layer_count: number of layers with sliding-window attention
+    if (!out.sliding_window_pattern.empty()) {
+        for (bool v : out.sliding_window_pattern)
+            if (v) out.swa_layer_count++;
+    }
+
     return true;
+}
+
+/// Compute KV cache bytes-per-token using raw per-layer arrays from GGUF.
+///
+/// When head_count_kv_per_layer and sliding_window_pattern are populated,
+/// this gives a precise weighted sum that accounts for per-layer head-count
+/// variation combined with SWA-reduced key lengths.  When only scalar
+/// metadata is available, falls back to the proportional approximation.
+///
+/// @param gguf       GGUF metadata with raw arrays populated
+/// @param[out] scale_out  Output scaling factor (for logging). Set to 1.0 if
+///                        no architecture-specific scaling applies. May be null.
+/// @return Bytes per token for KV cache, or 0 if metadata is insufficient.
+inline double compute_weighted_kv_cache_bytes_per_token(const GgufMetadata& gguf,
+                                                        double* scale_out = nullptr) {
+    int64_t block_count = gguf.block_count;
+    int64_t key_length = gguf.key_length;
+    int64_t key_length_swa = gguf.key_length_swa;
+
+    if (block_count <= 0 || key_length <= 0)
+        return 0.0;
+
+    // Hybrid SSM-attention: only 1 every N layers grows KV cache;
+    // the rest use SSM recurrent state (constant memory regardless of context).
+    // Full-attention layers at indices 0, interval, 2*interval, …
+    // Exact count: floor((block_count - 1) / interval) + 1
+    if (gguf.full_attention_interval > 1) {
+        int64_t full_attn_layers = (block_count - 1) / gguf.full_attention_interval + 1;
+        double factor = static_cast<double>(full_attn_layers)
+                      / static_cast<double>(block_count);
+        if (scale_out) *scale_out = factor;
+        int64_t total_heads = gguf.head_count_kv;
+        if (total_heads <= 0)
+            return 0.0;
+        return static_cast<double>(total_heads)
+             * static_cast<double>(key_length)
+             * 2.0  // F16
+             * 2.0  // K+V
+             * factor;
+    }
+
+    // ── SWA or standard MHA/GQA ──────────────────────────────────────
+    bool has_swa = (key_length_swa > 0 && key_length_swa < key_length);
+
+    if (has_swa && !gguf.head_count_kv_per_layer.empty() && !gguf.sliding_window_pattern.empty()) {
+        // Precise per-layer weighted sum using raw arrays.
+        // Each layer contributes: heads[layer] × key_len[layer] × 2[F16] × 2[K+V]
+        // where key_len[layer] = key_length_swa if SWA, key_length otherwise.
+        size_t n = gguf.head_count_kv_per_layer.size();
+        double weighted_sum = 0.0;
+        double unweighted_sum = 0.0;
+
+        for (size_t i = 0; i < n; ++i) {
+            int64_t heads = gguf.head_count_kv_per_layer[i];
+            if (heads <= 0) continue;
+            double kl = gguf.sliding_window_pattern[i] ? key_length_swa : key_length;
+            weighted_sum += static_cast<double>(heads) * kl;
+            unweighted_sum += static_cast<double>(heads) * key_length;
+        }
+
+        if (weighted_sum > 0 && scale_out) {
+            *scale_out = (unweighted_sum > 0) ? weighted_sum / unweighted_sum : 1.0;
+        }
+
+        return weighted_sum * 2.0 * 2.0;
+    }
+
+    // Scalar/uniform case: use proportional approximation.
+    // This also covers the non-SWA standard MHA/GQA path.
+    int64_t total_heads = gguf.head_count_kv;
+    if (total_heads <= 0)
+        return 0.0;
+
+    double factor = 1.0;
+    if (has_swa && gguf.swa_layer_count > 0) {
+        double swa_ratio = static_cast<double>(gguf.swa_layer_count)
+                         / static_cast<double>(block_count);
+        double dim_ratio = static_cast<double>(key_length_swa)
+                         / static_cast<double>(key_length);
+        factor = 1.0 - swa_ratio + swa_ratio * dim_ratio;
+        factor = std::max(0.1, factor);
+    }
+
+    if (scale_out) *scale_out = factor;
+
+    return static_cast<double>(total_heads)
+         * static_cast<double>(key_length)
+         * 2.0  // F16
+         * 2.0  // K+V
+         * factor;
 }
 
 } // namespace lemon

--- a/src/cpp/include/lemon/gguf_reader.h
+++ b/src/cpp/include/lemon/gguf_reader.h
@@ -1,0 +1,303 @@
+#pragma once
+
+/// GGUF binary format reader and metadata extraction.
+///
+/// Provides a single-pass reader over the GGUF KV-header that extracts
+/// architecture name, context length, block count, embedding dimension,
+/// attention head / key dimensions, and capability hints (vision, tool-calling,
+/// MTP).  All helpers are static — no stateful reader class is needed because
+/// the header is read sequentially in one shot.
+
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <ios>
+#include <limits>
+#include <string>
+#include <lemon/gguf_capabilities.h>
+#include <lemon/utils/path_utils.h>
+
+namespace lemon {
+
+/// Metadata extracted from a GGUF file's KV header.
+///
+/// Stored inside ModelInfo for llama.cpp models so that auto-tune and other
+/// subsystems can estimate KV-cache pressure and clamp context size.
+struct GgufMetadata {
+    std::string architecture;
+    int64_t context_length = 0;
+    int64_t block_count = 0;
+    int64_t embedding_length = 0;
+    int64_t head_count_kv = 0;
+    int64_t key_length = 0;
+    GgufCapabilities caps;
+};
+
+// ── Low-level binary readers ──────────────────────────────────────────
+
+template <typename T>
+static bool read_gguf_le(std::istream& in, T& value) {
+    in.read(reinterpret_cast<char*>(&value), sizeof(T));
+    return static_cast<bool>(in);
+}
+
+static bool read_gguf_string(std::istream& in, std::string& value) {
+    uint64_t len = 0;
+    if (!read_gguf_le(in, len)) return false;
+    if (len > 1024 * 1024) return false;
+    value.assign(static_cast<size_t>(len), '\0');
+    if (len == 0) return true;
+    in.read(&value[0], static_cast<std::streamsize>(len));
+    return static_cast<bool>(in);
+}
+
+static bool skip_gguf_bytes(std::istream& in, uint64_t bytes) {
+    if (bytes > static_cast<uint64_t>(std::numeric_limits<std::streamoff>::max())) return false;
+    in.seekg(static_cast<std::streamoff>(bytes), std::ios::cur);
+    return static_cast<bool>(in);
+}
+
+static uint64_t gguf_scalar_size(uint32_t type) {
+    switch (type) {
+        case 0:  // UINT8
+        case 1:  // INT8
+        case 7:  // BOOL
+            return 1;
+        case 2:  // UINT16
+        case 3:  // INT16
+            return 2;
+        case 4:  // UINT32
+        case 5:  // INT32
+        case 6:  // FLOAT32
+            return 4;
+        case 10: // UINT64
+        case 11: // INT64
+        case 12: // FLOAT64
+            return 8;
+        default:
+            return 0;
+    }
+}
+
+// Forward declaration (mutual recursion with integer reader)
+static bool skip_gguf_value(std::istream& in, uint32_t type);
+
+static bool read_gguf_integer_value(std::istream& in, uint32_t type, int64_t& value) {
+    switch (type) {
+        case 0: { uint8_t v = 0; if (!read_gguf_le(in, v)) return false; value = v; return true; }
+        case 1: { int8_t v = 0; if (!read_gguf_le(in, v)) return false; value = v; return true; }
+        case 2: { uint16_t v = 0; if (!read_gguf_le(in, v)) return false; value = v; return true; }
+        case 3: { int16_t v = 0; if (!read_gguf_le(in, v)) return false; value = v; return true; }
+        case 4: { uint32_t v = 0; if (!read_gguf_le(in, v)) return false; value = v; return true; }
+        case 5: { int32_t v = 0; if (!read_gguf_le(in, v)) return false; value = v; return true; }
+        case 10: {
+            uint64_t v = 0;
+            if (!read_gguf_le(in, v)) return false;
+            if (v > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) return false;
+            value = static_cast<int64_t>(v);
+            return true;
+        }
+        case 11: { int64_t v = 0; if (!read_gguf_le(in, v)) return false; value = v; return true; }
+        default:
+            return skip_gguf_value(in, type) && false;
+    }
+}
+
+static bool skip_gguf_value(std::istream& in, uint32_t type) {
+    if (type == 8) {  // STRING
+        std::string ignored;
+        return read_gguf_string(in, ignored);
+    }
+
+    if (type == 9) {  // ARRAY
+        uint32_t elem_type = 0;
+        uint64_t count = 0;
+        if (!read_gguf_le(in, elem_type) || !read_gguf_le(in, count)) return false;
+
+        if (elem_type == 8) {
+            for (uint64_t i = 0; i < count; ++i) {
+                std::string ignored;
+                if (!read_gguf_string(in, ignored)) return false;
+            }
+            return true;
+        }
+
+        if (elem_type == 9) return false;
+        uint64_t elem_size = gguf_scalar_size(elem_type);
+        if (elem_size == 0) return false;
+        if (count > std::numeric_limits<uint64_t>::max() / elem_size) return false;
+        return skip_gguf_bytes(in, count * elem_size);
+    }
+
+    uint64_t size = gguf_scalar_size(type);
+    return size > 0 && skip_gguf_bytes(in, size);
+}
+
+// ── Helpers used by the metadata reader ───────────────────────────────
+
+namespace gguf_reader_detail {
+
+inline std::string to_lower(const std::string& str) {
+    std::string result = str;
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return result;
+}
+
+inline bool ends_with_ignore_case(const std::string& str, const std::string& suffix) {
+    if (suffix.length() > str.length()) return false;
+    return to_lower(str.substr(str.length() - suffix.length())) == to_lower(suffix);
+}
+
+inline bool contains_ignore_case(const std::string& str, const std::string& substr) {
+    return to_lower(str).find(to_lower(substr)) != std::string::npos;
+}
+
+} // namespace gguf_reader_detail
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/// Read GGUF metadata from a file in a single pass over the KV header.
+///
+/// Returns true on success (out is populated).  Returns false if the file
+/// cannot be opened or does not have a valid GGUF header.
+inline bool read_gguf_metadata(GgufMetadata& out, const std::string& path) {
+    std::ifstream in(lemon::utils::path_from_utf8(path), std::ios::binary);
+    if (!in) return false;
+
+    char magic[4] = {};
+    in.read(magic, sizeof(magic));
+    if (!in || std::memcmp(magic, "GGUF", 4) != 0) return false;
+
+    uint32_t version = 0;
+    uint64_t tensor_count = 0;
+    uint64_t kv_count = 0;
+    if (!read_gguf_le(in, version) || !read_gguf_le(in, tensor_count) || !read_gguf_le(in, kv_count)) {
+        return false;
+    }
+    (void)version;
+    (void)tensor_count;
+
+    int64_t pending_context_length = 0;
+
+    for (uint64_t i = 0; i < kv_count; ++i) {
+        std::string key;
+        uint32_t type = 0;
+        if (!read_gguf_string(in, key) || !read_gguf_le(in, type)) return false;
+
+        // Read architecture
+        if (key == "general.architecture" && type == 8) {
+            if (!read_gguf_string(in, out.architecture)) return false;
+            if (pending_context_length > 0) {
+                out.context_length = pending_context_length;
+            }
+            continue;
+        }
+
+        // Context length
+        const bool context_key = !out.architecture.empty()
+                                 && key == out.architecture + ".context_length";
+        const bool possible_context_key =
+            out.architecture.empty() && key.size() > std::strlen(".context_length")
+            && gguf_reader_detail::ends_with_ignore_case(key, ".context_length");
+        if (context_key || possible_context_key) {
+            int64_t value = 0;
+            if (read_gguf_integer_value(in, type, value) && value > 0) {
+                if (context_key) {
+                    out.context_length = value;
+                } else {
+                    pending_context_length = value;
+                }
+            }
+            continue;
+        }
+
+        // Architecture fields for KV cache estimation
+        if (!out.architecture.empty()) {
+            if (key == out.architecture + ".block_count") {
+                int64_t value = 0;
+                if (read_gguf_integer_value(in, type, value) && value > 0)
+                    out.block_count = value;
+                continue;
+            }
+            if (key == out.architecture + ".embedding_length") {
+                int64_t value = 0;
+                if (read_gguf_integer_value(in, type, value) && value > 0)
+                    out.embedding_length = value;
+                continue;
+            }
+            if (key == out.architecture + ".attention.head_count_kv") {
+                if (type == 9) {
+                    // Array of integers: one entry per block — sum to get total KV heads
+                    uint32_t elem_type = 0;
+                    uint64_t count = 0;
+                    if (read_gguf_le(in, elem_type) && read_gguf_le(in, count)) {
+                        int64_t total = 0;
+                        for (uint64_t j = 0; j < count; ++j) {
+                            int64_t v = 0;
+                            if (read_gguf_integer_value(in, elem_type, v) && v > 0)
+                                total += v;
+                        }
+                        out.head_count_kv = total;
+                    }
+                } else {
+                    // Scalar: per-block count, multiply by block_count for total
+                    int64_t value = 0;
+                    if (read_gguf_integer_value(in, type, value) && value > 0)
+                        out.head_count_kv = value * out.block_count;
+                }
+                continue;
+            }
+            if (key == out.architecture + ".attention.key_length") {
+                int64_t value = 0;
+                if (read_gguf_integer_value(in, type, value) && value > 0)
+                    out.key_length = value;
+                continue;
+            }
+        }
+
+        // Capability detection (vision, tool-calling, MTP)
+        if (type == 4) {
+            uint32_t val = 0;
+            if (read_gguf_le(in, val)) {
+                if (gguf_reader_detail::contains_ignore_case(key, "nextn_predict_layers") && val > 0)
+                    out.caps.mtp = true;
+            }
+        } else if (type == 8) {
+            std::string value;
+            if (read_gguf_string(in, value)) {
+                inspect_gguf_string(key, value, out.caps);
+            }
+        } else if (type == 9) {
+            // Array — check string elements for capability hints
+            uint32_t elem_type = 0;
+            uint64_t count = 0;
+            if (read_gguf_le(in, elem_type) && read_gguf_le(in, count)) {
+                if (elem_type == 8) {
+                    for (uint64_t j = 0; j < count; ++j) {
+                        std::string value;
+                        if (!read_gguf_string(in, value)) return false;
+                        inspect_gguf_string(key, value, out.caps);
+                    }
+                } else if (elem_type != 9) {
+                    uint64_t elem_size = gguf_scalar_size(elem_type);
+                    if (elem_size == 0) return false;
+                    if (!skip_gguf_bytes(in, count * elem_size)) return false;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        } else {
+            if (!skip_gguf_value(in, type)) return false;
+        }
+    }
+
+    if (out.context_length == 0 && pending_context_length > 0) {
+        out.context_length = pending_context_length;
+    }
+    return true;
+}
+
+} // namespace lemon

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -12,6 +12,7 @@
 #include <nlohmann/json.hpp>
 #include "canonical_id.h"
 #include "directory_watcher.h"
+#include "gguf_reader.h"
 #include "model_types.h"
 #include "recipe_options.h"
 
@@ -85,10 +86,7 @@ struct ModelInfo {
     int64_t max_context_window = 0;  // Static model-supported text context, when known
 
     // GGUF architecture metadata (populated for llamacpp models, used for auto ctx_size)
-    int64_t gguf_block_count = 0;       // number of transformer blocks (layers)
-    int64_t gguf_embedding_length = 0;  // hidden size
-    int64_t gguf_head_count_kv = 0;     // KV attention heads
-    int64_t gguf_key_length = 0;        // key head dimension
+    GgufMetadata gguf;
     RecipeOptions recipe_options;
 
     // Multi-model support fields

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -26,7 +26,6 @@
 #include <tuple>
 #include <unordered_set>
 #include <iomanip>
-#include <limits>
 #include <lemon/utils/aixlog.hpp>
 
 #ifndef _WIN32
@@ -111,38 +110,11 @@ namespace lemon {
 // Properties which are defined by the user for model registration.
 static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults", "components", "recipe_options"};
 
-// Helper functions for string operations
-static std::string to_lower(const std::string& str) {
-    std::string result = str;
-    std::transform(result.begin(), result.end(), result.begin(), ::tolower);
-    return result;
-}
-
-static bool ends_with_ignore_case(const std::string& str, const std::string& suffix) {
-    if (suffix.length() > str.length()) {
-        return false;
-    }
-    return to_lower(str.substr(str.length() - suffix.length())) == to_lower(suffix);
-}
-
-static bool starts_with_ignore_case(const std::string& str, const std::string& prefix) {
-    if (prefix.length() > str.length()) {
-        return false;
-    }
-    return to_lower(str.substr(0, prefix.length())) == to_lower(prefix);
-}
-
-static bool contains_ignore_case(const std::string& str, const std::string& substr) {
-    return to_lower(str).find(to_lower(substr)) != std::string::npos;
-}
+// Helper functions for string operations — use shared implementations from gguf_reader_detail
 
 static constexpr const char USER_MODEL_PREFIX[] = "user.";
 static constexpr size_t USER_MODEL_PREFIX_LEN = sizeof(USER_MODEL_PREFIX) - 1;
 static constexpr const char EXTRA_MODEL_PREFIX[] = "extra.";
-
-static bool has_label(const ModelInfo& info, const std::string& label) {
-    return std::find(info.labels.begin(), info.labels.end(), label) != info.labels.end();
-}
 
 // Built-ins are keyed bare in models_cache_; user.* and extra.* keys already
 // include their canonical prefix. This helper returns the canonical ID for any
@@ -252,7 +224,7 @@ static void populate_model_metadata(ModelInfo& info) {
 
     if (info.recipe == "llamacpp") {
         std::string gguf_path = info.resolved_path();
-        if (!gguf_path.empty() && ends_with_ignore_case(gguf_path, ".gguf") && safe_exists(path_from_utf8(gguf_path))) {
+        if (!gguf_path.empty() && gguf_reader_detail::ends_with_ignore_case(gguf_path, ".gguf") && safe_exists(path_from_utf8(gguf_path))) {
             GgufMetadata meta;
             if (read_gguf_metadata(meta, gguf_path)) {
                 info.max_context_window = meta.context_length;
@@ -731,7 +703,7 @@ static GGUFFiles identify_gguf_models(
     // (case 0) Wildcard, download everything
     if (!variant.empty() && variant == "*") {
         for (const auto& f : repo_files) {
-            if (ends_with_ignore_case(f, ".gguf")) {
+            if (gguf_reader_detail::ends_with_ignore_case(f, ".gguf")) {
                 sharded_files.push_back(f);
             }
         }
@@ -747,7 +719,7 @@ static GGUFFiles identify_gguf_models(
         variant_name = sharded_files[0];
     }
     // (case 1) If variant ends in .gguf or .bin, use it directly
-    else if (!variant.empty() && (ends_with_ignore_case(variant, ".gguf") || ends_with_ignore_case(variant, ".bin"))) {
+    else if (!variant.empty() && (gguf_reader_detail::ends_with_ignore_case(variant, ".gguf") || gguf_reader_detail::ends_with_ignore_case(variant, ".bin"))) {
         variant_name = variant;
 
         // Validate file exists in repo
@@ -769,7 +741,7 @@ static GGUFFiles identify_gguf_models(
     else if (variant.empty()) {
         std::vector<std::string> all_variants;
         for (const auto& f : repo_files) {
-            if (ends_with_ignore_case(f, ".gguf") && !contains_ignore_case(f, "mmproj")) {
+            if (gguf_reader_detail::ends_with_ignore_case(f, ".gguf") && !gguf_reader_detail::contains_ignore_case(f, "mmproj")) {
                 all_variants.push_back(f);
             }
         }
@@ -786,7 +758,7 @@ static GGUFFiles identify_gguf_models(
         auto vset = lemon::enumerate_gguf_variants(repo_files);
         std::vector<lemon::GgufVariant> exact_matches;
         for (const auto& v : vset.variants) {
-            if (to_lower(v.name) == to_lower(variant)) {
+            if (gguf_reader_detail::to_lower(v.name) == gguf_reader_detail::to_lower(variant)) {
                 exact_matches.push_back(v);
             }
         }
@@ -811,7 +783,7 @@ static GGUFFiles identify_gguf_models(
             std::string variant_suffix = variant + ".gguf";
 
             for (const auto& f : repo_files) {
-                if (ends_with_ignore_case(f, variant_suffix) && !contains_ignore_case(f, "mmproj")) {
+                if (gguf_reader_detail::ends_with_ignore_case(f, variant_suffix) && !gguf_reader_detail::contains_ignore_case(f, "mmproj")) {
                     end_with_variant.push_back(f);
                 }
             }
@@ -830,7 +802,7 @@ static GGUFFiles identify_gguf_models(
             else {
                 std::string folder_prefix = variant + "/";
                 for (const auto& f : repo_files) {
-                    if (ends_with_ignore_case(f, ".gguf") && starts_with_ignore_case(f, folder_prefix)) {
+                    if (gguf_reader_detail::ends_with_ignore_case(f, ".gguf") && gguf_reader_detail::starts_with_ignore_case(f, folder_prefix)) {
                         sharded_files.push_back(f);
                     }
                 }
@@ -842,12 +814,12 @@ static GGUFFiles identify_gguf_models(
                     std::string suffix_dash = "-" + variant + "/";
                     std::string suffix_underscore = "_" + variant + "/";
                     for (const auto& f : repo_files) {
-                        if (!ends_with_ignore_case(f, ".gguf")) continue;
+                        if (!gguf_reader_detail::ends_with_ignore_case(f, ".gguf")) continue;
                         size_t slash_pos = f.find('/');
                         if (slash_pos != std::string::npos) {
                             std::string folder = f.substr(0, slash_pos + 1);
-                            if (ends_with_ignore_case(folder, suffix_dash) ||
-                                ends_with_ignore_case(folder, suffix_underscore)) {
+                            if (gguf_reader_detail::ends_with_ignore_case(folder, suffix_dash) ||
+                                gguf_reader_detail::ends_with_ignore_case(folder, suffix_underscore)) {
                                 sharded_files.push_back(f);
                             }
                         }
@@ -1037,7 +1009,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
     static constexpr const char* EXTRA_MODEL_SOURCE = "extra_models_dir";
 
     // Helper to initialize common ModelInfo fields for discovered models
-    auto init_extra_model_info = [this](const std::string& name) -> ModelInfo {
+    auto init_extra_model_info = [](const std::string& name) -> ModelInfo {
         ModelInfo info;
         info.model_name = name;
         info.recipe = EXTRA_MODEL_RECIPE;
@@ -1060,7 +1032,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
 
             std::string filename = entry.path().filename().string();
 
-            if (!ends_with_ignore_case(filename, ".gguf")) continue;
+            if (!gguf_reader_detail::ends_with_ignore_case(filename, ".gguf")) continue;
 
             fs::path parent_dir = entry.path().parent_path();
 
@@ -1083,7 +1055,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
         std::string filename = gguf_path.filename().string();
 
         // Skip mmproj files - they're part of multimodal models
-        if (contains_ignore_case(filename, "mmproj")) continue;
+        if (gguf_reader_detail::contains_ignore_case(filename, "mmproj")) continue;
 
         std::string model_name = std::string(EXTRA_MODEL_PREFIX) + gguf_path.stem().string();
         ModelInfo info = init_extra_model_info(model_name);
@@ -1122,7 +1094,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
             } catch (...) {}
 
             // Check if this is an mmproj file (can be anywhere in filename)
-            if (contains_ignore_case(gguf_path.filename().string(), "mmproj")) {
+            if (gguf_reader_detail::contains_ignore_case(gguf_path.filename().string(), "mmproj")) {
                 mmproj_file = gguf_path;
                 continue;
             }
@@ -1419,7 +1391,7 @@ std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::s
             std::vector<std::string> enumerated_matches;
             auto local_variants = lemon::enumerate_gguf_variants(relative_gguf_files);
             for (const auto& local_variant : local_variants.variants) {
-                if (to_lower(local_variant.name) != variant_lower) {
+                if (gguf_reader_detail::to_lower(local_variant.name) != variant_lower) {
                     continue;
                 }
 
@@ -1810,7 +1782,7 @@ static bool are_required_checkpoints_complete(const ModelInfo& info) {
         fs::path resolved = path_from_utf8(resolved_path);
         if (info.recipe == "llamacpp" &&
             !safe_is_directory(resolved) &&
-            ends_with_ignore_case(resolved_path, ".gguf") &&
+            gguf_reader_detail::ends_with_ignore_case(resolved_path, ".gguf") &&
             !is_valid_gguf_file_for_cache(resolved_path)) {
             LOG(WARNING, "ModelManager")
                 << "Invalid GGUF cache file; marking model as not downloaded: "
@@ -2373,12 +2345,6 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
 
     filtered_out_models_.clear();
 
-#ifdef __APPLE__
-    bool is_macos = true;
-#else
-    bool is_macos = false;
-#endif
-
     json system_info = SystemInfoCache::get_system_info_with_cache();
     json hardware = system_info.contains("devices") ? system_info["devices"] : json::object();
 
@@ -2459,7 +2425,6 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
         debug_printed = true;
     }
 
-    int filtered_count = 0;
     for (const auto& [name, info] : models) {
         const std::string& recipe = info.recipe;
         bool filter_out = false;
@@ -2522,7 +2487,6 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
 #endif
 
         if (filter_out) {
-            filtered_count++;
             // Store the filter reason for later lookup
             filtered_out_models_[name] = filter_reason;
             continue;
@@ -3800,24 +3764,6 @@ void ModelManager::download_from_manifest(const json& manifest, std::map<std::st
     int file_index = 0;
     std::string download_path = manifest["download_path"].get<std::string>();
     int total_files = manifest["files_count"].get<int>();
-    auto ends_with_ignore_case_local = [](std::string value, std::string suffix) {
-        std::transform(value.begin(), value.end(), value.begin(), ::tolower);
-        std::transform(suffix.begin(), suffix.end(), suffix.begin(), ::tolower);
-        return value.size() >= suffix.size() &&
-               value.compare(value.size() - suffix.size(), suffix.size(), suffix) == 0;
-    };
-
-    auto has_gguf_magic = [](const std::string& path) {
-        std::ifstream in(path_from_utf8(path), std::ios::binary);
-        if (!in.is_open()) {
-            return false;
-        }
-        char magic[4] = {};
-        in.read(magic, sizeof(magic));
-        return in.gcount() == static_cast<std::streamsize>(sizeof(magic)) &&
-               magic[0] == 'G' && magic[1] == 'G' &&
-               magic[2] == 'U' && magic[3] == 'F';
-    };
 
 
     // Compute total download size across all files for accurate progress reporting
@@ -3935,9 +3881,9 @@ void ModelManager::download_from_manifest(const json& manifest, std::map<std::st
         // Reject that cache entry before HttpClient can treat the final path
         // as already complete. SHA validation still remains the primary check
         // when Hugging Face exposes an LFS object id.
-        if (ends_with_ignore_case_local(filename, ".gguf") &&
+        if (gguf_reader_detail::ends_with_ignore_case(filename, ".gguf") &&
             fs::exists(output_path) && !fs::exists(partial_path) &&
-            !has_gguf_magic(output_path)) {
+            !gguf_reader_detail::has_gguf_magic(output_path)) {
             LOG(WARNING, "ModelManager") << "Removing invalid GGUF cache file before download: "
                                          << filename << std::endl;
             std::error_code remove_ec;
@@ -4097,7 +4043,7 @@ void ModelManager::download_from_manifest(const json& manifest, std::map<std::st
         // an HTML/error/pointer file. Surface that as download validation
         // failure instead, and remove the invalid final file so the next pull
         // starts fresh.
-        if (ends_with_ignore_case_local(filename, ".gguf") && !has_gguf_magic(expected_path)) {
+        if (gguf_reader_detail::ends_with_ignore_case(filename, ".gguf") && !gguf_reader_detail::has_gguf_magic(expected_path)) {
             all_valid = false;
             LOG(ERROR, "ModelManager") << "Invalid GGUF file: " << filename
                                        << " (missing GGUF magic header)" << std::endl;
@@ -4240,7 +4186,7 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
                 folder_prefix += "/";
             }
             for (const auto& file : repo_files) {
-                if (starts_with_ignore_case(file, folder_prefix)) {
+                if (gguf_reader_detail::starts_with_ignore_case(file, folder_prefix)) {
                     files_to_download[main_repo_id].push_back(file);
                 }
             }

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2,6 +2,7 @@
 #include <lemon/runtime_config.h>
 #include <lemon/hf_variants.h>
 #include <lemon/gguf_capabilities.h>
+#include <lemon/gguf_reader.h>
 #include <lemon/utils/json_utils.h>
 #include <lemon/utils/http_client.h>
 #include <lemon/utils/process_manager.h>
@@ -153,235 +154,6 @@ static std::string cache_key_to_canonical_id(const std::string& cache_key) {
     return canonical_id(ModelSource::Builtin, cache_key);
 }
 
-template <typename T>
-static bool read_le(std::istream& in, T& value) {
-    in.read(reinterpret_cast<char*>(&value), sizeof(T));
-    return static_cast<bool>(in);
-}
-
-static bool read_gguf_string(std::istream& in, std::string& value) {
-    uint64_t len = 0;
-    if (!read_le(in, len)) return false;
-    if (len > 1024 * 1024) return false;
-    value.assign(static_cast<size_t>(len), '\0');
-    if (len == 0) return true;
-    in.read(&value[0], static_cast<std::streamsize>(len));
-    return static_cast<bool>(in);
-}
-
-static bool skip_bytes(std::istream& in, uint64_t bytes) {
-    if (bytes > static_cast<uint64_t>(std::numeric_limits<std::streamoff>::max())) return false;
-    in.seekg(static_cast<std::streamoff>(bytes), std::ios::cur);
-    return static_cast<bool>(in);
-}
-
-static uint64_t gguf_scalar_size(uint32_t type) {
-    switch (type) {
-        case 0:  // UINT8
-        case 1:  // INT8
-        case 7:  // BOOL
-            return 1;
-        case 2:  // UINT16
-        case 3:  // INT16
-            return 2;
-        case 4:  // UINT32
-        case 5:  // INT32
-        case 6:  // FLOAT32
-            return 4;
-        case 10: // UINT64
-        case 11: // INT64
-        case 12: // FLOAT64
-            return 8;
-        default:
-            return 0;
-    }
-}
-
-static bool skip_gguf_value(std::istream& in, uint32_t type);
-
-static bool read_gguf_integer_value(std::istream& in, uint32_t type, int64_t& value) {
-    switch (type) {
-        case 0: { uint8_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 1: { int8_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 2: { uint16_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 3: { int16_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 4: { uint32_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 5: { int32_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        case 10: {
-            uint64_t v = 0;
-            if (!read_le(in, v)) return false;
-            if (v > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) return false;
-            value = static_cast<int64_t>(v);
-            return true;
-        }
-        case 11: { int64_t v = 0; if (!read_le(in, v)) return false; value = v; return true; }
-        default:
-            return skip_gguf_value(in, type) && false;
-    }
-}
-
-static bool skip_gguf_value(std::istream& in, uint32_t type) {
-    if (type == 8) {  // STRING
-        std::string ignored;
-        return read_gguf_string(in, ignored);
-    }
-
-    if (type == 9) {  // ARRAY
-        uint32_t elem_type = 0;
-        uint64_t count = 0;
-        if (!read_le(in, elem_type) || !read_le(in, count)) return false;
-
-        if (elem_type == 8) {
-            for (uint64_t i = 0; i < count; ++i) {
-                std::string ignored;
-                if (!read_gguf_string(in, ignored)) return false;
-            }
-            return true;
-        }
-
-        if (elem_type == 9) return false;
-        uint64_t elem_size = gguf_scalar_size(elem_type);
-        if (elem_size == 0) return false;
-        if (count > std::numeric_limits<uint64_t>::max() / elem_size) return false;
-        return skip_bytes(in, count * elem_size);
-    }
-
-    uint64_t size = gguf_scalar_size(type);
-    return size > 0 && skip_bytes(in, size);
-}
-
-// All GGUF metadata extracted in a single pass over the KV header.
-// Replaces the previous three separate readers (context_length, arch_info, capabilities)
-// that each opened the file independently.
-struct GgufMetadata {
-    std::string architecture;
-    int64_t context_length = 0;
-    int64_t block_count = 0;
-    int64_t embedding_length = 0;
-    int64_t head_count_kv = 0;
-    int64_t key_length = 0;
-    GgufCapabilities caps;
-};
-
-static bool read_gguf_metadata(GgufMetadata& out, const std::string& path) {
-    std::ifstream in(path_from_utf8(path), std::ios::binary);
-    if (!in) return false;
-
-    char magic[4] = {};
-    in.read(magic, sizeof(magic));
-    if (!in || std::memcmp(magic, "GGUF", 4) != 0) return false;
-
-    uint32_t version = 0;
-    uint64_t tensor_count = 0;
-    uint64_t kv_count = 0;
-    if (!read_le(in, version) || !read_le(in, tensor_count) || !read_le(in, kv_count)) return false;
-    (void)version;
-    (void)tensor_count;
-
-    int64_t pending_context_length = 0;
-
-    for (uint64_t i = 0; i < kv_count; ++i) {
-        std::string key;
-        uint32_t type = 0;
-        if (!read_gguf_string(in, key) || !read_le(in, type)) return false;
-
-        // Read architecture
-        if (key == "general.architecture" && type == 8) {
-            if (!read_gguf_string(in, out.architecture)) return false;
-            if (pending_context_length > 0) {
-                out.context_length = pending_context_length;
-            }
-            continue;
-        }
-
-        // Context length
-        const bool context_key = !out.architecture.empty() && key == out.architecture + ".context_length";
-        const bool possible_context_key = out.architecture.empty() && key.size() > std::strlen(".context_length") &&
-                                          ends_with_ignore_case(key, ".context_length");
-        if (context_key || possible_context_key) {
-            int64_t value = 0;
-            if (read_gguf_integer_value(in, type, value) && value > 0) {
-                if (context_key) {
-                    out.context_length = value;
-                } else {
-                    pending_context_length = value;
-                }
-            }
-            continue;
-        }
-
-        // Architecture fields for KV cache estimation
-        if (!out.architecture.empty()) {
-            if (key == out.architecture + ".block_count") {
-                int64_t value = 0;
-                if (read_gguf_integer_value(in, type, value) && value > 0)
-                    out.block_count = value;
-                continue;
-            }
-            if (key == out.architecture + ".embedding_length") {
-                int64_t value = 0;
-                if (read_gguf_integer_value(in, type, value) && value > 0)
-                    out.embedding_length = value;
-                continue;
-            }
-            if (key == out.architecture + ".attention.head_count_kv") {
-                int64_t value = 0;
-                if (read_gguf_integer_value(in, type, value) && value > 0)
-                    out.head_count_kv = value;
-                continue;
-            }
-            if (key == out.architecture + ".attention.key_length") {
-                int64_t value = 0;
-                if (read_gguf_integer_value(in, type, value) && value > 0)
-                    out.key_length = value;
-                continue;
-            }
-        }
-
-        // Capability detection (vision, tool-calling, MTP)
-        if (type == 4) {
-            uint32_t val = 0;
-            if (read_le(in, val)) {
-                if (contains_ignore_case(key, "nextn_predict_layers") && val > 0)
-                    out.caps.mtp = true;
-            }
-        } else if (type == 8) {
-            std::string value;
-            if (read_gguf_string(in, value)) {
-                inspect_gguf_string(key, value, out.caps);
-            }
-        } else if (type == 9) {
-            // Array — check string elements for capability hints
-            uint32_t elem_type = 0;
-            uint64_t count = 0;
-            if (read_le(in, elem_type) && read_le(in, count)) {
-                if (elem_type == 8) {
-                    for (uint64_t j = 0; j < count; ++j) {
-                        std::string value;
-                        if (!read_gguf_string(in, value)) return false;
-                        inspect_gguf_string(key, value, out.caps);
-                    }
-                } else if (elem_type != 9) {
-                    uint64_t elem_size = gguf_scalar_size(elem_type);
-                    if (elem_size == 0) return false;
-                    if (!skip_bytes(in, count * elem_size)) return false;
-                } else {
-                    return false;
-                }
-            } else {
-                return false;
-            }
-        } else {
-            if (!skip_gguf_value(in, type)) return false;
-        }
-    }
-
-    if (out.context_length == 0 && pending_context_length > 0) {
-        out.context_length = pending_context_length;
-    }
-    return true;
-}
-
 // Candidate roots that FLM may use to store models. FLM resolves its model
 // directory from the FLM_MODEL_PATH env var (set by the installer) and falls
 // back to a built-in default that has changed across releases. lemond is often
@@ -484,17 +256,14 @@ static void populate_model_metadata(ModelInfo& info) {
             GgufMetadata meta;
             if (read_gguf_metadata(meta, gguf_path)) {
                 info.max_context_window = meta.context_length;
-                info.gguf_block_count = meta.block_count;
-                info.gguf_embedding_length = meta.embedding_length;
-                info.gguf_head_count_kv = meta.head_count_kv;
-                info.gguf_key_length = meta.key_length;
+                info.gguf = std::move(meta);
 
                 // GGUF vision/tool metadata are LLM capabilities. Do not apply
                 // them to embedding/reranking models, otherwise labels such as
                 // tool-calling would reclassify the model away from its endpoint
                 // type and break /embeddings or /rerank.
                 if (info.type == ModelType::LLM) {
-                    apply_gguf_capability_labels(info.labels, meta.caps);
+                    apply_gguf_capability_labels(info.labels, info.gguf.caps);
                 }
             }
         }

--- a/test/cpp/test_auto_tune.cpp
+++ b/test/cpp/test_auto_tune.cpp
@@ -1,0 +1,356 @@
+// Standalone test for GGUF array storage and weighted KV cache computation.
+//
+// Covers:
+//  - GgufMetadata raw array fields (head_count_kv_per_layer, sliding_window_pattern)
+//  - Post-loop derivation of scalar convenience fields
+//  - compute_weighted_kv_cache_bytes_per_token() with per-layer arrays
+//  - full_attention_interval exact count (floor((n-1)/interval) + 1)
+//  - SWA precise weighted sum vs proportional approximation
+//
+// Compile: g++ -std=c++17 -I src/cpp/include test/cpp/test_auto_tune.cpp -o test_auto_tune
+
+#include "lemon/gguf_reader.h"
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+using lemon::GgufMetadata;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+// Floating-point equality with tolerance
+static bool approx_eq(double a, double b, double tol = 0.001) {
+    return std::fabs(a - b) < tol;
+}
+
+// ── Helpers to simulate post-loop derivation ─────────────────────────
+
+/// Simulate what read_gguf_metadata does after the KV loop:
+/// derive head_count_kv and swa_layer_count from raw arrays/scalars.
+static void derive_scalars(GgufMetadata& m) {
+    // head_count_kv derivation
+    if (!m.head_count_kv_per_layer.empty()) {
+        for (int64_t v : m.head_count_kv_per_layer)
+            m.head_count_kv += v;
+    } else if (m.head_count_kv_scalar > 0 && m.block_count > 0) {
+        m.head_count_kv = m.head_count_kv_scalar * m.block_count;
+        m.head_count_kv_per_layer.assign(m.block_count, m.head_count_kv_scalar);
+    }
+
+    // swa_layer_count derivation
+    if (!m.sliding_window_pattern.empty()) {
+        for (bool v : m.sliding_window_pattern)
+            if (v) m.swa_layer_count++;
+    }
+}
+
+// ── Test: scalar head_count_kv derivation ─────────────────────────────
+
+static void test_scalar_head_count_kv() {
+    GgufMetadata m;
+    m.block_count = 32;
+    m.head_count_kv_scalar = 4;  // 4 KV heads per block
+
+    derive_scalars(m);
+
+    check("scalar: head_count_kv = scalar * block_count",
+          m.head_count_kv == 4 * 32);
+    check("scalar: per_layer array populated uniformly",
+          m.head_count_kv_per_layer.size() == 32);
+    check("scalar: per_layer values all equal scalar",
+          std::all_of(m.head_count_kv_per_layer.begin(),
+                      m.head_count_kv_per_layer.end(),
+                      [](int64_t v) { return v == 4; }));
+}
+
+// ── Test: array head_count_kv derivation ──────────────────────────────
+
+static void test_array_head_count_kv() {
+    GgufMetadata m;
+    m.block_count = 4;
+    m.head_count_kv_per_layer = {8, 16, 8, 16};  // varying per block
+
+    derive_scalars(m);
+
+    check("array: head_count_kv = sum of array",
+          m.head_count_kv == 8 + 16 + 8 + 16);
+    check("array: scalar not used when array present",
+          m.head_count_kv == 48);
+}
+
+// ── Test: sliding_window_pattern derivation ───────────────────────────
+
+static void test_swa_pattern_derivation() {
+    GgufMetadata m;
+    m.block_count = 8;
+    m.sliding_window_pattern = {false, true, false, true, false, true, false, true};
+
+    derive_scalars(m);
+
+    check("swa: swa_layer_count = number of true entries",
+          m.swa_layer_count == 4);
+}
+
+// ── Test: standard MHA/GQA (no scaling) ──────────────────────────────
+
+static void test_standard_mha() {
+    GgufMetadata m;
+    m.block_count = 32;
+    m.key_length = 128;
+    m.head_count_kv_per_layer.assign(32, 4);  // 4 KV heads per block
+
+    derive_scalars(m);
+    // Expected: 128 total heads * 128 key_len * 2[F16] * 2[K+V] = 65536
+    double bytes = lemon::compute_weighted_kv_cache_bytes_per_token(m);
+
+    check("standard: kv_bytes = total_heads * key_len * 4",
+          approx_eq(bytes, 128.0 * 128.0 * 4.0));
+}
+
+// ── Test: SWA with per-layer arrays (precise weighted sum) ───────────
+
+static void test_swa_precise() {
+    GgufMetadata m;
+    m.block_count = 4;
+    m.key_length = 256;
+    m.key_length_swa = 128;  // SWA layers use half the key dim
+
+    // 2 full layers (8 heads each), 2 SWA layers (4 heads each)
+    m.head_count_kv_per_layer = {8, 4, 8, 4};
+    m.sliding_window_pattern = {false, true, false, true};
+
+    derive_scalars(m);
+
+    // Expected weighted sum:
+    //   layer 0: 8 * 256 = 2048  (full)
+    //   layer 1: 4 * 128 = 512   (swa)
+    //   layer 2: 8 * 256 = 2048  (full)
+    //   layer 3: 4 * 128 = 512   (swa)
+    //   total weighted = 5120
+    //   bytes = 5120 * 4 = 20480
+    double bytes = lemon::compute_weighted_kv_cache_bytes_per_token(m);
+
+    check("swa-precise: weighted kv_bytes correct",
+          approx_eq(bytes, 5120.0 * 4.0));
+
+    double scale = 0;
+    lemon::compute_weighted_kv_cache_bytes_per_token(m, &scale);
+    // Unweighted: (8+4+8+4) * 256 = 4608
+    // scale = 5120 / 4608 ≈ 1.1111... wait, that's > 1 which is wrong
+    // Actually: weighted = 8*256 + 4*128 + 8*256 + 4*128 = 2048+512+2048+512 = 5120
+    // unweighted = (8+4+8+4) * 256 = 24 * 256 = 6144
+    // scale = 5120 / 6144 ≈ 0.8333
+    check("swa-precise: scale factor < 1.0",
+          scale > 0.0 && scale < 1.0);
+    check("swa-precise: scale ≈ 0.8333",
+          approx_eq(scale, 5120.0 / 6144.0));
+}
+
+// ── Test: SWA with scalar fallback (proportional approximation) ──────
+
+static void test_swa_scalar_fallback() {
+    GgufMetadata m;
+    m.block_count = 4;
+    m.key_length = 256;
+    m.key_length_swa = 128;
+
+    // Scalar case: no per-layer array, no sliding_window_pattern
+    m.head_count_kv_scalar = 8;  // uniform 8 heads per block
+
+    derive_scalars(m);
+    // After derivation, per_layer IS populated from scalar, and swa_pattern is empty.
+    // Since swa_pattern is empty, the precise path is NOT taken.
+    // Falls back to proportional: factor = 1 - swa_ratio + swa_ratio * dim_ratio
+    // But swa_layer_count = 0 (no pattern), so factor = 1.0
+
+    double bytes = lemon::compute_weighted_kv_cache_bytes_per_token(m);
+    // No SWA detected (no pattern), so standard formula:
+    // 32 heads * 256 * 4 = 32768
+    check("swa-scalar-no-pattern: uses standard formula when no pattern",
+          approx_eq(bytes, 32.0 * 256.0 * 4.0));
+}
+
+// ── Test: SWA with scalar + manually set swa_layer_count ─────────────
+
+static void test_swa_scalar_with_count() {
+    GgufMetadata m;
+    m.block_count = 4;
+    m.key_length = 256;
+    m.key_length_swa = 128;
+    m.swa_layer_count = 2;  // 2 out of 4 layers are SWA
+
+    m.head_count_kv_scalar = 8;
+
+    derive_scalars(m);
+    // per_layer populated from scalar, pattern empty → proportional fallback
+    // factor = 1 - 2/4 + 2/4 * 128/256 = 1 - 0.5 + 0.25 = 0.75
+    // bytes = 32 * 256 * 4 * 0.75 = 24576
+
+    double bytes = lemon::compute_weighted_kv_cache_bytes_per_token(m);
+    check("swa-scalar-count: proportional factor applied",
+          approx_eq(bytes, 32.0 * 256.0 * 4.0 * 0.75));
+}
+
+// ── Test: full_attention_interval exact count ─────────────────────────
+
+static void test_full_attention_interval() {
+    // For each (blocks, interval), verify the exact count:
+    // floor((blocks - 1) / interval) + 1
+    struct TestCase {
+        int64_t blocks;
+        int64_t interval;
+        int64_t expected_full_layers;
+        double expected_factor;  // expected_full_layers / blocks
+    };
+
+    TestCase cases[] = {
+        {1, 12, 1, 1.0 / 1},        // single layer, all attention
+        {11, 12, 1, 1.0 / 11},      // less than one interval
+        {12, 12, 1, 1.0 / 12},      // exactly one interval (layer 0 only)
+        {13, 12, 2, 2.0 / 13},      // just over one interval
+        {36, 12, 3, 3.0 / 36},      // layers 0, 12, 24
+        {37, 12, 4, 4.0 / 37},      // layers 0, 12, 24, 36
+        {48, 12, 4, 4.0 / 48},      // layers 0, 12, 24, 36
+        {49, 12, 5, 5.0 / 49},      // layers 0, 12, 24, 36, 48
+        {96, 12, 8, 8.0 / 96},      // evenly divisible
+        {97, 12, 9, 9.0 / 97},      // one over
+    };
+
+    for (const auto& tc : cases) {
+        GgufMetadata m;
+        m.block_count = tc.blocks;
+        m.key_length = 128;
+        m.full_attention_interval = tc.interval;
+        m.head_count_kv_per_layer.assign(tc.blocks, 4);
+
+        derive_scalars(m);
+
+        double bytes = lemon::compute_weighted_kv_cache_bytes_per_token(m);
+        double scale = 0;
+        lemon::compute_weighted_kv_cache_bytes_per_token(m, &scale);
+
+        // Total heads = blocks * 4, base bytes = total_heads * 128 * 4
+        double base_bytes = static_cast<double>(tc.blocks) * 4.0 * 128.0 * 4.0;
+        double expected_bytes = base_bytes * tc.expected_factor;
+
+        char buf[128];
+        std::snprintf(buf, sizeof(buf),
+                      "fai: blocks=%ld interval=%ld → factor=%.4f",
+                      (long)tc.blocks, (long)tc.interval, scale);
+        check(buf, approx_eq(scale, tc.expected_factor, 0.001));
+
+        std::snprintf(buf, sizeof(buf),
+                      "fai: blocks=%ld interval=%ld → bytes",
+                      (long)tc.blocks, (long)tc.interval);
+        check(buf, approx_eq(bytes, expected_bytes, 1.0));
+    }
+}
+
+// ── Test: full_attention_interval formula vs old approximation ────────
+
+static void test_fai_improvement() {
+    // Demonstrate that the exact formula differs meaningfully from 1/interval
+    // for non-divisible block counts.
+    GgufMetadata m;
+    m.block_count = 37;
+    m.key_length = 128;
+    m.full_attention_interval = 12;
+    m.head_count_kv_per_layer.assign(37, 4);
+
+    derive_scalars(m);
+
+    double scale = 0;
+    lemon::compute_weighted_kv_cache_bytes_per_token(m, &scale);
+
+    double old_approx = 1.0 / 12.0;   // ≈ 0.0833
+    double exact = 4.0 / 37.0;        // ≈ 0.1081
+
+    check("fai-improvement: exact ≠ old approximation for 37/12",
+          !approx_eq(old_approx, exact, 0.01));
+    check("fai-improvement: uses exact count (4/37 ≈ 0.1081)",
+          approx_eq(scale, exact, 0.001));
+    check("fai-improvement: exact > old (conservative: over-estimates KV)",
+          scale > old_approx);
+}
+
+// ── Test: missing metadata returns 0 ──────────────────────────────────
+
+static void test_missing_metadata() {
+    GgufMetadata m_empty;
+    double bytes = lemon::compute_weighted_kv_cache_bytes_per_token(m_empty);
+    check("missing: no metadata returns 0", bytes == 0.0);
+
+    GgufMetadata m_no_blocks;
+    m_no_blocks.key_length = 128;
+    m_no_blocks.head_count_kv = 64;
+    bytes = lemon::compute_weighted_kv_cache_bytes_per_token(m_no_blocks);
+    check("missing: no block_count returns 0", bytes == 0.0);
+
+    GgufMetadata m_no_keylen;
+    m_no_keylen.block_count = 32;
+    m_no_keylen.head_count_kv = 64;
+    bytes = lemon::compute_weighted_kv_cache_bytes_per_token(m_no_keylen);
+    check("missing: no key_length returns 0", bytes == 0.0);
+}
+
+// ── Test: varying head counts with SWA ────────────────────────────────
+
+static void test_varying_heads_swa() {
+    // Model where SWA layers have FEWER heads than full layers.
+    // This is where the precise weighted sum matters most.
+    GgufMetadata m;
+    m.block_count = 6;
+    m.key_length = 256;
+    m.key_length_swa = 64;  // 4x reduction in SWA
+
+    // Full layers: 16 heads, SWA layers: 4 heads
+    m.head_count_kv_per_layer = {16, 4, 16, 4, 16, 4};
+    m.sliding_window_pattern = {false, true, false, true, false, true};
+
+    derive_scalars(m);
+
+    // Precise:
+    //   full: 16*256 + 16*256 + 16*256 = 12288
+    //   swa:  4*64  + 4*64  + 4*64  = 768
+    //   weighted = 13056
+    //   bytes = 13056 * 4 = 52224
+    double bytes = lemon::compute_weighted_kv_cache_bytes_per_token(m);
+    check("varying-heads-swa: precise weighted sum",
+          approx_eq(bytes, 13056.0 * 4.0));
+
+    // Old proportional approximation (with uniform head count = total/6 = 6):
+    //   factor = 1 - 3/6 + 3/6 * 64/256 = 1 - 0.5 + 0.125 = 0.625
+    //   bytes = 60 * 256 * 4 * 0.625 = 38400
+    // The precise value (52224) is significantly different!
+    double old_approx = 60.0 * 256.0 * 4.0 * 0.625;
+    check("varying-heads-swa: precise differs from proportional",
+          !approx_eq(bytes, old_approx, 1000.0));
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+int main() {
+    test_scalar_head_count_kv();
+    test_array_head_count_kv();
+    test_swa_pattern_derivation();
+    test_standard_mha();
+    test_swa_precise();
+    test_swa_scalar_fallback();
+    test_swa_scalar_with_count();
+    test_full_attention_interval();
+    test_fai_improvement();
+    test_missing_metadata();
+    test_varying_heads_swa();
+
+    if (g_failures == 0) {
+        std::printf("\nAll auto_tune tests passed\n");
+        return 0;
+    }
+    std::printf("\n%d auto_tune test(s) FAILED\n", g_failures);
+    return 1;
+}


### PR DESCRIPTION
Account for different model architectures to provide better estimate to maximize the automatic ctx_size value. While the estimates are still on the conservative size, they are much closer to real especially for Qwen3.5/3.6