### PR TITLE
fix(config): accept flat backend keys like vllm_args in config set (#1824)

### DIFF
--- a/docs/guide/configuration/vllm.md
+++ b/docs/guide/configuration/vllm.md
@@ -49,12 +49,14 @@ Standard OpenAI-compatible endpoints (`/v1/chat/completions`, `/v1/completions`)
 
 ## Tuning
 
-Free-form CLI args can be appended to `vllm-server` via `vllm_args`:
+Free-form CLI args can be appended to `vllm-server` via `vllm.args`:
 
 ```bash
 # Allow more concurrent sequences and turn on prefix caching
-lemonade config set vllm_args="--max-num-seqs 128 --enable-prefix-caching"
+lemonade config set vllm.args="--max-num-seqs 128 --enable-prefix-caching"
 ```
+
+The flat form (`vllm_args=...`) is also accepted and maps to the same setting.
 
 ## Known gotchas
 

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -67,6 +67,41 @@ static std::pair<json, std::string> normalize_config_set_changes(const json& cha
         LOG(WARNING) << message << std::endl;
     }
 
+    // Promote flat backend keys (e.g. "vllm_args", "llamacpp_backend") into
+    // their nested form ("vllm": {"args": ...}). Backend CLI flags and docs use
+    // the flat underscore form, but config.json stores backend options nested.
+    // Only keys whose prefix (before the first underscore) is a known backend
+    // are promoted; no top-level config key starts with a backend name, so this
+    // mapping is unambiguous. See issue #1824.
+    std::vector<std::string> flat_backend_keys;
+    for (auto& [key, value] : normalized.items()) {
+        size_t underscore = key.find('_');
+        if (underscore == std::string::npos) continue;
+        if (is_backend_name(key.substr(0, underscore))) {
+            flat_backend_keys.push_back(key);
+        }
+    }
+    for (const auto& key : flat_backend_keys) {
+        size_t underscore = key.find('_');
+        std::string backend = key.substr(0, underscore);
+        std::string field = key.substr(underscore + 1);
+        json value = normalized[key];
+
+        if (!normalized.contains(backend)) {
+            normalized[backend] = json::object();
+        } else if (!normalized[backend].is_object()) {
+            throw std::invalid_argument(
+                "Ambiguous config: '" + key + "' conflicts with non-object '" + backend + "'");
+        }
+        if (normalized[backend].contains(field) && normalized[backend][field] != value) {
+            throw std::invalid_argument(
+                "Ambiguous config: both '" + key + "' and '" + backend + "." + field +
+                "' were provided with different values");
+        }
+        normalized[backend][field] = value;
+        normalized.erase(key);
+    }
+
     return {normalized, message};
 }
 

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -639,6 +639,31 @@ sys.exit(0)
             # Best-effort restore — don't fail the test
             print(f"Warning: Failed to restore host to localhost: {e}")
 
+    def test_044_config_set_flat_backend_key(self):
+        """Flat backend keys (e.g. vllm_args) map to their nested form (issue #1824)."""
+        try:
+            # The flat underscore form is what the CLI flags and docs use; it
+            # must be accepted and stored under the nested "vllm.args" key.
+            self.assertCommandSucceeds(
+                ["config", "set", "vllm_args=--max-num-seqs 128"]
+            )
+
+            result = self.assertCommandSucceeds(["config"])
+            output = result.stdout
+            self.assertIn(
+                "vllm.args",
+                output,
+                f"vllm.args should appear in config output: {output}",
+            )
+            self.assertIn(
+                "--max-num-seqs 128",
+                output,
+                f"flat vllm_args value should be stored under vllm.args: {output}",
+            )
+        finally:
+            # Restore the default (empty) value so later tests are unaffected.
+            run_cli_command(["config", "set", "vllm.args="])
+
     # =============================================================================
     # Pull Tests
     # =============================================================================


### PR DESCRIPTION
## Summary

Fixes #1824. `lemonade config set vllm_args="--max-num-seqs 128 --enable-prefix-caching"` (the exact command from the docs) failed with `unknown config key \`vllm_args\``. Two users hit this.

**Root cause:** backend CLI flags and docs use the flat underscore form (`vllm_args`, `llamacpp_backend`), but `config.json` stores backend options nested (`vllm.args`). The CLI only promotes a key to a nested section when it contains a `.`, so `vllm_args` was sent as a top-level key and rejected by the server's validator.

> Note: part 1 of the issue — the missing `[vllm]` section in `lemonade config` — was already fixed by #1919. This PR closes the remaining `config set` gap.

## Changes

- **`src/cpp/server/runtime_config.cpp`** — In `normalize_config_set_changes`, promote flat `<backend>_<field>` keys into nested form (`vllm_args` → `vllm.args`). Done server-side so every client (CLI, web app, raw `/internal/set`) benefits. Only keys whose prefix is a known backend (`llamacpp`, `whispercpp`, `moonshine`, `sdcpp`, `flm`, `vllm`, `ryzenai`, `kokoro`) are promoted — no top-level config key starts with a backend name, so the mapping is unambiguous. Conflicting flat+dotted values raise a clear error.
- **`docs/guide/configuration/vllm.md`** — Align the tuning example to the dotted form (`vllm.args`), consistent with every other backend doc; note the flat form is still accepted.
- **`test/server_cli2.py`** — Add `test_044_config_set_flat_backend_key`: runs `config set vllm_args=...` and verifies the value lands under `vllm.args`.

## Verification

`lemond` and `lemonade` compile cleanly. Live-tested against a running server:

- `config set "vllm_args=--max-num-seqs 128 --enable-prefix-caching"` (issue's exact command) → stored under `vllm.args`, shown under `[vllm]`. ✅
- `llamacpp_backend=auto` → `llamacpp.backend`. ✅
- `max_loaded_models=2` stays a top-level key (not wrongly promoted). ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)