### PR TITLE
[Router] 2381 semantic_similarity classifier (M5)

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -279,8 +279,9 @@ jobs:
           cmake --build --preset default --target test_routing_policy_contract
           cmake --build --preset default --target test_routing_policy_evaluator
           cmake --build --preset default --target test_routing_policy_registry
+          cmake --build --preset default --target test_routing_policy_semantic
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry)Test"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic)Test"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -542,8 +543,9 @@ jobs:
           cmake --build --preset default --target test_routing_policy_contract
           cmake --build --preset default --target test_routing_policy_evaluator
           cmake --build --preset default --target test_routing_policy_registry
+          cmake --build --preset default --target test_routing_policy_semantic
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry)Test"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic)Test"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1859,6 +1859,28 @@ if(EXISTS "${_ROUTING_REGISTRY_TEST_SRC}")
     add_test(NAME RoutingPolicyRegistryTest COMMAND test_routing_policy_registry)
 endif()
 
+# Routing semantic_similarity classifier (issue #2381): max-cosine scoring over
+# reference phrases, reference-phrase embedding caching, inclusive band
+# boundaries, and on_error handling, all against a fake embedder.
+set(_ROUTING_SEMANTIC_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_semantic.cpp"
+)
+if(EXISTS "${_ROUTING_SEMANTIC_TEST_SRC}")
+    add_executable(test_routing_policy_semantic
+        test/cpp/test_routing_policy_semantic.cpp
+        src/cpp/server/routing_policy.cpp
+    )
+    target_include_directories(test_routing_policy_semantic PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_routing_policy_semantic PRIVATE nlohmann_json::nlohmann_json)
+
+    include(CTest)
+    add_test(NAME RoutingPolicySemanticTest COMMAND test_routing_policy_semantic)
+endif()
+
 # Auto-tune: GGUF array storage, scalar derivation, weighted KV cache computation.
 # Covers head_count_kv_per_layer, sliding_window_pattern, SWA precise weighted sum,
 # full_attention_interval exact count, and scalar fallback paths.

--- a/src/cpp/server/routing_policy.cpp
+++ b/src/cpp/server/routing_policy.cpp
@@ -1,8 +1,11 @@
 #include "lemon/routing_policy.h"
 
 #include <algorithm>
+#include <cmath>
+#include <mutex>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 #include <lemon/utils/aixlog.hpp>
 
 namespace lemon {
@@ -12,6 +15,30 @@ Score failed_score() {
     Score score;
     score.ok = false;
     return score;
+}
+
+// Cosine similarity of two equal-length, non-zero vectors. Returns nullopt when
+// the vectors are empty, mismatched in length, or either has zero magnitude —
+// all of which the caller treats as a classifier failure (Score::ok=false).
+std::optional<double> cosine_similarity(const std::vector<float>& a,
+                                        const std::vector<float>& b) {
+    if (a.empty() || a.size() != b.size()) {
+        return std::nullopt;
+    }
+    double dot = 0.0;
+    double norm_a = 0.0;
+    double norm_b = 0.0;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        const double ai = static_cast<double>(a[i]);
+        const double bi = static_cast<double>(b[i]);
+        dot += ai * bi;
+        norm_a += ai * ai;
+        norm_b += bi * bi;
+    }
+    if (norm_a <= 0.0 || norm_b <= 0.0) {
+        return std::nullopt;
+    }
+    return dot / (std::sqrt(norm_a) * std::sqrt(norm_b));
 }
 
 void validate_children(const std::vector<ConditionPtr>& children,
@@ -205,6 +232,92 @@ private:
     std::string model_;
 };
 
