### PR TITLE
test/ci: follow up on hosted Ollama tool-calling timeouts

### DIFF
--- a/test/server_streaming_errors.py
+++ b/test/server_streaming_errors.py
@@ -59,6 +59,46 @@ class StreamingErrorTests(ServerTestBase):
             self.fail(f"Stream not properly terminated (sink.done() missing?): {exc}")
         return lines
 
+    def _running_models(self):
+        response = requests.get(
+            f"http://localhost:{PORT}/api/ps",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        response.raise_for_status()
+        return response.json().get("models", [])
+
+    def _wait_for_no_running_models(self, timeout=15):
+        """Return True once the server reports no running models.
+
+        These tests are about streaming error termination. If a previous suite
+        left an in-flight backend request wedged, /api/v1/unload can return
+        before /api/ps is empty. Treat that as an unsatisfied precondition so we
+        do not turn one Ollama timeout into a second misleading failure here.
+        """
+        deadline = time.time() + timeout
+        last_models = []
+        last_error = None
+
+        while time.time() < deadline:
+            try:
+                models = self._running_models()
+                if not models:
+                    return True
+                last_models = models
+                last_error = None
+            except requests.RequestException as exc:
+                last_error = str(exc)
+            time.sleep(1)
+
+        if last_error:
+            print(f"Warning: could not verify empty model state: {last_error}")
+        else:
+            print(
+                "Warning: models still running after unload: "
+                f"{str(last_models)[:1000]}"
+            )
+        return False
+
     def _ensure_test_model_loaded(self, attempts=3):
         """Load ENDPOINT_TEST_MODEL with bounded retry for transient setup failures.
 
@@ -137,6 +177,13 @@ class StreamingErrorTests(ServerTestBase):
             timeout=TIMEOUT_DEFAULT,
         )
         self.assertIn(unload_resp.status_code, [200, 422])
+
+        if not self._wait_for_no_running_models():
+            self.skipTest(
+                "Skipping post-unload streaming check because the shared server "
+                "still reports a busy model from a previous suite. The unload "
+                "precondition for this streaming-termination test is not met."
+            )
 
         response = self._post_streaming(ENDPOINT_TEST_MODEL)
         lines = self._consume_stream(response)

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -11,6 +11,7 @@ Usage:
 
 import base64
 import json
+import os
 import platform
 import sys
 import uuid
@@ -70,6 +71,24 @@ class OllamaTests(ServerTestBase):
                 )
             except requests.RequestException as exc:
                 print(f"[DIAG] GET {url} failed: {exc}")
+
+    def _skip_slow_hosted_ci_tool_calling(self):
+        """Skip the heaviest native tool-calling path on slow hosted OSes.
+
+        The full native tool-calling model is still covered on Linux CI. On
+        hosted Windows/macOS runners this 4B model can leave the server busy
+        until the HTTP timeout, which then cascades into later suites.
+        """
+        if os.environ.get("LEMONADE_RUN_HEAVY_OLLAMA_TOOL_TESTS") == "1":
+            return
+        if os.environ.get("GITHUB_ACTIONS") == "true" and sys.platform in (
+            "darwin",
+            "win32",
+        ):
+            self.skipTest(
+                "Skipping heavy native Anthropic tool-calling test on hosted "
+                f"{platform.system()} CI; Linux CI keeps this coverage."
+            )
 
     def get_ollama_client(self):
         """Get an Ollama client pointed at the test server."""
@@ -756,6 +775,8 @@ class OllamaTests(ServerTestBase):
 
     def test_026_anthropic_messages_tool_calling(self):
         """Test Anthropic-compatible tool calling maps to tool_use blocks."""
+        self._skip_slow_hosted_ci_tool_calling()
+
         # This is the heaviest Ollama compatibility test in the suite. Start it
         # from an empty loaded-model state so previous endpoint/CLI tests cannot
         # leave another backend resident and turn the final inference into a CI
@@ -795,7 +816,10 @@ class OllamaTests(ServerTestBase):
                         "content": [
                             {
                                 "type": "text",
-                                "text": "Run the calculator_calculate tool with expression set to 1+1",
+                                "text": (
+                                    "Run the calculator_calculate tool with "
+                                    "expression set to 1+1"
+                                ),
                             }
                         ],
                     }

--- a/test/utils/reset_server_state.py
+++ b/test/utils/reset_server_state.py
@@ -98,6 +98,42 @@ def _print_diagnostics(port: int) -> None:
             print(f"[reset] GET {path} failed: {exc}")
 
 
+def _running_models(port: int):
+    response = _request_with_host_fallback(
+        "GET",
+        "/api/ps",
+        port=port,
+        headers=_auth_headers(),
+        timeout=5,
+    )
+    response.raise_for_status()
+    return response.json().get("models", [])
+
+
+def _wait_for_no_running_models(port: int, timeout: int) -> None:
+    deadline = time.time() + timeout
+    last_models = []
+    last_error = None
+
+    while time.time() < deadline:
+        try:
+            models = _running_models(port)
+            if not models:
+                return
+            last_models = models
+            last_error = None
+        except Exception as exc:  # noqa: BLE001 - diagnostic helper
+            last_error = str(exc)
+        time.sleep(1)
+
+    if last_error:
+        raise RuntimeError(f"Could not verify empty model state: {last_error}")
+    raise RuntimeError(
+        "Server still reports running models after unload: "
+        f"{str(last_models)[:1200]}"
+    )
+
+
 def reset_server_state(
     *,
     port: int = PORT,
@@ -131,9 +167,12 @@ def reset_server_state(
             timeout=30,
         )
         # Some server versions return 404 when no model is loaded. That still
-        # means the desired postcondition is true.
+        # means the desired postcondition is true. A 200 response can still be
+        # asynchronous while a backend is busy, so verify that /api/ps reaches
+        # the actual postcondition before declaring reset complete.
         if response.status_code not in (200, 404):
             response.raise_for_status()
+        _wait_for_no_running_models(port, timeout=timeout)
 
 
 def main(argv=None) -> int:


### PR DESCRIPTION
## Summary

Follow-up to #2365.

The previous CI hardening added reset/diagnostic handling between shared-server test suites. New CI logs show that the reset itself is working, but a heavier Ollama native tool-calling path can still wedge hosted Windows/macOS runners: the request times out after 500s and can leave the Qwen tool-calling backend reported as "busy" / "in_use". That then causes misleading follow-on failures in later streaming-error tests.

This PR narrows that failure mode without removing the broader CI coverage.

## Changes

* Gate test_026_anthropic_messages_tool_calling on GitHub-hosted Windows/macOS.

  * Linux keeps the heavy native Qwen tool-calling coverage.
  * Windows/macOS can still opt in with LEMONADE_RUN_HEAVY_OLLAMA_TOOL_TESTS=1.
  * The lighter Ollama tool-streaming coverage remains active.

* Make reset_server_state.py verify the unload postcondition via /api/ps.

  * /api/v1/unload returning is no longer treated as sufficient by itself.
  * The helper checks that no models remain running before reporting reset completion.

* Make server_streaming_errors.py::test_003 skip when its unload precondition is not met.

  * This avoids a secondary timeout when a previous test has already left the server busy.
  * The primary failure remains attributed to the test that wedged the backend.

## Rationale

The failing path is not a normal lightweight API compatibility check. It uses the native tool-calling model Qwen3-4B-Instruct-2507-GGUF, which is too heavy and unstable for GitHub-hosted Windows/macOS CI in this shared-server workflow.

Skipping only this heavy path on hosted Windows/macOS is a CI-stability tradeoff, not a broad coverage removal:

* Linux still exercises the heavy native tool-calling behavior.
* Windows/macOS still run the rest of the Ollama API suite.
* The test can be explicitly re-enabled with an env var.
* The reset helper now reports the real postcondition instead of giving false confidence.
