### PR TITLE
fix(backends): fallback to installed backend when offline

### DIFF
--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -306,14 +306,17 @@ the generator instead. Prose outside the markers is preserved. -->
 | `SDXL-Turbo` | 6.94 | image |
 | `Z-Image-Turbo` | 20.7 | image |
 
-#### `vllm` — vLLM ROCm (experimental) (4 models)
+#### `vllm` — vLLM ROCm (experimental) (7 models)
 
 | Model | Size (GB) | Labels |
 |-------|-----------|--------|
+| `GLM-4.7-Flash-FP16-vLLM` | 62.47 | reasoning, tool-calling |
 | `Qwen3.5-0.8B-FP16-vLLM` | 1.77 | reasoning |
 | `Qwen3.5-2B-FP16-vLLM` | 4.57 | reasoning, tool-calling |
 | `Qwen3.5-4B-FP16-vLLM` | 9.34 | reasoning, hot, tool-calling |
 | `Qwen3.5-9B-FP16-vLLM` | 19.3 | reasoning, tool-calling |
+| `Qwen3.6-27B-FP16-vLLM` | 55.59 | reasoning, tool-calling, vision |
+| `Qwen3.6-35B-A3B-FP16-vLLM` | 71.93 | reasoning, tool-calling, vision |
 
 #### `whispercpp` — Whisper.cpp (6 models)
 

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -149,6 +149,10 @@ void report_backend_ready(const std::string& recipe,
     progress_cb(p);
 }
 
