### PR TITLE
Router/2378 2379 evaluator registry

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -277,8 +277,10 @@ jobs:
           cmake --build --preset default --target test_directory_watcher
           cmake --build --preset default --target test_latest_version_fallback
           cmake --build --preset default --target test_routing_policy_contract
+          cmake --build --preset default --target test_routing_policy_evaluator
+          cmake --build --preset default --target test_routing_policy_registry
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicyContract"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry)Test"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -538,8 +540,10 @@ jobs:
           cmake --build --preset default --target test_directory_watcher
           cmake --build --preset default --target test_latest_version_fallback
           cmake --build --preset default --target test_routing_policy_contract
+          cmake --build --preset default --target test_routing_policy_evaluator
+          cmake --build --preset default --target test_routing_policy_registry
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicyContract"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry)Test"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1813,6 +1813,47 @@ if(EXISTS "${_ROUTING_CONTRACT_TEST_SRC}")
     add_test(NAME RoutingPolicyContractTest COMMAND test_routing_policy_contract)
 endif()
 
+# Routing match evaluator (issue #2378): composite Condition nodes,
+# classifier-band leaf evaluation, MatchExpr compilation, trace and memoization.
+set(_ROUTING_EVALUATOR_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_evaluator.cpp"
+)
+if(EXISTS "${_ROUTING_EVALUATOR_TEST_SRC}")
+    add_executable(test_routing_policy_evaluator
+        test/cpp/test_routing_policy_evaluator.cpp
+        src/cpp/server/routing_policy.cpp
+    )
+    target_include_directories(test_routing_policy_evaluator PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_routing_policy_evaluator PRIVATE nlohmann_json::nlohmann_json)
+
+    include(CTest)
+    add_test(NAME RoutingPolicyEvaluatorTest COMMAND test_routing_policy_evaluator)
+endif()
+
+# Routing classifier/condition registry (issue #2379): classifier JSON
+# instantiation, classifier leaf resolution, deterministic leaf dispatch seams.
+set(_ROUTING_REGISTRY_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_registry.cpp"
+)
+if(EXISTS "${_ROUTING_REGISTRY_TEST_SRC}")
+    add_executable(test_routing_policy_registry
+        test/cpp/test_routing_policy_registry.cpp
+        src/cpp/server/routing_policy.cpp
+    )
+    target_include_directories(test_routing_policy_registry PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_routing_policy_registry PRIVATE nlohmann_json::nlohmann_json)
+
+    include(CTest)
+    add_test(NAME RoutingPolicyRegistryTest COMMAND test_routing_policy_registry)
+endif()
+
 # Auto-tune: GGUF array storage, scalar derivation, weighted KV cache computation.
 # Covers head_count_kv_per_layer, sliding_window_pattern, SWA precise weighted sum,
 # full_attention_interval exact count, and scalar fallback paths.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,6 +595,7 @@ set(SOURCES_CORE
     src/cpp/server/streaming_proxy.cpp
     src/cpp/server/system_info.cpp
     src/cpp/server/recipe_options.cpp
+    src/cpp/server/routing_policy.cpp
     src/cpp/server/runtime_config.cpp
     src/cpp/server/logging_config.cpp
     src/cpp/server/log_stream.cpp

