### PR TITLE
Fix three broken doc links found by zensical

### DIFF
--- a/docs/api/llamacpp.md
+++ b/docs/api/llamacpp.md
@@ -184,7 +184,7 @@ Save the prompt cache of a specific slot to a file. This allows you to persist t
 
 > **Note:** This endpoint is part of Lemonade's llama.cpp compatibility layer. Internally, Lemonade forwards the request to llama.cpp's `/slots/{id}?action=save` endpoint.
 
-> **Note:** The llama.cpp server must be started with the `--slot-save-path` argument for save operations to work. See [Server Configuration](../server/configuration.md) for details on configuring backend arguments.
+> **Note:** The llama.cpp server must be started with the `--slot-save-path` argument for save operations to work. See [Server Configuration](../guide/configuration/README.md) for details on configuring backend arguments.
 >
 > Example configuration:
 > ```bash

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -14,7 +14,7 @@ This guide covers everything you need to build, test, and contribute to Lemonade
 - [Building Installers](#building-installers)
   - [Windows Installer (WiX/MSI)](#windows-installer-wixmsi)
   - [Linux .deb Package (Debian/Ubuntu)](#linux-deb-package-debianubuntu)
-  - [Linux .rpm Package (Fedora, RHEL etc)](#linux-rpm-package-fedora-rhel-etc)
+  - [Linux .rpm Package (Fedora, RHEL etc)](#linux-rpm-package-fedora-43-44)
 - [Developer IDE and Build Steps](#developer-ide-and-build-steps)
 - [Code Structure](#code-structure)
 - [Architecture Overview](#architecture-overview)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -27,7 +27,7 @@ The `lemonade` CLI is the primary tool for interacting with Lemonade Server from
 | Command             | Description                         |
 |---------------------|-------------------------------------|
 | `run MODEL_NAME`    | Load a model for inference and open the web app in the browser. See command options [below](#options-for-run). |
-| `chat [MODEL_NAME]` | Open an interactive chat REPL in the terminal. See the [chat guide](../server/cli-chat.md). |
+| `chat [MODEL_NAME]` | Open an interactive chat REPL in the terminal. See the [chat guide](./cli-chat.md). |
 | `launch AGENT`      | Launch an agent with a model. See command options [below](#options-for-launch). |
 
 ### Server


### PR DESCRIPTION
Fix three broken doc links:

| File | Link | Fix |
|------|------|-----|
| `api/llamacpp.md:187` | `../server/configuration.md` | `../guide/configuration/README.md` |
| `dev/getting-started.md:17` | `#linux-rpm-package-fedora-rhel-etc` | `#linux-rpm-package-fedora-43-44` |
| `guide/cli.md:30` | `../server/cli-chat.md` | `./cli-chat.md` |
