### PR TITLE
Feat(GUI3): master-detail model view, remove preset rails (#2355 Slice 1)

### DIFF
--- a/prototype/ui-redesign/ACCESSIBILITY.md
+++ b/prototype/ui-redesign/ACCESSIBILITY.md
@@ -3,8 +3,35 @@
 **Date:** 2026-06-25  
 **Branch:** `feat/gui3-model-detail-redesign`  
 **Scope:** `prototype/ui-redesign/` only  
-**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete, Group G (Left navigation rail — three-pane model view) ✅ complete, Group H (Model-detail Presets card grid — #2424 fl0rianr) ✅ complete  
-**Test status (2026-06-25):** All 157 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A137–A141 added for the model-detail Presets compact card grid)
+**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete, Group G (Left navigation rail — three-pane model view) ✅ complete, Group H (Model-detail Presets card grid — #2424 fl0rianr) ✅ complete, Group I (Model view refinements — #2424 fl0rianr review) ✅ complete  
+**Test status (2026-06-25):** All 164 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A142–A148 added for the #2424 model-view refinements)
+
+---
+
+## Group I — Model view refinements (#2424 fl0rianr review, 2026-06-25)
+
+fl0rianr's PR #2424 review raised five items, all addressed in `prototype/ui-redesign/`:
+
+1. **Favorite star toggle in the detail panel.** `ModelDetailPanel` now renders a star (☆/★) toggle button in the header actions row. It reuses the EXISTING client-local pin/favorite store (`pinned_models` localStorage via `togglePinnedModel`/`pinnedNameSet` in `ModelManager.tsx`) — no parallel store. The Favorites nav-rail count reflects it immediately. The icon button is an `aria-pressed` toggle whose `aria-label` names the model and the action ("Add … to favorites" / "Remove … from favorites").
+2. **Removed preset search + "+ New" from the left rail.** Deleted the `model-nav-rail__preset-row` (search box + button) and its state/CSS. Model search remains in the middle pane.
+3. **"Back to models" hidden on desktop.** `.model-detail-panel__back-btn` is now `display:none` at desktop widths and only re-enabled inside the `≤700px` media query (with raised specificity `.manager--detail .model-detail-panel__back-btn` so it wins over the later base rule).
+4. **Funnel filter scoped to capabilities + opaque popover.** The popover already filtered by capability categories; relabelled to "Filter by capability" and the button/group `aria-label`s updated. The popover background was `var(--surface-overlay)` (an undefined token → transparent); switched to the solid `var(--surface-3)` surface so list content no longer bleeds through.
+5. **Left rail no longer clips the screen.** Root cause: `.manager--detail` inherited `grid-template-rows: auto 1fr` from `.manager`, so the panes landed in the content-sized `auto` row and grew past the viewport with no scroll. Added `grid-template-rows: minmax(0, 1fr)` (+ `min-height: 0`) so the row is bounded to the viewport and each pane's own `overflow-y:auto` (the rail's included) takes over. The Storage meter stays reachable by scrolling the rail.
+
+**a11y decisions:**
+- The favorite toggle is a real `<button>` with `aria-pressed`; the glyph is `aria-hidden` so the state is conveyed by the label, not the star colour.
+- "Back to models" is kept in the DOM (not conditionally unmounted) and hidden via CSS, so the narrow-viewport behaviour is purely responsive.
+
+**Tests added:** A142–A148 (7 tests) in `tests/a11y.spec.ts`.
+- A142: detail favorite star is an `aria-pressed` toggle naming the model
+- A143: favoriting updates the Favorites nav count and persists to the existing `pinned_models` store
+- A144: "Back to models" is hidden on desktop widths
+- A145: funnel popover filters by capability and has a solid (non-transparent) background
+- A146: picking a capability in the funnel popover filters the list
+- A147: the left nav rail is independently scrollable and reaches the Storage meter
+- A148: refined model view (favorite set + filter open) passes WCAG 2.1 AA axe-core scan
+
+**Files changed:** `ModelDetailPanel.tsx`, `ModelNavRail.tsx`, `ModelListPanel.tsx`, `ModelManager.tsx`, `styles/styles.css`, `tests/a11y.spec.ts`, `ACCESSIBILITY.md`.
 
 ---
 
@@ -89,7 +116,7 @@ fl0rianr posted a canonical three-pane target: a NEW left **navigation** rail (`
 - A133: custom-model buttons grounded group at the top, keyboard reachable
 - A134: responsive nav toggle (`aria-controls`/`aria-expanded`) reveals the rail
 - A135: full three-pane view passes WCAG 2.1 AA axe-core scan
-- A136: preset quick-search input is labelled
+- A136: preset quick-search and "+ New" removed from the nav rail (#2424)
 
 ---
 
@@ -857,4 +884,4 @@ Tests A25–A27 only verify that the aria-live regions **exist**. Verifying that
 
 ---
 
-*Last updated: 2026-06-25 by Mattingly (Group H: model-detail Presets card grid #2424 — rows → neat compact card grid matching global preset cards; `<ul role="list">` to avoid nested-interactive; aria-current + text badges; tests A137–A141)*
+*Last updated: 2026-06-25 by Mattingly (Group I: model-view refinements #2424 — favorite star toggle reusing the pin store, preset search/+New removed from rail, Back-to-models desktop-hidden, funnel scoped to capabilities + opaque popover, rail grid-row scroll fix; tests A142–A148)*

--- a/prototype/ui-redesign/ACCESSIBILITY.md
+++ b/prototype/ui-redesign/ACCESSIBILITY.md
@@ -1,14 +1,62 @@
 # Accessibility Plan — Lemonade UI Redesign Prototype
 
-**Date:** 2026-06-14  
-**Branch:** `kpoin/ui-accessibility`  
+**Date:** 2026-06-25  
+**Branch:** `feat/gui3-model-detail-redesign`  
 **Scope:** `prototype/ui-redesign/` only  
-**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete  
-**Test status (2026-06-25):** All 106 automated tests passing, 7 skipped, 0 failed on `feat/gui3-mcp-dashboard` (A89–A90 added in review pass)
+**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete  
+**Test status (2026-06-25):** All 121 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A91–A105 added for Slice 1)
 
 ---
 
-## Group D — MCP Gateway panel (2026-06-25, `feat/gui3-mcp-dashboard`)
+## Group E — Master-detail model view (#2355 Slice 1, 2026-06-25)
+
+Replaces the old preset-rail layout with an email-client-style master-detail split in `ModelManager.tsx`, using new `ModelListPanel.tsx` (left) and `ModelDetailPanel.tsx` (right). Old `renderPresetRail()` is removed.
+
+### E1 — #2355: Left model list panel
+
+- **Status:** ✅ **Implemented 2026-06-25**
+- **What:** `ModelListPanel` renders a `<ul role="listbox" aria-label="Model list">` with `<li role="option" aria-selected>` items. Search input `<input id="model-list-search" role="searchbox">` is associated with `<label htmlFor="model-list-search">`. Filter popover trigger has `aria-haspopup="dialog"` and `aria-expanded`. Filter popover itself has `role="dialog"`. Keyboard nav: ArrowUp/Down/Home/End on the listbox move focus + selection. The listbox receives `tabIndex={0}` when no item is selected so the scrollable region is always keyboard-accessible (fixes `scrollable-region-focusable` axe rule). Title `<h1>Models</h1>` inside `.manager__title` preserves the existing test assertion on `.manager__title h1`.
+- **WCAG:** 1.3.1 (Info and Relationships), 2.1.1 (Keyboard), 4.1.2 (Name, Role, Value)
+
+### E2 — #2355: Right model detail panel with tablist
+
+- **Status:** ✅ **Implemented 2026-06-25**
+- **What:** `ModelDetailPanel` renders `role="tablist"` with `role="tab"` buttons (roving tabindex, `aria-selected`, `aria-controls`) and `role="tabpanel"` panels (`aria-labelledby`). Tabs: README (Markdown via markdown-it + DOMPurify), Presets (preset linking via `presetStore.ts`), Files (stub, deferred). ArrowLeft/Right/Home/End navigate tabs. Focus moves to the panel heading when model selection changes. Action buttons carry model-qualified `aria-label`s (e.g. `"Load Llama-3.1-8B"`). Empty state panel shown when no model is selected.
+- **WCAG:** 1.3.1, 2.1.1, 4.1.2
+
+### E3 — #2355: Preset linking in Presets tab
+
+- **Status:** ✅ **Implemented 2026-06-25**
+- **What:** `ModelPresetsTab` uses `presetStore.ts` `loadApplied`/`saveApplied` for client-local preset linking (localStorage). Linked preset card has `aria-current="true"`. Detach button has a qualifying `aria-label`. Attach buttons on candidate presets carry `aria-label="Attach preset "X" to ModelName"`. A `role="status" aria-live="polite"` region announces the attach confirmation.
+- **WCAG:** 4.1.2, 4.1.3
+
+### E4 — #2355: Funnel filter icon (the only new icon)
+
+- **Status:** ✅ **Added 2026-06-25**
+- **What:** Added `'funnel'` to `IconName` in `Icon.tsx` with the matching SVG path. Used on the filter toggle button in `ModelListPanel`.
+- **WCAG:** 1.1.1 (icon buttons have explicit `aria-label`; icon SVG has `aria-hidden="true"`)
+
+**Tests added:** A91–A105 (15 tests) in `tests/a11y.spec.ts`.  
+- A91–A92: layout landmarks and heading  
+- A93–A94: search input association and filtering  
+- A95–A96: funnel filter button ARIA attributes and popover  
+- A97–A99: listbox role + option role + keyboard navigation  
+- A100–A101: tablist ARIA structure + keyboard tab navigation  
+- A102–A103: Presets tab keyboard reachability and panel label  
+- A104: Custom model / Omni collection buttons visible + keyboard-accessible  
+- A105: Full axe-core WCAG 2.1 AA scan with mock data + selected model  
+
+**Files changed:** `ModelDetailPanel.tsx` (new), `ModelListPanel.tsx` (new), `ModelManager.tsx`, `Icon.tsx`, `styles/styles.css`, `tests/a11y.spec.ts`, `tests/features.spec.ts`, `ACCESSIBILITY.md`.
+
+**Deferred to follow-up slices:**
+- Files tab (stub only in Slice 1)
+- Full recommended-preset card polish
+- Sorting refinements  
+- #2356 (Update-preset-while-loaded — builds on detail panel)
+
+---
+
+
 
 Adds a new read-only MCP dashboard section to `ConnectView.tsx` exposing the existing `POST /mcp` Streamable HTTP endpoint.
 

--- a/prototype/ui-redesign/ACCESSIBILITY.md
+++ b/prototype/ui-redesign/ACCESSIBILITY.md
@@ -3,8 +3,31 @@
 **Date:** 2026-06-25  
 **Branch:** `feat/gui3-model-detail-redesign`  
 **Scope:** `prototype/ui-redesign/` only  
-**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete, Group G (Left navigation rail — three-pane model view) ✅ complete  
-**Test status (2026-06-25):** All 152 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A124–A136 added for the left navigation rail / three-pane model view)
+**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete, Group G (Left navigation rail — three-pane model view) ✅ complete, Group H (Model-detail Presets card grid — #2424 fl0rianr) ✅ complete  
+**Test status (2026-06-25):** All 157 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A137–A141 added for the model-detail Presets compact card grid)
+
+---
+
+## Group H — Model-detail Presets card grid (#2424 fl0rianr, 2026-06-25)
+
+fl0rianr's 18:12Z feedback on PR #2424: the model-detail **Presets** tab rendered the linked + compatible presets as full-width stacked **rows**; he wanted "neat cards — a slightly smaller, focused version of the cards in the global preset view." Restyled `ModelDetailPanel.tsx`'s `ModelPresetsTab` so the **Linked preset** sits above as a single highlighted card and the **Recommended presets** render as a neat responsive **grid of compact cards** (icon + name, 1–2 line description, a compact `temp · ctx · tools` / `steps · cfg` meta line, and an Attach/Switch action), visually consistent with the global `.recipe-card` (Presets page) but smaller and focused.
+
+**a11y decisions:**
+- The recommended grid is a `<ul role="list">` of `<li>` cards (NOT `role="listbox"`/`option`). An option is an interactive role; placing the per-card Attach/Switch `<button>` inside it triggers axe `nested-interactive` (focusable descendant of an interactive element). `listitem` is non-interactive, so a button inside is allowed.
+- Linked/active state is exposed via **text + ARIA, not color alone**: the linked card carries `aria-current="true"` + a visible "Active" badge; the matching grid card carries `aria-current="true"` + a "Linked" text badge and a "Currently linked" note in place of the Attach button.
+- Every Attach/Switch button's `aria-label` names its preset and the model, e.g. `Attach preset "Balanced" for Llama-3.1-8B` (relabels to `Switch to preset …` when a non-default preset is already linked).
+- The inline Change chooser (`role="dialog"`, `aria-modal`, focus return to the Change button) is unchanged and still works.
+- A "Browse presets" / "Manage presets" deep-link dispatches a client-local `lemonade:navigate` CustomEvent that `App.tsx` listens for to switch to the global Presets view (no lemond involvement).
+- Cards wrap/grid down gracefully via `grid-template-columns: repeat(auto-fill, minmax(180px, 1fr))`.
+
+**Tests added:** A137–A141 (5 tests) in `tests/a11y.spec.ts`.
+- A137: recommended presets render as a `role="list"` grid of compact cards (old `.detail-presets__preset-list` row container gone; `display: grid`)
+- A138: each Attach/Switch button's accessible name includes its preset name
+- A139: linked/active state exposed via text + `aria-current` (not color only)
+- A140: Change dialog still opens from the linked card and closes
+- A141: the Presets card grid passes WCAG 2.1 AA axe-core scan
+
+**Files changed:** `ModelDetailPanel.tsx`, `App.tsx`, `styles/styles.css`, `tests/a11y.spec.ts`, `ACCESSIBILITY.md`.
 
 ---
 
@@ -834,4 +857,4 @@ Tests A25–A27 only verify that the aria-live regions **exist**. Verifying that
 
 ---
 
-*Last updated: 2026-06-25 by Mattingly (Group H: left-rail pin/favorite parity #2355 — re-wired client-local pin store into ModelListPanel; non-button pin span + aria-keyshortcuts="P"; tests A118–A123)*
+*Last updated: 2026-06-25 by Mattingly (Group H: model-detail Presets card grid #2424 — rows → neat compact card grid matching global preset cards; `<ul role="list">` to avoid nested-interactive; aria-current + text badges; tests A137–A141)*

--- a/prototype/ui-redesign/ACCESSIBILITY.md
+++ b/prototype/ui-redesign/ACCESSIBILITY.md
@@ -3,8 +3,8 @@
 **Date:** 2026-06-25  
 **Branch:** `feat/gui3-model-detail-redesign`  
 **Scope:** `prototype/ui-redesign/` only  
-**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete  
-**Test status (2026-06-25):** All 121 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A91–A105 added for Slice 1)
+**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete  
+**Test status (2026-06-25):** All 131 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A106–A115 added for reconciliation)
 
 ---
 
@@ -51,11 +51,46 @@ Replaces the old preset-rail layout with an email-client-style master-detail spl
 **Deferred to follow-up slices:**
 - Files tab (stub only in Slice 1)
 - Full recommended-preset card polish
-- Sorting refinements  
 - #2356 (Update-preset-while-loaded — builds on detail panel)
 
 ---
 
+## Group F — #2355 Slice 1 reconciliation — fl0rianr 2026-06-25 clarifications
+
+Closes 4 gaps against @fl0rianr's six-point clarification comment (2026-06-25T16:30Z).
+
+### F1 — README checkpoint derivation (tightened)
+
+- **Status:** ✅ **Fixed 2026-06-25**
+- **What:** `hfReadmeUrl` replaced by `deriveHFRepo(checkpoint, checkpoints)` in `ModelDetailPanel.tsx`. Now tries `model.checkpoint` first, then `model.checkpoints.main`, then first value in `model.checkpoints` map. Strips `:variant` suffix via `.split(':')[0]`. Validates with regex `/^[\w.-]+\/[\w.-]+$/` before attempting fetch — non-matching values are silently skipped (no fetch attempt, README placeholder shown). `ModelReadmeTab` caches by derived URL. HF link in the header also uses `deriveHFRepo`.
+- **WCAG:** 1.3.1, 4.1.2 (no new a11y concern; tightened correctness)
+
+### F2 — Sort controls (model list)
+
+- **Status:** ✅ **Added 2026-06-25**
+- **What:** `ModelListPanel` now renders a `<label htmlFor="model-list-sort">Sort</label>` + `<select id="model-list-sort">` with four options: Name (A–Z, default), Size (largest first), Last used, Download count. Sort logic in `flatList` useMemo: Name keeps the status-group ordering (running → downloaded → available) as secondary sort; Size/Last used/Downloads are primary with graceful fallback to name when the relevant data is absent. No crash when `last_used` or `downloads` fields are missing.
+- **WCAG:** 1.3.1, 2.1.1, 4.1.2 (labeled form control, keyboard-operable `<select>`)
+
+### F3 — Responsive list-first pattern
+
+- **Status:** ✅ **Added 2026-06-25**
+- **What:** At `max-width: 700px`, `ModelManager` adds `.manager--detail-mobile-open` class to the grid container when a model is selected. CSS hides the list and shows the detail panel (not stacked — mutually exclusive). A "Back to models" `<button class="model-detail-panel__back-btn" aria-label="Back to models list">` is injected at the top of `ModelDetailPanel` when `onBack` prop is provided. Focus moves to the detail heading on open (`panelHeadingRef` focus in `useEffect`) and back to the selected `[data-model-id]` list item on Back (via `document.querySelector` + `focus()`).
+- **WCAG:** 2.1.1 (keyboard), 2.4.3 (focus order), 4.1.2 (button accessible name)
+
+### F4 — Presets tab — Change linked preset (inline chooser)
+
+- **Status:** ✅ **Added 2026-06-25**
+- **What:** When a non-default preset is linked, the linked preset card gains a "Change" `<button aria-haspopup="dialog" aria-expanded>`. Clicking it toggles an inline `<div role="dialog" aria-label="Switch linked preset" aria-modal="true">` rendered directly in the Presets tab, listing compatible presets (excluding the currently linked one) as clickable `<li role="option">` buttons with aria-labels. Selecting one calls `handleAttach` and closes the chooser, returning focus to the Change button. A ✕ close button also returns focus. The compatible presets list below continues to show "Switch" (renamed from "Attach" when a non-default preset is linked) for direct in-list attaching.
+- **WCAG:** 2.1.1, 2.4.3, 4.1.2
+
+**Tests added:** A106–A115 (10 tests) in `tests/a11y.spec.ts`.
+- A106–A109: sort control label, options, default value, keyboard operability
+- A110–A113: narrow viewport list-first, model selection shows detail, Back button label, Back returns to list
+- A114–A115: preset Change button ARIA attributes, chooser dialog opens/closes with focus
+
+**Files changed:** `ModelDetailPanel.tsx`, `ModelListPanel.tsx`, `ModelManager.tsx`, `styles/styles.css`, `tests/a11y.spec.ts`, `ACCESSIBILITY.md`.
+
+---
 
 
 Adds a new read-only MCP dashboard section to `ConnectView.tsx` exposing the existing `POST /mcp` Streamable HTTP endpoint.

--- a/prototype/ui-redesign/ACCESSIBILITY.md
+++ b/prototype/ui-redesign/ACCESSIBILITY.md
@@ -3,8 +3,36 @@
 **Date:** 2026-06-25  
 **Branch:** `feat/gui3-model-detail-redesign`  
 **Scope:** `prototype/ui-redesign/` only  
-**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete, Group G (Left navigation rail — three-pane model view) ✅ complete, Group H (Model-detail Presets card grid — #2424 fl0rianr) ✅ complete, Group I (Model view refinements — #2424 fl0rianr review) ✅ complete  
-**Test status (2026-06-25):** All 164 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A142–A148 added for the #2424 model-view refinements)
+**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete, Group G (Left navigation rail — three-pane model view) ✅ complete, Group H (Model-detail Presets card grid — #2424 fl0rianr) ✅ complete, Group I (Model view refinements — #2424 fl0rianr review) ✅ complete, Group J (Model view merge items — #2424 fl0rianr 2nd review) ✅ complete  
+**Test status (2026-06-25):** All 168 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A149–A153 added for the #2424 second-round merge items)
+
+---
+
+## Group J — Model view merge items (#2424 fl0rianr 2nd review, 2026-06-25)
+
+fl0rianr's second-round review on PR #2424 raised five merge-blocking items, all addressed in `prototype/ui-redesign/`:
+
+1. **Favorites is now DISTINCT from Pinned.** Added a separate client-local `favorite_models` localStorage store (`favoriteModelsKey`/`loadFavoriteModels`/`saveFavoriteModels`, `favoriteModels` state, `toggleFavoriteModel`, `favoriteNameSet` in `ModelManager.tsx`) — no longer aliasing `pinned_models`. The detail-panel star toggles FAVORITE; the left-rail "Favorites" nav entry uses a STAR icon (was a pin); its count reflects `favoriteNames`. Pinned remains its own concept (pinned rows still float to the top of the middle list).
+2. **"No model selected" empty state moved to the RIGHT detail pane.** Removed the registry-empty `model-list-panel__empty` `<li>` from the middle list (it now only renders for an active search-with-no-matches). `ModelDetailPanel`'s placeholder shows "No model selected" / "No models found" (with a `noModelsAvailable` prop driving the guidance copy).
+3. **Funnel = functional capability tags; rows show multiple capability icons.** Added a capability-tags model (`CapabilityTag`, `CAPABILITY_TAG_ORDER`, `CAPABILITY_TAG_LABELS`, `modelCapabilityTags`, `modelMatchesCapabilityTags` in `modelCapabilities.ts`). The funnel is now a MULTI-SELECT (`capabilityFilter: Set<string>`) listing the capability tags present in the data (Popular, Chat, Omni, Vision, Tool use, Reasoning, Code, Audio, Image, Speech, Embeddings, Reranking). Each middle-row renders one small icon per capability (`model-list-item__caps`, `role="img"` + label). Popover stays opaque (`--surface-3`).
+4. **Storage meter uses real-or-derived data, no 32/512 mock.** Removed the hardcoded literals. Added `api.getStorageInfo()` which probes `system-info` for a future disk field and returns real bytes when present, else `null`. `ModelNavRail` consumes a `storageInfo` prop: real stats when available, otherwise a graceful estimate (used = Σ downloaded model sizes, total = a headroom-rounded bucket via `deriveFallbackTotalGb`, never a fixed literal). The meter is labelled "(est.)" / "estimated" in the fallback path. **POC limitation surfaced to fl0rianr** — lemond exposes no disk endpoint and is off-limits.
+5. **Hugging Face nav entry in the left rail.** When the model search triggers an HF search with matches, a "Hugging Face" entry appears BELOW My Models/Favorites (star) showing the live match count; clicking it (`primaryFilter='huggingface'`) feeds the HF results (mapped to `ModelInfo`) into the middle list. It disappears and resets to All Models when the search clears.
+
+**a11y decisions:**
+- The Favorites star and capability icons convey state/meaning via text labels, never color alone. Each row's capability cluster is a single `role="img"` with an aria-label listing every capability ("Capabilities: Chat, Tool use").
+- The HF nav entry is a real `<button>` with `aria-current` and an sr-only count phrase; it is keyboard operable (focus + Enter).
+- The storage progressbar keeps `aria-valuenow/min/max` and an `aria-valuetext`/label that marks estimated data when no real source is available.
+
+**Tests added:** A149–A153 (5 tests) in `tests/a11y.spec.ts`; A143/A145/A146 updated for the new behaviour.
+- A149: middle-list rows show multiple capability icons with an accessible label
+- A150: the "no model selected" empty state lives in the detail pane, not the middle list
+- A151: Storage meter derives from data (no hardcoded 512 GB) and labels the estimate
+- A152: a HuggingFace nav entry appears on search, shows the count, is keyboard operable, and clears
+- A153: the model view with an active HuggingFace search passes WCAG 2.1 AA axe-core scan
+
+**Files changed:** `modelCapabilities.ts`, `Icon.tsx`, `api.ts`, `ModelDetailPanel.tsx`, `ModelNavRail.tsx`, `ModelListPanel.tsx`, `ModelManager.tsx`, `styles/styles.css`, `tests/a11y.spec.ts`, `ACCESSIBILITY.md`.
+
+---
 
 ---
 
@@ -24,7 +52,7 @@ fl0rianr's PR #2424 review raised five items, all addressed in `prototype/ui-red
 
 **Tests added:** A142–A148 (7 tests) in `tests/a11y.spec.ts`.
 - A142: detail favorite star is an `aria-pressed` toggle naming the model
-- A143: favoriting updates the Favorites nav count and persists to the existing `pinned_models` store
+- A143: favoriting updates the Favorites nav count and persists (store split into a DISTINCT `favorite_models` key in Group J — see below)
 - A144: "Back to models" is hidden on desktop widths
 - A145: funnel popover filters by capability and has a solid (non-transparent) background
 - A146: picking a capability in the funnel popover filters the list

--- a/prototype/ui-redesign/ACCESSIBILITY.md
+++ b/prototype/ui-redesign/ACCESSIBILITY.md
@@ -4,7 +4,7 @@
 **Branch:** `feat/gui3-model-detail-redesign`  
 **Scope:** `prototype/ui-redesign/` only  
 **Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete  
-**Test status (2026-06-25):** All 133 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A116–A117 added for README raw-HTML rendering fix)
+**Test status (2026-06-25):** All 139 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A118–A123 added for left-rail pin/favorite parity)
 
 ---
 
@@ -104,6 +104,26 @@ Closes 4 gaps against @fl0rianr's six-point clarification comment (2026-06-25T16
 - A117: a leading YAML frontmatter block is stripped — the real heading renders and frontmatter keys (`license:`, `pipeline_tag`) are not shown.
 
 **Files changed:** `ModelDetailPanel.tsx`, `tests/a11y.spec.ts`, `ACCESSIBILITY.md`.
+
+---
+
+### Group H — Left-rail pin/favorite parity (#2355 fl0rianr follow-up)
+
+- **Status:** ✅ **Added 2026-06-25**
+- **Problem:** fl0rianr's follow-up on #2355 noted the new master-detail rail was still "missing the real left rail's features." The original/prototype rail let users **pin (favorite)** a model so it floats to the top of the list; that client-local affordance was dropped when `ModelListPanel` replaced the old rail. The pin store (`loadPinnedModels`/`savePinnedModels`/`togglePinnedModel`, localStorage-scoped `pinned_models`) still lived in `ModelManager` but was no longer surfaced.
+- **Fix:** Re-wired the existing client-local pin store into `ModelListPanel` via new `pinnedNames`/`onTogglePin` props (no `lemond` involvement — pins persist to the scoped `pinned_models` localStorage key, per the per-client-state invariant). Pinned models float to the top while preserving the active sort order within groups.
+- **A11y design:** The per-row pin affordance is a **non-button `<span>`** (pointer convenience), so it does **not** nest an interactive control inside `role="option"` (avoids the axe `nested-interactive` rule). For keyboard/AT users, the row advertises `aria-keyshortcuts="P"` and the focusable selected row (`tabIndex=0`, reachable via Shift+Tab from the detail panel) toggles its pin on "P". Pinned state is exposed in each row's `aria-label` (", pinned"). The pin `<span>` is `aria-hidden` because its state and action are fully represented by the row.
+- **WCAG:** 2.1.1 (keyboard — pin toggle operable via the advertised "P" shortcut), 4.1.2 (name/role/value — pinned state exposed in the row label and `aria-pressed`-equivalent labelling), 1.3.1 (info & relationships).
+
+**Tests added:** A118–A123 (6 tests) in `tests/a11y.spec.ts`.
+- A118: each row exposes a pin affordance with an accessible `title`.
+- A119: the pin affordance is a `<span>`, not a nested interactive control inside `role="option"` (no `button` inside any option).
+- A120: clicking the pin toggles the row pinned state, `model-list-item--pinned` class, and aria-label; clicking again removes it.
+- A121: the selected row advertises `aria-keyshortcuts="P"` and toggles its pin via the "P" key.
+- A122: pinned state persists client-locally to a `*pinned_models` localStorage key (no `lemond`).
+- A123: the model list with a pinned row passes the WCAG 2.1 AA axe-core scan (confirms no `nested-interactive` regression).
+
+**Files changed:** `ModelListPanel.tsx`, `ModelManager.tsx`, `styles/styles.css`, `tests/a11y.spec.ts`, `ACCESSIBILITY.md`.
 
 ---
 
@@ -752,4 +772,4 @@ Tests A25–A27 only verify that the aria-live regions **exist**. Verifying that
 
 ---
 
-*Last updated: 2026-06-25 by Mattingly (Group G: model README raw-HTML rendering fix #2355 — markdown-it html:true behind DOMPurify allowlist + YAML frontmatter strip; tests A116–A117)*
+*Last updated: 2026-06-25 by Mattingly (Group H: left-rail pin/favorite parity #2355 — re-wired client-local pin store into ModelListPanel; non-button pin span + aria-keyshortcuts="P"; tests A118–A123)*

--- a/prototype/ui-redesign/ACCESSIBILITY.md
+++ b/prototype/ui-redesign/ACCESSIBILITY.md
@@ -3,8 +3,70 @@
 **Date:** 2026-06-25  
 **Branch:** `feat/gui3-model-detail-redesign`  
 **Scope:** `prototype/ui-redesign/` only  
-**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete  
-**Test status (2026-06-25):** All 139 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A118–A123 added for left-rail pin/favorite parity)
+**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete, Group G (Left navigation rail — three-pane model view) ✅ complete  
+**Test status (2026-06-25):** All 152 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A124–A136 added for the left navigation rail / three-pane model view)
+
+---
+
+## Group G — Left navigation rail, three-pane model view (#2355 follow-up, 2026-06-25)
+
+fl0rianr posted a canonical three-pane target: a NEW left **navigation** rail (`ModelNavRail.tsx`) + the existing `ModelListPanel.tsx` (middle, unchanged in layout) + `ModelDetailPanel.tsx` (right). The rail surfaces filter dimensions — primary nav, collapsible Categories, a Backends select, collapsible Tags, and a Storage meter — all derived **client-side** from the model list the prototype already loads (no lemond). Selecting any dimension filters the middle list via shared predicates exported from `ModelListPanel.tsx`.
+
+### G1 — Primary navigation list
+
+- **Status:** ✅ **Implemented 2026-06-25**
+- **What:** `<nav class="model-nav-rail" aria-label="Model filters">` contains a `<ul role="list">` of `<button>`s (All Models / Downloaded / My Models / Favorites). The active item exposes `aria-current="true"`. Each button has a visible count chip plus an `sr-only` "N models" phrase, so the count is never conveyed by the digit alone. Buttons are natively keyboard operable (focus + Enter/Space).
+- **WCAG:** 1.3.1, 1.4.1 (count not the only signal), 2.1.1, 4.1.2
+
+### G2 — Collapsible Categories & Tags sections
+
+- **Status:** ✅ **Implemented 2026-06-25**
+- **What:** Each section header is an `<h2>` wrapping a `<button aria-expanded aria-controls>` that toggles the body (`#nav-categories`, `#nav-tags`). Category items are buttons in a `<ul role="list">` with `aria-current` on the active one. Tag chips are `<button aria-pressed>` inside a `role="group"` labelled "Filter by tag"; selecting a chip filters the middle list and toggling re-selects/clears.
+- **WCAG:** 1.3.1, 2.1.1, 4.1.2
+
+### G3 — Backends select
+
+- **Status:** ✅ **Implemented 2026-06-25**
+- **What:** `<select id="nav-backend-select">` associated with `<label for="nav-backend-select">Backends</label>`. Options are distinct recipes (with counts) derived from the model list; selecting one filters the middle list by recipe.
+- **WCAG:** 1.3.1, 2.1.1, 4.1.2
+
+### G4 — Storage meter
+
+- **Status:** ✅ **Implemented 2026-06-25**
+- **What:** `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax`, an `aria-valuetext`, and an `aria-label="Model storage used"`. Used space is derived from downloaded model sizes when present; total capacity is a **MOCK** placeholder (`512 GB`) because no client-available disk-usage source exists and lemond is off-limits.
+- **WCAG:** 1.3.1, 4.1.2
+
+### G5 — Custom-model buttons moved to the top
+
+- **Status:** ✅ **Implemented 2026-06-25**
+- **What:** The "+ Custom model" / "+ Omni collection" buttons moved from the bottom footer of `ModelListPanel` to a grounded `role="group"` (`.model-list-panel__add-group`, with its own background) at the **top** of the list area, per fl0rianr. Both remain keyboard reachable.
+- **WCAG:** 1.4.1, 2.1.1
+
+### G6 — Responsive nav-rail toggle
+
+- **Status:** ✅ **Implemented 2026-06-25**
+- **What:** At ≤700px the rail is hidden behind a `.manager__nav-toggle` button (`aria-expanded`, `aria-controls="model-nav-rail"`) that stacks the rail above the list when opened. Keeps the list-first → tap-to-detail responsive pattern intact and the rail keyboard reachable.
+- **WCAG:** 1.4.10 (Reflow), 2.1.1, 4.1.2
+
+### G7 — Status dot retained (no "Downloaded" badge)
+
+- **Status:** ✅ **Confirmed 2026-06-25**
+- **What:** Per fl0rianr, downloaded status stays a simple dot (`.model-list-item__dot--ready`) rather than a separate text badge. Status remains in each row's `aria-label`.
+- **WCAG:** 1.4.1
+
+**Note (POC / deferred):** The rail's top "Search presets…" input + "+ New" button are accessible POC placeholders (labelled input, `aria-label`ed button); preset management lives in the model-detail Presets tab per fl0rianr's "2) a". Wiring of preset quick-create is deferred and flagged for fl0rianr's confirmation.
+
+**Tests added:** A124–A136 (13 tests) in `tests/a11y.spec.ts`.
+- A124: rail `<nav>` landmark with accessible name
+- A125–A127: primary nav counts (not sole signal), `aria-current` + list filtering, keyboard operability
+- A128–A129: collapsible Categories (`aria-expanded` toggle) + category filtering
+- A130: labelled Backends select filters by recipe
+- A131: Tags `aria-pressed` chips filter the list
+- A132: Storage meter `role="progressbar"` value range + accessible name
+- A133: custom-model buttons grounded group at the top, keyboard reachable
+- A134: responsive nav toggle (`aria-controls`/`aria-expanded`) reveals the rail
+- A135: full three-pane view passes WCAG 2.1 AA axe-core scan
+- A136: preset quick-search input is labelled
 
 ---
 

--- a/prototype/ui-redesign/ACCESSIBILITY.md
+++ b/prototype/ui-redesign/ACCESSIBILITY.md
@@ -4,7 +4,7 @@
 **Branch:** `feat/gui3-model-detail-redesign`  
 **Scope:** `prototype/ui-redesign/` only  
 **Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete  
-**Test status (2026-06-25):** All 131 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A106–A115 added for reconciliation)
+**Test status (2026-06-25):** All 133 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A116–A117 added for README raw-HTML rendering fix)
 
 ---
 
@@ -89,6 +89,21 @@ Closes 4 gaps against @fl0rianr's six-point clarification comment (2026-06-25T16
 - A114–A115: preset Change button ARIA attributes, chooser dialog opens/closes with focus
 
 **Files changed:** `ModelDetailPanel.tsx`, `ModelListPanel.tsx`, `ModelManager.tsx`, `styles/styles.css`, `tests/a11y.spec.ts`, `ACCESSIBILITY.md`.
+
+---
+
+### Group G — Model README raw-HTML rendering (#2355 README tab fix)
+
+- **Status:** ✅ **Added 2026-06-25**
+- **Problem:** The README tab built its markdown-it instance with `{ html: false }`, which *escaped* any raw HTML embedded in Hugging Face model READMEs (e.g. `<div align="center">`, `<img>`, badges, tables). The user saw literal `<div ...>` tags as text instead of formatted content.
+- **Fix:** `ModelDetailPanel.tsx` — flipped the README `MarkdownIt` instance to `{ html: true }`. This is safe because the rendered output already passes through the strict `README_PURIFY_CONFIG` DOMPurify allowlist (no `script`/`style`/`iframe`/`object`/`form`/event-handler attrs) before `dangerouslySetInnerHTML` injection — the same render→sanitize pattern used in `MarkdownMessage.tsx`. Added a defensive `stripFrontmatter()` helper that removes a well-formed leading YAML frontmatter block (`---` … `---`) so HF metadata does not render as a stray `<hr>` + dumped key/value text. Conservatively widened the allowlist with common, safe tags (`tfoot`, `caption`, `colgroup`, `col`, `picture`, `source`, `sup`, `sub`, `kbd`, `samp`, `var`) and attrs (`srcset`, `align`, `colspan`, `rowspan`).
+- **WCAG:** 1.3.1 (info & relationships — semantic structure now renders instead of literal markup text)
+
+**Tests added:** A116–A117 (2 tests) in `tests/a11y.spec.ts`.
+- A116: raw HTML in a README renders as real DOM elements (`div[align]`, `strong`, `img`) and NOT as escaped/literal `<div`/`&lt;div` text. HF README fetch mocked via Playwright route.
+- A117: a leading YAML frontmatter block is stripped — the real heading renders and frontmatter keys (`license:`, `pipeline_tag`) are not shown.
+
+**Files changed:** `ModelDetailPanel.tsx`, `tests/a11y.spec.ts`, `ACCESSIBILITY.md`.
 
 ---
 
