### PR TITLE
fix(packaging): don't auto-enable the per-user lemond.service (Closes #2125)

### DIFF
--- a/contrib/debian/lemonade-server.postinst
+++ b/contrib/debian/lemonade-server.postinst
@@ -30,4 +30,15 @@ if [ "$1" = "configure" ]; then
 	fi
 fi
 
+# #2125: migrate pre-fix upgrades — disable per-user lemond.service and stop
+# any still-running instance that conflicts with the system service.
+if [ "$1" = "configure" ] && [ -n "$2" ] && dpkg --compare-versions "$2" lt "10.8.1~"; then
+	if command -v deb-systemd-helper > /dev/null 2>&1; then
+		deb-systemd-helper --user disable lemond.service > /dev/null 2>&1 || true
+	fi
+	if [ -d /run/systemd/system ] && command -v deb-systemd-invoke > /dev/null 2>&1; then
+		deb-systemd-invoke --user stop lemond.service > /dev/null 2>&1 || true
+	fi
+fi
+
 #DEBHELPER#

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -13,3 +13,8 @@ override_dh_auto_test:
 
 override_dh_install:
 	dh_install
+
+# #2125: ship per-user lemond.service DISABLED to avoid port conflicts with
+# the system service in every --user session.
+override_dh_installsystemduser:
+	dh_installsystemduser --no-enable


### PR DESCRIPTION
## Problem

`dh_installsystemduser` enables user units globally by default, so the package enabled the per-user `lemond.service` (`WantedBy=default.target`) on top of the already-enabled system unit — and both bind `:13305`. systemd then starts a per-user `lemond` in *every* `--user` session:

- The **gdm-greeter** dynamic-user session reaches `default.target` at the login screen and binds `:13305` **before anyone logs in**, blocking the system service and the user's own session (the reported bug).
- **Any** other session — a desktop login or an SSH login — likewise spawns a redundant instance that can't serve, since it collides with the system service on `:13305`.

On one of our Ubuntu 26.04 servers this leaves **three** `lemond` processes running: the system service plus a per-session instance for each of two logged-in users (~18 MB each), only the system one able to serve.

## Reproduced (Ubuntu 26.04 + GDM)

Installed the package and rebooted; at the login screen, before any login, `lemond` was running as `gdm-greeter` (uid 60578) holding `127.0.0.1:13305` and `[::1]:13305`, with a second session's instance cycling on `Restart=on-failure`. With the fix (user unit not globally enabled) the greeter does not start it and `:13305` is free; the system service still serves.

## Fix

Debian DEB path only — the RPM postinst enables only the system unit, and the cpack DEB doesn't use `dh_installsystemduser`:

1. **`contrib/debian/rules`** — `dh_installsystemduser --no-enable`, so fresh installs ship the per-user unit present but disabled. Nothing is removed: the system service keeps serving `:13305` by default, and a user can still opt into a per-user instance with `systemctl --user enable --now lemond` (after freeing the port from the system unit). This complements #2173, which makes the user unit reliably available across install layouts.

2. **`contrib/debian/lemonade-server.postinst`** — `--no-enable` doesn't undo enablement left by an affected prior release, so on upgrade from a pre-fix version a version-gated, one-shot migration disables the leftover global user-unit enable **and** stops any per-user instance still holding the port (`deb-systemd-invoke --user stop`), so the conflict clears without a reboot. A user's deliberate later enable is preserved.

> **Maintainer note:** the migration's version threshold (`10.8.1~`) is a placeholder — please set it to the first release that ships this change.

Closes #2125.
