### PR TITLE
Router Schemas

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -30,6 +30,11 @@ Writing or improving docs? Read the [documentation guide](./documentation.md) fo
 
 Lemonade has a unique capability to group LLM, image, and speech models together to present a unified omni-modal "model" to end-users. These one-click bundles are called Lemonade Omni Models, and they're routed via an internal mechanism called OmniRouter. Learn more [here](./lemonade-omni.md).
 
+### Lemonade Router
+
+The generic Lemonade Router schema defines `collection.router` model policies
+for selecting between bundled candidate models. Learn more [here](./lemonade-router.md).
+
 ### CI System
 
 Lemonade has a CI system that tests pull requests on real AI PC hardware targets. The [self-hosted runners](./self-hosted-runners.md) guide documents how those are set up.

--- a/docs/dev/lemonade-router.md
+++ b/docs/dev/lemonade-router.md
@@ -1,0 +1,299 @@
+# Lemonade Router
+
+Lemonade Router is a generic model-selection layer. A router is distributed as a
+normal Lemonade collection model with `recipe: "collection.router"`. Clients
+invoke it by sending a standard OpenAI-compatible request whose `model` names the
+router collection. The router evaluates the collection's policy, selects a
+concrete candidate model, and dispatches the request to that model.
+
+The router core performs pure model selection. It does not interpret trust
+concepts such as warn, block, consent, or audit persistence. Policy authors can
+attach arbitrary rule `outputs`; the engine copies them into the route decision
+without interpreting them.
+
+## Model Shape
+
+A router collection is a model definition with `components` and a `routing`
+block:
+
+```jsonc
+{
+  "model_name": "user.Router-Shopping",
+  "recipe": "collection.router",
+  "checkpoint": "",
+  "components": [
+    "Qwen3-8B-GGUF",
+    "vllm.qwen3-32b",
+    "nomic-embed-text-v1.5-GGUF"
+  ],
+  "routing": {
+    "candidates": ["Qwen3-8B-GGUF", "vllm.qwen3-32b"],
+    "default_model": "vllm.qwen3-32b",
+    "classifiers": [
+      {
+        "id": "sim_returns",
+        "type": "semantic_similarity",
+        "model": "nomic-embed-text-v1.5-GGUF",
+        "candidates": ["how do I return", "track my order"]
+      }
+    ],
+    "rules": [
+      {
+        "id": "support",
+        "match": {
+          "classifier": "sim_returns",
+          "min_score": 0.75
+        },
+        "route_to": "vllm.qwen3-32b"
+      }
+    ]
+  }
+}
+```
+
+`components` lists every model bundled with the router, including routing
+targets and classifier models. `routing.candidates` is the explicit set of
+models that rules may route to. `default_model` is the fail-open target and must
+be one of the candidates.
+
+The optional top-level `models` array is for self-contained redistribution, such
+as Hugging Face collection JSONs. Local authoring usually only needs
+`components` plus `routing`.
+
+## Routing Rules
+
+Rules are evaluated in order. The first matching rule wins:
+
+```jsonc
+{
+  "id": "keep-private",
+  "match": {
+    "any": [
+      { "classifier": "pii", "min_score": 0.5 },
+      { "keywords_any": ["ssn", "credit card"] }
+    ]
+  },
+  "route_to": "Qwen3-8B-GGUF",
+  "outputs": { "verdict": "warn" }
+}
+```
+
+If no rule matches, the router uses `default_model`.
+
+`outputs` is an engine-opaque object. It can carry consumer-specific fields, but
+the generic router does not interpret them.
+
+## Match Expressions
+
+Match expressions support logical operators:
+
+- `any`: true when any child expression matches.
+- `all`: true when every child expression matches.
+- `not`: true when the child expression is false.
+
+Supported deterministic leaves:
+
+- `keywords_any`
+- `keywords_all`
+- `regex`
+- `min_chars`
+- `max_chars`
+- `has_tools`
+- `has_images`
+
+Supported classifier leaves:
+
+- `classifier`: classifier id.
+- `label`: optional label constraint.
+- `min_score`: optional score lower bound.
+- `max_score`: optional score upper bound.
+
+If a classifier condition omits both score bounds, runtime evaluation uses
+`min_score: 0.5`.
+
+Multiple leaf fields in one object are treated as an implicit `all`:
+
+```jsonc
+{
+  "keywords_any": ["return", "refund"],
+  "max_chars": 1000
+}
+```
+
+Logical operators cannot be mixed with leaf fields in the same object. Write the
+grouping explicitly instead:
+
+```jsonc
+{
+  "all": [
+    {
+      "any": [
+        { "keywords_any": ["return"] },
+        { "keywords_any": ["refund"] }
+      ]
+    },
+    { "max_chars": 1000 }
+  ]
+}
+```
+
+Empty match objects are invalid. Use `default_model` for fallback.
+
+## Classifiers
+
+Active v1 classifier types:
+
+- `semantic_similarity`
+- `classifier`
+
+Reserved preset names:
+
+- `pii_detection`
+- `prompt_safety`
+- `language_detection`
+- `domain_classification`
+- `complexity`
+- `sentiment`
+
+Reserved presets are schema-valid vocabulary, but runtime support can be staged.
+
+### Semantic Similarity
+
+`semantic_similarity` compares the request text with configured candidate
+phrases using embeddings and cosine similarity:
+
+```jsonc
+{
+  "id": "sim_returns",
+  "type": "semantic_similarity",
+  "model": "nomic-embed-text-v1.5-GGUF",
+  "candidates": ["how do I return", "track my order"]
+}
+```
+
+### Generic Classifier
+
+`classifier` represents model-backed text classification. Results are modeled as
+`label -> score` with scores in `[0, 1]`.
+
+```jsonc
+{
+  "id": "pii",
+  "type": "classifier",
+  "model": "pii-detector-small",
+  "labels": ["PII", "NO_PII"],
+  "default_label": "PII",
+  "on_error": "match_true"
+}
+```
+
+If `on_error` is omitted, it defaults to `match_false`.
+
+### LLM Router
+
+For zero-config LLM-as-router authoring, use `routing.router`:
+
+```jsonc
+{
+  "routing": {
+    "candidates": ["Qwen3-8B-GGUF", "vllm.qwen3-32b"],
+    "default_model": "Qwen3-8B-GGUF",
+    "router": {
+      "type": "llm",
+      "model": "Qwen3-1.7B-GGUF",
+      "prompt": "Choose the cheapest model that can handle the request."
+    }
+  }
+}
+```
+
+`routing.router` is the only v1 authoring surface for LLM-as-router. The parser
+can lower it into internal classifier/rule structures later, but explicit
+`type: "llm"` entries in `routing.classifiers[]` are not part of the v1 schema.
+
+If `routing.router` is combined with authored `rules`, parser-generated router
+rules are appended after authored rules so explicit policy rules have
+first-match priority.
+
+## Request Extensions
+
+Routing inputs ride the standard OpenAI `metadata` field:
+
+```jsonc
+{
+  "model": "user.Router-Shopping",
+  "messages": [{ "role": "user", "content": "..." }],
+  "metadata": {
+    "task_class": "payment",
+    "site_tags": "shopping,checkout"
+  },
+  "route_trace": true
+}
+```
+
+For this contract, metadata values are strings. Lists are comma-encoded strings.
+Nested objects and arrays are not accepted.
+
+`route_trace: true` opts the client into full route trace. Without it, response
+attachment includes the small route object only.
+
+## Response Attachment
+
+When attached to a response, route information lives in `x_lemonade_route`:
+
+```jsonc
+{
+  "x_lemonade_route": {
+    "route_to": "Qwen3-8B-GGUF",
+    "matched_rule": "keep-private",
+    "default_used": false,
+    "outputs": { "verdict": "warn" },
+    "trace": [
+      { "condition": "classifier:pii", "score": 0.81, "result": true },
+      { "condition": "keywords_any", "result": false }
+    ]
+  }
+}
+```
+
+`trace` is present only when requested with `route_trace: true`.
+
+Fallback decisions use:
+
+```jsonc
+{
+  "x_lemonade_route": {
+    "route_to": "vllm.qwen3-32b",
+    "matched_rule": null,
+    "default_used": true,
+    "outputs": {}
+  }
+}
+```
+
+The HTTP header `x-lemonade-route` carries the matched rule id. For fallback
+decisions, the header value is `default`.
+
+Trace entries include evaluated conditions only. Short-circuited branches are
+omitted. Trace entries must not include raw user input.
+
+## Validation Boundary
+
+JSON Schema validates the structural contract:
+
+- Required fields.
+- Field types.
+- Enum values.
+- Score ranges.
+- Strict classifier shapes.
+- Match expression structure.
+
+The runtime parser validates semantic cross references later:
+
+- `default_model` is in `routing.candidates`.
+- Every `route_to` is in `routing.candidates`.
+- Every candidate is in `components`.
+- Every classifier model is in `components`.
+- Every condition classifier id exists.
+- Every classifier label reference exists.
+- `min_score <= max_score`.

