### PR TITLE
Fix flaky Ollama tool-calling CI by disabling default thinking for tool requests

### DIFF
--- a/src/cpp/server/ollama_api.cpp
+++ b/src/cpp/server/ollama_api.cpp
@@ -445,9 +445,20 @@ json OllamaApi::convert_ollama_to_openai_chat(const json& ollama_request) {
         openai_req["response_format"] = {{"type", "json_object"}};
     }
 
-    // Map think parameter → enable_thinking (controls reasoning output)
+    // Map think parameter -> enable_thinking (controls reasoning output).
+    //
+    // Tool-calling requests should default to no reasoning unless the caller
+    // explicitly asks for it. Some Qwen3 llama.cpp templates enable thinking by
+    // default; on small CI runners this can spend the whole request budget before
+    // producing a tool call, making the Ollama streaming-tool compatibility test
+    // flaky. Preserve explicit Ollama behavior: callers can still pass
+    // {"think": true}.
     if (ollama_request.contains("think")) {
         openai_req["enable_thinking"] = ollama_request["think"];
+    } else if (ollama_request.contains("tools") &&
+               ollama_request["tools"].is_array() &&
+               !ollama_request["tools"].empty()) {
+        openai_req["enable_thinking"] = false;
     }
 
     // Stream flag is handled by the caller

--- a/src/cpp/server/ollama_api.cpp
+++ b/src/cpp/server/ollama_api.cpp
@@ -445,20 +445,9 @@ json OllamaApi::convert_ollama_to_openai_chat(const json& ollama_request) {
         openai_req["response_format"] = {{"type", "json_object"}};
     }
 
-    // Map think parameter -> enable_thinking (controls reasoning output).
-    //
-    // Tool-calling requests should default to no reasoning unless the caller
-    // explicitly asks for it. Some Qwen3 llama.cpp templates enable thinking by
-    // default; on small CI runners this can spend the whole request budget before
-    // producing a tool call, making the Ollama streaming-tool compatibility test
-    // flaky. Preserve explicit Ollama behavior: callers can still pass
-    // {"think": true}.
+    // Map think parameter → enable_thinking (controls reasoning output)
     if (ollama_request.contains("think")) {
         openai_req["enable_thinking"] = ollama_request["think"];
-    } else if (ollama_request.contains("tools") &&
-               ollama_request["tools"].is_array() &&
-               !ollama_request["tools"].empty()) {
-        openai_req["enable_thinking"] = false;
     }
 
     // Stream flag is handled by the caller

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -11,7 +11,6 @@ Usage:
 
 import base64
 import json
-import os
 import platform
 import sys
 import uuid
@@ -40,6 +39,7 @@ from utils.test_models import (
 )
 
 OLLAMA_BASE_URL = f"http://localhost:{PORT}"
+TOOL_CALLING_LLAMA_ARGS = "--reasoning-format none"
 
 
 class OllamaTests(ServerTestBase):
@@ -71,24 +71,6 @@ class OllamaTests(ServerTestBase):
                 )
             except requests.RequestException as exc:
                 print(f"[DIAG] GET {url} failed: {exc}")
-
-    def _skip_slow_hosted_ci_tool_calling(self):
-        """Skip the heaviest native tool-calling path on slow hosted OSes.
-
-        The full native tool-calling model is still covered on Linux CI. On
-        hosted Windows/macOS runners this 4B model can leave the server busy
-        until the HTTP timeout, which then cascades into later suites.
-        """
-        if os.environ.get("LEMONADE_RUN_HEAVY_OLLAMA_TOOL_TESTS") == "1":
-            return
-        if os.environ.get("GITHUB_ACTIONS") == "true" and sys.platform in (
-            "darwin",
-            "win32",
-        ):
-            self.skipTest(
-                "Skipping heavy native Anthropic tool-calling test on hosted "
-                f"{platform.system()} CI; Linux CI keeps this coverage."
-            )
 
     def get_ollama_client(self):
         """Get an Ollama client pointed at the test server."""
@@ -376,7 +358,13 @@ class OllamaTests(ServerTestBase):
 
             response = requests.post(
                 f"{self.base_url}/load",
-                json={"model_name": TOOL_CALLING_MODEL, "ctx_size": 8192},
+                json={
+                    "model_name": TOOL_CALLING_MODEL,
+                    "ctx_size": 4096,
+                    # Keep this CI test deterministic without adding Ollama API
+                    # behavior: disable reasoning at llama-server load time.
+                    "llamacpp_args": TOOL_CALLING_LLAMA_ARGS,
+                },
                 timeout=TIMEOUT_MODEL_OPERATION,
             )
             self.assertEqual(response.status_code, 200)
