### PR TITLE
Feat(GUI3): update preset while loaded (#2356)

### DIFF
--- a/prototype/ui-redesign/ACCESSIBILITY.md
+++ b/prototype/ui-redesign/ACCESSIBILITY.md
@@ -4,25 +4,27 @@
 **Branch:** `feat/gui3-model-detail-redesign`  
 **Scope:** `prototype/ui-redesign/` only  
 **Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete, Group G (Left navigation rail — three-pane model view) ✅ complete, Group H (Model-detail Presets card grid — #2424 fl0rianr) ✅ complete, Group I (Model view refinements — #2424 fl0rianr review) ✅ complete, Group J (Model view merge items — #2424 fl0rianr 2nd review) ✅ complete, Group K (Update preset while loaded — #2356) ✅ complete  
-**Test status (2026-06-25):** All 178 automated tests passing, 7 skipped, 0 failed on `feat/gui3-update-preset-while-loaded` (A154–A163 added for #2356 update-preset-while-loaded)
+**Test status (2026-06-26):** All 181 automated tests passing, 7 skipped, 0 failed on `feat/gui3-update-preset-while-loaded` (A154–A166 cover #2356 update-preset-while-loaded, simplified design)
 
 ---
 
-## Group K — Update preset while a model is loaded (#2356, 2026-06-25)
+## Group K — Update preset while a model is loaded (#2356, 2026-06-26, simplified)
 
-Lets a user change the preset of an already-loaded model without a manual unload→reload. When a model is loaded and a **different** preset is linked to it, an **"Update preset"** button appears next to **Unload** in the detail-panel header actions.
+Lets a user change the preset of an already-loaded model. When a model is loaded and a **different** preset is linked to it, an **"Apply preset"** (live) / **"Reload to apply preset"** (load-time) button appears next to **Unload** in the detail-panel header actions.
 
-1. **Live vs reload classification (client-local).** `classifyPresetChange(running, next)` in `presetStore.ts` returns `'none' | 'live' | 'reload'`. Reload-requiring fields = `recipe_options`, `engine_hint` (runtime binds them at init). Live-updateable fields = `sampling`, `system_prompt_id`, `system_prompts`, `tools_enabled` (request-time). Live changes apply with no reload; reload changes trigger an automatic reload flow (the user never manually unloads/loads).
-2. **Running-preset store.** A distinct `running_presets` localStorage map (`loadRunningPresets`/`setRunningPreset`/`clearRunningPreset`/`runningPresetIdForModel`) records the preset each loaded model is actually running. Snapshotted on load (= linked preset at load time), cleared on unload. The divergence between *linked* (`applied_presets`) and *running* is what surfaces the button.
-3. **api.updatePreset contract.** `api.updatePreset(modelName, presetId, mode, payload)` POSTs to the proposed `POST /api/v{0,1}/update-preset` endpoint (quad-prefix per invariant #1). DEFERRED to backend: the real reload mechanics + the Lemonade-tools "change the preset" wiring (both live in lemond, off-limits to the POC). Contract documented in `docs/UPDATE_PRESET_CONTRACT.md` and in code on `api.updatePreset`.
+Simplified per maintainer @fl0rianr review + Lovell: **no `update-preset` endpoint and no client `mode` parameter** — the UI is not the source of truth for runtime capability.
+
+1. **Live vs reload classification (client-local).** `classifyPresetChange(running, next)` in `presetStore.ts` returns `'none' | 'live' | 'reload'`. Reload-requiring fields = `recipe_options`, `engine_hint` (runtime binds them at init). Live-updateable fields = `sampling`, `system_prompt_id`, `system_prompts`, `tools_enabled` (request-time). **Correctness fix:** the function no longer early-returns `'none'` on identical preset ids — same-id in-place edits (changed temperature/system_prompt/ctx_size) now classify correctly.
+2. **Running-preset store.** A distinct `running_presets` localStorage map records the preset each loaded model is actually running. The divergence between *linked* (`applied_presets`) and *running* is what surfaces the button.
+3. **No endpoint, no mode param.** Live changes are a pure client-local **rebind** of the active preset — request composition (`samplingForModel` in `api.ts`, `systemPromptTextForPreset` in `ChatView.tsx`) carries the new values on the next generation request; nothing is POSTed. Load-time changes go through `api.reloadModel(modelName, recipeOptions, modelInfo)` = **unload + load** (named for a possible future in-place backend reload). The active-preset binding **persists across the reload** so the reloaded model runs the newly-bound preset. The same primitives back the `change_preset` Lemonade tool (`src/tools/lemonadeTools.ts`). Documented in `docs/UPDATE_PRESET_CONTRACT.md`.
 
 **a11y specifics**
-- The button is a real `<button>`; its `aria-label` names the model and, for reload-requiring changes, states "(reloads the model)". `aria-busy` is set while updating.
+- The button is a real `<button>`; its `aria-label` names the model: "Apply preset for {name}" (live) vs "Reload {name} to apply preset" (load-time). `aria-busy` is set while reloading.
 - An always-present `role="status" aria-live="polite" aria-atomic="true"` region announces the outcome ("applied live, no reload needed" / "model reloaded"). A sighted hint (`aria-hidden`) explains why the button appeared.
-- Focus is moved to the **Unload** button on success (button unmounts once running == linked) to avoid focus loss; stays on the Update button on error.
+- Focus is moved to the **Unload** button on success (button unmounts once running == linked) to avoid focus loss; stays on the Apply/Reload button on error.
 - The reload spinner respects `prefers-reduced-motion`. Contrast for status colours ≥ 4.5:1.
 
-**Tests added:** A154–A163 (10 tests) in `tests/a11y.spec.ts`.
+**Tests added:** A154–A166 (13 tests) in `tests/a11y.spec.ts`.
 - A154: no Update preset button when linked == running
 - A155: switching to a live-only preset reveals Update preset next to Unload (label has no "reload")
 - A156: clicking (live) calls the contract with `mode=live` and announces no reload; button disappears

--- a/prototype/ui-redesign/ACCESSIBILITY.md
+++ b/prototype/ui-redesign/ACCESSIBILITY.md
@@ -3,8 +3,38 @@
 **Date:** 2026-06-25  
 **Branch:** `feat/gui3-model-detail-redesign`  
 **Scope:** `prototype/ui-redesign/` only  
-**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete, Group G (Left navigation rail — three-pane model view) ✅ complete, Group H (Model-detail Presets card grid — #2424 fl0rianr) ✅ complete, Group I (Model view refinements — #2424 fl0rianr review) ✅ complete, Group J (Model view merge items — #2424 fl0rianr 2nd review) ✅ complete  
-**Test status (2026-06-25):** All 168 automated tests passing, 7 skipped, 0 failed on `feat/gui3-model-detail-redesign` (A149–A153 added for the #2424 second-round merge items)
+**Status:** Phase 1 ✅ complete, Phase 2 ✅ mostly complete (items 16–18 deferred to Phase 3), Phase 3 (GUI3 preset a11y) ✅ complete, Group C (BackendManager) ✅ complete, Group D (MCP Gateway panel) ✅ complete, Group E (Master-detail model view, #2355 Slice 1) ✅ complete, Group F (#2355 Slice 1 reconciliation — fl0rianr clarifications) ✅ complete, Group G (Left navigation rail — three-pane model view) ✅ complete, Group H (Model-detail Presets card grid — #2424 fl0rianr) ✅ complete, Group I (Model view refinements — #2424 fl0rianr review) ✅ complete, Group J (Model view merge items — #2424 fl0rianr 2nd review) ✅ complete, Group K (Update preset while loaded — #2356) ✅ complete  
+**Test status (2026-06-25):** All 178 automated tests passing, 7 skipped, 0 failed on `feat/gui3-update-preset-while-loaded` (A154–A163 added for #2356 update-preset-while-loaded)
+
+---
+
+## Group K — Update preset while a model is loaded (#2356, 2026-06-25)
+
+Lets a user change the preset of an already-loaded model without a manual unload→reload. When a model is loaded and a **different** preset is linked to it, an **"Update preset"** button appears next to **Unload** in the detail-panel header actions.
+
+1. **Live vs reload classification (client-local).** `classifyPresetChange(running, next)` in `presetStore.ts` returns `'none' | 'live' | 'reload'`. Reload-requiring fields = `recipe_options`, `engine_hint` (runtime binds them at init). Live-updateable fields = `sampling`, `system_prompt_id`, `system_prompts`, `tools_enabled` (request-time). Live changes apply with no reload; reload changes trigger an automatic reload flow (the user never manually unloads/loads).
+2. **Running-preset store.** A distinct `running_presets` localStorage map (`loadRunningPresets`/`setRunningPreset`/`clearRunningPreset`/`runningPresetIdForModel`) records the preset each loaded model is actually running. Snapshotted on load (= linked preset at load time), cleared on unload. The divergence between *linked* (`applied_presets`) and *running* is what surfaces the button.
+3. **api.updatePreset contract.** `api.updatePreset(modelName, presetId, mode, payload)` POSTs to the proposed `POST /api/v{0,1}/update-preset` endpoint (quad-prefix per invariant #1). DEFERRED to backend: the real reload mechanics + the Lemonade-tools "change the preset" wiring (both live in lemond, off-limits to the POC). Contract documented in `docs/UPDATE_PRESET_CONTRACT.md` and in code on `api.updatePreset`.
+
+**a11y specifics**
+- The button is a real `<button>`; its `aria-label` names the model and, for reload-requiring changes, states "(reloads the model)". `aria-busy` is set while updating.
+- An always-present `role="status" aria-live="polite" aria-atomic="true"` region announces the outcome ("applied live, no reload needed" / "model reloaded"). A sighted hint (`aria-hidden`) explains why the button appeared.
+- Focus is moved to the **Unload** button on success (button unmounts once running == linked) to avoid focus loss; stays on the Update button on error.
+- The reload spinner respects `prefers-reduced-motion`. Contrast for status colours ≥ 4.5:1.
+
+**Tests added:** A154–A163 (10 tests) in `tests/a11y.spec.ts`.
+- A154: no Update preset button when linked == running
+- A155: switching to a live-only preset reveals Update preset next to Unload (label has no "reload")
+- A156: clicking (live) calls the contract with `mode=live` and announces no reload; button disappears
+- A157: switching to a reload-requiring preset labels the button as reloading
+- A158: clicking (reload) calls the contract with `mode=reload` and announces a reload
+- A159: Update preset is keyboard operable (Enter)
+- A160: feedback is a polite live region (`role=status`, `aria-live=polite`)
+- A161: no Update preset button for a non-loaded model
+- A162: Update-preset visible state passes WCAG 2.1 AA axe-core scan
+- A163: focus moves to Unload after a live update (no focus loss)
+
+**Files changed:** `presetStore.ts`, `api.ts`, `components/ModelDetailPanel.tsx`, `components/ModelManager.tsx`, `styles/styles.css`, `tests/a11y.spec.ts`, `docs/UPDATE_PRESET_CONTRACT.md`, `ACCESSIBILITY.md`.
 
 ---
 

--- a/prototype/ui-redesign/docs/UPDATE_PRESET_CONTRACT.md
+++ b/prototype/ui-redesign/docs/UPDATE_PRESET_CONTRACT.md
@@ -1,101 +1,159 @@
-# Update preset while loaded — `window.api` / HTTP contract (#2356)
+# Update preset while loaded — design & `window.api` contract (#2356)
 
-**Status:** UI POC complete on `feat/gui3-update-preset-while-loaded`. Backend
-pieces (the real reload + the Lemonade-tools wiring) are **DEFERRED to the
-backend team** — `lemond` is off-limits to the UI POC.
+**Status:** UI POC on `feat/gui3-update-preset-while-loaded` (PR #2429).
+**Revised** per maintainer feedback (@fl0rianr) to drop the dedicated
+`update-preset` endpoint and the client-provided `mode` parameter. `lemond`
+remains off-limits to this POC.
 
-This document is the proposed contract so the UI-triggered and tool-triggered
-preset updates behave identically once the backend implements it.
+The previous revision of this doc proposed a `POST /api/v{0,1}/update-preset`
+endpoint that took a client-classified `mode: 'live' | 'reload'`. That put
+runtime-capability responsibility on the UI and required a new backend endpoint.
+It is **withdrawn**. The simplified design below uses the existing request and
+load/unload paths only.
 
-## What the POC ships (UI only)
+## Guiding principle (from review)
 
-- An **"Update preset"** button that appears next to **Unload** in the model
-  detail panel when a model is **loaded** AND a **different** preset is linked
-  to it (linked ≠ running).
-- A client-side **live-vs-reload classification** of the change.
-- The correct UX for each path: live = inline "applied live, no reload" status;
-  reload = an automatic "Reloading…" flow (no manual unload/load).
-- A clean `api.updatePreset(...)` hook the UI calls.
-- Screen-reader announcements (polite live region), keyboard operability, focus
-  management, and Playwright/axe coverage (A154–A163).
+> The UI should not be the source of truth for runtime capability.
 
-## What is DEFERRED to the backend (lemond)
+Preset changes fall into two kinds, and each already has a home in the existing
+architecture — no new endpoint and no client `mode` flag are needed:
 
-1. **Real reload mechanics.** For `mode='reload'`, lemond must reinitialize the
-   model **in place** (perform the unload+load itself); the client must never
-   issue a manual unload/load pair.
-2. **Live apply.** For `mode='live'`, lemond must apply request-time fields
-   (system prompt, sampling) to the running process without reinitializing.
-3. **Lemonade-tools parity.** The same update logic must back a tool such as
-   "change the preset", so tool-triggered and UI-triggered updates are
-   consistent. The tool should call the same code path / endpoint below.
+- **Request-time fields** (`system_prompt`, `sampling`/temperature, `tools`):
+  applied by **request composition** in the frontend on the next generation
+  request. No model runtime state changes; no reload.
+- **Load-time fields** (`ctx_size`, `backend`, `device`, model args via
+  `recipe_options`): require a real reload. The client performs an
+  **unload + load** (exactly as `main` does today). A named `reloadModel`
+  helper may wrap this so a future in-place backend reload can drop in, but for
+  now it is literally unload->load.
 
-## Proposed HTTP endpoint
+## Active-preset binding (UI state)
 
-Per project invariant #1, register under all four prefixes:
-`/api/v0/update-preset`, `/api/v1/update-preset`, `/v0/update-preset`, `/v1/update-preset`.
+The UI stores a per-model **active-preset binding** (`linkedPresetId`) in
+client-local storage (invariant #11 — never in `lemond`). This already exists:
 
+- `activePresetForModel(modelName)` resolves the linked preset.
+- Request composition already reads it:
+  - sampling — `api.ts` spreads `samplingForModel(model)` into chat bodies.
+  - system prompt — `ChatView.tsx` pushes `systemPromptTextForPreset(currentPreset)`.
+
+So for request-time changes, **rebinding the active preset is the whole
+operation** — the next request automatically carries the new values. There is
+nothing to POST.
+
+## Live vs reload classification
+
+`classifyPresetChange(running, next)` in `src/presetStore.ts` returns
+`'none' | 'live' | 'reload'`:
+
+| Field group      | Fields                                                                                  | Kind     | Why |
+|------------------|-----------------------------------------------------------------------------------------|----------|-----|
+| Reload-requiring | `recipe_options` (ctx_size, backend, device, args, steps, cfg, ...), `engine_hint`      | `reload` | Bound at init; needs reinitialization. |
+| Live-updateable  | `sampling`, `system_prompt_id`, `system_prompts`, `tools_enabled`                       | `live`   | Applied per request at generation time. |
+| Everything else  | name, description, applies_to, id, ...                                                   | `none`   | No effect on a running model. |
+
+First reload-requiring diff wins (-> `reload`); else any live diff -> `live`;
+else `none`.
+
+### Correctness fix (same-ID edits)
+
+The current implementation short-circuits on identical ids:
+
+```ts
+if (running.id === next.id) return 'none';   // presetStore.ts:570 — BUG
 ```
-POST /api/v1/update-preset
-Content-Type: application/json
 
-{
-  "model_name": "Llama-3.1-8B",     // the loaded model to update
-  "preset_id":  "p-live",            // client-local preset id (opaque to lemond)
-  "mode":       "live" | "reload",   // UI's classification of the change
-  "recipe_options": { ... },          // load-time options (sent when mode="reload")
-  "sampling":       { ... },          // request-time generation params (mode="live")
-  "system_prompt":  "..." | null      // resolved system prompt text (mode="live")
+This means **editing a preset in place** (same id, but changed `temperature`,
+`system_prompt`, or `ctx_size`) classifies as `none`, so the model keeps running
+stale values and no Apply/Reload affordance appears. **Remove that early
+`return 'none'`** and let the `RELOAD_FIELDS` / `LIVE_FIELDS` comparisons run
+regardless of whether the id matches. Only return `none` when no field in either
+group actually differs.
+
+## UI affordance
+
+When the active preset differs from the running preset (now also true for
+same-id edits after the fix), the detail panel shows a button next to **Unload**:
+
+- **live-only changes** -> label **"Apply preset"**.
+  Action: rebind the active preset; request composition handles the rest. The
+  prior "POST live" call is removed.
+- **load-time changes** -> label **"Reload to apply preset"**, and the loaded
+  model is marked **"needs reload"**.
+  Action: `reloadModel(modelName, recipeOptions)` = `api.unloadModel()` then
+  `api.loadModel(modelName, recipeOptions, modelInfo)`.
+
+a11y: the button's accessible name conveys which path it takes ("Apply preset
+for {name}" vs "Reload {name} to apply preset"); status uses the existing polite
+live region; focus management preserved. New/changed controls get aria-labels
+and Playwright coverage (next ids **A164+**). Existing A154–A163 must be updated
+to the new (no-`mode`, no-endpoint) workflow so the suite stays green.
+
+## `window.api` surface
+
+No `updatePreset(...)` and no `mode` parameter. The POC uses only existing
+methods:
+
+```ts
+api.loadModel(modelName, recipeOptions?, modelInfo?): Promise<unknown>;
+api.unloadModel(modelName?): Promise<unknown>;
+```
+
+A thin client helper expresses the load-time path (future-proofing only — it is
+unload->load today):
+
+```ts
+// src/api.ts (or a small wrapper)
+async reloadModel(
+  modelName: string,
+  recipeOptions?: Record<string, unknown>,
+  modelInfo?: unknown,
+): Promise<unknown> {
+  await this.unloadModel(modelName);
+  return this.loadModel(modelName, recipeOptions, modelInfo);
 }
 ```
 
-**Behaviour**
+If a real in-place backend reload ever lands, only this helper's body changes;
+callers and tests stay the same. The old `api.updatePreset(...)` method and its
+`/api/v1/update-preset` POST are removed.
 
-| `mode`   | lemond action                                                                 | Response |
-|----------|-------------------------------------------------------------------------------|----------|
-| `live`   | Apply request-time fields to the running process. **No** reinitialization.     | `200` once applied |
-| `reload` | Reinitialize the model in place (lemond does the unload+load). No client unload/load. | `200` once the model is ready again |
+## Lemonade tools (`src/tools/lemonadeTools.ts`)
 
-The endpoint is idempotent for an unchanged preset (returns `200` no-op).
+Add a **`change_preset`** tool that drives the same preset-update workflow
+directly, so chat-/agent-triggered preset changes behave identically to the UI
+button:
 
-## `window.api` / client method
+- Inputs: `model_name` (optional -> most-recently-used loaded model),
+  `preset` / `preset_id` / `preset_name` (reuse the existing
+  `presetSpecifier` / `resolvePreset` helpers already used by `load_model`).
+- Steps:
+  1. Resolve model + preset; reject incompatible presets via `isCompatible`
+     (same error shape as `load_model`).
+  2. Rebind the active preset (`applyPresetBinding`).
+  3. `classifyPresetChange(running, next)`:
+     - `live` -> no further action; report "applied live".
+     - `reload` -> `reloadModel(...)` (unload->load); report "reloaded".
+     - `none` -> report no-op.
+- Return the usual `toolPayload` summary with an `answer_instruction`.
 
-```ts
-api.updatePreset(
-  modelName: string,
-  presetId:  string,
-  mode: 'live' | 'reload',
-  payload?: {
-    recipe_options?: Record<string, unknown>; // for mode='reload'
-    sampling?: Record<string, unknown>;        // for mode='live'
-    system_prompt?: string | null;             // for mode='live'
-  },
-): Promise<unknown>;
-```
+This replaces the deferred "tool calls the update-preset endpoint" plan: the
+tool now executes the workflow with the same primitives as the UI.
 
-Defined in `src/api.ts`. In the POC it POSTs to `/api/v1/update-preset`; the
-Playwright suite mocks that endpoint.
+## What is NOT in this POC
 
-## Live-vs-reload field classification
-
-Implemented in `src/presetStore.ts` as `classifyPresetChange(running, next)`,
-returning `'none' | 'live' | 'reload'`.
-
-| Field group        | Fields                                                              | Kind     | Rationale |
-|--------------------|--------------------------------------------------------------------|----------|-----------|
-| Reload-requiring   | `recipe_options` (ctx_size, backend, device, args, steps, cfg, …), `engine_hint` | `reload` | The runtime binds these at init; changing them needs reinitialization. |
-| Live-updateable    | `sampling` (temperature/top_p/top_k/repeat_penalty), `system_prompt_id`, `system_prompts`, `tools_enabled` | `live` | Applied per request at generation time. |
-| (everything else)  | name, description, applies_to, id, …                               | `none`   | No effect on a running model. |
-
-The first reload-requiring difference wins (→ `reload`); otherwise any
-live-updateable difference → `live`; otherwise `none`.
+- No `lemond` changes, no new HTTP endpoint, no server-side preset registry.
+- No client `mode` flag is sent anywhere.
+- Presets remain 100% client-local (invariant #11).
 
 ## Open questions for @fl0rianr
 
-1. Confirm the **endpoint shape** (a dedicated `update-preset` endpoint vs.
-   overloading `load` with an `update_preset` flag).
-2. Confirm the **live-vs-reload field split** above — in particular whether any
-   `recipe_options` sub-fields are in fact live-applyable, and whether sampling
-   is truly request-time for every backend.
-3. Confirm whether `preset_id` should be opaque to lemond (UI resolves all
-   fields) or whether lemond should resolve presets from a shared registry.
+1. Should the active-preset binding **persist across an unload/reload** (the UI
+   re-binds before reloading, so the reloaded model runs the new preset), and is
+   that the behaviour you want for the tool path too?
+2. Request-time **tool** changes: confirm tools belong on the request-composition
+   side for every backend (we compose them with sampling + system prompt), with
+   no reload — i.e. nothing tool-related is load-time.
+3. If a future backend gains real in-place reload, do you want it surfaced as a
+   distinct capability flag, or is the silent `reloadModel` swap (unload->load ->
+   in-place) acceptable since the contract is identical to callers?

--- a/prototype/ui-redesign/docs/UPDATE_PRESET_CONTRACT.md
+++ b/prototype/ui-redesign/docs/UPDATE_PRESET_CONTRACT.md
@@ -1,0 +1,101 @@
+# Update preset while loaded — `window.api` / HTTP contract (#2356)
+
+**Status:** UI POC complete on `feat/gui3-update-preset-while-loaded`. Backend
+pieces (the real reload + the Lemonade-tools wiring) are **DEFERRED to the
+backend team** — `lemond` is off-limits to the UI POC.
+
+This document is the proposed contract so the UI-triggered and tool-triggered
+preset updates behave identically once the backend implements it.
+
+## What the POC ships (UI only)
+
+- An **"Update preset"** button that appears next to **Unload** in the model
+  detail panel when a model is **loaded** AND a **different** preset is linked
+  to it (linked ≠ running).
+- A client-side **live-vs-reload classification** of the change.
+- The correct UX for each path: live = inline "applied live, no reload" status;
+  reload = an automatic "Reloading…" flow (no manual unload/load).
+- A clean `api.updatePreset(...)` hook the UI calls.
+- Screen-reader announcements (polite live region), keyboard operability, focus
+  management, and Playwright/axe coverage (A154–A163).
+
+## What is DEFERRED to the backend (lemond)
+
+1. **Real reload mechanics.** For `mode='reload'`, lemond must reinitialize the
+   model **in place** (perform the unload+load itself); the client must never
+   issue a manual unload/load pair.
+2. **Live apply.** For `mode='live'`, lemond must apply request-time fields
+   (system prompt, sampling) to the running process without reinitializing.
+3. **Lemonade-tools parity.** The same update logic must back a tool such as
+   "change the preset", so tool-triggered and UI-triggered updates are
+   consistent. The tool should call the same code path / endpoint below.
+
+## Proposed HTTP endpoint
+
+Per project invariant #1, register under all four prefixes:
+`/api/v0/update-preset`, `/api/v1/update-preset`, `/v0/update-preset`, `/v1/update-preset`.
+
+```
+POST /api/v1/update-preset
+Content-Type: application/json
+
+{
+  "model_name": "Llama-3.1-8B",     // the loaded model to update
+  "preset_id":  "p-live",            // client-local preset id (opaque to lemond)
+  "mode":       "live" | "reload",   // UI's classification of the change
+  "recipe_options": { ... },          // load-time options (sent when mode="reload")
+  "sampling":       { ... },          // request-time generation params (mode="live")
+  "system_prompt":  "..." | null      // resolved system prompt text (mode="live")
+}
+```
+
+**Behaviour**
+
+| `mode`   | lemond action                                                                 | Response |
+|----------|-------------------------------------------------------------------------------|----------|
+| `live`   | Apply request-time fields to the running process. **No** reinitialization.     | `200` once applied |
+| `reload` | Reinitialize the model in place (lemond does the unload+load). No client unload/load. | `200` once the model is ready again |
+
+The endpoint is idempotent for an unchanged preset (returns `200` no-op).
+
+## `window.api` / client method
+
+```ts
+api.updatePreset(
+  modelName: string,
+  presetId:  string,
+  mode: 'live' | 'reload',
+  payload?: {
+    recipe_options?: Record<string, unknown>; // for mode='reload'
+    sampling?: Record<string, unknown>;        // for mode='live'
+    system_prompt?: string | null;             // for mode='live'
+  },
+): Promise<unknown>;
+```
+
+Defined in `src/api.ts`. In the POC it POSTs to `/api/v1/update-preset`; the
+Playwright suite mocks that endpoint.
+
+## Live-vs-reload field classification
+
+Implemented in `src/presetStore.ts` as `classifyPresetChange(running, next)`,
+returning `'none' | 'live' | 'reload'`.
+
+| Field group        | Fields                                                              | Kind     | Rationale |
+|--------------------|--------------------------------------------------------------------|----------|-----------|
+| Reload-requiring   | `recipe_options` (ctx_size, backend, device, args, steps, cfg, …), `engine_hint` | `reload` | The runtime binds these at init; changing them needs reinitialization. |
+| Live-updateable    | `sampling` (temperature/top_p/top_k/repeat_penalty), `system_prompt_id`, `system_prompts`, `tools_enabled` | `live` | Applied per request at generation time. |
+| (everything else)  | name, description, applies_to, id, …                               | `none`   | No effect on a running model. |
+
+The first reload-requiring difference wins (→ `reload`); otherwise any
+live-updateable difference → `live`; otherwise `none`.
+
+## Open questions for @fl0rianr
+
+1. Confirm the **endpoint shape** (a dedicated `update-preset` endpoint vs.
+   overloading `load` with an `update_preset` flag).
+2. Confirm the **live-vs-reload field split** above — in particular whether any
+   `recipe_options` sub-fields are in fact live-applyable, and whether sampling
+   is truly request-time for every backend.
+3. Confirm whether `preset_id` should be opaque to lemond (UI resolves all
+   fields) or whether lemond should resolve presets from a shared registry.

--- a/prototype/ui-redesign/src/api.ts
+++ b/prototype/ui-redesign/src/api.ts
@@ -963,50 +963,30 @@ class LemonadeAPI {
   }
 
   /**
-   * Update the preset of an already-LOADED model without a manual unload→reload
-   * (#2356). The UI decides, per the live-vs-reload field classification (see
-   * `classifyPresetChange` in presetStore), whether the change can be applied
-   * live or needs the runtime reinitialized, and passes that as `mode`.
+   * Apply a *load-time* preset change to an already-loaded model (#2356).
    *
-   * ── PROPOSED BACKEND CONTRACT (lemond — to be implemented; OFF-LIMITS to the
-   *    UI POC, see #2356) ──────────────────────────────────────────────────────
-   *   POST /api/v{0,1}/update-preset   (quad-prefix per project invariant #1)
-   *   Request body:
-   *     {
-   *       model_name: string,        // the loaded model to update
-   *       preset_id:  string,        // client-local preset identifier (opaque to lemond)
-   *       mode: 'live' | 'reload',   // UI's classification of the change
-   *       recipe_options?: object,   // load-time options (sent for mode='reload')
-   *       sampling?: object,         // request-time generation params (mode='live')
-   *       system_prompt?: string|null // resolved system prompt text (mode='live')
-   *     }
-   *   Behaviour:
-   *     - mode 'live'   → apply request-time fields to the running process; return
-   *                       200 WITHOUT reinitializing (no model downtime).
-   *     - mode 'reload' → reinitialize the model in place (lemond performs the
-   *                       unload+load itself; the client never issues a manual
-   *                       unload/load); return 200 once the model is ready again.
-   *   The SAME endpoint backs the Lemonade-tools "change the preset" flow so
-   *   tool-triggered and UI-triggered updates are identical.
+   * Simplified design (per @fl0rianr review + Lovell): there is NO dedicated
+   * update-preset endpoint and NO client-provided `mode` parameter — the UI is
+   * not the source of truth for runtime capability. Load-time fields (ctx_size,
+   * backend, device, model args via recipe_options) require a real reload, which
+   * today is literally an unload followed by a load, exactly as `main` does.
    *
-   * POC NOTE: until lemond ships the endpoint, this method posts to
-   * `/api/v1/update-preset`; the prototype's Playwright suite mocks it.
+   * This helper is named `reloadModel` (rather than inlining unload→load at every
+   * call site) so that if a real in-place backend reload ever lands, only this
+   * method's body changes; callers and tests stay identical.
+   *
+   * Request-time fields (system_prompt, sampling/temperature, tools) are NOT
+   * handled here — rebinding the active preset is the whole "live" operation and
+   * request composition (`samplingForModel`, `systemPromptTextForPreset`) carries
+   * the new values on the next generation request; nothing is POSTed.
    */
-  async updatePreset(
+  async reloadModel(
     modelName: string,
-    presetId: string,
-    mode: 'live' | 'reload',
-    payload: Record<string, unknown> = {},
+    recipeOptions?: Record<string, unknown>,
+    modelInfo?: ModelInfo | null,
   ): Promise<unknown> {
-    const body: Record<string, unknown> = {
-      model_name: modelName,
-      preset_id: presetId,
-      mode,
-      ...payload,
-    };
-    const result = await this._json('/api/v1/update-preset', { method: 'POST', body });
-    this._notifyModelsChanged();
-    return result;
+    await this.unloadModel(modelName);
+    return this.loadModel(modelName, recipeOptions, modelInfo);
   }
 
   async deleteModel(modelName: string): Promise<unknown> {

--- a/prototype/ui-redesign/src/api.ts
+++ b/prototype/ui-redesign/src/api.ts
@@ -962,6 +962,53 @@ class LemonadeAPI {
     return result;
   }
 
+  /**
+   * Update the preset of an already-LOADED model without a manual unload→reload
+   * (#2356). The UI decides, per the live-vs-reload field classification (see
+   * `classifyPresetChange` in presetStore), whether the change can be applied
+   * live or needs the runtime reinitialized, and passes that as `mode`.
+   *
+   * ── PROPOSED BACKEND CONTRACT (lemond — to be implemented; OFF-LIMITS to the
+   *    UI POC, see #2356) ──────────────────────────────────────────────────────
+   *   POST /api/v{0,1}/update-preset   (quad-prefix per project invariant #1)
+   *   Request body:
+   *     {
+   *       model_name: string,        // the loaded model to update
+   *       preset_id:  string,        // client-local preset identifier (opaque to lemond)
+   *       mode: 'live' | 'reload',   // UI's classification of the change
+   *       recipe_options?: object,   // load-time options (sent for mode='reload')
+   *       sampling?: object,         // request-time generation params (mode='live')
+   *       system_prompt?: string|null // resolved system prompt text (mode='live')
+   *     }
+   *   Behaviour:
+   *     - mode 'live'   → apply request-time fields to the running process; return
+   *                       200 WITHOUT reinitializing (no model downtime).
+   *     - mode 'reload' → reinitialize the model in place (lemond performs the
+   *                       unload+load itself; the client never issues a manual
+   *                       unload/load); return 200 once the model is ready again.
+   *   The SAME endpoint backs the Lemonade-tools "change the preset" flow so
+   *   tool-triggered and UI-triggered updates are identical.
+   *
+   * POC NOTE: until lemond ships the endpoint, this method posts to
+   * `/api/v1/update-preset`; the prototype's Playwright suite mocks it.
+   */
+  async updatePreset(
+    modelName: string,
+    presetId: string,
+    mode: 'live' | 'reload',
+    payload: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    const body: Record<string, unknown> = {
+      model_name: modelName,
+      preset_id: presetId,
+      mode,
+      ...payload,
+    };
+    const result = await this._json('/api/v1/update-preset', { method: 'POST', body });
+    this._notifyModelsChanged();
+    return result;
+  }
+
   async deleteModel(modelName: string): Promise<unknown> {
     const result = await this._json('/api/v1/delete', {
       method: 'POST',

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -14,7 +14,7 @@ import {
   allStoredPresets, isCompatible, loadApplied, saveApplied,
   effectivePresetParamPreviewLines, activePresetForModel,
   runningPresetIdForModel, setRunningPreset, clearRunningPreset,
-  classifyPresetChange, systemPromptTextForPreset,
+  classifyPresetChange,
 } from '../presetStore';
 import { Icon, CapabilityIcon, PresetIcon } from './Icon';
 
@@ -468,16 +468,15 @@ export interface ModelDetailPanelProps {
   onLoad: (model: ModelInfo) => void;
   onUnload: (model: LoadedModel) => void;
   /**
-   * Apply a newly-linked preset to an already-loaded model (#2356).
-   * `mode` is the UI's live-vs-reload classification; `payload` carries the
-   * relevant fields (sampling/system_prompt for live, recipe_options for reload).
-   * Resolves once lemond reports the update applied (or the reload completed).
+   * Reload an already-loaded model so a *load-time* preset change takes effect
+   * (#2356). This is the only server round-trip in the simplified design: it is
+   * literally an unload + load (see `api.reloadModel`). Live (request-time)
+   * changes do NOT call this — rebinding the active preset is the whole live op.
+   * Resolves once the reload completes.
    */
-  onUpdatePreset?: (
+  onReloadModel?: (
     model: LoadedModel,
-    presetId: string,
-    mode: 'live' | 'reload',
-    payload: Record<string, unknown>,
+    recipeOptions?: Record<string, unknown>,
   ) => Promise<void>;
   onPull: (model: ModelInfo) => void;
   onPullAndLoad: (model: ModelInfo) => void;
@@ -511,7 +510,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   loadError,
   onLoad,
   onUnload,
-  onUpdatePreset,
+  onReloadModel,
   onPull,
   onPullAndLoad,
   onDelete,
@@ -575,7 +574,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   }, [updateStatus]);
 
   const handleUpdatePreset = useCallback(async () => {
-    if (!model || !loadedModel || !onUpdatePreset) return;
+    if (!model || !loadedModel) return;
     const targetName = mdName(model);
     const linked = activePresetForModel(targetName);
     const runId = runningPresetIdForModel(targetName);
@@ -584,25 +583,22 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
     if (kind === 'none') return;
 
     if (kind === 'live') {
-      setUpdateStatus({ phase: 'live', msg: `Applying preset “${linked.name}” to ${targetName}…` });
-      try {
-        await onUpdatePreset(loadedModel, linked.id, 'live', {
-          sampling: linked.sampling,
-          system_prompt: systemPromptTextForPreset(linked),
-        });
-        setRunningPreset(targetName, linked.id);
-        setUpdateStatus({ phase: 'done-live', msg: `Preset updated to “${linked.name}” — applied live, no reload needed.` });
-        requestAnimationFrame(() => unloadBtnRef.current?.focus());
-      } catch {
-        setUpdateStatus({ phase: 'error', msg: `Couldn’t update the preset for ${targetName}. Please try again.` });
-        requestAnimationFrame(() => updateBtnRef.current?.focus());
-      }
+      // Live (request-time) change: rebinding the active preset IS the whole
+      // operation. Nothing is POSTed — request composition (`samplingForModel`
+      // in api.ts, `systemPromptTextForPreset` in ChatView) carries the new
+      // sampling / system_prompt / tools on the next generation request. We
+      // record the new running preset so the affordance clears.
+      setRunningPreset(targetName, linked.id);
+      setUpdateStatus({ phase: 'done-live', msg: `Preset updated to “${linked.name}” — applied live, no reload needed.` });
+      requestAnimationFrame(() => unloadBtnRef.current?.focus());
     } else {
+      // Load-time change: a real reload (unload + load) is required. The
+      // active-preset binding PERSISTS across the reload — `linked` is already
+      // the active preset, so the reloaded model comes up running it; we then
+      // snapshot it as the running preset. (Assumption flagged to @fl0rianr.)
       setUpdateStatus({ phase: 'reload', msg: `Reloading ${targetName} with preset “${linked.name}”…` });
       try {
-        await onUpdatePreset(loadedModel, linked.id, 'reload', {
-          recipe_options: linked.recipe_options,
-        });
+        await onReloadModel?.(loadedModel, linked.recipe_options as Record<string, unknown> | undefined);
         setRunningPreset(targetName, linked.id);
         setUpdateStatus({ phase: 'done-reload', msg: `Preset updated to “${linked.name}” — model reloaded.` });
         requestAnimationFrame(() => unloadBtnRef.current?.focus());
@@ -611,7 +607,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
         requestAnimationFrame(() => updateBtnRef.current?.focus());
       }
     }
-  }, [model, loadedModel, onUpdatePreset]);
+  }, [model, loadedModel, onReloadModel]);
 
   // Roving tabindex: keyboard navigation across tabs
   const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
@@ -677,7 +673,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
     ? classifyPresetChange(runningPreset, linkedPreset)
     : 'none';
   const isUpdatingPreset = updateStatus.phase === 'live' || updateStatus.phase === 'reload';
-  const canUpdatePreset = isLoaded && !!onUpdatePreset && presetChangeKind !== 'none' && !isUpdatingPreset && !isLoadingThis;
+  const canUpdatePreset = isLoaded && presetChangeKind !== 'none' && !isUpdatingPreset && !isLoadingThis;
 
   return (
     <div className="model-detail-panel" role="region" aria-label={`Model details: ${name}`}>
@@ -776,16 +772,16 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
                   aria-busy={isUpdatingPreset}
                   aria-label={
                     isUpdatingPreset
-                      ? (updateStatus.phase === 'reload' ? `Reloading ${name} with new preset…` : `Updating preset for ${name}…`)
+                      ? (updateStatus.phase === 'reload' ? `Reloading ${name} with new preset…` : `Applying preset for ${name}…`)
                       : (presetChangeKind === 'reload'
-                        ? `Update preset for ${name} (reloads the model)`
-                        : `Update preset for ${name}`)
+                        ? `Reload ${name} to apply preset`
+                        : `Apply preset for ${name}`)
                   }
                 >
                   <Icon name="rotate-ccw" size={13} aria-hidden="true" />{' '}
                   {isUpdatingPreset
-                    ? (updateStatus.phase === 'reload' ? 'Reloading…' : 'Updating…')
-                    : 'Update preset'}
+                    ? (updateStatus.phase === 'reload' ? 'Reloading…' : 'Applying…')
+                    : (presetChangeKind === 'reload' ? 'Reload to apply preset' : 'Apply preset')}
                 </button>
               )}
               <button

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -10,9 +10,11 @@ import DOMPurify from 'dompurify';
 import type { ModelInfo, LoadedModel } from '../api';
 import { capabilityFromModelInfo, capabilityLabel } from '../modelCapabilities';
 import {
-  DEFAULT_PRESET, PRESET_STORE_EVENT, Preset,
+  DEFAULT_PRESET, PRESET_STORE_EVENT, Preset, PresetChangeKind,
   allStoredPresets, isCompatible, loadApplied, saveApplied,
-  effectivePresetParamPreviewLines,
+  effectivePresetParamPreviewLines, activePresetForModel,
+  runningPresetIdForModel, setRunningPreset, clearRunningPreset,
+  classifyPresetChange, systemPromptTextForPreset,
 } from '../presetStore';
 import { Icon, CapabilityIcon, PresetIcon } from './Icon';
 
@@ -465,6 +467,18 @@ export interface ModelDetailPanelProps {
   loadError: { modelName: string; message: string } | null;
   onLoad: (model: ModelInfo) => void;
   onUnload: (model: LoadedModel) => void;
+  /**
+   * Apply a newly-linked preset to an already-loaded model (#2356).
+   * `mode` is the UI's live-vs-reload classification; `payload` carries the
+   * relevant fields (sampling/system_prompt for live, recipe_options for reload).
+   * Resolves once lemond reports the update applied (or the reload completed).
+   */
+  onUpdatePreset?: (
+    model: LoadedModel,
+    presetId: string,
+    mode: 'live' | 'reload',
+    payload: Record<string, unknown>,
+  ) => Promise<void>;
   onPull: (model: ModelInfo) => void;
   onPullAndLoad: (model: ModelInfo) => void;
   onDelete: (model: ModelInfo) => void;
@@ -497,6 +511,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   loadError,
   onLoad,
   onUnload,
+  onUpdatePreset,
   onPull,
   onPullAndLoad,
   onDelete,
@@ -509,11 +524,94 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   const [activeTab, setActiveTab] = useState<DetailTab>('readme');
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const panelHeadingRef = useRef<HTMLHeadingElement>(null);
+  const updateBtnRef = useRef<HTMLButtonElement>(null);
+  const unloadBtnRef = useRef<HTMLButtonElement>(null);
+
+  // ── Update-preset-while-loaded state (#2356) ──────────────────────────────
+  // storeTick forces a re-read of the applied/running preset stores whenever
+  // they change (e.g. the user re-links a preset in the Presets tab).
+  const [storeTick, setStoreTick] = useState(0);
+  type UpdatePhase = 'idle' | 'live' | 'reload' | 'done-live' | 'done-reload' | 'error';
+  const [updateStatus, setUpdateStatus] = useState<{ phase: UpdatePhase; msg: string }>({ phase: 'idle', msg: '' });
+
+  const detailName = model ? mdName(model) : '';
+  const detailLoaded = !!loadedModel;
 
   // Move focus to heading when model changes
   useEffect(() => {
     if (model) panelHeadingRef.current?.focus();
   }, [model?.id]);
+
+  // Re-render when the preset store changes (applied/running/user presets).
+  useEffect(() => {
+    const handler = () => setStoreTick(t => t + 1);
+    window.addEventListener(PRESET_STORE_EVENT, handler);
+    return () => window.removeEventListener(PRESET_STORE_EVENT, handler);
+  }, []);
+
+  // Snapshot the running preset when a model becomes loaded; clear it when it
+  // unloads. The snapshot baseline = the preset linked at the moment we first
+  // observe the model loaded, so later re-links diverge and surface "Update preset".
+  useEffect(() => {
+    if (!detailName) return;
+    if (detailLoaded) {
+      if (runningPresetIdForModel(detailName) === undefined) {
+        setRunningPreset(detailName, activePresetForModel(detailName).id);
+      }
+    } else if (runningPresetIdForModel(detailName) !== undefined) {
+      clearRunningPreset(detailName);
+    }
+  }, [detailName, detailLoaded, storeTick]);
+
+  // Reset transient update feedback when the selected model changes.
+  useEffect(() => { setUpdateStatus({ phase: 'idle', msg: '' }); }, [model?.id]);
+
+  // Auto-dismiss terminal update messages so the live region settles.
+  useEffect(() => {
+    if (['done-live', 'done-reload', 'error'].includes(updateStatus.phase)) {
+      const t = window.setTimeout(() => setUpdateStatus({ phase: 'idle', msg: '' }), 6000);
+      return () => window.clearTimeout(t);
+    }
+  }, [updateStatus]);
+
+  const handleUpdatePreset = useCallback(async () => {
+    if (!model || !loadedModel || !onUpdatePreset) return;
+    const targetName = mdName(model);
+    const linked = activePresetForModel(targetName);
+    const runId = runningPresetIdForModel(targetName);
+    const running = runId ? (allStoredPresets().find(p => p.id === runId) ?? null) : null;
+    const kind = classifyPresetChange(running, linked);
+    if (kind === 'none') return;
+
+    if (kind === 'live') {
+      setUpdateStatus({ phase: 'live', msg: `Applying preset “${linked.name}” to ${targetName}…` });
+      try {
+        await onUpdatePreset(loadedModel, linked.id, 'live', {
+          sampling: linked.sampling,
+          system_prompt: systemPromptTextForPreset(linked),
+        });
+        setRunningPreset(targetName, linked.id);
+        setUpdateStatus({ phase: 'done-live', msg: `Preset updated to “${linked.name}” — applied live, no reload needed.` });
+        requestAnimationFrame(() => unloadBtnRef.current?.focus());
+      } catch {
+        setUpdateStatus({ phase: 'error', msg: `Couldn’t update the preset for ${targetName}. Please try again.` });
+        requestAnimationFrame(() => updateBtnRef.current?.focus());
+      }
+    } else {
+      setUpdateStatus({ phase: 'reload', msg: `Reloading ${targetName} with preset “${linked.name}”…` });
+      try {
+        await onUpdatePreset(loadedModel, linked.id, 'reload', {
+          recipe_options: linked.recipe_options,
+        });
+        setRunningPreset(targetName, linked.id);
+        setUpdateStatus({ phase: 'done-reload', msg: `Preset updated to “${linked.name}” — model reloaded.` });
+        requestAnimationFrame(() => unloadBtnRef.current?.focus());
+      } catch {
+        setUpdateStatus({ phase: 'error', msg: `Couldn’t reload ${targetName} with the new preset. Please try again.` });
+        requestAnimationFrame(() => updateBtnRef.current?.focus());
+      }
+    }
+  }, [model, loadedModel, onUpdatePreset]);
 
   // Roving tabindex: keyboard navigation across tabs
   const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
@@ -566,6 +664,20 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   const pullPct = pulling[name] ?? 0;
   const isDownloaded = Boolean((model as any).downloaded);
   const cap = capabilityFromModelInfo(model);
+
+  // ── Update-preset-while-loaded derivation (#2356) ─────────────────────────
+  // Reference storeTick so this recomputes when the preset store changes.
+  void storeTick;
+  const linkedPreset = activePresetForModel(name);
+  const runningPresetId = isLoaded ? runningPresetIdForModel(name) : undefined;
+  const runningPreset = runningPresetId
+    ? (allStoredPresets().find(p => p.id === runningPresetId) ?? null)
+    : null;
+  const presetChangeKind: PresetChangeKind = isLoaded && runningPreset
+    ? classifyPresetChange(runningPreset, linkedPreset)
+    : 'none';
+  const isUpdatingPreset = updateStatus.phase === 'live' || updateStatus.phase === 'reload';
+  const canUpdatePreset = isLoaded && !!onUpdatePreset && presetChangeKind !== 'none' && !isUpdatingPreset && !isLoadingThis;
 
   return (
     <div className="model-detail-panel" role="region" aria-label={`Model details: ${name}`}>
@@ -651,15 +763,42 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
               </button>
             </>
           ) : isLoaded ? (
-            <button
-              type="button"
-              className="btn btn--ghost btn--sm"
-              onClick={() => onUnload(loadedModel!)}
-              disabled={isLoadingThis}
-              aria-label={isLoadingThis ? `Working on ${name}…` : `Unload ${name}`}
-            >
-              {isLoadingThis ? 'Working…' : 'Unload'}
-            </button>
+            <>
+              {/* Update preset (#2356): appears next to Unload when a different
+                  preset has been linked to this loaded model. */}
+              {(canUpdatePreset || isUpdatingPreset) && (
+                <button
+                  ref={updateBtnRef}
+                  type="button"
+                  className="btn btn--primary btn--sm model-detail-panel__update-preset-btn"
+                  onClick={handleUpdatePreset}
+                  disabled={isUpdatingPreset || !canUpdatePreset}
+                  aria-busy={isUpdatingPreset}
+                  aria-label={
+                    isUpdatingPreset
+                      ? (updateStatus.phase === 'reload' ? `Reloading ${name} with new preset…` : `Updating preset for ${name}…`)
+                      : (presetChangeKind === 'reload'
+                        ? `Update preset for ${name} (reloads the model)`
+                        : `Update preset for ${name}`)
+                  }
+                >
+                  <Icon name="rotate-ccw" size={13} aria-hidden="true" />{' '}
+                  {isUpdatingPreset
+                    ? (updateStatus.phase === 'reload' ? 'Reloading…' : 'Updating…')
+                    : 'Update preset'}
+                </button>
+              )}
+              <button
+                ref={unloadBtnRef}
+                type="button"
+                className="btn btn--ghost btn--sm"
+                onClick={() => onUnload(loadedModel!)}
+                disabled={isLoadingThis || isUpdatingPreset}
+                aria-label={isLoadingThis ? `Working on ${name}…` : `Unload ${name}`}
+              >
+                {isLoadingThis ? 'Working…' : 'Unload'}
+              </button>
+            </>
           ) : isDownloaded ? (
             <button
               type="button"
@@ -708,6 +847,32 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
           <div className="model-detail-panel__error" role="alert">
             <Icon name="alert" size={13} /> {loadError.message}
           </div>
+        )}
+
+        {/* Update-preset feedback + live region (#2356).
+            Always-present polite live region so screen readers announce the
+            live-apply / reload outcome; a visible pill mirrors it sighted. */}
+        <div
+          className={`model-detail-panel__preset-update${updateStatus.phase !== 'idle' ? ' model-detail-panel__preset-update--active' : ''}`}
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          data-preset-update-phase={updateStatus.phase}
+        >
+          {updateStatus.phase === 'reload' && (
+            <span className="model-detail-panel__preset-update-spinner" aria-hidden="true" />
+          )}
+          {updateStatus.msg}
+        </div>
+
+        {/* Sighted hint explaining why Update preset appeared (not announced —
+            the button's accessible name already conveys the reload semantics). */}
+        {canUpdatePreset && updateStatus.phase === 'idle' && (
+          <p className="model-detail-panel__preset-update-hint" aria-hidden="true">
+            {presetChangeKind === 'reload'
+              ? 'A different preset is linked. Updating will reload the model to apply it.'
+              : 'A different preset is linked. Updating applies it live — no reload needed.'}
+          </p>
         )}
 
         {/* HF link */}

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -1295,18 +1295,19 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     setLoadingModel(null);
   };
 
-  // #2356: apply a re-linked preset to an already-loaded model. The detail
-  // panel decides live-vs-reload and records the new running preset; here we
-  // just relay to the (POC: mocked) backend and refresh on reload so the
-  // loaded-model snapshot reflects any reinitialization.
-  const handleUpdatePreset = async (
+  // #2356 (simplified): a load-time preset change needs a real reload. The
+  // detail panel already classifies live-vs-reload and rebinds the active
+  // preset; here we just perform the reload (unload + load via api.reloadModel)
+  // and refresh so the loaded-model snapshot reflects the reinitialization.
+  // Live (request-time) changes never reach here — they are a pure client-local
+  // rebind handled entirely in the panel (no server round-trip).
+  const handleReloadModel = async (
     model: LoadedModel,
-    presetId: string,
-    mode: 'live' | 'reload',
-    payload: Record<string, unknown>,
+    recipeOptions?: Record<string, unknown>,
   ) => {
-    await api.updatePreset(model.model_name, presetId, mode, payload);
-    if (mode === 'reload') await refresh();
+    const info = listModels.find(m => modelName(m) === model.model_name) ?? null;
+    await api.reloadModel(model.model_name, recipeOptions, info);
+    await refresh();
   };
 
   const handleDelete = async (model: ModelInfo) => {
@@ -2743,7 +2744,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
           loadError={loadError}
           onLoad={handleLoad}
           onUnload={handleUnload}
-          onUpdatePreset={handleUpdatePreset}
+          onReloadModel={handleReloadModel}
           onPull={handlePull}
           onPullAndLoad={handlePullAndLoad}
           onDelete={handleDelete}

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -1295,6 +1295,20 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     setLoadingModel(null);
   };
 
+  // #2356: apply a re-linked preset to an already-loaded model. The detail
+  // panel decides live-vs-reload and records the new running preset; here we
+  // just relay to the (POC: mocked) backend and refresh on reload so the
+  // loaded-model snapshot reflects any reinitialization.
+  const handleUpdatePreset = async (
+    model: LoadedModel,
+    presetId: string,
+    mode: 'live' | 'reload',
+    payload: Record<string, unknown>,
+  ) => {
+    await api.updatePreset(model.model_name, presetId, mode, payload);
+    if (mode === 'reload') await refresh();
+  };
+
   const handleDelete = async (model: ModelInfo) => {
     const name = modelName(model);
     if ((model as any).custom) {
@@ -2729,6 +2743,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
           loadError={loadError}
           onLoad={handleLoad}
           onUnload={handleUnload}
+          onUpdatePreset={handleUpdatePreset}
           onPull={handlePull}
           onPullAndLoad={handlePullAndLoad}
           onDelete={handleDelete}

--- a/prototype/ui-redesign/src/presetStore.ts
+++ b/prototype/ui-redesign/src/presetStore.ts
@@ -504,8 +504,9 @@ export function activePresetForBackend(key: string): Preset {
  * If the user later re-links a different preset, `running` lags behind `linked`
  * and an "Update preset" action becomes available in the detail panel.
  *
- * This is purely client-local bookkeeping for the POC. The real apply/reload
- * is owned by lemond (off-limits to the UI POC) via `api.updatePreset`. */
+ * This is purely client-local bookkeeping for the POC. Live (request-time)
+ * changes are applied by request composition; load-time changes go through a
+ * real reload (`api.reloadModel` = unload + load). See UPDATE_PRESET_CONTRACT.md. */
 
 export function loadRunningPresets(): Record<string, string> {
   try {
@@ -567,14 +568,17 @@ export function classifyPresetChange(
   next: Preset | null | undefined,
 ): PresetChangeKind {
   if (!running || !next) return 'none';
-  if (running.id === next.id) return 'none';
+  // NOTE: do NOT early-return on running.id === next.id. Editing a preset in
+  // place (same id, but changed temperature / system_prompt / ctx_size) must
+  // still classify as 'live' or 'reload'. Only the actual field comparisons
+  // below decide; 'none' is returned solely when nothing relevant differs.
   for (const field of RELOAD_FIELDS) {
     if (!stableEqual(running[field], next[field])) return 'reload';
   }
   for (const field of LIVE_FIELDS) {
     if (!stableEqual(running[field], next[field])) return 'live';
   }
-  // Different preset id but identical load-affecting + request-time fields.
+  // No load-affecting or request-time field differs (regardless of id).
   return 'none';
 }
 

--- a/prototype/ui-redesign/src/presetStore.ts
+++ b/prototype/ui-redesign/src/presetStore.ts
@@ -65,6 +65,12 @@ export interface Preset {
 export const LS_USER_PRESETS = 'user_presets';
 export const LS_APPLIED_PRESETS = 'applied_presets';
 export const LS_BACKEND_PRESETS = 'backend_presets';
+// Client-local record of which preset each *currently-loaded* model is actually
+// running with. Distinct from `applied_presets` (the preset LINKED to a model):
+// the linked preset can be changed while a model is loaded, and the divergence
+// between linked vs running is what surfaces the "Update preset" affordance
+// (#2356). Cleared when the model unloads. Never sent to lemond.
+export const LS_RUNNING_PRESETS = 'running_presets';
 export const PRESET_STORE_EVENT = 'lemonade:preset-store-changed';
 export const DEFAULT_CONTEXT_SIZE = 4096;
 
@@ -489,6 +495,87 @@ export function activePresetForModel(modelName: string): Preset {
 export function activePresetForBackend(key: string): Preset {
   const presetId = loadBackendApplied()[key] || DEFAULT_PRESET.id;
   return allStoredPresets().find(p => p.id === presetId) || DEFAULT_PRESET;
+}
+
+/* ── Running-preset store (#2356: update preset while loaded) ─────
+ *
+ * Tracks the preset a *loaded* model is currently running with. When a model
+ * is loaded we snapshot its running preset = its linked preset at load time.
+ * If the user later re-links a different preset, `running` lags behind `linked`
+ * and an "Update preset" action becomes available in the detail panel.
+ *
+ * This is purely client-local bookkeeping for the POC. The real apply/reload
+ * is owned by lemond (off-limits to the UI POC) via `api.updatePreset`. */
+
+export function loadRunningPresets(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(scopedPresetKey(LS_RUNNING_PRESETS));
+    if (raw) return JSON.parse(raw);
+  } catch {}
+  return {};
+}
+
+export function saveRunningPresets(running: Record<string, string>): void {
+  localStorage.setItem(scopedPresetKey(LS_RUNNING_PRESETS), JSON.stringify(running));
+  emitPresetStoreEvent();
+}
+
+export function runningPresetIdForModel(modelName: string): string | undefined {
+  return loadRunningPresets()[modelName];
+}
+
+/** Record (snapshot) the preset a model is now running with. */
+export function setRunningPreset(modelName: string, presetId: string): void {
+  if (!modelName) return;
+  const next = { ...loadRunningPresets() };
+  if (next[modelName] === presetId) return;
+  next[modelName] = presetId;
+  saveRunningPresets(next);
+}
+
+/** Forget a model's running preset (call when it unloads). */
+export function clearRunningPreset(modelName: string): void {
+  if (!modelName) return;
+  const next = { ...loadRunningPresets() };
+  if (!(modelName in next)) return;
+  delete next[modelName];
+  saveRunningPresets(next);
+}
+
+/**
+ * How an already-loaded model must absorb a preset change.
+ *  - 'none'   : presets are equivalent in every field that affects a load.
+ *  - 'live'   : only request-time fields differ (system prompt, sampling,
+ *               tools toggle) — apply live, NO reload.
+ *  - 'reload' : a field that the runtime binds at init differs (recipe_options
+ *               such as ctx_size / backend / device / args / steps, or the
+ *               engine hint) — the model must be reinitialized (reloaded).
+ */
+export type PresetChangeKind = 'none' | 'live' | 'reload';
+
+/** Fields that the backend/runtime binds at load time → require a reload. */
+const RELOAD_FIELDS: Array<keyof Preset> = ['recipe_options', 'engine_hint'];
+/** Fields applied per request at generation time → can be updated live. */
+const LIVE_FIELDS: Array<keyof Preset> = ['sampling', 'system_prompt_id', 'system_prompts', 'tools_enabled'];
+
+function stableEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+export function classifyPresetChange(
+  running: Preset | null | undefined,
+  next: Preset | null | undefined,
+): PresetChangeKind {
+  if (!running || !next) return 'none';
+  if (running.id === next.id) return 'none';
+  for (const field of RELOAD_FIELDS) {
+    if (!stableEqual(running[field], next[field])) return 'reload';
+  }
+  for (const field of LIVE_FIELDS) {
+    if (!stableEqual(running[field], next[field])) return 'live';
+  }
+  // Different preset id but identical load-affecting + request-time fields.
+  return 'none';
 }
 
 function pickRecipeOptions(options: RecipeOptions, keys: Array<keyof RecipeOptions>): RecipeOptions {

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -8655,6 +8655,66 @@ input, textarea {
   gap: var(--space-1);
 }
 
+/* ── Update preset while loaded (#2356) ───────────────────────── */
+
+.model-detail-panel__update-preset-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.model-detail-panel__update-preset-btn[aria-busy='true'] {
+  opacity: 0.85;
+  cursor: progress;
+}
+
+.model-detail-panel__preset-update {
+  font-size: var(--text-xs);
+  color: var(--text-secondary, #c9c9c9);
+  display: none;
+  align-items: center;
+  gap: 6px;
+  margin-top: var(--space-1);
+}
+
+.model-detail-panel__preset-update--active {
+  display: flex;
+}
+
+.model-detail-panel__preset-update[data-preset-update-phase='done-live'],
+.model-detail-panel__preset-update[data-preset-update-phase='done-reload'] {
+  color: var(--status-success, #4ade80);
+}
+
+.model-detail-panel__preset-update[data-preset-update-phase='error'] {
+  color: var(--status-error, #f87171);
+}
+
+.model-detail-panel__preset-update-spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--border-strong, rgba(255, 255, 255, 0.35));
+  border-top-color: var(--accent-fg, #f5c518);
+  border-radius: 50%;
+  flex-shrink: 0;
+  animation: model-detail-preset-spin 0.7s linear infinite;
+}
+
+@keyframes model-detail-preset-spin {
+  to { transform: rotate(360deg); }
+}
+
+.model-detail-panel__preset-update-hint {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  margin: var(--space-1) 0 0;
+  line-height: 1.35;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .model-detail-panel__preset-update-spinner { animation: none; }
+}
+
 .model-detail-panel__hf-link {
   font-size: var(--text-xs);
   color: var(--text-tertiary);

--- a/prototype/ui-redesign/src/tools/lemonadeTools.ts
+++ b/prototype/ui-redesign/src/tools/lemonadeTools.ts
@@ -3,7 +3,7 @@
  * Exposes lemonade server management as OpenAI-compatible function calling tools.
  */
 import api, { searchHuggingFace, HFModelResult, PullVariantsResult } from '../api';
-import { allStoredPresets, isCompatible, loadApplied, saveApplied, type Preset } from '../presetStore';
+import { allStoredPresets, isCompatible, loadApplied, saveApplied, classifyPresetChange, runningPresetIdForModel, setRunningPreset, activePresetForModel, type Preset } from '../presetStore';
 import { getCollectionComponents, isCollectionModel } from '../features/collections/collectionModels';
 
 /* ── Tool schemas (OpenAI function calling format) ─────────────── */
@@ -68,6 +68,23 @@ export const LEMONADE_TOOLS: ToolFunction[] = [
           preset_name: { type: 'string', description: 'Optional exact preset name to assign before loading.' },
         },
         required: ['model_name'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'change_preset',
+      description: 'Change the active preset of an already-LOADED model (#2356). Use this when the user asks to switch/apply a different preset to a model that is currently loaded (e.g. "use the Creative preset", "make it more deterministic", "give it a bigger context window"). Request-time changes (system prompt, sampling/temperature, tools) apply live on the next message with NO reload. Load-time changes (ctx_size, backend, device, model args) require a reload, which this tool performs automatically (unload + load). Specify the preset via preset, preset_id, or preset_name. If model_name is omitted, the most recently loaded model is used.',
+      parameters: {
+        type: 'object',
+        properties: {
+          model_name: { type: 'string', description: 'The loaded model to re-preset. Optional — uses the most recently loaded model if omitted.' },
+          preset: { type: 'string', description: 'Preset id or name to bind. Examples: Default, Balanced, Quality, Fast, Creative, Long Context, Code.' },
+          preset_id: { type: 'string', description: 'Optional exact preset id to bind.' },
+          preset_name: { type: 'string', description: 'Optional exact preset name to bind.' },
+        },
+        required: [],
       },
     },
   },
@@ -757,6 +774,104 @@ export async function executeTool(call: ToolCall): Promise<ToolResult> {
         };
         const presetText = appliedPreset ? ` using preset ${appliedPreset.name}` : '';
         return toolPayload(call, result, `Loaded ${targetModelName}${presetText}${Object.keys(opts).length ? ` with ${shortJson(opts, 120)}` : ''}`);
+      }
+
+      case 'change_preset': {
+        // #2356 (simplified): re-preset an already-loaded model with the same
+        // primitives as the UI button. No update-preset endpoint, no `mode`
+        // parameter — request-time changes are a pure client-local rebind;
+        // load-time changes go through reloadModel (= unload + load).
+        const health = await api.health().catch(() => null);
+        const loaded = health?.all_models_loaded || [];
+        if (loaded.length === 0) {
+          return toolPayload(call, {
+            error: 'No model is loaded. Load a model first, then change its preset.',
+            answer_instruction: 'Tell the user no model is loaded, so there is nothing to re-preset. Suggest load_model.',
+          }, 'No model loaded', true);
+        }
+        const data = await api.models(true).catch(() => ({ data: [] as AnyModel[] }));
+        // Resolve the target; default to the most-recently-loaded model (last entry).
+        const resolved = args.model_name
+          ? resolveModel(data.data as AnyModel[], loaded, args.model_name)
+          : (data.data as AnyModel[]).find(m => modelName(m).toLowerCase() === asString(loaded[loaded.length - 1]?.model_name).toLowerCase()) || null;
+        const targetModelName = resolved
+          ? modelName(resolved)
+          : (asString(args.model_name) || asString(loaded[loaded.length - 1]?.model_name));
+        if (!targetModelName) {
+          return toolPayload(call, { error: 'Could not determine which loaded model to re-preset.' }, 'Error: missing model name', true);
+        }
+        const loadedTarget = loaded.find(m => asString(m.model_name).toLowerCase() === targetModelName.toLowerCase());
+        if (!loadedTarget) {
+          return toolPayload(call, {
+            error: `Model ${targetModelName} is not currently loaded.`,
+            answer_instruction: 'Tell the user that model is not loaded, so its preset cannot be changed live. Suggest load_model with the preset instead.',
+          }, `Model ${targetModelName} is not loaded`, true);
+        }
+
+        const requestedPreset = presetSpecifier(args);
+        if (!requestedPreset) {
+          const choices = allStoredPresets().map(preset => `${preset.name} (${preset.id})`).slice(0, 12);
+          return toolPayload(call, {
+            error: 'Missing preset. Specify a preset to bind.',
+            available_presets: choices,
+            answer_instruction: 'Ask the user which preset to apply, listing the available presets.',
+          }, 'Error: missing preset', true);
+        }
+        const nextPreset = resolvePreset(requestedPreset);
+        if (!nextPreset) {
+          const choices = allStoredPresets().map(preset => `${preset.name} (${preset.id})`).slice(0, 12);
+          return toolPayload(call, {
+            error: `Preset not found: ${requestedPreset}`,
+            available_presets: choices,
+            answer_instruction: 'Tell the user the requested preset was not found and ask them to choose one of the available presets.',
+          }, `Preset not found: ${requestedPreset}`, true);
+        }
+        if (resolved && !isCompatible(nextPreset, resolved as any)) {
+          return toolPayload(call, {
+            error: `Preset ${nextPreset.name} is not compatible with ${targetModelName}`,
+            preset: { id: nextPreset.id, name: nextPreset.name, applies_to: nextPreset.applies_to },
+            answer_instruction: 'Tell the user the preset is incompatible with the loaded model and ask for a compatible preset.',
+          }, `Preset ${nextPreset.name} is not compatible with ${targetModelName}`, true);
+        }
+
+        // Determine the running preset (what the model is actually running) BEFORE
+        // rebinding, so we can classify the change correctly.
+        const runId = runningPresetIdForModel(targetModelName);
+        const running = runId ? (allStoredPresets().find(p => p.id === runId) ?? null) : (activePresetForModel(targetModelName) ?? null);
+        const kind = classifyPresetChange(running, nextPreset);
+
+        // Rebind the active preset (client-local — invariant #11). For live
+        // changes this is the entire operation; request composition carries the
+        // new values on the next request. The binding PERSISTS across a reload.
+        applyPresetBinding(targetModelName, nextPreset);
+
+        if (kind === 'reload') {
+          await api.reloadModel(targetModelName, nextPreset.recipe_options as Record<string, unknown> | undefined, resolved as any || null);
+          setRunningPreset(targetModelName, nextPreset.id);
+          const result = {
+            status: 'reloaded',
+            model: targetModelName,
+            preset: { id: nextPreset.id, name: nextPreset.name, applies_to: nextPreset.applies_to },
+            change: 'reload',
+            answer_instruction: 'Tell the user the preset was applied and the model was reloaded (load-time settings such as context size/backend require a reload).',
+          };
+          return toolPayload(call, result, `Reloaded ${targetModelName} with preset ${nextPreset.name}`);
+        }
+
+        // 'live' or 'none' — no server round-trip.
+        setRunningPreset(targetModelName, nextPreset.id);
+        const result = {
+          status: kind === 'live' ? 'applied_live' : 'no_change',
+          model: targetModelName,
+          preset: { id: nextPreset.id, name: nextPreset.name, applies_to: nextPreset.applies_to },
+          change: kind,
+          answer_instruction: kind === 'live'
+            ? 'Tell the user the preset was applied live — it takes effect on the next message, no reload needed.'
+            : 'Tell the user the preset was already effectively in use, so nothing changed.',
+        };
+        return toolPayload(call, result, kind === 'live'
+          ? `Applied preset ${nextPreset.name} to ${targetModelName} (live, no reload)`
+          : `Preset ${nextPreset.name} already active on ${targetModelName}`);
       }
 
       case 'unload_model': {

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -3027,3 +3027,226 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     expect(critical, formatViolations(critical)).toHaveLength(0);
   });
 });
+
+
+// ─── 31. Update preset while a model is loaded (#2356) ────────────────────────
+//
+// When a model is loaded and a DIFFERENT preset is linked to it, an
+// "Update preset" button appears next to "Unload". Live-updateable changes
+// (sampling / system prompt) apply without a reload; reload-requiring changes
+// (recipe_options) trigger an automatic reload flow. All via api.updatePreset
+// against the proposed POST /api/v{0,1}/update-preset backend contract.
+// Range: A154–A163.
+
+test.describe('Accessibility — update preset while loaded (#2356)', () => {
+  const MODEL = 'Llama-3.1-8B';
+
+  function preset(id: string, name: string, extra: Record<string, unknown> = {}) {
+    return {
+      id, name,
+      description: `${name} preset`,
+      applies_to: ['chat'],
+      recipe_options: { ctx_size: 4096 },
+      sampling: { temperature: 0.7, top_p: 0.9, top_k: 40, repeat_penalty: 1.05 },
+      engine_hint: 'auto',
+      starter: false,
+      auto_opt_run_id: null,
+      auto_opt_enabled: true,
+      system_prompt_id: 'none',
+      system_prompts: [],
+      tools_enabled: false,
+      ...extra,
+    };
+  }
+
+  // p-base: running baseline. p-live: only sampling differs (live).
+  // p-reload: recipe_options differ (reload).
+  const PRESETS = [
+    preset('p-base', 'Base'),
+    preset('p-live', 'Live Tweaks', { sampling: { temperature: 0.2, top_p: 0.9, top_k: 40, repeat_penalty: 1.05 } }),
+    preset('p-reload', 'Big Context', { recipe_options: { ctx_size: 8192 } }),
+  ];
+
+  type UpdateCall = { model_name?: string; preset_id?: string; mode?: string };
+
+  /**
+   * Seed presets, mark the model loaded (health.all_models_loaded), capture
+   * update-preset calls, navigate to Models, and select the loaded model.
+   * Returns the captured-calls array (mutated as requests arrive).
+   */
+  async function setup(page: Page, appliedPresetId: string): Promise<UpdateCall[]> {
+    const calls: UpdateCall[] = [];
+    await page.addInitScript(
+      ({ presets, applied, model }) => {
+        localStorage.setItem('lemonade:guest:shared:user_presets', JSON.stringify(presets));
+        localStorage.setItem('lemonade:guest:shared:applied_presets', JSON.stringify({ [model]: applied }));
+        localStorage.removeItem('lemonade:guest:shared:running_presets');
+      },
+      { presets: PRESETS, applied: appliedPresetId, model: MODEL },
+    );
+
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'ok', version: 'test',
+          all_models_loaded: [
+            { model_name: MODEL, recipe: 'llamacpp', device: 'gpu', type: 'llm', backend_url: 'http://x', pid: 1 },
+          ],
+        }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [{ id: MODEL, name: MODEL, labels: ['llm'], recipe: 'llamacpp', downloaded: true }] }),
+      }),
+    );
+    await page.route('**/api/v1/update-preset', async route => {
+      try { calls.push(route.request().postDataJSON() as UpdateCall); } catch { /* ignore */ }
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) });
+    });
+
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await page.locator('.titlebar__nav').getByText('Models').click();
+    await page.waitForSelector('.manager--detail');
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+    return calls;
+  }
+
+  /** Switch the linked preset via the Presets-tab Change chooser. */
+  async function switchLinkedPreset(page: Page, presetName: string): Promise<void> {
+    const presetsTab = page.locator('[role="tab"]').filter({ hasText: /Preset/i });
+    await presetsTab.click();
+    await page.waitForTimeout(100);
+    await page.locator('.detail-presets__change-btn').click();
+    await page.waitForTimeout(100);
+    await page.locator(`.detail-presets__chooser-option[aria-label*="${presetName}"]`).click();
+    await page.waitForTimeout(150);
+  }
+
+  const updateBtn = '.model-detail-panel__update-preset-btn';
+
+  test('A154 — no Update preset button when the loaded model already runs its linked preset', async ({ page }) => {
+    await setup(page, 'p-base');
+    // Model is loaded (Unload button present); linked == running (p-base).
+    await expect(page.locator('.model-detail-panel__actions').getByRole('button', { name: /Unload/i })).toBeVisible();
+    await expect(page.locator(updateBtn)).toHaveCount(0);
+  });
+
+  test('A155 — switching to a live-only preset reveals Update preset next to Unload', async ({ page }) => {
+    await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Live Tweaks');
+    const btn = page.locator(updateBtn);
+    await expect(btn).toBeVisible();
+    // Sits in the same actions group as Unload.
+    await expect(page.locator('.model-detail-panel__actions').locator(updateBtn)).toBeVisible();
+    const label = await btn.getAttribute('aria-label');
+    expect(label).toMatch(/update preset/i);
+    expect(label).not.toMatch(/reload/i);
+  });
+
+  test('A156 — clicking Update preset (live) calls the contract with mode=live and announces no reload', async ({ page }) => {
+    const calls = await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Live Tweaks');
+    await page.locator(updateBtn).click();
+    await page.waitForTimeout(300);
+    expect(calls.length).toBe(1);
+    expect(calls[0].mode).toBe('live');
+    expect(calls[0].preset_id).toBe('p-live');
+    expect(calls[0].model_name).toBe(MODEL);
+    const status = page.locator('.model-detail-panel__preset-update');
+    await expect(status).toContainText(/applied live|no reload/i);
+    // Button disappears once running == linked again.
+    await expect(page.locator(updateBtn)).toHaveCount(0);
+  });
+
+  test('A157 — switching to a reload-requiring preset labels Update preset as reloading', async ({ page }) => {
+    await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Big Context');
+    const btn = page.locator(updateBtn);
+    await expect(btn).toBeVisible();
+    const label = await btn.getAttribute('aria-label');
+    expect(label).toMatch(/reload/i);
+  });
+
+  test('A158 — clicking Update preset (reload) calls the contract with mode=reload and announces a reload', async ({ page }) => {
+    const calls = await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Big Context');
+    await page.locator(updateBtn).click();
+    await page.waitForTimeout(400);
+    expect(calls.length).toBe(1);
+    expect(calls[0].mode).toBe('reload');
+    expect(calls[0].preset_id).toBe('p-reload');
+    const status = page.locator('.model-detail-panel__preset-update');
+    await expect(status).toContainText(/reload/i);
+    await expect(page.locator(updateBtn)).toHaveCount(0);
+  });
+
+  test('A159 — Update preset button is keyboard operable (Enter triggers the update)', async ({ page }) => {
+    const calls = await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Live Tweaks');
+    const btn = page.locator(updateBtn);
+    await btn.focus();
+    await expect(btn).toBeFocused();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    expect(calls.length).toBe(1);
+    expect(calls[0].mode).toBe('live');
+  });
+
+  test('A160 — preset update feedback is a polite live region', async ({ page }) => {
+    await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Live Tweaks');
+    const status = page.locator('.model-detail-panel__preset-update');
+    await expect(status).toHaveAttribute('role', 'status');
+    await expect(status).toHaveAttribute('aria-live', 'polite');
+  });
+
+  test('A161 — no Update preset button for a non-loaded model even with a non-default preset linked', async ({ page }) => {
+    // Model NOT in all_models_loaded → not loaded.
+    await page.addInitScript(
+      ({ presets, model }) => {
+        localStorage.setItem('lemonade:guest:shared:user_presets', JSON.stringify(presets));
+        localStorage.setItem('lemonade:guest:shared:applied_presets', JSON.stringify({ [model]: 'p-live' }));
+        localStorage.removeItem('lemonade:guest:shared:running_presets');
+      },
+      { presets: PRESETS, model: MODEL },
+    );
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }) }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify({ data: [{ id: MODEL, name: MODEL, labels: ['llm'], recipe: 'llamacpp', downloaded: true }] }) }),
+    );
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await page.locator('.titlebar__nav').getByText('Models').click();
+    await page.waitForSelector('.manager--detail');
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(200);
+    await expect(page.locator(updateBtn)).toHaveCount(0);
+  });
+
+  test('A162 — Update preset visible state passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
+    await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Big Context');
+    await expect(page.locator(updateBtn)).toBeVisible();
+    const results = await new AxeBuilder({ page }).withTags([...WCAG_TAGS]).analyze();
+    const critical = results.violations.filter(v => v.impact === 'critical' || v.impact === 'serious');
+    expect(critical, formatViolations(critical)).toHaveLength(0);
+  });
+
+  test('A163 — after a live update, focus moves to the Unload button (no focus loss)', async ({ page }) => {
+    await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Live Tweaks');
+    await page.locator(updateBtn).click();
+    await page.waitForTimeout(300);
+    const unload = page.locator('.model-detail-panel__actions').getByRole('button', { name: /Unload/i });
+    await expect(unload).toBeFocused();
+  });
+});

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -3029,14 +3029,16 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
 });
 
 
-// ─── 31. Update preset while a model is loaded (#2356) ────────────────────────
+// ─── 31. Update preset while a model is loaded (#2356, simplified) ────────────
 //
 // When a model is loaded and a DIFFERENT preset is linked to it, an
-// "Update preset" button appears next to "Unload". Live-updateable changes
-// (sampling / system prompt) apply without a reload; reload-requiring changes
-// (recipe_options) trigger an automatic reload flow. All via api.updatePreset
-// against the proposed POST /api/v{0,1}/update-preset backend contract.
-// Range: A154–A163.
+// "Apply preset" / "Reload to apply preset" button appears next to "Unload".
+// Simplified design (no update-preset endpoint, no client `mode` param):
+//   • Live changes (sampling / system prompt / tools) are a pure client-local
+//     rebind — NO network call, applied by request composition next request.
+//   • Load-time changes (recipe_options) perform a real reload = unload + load
+//     (api.reloadModel). The active-preset binding persists across the reload.
+// Range: A154–A166.
 
 test.describe('Accessibility — update preset while loaded (#2356)', () => {
   const MODEL = 'Llama-3.1-8B';
@@ -3067,15 +3069,16 @@ test.describe('Accessibility — update preset while loaded (#2356)', () => {
     preset('p-reload', 'Big Context', { recipe_options: { ctx_size: 8192 } }),
   ];
 
-  type UpdateCall = { model_name?: string; preset_id?: string; mode?: string };
+  type ReloadCall = { kind: 'unload' | 'load'; model_name?: string };
 
   /**
    * Seed presets, mark the model loaded (health.all_models_loaded), capture
-   * update-preset calls, navigate to Models, and select the loaded model.
+   * unload/load calls (the only server round-trip — for load-time reloads),
+   * navigate to Models, and select the loaded model.
    * Returns the captured-calls array (mutated as requests arrive).
    */
-  async function setup(page: Page, appliedPresetId: string): Promise<UpdateCall[]> {
-    const calls: UpdateCall[] = [];
+  async function setup(page: Page, appliedPresetId: string): Promise<ReloadCall[]> {
+    const calls: ReloadCall[] = [];
     await page.addInitScript(
       ({ presets, applied, model }) => {
         localStorage.setItem('lemonade:guest:shared:user_presets', JSON.stringify(presets));
@@ -3102,8 +3105,16 @@ test.describe('Accessibility — update preset while loaded (#2356)', () => {
         body: JSON.stringify({ data: [{ id: MODEL, name: MODEL, labels: ['llm'], recipe: 'llamacpp', downloaded: true }] }),
       }),
     );
-    await page.route('**/api/v1/update-preset', async route => {
-      try { calls.push(route.request().postDataJSON() as UpdateCall); } catch { /* ignore */ }
+    await page.route('**/api/v1/unload', async route => {
+      let model_name: string | undefined;
+      try { model_name = (route.request().postDataJSON() as any)?.model_name; } catch { /* ignore */ }
+      calls.push({ kind: 'unload', model_name });
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) });
+    });
+    await page.route('**/api/v1/load', async route => {
+      let model_name: string | undefined;
+      try { model_name = (route.request().postDataJSON() as any)?.model_name; } catch { /* ignore */ }
+      calls.push({ kind: 'load', model_name });
       await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) });
     });
 
@@ -3130,63 +3141,63 @@ test.describe('Accessibility — update preset while loaded (#2356)', () => {
 
   const updateBtn = '.model-detail-panel__update-preset-btn';
 
-  test('A154 — no Update preset button when the loaded model already runs its linked preset', async ({ page }) => {
+  test('A154 — no Apply preset button when the loaded model already runs its linked preset', async ({ page }) => {
     await setup(page, 'p-base');
     // Model is loaded (Unload button present); linked == running (p-base).
     await expect(page.locator('.model-detail-panel__actions').getByRole('button', { name: /Unload/i })).toBeVisible();
     await expect(page.locator(updateBtn)).toHaveCount(0);
   });
 
-  test('A155 — switching to a live-only preset reveals Update preset next to Unload', async ({ page }) => {
+  test('A155 — switching to a live-only preset reveals "Apply preset" next to Unload', async ({ page }) => {
     await setup(page, 'p-base');
     await switchLinkedPreset(page, 'Live Tweaks');
     const btn = page.locator(updateBtn);
     await expect(btn).toBeVisible();
     // Sits in the same actions group as Unload.
     await expect(page.locator('.model-detail-panel__actions').locator(updateBtn)).toBeVisible();
+    await expect(btn).toContainText(/apply preset/i);
     const label = await btn.getAttribute('aria-label');
-    expect(label).toMatch(/update preset/i);
+    expect(label).toMatch(/apply preset/i);
     expect(label).not.toMatch(/reload/i);
   });
 
-  test('A156 — clicking Update preset (live) calls the contract with mode=live and announces no reload', async ({ page }) => {
+  test('A156 — clicking Apply preset (live) is a pure rebind: no reload call, announces no reload', async ({ page }) => {
     const calls = await setup(page, 'p-base');
     await switchLinkedPreset(page, 'Live Tweaks');
     await page.locator(updateBtn).click();
     await page.waitForTimeout(300);
-    expect(calls.length).toBe(1);
-    expect(calls[0].mode).toBe('live');
-    expect(calls[0].preset_id).toBe('p-live');
-    expect(calls[0].model_name).toBe(MODEL);
+    // Live op makes NO server round-trip (no unload/load).
+    expect(calls.length).toBe(0);
     const status = page.locator('.model-detail-panel__preset-update');
     await expect(status).toContainText(/applied live|no reload/i);
     // Button disappears once running == linked again.
     await expect(page.locator(updateBtn)).toHaveCount(0);
   });
 
-  test('A157 — switching to a reload-requiring preset labels Update preset as reloading', async ({ page }) => {
+  test('A157 — switching to a reload-requiring preset labels the button as reloading', async ({ page }) => {
     await setup(page, 'p-base');
     await switchLinkedPreset(page, 'Big Context');
     const btn = page.locator(updateBtn);
     await expect(btn).toBeVisible();
+    await expect(btn).toContainText(/reload to apply preset/i);
     const label = await btn.getAttribute('aria-label');
     expect(label).toMatch(/reload/i);
   });
 
-  test('A158 — clicking Update preset (reload) calls the contract with mode=reload and announces a reload', async ({ page }) => {
+  test('A158 — clicking Reload to apply preset performs a real reload (unload + load) and announces it', async ({ page }) => {
     const calls = await setup(page, 'p-base');
     await switchLinkedPreset(page, 'Big Context');
     await page.locator(updateBtn).click();
-    await page.waitForTimeout(400);
-    expect(calls.length).toBe(1);
-    expect(calls[0].mode).toBe('reload');
-    expect(calls[0].preset_id).toBe('p-reload');
+    await page.waitForTimeout(500);
+    // Reload = unload followed by load, both targeting the model.
+    expect(calls.map(c => c.kind)).toEqual(['unload', 'load']);
+    expect(calls.every(c => c.model_name === MODEL)).toBe(true);
     const status = page.locator('.model-detail-panel__preset-update');
     await expect(status).toContainText(/reload/i);
     await expect(page.locator(updateBtn)).toHaveCount(0);
   });
 
-  test('A159 — Update preset button is keyboard operable (Enter triggers the update)', async ({ page }) => {
+  test('A159 — Apply preset button is keyboard operable (Enter triggers the rebind)', async ({ page }) => {
     const calls = await setup(page, 'p-base');
     await switchLinkedPreset(page, 'Live Tweaks');
     const btn = page.locator(updateBtn);
@@ -3194,8 +3205,9 @@ test.describe('Accessibility — update preset while loaded (#2356)', () => {
     await expect(btn).toBeFocused();
     await page.keyboard.press('Enter');
     await page.waitForTimeout(300);
-    expect(calls.length).toBe(1);
-    expect(calls[0].mode).toBe('live');
+    // Live rebind: no reload call; affordance clears.
+    expect(calls.length).toBe(0);
+    await expect(page.locator(updateBtn)).toHaveCount(0);
   });
 
   test('A160 — preset update feedback is a polite live region', async ({ page }) => {
@@ -3206,7 +3218,7 @@ test.describe('Accessibility — update preset while loaded (#2356)', () => {
     await expect(status).toHaveAttribute('aria-live', 'polite');
   });
 
-  test('A161 — no Update preset button for a non-loaded model even with a non-default preset linked', async ({ page }) => {
+  test('A161 — no Apply preset button for a non-loaded model even with a non-default preset linked', async ({ page }) => {
     // Model NOT in all_models_loaded → not loaded.
     await page.addInitScript(
       ({ presets, model }) => {
@@ -3232,7 +3244,7 @@ test.describe('Accessibility — update preset while loaded (#2356)', () => {
     await expect(page.locator(updateBtn)).toHaveCount(0);
   });
 
-  test('A162 — Update preset visible state passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
+  test('A162 — Apply/Reload preset visible state passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
     await setup(page, 'p-base');
     await switchLinkedPreset(page, 'Big Context');
     await expect(page.locator(updateBtn)).toBeVisible();
@@ -3241,11 +3253,34 @@ test.describe('Accessibility — update preset while loaded (#2356)', () => {
     expect(critical, formatViolations(critical)).toHaveLength(0);
   });
 
-  test('A163 — after a live update, focus moves to the Unload button (no focus loss)', async ({ page }) => {
+  test('A163 — after a live apply, focus moves to the Unload button (no focus loss)', async ({ page }) => {
     await setup(page, 'p-base');
     await switchLinkedPreset(page, 'Live Tweaks');
     await page.locator(updateBtn).click();
     await page.waitForTimeout(300);
+    const unload = page.locator('.model-detail-panel__actions').getByRole('button', { name: /Unload/i });
+    await expect(unload).toBeFocused();
+  });
+
+  test('A164 — live Apply preset button accessible name names the target model', async ({ page }) => {
+    await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Live Tweaks');
+    const label = await page.locator(updateBtn).getAttribute('aria-label');
+    expect(label).toMatch(new RegExp(`apply preset for ${MODEL}`, 'i'));
+  });
+
+  test('A165 — reload Apply preset button accessible name names the target model', async ({ page }) => {
+    await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Big Context');
+    const label = await page.locator(updateBtn).getAttribute('aria-label');
+    expect(label).toMatch(new RegExp(`reload ${MODEL} to apply preset`, 'i'));
+  });
+
+  test('A166 — after a reload apply, focus moves to the Unload button (no focus loss)', async ({ page }) => {
+    await setup(page, 'p-base');
+    await switchLinkedPreset(page, 'Big Context');
+    await page.locator(updateBtn).click();
+    await page.waitForTimeout(500);
     const unload = page.locator('.model-detail-panel__actions').getByRole('button', { name: /Unload/i });
     await expect(unload).toBeFocused();
   });


### PR DESCRIPTION
Part of #2356.

## What shipped (UI / POC)

Adds an **"Update preset"** action to the model detail panel that appears **next to Unload** when a model is **loaded** and a **different** preset is linked to it (linked ≠ running):

- **Live-updateable changes** (sampling, system prompt, tools toggle) apply **without a reload** — inline "applied live, no reload needed" status.
- **Reload-requiring changes** (`recipe_options` such as ctx_size/backend/device/args/steps, or the engine hint) trigger an **automatic reload flow** with a "Reloading…" spinner/status — the user never manually unloads/loads.
- Client-local **running-preset** tracking (`running_presets` store) + `classifyPresetChange(running, next) → 'none' | 'live' | 'reload'` in `presetStore.ts`.
- A clean `api.updatePreset(modelName, presetId, mode, payload)` hook against the proposed `POST /api/v{0,1}/update-preset` contract.

## Accessibility
- Real `<button>`; `aria-label` names the model and states "(reloads the model)" for reload changes; `aria-busy` while updating.
- Always-present `role="status" aria-live="polite"` region announces the outcome; sighted `aria-hidden` hint explains why the button appeared.
- Focus moves to **Unload** on success (the button unmounts once running == linked) to avoid focus loss.
- Reload spinner respects `prefers-reduced-motion`.
- Playwright/axe coverage **A154–A163** (10 new tests). **All 178 tests pass, 7 skipped, 0 failed.**

## Deferred to backend (lemond is off-limits to the UI POC)
- The **real reload mechanics** (lemond reinitializing the model in place).
- The **Lemonade-tools "change the preset"** integration (must reuse the same update logic for UI/tool parity).
- Proposed `window.api` + HTTP contract and the live-vs-reload field split are documented in `prototype/ui-redesign/docs/UPDATE_PRESET_CONTRACT.md` — **@fl0rianr please confirm the contract + the field classification.**

## Acceptance criteria satisfied in the POC
- [x] Loaded model no longer needs manual unload→reload to change preset
- [x] Selecting a different preset on a loaded model enables Update preset
- [x] Update preset sits next to Unload
- [x] Live changes (system prompt / sampling) apply without reload
- [x] Reload-requiring changes trigger the automatic reload flow
- [x] SR roles/names/states, keyboard operability, axe coverage, all tests pass

Tool-parity + real-reload criteria are **deferred to backend** (noted above).