--- a/src/cpp/resources/schemas/collection-router.schema.json
+++ b/src/cpp/resources/schemas/collection-router.schema.json
@@ -1,0 +1,376 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lemonade-sdk.github.io/schemas/collection-router.schema.json",
+  "title": "Lemonade collection.router model",
+  "description": "Schema for Lemonade Router collection model definitions.",
+  "type": "object",
+  "required": ["model_name", "recipe", "components", "routing"],
+  "properties": {
+    "model_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "recipe": {
+      "const": "collection.router"
+    },
+    "checkpoint": {
+      "type": "string"
+    },
+    "checkpoints": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "models": {
+      "description": "Optional embedded component model definitions for redistribution.",
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "routing": {
+      "$ref": "#/$defs/routing"
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "routing": {
+      "type": "object",
+      "required": ["candidates", "default_model"],
+      "properties": {
+        "candidates": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "default_model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "classifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/classifier"
+          }
+        },
+        "router": {
+          "$ref": "#/$defs/llmRouter"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/rule"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": ["router"]
+        },
+        {
+          "required": ["rules"],
+          "properties": {
+            "rules": {
+              "minItems": 1
+            }
+          }
+        }
+      ]
+    },
+    "rule": {
+      "type": "object",
+      "required": ["id", "match", "route_to"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "match": {
+          "$ref": "#/$defs/matchExpression"
+        },
+        "route_to": {
+          "type": "string",
+          "minLength": 1
+        },
+        "outputs": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "matchExpression": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/anyExpression"
+        },
+        {
+          "$ref": "#/$defs/allExpression"
+        },
+        {
+          "$ref": "#/$defs/notExpression"
+        },
+        {
+          "$ref": "#/$defs/leafCondition"
+        }
+      ]
+    },
+    "anyExpression": {
+      "type": "object",
+      "required": ["any"],
+      "properties": {
+        "any": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/matchExpression"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "allExpression": {
+      "type": "object",
+      "required": ["all"],
+      "properties": {
+        "all": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/matchExpression"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "notExpression": {
+      "type": "object",
+      "required": ["not"],
+      "properties": {
+        "not": {
+          "$ref": "#/$defs/matchExpression"
+        }
+      },
+      "additionalProperties": false
+    },
+    "leafCondition": {
+      "type": "object",
+      "properties": {
+        "keywords_any": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "keywords_all": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "regex": {
+          "type": "string",
+          "minLength": 1
+        },
+        "min_chars": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "max_chars": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "has_tools": {
+          "type": "boolean"
+        },
+        "has_images": {
+          "type": "boolean"
+        },
+        "classifier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "min_score": {
+          "$ref": "#/$defs/score"
+        },
+        "max_score": {
+          "$ref": "#/$defs/score"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": ["keywords_any"]
+        },
+        {
+          "required": ["keywords_all"]
+        },
+        {
+          "required": ["regex"]
+        },
+        {
+          "required": ["min_chars"]
+        },
+        {
+          "required": ["max_chars"]
+        },
+        {
+          "required": ["has_tools"]
+        },
+        {
+          "required": ["has_images"]
+        },
+        {
+          "required": ["classifier"]
+        }
+      ],
+      "allOf": [
+        {
+          "if": {
+            "required": ["min_score"]
+          },
+          "then": {
+            "required": ["classifier"]
+          }
+        },
+        {
+          "if": {
+            "required": ["max_score"]
+          },
+          "then": {
+            "required": ["classifier"]
+          }
+        },
+        {
+          "if": {
+            "required": ["label"]
+          },
+          "then": {
+            "required": ["classifier"]
+          }
+        }
+      ]
+    },
+    "classifier": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/semanticSimilarityClassifier"
+        },
+        {
+          "$ref": "#/$defs/textClassifier"
+        }
+      ]
+    },
+    "semanticSimilarityClassifier": {
+      "type": "object",
+      "required": ["id", "type", "model", "candidates"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "const": "semantic_similarity"
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "candidates": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "on_error": {
+          "$ref": "#/$defs/onError"
+        }
+      },
+      "additionalProperties": false
+    },
+    "textClassifier": {
+      "type": "object",
+      "required": ["id", "type", "model"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "enum": [
+            "classifier",
+            "pii_detection",
+            "prompt_safety",
+            "language_detection",
+            "domain_classification",
+            "complexity",
+            "sentiment"
+          ]
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "labels": {
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "default_label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "on_error": {
+          "$ref": "#/$defs/onError"
+        }
+      },
+      "additionalProperties": false
+    },
+    "llmRouter": {
+      "type": "object",
+      "required": ["type", "model", "prompt"],
+      "properties": {
+        "type": {
+          "const": "llm"
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prompt": {
+          "type": "string",
+          "minLength": 1
+        },
+        "on_error": {
+          "$ref": "#/$defs/onError"
+        }
+      },
+      "additionalProperties": false
+    },
+    "nonEmptyStringArray": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "onError": {
+      "enum": ["match_false", "match_true"]
+    }
+  }
+}