+class SemanticSimilarityClassifier final : public Classifier {
+public:
+    SemanticSimilarityClassifier(std::string id, std::string type, std::string model,
+                                 std::vector<std::string> reference_phrases, OnError on_error)
+        : Classifier(std::move(id), std::move(type), on_error),
+          model_(std::move(model)),
+          reference_phrases_(std::move(reference_phrases)) {
+        if (model_.empty()) {
+            throw std::invalid_argument("semantic_similarity classifier requires model");
+        }
+        if (reference_phrases_.empty()) {
+            throw std::invalid_argument(
+                "semantic_similarity classifier requires reference_phrases");
+        }
+    }
+
+    Score evaluate(const ClassifierContext& ctx) const override {
+        if (!ctx.services.embed) {
+            return failed_score();
+        }
+
+        const std::vector<std::vector<float>>* references = nullptr;
+        try {
+            references = &reference_embeddings(ctx.services);
+        } catch (...) {
+            return failed_score();
+        }
+
+        std::vector<float> input_embedding;
+        try {
+            input_embedding = ctx.services.embed(model_, ctx.request.input);
+        } catch (...) {
+            return failed_score();
+        }
+
+        // Note: this clamps the max cosine into [0,1] to satisfy the band contract. The
+        // cosine similarity itself can be [-1,1], at least in principle (most embeddings
+        // are non-negative, so the practical range usually is [0,1] anyways).
+        double max_cosine = 0.0;
+        for (const auto& reference : *references) {
+            std::optional<double> cosine = cosine_similarity(input_embedding, reference);
+            if (!cosine.has_value()) {
+                return failed_score();
+            }
+            max_cosine = (std::max)(max_cosine, *cosine);
+        }
+
+        Score score;
+        // The cosine score is reported under the empty-string key and read back
+        // via Score::primary(). Clamp into the [0,1] band contract.
+        score.labels[""] = std::clamp(max_cosine, 0.0, 1.0);
+        score.ok = true;
+        return score;
+    }
+
+private:
+    // Embeds every reference phrase exactly once and caches the vectors on the
+    // instance. Classifiers are shared across concurrent router requests, so the
+    // cache is guarded by mutex.
+    // TODO: consider whether this should be done at construction time instead of lazily on the first evaluate() call. The
+    // constructor already has the model and reference phrases, so it could embed them immediately. The
+    // downside is that it would require the ClassifierServices to be available at construction time,
+    // which may not be the case in all contexts.
+    const std::vector<std::vector<float>>& reference_embeddings(
+        const ClassifierServices& services) const {
+        std::lock_guard<std::mutex> lock(cache_mutex_);
+        if (!cached_) {
+            std::vector<std::vector<float>> embeddings;
+            embeddings.reserve(reference_phrases_.size());
+            for (const auto& phrase : reference_phrases_) {
+                embeddings.push_back(services.embed(model_, phrase));
+            }
+            reference_embeddings_ = std::move(embeddings);
+            cached_ = true;
+        }
+        return reference_embeddings_;
+    }
+
+    std::string model_;
+    std::vector<std::string> reference_phrases_;
+
+    mutable std::mutex cache_mutex_;
+    mutable bool cached_ = false;
+    mutable std::vector<std::vector<float>> reference_embeddings_;
+};
+
 std::vector<ConditionPtr> compile_children(const std::vector<MatchExpr>& children,
                                            const LeafFactory& leaf_factory,
                                            std::size_t depth);
@@ -330,7 +443,34 @@ ClassifierPtr make_classifier(const json& config) {
             id, type, config.value("model", ""), on_error, std::move(labels), std::move(default_label));
     }
 
