### PR TITLE
fix(cli): resolve option inheritance bug in launch help options

### DIFF
--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -129,16 +129,14 @@ static bool is_launch_provider_misuse(int argc, char* argv[]) {
     return false;
 }
 
-static void hide_option(CLI::Option* option) {
-    if (option != nullptr) {
-        option->group("");
-    }
-}
-
-static void hide_new_options(CLI::App& app, size_t start_index) {
-    std::vector<CLI::Option*> options = app.get_options();
-    for (size_t i = start_index; i < options.size(); ++i) {
-        hide_option(options[i]);
+static void hide_all_options_except_help(CLI::App& app) {
+    for (auto* opt : app.get_options()) {
+        if (opt != nullptr) {
+            const std::string name = opt->get_name();
+            if (name != "--help" && name != "--help-all" && name != "-h") {
+                opt->group("");
+            }
+        }
     }
 }
 
@@ -1319,12 +1317,9 @@ int main(int argc, char* argv[]) {
             ->default_val(config.agent_args);
     };
 
-    size_t launch_option_count = launch_cmd->get_options().size();
     add_common_launch_options(*launch_cmd);
-    hide_new_options(*launch_cmd, launch_option_count);
-    launch_option_count = launch_cmd->get_options().size();
     lemon::RecipeOptions::add_cli_options(*launch_cmd, config.recipe_options);
-    hide_new_options(*launch_cmd, launch_option_count);
+    hide_all_options_except_help(*launch_cmd);
 
     CLI::Option* codex_provider_opt = nullptr;
     for (const std::string& agent_name : SUPPORTED_AGENTS) {


### PR DESCRIPTION
Replace index-based option hiding with a version-agnostic name filter that hides all options on the launch subcommand except help flags. This prevents CLI11 version discrepancies (2.4.2 vs 2.6.2) from causing option index shifts that corrupted option groups and help outputs.

Motivation for me was because cli tests were failing when I was using system libs, so every time the tests would fail on local.

Below are the before-and-after snapshots of the CLI help output behavior.

### 🛑 Before (Index-shifting / Option Leakage Bug)
Due to option index shifting under different CLI11 versions, options defined on the `launch` subcommand (like `--model`, `--directory`, etc.) leaked into the root help output. This bloated the root command output and caused CI/CD consistency test assertions to fail:

```
$ lemonade launch --help
Launch an agent with a model

Usage: lemonade launch [OPTIONS] [SUBCOMMAND]

OPTIONS:
  -h, --help                  Display help information
      --help-all              Display help information for all subcommands
  -m, --model MODEL           Model name to load
      --directory DIR         Remote recipe directory used only if you choose recipe import at prompt
      --recipe-file FILE      Remote recipe JSON filename used only if you choose recipe import at prompt
      --agent-args ARGS       Custom arguments to pass directly to the launched agent process

Agents:
  claude                      Launch claude with a model
  codex                       Launch codex with a model
  opencode                    Launch opencode with a model
  pi                          Launch pi with a model
```

---

### ✅ After (Version-Agnostic Name Filtering Fix)
With the new version-agnostic name filtering, all option leakage on the parent subcommand is completely avoided.

#### 1. Root `launch` Help Output (Options properly hidden)
```
$ lemonade launch --help
Launch an agent with a model

Usage: lemonade launch [OPTIONS] [SUBCOMMAND]

OPTIONS:
  -h, --help                  Display help information
      --help-all              Display help information for all subcommands

Agents:
  claude                      Launch claude with a model
  codex                       Launch codex with a model
  opencode                    Launch opencode with a model
  pi                          Launch pi with a model
```

#### 2. Agent Subcommand Help Output (Options correctly preserved on subcommands)
When checking help for a specific agent subcommand, the options are fully visible and accessible:
```
$ lemonade launch claude --help
Launch claude with a model

Usage: lemonade launch claude [OPTIONS]

OPTIONS:
  -h, --help                  Display help information
      --help-all              Display help information for all subcommands
  -m, --model MODEL           Model name to load
      --directory DIR         Remote recipe directory used only if you choose recipe import at prompt
      --recipe-file FILE      Remote recipe JSON filename used only if you choose recipe import at prompt
      --agent-args ARGS       Custom arguments to pass directly to the launched agent process
```