### PR TITLE
Fix startup self-deadlock with a thread-local recursion guard (minimal alt to #2443)

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -3952,10 +3952,11 @@ static bool s_recipes_computed = false;
 static thread_local bool s_building_recipes = false;
 
 json SystemInfoCache::get_system_info_with_cache() {
-    // Re-entrant call from within our own build_recipes_info(): hardware is
-    // already computed and cached, and we still hold the mutex from the outer
-    // frame, so return the hardware snapshot the nested caller needs instead of
-    // self-deadlocking on a re-lock.
+    // Re-entrant call from within our own build_recipes_info(). The flag is set
+    // only after hardware detection, so s_cached_system_info already holds
+    // "devices" here, and the outer frame still owns the mutex — return that
+    // snapshot (all the nested caller needs) instead of self-deadlocking on a
+    // re-lock.
     if (s_building_recipes) {
         return s_cached_system_info;
     }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -3942,7 +3942,24 @@ static json s_cached_system_info;
 static bool s_hardware_computed = false;
 static bool s_recipes_computed = false;
 
+// True while THIS thread is inside build_recipes_info(). That computation can
+// call back into get_system_info_with_cache() on the same thread (e.g.
+// SystemInfo::get_rocm_arch() while resolving a backend's install params).
+// Because the outer call holds s_system_info_mutex, the nested call must not
+// try to re-lock it. thread_local (not a shared atomic) is deliberate: only the
+// recursing thread short-circuits — genuinely concurrent threads still block on
+// the mutex and receive fully-populated data, never a recipe-less snapshot.
+static thread_local bool s_building_recipes = false;
+
 json SystemInfoCache::get_system_info_with_cache() {
+    // Re-entrant call from within our own build_recipes_info(): hardware is
+    // already computed and cached, and we still hold the mutex from the outer
+    // frame, so return the hardware snapshot the nested caller needs instead of
+    // self-deadlocking on a re-lock.
+    if (s_building_recipes) {
+        return s_cached_system_info;
+    }
+
     std::lock_guard<std::mutex> lock(s_system_info_mutex);
 
     // Return fully cached result if both hardware and recipes are computed
@@ -3992,6 +4009,14 @@ json SystemInfoCache::get_system_info_with_cache() {
 
     // Compute recipes if not cached (or invalidated)
     if (!s_recipes_computed) {
+        // Mark this thread as building recipes so any re-entrant call (via
+        // get_rocm_arch() etc.) short-circuits instead of re-locking. The guard
+        // clears on every exit path, including exceptions.
+        struct RecipeBuildGuard {
+            ~RecipeBuildGuard() { s_building_recipes = false; }
+        } recipe_build_guard;
+        s_building_recipes = true;
+
         try {
             auto sys_info = create_system_info();
             json devices = s_cached_system_info.contains("devices")


### PR DESCRIPTION
Minimal alternative to #2443 for the startup deadlock (#2414).

Closes https://github.com/lemonade-sdk/lemonade/issues/2414

## Root cause
`get_system_info_with_cache()` holds `s_system_info_mutex` across the whole recipe build. `build_recipes_info()` can re-enter the function **on the same thread** — `build_recipes_info → backend install-params (e.g. SdServer) → SystemInfo::get_rocm_arch() → get_system_info_with_cache()` — and re-locking the non-recursive mutex self-deadlocks, hanging at "Building models cache...". Triggered on AMD ROCm systems with an sd-cpp/llamacpp backend pinned to `_bin = latest`.

## Fix (25 lines, one file)
A `thread_local bool s_building_recipes` guard. The re-entrant call returns the already-computed hardware snapshot (all `get_rocm_arch()` needs) instead of re-locking. `thread_local` is deliberate: only the recursing thread short-circuits, so genuinely concurrent threads still block on the mutex and receive fully-populated data.

## Why this instead of #2443
The only real deadlock here is the same-thread recursion — no path in the recipe-build chain ever acquires `models_cache_mutex_`, so there is no ABBA between the two mutexes. That lets the fix stay tiny and avoids the trade-offs in #2443:
- A **global** `s_phase2_in_progress` atomic can't tell same-thread recursion from a concurrent caller, so a thread arriving during the cold recipe build skips recipe computation and returns a recipe-less snapshot (FLM reported unsupported; models filtered out as "Recipe not found"). A `thread_local` guard avoids that race by construction.
- No need for `detect_rocm_arch_from_sysfs()` + the hand-maintained PCI-ID→gfx table (a maintenance liability that doesn't even cover the gfx115x targets), the generation counter, or the duplicated `_from_cache` / `(…, si)` overloads.

Net: +25/-0 vs #2443's +383/-82.

## Testing
- Builds clean (`cmake --build --preset default --target lemond`).
- `lemond` starts, passes "Building models cache...", `/health` returns ok, and `/api/v1/models` returns a populated list (recipes built, nothing wrongly filtered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)