-    if (type == "semantic_similarity" || type == "llm" ||
+    if (type == "semantic_similarity") {
+        if (!labels.empty() || default_label.has_value()) {
+            throw std::invalid_argument(
+                "semantic_similarity classifier '" + id + "' does not support labels");
+        }
+        if (!config.contains("reference_phrases")) {
+            throw std::invalid_argument(
+                "semantic_similarity classifier '" + id + "' requires reference_phrases");
+        }
+        if (!config["reference_phrases"].is_array() || config["reference_phrases"].empty()) {
+            throw std::invalid_argument(
+                "semantic_similarity classifier '" + id +
+                "' reference_phrases must be a non-empty array");
+        }
+        std::vector<std::string> reference_phrases;
+        for (const auto& item : config["reference_phrases"]) {
+            if (!item.is_string() || item.get<std::string>().empty()) {
+                throw std::invalid_argument(
+                    "semantic_similarity classifier '" + id +
+                    "' reference_phrases must be non-empty strings");
+            }
+            reference_phrases.push_back(item.get<std::string>());
+        }
+        return std::make_shared<SemanticSimilarityClassifier>(
+            id, type, config.value("model", ""), std::move(reference_phrases), on_error);
+    }
+
+    if (type == "llm" ||
         type == "pii_detection" || type == "prompt_safety" ||
         type == "language_detection" || type == "domain_classification" ||
         type == "complexity" || type == "sentiment") {

--- a/test/cpp/fake_classifier_services.h
+++ b/test/cpp/fake_classifier_services.h
@@ -28,6 +28,23 @@ public:
         embeddings_[model] = std::move(vec);
     }
 
+    // Configure a fixed embedding for a specific (model, text) pair. Takes
+    // precedence over the per-model default, letting tests give each reference
+    // phrase and the input their own vector.
+    void set_embedding(const std::string& model, const std::string& text,
+                       std::vector<float> vec) {
+        text_embeddings_[model][text] = std::move(vec);
+    }
+
+    // Number of embed() calls observed for `text` (across all models).
+    int embed_calls(const std::string& text) const {
+        auto it = embed_calls_.find(text);
+        return it == embed_calls_.end() ? 0 : it->second;
+    }
+
+    // Total embed() calls observed.
+    int total_embed_calls() const { return total_embed_calls_; }
+
     // Configure a fixed label->score map returned for `model`.
     void set_classifier_scores(const std::string& model,
                                std::map<std::string, double> scores) {
@@ -45,7 +62,14 @@ public:
     ClassifierServices make() {
         ClassifierServices svc;
         FakeClassifierServices* self = this;
-        svc.embed = [self](const std::string& model, const std::string&) {
+        svc.embed = [self](const std::string& model, const std::string& text) {
+            ++self->total_embed_calls_;
+            ++self->embed_calls_[text];
+            auto model_it = self->text_embeddings_.find(model);
+            if (model_it != self->text_embeddings_.end()) {
+                auto text_it = model_it->second.find(text);
+                if (text_it != model_it->second.end()) return text_it->second;
+            }
             auto it = self->embeddings_.find(model);
             if (it != self->embeddings_.end()) return it->second;
             return std::vector<float>{1.0f, 0.0f, 0.0f};
@@ -66,6 +90,9 @@ public:
 
 private:
     std::map<std::string, std::vector<float>> embeddings_;
+    std::map<std::string, std::map<std::string, std::vector<float>>> text_embeddings_;
+    std::map<std::string, int> embed_calls_;
+    int total_embed_calls_ = 0;
     std::map<std::string, std::map<std::string, double>> classifier_scores_;
     std::map<std::string, std::string> chat_replies_;
 };

--- a/test/cpp/test_routing_policy_registry.cpp
+++ b/test/cpp/test_routing_policy_registry.cpp
@@ -124,11 +124,46 @@ static void test_make_classifier_rejections() {
               lemon::make_classifier(json{{"id", "x"}, {"type", "mystery"},
                                           {"model", "m"}});
           }));
-    check("make_classifier clearly rejects semantic_similarity for now",
+    check("make_classifier accepts semantic_similarity", [] {
+        try {
+            auto c = lemon::make_classifier(
+                json{{"id", "sim"}, {"type", "semantic_similarity"},
+                     {"model", "m"},
+                     {"reference_phrases", json::array({"return", "function"})}});
+            return c && c->id() == "sim" && c->type() == "semantic_similarity" &&
+                   c->labels().empty() && !c->default_label().has_value();
+        } catch (...) {
+            return false;
+        }
+    }());
+    check("make_classifier rejects semantic_similarity without reference_phrases",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "sim"}, {"type", "semantic_similarity"},
+                                          {"model", "m"}});
+          }));
+    check("make_classifier rejects semantic_similarity with empty reference_phrases",
           throws_invalid_arg([] {
               lemon::make_classifier(json{{"id", "sim"}, {"type", "semantic_similarity"},
                                           {"model", "m"},
+                                          {"reference_phrases", json::array()}});
+          }));
+    check("make_classifier rejects semantic_similarity with empty phrase string",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "sim"}, {"type", "semantic_similarity"},
+                                          {"model", "m"},
+                                          {"reference_phrases", json::array({""})}});
+          }));
+    check("make_classifier rejects semantic_similarity without model",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "sim"}, {"type", "semantic_similarity"},
                                           {"reference_phrases", json::array({"return"})}});
