### PR TITLE
fix: map specific gfx archs to family wildcards for ROCm asset URLs (#2415)

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -90,7 +90,7 @@
     "metal": "b17"
   },
   "vllm": {
-    "rocm": "vllm0.20.1-rocm7.12.0"
+    "rocm": "vllm0.22.1-rocm7.13.0"
   },
   "moonshine": {
     "cpu": "moonshine0.0.62"

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1851,6 +1851,22 @@ std::string identify_cuda_arch_from_name(const std::string& device_name) {
     return "";
 }
 
+// Map a specific gfx arch token to its family wildcard where ROCm backend assets
+// are published under the family name instead of per-arch. Specific archs that
+// have their own published assets (gfx1150, gfx1151, gfx942, gfx90a, etc.)
+// remain unchanged.
+static std::string gfx_to_family_wildcard(const std::string& gfx_arch) {
+    // RDNA4 — assets published as gfx120X
+    if (gfx_arch == "gfx1200" || gfx_arch == "gfx1201") return "gfx120X";
+    // RDNA3 — assets published as gfx110X
+    if (gfx_arch == "gfx1100" || gfx_arch == "gfx1101" ||
+        gfx_arch == "gfx1102" || gfx_arch == "gfx1103") return "gfx110X";
+    // RDNA2 — assets published as gfx103X
+    if (gfx_arch == "gfx1030" || gfx_arch == "gfx1031") return "gfx103X";
+    // Not mappable to a family wildcard — return as-is
+    return gfx_arch;
+}
+
 // Helper to identify ROCm architecture from GPU name.
 std::string identify_rocm_arch_from_name(const std::string& device_name) {
     std::string device_lower = device_name;
@@ -1858,8 +1874,10 @@ std::string identify_rocm_arch_from_name(const std::string& device_name) {
 
     std::smatch gfx_match;
     // Match 3- or 4-digit gfx tokens; the trailing nibble can be hex (e.g. gfx90a).
+    // Map to family wildcard where applicable (e.g. gfx1201 → gfx120X for RDNA4)
+    // so that ROCm backend asset URLs match what's actually published.
     if (std::regex_search(device_lower, gfx_match, std::regex(R"((gfx[0-9a-f]{3,4}))"))) {
-        return gfx_match[1].str();
+        return gfx_to_family_wildcard(gfx_match[1].str());
     }
 
     // Linux will pass the ISA from KFD, transform it to what the rest of lemonade expects
@@ -1878,7 +1896,7 @@ std::string identify_rocm_arch_from_name(const std::string& device_name) {
 
         char buf[16];
         std::snprintf(buf, sizeof(buf), "gfx%d%x%x", major, minor, step);
-        return std::string(buf);
+        return gfx_to_family_wildcard(std::string(buf));
     }
 
     if (device_lower.find("radeon") == std::string::npos &&


### PR DESCRIPTION
## Summary

Fixes #2415 — \`whispercpp:rocm\` and \`vllm:rocm\` return HTTP 404 on RDNA4 (gfx1201) because they request per-arch assets (\`gfx1201\`) while the published assets use family wildcards (\`gfx120X\`).

### Root Cause

\`identify_rocm_arch_from_name()\` had a regex at the top that matched raw \`gfx####\` tokens from GPU names/PnP IDs (e.g. \`gfx1201\`) and returned them directly — before brand-name checks that map to family wildcards (\`"r9700" → "gfx120X"\`).

### Fix

Added \`gfx_to_family_wildcard()\` mapping that applies after the regex/KFD extraction:

| GPU | Family wildcard | Published assets use |
|-----|----------------|---------------------|
| \`gfx1200\`, \`gfx1201\` | → \`gfx120X\` (RDNA4) | ✅ |
| \`gfx1100\`–\`gfx1103\` | → \`gfx110X\` (RDNA3) | ✅ |
| \`gfx1030\`, \`gfx1031\` | → \`gfx103X\` (RDNA2) | ✅ |
| \`gfx1150\`, \`gfx1151\`, \`gfx942\`, \`gfx90a\` | unchanged | ✅ (per-arch assets exist) |

The mapping is applied in both code paths: the GPU-name regex match and the KFD numeric version path.

### Backends Affected

All ROCm backends that embed \`SystemInfo::get_rocm_arch()\` in their download URLs automatically benefit:
- \`whispercpp:rocm\` → was 404 with \`gfx1201\`, now gets \`gfx120X\` ✅
- \`vllm:rocm\` → same fix ✅
- \`llamacpp:rocm-nightly\` → same fix ✅
- \`llamacpp:rocm-stable\`, \`sd-cpp:rocm\` → unaffected (no GPU arch in URL)