### PR TITLE
feat(cli): introduce model filtering for the list command

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -159,15 +159,42 @@ lemonade export Qwen3-0.6B-GGUF --output model-info.json
 
 ## Options for list
 
-The `list` command displays all models. By default, the output is partitioned into **Local** (downloaded) and **Available for Download** sections. You can restrict the output to only local models by passing the `--downloaded` flag:
+The `list` command displays all models. By default, the output is partitioned into **Local** (downloaded) and **Available for Download** sections. You can restrict and filter the output using the following options:
 
 ```bash
-lemonade list [options]
+lemonade list [options] [name_filter]
 ```
 
 | Option                         | Description                         | Default |
 |--------------------------------|-------------------------------------|---------|
+| `name_filter`                  | Optional case-insensitive model-name filter; supports `*` wildcards | |
 | `--downloaded`                 | Show only downloaded models | False |
+| `--json`                       | Format output as JSON | False |
+| `--type <type>`                | Filter by model type (`llm`, `embedding`, `reranking`, `transcription`, `image`, `tts`) | |
+| `--source <source>`            | Filter by model source (`builtin`, `user`, `extra`, `cloud`) | |
+| `--device <device>`            | Filter by model device (`cpu`, `gpu`, `npu`) | |
+| `--suggested`                  | Show only suggested models | False |
+| `--label <label>`              | Filter by one or more labels (repeatable, matches models containing all specified labels) | |
+| `--backend <backend>`          | Filter by backend/recipe | |
+
+**Examples:**
+
+```bash
+# List only downloaded models
+lemonade list --downloaded
+
+# Filter by type and device
+lemonade list --type llm --device gpu
+
+# Filter by multiple labels (AND conjunction)
+lemonade list --label chat --label reasoning
+
+# Filter models by name with wildcard
+lemonade list "Qwen*"
+
+# Output filtered models in JSON format
+lemonade list --type embedding --json
+```
 
 ## Options for pull
 

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -1,13 +1,15 @@
 #include "lemon_cli/lemonade_client.h"
 #include "lemon/utils/url_utils.h"
 #include <httplib.h>
-#include <iostream>
 #include <algorithm>
+#include <cctype>
 #include <iomanip>
+#include <iostream>
+#include <numeric>
 #include <regex>
 #include <sstream>
+#include <string_view>
 #include <nlohmann/json.hpp>
