### PR TITLE
fix: enable --fit, make --no-mmproj-offload overridable, add -ngl (#1848 #2358 #2215)

### DIFF
--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
@@ -29,6 +29,8 @@ inline const BackendDescriptor descriptor = {
          "Comma-separated list of accelerator devices to use (e.g. Vulkan0)", "Llama.cpp Backend Options"},
         {"llamacpp_args", "--llamacpp-args", "", "ARGS",
          "Custom arguments to pass to llama-server", "Llama.cpp Backend Options"},
+        {"llamacpp_ngl", "", "-1", "INT",
+         "Number of GPU layers to offload (-1 = auto: 99 for GPU, 0 for CPU)", "Llama.cpp Backend Options"},
     },
     /*support*/ {
         {"system", {"linux"}, {{"cpu", {"x86_64", "arm64"}}}, "x86_64/ARM64 CPU, GPU"},

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -351,13 +351,32 @@ void LlamaCppServer::load(const std::string& model_name,
     LOG(DEBUG, "LlamaCpp") << "Using backend: " << llamacpp_backend << "\n"
             << "[LlamaCpp] Use GPU: " << (use_gpu ? "true" : "false") << std::endl;
 
+    // Enable --fit by default on GPU backends so llama-server auto-tunes
+    // model parameters to fit within available device memory. Users can
+    // opt out via --no-fit in llamacpp_args. See #1848.
+    if (use_gpu) {
+        push_overridable_arg(args, llamacpp_args, "--fit");
+    }
+
+    // Set -ngl (num_gpu_layers) based on backend type: 99 for GPU backends
+    // (offload all layers), 0 for CPU-only. Users can override via -ngl N
+    // in llamacpp_args, or by setting llamacpp_ngl in recipe options.
+    // See #2215.
+    {
+        int ngl = options.get_option("llamacpp_ngl");
+        if (ngl < 0) {
+            ngl = use_gpu ? 99 : 0;
+        }
+        push_overridable_arg(args, llamacpp_args, "-ngl", std::to_string(ngl));
+    }
+
     // Add mmproj file if present (for vision models). Skip when hf_load is set —
     // llama-server resolves the mmproj companion itself from the HF repo.
     if (!mmproj_path.empty() && !model_info.extra<bool>("hf_load", false)) {
         push_arg(args, reserved_flags, "--mmproj", mmproj_path);
         if (!use_gpu) {
             LOG(DEBUG, "LlamaCpp") << "Skipping mmproj argument since GPU mode is not enabled" << std::endl;
-            push_arg(args, reserved_flags, "--no-mmproj-offload");
+            push_overridable_arg(args, llamacpp_args, "--no-mmproj-offload");
         }
     }
     push_reserved(reserved_flags, "--mmproj", std::vector<std::string>{"-mm", "-mmu", "--mmproj-url", "--no-mmproj", "--mmproj-auto", "--no-mmproj-auto"});


### PR DESCRIPTION
Three fixes in llamacpp_server.cpp:

**#1848 — Enable --fit by default on GPU backends**  
llama-server's \`--fit\` flag auto-tunes model parameters to fit within available device memory. Previously not passed at all. Users can opt out via \`--no-fit\` in \`llamacpp_args\`.

**#2358 — Make --no-mmproj-offload overridable**  
Changed from \`push_arg\` (hardcoded, reserved) to \`push_overridable_arg\`. Users can now pass \`--mmproj-offload\` in \`llamacpp_args\` to force mmproj offload even on CPU backends. Removed from the reserved flags set.

**#2215 — Add configurable -ngl (num_gpu_layers)**  
llama-server now receives \`-ngl 99\` for GPU backends and \`-ngl 0\` for CPU. Users can override via \`-ngl N\` in \`llamacpp_args\` or by setting \`llamacpp_ngl\` in recipe options. Default is \`-1\` (auto = 99 for GPU, 0 for CPU).