### PR TITLE
Add NPU/GPU pipeline collection recipe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,7 @@ include_directories(
 set(SOURCES_CORE
     src/cpp/server/server.cpp
     src/cpp/server/collection_orchestrator.cpp
+    src/cpp/server/npu_gpu_pipeline_orchestrator.cpp
     src/cpp/server/router.cpp
     src/cpp/server/global_vram_monitor.cpp
     src/cpp/server/eviction_engine.cpp

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -71,9 +71,9 @@ Supported registration flags:
 | Flag | Description |
 |------|-------------|
 | `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
-| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: `llamacpp`, `flm`, `ryzenai-llm`, `vllm`, `whispercpp`, `moonshine`, `sd-cpp`, `kokoro`, `collection.omni`. |
+| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: `llamacpp`, `flm`, `ryzenai-llm`, `vllm`, `whispercpp`, `moonshine`, `sd-cpp`, `kokoro`, `collection.omni`, `collection.npu_gpu`. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `coding`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. |
-| `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |
+| `--components MODEL [MODEL ...]` | Components for a collection (see below). Use with `--recipe collection.omni` or `--recipe collection.npu_gpu`. |
 
 ### Register an omni collection
 
@@ -88,6 +88,32 @@ lemonade pull user.MyKit \
 ```
 
 `lemonade load user.MyKit` loads every component. `lemonade delete user.MyKit` removes only the collection entry; component files stay on disk.
+
+### Register an NPU + GPU pipeline collection
+
+`recipe: "collection.npu_gpu"` registers a two-component chat pipeline for Strix Halo-style systems with an AMD NPU and a GPU-capable LLM backend. The first component must be an FLM model that runs on the NPU. The second component must be a non-FLM LLM, commonly a llama.cpp MTP model. At request time Lemonade asks the NPU model for a short assistant prefix, then continues the same chat with the GPU verifier model.
+
+```bash
+lemonade pull user.StrixPipeline \
+    --recipe collection.npu_gpu \
+    --components qwen3.5-0.8b-FLM Qwen3.6-27B-MTP-GGUF \
+    --label mtp
+```
+
+Tune the NPU prefix length per request with `npu_draft_tokens`:
+
+```bash
+curl http://localhost:13305/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "user.StrixPipeline",
+        "messages": [{"role": "user", "content": "Write one short sentence."}],
+        "max_tokens": 64,
+        "npu_draft_tokens": 12
+    }'
+```
+
+The pipeline needs enough loaded-model slots for both components; set `max_loaded_models` to at least `2` if your server uses the default single-model limit. This recipe does not replace llama.cpp's internal MTP implementation: if the verifier model is an MTP GGUF, Lemonade still enables llama.cpp draft-MTP for that GPU pass.
 
 ### Register a custom Omni Model from the desktop app
 

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -361,7 +361,7 @@ static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig
     if (has_manual_pull_options(config)) {
         if (lemon::is_collection_recipe(config.recipe)) {
             if (config.components.empty()) {
-                std::cerr << "Error: omni pull requires --components MODEL [MODEL ...]."
+                std::cerr << "Error: collection pull requires --components MODEL [MODEL ...]."
                           << std::endl;
                 std::cerr << "       See 'lemonade pull --help'." << std::endl;
                 return 1;
@@ -1237,7 +1237,7 @@ int main(int argc, char* argv[]) {
         ->type_name("TYPE CHECKPOINT")
         ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     pull_cmd->add_option("--recipe", config.recipe,
-        "Recipe for the custom user.* model (e.g., llamacpp, flm, sd-cpp, whispercpp, collection.omni)")
+        "Recipe for the custom user.* model (e.g., llamacpp, flm, sd-cpp, whispercpp, collection.omni, collection.npu_gpu)")
         ->group("Manual Configuration Options")
         ->type_name("RECIPE")
         ->default_val(config.recipe);
@@ -1247,7 +1247,7 @@ int main(int argc, char* argv[]) {
         ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll)
         ->check(CLI::IsMember(VALID_LABELS));
     pull_cmd->add_option("--components", config.components,
-        "Components for a user.* omni collection (use with --recipe collection.omni). "
+        "Components for a user.* collection (use with --recipe collection.omni or collection.npu_gpu). "
         "Components must already be registered (built-in or previously pulled user.* models).")
         ->group("Manual Configuration Options")
         ->type_name("MODEL")

--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -7,9 +7,11 @@
 namespace lemon {
 
 constexpr const char* COLLECTION_OMNI_MODEL_RECIPE = "collection.omni";
+constexpr const char* COLLECTION_NPU_GPU_MODEL_RECIPE = "collection.npu_gpu";
 
 inline bool is_collection_recipe(const std::string& recipe) {
-    return recipe == COLLECTION_OMNI_MODEL_RECIPE;
+    return recipe == COLLECTION_OMNI_MODEL_RECIPE ||
+           recipe == COLLECTION_NPU_GPU_MODEL_RECIPE;
 }
 
 enum class ModelState {

--- a/src/cpp/include/lemon/npu_gpu_pipeline_orchestrator.h
+++ b/src/cpp/include/lemon/npu_gpu_pipeline_orchestrator.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <functional>
+#include <string>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include "model_manager.h"
+#include "router.h"
+
+namespace lemon {
+
+using json = nlohmann::json;
+
+// Server-side Strix Halo style pipeline for collection.npu_gpu models.
+//
+// A collection.npu_gpu model has exactly two components:
+//   1. an FLM/NPU draft model
+//   2. a GPU verifier model (typically llamacpp, including MTP-labelled GGUFs)
+//
+// Request flow:
+//   - Generate a short draft/prefix on the NPU.
+//   - Append that draft as an assistant prefill for the verifier.
+//   - Ask the GPU verifier to continue. If the verifier echoes the prefill,
+//     strip the duplicate so clients see the draft only once.
+class NpuGpuPipelineOrchestrator {
+public:
+    using AutoLoadFn = std::function<void(const std::string&)>;
+
+    NpuGpuPipelineOrchestrator(Router& router,
+                               ModelManager& model_manager,
+                               AutoLoadFn auto_load);
+
+    json chat_completion(const json& request, const ModelInfo& collection_info);
+    void chat_completion_stream(const json& request,
+                                const ModelInfo& collection_info,
+                                httplib::DataSink& sink);
+
+private:
+    struct Components {
+        std::string draft_model;
+        std::string verifier_model;
+    };
+
+    Components resolve_components(const ModelInfo& collection_info) const;
+    int resolve_max_tokens(const json& request) const;
+    int resolve_draft_tokens(const json& request,
+                             const ModelInfo& collection_info,
+                             int max_tokens) const;
+    json make_draft_request(const json& request,
+                            const std::string& draft_model,
+                            int draft_tokens) const;
+    json make_verifier_request(const json& request,
+                               const std::string& verifier_model,
+                               const std::string& draft_text,
+                               int verifier_tokens,
+                               bool stream) const;
+    std::string extract_message_content(const json& response) const;
+    std::string strip_duplicate_prefix(const std::string& text,
+                                       const std::string& prefix) const;
+    json make_response(const json& request,
+                       const ModelInfo& collection_info,
+                       const std::string& content,
+                       const json& draft_response,
+                       const json& verifier_response) const;
+    void write_sse_chunk(httplib::DataSink& sink,
+                         const std::string& id,
+                         long created,
+                         const std::string& model,
+                         const std::string& content,
+                         bool final) const;
+
+    Router& router_;
+    ModelManager& model_manager_;
+    AutoLoadFn auto_load_;
+};
+
+} // namespace lemon

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -96,6 +96,10 @@ private:
     void handle_collection_chat_completions(const nlohmann::json& request_json,
                                             const ModelInfo& collection_info,
                                             httplib::Response& res);
+    // Server-side NPU draft + GPU verifier orchestration for collection.npu_gpu models.
+    void handle_npu_gpu_chat_completions(const nlohmann::json& request_json,
+                                         const ModelInfo& collection_info,
+                                         httplib::Response& res);
     void handle_completions(const httplib::Request& req, httplib::Response& res);
     void handle_embeddings(const httplib::Request& req, httplib::Response& res);
     void handle_reranking(const httplib::Request& req, httplib::Response& res);

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3321,7 +3321,7 @@ void ModelManager::download_model(const std::string& model_name,
             if (auto err = validate_collection_request(model_name, model_data)) {
                 throw std::runtime_error(*err);
             }
-            LOG(INFO, "ModelManager") << "Registering new omni collection: " << model_name << std::endl;
+            LOG(INFO, "ModelManager") << "Registering new collection: " << model_name << std::endl;
         } else {
             // Check that required arguments are provided
             if (actual_checkpoint.empty() || actual_recipe.empty()) {
@@ -5014,7 +5014,8 @@ std::optional<std::string> ModelManager::validate_collection_request(
         if (!checkpoint_pointer.empty()) {
             return std::nullopt;  // pointer-only HF-backed collection
         }
-        return std::string("recipe='collection.omni' requires a non-empty 'components' array");
+        return std::string("recipe='") + model_data.value("recipe", std::string("collection")) +
+               "' requires a non-empty 'components' array";
     }
     // An inline collection import carries its component definitions in a `models`
     // array. Every component must be *resolvable*: either it is already

--- a/src/cpp/server/npu_gpu_pipeline_orchestrator.cpp
+++ b/src/cpp/server/npu_gpu_pipeline_orchestrator.cpp
@@ -1,0 +1,329 @@
+#include "lemon/npu_gpu_pipeline_orchestrator.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <ctime>
+#include <stdexcept>
+
+#include "lemon/error_types.h"
+#include "lemon/model_types.h"
+#include <lemon/utils/aixlog.hpp>
+
+namespace lemon {
+
+namespace {
+
+std::string new_pipeline_completion_id() {
+    static std::atomic<uint64_t> counter{0};
+    return "chatcmpl-npu-gpu-" + std::to_string(static_cast<long>(std::time(nullptr))) +
+           "-" + std::to_string(counter.fetch_add(1));
+}
+
+bool starts_with(const std::string& text, const std::string& prefix) {
+    return text.size() >= prefix.size() &&
+           std::equal(prefix.begin(), prefix.end(), text.begin());
+}
+
+std::string trim_copy(std::string s) {
+    auto not_space = [](unsigned char c) { return !std::isspace(c); };
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), not_space));
+    s.erase(std::find_if(s.rbegin(), s.rend(), not_space).base(), s.end());
+    return s;
+}
+
+int json_int_or(const json& value, int fallback) {
+    if (value.is_number_integer()) return value.get<int>();
+    if (value.is_number_unsigned()) return static_cast<int>(value.get<unsigned int>());
+    if (value.is_string()) {
+        try {
+            return std::stoi(value.get<std::string>());
+        } catch (...) {
+            return fallback;
+        }
+    }
+    return fallback;
+}
+
+} // namespace
+
+NpuGpuPipelineOrchestrator::NpuGpuPipelineOrchestrator(Router& router,
+                                                       ModelManager& model_manager,
+                                                       AutoLoadFn auto_load)
+    : router_(router), model_manager_(model_manager), auto_load_(std::move(auto_load)) {}
+
+NpuGpuPipelineOrchestrator::Components
+NpuGpuPipelineOrchestrator::resolve_components(const ModelInfo& collection_info) const {
+    if (collection_info.components.size() != 2) {
+        throw std::runtime_error(
+            "collection.npu_gpu requires exactly two components: an FLM/NPU draft model "
+            "followed by a GPU verifier model");
+    }
+
+    Components components{collection_info.components[0], collection_info.components[1]};
+    ModelInfo draft_info = model_manager_.get_model_info(components.draft_model);
+    ModelInfo verifier_info = model_manager_.get_model_info(components.verifier_model);
+
+    if (draft_info.recipe != "flm" || !(draft_info.device & DEVICE_NPU)) {
+        throw std::runtime_error(
+            "collection.npu_gpu first component must be an FLM/NPU model: " +
+            components.draft_model);
+    }
+    if (verifier_info.type != ModelType::LLM || verifier_info.recipe == "flm") {
+        throw std::runtime_error(
+            "collection.npu_gpu second component must be a non-FLM LLM verifier model: " +
+            components.verifier_model);
+    }
+
+    return components;
+}
+
+int NpuGpuPipelineOrchestrator::resolve_max_tokens(const json& request) const {
+    if (request.contains("max_completion_tokens")) {
+        return std::max(1, json_int_or(request["max_completion_tokens"], 2048));
+    }
+    if (request.contains("max_tokens")) {
+        return std::max(1, json_int_or(request["max_tokens"], 2048));
+    }
+    return 2048;
+}
+
+int NpuGpuPipelineOrchestrator::resolve_draft_tokens(const json& request,
+                                                     const ModelInfo& collection_info,
+                                                     int max_tokens) const {
+    int configured = 128;
+    json options = collection_info.recipe_options.to_json();
+    if (options.contains("draft_tokens")) {
+        configured = json_int_or(options["draft_tokens"], configured);
+    }
+    if (request.contains("npu_draft_tokens")) {
+        configured = json_int_or(request["npu_draft_tokens"], configured);
+    }
+    configured = std::max(1, configured);
+    return std::max(1, std::min(configured, std::max(1, max_tokens / 2)));
+}
+
+json NpuGpuPipelineOrchestrator::make_draft_request(const json& request,
+                                                    const std::string& draft_model,
+                                                    int draft_tokens) const {
+    json draft = request;
+    draft["model"] = draft_model;
+    draft["stream"] = false;
+    draft["max_tokens"] = draft_tokens;
+    draft.erase("max_completion_tokens");
+    // Draft models are used only to produce text prefix. Tool and structured-output
+    // directives belong to the verifier pass, where the full model can honor them.
+    draft.erase("tools");
+    draft.erase("tool_choice");
+    draft.erase("parallel_tool_calls");
+    draft.erase("response_format");
+    draft.erase("npu_draft_tokens");
+    return draft;
+}
+
+json NpuGpuPipelineOrchestrator::make_verifier_request(const json& request,
+                                                       const std::string& verifier_model,
+                                                       const std::string& draft_text,
+                                                       int verifier_tokens,
+                                                       bool stream) const {
+    json verifier = request;
+    verifier["model"] = verifier_model;
+    verifier["stream"] = stream;
+    verifier["max_tokens"] = std::max(1, verifier_tokens);
+    verifier.erase("max_completion_tokens");
+    verifier.erase("npu_draft_tokens");
+
+    if (!draft_text.empty()) {
+        json messages = verifier.value("messages", json::array());
+        if (!messages.is_array()) {
+            throw std::runtime_error("chat completion request must contain a messages array");
+        }
+        messages.push_back({{"role", "assistant"}, {"content", draft_text}});
+        verifier["messages"] = messages;
+    }
+    return verifier;
+}
+
+std::string NpuGpuPipelineOrchestrator::extract_message_content(const json& response) const {
+    try {
+        if (response.contains("choices") && response["choices"].is_array() &&
+            !response["choices"].empty()) {
+            const json& choice = response["choices"][0];
+            if (choice.contains("message") && choice["message"].is_object() &&
+                choice["message"].contains("content") &&
+                choice["message"]["content"].is_string()) {
+                return choice["message"]["content"].get<std::string>();
+            }
+            if (choice.contains("text") && choice["text"].is_string()) {
+                return choice["text"].get<std::string>();
+            }
+        }
+    } catch (...) {
+    }
+    return "";
+}
+
+std::string NpuGpuPipelineOrchestrator::strip_duplicate_prefix(const std::string& text,
+                                                               const std::string& prefix) const {
+    if (prefix.empty() || text.empty()) return text;
+    if (starts_with(text, prefix)) {
+        return text.substr(prefix.size());
+    }
+    const std::string trimmed_text = trim_copy(text);
+    const std::string trimmed_prefix = trim_copy(prefix);
+    if (!trimmed_prefix.empty() && starts_with(trimmed_text, trimmed_prefix)) {
+        return trim_copy(trimmed_text.substr(trimmed_prefix.size()));
+    }
+    return text;
+}
+
+json NpuGpuPipelineOrchestrator::make_response(const json& request,
+                                               const ModelInfo& collection_info,
+                                               const std::string& content,
+                                               const json& draft_response,
+                                               const json& verifier_response) const {
+    const std::string model = request.value("model", collection_info.model_name);
+    json response = {
+        {"id", new_pipeline_completion_id()},
+        {"object", "chat.completion"},
+        {"created", static_cast<long>(std::time(nullptr))},
+        {"model", model},
+        {"choices", json::array({{
+            {"index", 0},
+            {"message", {{"role", "assistant"}, {"content", content}}},
+            {"finish_reason", "stop"}
+        }})},
+        {"lemonade_pipeline", {
+            {"type", COLLECTION_NPU_GPU_MODEL_RECIPE},
+            {"draft_response", draft_response},
+            {"verifier_response", verifier_response}
+        }}
+    };
+
+    int prompt_tokens = 0;
+    int completion_tokens = 0;
+    if (draft_response.contains("usage")) {
+        prompt_tokens += draft_response["usage"].value("prompt_tokens", 0);
+        completion_tokens += draft_response["usage"].value("completion_tokens", 0);
+    }
+    if (verifier_response.contains("usage")) {
+        prompt_tokens += verifier_response["usage"].value("prompt_tokens", 0);
+        completion_tokens += verifier_response["usage"].value("completion_tokens", 0);
+    }
+    response["usage"] = {
+        {"prompt_tokens", prompt_tokens},
+        {"completion_tokens", completion_tokens},
+        {"total_tokens", prompt_tokens + completion_tokens}
+    };
+    return response;
+}
+
+json NpuGpuPipelineOrchestrator::chat_completion(const json& request,
+                                                 const ModelInfo& collection_info) {
+    Components components = resolve_components(collection_info);
+    auto_load_(components.draft_model);
+    auto_load_(components.verifier_model);
+
+    const int max_tokens = resolve_max_tokens(request);
+    const int draft_tokens = resolve_draft_tokens(request, collection_info, max_tokens);
+    const int verifier_tokens = std::max(1, max_tokens - draft_tokens);
+
+    json draft_request = make_draft_request(request, components.draft_model, draft_tokens);
+    json draft_response = router_.chat_completion(draft_request);
+    if (draft_response.contains("error")) return draft_response;
+
+    std::string draft_text = extract_message_content(draft_response);
+
+    json verifier_request = make_verifier_request(request, components.verifier_model,
+                                                  draft_text, verifier_tokens, false);
+    json verifier_response = router_.chat_completion(verifier_request);
+    if (verifier_response.contains("error")) return verifier_response;
+
+    std::string verifier_text = strip_duplicate_prefix(extract_message_content(verifier_response),
+                                                       draft_text);
+    return make_response(request, collection_info, draft_text + verifier_text,
+                         draft_response, verifier_response);
+}
+
+void NpuGpuPipelineOrchestrator::write_sse_chunk(httplib::DataSink& sink,
+                                                 const std::string& id,
+                                                 long created,
+                                                 const std::string& model,
+                                                 const std::string& content,
+                                                 bool final) const {
+    json chunk = {
+        {"id", id},
+        {"object", "chat.completion.chunk"},
+        {"created", created},
+        {"model", model},
+        {"choices", json::array({{
+            {"index", 0},
+            {"delta", final ? json::object() : json{{"content", content}}},
+            {"finish_reason", final ? json("stop") : json(nullptr)}
+        }})}
+    };
+    std::string wire = "data: " + chunk.dump() + "\n\n";
+    sink.write(wire.c_str(), wire.size());
+}
+
+void NpuGpuPipelineOrchestrator::chat_completion_stream(const json& request,
+                                                        const ModelInfo& collection_info,
+                                                        httplib::DataSink& sink) {
+    try {
+        Components components = resolve_components(collection_info);
+        auto_load_(components.draft_model);
+        auto_load_(components.verifier_model);
+
+        const std::string model = request.value("model", collection_info.model_name);
+        const std::string id = new_pipeline_completion_id();
+        const long created = static_cast<long>(std::time(nullptr));
+        const int max_tokens = resolve_max_tokens(request);
+        const int draft_tokens = resolve_draft_tokens(request, collection_info, max_tokens);
+        const int verifier_tokens = std::max(1, max_tokens - draft_tokens);
+
+        json draft_request = make_draft_request(request, components.draft_model, draft_tokens);
+        json draft_response = router_.chat_completion(draft_request);
+        if (draft_response.contains("error")) {
+            std::string err = "data: " + draft_response.dump() + "\n\n";
+            sink.write(err.c_str(), err.size());
+            sink.done();
+            return;
+        }
+
+        std::string draft_text = extract_message_content(draft_response);
+        if (!draft_text.empty()) {
+            write_sse_chunk(sink, id, created, model, draft_text, false);
+        }
+
+        // First PR implementation uses chunk-level verifier streaming: the NPU
+        // prefix reaches the client early, then the verifier continuation is sent
+        // as the next chunk. A future refinement can proxy verifier SSE and strip
+        // duplicate prefill incrementally.
+        json verifier_request = make_verifier_request(request, components.verifier_model,
+                                                      draft_text, verifier_tokens, false);
+        json verifier_response = router_.chat_completion(verifier_request);
+        if (verifier_response.contains("error")) {
+            std::string err = "data: " + verifier_response.dump() + "\n\n";
+            sink.write(err.c_str(), err.size());
+            sink.done();
+            return;
+        }
+        std::string verifier_text = strip_duplicate_prefix(extract_message_content(verifier_response),
+                                                           draft_text);
+        if (!verifier_text.empty()) {
+            write_sse_chunk(sink, id, created, model, verifier_text, false);
+        }
+        write_sse_chunk(sink, id, created, model, "", true);
+        std::string done = "data: [DONE]\n\n";
+        sink.write(done.c_str(), done.size());
+        sink.done();
+    } catch (const std::exception& e) {
+        json error = ErrorResponse::create(e.what(), ErrorType::BACKEND_ERROR,
+                                           {{"code", "npu_gpu_pipeline_error"}});
+        std::string err = "data: " + error.dump() + "\n\n";
+        sink.write(err.c_str(), err.size());
+        sink.done();
+    }
+}
+
+} // namespace lemon

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -39,6 +39,9 @@ static const json DEFAULTS = {
     // per-model cloud_provider field). The empty string satisfies Router's
     // per-backend-args lookup; cloud reads no backend-specific config.
     {"cloud_backend", ""},
+    // NPU+GPU collection recipe: number of assistant-prefix tokens to draft on
+    // the NPU before handing continuation to the GPU verifier.
+    {"draft_tokens", 128},
 
     // Auto-eviction options
     {"auto_evict", nullptr},          // nullptr means fallback to global config
@@ -84,6 +87,8 @@ static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
         keys = {"sd-cpp_backend", "sdcpp_args", "steps", "cfg_scale", "width", "height", "sampling_method", "flow_shift", "merge_args"};
     } else if (recipe == "vllm") {
         keys = {"ctx_size", "vllm_backend", "vllm_args", "merge_args"};
+    } else if (recipe == "collection.npu_gpu") {
+        keys = {"draft_tokens"};
     }
 
     // Add auto-eviction options for all recipes

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1,6 +1,7 @@
 #include "lemon/server.h"
 #include <optional>
 #include "lemon/collection_orchestrator.h"
+#include "lemon/npu_gpu_pipeline_orchestrator.h"
 #include "lemon/hf_variants.h"
 #include "lemon/config_file.h"
 #include "lemon/mcp_server.h"
@@ -1964,6 +1965,58 @@ void Server::handle_collection_chat_completions(const nlohmann::json& request_js
     res.set_content(response.dump(), "application/json");
 }
 
+void Server::handle_npu_gpu_chat_completions(const nlohmann::json& request_json,
+                                             const ModelInfo& collection_info,
+                                             httplib::Response& res) {
+    try {
+        ensure_collection_loaded(collection_info);
+    } catch (const std::exception& e) {
+        LOG(ERROR, "Server") << "Failed to load NPU+GPU collection '"
+                             << collection_info.model_name << "': " << e.what()
+                             << std::endl;
+        auto error_response = create_model_error(collection_info.model_name, e.what());
+        std::string error_code = error_response["error"]["code"].get<std::string>();
+        res.status = get_http_status_from_error(error_code);
+        res.set_content(error_response.dump(), "application/json");
+        return;
+    }
+
+    const bool is_streaming = request_json.contains("stream") &&
+                              request_json["stream"].is_boolean() &&
+                              request_json["stream"].get<bool>();
+
+    if (is_streaming) {
+        LOG(INFO, "Server") << "POST /api/v1/chat/completions - NPU+GPU collection (streaming): "
+                            << collection_info.model_name << std::endl;
+        res.set_header("Cache-Control", "no-cache");
+        res.set_header("Connection", "keep-alive");
+        res.set_header("X-Accel-Buffering", "no");
+        res.set_chunked_content_provider(
+            "text/event-stream",
+            [this, request_json, collection_info](size_t offset, httplib::DataSink& sink) {
+                if (offset > 0) return false;
+                NpuGpuPipelineOrchestrator orchestrator(
+                    *router_, *model_manager_,
+                    [this](const std::string& m) { auto_load_model_if_needed(m); });
+                orchestrator.chat_completion_stream(request_json, collection_info, sink);
+                return false;
+            });
+        return;
+    }
+
+    LOG(INFO, "Server") << "POST /api/v1/chat/completions - NPU+GPU collection: "
+                        << collection_info.model_name << std::endl;
+    NpuGpuPipelineOrchestrator orchestrator(
+        *router_, *model_manager_,
+        [this](const std::string& m) { auto_load_model_if_needed(m); });
+    json response = orchestrator.chat_completion(request_json, collection_info);
+    if (response.contains("error")) {
+        set_error_response(response, res);
+        return;
+    }
+    res.set_content(response.dump(), "application/json");
+}
+
 void Server::handle_chat_completions(const httplib::Request& req, httplib::Response& res) {
     nlohmann::json request_json;
     if (!parse_required_json_body(req, res, request_json)) return;
@@ -1993,7 +2046,11 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 if (model_manager_->model_exists(requested_model)) {
                     ModelInfo info = model_manager_->get_model_info(requested_model);
                     if (is_collection_recipe(info.recipe)) {
-                        handle_collection_chat_completions(request_json, info, res);
+                        if (info.recipe == COLLECTION_NPU_GPU_MODEL_RECIPE) {
+                            handle_npu_gpu_chat_completions(request_json, info, res);
+                        } else {
+                            handle_collection_chat_completions(request_json, info, res);
+                        }
                         return;
                     }
                 }


### PR DESCRIPTION
## Summary
- add a new `collection.npu_gpu` recipe for two-component NPU-prefix + GPU-verifier chat pipelines
- route `collection.npu_gpu` chat completions through a server-side orchestrator that drafts a short assistant prefix with an FLM/NPU model, then continues with a non-FLM LLM verifier
- document the registration flow and `npu_draft_tokens` request override

## Validation
- `PATH=/home/linuxbrew/.linuxbrew/bin:$PATH cmake --build --preset default --target lemond lemonade -j 6`
- `git diff --check`
- smoke-tested a local `lemond` on `127.0.0.1:13307` with:
  - `qwen3.5-0.8b-FLM` as the NPU draft component
  - `Qwen3.6-27B-MTP-GGUF` as the GPU verifier component
  - non-streaming `/api/v1/chat/completions`, confirming the response contains both `lemonade_pipeline.draft_response` and `lemonade_pipeline.verifier_response`
  - streaming `/api/v1/chat/completions`, confirming SSE emits the NPU prefix chunk, verifier continuation chunk, and `[DONE]`
- verifier response timings showed llama.cpp MTP active: `draft_n=6`, `draft_n_accepted=6`

## Notes
This intentionally does not replace llama.cpp's internal MTP implementation. If the verifier is an MTP GGUF, Lemonade still enables llama.cpp draft-MTP for the GPU pass; the FLM/NPU component supplies an outer early assistant prefix.