-#include <sstream>
 
 namespace lemonade {
 
@@ -52,12 +54,12 @@ static std::regex build_name_filter_regex(const std::string& name_filter) {
     return std::regex(regex_pattern, std::regex_constants::ECMAScript | std::regex_constants::icase);
 }
 
-static bool starts_with(const std::string& value, const std::string& prefix) {
+static bool starts_with(std::string_view value, std::string_view prefix) {
     return value.rfind(prefix, 0) == 0;
 }
 
-static std::string strip_canonical_prefix(const std::string& model_name) {
-    static const std::vector<std::string> prefixes = {"user.", "extra.", "builtin."};
+static std::string_view strip_canonical_prefix(std::string_view model_name) {
+    static constexpr std::string_view prefixes[] = {"user.", "extra.", "builtin."};
     for (const auto& prefix : prefixes) {
         if (starts_with(model_name, prefix)) {
             return model_name.substr(prefix.size());
@@ -66,7 +68,7 @@ static std::string strip_canonical_prefix(const std::string& model_name) {
     return model_name;
 }
 
-static int model_source_sort_rank(const std::string& model_name) {
+static int model_source_sort_rank(std::string_view model_name) {
     if (starts_with(model_name, "user.")) return 1;
     if (starts_with(model_name, "extra.")) return 2;
     if (starts_with(model_name, "builtin.")) return 3;
@@ -413,10 +415,12 @@ static double get_collection_component_size(const json& model) {
 static std::vector<double> get_collection_sizes(const json& collection_components, const json& server_models) {
     std::vector<double> collection_sizes;
     double component_size = UNKNOWN_MODEL_SIZE;
-    for (const auto component : collection_components){
+    for (const auto& component : collection_components) {
+        if (!component.is_string()) continue;
+        const std::string& comp_str = component.get_ref<const std::string&>();
         component_size = UNKNOWN_MODEL_SIZE;
         for (const auto& model : server_models) {
-            if (model.contains("id") && model["id"].get<std::string>() == component) {
+            if (model.contains("id") && model["id"].is_string() && model["id"].get_ref<const std::string&>() == comp_str) {
                 component_size = get_collection_component_size(model);
                 break;
             }
@@ -452,84 +456,177 @@ static std::string model_size_to_str(const ModelInfo& model) {
 std::vector<ModelInfo> LemonadeClient::get_models(bool show_all) const {
     std::vector<ModelInfo> models;
 
-    try {
-        std::string response = make_request("/api/v1/models?show_all=" + std::string(show_all ? "true" : "false"));
-        auto json_response = json::parse(response);
+    std::string response = make_request("/api/v1/models?show_all=" + std::string(show_all ? "true" : "false"));
+    auto json_response = json::parse(response);
 
-        if (!json_response.contains("data") || !json_response["data"].is_array()) {
-            return models;
+    if (!json_response.contains("data") || !json_response["data"].is_array()) {
+        return models;
+    }
+
+    for (const auto& model_item : json_response["data"]) {
+        ModelInfo info;
+
+        if (model_item.contains("id") && model_item["id"].is_string()) {
+            info.id = model_item["id"].get<std::string>();
         }
 
-        for (const auto& model_item : json_response["data"]) {
-            ModelInfo info;
+        if (model_item.contains("checkpoint") && model_item["checkpoint"].is_string()) {
+            info.checkpoint = model_item["checkpoint"].get<std::string>();
+        }
 
-            if (model_item.contains("id") && model_item["id"].is_string()) {
-                info.id = model_item["id"].get<std::string>();
-            }
+        if (model_item.contains("recipe") && model_item["recipe"].is_string()) {
+            info.recipe = model_item["recipe"].get<std::string>();
+        }
 
-            if (model_item.contains("checkpoint") && model_item["checkpoint"].is_string()) {
-                info.checkpoint = model_item["checkpoint"].get<std::string>();
-            }
+        if (model_item.contains("downloaded") && model_item["downloaded"].is_boolean()) {
+            info.downloaded = model_item["downloaded"].get<bool>();
+        }
 
-            if (model_item.contains("recipe") && model_item["recipe"].is_string()) {
-                info.recipe = model_item["recipe"].get<std::string>();
-            }
+        if (model_item.contains("suggested") && model_item["suggested"].is_boolean()) {
+            info.suggested = model_item["suggested"].get<bool>();
+        }
 
-            if (model_item.contains("downloaded") && model_item["downloaded"].is_boolean()) {
-                info.downloaded = model_item["downloaded"].get<bool>();
-            }
-
-            if (model_item.contains("suggested") && model_item["suggested"].is_boolean()) {
-                info.suggested = model_item["suggested"].get<bool>();
-            }
-
-            if (model_item.contains("labels") && model_item["labels"].is_array()) {
-                for (const auto& label : model_item["labels"]) {
-                    if (label.is_string()) {
-                        info.labels.push_back(label.get<std::string>());
-                    }
+        if (model_item.contains("labels") && model_item["labels"].is_array()) {
+            for (const auto& label : model_item["labels"]) {
+                if (label.is_string()) {
+                    info.labels.push_back(label.get<std::string>());
                 }
             }
-            if (model_item.contains("components") && model_item["components"].is_array() && !model_item["components"].empty()) {
-                info.component_sizes=get_collection_sizes(model_item["components"], json_response["data"]);
-            } else {
-                info.component_sizes.push_back(get_collection_component_size(model_item));
-            }
-
-            if (!info.id.empty()) {
-                models.push_back(info);
-            }
         }
 
-    } catch (const HttpError& e) {
-        std::cerr << "Error listing models: " << extract_server_error_message(e) << std::endl;
-        return {};
-    } catch (const json::exception& e) {
-        std::cerr << "Error parsing models JSON: " << e.what() << std::endl;
+        if (model_item.contains("source") && model_item["source"].is_string()) {
+            info.source = model_item["source"].get<std::string>();
+        } else {
+            info.source = "builtin";
+        }
+
+        if (model_item.contains("type") && model_item["type"].is_string()) {
+            info.type = model_item["type"].get<std::string>();
+        } else {
+            info.type = "llm";
+        }
+
+        if (model_item.contains("device") && model_item["device"].is_string()) {
+            info.device = model_item["device"].get<std::string>();
+        } else {
+            info.device = "none";
+        }
+
+        if (model_item.contains("recipe_options") && model_item["recipe_options"].is_object()) {
+            info.recipe_options = model_item["recipe_options"];
+        } else {
+            info.recipe_options = nlohmann::json::object();
+        }
+        if (model_item.contains("components") && model_item["components"].is_array() && !model_item["components"].empty()) {
+            info.component_sizes = get_collection_sizes(model_item["components"], json_response["data"]);
+        } else {
+            info.component_sizes.push_back(get_collection_component_size(model_item));
+        }
+
+        if (!info.id.empty()) {
+            models.push_back(info);
+        }
     }
 
     return models;
 }
 
-int LemonadeClient::list_models(bool show_all, const std::string& name_filter) const {
-    try {
-        std::vector<ModelInfo> models = get_models(show_all);
+// Case-insensitive helpers (avoids allocating new strings)
+static bool iequals(std::string_view a, std::string_view b) {
+    return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin(),
+        [](char c1, char c2) { return std::tolower(static_cast<unsigned char>(c1)) == std::tolower(static_cast<unsigned char>(c2)); });
+}
 
-        if (!name_filter.empty()) {
-            const std::regex filter_regex = build_name_filter_regex(name_filter);
-            models.erase(
-                std::remove_if(models.begin(), models.end(),
-                    [&](const ModelInfo& m) {
-                        return !std::regex_search(m.id, filter_regex) &&
-                               !std::regex_search(strip_canonical_prefix(m.id), filter_regex);
-                    }),
-                models.end());
+static bool device_matches(std::string_view m_device, std::string_view f_device) {
+    size_t start = 0;
+    while (start < m_device.size()) {
+        size_t pipe = m_device.find('|', start);
+        size_t len = (pipe == std::string_view::npos) ? m_device.size() - start : pipe - start;
+        if (iequals(m_device.substr(start, len), f_device)) {
+            return true;
         }
+        if (pipe == std::string_view::npos) {
+            break;
+        }
+        start = pipe + 1;
+    }
+    return false;
+}
+
+int LemonadeClient::list_models(const ListModelOptions& options) const {
+    try {
+        std::vector<ModelInfo> models = get_models(options.show_all);
+
+        // Pre-lowercase filter criteria once
+        std::string f_type = options.type;
+        std::transform(f_type.begin(), f_type.end(), f_type.begin(), ::tolower);
+
+        std::string f_source = options.source;
+        std::transform(f_source.begin(), f_source.end(), f_source.begin(), ::tolower);
+
+        std::string f_device = options.device;
+        std::transform(f_device.begin(), f_device.end(), f_device.begin(), ::tolower);
+
+        std::string f_backend = options.backend;
+        std::transform(f_backend.begin(), f_backend.end(), f_backend.begin(), ::tolower);
+
+        std::vector<std::string> f_labels = options.labels;
+        for (auto& l : f_labels) {
+            std::transform(l.begin(), l.end(), l.begin(), ::tolower);
+        }
+
+        // Build name filter regex once if specified
+        std::optional<std::regex> name_regex;
+        if (!options.name_filter.empty()) {
+            name_regex = build_name_filter_regex(options.name_filter);
+        }
+
+        // Single-pass filter
+        models.erase(
+            std::remove_if(models.begin(), models.end(),
+                [&](const ModelInfo& m) {
+                    // Return true to REMOVE the item
+
+                    // 1. Name Filter
+                    if (name_regex.has_value() && !std::regex_search(m.id, *name_regex)) {
+                        return true;
+                    }
+
+                    // 2. Type Filter
+                    if (!f_type.empty() && !iequals(m.type, f_type)) return true;
+
+                    // 3. Source Filter
+                    if (!f_source.empty() && !iequals(m.source, f_source)) return true;
+
+                    // 4. Device Filter
+                    if (!f_device.empty() && !device_matches(m.device, f_device)) return true;
+
+                    // 5. Suggested Filter
+                    if (options.suggested_only && !m.suggested) return true;
+
+                    // 6. Backend Filter
+                    if (!f_backend.empty() && !iequals(m.recipe, f_backend)) return true;
+
+                    // 7. Labels Filter
+                    for (const auto& f_label_lower : f_labels) {
+                        bool label_found = false;
+                        for (const auto& m_label : m.labels) {
+                            if (iequals(m_label, f_label_lower)) {
+                                label_found = true;
+                                break;
+                            }
+                        }
+                        if (!label_found) return true; // Label not found, remove
+                    }
+
+                    return false; // Keep the model
+                }),
+            models.end());
 
         std::sort(models.begin(), models.end(),
             [](const ModelInfo& a, const ModelInfo& b) {
-                const std::string bare_a = strip_canonical_prefix(a.id);
-                const std::string bare_b = strip_canonical_prefix(b.id);
+                const std::string_view bare_a = strip_canonical_prefix(a.id);
+                const std::string_view bare_b = strip_canonical_prefix(b.id);
                 const int bare_compare = bare_a.compare(bare_b);
                 if (bare_compare != 0) return bare_compare < 0;
 
@@ -539,8 +636,30 @@ int LemonadeClient::list_models(bool show_all, const std::string& name_filter) c
                 return a.id < b.id;
             });
 
+        if (options.json_output) {
+            nlohmann::json json_models = nlohmann::json::array();
+            for (const auto& model : models) {
+                nlohmann::json model_json = {
+                    {"id", model.id},
+                    {"checkpoint", model.checkpoint},
+                    {"recipe", model.recipe},
+                    {"downloaded", model.downloaded},
+                    {"suggested", model.suggested},
+                    {"labels", model.labels},
+                    {"source", model.source},
+                    {"type", model.type},
+                    {"device", model.device},
+                    {"recipe_options", model.recipe_options}
+                };
+                model_json["size_gb"] = std::accumulate(model.component_sizes.begin(), model.component_sizes.end(), 0.0);
+                json_models.push_back(model_json);
+            }
+            std::cout << json_models.dump(4) << std::endl;
+            return 0;
+        }
+
         if (models.empty()) {
-            std::cout << (show_all ? "No models available" : "No local models downloaded.") << std::endl;
+            std::cout << (options.show_all ? "No models available" : "No local models downloaded.") << std::endl;
             return 0;
         }
 
@@ -552,12 +671,6 @@ int LemonadeClient::list_models(bool show_all, const std::string& name_filter) c
                       << "Details" << std::endl;
             std::cout << std::string(100, '-') << std::endl;
 
-            // Model Name is the API id emitted verbatim by `/v1/models`. For each
-            // bare name, the precedence-winning source (registered > imported >
-            // builtin) shows as the bare name; any shadowed sources show as their
-            // canonical id (user.NAME / extra.NAME / builtin.NAME). Either form is
-            // valid input to `lemonade load`, `lemonade delete`, etc., so the
-            // column is always copy-paste-safe.
             for (const auto& model : models) {
                 std::string downloaded = model.downloaded ? "Yes" : "No";
                 std::string details = model.recipe.empty() ? "-" : model.recipe;
@@ -570,7 +683,7 @@ int LemonadeClient::list_models(bool show_all, const std::string& name_filter) c
             std::cout << std::string(100, '-') << std::endl;
         };
 
-        if (!show_all) {
+        if (!options.show_all) {
             print_model_table(models);
             return 0;
         }

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -178,6 +178,15 @@ struct CliConfig {
     std::string codex_model_provider = "lemonade";
     std::string agent_args;
 
+    // List command filtering options
+    bool list_json = false;
+    std::string list_type;
+    std::string list_source;
+    std::string list_device;
+    bool list_suggested = false;
+    std::vector<std::string> list_labels;
+    std::string list_backend;
+
     // Cloud provider commands
     std::string cloud_provider;
     std::string cloud_base_url;
@@ -1295,6 +1304,14 @@ int main(int argc, char* argv[]) {
 
     // List options
     list_cmd->add_flag("--downloaded", config.downloaded, "Show only downloaded models");
+    list_cmd->add_flag("--json", config.list_json, "Format output as JSON");
+    list_cmd->add_option("--type", config.list_type, "Filter by model type (llm, embedding, reranking, transcription, image, tts)");
+    list_cmd->add_option("--source", config.list_source, "Filter by model source (builtin, user, extra, cloud)");
+    list_cmd->add_option("--device", config.list_device, "Filter by model device (cpu, gpu, npu)");
+    list_cmd->add_flag("--suggested", config.list_suggested, "Show only suggested models");
+    list_cmd->add_option("--label", config.list_labels, "Filter by one or more labels")
+        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
+    list_cmd->add_option("--backend", config.list_backend, "Filter by backend/recipe");
     list_cmd->add_option("name_filter", config.list_filter,
         "Optional case-insensitive model-name filter; supports * wildcards")
         ->type_name("NAME_FILTER");
@@ -1568,7 +1585,17 @@ int main(int argc, char* argv[]) {
         }
         return client.status(config.port);
     } else if (list_cmd->count() > 0) {
-        return client.list_models(!config.downloaded, config.list_filter);
+        lemonade::ListModelOptions opts;
+        opts.show_all = !config.downloaded;
+        opts.name_filter = config.list_filter;
+        opts.json_output = config.list_json;
+        opts.type = config.list_type;
+        opts.source = config.list_source;
+        opts.device = config.list_device;
+        opts.suggested_only = config.list_suggested;
+        opts.labels = config.list_labels;
+        opts.backend = config.list_backend;
+        return client.list_models(opts);
     } else if (check_updates_cmd->count() > 0) {
         return client.check_model_updates();
     } else if (pull_cmd->count() > 0) {

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -54,6 +54,10 @@ struct ModelInfo {
     std::string download_url;
     std::string description;
     std::vector<double> component_sizes;
+    std::string source;
+    std::string type;
+    std::string device;
+    nlohmann::json recipe_options;
 };
 
 // Recipe backend status structure
@@ -71,6 +75,18 @@ struct RecipeStatus {
     std::vector<BackendStatus> backends;
 };
 
+struct ListModelOptions {
+    bool show_all = false;
+    std::string name_filter;
+    bool json_output = false;
+    std::string type;
+    std::string source;
+    std::string device;
+    bool suggested_only = false;
+    std::vector<std::string> labels;
+    std::string backend;
+};
+
 // Main CLI client class
 class LemonadeClient {
 public:
@@ -80,7 +96,7 @@ public:
     ~LemonadeClient();
 
     // Model management commands
-    int list_models(bool show_all, const std::string& name_filter = "") const;
+    int list_models(const ListModelOptions& options) const;
     int check_model_updates() const;
     // Pulls/registers a model. By default the pull is cache-first
     // (do_not_upgrade=true): an already-downloaded model is reused without

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3,6 +3,7 @@
 #include "lemon/auto_tune.h"
 #include "lemon/error_types.h"
 #include <optional>
+#include "lemon/canonical_id.h"
 #include "lemon/collection_orchestrator.h"
 #include "lemon/hf_variants.h"
 #include "lemon/model_registry.h"
@@ -2965,6 +2966,26 @@ nlohmann::json Server::model_info_to_json(const std::string& model_id, const Mod
     for (const auto& component : info.components) {
         public_components.push_back(model_manager_->get_public_model_name(component));
     }
+    std::string source_str = "builtin";
+    if (info.recipe == "cloud") {
+        source_str = "cloud";
+    } else {
+        std::string canonical_name = model_manager_->resolve_model_name(model_id);
+        if (auto canon = parse_canonical_id(canonical_name)) {
+            switch (canon->source) {
+                case ModelSource::Registered:
+                    source_str = "user";
+                    break;
+                case ModelSource::Imported:
+                    source_str = "extra";
+                    break;
+                case ModelSource::Builtin:
+                    source_str = "builtin";
+                    break;
+            }
+        }
+    }
+
     nlohmann::json model_json = {
         {"id", model_id},
         {"object", "model"},
@@ -2976,11 +2997,13 @@ nlohmann::json Server::model_info_to_json(const std::string& model_id, const Mod
         {"downloaded", info.downloaded},
         {"update_available", info.update_available},
         {"suggested", info.suggested},
-        {"source", info.source.empty() ? info.registry_source : info.source},
         {"registry_source", info.registry_source},
         {"labels", info.labels},
         {"components", public_components},
         {"recipe_options", info.recipe_options.to_json()},
+        {"type", model_type_to_string(info.type)},
+        {"device", device_type_to_string(info.device)},
+        {"source", source_str},
     };
 
     // Surface the cloud provider on cloud entries so the Model Manager can

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -434,13 +434,18 @@ sys.exit(0)
                 or "No models available" in line
             ):
                 continue
-            parts = line.split()
-            if len(parts) >= 2:
-                name = parts[0]
-                downloaded = parts[1] == "Yes"
-                details = parts[2] if len(parts) > 2 else ""
+
+            match = re.search(
+                r"^(.*?)\s*(Yes|No)\s+(>?\d+(?:\.\d+)?|N/A)(?:\s+[KMG]?B)?(?:\s+(.*))?$",
+                line,
+            )
+            if match:
                 parsed_models.append(
-                    {"name": name, "downloaded": downloaded, "details": details}
+                    {
+                        "name": match.group(1).strip(),
+                        "downloaded": match.group(2) == "Yes",
+                        "details": match.group(4).strip() if match.group(4) else "",
+                    }
                 )
         return parsed_models
 
@@ -519,6 +524,139 @@ sys.exit(0)
                     name,
                     downloaded_names,
                     f"Non-downloaded model {name} should not be in --downloaded list",
+                )
+
+    def test_022_list_json_format(self):
+        """Test list --json flag output and structure."""
+        result = self.assertCommandSucceeds(["list", "--json"])
+        output = result.stdout + result.stderr
+        try:
+            models_list = json.loads(output)
+        except Exception as e:
+            self.fail(f"list --json did not output valid JSON: {e}")
+
+        self.assertIsInstance(models_list, list)
+        if len(models_list) > 0:
+            first_model = models_list[0]
+            self.assertIn("id", first_model)
+            self.assertIn("checkpoint", first_model)
+            self.assertIn("recipe", first_model)
+            self.assertIn("downloaded", first_model)
+            self.assertIn("suggested", first_model)
+            self.assertIn("labels", first_model)
+            self.assertIn("source", first_model)
+            self.assertIn("type", first_model)
+            self.assertIn("device", first_model)
+            self.assertIn("recipe_options", first_model)
+            self.assertIn("size_gb", first_model)
+
+    def test_023_list_filters(self):
+        """Test list filtering by type, source, device, suggested, labels, backend, name filter, and case-insensitivity."""
+        # Query JSON list to analyze models
+        all_models = json.loads(self.assertCommandSucceeds(["list", "--json"]).stdout)
+
+        # Test --downloaded with --json
+        downloaded_json = json.loads(
+            self.assertCommandSucceeds(["list", "--downloaded", "--json"]).stdout
+        )
+        for m in downloaded_json:
+            self.assertTrue(m["downloaded"])
+
+        # Test --type filter
+        types = set(m["type"] for m in all_models if m.get("type"))
+        for t in types:
+            filtered = json.loads(
+                self.assertCommandSucceeds(["list", "--type", t, "--json"]).stdout
+            )
+            for m in filtered:
+                self.assertEqual(m["type"], t)
+
+        # Test case-insensitivity for --type
+        if types:
+            sample_type = list(types)[0]
+            filtered_upper = json.loads(
+                self.assertCommandSucceeds(
+                    ["list", "--type", sample_type.upper(), "--json"]
+                ).stdout
+            )
+            for m in filtered_upper:
+                self.assertEqual(m["type"], sample_type)
+
+        # Test --source filter
+        sources = set(m["source"] for m in all_models if m.get("source"))
+        for s in sources:
+            filtered = json.loads(
+                self.assertCommandSucceeds(["list", "--source", s, "--json"]).stdout
+            )
+            for m in filtered:
+                self.assertEqual(m["source"], s)
+
+        # Test --device filter
+        devices = set(m["device"] for m in all_models if m.get("device"))
+        for d in devices:
+            filtered = json.loads(
+                self.assertCommandSucceeds(["list", "--device", d, "--json"]).stdout
+            )
+            for m in filtered:
+                self.assertIn(d, m["device"])
+
+        # Test --suggested filter
+        filtered_suggested = json.loads(
+            self.assertCommandSucceeds(["list", "--suggested", "--json"]).stdout
+        )
+        for m in filtered_suggested:
+            self.assertTrue(m["suggested"])
+
+        # Test --backend filter
+        backends = set(m["recipe"] for m in all_models if m.get("recipe"))
+        for b in backends:
+            filtered = json.loads(
+                self.assertCommandSucceeds(["list", "--backend", b, "--json"]).stdout
+            )
+            for m in filtered:
+                self.assertEqual(m["recipe"], b)
+
+        # Test --label filter
+        labels = set()
+        for m in all_models:
+            if m.get("labels"):
+                labels.update(m["labels"])
+        if labels:
+            test_label = list(labels)[0]
+            filtered = json.loads(
+                self.assertCommandSucceeds(
+                    ["list", "--label", test_label, "--json"]
+                ).stdout
+            )
+            for m in filtered:
+                self.assertIn(test_label, m["labels"])
+
+        # Test multi-label AND conjunction filter if a model has >= 2 labels
+        multi_label_model = next(
+            (m for m in all_models if len(m.get("labels", [])) >= 2), None
+        )
+        if multi_label_model:
+            l1, l2 = multi_label_model["labels"][0], multi_label_model["labels"][1]
+            multi_filtered = json.loads(
+                self.assertCommandSucceeds(
+                    ["list", "--label", l1, "--label", l2, "--json"]
+                ).stdout
+            )
+            for m in multi_filtered:
+                self.assertIn(l1, m["labels"])
+                self.assertIn(l2, m["labels"])
+
+        # Test positional name_filter with wildcard
+        if len(all_models) > 0:
+            sample_name = all_models[0]["id"]
+            prefix = sample_name[:4]
+            wildcard_filtered = json.loads(
+                self.assertCommandSucceeds(["list", f"{prefix}*", "--json"]).stdout
+            )
+            for m in wildcard_filtered:
+                self.assertTrue(
+                    m["id"].lower().startswith(prefix.lower())
+                    or prefix.lower() in m["id"].lower()
                 )
 
     # =============================================================================


### PR DESCRIPTION
Extends the C++ server API and CLI client to support comprehensive model filtering and JSON output formatting. This allows CLI users to query, filter, and programmatically consume both local and downloadable models based on metadata.

## User Value
- **Advanced CLI Filtering**: Users can filter models using options like `--type`, `--source`, `--device`, `--suggested`, `--label`, and `--backend`.
- **JSON Formatting**: Adding the `--json` flag dumps the entire model list (with extended properties like device, backend options, size, labels, etc.) as a structured JSON array, enabling easy scripting and automation.
- **Layout Preservation**: Reliably handles very long model names without breaking column alignment or state indicators.
- **Up-to-Date Documentation**: Documented the new options under the CLI guide in the project's documentation (`docs/guide/cli.md`).

---

## Command Help Output (`lemonade list --help`)
```
List available models. Use --downloaded to show only local models.

./build/lemonade list [OPTIONS] [name_filter]

POSITIONALS:
  name_filter NAME_FILTER     Optional case-insensitive model-name filter; supports * wildcards

OPTIONS:
  -h,     --help              Display help information
          --help-all          Display help information for all subcommands
          --downloaded        Show only downloaded models
          --json              Format output as JSON
          --type TEXT         Filter by model type (llm, embedding, reranking, transcription,
                              image, tts)
          --source TEXT       Filter by model source (builtin, user, extra, cloud)
          --device TEXT       Filter by model device (cpu, gpu, npu)
          --suggested         Show only suggested models
          --label TEXT ...    Filter by one or more labels
          --backend TEXT      Filter by backend/recipe
```

---

## CLI Output Examples

### 1. Filtered List Example (`lemonade list --type llm`)
```
Local
Model Name                              Downloaded     Size (GB)      Details
----------------------------------------------------------------------------------------------------
Baguettotron-BF16                       Yes                0.60       llamacpp
Bonsai-1.7B-gguf                        Yes                0.25       llamacpp
GLM-4.7-Flash-GGUF                      Yes               17.50       llamacpp
```

### 2. JSON Format Example (`lemonade list --json`)
```json
[
    {
        "checkpoint": "PleIAs/Baguettotron-GGUF:Baguettotron-BF16.gguf",
        "device": "gpu",
        "downloaded": true,
        "id": "Baguettotron-BF16",
        "labels": [
            "custom",
            "llamacpp",
            "reasoning"
        ],
        "recipe": "llamacpp",
        "recipe_options": {
            "ctx_size": 0,
            "llamacpp_args": "--temp 0.7 --top-p 0.95 --flash-attn on --cache-type-k q8_0 --cache-type-v q8_0 --chat-template-kwargs '{\"preserve_thinking\": true}' -b 4096 -ub 1024",
            "llamacpp_backend": "vulkan"
        },
        "size_gb": 0.6,
        "source": "builtin",
        "suggested": true,
        "type": "llm"
    }
]
```