--- a/src/cpp/include/lemon/routing_policy.h
+++ b/src/cpp/include/lemon/routing_policy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <memory>
@@ -34,6 +35,11 @@
 namespace lemon {
 
 using json = nlohmann::json;
+
+// Maximum nesting for routing match expressions. The parser should enforce this
+// at policy load time; compile_match_expr also uses it defensively for manually
+// constructed ASTs.
+constexpr std::size_t kMaxMatchExprDepth = 64;
 
 // ---------------------------------------------------------------------------
 // Request-side context
@@ -86,7 +92,8 @@ struct Score {
     // — surfaced in the trace, never used for matching.
     std::string rationale;
 
-    // Score for an explicit label, or 0.0 if absent.
+    // Score for an explicit label, or 0.0 if absent. Extra labels returned by
+    // a classifier are ignored unless a condition references them.
     double score_of(const std::string& label) const {
         auto it = labels.find(label);
         return it == labels.end() ? 0.0 : it->second;
@@ -295,6 +302,36 @@ using ConditionPtr = std::shared_ptr<Condition>;
 // ops + classifier-band) registered downstream — neither side depends on the
 // other's implementation, only on this typedef.
 using LeafFactory = std::function<ConditionPtr(const json& leaf)>;
+using NamedLeafFactories = std::map<std::string, LeafFactory>;
+
+// Composite evaluator nodes and compiler (#2378). These are pure structural
+// conditions; concrete leaf behavior is supplied through LeafFactory.
+ConditionPtr make_all_condition(std::vector<ConditionPtr> children);
+ConditionPtr make_any_condition(std::vector<ConditionPtr> children);
+ConditionPtr make_not_condition(ConditionPtr child);
+
+// Classifier-band leaf (#2378). Applies an inclusive score band to a resolved
+// Classifier's Score, memoizing classifier execution in EvalContext.
+ConditionPtr make_classifier_band_condition(ClassifierPtr classifier,
+                                            std::optional<std::string> label,
+                                            std::optional<double> min_score,
+                                            std::optional<double> max_score);
+
+// Compile a parsed MatchExpr into an executable Condition tree. Composite nodes
+// are built here; leaf nodes delegate to the injected factory so deterministic
+// ops and classifier-band leaves can be registered independently.
+ConditionPtr compile_match_expr(const MatchExpr& expr, const LeafFactory& leaf_factory);
+
+// Classifier / condition registry helpers (#2379). These instantiate the
+// behavior-free contract objects from policy JSON while keeping live backend
+// access behind ClassifierServices.
+ClassifierPtr make_classifier(const json& config);
+std::map<std::string, ClassifierPtr> make_classifiers(const json& classifiers_json);
+
+// Builds the leaf factory used by compile_match_expr. Classifier leaves are
+// resolved here; deterministic leaf types are supplied by later issues.
+LeafFactory make_leaf_factory(const std::map<std::string, ClassifierPtr>& classifiers,
+                              NamedLeafFactories deterministic_factories = {});
 
 // ---------------------------------------------------------------------------
 // Policy + engine (constructor signature only here)

--- a/src/cpp/resources/schemas/README.md
+++ b/src/cpp/resources/schemas/README.md
@@ -80,6 +80,7 @@ v1** (pinned in the schema field descriptions):
 | `min_score` / `max_score` | **inclusive** band (`>=` / `<=`); default `min_score: 0.5` when neither bound is given |
 | `min_chars` / `max_chars` | input length in **UTF-8 bytes** (not code points) |
 | `metadata` | reads a request `metadata` key; **case-sensitive** comparison, value decoded into a comma-split, trimmed **token set** (`equals` exact / `any` set-intersection / `exists` presence) |
+| multi-key leaf object | interpreted as implicit **`all`**; e.g. `{"keywords_any":[...],"max_chars":1000}` means both leaves must match |
 | `on_error` (omitted) | default **`match_false`** (fail-open) |
 | `routing.router` desugaring | expansion to one `llm` classifier + identity rules is deterministic and behavior-equivalent across versions |
 

--- a/src/cpp/server/routing_policy.cpp
+++ b/src/cpp/server/routing_policy.cpp
@@ -1,0 +1,446 @@
+#include "lemon/routing_policy.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+#include <lemon/utils/aixlog.hpp>
+
+namespace lemon {
+namespace {
+
+Score failed_score() {
+    Score score;
+    score.ok = false;
+    return score;
+}
+
+void validate_children(const std::vector<ConditionPtr>& children,
+                       const char* condition_name) {
+    for (const auto& child : children) {
+        if (!child) {
+            throw std::invalid_argument(std::string(condition_name) +
+                                        " condition contains a null child");
+        }
+    }
+}
+
+class AllCondition final : public Condition {
+public:
+    explicit AllCondition(std::vector<ConditionPtr> children)
+        : children_(std::move(children)) {
+        if (children_.empty()) {
+            throw std::invalid_argument("all condition requires at least one child");
+        }
+        validate_children(children_, "all");
+    }
+
+    bool evaluate(EvalContext& ctx) const override {
+        for (const auto& child : children_) {
+            if (!child->evaluate(ctx)) return false;
+        }
+        return true;
+    }
+
+private:
+    std::vector<ConditionPtr> children_;
+};
+
+class AnyCondition final : public Condition {
+public:
+    explicit AnyCondition(std::vector<ConditionPtr> children)
+        : children_(std::move(children)) {
+        if (children_.empty()) {
+            throw std::invalid_argument("any condition requires at least one child");
+        }
+        validate_children(children_, "any");
+    }
+
+    bool evaluate(EvalContext& ctx) const override {
+        for (const auto& child : children_) {
+            if (child->evaluate(ctx)) return true;
+        }
+        return false;
+    }
+
+private:
+    std::vector<ConditionPtr> children_;
+};
+
+class NotCondition final : public Condition {
+public:
+    explicit NotCondition(ConditionPtr child)
+        : child_(std::move(child)) {
+        if (!child_) {
+            throw std::invalid_argument("not condition requires one child");
+        }
+    }
+
+    bool evaluate(EvalContext& ctx) const override {
+        return !child_->evaluate(ctx);
+    }
+
+private:
+    ConditionPtr child_;
+};
+
+class ClassifierBandCondition final : public Condition {
+public:
+    ClassifierBandCondition(ClassifierPtr classifier,
+                            std::optional<std::string> label,
+                            std::optional<double> min_score,
+                            std::optional<double> max_score)
+        : classifier_(std::move(classifier)),
+          label_(std::move(label)),
+          min_score_(min_score),
+          max_score_(max_score) {
+        if (!classifier_) {
+            throw std::invalid_argument("classifier condition requires a classifier");
+        }
+        if (!min_score_.has_value() && !max_score_.has_value()) {
+            min_score_ = 0.5;
+        }
+        if (min_score_.has_value() && max_score_.has_value() && *min_score_ > *max_score_) {
+            throw std::invalid_argument("classifier condition min_score cannot exceed max_score");
+        }
+    }
+
+    bool evaluate(EvalContext& ctx) const override {
+        const Score& score = score_for(ctx);
+
+        std::optional<double> traced_score;
+        bool result = false;
+        if (!score.ok) {
+            result = classifier_->on_error() == OnError::MatchTrue;
+        } else {
+            double value = selected_score(score);
+            traced_score = value;
+            result = in_band(value);
+        }
+
+        if (ctx.want_trace) {
+            ctx.trace.push_back(TraceEntry{"classifier:" + classifier_->id(), traced_score, result});
+        }
+        return result;
+    }
+
+private:
+    const Score& score_for(EvalContext& ctx) const {
+        auto [it, inserted] = ctx.memo.try_emplace(classifier_->id());
+        if (inserted) {
+            try {
+                it->second = classifier_->evaluate(ClassifierContext{ctx.request, ctx.services});
+            } catch (const std::exception& e) {
+                // Classifier implementations should return Score{ok=false}
+                // rather than throw. Keep this catch as a permanent safety
+                // net: model-backed services can fail in unexpected ways, and
+                // routing must convert that to on_error rather than letting an
+                // exception escape evaluation.
+                LOG(WARNING, "Routing") << "Classifier '" << classifier_->id()
+                                        << "' threw during evaluation: " << e.what()
+                                        << std::endl;
+                it->second = failed_score();
+            } catch (...) {
+                LOG(WARNING, "Routing") << "Classifier '" << classifier_->id()
+                                        << "' threw an unknown exception during evaluation"
+                                        << std::endl;
+                it->second = failed_score();
+            }
+        }
+        return it->second;
+    }
+
+    double selected_score(const Score& score) const {
+        if (label_.has_value()) {
+            return score.score_of(*label_);
+        }
+        if (classifier_->default_label().has_value()) {
+            return score.score_of(*classifier_->default_label());
+        }
+        // Single-score classifiers, e.g. semantic_similarity, declare no labels
+        // and report their score under the empty-string key.
+        return score.primary();
+    }
+
+    bool in_band(double value) const {
+        if (min_score_.has_value() && value < *min_score_) return false;
+        if (max_score_.has_value() && value > *max_score_) return false;
+        return true;
+    }
+
+    ClassifierPtr classifier_;
+    std::optional<std::string> label_;
+    std::optional<double> min_score_;
+    std::optional<double> max_score_;
+};
+
+class ModelClassifier final : public Classifier {
+public:
+    ModelClassifier(std::string id, std::string type, std::string model, OnError on_error,
+                    std::vector<std::string> labels,
+                    std::optional<std::string> default_label)
+        : Classifier(std::move(id), std::move(type), on_error, std::move(labels),
+                     std::move(default_label)),
+          model_(std::move(model)) {
+        if (model_.empty()) {
+            throw std::invalid_argument("classifier requires model");
+        }
+    }
+
+    Score evaluate(const ClassifierContext& ctx) const override {
+        Score score;
+        if (!ctx.services.run_classifier) {
+            return failed_score();
+        }
+
+        try {
+            score.labels = ctx.services.run_classifier(model_, ctx.request.input);
+            score.ok = true;
+        } catch (...) {
+            score = failed_score();
+        }
+        return score;
+    }
+
+private:
+    std::string model_;
+};
+
+std::vector<ConditionPtr> compile_children(const std::vector<MatchExpr>& children,
+                                           const LeafFactory& leaf_factory,
+                                           std::size_t depth);
+
+ConditionPtr compile_match_expr_impl(const MatchExpr& expr,
+                                     const LeafFactory& leaf_factory,
+                                     std::size_t depth) {
+    if (depth > kMaxMatchExprDepth) {
+        throw std::invalid_argument("match expression nesting exceeds maximum depth");
+    }
+
+    switch (expr.op) {
+        case MatchExpr::Op::Leaf: {
+            if (!leaf_factory) {
+                throw std::invalid_argument("leaf factory is required");
+            }
+            auto condition = leaf_factory(expr.leaf);
+            if (!condition) {
+                throw std::invalid_argument("leaf factory returned null condition");
+            }
+            return condition;
+        }
+        case MatchExpr::Op::All:
+            if (expr.children.empty()) {
+                throw std::invalid_argument("all expression requires at least one child");
+            }
+            return make_all_condition(compile_children(expr.children, leaf_factory, depth + 1));
+        case MatchExpr::Op::Any:
+            if (expr.children.empty()) {
+                throw std::invalid_argument("any expression requires at least one child");
+            }
+            return make_any_condition(compile_children(expr.children, leaf_factory, depth + 1));
+        case MatchExpr::Op::Not:
+            if (expr.children.size() != 1) {
+                throw std::invalid_argument("not expression requires exactly one child");
+            }
+            return make_not_condition(compile_match_expr_impl(expr.children[0], leaf_factory, depth + 1));
+    }
+    throw std::invalid_argument("unsupported match expression op");
+}
+
+std::vector<ConditionPtr> compile_children(const std::vector<MatchExpr>& children,
+                                           const LeafFactory& leaf_factory,
+                                           std::size_t depth) {
+    std::vector<ConditionPtr> compiled;
+    compiled.reserve(children.size());
+    for (const auto& child : children) {
+        compiled.push_back(compile_match_expr_impl(child, leaf_factory, depth));
+    }
+    return compiled;
+}
+
+} // namespace
+
+ConditionPtr make_all_condition(std::vector<ConditionPtr> children) {
+    return std::make_shared<AllCondition>(std::move(children));
+}
+
+ConditionPtr make_any_condition(std::vector<ConditionPtr> children) {
+    return std::make_shared<AnyCondition>(std::move(children));
+}
+
+ConditionPtr make_not_condition(ConditionPtr child) {
+    return std::make_shared<NotCondition>(std::move(child));
+}
+
+ConditionPtr make_classifier_band_condition(ClassifierPtr classifier,
+                                            std::optional<std::string> label,
+                                            std::optional<double> min_score,
+                                            std::optional<double> max_score) {
+    return std::make_shared<ClassifierBandCondition>(
+        std::move(classifier), std::move(label), min_score, max_score);
+}
+
+ConditionPtr compile_match_expr(const MatchExpr& expr, const LeafFactory& leaf_factory) {
+    return compile_match_expr_impl(expr, leaf_factory, 0);
+}
+
+ClassifierPtr make_classifier(const json& config) {
+    if (!config.is_object()) {
+        throw std::invalid_argument("classifier entry must be an object");
+    }
+
+    const std::string id = config.value("id", "");
+    const std::string type = config.value("type", "");
+    if (id.empty()) {
+        throw std::invalid_argument("classifier is missing id");
+    }
+    if (type.empty()) {
+        throw std::invalid_argument("classifier '" + id + "' is missing type");
+    }
+
+    OnError on_error = parse_on_error(config.value("on_error", "match_false"));
+    std::vector<std::string> labels;
+    if (config.contains("labels")) {
+        if (!config["labels"].is_array()) {
+            throw std::invalid_argument("classifier '" + id + "' labels must be an array");
+        }
+        for (const auto& item : config["labels"]) {
+            if (!item.is_string() || item.get<std::string>().empty()) {
+                throw std::invalid_argument("classifier '" + id + "' labels must be non-empty strings");
+            }
+            labels.push_back(item.get<std::string>());
+        }
+    }
+
+    std::optional<std::string> default_label;
+    if (config.contains("default_label")) {
+        if (!config["default_label"].is_string() || config["default_label"].get<std::string>().empty()) {
+            throw std::invalid_argument("classifier '" + id + "' default_label must be a non-empty string");
+        }
+        default_label = config["default_label"].get<std::string>();
+        if (labels.empty()) {
+            throw std::invalid_argument("classifier '" + id + "' default_label requires labels");
+        }
+        if (std::find(labels.begin(), labels.end(), *default_label) == labels.end()) {
+            throw std::invalid_argument("classifier '" + id + "' default_label is not declared in labels");
+        }
+    }
+
+    if (type == "classifier") {
+        return std::make_shared<ModelClassifier>(
+            id, type, config.value("model", ""), on_error, std::move(labels), std::move(default_label));
+    }
+
+    if (type == "semantic_similarity" || type == "llm" ||
+        type == "pii_detection" || type == "prompt_safety" ||
+        type == "language_detection" || type == "domain_classification" ||
+        type == "complexity" || type == "sentiment") {
+        throw std::invalid_argument("classifier type not implemented yet: " + type);
+    }
+
+    throw std::invalid_argument("unknown classifier type: " + type);
+}
+
+std::map<std::string, ClassifierPtr> make_classifiers(const json& classifiers_json) {
+    std::map<std::string, ClassifierPtr> classifiers;
+    if (classifiers_json.is_null()) {
+        return classifiers;
+    }
+    if (!classifiers_json.is_array()) {
+        throw std::invalid_argument("routing.classifiers must be an array");
+    }
+
+    for (const auto& item : classifiers_json) {
+        auto classifier = make_classifier(item);
+        if (!classifiers.emplace(classifier->id(), classifier).second) {
+            throw std::invalid_argument("duplicate classifier id: " + classifier->id());
+        }
+    }
+    return classifiers;
+}
+
+LeafFactory make_leaf_factory(const std::map<std::string, ClassifierPtr>& classifiers,
+                              NamedLeafFactories deterministic_factories) {
+    return [classifiers, deterministic_factories = std::move(deterministic_factories)](
+               const json& leaf) -> ConditionPtr {
+        if (!leaf.is_object()) {
+            throw std::invalid_argument("leaf condition must be an object");
+        }
+
+        std::vector<ConditionPtr> conditions;
+        if (leaf.contains("classifier")) {
+            if (!leaf["classifier"].is_string() || leaf["classifier"].get<std::string>().empty()) {
+                throw std::invalid_argument("classifier leaf requires non-empty classifier id");
+            }
+            const std::string id = leaf["classifier"].get<std::string>();
+            auto classifier_it = classifiers.find(id);
+            if (classifier_it == classifiers.end()) {
+                throw std::invalid_argument("unknown classifier reference: " + id);
+            }
+            const auto& classifier = classifier_it->second;
+
+            std::optional<std::string> label;
+            if (leaf.contains("label")) {
+                if (!leaf["label"].is_string() || leaf["label"].get<std::string>().empty()) {
+                    throw std::invalid_argument("classifier leaf label must be a non-empty string");
+                }
+                label = leaf["label"].get<std::string>();
+                const auto& labels = classifier->labels();
+                if (labels.empty() ||
+                    std::find(labels.begin(), labels.end(), *label) == labels.end()) {
+                    throw std::invalid_argument("classifier '" + id + "' has no label: " + *label);
+                }
+            } else if (!classifier->labels().empty() && !classifier->default_label().has_value()) {
+                throw std::invalid_argument(
+                    "classifier leaf omits label but classifier has no default_label: " + id);
+            }
+
+            std::optional<double> min_score;
+            std::optional<double> max_score;
+            if (leaf.contains("min_score")) {
+                if (!leaf["min_score"].is_number()) {
+                    throw std::invalid_argument("classifier leaf min_score must be numeric");
+                }
+                min_score = leaf["min_score"].get<double>();
+            }
+            if (leaf.contains("max_score")) {
+                if (!leaf["max_score"].is_number()) {
+                    throw std::invalid_argument("classifier leaf max_score must be numeric");
+                }
+                max_score = leaf["max_score"].get<double>();
+            }
+            conditions.push_back(
+                make_classifier_band_condition(classifier, label, min_score, max_score));
+        } else {
+            for (const char* classifier_only : {"label", "min_score", "max_score"}) {
+                if (leaf.contains(classifier_only)) {
+                    throw std::invalid_argument(
+                        std::string("classifier leaf field requires classifier: ") + classifier_only);
+                }
+            }
+        }
+
+        for (const auto& [key, factory] : deterministic_factories) {
+            if (!leaf.contains(key)) continue;
+            if (!factory) {
+                throw std::invalid_argument("deterministic leaf factory is null: " + key);
+            }
+            json single = json::object();
+            single[key] = leaf.at(key);
+            auto condition = factory(single);
+            if (!condition) {
+                throw std::invalid_argument("deterministic leaf factory returned null: " + key);
+            }
+            conditions.push_back(std::move(condition));
+        }
+
+        if (conditions.empty()) {
+            throw std::invalid_argument("unknown leaf condition");
+        }
+        if (conditions.size() == 1) {
+            return conditions.front();
+        }
+        return make_all_condition(std::move(conditions));
+    };
+}
+
+} // namespace lemon

--- a/test/cpp/test_routing_policy_evaluator.cpp
+++ b/test/cpp/test_routing_policy_evaluator.cpp
@@ -1,0 +1,337 @@
+// Unit tests for the Lemonade Router match evaluator (#2378).
+//
+// Compile (standalone):
+//   g++ -std=c++17 -I src/cpp/include -I build/_deps/json-src/include \
+//       test/cpp/test_routing_policy_evaluator.cpp src/cpp/server/routing_policy.cpp \
+//       -o test_routing_policy_evaluator
+
+#include "lemon/routing_policy.h"
+
+#include <cstdio>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using lemon::Classifier;
+using lemon::ClassifierContext;
+using lemon::Condition;
+using lemon::ConditionPtr;
+using lemon::EvalContext;
+using lemon::LeafFactory;
+using lemon::MatchExpr;
+using lemon::OnError;
+using lemon::RouteContext;
+using lemon::Score;
+using lemon::json;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+namespace {
+
+struct CountingCondition : Condition {
+    bool value;
+    int* calls;
+    std::string trace_name;
+
+    CountingCondition(bool v, int* c, std::string name = "counting")
+        : value(v), calls(c), trace_name(std::move(name)) {}
+
+    bool evaluate(EvalContext& ctx) const override {
+        ++(*calls);
+        if (ctx.want_trace) {
+            ctx.trace.push_back(lemon::TraceEntry{trace_name, std::nullopt, value});
+        }
+        return value;
+    }
+};
+
+struct FixedClassifier : Classifier {
+    mutable int calls = 0;
+    Score score;
+
+    FixedClassifier(std::string id, OnError on_error, Score s,
+                    std::vector<std::string> labels = {},
+                    std::optional<std::string> default_label = std::nullopt)
+        : Classifier(std::move(id), "classifier", on_error, std::move(labels),
+                     std::move(default_label)),
+          score(std::move(s)) {}
+
+    Score evaluate(const ClassifierContext&) const override {
+        ++calls;
+        return score;
+    }
+};
+
+struct ThrowingClassifier : Classifier {
+    mutable int calls = 0;
+
+    ThrowingClassifier(std::string id, OnError on_error)
+        : Classifier(std::move(id), "classifier", on_error) {}
+
+    Score evaluate(const ClassifierContext&) const override {
+        ++calls;
+        throw std::runtime_error("boom");
+    }
+};
+
+} // namespace
+
+static EvalContext make_eval_context(bool want_trace = false) {
+    static RouteContext route;
+    static lemon::ClassifierServices services;
+    route.input = "hello";
+    route.params.model = "user.Router";
+    route.params.chars = route.input.size();
+    EvalContext ctx{route, services};
+    ctx.want_trace = want_trace;
+    return ctx;
+}
+
+static void test_composite_short_circuit() {
+    int a = 0, b = 0;
+    EvalContext ctx = make_eval_context();
+    auto all = lemon::make_all_condition({
+        std::make_shared<CountingCondition>(false, &a),
+        std::make_shared<CountingCondition>(true, &b),
+    });
+    check("all short-circuits on first false", !all->evaluate(ctx) && a == 1 && b == 0);
+
+    a = 0;
+    b = 0;
+    auto any = lemon::make_any_condition({
+        std::make_shared<CountingCondition>(true, &a),
+        std::make_shared<CountingCondition>(false, &b),
+    });
+    check("any short-circuits on first true", any->evaluate(ctx) && a == 1 && b == 0);
+}
+
+static void test_not_and_deep_compile() {
+    int calls = 0;
+    LeafFactory factory = [&](const json& leaf) -> ConditionPtr {
+        return std::make_shared<CountingCondition>(leaf.value("value", false), &calls);
+    };
+
+    MatchExpr leaf_false;
+    leaf_false.op = MatchExpr::Op::Leaf;
+    leaf_false.leaf = json{{"value", false}};
+    MatchExpr not_false;
+    not_false.op = MatchExpr::Op::Not;
+    not_false.children = {leaf_false};
+
+    EvalContext ctx = make_eval_context();
+    auto not_condition = lemon::compile_match_expr(not_false, factory);
+    check("not inverts child result", not_condition->evaluate(ctx) && calls == 1);
+
+    MatchExpr leaf_true;
+    leaf_true.op = MatchExpr::Op::Leaf;
+    leaf_true.leaf = json{{"value", true}};
+    MatchExpr any;
+    any.op = MatchExpr::Op::Any;
+    any.children = {leaf_false, leaf_true};
+    MatchExpr all;
+    all.op = MatchExpr::Op::All;
+    all.children = {not_false, any};
+
+    calls = 0;
+    auto deep = lemon::compile_match_expr(all, factory);
+    check("deep nested compile/evaluate succeeds", deep->evaluate(ctx) && calls == 3);
+}
+
+static void test_compile_rejects_malformed_ast() {
+    static int unused_calls = 0;
+    LeafFactory factory = [](const json&) -> ConditionPtr {
+        return std::make_shared<CountingCondition>(true, &unused_calls);
+    };
+
+    bool threw_any = false;
+    try {
+        MatchExpr bad;
+        bad.op = MatchExpr::Op::Any;
+        lemon::compile_match_expr(bad, factory);
+    } catch (const std::invalid_argument&) {
+        threw_any = true;
+    }
+    check("compile rejects empty any", threw_any);
+
+    bool threw_not = false;
+    try {
+        MatchExpr bad;
+        bad.op = MatchExpr::Op::Not;
+        bad.children = {MatchExpr{}, MatchExpr{}};
+        lemon::compile_match_expr(bad, factory);
+    } catch (const std::invalid_argument&) {
+        threw_not = true;
+    }
+    check("compile rejects not with multiple children", threw_not);
+}
+
+static void test_compile_rejects_excessive_depth() {
+    LeafFactory factory = [](const json&) -> ConditionPtr {
+        static int calls = 0;
+        return std::make_shared<CountingCondition>(true, &calls);
+    };
+
+    MatchExpr leaf;
+    leaf.op = MatchExpr::Op::Leaf;
+    leaf.leaf = json{{"value", true}};
+
+    MatchExpr nested = leaf;
+    for (int i = 0; i < 70; ++i) {
+        MatchExpr parent;
+        parent.op = MatchExpr::Op::Not;
+        parent.children = {nested};
+        nested = parent;
+    }
+
+    bool threw = false;
+    try {
+        lemon::compile_match_expr(nested, factory);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("compile rejects excessive match depth", threw);
+}
+
+static void test_classifier_band_boundaries_and_defaults() {
+    Score s;
+    s.labels["PII"] = 0.5;
+    auto classifier = std::make_shared<FixedClassifier>(
+        "pii", OnError::MatchFalse, s, std::vector<std::string>{"PII"}, std::string("PII"));
+
+    EvalContext ctx = make_eval_context();
+    auto min_ok = lemon::make_classifier_band_condition(classifier, std::nullopt, 0.5, std::nullopt);
+    check("classifier min_score boundary is inclusive", min_ok->evaluate(ctx));
+
+    EvalContext ctx2 = make_eval_context();
+    auto max_ok = lemon::make_classifier_band_condition(classifier, std::string("PII"), std::nullopt, 0.5);
+    check("classifier max_score boundary is inclusive", max_ok->evaluate(ctx2));
+
+    EvalContext ctx3 = make_eval_context();
+    auto default_min = lemon::make_classifier_band_condition(classifier, std::nullopt, std::nullopt, std::nullopt);
+    check("classifier omitted band defaults to min_score 0.5", default_min->evaluate(ctx3));
+
+    Score low;
+    low.labels["PII"] = 0.49;
+    auto low_classifier = std::make_shared<FixedClassifier>(
+        "low", OnError::MatchFalse, low, std::vector<std::string>{"PII"}, std::string("PII"));
+    EvalContext ctx4 = make_eval_context();
+    auto low_default = lemon::make_classifier_band_condition(low_classifier, std::nullopt, std::nullopt, std::nullopt);
+    check("classifier default min_score rejects below 0.5", !low_default->evaluate(ctx4));
+}
+
+static void test_classifier_score_selection_and_primary() {
+    Score labeled;
+    labeled.labels["PII"] = 0.1;
+    labeled.labels["NO_PII"] = 0.9;
+    auto classifier = std::make_shared<FixedClassifier>(
+        "pii", OnError::MatchFalse, labeled, std::vector<std::string>{"PII", "NO_PII"},
+        std::string("NO_PII"));
+
+    EvalContext ctx = make_eval_context();
+    auto condition = lemon::make_classifier_band_condition(classifier, std::nullopt, 0.8, std::nullopt);
+    check("classifier condition uses default_label when label omitted", condition->evaluate(ctx));
+
+    Score single;
+    single.labels[""] = 0.72;
+    auto similarity = std::make_shared<FixedClassifier>(
+        "sim", OnError::MatchFalse, single);
+    EvalContext ctx2 = make_eval_context();
+    auto primary = lemon::make_classifier_band_condition(similarity, std::nullopt, 0.7, std::nullopt);
+    check("classifier condition falls back to Score::primary", primary->evaluate(ctx2));
+
+    Score missing;
+    missing.labels["NO_PII"] = 0.99;
+    auto missing_label_classifier = std::make_shared<FixedClassifier>(
+        "missing", OnError::MatchFalse, missing,
+        std::vector<std::string>{"PII", "NO_PII"}, std::string("PII"));
+    EvalContext ctx3 = make_eval_context();
+    auto missing_label = lemon::make_classifier_band_condition(
+        missing_label_classifier, std::nullopt, 0.5, std::nullopt);
+    check("missing classifier output label scores as 0", !missing_label->evaluate(ctx3));
+}
+
+static void test_classifier_on_error_and_throwing() {
+    Score failed;
+    failed.ok = false;
+
+    auto fail_true = std::make_shared<FixedClassifier>("fail_true", OnError::MatchTrue, failed);
+    EvalContext ctx = make_eval_context();
+    auto true_condition = lemon::make_classifier_band_condition(fail_true, std::nullopt, 0.5, std::nullopt);
+    check("classifier on_error match_true returns true", true_condition->evaluate(ctx));
+
+    auto fail_false = std::make_shared<FixedClassifier>("fail_false", OnError::MatchFalse, failed);
+    EvalContext ctx2 = make_eval_context();
+    auto false_condition = lemon::make_classifier_band_condition(fail_false, std::nullopt, 0.5, std::nullopt);
+    check("classifier on_error match_false returns false", !false_condition->evaluate(ctx2));
+
+    auto throwing = std::make_shared<ThrowingClassifier>("throwing", OnError::MatchTrue);
+    EvalContext ctx3 = make_eval_context();
+    auto throwing_condition = lemon::make_classifier_band_condition(throwing, std::nullopt, 0.5, std::nullopt);
+    check("classifier exceptions become on_error decisions", throwing_condition->evaluate(ctx3));
+}
+
+static void test_classifier_memoization_and_trace() {
+    Score s;
+    s.labels["PII"] = 0.9;
+    auto classifier = std::make_shared<FixedClassifier>(
+        "pii", OnError::MatchFalse, s, std::vector<std::string>{"PII"}, std::string("PII"));
+
+    auto left = lemon::make_classifier_band_condition(classifier, std::nullopt, 0.5, std::nullopt);
+    auto right = lemon::make_classifier_band_condition(classifier, std::string("PII"), 0.8, std::nullopt);
+    auto all = lemon::make_all_condition({left, right});
+
+    EvalContext ctx = make_eval_context(true);
+    check("classifier memoized across multiple conditions", all->evaluate(ctx) && classifier->calls == 1);
+    check("trace includes evaluated classifier leaves", ctx.trace.size() == 2 &&
+              ctx.trace[0].condition == "classifier:pii" &&
+              ctx.trace[0].score.has_value() && *ctx.trace[0].score == 0.9);
+
+    int skipped_calls = 0;
+    auto short_circuit = lemon::make_any_condition({
+        std::make_shared<CountingCondition>(true, &skipped_calls, "first"),
+        std::make_shared<CountingCondition>(true, &skipped_calls, "second"),
+    });
+    EvalContext trace_ctx = make_eval_context(true);
+    check("trace omits short-circuited branches", short_circuit->evaluate(trace_ctx) &&
+              skipped_calls == 1 && trace_ctx.trace.size() == 1 &&
+              trace_ctx.trace[0].condition == "first");
+
+    EvalContext no_trace_ctx = make_eval_context(false);
+    check("trace disabled leaves trace empty", left->evaluate(no_trace_ctx) &&
+              no_trace_ctx.trace.empty());
+}
+
+static void test_classifier_band_rejects_bad_band() {
+    auto classifier = std::make_shared<FixedClassifier>("pii", OnError::MatchFalse, Score{});
+    bool threw = false;
+    try {
+        lemon::make_classifier_band_condition(classifier, std::nullopt, 0.9, 0.1);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("classifier band rejects min_score > max_score", threw);
+}
+
+int main() {
+    test_composite_short_circuit();
+    test_not_and_deep_compile();
+    test_compile_rejects_malformed_ast();
+    test_compile_rejects_excessive_depth();
+    test_classifier_band_boundaries_and_defaults();
+    test_classifier_score_selection_and_primary();
+    test_classifier_on_error_and_throwing();
+    test_classifier_memoization_and_trace();
+    test_classifier_band_rejects_bad_band();
+
+    std::printf("\n%s\n", g_failures == 0 ? "ALL EVALUATOR TESTS PASSED"
+                                          : "EVALUATOR TESTS FAILED");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_routing_policy_registry.cpp
+++ b/test/cpp/test_routing_policy_registry.cpp
@@ -1,0 +1,272 @@
+// Unit tests for the Lemonade Router classifier/leaf registry (#2379).
+
+#include "fake_classifier_services.h"
+#include "lemon/routing_policy.h"
+
+#include <cstdio>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+using lemon::Condition;
+using lemon::ConditionPtr;
+using lemon::EvalContext;
+using lemon::NamedLeafFactories;
+using lemon::RouteContext;
+using lemon::json;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+namespace {
+
+struct ConstCondition : Condition {
+    bool value;
+    int* calls;
+    std::string trace_name;
+
+    ConstCondition(bool v, int* c, std::string name)
+        : value(v), calls(c), trace_name(std::move(name)) {}
+
+    bool evaluate(EvalContext& ctx) const override {
+        ++(*calls);
+        if (ctx.want_trace) ctx.trace.push_back(lemon::TraceEntry{trace_name, std::nullopt, value});
+        return value;
+    }
+};
+
+} // namespace
+
+static RouteContext make_route_context() {
+    RouteContext route;
+    route.input = "my ssn is 123";
+    route.params.model = "user.Router";
+    route.params.chars = route.input.size();
+    return route;
+}
+
+static EvalContext make_eval_context(const RouteContext& route,
+                                     const lemon::ClassifierServices& services,
+                                     bool want_trace = false) {
+    EvalContext ctx{route, services};
+    ctx.want_trace = want_trace;
+    return ctx;
+}
+
+static bool throws_invalid_arg(const std::function<void()>& fn) {
+    try {
+        fn();
+    } catch (const std::invalid_argument&) {
+        return true;
+    }
+    return false;
+}
+
+static void test_make_classifier() {
+    json cfg = {
+        {"id", "pii"},
+        {"type", "classifier"},
+        {"model", "pii-detector-small"},
+        {"labels", json::array({"PII", "NO_PII"})},
+        {"default_label", "PII"},
+        {"on_error", "match_true"},
+    };
+    auto classifier = lemon::make_classifier(cfg);
+    check("make_classifier builds generic classifier", classifier->id() == "pii" &&
+              classifier->type() == "classifier");
+    check("make_classifier preserves labels/default/on_error",
+          classifier->labels().size() == 2 &&
+              classifier->default_label().has_value() &&
+              *classifier->default_label() == "PII" &&
+              classifier->on_error() == lemon::OnError::MatchTrue);
+
+    lemon::testing::FakeClassifierServices fake;
+    fake.set_classifier_scores("pii-detector-small", {{"PII", 0.91}, {"NO_PII", 0.09}});
+    auto services = fake.make();
+    auto route = make_route_context();
+    EvalContext ctx = make_eval_context(route, services);
+    auto score = classifier->evaluate(lemon::ClassifierContext{ctx.request, ctx.services});
+    check("generic classifier calls run_classifier service", score.ok && score.score_of("PII") == 0.91);
+}
+
+static void test_make_classifier_rejections() {
+    check("make_classifier rejects missing id",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"type", "classifier"}, {"model", "m"}});
+          }));
+    check("make_classifier rejects missing type",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "x"}, {"model", "m"}});
+          }));
+    check("make_classifier rejects missing model for classifier",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "x"}, {"type", "classifier"}});
+          }));
+    check("make_classifier rejects default_label without labels",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "x"}, {"type", "classifier"},
+                                          {"model", "m"}, {"default_label", "PII"}});
+          }));
+    check("make_classifier rejects default_label not in labels",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "x"}, {"type", "classifier"},
+                                          {"model", "m"},
+                                          {"labels", json::array({"NO_PII"})},
+                                          {"default_label", "PII"}});
+          }));
+    check("make_classifier rejects unknown type",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "x"}, {"type", "mystery"},
+                                          {"model", "m"}});
+          }));
+    check("make_classifier clearly rejects semantic_similarity for now",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "sim"}, {"type", "semantic_similarity"},
+                                          {"model", "m"},
+                                          {"reference_phrases", json::array({"return"})}});
+          }));
+    check("make_classifier clearly rejects llm for now",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "router"}, {"type", "llm"},
+                                          {"model", "m"}, {"prompt", "choose"}});
+          }));
+    check("make_classifier clearly rejects reserved presets for now",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "pii"}, {"type", "pii_detection"},
+                                          {"model", "m"}});
+          }));
+}
+
+static void test_make_classifiers() {
+    json configs = json::array({
+        json{{"id", "pii"}, {"type", "classifier"}, {"model", "pii-detector-small"}},
+        json{{"id", "jailbreak"}, {"type", "classifier"}, {"model", "jailbreak-detector-small"}},
+    });
+    auto classifiers = lemon::make_classifiers(configs);
+    check("make_classifiers builds classifier map", classifiers.size() == 2 &&
+              classifiers.count("pii") == 1 && classifiers.count("jailbreak") == 1);
+
+    json dupes = json::array({
+        json{{"id", "pii"}, {"type", "classifier"}, {"model", "a"}},
+        json{{"id", "pii"}, {"type", "classifier"}, {"model", "b"}},
+    });
+    check("make_classifiers rejects duplicate ids",
+          throws_invalid_arg([&] { lemon::make_classifiers(dupes); }));
+}
+
+static void test_leaf_factory_classifier_refs() {
+    auto classifier = lemon::make_classifier(json{
+        {"id", "pii"},
+        {"type", "classifier"},
+        {"model", "pii-detector-small"},
+        {"labels", json::array({"PII", "NO_PII"})},
+        {"default_label", "PII"},
+    });
+    std::map<std::string, lemon::ClassifierPtr> classifiers = {{"pii", classifier}};
+    auto leaf_factory = lemon::make_leaf_factory(classifiers);
+
+    lemon::testing::FakeClassifierServices fake;
+    fake.set_classifier_scores("pii-detector-small", {{"PII", 0.88}, {"NO_PII", 0.12}});
+    auto services = fake.make();
+    auto route = make_route_context();
+    EvalContext ctx = make_eval_context(route, services, true);
+    auto condition = leaf_factory(json{{"classifier", "pii"}});
+    check("leaf factory uses classifier default_label", condition->evaluate(ctx) &&
+              ctx.trace.size() == 1 && ctx.trace[0].score.has_value() &&
+              *ctx.trace[0].score == 0.88);
+
+    check("leaf factory rejects dangling classifier ref",
+          throws_invalid_arg([&] { leaf_factory(json{{"classifier", "missing"}}); }));
+    check("leaf factory rejects dangling label ref",
+          throws_invalid_arg([&] {
+              leaf_factory(json{{"classifier", "pii"}, {"label", "SECRET"}});
+          }));
+
+    auto no_default = lemon::make_classifier(json{
+        {"id", "ambiguous"},
+        {"type", "classifier"},
+        {"model", "pii-detector-small"},
+        {"labels", json::array({"PII", "NO_PII"})},
+    });
+    check("leaf factory rejects omitted label without default_label",
+          throws_invalid_arg([&] {
+              auto lf = lemon::make_leaf_factory({{"ambiguous", no_default}});
+              lf(json{{"classifier", "ambiguous"}});
+          }));
+}
+
+static void test_leaf_factory_deterministic_dispatch_and_implicit_all() {
+    int keywords_calls = 0;
+    int chars_calls = 0;
+    NamedLeafFactories factories;
+    factories["keywords_any"] = [&](const json& leaf) -> ConditionPtr {
+        check("deterministic factory receives isolated keywords leaf",
+              leaf.size() == 1 && leaf.contains("keywords_any"));
+        return std::make_shared<ConstCondition>(true, &keywords_calls, "keywords_any");
+    };
+    factories["max_chars"] = [&](const json& leaf) -> ConditionPtr {
+        check("deterministic factory receives isolated max_chars leaf",
+              leaf.size() == 1 && leaf.contains("max_chars"));
+        return std::make_shared<ConstCondition>(true, &chars_calls, "max_chars");
+    };
+
+    auto leaf_factory = lemon::make_leaf_factory({}, factories);
+    auto condition = leaf_factory(json{{"keywords_any", json::array({"return"})}, {"max_chars", 1000}});
+
+    lemon::testing::FakeClassifierServices fake;
+    auto services = fake.make();
+    auto route = make_route_context();
+    EvalContext ctx = make_eval_context(route, services, true);
+    check("multi-key deterministic leaf composes as implicit all", condition->evaluate(ctx) &&
+              keywords_calls == 1 && chars_calls == 1 && ctx.trace.size() == 2);
+
+    check("leaf factory rejects unknown leaf",
+          throws_invalid_arg([&] { leaf_factory(json{{"unknown", true}}); }));
+    check("classifier-only fields require classifier",
+          throws_invalid_arg([&] { leaf_factory(json{{"min_score", 0.5}}); }));
+}
+
+static void test_leaf_factory_classifier_and_deterministic_implicit_all() {
+    auto classifier = lemon::make_classifier(json{
+        {"id", "pii"},
+        {"type", "classifier"},
+        {"model", "pii-detector-small"},
+        {"labels", json::array({"PII", "NO_PII"})},
+        {"default_label", "PII"},
+    });
+
+    int max_chars_calls = 0;
+    NamedLeafFactories factories;
+    factories["max_chars"] = [&](const json&) -> ConditionPtr {
+        return std::make_shared<ConstCondition>(true, &max_chars_calls, "max_chars");
+    };
+
+    auto leaf_factory = lemon::make_leaf_factory({{"pii", classifier}}, factories);
+    auto condition = leaf_factory(json{{"classifier", "pii"}, {"min_score", 0.5}, {"max_chars", 1000}});
+
+    lemon::testing::FakeClassifierServices fake;
+    fake.set_classifier_scores("pii-detector-small", {{"PII", 0.75}, {"NO_PII", 0.25}});
+    auto services = fake.make();
+    auto route = make_route_context();
+    EvalContext ctx = make_eval_context(route, services, true);
+    check("classifier plus deterministic leaf composes as implicit all",
+          condition->evaluate(ctx) && max_chars_calls == 1 && ctx.trace.size() == 2);
+}
+
+int main() {
+    test_make_classifier();
+    test_make_classifier_rejections();
+    test_make_classifiers();
+    test_leaf_factory_classifier_refs();
+    test_leaf_factory_deterministic_dispatch_and_implicit_all();
+    test_leaf_factory_classifier_and_deterministic_implicit_all();
+
+    std::printf("\n%s\n", g_failures == 0 ? "ALL REGISTRY TESTS PASSED"
+                                          : "REGISTRY TESTS FAILED");
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
 ## Summary                                                        
                                                                                                          
  Implements the initial Lemonade Router evaluator and registry behavior for #2378 and #2379.
                                                                                                                                                                                                                     
  This builds on the #2407 routing foundation types and keeps the implementation pure/backend-free.
                                                                                                          
  ## What Changed                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  - Added routing evaluator implementation:                                                               
    - composite `all` / `any` / `not` conditions                                                                                                                                                                     
    - strict `MatchExpr` compilation                                                                      
    - classifier-band leaf condition                                                    
    - inclusive score-band evaluation                                                                     
    - default classifier band of `min_score: 0.5`         
    - classifier memoization through `EvalContext::memo`                                                  
    - trace emission only when `want_trace` is enabled                             
                                                                                                          
  - Added classifier/leaf registry helpers:                                                               
    - `make_classifier`                                                                                                                                                                                                                                                                                                                                                                                                                    
    - `make_classifiers`                                                                                  
    - `make_leaf_factory`                                                                                                                                                                                                                                                                                                                                                                                                                  
    - generic model-backed `classifier` support via `ClassifierServices::run_classifier`                  
    - clear rejection for `semantic_similarity`, `llm`, and reserved preset types until their follow-up issues land                                                                                                  
    - classifier label/default-label validation                                                           
    - dangling classifier reference rejection                                                                                                                                                                                                                                                                                                                                                                                              
    - deterministic leaf dispatch seam for #2380                                                                                                                                                                                                                                                                                                                                                                                           
    - multi-key leaf support as implicit `all`                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                          
  - Added standalone C++ tests for evaluator and registry behavior.                     
                                                                                                          
  ## Out Of Scope                 

  This does not implement deterministic condition logic (#2380), `semantic_similarity` scoring (#2381), LLM router classifier behavior (#2405), full engine assembly (#2382), policy parsing (#2383), live Router wiring (#2384), or `collection.router` dispatch (#2385).                                                                                                                                                                 
                                                                                                          
  ## Validation                                                             
                                                                                                          
  Built and ran the routing C++ tests with CMake/CTest:         
                                                                                                          
  ```bash              
  /tmp/lemonade-cmake-venv/bin/cmake --build build \                                                      
    --target test_routing_policy_evaluator test_routing_policy_registry test_routing_policy_contract \
    -j2                                                                                                   
                                                                                                          
  cd build                                                                                                                                                                                                           
  /tmp/lemonade-cmake-venv/bin/ctest -R 'RoutingPolicy(Contract|Evaluator|Registry)Test' --output-on-failure   ```                                                                                                      
                                                                                                          
  Result:                                                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                           
  100% tests passed, 0 tests failed out of 3                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                          
  Also ran schema/fixture checks:

  /tmp/lemonade-router-schema-venv/bin/python test/test_routing_fixtures.py
  python3 test/test_schema_lock.py

  Both passed.