@@ -737,4 +752,4 @@ Tests A25–A27 only verify that the aria-live regions **exist**. Verifying that
 
 ---
 
-*Last updated: 2026-06-22 by Mattingly (GUI3 preset a11y items #2338 #2339 #2345 #2350 #2352; BackendManager #2343 #2344 #2351; model row qualified names #2341; download progress bar semantics #2342; Group E: conversation rail listbox + account menu modal dialog; Group F: combobox semantics, durable form labels, icon names)*
+*Last updated: 2026-06-25 by Mattingly (Group G: model README raw-HTML rendering fix #2355 — markdown-it html:true behind DOMPurify allowlist + YAML frontmatter strip; tests A116–A117)*

--- a/prototype/ui-redesign/src/App.tsx
+++ b/prototype/ui-redesign/src/App.tsx
@@ -316,6 +316,18 @@ const App: React.FC = () => {
     return () => window.removeEventListener('hashchange', onHashChange);
   }, []);
 
+  // Client-local in-app deep-link: components dispatch
+  // `lemonade:navigate` with { view } to switch views without involving lemond.
+  useEffect(() => {
+    const onAppNavigate = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { view?: string } | undefined;
+      const target = detail?.view;
+      if (target && (VALID_VIEWS as string[]).includes(target)) setView(target as View);
+    };
+    window.addEventListener('lemonade:navigate', onAppNavigate as EventListener);
+    return () => window.removeEventListener('lemonade:navigate', onAppNavigate as EventListener);
+  }, [setView]);
+
   useEffect(() => {
     const unsubStatus = api.onStatusChange(setStatus);
     const refreshGlobalModels = () => {

--- a/prototype/ui-redesign/src/api.ts
+++ b/prototype/ui-redesign/src/api.ts
@@ -134,6 +134,12 @@ export interface ModelsData {
   data: ModelInfo[];
 }
 
+/** Real disk usage for the model-storage drive (bytes). */
+export interface StorageInfo {
+  usedBytes: number;
+  totalBytes: number;
+}
+
 export interface CloudProviderRow {
   name: string;
   base_url: string;
@@ -969,6 +975,39 @@ class LemonadeAPI {
     const data = await this._json<Record<string, unknown>>('/api/v1/system-info');
     this._systemInfoData = data;
     return data;
+  }
+
+  /**
+   * Real used/total bytes of the drive where models are stored.
+   *
+   * POC LIMITATION (fl0rianr #2424): lemond is OFF LIMITS and exposes no
+   * disk-usage field today (verified: /system-info and /system-stats lack it).
+   * This probes system-info for a future `storage` / `disk` shape so the meter
+   * lights up the moment the backend team adds it — no client changes needed.
+   * Returns null when no real source is reachable, letting the UI fall back to a
+   * derived estimate instead of a hardcoded mock.
+   */
+  async getStorageInfo(): Promise<StorageInfo | null> {
+    try {
+      const info = await this.systemInfo();
+      const candidates = [
+        (info as any).storage,
+        (info as any).disk,
+        (info as any).model_storage,
+        (info as any).Storage,
+      ];
+      for (const c of candidates) {
+        if (!isObject(c)) continue;
+        const total = Number((c as any).total_bytes ?? (c as any).totalBytes ?? (c as any).total);
+        const used = Number((c as any).used_bytes ?? (c as any).usedBytes ?? (c as any).used);
+        if (Number.isFinite(total) && total > 0 && Number.isFinite(used) && used >= 0) {
+          return { usedBytes: used, totalBytes: total };
+        }
+      }
+    } catch {
+      /* unreachable in the browser-served POC — fall through to null */
+    }
+    return null;
   }
 
 

--- a/prototype/ui-redesign/src/components/Icon.tsx
+++ b/prototype/ui-redesign/src/components/Icon.tsx
@@ -10,6 +10,7 @@ export type IconName =
   | 'search' | 'search-check' | 'edit' | 'download' | 'play' | 'pause' | 'trash' | 'rotate-ccw' | 'chevron-down' | 'chevron-right' | 'plug' | 'box' | 'alert' | 'clock'
   | 'citrus' | 'scale' | 'scan-eye' | 'gem' | 'gauge' | 'timer' | 'pen-line' | 'library'
   | 'hard-drive' | 'sliders-horizontal' | 'flame' | 'wrench' | 'brain' | 'rocket' | 'pin'
+  | 'star' | 'hugging-face'
   | 'speech' | 'book-open' | 'newspaper' | 'github' | 'discord' | 'funnel';
 
 interface IconProps {
@@ -81,6 +82,8 @@ export const Icon: React.FC<IconProps> = ({ name, size = 16, className, title })
       case 'brain': return <><path d="M9 4a3 3 0 00-3 3v.4A3.5 3.5 0 003.5 11 3.5 3.5 0 006 14.4V17a3 3 0 003 3" /><path d="M15 4a3 3 0 013 3v.4a3.5 3.5 0 012.5 3.6 3.5 3.5 0 01-2.5 3.4V17a3 3 0 01-3 3" /><path d="M9 4v16M15 4v16M9 8h2M13 8h2M9 12h2M13 12h2M9 16h2M13 16h2" /></>;
       case 'rocket': return <><path d="M5 19c1.5-.4 2.8-1.2 3.8-2.2" /><path d="M15 14l-5-5c1.8-3.2 4.8-5.3 9-6 0 4.2-2 7.2-5.2 9" /><path d="M9 15l-3 3" /><path d="M14 9h.01" /><path d="M7 11l-3 1 2-4 4-2" /><path d="M13 17l-1 3 4-2 2-4" /></>;
       case 'pin': return <><path d="M12 17v5" /><path d="M5 17h14v-2l-4-4V5l2-2V2H7v1l2 2v6l-4 4v2z" /></>;
+      case 'star': return <path d="M12 2.5l2.9 6.1 6.6.7-4.9 4.5 1.3 6.5L12 17.8 6.1 20.8l1.3-6.5-4.9-4.5 6.6-.7z" />;
+      case 'hugging-face': return <><circle cx="12" cy="12" r="9" /><path d="M8.5 14a4 4 0 007 0" /><path d="M9 10h.01" /><path d="M15 10h.01" /></>;
       case 'speech': return <><path d="M21 15a4 4 0 01-4 4H8l-5 3V7a4 4 0 014-4h10a4 4 0 014 4z" /><path d="M8 9h8" /><path d="M8 13h5" /></>;
       case 'book-open': return <><path d="M12 7v14" /><path d="M3 5.5A2.5 2.5 0 015.5 3H12v18H5.5A2.5 2.5 0 013 18.5z" /><path d="M21 5.5A2.5 2.5 0 0018.5 3H12v18h6.5a2.5 2.5 0 002.5-2.5z" /></>;
       case 'newspaper': return <><path d="M4 5h13a3 3 0 013 3v11H7a3 3 0 01-3-3z" /><path d="M4 16a3 3 0 003 3" /><path d="M8 8h6" /><path d="M8 12h8" /><path d="M8 15h5" /></>;
@@ -99,12 +102,13 @@ export const Icon: React.FC<IconProps> = ({ name, size = 16, className, title })
   );
 };
 
-export type CapabilityIconTarget = ModelCapability | 'all' | 'vision' | 'code' | 'transcription' | 'popular' | 'tools' | 'reasoning' | 'mtp';
+export type CapabilityIconTarget = ModelCapability | 'all' | 'vision' | 'code' | 'transcription' | 'popular' | 'tool' | 'tools' | 'reasoning' | 'mtp';
 
 export function capabilityIconName(capability: CapabilityIconTarget): IconName {
   switch (capability) {
     case 'all': return 'globe';
     case 'popular': return 'flame';
+    case 'tool': return 'wrench';
     case 'tools': return 'wrench';
     case 'reasoning': return 'brain';
     case 'mtp': return 'rocket';

--- a/prototype/ui-redesign/src/components/Icon.tsx
+++ b/prototype/ui-redesign/src/components/Icon.tsx
@@ -10,7 +10,7 @@ export type IconName =
   | 'search' | 'search-check' | 'edit' | 'download' | 'play' | 'pause' | 'trash' | 'rotate-ccw' | 'chevron-down' | 'chevron-right' | 'plug' | 'box' | 'alert' | 'clock'
   | 'citrus' | 'scale' | 'scan-eye' | 'gem' | 'gauge' | 'timer' | 'pen-line' | 'library'
   | 'hard-drive' | 'sliders-horizontal' | 'flame' | 'wrench' | 'brain' | 'rocket' | 'pin'
-  | 'speech' | 'book-open' | 'newspaper' | 'github' | 'discord';
+  | 'speech' | 'book-open' | 'newspaper' | 'github' | 'discord' | 'funnel';
 
 interface IconProps {
   name: IconName;
@@ -86,6 +86,7 @@ export const Icon: React.FC<IconProps> = ({ name, size = 16, className, title })
       case 'newspaper': return <><path d="M4 5h13a3 3 0 013 3v11H7a3 3 0 01-3-3z" /><path d="M4 16a3 3 0 003 3" /><path d="M8 8h6" /><path d="M8 12h8" /><path d="M8 15h5" /></>;
       case 'github': return <><path d="M9 19c-4.5 1.4-4.5-2.2-6-2.7" /><path d="M15 22v-3.9a3.4 3.4 0 00-.9-2.6c3-.3 6.1-1.5 6.1-6.7a5.2 5.2 0 00-1.4-3.6 4.8 4.8 0 00-.1-3.6s-1.1-.4-3.7 1.4a12.8 12.8 0 00-6.7 0C5.7.2 4.6.6 4.6.6a4.8 4.8 0 00-.1 3.6A5.2 5.2 0 003.1 7.8c0 5.2 3.1 6.4 6.1 6.7a3 3 0 00-.8 1.8V22" /></>;
       case 'discord': return <><path d="M8.6 7.5a11 11 0 016.8 0" /><path d="M7.2 18.5c-1.5-.4-2.8-1.1-4-2.2.4-4.2 1.5-7.5 3.4-10a12.9 12.9 0 013.5-1.1l.4.8a11.8 11.8 0 013 0l.4-.8a12.9 12.9 0 013.5 1.1c1.9 2.5 3 5.8 3.4 10a10.2 10.2 0 01-4 2.2l-.9-1.4a9.5 9.5 0 01-7.8 0z" /><circle cx="9.5" cy="12.5" r="1" /><circle cx="14.5" cy="12.5" r="1" /></>;
+      case 'funnel': return <path d="M3 4h18l-7 9v6l-4-2V13L3 4z" />;
       default: return <><rect x="5" y="5" width="14" height="14" rx="3" /><path d="M9 9h6v6H9z" /></>;
     }
   })();

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -470,6 +470,10 @@ export interface ModelDetailPanelProps {
   onDelete: (model: ModelInfo) => void;
   onCancelPull: (name: string) => void;
   serverDefaultCtxSize: number;
+  /** Whether this model is currently marked a favorite (client-local pin store). */
+  isFavorite?: boolean;
+  /** Toggle this model's favorite/pin state. Receives the model name. */
+  onToggleFavorite?: (name: string) => void;
   /** Called when the "Back to models" button is clicked (narrow viewports). */
   onBack?: () => void;
 }
@@ -494,6 +498,8 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   onPullAndLoad,
   onDelete,
   onCancelPull,
+  isFavorite = false,
+  onToggleFavorite,
   onBack,
 }) => {
   const [activeTab, setActiveTab] = useState<DetailTab>('readme');
@@ -606,6 +612,18 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
 
         {/* Primary actions */}
         <div className="model-detail-panel__actions" aria-label={`Actions for ${name}`}>
+          {onToggleFavorite && (
+            <button
+              type="button"
+              className={`model-detail-panel__fav-btn${isFavorite ? ' model-detail-panel__fav-btn--on' : ''}`}
+              onClick={() => onToggleFavorite(name)}
+              aria-pressed={isFavorite}
+              aria-label={isFavorite ? `Remove ${name} from favorites` : `Add ${name} to favorites`}
+              title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+            >
+              <span aria-hidden="true" className="model-detail-panel__fav-icon">{isFavorite ? '★' : '☆'}</span>
+            </button>
+          )}
           {isPulling ? (
             <>
               <div className="row__progress">

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -253,6 +253,11 @@ const ModelPresetsTab: React.FC<{
     requestAnimationFrame(() => changeBtnRef.current?.focus());
   }, []);
 
+  const navigateToPresets = useCallback(() => {
+    // Client-local deep-link to the global Presets page (no lemond involvement).
+    window.dispatchEvent(new CustomEvent('lemonade:navigate', { detail: { view: 'presets' } }));
+  }, []);
+
   if (!isActive) return null;
 
   const previewLines = effectivePresetParamPreviewLines(linkedPreset, model, undefined);
@@ -268,7 +273,7 @@ const ModelPresetsTab: React.FC<{
       <section className="detail-presets__linked-section" aria-label="Linked preset">
         <h3 className="detail-presets__section-title">Linked preset</h3>
         <div
-          className="detail-presets__linked-card"
+          className="detail-presets__card detail-presets__linked-card"
           aria-current="true"
           aria-label={`Active preset: ${linkedPreset.name}`}
         >
@@ -281,9 +286,9 @@ const ModelPresetsTab: React.FC<{
             <p className="detail-presets__card-desc">{linkedPreset.description}</p>
           )}
           {previewLines.length > 0 && (
-            <div className="detail-presets__card-params" aria-label="Preset parameters">
-              {previewLines.map(line => <span key={line} className="detail-presets__param-line">{line}</span>)}
-            </div>
+            <p className="detail-presets__card-meta" aria-label="Preset parameters">
+              {previewLines.join(' · ')}
+            </p>
           )}
           {linkedPreset.id !== DEFAULT_PRESET.id && (
             <div className="detail-presets__linked-actions">
@@ -362,58 +367,79 @@ const ModelPresetsTab: React.FC<{
         )}
       </section>
 
-      {/* Compatible presets */}
+      {/* Recommended / compatible presets — a neat grid of compact cards */}
       {compatiblePresets.length > 0 && (
-        <section className="detail-presets__recommended-section" aria-label="Compatible presets">
-          <h3 className="detail-presets__section-title">Compatible presets</h3>
-          <div
-            className="detail-presets__preset-list"
-            role="listbox"
-            aria-label="Compatible presets — select to attach"
+        <section className="detail-presets__recommended-section" aria-label="Recommended presets">
+          <div className="detail-presets__section-head">
+            <h3 className="detail-presets__section-title">Recommended presets</h3>
+            <button
+              type="button"
+              className="btn btn--ghost btn--tiny detail-presets__browse-btn"
+              onClick={navigateToPresets}
+              aria-label="Browse all presets in the Presets page"
+            >
+              Browse presets
+            </button>
+          </div>
+          <ul
+            className="detail-presets__preset-grid"
+            role="list"
+            aria-label="Recommended presets — select to attach"
           >
             {compatiblePresets.map(preset => {
               const isLinked = preset.id === linkedPresetId;
               const paramLines = effectivePresetParamPreviewLines(preset, model, undefined);
               return (
-                <div
+                <li
                   key={preset.id}
-                  role="option"
-                  aria-selected={isLinked}
-                  className={`detail-presets__preset-card${isLinked ? ' detail-presets__preset-card--selected' : ''}`}
+                  aria-current={isLinked ? 'true' : undefined}
+                  className={`detail-presets__card detail-presets__preset-card detail-presets__preset-card--sm${isLinked ? ' detail-presets__preset-card--selected' : ''}`}
                   aria-label={`${preset.name}${isLinked ? ' (currently linked)' : ''}`}
                 >
                   <div className="detail-presets__card-header">
                     <PresetIcon preset={preset} size={13} />
                     <strong className="detail-presets__card-name">{preset.name}</strong>
-                    {isLinked && <span className="detail-presets__card-badge detail-presets__card-badge--linked" aria-hidden="true">Linked</span>}
+                    {isLinked && <span className="detail-presets__card-badge detail-presets__card-badge--linked">Linked</span>}
                   </div>
                   {preset.description && (
                     <p className="detail-presets__card-desc">{preset.description}</p>
                   )}
                   {paramLines.length > 0 && (
-                    <div className="detail-presets__card-params">
-                      {paramLines.map(line => <span key={line} className="detail-presets__param-line">{line}</span>)}
-                    </div>
+                    <p className="detail-presets__card-meta">{paramLines.join(' · ')}</p>
                   )}
-                  {!isLinked && (
-                    <button
-                      type="button"
-                      className="btn btn--primary btn--tiny detail-presets__attach-btn"
-                      onClick={() => handleAttach(preset)}
-                      aria-label={`${linkedPreset.id !== DEFAULT_PRESET.id ? 'Switch to' : 'Attach'} preset "${preset.name}" for ${name}`}
-                    >
-                      {linkedPreset.id !== DEFAULT_PRESET.id ? 'Switch' : 'Attach'}
-                    </button>
-                  )}
-                </div>
+                  <div className="detail-presets__card-footer">
+                    {isLinked ? (
+                      <span className="detail-presets__card-linked-note">Currently linked</span>
+                    ) : (
+                      <button
+                        type="button"
+                        className="btn btn--primary btn--tiny detail-presets__attach-btn"
+                        onClick={() => handleAttach(preset)}
+                        aria-label={`${linkedPreset.id !== DEFAULT_PRESET.id ? 'Switch to' : 'Attach'} preset "${preset.name}" for ${name}`}
+                      >
+                        {linkedPreset.id !== DEFAULT_PRESET.id ? 'Switch' : 'Attach'}
+                      </button>
+                    )}
+                  </div>
+                </li>
               );
             })}
-          </div>
+          </ul>
         </section>
       )}
 
       {compatiblePresets.length === 0 && (
-        <p className="detail-presets__empty">No compatible presets found. Create a preset in the Presets page and set the model type to match this model.</p>
+        <div className="detail-presets__empty-block">
+          <p className="detail-presets__empty">No compatible presets found. Create a preset in the Presets page and set the model type to match this model.</p>
+          <button
+            type="button"
+            className="btn btn--ghost btn--tiny detail-presets__browse-btn"
+            onClick={navigateToPresets}
+            aria-label="Manage presets in the Presets page"
+          >
+            Manage presets
+          </button>
+        </div>
       )}
     </div>
   );

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -75,19 +75,45 @@ function deriveHFRepo(
 
 /* ── Shared markdown-it instance for README rendering ─────────── */
 
-const readmeMd = new MarkdownIt({ html: false, linkify: true, typographer: true });
+// html:true is safe here because the rendered output is passed through the
+// strict DOMPurify allowlist (README_PURIFY_CONFIG) below before injection.
+// HF model READMEs commonly embed raw HTML (<div align="center">, <img>,
+// tables, badges); with html:false markdown-it escapes those to literal text.
+const readmeMd = new MarkdownIt({ html: true, linkify: true, typographer: true });
 
 const README_PURIFY_CONFIG: DOMPurify.Config = {
   ALLOWED_TAGS: [
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'br', 'hr',
     'ul', 'ol', 'li', 'dl', 'dt', 'dd',
-    'table', 'thead', 'tbody', 'tr', 'th', 'td',
-    'div', 'span', 'a', 'img',
+    'table', 'thead', 'tbody', 'tfoot', 'tr', 'th', 'td', 'caption', 'colgroup', 'col',
+    'div', 'span', 'a', 'img', 'picture', 'source',
     'strong', 'em', 'b', 'i', 'u', 's', 'del', 'mark', 'code', 'pre',
+    'sup', 'sub', 'kbd', 'samp', 'var',
     'blockquote', 'details', 'summary', 'figure', 'figcaption', 'abbr',
   ],
-  ALLOWED_ATTR: ['class', 'href', 'target', 'rel', 'src', 'alt', 'title', 'width', 'height'],
+  ALLOWED_ATTR: ['class', 'href', 'target', 'rel', 'src', 'srcset', 'alt', 'title', 'width', 'height', 'align', 'colspan', 'rowspan'],
 };
+
+/**
+ * Strip a leading YAML frontmatter block from an HF README.
+ * HF READMEs begin with metadata delimited by `---` ... `---`. With html:true
+ * this would otherwise render as a stray <hr> plus dumped key/value text.
+ * Defensive: only strips a well-formed leading block; never throws.
+ */
+function stripFrontmatter(source: string): string {
+  if (typeof source !== 'string') return '';
+  const leading = source.replace(/^\s+/, '');
+  if (!leading.startsWith('---\n') && !leading.startsWith('---\r\n')) return source;
+  const lines = leading.split('\n');
+  // lines[0] is the opening '---'; find the next line that is exactly '---'.
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].replace(/\r$/, '').trim() === '---') {
+      return lines.slice(i + 1).join('\n');
+    }
+  }
+  // No closing delimiter found: not a well-formed block, leave untouched.
+  return source;
+}
 
 const readmeCache = new Map<string, string>();
 
@@ -144,7 +170,7 @@ const ModelReadmeTab: React.FC<{ model: ModelInfo | null | undefined; isActive: 
     );
   }
 
-  const html = DOMPurify.sanitize(readmeMd.render(readme), README_PURIFY_CONFIG);
+  const html = DOMPurify.sanitize(readmeMd.render(stripFrontmatter(readme)), README_PURIFY_CONFIG);
 
   return (
     <div

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -476,6 +476,9 @@ export interface ModelDetailPanelProps {
   onToggleFavorite?: (name: string) => void;
   /** Called when the "Back to models" button is clicked (narrow viewports). */
   onBack?: () => void;
+  /** True when the registry has no models at all (empty state guidance differs
+      from the normal "nothing selected yet" copy). */
+  noModelsAvailable?: boolean;
 }
 
 type DetailTab = 'readme' | 'presets' | 'files';
@@ -501,6 +504,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   isFavorite = false,
   onToggleFavorite,
   onBack,
+  noModelsAvailable = false,
 }) => {
   const [activeTab, setActiveTab] = useState<DetailTab>('readme');
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -540,7 +544,12 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
         )}
         <div className="model-detail-panel__placeholder">
           <Icon name="model" size={40} aria-hidden="true" />
