### PR TITLE
fix: cancel model download on Ctrl+C (SIGINT) via libcurl progress callback (#1385)

### DIFF
--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -208,5 +208,9 @@ inline ProgressCallback create_throttled_progress_callback(size_t resume_offset 
     };
 }
 
+// Global flag: set from signal handler to cancel in-progress model downloads.
+// Checked by the libcurl progress callback during transfer.
+extern std::atomic<bool> g_download_cancelled;
+
 } // namespace utils
 } // namespace lemon

--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -8,6 +8,7 @@
 #include <lemon/logging_config.h>
 #include <lemon/server.h>
 #include <lemon/system_info.h>
+#include <lemon/utils/http_client.h>
 #include <lemon/version.h>
 #include <lemon/utils/path_utils.h>
 #include <lemon/utils/aixlog.hpp>
@@ -34,6 +35,10 @@ void signal_handler(int signal) {
         ssize_t written = write(STDOUT_FILENO, msg, 38);
         (void)written;
 #endif
+
+        // Cancel any in-progress model download immediately. The libcurl
+        // progress callback checks this flag and aborts the transfer.
+        utils::g_download_cancelled.store(true);
 
         // Signal shutdown via the Server instance. The main loop will detect
         // this flag and call server->stop() for graceful cleanup (unloading

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -22,6 +22,8 @@ namespace fs = std::filesystem;
 namespace lemon {
 namespace utils {
 
+std::atomic<bool> g_download_cancelled{false};
+
 std::atomic<long> HttpClient::default_timeout_seconds_{300};
 
 namespace {
@@ -344,6 +346,10 @@ static int progress_callback(void* clientp, curl_off_t dltotal, curl_off_t dlnow
                              curl_off_t ultotal, curl_off_t ulnow) {
     (void)ultotal;
     (void)ulnow;
+
+    if (g_download_cancelled.load()) {
+        return 1;  // Abort transfer
+    }
 
     ProgressData* data = static_cast<ProgressData*>(clientp);
     if (!data) return 0;


### PR DESCRIPTION
## Summary

Fixes #1385 — `lemonade-server pull` ignores Ctrl+C (SIGINT) during model download.

## Problem

Model downloads use libcurl which blocks in a system call. The existing SIGINT handler only sets a graceful-shutdown flag, but in-progress downloads continue uninterrupted until completion. The user's only option was `kill -9`.

## Fix

1. Added a global `std::atomic<bool> g_download_cancelled` flag in `http_client.cpp`
2. Check it in the libcurl progress callback (called periodically during transfer)
3. Set it from the SIGINT handler in `main.cpp`, BEFORE the shutdown flag

When Ctrl+C is pressed during a download:
1. SIGINT handler sets `g_download_cancelled = true`
2. Libcurl's progress callback detects the flag on its next invocation
3. Returns non-zero to abort the transfer
4. `download_attempt` returns `cancelled = true`
5. The partial file is preserved on disk for later resume

## Testing

Start a model download, press Ctrl+C mid-transfer. The download should stop within ~1 second (libcurl's progress callback polling interval), and the partial file should remain for resume.
