### PR TITLE
feat: expand system stats with storage infos

### DIFF
--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -881,6 +881,12 @@ curl "http://localhost:13305/v1/system-info"
   "BIOS Version": "1.0.0",
   "CPU Max Clock": "5100 MHz",
   "Windows Power Setting": "Balanced",
+  "model_storage": {
+    "path": "/path/to/models",
+    "used_bytes": 123456789,
+    "total_bytes": 987654321,
+    "free_bytes": 864197532
+  },
   "devices": {
     "cpu": {
       "name": "AMD Ryzen AI 9 HX 375 w/ Radeon 890M",
@@ -994,6 +1000,12 @@ curl "http://localhost:13305/v1/system-info"
   - `BIOS Version` - BIOS information (Windows only)
   - `CPU Max Clock` - Maximum CPU clock speed (Windows only)
   - `Windows Power Setting` - Current power plan (Windows only)
+
+- `model_storage` - Drive-level storage information for the active configured model storage path. Values are reported in bytes for storage meters; this is not a recursive sum of Lemonade model files.
+  - `path` - Active model storage path from server configuration
+  - `used_bytes` - Used bytes on the model-storage drive
+  - `total_bytes` - Total capacity of the model-storage drive
+  - `free_bytes` - Free bytes available to the Lemonade Server process on the model-storage drive
 
 - `devices` - Hardware devices detected on the system (no software/support information)
   - `cpu` - CPU information (name, cores, threads)

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -30,6 +30,7 @@
 #include <chrono>
 #include <mutex>
 #include <filesystem>
+#include <system_error>
 #include <algorithm>
 #include <cmath>
 #include <set>
@@ -218,6 +219,96 @@ void attach_warnings(json& response, const std::vector<std::string>& warnings) {
     response["warnings"] = warnings;
     // Backward-compatible single-string field for older clients.
     response["warning"] = join_warnings(warnings);
+}
+
+nlohmann::json get_model_storage_stats(const std::string& model_storage_path) {
+    auto make_error_result = [](const fs::path& path, const std::string& error) {
+        return nlohmann::json{
+            {"path", utils::path_to_utf8(path)},
+            {"used_bytes", nullptr},
+            {"total_bytes", nullptr},
+            {"free_bytes", nullptr},
+            {"error", error}
+        };
+    };
+
+    std::error_code ec;
+    fs::path configured_path;
+
+    if (!model_storage_path.empty()) {
+        configured_path = utils::path_from_utf8(model_storage_path);
+    }
+
+    if (configured_path.empty()) {
+        configured_path = fs::current_path(ec);
+        if (ec) {
+            LOG(WARNING, "Server") << "Unable to resolve current path for model storage stats: "
+                                   << ec.message() << std::endl;
+            return make_error_result(
+                fs::path{},
+                "Unable to resolve current path: " + ec.message()
+            );
+        }
+    } else if (configured_path.is_relative()) {
+        configured_path = fs::absolute(configured_path, ec);
+        if (ec) {
+            LOG(WARNING, "Server") << "Unable to resolve model storage path "
+                                   << model_storage_path << ": " << ec.message() << std::endl;
+            return make_error_result(
+                configured_path,
+                "Unable to resolve model storage path: " + ec.message()
+            );
+        }
+    }
+
+    configured_path = configured_path.lexically_normal();
+
+    fs::path probe_path = configured_path;
+    while (!probe_path.empty()) {
+        std::error_code exists_ec;
+        if (fs::exists(probe_path, exists_ec)) {
+            break;
+        }
+
+        if (exists_ec) {
+            LOG(WARNING, "Server") << "Unable to inspect model storage path "
+                                   << utils::path_to_utf8(probe_path) << ": "
+                                   << exists_ec.message() << std::endl;
+            return make_error_result(
+                configured_path,
+                "Unable to inspect model storage path: " + exists_ec.message()
+            );
+        }
+
+        fs::path parent_path = probe_path.parent_path();
+        if (parent_path == probe_path) {
+            break;
+        }
+
+        probe_path = parent_path;
+    }
+
+    auto space_info = fs::space(probe_path, ec);
+    if (ec) {
+        LOG(WARNING, "Server") << "Unable to read model storage stats for "
+                               << utils::path_to_utf8(probe_path) << ": "
+                               << ec.message() << std::endl;
+        return make_error_result(
+            configured_path,
+            "Unable to read model storage stats: " + ec.message()
+        );
+    }
+
+    const uintmax_t total_bytes = space_info.capacity;
+    const uintmax_t free_bytes = std::min(space_info.available, space_info.capacity);
+    const uintmax_t used_bytes = total_bytes - free_bytes;
+
+    return nlohmann::json{
+        {"path", utils::path_to_utf8(configured_path)},
+        {"used_bytes", static_cast<uint64_t>(used_bytes)},
+        {"total_bytes", static_cast<uint64_t>(total_bytes)},
+        {"free_bytes", static_cast<uint64_t>(free_bytes)}
+    };
 }
 
 } // namespace
@@ -4315,6 +4406,10 @@ void Server::handle_system_info(const httplib::Request& req, httplib::Response& 
         system_info["no_fetch_executables"] = cfg->no_fetch_executables();
     }
 
+    if (config_) {
+        system_info["model_storage"] = get_model_storage_stats(utils::get_hf_cache_dir());
+    }
+    
     // Cloud providers: per-provider {name, base_url, env_var_set,
     // runtime_key_set, models_discovered}. Never includes the key itself.
     // Clients use this to decide whether to prompt for an API key, show a


### PR DESCRIPTION
## Summary

Adds real drive-level model storage information to GET /v1/system-info.

The new model_storage field reports the active resolved model storage path and filesystem capacity information:

```json
{
  "model_storage": {
    "path": "/path/to/models",
    "used_bytes": 123456789,
    "total_bytes": 987654321,
    "free_bytes": 864197532
  }
}
```

This is useful for GUI clients, CLIs, dashboards, and other callers that need to show storage availability before or during model downloads. GUI3 already has storage display plumbing and can consume this directly, but the endpoint is generally useful for any client that needs model-storage telemetry.

## Details

* Uses std::filesystem::space() to report drive-level storage stats.
* Uses the resolved Hugging Face/model cache path via Lemonade’s existing model-storage path resolution
* Reports drive usage/capacity, not a recursive sum of Lemonade model files.
* Walks up to the nearest existing parent directory so a not-yet-created model directory can still report the correct storage drive.
* Keeps the data on `system-info`, alongside other host/system information, instead of adding a separate endpoint.

## Testing

Tested locally with:

```bash
curl -s http://localhost:13305/v1/system-info | jq '.model_storage'
```

Verified that the response contains plausible drive-level byte values and reports the resolved active model cache path.