-          <p>Select a model to view details</p>
+          <p>{noModelsAvailable ? 'No models found' : 'No model selected'}</p>
+          <p className="model-detail-panel__placeholder-sub">
+            {noModelsAvailable
+              ? 'No models are available in the registry yet. Pull a model or adjust your filters to get started.'
+              : 'Select a model from the list to view its details.'}
+          </p>
         </div>
       </div>
     );

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -1,0 +1,556 @@
+/**
+ * ModelDetailPanel — right-side detail view for the selected model.
+ * Contains: header (title, metadata, primary actions) + tablist (README / Presets / Files).
+ *
+ * Part of the master-detail layout introduced in #2355 Slice 1.
+ */
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import MarkdownIt from 'markdown-it';
+import DOMPurify from 'dompurify';
+import type { ModelInfo, LoadedModel } from '../api';
+import { capabilityFromModelInfo, capabilityLabel } from '../modelCapabilities';
+import {
+  DEFAULT_PRESET, PRESET_STORE_EVENT, Preset,
+  allStoredPresets, isCompatible, loadApplied, saveApplied,
+  effectivePresetParamPreviewLines,
+} from '../presetStore';
+import { Icon, CapabilityIcon, PresetIcon } from './Icon';
+
+/* ── Helpers (local copies to keep component self-contained) ──── */
+
+function mdName(m: ModelInfo | null | undefined): string {
+  if (!m) return '';
+  return String((m as any).model_name ?? m.name ?? m.id ?? '').trim();
+}
+
+function fmtSize(gb: number): string {
+  if (!Number.isFinite(gb) || gb <= 0) return '';
+  if (gb >= 1) return `${gb.toFixed(1)} GB`;
+  if (gb >= 0.01) return `${(gb * 1000).toFixed(0)} MB`;
+  return '< 1 MB';
+}
+
+function recipeDisplayLabel(recipe: string): string {
+  const n = String(recipe || '').toLowerCase();
+  switch (n) {
+    case 'llamacpp': return 'llama.cpp';
+    case 'vllm': return 'vLLM';
+    case 'flm': return 'FastFlowLM';
+    case 'ryzenai-llm': return 'RyzenAI';
+    case 'sd-cpp': return 'Stable Diffusion';
+    case 'whispercpp': return 'Whisper';
+    case 'moonshine': return 'Moonshine';
+    case 'kokoro': return 'Kokoro TTS';
+    case 'collection.omni': return 'Omni Collection';
+    case 'collection': return 'Collection';
+    default: return recipe || 'Unknown';
+  }
+}
+
+function hfReadmeUrl(checkpoint: string): string | null {
+  if (!checkpoint) return null;
+  const repo = checkpoint.split(':')[0];
+  if (!repo.includes('/')) return null;
+  return `https://huggingface.co/${repo}/raw/main/README.md`;
+}
+
+/* ── Shared markdown-it instance for README rendering ─────────── */
+
+const readmeMd = new MarkdownIt({ html: false, linkify: true, typographer: true });
+
+const README_PURIFY_CONFIG: DOMPurify.Config = {
+  ALLOWED_TAGS: [
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'br', 'hr',
+    'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td',
+    'div', 'span', 'a', 'img',
+    'strong', 'em', 'b', 'i', 'u', 's', 'del', 'mark', 'code', 'pre',
+    'blockquote', 'details', 'summary', 'figure', 'figcaption', 'abbr',
+  ],
+  ALLOWED_ATTR: ['class', 'href', 'target', 'rel', 'src', 'alt', 'title', 'width', 'height'],
+};
+
+const readmeCache = new Map<string, string>();
+
+/* ── README tab ──────────────────────────────────────────────── */
+
+const ModelReadmeTab: React.FC<{ checkpoint: string | undefined | null; isActive: boolean }> = ({ checkpoint, isActive }) => {
+  const [readme, setReadme] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isActive) return;
+    if (!checkpoint) { setReadme(''); return; }
+    const url = hfReadmeUrl(checkpoint);
+    if (!url) { setReadme(''); return; }
+
+    const cached = readmeCache.get(checkpoint);
+    if (cached !== undefined) { setReadme(cached); return; }
+
+    let cancelled = false;
+    setLoading(true);
+    fetch(url)
+      .then(r => r.ok ? r.text() : null)
+      .then(text => {
+        if (cancelled) return;
+        const content = text || '';
+        readmeCache.set(checkpoint, content);
+        setReadme(content);
+      })
+      .catch(() => {
+        if (!cancelled) { readmeCache.set(checkpoint ?? '', ''); setReadme(''); }
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [checkpoint, isActive]);
+
+  if (loading) {
+    return (
+      <div className="detail-tab-content detail-readme detail-readme--loading" aria-live="polite" aria-busy="true">
+        <span>Loading README…</span>
+      </div>
+    );
+  }
+
+  if (!readme) {
+    return (
+      <div className="detail-tab-content detail-readme detail-readme--empty">
+        <Icon name="book-open" size={32} aria-hidden="true" />
+        <p>README unavailable for this model.</p>
+      </div>
+    );
+  }
+
+  const html = DOMPurify.sanitize(readmeMd.render(readme), README_PURIFY_CONFIG);
+
+  return (
+    <div
+      className="detail-tab-content detail-readme"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+};
+
+/* ── Presets tab ─────────────────────────────────────────────── */
+
+const ModelPresetsTab: React.FC<{
+  model: ModelInfo;
+  isActive: boolean;
+}> = ({ model, isActive }) => {
+  const name = mdName(model);
+  const [allPresets, setAllPresets] = useState<Preset[]>(() => allStoredPresets());
+  const [appliedPresets, setAppliedPresets] = useState<Record<string, string>>(() => loadApplied());
+  const [notice, setNotice] = useState<string | null>(null);
+  const liveRef = useRef<HTMLDivElement>(null);
+
+  // Reload when preset store changes
+  useEffect(() => {
+    const handler = () => {
+      setAllPresets(allStoredPresets());
+      setAppliedPresets(loadApplied());
+    };
+    window.addEventListener(PRESET_STORE_EVENT, handler);
+    return () => window.removeEventListener(PRESET_STORE_EVENT, handler);
+  }, []);
+
+  const linkedPresetId = appliedPresets[name] || DEFAULT_PRESET.id;
+  const linkedPreset = allPresets.find(p => p.id === linkedPresetId) || DEFAULT_PRESET;
+
+  const compatiblePresets = useMemo(
+    () => allPresets.filter(p => p.id !== DEFAULT_PRESET.id && isCompatible(p, model)),
+    [allPresets, model],
+  );
+
+  const handleAttach = useCallback((preset: Preset) => {
+    if (!name) return;
+    setAppliedPresets(prev => {
+      const next = { ...prev };
+      if (preset.id === DEFAULT_PRESET.id) delete next[name];
+      else next[name] = preset.id;
+      saveApplied(next);
+      return next;
+    });
+    const msg = preset.id === DEFAULT_PRESET.id
+      ? `Reset to default preset for ${name}`
+      : `Attached "${preset.name}" to ${name}`;
+    setNotice(msg);
+    setTimeout(() => setNotice(null), 2500);
+  }, [name]);
+
+  if (!isActive) return null;
+
+  const previewLines = effectivePresetParamPreviewLines(linkedPreset, model, undefined);
+
+  return (
+    <div className="detail-tab-content detail-presets">
+      {/* Always-present live region for attachment announcements */}
+      <div ref={liveRef} role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {notice || ''}
+      </div>
+
+      {/* Linked preset */}
+      <section className="detail-presets__linked-section" aria-label="Linked preset">
+        <h3 className="detail-presets__section-title">Linked preset</h3>
+        <div
+          className="detail-presets__linked-card"
+          aria-current="true"
+          aria-label={`Active preset: ${linkedPreset.name}`}
+        >
+          <div className="detail-presets__card-header">
+            <PresetIcon preset={linkedPreset} size={14} />
+            <strong className="detail-presets__card-name">{linkedPreset.name}</strong>
+            <span className="detail-presets__card-badge detail-presets__card-badge--linked">Active</span>
+          </div>
+          {linkedPreset.description && (
+            <p className="detail-presets__card-desc">{linkedPreset.description}</p>
+          )}
+          {previewLines.length > 0 && (
+            <div className="detail-presets__card-params" aria-label="Preset parameters">
+              {previewLines.map(line => <span key={line} className="detail-presets__param-line">{line}</span>)}
+            </div>
+          )}
+          {linkedPreset.id !== DEFAULT_PRESET.id && (
+            <button
+              type="button"
+              className="btn btn--ghost btn--tiny detail-presets__detach-btn"
+              onClick={() => handleAttach(DEFAULT_PRESET)}
+              aria-label={`Detach preset "${linkedPreset.name}" from ${name}, reset to default`}
+            >
+              Reset to default
+            </button>
+          )}
+        </div>
+      </section>
+
+      {/* Compatible presets */}
+      {compatiblePresets.length > 0 && (
+        <section className="detail-presets__recommended-section" aria-label="Compatible presets">
+          <h3 className="detail-presets__section-title">Compatible presets</h3>
+          <div
+            className="detail-presets__preset-list"
+            role="listbox"
+            aria-label="Compatible presets — select to attach"
+          >
+            {compatiblePresets.map(preset => {
+              const isLinked = preset.id === linkedPresetId;
+              const paramLines = effectivePresetParamPreviewLines(preset, model, undefined);
+              return (
+                <div
+                  key={preset.id}
+                  role="option"
+                  aria-selected={isLinked}
+                  className={`detail-presets__preset-card${isLinked ? ' detail-presets__preset-card--selected' : ''}`}
+                  aria-label={`${preset.name}${isLinked ? ' (currently linked)' : ''}`}
+                >
+                  <div className="detail-presets__card-header">
+                    <PresetIcon preset={preset} size={13} />
+                    <strong className="detail-presets__card-name">{preset.name}</strong>
+                    {isLinked && <span className="detail-presets__card-badge detail-presets__card-badge--linked" aria-hidden="true">Linked</span>}
+                  </div>
+                  {preset.description && (
+                    <p className="detail-presets__card-desc">{preset.description}</p>
+                  )}
+                  {paramLines.length > 0 && (
+                    <div className="detail-presets__card-params">
+                      {paramLines.map(line => <span key={line} className="detail-presets__param-line">{line}</span>)}
+                    </div>
+                  )}
+                  {!isLinked && (
+                    <button
+                      type="button"
+                      className="btn btn--primary btn--tiny detail-presets__attach-btn"
+                      onClick={() => handleAttach(preset)}
+                      aria-label={`Attach preset "${preset.name}" to ${name}`}
+                    >
+                      Attach
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {compatiblePresets.length === 0 && (
+        <p className="detail-presets__empty">No compatible presets found. Create a preset in the Presets page and set the model type to match this model.</p>
+      )}
+    </div>
+  );
+};
+
+/* ── Files tab stub ──────────────────────────────────────────── */
+
+const ModelFilesTab: React.FC = () => (
+  <div className="detail-tab-content detail-files detail-files--stub">
+    <Icon name="hard-drive" size={28} aria-hidden="true" />
+    <p>Files tab — coming in a future update.</p>
+    <small>Requires a <code>GET /api/v1/models/&#123;id&#125;/files</code> endpoint in lemond.</small>
+  </div>
+);
+
+/* ── ModelDetailPanel ────────────────────────────────────────── */
+
+export interface ModelDetailPanelProps {
+  model: ModelInfo | null;
+  loadedModel: LoadedModel | null;
+  loadingModel: string | null;
+  pulling: Record<string, number>;
+  loadError: { modelName: string; message: string } | null;
+  onLoad: (model: ModelInfo) => void;
+  onUnload: (model: LoadedModel) => void;
+  onPull: (model: ModelInfo) => void;
+  onPullAndLoad: (model: ModelInfo) => void;
+  onDelete: (model: ModelInfo) => void;
+  onCancelPull: (name: string) => void;
+  serverDefaultCtxSize: number;
+}
+
+type DetailTab = 'readme' | 'presets' | 'files';
+
+const TABS: Array<{ id: DetailTab; label: string }> = [
+  { id: 'readme', label: 'README' },
+  { id: 'presets', label: 'Presets' },
+  { id: 'files', label: 'Files' },
+];
+
+export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
+  model,
+  loadedModel,
+  loadingModel,
+  pulling,
+  loadError,
+  onLoad,
+  onUnload,
+  onPull,
+  onPullAndLoad,
+  onDelete,
+  onCancelPull,
+}) => {
+  const [activeTab, setActiveTab] = useState<DetailTab>('readme');
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const panelHeadingRef = useRef<HTMLHeadingElement>(null);
+
+  // Move focus to heading when model changes
+  useEffect(() => {
+    if (model) panelHeadingRef.current?.focus();
+  }, [model?.id]);
+
+  // Roving tabindex: keyboard navigation across tabs
+  const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    const count = TABS.length;
+    let next = -1;
+    if (e.key === 'ArrowRight') { e.preventDefault(); next = (index + 1) % count; }
+    else if (e.key === 'ArrowLeft') { e.preventDefault(); next = (index - 1 + count) % count; }
+    else if (e.key === 'Home') { e.preventDefault(); next = 0; }
+    else if (e.key === 'End') { e.preventDefault(); next = count - 1; }
+    if (next >= 0) {
+      setActiveTab(TABS[next].id);
+      tabRefs.current[next]?.focus();
+    }
+  };
+
+  if (!model) {
+    return (
+      <div className="model-detail-panel model-detail-panel--empty" aria-label="Model detail">
+        <div className="model-detail-panel__placeholder">
+          <Icon name="model" size={40} aria-hidden="true" />
+          <p>Select a model to view details</p>
+        </div>
+      </div>
+    );
+  }
+
+  const name = mdName(model);
+  const recipe = String((model as any).recipe || '');
+  const checkpoint = String((model as any).checkpoint || '');
+  const isLoaded = !!loadedModel;
+  const isLoadingThis = loadingModel === name;
+  const isPulling = pulling[name] !== undefined;
+  const pullPct = pulling[name] ?? 0;
+  const isDownloaded = Boolean((model as any).downloaded);
+  const cap = capabilityFromModelInfo(model);
+
+  return (
+    <div className="model-detail-panel" role="region" aria-label={`Model details: ${name}`}>
+
+      {/* Header */}
+      <div className="model-detail-panel__head">
+        <h2
+          className="model-detail-panel__name"
+          ref={panelHeadingRef}
+          tabIndex={-1}
+          id="detail-panel-heading"
+        >
+          {model.display_name || name}
+        </h2>
+
+        {/* Metadata row */}
+        <div className="model-detail-panel__meta">
+          {recipe && (
+            <span className="model-detail-panel__badge model-detail-panel__badge--recipe">
+              {recipeDisplayLabel(recipe)}
+            </span>
+          )}
+          {model.size != null && model.size > 0 && (
+            <span className="model-detail-panel__badge">{fmtSize(model.size)}</span>
+          )}
+          {cap && (
+            <span className="model-detail-panel__badge model-detail-panel__badge--cap">
+              <CapabilityIcon capability={cap} size={11} />
+              {capabilityLabel(cap)}
+            </span>
+          )}
+          {isLoaded && (
+            <span className="model-detail-panel__status model-detail-panel__status--running">
+              <span className="row__pulse" aria-hidden="true" /> Running
+            </span>
+          )}
+          {isDownloaded && !isLoaded && (
+            <span className="model-detail-panel__status model-detail-panel__status--ready">Ready</span>
+          )}
+        </div>
+
+        {/* Primary actions */}
+        <div className="model-detail-panel__actions" aria-label={`Actions for ${name}`}>
+          {isPulling ? (
+            <>
+              <div className="row__progress">
+                <div className="row__progress-bar">
+                  <div className="row__progress-fill" style={{ width: `${pullPct}%` }} />
+                </div>
+                <span className="row__progress-text">{pullPct.toFixed(0)}%</span>
+              </div>
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                onClick={() => onCancelPull(name)}
+                aria-label={`Cancel download of ${name}`}
+              >
+                Cancel
+              </button>
+            </>
+          ) : isLoaded ? (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm"
+              onClick={() => onUnload(loadedModel!)}
+              disabled={isLoadingThis}
+              aria-label={isLoadingThis ? `Working on ${name}…` : `Unload ${name}`}
+            >
+              {isLoadingThis ? 'Working…' : 'Unload'}
+            </button>
+          ) : isDownloaded ? (
+            <button
+              type="button"
+              className="btn btn--primary btn--sm"
+              onClick={() => onLoad(model)}
+              disabled={isLoadingThis}
+              aria-label={isLoadingThis ? `Loading ${name}…` : `Load ${name}`}
+            >
+              {isLoadingThis ? 'Loading…' : <><Icon name="play" size={13} /> Load</>}
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                className="btn btn--ghost btn--sm"
+                onClick={() => onPull(model)}
+                aria-label={`Download ${name}`}
+              >
+                <Icon name="download" size={13} /> Download
+              </button>
+              <button
+                type="button"
+                className="btn btn--primary btn--sm"
+                onClick={() => onPullAndLoad(model)}
+                aria-label={`Get and load ${name}`}
+              >
+                <Icon name="download" size={13} /> Get & Load
+              </button>
+            </>
+          )}
+          {(isDownloaded || isLoaded) && (
+            <button
+              type="button"
+              className="btn btn--ghost btn--sm btn--danger"
+              onClick={() => onDelete(model)}
+              disabled={isLoadingThis}
+              aria-label={(model as any).custom ? `Delete custom model definition for ${name}` : `Delete downloaded files for ${name}`}
+            >
+              <Icon name="trash" size={13} />
+            </button>
+          )}
+        </div>
+
+        {/* Load error */}
+        {loadError?.modelName === name && (
+          <div className="model-detail-panel__error" role="alert">
+            <Icon name="alert" size={13} /> {loadError.message}
+          </div>
+        )}
+
+        {/* HF link */}
+        {checkpoint && hfReadmeUrl(checkpoint) && (
+          <a
+            className="model-detail-panel__hf-link"
+            href={`https://huggingface.co/${checkpoint.split(':')[0]}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`View ${name} on Hugging Face (opens in new tab)`}
+          >
+            <Icon name="globe" size={12} /> Hugging Face
+          </a>
+        )}
+      </div>
+
+      {/* Tablist */}
+      <div
+        className="detail-tabs__tablist"
+        role="tablist"
+        aria-label="Model details sections"
+        aria-labelledby="detail-panel-heading"
+      >
+        {TABS.map((tab, i) => (
+          <button
+            key={tab.id}
+            ref={el => { tabRefs.current[i] = el; }}
+            role="tab"
+            id={`detail-tab-${tab.id}`}
+            aria-selected={activeTab === tab.id}
+            aria-controls={`detail-panel-${tab.id}`}
+            tabIndex={activeTab === tab.id ? 0 : -1}
+            className={`detail-tabs__tab${activeTab === tab.id ? ' detail-tabs__tab--active' : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+            onKeyDown={e => handleTabKeyDown(e, i)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab panels */}
+      {TABS.map(tab => (
+        <div
+          key={tab.id}
+          id={`detail-panel-${tab.id}`}
+          role="tabpanel"
+          aria-labelledby={`detail-tab-${tab.id}`}
+          className={`detail-tabs__panel${activeTab === tab.id ? ' detail-tabs__panel--active' : ''}`}
+          hidden={activeTab !== tab.id}
+        >
+          {tab.id === 'readme' && (
+            <ModelReadmeTab checkpoint={checkpoint} isActive={activeTab === 'readme'} />
+          )}
+          {tab.id === 'presets' && (
+            <ModelPresetsTab model={model} isActive={activeTab === 'presets'} />
+          )}
+          {tab.id === 'files' && <ModelFilesTab />}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ModelDetailPanel;

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -47,11 +47,30 @@ function recipeDisplayLabel(recipe: string): string {
   }
 }
 
-function hfReadmeUrl(checkpoint: string): string | null {
-  if (!checkpoint) return null;
-  const repo = checkpoint.split(':')[0];
-  if (!repo.includes('/')) return null;
-  return `https://huggingface.co/${repo}/raw/main/README.md`;
+/** Regex: only attempt HF README fetch when the derived value looks like `owner/repo`. */
+const HF_REPO_RE = /^[\w.-]+\/[\w.-]+$/;
+
+/**
+ * Derive the best-effort HF repo from model.checkpoint or model.checkpoints.main
+ * (falling back to the first available checkpoint value).
+ * Strips the variant/file suffix after `:`.
+ * Returns null if no valid `owner/repo` can be derived.
+ */
+function deriveHFRepo(
+  checkpoint: string | null | undefined,
+  checkpoints: Record<string, string> | null | undefined,
+): string | null {
+  const candidates: (string | undefined)[] = [
+    checkpoint ?? undefined,
+    checkpoints?.main,
+    ...(checkpoints ? Object.values(checkpoints) : []),
+  ];
+  for (const c of candidates) {
+    if (!c) continue;
+    const repo = c.split(':')[0].trim();
+    if (HF_REPO_RE.test(repo)) return repo;
+  }
+  return null;
 }
 
 /* ── Shared markdown-it instance for README rendering ─────────── */
@@ -74,36 +93,39 @@ const readmeCache = new Map<string, string>();
 
 /* ── README tab ──────────────────────────────────────────────── */
 
-const ModelReadmeTab: React.FC<{ checkpoint: string | undefined | null; isActive: boolean }> = ({ checkpoint, isActive }) => {
+const ModelReadmeTab: React.FC<{ model: ModelInfo | null | undefined; isActive: boolean }> = ({ model, isActive }) => {
+  const checkpoint = model ? String((model as any).checkpoint || '') : '';
+  const checkpoints = model ? ((model as any).checkpoints as Record<string, string> | null ?? null) : null;
+  const hfRepo = deriveHFRepo(checkpoint || null, checkpoints);
+  const readmeUrl = hfRepo ? `https://huggingface.co/${hfRepo}/raw/main/README.md` : null;
+
   const [readme, setReadme] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!isActive) return;
-    if (!checkpoint) { setReadme(''); return; }
-    const url = hfReadmeUrl(checkpoint);
-    if (!url) { setReadme(''); return; }
+    if (!readmeUrl) { setReadme(''); return; }
 
-    const cached = readmeCache.get(checkpoint);
+    const cached = readmeCache.get(readmeUrl);
     if (cached !== undefined) { setReadme(cached); return; }
 
     let cancelled = false;
     setLoading(true);
-    fetch(url)
+    fetch(readmeUrl)
       .then(r => r.ok ? r.text() : null)
       .then(text => {
         if (cancelled) return;
         const content = text || '';
-        readmeCache.set(checkpoint, content);
+        readmeCache.set(readmeUrl, content);
         setReadme(content);
       })
       .catch(() => {
-        if (!cancelled) { readmeCache.set(checkpoint ?? '', ''); setReadme(''); }
+        if (!cancelled) { readmeCache.set(readmeUrl, ''); setReadme(''); }
       })
       .finally(() => { if (!cancelled) setLoading(false); });
 
     return () => { cancelled = true; };
-  }, [checkpoint, isActive]);
+  }, [readmeUrl, isActive]);
 
   if (loading) {
     return (
@@ -142,7 +164,10 @@ const ModelPresetsTab: React.FC<{
   const [allPresets, setAllPresets] = useState<Preset[]>(() => allStoredPresets());
   const [appliedPresets, setAppliedPresets] = useState<Record<string, string>>(() => loadApplied());
   const [notice, setNotice] = useState<string | null>(null);
+  const [showChooser, setShowChooser] = useState(false);
   const liveRef = useRef<HTMLDivElement>(null);
+  const changeBtnRef = useRef<HTMLButtonElement>(null);
+  const chooserRef = useRef<HTMLDivElement>(null);
 
   // Reload when preset store changes
   useEffect(() => {
@@ -153,6 +178,19 @@ const ModelPresetsTab: React.FC<{
     window.addEventListener(PRESET_STORE_EVENT, handler);
     return () => window.removeEventListener(PRESET_STORE_EVENT, handler);
   }, []);
+
+  // Close chooser when model changes
+  useEffect(() => { setShowChooser(false); }, [name]);
+
+  // Focus first focusable element in chooser when it opens
+  useEffect(() => {
+    if (showChooser) {
+      requestAnimationFrame(() => {
+        const first = chooserRef.current?.querySelector<HTMLElement>('button:not(.detail-presets__chooser-close), [tabindex="0"]');
+        first?.focus();
+      });
+    }
+  }, [showChooser]);
 
   const linkedPresetId = appliedPresets[name] || DEFAULT_PRESET.id;
   const linkedPreset = allPresets.find(p => p.id === linkedPresetId) || DEFAULT_PRESET;
@@ -177,6 +215,17 @@ const ModelPresetsTab: React.FC<{
     setNotice(msg);
     setTimeout(() => setNotice(null), 2500);
   }, [name]);
+
+  const handleAttachFromChooser = useCallback((preset: Preset) => {
+    handleAttach(preset);
+    setShowChooser(false);
+    requestAnimationFrame(() => changeBtnRef.current?.focus());
+  }, [handleAttach]);
+
+  const handleCloseChooser = useCallback(() => {
+    setShowChooser(false);
+    requestAnimationFrame(() => changeBtnRef.current?.focus());
+  }, []);
 
   if (!isActive) return null;
 
@@ -211,16 +260,80 @@ const ModelPresetsTab: React.FC<{
             </div>
           )}
           {linkedPreset.id !== DEFAULT_PRESET.id && (
-            <button
-              type="button"
-              className="btn btn--ghost btn--tiny detail-presets__detach-btn"
-              onClick={() => handleAttach(DEFAULT_PRESET)}
-              aria-label={`Detach preset "${linkedPreset.name}" from ${name}, reset to default`}
-            >
-              Reset to default
-            </button>
+            <div className="detail-presets__linked-actions">
+              <button
+                ref={changeBtnRef}
+                type="button"
+                className="btn btn--primary btn--tiny detail-presets__change-btn"
+                onClick={() => setShowChooser(v => !v)}
+                aria-label={`Change linked preset for ${name}`}
+                aria-expanded={showChooser}
+                aria-haspopup="dialog"
+              >
+                Change
+              </button>
+              <button
+                type="button"
+                className="btn btn--ghost btn--tiny detail-presets__detach-btn"
+                onClick={() => handleAttach(DEFAULT_PRESET)}
+                aria-label={`Detach preset "${linkedPreset.name}" from ${name}, reset to default`}
+              >
+                Reset to default
+              </button>
+            </div>
           )}
         </div>
+
+        {/* Inline change-preset chooser */}
+        {showChooser && (
+          <div
+            ref={chooserRef}
+            className="detail-presets__change-chooser"
+            role="dialog"
+            aria-label="Switch linked preset"
+            aria-modal="true"
+          >
+            <div className="detail-presets__chooser-head">
+              <span className="detail-presets__chooser-title">Switch to a different preset</span>
+              <button
+                type="button"
+                className="detail-presets__chooser-close btn btn--ghost btn--tiny"
+                onClick={handleCloseChooser}
+                aria-label="Close preset chooser"
+              >
+                <Icon name="x" size={12} />
+              </button>
+            </div>
+            {compatiblePresets.filter(p => p.id !== linkedPresetId).length === 0 ? (
+              <p className="detail-presets__chooser-empty">
+                {compatiblePresets.length === 0
+                  ? 'No compatible presets available. Create one in the Presets page.'
+                  : 'No other compatible presets to switch to.'}
+              </p>
+            ) : (
+              <ul className="detail-presets__chooser-list" role="listbox" aria-label="Select a preset to switch to">
+                {compatiblePresets
+                  .filter(p => p.id !== linkedPresetId)
+                  .map(preset => (
+                    <li key={preset.id} role="option" aria-selected={false}>
+                      <button
+                        type="button"
+                        className="detail-presets__chooser-option"
+                        onClick={() => handleAttachFromChooser(preset)}
+                        aria-label={`Switch to preset "${preset.name}"`}
+                      >
+                        <PresetIcon preset={preset} size={12} />
+                        <span className="detail-presets__chooser-option-name">{preset.name}</span>
+                        {preset.description && (
+                          <span className="detail-presets__chooser-option-desc">{preset.description}</span>
+                        )}
+                      </button>
+                    </li>
+                  ))}
+              </ul>
+            )}
+          </div>
+        )}
       </section>
 
       {/* Compatible presets */}
@@ -261,9 +374,9 @@ const ModelPresetsTab: React.FC<{
                       type="button"
                       className="btn btn--primary btn--tiny detail-presets__attach-btn"
                       onClick={() => handleAttach(preset)}
-                      aria-label={`Attach preset "${preset.name}" to ${name}`}
+                      aria-label={`${linkedPreset.id !== DEFAULT_PRESET.id ? 'Switch to' : 'Attach'} preset "${preset.name}" for ${name}`}
                     >
-                      Attach
+                      {linkedPreset.id !== DEFAULT_PRESET.id ? 'Switch' : 'Attach'}
                     </button>
                   )}
                 </div>
@@ -305,6 +418,8 @@ export interface ModelDetailPanelProps {
   onDelete: (model: ModelInfo) => void;
   onCancelPull: (name: string) => void;
   serverDefaultCtxSize: number;
+  /** Called when the "Back to models" button is clicked (narrow viewports). */
+  onBack?: () => void;
 }
 
 type DetailTab = 'readme' | 'presets' | 'files';
@@ -327,6 +442,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   onPullAndLoad,
   onDelete,
   onCancelPull,
+  onBack,
 }) => {
   const [activeTab, setActiveTab] = useState<DetailTab>('readme');
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -354,6 +470,16 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   if (!model) {
     return (
       <div className="model-detail-panel model-detail-panel--empty" aria-label="Model detail">
+        {onBack && (
+          <button
+            type="button"
+            className="model-detail-panel__back-btn"
+            onClick={onBack}
+            aria-label="Back to models list"
+          >
+            ← Back to models
+          </button>
+        )}
         <div className="model-detail-panel__placeholder">
           <Icon name="model" size={40} aria-hidden="true" />
           <p>Select a model to view details</p>
@@ -365,6 +491,8 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   const name = mdName(model);
   const recipe = String((model as any).recipe || '');
   const checkpoint = String((model as any).checkpoint || '');
+  const checkpoints = (model as any).checkpoints as Record<string, string> | null ?? null;
+  const hfRepo = deriveHFRepo(checkpoint || null, checkpoints);
   const isLoaded = !!loadedModel;
   const isLoadingThis = loadingModel === name;
   const isPulling = pulling[name] !== undefined;
@@ -374,6 +502,18 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
 
   return (
     <div className="model-detail-panel" role="region" aria-label={`Model details: ${name}`}>
+
+      {/* Back button for narrow viewports */}
+      {onBack && (
+        <button
+          type="button"
+          className="model-detail-panel__back-btn"
+          onClick={onBack}
+          aria-label="Back to models list"
+        >
+          ← Back to models
+        </button>
+      )}
 
       {/* Header */}
       <div className="model-detail-panel__head">
@@ -492,10 +632,10 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
         )}
 
         {/* HF link */}
-        {checkpoint && hfReadmeUrl(checkpoint) && (
+        {hfRepo && (
           <a
             className="model-detail-panel__hf-link"
-            href={`https://huggingface.co/${checkpoint.split(':')[0]}`}
+            href={`https://huggingface.co/${hfRepo}`}
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`View ${name} on Hugging Face (opens in new tab)`}
@@ -541,7 +681,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
           hidden={activeTab !== tab.id}
         >
           {tab.id === 'readme' && (
-            <ModelReadmeTab checkpoint={checkpoint} isActive={activeTab === 'readme'} />
+            <ModelReadmeTab model={model} isActive={activeTab === 'readme'} />
           )}
           {tab.id === 'presets' && (
             <ModelPresetsTab model={model} isActive={activeTab === 'presets'} />

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -13,7 +13,7 @@ import { activeDownloadForModel, type DownloadListItem } from '../features/downl
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
-function listModelName(m: ModelInfo): string {
+export function listModelName(m: ModelInfo): string {
   return String((m as any).model_name ?? m.name ?? m.id ?? '').trim();
 }
 
@@ -28,7 +28,7 @@ function listFmtSize(gb: number): string {
   return '< 1 MB';
 }
 
-function listRecipeBadgeText(recipe: string): string {
+export function listRecipeBadgeText(recipe: string): string {
   const n = String(recipe || '').toLowerCase();
   switch (n) {
     case 'llamacpp': return 'llama.cpp';
@@ -74,7 +74,7 @@ const FILTER_TABS: Array<{ key: FilterTab; label: string; iconName: IconName }> 
   { key: 'embedding', label: 'Embed', iconName: 'embedding' },
 ];
 
-function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
+export function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
   if (filter === 'all') return true;
   const cap = capabilityFromModelInfo(m);
   if (filter === 'omni') {
@@ -84,6 +84,60 @@ function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
   if (filter === 'embedding') return cap === 'embedding' || cap === 'reranking';
   if (filter === 'llm') return cap === 'chat' || cap === 'unknown';
   return (cap as string) === filter;
+}
+
+/* ── Left-nav-rail filter dimensions ─────────────────────────────
+   These predicates are the single source of truth shared by the
+   middle list (filtering) and the left nav rail (deriving counts),
+   so both stay perfectly in sync. All derivation is client-side from
+   the model list the prototype already loads — no lemond calls. */
+
+/** Primary nav buckets in the left rail. */
+export type PrimaryFilter = 'all' | 'downloaded' | 'my-models' | 'favorites';
+
+/** A model counts as "downloaded" if it is locally present or running. */
+export function modelIsDownloaded(m: ModelInfo, loadedNames: Set<string>): boolean {
+  const name = listModelName(m);
+  return loadedNames.has(name) || Boolean((m as any).downloaded);
+}
+
+/** Custom / user-registered models (client-local store). */
+export function modelIsCustom(m: ModelInfo): boolean {
+  return (m as any).custom === true;
+}
+
+export function modelMatchesPrimary(
+  m: ModelInfo,
+  primary: PrimaryFilter,
+  loadedNames: Set<string>,
+  pinnedNames?: Set<string>,
+): boolean {
+  switch (primary) {
+    case 'downloaded': return modelIsDownloaded(m, loadedNames);
+    case 'my-models': return modelIsCustom(m);
+    case 'favorites': return pinnedNames?.has(listModelName(m).toLowerCase()) ?? false;
+    case 'all':
+    default: return true;
+  }
+}
+
+/** Backend filter — `backend` is 'all' or a lowercased recipe id. */
+export function modelMatchesBackend(m: ModelInfo, backend: string): boolean {
+  if (!backend || backend === 'all') return true;
+  return String((m as any).recipe || '').toLowerCase() === backend;
+}
+
+/** Curated tag chips (model families + size hints) shown in the left rail. */
+export const TAG_CHIPS: string[] = ['Llama', 'Qwen', 'Phi', 'Mistral', 'Gemma', 'Bonsai', 'Small'];
+
+/** A tag matches when it appears in the model's labels OR its name/family. */
+export function modelMatchesTag(m: ModelInfo, tag: string | null): boolean {
+  if (!tag) return true;
+  const t = tag.toLowerCase();
+  const labels = (m.labels || []).map(l => String(l).toLowerCase());
+  if (labels.includes(t)) return true;
+  const hay = `${listModelName(m)} ${m.display_name || ''}`.toLowerCase();
+  return hay.includes(t);
 }
 
 /* ── Types ───────────────────────────────────────────────────── */
@@ -110,6 +164,12 @@ export interface ModelListPanelProps {
   onSearchChange: (q: string) => void;
   filterTab: FilterTab;
   onFilterChange: (tab: FilterTab) => void;
+  /** Primary nav bucket selected in the left rail. */
+  primaryFilter?: PrimaryFilter;
+  /** Backend filter ('all' or lowercased recipe id) from the left rail. */
+  backendFilter?: string;
+  /** Active tag chip from the left rail (null = no tag filter). */
+  tagFilter?: string | null;
   searchInputRef?: React.RefObject<HTMLInputElement | null>;
   onAddCustomModel?: () => void;
   onAddOmniCollection?: () => void;
@@ -132,6 +192,9 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   onSearchChange,
   filterTab,
   onFilterChange,
+  primaryFilter = 'all',
+  backendFilter = 'all',
+  tagFilter = null,
   searchInputRef,
   onAddCustomModel,
   onAddOmniCollection,
@@ -157,6 +220,11 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
 
       // Filter by type
       if (!modelMatchesFilter(m, filterTab)) continue;
+
+      // Left-rail filter dimensions (primary bucket / backend / tag)
+      if (!modelMatchesPrimary(m, primaryFilter, loadedNames, pinnedNames)) continue;
+      if (!modelMatchesBackend(m, backendFilter)) continue;
+      if (!modelMatchesTag(m, tagFilter)) continue;
 
       // Filter by search
       if (q) {
@@ -225,7 +293,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
     }
 
     return result;
-  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy, pinnedNames]);
+  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy, pinnedNames, primaryFilter, backendFilter, tagFilter]);
 
   // Keyboard navigation on the list (ArrowUp/Down/Home/End)
   const handleListKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -264,6 +332,31 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
       <div className="model-list-panel__title manager__title">
         <h1>Models</h1>
       </div>
+
+      {/* Custom model / Omni collection actions — grounded button group at the
+          top of the list area (moved from the bottom per fl0rianr). */}
+      {(onAddCustomModel || onAddOmniCollection) && (
+        <div className="model-list-panel__add-group" role="group" aria-label="Add custom models">
+          {onAddCustomModel && (
+            <button
+              type="button"
+              className="btn btn--ghost btn--tiny model-list-panel__add-btn manager__custom-btn"
+              onClick={onAddCustomModel}
+            >
+              + Custom model
+            </button>
+          )}
+          {onAddOmniCollection && (
+            <button
+              type="button"
+              className="btn btn--ghost btn--tiny model-list-panel__add-btn manager__custom-btn manager__custom-btn--omni"
+              onClick={onAddOmniCollection}
+            >
+              + Omni collection
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Search bar */}
       <div className="model-list-panel__search-row">
@@ -455,30 +548,6 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
           </li>
         )}
       </ul>
-
-      {/* Custom model / Omni collection actions */}
-      {(onAddCustomModel || onAddOmniCollection) && (
-        <div className="model-list-panel__footer" aria-label="Add custom models">
-          {onAddCustomModel && (
-            <button
-              type="button"
-              className="btn btn--ghost btn--tiny manager__custom-btn"
-              onClick={onAddCustomModel}
-            >
-              + Custom model
-            </button>
-          )}
-          {onAddOmniCollection && (
-            <button
-              type="button"
-              className="btn btn--ghost btn--tiny manager__custom-btn manager__custom-btn--omni"
-              onClick={onAddOmniCollection}
-            >
-              + Omni collection
-            </button>
-          )}
-        </div>
-      )}
     </div>
   );
 };

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -88,6 +88,8 @@ function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
 
 /* ── Types ───────────────────────────────────────────────────── */
 
+export type SortBy = 'name' | 'size' | 'last-used' | 'downloads';
+
 export type ModelStatus = 'running' | 'downloaded' | 'available' | 'downloading';
 
 export interface FlatModelEntry {
@@ -130,13 +132,14 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   onAddOmniCollection,
 }) => {
   const [filterOpen, setFilterOpen] = useState(false);
+  const [sortBy, setSortBy] = useState<SortBy>('name');
   const filterBtnRef = useRef<HTMLButtonElement>(null);
   const filterPopoverRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const defaultSearchRef = useRef<HTMLInputElement>(null);
   const inputRef = (searchInputRef ?? defaultSearchRef) as React.RefObject<HTMLInputElement>;
 
-  // Build flat sorted list: running → downloaded → available
+  // Build flat list filtered by search + type; sort based on sortBy
   const flatList = useMemo((): FlatModelEntry[] => {
     const q = searchQuery.trim().toLowerCase();
     const result: FlatModelEntry[] = [];
@@ -171,16 +174,45 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
       result.push({ model: m, status, downloadPct: pullPct });
     }
 
-    // Sort: running first, then downloaded, then available
-    const rank: Record<ModelStatus, number> = { running: 0, downloaded: 1, downloading: 1, available: 2 };
-    result.sort((a, b) => {
-      const r = rank[a.status] - rank[b.status];
-      if (r !== 0) return r;
-      return listModelDisplayName(a.model).localeCompare(listModelDisplayName(b.model));
-    });
+    if (sortBy === 'name') {
+      // Default: running → downloaded → available, then alphabetical within group
+      const rank: Record<ModelStatus, number> = { running: 0, downloaded: 1, downloading: 1, available: 2 };
+      result.sort((a, b) => {
+        const r = rank[a.status] - rank[b.status];
+        if (r !== 0) return r;
+        return listModelDisplayName(a.model).localeCompare(listModelDisplayName(b.model));
+      });
+    } else if (sortBy === 'size') {
+      result.sort((a, b) => {
+        const sa = a.model.size ?? -1;
+        const sb = b.model.size ?? -1;
+        if (sa !== sb) return sb - sa; // largest first; unknown size (-1) sinks to bottom
+        return listModelDisplayName(a.model).localeCompare(listModelDisplayName(b.model));
+      });
+    } else if (sortBy === 'last-used') {
+      // Graceful fallback to name if last_used absent
+      result.sort((a, b) => {
+        const la: string | null = (a.model as any).last_used ?? null;
+        const lb: string | null = (b.model as any).last_used ?? null;
+        if (la && lb) return new Date(lb).getTime() - new Date(la).getTime();
+        if (la) return -1;
+        if (lb) return 1;
+        return listModelDisplayName(a.model).localeCompare(listModelDisplayName(b.model));
+      });
+    } else if (sortBy === 'downloads') {
+      // Graceful fallback to name if download_count absent
+      result.sort((a, b) => {
+        const da: number | null = (a.model as any).downloads ?? (a.model as any).download_count ?? null;
+        const db: number | null = (b.model as any).downloads ?? (b.model as any).download_count ?? null;
+        if (da !== null && db !== null) return db - da; // most downloads first
+        if (da !== null) return -1;
+        if (db !== null) return 1;
+        return listModelDisplayName(a.model).localeCompare(listModelDisplayName(b.model));
+      });
+    }
 
     return result;
-  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab]);
+  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy]);
 
   // Keyboard navigation on the list (ArrowUp/Down/Home/End)
   const handleListKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -295,6 +327,23 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
             </div>
           )}
         </div>
+      </div>
+
+      {/* Sort control */}
+      <div className="model-list-panel__sort-row">
+        <label htmlFor="model-list-sort" className="model-list-panel__sort-label">Sort</label>
+        <select
+          id="model-list-sort"
+          className="model-list-panel__sort-select"
+          value={sortBy}
+          onChange={e => setSortBy(e.target.value as SortBy)}
+          aria-label="Sort models by"
+        >
+          <option value="name">Name (A–Z)</option>
+          <option value="size">Size (largest first)</option>
+          <option value="last-used">Last used</option>
+          <option value="downloads">Download count</option>
+        </select>
       </div>
 
       {/* List count */}

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -391,7 +391,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
             type="button"
             className={`model-list-panel__filter-btn${filterOpen ? ' model-list-panel__filter-btn--open' : ''}${filterTab !== 'all' ? ' model-list-panel__filter-btn--active' : ''}`}
             onClick={handleFilterBtnClick}
-            aria-label="Filter models"
+            aria-label="Filter models by capability"
             aria-expanded={filterOpen}
             aria-haspopup="dialog"
           >
@@ -407,7 +407,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
               aria-modal="false"
             >
               <div className="model-list-panel__filter-popover-head">
-                <span>Filter by type</span>
+                <span>Filter by capability</span>
                 <button
                   type="button"
                   className="model-list-panel__filter-popover-close"
@@ -417,7 +417,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                   <Icon name="x" size={13} />
                 </button>
               </div>
-              <div className="model-list-panel__filter-options" role="group" aria-label="Model type filter">
+              <div className="model-list-panel__filter-options" role="group" aria-label="Model capability filter">
                 {FILTER_TABS.map(tab => (
                   <button
                     key={tab.key}

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -6,9 +6,17 @@
  */
 import React, { useCallback, useRef, useMemo, useState } from 'react';
 import type { ModelInfo, LoadedModel } from '../api';
-import { capabilityFromModelInfo } from '../modelCapabilities';
+import {
+  capabilityFromModelInfo,
+  modelCapabilityTags,
+  modelMatchesCapabilityTags,
+  CAPABILITY_TAG_ORDER,
+  CAPABILITY_TAG_LABELS,
+  type CapabilityTag,
+} from '../modelCapabilities';
 import { Icon, CapabilityIcon } from './Icon';
 import type { IconName } from './Icon';
+import type { CapabilityIconTarget } from './Icon';
 import { activeDownloadForModel, type DownloadListItem } from '../features/downloadManager/downloadStore';
 
 /* ── Helpers ─────────────────────────────────────────────────── */
@@ -93,7 +101,7 @@ export function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
    the model list the prototype already loads — no lemond calls. */
 
 /** Primary nav buckets in the left rail. */
-export type PrimaryFilter = 'all' | 'downloaded' | 'my-models' | 'favorites';
+export type PrimaryFilter = 'all' | 'downloaded' | 'my-models' | 'favorites' | 'huggingface';
 
 /** A model counts as "downloaded" if it is locally present or running. */
 export function modelIsDownloaded(m: ModelInfo, loadedNames: Set<string>): boolean {
@@ -110,15 +118,23 @@ export function modelMatchesPrimary(
   m: ModelInfo,
   primary: PrimaryFilter,
   loadedNames: Set<string>,
-  pinnedNames?: Set<string>,
+  favoriteNames?: Set<string>,
 ): boolean {
   switch (primary) {
     case 'downloaded': return modelIsDownloaded(m, loadedNames);
     case 'my-models': return modelIsCustom(m);
-    case 'favorites': return pinnedNames?.has(listModelName(m).toLowerCase()) ?? false;
+    case 'favorites': return favoriteNames?.has(listModelName(m).toLowerCase()) ?? false;
+    // Hugging Face results are supplied as their own list, so every entry matches.
+    case 'huggingface': return true;
     case 'all':
     default: return true;
   }
+}
+
+/** Map a functional capability tag onto its icon target (tags reuse the
+    capability icon set; 'tool' shares the wrench glyph). */
+export function capabilityTagIconTarget(tag: CapabilityTag): CapabilityIconTarget {
+  return tag as CapabilityIconTarget;
 }
 
 /** Backend filter — `backend` is 'all' or a lowercased recipe id. */
@@ -164,6 +180,9 @@ export interface ModelListPanelProps {
   onSearchChange: (q: string) => void;
   filterTab: FilterTab;
   onFilterChange: (tab: FilterTab) => void;
+  /** Selected functional capability tags (multi-select funnel). Empty = no filter. */
+  capabilityFilter?: Set<string>;
+  onCapabilityFilterChange?: (next: Set<string>) => void;
   /** Primary nav bucket selected in the left rail. */
   primaryFilter?: PrimaryFilter;
   /** Backend filter ('all' or lowercased recipe id) from the left rail. */
@@ -173,10 +192,12 @@ export interface ModelListPanelProps {
   searchInputRef?: React.RefObject<HTMLInputElement | null>;
   onAddCustomModel?: () => void;
   onAddOmniCollection?: () => void;
-  /** Lowercased set of pinned (favorited) model names. Client-local, no lemond. */
+  /** Lowercased set of pinned model names. Pinned rows float to the top. Client-local. */
   pinnedNames?: Set<string>;
-  /** Toggle a model's pinned/favorite state. Receives the model name. */
+  /** Toggle a model's pinned state. Receives the model name. */
   onTogglePin?: (name: string) => void;
+  /** Lowercased set of favorited model names (distinct from pinned). Client-local. */
+  favoriteNames?: Set<string>;
 }
 
 /* ── ModelListPanel ──────────────────────────────────────────── */
@@ -192,6 +213,8 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   onSearchChange,
   filterTab,
   onFilterChange,
+  capabilityFilter,
+  onCapabilityFilterChange,
   primaryFilter = 'all',
   backendFilter = 'all',
   tagFilter = null,
@@ -200,6 +223,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   onAddOmniCollection,
   pinnedNames,
   onTogglePin,
+  favoriteNames,
 }) => {
   const [filterOpen, setFilterOpen] = useState(false);
   const [sortBy, setSortBy] = useState<SortBy>('name');
@@ -222,9 +246,12 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
       if (!modelMatchesFilter(m, filterTab)) continue;
 
       // Left-rail filter dimensions (primary bucket / backend / tag)
-      if (!modelMatchesPrimary(m, primaryFilter, loadedNames, pinnedNames)) continue;
+      if (!modelMatchesPrimary(m, primaryFilter, loadedNames, favoriteNames)) continue;
       if (!modelMatchesBackend(m, backendFilter)) continue;
       if (!modelMatchesTag(m, tagFilter)) continue;
+
+      // Funnel: functional capability tags (multi-select). Empty = no filter.
+      if (!modelMatchesCapabilityTags(m, capabilityFilter ?? new Set())) continue;
 
       // Filter by search
       if (q) {
@@ -286,14 +313,35 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
       });
     }
 
-    // Pinned (favorited) models always float to the top, preserving the
-    // chosen sort order within the pinned and unpinned groups. Client-local only.
+    // Pinned models always float to the top, preserving the chosen sort order
+    // within the pinned and unpinned groups. Client-local only; distinct from
+    // favorites (which is a separate filter/count, not a sort).
     if (pinnedNames && pinnedNames.size > 0) {
       result.sort((a, b) => Number(b.pinned ?? false) - Number(a.pinned ?? false));
     }
 
     return result;
-  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy, pinnedNames, primaryFilter, backendFilter, tagFilter]);
+  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy, pinnedNames, favoriteNames, primaryFilter, backendFilter, tagFilter, capabilityFilter]);
+
+  // Funnel options: the union of functional capability tags present across the
+  // models, in canonical order. Derived client-side from the model labels —
+  // "Define the capability set from the mock model data" (fl0rianr #2424).
+  const availableCapabilityTags = useMemo<CapabilityTag[]>(() => {
+    const present = new Set<CapabilityTag>();
+    for (const m of allModels) {
+      if (!listModelName(m)) continue;
+      for (const tag of modelCapabilityTags(m)) present.add(tag);
+    }
+    return CAPABILITY_TAG_ORDER.filter(tag => present.has(tag));
+  }, [allModels]);
+
+  const capabilityFilterSize = capabilityFilter?.size ?? 0;
+  const toggleCapability = useCallback((tag: CapabilityTag) => {
+    if (!onCapabilityFilterChange) return;
+    const next = new Set(capabilityFilter ?? new Set<string>());
+    if (next.has(tag)) next.delete(tag); else next.add(tag);
+    onCapabilityFilterChange(next);
+  }, [capabilityFilter, onCapabilityFilterChange]);
 
   // Keyboard navigation on the list (ArrowUp/Down/Home/End)
   const handleListKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -389,9 +437,9 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
           <button
             ref={filterBtnRef}
             type="button"
-            className={`model-list-panel__filter-btn${filterOpen ? ' model-list-panel__filter-btn--open' : ''}${filterTab !== 'all' ? ' model-list-panel__filter-btn--active' : ''}`}
+            className={`model-list-panel__filter-btn${filterOpen ? ' model-list-panel__filter-btn--open' : ''}${capabilityFilterSize > 0 ? ' model-list-panel__filter-btn--active' : ''}`}
             onClick={handleFilterBtnClick}
-            aria-label="Filter models by capability"
+            aria-label={capabilityFilterSize > 0 ? `Filter models by capability (${capabilityFilterSize} active)` : 'Filter models by capability'}
             aria-expanded={filterOpen}
             aria-haspopup="dialog"
           >
@@ -418,18 +466,33 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                 </button>
               </div>
               <div className="model-list-panel__filter-options" role="group" aria-label="Model capability filter">
-                {FILTER_TABS.map(tab => (
+                {availableCapabilityTags.length === 0 && (
+                  <span className="model-list-panel__filter-empty">No capabilities available</span>
+                )}
+                {availableCapabilityTags.map(tag => {
+                  const active = capabilityFilter?.has(tag) ?? false;
+                  return (
+                    <button
+                      key={tag}
+                      type="button"
+                      className={`model-list-panel__filter-option${active ? ' model-list-panel__filter-option--active' : ''}`}
+                      onClick={() => toggleCapability(tag)}
+                      aria-pressed={active}
+                    >
+                      <CapabilityIcon capability={capabilityTagIconTarget(tag) as any} size={12} aria-hidden="true" />
+                      {CAPABILITY_TAG_LABELS[tag]}
+                    </button>
+                  );
+                })}
+                {capabilityFilterSize > 0 && (
                   <button
-                    key={tab.key}
                     type="button"
-                    className={`model-list-panel__filter-option${filterTab === tab.key ? ' model-list-panel__filter-option--active' : ''}`}
-                    onClick={() => { onFilterChange(tab.key); setFilterOpen(false); }}
-                    aria-pressed={filterTab === tab.key}
+                    className="model-list-panel__filter-clear"
+                    onClick={() => onCapabilityFilterChange?.(new Set())}
                   >
-                    <CapabilityIcon capability={tab.key === 'llm' ? 'chat' : tab.key === 'embedding' ? 'embedding' : tab.key as any} size={12} />
-                    {tab.label}
+                    Clear all
                   </button>
-                ))}
+                )}
               </div>
             </div>
           )}
@@ -474,7 +537,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
           const displayName = listModelDisplayName(model);
           const recipe = String((model as any).recipe || '');
           const isSelected = mId === selectedModelId;
-          const cap = capabilityFromModelInfo(model);
+          const capTags = modelCapabilityTags(model);
 
           return (
             <li
@@ -507,8 +570,12 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                   {model.size != null && model.size > 0 && (
                     <span className="model-list-item__size">{listFmtSize(model.size)}</span>
                   )}
-                  <span className="model-list-item__cap">
-                    <CapabilityIcon capability={cap} size={10} aria-hidden="true" />
+                  <span className="model-list-item__caps" role="img" aria-label={`Capabilities: ${capTags.map(t => CAPABILITY_TAG_LABELS[t]).join(', ')}`}>
+                    {capTags.map(tag => (
+                      <span key={tag} className="model-list-item__cap" title={CAPABILITY_TAG_LABELS[tag]}>
+                        <CapabilityIcon capability={capabilityTagIconTarget(tag) as any} size={10} aria-hidden="true" />
+                      </span>
+                    ))}
                   </span>
                 </span>
               </span>
@@ -541,10 +608,14 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
           );
         })}
 
-        {flatList.length === 0 && (
+        {/* Search-no-match feedback stays in the middle list. The "no model
+            selected" / empty-registry placeholder now lives in the RIGHT detail
+            pane (ModelDetailPanel) per fl0rianr #2424 — it must NOT leak into the
+            top of the model list. */}
+        {flatList.length === 0 && searchQuery && (
           <li className="model-list-panel__empty manager__empty" aria-live="polite">
             <Icon name="search" size={18} aria-hidden="true" />
-            <span>{searchQuery ? 'No models match your search.' : 'No models found.'}</span>
+            <span>No models match your search.</span>
           </li>
         )}
       </ul>

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -96,6 +96,7 @@ export interface FlatModelEntry {
   model: ModelInfo;
   status: ModelStatus;
   downloadPct?: number;
+  pinned?: boolean;
 }
 
 export interface ModelListPanelProps {
@@ -112,6 +113,10 @@ export interface ModelListPanelProps {
   searchInputRef?: React.RefObject<HTMLInputElement | null>;
   onAddCustomModel?: () => void;
   onAddOmniCollection?: () => void;
+  /** Lowercased set of pinned (favorited) model names. Client-local, no lemond. */
+  pinnedNames?: Set<string>;
+  /** Toggle a model's pinned/favorite state. Receives the model name. */
+  onTogglePin?: (name: string) => void;
 }
 
 /* ── ModelListPanel ──────────────────────────────────────────── */
@@ -130,6 +135,8 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   searchInputRef,
   onAddCustomModel,
   onAddOmniCollection,
+  pinnedNames,
+  onTogglePin,
 }) => {
   const [filterOpen, setFilterOpen] = useState(false);
   const [sortBy, setSortBy] = useState<SortBy>('name');
@@ -171,7 +178,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
         status = 'available';
       }
 
-      result.push({ model: m, status, downloadPct: pullPct });
+      result.push({ model: m, status, downloadPct: pullPct, pinned: pinnedNames?.has(mName.toLowerCase()) ?? false });
     }
 
     if (sortBy === 'name') {
@@ -211,8 +218,14 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
       });
     }
 
+    // Pinned (favorited) models always float to the top, preserving the
+    // chosen sort order within the pinned and unpinned groups. Client-local only.
+    if (pinnedNames && pinnedNames.size > 0) {
+      result.sort((a, b) => Number(b.pinned ?? false) - Number(a.pinned ?? false));
+    }
+
     return result;
-  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy]);
+  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy, pinnedNames]);
 
   // Keyboard navigation on the list (ArrowUp/Down/Home/End)
   const handleListKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -239,7 +252,8 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
 
   const handleItemKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, modelId: string) => {
     if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelectModel(modelId); }
