### PR TITLE
test: fix whisper realtime macOS VAD flake

### DIFF
--- a/test/server_whisper.py
+++ b/test/server_whisper.py
@@ -372,7 +372,7 @@ class WhisperTests(ServerTestBase):
             f"{len(pcm_data) // 2 / 16000:.1f}s)"
         )
 
-        chunk_size = 8192
+        chunk_size = 2048
         chunks = [
             pcm_data[i : i + chunk_size] for i in range(0, len(pcm_data), chunk_size)
         ]


### PR DESCRIPTION
This change modifies `server_whisper.py` to reduce the test client's chunk size to `2048` bytes (`64ms`). Since `64ms < 100ms`, VAD now processes 100% of the audio stream without skipping samples. 

The failure was a timing/flakiness issue in the server-side Voice Activity Detection (VAD) during the WebSocket test that [caused CI runs to be flakey](https://github.com/lemonade-sdk/lemonade/actions/runs/28205524109/job/83767999126?pr=2330#step:12:37).

* `RealtimeSessionManager::process_vad` analyzes only the last `100ms` of the buffer whenever a chunk is appended.
* In `test_007_realtime_websocket_transcription`, the test client was chunking the audio into large `256ms` (`8192` bytes) blocks.
* Because the chunk size was greater than the VAD analysis window, **156ms of audio (60% of the stream) was skipped** by VAD on every chunk.
* On slow macOS CI runners, this data loss caused VAD's energy-based calculations in `SimpleVAD::process` to trigger early silent segments. 
* When the client broke out of its loop on the first `completed` event (which was empty due to the silent segment), the test assertion failed.
