### PR TITLE
feat(vllm): add Qwen3.6 + GLM-4.7-Flash models; fix AWQ dtype

### DIFF
--- a/src/cpp/include/lemon/backends/vllm_arg_resolver.h
+++ b/src/cpp/include/lemon/backends/vllm_arg_resolver.h
@@ -10,6 +10,9 @@ namespace backends {
 struct VLLMArgResolution {
     std::vector<std::string> args;
     bool has_memory_budget_arg = false;
+    // True when the user/family already supplied --dtype, so backend code
+    // should not force its own (e.g. the AWQ float16 default).
+    bool has_dtype_arg = false;
 };
 
 VLLMArgResolution resolve_vllm_args(const std::string& model_name,

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1640,5 +1640,37 @@
             "tool-calling"
         ],
         "size": 19.3
+    },
+    "Qwen3.6-27B-FP16-vLLM": {
+        "checkpoint": "Qwen/Qwen3.6-27B",
+        "recipe": "vllm",
+        "suggested": true,
+        "labels": [
+            "reasoning",
+            "tool-calling",
+            "vision"
+        ],
+        "size": 55.59
+    },
+    "Qwen3.6-35B-A3B-FP16-vLLM": {
+        "checkpoint": "Qwen/Qwen3.6-35B-A3B",
+        "recipe": "vllm",
+        "suggested": true,
+        "labels": [
+            "reasoning",
+            "tool-calling",
+            "vision"
+        ],
+        "size": 71.93
+    },
+    "GLM-4.7-Flash-FP16-vLLM": {
+        "checkpoint": "zai-org/GLM-4.7-Flash",
+        "recipe": "vllm",
+        "suggested": true,
+        "labels": [
+            "reasoning",
+            "tool-calling"
+        ],
+        "size": 62.47
     }
 }

--- a/src/cpp/resources/vllm_model_config.json
+++ b/src/cpp/resources/vllm_model_config.json
@@ -9,6 +9,14 @@
         }
       ],
       "args": "--enable-auto-tool-choice --tool-call-parser qwen3_coder"
+    },
+    "glm4.7": {
+      "match": [
+        {
+          "checkpoint_regex": "GLM-4\\.7"
+        }
+      ],
+      "args": "--enable-auto-tool-choice --tool-call-parser glm47"
     }
   },
   "models": {
@@ -23,6 +31,15 @@
     },
     "Qwen3.5-9B-FP16-vLLM": {
       "family": "qwen3."
+    },
+    "Qwen3.6-27B-FP16-vLLM": {
+      "family": "qwen3."
+    },
+    "Qwen3.6-35B-A3B-FP16-vLLM": {
+      "family": "qwen3."
+    },
+    "GLM-4.7-Flash-FP16-vLLM": {
+      "family": "glm4.7"
     }
   }
 }

--- a/src/cpp/server/backends/vllm_arg_resolver.cpp
+++ b/src/cpp/server/backends/vllm_arg_resolver.cpp
@@ -233,6 +233,11 @@ bool has_memory_budget_arg(const std::vector<ParsedArg>& args) {
     return std::any_of(args.begin(), args.end(), is_memory_budget_arg);
 }
 
+bool has_dtype_arg(const std::vector<ParsedArg>& args) {
+    return std::any_of(args.begin(), args.end(),
+                       [](const ParsedArg& arg) { return arg.flag == "--dtype"; });
+}
+
 } // namespace
 
 VLLMArgResolution resolve_vllm_args(const std::string& model_name,
@@ -277,7 +282,7 @@ VLLMArgResolution resolve_vllm_args(const std::string& model_name,
 
     merge_layer(resolved, parse_args(user_vllm_args, "vllm_args"));
 
-    return {flatten_args(resolved), has_memory_budget_arg(resolved)};
+    return {flatten_args(resolved), has_memory_budget_arg(resolved), has_dtype_arg(resolved)};
 }
 
 } // namespace backends

