### PR TITLE
fix: add gfx1152 (Krackan APU) to whispercpp:rocm and vllm:rocm (#2002)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td rowspan="1"><code>vllm</code> (experimental)</td>
       <td><code>rocm</code></td>
-      <td>Strix Halo iGPU (gfx1151)</td>
+      <td>Strix Halo / Krackan Point iGPU (gfx1151, gfx1152)</td>
       <td>Linux</td>
     </tr>
     <tr>

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -64,11 +64,11 @@ the generator instead. Prose outside the markers is preserved. -->
 | `trellis` | cuda | linux, windows | nvidia_gpu |
 | `trellis` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
 | `trellis` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
-| `vllm` | rocm | linux | amd_gpu (gfx110X, gfx1150, gfx1151, gfx120X) |
+| `vllm` | rocm | linux | amd_gpu (gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `whispercpp` | npu | windows | amd_npu (XDNA2) |
 | `whispercpp` | metal | macos | metal |
 | `whispercpp` | vulkan | linux, windows | amd_gpu; cpu (x86_64) |
-| `whispercpp` | rocm | linux, windows | amd_gpu (gfx110X, gfx1150, gfx1151, gfx120X) |
+| `whispercpp` | rocm | linux, windows | amd_gpu (gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `whispercpp` | cpu | linux, windows | cpu (x86_64) |
 <!-- END GENERATED: backends-matrix -->
 

--- a/src/cpp/include/lemon/backends/vllm/vllm.h
+++ b/src/cpp/include/lemon/backends/vllm/vllm.h
@@ -27,7 +27,7 @@ inline const BackendDescriptor descriptor = {
     /*support*/ {
         // gfx942/gfx950 (CDNA) omitted until their vLLM/ROCm assets ship in lemonade-sdk/vllm-rocm;
         // everything else is wired (incl. the rocm_arch_overrides pins), so re-add them here once that lands.
-        {"rocm", {"linux"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx110X", "gfx120X"}}}, "Strix Halo iGPU (gfx1151)"},
+        {"rocm", {"linux"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx110X", "gfx120X"}}}, "Strix Halo / Krackan Point iGPU (gfx1151, gfx1152)"},
     },
     /*supported_modes*/ {"chat"},
     /*required_checkpoints*/ {"main"},

--- a/src/cpp/include/lemon/backends/whispercpp/whispercpp.h
+++ b/src/cpp/include/lemon/backends/whispercpp/whispercpp.h
@@ -33,7 +33,7 @@ inline const BackendDescriptor descriptor = {
         {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
         {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}}, "x86_64 CPU"},
         {"rocm", {"windows", "linux"},
-         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families*"},
+         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families*"},
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
     },
     /*supported_modes*/ {"transcription"},


### PR DESCRIPTION
## Summary

Fixes #2002 — Krackan APU (Radeon 840M/860M, gfx1152) shows "Unsupported GPU: gfx1152" when trying to install whispercpp:rocm or vllm:rocm.

## Root Cause

gfx1152 was already in `llamacpp:rocm` and `sd-cpp:rocm` RECIPE_DEFS, but missing from whispercpp:rocm and vllm:rocm.

## Fix

Add "gfx1152" to the amd_gpu device constraints for whispercpp:rocm and vllm:rocm.
