### PR TITLE
fix(launch): resolve npm .cmd launcher on Windows for pi and codex

### DIFF
--- a/src/cpp/cli/agent_launcher.cpp
+++ b/src/cpp/cli/agent_launcher.cpp
@@ -137,10 +137,13 @@ void configure_codex_agent(const std::string& base_url,
                            AgentConfig& config) {
     const std::string resolved_api_key = api_key.empty() ? kDefaultAgentApiKey : api_key;
 
-    config.binary_name = "codex";
 #ifdef _WIN32
-    config.binary_alternatives = {"codex.cmd", "codex.exe"};
+    // npm puts a Unix shell script named just "codex" next to codex.cmd.
+    // Windows cannot run the shell script, so look for .cmd/.exe first.
+    config.binary_name = "codex.cmd";
+    config.binary_alternatives = {"codex.exe", "codex"};
 #else
+    config.binary_name = "codex";
     config.binary_alternatives = {};
 #endif
     config.fallback_paths = {
@@ -220,10 +223,13 @@ void configure_pi_agent(const std::string& model,
                         AgentConfig& config) {
     const std::string resolved_api_key = api_key.empty() ? kDefaultAgentApiKey : api_key;
 
-    config.binary_name = "pi";
 #ifdef _WIN32
-    config.binary_alternatives = {"pi.cmd", "pi.exe"};
+    // npm puts a Unix shell script named just "pi" next to pi.cmd.
+    // Windows cannot run the shell script, so look for .cmd/.exe first.
+    config.binary_name = "pi.cmd";
+    config.binary_alternatives = {"pi.exe", "pi"};
 #else
+    config.binary_name = "pi";
     config.binary_alternatives = {};
 #endif
     config.fallback_paths = {


### PR DESCRIPTION
## Summary
On Windows, `lemonade launch pi` failed with `%1 is not a valid Win32 application` (error 193). npm installs an extensionless Unix shell shim (`pi`) next to `pi.cmd`; `find_agent_binary()` searched the bare name first and resolved the shim, which `CreateProcess` cannot execute.

Fix: prefer the `.cmd` launcher on Windows for the `pi` and `codex` agents, matching what the `claude` and `opencode` configs already do.

## Test
- Rebuilt `lemonade.exe`; `lemonade launch pi` now spawns `pi.cmd` and runs instead of exiting with error 193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)