-  }, [onSelectModel]);
+    else if ((e.key === 'p' || e.key === 'P') && onTogglePin) { e.preventDefault(); onTogglePin(modelId); }
+  }, [onSelectModel, onTogglePin]);
 
   // Close filter popover on outside click
   const handleFilterBtnClick = () => setFilterOpen(v => !v);
@@ -362,7 +376,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
         tabIndex={flatList.some(e => e.model && listModelName(e.model) === selectedModelId) ? -1 : 0}
         onKeyDown={handleListKeyDown}
       >
-        {flatList.map(({ model, status, downloadPct }) => {
+        {flatList.map(({ model, status, downloadPct, pinned }) => {
           const mId = listModelName(model);
           const displayName = listModelDisplayName(model);
           const recipe = String((model as any).recipe || '');
@@ -376,10 +390,11 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
               tabIndex={isSelected ? 0 : -1}
               aria-selected={isSelected}
               data-model-id={mId}
-              className={`model-list-item${isSelected ? ' model-list-item--selected' : ''} model-list-item--${status}`}
+              aria-keyshortcuts={onTogglePin ? 'P' : undefined}
+              className={`model-list-item${isSelected ? ' model-list-item--selected' : ''}${pinned ? ' model-list-item--pinned' : ''} model-list-item--${status}`}
               onClick={() => onSelectModel(mId)}
               onKeyDown={e => handleItemKeyDown(e, mId)}
-              aria-label={`${displayName}${status === 'running' ? ', running' : status === 'downloaded' ? ', downloaded' : status === 'downloading' ? ', downloading' : ', available'}${recipe ? `, ${listRecipeBadgeText(recipe)}` : ''}`}
+              aria-label={`${displayName}${pinned ? ', pinned' : ''}${status === 'running' ? ', running' : status === 'downloaded' ? ', downloaded' : status === 'downloading' ? ', downloading' : ', available'}${recipe ? `, ${listRecipeBadgeText(recipe)}` : ''}`}
             >
               {/* Backend badge */}
               {recipe && (
@@ -413,6 +428,22 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                 )}
                 {status === 'downloaded' && <span className="model-list-item__dot model-list-item__dot--ready" />}
               </span>
+
+              {/* Pin / favorite (client-local). Rendered as a non-button so it
+                  does not nest an interactive control inside role="option"
+                  (axe nested-interactive). Pointer users click it; keyboard/AT
+                  users toggle via the "P" shortcut on the focused row, and the
+                  pinned state is exposed in the row's aria-label. */}
+              {onTogglePin && (
+                <span
+                  className={`model-list-item__pin row__pin${pinned ? ' row__pin--active model-list-item__pin--active' : ''}`}
+                  onClick={e => { e.stopPropagation(); onTogglePin(mId); }}
+                  aria-hidden="true"
+                  title={pinned ? `Unpin ${displayName} (P)` : `Pin ${displayName} (P)`}
+                >
+                  <Icon name="pin" size={12} aria-hidden="true" />
+                </span>
+              )}
             </li>
           );
         })}

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -1,0 +1,407 @@
+/**
+ * ModelListPanel — left panel of the master-detail model view.
+ * Compact, searchable, filterable list of models with keyboard navigation.
+ *
+ * Part of the master-detail layout introduced in #2355 Slice 1.
+ */
+import React, { useCallback, useRef, useMemo, useState } from 'react';
+import type { ModelInfo, LoadedModel } from '../api';
+import { capabilityFromModelInfo } from '../modelCapabilities';
+import { Icon, CapabilityIcon } from './Icon';
+import type { IconName } from './Icon';
+import { activeDownloadForModel, type DownloadListItem } from '../features/downloadManager/downloadStore';
+
+/* ── Helpers ─────────────────────────────────────────────────── */
+
+function listModelName(m: ModelInfo): string {
+  return String((m as any).model_name ?? m.name ?? m.id ?? '').trim();
+}
+
+function listModelDisplayName(m: ModelInfo): string {
+  return String(m.display_name || listModelName(m));
+}
+
+function listFmtSize(gb: number): string {
+  if (!Number.isFinite(gb) || gb <= 0) return '';
+  if (gb >= 1) return `${gb.toFixed(1)} GB`;
+  if (gb >= 0.01) return `${(gb * 1000).toFixed(0)} MB`;
+  return '< 1 MB';
+}
+
+function listRecipeBadgeText(recipe: string): string {
+  const n = String(recipe || '').toLowerCase();
+  switch (n) {
+    case 'llamacpp': return 'llama.cpp';
+    case 'vllm': return 'vLLM';
+    case 'flm': return 'FLM';
+    case 'ryzenai-llm': return 'RyzenAI';
+    case 'sd-cpp': return 'SD.cpp';
+    case 'whispercpp': return 'Whisper';
+    case 'moonshine': return 'Moonshine';
+    case 'kokoro': return 'Kokoro';
+    case 'collection.omni': return 'Omni';
+    case 'collection': return 'Collection';
+    default: return recipe || 'Backend';
+  }
+}
+
+function listRecipeColor(recipe: string): string {
+  const n = String(recipe || '').toLowerCase();
+  switch (n) {
+    case 'llamacpp': return '#facc15';
+    case 'vllm': return '#60a5fa';
+    case 'flm': return '#34d399';
+    case 'ryzenai-llm': return '#f97316';
+    case 'sd-cpp': return '#c084fc';
+    case 'whispercpp': return '#38bdf8';
+    case 'moonshine': return '#22d3ee';
+    case 'kokoro': return '#f472b6';
+    case 'collection.omni': return '#a78bfa';
+    case 'collection': return '#94a3b8';
+    default: return 'var(--text-tertiary)';
+  }
+}
+
+type FilterTab = 'all' | 'llm' | 'omni' | 'image' | 'audio' | 'tts' | 'embedding';
+
+const FILTER_TABS: Array<{ key: FilterTab; label: string; iconName: IconName }> = [
+  { key: 'all', label: 'All', iconName: 'globe' },
+  { key: 'llm', label: 'LLM', iconName: 'chat' },
+  { key: 'omni', label: 'Omni', iconName: 'omni' },
+  { key: 'image', label: 'Image', iconName: 'image' },
+  { key: 'audio', label: 'Audio', iconName: 'audio' },
+  { key: 'tts', label: 'TTS', iconName: 'tts' },
+  { key: 'embedding', label: 'Embed', iconName: 'embedding' },
+];
+
+function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
+  if (filter === 'all') return true;
+  const cap = capabilityFromModelInfo(m);
+  if (filter === 'omni') {
+    const recipe = String((m as any).recipe || '').toLowerCase();
+    return recipe === 'collection.omni' || recipe === 'collection';
+  }
+  if (filter === 'embedding') return cap === 'embedding' || cap === 'reranking';
+  if (filter === 'llm') return cap === 'chat' || cap === 'unknown';
+  return (cap as string) === filter;
+}
+
+/* ── Types ───────────────────────────────────────────────────── */
+
+export type ModelStatus = 'running' | 'downloaded' | 'available' | 'downloading';
+
+export interface FlatModelEntry {
+  model: ModelInfo;
+  status: ModelStatus;
+  downloadPct?: number;
+}
+
+export interface ModelListPanelProps {
+  allModels: ModelInfo[];
+  loadedNames: Set<string>;
+  pulling: Record<string, number>;
+  downloadItems: DownloadListItem[];
+  selectedModelId: string | null;
+  onSelectModel: (id: string) => void;
+  searchQuery: string;
+  onSearchChange: (q: string) => void;
+  filterTab: FilterTab;
+  onFilterChange: (tab: FilterTab) => void;
+  searchInputRef?: React.RefObject<HTMLInputElement | null>;
+  onAddCustomModel?: () => void;
+  onAddOmniCollection?: () => void;
+}
+
+/* ── ModelListPanel ──────────────────────────────────────────── */
+
+export const ModelListPanel: React.FC<ModelListPanelProps> = ({
+  allModels,
+  loadedNames,
+  pulling,
+  downloadItems,
+  selectedModelId,
+  onSelectModel,
+  searchQuery,
+  onSearchChange,
+  filterTab,
+  onFilterChange,
+  searchInputRef,
+  onAddCustomModel,
+  onAddOmniCollection,
+}) => {
+  const [filterOpen, setFilterOpen] = useState(false);
+  const filterBtnRef = useRef<HTMLButtonElement>(null);
+  const filterPopoverRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const defaultSearchRef = useRef<HTMLInputElement>(null);
+  const inputRef = (searchInputRef ?? defaultSearchRef) as React.RefObject<HTMLInputElement>;
+
+  // Build flat sorted list: running → downloaded → available
+  const flatList = useMemo((): FlatModelEntry[] => {
+    const q = searchQuery.trim().toLowerCase();
+    const result: FlatModelEntry[] = [];
+
+    for (const m of allModels) {
+      const mName = listModelName(m);
+      if (!mName) continue;
+
+      // Filter by type
+      if (!modelMatchesFilter(m, filterTab)) continue;
+
+      // Filter by search
+      if (q) {
+        const haystack = `${mName} ${m.display_name || ''} ${(m as any).recipe || ''} ${(m.labels || []).join(' ')}`.toLowerCase();
+        if (!haystack.includes(q)) continue;
+      }
+
+      const activeDownload = activeDownloadForModel(downloadItems, mName);
+      const pullPct = activeDownload?.percent ?? pulling[mName];
+
+      let status: ModelStatus;
+      if (loadedNames.has(mName)) {
+        status = 'running';
+      } else if (pullPct !== undefined) {
+        status = 'downloading';
+      } else if (Boolean((m as any).downloaded)) {
+        status = 'downloaded';
+      } else {
+        status = 'available';
+      }
+
+      result.push({ model: m, status, downloadPct: pullPct });
+    }
+
+    // Sort: running first, then downloaded, then available
+    const rank: Record<ModelStatus, number> = { running: 0, downloaded: 1, downloading: 1, available: 2 };
+    result.sort((a, b) => {
+      const r = rank[a.status] - rank[b.status];
+      if (r !== 0) return r;
+      return listModelDisplayName(a.model).localeCompare(listModelDisplayName(b.model));
+    });
+
+    return result;
+  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab]);
+
+  // Keyboard navigation on the list (ArrowUp/Down/Home/End)
+  const handleListKeyDown = useCallback((e: React.KeyboardEvent) => {
+    const options = listRef.current?.querySelectorAll<HTMLElement>('[role="option"]');
+    if (!options?.length) return;
+
+    const focusedEl = document.activeElement as HTMLElement;
+    const items = Array.from(options);
+    const currentIdx = items.indexOf(focusedEl);
+
+    let next = -1;
+    if (e.key === 'ArrowDown') { e.preventDefault(); next = currentIdx < 0 ? 0 : Math.min(currentIdx + 1, items.length - 1); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); next = currentIdx <= 0 ? 0 : currentIdx - 1; }
+    else if (e.key === 'Home') { e.preventDefault(); next = 0; }
+    else if (e.key === 'End') { e.preventDefault(); next = items.length - 1; }
+
+    if (next >= 0) {
+      items[next].focus();
+      // Single-select listbox: arrow key navigation also selects (ARIA APG)
+      const modelId = items[next].getAttribute('data-model-id');
+      if (modelId) onSelectModel(modelId);
+    }
+  }, [onSelectModel]);
+
+  const handleItemKeyDown = useCallback((e: React.KeyboardEvent<HTMLElement>, modelId: string) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelectModel(modelId); }
+  }, [onSelectModel]);
+
+  // Close filter popover on outside click
+  const handleFilterBtnClick = () => setFilterOpen(v => !v);
+
+  return (
+    <div className="model-list-panel">
+      {/* Title */}
+      <div className="model-list-panel__title manager__title">
+        <h1>Models</h1>
+      </div>
+
+      {/* Search bar */}
+      <div className="model-list-panel__search-row">
+        <label htmlFor="model-list-search" className="sr-only">Search models</label>
+        <div className="model-list-panel__search-wrap">
+          <Icon name="search" size={14} aria-hidden="true" className="model-list-panel__search-icon" />
+          <input
+            id="model-list-search"
+            ref={inputRef as React.RefObject<HTMLInputElement>}
+            role="searchbox"
+            type="text"
+              className="model-list-panel__search-input manager__search-input"
+            placeholder="Search models… (Ctrl+K)"
+            value={searchQuery}
+            onChange={e => onSearchChange(e.target.value)}
+            aria-label="Search models"
+            autoComplete="off"
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              className="model-list-panel__search-clear"
+              onClick={() => onSearchChange('')}
+              aria-label="Clear search"
+            >×</button>
+          )}
+        </div>
+        {/* Funnel filter button */}
+        <div className="model-list-panel__filter-wrap">
+          <button
+            ref={filterBtnRef}
+            type="button"
+            className={`model-list-panel__filter-btn${filterOpen ? ' model-list-panel__filter-btn--open' : ''}${filterTab !== 'all' ? ' model-list-panel__filter-btn--active' : ''}`}
+            onClick={handleFilterBtnClick}
+            aria-label="Filter models"
+            aria-expanded={filterOpen}
+            aria-haspopup="dialog"
+          >
+            <Icon name="funnel" size={14} aria-hidden="true" />
+          </button>
+
+          {filterOpen && (
+            <div
+              ref={filterPopoverRef}
+              className="model-list-panel__filter-popover"
+              role="dialog"
+              aria-label="Model filters"
+              aria-modal="false"
+            >
+              <div className="model-list-panel__filter-popover-head">
+                <span>Filter by type</span>
+                <button
+                  type="button"
+                  className="model-list-panel__filter-popover-close"
+                  onClick={() => setFilterOpen(false)}
+                  aria-label="Close filter panel"
+                >
+                  <Icon name="x" size={13} />
+                </button>
+              </div>
+              <div className="model-list-panel__filter-options" role="group" aria-label="Model type filter">
+                {FILTER_TABS.map(tab => (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    className={`model-list-panel__filter-option${filterTab === tab.key ? ' model-list-panel__filter-option--active' : ''}`}
+                    onClick={() => { onFilterChange(tab.key); setFilterOpen(false); }}
+                    aria-pressed={filterTab === tab.key}
+                  >
+                    <CapabilityIcon capability={tab.key === 'llm' ? 'chat' : tab.key === 'embedding' ? 'embedding' : tab.key as any} size={12} />
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* List count */}
+      <div className="model-list-panel__count" aria-live="polite" aria-atomic="true">
+        {flatList.length} model{flatList.length !== 1 ? 's' : ''}
+        {filterTab !== 'all' && ` (${FILTER_TABS.find(t => t.key === filterTab)?.label})`}
+      </div>
+
+      {/* Model list */}
+      <ul
+        ref={listRef}
+        className="model-list-panel__list"
+        role="listbox"
+        aria-label="Model list"
+        aria-multiselectable="false"
+        tabIndex={flatList.some(e => e.model && listModelName(e.model) === selectedModelId) ? -1 : 0}
+        onKeyDown={handleListKeyDown}
+      >
+        {flatList.map(({ model, status, downloadPct }) => {
+          const mId = listModelName(model);
+          const displayName = listModelDisplayName(model);
+          const recipe = String((model as any).recipe || '');
+          const isSelected = mId === selectedModelId;
+          const cap = capabilityFromModelInfo(model);
+
+          return (
+            <li
+              key={mId}
+              role="option"
+              tabIndex={isSelected ? 0 : -1}
+              aria-selected={isSelected}
+              data-model-id={mId}
+              className={`model-list-item${isSelected ? ' model-list-item--selected' : ''} model-list-item--${status}`}
+              onClick={() => onSelectModel(mId)}
+              onKeyDown={e => handleItemKeyDown(e, mId)}
+              aria-label={`${displayName}${status === 'running' ? ', running' : status === 'downloaded' ? ', downloaded' : status === 'downloading' ? ', downloading' : ', available'}${recipe ? `, ${listRecipeBadgeText(recipe)}` : ''}`}
+            >
+              {/* Backend badge */}
+              {recipe && (
+                <span
+                  className="model-list-item__backend"
+                  style={{ '--list-backend-color': listRecipeColor(recipe) } as React.CSSProperties}
+                  aria-hidden="true"
+                >
+                  {listRecipeBadgeText(recipe)}
+                </span>
+              )}
+
+              {/* Name + meta */}
+              <span className="model-list-item__body">
+                <span className="model-list-item__name">{displayName}</span>
+                <span className="model-list-item__meta">
+                  {model.size != null && model.size > 0 && (
+                    <span className="model-list-item__size">{listFmtSize(model.size)}</span>
+                  )}
+                  <span className="model-list-item__cap">
+                    <CapabilityIcon capability={cap} size={10} aria-hidden="true" />
+                  </span>
+                </span>
+              </span>
+
+              {/* Status indicator */}
+              <span className="model-list-item__status" aria-hidden="true">
+                {status === 'running' && <span className="row__pulse" />}
+                {status === 'downloading' && downloadPct != null && (
+                  <span className="model-list-item__pct">{downloadPct.toFixed(0)}%</span>
+                )}
+                {status === 'downloaded' && <span className="model-list-item__dot model-list-item__dot--ready" />}
+              </span>
+            </li>
+          );
+        })}
+
+        {flatList.length === 0 && (
+          <li className="model-list-panel__empty manager__empty" aria-live="polite">
+            <Icon name="search" size={18} aria-hidden="true" />
+            <span>{searchQuery ? 'No models match your search.' : 'No models found.'}</span>
+          </li>
+        )}
+      </ul>
+
+      {/* Custom model / Omni collection actions */}
+      {(onAddCustomModel || onAddOmniCollection) && (
+        <div className="model-list-panel__footer" aria-label="Add custom models">
+          {onAddCustomModel && (
+            <button
+              type="button"
+              className="btn btn--ghost btn--tiny manager__custom-btn"
+              onClick={onAddCustomModel}
+            >
+              + Custom model
+            </button>
+          )}
+          {onAddOmniCollection && (
+            <button
+              type="button"
+              className="btn btn--ghost btn--tiny manager__custom-btn manager__custom-btn--omni"
+              onClick={onAddOmniCollection}
+            >
+              + Omni collection
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export type { FilterTab };
+export default ModelListPanel;

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -9,6 +9,8 @@ import { DEFAULT_CONTEXT_SIZE, DEFAULT_PRESET, PRESET_STORE_EVENT, Preset, START
 import { DownloadListItem, activeDownloadForModel, downloadStore } from '../features/downloadManager/downloadStore';
 import { TTS_SETTINGS_EVENT, TtsPlaybackMode, loadTtsPlaybackSettings, saveActiveTtsModel, saveSpeakUserText, saveTtsPlaybackMode } from '../features/audio/ttsSettings';
 import { ModelListPanel } from './ModelListPanel';
+import type { PrimaryFilter } from './ModelListPanel';
+import { ModelNavRail } from './ModelNavRail';
 import { ModelDetailPanel } from './ModelDetailPanel';
 
 /* ── Helpers ─────────────────────────────────────────────────── */
@@ -962,6 +964,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [filterTab, setFilterTab] = useState<FilterTab>('all');
+  // Left nav-rail filter dimensions (client-local, derived from the model list).
+  const [primaryFilter, setPrimaryFilter] = useState<PrimaryFilter>('all');
+  const [backendFilter, setBackendFilter] = useState<string>('all');
+  const [tagFilter, setTagFilter] = useState<string | null>(null);
+  const [navRailOpen, setNavRailOpen] = useState(false);
   const [showAllAvailable, setShowAllAvailable] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -2421,8 +2428,35 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     </section>
   );
   return (
-    <div className={`manager manager--detail${mobileDetailOpen ? ' manager--detail-mobile-open' : ''}`}>
-      {/* Left panel: searchable/filterable model list */}
+    <div className={`manager manager--detail${mobileDetailOpen ? ' manager--detail-mobile-open' : ''}${navRailOpen ? ' manager--nav-open' : ''}`}>
+      {/* Responsive: toggle the left nav rail on narrow viewports */}
+      <button
+        type="button"
+        className="manager__nav-toggle"
+        aria-expanded={navRailOpen}
+        aria-controls="model-nav-rail"
+        onClick={() => setNavRailOpen(v => !v)}
+      >
+        <Icon name="sliders-horizontal" size={15} aria-hidden="true" />
+        <span>Filters</span>
+      </button>
+
+      {/* Left rail: navigation / filter dimensions */}
+      <ModelNavRail
+        allModels={allModels}
+        loadedNames={loadedNames}
+        pinnedNames={pinnedNameSet}
+        primaryFilter={primaryFilter}
+        onPrimaryFilterChange={(f) => { setPrimaryFilter(f); setNavRailOpen(false); }}
+        categoryFilter={filterTab}
+        onCategoryFilterChange={(f) => { setFilterTab(f); setNavRailOpen(false); }}
+        backendFilter={backendFilter}
+        onBackendFilterChange={setBackendFilter}
+        tagFilter={tagFilter}
+        onTagFilterChange={(t) => { setTagFilter(t); setNavRailOpen(false); }}
+      />
+
+      {/* Middle panel: searchable/filterable model list */}
       <ModelListPanel
         allModels={allModels}
         loadedNames={loadedNames}
@@ -2438,6 +2472,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         onSearchChange={setSearchQuery}
         filterTab={filterTab}
         onFilterChange={setFilterTab}
+        primaryFilter={primaryFilter}
+        backendFilter={backendFilter}
+        tagFilter={tagFilter}
         searchInputRef={searchRef}
         onAddCustomModel={() => (showCustomForm && !isCustomOmniCollectionDraft) ? closeCustomForm() : openCustomForm('model')}
         onAddOmniCollection={() => openCustomForm('omni-collection')}

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -959,6 +959,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   const pullAbortRef = useRef<Record<string, AbortController>>({});
   const [expandedModel, setExpandedModel] = useState<string | null>(null);
   const [selectedDetailModelId, setSelectedDetailModelId] = useState<string | null>(null);
+  const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [filterTab, setFilterTab] = useState<FilterTab>('all');
   const [showAllAvailable, setShowAllAvailable] = useState(false);
@@ -2420,7 +2421,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     </section>
   );
   return (
-    <div className="manager manager--detail">
+    <div className={`manager manager--detail${mobileDetailOpen ? ' manager--detail-mobile-open' : ''}`}>
       {/* Left panel: searchable/filterable model list */}
       <ModelListPanel
         allModels={allModels}
@@ -2428,7 +2429,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         pulling={pulling}
         downloadItems={downloadItems}
         selectedModelId={selectedDetailModelId}
-        onSelectModel={(id) => { setSelectedDetailModelId(id); if (showCustomForm) closeCustomForm(); }}
+        onSelectModel={(id) => {
+          setSelectedDetailModelId(id);
+          setMobileDetailOpen(true);
+          if (showCustomForm) closeCustomForm();
+        }}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         filterTab={filterTab}
@@ -2608,6 +2613,16 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
           onDelete={handleDelete}
           onCancelPull={handleCancelPull}
           serverDefaultCtxSize={serverDefaultCtxSize}
+          onBack={() => {
+            setMobileDetailOpen(false);
+            // Return focus to the selected list item
+            if (selectedDetailModelId) {
+              requestAnimationFrame(() => {
+                const sel = document.querySelector<HTMLElement>(`[data-model-id="${CSS.escape(selectedDetailModelId)}"]`);
+                sel?.focus();
+              });
+            }
+          }}
         />
       )}
     </div>

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -613,6 +613,28 @@ function savePinnedModels(scope: string, names: string[]): void {
   } catch {}
 }
 
+// Favorites are a DISTINCT client-local concept from Pinned (fl0rianr #2424).
+// Pinned models float to the top of the middle list; favorites is a separate
+// filter/count surfaced by the left-rail "Favorites" (star) entry. Stored under
+// a separate `favorite_models` key so the two never alias.
+function favoriteModelsKey(scope: string): string {
+  return scopedStorageKey(scope, 'favorite_models');
+}
+
+function loadFavoriteModels(scope: string): string[] {
+  try {
+    const raw = localStorage.getItem(favoriteModelsKey(scope));
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.map(v => String(v).trim()).filter(Boolean) : [];
+  } catch { return []; }
+}
+
+function saveFavoriteModels(scope: string, names: string[]): void {
+  try {
+    localStorage.setItem(favoriteModelsKey(scope), JSON.stringify(Array.from(new Set(names.filter(Boolean)))));
+  } catch {}
+}
+
 /* ── Filter / search types ─────────────────────────────────── */
 
 type FilterTab = 'all' | 'llm' | 'omni' | 'image' | 'audio' | 'tts' | 'embedding';
@@ -990,6 +1012,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   const [dynamicRecipeOptions, setDynamicRecipeOptions] = useState<Partial<Record<CustomModelCapability, CustomRecipeOption[]>>>({});
   const [customRecipeAvailabilityLoaded, setCustomRecipeAvailabilityLoaded] = useState(false);
   const [pinnedModels, setPinnedModels] = useState<string[]>(() => loadPinnedModels(accountSession.storageScope));
+  const [favoriteModels, setFavoriteModels] = useState<string[]>(() => loadFavoriteModels(accountSession.storageScope));
+  // Multi-select functional capability filter driven by the funnel popover.
+  const [capabilityFilter, setCapabilityFilter] = useState<Set<string>>(() => new Set());
+  // Real disk usage for the storage meter (null until/unless lemond exposes it).
+  const [storageInfo, setStorageInfo] = useState<import('../api').StorageInfo | null>(null);
   const [ttsPlaybackSettings, setTtsPlaybackSettings] = useState(() => loadTtsPlaybackSettings(accountSession.storageScope));
   const customJsonInputRef = useRef<HTMLInputElement>(null);
 
@@ -1017,7 +1044,19 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
 
   useEffect(() => {
     setPinnedModels(loadPinnedModels(accountSession.storageScope));
+    setFavoriteModels(loadFavoriteModels(accountSession.storageScope));
   }, [accountSession.storageScope]);
+
+  // Fetch real model-storage disk stats. Returns null in the POC (lemond has no
+  // disk endpoint yet) → the rail derives a graceful fallback. Re-runs when the
+  // model set changes so the meter refreshes as downloads complete.
+  useEffect(() => {
+    let cancelled = false;
+    api.getStorageInfo()
+      .then(info => { if (!cancelled) setStorageInfo(info); })
+      .catch(() => { if (!cancelled) setStorageInfo(null); });
+    return () => { cancelled = true; };
+  }, [models.length]);
 
   useEffect(() => {
     const reloadTtsSettings = () => setTtsPlaybackSettings(loadTtsPlaybackSettings(accountSession.storageScope));
@@ -1485,6 +1524,15 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     });
   };
 
+  const toggleFavoriteModel = (name: string) => {
+    setFavoriteModels(prev => {
+      const exists = prev.some(item => item.toLowerCase() === name.toLowerCase());
+      const next = exists ? prev.filter(item => item.toLowerCase() !== name.toLowerCase()) : [name, ...prev];
+      saveFavoriteModels(accountSession.storageScope, next);
+      return next;
+    });
+  };
+
   const activeTtsModelName = ttsPlaybackSettings.modelName;
 
   const toggleTtsSpeechModel = (name: string) => {
@@ -1677,6 +1725,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
 
 
   const pinnedNameSet = useMemo(() => new Set(pinnedModels.map(name => name.toLowerCase())), [pinnedModels]);
+  const favoriteNameSet = useMemo(() => new Set(favoriteModels.map(name => name.toLowerCase())), [favoriteModels]);
 
   const { downloaded, available } = useMemo(() => {
     const dl: ModelInfo[] = [];
@@ -1769,6 +1818,33 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     const localIds = new Set(allModels.map(m => modelName(m).toLowerCase()));
     return hfResults.filter(r => !localIds.has(r.id.toLowerCase()));
   }, [hfResults, allModels, filterTab]);
+
+  // The "Hugging Face" rail entry is live only while a search yields HF matches.
+  const hfSearchActive = filteredHfResults.length > 0;
+
+  // Map HF search results into ModelInfo rows so the SAME middle list can render
+  // them when the Hugging Face nav entry is selected (#2424 item 5).
+  const hfModelInfos = useMemo<ModelInfo[]>(() => filteredHfResults.map(r => ({
+    id: r.id,
+    name: r.id,
+    display_name: r.modelId || r.id,
+    labels: [...(Array.isArray(r.tags) ? r.tags : []), ...(r.pipeline_tag ? [r.pipeline_tag] : [])],
+    downloads: r.downloads,
+    recipe: 'huggingface',
+    huggingface: true,
+  } as ModelInfo)), [filteredHfResults]);
+
+  // When the HF search clears, drop out of the HF view back to All Models.
+  useEffect(() => {
+    if (!hfSearchActive && primaryFilter === 'huggingface') {
+      setPrimaryFilter('all');
+    }
+  }, [hfSearchActive, primaryFilter]);
+
+  // The middle list shows HF results when the HF nav entry is active, otherwise
+  // the normal local registry.
+  const hfMode = primaryFilter === 'huggingface' && hfSearchActive;
+  const listModels = hfMode ? hfModelInfos : allModels;
 
   /* ── Toggle detail ───────────────────────────────────────── */
   const toggleDetail = (name: string) => {
@@ -2446,6 +2522,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         allModels={allModels}
         loadedNames={loadedNames}
         pinnedNames={pinnedNameSet}
+        favoriteNames={favoriteNameSet}
         primaryFilter={primaryFilter}
         onPrimaryFilterChange={(f) => { setPrimaryFilter(f); setNavRailOpen(false); }}
         categoryFilter={filterTab}
@@ -2454,11 +2531,13 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         onBackendFilterChange={setBackendFilter}
         tagFilter={tagFilter}
         onTagFilterChange={(t) => { setTagFilter(t); setNavRailOpen(false); }}
+        storageInfo={storageInfo}
+        hfCount={filteredHfResults.length}
       />
 
       {/* Middle panel: searchable/filterable model list */}
       <ModelListPanel
-        allModels={allModels}
+        allModels={listModels}
         loadedNames={loadedNames}
         pulling={pulling}
         downloadItems={downloadItems}
@@ -2470,16 +2549,19 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         }}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
-        filterTab={filterTab}
+        filterTab={hfMode ? 'all' : filterTab}
         onFilterChange={setFilterTab}
+        capabilityFilter={capabilityFilter}
+        onCapabilityFilterChange={setCapabilityFilter}
         primaryFilter={primaryFilter}
-        backendFilter={backendFilter}
-        tagFilter={tagFilter}
+        backendFilter={hfMode ? 'all' : backendFilter}
+        tagFilter={hfMode ? null : tagFilter}
         searchInputRef={searchRef}
         onAddCustomModel={() => (showCustomForm && !isCustomOmniCollectionDraft) ? closeCustomForm() : openCustomForm('model')}
         onAddOmniCollection={() => openCustomForm('omni-collection')}
         pinnedNames={pinnedNameSet}
         onTogglePin={togglePinnedModel}
+        favoriteNames={favoriteNameSet}
       />
 
       {/* Right panel: custom form overlay OR model detail */}
@@ -2637,7 +2719,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
       ) : (
         <ModelDetailPanel
           model={selectedDetailModelId
-            ? (allModels.find(m => modelName(m) === selectedDetailModelId) ?? null)
+            ? (listModels.find(m => modelName(m) === selectedDetailModelId) ?? null)
             : null}
           loadedModel={selectedDetailModelId
             ? (displayLoadedModels.find(m => m.model_name === selectedDetailModelId) ?? null)
@@ -2652,8 +2734,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
           onDelete={handleDelete}
           onCancelPull={handleCancelPull}
           serverDefaultCtxSize={serverDefaultCtxSize}
-          isFavorite={selectedDetailModelId ? pinnedNameSet.has(selectedDetailModelId.toLowerCase()) : false}
-          onToggleFavorite={togglePinnedModel}
+          isFavorite={selectedDetailModelId ? favoriteNameSet.has(selectedDetailModelId.toLowerCase()) : false}
+          onToggleFavorite={toggleFavoriteModel}
+          noModelsAvailable={allModels.length === 0}
           onBack={() => {
             setMobileDetailOpen(false);
             // Return focus to the selected list item

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -2652,6 +2652,8 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
           onDelete={handleDelete}
           onCancelPull={handleCancelPull}
           serverDefaultCtxSize={serverDefaultCtxSize}
+          isFavorite={selectedDetailModelId ? pinnedNameSet.has(selectedDetailModelId.toLowerCase()) : false}
+          onToggleFavorite={togglePinnedModel}
           onBack={() => {
             setMobileDetailOpen(false);
             // Return focus to the selected list item

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -8,6 +8,8 @@ import { collectionComponentLabel, getCollectionComponents, isCollectionModel, i
 import { DEFAULT_CONTEXT_SIZE, DEFAULT_PRESET, PRESET_STORE_EVENT, Preset, STARTERS, effectivePresetParamPreviewLines, isCompatible, loadApplied, loadUserPresets, modelContextSize, presetHasApplicablePreviewOverrides, presetParamPreviewLines, saveApplied } from '../presetStore';
 import { DownloadListItem, activeDownloadForModel, downloadStore } from '../features/downloadManager/downloadStore';
 import { TTS_SETTINGS_EVENT, TtsPlaybackMode, loadTtsPlaybackSettings, saveActiveTtsModel, saveSpeakUserText, saveTtsPlaybackMode } from '../features/audio/ttsSettings';
+import { ModelListPanel } from './ModelListPanel';
+import { ModelDetailPanel } from './ModelDetailPanel';
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
@@ -956,6 +958,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   const [downloadItems, setDownloadItems] = useState<DownloadListItem[]>(() => downloadStore.snapshot());
   const pullAbortRef = useRef<Record<string, AbortController>>({});
   const [expandedModel, setExpandedModel] = useState<string | null>(null);
+  const [selectedDetailModelId, setSelectedDetailModelId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [filterTab, setFilterTab] = useState<FilterTab>('all');
   const [showAllAvailable, setShowAllAvailable] = useState(false);
@@ -984,10 +987,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
 
   const [userPresets, setUserPresets] = useState<Preset[]>(loadUserPresets);
   const [appliedPresets, setAppliedPresets] = useState<Record<string, string>>(loadApplied);
-  const [presetRailCollapsed, setPresetRailCollapsed] = useState(false);
-  const [selectedRailPresetId, setSelectedRailPresetId] = useState<string>(DEFAULT_PRESET.id);
-  const [presetRailHovered, setPresetRailHovered] = useState(false);
-  const [hoveredRailPresetId, setHoveredRailPresetId] = useState<string | null>(null);
   const [presetNotice, setPresetNotice] = useState<string | null>(null);
   const [serverDefaultCtxSize, setServerDefaultCtxSize] = useState<number>(DEFAULT_CONTEXT_SIZE);
   const hasVisibleModelsRef = useRef(false);
@@ -1624,32 +1623,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     return withLoadedRecipeOptions(info, loaded);
   }, [allModels, focusedModelName, loadedModels]);
   const focusedPreset = focusedModelName ? activePresetForName(focusedModelName) : null;
-  const selectedRailPreset = allPresets.find(p => p.id === selectedRailPresetId) || DEFAULT_PRESET;
-  const railSummaryPreset = (focusedModelName && focusedPreset) ? focusedPreset : selectedRailPreset;
-  const highlightedPresetId = presetRailHovered ? (hoveredRailPresetId || selectedRailPreset.id) : null;
-  const assignedToRailSummaryPreset = useMemo(
-    () => allModels.filter(m => canShowPresetHighlight(m) && activePresetForName(modelName(m)).id === railSummaryPreset.id),
-    [allModels, activePresetForName, railSummaryPreset.id],
-  );
-
-  const handlePresetRailPick = useCallback((preset: Preset) => {
-    setSelectedRailPresetId(preset.id);
-    if (!focusedModelInfo || !focusedModelName) return;
-    if (preset.id !== DEFAULT_PRESET.id && !isCompatible(preset, focusedModelInfo)) {
-      setPresetNotice(`“${preset.name}” is not compatible with ${focusedModelName}.`);
-      window.setTimeout(() => setPresetNotice(null), 2800);
-      return;
-    }
-    setAppliedPresets(prev => {
-      const next = { ...prev };
-      if (preset.id === DEFAULT_PRESET.id) delete next[focusedModelName];
-      else next[focusedModelName] = preset.id;
-      saveApplied(next);
-      return next;
-    });
-    setPresetNotice(`${focusedModelName} → ${preset.name}`);
-    window.setTimeout(() => setPresetNotice(null), 2200);
-  }, [focusedModelInfo, focusedModelName]);
 
   const omniComponentOptions = useMemo(() => {
     const roles: Record<OmniComponentRole, OmniComponentOption[]> = {
@@ -1985,11 +1958,8 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     const selectable = canSelectInComposer(m) || (cap === 'chat' || cap === 'omni' || cap === 'image' || cap === 'audio' || cap === 'tts');
     const activePreset = activePresetForName(m.model_name);
     const isPinned = pinnedNameSet.has(m.model_name.toLowerCase());
-    const isPresetHighlighted = Boolean(highlightedPresetId
-      && activePreset.id === highlightedPresetId
-      && (info ? canShowPresetHighlight(info) : !loadedIsVirtualOmniCollection(m)));
     return (
-      <div className={`row row--running${isActive ? ' row--active' : ''}${isPresetHighlighted ? ' row--preset-highlight' : ''}`} key={m.model_name}>
+      <div className={`row row--running${isActive ? ' row--active' : ''}`} key={m.model_name}>
         <div className="row__summary">
           <button type="button" className="row__content" onClick={() => toggleDetail(m.model_name)} aria-expanded={expandedModel === m.model_name}>
             <div className="row__main">
@@ -2085,12 +2055,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     const cap = capabilityFromModelInfo(m);
     const isPinned = pinnedNameSet.has(name.toLowerCase());
     const rowCtx = contextSizeForDisplay(m, undefined, serverDefaultCtxSize);
-    const isPresetHighlighted = Boolean(highlightedPresetId
-      && activePreset.id === highlightedPresetId
-      && canShowPresetHighlight(m));
 
     return (
-      <div className={`row${expandedModel === name ? ' row--expanded' : ''}${isPresetHighlighted ? ' row--preset-highlight' : ''}`} key={name}>
+      <div className={`row${expandedModel === name ? ' row--expanded' : ''}`} key={name}>
         <div className="row__summary">
           <button type="button" className="row__content" onClick={() => toggleDetail(name)} aria-expanded={expandedModel === name}>
             <div className="row__main">
@@ -2341,58 +2308,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     );
   };
 
-  const renderPresetRail = () => (
-    <aside
-      className={`context-rail context-rail--presets${presetRailCollapsed ? ' is-collapsed' : ''}`}
-      aria-label="Preset rail"
-      onMouseEnter={() => setPresetRailHovered(true)}
-      onMouseLeave={() => { setPresetRailHovered(false); setHoveredRailPresetId(null); }}
-    >
-      <div className="context-rail__head">
-        <button type="button" className="context-rail__toggle" onClick={() => setPresetRailCollapsed(v => !v)} aria-label="Toggle preset rail">☰</button>
-        <div className="context-rail__title-wrap">
-          <span className="context-rail__eyebrow">By model</span>
-          <strong className="context-rail__title">{focusedModelName ? `For ${focusedModelName}` : 'Presets'}</strong>
-        </div>
-      </div>
-      <div className="context-rail__body">
-        <div className="preset-rail-summary">
-          <span className="preset-rail-summary__label">Selected preset</span>
-          <strong><PresetIcon preset={railSummaryPreset} /> {railSummaryPreset.name}</strong>
-          <span>{focusedModelName ? 'Active for this model' : `${assignedToRailSummaryPreset.length} model${assignedToRailSummaryPreset.length === 1 ? '' : 's'} assigned`}</span>
-          <span className="preset-param-lines">{effectivePresetParamPreviewLines(railSummaryPreset, focusedModelInfo, focusedModelInfo ? contextSizeForDisplay(focusedModelInfo, undefined, serverDefaultCtxSize) : serverDefaultCtxSize).map(line => <span key={line}>{line}</span>)}</span>
-        </div>
-        <p className="context-rail__hint">
-          {focusedModelName ? 'Click a preset to assign it to this model. Backend selection stays automatic.' : 'Hover or pick a preset to outline matching models.'}
-        </p>
-        <div className="preset-rail-list">
-          {allPresets.map(preset => {
-            const isActive = focusedModelName ? focusedPreset?.id === preset.id : selectedRailPreset.id === preset.id;
-            const disabled = Boolean(focusedModelInfo && preset.id !== DEFAULT_PRESET.id && !isCompatible(preset, focusedModelInfo));
-            return (
-              <button
-                key={preset.id}
-                type="button"
-                className={`preset-rail-card${isActive ? ' is-active' : ''}${disabled ? ' is-disabled' : ''}`}
-                onClick={() => handlePresetRailPick(preset)}
-                onMouseEnter={() => setHoveredRailPresetId(preset.id)}
-                onFocus={() => setHoveredRailPresetId(preset.id)}
-                onBlur={() => setHoveredRailPresetId(null)}
-                title={disabled ? 'Incompatible with selected model' : preset.description}
-              >
-                <span className="preset-rail-card__icon">{isActive ? <Icon name="check" size={13} /> : <PresetIcon preset={preset} />}</span>
-                <span className="preset-rail-card__text">
-                  <strong>{preset.name}</strong>
-                  <span className="preset-rail-card__params preset-param-lines">{(focusedModelInfo ? effectivePresetParamPreviewLines(preset, focusedModelInfo, contextSizeForDisplay(focusedModelInfo, undefined, serverDefaultCtxSize)) : presetParamPreviewLines(preset, undefined, serverDefaultCtxSize)).map(line => <span key={line}>{line}</span>)}</span>
-                </span>
-              </button>
-            );
-          })}
-        </div>
-        {presetNotice && <div className="context-rail__notice">{presetNotice}</div>}
-      </div>
-    </aside>
-  );
 
 
   /* ── Keyboard shortcut ───────────────────────────────────── */
@@ -2505,79 +2420,27 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     </section>
   );
   return (
-    <div className={`manager manager--with-rail${presetRailCollapsed ? ' context-rail-collapsed' : ''}`}>
-      {renderPresetRail()}
-      <div className="manager__main">
-      <div className="manager__head">
-        <div className="manager__title">
-          <h1>Models</h1>
-          <div className="manager__stats">
-            <span className="manager__stat">
-              <span className="manager__stat-num">{displayLoadedModels.length}</span> running
-            </span>
-            <span className="manager__stat-sep">·</span>
-            <span className="manager__stat">
-              <span className="manager__stat-num">{totalDownloaded}</span> downloaded
-            </span>
-            <span className="manager__stat-sep">·</span>
-            <span className="manager__stat">
-              <span className="manager__stat-num">{allModels.length}</span> available
-            </span>
-            {totalPulling > 0 && (
-              <>
-                <span className="manager__stat-sep">·</span>
-                <span className="manager__stat manager__stat--active">
-                  <span className="manager__stat-num">{totalPulling}</span> downloading
-                </span>
-              </>
-            )}
-          </div>
-        </div>
+    <div className="manager manager--detail">
+      {/* Left panel: searchable/filterable model list */}
+      <ModelListPanel
+        allModels={allModels}
+        loadedNames={loadedNames}
+        pulling={pulling}
+        downloadItems={downloadItems}
+        selectedModelId={selectedDetailModelId}
+        onSelectModel={(id) => { setSelectedDetailModelId(id); if (showCustomForm) closeCustomForm(); }}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        filterTab={filterTab}
+        onFilterChange={setFilterTab}
+        searchInputRef={searchRef}
+        onAddCustomModel={() => (showCustomForm && !isCustomOmniCollectionDraft) ? closeCustomForm() : openCustomForm('model')}
+        onAddOmniCollection={() => openCustomForm('omni-collection')}
+      />
 
-        {/* Search & filter bar */}
-        <div className="manager__toolbar">
-          <div className="manager__search">
-            <span className="manager__search-icon">⌕</span>
-            <input
-              ref={searchRef}
-              className="manager__search-input"
-              type="text"
-              placeholder="Search models… (Ctrl+K)"
-              value={searchQuery}
-              onChange={e => setSearchQuery(e.target.value)}
-            />
-            {searchQuery && (
-              <button className="manager__search-clear" onClick={() => setSearchQuery('')}>×</button>
-            )}
-          </div>
-          <div className="manager__custom-actions">
-            <button className="btn btn--ghost manager__custom-btn" onClick={() => (showCustomForm && !isCustomOmniCollectionDraft) ? closeCustomForm() : openCustomForm('model')}>+ Custom model</button>
-            <button className="btn btn--ghost manager__custom-btn manager__custom-btn--omni" onClick={() => openCustomForm('omni-collection')}>+ Omni collection</button>
-            <input
-              ref={customJsonInputRef}
-              className="hidden-file-input"
-              type="file"
-              accept="application/json,.json"
-              onChange={e => { void handleImportCustomModels(e.target.files?.[0]); }}
-            />
-          </div>
-          <div className="manager__filters">
-            {FILTER_TABS.map(tab => (
-              <button
-                key={tab.key}
-                className={`manager__filter${filterTab === tab.key ? ' manager__filter--active' : ''}`}
-                onClick={() => setFilterTab(tab.key)}
-              >
-                <span className="manager__filter-icon"><CapabilityIcon capability={tab.icon} size={13} /></span>
-                {tab.label}
-              </button>
-            ))}
-          </div>
-        </div>
-      </div>
-
-      <div className="manager__body">
-        {showCustomForm && (
+      {/* Right panel: custom form overlay OR model detail */}
+      {showCustomForm ? (
+        <div className="manager__detail-form-panel">
           <section className="zone custom-model-form" aria-label={`Add ${customFormTitle}`}>
             <div className="zone__head">
               <span className="zone__dot zone__dot--available" />
@@ -2718,95 +2581,37 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
               </div>
             </form>
           </section>
-        )}
-
-        {modelsLoading && (
-          <section className="zone" aria-label="Loading models">
-            <div className="zone__head">
-              <span className="zone__dot zone__dot--available" />
-              <span className="zone__title">Loading models…</span>
-              <span className="zone__rule" />
-            </div>
-            <div className="manager__loading">Refreshing Lemonade model registry…</div>
-          </section>
-        )}
-
-        {shouldPinHuggingFaceZone && renderHuggingFaceZone()}
-
-        {customJsonNotice && <div className="manager__inline-notice">{customJsonNotice}</div>}
-
-        {pinnedVisibleModels.length > 0 && (
-          <section className="zone zone--pinned">
-            <div className="zone__head">
-              <span className="zone__dot zone__dot--ready" />
-              <span className="zone__title">Pinned Models</span>
-              <span className="zone__count">{pinnedVisibleModels.length}</span>
-              <span className="zone__rule" />
-            </div>
-            {pinnedVisibleModels.map(m => renderModelRow(m, downloaded.some(d => modelName(d).toLowerCase() === modelName(m).toLowerCase())))}
-          </section>
-        )}
-
-        {/* Running zone */}
-        {filteredRunning.length > 0 && (
-          <section className="zone zone--running">
-            <div className="zone__head">
-              <span className="zone__dot zone__dot--running" />
-              <span className="zone__title">Loaded Models</span>
-              <span className="zone__count">{filteredRunning.length}</span>
-              <span className="zone__rule" />
-            </div>
-            {filteredRunning.map(m => renderRunningModel(m))}
-          </section>
-        )}
-
-        {/* Downloaded / Ready zone */}
-        {visibleFilteredDownloaded.length > 0 && (
-          <section className="zone zone--downloaded">
-            <div className="zone__head">
-              <span className="zone__dot zone__dot--ready" />
-              <span className="zone__title">Downloaded</span>
-              <span className="zone__count">{visibleFilteredDownloaded.length}</span>
-              <span className="zone__rule" />
-            </div>
-            {visibleFilteredDownloaded.map(m => renderModelRow(m, true))}
-          </section>
-        )}
-
-        {/* Available zone */}
-        {visibleFilteredAvailable.length > 0 && (
-          <section className="zone">
-            <div className="zone__head">
-              <span className="zone__dot zone__dot--available" />
-              <span className="zone__title">Lemonade Registry</span>
-              <span className="zone__count">{visibleFilteredAvailable.length}</span>
-              <span className="zone__rule" />
-            </div>
-            {visibleAvailable.map(m => renderModelRow(m, false))}
-            {hiddenAvailableCount > 0 && (
-              <button
-                className="zone__show-more"
-                onClick={() => setShowAllAvailable(true)}
-              >
-                Show {hiddenAvailableCount} more models
-              </button>
-            )}
-          </section>
-        )}
-
-        {!shouldPinHuggingFaceZone && renderHuggingFaceZone()}
-
-        <div className={`manager__empty${showManagerEmpty ? '' : ' manager__empty--hidden'}`} aria-hidden={!showManagerEmpty}>
-          <span className="manager__empty-icon">{api.isConnected ? <Icon name="box" size={42} /> : <Icon name="plug" size={42} />}</span>
-          <p>{api.isConnected
-            ? 'No models found matching your search.'
-            : 'Connect to a Lemonade server to see models.'
-          }</p>
+          <input
+            ref={customJsonInputRef}
+            className="hidden-file-input"
+            type="file"
+            accept="application/json,.json"
+            onChange={e => { void handleImportCustomModels(e.target.files?.[0]); }}
+          />
+          {customJsonNotice && <div className="manager__inline-notice">{customJsonNotice}</div>}
         </div>
-      </div>
-      </div>
+      ) : (
+        <ModelDetailPanel
+          model={selectedDetailModelId
+            ? (allModels.find(m => modelName(m) === selectedDetailModelId) ?? null)
+            : null}
+          loadedModel={selectedDetailModelId
+            ? (displayLoadedModels.find(m => m.model_name === selectedDetailModelId) ?? null)
+            : null}
+          loadingModel={loadingModel}
+          pulling={pulling}
+          loadError={loadError}
+          onLoad={handleLoad}
+          onUnload={handleUnload}
+          onPull={handlePull}
+          onPullAndLoad={handlePullAndLoad}
+          onDelete={handleDelete}
+          onCancelPull={handleCancelPull}
+          serverDefaultCtxSize={serverDefaultCtxSize}
+        />
+      )}
     </div>
   );
 };
 
-export default ModelManager;
+export default ModelManager;

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -2441,6 +2441,8 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         searchInputRef={searchRef}
         onAddCustomModel={() => (showCustomForm && !isCustomOmniCollectionDraft) ? closeCustomForm() : openCustomForm('model')}
         onAddOmniCollection={() => openCustomForm('omni-collection')}
+        pinnedNames={pinnedNameSet}
+        onTogglePin={togglePinnedModel}
       />
 
       {/* Right panel: custom form overlay OR model detail */}

--- a/prototype/ui-redesign/src/components/ModelNavRail.tsx
+++ b/prototype/ui-redesign/src/components/ModelNavRail.tsx
@@ -19,7 +19,7 @@
  * download sizes where available, falling back to MOCK placeholder values.
  */
 import React, { useMemo, useState } from 'react';
-import type { ModelInfo } from '../api';
+import type { ModelInfo, StorageInfo } from '../api';
 import { Icon } from './Icon';
 import type { IconName } from './Icon';
 import {
@@ -39,7 +39,8 @@ const PRIMARY_ITEMS: Array<{ key: PrimaryFilter; label: string; iconName: IconNa
   { key: 'all', label: 'All Models', iconName: 'library' },
   { key: 'downloaded', label: 'Downloaded', iconName: 'download' },
   { key: 'my-models', label: 'My Models', iconName: 'box' },
-  { key: 'favorites', label: 'Favorites', iconName: 'pin' },
+  // Favorites is a DISTINCT concept from Pinned (#2424): star icon, own store.
+  { key: 'favorites', label: 'Favorites', iconName: 'star' },
 ];
 
 const CATEGORY_ITEMS: Array<{ key: FilterTab; label: string; iconName: IconName }> = [
@@ -53,11 +54,21 @@ const CATEGORY_ITEMS: Array<{ key: FilterTab; label: string; iconName: IconName 
 ];
 
 /* ── Storage (POC) ───────────────────────────────────────────────
-   No lemond disk-usage endpoint is available to the client, so the
-   total capacity is a MOCK placeholder. Used space is derived from the
-   sizes of downloaded models when present, otherwise a MOCK value. */
-const MOCK_TOTAL_STORAGE_GB = 512;
-const MOCK_USED_STORAGE_GB = 128;
+   Preferred source is real disk stats via `storageInfo` (api.getStorageInfo()).
+   When lemond exposes no disk-usage endpoint (current POC reality), the meter
+   falls back to a derived estimate: used = sum of downloaded model sizes, total
+   = a headroom-rounded capacity above that — never a hardcoded literal. */
+const BYTES_PER_GB = 1024 * 1024 * 1024;
+
+/** Round up to a "nice" capacity (GB) that leaves headroom above `usedGb`. */
+function deriveFallbackTotalGb(usedGb: number): number {
+  const steps = [16, 32, 64, 128, 256, 512, 1024, 2048, 4096];
+  const target = Math.max(usedGb * 2, usedGb + 8, 16);
+  for (const step of steps) {
+    if (step >= target) return step;
+  }
+  return Math.ceil(target / 1024) * 1024;
+}
 
 /* ── Props ───────────────────────────────────────────────────── */
 
@@ -65,6 +76,8 @@ export interface ModelNavRailProps {
   allModels: ModelInfo[];
   loadedNames: Set<string>;
   pinnedNames: Set<string>;
+  /** Favorited model names (distinct from pinned) — drives the Favorites count. */
+  favoriteNames: Set<string>;
   primaryFilter: PrimaryFilter;
   onPrimaryFilterChange: (f: PrimaryFilter) => void;
   categoryFilter: FilterTab;
@@ -73,6 +86,12 @@ export interface ModelNavRailProps {
   onBackendFilterChange: (b: string) => void;
   tagFilter: string | null;
   onTagFilterChange: (t: string | null) => void;
+  /** Real disk usage of the model-storage drive, when available (else null →
+      derived fallback). Sourced from api.getStorageInfo(). */
+  storageInfo?: StorageInfo | null;
+  /** Count of HuggingFace search matches. When > 0, a "Hugging Face" nav entry
+      appears below the primary list; clicking it filters to HF results. */
+  hfCount?: number;
   /** id used by the responsive nav toggle's aria-controls. */
   id?: string;
 }
@@ -83,6 +102,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
   allModels,
   loadedNames,
   pinnedNames,
+  favoriteNames,
   primaryFilter,
   onPrimaryFilterChange,
   categoryFilter,
@@ -91,6 +111,8 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
   onBackendFilterChange,
   tagFilter,
   onTagFilterChange,
+  storageInfo,
+  hfCount = 0,
   id = 'model-nav-rail',
 }) => {
   const [categoriesOpen, setCategoriesOpen] = useState(true);
@@ -98,16 +120,16 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
 
   // ── Client-side derived counts ──────────────────────────────
   const primaryCounts = useMemo<Record<PrimaryFilter, number>>(() => {
-    const counts: Record<PrimaryFilter, number> = { all: 0, downloaded: 0, 'my-models': 0, favorites: 0 };
+    const counts: Record<PrimaryFilter, number> = { all: 0, downloaded: 0, 'my-models': 0, favorites: 0, huggingface: 0 };
     for (const m of allModels) {
       if (!listModelName(m)) continue;
       counts.all += 1;
-      if (modelMatchesPrimary(m, 'downloaded', loadedNames, pinnedNames)) counts.downloaded += 1;
-      if (modelMatchesPrimary(m, 'my-models', loadedNames, pinnedNames)) counts['my-models'] += 1;
-      if (modelMatchesPrimary(m, 'favorites', loadedNames, pinnedNames)) counts.favorites += 1;
+      if (modelMatchesPrimary(m, 'downloaded', loadedNames, favoriteNames)) counts.downloaded += 1;
+      if (modelMatchesPrimary(m, 'my-models', loadedNames, favoriteNames)) counts['my-models'] += 1;
+      if (modelMatchesPrimary(m, 'favorites', loadedNames, favoriteNames)) counts.favorites += 1;
     }
     return counts;
-  }, [allModels, loadedNames, pinnedNames]);
+  }, [allModels, loadedNames, favoriteNames]);
 
   const categoryCounts = useMemo<Record<string, number>>(() => {
     const counts: Record<string, number> = {};
@@ -147,19 +169,27 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
     return counts;
   }, [allModels]);
 
-  // ── Storage meter (derived where possible, else MOCK) ───────
+  // ── Storage meter ───────────────────────────────────────────
+  // Prefer REAL disk stats (storageInfo). When unavailable in the POC, derive
+  // a graceful estimate from downloaded model sizes — no hardcoded capacity.
   const storage = useMemo(() => {
+    if (storageInfo && storageInfo.totalBytes > 0) {
+      const usedGb = Math.max(0, Math.round(storageInfo.usedBytes / BYTES_PER_GB));
+      const totalGb = Math.max(1, Math.round(storageInfo.totalBytes / BYTES_PER_GB));
+      const pct = Math.min(100, Math.round((storageInfo.usedBytes / storageInfo.totalBytes) * 100));
+      return { used: usedGb, total: totalGb, pct, real: true };
+    }
     let usedGb = 0;
     for (const m of allModels) {
-      const downloaded = modelMatchesPrimary(m, 'downloaded', loadedNames, pinnedNames);
+      const downloaded = modelMatchesPrimary(m, 'downloaded', loadedNames, favoriteNames);
       const size = Number((m as any).size);
       if (downloaded && Number.isFinite(size) && size > 0) usedGb += size;
     }
-    const used = usedGb > 0 ? Math.round(usedGb) : MOCK_USED_STORAGE_GB;
-    const total = MOCK_TOTAL_STORAGE_GB;
+    const used = Math.max(1, Math.round(usedGb));
+    const total = deriveFallbackTotalGb(used);
     const pct = Math.min(100, Math.round((used / total) * 100));
-    return { used, total, pct };
-  }, [allModels, loadedNames, pinnedNames]);
+    return { used, total, pct, real: false };
+  }, [storageInfo, allModels, loadedNames, favoriteNames]);
 
   return (
     <nav className="model-nav-rail" id={id} aria-label="Model filters">
@@ -183,9 +213,25 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
             </li>
           );
         })}
+        {/* HuggingFace search results — only present while a search is active.
+            Positioned BELOW My Models and Favorites (#2424). Count reflects the
+            current HF search matches; clicking filters the middle list to them. */}
+        {hfCount > 0 && (
+          <li>
+            <button
+              type="button"
+              className={`model-nav-rail__nav-item${primaryFilter === 'huggingface' ? ' model-nav-rail__nav-item--active' : ''}`}
+              aria-current={primaryFilter === 'huggingface' ? 'true' : undefined}
+              onClick={() => onPrimaryFilterChange('huggingface')}
+            >
+              <Icon name="hugging-face" size={15} aria-hidden="true" className="model-nav-rail__nav-icon" />
+              <span className="model-nav-rail__nav-label">Hugging Face</span>
+              <span className="model-nav-rail__nav-count" aria-hidden="true">{hfCount}</span>
+              <span className="sr-only">{`, ${hfCount} HuggingFace search results`}</span>
+            </button>
+          </li>
+        )}
       </ul>
-
-      {/* 2. Categories (collapsible) */}
       <section className="model-nav-rail__section">
         <h2 className="model-nav-rail__section-head">
           <button
@@ -283,17 +329,17 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
       {/* 5. Storage meter */}
       <div className="model-nav-rail__storage">
         <div className="model-nav-rail__storage-row">
-          <span className="model-nav-rail__storage-label">Storage</span>
+          <span className="model-nav-rail__storage-label">Storage{storage.real ? '' : ' (est.)'}</span>
           <span className="model-nav-rail__storage-value">{`${storage.used} GB / ${storage.total} GB`}</span>
         </div>
         <div
           className="model-nav-rail__storage-bar"
           role="progressbar"
-          aria-label="Model storage used"
+          aria-label={storage.real ? 'Model storage used' : 'Model storage used (estimated)'}
           aria-valuenow={storage.used}
           aria-valuemin={0}
           aria-valuemax={storage.total}
-          aria-valuetext={`${storage.used} of ${storage.total} gigabytes used`}
+          aria-valuetext={`${storage.used} of ${storage.total} gigabytes used${storage.real ? '' : ' (estimated)'}`}
         >
           <span className="model-nav-rail__storage-fill" style={{ width: `${storage.pct}%` }} aria-hidden="true" />
         </div>

--- a/prototype/ui-redesign/src/components/ModelNavRail.tsx
+++ b/prototype/ui-redesign/src/components/ModelNavRail.tsx
@@ -8,13 +8,11 @@
  *   └──────────────┴──────────────────┴─────────────────────────┘
  *
  * The rail surfaces filter dimensions that drive the middle list:
- *   1. Preset quick-search + "+ New" (POC placeholder — presets live in the
- *      model-detail Presets tab per fl0rianr's "2) a"; wiring deferred).
- *   2. Primary nav: All Models / Downloaded / My Models / Favorites.
- *   3. CATEGORIES (collapsible): All / LLM / Omni / Image / Audio / TTS / Embed.
- *   4. Backends (collapsible select): filter by recipe.
- *   5. TAGS (collapsible): model-family + size chips.
- *   6. Storage meter (role="progressbar").
+ *   1. Primary nav: All Models / Downloaded / My Models / Favorites.
+ *   2. CATEGORIES (collapsible): All / LLM / Omni / Image / Audio / TTS / Embed.
+ *   3. Backends (collapsible select): filter by recipe.
+ *   4. TAGS (collapsible): model-family + size chips.
+ *   5. Storage meter (role="progressbar").
  *
  * ALL counts/categories/tags/backends are derived CLIENT-SIDE from the model
  * list the prototype already loads — no lemond calls. Storage uses derived
@@ -95,7 +93,6 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
   onTagFilterChange,
   id = 'model-nav-rail',
 }) => {
-  const [presetQuery, setPresetQuery] = useState('');
   const [categoriesOpen, setCategoriesOpen] = useState(true);
   const [tagsOpen, setTagsOpen] = useState(true);
 
@@ -166,27 +163,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
 
   return (
     <nav className="model-nav-rail" id={id} aria-label="Model filters">
-      {/* 1. Preset quick-search + New (POC placeholder) */}
-      <div className="model-nav-rail__preset-row">
-        <div className="model-nav-rail__preset-search">
-          <Icon name="search" size={13} aria-hidden="true" className="model-nav-rail__preset-icon" />
-          <label htmlFor="nav-preset-search" className="sr-only">Search presets</label>
-          <input
-            id="nav-preset-search"
-            type="text"
-            className="model-nav-rail__preset-input"
-            placeholder="Search presets…"
-            value={presetQuery}
-            onChange={e => setPresetQuery(e.target.value)}
-            autoComplete="off"
-          />
-        </div>
-        <button type="button" className="btn btn--ghost btn--tiny model-nav-rail__new-btn" aria-label="New preset">
-          + New
-        </button>
-      </div>
-
-      {/* 2. Primary nav */}
+      {/* 1. Primary nav */}
       <ul className="model-nav-rail__primary" role="list">
         {PRIMARY_ITEMS.map(item => {
           const active = primaryFilter === item.key;
@@ -208,7 +185,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
         })}
       </ul>
 
-      {/* 3. Categories (collapsible) */}
+      {/* 2. Categories (collapsible) */}
       <section className="model-nav-rail__section">
         <h2 className="model-nav-rail__section-head">
           <button
@@ -246,7 +223,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
         )}
       </section>
 
-      {/* 4. Backends select */}
+      {/* 3. Backends select */}
       <div className="model-nav-rail__backends">
         <label htmlFor="nav-backend-select" className="model-nav-rail__backends-label">Backends</label>
         <select
@@ -262,7 +239,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
         </select>
       </div>
 
-      {/* 5. Tags (collapsible) */}
+      {/* 4. Tags (collapsible) */}
       <section className="model-nav-rail__section">
         <h2 className="model-nav-rail__section-head">
           <button
@@ -303,7 +280,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
         )}
       </section>
 
-      {/* 6. Storage meter */}
+      {/* 5. Storage meter */}
       <div className="model-nav-rail__storage">
         <div className="model-nav-rail__storage-row">
           <span className="model-nav-rail__storage-label">Storage</span>

--- a/prototype/ui-redesign/src/components/ModelNavRail.tsx
+++ b/prototype/ui-redesign/src/components/ModelNavRail.tsx
@@ -1,0 +1,328 @@
+/**
+ * ModelNavRail — the LEFT navigation rail of the three-pane model view.
+ *
+ * Pane layout (GUI3, #2355 follow-up requested by fl0rianr):
+ *   ┌──────────────┬──────────────────┬─────────────────────────┐
+ *   │ ModelNavRail │  ModelListPanel  │     ModelDetailPanel     │
+ *   │   (left)     │     (middle)     │         (right)          │
+ *   └──────────────┴──────────────────┴─────────────────────────┘
+ *
+ * The rail surfaces filter dimensions that drive the middle list:
+ *   1. Preset quick-search + "+ New" (POC placeholder — presets live in the
+ *      model-detail Presets tab per fl0rianr's "2) a"; wiring deferred).
+ *   2. Primary nav: All Models / Downloaded / My Models / Favorites.
+ *   3. CATEGORIES (collapsible): All / LLM / Omni / Image / Audio / TTS / Embed.
+ *   4. Backends (collapsible select): filter by recipe.
+ *   5. TAGS (collapsible): model-family + size chips.
+ *   6. Storage meter (role="progressbar").
+ *
+ * ALL counts/categories/tags/backends are derived CLIENT-SIDE from the model
+ * list the prototype already loads — no lemond calls. Storage uses derived
+ * download sizes where available, falling back to MOCK placeholder values.
+ */
+import React, { useMemo, useState } from 'react';
+import type { ModelInfo } from '../api';
+import { Icon } from './Icon';
+import type { IconName } from './Icon';
+import {
+  listModelName,
+  listRecipeBadgeText,
+  modelMatchesFilter,
+  modelMatchesPrimary,
+  modelMatchesTag,
+  TAG_CHIPS,
+  type FilterTab,
+  type PrimaryFilter,
+} from './ModelListPanel';
+
+/* ── Static config ───────────────────────────────────────────── */
+
+const PRIMARY_ITEMS: Array<{ key: PrimaryFilter; label: string; iconName: IconName }> = [
+  { key: 'all', label: 'All Models', iconName: 'library' },
+  { key: 'downloaded', label: 'Downloaded', iconName: 'download' },
+  { key: 'my-models', label: 'My Models', iconName: 'box' },
+  { key: 'favorites', label: 'Favorites', iconName: 'pin' },
+];
+
+const CATEGORY_ITEMS: Array<{ key: FilterTab; label: string; iconName: IconName }> = [
+  { key: 'all', label: 'All', iconName: 'globe' },
+  { key: 'llm', label: 'LLM', iconName: 'chat' },
+  { key: 'omni', label: 'Omni', iconName: 'omni' },
+  { key: 'image', label: 'Image', iconName: 'image' },
+  { key: 'audio', label: 'Audio', iconName: 'audio' },
+  { key: 'tts', label: 'TTS', iconName: 'tts' },
+  { key: 'embedding', label: 'Embed', iconName: 'embedding' },
+];
+
+/* ── Storage (POC) ───────────────────────────────────────────────
+   No lemond disk-usage endpoint is available to the client, so the
+   total capacity is a MOCK placeholder. Used space is derived from the
+   sizes of downloaded models when present, otherwise a MOCK value. */
+const MOCK_TOTAL_STORAGE_GB = 512;
+const MOCK_USED_STORAGE_GB = 128;
+
+/* ── Props ───────────────────────────────────────────────────── */
+
+export interface ModelNavRailProps {
+  allModels: ModelInfo[];
+  loadedNames: Set<string>;
+  pinnedNames: Set<string>;
+  primaryFilter: PrimaryFilter;
+  onPrimaryFilterChange: (f: PrimaryFilter) => void;
+  categoryFilter: FilterTab;
+  onCategoryFilterChange: (f: FilterTab) => void;
+  backendFilter: string;
+  onBackendFilterChange: (b: string) => void;
+  tagFilter: string | null;
+  onTagFilterChange: (t: string | null) => void;
+  /** id used by the responsive nav toggle's aria-controls. */
+  id?: string;
+}
+
+/* ── Component ───────────────────────────────────────────────── */
+
+export const ModelNavRail: React.FC<ModelNavRailProps> = ({
+  allModels,
+  loadedNames,
+  pinnedNames,
+  primaryFilter,
+  onPrimaryFilterChange,
+  categoryFilter,
+  onCategoryFilterChange,
+  backendFilter,
+  onBackendFilterChange,
+  tagFilter,
+  onTagFilterChange,
+  id = 'model-nav-rail',
+}) => {
+  const [presetQuery, setPresetQuery] = useState('');
+  const [categoriesOpen, setCategoriesOpen] = useState(true);
+  const [tagsOpen, setTagsOpen] = useState(true);
+
+  // ── Client-side derived counts ──────────────────────────────
+  const primaryCounts = useMemo<Record<PrimaryFilter, number>>(() => {
+    const counts: Record<PrimaryFilter, number> = { all: 0, downloaded: 0, 'my-models': 0, favorites: 0 };
+    for (const m of allModels) {
+      if (!listModelName(m)) continue;
+      counts.all += 1;
+      if (modelMatchesPrimary(m, 'downloaded', loadedNames, pinnedNames)) counts.downloaded += 1;
+      if (modelMatchesPrimary(m, 'my-models', loadedNames, pinnedNames)) counts['my-models'] += 1;
+      if (modelMatchesPrimary(m, 'favorites', loadedNames, pinnedNames)) counts.favorites += 1;
+    }
+    return counts;
+  }, [allModels, loadedNames, pinnedNames]);
+
+  const categoryCounts = useMemo<Record<string, number>>(() => {
+    const counts: Record<string, number> = {};
+    for (const item of CATEGORY_ITEMS) counts[item.key] = 0;
+    for (const m of allModels) {
+      if (!listModelName(m)) continue;
+      for (const item of CATEGORY_ITEMS) {
+        if (modelMatchesFilter(m, item.key)) counts[item.key] += 1;
+      }
+    }
+    return counts;
+  }, [allModels]);
+
+  // Distinct backends (recipes) with counts, derived from the model list.
+  const backends = useMemo<Array<{ value: string; label: string; count: number }>>(() => {
+    const counts = new Map<string, number>();
+    for (const m of allModels) {
+      const recipe = String((m as any).recipe || '').toLowerCase();
+      if (!recipe) continue;
+      counts.set(recipe, (counts.get(recipe) ?? 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([value, count]) => ({ value, label: listRecipeBadgeText(value), count }))
+      .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  }, [allModels]);
+
+  // Only show tag chips that match at least one model (keeps the rail honest).
+  const tagCounts = useMemo<Record<string, number>>(() => {
+    const counts: Record<string, number> = {};
+    for (const tag of TAG_CHIPS) counts[tag] = 0;
+    for (const m of allModels) {
+      if (!listModelName(m)) continue;
+      for (const tag of TAG_CHIPS) {
+        if (modelMatchesTag(m, tag)) counts[tag] += 1;
+      }
+    }
+    return counts;
+  }, [allModels]);
+
+  // ── Storage meter (derived where possible, else MOCK) ───────
+  const storage = useMemo(() => {
+    let usedGb = 0;
+    for (const m of allModels) {
+      const downloaded = modelMatchesPrimary(m, 'downloaded', loadedNames, pinnedNames);
+      const size = Number((m as any).size);
+      if (downloaded && Number.isFinite(size) && size > 0) usedGb += size;
+    }
+    const used = usedGb > 0 ? Math.round(usedGb) : MOCK_USED_STORAGE_GB;
+    const total = MOCK_TOTAL_STORAGE_GB;
+    const pct = Math.min(100, Math.round((used / total) * 100));
+    return { used, total, pct };
+  }, [allModels, loadedNames, pinnedNames]);
+
+  return (
+    <nav className="model-nav-rail" id={id} aria-label="Model filters">
+      {/* 1. Preset quick-search + New (POC placeholder) */}
+      <div className="model-nav-rail__preset-row">
+        <div className="model-nav-rail__preset-search">
+          <Icon name="search" size={13} aria-hidden="true" className="model-nav-rail__preset-icon" />
+          <label htmlFor="nav-preset-search" className="sr-only">Search presets</label>
+          <input
+            id="nav-preset-search"
+            type="text"
+            className="model-nav-rail__preset-input"
+            placeholder="Search presets…"
+            value={presetQuery}
+            onChange={e => setPresetQuery(e.target.value)}
+            autoComplete="off"
+          />
+        </div>
+        <button type="button" className="btn btn--ghost btn--tiny model-nav-rail__new-btn" aria-label="New preset">
+          + New
+        </button>
+      </div>
+
+      {/* 2. Primary nav */}
+      <ul className="model-nav-rail__primary" role="list">
+        {PRIMARY_ITEMS.map(item => {
+          const active = primaryFilter === item.key;
+          return (
+            <li key={item.key}>
+              <button
+                type="button"
+                className={`model-nav-rail__nav-item${active ? ' model-nav-rail__nav-item--active' : ''}`}
+                aria-current={active ? 'true' : undefined}
+                onClick={() => onPrimaryFilterChange(item.key)}
+              >
+                <Icon name={item.iconName} size={15} aria-hidden="true" className="model-nav-rail__nav-icon" />
+                <span className="model-nav-rail__nav-label">{item.label}</span>
+                <span className="model-nav-rail__nav-count" aria-hidden="true">{primaryCounts[item.key]}</span>
+                <span className="sr-only">{`, ${primaryCounts[item.key]} models`}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* 3. Categories (collapsible) */}
+      <section className="model-nav-rail__section">
+        <h2 className="model-nav-rail__section-head">
+          <button
+            type="button"
+            className="model-nav-rail__section-toggle"
+            aria-expanded={categoriesOpen}
+            aria-controls="nav-categories"
+            onClick={() => setCategoriesOpen(v => !v)}
+          >
+            <Icon name={categoriesOpen ? 'chevron-down' : 'chevron-right'} size={13} aria-hidden="true" />
+            <span>Categories</span>
+          </button>
+        </h2>
+        {categoriesOpen && (
+          <ul className="model-nav-rail__cat-list" id="nav-categories" role="list">
+            {CATEGORY_ITEMS.map(item => {
+              const active = categoryFilter === item.key;
+              return (
+                <li key={item.key}>
+                  <button
+                    type="button"
+                    className={`model-nav-rail__cat-item${active ? ' model-nav-rail__cat-item--active' : ''}`}
+                    aria-current={active ? 'true' : undefined}
+                    onClick={() => onCategoryFilterChange(item.key)}
+                  >
+                    <Icon name={item.iconName} size={14} aria-hidden="true" className="model-nav-rail__cat-icon" />
+                    <span className="model-nav-rail__cat-label">{item.label}</span>
+                    <span className="model-nav-rail__nav-count" aria-hidden="true">{categoryCounts[item.key]}</span>
+                    <span className="sr-only">{`, ${categoryCounts[item.key]} models`}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      {/* 4. Backends select */}
+      <div className="model-nav-rail__backends">
+        <label htmlFor="nav-backend-select" className="model-nav-rail__backends-label">Backends</label>
+        <select
+          id="nav-backend-select"
+          className="model-nav-rail__backends-select"
+          value={backendFilter}
+          onChange={e => onBackendFilterChange(e.target.value)}
+        >
+          <option value="all">All backends</option>
+          {backends.map(b => (
+            <option key={b.value} value={b.value}>{`${b.label} (${b.count})`}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* 5. Tags (collapsible) */}
+      <section className="model-nav-rail__section">
+        <h2 className="model-nav-rail__section-head">
+          <button
+            type="button"
+            className="model-nav-rail__section-toggle"
+            aria-expanded={tagsOpen}
+            aria-controls="nav-tags"
+            onClick={() => setTagsOpen(v => !v)}
+          >
+            <Icon name={tagsOpen ? 'chevron-down' : 'chevron-right'} size={13} aria-hidden="true" />
+            <span>Tags</span>
+          </button>
+        </h2>
+        {tagsOpen && (
+          <div className="model-nav-rail__tags" id="nav-tags" role="group" aria-label="Filter by tag">
+            {TAG_CHIPS.filter(tag => tagCounts[tag] > 0).map(tag => {
+              const active = tagFilter?.toLowerCase() === tag.toLowerCase();
+              return (
+                <button
+                  key={tag}
+                  type="button"
+                  className={`model-nav-rail__tag${active ? ' model-nav-rail__tag--active' : ''}`}
+                  aria-pressed={active}
+                  onClick={() => onTagFilterChange(active ? null : tag)}
+                >
+                  {tag}
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              className="model-nav-rail__tag model-nav-rail__tag--recommended"
+              aria-label="Show recommended tags"
+            >
+              + Recommended +
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* 6. Storage meter */}
+      <div className="model-nav-rail__storage">
+        <div className="model-nav-rail__storage-row">
+          <span className="model-nav-rail__storage-label">Storage</span>
+          <span className="model-nav-rail__storage-value">{`${storage.used} GB / ${storage.total} GB`}</span>
+        </div>
+        <div
+          className="model-nav-rail__storage-bar"
+          role="progressbar"
+          aria-label="Model storage used"
+          aria-valuenow={storage.used}
+          aria-valuemin={0}
+          aria-valuemax={storage.total}
+          aria-valuetext={`${storage.used} of ${storage.total} gigabytes used`}
+        >
+          <span className="model-nav-rail__storage-fill" style={{ width: `${storage.pct}%` }} aria-hidden="true" />
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export default ModelNavRail;

--- a/prototype/ui-redesign/src/modelCapabilities.ts
+++ b/prototype/ui-redesign/src/modelCapabilities.ts
@@ -207,3 +207,67 @@ export function selectPreferredLoadedModel(loadedModels: LoadedModel[]): LoadedM
 
 export function modelDisplayName(model: ModelSnapshot | null | undefined): string { return model?.name || 'Assistant'; }
 export function modelInitial(model: ModelSnapshot | null | undefined): string { return modelDisplayName(model).charAt(0).toUpperCase(); }
+
+/* ── Functional capability tags (PR #2424 fl0rianr) ────────────────
+   A single model can expose MULTIPLE functional capabilities (tool use,
+   vision, popular, audio, …). These drive BOTH the funnel multi-select
+   filter and the capability icons shown on each middle-panel row. They are
+   derived client-side from the model's labels plus its base modality — no
+   lemond calls. */
+export type CapabilityTag =
+  | 'popular' | 'chat' | 'omni' | 'vision' | 'tool' | 'reasoning'
+  | 'code' | 'audio' | 'image' | 'tts' | 'embedding' | 'reranking';
+
+/** Canonical display order for tags (funnel options + row icons). */
+export const CAPABILITY_TAG_ORDER: CapabilityTag[] = [
+  'popular', 'chat', 'omni', 'vision', 'tool', 'reasoning',
+  'code', 'audio', 'image', 'tts', 'embedding', 'reranking',
+];
+
+export const CAPABILITY_TAG_LABELS: Record<CapabilityTag, string> = {
+  popular: 'Popular', chat: 'Chat', omni: 'Omni', vision: 'Vision',
+  tool: 'Tool use', reasoning: 'Reasoning', code: 'Code', audio: 'Audio',
+  image: 'Image', tts: 'Speech (TTS)', embedding: 'Embeddings', reranking: 'Reranking',
+};
+
+/** Label/tag aliases that map a model's free-form labels onto a capability. */
+const CAPABILITY_TAG_ALIASES: Record<CapabilityTag, string[]> = {
+  popular: ['popular', 'trending', 'featured', 'recommended'],
+  chat: ['chat', 'llm', 'text', 'language', 'instruct', 'text-generation'],
+  omni: ['omni', 'multimodal', 'multi-modal'],
+  vision: ['vision', 'vlm', 'vision-language', 'image-input', 'image-text-to-text'],
+  tool: ['tool', 'tools', 'tool-use', 'tool-calling', 'tools-enabled', 'function-calling'],
+  reasoning: ['reasoning', 'thinking', 'reasoner', 'mtp'],
+  code: ['code', 'coding', 'coder'],
+  audio: ['audio', 'transcription', 'asr', 'stt', 'speech-to-text', 'realtime-transcription'],
+  image: ['image', 'image-generation', 'diffusion', 'edit', 'upscaling', 'text-to-image'],
+  tts: ['tts', 'speech', 'text-to-speech'],
+  embedding: ['embedding', 'embeddings'],
+  reranking: ['reranking', 'reranker'],
+};
+
+const BASE_CAPABILITY_TAG: Partial<Record<ModelCapability, CapabilityTag>> = {
+  chat: 'chat', omni: 'omni', image: 'image', audio: 'audio',
+  tts: 'tts', embedding: 'embedding', reranking: 'reranking',
+};
+
+/** All functional capability tags a model exposes (always ≥1, ordered). */
+export function modelCapabilityTags(model: ModelInfo): CapabilityTag[] {
+  const labels = (model.labels || []).map(l => String(l).toLowerCase().trim()).filter(Boolean);
+  const labelSet = new Set(labels);
+  const found = new Set<CapabilityTag>();
+  for (const tag of CAPABILITY_TAG_ORDER) {
+    if (CAPABILITY_TAG_ALIASES[tag].some(alias => labelSet.has(alias))) found.add(tag);
+  }
+  const base = BASE_CAPABILITY_TAG[capabilityFromModelInfo(model)];
+  if (base) found.add(base);
+  if (found.size === 0) found.add('chat');
+  return CAPABILITY_TAG_ORDER.filter(tag => found.has(tag));
+}
+
+/** True when the model has at least one of the selected capability tags
+    (empty selection = no capability filter applied). */
+export function modelMatchesCapabilityTags(model: ModelInfo, selected: Set<string>): boolean {
+  if (!selected || selected.size === 0) return true;
+  return modelCapabilityTags(model).some(tag => selected.has(tag));
+}

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -7926,3 +7926,618 @@ input, textarea {
   color: var(--text-secondary);
   line-height: 1.4;
 }
+
+
+/* ═══════════════════════════════════════════════════════════════
+   Master-detail model view — #2355 Slice 1
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Layout shell ─────────────────────────────────────────────── */
+
+.manager--detail {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Model list panel (left) ──────────────────────────────────── */
+
+.model-list-panel {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border-subtle);
+  background: var(--surface-1);
+  height: 100%;
+  overflow: hidden;
+}
+
+.model-list-panel__search-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-3) var(--space-2);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.model-list-panel__search-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.model-list-panel__search-icon {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+
+.model-list-panel__search-input {
+  width: 100%;
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  height: 32px;
+  padding: 0 28px 0 30px;
+  box-sizing: border-box;
+}
+
+.model-list-panel__search-input:focus {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 0;
+  border-color: transparent;
+}
+
+.model-list-panel__search-clear {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 2px 4px;
+}
+
+.model-list-panel__search-clear:hover { color: var(--text-primary); }
+.model-list-panel__search-clear:focus-visible { outline: 2px solid var(--accent-focus); border-radius: 2px; }
+
+/* Funnel filter button */
+.model-list-panel__filter-wrap { position: relative; }
+
+.model-list-panel__filter-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.model-list-panel__filter-btn:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.model-list-panel__filter-btn:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+.model-list-panel__filter-btn--active { color: var(--accent-fg); border-color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 12%, transparent); }
+
+/* Filter popover */
+.model-list-panel__filter-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 50;
+  background: var(--surface-overlay);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-2);
+  min-width: 160px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+}
+
+.model-list-panel__filter-popover-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-1) var(--space-2) var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+.model-list-panel__filter-popover-close {
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  padding: 2px;
+  display: inline-flex;
+}
+
+.model-list-panel__filter-popover-close:hover { color: var(--text-primary); }
+.model-list-panel__filter-popover-close:focus-visible { outline: 2px solid var(--accent-focus); border-radius: 2px; }
+
+.model-list-panel__filter-options {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.model-list-panel__filter-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  text-align: left;
+}
+
+.model-list-panel__filter-option:hover { background: var(--surface-2); color: var(--text-primary); }
+.model-list-panel__filter-option:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+.model-list-panel__filter-option--active { color: var(--accent-fg); font-weight: 600; }
+
+/* Count badge */
+.model-list-panel__count {
+  padding: var(--space-2) var(--space-3) var(--space-1);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+/* Scrollable list */
+.model-list-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-1) var(--space-2);
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+/* Model list items */
+.model-list-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-2);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  border: 1px solid transparent;
+  user-select: none;
+}
+
+.model-list-item:hover { background: var(--surface-2); }
+.model-list-item:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 0; }
+
+.model-list-item--selected {
+  background: color-mix(in srgb, var(--accent-fg) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent-fg) 30%, transparent);
+}
+
+.model-list-item--selected:hover {
+  background: color-mix(in srgb, var(--accent-fg) 18%, transparent);
+}
+
+.model-list-item__backend {
+  font-size: 9px;
+  font-weight: 600;
+  border-radius: 3px;
+  padding: 1px 4px;
+  flex-shrink: 0;
+  border: 1px solid color-mix(in srgb, var(--list-backend-color, var(--text-tertiary)) 40%, transparent);
+  color: var(--list-backend-color, var(--text-tertiary));
+  background: color-mix(in srgb, var(--list-backend-color, var(--text-tertiary)) 10%, transparent);
+  max-width: 52px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.model-list-item__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.model-list-item__name {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-list-item__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 10px;
+  color: var(--text-tertiary);
+}
+
+.model-list-item__status {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.model-list-item__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.model-list-item__dot--ready { background: var(--status-ok, #22c55e); }
+
+.model-list-item__pct {
+  font-size: 10px;
+  color: var(--accent-fg);
+}
+
+.model-list-panel__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-6);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  text-align: center;
+}
+
+/* ── Model detail panel (right) ───────────────────────────────── */
+
+.model-detail-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--surface-base);
+}
+
+.model-detail-panel--empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.model-detail-panel__placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+}
+
+.model-detail-panel__head {
+  padding: var(--space-4) var(--space-5) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.model-detail-panel__name {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  outline: none;
+}
+
+.model-detail-panel__name:focus-visible { outline: 2px solid var(--accent-focus); border-radius: 2px; }
+
+.model-detail-panel__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.model-detail-panel__badge {
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-subtle);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.model-detail-panel__badge--recipe {
+  background: color-mix(in srgb, var(--accent-secondary, #facc15) 10%, transparent);
+  border-color: color-mix(in srgb, var(--accent-secondary, #facc15) 30%, transparent);
+  color: var(--text-primary);
+}
+
+.model-detail-panel__badge--cap {
+  background: color-mix(in srgb, var(--accent-fg) 8%, transparent);
+  border-color: color-mix(in srgb, var(--accent-fg) 20%, transparent);
+}
+
+.model-detail-panel__status {
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.model-detail-panel__status--running {
+  background: color-mix(in srgb, var(--status-ok, #22c55e) 10%, transparent);
+  color: var(--status-ok, #22c55e);
+  border: 1px solid color-mix(in srgb, var(--status-ok, #22c55e) 30%, transparent);
+}
+
+.model-detail-panel__status--ready {
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-subtle);
+}
+
+.model-detail-panel__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.model-detail-panel__error {
+  font-size: var(--text-xs);
+  color: var(--status-error, #f87171);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.model-detail-panel__hf-link {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.model-detail-panel__hf-link:hover { color: var(--accent-fg); }
+.model-detail-panel__hf-link:focus-visible { outline: 2px solid var(--accent-focus); border-radius: 2px; }
+
+/* ── Tab list ─────────────────────────────────────────────────── */
+
+.detail-tabs__tablist {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 0 var(--space-4);
+  flex-shrink: 0;
+}
+
+.detail-tabs__tab {
+  padding: var(--space-2) var(--space-3);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.detail-tabs__tab:hover { color: var(--text-primary); }
+.detail-tabs__tab:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 2px; border-radius: 2px; }
+
+.detail-tabs__tab--active {
+  color: var(--accent-fg);
+  border-bottom-color: var(--accent-fg);
+}
+
+.detail-tabs__panel {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.detail-tabs__panel[hidden] { display: none; }
+.detail-tabs__panel--active { display: flex; flex-direction: column; }
+
+/* ── README tab ───────────────────────────────────────────────── */
+
+.detail-readme {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-5);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  line-height: 1.7;
+}
+
+.detail-readme h1, .detail-readme h2, .detail-readme h3 { margin: 1.2em 0 0.4em; }
+.detail-readme h1 { font-size: 1.3em; }
+.detail-readme h2 { font-size: 1.15em; }
+.detail-readme h3 { font-size: 1em; }
+.detail-readme p { margin: 0.5em 0; }
+.detail-readme pre { background: var(--surface-2); border-radius: var(--radius-md); padding: var(--space-3); overflow-x: auto; font-size: 0.88em; }
+.detail-readme code { font-family: var(--font-mono, monospace); font-size: 0.88em; background: var(--surface-2); padding: 1px 4px; border-radius: 3px; }
+.detail-readme pre code { background: none; padding: 0; }
+.detail-readme a { color: var(--accent-fg); }
+.detail-readme table { border-collapse: collapse; width: 100%; font-size: 0.9em; }
+.detail-readme th, .detail-readme td { border: 1px solid var(--border-subtle); padding: var(--space-2) var(--space-3); }
+.detail-readme th { background: var(--surface-2); font-weight: 600; }
+.detail-readme blockquote { border-left: 3px solid var(--border-strong); padding-left: var(--space-3); color: var(--text-secondary); margin: var(--space-3) 0; }
+.detail-readme img { max-width: 100%; height: auto; }
+
+.detail-readme--loading,
+.detail-readme--empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  color: var(--text-tertiary);
+  text-align: center;
+  min-height: 160px;
+}
+
+/* ── Presets tab ──────────────────────────────────────────────── */
+
+.detail-presets {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.detail-presets__section-title {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-tertiary);
+  margin: 0 0 var(--space-2);
+}
+
+.detail-presets__linked-card,
+.detail-presets__preset-card {
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-3) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.detail-presets__linked-card {
+  border-color: color-mix(in srgb, var(--accent-fg) 30%, transparent);
+  background: color-mix(in srgb, var(--accent-fg) 6%, transparent);
+}
+
+.detail-presets__preset-card--selected {
+  border-color: color-mix(in srgb, var(--accent-fg) 40%, transparent);
+  background: color-mix(in srgb, var(--accent-fg) 10%, transparent);
+}
+
+.detail-presets__card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.detail-presets__card-name {
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.detail-presets__card-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-1);
+  color: var(--text-tertiary);
+}
+
+.detail-presets__card-badge--linked {
+  background: color-mix(in srgb, var(--accent-fg) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent-fg) 30%, transparent);
+  color: var(--accent-fg);
+}
+
+.detail-presets__card-desc {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.detail-presets__card-params {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.detail-presets__param-line {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 1px 6px;
+}
+
+.detail-presets__attach-btn,
+.detail-presets__detach-btn {
+  align-self: flex-start;
+  margin-top: var(--space-1);
+}
+
+.detail-presets__preset-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.detail-presets__empty {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}
+
+/* ── Files tab stub ───────────────────────────────────────────── */
+
+.detail-files--stub {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+  text-align: center;
+  padding: var(--space-6);
+}
+
+.detail-files--stub small { font-size: var(--text-xs); }
+
+/* ── btn size helpers ─────────────────────────────────────────── */
+
+.btn--sm {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  height: 28px;
+}
+
+.btn--danger { color: var(--status-error, #f87171); }
+.btn--danger:hover { background: color-mix(in srgb, var(--status-error, #f87171) 12%, transparent); border-color: var(--status-error, #f87171); }
+
+/* ── Responsive: narrow viewport stacks the panels ──────────────  */
+@media (max-width: 700px) {
+  .manager--detail { grid-template-columns: 1fr; grid-template-rows: 260px 1fr; }
+}

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -8754,15 +8754,20 @@ input, textarea {
   margin: 0 0 var(--space-2);
 }
 
-.detail-presets__linked-card,
-.detail-presets__preset-card {
-  background: var(--surface-2);
+/* Shared card base — a slightly smaller, focused version of the global
+ * .recipe-card (Presets page) so the model-detail presets feel consistent. */
+.detail-presets__card {
+  position: relative;
+  background: linear-gradient(180deg, var(--surface-2) 0%, var(--surface-1) 100%);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: var(--space-1);
+  gap: var(--space-2);
+  transition: border-color var(--duration-fast) var(--ease-out),
+              transform var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out);
 }
 
 .detail-presets__linked-card {
@@ -8770,9 +8775,25 @@ input, textarea {
   background: color-mix(in srgb, var(--accent-fg) 6%, transparent);
 }
 
+/* Linked preset sits above as a single highlighted card */
+.detail-presets__linked-card {
+  padding: var(--space-3) var(--space-4);
+}
+
+.detail-presets__preset-card--sm:hover {
+  border-color: var(--border-strong);
+  background: linear-gradient(180deg, var(--surface-3) 0%, var(--surface-2) 100%);
+  transform: translateY(-1px);
+}
+
 .detail-presets__preset-card--selected {
   border-color: color-mix(in srgb, var(--accent-fg) 40%, transparent);
   background: color-mix(in srgb, var(--accent-fg) 10%, transparent);
+}
+
+.detail-presets__preset-card:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 2px;
 }
 
 .detail-presets__card-header {
@@ -8783,11 +8804,18 @@ input, textarea {
 
 .detail-presets__card-name {
   flex: 1;
+  min-width: 0;
   font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
+  letter-spacing: var(--tracking-tight);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .detail-presets__card-badge {
+  flex: none;
   font-size: 10px;
   padding: 1px 6px;
   border-radius: var(--radius-sm);
@@ -8805,39 +8833,76 @@ input, textarea {
 .detail-presets__card-desc {
   font-size: var(--text-xs);
   color: var(--text-secondary);
+  line-height: var(--leading-snug);
   margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
-.detail-presets__card-params {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-1);
-}
-
-.detail-presets__param-line {
+/* Compact meta line: e.g. "temp 0.70 · ctx 4096 · tools ON" */
+.detail-presets__card-meta {
+  font-family: var(--font-mono);
   font-size: 10px;
   color: var(--text-tertiary);
-  background: var(--surface-1);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  padding: 1px 6px;
+  margin: 0;
+  padding-top: var(--space-2);
+  border-top: 1px dashed var(--border-subtle);
+  word-break: break-word;
 }
 
-.detail-presets__attach-btn,
+.detail-presets__card-footer {
+  display: flex;
+  align-items: center;
+  margin-top: auto;
+  padding-top: var(--space-1);
+}
+
+.detail-presets__attach-btn { align-self: flex-start; }
+
+.detail-presets__card-linked-note {
+  font-size: 10px;
+  color: var(--accent-fg);
+  letter-spacing: 0.02em;
+}
+
 .detail-presets__detach-btn {
   align-self: flex-start;
   margin-top: var(--space-1);
 }
 
-.detail-presets__preset-list {
+/* Recommended presets — a neat responsive grid of compact cards */
+.detail-presets__preset-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--space-3);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.detail-presets__section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.detail-presets__section-head .detail-presets__section-title { margin: 0; }
+
+.detail-presets__empty-block {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: var(--space-2);
 }
 
 .detail-presets__empty {
   font-size: var(--text-xs);
   color: var(--text-tertiary);
+  margin: 0;
 }
 
 /* ── Files tab stub ───────────────────────────────────────────── */

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -7936,12 +7936,275 @@ input, textarea {
 
 .manager--detail {
   display: grid;
-  grid-template-columns: 280px minmax(0, 1fr);
+  grid-template-columns: 232px 280px minmax(0, 1fr);
   height: 100%;
   overflow: hidden;
 }
 
-/* ── Model list panel (left) ──────────────────────────────────── */
+/* Responsive nav-rail toggle — hidden on wide viewports (rail always shown) */
+.manager__nav-toggle {
+  display: none;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  background: var(--surface-1);
+  border: none;
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+}
+
+.manager__nav-toggle:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: -2px; }
+.manager__nav-toggle:hover { color: var(--text-primary); }
+
+/* ── Left navigation rail (new three-pane left column) ────────── */
+
+.model-nav-rail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  border-right: 1px solid var(--border-subtle);
+  background: var(--surface-1);
+  height: 100%;
+  overflow-y: auto;
+  padding: var(--space-3) var(--space-2) var(--space-2);
+  box-sizing: border-box;
+}
+
+/* 1. Preset quick-search + New */
+.model-nav-rail__preset-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.model-nav-rail__preset-search {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+.model-nav-rail__preset-icon {
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-tertiary);
+  pointer-events: none;
+}
+
+.model-nav-rail__preset-input {
+  width: 100%;
+  box-sizing: border-box;
+  height: 30px;
+  padding: 0 8px 0 28px;
+  font-size: var(--text-xs);
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+}
+
+.model-nav-rail__preset-input:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 0;
+  border-color: transparent;
+}
+
+.model-nav-rail__new-btn { white-space: nowrap; flex-shrink: 0; }
+
+/* 2. Primary nav */
+.model-nav-rail__primary {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.model-nav-rail__nav-item,
+.model-nav-rail__cat-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--space-2) var(--space-2);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  text-align: left;
+}
+
+.model-nav-rail__nav-item:hover,
+.model-nav-rail__cat-item:hover { background: var(--surface-2); color: var(--text-primary); }
+
+.model-nav-rail__nav-item:focus-visible,
+.model-nav-rail__cat-item:focus-visible,
+.model-nav-rail__section-toggle:focus-visible,
+.model-nav-rail__tag:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 0;
+}
+
+.model-nav-rail__nav-item--active,
+.model-nav-rail__cat-item--active {
+  background: var(--accent-soft);
+  border-color: color-mix(in srgb, var(--accent-fg) 30%, transparent);
+  color: var(--accent-fg);
+}
+
+.model-nav-rail__nav-icon,
+.model-nav-rail__cat-icon { flex-shrink: 0; }
+
+.model-nav-rail__nav-label,
+.model-nav-rail__cat-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-nav-rail__nav-count {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary);
+}
+
+.model-nav-rail__nav-item--active .model-nav-rail__nav-count,
+.model-nav-rail__cat-item--active .model-nav-rail__nav-count { color: var(--accent-fg); }
+
+/* 3 & 5. Collapsible sections */
+.model-nav-rail__section { display: flex; flex-direction: column; gap: 2px; }
+
+.model-nav-rail__section-head { margin: 0; }
+
+.model-nav-rail__section-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  width: 100%;
+  padding: var(--space-1) var(--space-2);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.model-nav-rail__section-toggle:hover { color: var(--text-secondary); }
+
+.model-nav-rail__cat-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* 4. Backends select */
+.model-nav-rail__backends { display: flex; flex-direction: column; gap: 4px; }
+
+.model-nav-rail__backends-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  padding: 0 var(--space-2);
+}
+
+.model-nav-rail__backends-select {
+  width: 100%;
+  box-sizing: border-box;
+  height: 30px;
+  padding: 0 var(--space-2);
+  font-size: var(--text-xs);
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  cursor: pointer;
+  appearance: auto;
+}
+
+.model-nav-rail__backends-select:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+
+/* 5. Tag chips */
+.model-nav-rail__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 2px var(--space-2) 0;
+}
+
+.model-nav-rail__tag {
+  padding: 3px 8px;
+  font-size: 11px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.model-nav-rail__tag:hover { color: var(--text-primary); border-color: var(--border-strong); }
+
+.model-nav-rail__tag--active {
+  background: var(--accent-soft);
+  border-color: var(--accent-fg);
+  color: var(--accent-fg);
+}
+
+.model-nav-rail__tag--recommended { color: var(--accent-fg); }
+
+/* 6. Storage meter */
+.model-nav-rail__storage {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: var(--space-2) var(--space-2) 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.model-nav-rail__storage-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 11px;
+}
+
+.model-nav-rail__storage-label { color: var(--text-tertiary); }
+.model-nav-rail__storage-value { color: var(--text-secondary); font-variant-numeric: tabular-nums; }
+
+.model-nav-rail__storage-bar {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+
+.model-nav-rail__storage-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent-fg);
+}
+
+/* ── Model list panel (middle) ────────────────────────────────── */
 
 .model-list-panel {
   display: flex;
@@ -8091,6 +8354,19 @@ input, textarea {
 .model-list-panel__filter-option--active { color: var(--accent-fg); font-weight: 600; }
 
 /* Count badge */
+/* Custom-model action group — grounded button group at the TOP of the list */
+.model-list-panel__add-group {
+  display: flex;
+  gap: var(--space-2);
+  margin: var(--space-2) var(--space-3) 0;
+  padding: var(--space-2);
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.model-list-panel__add-btn { flex: 1; justify-content: center; }
+
 .model-list-panel__count {
   padding: var(--space-2) var(--space-3) var(--space-1);
   font-size: 10px;
@@ -8601,6 +8877,22 @@ input, textarea {
     overflow: hidden;
     height: 100%;
   }
+
+  /* Show the nav-rail toggle button */
+  .manager__nav-toggle { display: inline-flex; width: 100%; box-sizing: border-box; }
+
+  /* Hide the nav rail by default; reveal when toggled open */
+  .manager--detail .model-nav-rail { display: none; }
+  .manager--detail.manager--nav-open .model-nav-rail {
+    display: flex;
+    height: auto;
+    max-height: 70vh;
+    border-right: none;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  /* When the nav rail is open, hide the list beneath it */
+  .manager--detail.manager--nav-open .model-list-panel { display: none; }
 
   /* Default state: show list only */
   .manager--detail .model-list-panel {

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -8226,6 +8226,27 @@ input, textarea {
   color: var(--accent-fg);
 }
 
+/* Pin / favorite affordance — compact, revealed on hover/selection or when pinned */
+.model-list-item__pin {
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.model-list-item:hover .model-list-item__pin,
+.model-list-item--selected .model-list-item__pin,
+.model-list-item:focus-visible .model-list-item__pin,
+.model-list-item--pinned .model-list-item__pin {
+  opacity: 1;
+}
+
+.model-list-item__pin--active {
+  opacity: 1;
+}
+
 .model-list-panel__empty {
   display: flex;
   flex-direction: column;

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -8099,6 +8099,40 @@ input, textarea {
   text-transform: uppercase;
 }
 
+/* Sort control row */
+.model-list-panel__sort-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3) var(--space-2);
+}
+
+.model-list-panel__sort-label {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.model-list-panel__sort-select {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  padding: 2px var(--space-2);
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+  appearance: auto;
+  height: 24px;
+}
+
+.model-list-panel__sort-select:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 1px;
+}
+
 /* Scrollable list */
 .model-list-panel__list {
   list-style: none;
@@ -8537,7 +8571,139 @@ input, textarea {
 .btn--danger { color: var(--status-error, #f87171); }
 .btn--danger:hover { background: color-mix(in srgb, var(--status-error, #f87171) 12%, transparent); border-color: var(--status-error, #f87171); }
 
-/* ── Responsive: narrow viewport stacks the panels ──────────────  */
+/* ── Responsive: list-first → tap-to-detail on narrow viewports ── */
 @media (max-width: 700px) {
-  .manager--detail { grid-template-columns: 1fr; grid-template-rows: 260px 1fr; }
+  /* Remove grid; each panel takes full width/height */
+  .manager--detail {
+    display: block;
+    position: relative;
+    overflow: hidden;
+    height: 100%;
+  }
+
+  /* Default state: show list only */
+  .manager--detail .model-list-panel {
+    height: 100%;
+    border-right: none;
+  }
+
+  /* Hide detail panel until a model is selected */
+  .manager--detail .model-detail-panel,
+  .manager--detail .manager__detail-form-panel {
+    display: none;
+  }
+
+  /* When detail is open: show detail only, hide list */
+  .manager--detail.manager--detail-mobile-open .model-list-panel {
+    display: none;
+  }
+
+  .manager--detail.manager--detail-mobile-open .model-detail-panel,
+  .manager--detail.manager--detail-mobile-open .manager__detail-form-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow-y: auto;
+  }
+}
+
+/* ── Back button (visible on narrow viewports via onBack prop) ─── */
+.model-detail-panel__back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--accent-fg);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border-subtle);
+  width: 100%;
+  text-align: left;
+}
+
+.model-detail-panel__back-btn:hover { background: var(--surface-2); }
+.model-detail-panel__back-btn:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: -2px; }
+
+/* ── Preset Change inline chooser ──────────────────────────────── */
+.detail-presets__linked-actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-top: var(--space-2);
+}
+
+.detail-presets__change-chooser {
+  margin-top: var(--space-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  overflow: hidden;
+}
+
+.detail-presets__chooser-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface-1);
+}
+
+.detail-presets__chooser-title {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.detail-presets__chooser-close {
+  padding: 2px var(--space-2);
+  line-height: 1;
+}
+
+.detail-presets__chooser-close:focus-visible { outline: 2px solid var(--accent-focus); border-radius: 2px; }
+
+.detail-presets__chooser-list {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-1);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.detail-presets__chooser-list li { margin: 0; }
+
+.detail-presets__chooser-option {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-2);
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  text-align: left;
+}
+
+.detail-presets__chooser-option:hover { background: var(--surface-1); }
+.detail-presets__chooser-option:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: -1px; border-radius: var(--radius-sm); }
+
+.detail-presets__chooser-option-name { font-weight: 600; }
+
+.detail-presets__chooser-option-desc {
+  color: var(--text-tertiary);
+  font-size: 10px;
+  display: block;
+  line-height: 1.3;
+}
+
+.detail-presets__chooser-empty {
+  padding: var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-align: center;
 }

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -7937,7 +7937,15 @@ input, textarea {
 .manager--detail {
   display: grid;
   grid-template-columns: 232px 280px minmax(0, 1fr);
+  /* Override the `auto 1fr` rows inherited from `.manager` so the panes are
+     constrained to the viewport height. Without this, the panes land in the
+     `auto` row and grow to content height — making the left rail (categories,
+     backends, tags, storage) overflow and clip the bottom of the screen with
+     no way to scroll. A single bounded row lets each pane's own
+     `overflow-y: auto` take over. */
+  grid-template-rows: minmax(0, 1fr);
   height: 100%;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -7971,48 +7979,6 @@ input, textarea {
   padding: var(--space-3) var(--space-2) var(--space-2);
   box-sizing: border-box;
 }
-
-/* 1. Preset quick-search + New */
-.model-nav-rail__preset-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.model-nav-rail__preset-search {
-  position: relative;
-  flex: 1;
-  min-width: 0;
-}
-
-.model-nav-rail__preset-icon {
-  position: absolute;
-  left: 8px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--text-tertiary);
-  pointer-events: none;
-}
-
-.model-nav-rail__preset-input {
-  width: 100%;
-  box-sizing: border-box;
-  height: 30px;
-  padding: 0 8px 0 28px;
-  font-size: var(--text-xs);
-  background: var(--surface-2);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
-}
-
-.model-nav-rail__preset-input:focus-visible {
-  outline: 2px solid var(--accent-focus);
-  outline-offset: 0;
-  border-color: transparent;
-}
-
-.model-nav-rail__new-btn { white-space: nowrap; flex-shrink: 0; }
 
 /* 2. Primary nav */
 .model-nav-rail__primary {
@@ -8300,7 +8266,9 @@ input, textarea {
   top: calc(100% + 4px);
   right: 0;
   z-index: 50;
-  background: var(--surface-overlay);
+  /* Solid, opaque surface so list content behind the popover does not bleed
+     through (the previous `--surface-overlay` token is undefined → transparent). */
+  background: var(--surface-3);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
   padding: var(--space-2);
@@ -8983,11 +8951,19 @@ input, textarea {
     height: 100%;
     overflow-y: auto;
   }
+
+  /* "Back to models" is only useful on narrow viewports where the list and
+     detail are mutually exclusive. Higher specificity than the base
+     `display:none` rule (which appears later in the file) so it wins here. */
+  .manager--detail .model-detail-panel__back-btn { display: inline-flex; }
 }
 
-/* ── Back button (visible on narrow viewports via onBack prop) ─── */
+/* ── Back button (visible on narrow viewports only) ────────────── */
+/* Hidden on desktop — the list is always visible in the three-pane layout, so
+   "Back to models" is redundant. It is re-enabled inside the ≤700px media
+   query below, where the list and detail are mutually exclusive. */
 .model-detail-panel__back-btn {
-  display: inline-flex;
+  display: none;
   align-items: center;
   gap: var(--space-1);
   padding: var(--space-2) var(--space-3);
@@ -9003,6 +8979,33 @@ input, textarea {
 
 .model-detail-panel__back-btn:hover { background: var(--surface-2); }
 .model-detail-panel__back-btn:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: -2px; }
+
+/* ── Favorite (star) toggle in the detail header ───────────────── */
+.model-detail-panel__fav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  line-height: 1;
+}
+
+.model-detail-panel__fav-icon { font-size: 16px; line-height: 1; }
+
+.model-detail-panel__fav-btn:hover { background: var(--surface-3); color: var(--text-primary); }
+.model-detail-panel__fav-btn:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+
+.model-detail-panel__fav-btn--on {
+  color: #facc15;
+  border-color: #facc15;
+}
+.model-detail-panel__fav-btn--on:hover { color: #facc15; }
 
 /* ── Preset Change inline chooser ──────────────────────────────── */
 .detail-presets__linked-actions {

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -8320,6 +8320,40 @@ input, textarea {
 .model-list-panel__filter-option:hover { background: var(--surface-2); color: var(--text-primary); }
 .model-list-panel__filter-option:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
 .model-list-panel__filter-option--active { color: var(--accent-fg); font-weight: 600; }
+.model-list-panel__filter-option[aria-pressed="true"] { background: var(--surface-2); }
+
+.model-list-panel__filter-empty {
+  padding: var(--space-1) var(--space-2);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}
+
+.model-list-panel__filter-clear {
+  margin-top: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--accent-fg);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  text-align: left;
+  border-radius: var(--radius-sm);
+}
+.model-list-panel__filter-clear:hover { background: var(--surface-2); }
+.model-list-panel__filter-clear:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+
+/* Capability icons on a model row — one per functional capability tag (#2424). */
+.model-list-item__caps {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--text-tertiary);
+}
+.model-list-item__caps .model-list-item__cap {
+  display: inline-flex;
+  align-items: center;
+}
 
 /* Count badge */
 /* Custom-model action group — grounded button group at the TOP of the list */
@@ -8525,6 +8559,15 @@ input, textarea {
   gap: var(--space-3);
   color: var(--text-tertiary);
   font-size: var(--text-sm);
+  text-align: center;
+  max-width: 28rem;
+  padding: 0 var(--space-4);
+}
+.model-detail-panel__placeholder p { margin: 0; }
+.model-detail-panel__placeholder-sub {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  line-height: 1.5;
 }
 
 .model-detail-panel__head {

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -2198,3 +2198,105 @@ test.describe('Accessibility — #2355 Slice 1 reconciliation (fl0rianr clarific
     await expect(changeBtn).toHaveAttribute('aria-expanded', 'false');
   });
 });
+
+// ─── 25. Model README raw-HTML rendering (#2355 README tab fix) ───────────────
+//
+// HF model READMEs commonly embed raw HTML (<div align="center">, <img>, badges,
+// tables). The README tab previously used markdown-it { html: false }, which
+// ESCAPED that markup so it appeared as literal text. Fix: html:true behind the
+// existing strict DOMPurify allowlist + a leading YAML frontmatter strip.
+// Range: A116–A117.
+
+test.describe('Accessibility — model README raw-HTML rendering (#2355)', () => {
+  async function goToModelsWithReadme(page: Page, readmeBody: string): Promise<void> {
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true,
+              checkpoint: 'gguf-community/Llama-3.1-8B-Instruct:Q4_K_M.gguf' },
+          ],
+        }),
+      }),
+    );
+    // Mock the Hugging Face README fetch the component performs against
+    // https://huggingface.co/${hfRepo}/raw/main/README.md
+    await page.route('**/huggingface.co/**/raw/main/README.md', async route =>
+      route.fulfill({ contentType: 'text/plain', body: readmeBody }),
+    );
+
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await navigateToView(page, 'Models');
+    await page.waitForSelector('.manager--detail');
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.locator('.model-list-item').first().click();
+    // README is the default tab; wait for the rendered container.
+    await page.waitForSelector('.detail-readme', { timeout: 5000 });
+    await page.waitForTimeout(200);
+  }
+
+  test('A116 — raw HTML in README renders as real DOM elements, not escaped text', async ({ page }) => {
+    const readme = [
+      '# Model Card',
+      '',
+      '<div align="center"><strong>Centered Heading</strong></div>',
+      '',
+      '<img src="https://example.com/badge.svg" alt="build badge">',
+      '',
+      'Some normal markdown text.',
+    ].join('\n');
+
+    await goToModelsWithReadme(page, readme);
+
+    const container = page.locator('.detail-readme');
+    await expect(container).toBeVisible();
+
+    // Raw HTML must materialise as actual elements inside the README container.
+    await expect(container.locator('div[align="center"]')).toHaveCount(1);
+    await expect(container.locator('strong', { hasText: 'Centered Heading' })).toHaveCount(1);
+    await expect(container.locator('img[alt="build badge"]')).toHaveCount(1);
+
+    // And it must NOT appear as literal/escaped text.
+    const text = (await container.innerText()).toLowerCase();
+    expect(text).not.toContain('<div');
+    expect(text).not.toContain('&lt;div');
+    expect(text).not.toContain('<strong');
+    expect(text).not.toContain('<img');
+  });
+
+  test('A117 — leading YAML frontmatter block is stripped before rendering', async ({ page }) => {
+    const readme = [
+      '---',
+      'license: apache-2.0',
+      'pipeline_tag: text-generation',
+      'tags:',
+      '  - text-generation',
+      '---',
+      '',
+      '# Real Heading',
+      '',
+      'Body content goes here.',
+    ].join('\n');
+
+    await goToModelsWithReadme(page, readme);
+
+    const container = page.locator('.detail-readme');
+    await expect(container).toBeVisible();
+
+    // The real heading must render.
+    await expect(container.locator('h1', { hasText: 'Real Heading' })).toHaveCount(1);
+
+    // Frontmatter keys must NOT be visible as dumped text.
+    const text = await container.innerText();
+    expect(text).not.toContain('license: apache-2.0');
+    expect(text).not.toContain('pipeline_tag');
+  });
+});

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -2622,13 +2622,13 @@ test.describe('Accessibility — left navigation rail (#2355 three-pane)', () =>
     expect(critical, formatViolations(critical)).toHaveLength(0);
   });
 
-  test('A136 — preset quick-search input in the rail is labelled', async ({ page }) => {
+  test('A136 — preset quick-search and "+ New" are removed from the nav rail (#2424)', async ({ page }) => {
     await goToModelsWithNavMock(page);
-    const input = page.locator('#nav-preset-search');
-    await expect(input).toBeVisible();
-    // Associated <label> (sr-only) provides the accessible name.
-    const hasLabel = await page.locator('label[for="nav-preset-search"]').count();
-    expect(hasLabel).toBeGreaterThan(0);
+    await expect(page.locator('.model-nav-rail')).toBeVisible();
+    // The preset search box and "+ New" button no longer belong in the rail.
+    await expect(page.locator('#nav-preset-search')).toHaveCount(0);
+    await expect(page.locator('.model-nav-rail__preset-row')).toHaveCount(0);
+    await expect(page.locator('.model-nav-rail__new-btn')).toHaveCount(0);
   });
 });
 
@@ -2758,6 +2758,173 @@ test.describe('Accessibility — model-detail Presets card grid (#2424)', () => 
   test('A141 — the Presets card grid passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
     await goToPresetsTab(page, { applied: { 'Llama-3.1-8B': 'p-balanced' } });
     await expect(page.locator('.detail-presets__preset-grid')).toBeVisible();
+    const results = await new AxeBuilder({ page })
+      .withTags([...WCAG_TAGS])
+      .analyze();
+    const critical = results.violations.filter(
+      v => v.impact === 'critical' || v.impact === 'serious',
+    );
+    expect(critical, formatViolations(critical)).toHaveLength(0);
+  });
+});
+
+// ─── PR #2424 maintainer refinements (fl0rianr 2026-06-25) ──────────────────
+//
+// Five review items: (1) a favorite STAR toggle in the model DETAIL panel that
+// reuses the existing client-local pin store and updates the Favorites nav
+// count; (2) the preset search + "+ New" removed from the left rail (covered by
+// the updated A136); (3) "Back to models" hidden on desktop, shown on narrow;
+// (4) the funnel filter scoped to CAPABILITIES with a solid opaque popover
+// background; (5) the left rail scrolls independently instead of clipping the
+// lower part of the screen when its sections are expanded.
+// Range: A142–A148.
+
+test.describe('Accessibility — model view refinements (#2424)', () => {
+  async function goToModelsRefined(page: Page): Promise<void> {
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm', 'tools'], recipe: 'llamacpp', downloaded: true, size: 8 },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false, size: 7 },
+            { id: 'Whisper-Large-v3', name: 'Whisper-Large-v3', labels: ['audio'], recipe: 'whispercpp', downloaded: true, size: 3 },
+            { id: 'SDXL-Turbo', name: 'SDXL-Turbo', labels: ['image'], recipe: 'sd-cpp', downloaded: false, size: 6 },
+          ],
+        }),
+      }),
+    );
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await navigateToView(page, 'Models');
+    await page.waitForSelector('.manager--detail');
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.waitForTimeout(200);
+  }
+
+  // ── 1. Favorite star toggle in the detail panel ──────────────────────────
+
+  test('A142 — detail panel favorite star is an aria-pressed toggle naming the model', async ({ page }) => {
+    await goToModelsRefined(page);
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+    const star = page.locator('.model-detail-panel__fav-btn');
+    await expect(star).toBeVisible();
+    await expect(star).toHaveRole('button');
+    // Off state: not pressed, label invites adding to favorites and names the model.
+    expect(await star.getAttribute('aria-pressed')).toBe('false');
+    const offLabel = (await star.getAttribute('aria-label')) ?? '';
+    expect(offLabel.toLowerCase()).toContain('favorite');
+    expect(offLabel).toContain('Llama-3.1-8B');
+    // Toggle on.
+    await star.click();
+    await page.waitForTimeout(120);
+    expect(await star.getAttribute('aria-pressed')).toBe('true');
+    expect(((await star.getAttribute('aria-label')) ?? '').toLowerCase()).toContain('remove');
+  });
+
+  test('A143 — favoriting in the detail panel updates the Favorites nav count and persists', async ({ page }) => {
+    await goToModelsRefined(page);
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(150);
+    await page.locator('.model-detail-panel__fav-btn').click();
+    await page.waitForTimeout(150);
+
+    // Favorites primary-nav entry now reports one model (via its sr-only phrase).
+    const fav = page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Favorites' });
+    await expect(fav).toContainText('1');
+
+    // Reuses the SAME client-local pin store — a *pinned_models key exists.
+    const persisted = await page.evaluate(() => {
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.endsWith('pinned_models')) return localStorage.getItem(key);
+      }
+      return null;
+    });
+    expect(persisted, 'favorite must persist to the existing pinned_models store').toBeTruthy();
+    expect((persisted ?? '').toLowerCase()).toContain('llama-3.1-8b');
+  });
+
+  // ── 3. "Back to models" only on narrow viewports ─────────────────────────
+
+  test('A144 — "Back to models" is hidden on desktop widths', async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 800 });
+    await goToModelsRefined(page);
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+    // Present in the DOM but visually hidden on desktop.
+    await expect(page.locator('.model-detail-panel__back-btn')).toBeHidden();
+  });
+
+  // ── 4. Funnel filter: capabilities only + opaque background ───────────────
+
+  test('A145 — the funnel filter popover filters by capability and has a solid background', async ({ page }) => {
+    await goToModelsRefined(page);
+    const filterBtn = page.locator('.model-list-panel__filter-btn');
+    await filterBtn.click();
+    await page.waitForTimeout(120);
+    const popover = page.locator('.model-list-panel__filter-popover');
+    await expect(popover).toBeVisible();
+    await expect(popover).toContainText(/capabilit/i);
+
+    // The options are the capability categories (LLM / Omni / Image / Audio / TTS / Embed) + All.
+    const options = popover.locator('.model-list-panel__filter-option');
+    await expect(options).toHaveCount(7);
+
+    // Background must be opaque (not transparent) so list content does not bleed through.
+    const bg = await popover.evaluate(el => getComputedStyle(el).backgroundColor);
+    expect(bg).not.toBe('rgba(0, 0, 0, 0)');
+    expect(bg).not.toBe('transparent');
+  });
+
+  test('A146 — picking a capability in the funnel popover filters the list', async ({ page }) => {
+    await goToModelsRefined(page);
+    await page.locator('.model-list-panel__filter-btn').click();
+    await page.waitForTimeout(120);
+    const audio = page.locator('.model-list-panel__filter-option').filter({ hasText: /Audio/ });
+    await audio.click();
+    await page.waitForTimeout(150);
+    const rows = page.locator('.model-list-item');
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first()).toContainText('Whisper');
+  });
+
+  // ── 5. Left rail scrolls instead of clipping ─────────────────────────────
+
+  test('A147 — the left nav rail is independently scrollable and reaches the Storage meter', async ({ page }) => {
+    await page.setViewportSize({ width: 1100, height: 600 });
+    await goToModelsRefined(page);
+    const rail = page.locator('.model-nav-rail');
+    await expect(rail).toBeVisible();
+    // The rail must own its own scroll area …
+    const overflowY = await rail.evaluate(el => getComputedStyle(el).overflowY);
+    expect(overflowY).toBe('auto');
+    // … and must not exceed the viewport height (no clipping past the screen).
+    const box = await rail.boundingBox();
+    expect(box, 'rail bounding box').toBeTruthy();
+    expect((box!.y + box!.height)).toBeLessThanOrEqual(601);
+    // The Storage meter stays reachable by scrolling within the rail.
+    const storage = page.locator('.model-nav-rail__storage');
+    await storage.scrollIntoViewIfNeeded();
+    await expect(storage).toBeVisible();
+  });
+
+  // ── Axe scan with a favorite set + filter open ───────────────────────────
+
+  test('A148 — refined model view passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
+    await goToModelsRefined(page);
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(150);
+    await page.locator('.model-detail-panel__fav-btn').click();
+    await page.locator('.model-list-panel__filter-btn').click();
+    await page.waitForTimeout(150);
     const results = await new AxeBuilder({ page })
       .withTags([...WCAG_TAGS])
       .analyze();

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -2423,3 +2423,211 @@ test.describe('Accessibility — left-rail pin/favorite parity (#2355)', () => {
     expect(critical, formatViolations(critical)).toHaveLength(0);
   });
 });
+
+// ─── Left navigation rail — three-pane model view (#2355 follow-up) ──────────
+//
+// fl0rianr (2026-06-25) posted a canonical 3-pane target: a NEW left NAVIGATION
+// rail (ModelNavRail) + the existing ModelListPanel (middle) + ModelDetailPanel
+// (right). The left rail surfaces filter dimensions — primary nav (All/
+// Downloaded/My Models/Favorites), collapsible Categories, a Backends select,
+// collapsible Tags, and a Storage meter — all derived CLIENT-SIDE from the model
+// list (no lemond). Selecting any of them filters the middle list.
+// Range: A124–A136.
+
+test.describe('Accessibility — left navigation rail (#2355 three-pane)', () => {
+  async function goToModelsWithNavMock(page: Page): Promise<void> {
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm', 'tools'], recipe: 'llamacpp', downloaded: true, size: 8 },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false, size: 7 },
+            { id: 'Whisper-Large-v3', name: 'Whisper-Large-v3', labels: ['audio'], recipe: 'whispercpp', downloaded: true, size: 3 },
+            { id: 'SDXL-Turbo', name: 'SDXL-Turbo', labels: ['image'], recipe: 'sd-cpp', downloaded: false, size: 6 },
+          ],
+        }),
+      }),
+    );
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await navigateToView(page, 'Models');
+    await page.waitForSelector('.model-nav-rail', { state: 'attached' });
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.waitForTimeout(200);
+  }
+
+  // ── Landmark & structure ─────────────────────────────────────────────────
+
+  test('A124 — left rail is a <nav> landmark with an accessible name', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const rail = page.locator('nav.model-nav-rail');
+    await expect(rail).toBeVisible();
+    expect(await rail.getAttribute('aria-label')).toBeTruthy();
+  });
+
+  // ── Primary nav ──────────────────────────────────────────────────────────
+
+  test('A125 — primary nav items are buttons with counts that are not the only signal', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const allBtn = page.locator('.model-nav-rail__nav-item').filter({ hasText: 'All Models' });
+    await expect(allBtn).toBeVisible();
+    // Visible count chip plus an sr-only "N models" phrase so the count is not
+    // conveyed by the digit alone.
+    const accName = (await allBtn.getAttribute('aria-label')) ?? (await allBtn.textContent()) ?? '';
+    expect(accName.toLowerCase()).toContain('models');
+  });
+
+  test('A126 — selecting a primary nav item exposes selected state via aria-current and filters the list', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const before = await page.locator('.model-list-item').count();
+    const downloaded = page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Downloaded' });
+    await downloaded.click();
+    await page.waitForTimeout(150);
+    expect(await downloaded.getAttribute('aria-current')).toBe('true');
+    const after = await page.locator('.model-list-item').count();
+    // Two of four mock models are downloaded.
+    expect(after).toBeLessThan(before);
+    expect(after).toBe(2);
+  });
+
+  test('A127 — primary nav is keyboard operable (focus + Enter selects)', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const fav = page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Favorites' });
+    await fav.focus();
+    await expect(fav).toBeFocused();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(120);
+    expect(await fav.getAttribute('aria-current')).toBe('true');
+  });
+
+  // ── Categories (collapsible) ─────────────────────────────────────────────
+
+  test('A128 — Categories section header is a button with aria-expanded that toggles the list', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const toggle = page.locator('.model-nav-rail__section-toggle').filter({ hasText: 'Categories' });
+    expect(await toggle.getAttribute('aria-expanded')).toBe('true');
+    await expect(page.locator('#nav-categories')).toBeVisible();
+    await toggle.click();
+    await page.waitForTimeout(100);
+    expect(await toggle.getAttribute('aria-expanded')).toBe('false');
+    await expect(page.locator('#nav-categories')).toBeHidden();
+  });
+
+  test('A129 — selecting a category filters the middle list (Audio → whisper only)', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const audio = page.locator('.model-nav-rail__cat-item').filter({ hasText: 'Audio' });
+    await audio.click();
+    await page.waitForTimeout(150);
+    expect(await audio.getAttribute('aria-current')).toBe('true');
+    const rows = page.locator('.model-list-item');
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first()).toContainText('Whisper');
+  });
+
+  // ── Backends select ──────────────────────────────────────────────────────
+
+  test('A130 — Backends select is labelled and filters the list by recipe', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const select = page.locator('#nav-backend-select');
+    // Associated label.
+    const labelText = await page.locator('label[for="nav-backend-select"]').textContent();
+    expect((labelText ?? '').toLowerCase()).toContain('backend');
+    await select.selectOption('whispercpp');
+    await page.waitForTimeout(150);
+    await expect(page.locator('.model-list-item')).toHaveCount(1);
+  });
+
+  // ── Tags (collapsible chips) ─────────────────────────────────────────────
+
+  test('A131 — Tags section uses aria-pressed chips that filter the list', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const llamaTag = page.locator('.model-nav-rail__tag').filter({ hasText: /^Llama$/ });
+    await expect(llamaTag).toBeVisible();
+    expect(await llamaTag.getAttribute('aria-pressed')).toBe('false');
+    await llamaTag.click();
+    await page.waitForTimeout(150);
+    expect(await llamaTag.getAttribute('aria-pressed')).toBe('true');
+    const rows = page.locator('.model-list-item');
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first()).toContainText('Llama');
+  });
+
+  // ── Storage meter ────────────────────────────────────────────────────────
+
+  test('A132 — Storage meter is a role=progressbar with value range and accessible name', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const bar = page.locator('.model-nav-rail__storage-bar');
+    await expect(bar).toHaveAttribute('role', 'progressbar');
+    expect(await bar.getAttribute('aria-valuenow')).toBeTruthy();
+    expect(await bar.getAttribute('aria-valuemin')).toBe('0');
+    const max = await bar.getAttribute('aria-valuemax');
+    expect(Number(max)).toBeGreaterThan(0);
+    // Accessible name via aria-label.
+    expect((await bar.getAttribute('aria-label')) ?? '').not.toBe('');
+  });
+
+  // ── Custom-model buttons (moved to TOP) ──────────────────────────────────
+
+  test('A133 — custom-model buttons are a grounded group at the top and keyboard reachable', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const group = page.locator('.model-list-panel__add-group');
+    await expect(group).toBeVisible();
+    const customBtn = group.getByRole('button', { name: /custom model/i });
+    const omniBtn = group.getByRole('button', { name: /omni collection/i });
+    await expect(customBtn).toBeVisible();
+    await expect(omniBtn).toBeVisible();
+    await customBtn.focus();
+    await expect(customBtn).toBeFocused();
+    // The group sits above the model list in DOM order (top of the area).
+    const groupBox = await group.boundingBox();
+    const listBox = await page.locator('.model-list-panel__list').boundingBox();
+    expect(groupBox && listBox && groupBox.y < listBox.y).toBeTruthy();
+  });
+
+  // ── Responsive nav toggle ────────────────────────────────────────────────
+
+  test('A134 — on narrow viewport the nav toggle controls the rail and is keyboard reachable', async ({ page }) => {
+    await page.setViewportSize({ width: 640, height: 900 });
+    await goToModelsWithNavMock(page);
+    const toggle = page.locator('.manager__nav-toggle');
+    await expect(toggle).toBeVisible();
+    expect(await toggle.getAttribute('aria-controls')).toBe('model-nav-rail');
+    expect(await toggle.getAttribute('aria-expanded')).toBe('false');
+    // Rail hidden until toggled.
+    await expect(page.locator('.model-nav-rail')).toBeHidden();
+    await toggle.focus();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(150);
+    expect(await toggle.getAttribute('aria-expanded')).toBe('true');
+    await expect(page.locator('.model-nav-rail')).toBeVisible();
+  });
+
+  // ── Axe scan ─────────────────────────────────────────────────────────────
+
+  test('A135 — three-pane model view with the left rail passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const results = await new AxeBuilder({ page })
+      .withTags([...WCAG_TAGS])
+      .analyze();
+    const critical = results.violations.filter(
+      v => v.impact === 'critical' || v.impact === 'serious',
+    );
+    expect(critical, formatViolations(critical)).toHaveLength(0);
+  });
+
+  test('A136 — preset quick-search input in the rail is labelled', async ({ page }) => {
+    await goToModelsWithNavMock(page);
+    const input = page.locator('#nav-preset-search');
+    await expect(input).toBeVisible();
+    // Associated <label> (sr-only) provides the accessible name.
+    const hasLabel = await page.locator('label[for="nav-preset-search"]').count();
+    expect(hasLabel).toBeGreaterThan(0);
+  });
+});

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -981,12 +981,15 @@ test.describe('Accessibility — model row action qualified names (#2341)', () =
     await page.waitForSelector('.titlebar__nav');
     await navigateToView(page, 'Models');
     await page.waitForSelector('.manager');
-    // Wait for model rows to render from the mocked API response
-    await page.waitForSelector('.row', { timeout: 5000 }).catch(() => {});
+    // Wait for model list items to render from the mocked API response
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
     await page.waitForTimeout(300);
   });
 
   test('A46 — downloaded model row: Load button accessible name includes model name', async ({ page }) => {
+    // Click on Llama-3.1-8B in the list to open the detail panel
+    await page.locator('.model-list-item').filter({ hasText: 'Llama-3.1-8B' }).click();
+    await page.waitForTimeout(200);
     // aria-label="Load Llama-3.1-8B" makes the button uniquely identifiable in
     // a list of multiple loaded models when navigating by button role.
     await expect(
@@ -995,43 +998,60 @@ test.describe('Accessibility — model row action qualified names (#2341)', () =
   });
 
   test('A47 — downloaded model row: Delete button accessible name includes model name', async ({ page }) => {
+    // Click on Llama-3.1-8B in the list to open the detail panel
+    await page.locator('.model-list-item').filter({ hasText: 'Llama-3.1-8B' }).click();
+    await page.waitForTimeout(200);
     // Icon-only X button must carry aria-label="Delete Llama-3.1-8B" so it is
     // not announced as a nameless button to screen reader users.
     await expect(
-      page.getByRole('button', { name: /Delete Llama-3\.1-8B/ }),
+      page.getByRole('button', { name: /Delete.*Llama-3\.1-8B/ }),
     ).toBeVisible();
   });
 
   test('A48 — registry model row: Download button accessible name includes model name', async ({ page }) => {
+    // Click on Qwen2.5-7B in the list to open the detail panel
+    await page.locator('.model-list-item').filter({ hasText: 'Qwen2.5-7B' }).click();
+    await page.waitForTimeout(200);
     await expect(
       page.getByRole('button', { name: /Download Qwen2\.5-7B/ }),
     ).toBeVisible();
   });
 
   test('A49 — registry model row: "Get and load" button accessible name includes model name', async ({ page }) => {
+    // Click on Qwen2.5-7B in the list to open the detail panel
+    await page.locator('.model-list-item').filter({ hasText: 'Qwen2.5-7B' }).click();
+    await page.waitForTimeout(200);
     await expect(
       page.getByRole('button', { name: /Get and load Qwen2\.5-7B/i }),
     ).toBeVisible();
   });
 
-  test('A50 — no row action button in the model manager carries a bare unqualified accessible name', async ({ page }) => {
+  test('A50 — no model action button in the detail panel carries a bare unqualified accessible name', async ({ page }) => {
     // Buttons whose accessible name is just "Load", "Download", "Delete", etc.
     // cause collision when multiple model rows are rendered — NVDA hears
     // "Load, Load, Load…" with no way to distinguish targets.
+    // In the new master-detail layout, action buttons are in the detail panel.
     const genericExact = new Set([
       'Load', 'Download', 'Delete', 'Unload', 'Get & Load', 'Cancel download',
       'Pin model', 'Unpin model', 'Copy model name', 'Copy repository name',
     ]);
-    const labels = await page.locator('.row .row__right button').evaluateAll(
-      (btns: HTMLElement[]) =>
-        btns.map(b => (b.getAttribute('aria-label') ?? b.textContent ?? '').trim()),
-    );
-    for (const label of labels) {
-      if (!label) continue;
-      expect(
-        genericExact.has(label),
-        `Row action button carries bare generic accessible name: "${label}"`,
-      ).toBe(false);
+    // Click each model to check its action buttons
+    const items = page.locator('.model-list-item');
+    const count = await items.count();
+    for (let i = 0; i < count; i++) {
+      await items.nth(i).click();
+      await page.waitForTimeout(100);
+      const labels = await page.locator('.model-detail-panel__actions button').evaluateAll(
+        (btns: HTMLElement[]) =>
+          btns.map(b => (b.getAttribute('aria-label') ?? b.textContent ?? '').trim()),
+      );
+      for (const label of labels) {
+        if (!label) continue;
+        expect(
+          genericExact.has(label),
+          `Detail panel action button carries bare generic accessible name: "${label}"`,
+        ).toBe(false);
+      }
     }
   });
 });
@@ -1681,3 +1701,237 @@ test.describe('Accessibility — MCP Gateway panel (#2417)', () => {
     await expect(statusEl).not.toContainText('Connected');
   });
 });
+
+// ─── 23. Master-detail model view (#2355 Slice 1) ─────────────────────────────
+//
+// Covers: model list panel, detail panel tablist, funnel filter button,
+// preset attach flow, and keyboard navigation — all added in Slice 1.
+// Range: A91–A105.
+
+test.describe('Accessibility — master-detail model view (#2355 Slice 1)', () => {
+  /** Navigate to Models view and wait for the master-detail layout to mount. */
+  async function goToModels(page: Page): Promise<void> {
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await navigateToView(page, 'Models');
+    await page.waitForSelector('.manager--detail');
+  }
+
+  /** Navigate to Models with mock API data of two models. */
+  async function goToModelsWithMock(page: Page): Promise<void> {
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false },
+          ],
+        }),
+      }),
+    );
+    await goToModels(page);
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.waitForTimeout(200);
+  }
+
+  // ── Layout landmarks ─────────────────────────────────────────────────────────
+
+  test('A91 — manager--detail layout renders list panel and detail panel regions', async ({ page }) => {
+    await goToModels(page);
+    await expect(page.locator('.model-list-panel')).toBeVisible();
+    await expect(page.locator('.model-detail-panel, .manager__detail-form-panel')).toBeAttached();
+  });
+
+  test('A92 — model list panel has an h1 heading "Models"', async ({ page }) => {
+    await goToModels(page);
+    await expect(page.locator('.manager__title h1')).toContainText('Models');
+  });
+
+  // ── Search input ─────────────────────────────────────────────────────────────
+
+  test('A93 — model list search input is associated with a label', async ({ page }) => {
+    await goToModels(page);
+    const input = page.locator('#model-list-search');
+    await expect(input).toBeVisible();
+    // label must exist with for="model-list-search"
+    const label = page.locator('label[for="model-list-search"]');
+    await expect(label).toBeAttached();
+  });
+
+  test('A94 — typing in search input filters the model list (aria-live count updates)', async ({ page }) => {
+    await goToModelsWithMock(page);
+    const search = page.locator('#model-list-search');
+    await search.fill('zzznotamodel');
+    await page.waitForTimeout(200);
+    // Either empty state is visible or count shows 0 models
+    const countText = await page.locator('.model-list-panel__count').textContent();
+    const emptyVisible = await page.locator('.manager__empty').isVisible().catch(() => false);
+    expect(emptyVisible || (countText ?? '').startsWith('0')).toBeTruthy();
+  });
+
+  // ── Funnel filter ────────────────────────────────────────────────────────────
+
+  test('A95 — funnel filter button has aria-expanded and aria-haspopup', async ({ page }) => {
+    await goToModels(page);
+    const btn = page.locator('[aria-haspopup="dialog"]').filter({ has: page.locator('[aria-label*="filter" i], [aria-label*="Filter" i]') }).first();
+    // Fallback: any button with the funnel SVG class or the filter popover trigger
+    const filterBtn = page.locator('button[aria-haspopup="dialog"]').first();
+    await expect(filterBtn).toBeAttached();
+    await expect(filterBtn).toHaveAttribute('aria-expanded');
+  });
+
+  test('A96 — funnel filter popover opens on button click and has role=dialog', async ({ page }) => {
+    await goToModels(page);
+    const filterBtn = page.locator('button[aria-haspopup="dialog"]').first();
+    await filterBtn.click();
+    const popover = page.locator('[role="dialog"]').first();
+    await expect(popover).toBeVisible();
+    await expect(filterBtn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  // ── List keyboard navigation ─────────────────────────────────────────────────
+
+  test('A97 — model list container has role=listbox with accessible label', async ({ page }) => {
+    await goToModels(page);
+    const listbox = page.getByRole('listbox', { name: 'Model list' });
+    await expect(listbox).toBeAttached();
+    const label = await listbox.getAttribute('aria-label');
+    expect(label).toBeTruthy();
+  });
+
+  test('A98 — model list items have role=option with aria-selected', async ({ page }) => {
+    await goToModelsWithMock(page);
+    const items = page.locator('[role="option"]');
+    const count = await items.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < Math.min(count, 3); i++) {
+      await expect(items.nth(i)).toHaveAttribute('aria-selected');
+    }
+  });
+
+  test('A99 — ArrowDown/ArrowUp keyboard navigation moves selection in model list', async ({ page }) => {
+    await goToModelsWithMock(page);
+    const listbox = page.getByRole('listbox', { name: 'Model list' });
+    await listbox.focus();
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(100);
+    // At least one option should now be selected
+    const selectedCount = await page.locator('[role="option"][aria-selected="true"]').count();
+    expect(selectedCount).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── Detail panel tablist ─────────────────────────────────────────────────────
+
+  test('A100 — detail panel tablist has correct ARIA structure (role=tablist, tabs, tabpanels)', async ({ page }) => {
+    await goToModelsWithMock(page);
+    // Select a model to open the detail panel
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+
+    const tablist = page.locator('[role="tablist"]');
+    await expect(tablist).toBeVisible();
+
+    const tabs = page.locator('[role="tab"]');
+    const tabCount = await tabs.count();
+    expect(tabCount).toBeGreaterThanOrEqual(2); // README + Presets at minimum
+
+    // Each tab must have aria-selected
+    for (let i = 0; i < tabCount; i++) {
+      await expect(tabs.nth(i)).toHaveAttribute('aria-selected');
+    }
+
+    // Exactly one tab should be selected
+    const selectedTabs = await page.locator('[role="tab"][aria-selected="true"]').count();
+    expect(selectedTabs).toBe(1);
+
+    // Active tabpanel must be visible
+    const activePanel = page.locator('[role="tabpanel"]:visible');
+    await expect(activePanel).toBeVisible();
+  });
+
+  test('A101 — tab keyboard navigation (ArrowLeft/ArrowRight) moves focus between tabs', async ({ page }) => {
+    await goToModelsWithMock(page);
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+
+    const tabs = page.locator('[role="tab"]');
+    await tabs.first().focus();
+    const initialLabel = await tabs.first().getAttribute('aria-label') ?? await tabs.first().textContent();
+
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(100);
+
+    // Second tab should now have focus / be selected
+    const secondSelected = await page.locator('[role="tab"][aria-selected="true"]').textContent();
+    expect(secondSelected).not.toBe(initialLabel?.trim());
+  });
+
+  // ── Preset tab attach flow ────────────────────────────────────────────────────
+
+  test('A102 — Presets tab in detail panel is keyboard-reachable and focusable', async ({ page }) => {
+    await goToModelsWithMock(page);
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+
+    const presetsTab = page.locator('[role="tab"]').filter({ hasText: /Preset/i });
+    await expect(presetsTab).toBeVisible();
+    await presetsTab.click();
+    await page.waitForTimeout(100);
+    await expect(presetsTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('A103 — Presets tab panel has accessible heading or label', async ({ page }) => {
+    await goToModelsWithMock(page);
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+
+    const presetsTab = page.locator('[role="tab"]').filter({ hasText: /Preset/i });
+    await presetsTab.click();
+    await page.waitForTimeout(100);
+
+    const tabpanel = page.locator('[role="tabpanel"]:visible');
+    await expect(tabpanel).toBeVisible();
+    // Panel should have aria-labelledby referencing the tab
+    const labelledBy = await tabpanel.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+  });
+
+  // ── Custom model / Omni collection buttons ────────────────────────────────────
+
+  test('A104 — "+ Custom model" and "+ Omni collection" buttons are visible and keyboard-accessible', async ({ page }) => {
+    await goToModels(page);
+    const customBtn = page.getByText('+ Custom model');
+    const omniBtn = page.getByText('+ Omni collection');
+    await expect(customBtn).toBeVisible();
+    await expect(omniBtn).toBeVisible();
+    // Both should be real buttons
+    await expect(customBtn).toHaveRole('button');
+    await expect(omniBtn).toHaveRole('button');
+  });
+
+  test('A105 — master-detail Models view passes WCAG 2.1 AA axe-core scan with mock data', async ({ page }) => {
+    await goToModelsWithMock(page);
+    // Select first model to populate the detail panel
+    const items = page.locator('.model-list-item');
+    if (await items.count() > 0) {
+      await items.first().click();
+      await page.waitForTimeout(200);
+    }
+
+    const results = await new AxeBuilder({ page })
+      .withTags([...WCAG_TAGS])
+      .analyze();
+    const critical = results.violations.filter(
+      v => v.impact === 'critical' || v.impact === 'serious',
+    );
+    expect(critical, formatViolations(critical)).toHaveLength(0);
+  });
+});
+

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -2829,7 +2829,7 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     expect(((await star.getAttribute('aria-label')) ?? '').toLowerCase()).toContain('remove');
   });
 
-  test('A143 — favoriting in the detail panel updates the Favorites nav count and persists', async ({ page }) => {
+  test('A143 — favoriting in the detail panel updates the Favorites nav count and persists to a DISTINCT favorites store', async ({ page }) => {
     await goToModelsRefined(page);
     await page.locator('.model-list-item').first().click();
     await page.waitForTimeout(150);
@@ -2840,16 +2840,23 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     const fav = page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Favorites' });
     await expect(fav).toContainText('1');
 
-    // Reuses the SAME client-local pin store — a *pinned_models key exists.
-    const persisted = await page.evaluate(() => {
+    // Favorites is a DISTINCT concept from Pinned (#2424): it must persist to a
+    // SEPARATE favorite_models key, NOT the pinned_models store.
+    const stores = await page.evaluate(() => {
+      let favorite: string | null = null;
+      let pinned: string | null = null;
       for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
-        if (key && key.endsWith('pinned_models')) return localStorage.getItem(key);
+        if (!key) continue;
+        if (key.endsWith('favorite_models')) favorite = localStorage.getItem(key);
+        if (key.endsWith('pinned_models')) pinned = localStorage.getItem(key);
       }
-      return null;
+      return { favorite, pinned };
     });
-    expect(persisted, 'favorite must persist to the existing pinned_models store').toBeTruthy();
-    expect((persisted ?? '').toLowerCase()).toContain('llama-3.1-8b');
+    expect(stores.favorite, 'favorite must persist to a separate favorite_models store').toBeTruthy();
+    expect((stores.favorite ?? '').toLowerCase()).toContain('llama-3.1-8b');
+    // The pinned store must NOT have been touched by favoriting.
+    expect((stores.pinned ?? '').toLowerCase()).not.toContain('llama-3.1-8b');
   });
 
   // ── 3. "Back to models" only on narrow viewports ─────────────────────────
@@ -2865,7 +2872,7 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
 
   // ── 4. Funnel filter: capabilities only + opaque background ───────────────
 
-  test('A145 — the funnel filter popover filters by capability and has a solid background', async ({ page }) => {
+  test('A145 — the funnel filter popover filters by functional capability tags and has a solid background', async ({ page }) => {
     await goToModelsRefined(page);
     const filterBtn = page.locator('.model-list-panel__filter-btn');
     await filterBtn.click();
@@ -2874,9 +2881,12 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     await expect(popover).toBeVisible();
     await expect(popover).toContainText(/capabilit/i);
 
-    // The options are the capability categories (LLM / Omni / Image / Audio / TTS / Embed) + All.
+    // Options are the functional capability tags PRESENT in the data — the four
+    // mock models expose Chat, Tool use, Audio and Image (multi-select toggles).
     const options = popover.locator('.model-list-panel__filter-option');
-    await expect(options).toHaveCount(7);
+    await expect(options).toHaveCount(4);
+    await expect(popover).toContainText(/Tool use/i);
+    await expect(popover).toContainText(/Audio/i);
 
     // Background must be opaque (not transparent) so list content does not bleed through.
     const bg = await popover.evaluate(el => getComputedStyle(el).backgroundColor);
@@ -2884,13 +2894,15 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     expect(bg).not.toBe('transparent');
   });
 
-  test('A146 — picking a capability in the funnel popover filters the list', async ({ page }) => {
+  test('A146 — toggling a capability in the funnel popover filters the list (multi-select)', async ({ page }) => {
     await goToModelsRefined(page);
     await page.locator('.model-list-panel__filter-btn').click();
     await page.waitForTimeout(120);
     const audio = page.locator('.model-list-panel__filter-option').filter({ hasText: /Audio/ });
     await audio.click();
     await page.waitForTimeout(150);
+    // The toggle reports its pressed state (multi-select stays open).
+    await expect(audio).toHaveAttribute('aria-pressed', 'true');
     const rows = page.locator('.model-list-item');
     await expect(rows).toHaveCount(1);
     await expect(rows.first()).toContainText('Whisper');
@@ -2916,14 +2928,95 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     await expect(storage).toBeVisible();
   });
 
-  // ── Axe scan with a favorite set + filter open ───────────────────────────
+  // ── 6. Capability icons on rows + empty-state in detail pane (#2424) ──────
 
-  test('A148 — refined model view passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
+  test('A149 — middle-list rows show multiple capability icons with an accessible label', async ({ page }) => {
     await goToModelsRefined(page);
-    await page.locator('.model-list-item').first().click();
+    // The Llama row exposes both Chat and Tool-use capabilities → ≥2 icons.
+    const llamaRow = page.locator('.model-list-item').filter({ hasText: 'Llama-3.1-8B' });
+    const caps = llamaRow.locator('.model-list-item__caps');
+    await expect(caps).toHaveAttribute('role', 'img');
+    const label = (await caps.getAttribute('aria-label')) ?? '';
+    expect(label.toLowerCase()).toContain('capabilities');
+    expect(label).toMatch(/Tool use/i);
+    // Multiple capability icon slots rendered for this multi-capability model.
+    const iconCount = await caps.locator('.model-list-item__cap').count();
+    expect(iconCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test('A150 — the "no model selected" empty state lives in the detail pane, NOT the middle list', async ({ page }) => {
+    await goToModelsRefined(page);
+    // Nothing selected yet: the middle list must NOT render an empty placeholder…
+    await expect(page.locator('.model-list-panel__empty')).toHaveCount(0);
+    // …and the model rows are still present (the list is populated).
+    expect(await page.locator('.model-list-item').count()).toBeGreaterThan(0);
+    // The empty/placeholder message belongs to the RIGHT detail pane.
+    const placeholder = page.locator('.model-detail-panel__placeholder');
+    await expect(placeholder).toBeVisible();
+    await expect(placeholder).toContainText(/no model selected/i);
+  });
+
+  // ── 7. Storage meter uses derived data, not the 32/512 mock (#2424) ───────
+
+  test('A151 — Storage meter derives from data (no hardcoded 512 GB) and labels the estimate', async ({ page }) => {
+    await goToModelsRefined(page);
+    const value = page.locator('.model-nav-rail__storage-value');
+    const text = (await value.textContent()) ?? '';
+    // Downloaded mock sizes total 11 GB → derived capacity is a headroom bucket
+    // (32 GB), never the old 512 GB literal.
+    expect(text).not.toContain('512');
+    expect(text).toMatch(/\d+\s*GB\s*\/\s*\d+\s*GB/);
+    const bar = page.locator('.model-nav-rail__storage-bar');
+    // Without a real disk source in the POC the meter is flagged as estimated.
+    expect(((await bar.getAttribute('aria-label')) ?? '').toLowerCase()).toContain('estimat');
+    expect(Number(await bar.getAttribute('aria-valuemax'))).not.toBe(512);
+  });
+
+  // ── 8. HuggingFace search nav entry in the left rail (#2424) ──────────────
+
+  async function goToModelsRefinedWithHf(page: Page): Promise<void> {
+    await page.route('**huggingface.co/api/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { id: 'org/Mistral-7B-GGUF', modelId: 'org/Mistral-7B-GGUF', likes: 10, downloads: 999, tags: ['gguf', 'text-generation'], pipeline_tag: 'text-generation' },
+          { id: 'org/Phi-3-GGUF', modelId: 'org/Phi-3-GGUF', likes: 5, downloads: 500, tags: ['gguf'], pipeline_tag: 'text-generation' },
+        ]),
+      }),
+    );
+    await goToModelsRefined(page);
+  }
+
+  test('A152 — a HuggingFace nav entry appears below the primary list on search, shows the count, is keyboard operable, and clears', async ({ page }) => {
+    await goToModelsRefinedWithHf(page);
+    const search = page.locator('#model-list-search');
+    await search.fill('mistral');
+    // Allow the debounced HF search (400ms) + render to settle.
+    await page.waitForTimeout(900);
+
+    const hf = page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Hugging Face' });
+    await expect(hf).toBeVisible();
+    await expect(hf).toContainText('2');
+
+    // Keyboard operable: focus + Enter selects it and filters the middle list.
+    await hf.focus();
+    await page.keyboard.press('Enter');
     await page.waitForTimeout(150);
-    await page.locator('.model-detail-panel__fav-btn').click();
-    await page.locator('.model-list-panel__filter-btn').click();
+    expect(await hf.getAttribute('aria-current')).toBe('true');
+    const rows = page.locator('.model-list-item');
+    await expect(rows.first()).toContainText(/Mistral-7B|Phi-3/);
+
+    // Clearing the search removes the HF entry entirely.
+    await search.fill('');
+    await page.waitForTimeout(300);
+    await expect(page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Hugging Face' })).toHaveCount(0);
+  });
+
+  test('A153 — the model view with an active HuggingFace search passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
+    await goToModelsRefinedWithHf(page);
+    await page.locator('#model-list-search').fill('mistral');
+    await page.waitForTimeout(900);
+    await page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Hugging Face' }).click();
     await page.waitForTimeout(150);
     const results = await new AxeBuilder({ page })
       .withTags([...WCAG_TAGS])

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -2300,3 +2300,126 @@ test.describe('Accessibility — model README raw-HTML rendering (#2355)', () =>
     expect(text).not.toContain('pipeline_tag');
   });
 });
+
+// ─── 26. #2355 left-rail parity — pin / favorite (client-local) ───────────────
+//
+// fl0rianr feedback (2026-06-25): the master-detail rail dropped the original
+// rail's pin/favorite affordance. Re-wired the existing client-local pin store
+// (localStorage `pinned_models`, no lemond) into ModelListPanel. Pinned models
+// float to the top; the affordance is a non-button span (so it does not nest an
+// interactive control inside role="option"), and keyboard/AT users toggle via
+// the "P" shortcut on the focused row, with pinned state in the row aria-label.
+// Range: A118–A123.
+
+test.describe('Accessibility — left-rail pin/favorite parity (#2355)', () => {
+  async function goToModelsWithMock(page: Page): Promise<void> {
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false },
+          ],
+        }),
+      }),
+    );
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await navigateToView(page, 'Models');
+    await page.waitForSelector('.manager--detail');
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.waitForTimeout(200);
+  }
+
+  test('A118 — each model row exposes a pin affordance with an accessible title', async ({ page }) => {
+    await goToModelsWithMock(page);
+    const pins = page.locator('.model-list-item__pin');
+    const count = await pins.count();
+    expect(count).toBeGreaterThan(0);
+    // Title communicates the pin action to pointer users.
+    const title = await pins.first().getAttribute('title');
+    expect((title ?? '').toLowerCase()).toContain('pin');
+  });
+
+  test('A119 — pin affordance is NOT a nested interactive button inside role="option"', async ({ page }) => {
+    await goToModelsWithMock(page);
+    const pin = page.locator('.model-list-item__pin').first();
+    // It must be a span (not a button/anchor/input) so role=option does not nest
+    // an interactive control (axe nested-interactive).
+    const tag = await pin.evaluate(el => el.tagName.toLowerCase());
+    expect(tag).toBe('span');
+    // No button inside any option row.
+    expect(await page.locator('[role="option"] button').count()).toBe(0);
+  });
+
+  test('A120 — clicking the pin toggles the row pinned state and aria-label', async ({ page }) => {
+    await goToModelsWithMock(page);
+    const row = page.locator('.model-list-item').first();
+    const pin = row.locator('.model-list-item__pin');
+    await pin.click();
+    await page.waitForTimeout(100);
+    // The (now-pinned) model floats to the top; assert the first row is pinned.
+    const firstRow = page.locator('.model-list-item').first();
+    await expect(firstRow).toHaveClass(/model-list-item--pinned/);
+    const label = await firstRow.getAttribute('aria-label');
+    expect((label ?? '').toLowerCase()).toContain('pinned');
+    // Unpin and verify the pinned class is removed.
+    await firstRow.locator('.model-list-item__pin').click();
+    await page.waitForTimeout(100);
+    expect(await page.locator('.model-list-item--pinned').count()).toBe(0);
+  });
+
+  test('A121 — selected row is keyboard-operable: "P" toggles pin (aria-keyshortcuts)', async ({ page }) => {
+    await goToModelsWithMock(page);
+    // Select a model (focus moves to the detail panel in master-detail), then
+    // return focus to the now-focusable selected row (tabIndex 0) — the path a
+    // keyboard user takes via Shift+Tab — and press the advertised "P" shortcut.
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(150);
+    const selected = page.locator('.model-list-item--selected');
+    // The shortcut must be advertised to assistive tech.
+    expect(await selected.getAttribute('aria-keyshortcuts')).toBe('P');
+    await selected.focus();
+    await page.keyboard.press('p');
+    await page.waitForTimeout(100);
+    const pinnedCount = await page.locator('.model-list-item--pinned').count();
+    expect(pinnedCount).toBe(1);
+    const label = await page.locator('.model-list-item--pinned').first().getAttribute('aria-label');
+    expect((label ?? '').toLowerCase()).toContain('pinned');
+  });
+
+  test('A122 — pinned state persists client-locally to localStorage (no lemond)', async ({ page }) => {
+    await goToModelsWithMock(page);
+    await page.locator('.model-list-item').first().locator('.model-list-item__pin').click();
+    await page.waitForTimeout(100);
+    const persisted = await page.evaluate(() => {
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.endsWith('pinned_models')) return localStorage.getItem(key);
+      }
+      return null;
+    });
+    expect(persisted, 'a *pinned_models localStorage key should exist').toBeTruthy();
+    expect((persisted ?? '').length).toBeGreaterThan(2); // non-empty JSON array
+  });
+
+  test('A123 — model list with a pinned row passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
+    await goToModelsWithMock(page);
+    await page.locator('.model-list-item').first().locator('.model-list-item__pin').click();
+    await page.waitForTimeout(150);
+    const results = await new AxeBuilder({ page })
+      .withTags([...WCAG_TAGS])
+      .analyze();
+    const critical = results.violations.filter(
+      v => v.impact === 'critical' || v.impact === 'serious',
+    );
+    expect(critical, formatViolations(critical)).toHaveLength(0);
+  });
+});

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -2631,3 +2631,139 @@ test.describe('Accessibility — left navigation rail (#2355 three-pane)', () =>
     expect(hasLabel).toBeGreaterThan(0);
   });
 });