+          }));
+    check("make_classifier rejects semantic_similarity with labels",
+          throws_invalid_arg([] {
+              lemon::make_classifier(json{{"id", "sim"}, {"type", "semantic_similarity"},
+                                          {"model", "m"},
+                                          {"reference_phrases", json::array({"return"})},
+                                          {"labels", json::array({"X"})}});
           }));
     check("make_classifier clearly rejects llm for now",
           throws_invalid_arg([] {

--- a/test/cpp/test_routing_policy_semantic.cpp
+++ b/test/cpp/test_routing_policy_semantic.cpp
@@ -1,0 +1,184 @@
+// Unit tests for the Lemonade Router semantic_similarity classifier (#2381).
+//
+// Covers max-cosine computation against reference phrases, reference-phrase
+// embedding caching (embed called once per phrase), inclusive classifier-band
+// boundaries (incl. the default min_score of 0.5), and on_error handling when
+// the embedder fails. All backend access is faked via FakeClassifierServices.
+
+#include "fake_classifier_services.h"
+#include "lemon/routing_policy.h"
+
+#include <cmath>
+#include <cstdio>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+using lemon::ClassifierContext;
+using lemon::ClassifierPtr;
+using lemon::ClassifierServices;
+using lemon::Condition;
+using lemon::ConditionPtr;
+using lemon::EvalContext;
+using lemon::RouteContext;
+using lemon::Score;
+using lemon::json;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static bool near(double a, double b, double eps = 1e-9) {
+    return std::fabs(a - b) <= eps;
+}
+
+static RouteContext make_route(const std::string& input) {
+    RouteContext route;
+    route.input = input;
+    route.params.model = "user.Router";
+    route.params.chars = input.size();
+    return route;
+}
+
+static ClassifierPtr make_sim(const std::string& model,
+                              std::vector<std::string> phrases,
+                              const char* on_error = "match_false") {
+    json cfg = {
+        {"id", "is_coding"},
+        {"type", "semantic_similarity"},
+        {"model", model},
+        {"on_error", on_error},
+        {"reference_phrases", json::array()},
+    };
+    for (const auto& phrase : phrases) cfg["reference_phrases"].push_back(phrase);
+    return lemon::make_classifier(cfg);
+}
+
+static void test_max_cosine() {
+    lemon::testing::FakeClassifierServices fake;
+    const std::string model = "embed-m";
+    fake.set_embedding(model, "alpha", {1.0f, 0.0f, 0.0f});
+    fake.set_embedding(model, "beta", {0.0f, 1.0f, 0.0f});
+    // Input aligns exactly with "alpha" -> cosine 1.0 there, 0.0 with "beta".
+    fake.set_embedding(model, "find the bug", {1.0f, 0.0f, 0.0f});
+    ClassifierServices svc = fake.make();
+
+    auto sim = make_sim(model, {"alpha", "beta"});
+    RouteContext route = make_route("find the bug");
+    Score score = sim->evaluate(ClassifierContext{route, svc});
+
+    check("semantic_similarity reports a single empty-key score",
+          score.ok && score.labels.size() == 1 && score.labels.count("") == 1);
+    check("semantic_similarity returns max cosine across references",
+          near(score.primary(), 1.0));
+}
+
+static void test_max_cosine_partial() {
+    lemon::testing::FakeClassifierServices fake;
+    const std::string model = "embed-m";
+    fake.set_embedding(model, "alpha", {1.0f, 0.0f, 0.0f});
+    fake.set_embedding(model, "beta", {0.0f, 1.0f, 0.0f});
+    // 45 degrees from both axes -> cosine 1/sqrt(2) with each; max is that.
+    fake.set_embedding(model, "mixed", {1.0f, 1.0f, 0.0f});
+    ClassifierServices svc = fake.make();
+
+    auto sim = make_sim(model, {"alpha", "beta"});
+    RouteContext route = make_route("mixed");
+    Score score = sim->evaluate(ClassifierContext{route, svc});
+    check("semantic_similarity computes correct intermediate cosine",
+          score.ok && near(score.primary(), 1.0 / std::sqrt(2.0)));
+}
+
+static void test_reference_caching() {
+    lemon::testing::FakeClassifierServices fake;
+    const std::string model = "embed-m";
+    fake.set_embedding(model, "alpha", {1.0f, 0.0f, 0.0f});
+    fake.set_embedding(model, "beta", {0.0f, 1.0f, 0.0f});
+    fake.set_embedding(model, "q", {1.0f, 0.0f, 0.0f});
+    ClassifierServices svc = fake.make();
+
+    auto sim = make_sim(model, {"alpha", "beta"});
+    RouteContext route = make_route("q");
+
+    sim->evaluate(ClassifierContext{route, svc});
+    sim->evaluate(ClassifierContext{route, svc});
+    sim->evaluate(ClassifierContext{route, svc});
+
+    check("reference phrase 'alpha' embedded exactly once", fake.embed_calls("alpha") == 1);
+    check("reference phrase 'beta' embedded exactly once", fake.embed_calls("beta") == 1);
+    check("input embedded once per evaluation", fake.embed_calls("q") == 3);
+}
+
+// Build a band condition over a similarity classifier and evaluate it.
+static bool eval_band(const ClassifierPtr& sim, const ClassifierServices& svc,
+                      const RouteContext& route, std::optional<double> min_score,
+                      std::optional<double> max_score) {
+    ConditionPtr cond = lemon::make_classifier_band_condition(
+        sim, std::nullopt, min_score, max_score);
+    EvalContext ctx{route, svc};
+    return cond->evaluate(ctx);
+}
+
+static void test_band_boundaries() {
+    lemon::testing::FakeClassifierServices fake;
+    const std::string model = "embed-m";
+    // Vectors chosen so the cosine is exactly 0.5 in IEEE floating point:
+    // dot = 1, |input| = 1, |ref| = sqrt(4) = 2 -> 1 / 2 = 0.5.
+    fake.set_embedding(model, "alpha", {1.0f, 1.0f, 1.0f, 1.0f});
+    fake.set_embedding(model, "half", {1.0f, 0.0f, 0.0f, 0.0f});
+    ClassifierServices svc = fake.make();
+
+    auto sim = make_sim(model, {"alpha"});
+    RouteContext route = make_route("half");
+
+    check("default band min_score 0.5 includes a score of exactly 0.5",
+          eval_band(sim, svc, route, std::nullopt, std::nullopt));
+    check("min_score boundary is inclusive (0.5 >= 0.5)",
+          eval_band(sim, svc, route, 0.5, std::nullopt));
+    check("max_score boundary is inclusive (0.5 <= 0.5)",
+          eval_band(sim, svc, route, std::nullopt, 0.5));
+    check("score below min_score does not match",
+          !eval_band(sim, svc, route, 0.51, std::nullopt));
+    check("score above max_score does not match",
+          !eval_band(sim, svc, route, std::nullopt, 0.49));
+}
+
+static void test_on_error() {
+    lemon::testing::FakeClassifierServices fake;
+    const std::string model = "embed-m";
+    fake.set_embedding(model, "alpha", {1.0f, 0.0f, 0.0f});
+    // An empty input embedding forces a cosine failure -> Score::ok=false.
+    fake.set_embedding(model, "boom", std::vector<float>{});
+    ClassifierServices svc = fake.make();
+
+    RouteContext route = make_route("boom");
+
+    auto sim_false = make_sim(model, {"alpha"}, "match_false");
+    Score s = sim_false->evaluate(ClassifierContext{route, svc});
+    check("embed failure yields Score::ok=false", !s.ok);
+    check("on_error match_false fails open (no match)",
+          !eval_band(sim_false, svc, route, std::nullopt, std::nullopt));
+
+    auto sim_true = make_sim(model, {"alpha"}, "match_true");
+    check("on_error match_true fails closed (matches)",
+          eval_band(sim_true, svc, route, std::nullopt, std::nullopt));
+}
+
+int main() {
+    test_max_cosine();
+    test_max_cosine_partial();
+    test_reference_caching();
+    test_band_boundaries();
+    test_on_error();
+
+    if (g_failures == 0) {
+        std::printf("All semantic_similarity classifier tests passed.\n");
+    } else {
+        std::printf("%d semantic_similarity classifier test(s) failed.\n", g_failures);
+    }
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Implements the `semantic_similarity` classifier — the first model-backed classifier in the generic routing engine — against the existing `Classifier` interface. It scores an input by max cosine similarity against a set of `reference_phrases`, reported as a single score under the empty-string key and consumed via a classifier-band condition. Closes #2381.

### Changes
- **`SemanticSimilarityClassifier`** (routing_policy.cpp): embeds the input via `ClassifierServices::embed`, computes cosine against each reference exemplar, and returns `max` as `Score::labels[""]` (read by conditions through `Score::primary()`). Declares no labels.
- **Reference-phrase caching**: exemplars are embedded once and cached on the instance. Since classifiers are shared across concurrent router requests (AGENTS.md invariant #8), the lazy cache is guarded by a mutex; the input embedding is recomputed per request.
- **Registry wiring** (`make_classifier`): `semantic_similarity` now constructs the real classifier instead of throwing "not implemented". Requires `model` + non-empty `reference_phrases`; rejects `labels`/`default_label`.
- **Failure handling**: any embed failure (missing service, throw, empty/mismatched vectors) yields `Score::ok = false` so the owning band applies its `on_error` policy rather than letting an exception escape.
- **Tests**: extended `FakeClassifierServices` with per-`(model, text)` embeddings and embed call counters; added `test_routing_policy_semantic.cpp` covering max-cosine selection, reference-phrase caching (embed-once), inclusive band boundaries incl. the default `min_score: 0.5`, and `on_error`; updated the registry test for the now-accepted type.

### Notes
- The cosine score is clamped into `[0,1]` to satisfy the band contract (guards against floating-point overshoot past 1.0 for near-identical vectors).
- Out of scope per the issue: the real `embed()` ↔ Router wiring (#2384) and the other classifier types (`classifier`/`llm`). No schema change — the existing route_policy.schema.json already describes `reference_phrases`.

### Testing
`ctest -R RoutingPolicy` — all four suites (`Contract`, `Evaluator`, `Registry`, `Semantic`) pass.