@@ -397,10 +385,6 @@ class OllamaTests(ServerTestBase):
                         ],
                         "tools": [SAMPLE_TOOL],
                         "stream": True,
-                        # Keep this CI test deterministic and avoid Qwen3 reasoning
-                        # paths that can burn the whole read-timeout budget before
-                        # producing a tool call on macOS runners.
-                        "think": False,
                         "options": {
                             "num_predict": 64,
                             "temperature": 0,
@@ -784,8 +768,6 @@ class OllamaTests(ServerTestBase):
 
     def test_026_anthropic_messages_tool_calling(self):
         """Test Anthropic-compatible tool calling maps to tool_use blocks."""
-        self._skip_slow_hosted_ci_tool_calling()
-
         # This is the heaviest Ollama compatibility test in the suite. Start it
         # from an empty loaded-model state so previous endpoint/CLI tests cannot
         # leave another backend resident and turn the final inference into a CI
@@ -806,7 +788,14 @@ class OllamaTests(ServerTestBase):
 
             response = requests.post(
                 f"{self.base_url}/load",
-                json={"model_name": TOOL_CALLING_MODEL, "ctx_size": 8192},
+                json={
+                    "model_name": TOOL_CALLING_MODEL,
+                    "ctx_size": 4096,
+                    # Use the same load-time llama-server configuration as the
+                    # Ollama tool-call test so both heavy CI paths avoid
+                    # reasoning before tool selection.
+                    "llamacpp_args": TOOL_CALLING_LLAMA_ARGS,
+                },
                 timeout=TIMEOUT_MODEL_OPERATION,
             )
             self.assertEqual(response.status_code, 200)
@@ -825,10 +814,7 @@ class OllamaTests(ServerTestBase):
                         "content": [
                             {
                                 "type": "text",
-                                "text": (
-                                    "Run the calculator_calculate tool with "
-                                    "expression set to 1+1"
-                                ),
+                                "text": "Run the calculator_calculate tool with expression set to 1+1",
                             }
                         ],
                     }
@@ -837,9 +823,6 @@ class OllamaTests(ServerTestBase):
                 "tool_choice": {"type": "any"},
                 "max_tokens": 64,
                 "stream": False,
-                # Keep the later Anthropic compatibility tool-call test on the
-                # same deterministic path as the Ollama tool-call test.
-                "thinking": {"type": "disabled"},
                 "temperature": 0,
                 "top_p": 1,
             }

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -371,14 +371,23 @@ class OllamaTests(ServerTestBase):
                             {
                                 "role": "user",
                                 "content": (
-                                    "Run the calculator_calculate tool with "
-                                    "expression set to 1+1"
+                                    "Call the calculator_calculate tool exactly once "
+                                    "with expression set to 1+1. Do not answer in text."
                                 ),
                             }
                         ],
                         "tools": [SAMPLE_TOOL],
                         "stream": True,
-                        "options": {"num_predict": 64},
+                        # Keep this CI test deterministic and avoid Qwen3 reasoning
+                        # paths that can burn the whole read-timeout budget before
+                        # producing a tool call on macOS runners.
+                        "think": False,
+                        "options": {
+                            "num_predict": 64,
+                            "temperature": 0,
+                            "top_p": 1,
+                            "seed": 42,
+                        },
                     },
                     timeout=TIMEOUT_MODEL_OPERATION,
                     stream=True,
@@ -804,6 +813,11 @@ class OllamaTests(ServerTestBase):
                 "tool_choice": {"type": "any"},
                 "max_tokens": 64,
                 "stream": False,
+                # Keep the later Anthropic compatibility tool-call test on the
+                # same deterministic path as the Ollama tool-call test.
+                "thinking": {"type": "disabled"},
+                "temperature": 0,
+                "top_p": 1,
             }
 
             try:


### PR DESCRIPTION
Fixes a flaky macOS CI timeout in `test_010_chat_streaming_with_tools_returns_complete_tool_call`.

he heavy native Qwen tool-calling model can spend the request budget in the Qwen3 reasoning path before producing a tool call on hosted macOS runners. Instead of changing Ollama compatibility behavior, this keeps the API adapter unchanged and loads the test model with llama.cpp reasoning formatting disabled for these deterministic compatibility tests.

This change:

keeps convert_ollama_to_openai_chat() unchanged
loads TOOL_CALLING_MODEL with llamacpp_args: "--reasoning-format none"
reduces the tool-calling test context to ctx_size: 4096
keeps the tool-calling requests deterministic with temperature: 0, top_p: 1, and a fixed seed where applicable
applies the same load-time llama.cpp config to the Anthropic compatibility tool-calling test that uses the same heavy model