+
+// ─── 28. Model-detail Presets tab — neat compact card grid (#2424 fl0rianr) ───
+//
+// fl0rianr asked for the model-detail Presets tab to render presets as a neat
+// grid of small focused cards (matching the global Presets-page cards), not
+// full-width stacked rows. The linked preset sits above as a single highlighted
+// card; recommended presets render in a responsive grid. Each Attach/Switch
+// button names its preset, linked/active state is exposed via text + aria (not
+// color only), and the inline Change dialog still works.
+// Range: A137–A141.
+
+test.describe('Accessibility — model-detail Presets card grid (#2424)', () => {
+  async function goToPresetsTab(
+    page: Page,
+    opts: { applied?: Record<string, string> } = {},
+  ): Promise<void> {
+    const applied = opts.applied ?? {};
+    await page.addInitScript((appliedJson: string) => {
+      const presets = [
+        {
+          id: 'p-balanced', name: 'Balanced', description: 'Reliable defaults for everyday chat and general use.',
+          applies_to: ['chat'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: false,
+          auto_opt_run_id: null, auto_opt_enabled: true, system_prompt_id: 'none', system_prompts: [], tools_enabled: true,
+        },
+        {
+          id: 'p-thorough', name: 'Thorough', description: 'Careful answers for analysis, planning, and debugging.',
+          applies_to: ['chat'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: false,
+          auto_opt_run_id: null, auto_opt_enabled: true, system_prompt_id: 'none', system_prompts: [], tools_enabled: true,
+        },
+        {
+          id: 'p-creative', name: 'Creative', description: 'Higher creativity for brainstorming and writing.',
+          applies_to: ['chat'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: false,
+          auto_opt_run_id: null, auto_opt_enabled: true, system_prompt_id: 'none', system_prompts: [], tools_enabled: false,
+        },
+      ];
+      localStorage.setItem('lemonade:guest:shared:user_presets', JSON.stringify(presets));
+      localStorage.setItem('lemonade:guest:shared:applied_presets', appliedJson);
+    }, JSON.stringify(applied));
+
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
+          ],
+        }),
+      }),
+    );
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await navigateToView(page, 'Models');
+    await page.waitForSelector('.manager--detail');
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+    const presetsTab = page.locator('[role="tab"]').filter({ hasText: /Preset/i });
+    await presetsTab.click();
+    await page.waitForTimeout(150);
+  }
+
+  test('A137 — recommended presets render as a grid of compact cards (not full-width rows)', async ({ page }) => {
+    await goToPresetsTab(page);
+    // The old row container is gone; the new grid is present.
+    await expect(page.locator('.detail-presets__preset-list')).toHaveCount(0);
+    const grid = page.locator('.detail-presets__preset-grid');
+    await expect(grid).toBeVisible();
+    await expect(grid).toHaveAttribute('role', 'list');
+    // Multiple compact cards rendered as a grid.
+    const cards = grid.locator('.detail-presets__preset-card');
+    expect(await cards.count()).toBeGreaterThanOrEqual(2);
+    const display = await grid.evaluate(el => getComputedStyle(el).display);
+    expect(display).toBe('grid');
+  });
+
+  test('A138 — each Attach/Switch button has an accessible name that includes its preset name', async ({ page }) => {
+    await goToPresetsTab(page);
+    const attachButtons = page.locator('.detail-presets__attach-btn');
+    const count = await attachButtons.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+    for (let i = 0; i < count; i++) {
+      const label = await attachButtons.nth(i).getAttribute('aria-label');
+      expect(label).toMatch(/(Attach|Switch to) preset ".+" for /);
+    }
+  });
+
+  test('A139 — linked/active state is exposed via text + aria, not color alone', async ({ page }) => {
+    // Link "Balanced" so it is both the active linked card and the selected option.
+    await goToPresetsTab(page, { applied: { 'Llama-3.1-8B': 'p-balanced' } });
+
+    // Linked card above carries aria-current + visible "Active" badge text.
+    const linkedCard = page.locator('.detail-presets__linked-card');
+    await expect(linkedCard).toHaveAttribute('aria-current', 'true');
+    await expect(linkedCard.locator('.detail-presets__card-badge--linked')).toHaveText(/Active/i);
+
+    // The matching card in the grid exposes aria-current + a text "Linked" badge.
+    const selected = page.locator('.detail-presets__preset-card--selected');
+    await expect(selected).toHaveAttribute('aria-current', 'true');
+    await expect(selected).toContainText(/Linked/i);
+    // Selected card shows a text note instead of an Attach button (state not by color only).
+    await expect(selected.locator('.detail-presets__card-linked-note')).toBeVisible();
+  });
+
+  test('A140 — Change dialog still opens from the linked card and closes', async ({ page }) => {
+    await goToPresetsTab(page, { applied: { 'Llama-3.1-8B': 'p-balanced' } });
+    const changeBtn = page.locator('.detail-presets__change-btn');
+    await expect(changeBtn).toBeVisible();
+    await changeBtn.click();
+    await page.waitForTimeout(100);
+    const chooser = page.locator('.detail-presets__change-chooser');
+    await expect(chooser).toBeVisible();
+    await expect(chooser).toHaveAttribute('role', 'dialog');
+    await expect(changeBtn).toHaveAttribute('aria-expanded', 'true');
+    await page.locator('.detail-presets__chooser-close').click();
+    await page.waitForTimeout(100);
+    await expect(chooser).not.toBeVisible();
+  });
+
+  test('A141 — the Presets card grid passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
+    await goToPresetsTab(page, { applied: { 'Llama-3.1-8B': 'p-balanced' } });
+    await expect(page.locator('.detail-presets__preset-grid')).toBeVisible();
+    const results = await new AxeBuilder({ page })
+      .withTags([...WCAG_TAGS])
+      .analyze();
+    const critical = results.violations.filter(
+      v => v.impact === 'critical' || v.impact === 'serious',
+    );
+    expect(critical, formatViolations(critical)).toHaveLength(0);
+  });
+});

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -1935,3 +1935,266 @@ test.describe('Accessibility — master-detail model view (#2355 Slice 1)', () =
   });
 });
 