--- a/src/cpp/resources/schemas/route-decision.schema.json
+++ b/src/cpp/resources/schemas/route-decision.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lemonade-sdk.github.io/schemas/route-decision.schema.json",
+  "title": "Lemonade route decision and request extensions",
+  "description": "Schema for Lemonade Router request extensions and additive route response object.",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/routeRequestExtensions"
+    },
+    {
+      "$ref": "#/$defs/routeResponseExtensions"
+    },
+    {
+      "$ref": "#/$defs/xLemonadeRoute"
+    }
+  ],
+  "$defs": {
+    "routeRequestExtensions": {
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "$ref": "#/$defs/metadata"
+        },
+        "route_trace": {
+          "type": "boolean"
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["metadata"]
+        },
+        {
+          "required": ["route_trace"]
+        }
+      ],
+      "additionalProperties": true
+    },
+    "routeResponseExtensions": {
+      "type": "object",
+      "required": ["x_lemonade_route"],
+      "properties": {
+        "x_lemonade_route": {
+          "$ref": "#/$defs/xLemonadeRoute"
+        }
+      },
+      "additionalProperties": true
+    },
+    "xLemonadeRoute": {
+      "type": "object",
+      "required": ["route_to", "matched_rule", "default_used", "outputs"],
+      "properties": {
+        "route_to": {
+          "type": "string",
+          "minLength": 1
+        },
+        "matched_rule": {
+          "oneOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "default_used": {
+          "type": "boolean"
+        },
+        "outputs": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "trace": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/traceEntry"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "traceEntry": {
+      "type": "object",
+      "required": ["condition", "result"],
+      "properties": {
+        "condition": {
+          "type": "string",
+          "minLength": 1
+        },
+        "result": {
+          "type": "boolean"
+        },
+        "classifier": {
+          "type": "string",
+          "minLength": 1
+        },
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "error": {
+          "type": "string",
+          "minLength": 1
+        },
+        "on_error": {
+          "enum": ["match_false", "match_true"]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "propertyNames": {
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/test/fixtures/router/invalid/route_metadata_nested_value.json
+++ b/test/fixtures/router/invalid/route_metadata_nested_value.json
@@ -1,0 +1,14 @@
+{
+  "model": "user.Router-Shopping",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Can you help with checkout?"
+    }
+  ],
+  "metadata": {
+    "task_class": "payment",
+    "site_tags": ["shopping", "checkout"]
+  },
+  "route_trace": true
+}

--- a/test/fixtures/router/invalid/router_empty_match.json
+++ b/test/fixtures/router/invalid/router_empty_match.json
@@ -1,0 +1,21 @@
+{
+  "model_name": "user.Router-Empty-Match",
+  "recipe": "collection.router",
+  "checkpoint": "",
+  "components": [
+    "Qwen3-8B-GGUF"
+  ],
+  "routing": {
+    "candidates": [
+      "Qwen3-8B-GGUF"
+    ],
+    "default_model": "Qwen3-8B-GGUF",
+    "rules": [
+      {
+        "id": "empty",
+        "match": {},
+        "route_to": "Qwen3-8B-GGUF"
+      }
+    ]
+  }
+}

--- a/test/fixtures/router/invalid/router_invalid_classifier_type.json
+++ b/test/fixtures/router/invalid/router_invalid_classifier_type.json
@@ -1,0 +1,31 @@
+{
+  "model_name": "user.Router-Invalid-Classifier-Type",
+  "recipe": "collection.router",
+  "checkpoint": "",
+  "components": [
+    "Qwen3-8B-GGUF",
+    "unknown-classifier-model"
+  ],
+  "routing": {
+    "candidates": [
+      "Qwen3-8B-GGUF"
+    ],
+    "default_model": "Qwen3-8B-GGUF",
+    "classifiers": [
+      {
+        "id": "bad",
+        "type": "unknown",
+        "model": "unknown-classifier-model"
+      }
+    ],
+    "rules": [
+      {
+        "id": "bad-route",
+        "match": {
+          "classifier": "bad"
+        },
+        "route_to": "Qwen3-8B-GGUF"
+      }
+    ]
+  }
+}

--- a/test/fixtures/router/invalid/router_missing_candidates.json
+++ b/test/fixtures/router/invalid/router_missing_candidates.json
@@ -1,0 +1,20 @@
+{
+  "model_name": "user.Router-Missing-Candidates",
+  "recipe": "collection.router",
+  "checkpoint": "",
+  "components": [
+    "Qwen3-8B-GGUF"
+  ],
+  "routing": {
+    "default_model": "Qwen3-8B-GGUF",
+    "rules": [
+      {
+        "id": "local",
+        "match": {
+          "keywords_any": ["local"]
+        },
+        "route_to": "Qwen3-8B-GGUF"
+      }
+    ]
+  }
+}

--- a/test/fixtures/router/invalid/router_missing_rules_and_router.json
+++ b/test/fixtures/router/invalid/router_missing_rules_and_router.json
@@ -1,0 +1,14 @@
+{
+  "model_name": "user.Router-Missing-Rules-And-Router",
+  "recipe": "collection.router",
+  "checkpoint": "",
+  "components": [
+    "Qwen3-8B-GGUF"
+  ],
+  "routing": {
+    "candidates": [
+      "Qwen3-8B-GGUF"
+    ],
+    "default_model": "Qwen3-8B-GGUF"
+  }
+}

--- a/test/fixtures/router/invalid/router_mixed_logical_leaf.json
+++ b/test/fixtures/router/invalid/router_mixed_logical_leaf.json
@@ -1,0 +1,28 @@
+{
+  "model_name": "user.Router-Mixed-Logical-Leaf",
+  "recipe": "collection.router",
+  "checkpoint": "",
+  "components": [
+    "Qwen3-8B-GGUF"
+  ],
+  "routing": {
+    "candidates": [
+      "Qwen3-8B-GGUF"
+    ],
+    "default_model": "Qwen3-8B-GGUF",
+    "rules": [
+      {
+        "id": "mixed",
+        "match": {
+          "any": [
+            {
+              "keywords_any": ["return"]
+            }
+          ],
+          "max_chars": 1000
+        },
+        "route_to": "Qwen3-8B-GGUF"
+      }
+    ]
+  }
+}

--- a/test/fixtures/router/valid/l0a_llm_router.json
+++ b/test/fixtures/router/valid/l0a_llm_router.json
@@ -1,0 +1,24 @@
+{
+  "model_name": "user.Router-L0a",
+  "recipe": "collection.router",
+  "checkpoint": "",
+  "components": [
+    "Qwen3-8B-GGUF",
+    "vllm.qwen3-32b",
+    "claude-haiku-4-5",
+    "Qwen3-1.7B-GGUF"
+  ],
+  "routing": {
+    "candidates": [
+      "Qwen3-8B-GGUF",
+      "vllm.qwen3-32b",
+      "claude-haiku-4-5"
+    ],
+    "default_model": "Qwen3-8B-GGUF",
+    "router": {
+      "type": "llm",
+      "model": "Qwen3-1.7B-GGUF",
+      "prompt": "Route to the cheapest model that can handle the request."
+    }
+  }
+}

--- a/test/fixtures/router/valid/l1_deterministic_rules.json
+++ b/test/fixtures/router/valid/l1_deterministic_rules.json
@@ -1,0 +1,50 @@
+{
+  "model_name": "user.Router-L1",
+  "recipe": "collection.router",
+  "checkpoint": "",
+  "components": [
+    "Qwen3-8B-GGUF",
+    "vllm.qwen3-32b"
+  ],
+  "routing": {
+    "candidates": [
+      "Qwen3-8B-GGUF",
+      "vllm.qwen3-32b"
+    ],
+    "default_model": "vllm.qwen3-32b",
+    "rules": [
+      {
+        "id": "keep-private",
+        "match": {
+          "keywords_any": ["ssn", "credit card"],
+          "max_chars": 2000
+        },
+        "route_to": "Qwen3-8B-GGUF",
+        "outputs": {
+          "verdict": "warn"
+        }
+      },
+      {
+        "id": "support",
+        "match": {
+          "all": [
+            {
+              "any": [
+                {
+                  "keywords_any": ["return", "refund"]
+                },
+                {
+                  "regex": "\\btrack (my )?order\\b"
+                }
+              ]
+            },
+            {
+              "has_images": false
+            }
+          ]
+        },
+        "route_to": "vllm.qwen3-32b"
+      }
+    ]
+  }
+}

--- a/test/fixtures/router/valid/l2_semantic_similarity.json
+++ b/test/fixtures/router/valid/l2_semantic_similarity.json
@@ -1,0 +1,39 @@
+{
+  "model_name": "user.Router-L2",
+  "recipe": "collection.router",
+  "checkpoint": "",
+  "components": [
+    "Qwen3-8B-GGUF",
+    "vllm.qwen3-32b",
+    "nomic-embed-text-v1.5-GGUF"
+  ],
+  "routing": {
+    "candidates": [
+      "Qwen3-8B-GGUF",
+      "vllm.qwen3-32b"
+    ],
+    "default_model": "vllm.qwen3-32b",
+    "classifiers": [
+      {
+        "id": "sim_returns",
+        "type": "semantic_similarity",
+        "model": "nomic-embed-text-v1.5-GGUF",
+        "candidates": [
+          "how do I return an item",
+          "track my order",
+          "refund policy"
+        ]
+      }
+    ],
+    "rules": [
+      {
+        "id": "support",
+        "match": {
+          "classifier": "sim_returns",
+          "min_score": 0.75
+        },
+        "route_to": "vllm.qwen3-32b"
+      }
+    ]
+  }
+}

--- a/test/fixtures/router/valid/l3_classifier.json
+++ b/test/fixtures/router/valid/l3_classifier.json
@@ -1,0 +1,39 @@
+{
+  "model_name": "user.Router-L3",
+  "recipe": "collection.router",
+  "checkpoint": "",
+  "components": [
+    "Qwen3-8B-GGUF",
+    "vllm.qwen3-32b",
+    "pii-detector-small"
+  ],
+  "routing": {
+    "candidates": [
+      "Qwen3-8B-GGUF",
+      "vllm.qwen3-32b"
+    ],
+    "default_model": "vllm.qwen3-32b",
+    "classifiers": [
+      {
+        "id": "pii",
+        "type": "classifier",
+        "model": "pii-detector-small",
+        "labels": ["PII", "NO_PII"],
+        "default_label": "PII",
+        "on_error": "match_true"
+      }
+    ],
+    "rules": [
+      {
+        "id": "keep-private",
+        "match": {
+          "classifier": "pii"
+        },
+        "route_to": "Qwen3-8B-GGUF",
+        "outputs": {
+          "verdict": "warn"
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/router/valid/route_request_extensions.json
+++ b/test/fixtures/router/valid/route_request_extensions.json
@@ -1,0 +1,14 @@
+{
+  "model": "user.Router-Shopping",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Can you help with checkout?"
+    }
+  ],
+  "metadata": {
+    "task_class": "payment",
+    "site_tags": "shopping,checkout"
+  },
+  "route_trace": true
+}

--- a/test/fixtures/router/valid/x_lemonade_route_with_trace.json
+++ b/test/fixtures/router/valid/x_lemonade_route_with_trace.json
@@ -1,0 +1,23 @@
+{
+  "x_lemonade_route": {
+    "route_to": "Qwen3-8B-GGUF",
+    "matched_rule": "keep-private",
+    "default_used": false,
+    "outputs": {
+      "verdict": "warn"
+    },
+    "trace": [
+      {
+        "condition": "classifier:pii",
+        "classifier": "pii",
+        "label": "PII",
+        "score": 0.81,
+        "result": true
+      },
+      {
+        "condition": "keywords_any",
+        "result": false
+      }
+    ]
+  }
+}

--- a/test/fixtures/router/valid/x_lemonade_route_without_trace.json
+++ b/test/fixtures/router/valid/x_lemonade_route_without_trace.json
@@ -1,0 +1,10 @@
+{
+  "x_lemonade_route": {
+    "route_to": "Qwen3-8B-GGUF",
+    "matched_rule": "keep-private",
+    "default_used": false,
+    "outputs": {
+      "verdict": "warn"
+    }
+  }
+}

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -20,6 +20,9 @@ prometheus-client
 # Numerical computing (required for embedding similarity tests)
 numpy
 
+# JSON Schema validation (required for router schema contract tests)
+jsonschema
+
 # WebSocket client (required for realtime transcription tests)
 websockets
 

--- a/test/router_schema_contract.py
+++ b/test/router_schema_contract.py
@@ -1,0 +1,109 @@
+"""
+Contract tests for Lemonade Router JSON Schemas.
+
+These tests validate the schema-gate fixtures for:
+  - collection.router model definitions (#2375)
+  - route request/response extensions (#2376)
+
+They do not exercise runtime parser cross-reference checks such as
+route_to-in-candidates or candidate-in-components; those belong to the parser
+implementation.
+"""
+
+import json
+import unittest
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, ValidationError
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = REPO_ROOT / "src" / "cpp" / "resources" / "schemas"
+FIXTURE_DIR = REPO_ROOT / "test" / "fixtures" / "router"
+
+COLLECTION_ROUTER_SCHEMA = SCHEMA_DIR / "collection-router.schema.json"
+ROUTE_DECISION_SCHEMA = SCHEMA_DIR / "route-decision.schema.json"
+
+COLLECTION_ROUTER_VALID = [
+    "valid/l0a_llm_router.json",
+    "valid/l1_deterministic_rules.json",
+    "valid/l2_semantic_similarity.json",
+    "valid/l3_classifier.json",
+]
+
+COLLECTION_ROUTER_INVALID = [
+    "invalid/router_missing_candidates.json",
+    "invalid/router_missing_rules_and_router.json",
+    "invalid/router_empty_match.json",
+    "invalid/router_mixed_logical_leaf.json",
+    "invalid/router_invalid_classifier_type.json",
+]
+
+ROUTE_DECISION_VALID = [
+    "valid/x_lemonade_route_without_trace.json",
+    "valid/x_lemonade_route_with_trace.json",
+    "valid/route_request_extensions.json",
+]
+
+ROUTE_DECISION_INVALID = [
+    "invalid/route_metadata_nested_value.json",
+]
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+class RouterSchemaContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.collection_router_schema = load_json(COLLECTION_ROUTER_SCHEMA)
+        cls.route_decision_schema = load_json(ROUTE_DECISION_SCHEMA)
+
+        Draft202012Validator.check_schema(cls.collection_router_schema)
+        Draft202012Validator.check_schema(cls.route_decision_schema)
+
+        cls.collection_router_validator = Draft202012Validator(cls.collection_router_schema)
+        cls.route_decision_validator = Draft202012Validator(cls.route_decision_schema)
+
+    def assert_valid(self, validator: Draft202012Validator, fixture: str):
+        path = FIXTURE_DIR / fixture
+        instance = load_json(path)
+        errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.path))
+        if errors:
+            detail = "\n".join(
+                f"{'/'.join(str(p) for p in error.path) or '<root>'}: {error.message}"
+                for error in errors
+            )
+            self.fail(f"{fixture} should be valid, got:\n{detail}")
+
+    def assert_invalid(self, validator: Draft202012Validator, fixture: str):
+        path = FIXTURE_DIR / fixture
+        instance = load_json(path)
+        with self.assertRaises(ValidationError, msg=f"{fixture} should be invalid"):
+            validator.validate(instance)
+
+    def test_collection_router_valid_fixtures(self):
+        for fixture in COLLECTION_ROUTER_VALID:
+            with self.subTest(fixture=fixture):
+                self.assert_valid(self.collection_router_validator, fixture)
+
+    def test_collection_router_invalid_fixtures(self):
+        for fixture in COLLECTION_ROUTER_INVALID:
+            with self.subTest(fixture=fixture):
+                self.assert_invalid(self.collection_router_validator, fixture)
+
+    def test_route_decision_valid_fixtures(self):
+        for fixture in ROUTE_DECISION_VALID:
+            with self.subTest(fixture=fixture):
+                self.assert_valid(self.route_decision_validator, fixture)
+
+    def test_route_decision_invalid_fixtures(self):
+        for fixture in ROUTE_DECISION_INVALID:
+            with self.subTest(fixture=fixture):
+                self.assert_invalid(self.route_decision_validator, fixture)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
  ## Summary

  Adds the schema-gate contract for Lemonade Router.

  This PR introduces JSON Schemas and fixtures for:
  - `collection.router` model definitions and their `routing` policy block
  - route request extensions (`metadata`, `route_trace`)
  - additive route response metadata (`x_lemonade_route`)

  It also adds schema validation coverage with `jsonschema` and documents the router policy contract for developers.

  ## Details

  - Adds `collection-router.schema.json` for full `collection.router` model JSON.
  - Adds `route-decision.schema.json` for request extensions and route response objects.
  - Adds valid fixtures for L0a LLM router, deterministic rules, semantic similarity, and generic classifiers.
  - Adds invalid fixtures for missing candidates, missing rules/router, empty match, mixed logical/leaf expressions, invalid classifier type, and nested metadata.
  - Documents routing candidates, default model behavior, match expressions, classifier types, `routing.router`, request metadata, `route_trace`, and `x_lemonade_route`.

  This is schema/documentation/test work only. It does not add runtime routing, parser cross-reference validation, model import/export changes, or request dispatch.

  ## Test

  ```bash
  python test/router_schema_contract.py

  Result:

  Ran 4 tests in 0.020s

  OK