--- a/src/cpp/server/backends/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm_server.cpp
@@ -201,6 +201,15 @@ void VLLMServer::load(const std::string& model_name,
         LOG(DEBUG, "vLLM") << "Detected AWQ; forcing --quantization awq" << std::endl;
         args.push_back("--quantization");
         args.push_back("awq");
+        // vLLM's AWQ kernels only support float16. Many AWQ repos still declare
+        // bfloat16 in config.json, which makes vLLM abort with "torch.bfloat16 is
+        // not supported for quantization method awq". Force float16 so AWQ models
+        // load, unless the user already pinned a --dtype themselves.
+        if (!resolved_vllm_args.has_dtype_arg) {
+            LOG(DEBUG, "vLLM") << "Forcing --dtype float16 for AWQ" << std::endl;
+            args.push_back("--dtype");
+            args.push_back("float16");
+        }
     } else if (!quant_method.empty()) {
         LOG(DEBUG, "vLLM") << "Detected quantization '" << quant_method
                            << "'; letting vLLM auto-select kernel" << std::endl;

--- a/test/cpp/test_vllm_arg_resolver.cpp
+++ b/test/cpp/test_vllm_arg_resolver.cpp
@@ -68,6 +68,18 @@ static bool expect_args(const char* name,
     return ok;
 }
 
+static bool expect_dtype_flag(const char* name,
+                              const VLLMArgResolution& actual,
+                              bool expected_dtype) {
+    bool ok = actual.has_dtype_arg == expected_dtype;
+    std::printf("[%s] %s\n  got:  has_dtype_arg=%s\n  want: has_dtype_arg=%s\n",
+                ok ? "PASS" : "FAIL",
+                name,
+                actual.has_dtype_arg ? "true" : "false",
+                expected_dtype ? "true" : "false");
+    return ok;
+}
+
 static bool expect_error(const char* name,
                          const std::string& arg_string,
                          const std::string& expected_substring) {
@@ -258,6 +270,17 @@ int main() {
         "short vLLM flags still parse as flags",
         resolve_vllm_args("Unlisted-vLLM", "Other/Model", test_config(), "-tp 2 --max-num-seqs 4"),
         "-tp 2 --max-num-seqs 4");
+
+    // has_dtype_arg drives whether the backend forces --dtype float16 for AWQ.
+    failures += !expect_dtype_flag(
+        "no user --dtype leaves has_dtype_arg false",
+        resolve_vllm_args("Unlisted-vLLM", "Other/Model", test_config(), ""),
+        false);
+
+    failures += !expect_dtype_flag(
+        "user --dtype is detected",
+        resolve_vllm_args("Unlisted-vLLM", "Other/Model", test_config(), "--dtype bfloat16"),
+        true);
 
     std::printf("\n%d failures\n", failures);
     return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## What

Closes #1859 — adds three vLLM models to the registry and fixes AWQ model loading on the vLLM backend.

### New models (`server_models.json` + `vllm_model_config.json`)
| Model | Checkpoint | Size | Notes |
|---|---|---|---|
| `Qwen3.6-27B-FP16-vLLM` | `Qwen/Qwen3.6-27B` | 55.6 GB | reasoning, tool-calling, vision |
| `Qwen3.6-35B-A3B-FP16-vLLM` | `Qwen/Qwen3.6-35B-A3B` | 71.9 GB | reasoning, tool-calling, vision (MoE) |
| `GLM-4.7-Flash-FP16-vLLM` | `zai-org/GLM-4.7-Flash` | 62.5 GB | reasoning, tool-calling (MoE) |

- Qwen3.6 inherits the existing `qwen3.` family (`--tool-call-parser qwen3_coder`).
- New `glm4.7` family added with `--tool-call-parser glm47` (present in the pinned vLLM 0.20.1 bundle).

### AWQ dtype fix (`vllm_server.cpp`, `vllm_arg_resolver.*`)
When the backend detects AWQ and forces `--quantization awq`, it now also passes `--dtype float16` unless the user pinned a `--dtype` themselves. vLLM's AWQ kernels only support float16, but many AWQ repos still declare `bfloat16` in `config.json`, so vLLM aborts with `torch.bfloat16 is not supported for quantization method awq`. This is the blocker behind the `-lgcc_s`/AWQ report in #1859 — that specific `-lgcc_s` error is a separate host-toolchain gap (missing `libgcc_s.so` dev symlink) on the reporter's machine, not a lemonade bug.

A `has_dtype_arg` flag was added to `VLLMArgResolution` (mirroring `has_memory_budget_arg`) so a user-supplied `--dtype` takes precedence.

## Testing
Verified end-to-end on gfx1151 (Strix Halo) with the prebuilt vLLM ROCm backend:
- `Qwen3.6-27B-FP16-vLLM` — loads (51 GiB) and serves chat. ✅
- `GLM-4.7-Flash-FP16-vLLM` — loads (57.5 GiB), serves chat **and** a structured tool call via the `glm47` parser. ✅
- `Qwen3.6-35B-A3B-FP16-vLLM` (71.9 GB) — correctly filtered by the >80%-RAM guard on the 64 GB test box; targets ≥128 GB machines.
- AWQ regression: an AWQ Qwen3.6 checkpoint loaded via the **user-models** feature (`POST /pull` with `user.` prefix) previously failed with the bf16/AWQ error; with this fix it loads (22.95 GiB) and serves. ✅
- New unit cases added to `test/cpp/test_vllm_arg_resolver.cpp` for `has_dtype_arg` (all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)