+// ─── 24. #2355 Slice 1 reconciliation — sort, responsive, README derivation, preset change ──
+//
+// Covers the 4 gaps addressed in the fl0rianr 2026-06-25 clarifications:
+//   A: README checkpoint derivation (tightened regex + checkpoints.main fallback)
+//   B: Sort controls (labeled select with 4 options)
+//   C: Responsive list-first (narrow ≤700px shows list only; selecting shows detail + Back)
+//   D: Presets tab Change inline chooser (attach + detach already present)
+// Range: A106–A115.
+
+test.describe('Accessibility — #2355 Slice 1 reconciliation (fl0rianr clarifications)', () => {
+  async function goToModels(page: Page): Promise<void> {
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await navigateToView(page, 'Models');
+    await page.waitForSelector('.manager--detail');
+  }
+
+  async function goToModelsWithMock(page: Page): Promise<void> {
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true,
+              checkpoint: 'gguf-community/Llama-3.1-8B-Instruct:Q4_K_M.gguf' },
+            { id: 'Qwen2.5-7B', name: 'Qwen2.5-7B', labels: ['llm'], recipe: 'llamacpp', downloaded: false },
+          ],
+        }),
+      }),
+    );
+    await goToModels(page);
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.waitForTimeout(200);
+  }
+
+  // ── B: Sort controls ─────────────────────────────────────────────────────────
+
+  test('A106 — sort control is a labelled <select> with accessible name', async ({ page }) => {
+    await goToModels(page);
+    const sortSelect = page.locator('#model-list-sort');
+    await expect(sortSelect).toBeVisible();
+    await expect(sortSelect).toHaveRole('combobox');
+
+    // Label must reference the select
+    const label = page.locator('label[for="model-list-sort"]');
+    await expect(label).toBeVisible();
+  });
+
+  test('A107 — sort control offers Name, Size, Last used, Download count options', async ({ page }) => {
+    await goToModels(page);
+    const sortSelect = page.locator('#model-list-sort');
+    await expect(sortSelect).toBeVisible();
+
+    const opts = await sortSelect.locator('option').allTextContents();
+    expect(opts.some(t => /name/i.test(t))).toBe(true);
+    expect(opts.some(t => /size/i.test(t))).toBe(true);
+    expect(opts.some(t => /last.used/i.test(t))).toBe(true);
+    expect(opts.some(t => /download/i.test(t))).toBe(true);
+  });
+
+  test('A108 — sort select default value is Name (alphabetical)', async ({ page }) => {
+    await goToModels(page);
+    const sortSelect = page.locator('#model-list-sort');
+    await expect(sortSelect).toHaveValue('name');
+  });
+
+  test('A109 — sort select is keyboard-operable (can change value via keyboard)', async ({ page }) => {
+    await goToModelsWithMock(page);
+    const sortSelect = page.locator('#model-list-sort');
+    await sortSelect.focus();
+    await sortSelect.selectOption('size');
+    await expect(sortSelect).toHaveValue('size');
+    // Revert
+    await sortSelect.selectOption('name');
+    await expect(sortSelect).toHaveValue('name');
+  });
+
+  // ── C: Responsive list-first ──────────────────────────────────────────────────
+
+  test('A110 — on narrow viewport (640px), detail panel is hidden until model selected', async ({ page }) => {
+    await page.setViewportSize({ width: 640, height: 800 });
+    await goToModelsWithMock(page);
+
+    // Detail panel should not be visible before selection
+    const detailPanel = page.locator('.model-detail-panel');
+    await expect(detailPanel).not.toBeVisible();
+
+    // List should be visible
+    await expect(page.locator('.model-list-panel')).toBeVisible();
+  });
+
+  test('A111 — on narrow viewport, selecting a model shows the detail panel and hides the list', async ({ page }) => {
+    await page.setViewportSize({ width: 640, height: 800 });
+    await goToModelsWithMock(page);
+
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+
+    // Detail visible, list hidden
+    await expect(page.locator('.model-detail-panel')).toBeVisible();
+    await expect(page.locator('.model-list-panel')).not.toBeVisible();
+  });
+
+  test('A112 — narrow viewport detail view has a "Back to models" button with accessible label', async ({ page }) => {
+    await page.setViewportSize({ width: 640, height: 800 });
+    await goToModelsWithMock(page);
+
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+
+    const backBtn = page.locator('.model-detail-panel__back-btn');
+    await expect(backBtn).toBeVisible();
+    await expect(backBtn).toHaveRole('button');
+    const label = await backBtn.getAttribute('aria-label');
+    expect(label).toMatch(/back.+model/i);
+  });
+
+  test('A113 — Back button returns to list view and restores list visibility', async ({ page }) => {
+    await page.setViewportSize({ width: 640, height: 800 });
+    await goToModelsWithMock(page);
+
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+
+    const backBtn = page.locator('.model-detail-panel__back-btn');
+    await backBtn.click();
+    await page.waitForTimeout(200);
+
+    // List back, detail hidden
+    await expect(page.locator('.model-list-panel')).toBeVisible();
+    await expect(page.locator('.model-detail-panel')).not.toBeVisible();
+  });
+
+  // ── D: Preset Change inline chooser ──────────────────────────────────────────
+
+  test('A114 — preset Change button has aria-expanded and aria-haspopup="dialog"', async ({ page }) => {
+    // Inject a user preset via localStorage before page load
+    await page.addInitScript(() => {
+      // Seed a user preset compatible with LLM (chat), using scoped key
+      const preset = {
+        id: 'test-preset-1',
+        name: 'Test Chat Preset',
+        description: 'Seed preset for testing',
+        applies_to: ['chat'],
+        recipe_options: {},
+        sampling: {},
+        engine_hint: 'auto',
+        starter: false,
+        auto_opt_run_id: null,
+        auto_opt_enabled: true,
+        system_prompt_id: 'none',
+        system_prompts: [],
+        tools_enabled: false,
+      };
+      localStorage.setItem('lemonade:guest:shared:user_presets', JSON.stringify([preset]));
+      // Link the preset to Llama-3.1-8B
+      localStorage.setItem('lemonade:guest:shared:applied_presets', JSON.stringify({ 'Llama-3.1-8B': 'test-preset-1' }));
+    });
+
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
+          ],
+        }),
+      }),
+    );
+    await goToModels(page);
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+
+    // Navigate to Presets tab
+    const presetsTab = page.locator('[role="tab"]').filter({ hasText: /Preset/i });
+    await presetsTab.click();
+    await page.waitForTimeout(100);
+
+    // Change button should be visible (non-default preset is linked)
+    const changeBtn = page.locator('.detail-presets__change-btn');
+    await expect(changeBtn).toBeVisible();
+    await expect(changeBtn).toHaveAttribute('aria-haspopup', 'dialog');
+    const expanded = await changeBtn.getAttribute('aria-expanded');
+    expect(expanded).toBe('false');
+  });
+
+  test('A115 — preset Change chooser opens as role=dialog when Change clicked', async ({ page }) => {
+    await page.addInitScript(() => {
+      const preset = {
+        id: 'test-preset-2',
+        name: 'Alt Chat Preset',
+        description: 'Another preset',
+        applies_to: ['chat'],
+        recipe_options: {},
+        sampling: {},
+        engine_hint: 'auto',
+        starter: false,
+        auto_opt_run_id: null,
+        auto_opt_enabled: true,
+        system_prompt_id: 'none',
+        system_prompts: [],
+        tools_enabled: false,
+      };
+      localStorage.setItem('lemonade:guest:shared:user_presets', JSON.stringify([preset]));
+      localStorage.setItem('lemonade:guest:shared:applied_presets', JSON.stringify({ 'Llama-3.1-8B': 'test-preset-2' }));
+    });
+
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
+          ],
+        }),
+      }),
+    );
+    await goToModels(page);
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+
+    const presetsTab = page.locator('[role="tab"]').filter({ hasText: /Preset/i });
+    await presetsTab.click();
+    await page.waitForTimeout(100);
+
+    const changeBtn = page.locator('.detail-presets__change-btn');
+    await changeBtn.click();
+    await page.waitForTimeout(100);
+
+    // Chooser dialog should be visible
+    const chooser = page.locator('.detail-presets__change-chooser');
+    await expect(chooser).toBeVisible();
+    await expect(chooser).toHaveAttribute('role', 'dialog');
+    await expect(changeBtn).toHaveAttribute('aria-expanded', 'true');
+
+    // Close chooser
+    const closeBtn = page.locator('.detail-presets__chooser-close');
+    await closeBtn.click();
+    await page.waitForTimeout(100);
+    await expect(chooser).not.toBeVisible();
+    await expect(changeBtn).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/prototype/ui-redesign/tests/features.spec.ts
+++ b/prototype/ui-redesign/tests/features.spec.ts
@@ -798,7 +798,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.screenshot({ path: 'screenshots/19-streaming-badge-style.png', fullPage: true });
   });
 
