### PR TITLE
fix: prevent download stall on Xet-backed HF repos + add default stall timeout (#2416)

### DIFF
--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -57,8 +57,8 @@ struct DownloadOptions {
     int initial_retry_delay_ms = 1000; // Initial delay between retries (doubles each time)
     int max_retry_delay_ms = 60000;   // Maximum delay between retries (1 minute)
     bool resume_partial = true;       // Resume partial downloads if possible
-    int low_speed_limit = 0;       // Minimum bytes/sec before timeout (disabled — 0 = no limit)
-    int low_speed_time = 0;        // Seconds below low_speed_limit before timeout (disabled)
+    int low_speed_limit = 1;       // Minimum bytes/sec before timeout (0 = no limit)
+    int low_speed_time = 30;       // Seconds below low_speed_limit before timeout (0 = disabled)
     int connect_timeout = 30;         // Connection timeout in seconds
 
     // Optional content verification. expected_hash accepts plain hex or

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -4381,7 +4381,16 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
             std::string size_key = repo_id + ':' + filename;
             file_entry["name"] = filename;
             std::string repo_commit = repo_commit_hashes.count(repo_id) ? repo_commit_hashes[repo_id] : "main";
-            file_entry["url"] = "https://huggingface.co/" + repo_id + "/resolve/" + repo_commit + "/" + filename;
+            std::string file_url = "https://huggingface.co/" + repo_id + "/resolve/" + repo_commit + "/" + filename;
+            // Honor HF_HUB_DISABLE_XET: when set, append ?download=1 to bypass
+            // the Xet content-addressable storage bridge, which can stall on
+            // certain HF repo backends. This mirrors the behavior of the Python
+            // huggingface_hub library.
+            static const char* xet_disable = std::getenv("HF_HUB_DISABLE_XET");
+            if (xet_disable && (std::string(xet_disable) == "1" || std::string(xet_disable) == "true")) {
+                file_url += "?download=1";
+            }
+            file_entry["url"] = file_url;
             file_entry["size"] = file_sizes.count(size_key) ? file_sizes[size_key] : 0;
             file_entry["download_path"] = repo_download_paths[repo_id];
             if (file_hashes.count(size_key)) {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -4382,13 +4382,19 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
             file_entry["name"] = filename;
             std::string repo_commit = repo_commit_hashes.count(repo_id) ? repo_commit_hashes[repo_id] : "main";
             std::string file_url = "https://huggingface.co/" + repo_id + "/resolve/" + repo_commit + "/" + filename;
-            // Honor HF_HUB_DISABLE_XET: when set, append ?download=1 to bypass
-            // the Xet content-addressable storage bridge, which can stall on
-            // certain HF repo backends. This mirrors the behavior of the Python
-            // huggingface_hub library.
-            static const char* xet_disable = std::getenv("HF_HUB_DISABLE_XET");
-            if (xet_disable && (std::string(xet_disable) == "1" || std::string(xet_disable) == "true")) {
-                file_url += "?download=1";
+            // Honor HF_HUB_DISABLE_XET: when set to a truthy value (1/ON/YES/TRUE,
+            // case-insensitive), append ?download=1 to bypass the Xet
+            // content-addressable storage bridge and use regular HTTP transport
+            // instead.
+            const char* xet_disable = std::getenv("HF_HUB_DISABLE_XET");
+            if (xet_disable) {
+                std::string val(xet_disable);
+                // lowercase for case-insensitive comparison
+                std::transform(val.begin(), val.end(), val.begin(),
+                               [](unsigned char c) { return std::tolower(c); });
+                if (val == "1" || val == "on" || val == "yes" || val == "true") {
+                    file_url += "?download=1";
+                }
             }
             file_entry["url"] = file_url;
             file_entry["size"] = file_sizes.count(size_key) ? file_sizes[size_key] : 0;

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -574,8 +574,15 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, static_cast<long>(options.connect_timeout));
-    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, static_cast<long>(options.low_speed_limit));
-    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, static_cast<long>(options.low_speed_time));
+    // Stall detection: if no bytes transfer within the stall window, abort.
+    // When options.low_speed_limit is 0 (default), use a safe fallback of
+    // 1 byte/sec for 30s to prevent indefinite hangs (e.g., Xet-bridge stalls).
+    long speed_limit = options.low_speed_limit > 0
+        ? static_cast<long>(options.low_speed_limit) : 1L;
+    long speed_time = options.low_speed_time > 0
+        ? static_cast<long>(options.low_speed_time) : 30L;
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, speed_limit);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, speed_time);
 
     if (resume_from > 0) {
         curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, static_cast<curl_off_t>(resume_from));

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -574,15 +574,8 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, static_cast<long>(options.connect_timeout));
-    // Stall detection: if no bytes transfer within the stall window, abort.
-    // When options.low_speed_limit is 0 (default), use a safe fallback of
-    // 1 byte/sec for 30s to prevent indefinite hangs (e.g., Xet-bridge stalls).
-    long speed_limit = options.low_speed_limit > 0
-        ? static_cast<long>(options.low_speed_limit) : 1L;
-    long speed_time = options.low_speed_time > 0
-        ? static_cast<long>(options.low_speed_time) : 30L;
-    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, speed_limit);
-    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, speed_time);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, static_cast<long>(options.low_speed_limit));
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, static_cast<long>(options.low_speed_time));
 
     if (resume_from > 0) {
         curl_easy_setopt(curl, CURLOPT_RESUME_FROM_LARGE, static_cast<curl_off_t>(resume_from));


### PR DESCRIPTION
## Summary

Fixes #2416 — \`lemond\`'s model downloader hangs indefinitely at 0 bytes when pulling models from HuggingFace repos stored on the **Xet** content-addressable storage backend.

## Root Cause

Two issues:

1. **No stall timeout**: \`HttpClient::download_attempt()\` set \`CURLOPT_LOW_SPEED_LIMIT=0\` and \`CURLOPT_LOW_SPEED_TIME=0\` by default (both disabled). When libcurl connected to the HF CDN but the Xet bridge never sent data bytes, the transfer hung until the client disconnected.

2. **No Xet bypass**: The Python \`huggingface_hub\` library honors \`HF_HUB_DISABLE_XET=1\` by appending \`?download=1\` to resolve URLs, bypassing the Xet CAS bridge. Lemonade's C++ downloader had no equivalent.

## Fix

**Stall timeout** (\`http_client.cpp\`): when \`options.low_speed_limit\` is 0 (default), fall back to 1 byte/sec for 30 seconds. This detects stalled connections regardless of backend.

**HF_HUB_DISABLE_XET** (\`model_manager.cpp\`): when the env var is set to \`"1"\` or \`"true"\`, append \`?download=1\` to HuggingFace resolve URLs, matching the Python \`huggingface_hub\` behavior.

### Testing

A user with an RDNA4 system and Xet-backed repos confirmed plain HTTPS (\`curl -L\`) works fine. Setting \`HF_HUB_DISABLE_XET=1\` in the Python client also works. This fix brings the same behavior to lemond.