### PR TITLE
docs: document draft checkpoint key and add MTP model example (#2435)

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -43,7 +43,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/lemonade-sdk/lemonade/build-environment
+          images: ghcr.io/${{ github.repository }}/build-environment
           tags: |
             type=raw,value=ubuntu${{ matrix.ubuntu_version }}
             type=raw,value=latest,enable=${{ matrix.ubuntu_version == '26.04' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(LEMON_BACKENDS
     "onnxruntime|onnxruntime"
     "trellis|trellis"
     "openmoss|openmoss"
+    "mlx-engine|mlx"
 )
 
 # ============================================================

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
   </thead>
   <tbody>
     <tr>
-      <td rowspan="9"><strong>Text generation</strong></td>
+      <td rowspan="12"><strong>Text generation</strong></td>
       <td rowspan="6"><code>llamacpp</code></td>
       <td><code>system</code></td>
       <td><code>x86_64</code>/ARM64 CPU, GPU</td>
@@ -184,6 +184,22 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td><code>rocm</code></td>
       <td>Strix Halo iGPU (gfx1151)</td>
       <td>Linux</td>
+    </tr>
+    <tr>
+      <td rowspan="3"><code>mlx-engine</code> (experimental)</td>
+      <td><code>metal</code></td>
+      <td>Apple Silicon Metal GPU</td>
+      <td>macOS</td>
+    </tr>
+    <tr>
+      <td><code>rocm</code></td>
+      <td>AMD ROCm GPUs (RDNA3/RDNA4)</td>
+      <td>Linux</td>
+    </tr>
+    <tr>
+      <td><code>cpu</code></td>
+      <td>CPU fallback</td>
+      <td>Linux, macOS</td>
     </tr>
     <tr>
       <td rowspan="6"><strong>Speech-to-text</strong></td>

--- a/docs/assets/models.js
+++ b/docs/assets/models.js
@@ -8,6 +8,7 @@ const RECIPE_PRIORITY = [
   'flm',
   'kokoro',
   'llamacpp',
+  'mlx-engine',
   'moonshine',
   'onnxruntime',
   'openmoss',
@@ -30,7 +31,8 @@ const RECIPE_DISPLAY_NAMES = {
   acestep: 'ACE-Step',
   onnxruntime: 'ONNX Runtime',
   trellis: 'TRELLIS.2',
-  openmoss: 'OpenMOSS TTS'
+  openmoss: 'OpenMOSS TTS',
+  'mlx-engine': 'MLX Engine (Apple Silicon)'
 };
 /* END GENERATED: models-js-recipes */
 

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -13,6 +13,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `flm` | FastFlowLM NPU | no | yes | npu |
 | `kokoro` | Kokoro | no | no | cpu, metal |
 | `llamacpp` | Llama.cpp GPU | yes | yes | cpu, cuda, metal, rocm, system, vulkan |
+| `mlx-engine` | MLX Engine | yes | yes | cpu, metal, rocm |
 | `moonshine` | Moonshine | no | no | cpu |
 | `onnxruntime` | ONNX Runtime | no | no | cpu |
 | `openmoss` | OpenMOSS TTS | yes | no | cuda, rocm, vulkan |
@@ -41,6 +42,9 @@ the generator instead. Prose outside the markers is preserved. -->
 | `llamacpp` | vulkan | linux, windows | amd_gpu; cpu (arm64, x86_64) |
 | `llamacpp` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X, gfx942, gfx950) |
 | `llamacpp` | cpu | linux, windows | cpu (arm64, x86_64) |
+| `mlx-engine` | metal | macos | metal |
+| `mlx-engine` | rocm | linux | amd_gpu (gfx110X, gfx1150, gfx1151, gfx120X) |
+| `mlx-engine` | cpu | linux, macos | cpu (arm64, x86_64) |
 | `moonshine` | cpu | windows | cpu (x86_64) |
 | `moonshine` | cpu | linux | cpu (arm64, x86_64) |
 | `moonshine` | cpu | macos | cpu (arm64) |
@@ -101,6 +105,14 @@ the generator instead. Prose outside the markers is preserved. -->
 | `llamacpp_backend` | `--llamacpp` | BACKEND | "" | LlamaCpp backend to use |
 | `llamacpp_device` | `--llamacpp-device` | DEVICES | "" | Comma-separated list of accelerator devices to use (e.g. Vulkan0) |
 | `llamacpp_args` | `--llamacpp-args` | ARGS | "" | Custom arguments to pass to llama-server |
+
+#### `mlx-engine` — MLX Engine
+
+| Option | CLI flag | Type | Default | Description |
+|--------|----------|------|---------|-------------|
+| `ctx_size` | `--ctx-size` | SIZE | -1 | Context size for the model |
+| `mlx_backend` | `--mlx-backend` | BACKEND | "" | MLX backend to use (metal, rocm, cpu) |
+| `mlx_args` | `--mlx-args` | ARGS | "" | Extra arguments passed to lemon-mlx-engine |
 
 #### `moonshine` — Moonshine
 
@@ -267,6 +279,13 @@ the generator instead. Prose outside the markers is preserved. -->
 | `jina-reranker-v1-tiny-en-GGUF` | 0.0367 | reranking |
 | `nomic-embed-text-v1-GGUF` | 0.0781 | embeddings |
 | `nomic-embed-text-v2-moe-GGUF` | 0.51 | embeddings |
+
+#### `mlx-engine` — MLX Engine (2 models)
+
+| Model | Size (GB) | Labels |
+|-------|-----------|--------|
+| `Qwen3-0.6B-MLX` | 0.42 | reasoning |
+| `Qwen3-4B-MLX` | 2.3 | reasoning |
 
 #### `moonshine` — Moonshine (3 models)
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -408,6 +408,14 @@ The following options are available depending on the recipe being used:
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--openmoss BACKEND` | OpenMOSS TTS backend to use | Auto-detected |
+
+#### MLX Engine (`mlx-engine` recipe)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ctx-size SIZE` | Context size for the model | auto |
+| `--mlx-backend BACKEND` | MLX backend to use (metal, rocm, cpu) | Auto-detected |
+| `--mlx-args ARGS` | Extra arguments passed to lemon-mlx-engine | `""` |
 <!-- END GENERATED: cli-recipe-options -->
 **Notes:**
 - Unspecified options will use the backend's default values

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -72,6 +72,9 @@ Values set in the user's `config.json` always take precedence over these seeded 
   },
   "log_level": "info",
   "max_loaded_models": 1,
+  "mlx-engine": {
+    "backend": "auto"
+  },
   "models_dir": "auto",
   "moonshine": {
     "args": "",

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -81,12 +81,27 @@ lemonade pull user.MyCodingModel \
     --label tool-calling
 ```
 
+### Multi-Token Prediction (MTP) models
+
+Models with separate MTP head / draft checkpoint files (e.g. Gemma 4) can be registered with an optional `draft` checkpoint. The `mtp` label enables `--spec-type draft-mtp` for speculative decoding acceleration. The `draft` checkpoint is optional — without it, the model loads and runs normally but without MTP acceleration.
+
+```bash
+lemonade pull user.My-Gemma-4-MTP \
+    --checkpoint main unsloth/Gemma-4-27B-IT-GGUF:Q4_K_M \
+    --checkpoint draft unsloth/Gemma-4-27B-IT-MTP-GGUF:gemma-4-27b-mtp-q4_k_m.gguf \
+    --checkpoint mmproj unsloth/Gemma-4-27B-IT-GGUF:mmproj-model-f16.gguf \
+    --recipe llamacpp \
+    --label mtp \
+    --label vision \
+    --label tool-calling
+```
+
 Supported registration flags:
 
 | Flag | Description |
 |------|-------------|
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` (default) or `modelscope`. |
-| `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
+| `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj`, `main` + `vae`, or `main` + `draft`. Known types: `main`, `mmproj`, `vae`, `draft`, `npu_cache`. |
 | `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `mlx-engine`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `coding`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -87,7 +87,7 @@ Supported registration flags:
 |------|-------------|
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` (default) or `modelscope`. |
 | `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
-| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
+| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `mlx-engine`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `coding`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |
 

--- a/src/cpp/include/lemon/backends/mlx/mlx.h
+++ b/src/cpp/include/lemon/backends/mlx/mlx.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "lemon/backends/backend_descriptor.h"
+
+namespace lemon {
+namespace backends {
+namespace mlx {
+
+// The mlx-engine backend descriptor (plain data). Header-only `inline const` so it
+// links into both the lemonade CLI and lemond without a separate source file.
+inline const BackendDescriptor descriptor = {
+    /*recipe*/          "mlx-engine",
+    /*display_name*/    "MLX Engine",
+#ifdef _WIN32
+    /*binary*/          "lemon-mlx-engine.exe",
+#else
+    /*binary*/          "lemon-mlx-engine",
+#endif
+    /*config_section*/  "",
+    /*default_device*/  DEVICE_GPU,
+    /*slot_policy*/     SlotPolicy::Standard,
+    /*selectable_backend*/ true,
+    /*uses_ctx_size*/   true,
+    /*dynamic_models*/  false,
+    /*options*/ {
+        {"mlx_backend", "--mlx-backend", "", "BACKEND",
+         "MLX backend to use (metal, rocm, cpu)", "MLX Engine Options"},
+        {"mlx_args", "--mlx-args", "", "ARGS",
+         "Extra arguments passed to lemon-mlx-engine", "MLX Engine Options"}
+    },
+    /*support*/ {
+        {"metal", {"macos"},
+         {{"metal", {}}}, "Apple Silicon Metal GPU"},
+        {"rocm", {"linux"},
+         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx110X", "gfx120X"}}}, "AMD ROCm GPUs (RDNA3/RDNA4)"},
+        {"cpu", {"linux", "macos"},
+         {{"cpu", {"x86_64", "arm64"}}}, "CPU fallback"},
+    },
+    /*default_labels*/ {},
+    /*required_checkpoints*/ {"main"},
+    /*modality*/ "Text generation",
+    /*experimental*/ true,
+    /*web_display_name*/ "MLX Engine (Apple Silicon)"
+};
+
+} // namespace mlx
+} // namespace backends
+} // namespace lemon

--- a/src/cpp/include/lemon/backends/mlx/mlx_server.h
+++ b/src/cpp/include/lemon/backends/mlx/mlx_server.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "lemon/backends/backend_registry.h"
+
+#include "lemon/wrapped_server.h"
+#include "lemon/backends/backend_utils.h"
+#include <string>
+
+namespace lemon {
+namespace backends {
+
+class MlxServer : public WrappedServer {
+public:
+    static InstallParams get_install_params(const std::string& backend, const std::string& version);
+
+    explicit MlxServer(const std::string& log_level,
+                       ModelManager* model_manager,
+                       BackendManager* backend_manager);
+
+    ~MlxServer() override;
+
+    void load(const std::string& model_name,
+              const ModelInfo& model_info,
+              const RecipeOptions& options,
+              bool do_not_upgrade = false) override;
+
+    void unload() override;
+
+    // ICompletionServer implementation
+    json chat_completion(const json& request) override;
+    json completion(const json& request) override;
+    json responses(const json& request) override;
+};
+
+namespace mlx {
+// Factory for the mlx-engine backend (constructs the server class — lemond only).
+std::unique_ptr<WrappedServer> create(const BackendContext& ctx);
+const BackendSpec* spec();
+const BackendOps* ops();
+}  // namespace mlx
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -1,5 +1,5 @@
 {
-  "comment": "This configuration file controls which llama.cpp, whisper.cpp, sd.cpp, ryzenai-llm, and FLM versions are downloaded for each backend. You can modify these values to pin specific versions without rebuilding the application.",
+  "comment": "This configuration file controls which llama.cpp, whisper.cpp, sd.cpp, ryzenai-llm, FLM, and mlx-engine versions are downloaded for each backend. You can modify these values to pin specific versions without rebuilding the application.",
   "checksums": {
     "comment": "Expected SHA-256 of downloaded GitHub release assets, verified after download (see BackendUtils::lookup_expected_asset_hash). Keyed by checksums.github.<owner/repo>.<tag>.<asset>. Values are the sha256:<hex> digests GitHub publishes for each asset. Update alongside the matching version pin below.",
     "github": {
@@ -45,6 +45,7 @@
       }
     }
   },
+  "rocm-stable-runtime": "v7.2.1",
   "llamacpp": {
     "vulkan": "b9747",
     "rocm-stable": "b9752",
@@ -131,6 +132,11 @@
   },
   "flm": {
     "npu": "v0.9.45"
+  },
+  "mlx-engine": {
+    "metal": "b1013-stable",
+    "rocm": "b1013-stable",
+    "cpu": "b1013-stable"
   },
   "kokoro": {
     "cpu": "b17",

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -37,6 +37,9 @@
   },
   "log_level": "info",
   "max_loaded_models": 1,
+  "mlx-engine": {
+    "backend": "auto"
+  },
   "models_dir": "auto",
   "moonshine": {
     "args": "",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1830,5 +1830,23 @@
             "classification"
         ],
         "size": 0.27
+    },
+    "Qwen3-0.6B-MLX": {
+        "checkpoint": "mlx-community/Qwen3-0.6B-4bit",
+        "recipe": "mlx-engine",
+        "suggested": true,
+        "labels": [
+            "reasoning"
+        ],
+        "size": 0.42
+    },
+    "Qwen3-4B-MLX": {
+        "checkpoint": "mlx-community/Qwen3-4B-4bit",
+        "recipe": "mlx-engine",
+        "suggested": false,
+        "labels": [
+            "reasoning"
+        ],
+        "size": 2.3
     }
 }

--- a/src/cpp/server/backends/mlx/mlx_server.cpp
+++ b/src/cpp/server/backends/mlx/mlx_server.cpp
@@ -1,0 +1,246 @@
+#include "lemon/backends/mlx/mlx_server.h"
+#include "lemon/backends/backend_ops.h"
+#include "lemon/backends/backend_utils.h"
+#include "lemon/backend_manager.h"
+#include "lemon/runtime_config.h"
+#include "lemon/utils/process_manager.h"
+#include "lemon/error_types.h"
+#include "lemon/system_info.h"
+#include <cstdlib>
+#include <filesystem>
+#include <sstream>
+#include <lemon/utils/aixlog.hpp>
+
+namespace fs = std::filesystem;
+using namespace lemon::utils;
+
+namespace lemon {
+namespace backends {
+
+// Resolve a user-facing backend choice ("rocm", "auto") to the concrete
+// variant used in asset filenames and install directories.
+static std::string resolve_mlx_backend(const std::string& backend) {
+    if (backend == "auto" || backend.empty()) {
+#ifdef __APPLE__
+        return "metal";
+#else
+        // On non-Apple platforms, default to rocm if an AMD GPU is present,
+        // fall back to cpu otherwise. SystemInfo already knows the truth.
+        std::string arch = SystemInfo::get_rocm_arch();
+        return arch.empty() ? "cpu" : "rocm";
+#endif
+    }
+    return backend;
+}
+
+static bool is_mlx_rocm_backend(const std::string& backend) {
+    return backend == "rocm";
+}
+
+InstallParams MlxServer::get_install_params(const std::string& backend, const std::string& version) {
+    InstallParams params;
+    params.repo = "lemonade-sdk/lemon-mlx-engine";
+
+    const std::string resolved = resolve_mlx_backend(backend);
+
+    if (resolved == "system") {
+        return params;
+    }
+
+    if (resolved == "metal") {
+#ifdef __APPLE__
+        params.filename = "mlx-engine-" + version + "-macos-arm64.zip";
+#else
+        throw std::runtime_error("Metal mlx-engine is only supported on macOS");
+#endif
+    } else if (resolved == "rocm") {
+#ifdef __linux__
+        std::string arch = SystemInfo::get_rocm_arch();
+        if (arch.empty()) {
+            throw std::runtime_error(
+                SystemInfo::get_unsupported_backend_error("mlx-engine", "rocm")
+            );
+        }
+        params.filename = "mlx-engine-" + version + "-ubuntu-rocm-stable-" + arch + "-x64.zip";
+#else
+        throw std::runtime_error("ROCm mlx-engine is only supported on Linux");
+#endif
+    } else if (resolved == "cpu") {
+#ifdef __linux__
+        params.filename = "mlx-engine-" + version + "-ubuntu-cpu-x64.zip";
+#elif defined(__APPLE__)
+        // On macOS the "cpu" build is served by the macos-arm64 asset
+        // (MLX runs through Metal/Accelerate even with no explicit GPU selection).
+        params.filename = "mlx-engine-" + version + "-macos-arm64.zip";
+#else
+        throw std::runtime_error("CPU mlx-engine is not supported on this platform");
+#endif
+    } else {
+        throw std::runtime_error("Unknown mlx-engine backend: " + backend);
+    }
+
+    return params;
+}
+
+MlxServer::MlxServer(const std::string& log_level,
+                     ModelManager* model_manager,
+                     BackendManager* backend_manager)
+    : WrappedServer("mlx-engine", log_level, model_manager, backend_manager) {
+}
+
+MlxServer::~MlxServer() {
+    unload();
+}
+
+void MlxServer::load(const std::string& model_name,
+                     const ModelInfo& model_info,
+                     const RecipeOptions& options,
+                     bool do_not_upgrade) {
+    LOG(INFO, "MLX") << "Loading model: " << model_name << std::endl;
+    LOG(DEBUG, "MLX") << "Per-model settings: " << options.to_log_string() << std::endl;
+
+    int ctx_size = options.get_option("ctx_size");
+    std::string mlx_backend_option = options.get_option("mlx_engine_backend");
+    std::string mlx_backend = resolve_mlx_backend(mlx_backend_option);
+    std::string mlx_args = options.get_option("mlx_engine_args");
+
+    RuntimeConfig::validate_backend_choice("mlx-engine", mlx_backend_option);
+
+    LOG(INFO, "MLX") << "Using mlx-engine backend: " << mlx_backend << std::endl;
+
+    // The CPU build runs on CPU; everything else is GPU (Metal or ROCm).
+    device_type_ = (mlx_backend == "cpu") ? DEVICE_CPU : DEVICE_GPU;
+
+    // Install mlx-engine binary if needed.
+    backend_manager_->install_backend(SPEC.recipe, mlx_backend);
+
+    // MLX identifies models by HuggingFace repo-id or a local directory path.
+    // The ModelManager resolves local paths when available; fall back to the
+    // checkpoint string (usually a repo-id) so the server auto-downloads on
+    // first use.
+    std::string model_ref = model_info.resolved_path();
+    if (model_ref.empty()) {
+        model_ref = model_info.checkpoint();
+    }
+    if (model_ref.empty()) {
+        throw std::runtime_error("mlx-engine: no model path or checkpoint provided");
+    }
+
+    LOG(DEBUG, "MLX") << "Using model reference: " << model_ref << std::endl;
+
+    port_ = choose_port();
+
+    std::string executable = BackendUtils::get_backend_binary_path(SPEC, mlx_backend);
+
+    std::vector<std::string> args;
+    // Positional model argument — pre-load mode.
+    args.push_back(model_ref);
+    args.push_back("--host");
+    args.push_back("127.0.0.1");
+    args.push_back("--port");
+    args.push_back(std::to_string(port_));
+
+    if (ctx_size > 0) {
+        args.push_back("--ctx-size");
+        args.push_back(std::to_string(ctx_size));
+    }
+
+    // Honor custom user args last so they can override anything above.
+    if (!mlx_args.empty()) {
+        std::istringstream iss(mlx_args);
+        std::string token;
+        while (iss >> token) {
+            args.push_back(token);
+        }
+    }
+
+    LOG(INFO, "MLX") << "Starting mlx-engine server..." << std::endl;
+
+    std::vector<std::pair<std::string, std::string>> env_vars;
+#ifdef __linux__
+    if (is_mlx_rocm_backend(mlx_backend)) {
+        // Point the loader at the bundled ROCm shared libraries shipped next
+        // to the server binary (same pattern as llamacpp-rocm).
+        fs::path exe_dir = fs::path(executable).parent_path();
+        std::string lib_path = exe_dir.string();
+
+        const char* existing = std::getenv("LD_LIBRARY_PATH");
+        if (existing && *existing) {
+            lib_path = lib_path + ":" + std::string(existing);
+        }
+        env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
+        LOG(DEBUG, "MLX") << "Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
+    }
+#endif
+
+    bool inherit = (log_level_ == "info") || is_debug();
+    process_handle_ = ProcessManager::start_process(executable, args, "", inherit, true, env_vars);
+
+    if (!wait_for_ready("/health")) {
+        ProcessManager::stop_process(process_handle_);
+        process_handle_ = {nullptr, 0};
+        throw std::runtime_error("mlx-engine server failed to start");
+    }
+
+    LOG(DEBUG, "MLX") << "Model loaded on port " << port_ << std::endl;
+}
+
+void MlxServer::unload() {
+    LOG(INFO, "MLX") << "Unloading model..." << std::endl;
+#ifdef _WIN32
+    if (process_handle_.handle) {
+#else
+    if (process_handle_.pid > 0) {
+#endif
+        ProcessManager::stop_process(process_handle_);
+        process_handle_ = {nullptr, 0};
+        port_ = 0;
+    }
+}
+
+json MlxServer::chat_completion(const json& request) {
+    // OpenAI introduced `max_completion_tokens` to replace `max_tokens`
+    // (Sep 2024). MLX only understands the older name.
+    json modified = request;
+    if (modified.contains("max_completion_tokens") && !modified.contains("max_tokens")) {
+        modified["max_tokens"] = modified["max_completion_tokens"];
+    }
+    return forward_request("/v1/chat/completions", modified);
+}
+
+json MlxServer::completion(const json& request) {
+    json modified = request;
+    if (modified.contains("max_completion_tokens") && !modified.contains("max_tokens")) {
+        modified["max_tokens"] = modified["max_completion_tokens"];
+    }
+    return forward_request("/v1/completions", modified);
+}
+
+json MlxServer::responses(const json& request) {
+    return ErrorResponse::from_exception(
+        UnsupportedOperationException("Responses API", "mlx-engine")
+    );
+}
+
+} // namespace backends
+
+namespace {
+class MlxOps : public BackendOps {
+public:
+    std::string resolve_checkpoint_path(const ModelInfo&,
+                                        const CheckpointResolveContext& ctx) const override {
+        return ctx.model_cache_path;
+    }
+};
+}  // namespace
+
+namespace mlx {
+std::unique_ptr<WrappedServer> create(const BackendContext& ctx) {
+    return make_server<MlxServer>(ctx);
+}
+
+const BackendSpec* spec() { return make_spec<MlxServer>(descriptor); }
+const BackendOps* ops() { return single_ops<MlxOps>(); }
+}  // namespace mlx
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/server/backends/mlx/mlx_server.cpp
+++ b/src/cpp/server/backends/mlx/mlx_server.cpp
@@ -1,4 +1,5 @@
 #include "lemon/backends/mlx/mlx_server.h"
+#include "lemon/backends/mlx/mlx.h"
 #include "lemon/backends/backend_ops.h"
 #include "lemon/backends/backend_utils.h"
 #include "lemon/backend_manager.h"
@@ -112,7 +113,7 @@ void MlxServer::load(const std::string& model_name,
     device_type_ = (mlx_backend == "cpu") ? DEVICE_CPU : DEVICE_GPU;
 
     // Install mlx-engine binary if needed.
-    backend_manager_->install_backend(SPEC.recipe, mlx_backend);
+    backend_manager_->install_backend(mlx::spec()->recipe, mlx_backend);
 
     // MLX identifies models by HuggingFace repo-id or a local directory path.
     // The ModelManager resolves local paths when available; fall back to the
@@ -130,7 +131,7 @@ void MlxServer::load(const std::string& model_name,
 
     port_ = choose_port();
 
-    std::string executable = BackendUtils::get_backend_binary_path(SPEC, mlx_backend);
+    std::string executable = BackendUtils::get_backend_binary_path(*mlx::spec(), mlx_backend);
 
     std::vector<std::string> args;
     // Positional model argument — pre-load mode.
@@ -221,8 +222,6 @@ json MlxServer::responses(const json& request) {
         UnsupportedOperationException("Responses API", "mlx-engine")
     );
 }
-
-} // namespace backends
 
 namespace {
 class MlxOps : public BackendOps {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1691,6 +1691,7 @@ static bool are_required_checkpoints_complete(const ModelInfo& info) {
         (void)checkpoint;
 
         if (type == "npu_cache") continue;
+        if (type == "draft") continue;  // draft checkpoint is optional for MTP; missing is OK
 
         const std::string resolved_path = info.resolved_path(type);
         if (!is_checkpoint_path_complete(resolved_path)) {
@@ -4014,7 +4015,7 @@ void ModelManager::download_from_registry(const ModelInfo& info,
     // Auxiliary checkpoints inherit the model-level registry source. This is
     // intentional: a registration has one provenance and update domain.
     for (const auto& [type, checkpoint] : info.checkpoints) {
-        if (type == "main" || type == "npu_cache") continue;
+        if (type == "main" || type == "npu_cache" || type == "draft") continue;
         const std::string repo_id = checkpoint_to_repo_id(checkpoint);
         const std::string variant = checkpoint_to_variant(checkpoint);
         if (repo_id.empty() || variant.empty()) {


### PR DESCRIPTION
## Summary

Documents the `draft` checkpoint key and adds a complete `user_models.json` example for MTP (Multi-Token Prediction) models with a separate draft head.

Fixes #2435 (documentation component).

## Changes

**`docs/guide/configuration/custom-models.md`**

- **Checkpoint keys table** — added `draft` row (`llamacpp` | `Draft/MTP head for speculative decoding`)
- **New MTP example** — `My-Gemma-4-MTP` entry showing `"draft"` checkpoint + `"mtp"` label + `"mmproj"` in a single `user_models.json` definition
- **Explanatory note** — documents that the `draft` checkpoint is optional (model loads without MTP if the file is missing) and that the `mtp` label enables `--spec-type draft-mtp` defaults

## Background

The `draft` checkpoint key has been supported in code via `load_checkpoints()` and `llamacpp_server.cpp`'s `--model-draft` resolution since #2317, but it was never documented in the custom-models guide. Users with models like Gemma 4 (which ship separate MTP head GGUFs) had to guess the format or dig through source code.

The companion code fix (`7048b17f`) ensures that having a `draft` checkpoint doesn't break `are_required_checkpoints_complete()` when the draft GGUF hasn't been downloaded yet.
