### PR TITLE
test: fix stale docstring and add VAD rationale comment

### DIFF
--- a/test/server_whisper.py
+++ b/test/server_whisper.py
@@ -372,7 +372,7 @@ class WhisperTests(ServerTestBase):
             f"{len(pcm_data) // 2 / 16000:.1f}s)"
         )
 
-        chunk_size = 8192
+        chunk_size = 2048
         chunks = [
             pcm_data[i : i + chunk_size] for i in range(0, len(pcm_data), chunk_size)
         ]

--- a/test/server_whisper.py
+++ b/test/server_whisper.py
@@ -361,7 +361,7 @@ class WhisperTests(ServerTestBase):
         )
 
     def _get_pcm16_chunks(self):
-        """Load test audio and split it into ~256ms PCM16 chunks."""
+        """Load test audio and split it into ~64ms PCM16 chunks."""
         self.assertIsNotNone(self._test_audio_path, "Test audio file not downloaded")
 
         pcm_data = self._load_pcm16_from_wav()
@@ -372,6 +372,8 @@ class WhisperTests(ServerTestBase):
             f"{len(pcm_data) // 2 / 16000:.1f}s)"
         )
 
+        # 2048 bytes @ 16kHz/16-bit = 64ms, which is less than VAD's
+        # 100ms analysis window — prevents flaky CI runs.
         chunk_size = 2048
         chunks = [
             pcm_data[i : i + chunk_size] for i in range(0, len(pcm_data), chunk_size)


### PR DESCRIPTION
## Summary

Cleanup fix for PR #2442 (whisper realtime macOS VAD flake).

## Changes

- Fixed stale docstring: `~256ms` → `~64ms` to match the actual chunk size
- Added comment explaining *why* `chunk_size = 2048` — 2048 bytes @ 16kHz/16-bit = 64ms, which stays within VAD's 100ms analysis window to prevent flaky CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)