### PR TITLE
fix(auto-label): refactor community user checks to exclude bots

### DIFF
--- a/.github/scripts/auto_label.py
+++ b/.github/scripts/auto_label.py
@@ -264,7 +264,7 @@ def is_bot_user(user):
         return False
     login = user.get("login") or ""
     user_type = user.get("type") or ""
-    return user_type == "Bot" or login.endswith("[bot]")
+    return user_type == "Bot" or login.lower().endswith("[bot]")
 
 def _add_community_user(users, user, author_association, repo):
     if not user:

--- a/.github/scripts/auto_label.py
+++ b/.github/scripts/auto_label.py
@@ -203,8 +203,8 @@ KNOWN_LABELS = {
 AT_MOST_ONE_PREFIXES = ("engine::", "area::", "runtime::")
 
 # Deterministic community-priority labels. Computed from engagement counts
-# (commenters + supporting reactions), excluding anyone with write access so
-# maintainer discussion does not inflate signal.
+# (author + commenters + supporting reactions), excluding bots and anyone with
+# write access so automated/system or maintainer activity does not inflate signal.
 PRIORITY_WARM_LABEL = "priority::😎warm"
 PRIORITY_HOT_LABEL = "priority::🔥hot"
 COMMUNITY_WARM_THRESHOLD = 3
@@ -256,8 +256,22 @@ def has_write_access(login, repo):
         return False
     return data.get("permission") in WRITE_PERMISSIONS
 
+def is_bot_user(user):
+    """Return True for GitHub bot accounts.
+    Bot activity should not count as community engagement for priority labels.
+    """
+    if not user:
+        return False
+    login = user.get("login") or ""
+    user_type = user.get("type") or ""
+    return user_type == "Bot" or login.endswith("[bot]")
 
-def _add_community_user(users, login, author_association, repo):
+def _add_community_user(users, user, author_association, repo):
+    if not user:
+        return
+    if is_bot_user(user):
+        return
+    login = user.get("login")
     if not login:
         return
     if author_association in WRITE_ASSOCIATIONS:
@@ -296,7 +310,7 @@ def community_priority_labels(item_num, existing, repo):
 
     _add_community_user(
         users,
-        (issue.get("user") or {}).get("login"),
+        issue.get("user") or {},
         issue.get("author_association"),
         repo,
     )
@@ -304,7 +318,7 @@ def community_priority_labels(item_num, existing, repo):
     for comment in comments:
         _add_community_user(
             users,
-            (comment.get("user") or {}).get("login"),
+            comment.get("user") or {},
             comment.get("author_association"),
             repo,
         )
@@ -312,7 +326,10 @@ def community_priority_labels(item_num, existing, repo):
     for reaction in reactions:
         if reaction.get("content") not in SUPPORTING_REACTIONS:
             continue
-        login = (reaction.get("user") or {}).get("login")
+        user = reaction.get("user") or {}
+        if is_bot_user(user):
+            continue
+        login = user.get("login")
         if login and not has_write_access(login, repo):
             users.add(login)
 

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -5,13 +5,9 @@
 #      area::*, runtime::*, component, and type labels. Runs once per
 #      newly opened issue/PR.
 #   2. Deterministic priority::warm / priority::hot from community
-#      engagement counts (commenters + supporting reactions, excluding
 #      engagement counts (author + commenters + supporting reactions, 
-#      maintainers). Refreshed on every new comment (engagement event)
 #      excluding bots and write-access users). Refreshed on every new
-#      and via a daily cron (to pick up reaction-only changes, which
 #      comment (engagement event) and via a daily cron (to pick up
-#      don't fire webhook events).
 #      reaction-only changes, which don't fire webhook events).
 #
 # *** Labels applied by this workflow are ADVISORY ONLY. ***

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -6,9 +6,13 @@
 #      newly opened issue/PR.
 #   2. Deterministic priority::warm / priority::hot from community
 #      engagement counts (commenters + supporting reactions, excluding
+#      engagement counts (author + commenters + supporting reactions, 
 #      maintainers). Refreshed on every new comment (engagement event)
+#      excluding bots and write-access users). Refreshed on every new
 #      and via a daily cron (to pick up reaction-only changes, which
+#      comment (engagement event) and via a daily cron (to pick up
 #      don't fire webhook events).
+#      reaction-only changes, which don't fire webhook events).
 #
 # *** Labels applied by this workflow are ADVISORY ONLY. ***
 # Do not use them as inputs to CI gates, release gates, security


### PR DESCRIPTION
Currently a bot such as codex-connector-reviewer is evaluated as non-maintainer community member.

This way an issue or PR where a bot reacted on can be marked **priority::warm** with just one additional community comment or reaction.

This is unintentional and fixed by this PR.