### PR TITLE
fix: ROCm Support for RDNA2 Device Models

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1915,8 +1915,13 @@ std::string identify_rocm_arch_from_name(const std::string& device_name) {
         return "gfx110X";
     }
 
-    if (device_lower.find("6800") != std::string::npos ||
+	// AMD RDNA2 dGPUs (RX 6000 series) → gfx103X
+    if (device_lower.find("6950") != std::string::npos ||
+        device_lower.find("6900") != std::string::npos ||
+        device_lower.find("6800") != std::string::npos ||
+        device_lower.find("6750") != std::string::npos ||
         device_lower.find("6700") != std::string::npos ||
+        device_lower.find("6650") != std::string::npos ||
         device_lower.find("6600") != std::string::npos ||
         device_lower.find("6500") != std::string::npos) {
         return "gfx103X";


### PR DESCRIPTION
PR fixes #2403 

This pull request fixes support for AMD RDNA2 GPUs (RX 6000 series) in the ROCm architecture detection logic.

**Device detection and mapping improvements:**

- Updated the `identify_rocm_arch_from_name` function in `system_info.cpp` to explicitly include all relevant RDNA2 model numbers (`6950`, `6900`, `6800`, `6750`, `6700`, `6650`, `6600`, `6500`) in the mapping to `gfx103X`, ensuring accurate detection of these GPUs.
- Updated the backend support table in `README.md` to document the addition of `gfx103X` (RDNA2) support and list all corresponding Windows-compatible Radeon RX 6000 series GPUs.