+bool github_download_service_reachable() {
+    return utils::HttpClient::is_reachable("https://github.com/", 2);
+}
+
 bool has_matching_system_rocm_runtime(const std::string& expected_runtime_version) {
     const fs::path version_file = "/opt/rocm/.info/version";
     const std::string system_version = read_version_file(version_file);
@@ -497,28 +501,39 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
 
     const std::string existing_backend_binary =
         installed_backend_binary_path(*spec, resolved_backend);
-    if (!force && !existing_backend_binary.empty()) {
-        // Non-forced calls are used by model load / ensure flows. They must be
-        // cache-first: a model that worked yesterday must still load today when
-        // GitHub is unreachable or a newer backend tag exists. Explicit backend
-        // update/install actions pass force=true and take the normal download path.
-        LOG(INFO, "BackendManager")
-            << "Using installed " << recipe << ":" << resolved_backend
-            << " backend at " << existing_backend_binary
-            << "; skipping update check during ensure" << std::endl;
-        report_backend_ready(recipe, resolved_backend, progress_cb);
-        return;
-    }
+    const bool has_existing_backend = !existing_backend_binary.empty();
 
     if (auto* cfg = RuntimeConfig::global()) {
         const bool offline = cfg->offline();
         const bool no_fetch = cfg->no_fetch_executables();
         if (offline || no_fetch) {
+            if (!force && has_existing_backend) {
+                LOG(WARNING, "BackendManager")
+                    << (offline ? "offline mode" : "Fetching executable artifacts is disabled")
+                    << "; using installed " << recipe << ":" << resolved_backend
+                    << " backend at " << existing_backend_binary << std::endl;
+                report_backend_ready(recipe, resolved_backend, progress_cb);
+                return;
+            }
+
             throw std::runtime_error(
                 (offline ? "Cannot install " : "Fetching executable artifacts is disabled for ") +
                 recipe + ":" + resolved_backend +
                 (offline ? ": offline mode" : ""));
         }
+    }
+
+    if (!force && has_existing_backend && !github_download_service_reachable()) {
+        // enter install_from_github() when GitHub is reachable, so available
+        // backend updates are applied before the model starts. Only skip the
+        // update path when the machine is effectively offline and a usable
+        // backend binary is already present.
+        LOG(WARNING, "BackendManager")
+            << "GitHub is not reachable; using installed " << recipe << ":"
+            << resolved_backend << " backend at " << existing_backend_binary
+            << " and deferring update" << std::endl;
+        report_backend_ready(recipe, resolved_backend, progress_cb);
+        return;
     }
 
     auto params = get_install_params(recipe, resolved_backend);

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -116,29 +116,23 @@ std::string read_version_file(const fs::path& version_file) {
     return trim(version);
 }
 
-std::string read_installed_backend_version(const std::string& recipe,
-                                           const std::string& resolved_backend) {
-    const std::string install_dir = backends::BackendUtils::get_install_directory(
-        recipe, resolved_backend);
-    return read_version_file(fs::path(install_dir) / "version.txt");
-}
-
-bool has_installed_backend_binary(const backends::BackendSpec& spec,
-                                  const std::string& resolved_backend) {
-    if (!backends::BackendUtils::find_external_backend_binary(
-            spec.recipe, resolved_backend).empty()) {
-        return true;
+std::string installed_backend_binary_path(const backends::BackendSpec& spec,
+                                          const std::string& resolved_backend) {
+    std::string external_binary = backends::BackendUtils::find_external_backend_binary(
+        spec.recipe, resolved_backend);
+    if (!external_binary.empty()) {
+        return external_binary;
     }
 
     const std::string install_dir = backends::BackendUtils::get_install_directory(
         spec.recipe, resolved_backend);
-    return !backends::BackendUtils::find_executable_in_install_dir(
-        install_dir, spec.binary).empty();
+    return backends::BackendUtils::find_executable_in_install_dir(
+        install_dir, spec.binary);
 }
 
-void report_installed_backend_ready(const std::string& recipe,
-                                    const std::string& resolved_backend,
-                                    DownloadProgressCallback progress_cb) {
+void report_backend_ready(const std::string& recipe,
+                          const std::string& resolved_backend,
+                          DownloadProgressCallback progress_cb) {
     if (!progress_cb) {
         return;
     }
@@ -153,23 +147,6 @@ void report_installed_backend_ready(const std::string& recipe,
     p.percent = 100;
     p.complete = true;
     progress_cb(p);
-}
-
-bool github_reachable_for_backend_update() {
-    try {
-        std::map<std::string, std::string> headers = {
-            {"User-Agent", "lemonade"},
-            {"Accept", "application/vnd.github+json"},
-        };
-        auto response = utils::HttpClient::get(
-            "https://api.github.com/rate_limit", headers, /*timeout_seconds=*/3);
-        return response.status_code >= 200 && response.status_code < 500;
-    } catch (const std::exception& e) {
-        LOG(WARNING, "BackendManager")
-            << "GitHub reachability probe failed; deferring backend update: "
-            << e.what() << std::endl;
-        return false;
-    }
 }
 
 bool has_matching_system_rocm_runtime(const std::string& expected_runtime_version) {
@@ -518,11 +495,33 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
         throw std::runtime_error("[BackendManager] Unknown recipe: " + recipe);
     }
 
-    const std::string backend_install_dir =
-        backends::BackendUtils::get_install_directory(spec->recipe, resolved_backend);
-    const bool backend_install_dir_existed_before = fs::exists(backend_install_dir);
-    const bool backend_binary_available =
-        has_installed_backend_binary(*spec, resolved_backend);
+    const std::string existing_backend_binary =
+        installed_backend_binary_path(*spec, resolved_backend);
+    if (!force && !existing_backend_binary.empty()) {
+        // Non-forced calls are used by model load / ensure flows. They must be
+        // cache-first: a model that worked yesterday must still load today when
+        // GitHub is unreachable or a newer backend tag exists. Explicit backend
+        // update/install actions pass force=true and take the normal download path.
+        LOG(INFO, "BackendManager")
+            << "Using installed " << recipe << ":" << resolved_backend
+            << " backend at " << existing_backend_binary
+            << "; skipping update check during ensure" << std::endl;
+        report_backend_ready(recipe, resolved_backend, progress_cb);
+        return;
+    }
+
+    if (auto* cfg = RuntimeConfig::global()) {
+        const bool offline = cfg->offline();
+        const bool no_fetch = cfg->no_fetch_executables();
+        if (offline || no_fetch) {
+            throw std::runtime_error(
+                (offline ? "Cannot install " : "Fetching executable artifacts is disabled for ") +
+                recipe + ":" + resolved_backend +
+                (offline ? ": offline mode" : ""));
+        }
+    }
+
+    auto params = get_install_params(recipe, resolved_backend);
 
     // Check if we need to download additional runtime components after the main backend.
     // `will_install_therock` intentionally answers whether TheRock is applicable
@@ -540,50 +539,6 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
         therock_applicable &&
         (rocm_runtime_update_required ||
          !is_therock_installed_for_current_arch(backend_versions_));
-
-    if (auto* cfg = RuntimeConfig::global()) {
-        const bool offline = cfg->offline();
-        const bool no_fetch = cfg->no_fetch_executables();
-        if (offline || no_fetch) {
-            if (!force && backend_binary_available && !needs_therock_download) {
-                LOG(WARNING, "BackendManager")
-                    << (offline ? "offline mode" : "Fetching executable artifacts is disabled")
-                    << "; using installed " << recipe << ":" << resolved_backend
-                    << " backend" << std::endl;
-                report_installed_backend_ready(recipe, resolved_backend, progress_cb);
-                return;
-            }
-
-            if (!backend_binary_available) {
-                throw std::runtime_error(
-                    (offline ? "Cannot install " : "Fetching executable artifacts is disabled and ") +
-                    recipe + ":" + resolved_backend +
-                    (offline ? ": offline mode" : " is not installed"));
-            }
-
-            throw std::runtime_error(
-                (offline ? "Cannot install " : "Fetching executable artifacts is disabled for ") +
-                recipe + ":" + resolved_backend +
-                ": required runtime components are not installed");
-        }
-    }
-
-    // Non-forced calls come from model-load/ensure flows. They should still
-    // update when GitHub is reachable, but when the machine is effectively
-    // offline they must reuse the installed backend immediately instead of
-    // entering the archive downloader's multi-retry backoff. Explicit update
-    // paths pass force=true and skip this probe.
-    if (!force && backend_binary_available && !needs_therock_download &&
-        !github_reachable_for_backend_update()) {
-        LOG(WARNING, "BackendManager")
-            << "GitHub is not reachable; using installed "
-            << recipe << ":" << resolved_backend
-            << " backend and deferring update" << std::endl;
-        report_installed_backend_ready(recipe, resolved_backend, progress_cb);
-        return;
-    }
-
-    auto params = get_install_params(recipe, resolved_backend);
 
     struct RuntimeInstallStep {
         std::string name;
@@ -673,47 +628,15 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
         };
     }
 
+    const std::string backend_install_dir =
+        backends::BackendUtils::get_install_directory(spec->recipe, resolved_backend);
+    const bool backend_install_dir_existed_before = fs::exists(backend_install_dir);
+
     bool completion_reported = false;
 
     try {
-        try {
-            backends::BackendUtils::install_from_github(
-                *spec, params.version, params.repo, params.filename, resolved_backend, backend_progress_cb);
-        } catch (const std::exception& e) {
-            if (!force && backend_binary_available) {
-                LOG(WARNING, "BackendManager")
-                    << "Could not update " << recipe << ":" << resolved_backend
-                    << "; using installed backend instead: " << e.what()
-                    << std::endl;
-                report_installed_backend_ready(recipe, resolved_backend, progress_cb);
-                return;
-            }
-            throw;
-        }
-
-        const std::string installed_backend_version =
-            read_installed_backend_version(spec->recipe, resolved_backend);
-        const bool backend_update_was_deferred =
-            !force &&
-            backend_binary_available &&
-            !params.version.empty() &&
-            installed_backend_version != params.version;
-
-        if (backend_update_was_deferred) {
-            // A non-forced ensure kept an older working backend. Do not continue
-            // into follow-up runtime downloads (for example TheRock), because that
-            // would reintroduce slow/offline failures during model load. Explicit
-            // install/update calls pass force=true and still perform the refresh.
-            LOG(WARNING, "BackendManager")
-                << "Using existing " << recipe << ":" << resolved_backend
-                << " backend version "
-                << (installed_backend_version.empty() ? "unknown" : installed_backend_version)
-                << " instead of " << params.version
-                << "; deferring runtime updates until an explicit backend update"
-                << std::endl;
-            report_installed_backend_ready(recipe, resolved_backend, progress_cb);
-            return;
-        }
+        backends::BackendUtils::install_from_github(
+            *spec, params.version, params.repo, params.filename, resolved_backend, backend_progress_cb);
 
         const int logical_total_files = backend_total_files + static_cast<int>(runtime_steps.size());
         for (size_t i = 0; i < runtime_steps.size(); ++i) {

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -116,6 +116,62 @@ std::string read_version_file(const fs::path& version_file) {
     return trim(version);
 }
 
+std::string read_installed_backend_version(const std::string& recipe,
+                                           const std::string& resolved_backend) {
+    const std::string install_dir = backends::BackendUtils::get_install_directory(
+        recipe, resolved_backend);
+    return read_version_file(fs::path(install_dir) / "version.txt");
+}
+
+bool has_installed_backend_binary(const backends::BackendSpec& spec,
+                                  const std::string& resolved_backend) {
+    if (!backends::BackendUtils::find_external_backend_binary(
+            spec.recipe, resolved_backend).empty()) {
+        return true;
+    }
+
+    const std::string install_dir = backends::BackendUtils::get_install_directory(
+        spec.recipe, resolved_backend);
+    return !backends::BackendUtils::find_executable_in_install_dir(
+        install_dir, spec.binary).empty();
+}
+
+void report_installed_backend_ready(const std::string& recipe,
+                                    const std::string& resolved_backend,
+                                    DownloadProgressCallback progress_cb) {
+    if (!progress_cb) {
+        return;
+    }
+
+    DownloadProgress p;
+    p.file = recipe + ":" + resolved_backend;
+    p.file_index = 1;
+    p.total_files = 1;
+    p.bytes_downloaded = 0;
+    p.bytes_total = 0;
+    p.total_download_size = 0;
+    p.percent = 100;
+    p.complete = true;
+    progress_cb(p);
+}
+
+bool github_reachable_for_backend_update() {
+    try {
+        std::map<std::string, std::string> headers = {
+            {"User-Agent", "lemonade"},
+            {"Accept", "application/vnd.github+json"},
+        };
+        auto response = utils::HttpClient::get(
+            "https://api.github.com/rate_limit", headers, /*timeout_seconds=*/3);
+        return response.status_code >= 200 && response.status_code < 500;
+    } catch (const std::exception& e) {
+        LOG(WARNING, "BackendManager")
+            << "GitHub reachability probe failed; deferring backend update: "
+            << e.what() << std::endl;
+        return false;
+    }
+}
+
 bool has_matching_system_rocm_runtime(const std::string& expected_runtime_version) {
     const fs::path version_file = "/opt/rocm/.info/version";
     const std::string system_version = read_version_file(version_file);
@@ -457,18 +513,16 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
         return;
     }
 
-    if (auto* cfg = RuntimeConfig::global()) {
-        if (cfg->no_fetch_executables()) {
-            throw std::runtime_error(
-                "Fetching executable artifacts is disabled");
-        }
-    }
-
-    auto params = get_install_params(recipe, resolved_backend);
     auto* spec = backends::try_get_spec_for_recipe(recipe);
     if (!spec) {
         throw std::runtime_error("[BackendManager] Unknown recipe: " + recipe);
     }
+
+    const std::string backend_install_dir =
+        backends::BackendUtils::get_install_directory(spec->recipe, resolved_backend);
+    const bool backend_install_dir_existed_before = fs::exists(backend_install_dir);
+    const bool backend_binary_available =
+        has_installed_backend_binary(*spec, resolved_backend);
 
     // Check if we need to download additional runtime components after the main backend.
     // `will_install_therock` intentionally answers whether TheRock is applicable
@@ -486,6 +540,50 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
         therock_applicable &&
         (rocm_runtime_update_required ||
          !is_therock_installed_for_current_arch(backend_versions_));
+
+    if (auto* cfg = RuntimeConfig::global()) {
+        const bool offline = cfg->offline();
+        const bool no_fetch = cfg->no_fetch_executables();
+        if (offline || no_fetch) {
+            if (!force && backend_binary_available && !needs_therock_download) {
+                LOG(WARNING, "BackendManager")
+                    << (offline ? "offline mode" : "Fetching executable artifacts is disabled")
+                    << "; using installed " << recipe << ":" << resolved_backend
+                    << " backend" << std::endl;
+                report_installed_backend_ready(recipe, resolved_backend, progress_cb);
+                return;
+            }
+
+            if (!backend_binary_available) {
+                throw std::runtime_error(
+                    (offline ? "Cannot install " : "Fetching executable artifacts is disabled and ") +
+                    recipe + ":" + resolved_backend +
+                    (offline ? ": offline mode" : " is not installed"));
+            }
+
+            throw std::runtime_error(
+                (offline ? "Cannot install " : "Fetching executable artifacts is disabled for ") +
+                recipe + ":" + resolved_backend +
+                ": required runtime components are not installed");
+        }
+    }
+
+    // Non-forced calls come from model-load/ensure flows. They should still
+    // update when GitHub is reachable, but when the machine is effectively
+    // offline they must reuse the installed backend immediately instead of
+    // entering the archive downloader's multi-retry backoff. Explicit update
+    // paths pass force=true and skip this probe.
+    if (!force && backend_binary_available && !needs_therock_download &&
+        !github_reachable_for_backend_update()) {
+        LOG(WARNING, "BackendManager")
+            << "GitHub is not reachable; using installed "
+            << recipe << ":" << resolved_backend
+            << " backend and deferring update" << std::endl;
+        report_installed_backend_ready(recipe, resolved_backend, progress_cb);
+        return;
+    }
+
+    auto params = get_install_params(recipe, resolved_backend);
 
     struct RuntimeInstallStep {
         std::string name;
@@ -575,15 +673,47 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
         };
     }
 
-    const std::string backend_install_dir =
-        backends::BackendUtils::get_install_directory(spec->recipe, resolved_backend);
-    const bool backend_install_dir_existed_before = fs::exists(backend_install_dir);
-
     bool completion_reported = false;
 
     try {
-        backends::BackendUtils::install_from_github(
-            *spec, params.version, params.repo, params.filename, resolved_backend, backend_progress_cb);
+        try {
+            backends::BackendUtils::install_from_github(
+                *spec, params.version, params.repo, params.filename, resolved_backend, backend_progress_cb);
+        } catch (const std::exception& e) {
+            if (!force && backend_binary_available) {
+                LOG(WARNING, "BackendManager")
+                    << "Could not update " << recipe << ":" << resolved_backend
+                    << "; using installed backend instead: " << e.what()
+                    << std::endl;
+                report_installed_backend_ready(recipe, resolved_backend, progress_cb);
+                return;
+            }
+            throw;
+        }
+
+        const std::string installed_backend_version =
+            read_installed_backend_version(spec->recipe, resolved_backend);
+        const bool backend_update_was_deferred =
+            !force &&
+            backend_binary_available &&
+            !params.version.empty() &&
+            installed_backend_version != params.version;
+
+        if (backend_update_was_deferred) {
+            // A non-forced ensure kept an older working backend. Do not continue
+            // into follow-up runtime downloads (for example TheRock), because that
+            // would reintroduce slow/offline failures during model load. Explicit
+            // install/update calls pass force=true and still perform the refresh.
+            LOG(WARNING, "BackendManager")
+                << "Using existing " << recipe << ":" << resolved_backend
+                << " backend version "
+                << (installed_backend_version.empty() ? "unknown" : installed_backend_version)
+                << " instead of " << params.version
+                << "; deferring runtime updates until an explicit backend update"
+                << std::endl;
+            report_installed_backend_ready(recipe, resolved_backend, progress_cb);
+            return;
+        }
 
         const int logical_total_files = backend_total_files + static_cast<int>(runtime_steps.size());
         for (size_t i = 0; i < runtime_steps.size(); ++i) {


### PR DESCRIPTION
Fixes #2078.

This keeps already-installed backends usable when Lemonade cannot reach GitHub during an automatic backend update check. Model loading now falls back to the installed backend instead of failing after repeated download retries.

Explicit backend installs/updates still attempt the update when online, and the existing backend is kept until the replacement has been fully downloaded, extracted, verified, and swapped into place.