### PR TITLE
Move omni collection system prompt to per-model JSON

### DIFF
--- a/docs/dev/lemonade-omni.md
+++ b/docs/dev/lemonade-omni.md
@@ -40,6 +40,12 @@ The canonical definitions live in [`src/app/src/renderer/utils/toolDefinitions.j
 
 Endpoint request/response shapes are documented in the [Endpoints Spec](../api/README.md).
 
+### Per-collection system prompt override
+
+The default OmniRouter system prompt lives in `toolDefinitions.json` and is a *template* with `{tool_list}` and `{tool_guidance}` placeholders that the server (and app) expand at runtime based on which components are present.
+
+Each collection model can override that default by setting its own `system_prompt` template — either in its registry entry (`server_models.json` for built-ins), in its published Hugging Face collection JSON (for HF-backed collections like `LMX-Omni-*`), or via the desktop app's Omni Model editor for custom collections. When present, the per-collection value wins; otherwise the global default applies. Tool definitions stay global — only the prompt text is per-collection.
+
 ## How to Use Omni Models
 
 Any app can use an omni collection by simply requesting `/chat/completions` and receiving multi-media results in the response content. Apps that want a higher degree of customization can instead send their requests to the collection's planner LLM, with a custom system prompt and tool definitions, and receive tool calls in the response.

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -114,6 +114,8 @@ The Omni Model editor only offers already-registered compatible models for each 
 
 If a component model is deleted later, the Omni Model entry remains registered but is hidden from the chat picker until every referenced component is available again.
 
+The editor also exposes an optional **System Prompt** field. Leave it blank to use the default OmniRouter system prompt; supply a string to override it just for this collection. The override is a *template* — keep the `{tool_list}` and `{tool_guidance}` placeholders so the planner still sees the available tools (the server expands them at runtime based on which components are present).
+
 ### Share a collection: export, import, and Hugging Face
 
 `lemonade export <collection>` (and the desktop app's Export button) writes a *collection file*: the

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -114,7 +114,7 @@ The Omni Model editor only offers already-registered compatible models for each 
 
 If a component model is deleted later, the Omni Model entry remains registered but is hidden from the chat picker until every referenced component is available again.
 
-The editor also exposes an optional **System Prompt** field. Leave it blank to use the default OmniRouter system prompt; supply a string to override it just for this collection. The override is a *template* — keep the `{tool_list}` and `{tool_guidance}` placeholders so the planner still sees the available tools (the server expands them at runtime based on which components are present).
+The editor also exposes a **System Prompt** field, pre-filled with the shipped default so you can see the text you'd be replacing. Edit it to override the default for this collection only; the override stays a *template* — keep the `{tool_list}` and `{tool_guidance}` placeholders so the planner still sees the available tools (the server expands them at runtime based on which components are present). Leaving the text unchanged from the default — or clicking **Reset to default** — stores no override, so the collection keeps tracking whatever the global default is at runtime (including future updates to it).
 
 ### Share a collection: export, import, and Hugging Face
 

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -114,7 +114,7 @@ The Omni Model editor only offers already-registered compatible models for each 
 
 If a component model is deleted later, the Omni Model entry remains registered but is hidden from the chat picker until every referenced component is available again.
 
-The editor also exposes a **System Prompt** field, pre-filled with the shipped default so you can see the text you'd be replacing. Edit it to override the default for this collection only; the override stays a *template* — keep the `{tool_list}` and `{tool_guidance}` placeholders so the planner still sees the available tools (the server expands them at runtime based on which components are present). A collection whose textarea matches the default — or that has been reset via **Reset to default** — stores no override and keeps tracking whatever the global default is at runtime.
+The editor also exposes a **System Prompt** field, pre-filled with the shipped default so you can see the text you'd be replacing. Edit it to override the default for this collection only; the override stays a *template* — both the `{tool_list}` and `{tool_guidance}` placeholders are **required** in any custom prompt and the editor blocks save/export when either is missing, because the server expands them at runtime based on which components are present. A collection whose textarea matches the default — or that has been reset via **Reset to default** — stores no override and keeps tracking whatever the global default is at runtime.
 
 ### Share a collection: export, import, and Hugging Face
 

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -114,7 +114,7 @@ The Omni Model editor only offers already-registered compatible models for each 
 
 If a component model is deleted later, the Omni Model entry remains registered but is hidden from the chat picker until every referenced component is available again.
 
-The editor also exposes a **System Prompt** field, pre-filled with the shipped default so you can see the text you'd be replacing. Edit it to override the default for this collection only; the override stays a *template* — keep the `{tool_list}` and `{tool_guidance}` placeholders so the planner still sees the available tools (the server expands them at runtime based on which components are present). Leaving the text unchanged from the default — or clicking **Reset to default** — stores no override, so the collection keeps tracking whatever the global default is at runtime (including future updates to it).
+The editor also exposes a **System Prompt** field, pre-filled with the shipped default so you can see the text you'd be replacing. Edit it to override the default for this collection only; the override stays a *template* — keep the `{tool_list}` and `{tool_guidance}` placeholders so the planner still sees the available tools (the server expands them at runtime based on which components are present). A collection whose textarea matches the default — or that has been reset via **Reset to default** — stores no override and keeps tracking whatever the global default is at runtime.
 
 ### Share a collection: export, import, and Hugging Face
 

--- a/src/app/src/renderer/components/CustomCollectionPanel.tsx
+++ b/src/app/src/renderer/components/CustomCollectionPanel.tsx
@@ -336,7 +336,7 @@ const CustomCollectionPanel: React.FC<CustomCollectionPanelProps> = ({
         <div className="form-section">
           <label className="form-label">System Prompt</label>
           <div className="form-subtext">
-            Edit to override the default for this Omni Model. Keep the {'{tool_list}'} and {'{tool_guidance}'} placeholders so the planner sees the available tools. Leave the text unchanged (or use Reset) to keep using the shipped default — including any future updates to it.
+            Edit to override the default for this Omni Model. Keep the {'{tool_list}'} and {'{tool_guidance}'} placeholders so the planner sees the available tools.
           </div>
           <textarea
             className="form-input"

--- a/src/app/src/renderer/components/CustomCollectionPanel.tsx
+++ b/src/app/src/renderer/components/CustomCollectionPanel.tsx
@@ -6,6 +6,7 @@ import {
   CustomCollection,
   CustomCollectionDraft,
   CustomCollectionRole,
+  DEFAULT_OMNI_SYSTEM_PROMPT,
   getCollectionRoleOptions,
   getCustomCollectionRoleLabel,
   getCustomCollectionComponentList,
@@ -45,7 +46,10 @@ const emptyDraft = () => ({
   edit: '',
   transcription: '',
   speech: '',
-  systemPrompt: '',
+  // Pre-fill with the current default so authors can see the prompt they
+  // would otherwise inherit. formToDraft compares the textbox to this default
+  // and stores no override when they match — see DEFAULT_OMNI_SYSTEM_PROMPT.
+  systemPrompt: DEFAULT_OMNI_SYSTEM_PROMPT,
   createdAt: undefined as string | undefined,
 });
 
@@ -62,25 +66,34 @@ const draftFromCollection = (collection: CustomCollection, sourceId: string, isC
     edit: collection.components.edit ?? '',
     transcription: collection.components.transcription ?? '',
     speech: collection.components.speech ?? '',
-    systemPrompt: collection.systemPrompt ?? '',
+    systemPrompt: collection.systemPrompt ?? DEFAULT_OMNI_SYSTEM_PROMPT,
     createdAt: collection.createdAt,
   };
 };
 
-const formToDraft = (form: CollectionForm): CustomCollectionDraft => ({
-  id: form.selectedCollectionId || undefined,
-  name: form.name.trim(),
-  createdAt: form.createdAt,
-  components: {
-    llm: form.llm,
-    vision: form.vision || undefined,
-    image: form.image || undefined,
-    edit: form.edit || undefined,
-    transcription: form.transcription || undefined,
-    speech: form.speech || undefined,
-  },
-  systemPrompt: form.systemPrompt.trim() || undefined,
-});
+const formToDraft = (form: CollectionForm): CustomCollectionDraft => {
+  // Text identical to the shipped default is treated as "no override" so the
+  // collection stays on the global fallback — a later toolDefinitions.json
+  // update reaches existing collections instead of being shadowed by a frozen
+  // copy. A trimmed empty string maps to the same state (the textarea is
+  // pre-filled, but an author may clear it without using "Reset to default").
+  const trimmed = form.systemPrompt.trim();
+  const isDefault = !trimmed || form.systemPrompt === DEFAULT_OMNI_SYSTEM_PROMPT;
+  return {
+    id: form.selectedCollectionId || undefined,
+    name: form.name.trim(),
+    createdAt: form.createdAt,
+    components: {
+      llm: form.llm,
+      vision: form.vision || undefined,
+      image: form.image || undefined,
+      edit: form.edit || undefined,
+      transcription: form.transcription || undefined,
+      speech: form.speech || undefined,
+    },
+    systemPrompt: isDefault ? undefined : trimmed,
+  };
+};
 
 const componentListForForm = (form: CollectionForm): string[] => getCustomCollectionComponentList(formToDraft(form));
 
@@ -321,20 +334,28 @@ const CustomCollectionPanel: React.FC<CustomCollectionPanelProps> = ({
         </div>
 
         <div className="form-section">
-          <label
-            className="form-label"
-            title="Optional template that overrides the default OmniRouter system prompt. Leave blank to use the default. Keep the {tool_list} and {tool_guidance} placeholders so the planner sees the available tools."
-          >
-            System Prompt (optional)
-          </label>
+          <label className="form-label">System Prompt</label>
+          <div className="form-subtext">
+            Edit to override the default for this Omni Model. Keep the {'{tool_list}'} and {'{tool_guidance}'} placeholders so the planner sees the available tools. Leave the text unchanged (or use Reset) to keep using the shipped default — including any future updates to it.
+          </div>
           <textarea
             className="form-input"
-            rows={6}
+            rows={8}
             value={form.systemPrompt}
             onChange={(e) => updateForm({ systemPrompt: e.target.value })}
-            placeholder="Leave blank to use the default OmniRouter system prompt. To customize, keep the {tool_list} and {tool_guidance} placeholders."
             spellCheck={false}
           />
+          <div className="form-actions-inline">
+            <button
+              type="button"
+              className="settings-reset-button"
+              onClick={() => updateForm({ systemPrompt: DEFAULT_OMNI_SYSTEM_PROMPT })}
+              disabled={form.systemPrompt === DEFAULT_OMNI_SYSTEM_PROMPT}
+              title="Restore the shipped default OmniRouter system prompt."
+            >
+              Reset to default
+            </button>
+          </div>
         </div>
 
         {error && <div className="form-error">{error}</div>}

--- a/src/app/src/renderer/components/CustomCollectionPanel.tsx
+++ b/src/app/src/renderer/components/CustomCollectionPanel.tsx
@@ -45,6 +45,7 @@ const emptyDraft = () => ({
   edit: '',
   transcription: '',
   speech: '',
+  systemPrompt: '',
   createdAt: undefined as string | undefined,
 });
 
@@ -61,6 +62,7 @@ const draftFromCollection = (collection: CustomCollection, sourceId: string, isC
     edit: collection.components.edit ?? '',
     transcription: collection.components.transcription ?? '',
     speech: collection.components.speech ?? '',
+    systemPrompt: collection.systemPrompt ?? '',
     createdAt: collection.createdAt,
   };
 };
@@ -77,6 +79,7 @@ const formToDraft = (form: CollectionForm): CustomCollectionDraft => ({
     transcription: form.transcription || undefined,
     speech: form.speech || undefined,
   },
+  systemPrompt: form.systemPrompt.trim() || undefined,
 });
 
 const componentListForForm = (form: CollectionForm): string[] => getCustomCollectionComponentList(formToDraft(form));
@@ -315,6 +318,23 @@ const CustomCollectionPanel: React.FC<CustomCollectionPanelProps> = ({
             <div className="collection-warning">This planner LLM may not support tool calling. The Omni Model can still be saved, but OmniRouter tools may be unreliable with this model.</div>
           )}
           {OPTIONAL_ROLES.map((role) => renderRoleSelect(role))}
+        </div>
+
+        <div className="form-section">
+          <label
+            className="form-label"
+            title="Optional template that overrides the default OmniRouter system prompt. Leave blank to use the default. Keep the {tool_list} and {tool_guidance} placeholders so the planner sees the available tools."
+          >
+            System Prompt (optional)
+          </label>
+          <textarea
+            className="form-input"
+            rows={6}
+            value={form.systemPrompt}
+            onChange={(e) => updateForm({ systemPrompt: e.target.value })}
+            placeholder="Leave blank to use the default OmniRouter system prompt. To customize, keep the {tool_list} and {tool_guidance} placeholders."
+            spellCheck={false}
+          />
         </div>
 
         {error && <div className="form-error">{error}</div>}

--- a/src/app/src/renderer/components/CustomCollectionPanel.tsx
+++ b/src/app/src/renderer/components/CustomCollectionPanel.tsx
@@ -75,10 +75,11 @@ const formToDraft = (form: CollectionForm): CustomCollectionDraft => {
   // Text identical to the shipped default is treated as "no override" so the
   // collection stays on the global fallback — a later toolDefinitions.json
   // update reaches existing collections instead of being shadowed by a frozen
-  // copy. A trimmed empty string maps to the same state (the textarea is
-  // pre-filled, but an author may clear it without using "Reset to default").
+  // copy. Compare on trimmed values so accidental leading/trailing whitespace
+  // around the default doesn't get persisted as a real override. A blank
+  // textarea (after trim) maps to the same "no override" state.
   const trimmed = form.systemPrompt.trim();
-  const isDefault = !trimmed || form.systemPrompt === DEFAULT_OMNI_SYSTEM_PROMPT;
+  const isDefault = !trimmed || trimmed === DEFAULT_OMNI_SYSTEM_PROMPT.trim();
   return {
     id: form.selectedCollectionId || undefined,
     name: form.name.trim(),
@@ -279,7 +280,21 @@ const CustomCollectionPanel: React.FC<CustomCollectionPanelProps> = ({
       setError('Select a planner LLM for the Omni Model.');
       return null;
     }
-    return formToDraft({ ...form, name: cleanName });
+    const draft = formToDraft({ ...form, name: cleanName });
+    // Custom prompt templates must keep both substitution placeholders so the
+    // planner still sees the tool list/guidance after runtime substitution. The
+    // editor's subtext flags this; without enforcement an override missing a
+    // placeholder would silently produce a tool-blind planner prompt.
+    if (typeof draft.systemPrompt === 'string') {
+      const missing: string[] = [];
+      if (!draft.systemPrompt.includes('{tool_list}')) missing.push('{tool_list}');
+      if (!draft.systemPrompt.includes('{tool_guidance}')) missing.push('{tool_guidance}');
+      if (missing.length > 0) {
+        setError(`Custom System Prompt is missing required placeholder${missing.length > 1 ? 's' : ''}: ${missing.join(' and ')}. Add them back or click Reset to default.`);
+        return null;
+      }
+    }
+    return draft;
   };
 
   const handleSave = async () => {
@@ -350,7 +365,7 @@ const CustomCollectionPanel: React.FC<CustomCollectionPanelProps> = ({
               type="button"
               className="settings-reset-button"
               onClick={() => updateForm({ systemPrompt: DEFAULT_OMNI_SYSTEM_PROMPT })}
-              disabled={form.systemPrompt === DEFAULT_OMNI_SYSTEM_PROMPT}
+              disabled={form.systemPrompt.trim() === DEFAULT_OMNI_SYSTEM_PROMPT.trim()}
               title="Restore the shipped default OmniRouter system prompt."
             >
               Reset to default

--- a/src/app/src/renderer/utils/customCollections.ts
+++ b/src/app/src/renderer/utils/customCollections.ts
@@ -22,6 +22,10 @@ export interface CustomCollection {
   createdAt?: string;
   updatedAt?: string;
   components: CustomCollectionComponents;
+  // Optional per-collection system prompt template. Overrides the global
+  // default in toolDefinitions.json when set; still uses {tool_list} and
+  // {tool_guidance} placeholders for runtime substitution.
+  systemPrompt?: string;
 }
 
 export interface CustomCollectionDraft {
@@ -29,12 +33,15 @@ export interface CustomCollectionDraft {
   name: string;
   createdAt?: string;
   components: CustomCollectionComponents;
+  systemPrompt?: string;
 }
 
 export interface CustomCollectionPullRequest {
   model_name: string;
   recipe: typeof COLLECTION_OMNI_MODEL_RECIPE;
   components: string[];
+  // Optional template (matches the registry's system_prompt field).
+  system_prompt?: string;
 }
 
 const roleLabels: Record<CustomCollectionRole, string> = {
@@ -168,10 +175,15 @@ export const modelEntryToCustomCollection = (
   const components = normalizeComponents(info?.components, modelsData);
   if (!components) return null;
 
+  const systemPrompt = typeof info?.system_prompt === 'string' && info.system_prompt
+    ? info.system_prompt
+    : undefined;
+
   return {
     id: modelId,
     name: getCollectionDisplayName(modelId),
     components,
+    systemPrompt,
   };
 };
 
@@ -188,6 +200,10 @@ export const buildCustomCollectionPullRequest = (draft: CustomCollectionDraft): 
     recipe: COLLECTION_OMNI_MODEL_RECIPE,
     components,
   };
+  const systemPrompt = typeof draft.systemPrompt === 'string' ? draft.systemPrompt.trim() : '';
+  if (systemPrompt) {
+    request.system_prompt = systemPrompt;
+  }
   return request;
 };
 

--- a/src/app/src/renderer/utils/customCollections.ts
+++ b/src/app/src/renderer/utils/customCollections.ts
@@ -2,8 +2,16 @@ import type { ModelInfo, ModelsData } from './modelData';
 import { USER_MODEL_PREFIX } from './modelData';
 import { isChatPlannerCandidate } from './modelLabels';
 import { COLLECTION_OMNI_MODEL_RECIPE, isCollectionRecipe } from './recipeNames';
+import toolDefinitions from './toolDefinitions.json';
 
 export const CUSTOM_COLLECTION_PREFIX = USER_MODEL_PREFIX;
+
+// The shipped OmniRouter system prompt, exposed so the Omni Model editor can
+// show authors the text they're (potentially) overriding. Matched verbatim on
+// save: when the textarea content equals this string, the editor stores no
+// override and the collection stays on whatever the global default is at
+// runtime — so a future tweak to toolDefinitions.json propagates automatically.
+export const DEFAULT_OMNI_SYSTEM_PROMPT: string = toolDefinitions.system_prompt;
 
 export type CustomCollectionRole = 'llm' | 'vision' | 'image' | 'edit' | 'transcription' | 'speech';
 

--- a/src/app/src/renderer/utils/lemonadeTools.ts
+++ b/src/app/src/renderer/utils/lemonadeTools.ts
@@ -118,7 +118,12 @@ export function buildLemonadeTools(
 
   const toolList = tools.map(t => `- ${t.function.name}: ${t.function.description}`).join('\n');
   const toolGuidance = guidance.length ? `\n${guidance.join('\n')}` : '';
-  const systemPrompt = toolDefinitions.system_prompt
+  // The collection's own system_prompt (when set) overrides the global default
+  // — mirrors collection_orchestrator.cpp::build_tools on the server side.
+  const collectionPrompt = typeof info?.system_prompt === 'string' && info.system_prompt
+    ? info.system_prompt
+    : toolDefinitions.system_prompt;
+  const systemPrompt = collectionPrompt
     .replace('{tool_list}', toolList)
     .replace('{tool_guidance}', toolGuidance);
 

--- a/src/app/src/renderer/utils/modelData.ts
+++ b/src/app/src/renderer/utils/modelData.ts
@@ -31,6 +31,10 @@ export interface ModelInfo {
   vision?: boolean;
   downloaded?: boolean;
   image_defaults?: ImageDefaults;
+  // Per-collection system prompt template (collection.omni only). Overrides the
+  // global default in toolDefinitions.json when set. Keeps {tool_list} and
+  // {tool_guidance} placeholders so runtime substitution still works.
+  system_prompt?: string;
   [key: string]: unknown;
 }
 
@@ -132,6 +136,11 @@ const normalizeModelInfo = (info: unknown): ModelInfo | null => {
     normalized.reasoning = reasoning;
   }
 
+  const systemPrompt = info['system_prompt'];
+  if (typeof systemPrompt === 'string' && systemPrompt) {
+    normalized.system_prompt = systemPrompt;
+  }
+
   const vision = info['vision'];
   if (typeof vision === 'boolean') {
     normalized.vision = vision;
@@ -219,6 +228,10 @@ const fetchBuiltInModelsFromAPI = async (): Promise<ModelsData> => {
         modelInfo.vision = model.vision;
       }
 
+      if (typeof model.system_prompt === 'string' && model.system_prompt) {
+        modelInfo.system_prompt = model.system_prompt;
+      }
+
       // cloud_provider distinguishes per-provider buckets in the Model
       // Manager grouping (recipe="cloud" alone collapses all providers
       // into a single sub-heading).
@@ -275,6 +288,7 @@ const EXPORT_KNOWN_KEYS = new Set([
   'recipe',
   'recipe_options',
   'size',
+  'system_prompt',
 ]);
 
 const toExportEntry = (raw: Record<string, unknown>): Record<string, unknown> => {

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -2591,6 +2591,17 @@ footer {
     gap: 4px;
 }
 
+.form-subtext {
+    font-size: 0.7rem;
+    color: var(--text-tertiary);
+    line-height: 1.4;
+}
+
+.form-actions-inline {
+    display: flex;
+    justify-content: flex-end;
+}
+
 .info-icon {
     font-size: 0.6rem;
     color: var(--text-quaternary);

--- a/src/cpp/cli/recipe_import.cpp
+++ b/src/cpp/cli/recipe_import.cpp
@@ -30,7 +30,8 @@ const std::vector<std::string> kKnownKeys = {
     "labels",
     "recipe",
     "recipe_options",
-    "size"
+    "size",
+    "system_prompt"
 };
 
 bool is_json_recipe_file(const nlohmann::json& entry) {

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -96,6 +96,11 @@ struct ModelInfo {
     // Image generation defaults (for sd-cpp models)
     ImageDefaults image_defaults;
 
+    // Per-collection system prompt template (collection.omni models only).
+    // When non-empty, overrides the global default in toolDefinitions.json.
+    // Stays a template — {tool_list} / {tool_guidance} are substituted at runtime.
+    std::string system_prompt;
+
     // Cloud offload (for "cloud" recipe). Names the provider to dispatch to
     // (e.g., "fireworks"). Empty for non-cloud recipes.
     std::string cloud_provider;

--- a/src/cpp/server/collection_orchestrator.cpp
+++ b/src/cpp/server/collection_orchestrator.cpp
@@ -443,10 +443,17 @@ CollectionOrchestrator::ToolSet CollectionOrchestrator::build_tools(const ModelI
     }
     if (!tool_list.empty() && tool_list.back() == '\n') tool_list.pop_back();
 
-    // Build the omni system prompt.
-    if (defs.contains("system_prompt") && defs["system_prompt"].is_string()) {
-        std::string prompt = replace_all(defs["system_prompt"].get<std::string>(),
-                                         "{tool_list}", tool_list);
+    // Build the omni system prompt. The collection model's own `system_prompt`
+    // overrides the global default in toolDefinitions.json so authors can
+    // customize behavior per collection without forking the shared file.
+    std::string prompt_template;
+    if (!collection_info.system_prompt.empty()) {
+        prompt_template = collection_info.system_prompt;
+    } else if (defs.contains("system_prompt") && defs["system_prompt"].is_string()) {
+        prompt_template = defs["system_prompt"].get<std::string>();
+    }
+    if (!prompt_template.empty()) {
+        std::string prompt = replace_all(prompt_template, "{tool_list}", tool_list);
         result.system_prompt = replace_all(prompt, "{tool_guidance}", tool_guidance);
     }
 

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -108,7 +108,7 @@ static constexpr auto safe_dir_options = fs::directory_options::none;
 namespace lemon {
 
 // Properties which are defined by the user for model registration.
-static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults", "components", "recipe_options"};
+static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults", "components", "recipe_options", "system_prompt"};
 
 // Helper functions for string operations — use shared implementations from gguf_reader_detail
 
@@ -1821,6 +1821,7 @@ void ModelManager::build_cache() {
         info.size = JsonUtils::get_or_default<double>(value, "size", 0.0);
         info.cloud_provider = JsonUtils::get_or_default<std::string>(value, "cloud_provider", "");
         info.moonshine_arch = JsonUtils::get_or_default<int>(value, "moonshine_arch", -1);
+        info.system_prompt = JsonUtils::get_or_default<std::string>(value, "system_prompt", "");
 
         // HF-backed collections store their components on Hugging Face — the
         // cached manifest is the single source of truth. Rebuild the component
@@ -1875,6 +1876,7 @@ void ModelManager::build_cache() {
         info.size = JsonUtils::get_or_default<double>(value, "size", 0.0);
         info.cloud_provider = JsonUtils::get_or_default<std::string>(value, "cloud_provider", "");
         info.moonshine_arch = JsonUtils::get_or_default<int>(value, "moonshine_arch", -1);
+        info.system_prompt = JsonUtils::get_or_default<std::string>(value, "system_prompt", "");
 
         // HF-backed user collections (created by `lemonade pull <org>/<repo>`)
         // keep only a repo pointer in user_models.json; their components live in
@@ -2075,6 +2077,7 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
     info.suggested = JsonUtils::get_or_default<bool>(*model_json, "suggested", is_user_model);
     info.hf_load = JsonUtils::get_or_default<bool>(*model_json, "hf_load", false);
     info.source = JsonUtils::get_or_default<std::string>(*model_json, "source", "");
+    info.system_prompt = JsonUtils::get_or_default<std::string>(*model_json, "system_prompt", "");
 
     if (model_json->contains("labels") && (*model_json)["labels"].is_array()) {
         for (const auto& label : (*model_json)["labels"]) {
@@ -3249,6 +3252,14 @@ void ModelManager::populate_collection_components_from_cache_locked(ModelInfo& i
     // omits it.
     if (info.size == 0.0 && manifest.contains("size") && manifest["size"].is_number()) {
         info.size = manifest["size"].get<double>();
+    }
+
+    // Same lift-from-manifest pattern for the optional per-collection system
+    // prompt: the registry entry wins when it sets one, otherwise the published
+    // HF JSON acts as the source of truth.
+    if (info.system_prompt.empty() && manifest.contains("system_prompt") &&
+        manifest["system_prompt"].is_string()) {
+        info.system_prompt = manifest["system_prompt"].get<std::string>();
     }
 }
 
@@ -5199,6 +5210,7 @@ ModelInfo ModelManager::get_model_info_unfiltered(const std::string& model_name)
     info.suggested = JsonUtils::get_or_default<bool>(*model_json, "suggested", false);
     info.hf_load = JsonUtils::get_or_default<bool>(*model_json, "hf_load", false);
     info.source = JsonUtils::get_or_default<std::string>(*model_json, "source", "");
+    info.system_prompt = JsonUtils::get_or_default<std::string>(*model_json, "system_prompt", "");
 
     // Parse labels array
     if (model_json->contains("labels") && (*model_json)["labels"].is_array()) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1777,6 +1777,12 @@ nlohmann::json Server::model_info_to_json(const std::string& model_id, const Mod
         model_json["cost_output_per_million"] = info.cost_output_per_million;
     }
 
+    // Per-collection system prompt override (collection.omni only). Omitted on
+    // models that don't carry one so the field doesn't pollute every entry.
+    if (!info.system_prompt.empty()) {
+        model_json["system_prompt"] = info.system_prompt;
+    }
+
     // Add image_defaults if present (for sd-cpp models)
     if (info.image_defaults.has_defaults) {
         json img_def = {

--- a/test/app/app-regression/lemonadeTools.test.cjs
+++ b/test/app/app-regression/lemonadeTools.test.cjs
@@ -120,6 +120,70 @@ const tests = [
     },
   },
   {
+    name: 'collection-level system_prompt overrides the global default in buildLemonadeTools',
+    run() {
+      const source = normalizeWhitespace(readSource(LEMONADE_TOOLS));
+      assertIncludes(
+        source,
+        "typeof info?.system_prompt === 'string' && info.system_prompt",
+        'buildLemonadeTools should prefer the collection model\'s own system_prompt when set.',
+      );
+      assertIncludes(
+        source,
+        '? info.system_prompt',
+        'The override branch must read system_prompt off the collection\'s ModelInfo.',
+      );
+      assertIncludes(
+        source,
+        ': toolDefinitions.system_prompt',
+        'The fallback branch must keep the global default in toolDefinitions.json.',
+      );
+    },
+  },
+  {
+    name: 'system_prompt rides through the export/import allowlist',
+    run() {
+      const modelData = readSource('src/app/src/renderer/utils/modelData.ts');
+      assertIncludes(
+        modelData,
+        "'system_prompt',",
+        'EXPORT_KNOWN_KEYS must include system_prompt so round-trips do not drop it.',
+      );
+      assertIncludes(
+        modelData,
+        'system_prompt?: string',
+        'ModelInfo should expose system_prompt as an optional field.',
+      );
+      const recipeImport = readSource('src/cpp/cli/recipe_import.cpp');
+      assertIncludes(
+        recipeImport,
+        '"system_prompt"',
+        'kKnownKeys (CLI side) must mirror the desktop allowlist.',
+      );
+    },
+  },
+  {
+    name: 'custom collection draft carries an optional systemPrompt through to the pull request',
+    run() {
+      const customCollections = readSource('src/app/src/renderer/utils/customCollections.ts');
+      assertIncludes(
+        customCollections,
+        'systemPrompt?: string',
+        'CustomCollection / CustomCollectionDraft should carry an optional systemPrompt.',
+      );
+      assertIncludes(
+        customCollections,
+        "system_prompt?: string",
+        'CustomCollectionPullRequest should serialize system_prompt to the wire format.',
+      );
+      assertIncludes(
+        customCollections,
+        'request.system_prompt = systemPrompt',
+        'buildCustomCollectionPullRequest should attach the trimmed prompt when non-empty.',
+      );
+    },
+  },
+  {
     name: 'unavailable tool guidance is omitted from the planner prompt',
     run() {
       const source = normalizeWhitespace(readSource(LEMONADE_TOOLS));

--- a/test/app/app-regression/lemonadeTools.test.cjs
+++ b/test/app/app-regression/lemonadeTools.test.cjs
@@ -209,13 +209,18 @@ const tests = [
       );
       assertIncludes(
         panel,
-        'form.systemPrompt === DEFAULT_OMNI_SYSTEM_PROMPT',
-        'formToDraft should treat text equal to the default as "no override" so the global fallback wins.',
+        'trimmed === DEFAULT_OMNI_SYSTEM_PROMPT.trim()',
+        'formToDraft should compare trimmed values so accidental whitespace around the default does not persist as a real override.',
       );
       assertIncludes(
         panel,
         'systemPrompt: isDefault ? undefined : trimmed',
         'Saving with the default text should omit the override; edited text should persist trimmed.',
+      );
+      assertIncludes(
+        panel,
+        'form.systemPrompt.trim() === DEFAULT_OMNI_SYSTEM_PROMPT.trim()',
+        'The Reset button disabled state should also use the trimmed comparison.',
       );
       assertIncludes(
         panel,
@@ -226,6 +231,32 @@ const tests = [
         panel,
         'form-subtext',
         'The override instruction should render as subtext under the label.',
+      );
+    },
+  },
+  {
+    name: 'custom collection editor blocks overrides missing the {tool_list} or {tool_guidance} placeholders',
+    run() {
+      const panel = readSource('src/app/src/renderer/components/CustomCollectionPanel.tsx');
+      assertIncludes(
+        panel,
+        "draft.systemPrompt.includes('{tool_list}')",
+        'Save/Export validation should check that overrides keep the {tool_list} placeholder.',
+      );
+      assertIncludes(
+        panel,
+        "draft.systemPrompt.includes('{tool_guidance}')",
+        'Save/Export validation should check that overrides keep the {tool_guidance} placeholder.',
+      );
+      assertIncludes(
+        panel,
+        'Custom System Prompt is missing required placeholder',
+        'The validation error should name the missing placeholder explicitly.',
+      );
+      assertMatches(
+        panel,
+        /typeof draft\.systemPrompt === 'string'[\s\S]*?missing\.length > 0[\s\S]*?return null;/,
+        'Validation must short-circuit save/export when a placeholder is missing.',
       );
     },
   },

--- a/test/app/app-regression/lemonadeTools.test.cjs
+++ b/test/app/app-regression/lemonadeTools.test.cjs
@@ -181,6 +181,52 @@ const tests = [
         'request.system_prompt = systemPrompt',
         'buildCustomCollectionPullRequest should attach the trimmed prompt when non-empty.',
       );
+      assertIncludes(
+        customCollections,
+        'DEFAULT_OMNI_SYSTEM_PROMPT',
+        'The shipped default prompt should be exported so the editor can pre-fill it.',
+      );
+    },
+  },
+  {
+    name: 'custom collection editor pre-fills the default and only saves real overrides',
+    run() {
+      const panel = readSource('src/app/src/renderer/components/CustomCollectionPanel.tsx');
+      assertIncludes(
+        panel,
+        'DEFAULT_OMNI_SYSTEM_PROMPT',
+        'The editor should import the shipped default to populate the textarea.',
+      );
+      assertIncludes(
+        panel,
+        'systemPrompt: DEFAULT_OMNI_SYSTEM_PROMPT',
+        'Empty-draft initial state should pre-fill the textarea with the current default.',
+      );
+      assertIncludes(
+        panel,
+        'collection.systemPrompt ?? DEFAULT_OMNI_SYSTEM_PROMPT',
+        'Editing an existing collection should fall back to the default when no override exists.',
+      );
+      assertIncludes(
+        panel,
+        'form.systemPrompt === DEFAULT_OMNI_SYSTEM_PROMPT',
+        'formToDraft should treat text equal to the default as "no override" so the global fallback wins.',
+      );
+      assertIncludes(
+        panel,
+        'systemPrompt: isDefault ? undefined : trimmed',
+        'Saving with the default text should omit the override; edited text should persist trimmed.',
+      );
+      assertIncludes(
+        panel,
+        'Reset to default',
+        'A reset button should restore the shipped default.',
+      );
+      assertIncludes(
+        panel,
+        'form-subtext',
+        'The override instruction should render as subtext under the label.',
+      );
     },
   },
   {

--- a/test/app/customCollections.test.cjs
+++ b/test/app/customCollections.test.cjs
@@ -181,6 +181,21 @@ defineTest('regular-model export carries no collection fields', () => {
   assert.ok(!('created' in payload));
 });
 
+defineTest('DEFAULT_OMNI_SYSTEM_PROMPT is the canonical default from toolDefinitions.json', () => {
+  const toolDefinitionsPath = path.join(appRoot, 'src', 'renderer', 'utils', 'toolDefinitions.json');
+  const toolDefs = JSON.parse(fs.readFileSync(toolDefinitionsPath, 'utf8'));
+  assert.equal(
+    typeof collectionUtils.DEFAULT_OMNI_SYSTEM_PROMPT,
+    'string',
+    'The default prompt constant should be exported as a string.',
+  );
+  assert.equal(
+    collectionUtils.DEFAULT_OMNI_SYSTEM_PROMPT,
+    toolDefs.system_prompt,
+    'The editor default must match toolDefinitions.json verbatim so diff-on-save is exact.',
+  );
+});
+
 defineTest('buildCustomCollectionPullRequest attaches an optional system_prompt and omits it when blank', () => {
   const baseDraft = {
     name: 'WithPrompt',

--- a/test/app/customCollections.test.cjs
+++ b/test/app/customCollections.test.cjs
@@ -181,6 +181,78 @@ defineTest('regular-model export carries no collection fields', () => {
   assert.ok(!('created' in payload));
 });
 
+defineTest('buildCustomCollectionPullRequest attaches an optional system_prompt and omits it when blank', () => {
+  const baseDraft = {
+    name: 'WithPrompt',
+    components: { llm: 'planner' },
+  };
+
+  const withoutPrompt = collectionUtils.buildCustomCollectionPullRequest(baseDraft);
+  assert.equal(
+    'system_prompt' in withoutPrompt,
+    false,
+    'A draft without systemPrompt should not include the wire field.',
+  );
+
+  const blankPrompt = collectionUtils.buildCustomCollectionPullRequest({ ...baseDraft, systemPrompt: '   \n   ' });
+  assert.equal(
+    'system_prompt' in blankPrompt,
+    false,
+    'A whitespace-only systemPrompt should be treated as absent.',
+  );
+
+  const customPrompt = '   You are a helpful tester. Tools: {tool_list}{tool_guidance}\n   ';
+  const withPrompt = collectionUtils.buildCustomCollectionPullRequest({ ...baseDraft, systemPrompt: customPrompt });
+  assert.equal(withPrompt.system_prompt, customPrompt.trim());
+});
+
+defineTest('modelEntryToCustomCollection surfaces system_prompt back into the editable draft', () => {
+  const modelsData = {
+    'planner': model(['tool-calling']),
+    'user.MyKit': model(['collection'], true, 'collection.omni', {
+      components: ['planner'],
+      system_prompt: 'Greetings. {tool_list}{tool_guidance}',
+    }),
+  };
+
+  const custom = collectionUtils.modelEntryToCustomCollection('user.MyKit', modelsData['user.MyKit'], modelsData);
+  assert.equal(custom.systemPrompt, 'Greetings. {tool_list}{tool_guidance}');
+});
+
+defineTest('collection export round-trip preserves system_prompt on the import-ready payload', () => {
+  const raw = {
+    id: 'CreatorStudio',
+    object: 'model',
+    created: 1234567890,
+    owned_by: 'lemonade',
+    recipe: 'collection.omni',
+    checkpoint: '',
+    checkpoints: { main: '' },
+    components: ['planner'],
+    labels: [],
+    recipe_options: {},
+    suggested: true,
+    downloaded: true,
+    system_prompt: 'Custom override. {tool_list}{tool_guidance}',
+    models: [
+      {
+        id: 'planner', object: 'model', created: 1234567890, owned_by: 'lemonade',
+        recipe: 'llamacpp', checkpoint: 'org/planner:Q4_K_M',
+        checkpoints: { main: 'org/planner:Q4_K_M' },
+        components: [], labels: ['tool-calling'], recipe_options: {},
+        suggested: true, downloaded: true, size: 2.5,
+      },
+    ],
+  };
+
+  const { payload } = modelDataUtils.normalizeModelExportPayload(raw);
+  assert.equal(
+    payload.system_prompt,
+    'Custom override. {tool_list}{tool_guidance}',
+    'system_prompt should survive the export normalization step.',
+  );
+});
+
 defineTest('role options include registered concrete compatible models', () => {
   const modelsData = {
     'plain-chat': model(['tool-calling']),

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -2027,6 +2027,71 @@ class EndpointTests(ServerTestBase):
             except Exception:
                 pass
 
+    def test_021j_register_user_collection_with_system_prompt(self):
+        """A registered user collection round-trips an optional system_prompt.
+
+        Verifies the per-collection override path documented in
+        docs/dev/lemonade-omni.md: a custom omni model can ship its own
+        system_prompt template; the global default in toolDefinitions.json is
+        the fallback. The wire surface must echo the field on GET /models/{id}
+        and on /models?show_all=true so the desktop app can read it back when
+        re-opening the Omni Model editor.
+        """
+        canonical_name = f"user.PromptColl-{uuid.uuid4().hex[:8]}"
+        public_name = canonical_name[5:]
+        prompt_template = (
+            "You are a focused tester. Tools available:\n\n"
+            "{tool_list}\n\n"
+            "Use them sparingly.{tool_guidance}"
+        )
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": canonical_name,
+                    "recipe": "collection.omni",
+                    "components": [ENDPOINT_TEST_MODEL],
+                    "system_prompt": prompt_template,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(response.status_code, 200, response.text)
+
+            single = requests.get(
+                f"{self.base_url}/models/{public_name}",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(single.status_code, 200)
+            self.assertEqual(
+                single.json().get("system_prompt"),
+                prompt_template,
+                "GET /models/{id} must echo the registered system_prompt verbatim.",
+            )
+
+            listing = requests.get(
+                f"{self.base_url}/models?show_all=true",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(listing.status_code, 200)
+            entry = next(
+                (m for m in listing.json()["data"] if m["id"] == public_name),
+                None,
+            )
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry.get("system_prompt"), prompt_template)
+
+            print(f"[OK] system_prompt round-tripped for {public_name}")
+        finally:
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": canonical_name},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+
     def test_021k_register_collection_missing_components(self):
         """Collections referencing unknown components are rejected with 400."""
         canonical_name = f"user.BadColl-{uuid.uuid4().hex[:8]}"


### PR DESCRIPTION
## Summary

Closes #2367.


The below example shows creating a new omni collection with a modified system prompt and that prompt being honored during execution.

<img width="698" height="750" alt="image" src="https://github.com/user-attachments/assets/60797982-6768-41c2-bfe6-bec55a906ef9" />

<img width="1398" height="606" alt="image" src="https://github.com/user-attachments/assets/3452a77a-61ca-47fb-ad73-51777529ff8a" />


Moves the omni system prompt from the global `toolDefinitions.json` into each collection model's own JSON definition. The per-collection value overrides; the global default stays as the fallback so existing/imported collections without the field keep working unchanged. Tool definitions remain global — only the prompt text moved.

- **Server:** `ModelInfo` gains an optional `system_prompt`; built-in, user, and on-demand load paths all parse it. For HF-backed collections (`LMX-Omni-*`) the field is lifted from the cached manifest so the published HF JSON is the source of truth — no code change is needed when that text is later customized. `CollectionOrchestrator::build_tools` prefers the per-collection template; `GET /v1/models{,/{id}}` surfaces it when set.
- **App:** `buildLemonadeTools` mirrors the server fallback. `ModelInfo` (TS), `EXPORT_KNOWN_KEYS`, and the CLI's `kKnownKeys` all gain `system_prompt` so export/import round-trips don't drop it. The Custom Omni Model editor adds a "System Prompt (optional)" textarea threaded through `CustomCollectionDraft` → `CustomCollectionPullRequest`. `USER_DEFINED_MODEL_PROPS` carries it across `/pull` so user.* registrations persist it.
- **Docs:** `docs/dev/lemonade-omni.md` and `docs/guide/configuration/custom-models.md` document the override.
- **Tests:** 3 new behavioral tests in `customCollections.test.cjs` (pull-request shape, ModelInfo round-trip, export normalize), 3 static-source tests in `lemonadeTools.test.cjs`, and a wire round-trip test `test_021j_register_user_collection_with_system_prompt` in `server_endpoints.py`.
- **HF (already published):** The `system_prompt` field was added to `lemonade-sdk/LMX-Omni-52B-Halo.json` and `lemonade-sdk/LMX-Omni-5.5B-Lite.json` with the current default text — byte-identical no-op today, but reserves the canonical slot for future per-collection customization without a client update.

