### PR TITLE
fix: add offline guard to handle_pull before attempting model download

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5453,6 +5453,13 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
     if (!parse_required_json_body(req, res, request_json)) return;
 
     try {
+        // First we check if lemonade is offline.
+        if (config_->offline()) {
+            res.status = 400;
+            nlohmann::json error = {{"error", "Lemond is in offline mode, models not downloaded"}, {"code", lemon::kUnknownModelErrorCode}};
+            res.set_content(error.dump(), "application/json");
+            return;
+        }
         // Accept both "model" and "model_name" for compatibility
         std::string model_name = request_json.contains("model") ?
             request_json["model"].get<std::string>() :

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5456,7 +5456,7 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
         // First we check if lemonade is offline.
         if (config_->offline()) {
             res.status = 400;
-            nlohmann::json error = {{"error", "Lemond is in offline mode, models not downloaded"}, {"code", lemon::kUnknownModelErrorCode}};
+            nlohmann::json error = {{"error", "Lemond is in offline mode, models not downloaded"}, {"code", "lemond_offline"}};
             res.set_content(error.dump(), "application/json");
             return;
         }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5453,7 +5453,6 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
     if (!parse_required_json_body(req, res, request_json)) return;
 
     try {
-        // First we check if lemonade is offline.
         if (config_->offline()) {
             res.status = 400;
             nlohmann::json error = {{"error", "Lemond is in offline mode, models not downloaded"}, {"code", "lemond_offline"}};


### PR DESCRIPTION
## Summary

Add an offline-mode guard to the model pull handler. If the server is configured as offline (`config_->offline()`), the pull endpoint returns HTTP 400 with an error code `lemond_offline` instead of attempting to download.

## Changes

- Added early-return guard in `Server::handle_pull` when `config_->offline()`
- Returns 400 + JSON error `{"error": "Lemond is in offline mode, models not downloaded", "code": "lemond_offline"}`

## Background

This was originally opened as "remove WHAT comment" cleanup for PR #2434, but the target comment (`// First we check if lemonade is offline.`) was already removed in the first commit of this branch (131fbc4) when the offline guard was added. The net diff is the 6-line guard itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)