### PR TITLE
fix: prevent redundant TheRock download across multiple ROCm backend installs (#2413)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3056,6 +3056,13 @@ if(BUILD_TESTING AND EXISTS "${_GFX_ARCH_GATING_TEST_SRC}")
     add_cpp_ci_test(GfxArchGatingTest CI ON COMMAND test_gfx_arch_gating)
 endif()
 
+set(_THEROCK_PAYLOAD_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_therock_payload.cpp")
+if(BUILD_TESTING AND EXISTS "${_THEROCK_PAYLOAD_TEST_SRC}")
+    add_executable(test_therock_payload test/cpp/test_therock_payload.cpp)
+    target_link_libraries(test_therock_payload PRIVATE lemonade-server-core)
+    add_cpp_ci_test(TheRockPayloadTest CI ON COMMAND test_therock_payload)
+endif()
+
 set(_NETWORK_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_network_utils.cpp")
 if(BUILD_TESTING AND EXISTS "${_NETWORK_UTILS_TEST_SRC}")
     add_executable(test_network_utils test/cpp/test_network_utils.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3003,6 +3003,13 @@ if(BUILD_TESTING AND EXISTS "${_GFX_ARCH_GATING_TEST_SRC}")
     add_cpp_ci_test(GfxArchGatingTest CI ON COMMAND test_gfx_arch_gating)
 endif()
 
+set(_THEROCK_2722_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_therock_2722.cpp")
+if(BUILD_TESTING AND EXISTS "${_THEROCK_2722_TEST_SRC}")
+    add_executable(test_therock_2722 test/cpp/test_therock_2722.cpp)
+    target_link_libraries(test_therock_2722 PRIVATE lemonade-server-core)
+    add_cpp_ci_test(TheRock2722Test CI ON COMMAND test_therock_2722)
+endif()
+
 set(_NETWORK_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_network_utils.cpp")
 if(BUILD_TESTING AND EXISTS "${_NETWORK_UTILS_TEST_SRC}")
     add_executable(test_network_utils test/cpp/test_network_utils.cpp)

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -216,7 +216,7 @@ namespace lemon::backends {
 
         /**
          * Loader dir of the externally-resolved ROCm root (bin/ on Windows,
-         * lib/ on Linux), or "" when no external root resolves. When the user
+         * lib/ or lib64/ on Linux), or "" when no external root resolves. When the user
          * points ROCM_PATH at a hand-installed ROCm, that root's bin/ must be
          * on the backend child's PATH/LD_LIBRARY_PATH or DLL/SO loading fails
          * (rocsolver.dll not found, issue #2722). Use alongside (after)

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -173,6 +173,17 @@ namespace lemon::backends {
                                             std::string& filename,
                                             size_t& bytes_total);
 
+        /**
+         * True when dir holds a concrete, usable HIP runtime payload for the
+         * current platform: libamdhip64.so on Linux (lib/ or lib64/), or
+         * amdhip64.dll / amdhip64_<digits>.dll on Windows (bin/ or lib/).
+         * A lib/ or bin/ directory skeleton without the actual runtime files
+         * is NOT a valid install — callers must not treat it as installed.
+         * Shared by the TheRock installed-check and ROCm-root validation so
+         * both paths agree on what "installed" means.
+         */
+        static bool has_hip_runtime_payload(const std::string& dir);
+
         /** Download and install TheRock ROCm tarball for the specified architecture (Linux only) */
         static void install_therock(const std::string& arch, const std::string& version,
                                    DownloadProgressCallback progress_cb = nullptr);

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -173,6 +173,18 @@ namespace lemon::backends {
                                             std::string& filename,
                                             size_t& bytes_total);
 
+        /**
+         * After extracting a TheRock tarball into install_dir, locate the
+         * payload subdirectory (bin/ on Windows, lib/ on Linux). Upstream
+         * tarballs sometimes unpack under a wrapper directory whose name
+         * drifts from the URL (e.g. therock-dist-...-7.13.0rc2/), leaving the
+         * payload one level deep; when exactly one top-level subdirectory
+         * holds it, its contents are moved up into install_dir so the layout
+         * matches what every consumer expects. Returns the payload dir path,
+         * or "" when no usable payload is found.
+         */
+        static std::string normalize_therock_payload_dir(const std::string& install_dir);
+
         /** Download and install TheRock ROCm tarball for the specified architecture (Linux only) */
         static void install_therock(const std::string& arch, const std::string& version,
                                    DownloadProgressCallback progress_cb = nullptr);
@@ -201,6 +213,16 @@ namespace lemon::backends {
          *  only; returns 0 elsewhere. GetFileVersionInfoW returns stale data
          *  for system32 paths, so callers read versions from plain paths. */
         static uint64_t read_dll_version(const fs::path& dll);
+
+        /**
+         * Loader dir of the externally-resolved ROCm root (bin/ on Windows,
+         * lib/ on Linux), or "" when no external root resolves. When the user
+         * points ROCM_PATH at a hand-installed ROCm, that root's bin/ must be
+         * on the backend child's PATH/LD_LIBRARY_PATH or DLL/SO loading fails
+         * (rocsolver.dll not found, issue #2722). Use alongside (after)
+         * get_therock_lib_path so TheRock takes precedence when installed.
+         */
+        static std::string get_external_rocm_loader_dir();
 
         /** Get the path to the backend's binary. Gives precedence to the path set through environment variables, if set. Throws if not found. */
         static std::string get_backend_binary_path(const BackendSpec& spec, const std::string& backend);

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -192,21 +192,6 @@ bool has_matching_system_rocm_runtime(const fs::path& rocm_root, bool resolved_e
     return matches;
 }
 
-
-bool backend_update_required(const std::string& recipe, const std::string& backend) {
-    for (const auto& recipe_status : SystemInfo::get_all_recipe_statuses()) {
-        if (recipe_status.name != recipe) {
-            continue;
-        }
-        for (const auto& backend_status : recipe_status.backends) {
-            if (backend_status.name == backend) {
-                return backend_status.state == "update_required";
-            }
-        }
-    }
-    return false;
-}
-
 bool will_install_therock(const std::string& os, const json& backend_versions) {
     // TheRock is needed on Linux and Windows for ROCm stable channel.
     if (os != "linux" && os != "windows") {
@@ -308,7 +293,12 @@ bool is_therock_installed_for_current_arch(const json& backend_versions) {
     const fs::path tarball_version_file =
         fs::path(backends::BackendUtils::get_therock_install_dir(rocm_arch, version)) / "version.txt";
     if (read_version_file(tarball_version_file) == version) {
-        return true;
+        // version.txt can outlive a corrupt install, so require the actual
+        // HIP runtime payload (has_hip_runtime_payload) to treat the install
+        // as present — a broken tarball install re-downloads (repairs)
+        // instead of being silently skipped.
+        return backends::BackendUtils::has_hip_runtime_payload(
+            backends::BackendUtils::get_therock_install_dir(rocm_arch, version));
     }
 
     // The pip-wheel install records its own version marker in a separate tree.
@@ -628,16 +618,13 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
         resolved_backend == "rocm-stable";
     const bool therock_applicable =
         is_rocm_stable_backend && will_install_therock(os, backend_versions_);
-    const bool rocm_runtime_update_required =
-        therock_applicable && backend_update_required(recipe, backend);
-
-    // is_therock_installed_for_current_arch internally verifies method.txt
-    // when rocm_install_method is explicitly set, so callers don't need to
-    // check method mismatch separately.
+    // TheRock is shared across backends: install once per arch+version and
+    // let is_therock_installed_for_current_arch() be the single authority on
+    // whether it's present and usable, so a missing/corrupt runtime
+    // re-downloads exactly once instead of once per backend.
     const bool needs_therock_download =
         therock_applicable &&
-        (rocm_runtime_update_required ||
-         !is_therock_installed_for_current_arch(backend_versions_));
+        !is_therock_installed_for_current_arch(backend_versions_);
 
     struct RuntimeInstallStep {
         std::string name;
@@ -648,25 +635,12 @@ void BackendManager::install_backend(const std::string& recipe, const std::strin
     if (needs_therock_download) {
         runtime_steps.push_back({
             "TheRock runtime",
-            [this, os, rocm_runtime_update_required](DownloadProgressCallback runtime_progress_cb) {
-                if (rocm_runtime_update_required) {
-                    const std::string rocm_arch = SystemInfo::get_rocm_arch();
-                    if (rocm_arch.empty()) {
-                        throw std::runtime_error("Cannot repair TheRock runtime: ROCm architecture could not be detected");
-                    }
-
-                    const std::string version = backend_versions_["therock"]["version"].get<std::string>();
-                    const std::string install_dir =
-                        backends::BackendUtils::get_therock_install_dir(rocm_arch, version);
-
-                    std::error_code ec;
-                    fs::remove_all(install_dir, ec);
-                    if (ec) {
-                        throw std::runtime_error("Failed to remove existing TheRock runtime '" +
-                                                 install_dir + "': " + ec.message());
-                    }
-                }
-
+            [this, os](DownloadProgressCallback runtime_progress_cb) {
+                // install_therock_if_needed handles version+payload check:
+                //   - Already installed with correct version → skip
+                //   - Wrong version → download new one; cleanup_old_therock_versions()
+                //     removes stale directories after extraction (Linux only)
+                // No need to delete-and-re-download here.
                 install_therock_if_needed(os, backend_versions_, runtime_progress_cb);
             }
         });

--- a/src/cpp/server/backends/acestep/acestep_server.cpp
+++ b/src/cpp/server/backends/acestep/acestep_server.cpp
@@ -147,6 +147,16 @@ void AceStepServer::load(const std::string& model_name,
             dirs = BackendUtils::join_runtime_dirs(
                 BackendUtils::get_therock_lib_paths(arch));
         }
+        // Hand-installed ROCm (ROCM_PATH) must be loadable too (issue #2722).
+        // TheRock keeps precedence; the external root's dir is appended after it.
+        const std::string external = BackendUtils::get_external_rocm_loader_dir();
+        if (!external.empty()) {
+#ifdef _WIN32
+            dirs = dirs.empty() ? external : (dirs + ";" + external);
+#else
+            dirs = dirs.empty() ? external : (dirs + ":" + external);
+#endif
+        }
         prepend_loader_path(dirs);
     } else if (backend == "cuda") {
         prepend_loader_path("");

--- a/src/cpp/server/backends/acestep/acestep_server.cpp
+++ b/src/cpp/server/backends/acestep/acestep_server.cpp
@@ -147,8 +147,7 @@ void AceStepServer::load(const std::string& model_name,
             dirs = BackendUtils::join_runtime_dirs(
                 BackendUtils::get_therock_lib_paths(arch));
         }
-        // Hand-installed ROCm (ROCM_PATH) must be loadable too (issue #2722).
-        // TheRock keeps precedence; the external root's dir is appended after it.
+        // See BackendUtils::get_external_rocm_loader_dir() (issue #2722).
         const std::string external = BackendUtils::get_external_rocm_loader_dir();
         if (!external.empty()) {
 #ifdef _WIN32

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -860,45 +860,9 @@ namespace lemon::backends {
             if (root.empty() || !fs::exists(root, ec)) {
                 return std::nullopt;
             }
-#ifdef _WIN32
-            // ROCm 5.x/6.x ship bin\amdhip64.dll; ROCm 7.x version-suffixes it
-            // (bin\amdhip64_7.dll). Accept amdhip64.dll or amdhip64_<digits>.dll,
-            // not arbitrary suffixes like amdhip64_backup.dll.
-            const auto is_hip_runtime = [](const std::string& name) {
-                if (name == "amdhip64.dll") {
-                    return true;
-                }
-                static const std::string prefix = "amdhip64_";
-                static const std::string suffix = ".dll";
-                if (name.size() <= prefix.size() + suffix.size() ||
-                    name.compare(0, prefix.size(), prefix) != 0 ||
-                    name.compare(name.size() - suffix.size(), suffix.size(), suffix) != 0) {
-                    return false;
-                }
-                const auto digits = name.substr(
-                    prefix.size(), name.size() - prefix.size() - suffix.size());
-                return std::all_of(digits.begin(), digits.end(),
-                                   [](unsigned char c) { return std::isdigit(c); });
-            };
-            for (const char* subdir : {"bin", "lib"}) {
-                const fs::path dir = root / subdir;
-                if (!fs::is_directory(dir, ec)) {
-                    continue;
-                }
-                for (fs::directory_iterator it(dir, ec), end; it != end && !ec; it.increment(ec)) {
-                    if (it->is_regular_file(ec) &&
-                        is_hip_runtime(it->path().filename().string())) {
-                        return root;
-                    }
-                }
+            if (BackendUtils::has_hip_runtime_payload(root.string())) {
+                return root;
             }
-#else
-            for (const char* lib_subdir : {"lib", "lib64"}) {
-                if (fs::exists(root / lib_subdir / "libamdhip64.so", ec)) {
-                    return root;
-                }
-            }
-#endif
             return std::nullopt;
         }
 
@@ -1602,6 +1566,54 @@ namespace lemon::backends {
 #endif
     }
 
+    bool BackendUtils::has_hip_runtime_payload(const std::string& dir) {
+#if !defined(__linux__) && !defined(_WIN32)
+        return false;
+#else
+        std::error_code ec;
+#ifdef _WIN32
+        // ROCm 5.x/6.x ship bin\amdhip64.dll; ROCm 7.x version-suffixes it
+        // (bin\amdhip64_7.dll). Accept amdhip64.dll or amdhip64_<digits>.dll,
+        // not arbitrary suffixes like amdhip64_backup.dll.
+        const auto is_hip_runtime = [](const std::string& name) {
+            if (name == "amdhip64.dll") {
+                return true;
+            }
+            static const std::string prefix = "amdhip64_";
+            static const std::string suffix = ".dll";
+            if (name.size() <= prefix.size() + suffix.size() ||
+                name.compare(0, prefix.size(), prefix) != 0 ||
+                name.compare(name.size() - suffix.size(), suffix.size(), suffix) != 0) {
+                return false;
+            }
+            const auto digits = name.substr(
+                prefix.size(), name.size() - prefix.size() - suffix.size());
+            return std::all_of(digits.begin(), digits.end(),
+                               [](unsigned char c) { return std::isdigit(c); });
+        };
+        for (const char* subdir : {"bin", "lib"}) {
+            const fs::path d = fs::path(dir) / subdir;
+            if (!fs::is_directory(d, ec)) {
+                continue;
+            }
+            for (fs::directory_iterator it(d, ec), end; it != end && !ec; it.increment(ec)) {
+                if (it->is_regular_file(ec) &&
+                    is_hip_runtime(it->path().filename().string())) {
+                    return true;
+                }
+            }
+        }
+#else
+        for (const char* lib_subdir : {"lib", "lib64"}) {
+            if (fs::exists(fs::path(dir) / lib_subdir / "libamdhip64.so", ec)) {
+                return true;
+            }
+        }
+#endif
+        return false;
+#endif
+    }
+
     void BackendUtils::install_therock(const std::string& arch, const std::string& version,
                                        DownloadProgressCallback progress_cb) {
 #if !defined(__linux__) && !defined(_WIN32)
@@ -1610,13 +1622,18 @@ namespace lemon::backends {
         std::string install_dir = get_therock_install_dir(arch, version);
         std::string version_file = (fs::path(install_dir) / "version.txt").string();
 
+        // version.txt alone can survive a corrupt install; require the HIP
+        // runtime payload too (has_hip_runtime_payload) so repair re-downloads.
         if (fs::exists(install_dir) && fs::exists(version_file)) {
             std::string installed_version;
             std::ifstream vf(version_file);
             std::getline(vf, installed_version);
             vf.close();
 
-            if (installed_version == version) {
+            const bool payload_present =
+                BackendUtils::has_hip_runtime_payload(install_dir);
+
+            if (installed_version == version && payload_present) {
                 LOG(DEBUG, "BackendUtils") << "TheRock " << arch << "-" << version << " already installed" << std::endl;
                 return;
             }

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -123,6 +123,29 @@ namespace lemon::backends {
         return archive_platform->extract_tarball(tarball_path, dest_dir, backend_name);
     }
 
+    // Dump the on-disk layout under dir (two levels deep) so a failed install
+    // leaves evidence in the log instead of a silent delete (issue #2722).
+    static void log_install_tree(const fs::path& dir) {
+        std::error_code ec;
+        if (!fs::exists(dir, ec)) {
+            LOG(ERROR, "BackendUtils") << "Install dir " << dir.string() << " does not exist" << std::endl;
+            return;
+        }
+        LOG(ERROR, "BackendUtils") << "Extracted layout under " << dir.string() << ":" << std::endl;
+        for (fs::directory_iterator it(dir, ec), end; it != end && !ec; it.increment(ec)) {
+            LOG(ERROR, "BackendUtils") << "  " << it->path().filename().string()
+                                       << (it->is_directory(ec) ? "/" : "") << std::endl;
+            if (it->is_directory(ec)) {
+                for (fs::directory_iterator sub(dir / it->path().filename(), ec), sub_end;
+                     sub != sub_end && !ec; sub.increment(ec)) {
+                    LOG(ERROR, "BackendUtils") << "    " << sub->path().filename().string()
+                                               << (sub->is_directory(ec) ? "/" : "") << std::endl;
+                }
+                ec.clear();
+            }
+        }
+    }
+
     static bool ends_with(const std::string& s, const std::string& suffix) {
         return s.size() >= suffix.size() &&
             s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
@@ -1602,6 +1625,63 @@ namespace lemon::backends {
 #endif
     }
 
+    std::string BackendUtils::normalize_therock_payload_dir(const std::string& install_dir) {
+#if !defined(__linux__) && !defined(_WIN32)
+        return "";
+#else
+        std::error_code ec;
+#ifdef _WIN32
+        const std::string payload_name = "bin";
+#else
+        const std::string payload_name = "lib";
+#endif
+        const fs::path payload = fs::path(install_dir) / payload_name;
+        if (fs::is_directory(payload, ec)) {
+            return payload.string();
+        }
+
+        // Upstream TheRock tarballs sometimes unpack under a wrapper directory
+        // whose name drifts from the URL (e.g. therock-dist-...-7.13.0rc2/),
+        // leaving bin/ or lib/ one level deep. If exactly one top-level
+        // subdirectory holds the payload, move its contents up into
+        // install_dir so every consumer finds bin/ or lib/ where it expects.
+        fs::path wrapper;
+        bool multiple_dirs = false;
+        for (fs::directory_iterator it(install_dir, ec), end; it != end && !ec; it.increment(ec)) {
+            if (!it->is_directory(ec)) {
+                continue;
+            }
+            if (wrapper.empty()) {
+                wrapper = it->path();
+            } else if (wrapper != it->path()) {
+                multiple_dirs = true;
+                break;
+            }
+        }
+        if (!multiple_dirs && !wrapper.empty() &&
+            fs::is_directory(wrapper / payload_name, ec)) {
+            LOG(INFO, "BackendUtils") << "TheRock tarball unpacked under wrapper dir "
+                                      << wrapper.filename().string()
+                                      << "; moving contents into " << install_dir << std::endl;
+            for (fs::directory_iterator it(wrapper, ec), end; it != end && !ec; it.increment(ec)) {
+                const fs::path target = fs::path(install_dir) / it->path().filename();
+                fs::rename(it->path(), target, ec);
+                if (ec) {
+                    LOG(WARNING, "BackendUtils") << "Failed to move " << it->path().string()
+                                                 << " into " << install_dir << ": " << ec.message()
+                                                 << std::endl;
+                }
+                ec.clear();
+            }
+            fs::remove_all(wrapper, ec);
+            if (fs::is_directory(fs::path(install_dir) / payload_name, ec)) {
+                return (fs::path(install_dir) / payload_name).string();
+            }
+        }
+        return "";
+#endif
+    }
+
     void BackendUtils::install_therock(const std::string& arch, const std::string& version,
                                        DownloadProgressCallback progress_cb) {
 #if !defined(__linux__) && !defined(_WIN32)
@@ -1697,30 +1777,30 @@ namespace lemon::backends {
                                     << (file_size / 1024 / 1024) << " MB" << std::endl;
 
         if (!extract_tarball(tarball_path, install_dir, "TheRock")) {
+            log_install_tree(install_dir);
             fs::remove(tarball_path);
             fs::remove_all(install_dir);
             throw std::runtime_error("Failed to extract TheRock tarball: " + tarball_path);
         }
 
+        const std::string runtime_dir =
+            BackendUtils::normalize_therock_payload_dir(install_dir);
+        if (runtime_dir.empty()) {
+            // Dump the actual extracted layout instead of silently deleting
+            // the tree — the silent cleanup is why this failure was so hard
+            // to diagnose (issue #2722).
+            log_install_tree(install_dir);
+            fs::remove(tarball_path);
+            fs::remove_all(install_dir);
 #ifdef _WIN32
-        // On Windows, DLLs are in bin/ (lib/ contains only import .lib files)
-        fs::path runtime_dir = fs::path(install_dir) / "bin";
-        if (!fs::exists(runtime_dir)) {
-            fs::remove(tarball_path);
-            fs::remove_all(install_dir);
-            throw std::runtime_error("TheRock extraction failed: bin directory not found");
-        }
-        LOG(DEBUG, "BackendUtils") << "TheRock bin directory verified at: " << runtime_dir << std::endl;
+            throw std::runtime_error("TheRock extraction failed: bin directory not found in " +
+                                     install_dir);
 #else
-        // On Linux, shared libraries are in lib/
-        fs::path runtime_dir = fs::path(install_dir) / "lib";
-        if (!fs::exists(runtime_dir)) {
-            fs::remove(tarball_path);
-            fs::remove_all(install_dir);
-            throw std::runtime_error("TheRock extraction failed: lib directory not found");
-        }
-        LOG(DEBUG, "BackendUtils") << "TheRock lib directory verified at: " << runtime_dir << std::endl;
+            throw std::runtime_error("TheRock extraction failed: lib directory not found in " +
+                                     install_dir);
 #endif
+        }
+        LOG(DEBUG, "BackendUtils") << "TheRock runtime directory verified at: " << runtime_dir << std::endl;
 
         {
             std::ofstream mf(fs::path(install_dir) / "method.txt");
@@ -2034,6 +2114,29 @@ namespace lemon::backends {
         }
         LOG(ERROR, "BackendUtils") << "Failed to copy amdhip64_7.dll: " << ec.message() << std::endl;
         return false;
+#endif
+    }
+
+    std::string BackendUtils::get_external_rocm_loader_dir() {
+#if !defined(__linux__) && !defined(_WIN32)
+        return "";
+#else
+        std::error_code ec;
+        const auto root = resolve_rocm_root();
+        if (!root) {
+            return "";
+        }
+#ifdef _WIN32
+        const fs::path loader_dir = *root / "bin";
+#else
+        const fs::path loader_dir = *root / "lib";
+#endif
+        if (!fs::is_directory(loader_dir, ec)) {
+            return "";
+        }
+        LOG(DEBUG, "BackendUtils") << "Returning external ROCm loader dir: "
+                                   << loader_dir.string() << std::endl;
+        return loader_dir.string();
 #endif
     }
     void BackendUtils::apply_cuda_env_vars(

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -1663,17 +1663,28 @@ namespace lemon::backends {
             LOG(INFO, "BackendUtils") << "TheRock tarball unpacked under wrapper dir "
                                       << wrapper.filename().string()
                                       << "; moving contents into " << install_dir << std::endl;
+            // Snapshot the entries before renaming: mutating a directory while
+            // iterating it is unspecified, and the wrapper is only removed once
+            // every move succeeded so a failure can't lose payload content.
+            std::vector<fs::path> entries;
             for (fs::directory_iterator it(wrapper, ec), end; it != end && !ec; it.increment(ec)) {
-                const fs::path target = fs::path(install_dir) / it->path().filename();
-                fs::rename(it->path(), target, ec);
+                entries.push_back(it->path());
+            }
+            ec.clear();
+            bool all_moved = true;
+            for (const fs::path& entry : entries) {
+                fs::rename(entry, fs::path(install_dir) / entry.filename(), ec);
                 if (ec) {
-                    LOG(WARNING, "BackendUtils") << "Failed to move " << it->path().string()
+                    LOG(WARNING, "BackendUtils") << "Failed to move " << entry.string()
                                                  << " into " << install_dir << ": " << ec.message()
                                                  << std::endl;
+                    all_moved = false;
+                    ec.clear();
                 }
-                ec.clear();
             }
-            fs::remove_all(wrapper, ec);
+            if (all_moved) {
+                fs::remove_all(wrapper, ec);
+            }
             if (fs::is_directory(fs::path(install_dir) / payload_name, ec)) {
                 return (fs::path(install_dir) / payload_name).string();
             }
@@ -2129,9 +2140,20 @@ namespace lemon::backends {
 #ifdef _WIN32
         const fs::path loader_dir = *root / "bin";
 #else
-        const fs::path loader_dir = *root / "lib";
+        // validate_rocm_root accepts lib or lib64 roots; mirror that so a
+        // lib64-only layout still yields a loader dir for the backend child.
+        fs::path loader_dir;
+        for (const char* lib_subdir : {"lib", "lib64"}) {
+            ec.clear();
+            const fs::path candidate = *root / lib_subdir;
+            if (fs::is_directory(candidate, ec) &&
+                fs::exists(candidate / "libamdhip64.so", ec)) {
+                loader_dir = candidate;
+                break;
+            }
+        }
 #endif
-        if (!fs::is_directory(loader_dir, ec)) {
+        if (loader_dir.empty() || !fs::is_directory(loader_dir, ec)) {
             return "";
         }
         LOG(DEBUG, "BackendUtils") << "Returning external ROCm loader dir: "

--- a/src/cpp/server/backends/openmoss/openmoss_server.cpp
+++ b/src/cpp/server/backends/openmoss/openmoss_server.cpp
@@ -108,8 +108,7 @@ void OpenMossServer::load(const std::string& model_name,
             dirs = BackendUtils::join_runtime_dirs(
                 BackendUtils::get_therock_lib_paths(arch));
         }
-        // Hand-installed ROCm (ROCM_PATH) must be loadable too (issue #2722).
-        // TheRock keeps precedence; the external root's dir is appended after it.
+        // See BackendUtils::get_external_rocm_loader_dir() (issue #2722).
         const std::string external = BackendUtils::get_external_rocm_loader_dir();
         if (!external.empty()) {
 #ifdef _WIN32

--- a/src/cpp/server/backends/openmoss/openmoss_server.cpp
+++ b/src/cpp/server/backends/openmoss/openmoss_server.cpp
@@ -108,6 +108,16 @@ void OpenMossServer::load(const std::string& model_name,
             dirs = BackendUtils::join_runtime_dirs(
                 BackendUtils::get_therock_lib_paths(arch));
         }
+        // Hand-installed ROCm (ROCM_PATH) must be loadable too (issue #2722).
+        // TheRock keeps precedence; the external root's dir is appended after it.
+        const std::string external = BackendUtils::get_external_rocm_loader_dir();
+        if (!external.empty()) {
+#ifdef _WIN32
+            dirs = dirs.empty() ? external : (dirs + ";" + external);
+#else
+            dirs = dirs.empty() ? external : (dirs + ":" + external);
+#endif
+        }
         prepend_loader_path(dirs);
     } else if (backend == "cuda") {
         prepend_loader_path("");

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -300,6 +300,17 @@ void SDServer::load(const std::string& model_name,
 #ifndef _WIN32
     std::string lib_path = exe_dir.string();
 
+    // A hand-installed ROCm (ROCM_PATH) must be loadable too; its lib/ holds
+    // rocsolver/rocblas/hipblaslt that sd-server needs (issue #2722). Prepended
+    // BEFORE the TheRock entry below so TheRock (the pinned runtime) wins when
+    // both are present.
+    if (is_rocm_backend(resolved_backend)) {
+        const std::string external = BackendUtils::get_external_rocm_loader_dir();
+        if (!external.empty()) {
+            lib_path = external + ":" + lib_path;
+        }
+    }
+
     if (resolved_backend == "rocm-stable") {
         std::string rocm_arch = SystemInfo::get_rocm_arch();
         if (!rocm_arch.empty()) {
@@ -323,6 +334,17 @@ void SDServer::load(const std::string& model_name,
     // These DLLs are distributed alongside sd-server.exe but need PATH to be set for loading
     if (is_rocm_backend(resolved_backend)) {
         std::string new_path = path_to_utf8(exe_dir);
+
+        // A hand-installed ROCm (ROCM_PATH) must be loadable too; its bin/
+        // holds rocsolver/rocblas/hipblaslt DLLs that sd-server needs (issue
+        // #2722). Prepended BEFORE the TheRock entry below so TheRock (the
+        // pinned runtime) wins when both are present.
+        {
+            const std::string external = BackendUtils::get_external_rocm_loader_dir();
+            if (!external.empty()) {
+                new_path = path_to_utf8(fs::absolute(path_from_utf8(external))) + ";" + new_path;
+            }
+        }
 
         if (resolved_backend == "rocm-stable") {
             std::string rocm_arch = SystemInfo::get_rocm_arch();

--- a/src/cpp/server/backends/trellis/trellis_server.cpp
+++ b/src/cpp/server/backends/trellis/trellis_server.cpp
@@ -132,8 +132,7 @@ void TrellisServer::load(const std::string& model_name,
             dirs = BackendUtils::join_runtime_dirs(
                 BackendUtils::get_therock_lib_paths(arch));
         }
-        // Hand-installed ROCm (ROCM_PATH) must be loadable too (issue #2722).
-        // TheRock takes precedence; this only adds the external root when present.
+        // See BackendUtils::get_external_rocm_loader_dir() (issue #2722).
         const std::string external = BackendUtils::get_external_rocm_loader_dir();
         if (!external.empty()) {
             // TheRock (the pinned runtime) keeps precedence; the external

--- a/src/cpp/server/backends/trellis/trellis_server.cpp
+++ b/src/cpp/server/backends/trellis/trellis_server.cpp
@@ -132,6 +132,18 @@ void TrellisServer::load(const std::string& model_name,
             dirs = BackendUtils::join_runtime_dirs(
                 BackendUtils::get_therock_lib_paths(arch));
         }
+        // Hand-installed ROCm (ROCM_PATH) must be loadable too (issue #2722).
+        // TheRock takes precedence; this only adds the external root when present.
+        const std::string external = BackendUtils::get_external_rocm_loader_dir();
+        if (!external.empty()) {
+            // TheRock (the pinned runtime) keeps precedence; the external
+            // root's loader dir is appended after it.
+#ifdef _WIN32
+            dirs = dirs.empty() ? external : (dirs + ";" + external);
+#else
+            dirs = dirs.empty() ? external : (dirs + ":" + external);
+#endif
+        }
         prepend_loader_path(dirs);
     } else if (backend == "cuda") {
         prepend_loader_path("");

--- a/test/cpp/test_therock_2722.cpp
+++ b/test/cpp/test_therock_2722.cpp
@@ -116,6 +116,23 @@ int main() {
     }
 
     {
+        // Mixed wrapper contents (payload dirs + a stray file) all move up,
+        // and the wrapper is removed only after every entry moved.
+        const fs::path install = tmp / "wrapped_mixed";
+        const fs::path wrapper = install / "therock-dist-windows-gfx1151-7.13.0rc2";
+        write_stub(wrapper / "bin" / "amdhip64_7.dll");
+        write_stub(wrapper / "lib" / "rocsolver.dll");
+        write_stub(wrapper / "README.txt");
+
+        const std::string found = BackendUtils::normalize_therock_payload_dir(install.string());
+        check(!found.empty(), "normalize: mixed wrapper contents are located");
+        check(fs::exists(install / "README.txt"),
+              "normalize: stray wrapper file is moved up too");
+        check(!fs::exists(wrapper),
+              "normalize: wrapper dir removed only after every entry moved");
+    }
+
+    {
         // Multiple top-level dirs: no unambiguous wrapper — do not mangle.
         const fs::path install = tmp / "ambiguous_install";
         fs::create_directories(install / "dir_a");
@@ -166,6 +183,18 @@ int main() {
         BackendUtils::get_external_rocm_loader_dir();
         check(true, "no ROCM_PATH: get_external_rocm_loader_dir returns without throwing");
     }
+
+#ifndef _WIN32
+    {
+        // A lib64-only ROCm root (no lib/) must still resolve to a loader dir.
+        const fs::path root = tmp / "external_rocm_lib64";
+        write_stub(root / "lib64" / "libamdhip64.so");
+        set_rocm_path(root.string());
+        const std::string dir = BackendUtils::get_external_rocm_loader_dir();
+        check(!dir.empty() && fs::equivalent(fs::path(dir), root / "lib64"),
+              "loader dir resolves a lib64-only ROCm root");
+    }
+#endif
 
     fs::remove_all(tmp);
     if (g_failures) {

--- a/test/cpp/test_therock_2722.cpp
+++ b/test/cpp/test_therock_2722.cpp
@@ -4,14 +4,11 @@
 //
 // The upstream Windows tarball unpacks to a wrapper dir whose name includes an
 // rc suffix (e.g. therock-dist-windows-gfx1151-7.13.0rc2/), so bin/ lands one
-// level deep. normalize_therock_payload_dir() must find it and move it up so
-// every consumer (get_therock_lib_path etc.) sees install_dir/bin. The old
-// code deleted the tree on failure, destroying the evidence; the fix logs the
-// layout instead.
+// level deep; normalize_therock_payload_dir() must move it up so consumers
+// see install_dir/bin. The old code deleted the tree on failure, destroying
+// the evidence.
 //
-// get_external_rocm_loader_dir() must return the bin/ (Windows) or lib/
-// (Linux) of a ROCm root that resolves via ROCM_PATH — the directory sd-server
-// needs on its child PATH to find rocsolver.dll.
+// get_external_rocm_loader_dir() must return the resolved root's bin/ or lib/.
 
 #include <lemon/backends/backend_utils.h>
 

--- a/test/cpp/test_therock_2722.cpp
+++ b/test/cpp/test_therock_2722.cpp
@@ -1,0 +1,180 @@
+// Regression tests for issue #2722: TheRock tarball extraction robustness on
+// Windows (wrapper directory with a name that drifts from the URL) and the
+// ROCM_PATH loader dir that must reach the backend child process.
+//
+// The upstream Windows tarball unpacks to a wrapper dir whose name includes an
+// rc suffix (e.g. therock-dist-windows-gfx1151-7.13.0rc2/), so bin/ lands one
+// level deep. normalize_therock_payload_dir() must find it and move it up so
+// every consumer (get_therock_lib_path etc.) sees install_dir/bin. The old
+// code deleted the tree on failure, destroying the evidence; the fix logs the
+// layout instead.
+//
+// get_external_rocm_loader_dir() must return the bin/ (Windows) or lib/
+// (Linux) of a ROCm root that resolves via ROCM_PATH — the directory sd-server
+// needs on its child PATH to find rocsolver.dll.
+
+#include <lemon/backends/backend_utils.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+using lemon::backends::BackendUtils;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, const char* msg) {
+    if (cond) {
+        std::cout << "[ok] " << msg << std::endl;
+    } else {
+        std::cerr << "[FAIL] " << msg << std::endl;
+        ++g_failures;
+    }
+}
+
+void set_rocm_path(const std::string& value) {
+#ifdef _WIN32
+    _putenv_s("ROCM_PATH", value.c_str());
+#else
+    setenv("ROCM_PATH", value.c_str(), /*overwrite=*/1);
+#endif
+}
+
+void write_stub(const fs::path& p) {
+    fs::create_directories(p.parent_path());
+    std::ofstream(p) << "stub";
+}
+
+fs::path make_temp_root(const std::string& tag) {
+    fs::path root = fs::temp_directory_path() /
+                    ("lemon_therock_2722_" + tag + "_" + std::to_string(
+#ifdef _WIN32
+                        _getpid()
+#else
+                        getpid()
+#endif
+                        ));
+    fs::remove_all(root);
+    fs::create_directories(root);
+    return root;
+}
+
+}  // namespace
+
+int main() {
+    const fs::path tmp = make_temp_root("main");
+
+    // --- normalize_therock_payload_dir: wrapper dir (the Windows defect) ---
+
+    {
+        // Simulate the upstream tarball layout: one wrapper dir whose name
+        // drifts from the URL (rc suffix), payload one level deep.
+        const fs::path install = tmp / "wrapped_install";
+        const fs::path wrapper = install / "therock-dist-windows-gfx1151-7.13.0rc2";
+        write_stub(wrapper / "bin" / "amdhip64_7.dll");
+        write_stub(wrapper / "lib" / "rocsolver.dll");
+        write_stub(wrapper / "bin" / "rocm-smi.exe");
+
+        const std::string found = BackendUtils::normalize_therock_payload_dir(install.string());
+#ifdef _WIN32
+        const fs::path expected = install / "bin";
+#else
+        const fs::path expected = install / "lib";
+#endif
+        check(!found.empty(), "normalize: wrapper dir payload is located");
+        check(fs::exists(expected / (std::string(
+#ifdef _WIN32
+            "amdhip64_7.dll"
+#else
+            "libamdhip64.so"
+#endif
+            ))) ||
+              // Linux lib/ holds .so files; write one if the platform check needs it
+              (found == expected.string()),
+              "normalize: payload was moved up to install_dir/<payload>");
+    }
+
+    {
+        // No wrapper: payload already at the expected location.
+        const fs::path install = tmp / "flat_install";
+#ifdef _WIN32
+        write_stub(install / "bin" / "amdhip64_7.dll");
+#else
+        write_stub(install / "lib" / "libamdhip64.so");
+#endif
+        const std::string found = BackendUtils::normalize_therock_payload_dir(install.string());
+        check(!found.empty(), "normalize: flat layout is located unchanged");
+    }
+
+    {
+        // Multiple top-level dirs: no unambiguous wrapper — do not mangle.
+        const fs::path install = tmp / "ambiguous_install";
+        fs::create_directories(install / "dir_a");
+        fs::create_directories(install / "dir_b");
+#ifdef _WIN32
+        write_stub(install / "dir_a" / "bin" / "amdhip64_7.dll");
+#else
+        write_stub(install / "dir_a" / "lib" / "libamdhip64.so");
+#endif
+        const std::string found = BackendUtils::normalize_therock_payload_dir(install.string());
+        check(found.empty(), "normalize: ambiguous layout is left untouched (no guess)");
+    }
+
+    {
+        // Empty install dir.
+        const fs::path install = tmp / "empty_install";
+        fs::create_directories(install);
+        const std::string found = BackendUtils::normalize_therock_payload_dir(install.string());
+        check(found.empty(), "normalize: empty install dir yields no payload");
+    }
+
+    // --- get_external_rocm_loader_dir: ROCM_PATH root reaches the child ---
+
+    {
+        // A valid external ROCm root (HIP runtime present) resolves.
+        const fs::path root = tmp / "external_rocm";
+#ifdef _WIN32
+        write_stub(root / "bin" / "amdhip64_7.dll");
+#else
+        write_stub(root / "lib" / "libamdhip64.so");
+#endif
+        set_rocm_path(root.string());
+        const std::string dir = BackendUtils::get_external_rocm_loader_dir();
+#ifdef _WIN32
+        const fs::path expected = root / "bin";
+#else
+        const fs::path expected = root / "lib";
+#endif
+        check(!dir.empty(), "external ROCm root resolves to a loader dir");
+        check(fs::equivalent(fs::path(dir), expected),
+              "loader dir is the resolved root's bin/lib");
+    }
+
+    {
+        // Unset ROCM_PATH: no external loader dir on this host (host-dependent,
+        // so assert only the invariant that it returns without throwing).
+        set_rocm_path("");
+        BackendUtils::get_external_rocm_loader_dir();
+        check(true, "no ROCM_PATH: get_external_rocm_loader_dir returns without throwing");
+    }
+
+    fs::remove_all(tmp);
+    if (g_failures) {
+        std::cerr << g_failures << " failure(s)" << std::endl;
+        return 1;
+    }
+    std::cout << "all issue-2722 checks passed" << std::endl;
+    return 0;
+}

--- a/test/cpp/test_therock_payload.cpp
+++ b/test/cpp/test_therock_payload.cpp
@@ -1,0 +1,159 @@
+// Regression tests for the TheRock installed-check (issue #2413, PR #2454).
+//
+// Guards two behaviors the fix must keep:
+//   1. A complete TheRock install (version.txt matching AND a concrete HIP
+//      runtime payload present) counts as installed — so installing a second
+//      ROCm backend does not re-download the ~3 GB tarball.
+//   2. An incomplete install (version.txt present but the runtime payload
+//      missing/corrupt) counts as NOT installed — so install_therock falls
+//      through to re-download, repairing the broken install instead of
+//      silently skipping it (the update_required repair path from #2003).
+
+#include <lemon/backends/backend_utils.h>
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+using lemon::backends::BackendUtils;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, const char* msg) {
+    if (cond) {
+        std::cout << "[ok] " << msg << std::endl;
+    } else {
+        std::cerr << "[FAIL] " << msg << std::endl;
+        ++g_failures;
+    }
+}
+
+void set_cache_dir(const std::string& value) {
+#ifdef _WIN32
+    _putenv_s("LEMONADE_CACHE_DIR", value.c_str());
+#else
+    setenv("LEMONADE_CACHE_DIR", value.c_str(), /*overwrite=*/1);
+#endif
+}
+
+void write_stub(const fs::path& p) {
+    fs::create_directories(p.parent_path());
+    std::ofstream(p) << "stub";
+}
+
+// TheRock install dir layout: <cache>/bin/therock/<arch>-<version>/ with
+// version.txt plus lib/ (Linux) or bin/ (Windows) holding the HIP runtime.
+fs::path make_therock_install(const fs::path& tmp, const std::string& arch,
+                              const std::string& version, bool with_payload) {
+    const fs::path dir = tmp / "bin" / "therock" / (arch + "-" + version);
+    {
+        fs::create_directories(dir);
+        std::ofstream vf(dir / "version.txt");
+        vf << version;
+    }
+    if (with_payload) {
+#ifdef _WIN32
+        write_stub(dir / "bin" / "amdhip64.dll");
+#else
+        write_stub(dir / "lib" / "libamdhip64.so");
+#endif
+    } else {
+        // Skeleton only — the lib/ or bin/ directory exists but the actual
+        // HIP runtime file is missing (incomplete/corrupt install).
+#ifdef _WIN32
+        fs::create_directories(dir / "bin");
+#else
+        fs::create_directories(dir / "lib");
+#endif
+    }
+    return dir;
+}
+
+}  // namespace
+
+int main() {
+    fs::path tmp = fs::temp_directory_path() /
+                   ("lemon_therock_payload_test_" + std::to_string(
+#ifdef _WIN32
+                        _getpid()
+#else
+                        getpid()
+#endif
+                        ));
+    fs::remove_all(tmp);
+    fs::create_directories(tmp);
+    set_cache_dir(tmp.string());
+
+    const std::string arch = "gfx1100";
+    const std::string version = "6.4.1";
+
+    // --- has_hip_runtime_payload: the shared "is it really installed" gate ---
+
+    {
+        const fs::path complete = make_therock_install(tmp, arch, version, /*with_payload=*/true);
+        check(BackendUtils::has_hip_runtime_payload(complete.string()),
+              "complete install (version.txt + HIP payload) counts as installed");
+    }
+    {
+        const fs::path incomplete = make_therock_install(tmp, arch, "broken", /*with_payload=*/false);
+        check(!BackendUtils::has_hip_runtime_payload(incomplete.string()),
+              "incomplete install (dir skeleton, no HIP payload) is NOT installed");
+    }
+    {
+        const fs::path empty_dir = tmp / "bin" / "therock" / "empty";
+        fs::create_directories(empty_dir);
+        check(!BackendUtils::has_hip_runtime_payload(empty_dir.string()),
+              "empty install dir is NOT installed");
+    }
+#ifdef _WIN32
+    {
+        // ROCm 7.x version-suffixes the runtime (bin\amdhip64_7.dll); a bogus
+        // suffix (amdhip64_backup.dll) must not be mistaken for the runtime.
+        const fs::path versioned = tmp / "bin" / "therock" / "v7";
+        write_stub(versioned / "bin" / "amdhip64_7.dll");
+        check(BackendUtils::has_hip_runtime_payload(versioned.string()),
+              "version-suffixed HIP runtime (amdhip64_7.dll) counts as installed");
+        const fs::path bogus = tmp / "bin" / "therock" / "bogus";
+        write_stub(bogus / "bin" / "amdhip64_backup.dll");
+        check(!BackendUtils::has_hip_runtime_payload(bogus.string()),
+              "bogus suffix (amdhip64_backup.dll) is NOT a HIP runtime");
+    }
+#endif
+
+    // --- install_therock early-return: no download when already installed ---
+
+    {
+        // A progress callback that fails the test if it is ever invoked — the
+        // download path reports progress, the early-return path does not.
+        bool download_started = false;
+        auto cb = [&download_started](const lemon::DownloadProgress&) {
+            download_started = true;
+            return true;
+        };
+        make_therock_install(tmp, arch, version, /*with_payload=*/true);
+        // If the payload gate regresses, install_therock tries to download
+        // (and reports progress / throws) instead of returning immediately.
+        BackendUtils::install_therock(arch, version, cb);
+        check(!download_started,
+              "install_therock with a complete install returns without downloading");
+    }
+
+    fs::remove_all(tmp);
+    if (g_failures) {
+        std::cerr << g_failures << " failure(s)" << std::endl;
+        return 1;
+    }
+    std::cout << "all therock payload checks passed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #2413 — TheRock was downloaded once per ROCm backend install, not once globally.

### Root Cause

\`install_backend()\` computed \`needs_therock_download\` per-call. When hot-swapping multiple ROCm backends (e.g. \`llamacpp:rocm\` + \`sd-cpp:rocm\`), the second call set \`rocm_runtime_update_required = true\` (because sd-cpp:rocm also needed updating), which short-circuited the \`is_therock_installed_for_current_arch\` check via \`||\`. This caused the runtime step to **delete the existing TheRock directory** and re-download the full 3.2 GB tarball for the same arch+version.

### Fix

\`needs_therock_download\` now only checks \`is_therock_installed_for_current_arch()\`. If TheRock is already the correct version for the detected GPU architecture, no download occurs — regardless of per-backend \`update_required\` state.

Removed:
- \`rocm_runtime_update_required\` short-circuit (TheRock is a shared runtime, not per-backend)
- The \`fs::remove_all\` deletion block in the runtime step (\`install_therock()\` handles version upgrades via \`cleanup_old_therock_versions()\`)
- Unused \`backend_update_required()\` helper

### Before

First ROCm backend → download 3.2 GB ✓  
Second ROCm backend → delete, download 3.2 GB again ✗  

### After

First ROCm backend → download 3.2 GB ✓  
Second ROCm backend → TheRock already installed, skip ✓

---

**Update: merged PR #3190 into this branch** — both PRs touched the TheRock install path in `backend_utils.cpp` and would have conflicted at merge. Now this PR covers the full TheRock install story:

- **#2413**: prevent redundant TheRock download across multiple ROCm backend installs (once per arch+version, with `has_hip_runtime_payload()` validation so corrupt installs repair instead of being skipped)
- **#2722** (from #3190): tolerate wrapper-dir tarballs (`normalize_therock_payload_dir()`) + put external ROCm root on backend loader path (`get_external_rocm_loader_dir()`), wired into acestep/openmoss/sdcpp/trellis
- Both test targets registered (`test_therock_payload` + `test_therock_2722`)