### PR TITLE
Update backend reference docs for new vLLM models

### DIFF
--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -306,14 +306,17 @@ the generator instead. Prose outside the markers is preserved. -->
 | `SDXL-Turbo` | 6.94 | image |
 | `Z-Image-Turbo` | 20.7 | image |
 
-#### `vllm` — vLLM ROCm (experimental) (4 models)
+#### `vllm` — vLLM ROCm (experimental) (7 models)
 
 | Model | Size (GB) | Labels |
 |-------|-----------|--------|
+| `GLM-4.7-Flash-FP16-vLLM` | 62.47 | reasoning, tool-calling |
 | `Qwen3.5-0.8B-FP16-vLLM` | 1.77 | reasoning |
 | `Qwen3.5-2B-FP16-vLLM` | 4.57 | reasoning, tool-calling |
 | `Qwen3.5-4B-FP16-vLLM` | 9.34 | reasoning, hot, tool-calling |
 | `Qwen3.5-9B-FP16-vLLM` | 19.3 | reasoning, tool-calling |
+| `Qwen3.6-27B-FP16-vLLM` | 55.59 | reasoning, tool-calling, vision |
+| `Qwen3.6-35B-A3B-FP16-vLLM` | 71.93 | reasoning, tool-calling, vision |
 
 #### `whispercpp` — Whisper.cpp (6 models)
 


### PR DESCRIPTION
Regenerated docs/dev/backends-reference.md to include recently added vLLM models:
- GLM-4.7-Flash-FP16-vLLM
- Qwen3.6-27B-FP16-vLLM
- Qwen3.6-35B-A3B-FP16-vLLM

This fixes the backend-docs-drift CI check failure.