### PR TITLE
Allow HTTP custom backends with warnings

### DIFF
--- a/src/app/src/renderer/BackendManager.tsx
+++ b/src/app/src/renderer/BackendManager.tsx
@@ -34,9 +34,10 @@ interface BackendManagerProps {
   searchQuery: string;
   showError: (msg: string) => void;
   showSuccess: (msg: string) => void;
+  showWarning: (msg: string) => void;
 }
 
-const BackendManager: React.FC<BackendManagerProps> = ({ searchQuery, showError, showSuccess }) => {
+const BackendManager: React.FC<BackendManagerProps> = ({ searchQuery, showError, showSuccess, showWarning }) => {
   const { systemInfo, isLoading, refresh } = useSystem();
   const [backendAssetSizes, setBackendAssetSizes] = useState<Record<string, number>>({});
 
@@ -172,6 +173,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ searchQuery, showError,
       searchQuery={searchQuery}
       showError={showError}
       showSuccess={showSuccess}
+      showWarning={showWarning}
     />
   );
 

--- a/src/app/src/renderer/CloudProvidersSection.tsx
+++ b/src/app/src/renderer/CloudProvidersSection.tsx
@@ -10,6 +10,7 @@ import { useModels } from './hooks/useModels';
 interface CloudProviderRow {
   name: string;
   base_url: string;
+  allow_insecure_http: boolean;
   env_var: string;
   env_var_set: boolean;
   runtime_key_set: boolean;
@@ -41,6 +42,8 @@ const extractWarnings = (value: any): string[] => {
   return [];
 };
 
+const isHttpBaseUrl = (value: string): boolean => value.trim().toLowerCase().startsWith('http://');
+
 const fetchCloudProviders = async (): Promise<CloudProviderRow[]> => {
   const response = await serverConfig.fetch('/system-info');
   if (!response.ok) return [];
@@ -52,6 +55,7 @@ const fetchCloudProviders = async (): Promise<CloudProviderRow[]> => {
     .map((p: any) => ({
       name: String(p.name),
       base_url: typeof p.base_url === 'string' ? p.base_url : '',
+      allow_insecure_http: p.allow_insecure_http === true,
       env_var: typeof p.env_var === 'string' ? p.env_var : '',
       env_var_set: p.env_var_set === true,
       runtime_key_set: p.runtime_key_set === true,
@@ -88,12 +92,20 @@ const InstallModal: React.FC<InstallModalProps> = ({ onClose, onInstalled, showE
     setBusy(true);
     setError(null);
     try {
-      const body: Record<string, string> = {
+      const normalizedBaseUrl = baseUrl.trim();
+      const normalizedApiKey = apiKey.trim();
+      const needsInsecureOptIn = isHttpBaseUrl(normalizedBaseUrl) && !!normalizedApiKey;
+      if (needsInsecureOptIn && !window.confirm('Send this API key over http://? Traffic to this provider will not be encrypted.')) {
+        setBusy(false);
+        return;
+      }
+      const body: Record<string, string | boolean> = {
         backend: 'cloud',
         provider: provider.trim(),
-        base_url: baseUrl.trim(),
+        base_url: normalizedBaseUrl,
       };
-      if (apiKey.trim()) body.api_key = apiKey.trim();
+      if (needsInsecureOptIn) body.allow_insecure_http = true;
+      if (normalizedApiKey) body.api_key = normalizedApiKey;
       const response = await serverConfig.fetch('/install', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -239,10 +251,19 @@ const EditModal: React.FC<EditModalProps> = ({ row, onClose, onChanged, showErro
     }
     setBusy(true); setError(null);
     try {
+      const needsInsecureOptIn = isHttpBaseUrl(row.base_url) && !row.allow_insecure_http;
+      if (needsInsecureOptIn && !window.confirm('Send this API key over http://? Traffic to this provider will not be encrypted.')) {
+        setBusy(false);
+        return;
+      }
       const r = await serverConfig.fetch('/cloud/auth', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: row.name, api_key: apiKey.trim() }),
+        body: JSON.stringify({
+          provider: row.name,
+          api_key: apiKey.trim(),
+          ...(needsInsecureOptIn ? { allow_insecure_http: true } : {}),
+        }),
       });
       if (r.status === 409) {
         const body = await r.json().catch(() => null);
@@ -264,7 +285,7 @@ const EditModal: React.FC<EditModalProps> = ({ row, onClose, onChanged, showErro
       setError(`Set auth failed: ${err instanceof Error ? err.message : String(err)}`);
       setBusy(false);
     }
-  }, [apiKey, row.env_var, row.name, onChanged, showSuccess, showWarning]);
+  }, [apiKey, row.allow_insecure_http, row.base_url, row.env_var, row.name, onChanged, showSuccess, showWarning]);
 
   const clearKey = useCallback(async () => {
     setBusy(true); setError(null);

--- a/src/app/src/renderer/CloudProvidersSection.tsx
+++ b/src/app/src/renderer/CloudProvidersSection.tsx
@@ -14,12 +14,14 @@ interface CloudProviderRow {
   env_var_set: boolean;
   runtime_key_set: boolean;
   models_discovered: number;
+  warnings: string[];
 }
 
 interface CloudProvidersSectionProps {
   searchQuery: string;
   showError: (msg: string) => void;
   showSuccess: (msg: string) => void;
+  showWarning: (msg: string) => void;
 }
 
 const QUICK_FILL: Array<{ label: string; name: string; baseUrl: string }> = [
@@ -28,6 +30,16 @@ const QUICK_FILL: Array<{ label: string; name: string; baseUrl: string }> = [
   { label: 'OpenRouter', name: 'openrouter', baseUrl: 'https://openrouter.ai/api/v1' },
   { label: 'Together', name: 'together', baseUrl: 'https://api.together.xyz/v1' },
 ];
+
+const extractWarnings = (value: any): string[] => {
+  if (Array.isArray(value?.warnings)) {
+    return value.warnings.filter((w: any) => typeof w === 'string');
+  }
+  if (typeof value?.warning === 'string' && value.warning) {
+    return [value.warning];
+  }
+  return [];
+};
 
 const fetchCloudProviders = async (): Promise<CloudProviderRow[]> => {
   const response = await serverConfig.fetch('/system-info');
@@ -44,21 +56,23 @@ const fetchCloudProviders = async (): Promise<CloudProviderRow[]> => {
       env_var_set: p.env_var_set === true,
       runtime_key_set: p.runtime_key_set === true,
       models_discovered: typeof p.models_discovered === 'number' ? p.models_discovered : 0,
+      warnings: extractWarnings(p),
     }));
 };
 
 // Install modal — single source for both new-provider registration and
 // supplying an initial key. Optional api_key because LEMONADE_<P>_API_KEY may
-// already cover this provider on the server; in that case the server returns
-// a "warning" field which we surface verbatim.
+// already cover this provider on the server; any server warnings are surfaced
+// through the shared warning toast.
 interface InstallModalProps {
   onClose: () => void;
   onInstalled: () => void;
   showError: (msg: string) => void;
   showSuccess: (msg: string) => void;
+  showWarning: (msg: string) => void;
 }
 
-const InstallModal: React.FC<InstallModalProps> = ({ onClose, onInstalled, showError, showSuccess }) => {
+const InstallModal: React.FC<InstallModalProps> = ({ onClose, onInstalled, showError, showSuccess, showWarning }) => {
   const [provider, setProvider] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
   const [apiKey, setApiKey] = useState('');
@@ -93,17 +107,14 @@ const InstallModal: React.FC<InstallModalProps> = ({ onClose, onInstalled, showE
       }
       const result = await response.json();
       const discovered = result?.models_discovered ?? 0;
-      if (result?.warning) {
-        showSuccess(`Installed '${provider.trim()}' (${discovered} models). ${result.warning}`);
-      } else {
-        showSuccess(`Installed '${provider.trim()}' (${discovered} models).`);
-      }
+      showSuccess(`Installed '${provider.trim()}' (${discovered} models).`);
+      extractWarnings(result).forEach((warning) => showWarning(warning));
       onInstalled();
     } catch (err) {
       setError(`Install failed: ${err instanceof Error ? err.message : String(err)}`);
       setBusy(false);
     }
-  }, [provider, baseUrl, apiKey, onInstalled, showSuccess]);
+  }, [provider, baseUrl, apiKey, onInstalled, showSuccess, showWarning]);
 
   return (
     <>
@@ -212,9 +223,10 @@ interface EditModalProps {
   onChanged: () => void;
   showError: (msg: string) => void;
   showSuccess: (msg: string) => void;
+  showWarning: (msg: string) => void;
 }
 
-const EditModal: React.FC<EditModalProps> = ({ row, onClose, onChanged, showError, showSuccess }) => {
+const EditModal: React.FC<EditModalProps> = ({ row, onClose, onChanged, showError, showSuccess, showWarning }) => {
   const [apiKey, setApiKey] = useState('');
   const [showKey, setShowKey] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -246,12 +258,13 @@ const EditModal: React.FC<EditModalProps> = ({ row, onClose, onChanged, showErro
       }
       const result = await r.json();
       showSuccess(`API key stored for '${row.name}' (${result?.models_discovered ?? 0} models discovered).`);
+      extractWarnings(result).forEach((warning) => showWarning(warning));
       onChanged();
     } catch (err) {
       setError(`Set auth failed: ${err instanceof Error ? err.message : String(err)}`);
       setBusy(false);
     }
-  }, [apiKey, row.env_var, row.name, onChanged, showSuccess]);
+  }, [apiKey, row.env_var, row.name, onChanged, showSuccess, showWarning]);
 
   const clearKey = useCallback(async () => {
     setBusy(true); setError(null);
@@ -309,6 +322,17 @@ const EditModal: React.FC<EditModalProps> = ({ row, onClose, onChanged, showErro
             style={{ opacity: 0.7 }}
           />
         </div>
+
+        {row.warnings.length > 0 && (
+          <div className="form-section">
+            <label className="form-label">Warnings</label>
+            <div style={{ fontSize: '0.85rem', lineHeight: 1.5, color: 'var(--warning-color)' }}>
+              {row.warnings.map((warning) => (
+                <div key={warning}>{warning}</div>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="form-section">
           <label className="form-label">API key</label>
@@ -396,7 +420,7 @@ const EditModal: React.FC<EditModalProps> = ({ row, onClose, onChanged, showErro
   );
 };
 
-const CloudProvidersSection: React.FC<CloudProvidersSectionProps> = ({ searchQuery, showError, showSuccess }) => {
+const CloudProvidersSection: React.FC<CloudProvidersSectionProps> = ({ searchQuery, showError, showSuccess, showWarning }) => {
   const [providers, setProviders] = useState<CloudProviderRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [modal, setModal] = useState<
@@ -504,6 +528,14 @@ const CloudProvidersSection: React.FC<CloudProvidersSectionProps> = ({ searchQue
                           <span className="backend-version">
                             {p.models_discovered} model{p.models_discovered === 1 ? '' : 's'}
                           </span>
+                          {p.warnings.length > 0 && (
+                            <>
+                              <span className="backend-meta-separator">•</span>
+                              <span className="backend-version" style={{ color: 'var(--warning-color)' }}>
+                                {p.warnings[0]}
+                              </span>
+                            </>
+                          )}
                           {p.base_url && (
                             <>
                               <span className="backend-meta-separator">•</span>
@@ -546,6 +578,7 @@ const CloudProvidersSection: React.FC<CloudProvidersSectionProps> = ({ searchQue
                 onInstalled={() => { setModal(null); reloadAll(); }}
                 showError={showError}
                 showSuccess={showSuccess}
+                showWarning={showWarning}
               />
             ) : (
               <EditModal
@@ -554,6 +587,7 @@ const CloudProvidersSection: React.FC<CloudProvidersSectionProps> = ({ searchQue
                 onChanged={() => { setModal(null); reloadAll(); }}
                 showError={showError}
                 showSuccess={showSuccess}
+                showWarning={showWarning}
               />
             )}
           </div>

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -2081,6 +2081,7 @@ const [searchQuery, setSearchQuery] = useState('');
                 searchQuery={searchQuery}
                 showError={showError}
                 showSuccess={showSuccess}
+                showWarning={showWarning}
               />
             )}
             {currentView === 'settings' && <SettingsPanel isVisible={true} searchQuery={searchQuery} />}

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -132,6 +132,22 @@ std::string extract_server_error_message(const HttpError& error) {
     return error.what();
 }
 
+static void print_response_warnings(const json& value, const std::string& indent = "") {
+    if (value.contains("warnings") && value["warnings"].is_array()) {
+        for (const auto& warning : value["warnings"]) {
+            if (warning.is_string()) {
+                std::cout << indent << "Warning: " << warning.get<std::string>()
+                          << std::endl;
+            }
+        }
+        return;
+    }
+    if (value.contains("warning") && value["warning"].is_string()) {
+        std::cout << indent << "Warning: " << value["warning"].get<std::string>()
+                  << std::endl;
+    }
+}
+
 // Overloaded make_request with configurable timeouts (in milliseconds)
 std::string LemonadeClient::make_request(const std::string& path, const std::string& method,
                                           const std::string& body, const std::string& content_type,
@@ -884,7 +900,7 @@ int LemonadeClient::list_recipes(bool show_all) const {
                             << "-" << std::endl;
                 }
             } else {
-                for (const auto& backend : recipe.backends) {                    
+                for (const auto& backend : recipe.backends) {
                     std::string recipe_col = first_backend ? recipe.name : "";
                     std::string status_str = backend.state.empty() ? "unsupported" : backend.state;
 
@@ -1034,11 +1050,7 @@ int LemonadeClient::install_cloud_provider(const std::string& provider,
                       << response_json["models_discovered"].get<size_t>()
                       << std::endl;
         }
-        if (response_json.contains("warning")) {
-            std::cout << "Warning: "
-                      << response_json["warning"].get<std::string>()
-                      << std::endl;
-        }
+        print_response_warnings(response_json);
         return 0;
     } catch (const HttpError& e) {
         std::cerr << "Error installing cloud provider: "
@@ -1088,6 +1100,7 @@ int LemonadeClient::cloud_auth(const std::string& provider, const std::string& a
                       << response_json["models_discovered"].get<size_t>()
                       << std::endl;
         }
+        print_response_warnings(response_json);
         return 0;
     } catch (const HttpError& e) {
         // 409 (env conflict) and 404 (not installed) come through here with
@@ -1145,6 +1158,7 @@ int LemonadeClient::cloud_list() const {
                       << ", runtime_key_set=" << (p.value("runtime_key_set", false) ? "yes" : "no")
                       << ", models_discovered=" << p.value("models_discovered", size_t{0})
                       << std::endl;
+            print_response_warnings(p, "    ");
         }
         return 0;
     } catch (const HttpError& e) {

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -1017,7 +1017,8 @@ int LemonadeClient::uninstall_backend(const std::string& recipe, const std::stri
 
 int LemonadeClient::install_cloud_provider(const std::string& provider,
                                             const std::string& base_url,
-                                            const std::string& api_key) {
+                                            const std::string& api_key,
+                                            bool allow_insecure_http) {
     std::cout << "Installing cloud provider: " << provider
               << " (" << base_url << ")" << std::endl;
     try {
@@ -1026,6 +1027,9 @@ int LemonadeClient::install_cloud_provider(const std::string& provider,
             {"provider", provider},
             {"base_url", base_url}
         };
+        if (allow_insecure_http) {
+            body["allow_insecure_http"] = true;
+        }
         if (!api_key.empty()) {
             body["api_key"] = api_key;
         }
@@ -1088,9 +1092,14 @@ int LemonadeClient::uninstall_cloud_provider(const std::string& provider) {
     }
 }
 
-int LemonadeClient::cloud_auth(const std::string& provider, const std::string& api_key) {
+int LemonadeClient::cloud_auth(const std::string& provider,
+                               const std::string& api_key,
+                               bool allow_insecure_http) {
     try {
         json body = {{"provider", provider}, {"api_key", api_key}};
+        if (allow_insecure_http) {
+            body["allow_insecure_http"] = true;
+        }
         std::string response = make_request("/api/v1/cloud/auth", "POST",
                                              body.dump(), "application/json");
         auto response_json = json::parse(response);

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -177,6 +177,7 @@ struct CliConfig {
     std::string cloud_provider;
     std::string cloud_base_url;
     std::string cloud_api_key;
+    bool cloud_allow_insecure_http = false;
 
     // Chat REPL options
     bool chat_cli = false;
@@ -1211,6 +1212,8 @@ int main(int argc, char* argv[]) {
     cloud_install_cmd->add_option("--api-key", config.cloud_api_key,
         "Optional: store this key in process memory. Prefer setting LEMONADE_<PROVIDER>_API_KEY instead.")
         ->type_name("KEY");
+    cloud_install_cmd->add_flag("--allow-insecure-http", config.cloud_allow_insecure_http,
+        "Explicitly allow sending this provider's API key over http://.");
 
     CLI::App* cloud_uninstall_cmd = cloud_cmd->add_subcommand("uninstall", "Remove a cloud provider")->group("Subcommands");
     cloud_uninstall_cmd->add_option("provider", config.cloud_provider, "Provider name")->required()->type_name("PROVIDER");
@@ -1220,6 +1223,8 @@ int main(int argc, char* argv[]) {
     cloud_auth_cmd->add_option("--api-key", config.cloud_api_key,
         "API key. If omitted you'll be prompted (TTY only).")
         ->type_name("KEY");
+    cloud_auth_cmd->add_flag("--allow-insecure-http", config.cloud_allow_insecure_http,
+        "Explicitly allow sending this provider's API key over http://.");
 
     CLI::App* cloud_clear_cmd = cloud_cmd->add_subcommand("clear", "Clear the runtime API key (env var unaffected)")->group("Subcommands");
     cloud_clear_cmd->add_option("provider", config.cloud_provider, "Provider name")->required()->type_name("PROVIDER");
@@ -1457,7 +1462,8 @@ int main(int argc, char* argv[]) {
         if (cloud_install_cmd->count() > 0) {
             return client.install_cloud_provider(config.cloud_provider,
                                                   config.cloud_base_url,
-                                                  config.cloud_api_key);
+                                                  config.cloud_api_key,
+                                                  config.cloud_allow_insecure_http);
         }
         if (cloud_uninstall_cmd->count() > 0) {
             return client.uninstall_cloud_provider(config.cloud_provider);
@@ -1487,7 +1493,8 @@ int main(int argc, char* argv[]) {
                     return 1;
                 }
             }
-            return client.cloud_auth(config.cloud_provider, key);
+            return client.cloud_auth(config.cloud_provider, key,
+                                     config.cloud_allow_insecure_http);
         }
         if (cloud_clear_cmd->count() > 0) {
             return client.cloud_auth_clear(config.cloud_provider);

--- a/src/cpp/include/lemon/backends/cloud_server.h
+++ b/src/cpp/include/lemon/backends/cloud_server.h
@@ -87,6 +87,7 @@ private:
     struct ResolvedCreds {
         std::string api_key;
         std::string base_url;
+        bool insecure_http_blocked = false;
     };
 
     // Looks up creds from the registry. Returns empty fields when the
@@ -99,6 +100,8 @@ private:
     json rewrite_model_field(const json& request) const;
     json missing_creds_error() const;
     std::string missing_creds_sse() const;
+    json insecure_http_error() const;
+    std::string insecure_http_sse() const;
 
     std::string provider_;       // e.g., "fireworks", "openai", "groq"
     std::string upstream_model_; // provider's model id (from ModelInfo.checkpoint())

--- a/src/cpp/include/lemon/cloud_provider_registry.h
+++ b/src/cpp/include/lemon/cloud_provider_registry.h
@@ -100,12 +100,21 @@ public:
     // string on OK, a human-readable error message otherwise.
     static std::string validate_provider_name(const std::string& provider);
 
-    // Validates a candidate base URL: must be https:// (any host), or
-    // http:// limited to localhost / 127.0.0.1 / ::1 so the mock-provider
-    // tests still work. Anything else is rejected — a typo'd scheme would
-    // leak the Bearer API key in plaintext on every forwarded request.
+    // Validates a candidate base URL: must be https:// or http://. Plain HTTP
+    // is allowed because custom backends can legitimately live on a trusted LAN,
+    // but callers should surface base_url_warnings() so the user understands
+    // the transport tradeoff.
     // Returns empty string on OK, a human-readable error message otherwise.
     static std::string validate_base_url(const std::string& base_url);
+
+    // Returns true for an http:// base URL, false for https:// or invalid input.
+    static bool is_http_base_url(const std::string& base_url);
+
+    // Non-blocking warnings for a validated base URL. When api_key_available is
+    // true, includes a stronger warning that Lemonade will send Bearer auth over
+    // plaintext HTTP.
+    static std::vector<std::string> base_url_warnings(const std::string& base_url,
+                                                      bool api_key_available);
 
 private:
     static std::string normalize_base_url(std::string url);

--- a/src/cpp/include/lemon/cloud_provider_registry.h
+++ b/src/cpp/include/lemon/cloud_provider_registry.h
@@ -29,8 +29,9 @@ namespace lemon {
 class CloudProviderRegistry {
 public:
     struct Record {
-        std::string name;      // e.g. "fireworks", "openai"
-        std::string base_url;  // normalized: no trailing slash
+        std::string name;                         // e.g. "fireworks", "openai"
+        std::string base_url;                     // normalized: no trailing slash
+        bool allow_insecure_http = false;         // explicit opt-in for http:// + API key
     };
 
     struct AuthState {
@@ -52,7 +53,9 @@ public:
     // Idempotent. Adds the provider if absent, updates base_url if present.
     // Normalizes base_url (trims trailing slash). Returns true if the stored
     // record changed, false if it was already identical.
-    bool install(const std::string& provider, const std::string& base_url);
+    bool install(const std::string& provider,
+                 const std::string& base_url,
+                 bool allow_insecure_http = false);
 
     // Removes the provider record AND its runtime key. Returns true if a
     // record was removed.
@@ -65,6 +68,10 @@ public:
 
     // Base URL for a registered provider, or empty if not installed.
     std::string base_url_for(const std::string& provider) const;
+
+    // Whether this provider has explicit opt-in to send API keys to an
+    // http:// base URL. Irrelevant for https:// providers.
+    bool allow_insecure_http_for(const std::string& provider) const;
 
     // Resolves an API key for a provider:
     //   1. Returns the LEMONADE_<PROVIDER_UPPER>_API_KEY env var if set.

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -104,9 +104,12 @@ public:
     // server relies on env var or a later /v1/cloud/auth POST.
     int install_cloud_provider(const std::string& provider,
                                 const std::string& base_url,
-                                const std::string& api_key = "");
+                                const std::string& api_key = "",
+                                bool allow_insecure_http = false);
     int uninstall_cloud_provider(const std::string& provider);
-    int cloud_auth(const std::string& provider, const std::string& api_key);
+    int cloud_auth(const std::string& provider,
+                   const std::string& api_key,
+                   bool allow_insecure_http = false);
     int cloud_auth_clear(const std::string& provider);
     int cloud_list() const;
 

--- a/src/cpp/server/backends/cloud_server.cpp
+++ b/src/cpp/server/backends/cloud_server.cpp
@@ -392,6 +392,11 @@ CloudServer::ResolvedCreds CloudServer::resolve_creds() const {
     }
     creds.api_key = registry_->resolve_key(provider_);
     creds.base_url = registry_->base_url_for(provider_);
+    if (!creds.api_key.empty() &&
+        CloudProviderRegistry::is_http_base_url(creds.base_url) &&
+        !registry_->allow_insecure_http_for(provider_)) {
+        creds.insecure_http_blocked = true;
+    }
     // The registry already normalizes base_url on install, but a defensive
     // strip here keeps the contract local — anyone tracing post_with_auth
     // can see the joined URL can't double-slash.
@@ -439,6 +444,30 @@ std::string CloudServer::missing_creds_sse() const {
     return "data: " + err.dump() + "\n\n";
 }
 
+json CloudServer::insecure_http_error() const {
+    const std::string msg =
+        "Cloud provider '" + provider_ + "' uses http:// with an API key. "
+        "Reinstall or re-authenticate with allow_insecure_http=true to opt in.";
+    return ErrorResponse::create(
+        msg,
+        ErrorType::BACKEND_ERROR,
+        {{"provider", provider_}, {"code", "insecure_http_requires_opt_in"}}
+    );
+}
+
+std::string CloudServer::insecure_http_sse() const {
+    const std::string msg =
+        "Cloud provider '" + provider_ + "' uses http:// with an API key. "
+        "Reinstall or re-authenticate with allow_insecure_http=true to opt in.";
+    json err = {{"error", {
+        {"message", msg},
+        {"type", "backend_error"},
+        {"provider", provider_},
+        {"code", "insecure_http_requires_opt_in"}
+    }}};
+    return "data: " + err.dump() + "\n\n";
+}
+
 json CloudServer::rewrite_model_field(const json& request) const {
     json modified = request;
     modified["model"] = upstream_model_;
@@ -454,6 +483,9 @@ json CloudServer::post_with_auth(const std::string& path, const json& request,
                                   const ResolvedCreds& creds, long timeout_seconds) {
     if (!loaded_) {
         return ErrorResponse::from_exception(ModelNotLoadedException(server_name_));
+    }
+    if (creds.insecure_http_blocked) {
+        return insecure_http_error();
     }
     if (creds.api_key.empty() || creds.base_url.empty()) {
         return missing_creds_error();
@@ -563,6 +595,12 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
     }
 
     ResolvedCreds creds = resolve_creds();
+    if (creds.insecure_http_blocked) {
+        std::string error_msg = insecure_http_sse();
+        sink.write(error_msg.c_str(), error_msg.size());
+        sink.done();
+        return;
+    }
     if (creds.api_key.empty() || creds.base_url.empty()) {
         std::string error_msg = missing_creds_sse();
         sink.write(error_msg.c_str(), error_msg.size());

--- a/src/cpp/server/cloud_provider_registry.cpp
+++ b/src/cpp/server/cloud_provider_registry.cpp
@@ -10,6 +10,22 @@ namespace lemon {
 
 using json = nlohmann::json;
 
+namespace {
+
+std::string to_lower_copy(const std::string& value) {
+    std::string lower = value;
+    for (auto& c : lower) {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return lower;
+}
+
+bool starts_with_scheme(const std::string& value, const std::string& scheme) {
+    return to_lower_copy(value).compare(0, scheme.size(), scheme) == 0;
+}
+
+} // namespace
+
 std::string CloudProviderRegistry::env_var_name(const std::string& provider) {
     std::string upper = provider;
     for (auto& c : upper) {
@@ -40,32 +56,34 @@ std::string CloudProviderRegistry::validate_base_url(const std::string& base_url
     if (base_url.empty()) {
         return "Base URL is required";
     }
-    const std::string lower = [&]() {
-        std::string s = base_url;
-        for (auto& c : s) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-        return s;
-    }();
     const std::string https = "https://";
     const std::string http = "http://";
-    if (lower.compare(0, https.size(), https) == 0) {
+    if (starts_with_scheme(base_url, https) ||
+        starts_with_scheme(base_url, http)) {
         return "";
     }
-    if (lower.compare(0, http.size(), http) == 0) {
-        // Allow only loopback hosts so the Bearer API key isn't sent in
-        // plaintext on a typo'd scheme. Mock-provider tests use these.
-        const std::string host_and_rest = lower.substr(http.size());
-        auto host_end = host_and_rest.find_first_of(":/");
-        const std::string host = host_end == std::string::npos
-                                     ? host_and_rest
-                                     : host_and_rest.substr(0, host_end);
-        if (host == "localhost" || host == "127.0.0.1" || host == "[::1]") {
-            return "";
-        }
-        return "Base URL uses http:// to a non-loopback host (" + host +
-               "); refused because it would send the Bearer API key in plaintext. "
-               "Use https:// or set the host to localhost / 127.0.0.1 for local mocks.";
+    return "Base URL must start with https:// or http://";
+}
+
+bool CloudProviderRegistry::is_http_base_url(const std::string& base_url) {
+    return starts_with_scheme(base_url, "http://");
+}
+
+std::vector<std::string>
+CloudProviderRegistry::base_url_warnings(const std::string& base_url,
+                                         bool api_key_available) {
+    std::vector<std::string> warnings;
+    if (!is_http_base_url(base_url)) {
+        return warnings;
     }
-    return "Base URL must start with https:// (or http:// for localhost)";
+    warnings.push_back(
+        "Base URL uses http://; traffic to this provider is not encrypted.");
+    if (api_key_available) {
+        warnings.push_back(
+            "An API key is configured for this http:// provider; Lemonade will "
+            "send it as a Bearer token over plaintext HTTP.");
+    }
+    return warnings;
 }
 
 std::string CloudProviderRegistry::normalize_base_url(std::string url) {

--- a/src/cpp/server/cloud_provider_registry.cpp
+++ b/src/cpp/server/cloud_provider_registry.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
+#include <string>
 
 #include <nlohmann/json.hpp>
 
@@ -56,10 +57,20 @@ std::string CloudProviderRegistry::validate_base_url(const std::string& base_url
     if (base_url.empty()) {
         return "Base URL is required";
     }
+    if (std::any_of(base_url.begin(), base_url.end(), [](unsigned char c) {
+            return std::isspace(c) != 0;
+        })) {
+        return "Base URL must not contain whitespace";
+    }
     const std::string https = "https://";
     const std::string http = "http://";
     if (starts_with_scheme(base_url, https) ||
         starts_with_scheme(base_url, http)) {
+        const size_t host_start = base_url.find("://") + 3;
+        const size_t host_end = base_url.find_first_of("/?#", host_start);
+        if (host_end == host_start || host_start >= base_url.size()) {
+            return "Base URL must include a host";
+        }
         return "";
     }
     return "Base URL must start with https:// or http://";
@@ -106,6 +117,9 @@ void CloudProviderRegistry::load_from_config(const json& cloud_providers_array) 
         Record r;
         r.name = entry["name"].get<std::string>();
         r.base_url = normalize_base_url(entry["base_url"].get<std::string>());
+        if (entry.contains("allow_insecure_http") && entry["allow_insecure_http"].is_boolean()) {
+            r.allow_insecure_http = entry["allow_insecure_http"].get<bool>();
+        }
         if (r.name.empty() || r.base_url.empty()) continue;
         installed_.push_back(std::move(r));
     }
@@ -115,23 +129,32 @@ json CloudProviderRegistry::to_config_array() const {
     std::shared_lock lock(mu_);
     json arr = json::array();
     for (const auto& r : installed_) {
-        arr.push_back({{"name", r.name}, {"base_url", r.base_url}});
+        arr.push_back({
+            {"name", r.name},
+            {"base_url", r.base_url},
+            {"allow_insecure_http", r.allow_insecure_http}
+        });
     }
     return arr;
 }
 
 bool CloudProviderRegistry::install(const std::string& provider,
-                                    const std::string& base_url) {
+                                    const std::string& base_url,
+                                    bool allow_insecure_http) {
     std::unique_lock lock(mu_);
     std::string normalized = normalize_base_url(base_url);
     for (auto& r : installed_) {
         if (r.name == provider) {
-            if (r.base_url == normalized) return false;
+            if (r.base_url == normalized &&
+                r.allow_insecure_http == allow_insecure_http) {
+                return false;
+            }
             r.base_url = normalized;
+            r.allow_insecure_http = allow_insecure_http;
             return true;
         }
     }
-    installed_.push_back({provider, normalized});
+    installed_.push_back({provider, normalized, allow_insecure_http});
     return true;
 }
 
@@ -163,6 +186,14 @@ std::string CloudProviderRegistry::base_url_for(const std::string& provider) con
         if (r.name == provider) return r.base_url;
     }
     return "";
+}
+
+bool CloudProviderRegistry::allow_insecure_http_for(const std::string& provider) const {
+    std::shared_lock lock(mu_);
+    for (const auto& r : installed_) {
+        if (r.name == provider) return r.allow_insecure_http;
+    }
+    return false;
 }
 
 std::string CloudProviderRegistry::resolve_key(const std::string& provider) const {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2217,6 +2217,14 @@ void ModelManager::build_cache() {
                                            << " or POST /v1/cloud/auth)" << std::endl;
                 continue;
             }
+            if (CloudProviderRegistry::is_http_base_url(rec.base_url) &&
+                !rec.allow_insecure_http) {
+                LOG(WARNING, "ModelManager") << "Skipping cloud discovery for '"
+                                             << rec.name << "': http:// with API key "
+                                             << "requires allow_insecure_http=true"
+                                             << std::endl;
+                continue;
+            }
             std::vector<ModelInfo> discovered;
             try {
                 discovered = backends::CloudServer::discover_models(rec.name, api_key, rec.base_url);
@@ -2784,6 +2792,15 @@ size_t ModelManager::refresh_cloud_models(const std::string& provider) {
         // Drop any stale entries for this provider but don't try to discover —
         // there's nothing to discover with. The contract is "models present
         // after refresh", so return 0 (not the evicted count).
+        evict_cloud_models(provider);
+        return 0;
+    }
+    if (CloudProviderRegistry::is_http_base_url(base_url) &&
+        !cloud_registry_->allow_insecure_http_for(provider)) {
+        LOG(WARNING, "ModelManager") << "Skipping cloud discovery for provider '"
+                                      << provider << "': http:// with API key "
+                                      << "requires allow_insecure_http=true"
+                                      << std::endl;
         evict_cloud_models(provider);
         return 0;
     }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3891,6 +3891,18 @@ void Server::handle_cloud_auth_set(const httplib::Request& req, httplib::Respons
         }
         const auto provider = body["provider"].get<std::string>();
         const auto api_key = body["api_key"].get<std::string>();
+        bool allow_insecure_http = false;
+        if (body.contains("allow_insecure_http")) {
+            if (!body["allow_insecure_http"].is_boolean()) {
+                res.status = 400;
+                nlohmann::json error = {{"error", {
+                    {"message", "allow_insecure_http must be a boolean when provided"},
+                    {"type", "invalid_request_error"}}}};
+                res.set_content(error.dump(), "application/json");
+                return;
+            }
+            allow_insecure_http = body["allow_insecure_http"].get<bool>();
+        }
         if (provider.empty() || api_key.empty()) {
             res.status = 400;
             nlohmann::json error = {{"error", {
@@ -3909,6 +3921,26 @@ void Server::handle_cloud_auth_set(const httplib::Request& req, httplib::Respons
                 {"type", "invalid_request_error"}}}};
             res.set_content(error.dump(), "application/json");
             return;
+        }
+
+        const std::string base_url = cloud_registry_->base_url_for(provider);
+        if (CloudProviderRegistry::is_http_base_url(base_url)) {
+            const bool already_allowed = cloud_registry_->allow_insecure_http_for(provider);
+            if (!allow_insecure_http && !already_allowed) {
+                res.status = 400;
+                nlohmann::json error = {{"error", {
+                    {"message", "Cloud provider '" + provider + "' uses http://. "
+                                "Set allow_insecure_http=true to explicitly opt in before "
+                                "storing or using an API key over plaintext HTTP."},
+                    {"type", "invalid_request_error"},
+                    {"code", "insecure_http_requires_opt_in"}}}};
+                res.set_content(error.dump(), "application/json");
+                return;
+            }
+            if (allow_insecure_http && !already_allowed) {
+                cloud_registry_->install(provider, base_url, true);
+                persist_cloud_providers();
+            }
         }
 
         // env-wins-over-runtime: if the env var is set, refuse the runtime
@@ -3933,6 +3965,7 @@ void Server::handle_cloud_auth_set(const httplib::Request& req, httplib::Respons
         const auto state = cloud_registry_->auth_state(provider);
         nlohmann::json response = {
             {"provider", provider},
+            {"allow_insecure_http", cloud_registry_->allow_insecure_http_for(provider)},
             {"auth_state", {
                 {"env_var_set", state.env_var_set},
                 {"runtime_key_set", state.runtime_key_set}
@@ -3942,7 +3975,7 @@ void Server::handle_cloud_auth_set(const httplib::Request& req, httplib::Respons
         attach_warnings(
             response,
             CloudProviderRegistry::base_url_warnings(
-                cloud_registry_->base_url_for(provider),
+                base_url,
                 /*api_key_available=*/true));
         res.set_content(response.dump(), "application/json");
     } catch (const nlohmann::json::parse_error& e) {
@@ -4215,6 +4248,7 @@ void Server::handle_system_info(const httplib::Request& req, httplib::Response& 
             nlohmann::json provider = {
                 {"name", rec.name},
                 {"base_url", rec.base_url},
+                {"allow_insecure_http", rec.allow_insecure_http},
                 {"env_var", CloudProviderRegistry::env_var_name(rec.name)},
                 {"env_var_set", state.env_var_set},
                 {"runtime_key_set", state.runtime_key_set},
@@ -5045,11 +5079,24 @@ void Server::handle_install(const httplib::Request& req, httplib::Response& res)
         // (env var or POST /v1/cloud/auth). Shape:
         //   {backend: "cloud", provider: "fireworks",
         //    base_url: "https://api.fireworks.ai/inference/v1",
+        //    allow_insecure_http: false,
         //    api_key: "..."}  // optional
         if (request_json.value("backend", "") == "cloud") {
             const std::string provider = request_json.value("provider", "");
             const std::string base_url = request_json.value("base_url", "");
             const std::string api_key = request_json.value("api_key", "");
+            bool allow_insecure_http = false;
+            if (request_json.contains("allow_insecure_http")) {
+                if (!request_json["allow_insecure_http"].is_boolean()) {
+                    res.status = 400;
+                    nlohmann::json error = {{"error", {
+                        {"message", "allow_insecure_http must be a boolean when provided"},
+                        {"type", "invalid_request_error"}}}};
+                    res.set_content(error.dump(), "application/json");
+                    return;
+                }
+                allow_insecure_http = request_json["allow_insecure_http"].get<bool>();
+            }
             if (provider.empty() || base_url.empty()) {
                 res.status = 400;
                 nlohmann::json error = {{"error", {
@@ -5074,9 +5121,23 @@ void Server::handle_install(const httplib::Request& req, httplib::Response& res)
                 res.set_content(error.dump(), "application/json");
                 return;
             }
+            const auto env_state = cloud_registry_->auth_state(provider);
+            if (CloudProviderRegistry::is_http_base_url(base_url) &&
+                !allow_insecure_http &&
+                (!api_key.empty() || env_state.env_var_set)) {
+                res.status = 400;
+                nlohmann::json error = {{"error", {
+                    {"message", "Cloud provider '" + provider + "' uses http://. "
+                                "Set allow_insecure_http=true to explicitly opt in before "
+                                "storing or using an API key over plaintext HTTP."},
+                    {"type", "invalid_request_error"},
+                    {"code", "insecure_http_requires_opt_in"}}}};
+                res.set_content(error.dump(), "application/json");
+                return;
+            }
             LOG(INFO, "Server") << "Installing cloud provider '" << provider
                                   << "' with base_url " << base_url << std::endl;
-            cloud_registry_->install(provider, base_url);
+            cloud_registry_->install(provider, base_url, allow_insecure_http);
             persist_cloud_providers();
 
             // Best-effort optional auth: if api_key was supplied, treat this
@@ -5099,6 +5160,7 @@ void Server::handle_install(const httplib::Request& req, httplib::Response& res)
                 {"backend", "cloud"},
                 {"provider", provider},
                 {"base_url", cloud_registry_->base_url_for(provider)},
+                {"allow_insecure_http", cloud_registry_->allow_insecure_http_for(provider)},
                 {"models_discovered", models_after},
                 {"auth_state", {
                     {"env_var_set", state.env_var_set},

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <cmath>
 #include <set>
+#include <vector>
 #include <lemon/utils/aixlog.hpp>
 
 #ifdef _WIN32
@@ -194,6 +195,26 @@ bool is_quiet_polling_path(const std::string& path) {
            path == "/v0/system-stats" || path == "/v1/system-stats" ||
            path == "/api/v0/stats" || path == "/api/v1/stats" ||
            path == "/v0/stats" || path == "/v1/stats";
+}
+
+std::string join_warnings(const std::vector<std::string>& warnings) {
+    std::ostringstream joined;
+    for (size_t i = 0; i < warnings.size(); ++i) {
+        if (i > 0) {
+            joined << " | ";
+        }
+        joined << warnings[i];
+    }
+    return joined.str();
+}
+
+void attach_warnings(json& response, const std::vector<std::string>& warnings) {
+    if (warnings.empty()) {
+        return;
+    }
+    response["warnings"] = warnings;
+    // Backward-compatible single-string field for older clients.
+    response["warning"] = join_warnings(warnings);
 }
 
 } // namespace
@@ -3918,6 +3939,11 @@ void Server::handle_cloud_auth_set(const httplib::Request& req, httplib::Respons
             }},
             {"models_discovered", models_after}
         };
+        attach_warnings(
+            response,
+            CloudProviderRegistry::base_url_warnings(
+                cloud_registry_->base_url_for(provider),
+                /*api_key_available=*/true));
         res.set_content(response.dump(), "application/json");
     } catch (const nlohmann::json::parse_error& e) {
         res.status = 400;
@@ -4186,14 +4212,20 @@ void Server::handle_system_info(const httplib::Request& req, httplib::Response& 
         nlohmann::json providers = nlohmann::json::array();
         for (const auto& rec : cloud_registry_->list_installed()) {
             auto state = cloud_registry_->auth_state(rec.name);
-            providers.push_back({
+            nlohmann::json provider = {
                 {"name", rec.name},
                 {"base_url", rec.base_url},
                 {"env_var", CloudProviderRegistry::env_var_name(rec.name)},
                 {"env_var_set", state.env_var_set},
                 {"runtime_key_set", state.runtime_key_set},
                 {"models_discovered", model_manager_->count_cloud_models(rec.name)}
-            });
+            };
+            attach_warnings(
+                provider,
+                CloudProviderRegistry::base_url_warnings(
+                    rec.base_url,
+                    state.env_var_set || state.runtime_key_set));
+            providers.push_back(std::move(provider));
         }
         system_info["cloud"] = {{"providers", providers}};
     }
@@ -5073,10 +5105,14 @@ void Server::handle_install(const httplib::Request& req, httplib::Response& res)
                     {"runtime_key_set", state.runtime_key_set}
                 }}
             };
+            std::vector<std::string> warnings = CloudProviderRegistry::base_url_warnings(
+                cloud_registry_->base_url_for(provider),
+                state.env_var_set || state.runtime_key_set);
             if (!api_key.empty() && !runtime_key_stored) {
-                response["warning"] = CloudProviderRegistry::env_var_name(provider) +
-                    " is set; supplied api_key was ignored.";
+                warnings.push_back(CloudProviderRegistry::env_var_name(provider) +
+                    " is set; supplied api_key was ignored.");
             }
+            attach_warnings(response, warnings);
             res.set_content(response.dump(), "application/json");
             return;
         }

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -1192,57 +1192,120 @@ class EndpointTests(ServerTestBase):
             self.assertEqual(body["error"]["type"], "invalid_request_error")
         print("[OK] /install rejects non-[a-z0-9_-]+ provider names with 400")
 
-    def test_012h_install_rejects_insecure_http_base_url(self):
-        """An http:// base URL to a non-loopback host would leak the Bearer
-        API key in plaintext on every forwarded request. Refuse those at
-        install time. https:// and http://localhost are both allowed."""
-        # http:// to a non-loopback host: rejected.
-        resp = requests.post(
-            f"{self.base_url}/install",
-            json={
-                "backend": "cloud",
-                "provider": "httpguard",
-                "base_url": "http://api.example.com/v1",
-            },
-            timeout=TIMEOUT_DEFAULT,
-        )
-        self.assertEqual(resp.status_code, 400, resp.text)
-        body = resp.json()
-        self.assertEqual(body["error"]["type"], "invalid_request_error")
-        self.assertIn("plaintext", body["error"]["message"].lower())
+    def test_012h_http_base_url_is_allowed_with_warnings(self):
+        """Custom OpenAI-compatible backends may be on trusted LAN HTTP. Do
+        not block those URLs; warn generally for http:// and more explicitly
+        when Lemonade has a key it will send as Bearer auth over plaintext."""
+        installed = []
 
-        # gopher:// (any non-http(s) scheme): rejected.
-        resp = requests.post(
-            f"{self.base_url}/install",
-            json={
-                "backend": "cloud",
-                "provider": "schemeguard",
-                "base_url": "gopher://example.com/v1",
-            },
-            timeout=TIMEOUT_DEFAULT,
-        )
-        self.assertEqual(resp.status_code, 400, resp.text)
+        def cleanup(provider):
+            requests.post(
+                f"{self.base_url}/uninstall",
+                json={"backend": "cloud", "provider": provider},
+                timeout=TIMEOUT_DEFAULT,
+            )
 
-        # http://localhost: allowed (mock-provider tests need this).
-        resp = requests.post(
-            f"{self.base_url}/install",
-            json={
-                "backend": "cloud",
-                "provider": "localhttpguard",
-                "base_url": "http://localhost:1/v1",
-            },
-            timeout=TIMEOUT_DEFAULT,
-        )
-        self.assertEqual(resp.status_code, 200, resp.text)
-        # Clean up the test provider so the registry doesn't accumulate state.
-        requests.post(
-            f"{self.base_url}/uninstall",
-            json={"backend": "cloud", "provider": "localhttpguard"},
-            timeout=TIMEOUT_DEFAULT,
-        )
-        print(
-            "[OK] /install rejects http:// to non-loopback hosts, allows http://localhost"
-        )
+        try:
+            # http:// to a non-loopback host: accepted with a transport warning.
+            provider = "httpguard"
+            resp = requests.post(
+                f"{self.base_url}/install",
+                json={
+                    "backend": "cloud",
+                    "provider": provider,
+                    "base_url": "http://api.example.com/v1",
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            installed.append(provider)
+            self.assertEqual(resp.status_code, 200, resp.text)
+            body = resp.json()
+            self.assertEqual(body["status"], "success")
+            warnings = body.get("warnings", [])
+            self.assertTrue(any("http://" in w for w in warnings), body)
+            self.assertFalse(any("Bearer token" in w for w in warnings), body)
+            self.assertIn("warning", body)
+
+            info = requests.get(
+                f"{self.base_url}/system-info",
+                timeout=TIMEOUT_DEFAULT,
+            ).json()
+            entry = next(
+                p
+                for p in info.get("cloud", {}).get("providers", [])
+                if p["name"] == provider
+            )
+            self.assertTrue(any("http://" in w for w in entry.get("warnings", [])))
+
+            # gopher:// (any non-http(s) scheme): still rejected.
+            resp = requests.post(
+                f"{self.base_url}/install",
+                json={
+                    "backend": "cloud",
+                    "provider": "schemeguard",
+                    "base_url": "gopher://example.com/v1",
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 400, resp.text)
+
+            # Install + api_key in one request gets the stronger key warning.
+            provider = "httpkeyinstall"
+            base_url, stop_provider = self._start_mock_cloud_provider(
+                ["vendor/http-key"]
+            )
+            try:
+                resp = requests.post(
+                    f"{self.base_url}/install",
+                    json={
+                        "backend": "cloud",
+                        "provider": provider,
+                        "base_url": base_url,
+                        "api_key": "dummy-key",
+                    },
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                installed.append(provider)
+                self.assertEqual(resp.status_code, 200, resp.text)
+                warnings = resp.json().get("warnings", [])
+                self.assertTrue(any("http://" in w for w in warnings), resp.text)
+                self.assertTrue(any("Bearer token" in w for w in warnings), resp.text)
+            finally:
+                stop_provider()
+
+            # Auth after an HTTP install gets the same stronger key warning.
+            provider = "httpkeyauth"
+            base_url, stop_provider = self._start_mock_cloud_provider(
+                ["vendor/http-auth"]
+            )
+            try:
+                resp = requests.post(
+                    f"{self.base_url}/install",
+                    json={
+                        "backend": "cloud",
+                        "provider": provider,
+                        "base_url": base_url,
+                    },
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                installed.append(provider)
+                self.assertEqual(resp.status_code, 200, resp.text)
+                resp = requests.post(
+                    f"{self.base_url}/cloud/auth",
+                    json={"provider": provider, "api_key": "dummy-key"},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                self.assertEqual(resp.status_code, 200, resp.text)
+                warnings = resp.json().get("warnings", [])
+                self.assertTrue(any("http://" in w for w in warnings), resp.text)
+                self.assertTrue(any("Bearer token" in w for w in warnings), resp.text)
+            finally:
+                stop_provider()
+        finally:
+            for provider in installed:
+                cleanup(provider)
+
+        print("[OK] /install accepts http:// base URLs and warns when keys use HTTP")
 
     def test_012i_cloud_refresh_is_idempotent_no_duplicates(self):
         """refresh_cloud_models must evict-then-emplace this provider's prior

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -848,7 +848,11 @@ class EndpointTests(ServerTestBase):
             # (3) /cloud/auth stores the runtime key and triggers discovery.
             resp = requests.post(
                 f"{self.base_url}/cloud/auth",
-                json={"provider": provider, "api_key": "dummy-key"},
+                json={
+                    "provider": provider,
+                    "api_key": "dummy-key",
+                    "allow_insecure_http": True,
+                },
                 timeout=TIMEOUT_DEFAULT,
             )
             self.assertEqual(resp.status_code, 200, f"auth set failed: {resp.text}")
@@ -959,7 +963,11 @@ class EndpointTests(ServerTestBase):
             )
             requests.post(
                 f"{self.base_url}/cloud/auth",
-                json={"provider": provider, "api_key": "k"},
+                json={
+                    "provider": provider,
+                    "api_key": "k",
+                    "allow_insecure_http": True,
+                },
                 timeout=TIMEOUT_DEFAULT,
             )
             requests.delete(
@@ -1011,7 +1019,11 @@ class EndpointTests(ServerTestBase):
             )
             requests.post(
                 f"{self.base_url}/cloud/auth",
-                json={"provider": provider, "api_key": "k"},
+                json={
+                    "provider": provider,
+                    "api_key": "k",
+                    "allow_insecure_http": True,
+                },
                 timeout=TIMEOUT_DEFAULT,
             )
             # Load the model so the router holds a live CloudServer instance.
@@ -1118,7 +1130,11 @@ class EndpointTests(ServerTestBase):
             )
             requests.post(
                 f"{self.base_url}/cloud/auth",
-                json={"provider": provider, "api_key": "k"},
+                json={
+                    "provider": provider,
+                    "api_key": "k",
+                    "allow_insecure_http": True,
+                },
                 timeout=TIMEOUT_DEFAULT,
             )
 
@@ -1192,10 +1208,10 @@ class EndpointTests(ServerTestBase):
             self.assertEqual(body["error"]["type"], "invalid_request_error")
         print("[OK] /install rejects non-[a-z0-9_-]+ provider names with 400")
 
-    def test_012h_http_base_url_is_allowed_with_warnings(self):
+    def test_012h_http_base_url_requires_opt_in_for_keys(self):
         """Custom OpenAI-compatible backends may be on trusted LAN HTTP. Do
-        not block those URLs; warn generally for http:// and more explicitly
-        when Lemonade has a key it will send as Bearer auth over plaintext."""
+        not block keyless URLs, but require explicit opt-in before Lemonade
+        stores or uses an API key over plaintext HTTP."""
         installed = []
 
         def cleanup(provider):
@@ -1235,6 +1251,7 @@ class EndpointTests(ServerTestBase):
                 for p in info.get("cloud", {}).get("providers", [])
                 if p["name"] == provider
             )
+            self.assertFalse(entry["allow_insecure_http"])
             self.assertTrue(any("http://" in w for w in entry.get("warnings", [])))
 
             # gopher:// (any non-http(s) scheme): still rejected.
@@ -1249,7 +1266,22 @@ class EndpointTests(ServerTestBase):
             )
             self.assertEqual(resp.status_code, 400, resp.text)
 
-            # Install + api_key in one request gets the stronger key warning.
+            # Bare http(s) schemes without hosts are rejected.
+            for bad_url in ["http://", "https://"]:
+                resp = requests.post(
+                    f"{self.base_url}/install",
+                    json={
+                        "backend": "cloud",
+                        "provider": "bareurl",
+                        "base_url": bad_url,
+                    },
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                self.assertEqual(resp.status_code, 400, resp.text)
+                self.assertIn("host", resp.json()["error"]["message"])
+
+            # Install + api_key in one request is rejected by default, then
+            # accepted with explicit allow_insecure_http opt-in.
             provider = "httpkeyinstall"
             base_url, stop_provider = self._start_mock_cloud_provider(
                 ["vendor/http-key"]
@@ -1265,15 +1297,32 @@ class EndpointTests(ServerTestBase):
                     },
                     timeout=TIMEOUT_DEFAULT,
                 )
+                self.assertEqual(resp.status_code, 400, resp.text)
+                self.assertEqual(
+                    resp.json()["error"]["code"], "insecure_http_requires_opt_in"
+                )
+                resp = requests.post(
+                    f"{self.base_url}/install",
+                    json={
+                        "backend": "cloud",
+                        "provider": provider,
+                        "base_url": base_url,
+                        "api_key": "dummy-key",
+                        "allow_insecure_http": True,
+                    },
+                    timeout=TIMEOUT_DEFAULT,
+                )
                 installed.append(provider)
                 self.assertEqual(resp.status_code, 200, resp.text)
+                self.assertTrue(resp.json()["allow_insecure_http"])
                 warnings = resp.json().get("warnings", [])
                 self.assertTrue(any("http://" in w for w in warnings), resp.text)
                 self.assertTrue(any("Bearer token" in w for w in warnings), resp.text)
             finally:
                 stop_provider()
 
-            # Auth after an HTTP install gets the same stronger key warning.
+            # Auth after an HTTP install is rejected by default, then accepted
+            # with the same explicit opt-in.
             provider = "httpkeyauth"
             base_url, stop_provider = self._start_mock_cloud_provider(
                 ["vendor/http-auth"]
@@ -1295,7 +1344,21 @@ class EndpointTests(ServerTestBase):
                     json={"provider": provider, "api_key": "dummy-key"},
                     timeout=TIMEOUT_DEFAULT,
                 )
+                self.assertEqual(resp.status_code, 400, resp.text)
+                self.assertEqual(
+                    resp.json()["error"]["code"], "insecure_http_requires_opt_in"
+                )
+                resp = requests.post(
+                    f"{self.base_url}/cloud/auth",
+                    json={
+                        "provider": provider,
+                        "api_key": "dummy-key",
+                        "allow_insecure_http": True,
+                    },
+                    timeout=TIMEOUT_DEFAULT,
+                )
                 self.assertEqual(resp.status_code, 200, resp.text)
+                self.assertTrue(resp.json()["allow_insecure_http"])
                 warnings = resp.json().get("warnings", [])
                 self.assertTrue(any("http://" in w for w in warnings), resp.text)
                 self.assertTrue(any("Bearer token" in w for w in warnings), resp.text)
@@ -1305,7 +1368,7 @@ class EndpointTests(ServerTestBase):
             for provider in installed:
                 cleanup(provider)
 
-        print("[OK] /install accepts http:// base URLs and warns when keys use HTTP")
+        print("[OK] http:// cloud keys require explicit opt-in")
 
     def test_012i_cloud_refresh_is_idempotent_no_duplicates(self):
         """refresh_cloud_models must evict-then-emplace this provider's prior
@@ -1327,7 +1390,11 @@ class EndpointTests(ServerTestBase):
             # First auth: discover both upstream ids.
             resp = requests.post(
                 f"{self.base_url}/cloud/auth",
-                json={"provider": provider, "api_key": "k1"},
+                json={
+                    "provider": provider,
+                    "api_key": "k1",
+                    "allow_insecure_http": True,
+                },
                 timeout=TIMEOUT_DEFAULT,
             )
             self.assertEqual(resp.status_code, 200, resp.text)
@@ -1337,7 +1404,11 @@ class EndpointTests(ServerTestBase):
             # eviction step removes the previous entries before re-emplacing.
             resp = requests.post(
                 f"{self.base_url}/cloud/auth",
-                json={"provider": provider, "api_key": "k1"},
+                json={
+                    "provider": provider,
+                    "api_key": "k1",
+                    "allow_insecure_http": True,
+                },
                 timeout=TIMEOUT_DEFAULT,
             )
             self.assertEqual(resp.status_code, 200, resp.text)


### PR DESCRIPTION
Unblocks https://github.com/lemonade-sdk/lemonade/issues/1937#issuecomment-4775122225

This PR enables users to add custom/cloud backends with http with a warning.

<img width="924" height="826" alt="image" src="https://github.com/user-attachments/assets/71829e1f-4836-47ed-84da-9734feb4f687" />