-  test('20 — Models page shows all four zones with correct labels', async ({ page }) => {
+  test('20 — Models page shows model list panel with search', async ({ page }) => {
     await page.goto('/');
     await page.waitForSelector('.titlebar__nav');
 
@@ -806,39 +806,32 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.locator('.titlebar__nav').getByText('Models').click();
     await page.waitForSelector('.manager');
 
-    // HuggingFace zone should always be visible (not conditional on search)
-    const hfZone = page.locator('.zone--hf');
-    await expect(hfZone).toBeVisible();
+    // New master-detail layout: left panel with search input
+    const listPanel = page.locator('.model-list-panel');
+    await expect(listPanel).toBeVisible();
 
-    // HuggingFace zone title should say "HuggingFace" (not "Explore — HuggingFace")
-    await expect(hfZone.locator('.zone__title')).toContainText('HuggingFace');
-    await expect(hfZone.locator('.zone__title')).not.toContainText('Explore');
+    // Search input should be present and operable
+    const searchInput = page.locator('.manager__search-input');
+    await expect(searchInput).toBeVisible();
 
-    // HuggingFace should show the prompt when no search text
-    await expect(hfZone.locator('.hf-zone__empty')).toContainText('Type at least 2 characters');
-
-    // When disconnected, empty state should show appropriate message
+    // When disconnected / no models, empty state should show appropriate message
     const emptyState = page.locator('.manager__empty');
     if (await emptyState.isVisible().catch(() => false)) {
       const text = await emptyState.textContent();
-      // Should say either "Connect to a Lemonade server" or "No models found"
-      expect(text).toMatch(/Connect to a Lemonade server|No models found/);
+      expect(text).toMatch(/Connect to a Lemonade server|No models found|No models match/);
     }
 
-    // Search triggers HuggingFace search
-    const searchInput = page.locator('.manager__search-input');
-    await searchInput.fill('llama');
-    await page.waitForTimeout(1500); // debounce (400ms) + network time
+    // Model count annotation should be present (even "0 models")
+    const countEl = page.locator('.model-list-panel__count');
+    await expect(countEl).toBeVisible();
 
-    // HuggingFace zone should show results, loading spinner, or "no results" message
-    const hfEmpty = hfZone.locator('.hf-zone__empty');
-    const hfRows = hfZone.locator('.row--hf');
-    const hfLoading = hfZone.locator('.hf-zone__loading');
-    const hasResults = await hfRows.count() > 0;
-    const hasEmpty = await hfEmpty.isVisible().catch(() => false);
-    const isLoading = await hfLoading.isVisible().catch(() => false);
-    // One of these states should be true
-    expect(hasResults || hasEmpty || isLoading).toBeTruthy();
+    // Typing into search filters the list
+    await searchInput.fill('zzznotamodel');
+    await page.waitForTimeout(200);
+    // Either empty state appears, or count shows 0
+    const countText = await countEl.textContent();
+    const emptyVisible = await page.locator('.manager__empty').isVisible().catch(() => false);
+    expect(emptyVisible || (countText ?? '').startsWith('0')).toBeTruthy();
 
     await page.screenshot({ path: 'screenshots/20-models-zones.png', fullPage: true });
   });


### PR DESCRIPTION
## Summary

Implements Slice 1 of the master-detail model view (#2355). Replaces the old preset-rail model/preset flow with an email-client-style split layout in `prototype/ui-redesign/`.

Part of #2355

## What shipped in Slice 1

**Left panel — `ModelListPanel`**
- Searchable, filterable `role=listbox` with compact model rows (name, size, backend badge, downloaded dot, capability badge)
- Funnel filter button (the ONLY new icon — `'funnel'` added to `Icon.tsx`) with `role=dialog` popover
- Keyboard nav: ArrowUp/Down/Home/End on the listbox moves focus AND selection (ARIA APG single-select)
- Visible selected state (`aria-selected="true"` + `.model-list-item--selected`)
- `+ Custom model` / `+ Omni collection` buttons in footer — wired to existing `openCustomForm()` in ModelManager

**Right panel — `ModelDetailPanel`**
- Title, key metadata, primary actions (Load/Unload/Download/Delete/CancelPull) with model-qualified `aria-label`s
- `role=tablist` with tabs: README (fetch + markdown-it + DOMPurify), Presets (`loadApplied`/`saveApplied` via `presetStore.ts`), Files (stub)
- ArrowLeft/Right/Home/End tab keyboard navigation

**Preset linking (Presets tab)**
- Shows currently-linked preset (`aria-current="true"`) and compatible presets
- Attach/detach actions via client-local `presetStore.ts` (localStorage — never in lemond)
- `role=status aria-live=polite` attach confirmation

**Preset rail removed**
- `renderPresetRail()` (~2344-2395) removed per plan
- Rail state vars (`presetRailCollapsed`, `selectedRailPresetId`, etc.) removed
- Custom-model form re-wired as conditional overlay in the detail slot

## Accessibility (WCAG 2.1 AA — non-negotiable)
All keyboard and screen-reader patterns are implemented: searchbox label, listbox/option ARIA, funnel popover, tablist/tab/tabpanel, attach action, aria-live regions.

## Tests: **121 passed / 7 skipped / 0 failed**

- **A91–A105** (15 new tests): layout, search, funnel, listbox/option ARIA, keyboard nav, tablist, Presets tab, custom-model buttons, full axe-core scan with mock data
- Updated A46–A50, A71–A74, A79 to match new interaction model
- Updated features test 20 (HF zone removed in new layout)

## Files changed
| File | Change |
|------|--------|
| `src/components/ModelDetailPanel.tsx` | New — detail panel with tablist |
| `src/components/ModelListPanel.tsx` | New — searchable listbox with funnel |
| `src/components/ModelManager.tsx` | Remove preset rail, wire new panels |
| `src/components/Icon.tsx` | Add `'funnel'` icon |
| `src/styles/styles.css` | New component styles (~400 lines) |
| `tests/a11y.spec.ts` | A91–A105 + A46–A50 updates |
| `tests/features.spec.ts` | Test 20 update |
| `ACCESSIBILITY.md` | Group E section, count 121/7/0 |

## Deferred to follow-up slices
- Files tab (stub only — marked in UI)
- Full recommended-preset card polish
- Sorting refinements (alphabetical, popularity, etc.)
- #2356 (Update-preset-while-loaded — builds on this detail panel)
