### PR TITLE
add per-architecture options

### DIFF
--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -494,7 +494,8 @@ When loading a model, settings are resolved in this order (highest to lowest pri
 
 1. Values explicitly passed in the `/api/v1/load` request
 2. Per-model values from `recipe_options.json`
-3. Global configuration values, see [Server Configuration](./README.md)
+3. Per-architecture defaults from `architecture_defaults.json` (shipped resource; keyed by GGUF architecture name read from the model file)
+4. Global configuration values, see [Server Configuration](./README.md)
 
 **`*_args` merge behavior:** For options ending in `_args` (e.g., `llamacpp_args`, `whispercpp_args`, `sdcpp_args`, `vllm_args`), the CLI/API arguments are **merged** rather than replaced. The merge works at the flag level with higher priority settings taking priority.
 

--- a/docs/guide/configuration/multi-model.md
+++ b/docs/guide/configuration/multi-model.md
@@ -106,5 +106,7 @@ Each model can be loaded with custom settings (context size, llamacpp backend, l
 
 **Setting Priority Order:**
 1. Values passed explicitly in `/api/v1/load` request (highest priority)
-2. Values from environment variables or server startup arguments (see [Server Configuration](./README.md))
-3. Hardcoded defaults in `lemond` (lowest priority)
+2. Per-model values from `recipe_options.json`
+3. Per-architecture defaults from `architecture_defaults.json` (shipped resource; keyed by GGUF architecture name)
+4. Values from environment variables or server startup arguments (see [Server Configuration](./README.md))
+5. Hardcoded defaults in `lemond` (lowest priority)

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -242,6 +242,10 @@ public:
     // removed in the directory.
     void set_extra_models_dir(const std::string& dir);
 
+    // Per-architecture default recipe options (loaded from resources).
+    // Override global config defaults but are overridden by model-level recipe_options.
+    json get_architecture_defaults(const std::string& architecture) const;
+
     void save_model_options(const ModelInfo& info);
 
     void start_directory_watcher();
@@ -257,6 +261,7 @@ private:
                        std::set<std::string>& visited);
 
     json load_server_models();
+    json load_architecture_defaults();
     json load_optional_json(const std::string& path);
     void save_user_models(const json& user_models);
 
@@ -319,6 +324,7 @@ private:
     json server_models_;
     json user_models_;
     json recipe_options_;
+    json architecture_defaults_;  // Per-architecture recipe option overlays (from resources)
     std::string extra_models_dir_;  // Secondary directory for GGUF model discovery
     CloudProviderRegistry* cloud_registry_ = nullptr;  // Not owned
     std::unique_ptr<DirectoryWatcher> directory_watcher_;

--- a/src/cpp/resources/architecture_defaults.json
+++ b/src/cpp/resources/architecture_defaults.json
@@ -1,5 +1,6 @@
 {
-  "_comment": "Per-architecture default recipe options. Keys are GGUF architecture names (e.g. qwen35, gemma4). Values are recipe option key-value pairs that override global config defaults but are overridden by model-level recipe_options. Loaded from resources at startup; optional - missing file or unknown architecture silently applies no overlay.",
+  "_comment": "Per-architecture default recipe options. Keys are GGUF architecture names (e.g. qwen35, gemma4). Values are recipe option key-value pairs that override global config defaults but are overridden by model-level recipe_options.",
+  "_warning": "IMPORTANT: Do NOT define *_backend options here. This file is meant mostly for sampler options or other options that might be necessary to run a specific model family.",
   "gemma4": {
     "llamacpp_args": "--temp 1.0 --top-p 0.95 --top-k 64"
   },

--- a/src/cpp/resources/architecture_defaults.json
+++ b/src/cpp/resources/architecture_defaults.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Per-architecture default recipe options. Keys are GGUF architecture names (e.g. qwen35, gemma4). Values are recipe option key-value pairs that override global config defaults but are overridden by model-level recipe_options. Loaded from resources at startup; optional - missing file or unknown architecture silently applies no overlay.",
+  "gemma4": {
+    "llamacpp_args": "--temp 1.0 --top-p 0.95 --top-k 64"
+  },
+  "nemotron_h_moe": {
+    "llamacpp_args": "--temp 0.6 --top-p 0.95"
+  },
+  "qwen3": {
+    "llamacpp_args": "--temp 0.6 --top-p 0.85 --top-k 20 --min-p 0.0 --repeat-penalty 1.0"
+  },
+  "qwen3next": {
+    "llamacpp_args": "--temp 0.6 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.0"
+  },
+  "qwen35": {
+    "llamacpp_args": "--temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.00 --repeat-penalty 1.0 --chat-template-kwargs '{\"preserve_thinking\":true}'"
+  },
+  "qwen35moe": {
+    "llamacpp_args": "--temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.00 --repeat-penalty 1.0 --chat-template-kwargs '{\"preserve_thinking\":true}'"
+  }
+}

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -778,6 +778,7 @@ ModelManager::ModelManager(const std::string& extra_models_dir)
     server_models_ = load_server_models();
     user_models_ = load_optional_json(get_user_models_file());
     recipe_options_ = load_optional_json(get_recipe_options_file());
+    architecture_defaults_ = load_architecture_defaults();
 
     // One-shot migration of recipe_options.json: older Lemonade keyed built-in
     // entries by bare name; the current spec requires a canonical "builtin."
@@ -1126,6 +1127,27 @@ json ModelManager::load_optional_json(const std::string& path) {
         LOG(WARNING, "ModelManager") << "Could not load " << fs::path(path).filename() << ": " << e.what() << std::endl;
         return json::object();
     }
+}
+
+json ModelManager::load_architecture_defaults() {
+    try {
+        std::string path = get_resource_path("resources/architecture_defaults.json");
+        return JsonUtils::load_from_file(path);
+    } catch (const std::exception& e) {
+        LOG(WARNING, "ModelManager") << "Could not load architecture_defaults.json: " << e.what() << std::endl;
+        return json::object();
+    }
+}
+
+json ModelManager::get_architecture_defaults(const std::string& architecture) const {
+    if (architecture.empty() || !architecture_defaults_.is_object()) {
+        return json::object();
+    }
+    if (architecture_defaults_.contains(architecture) &&
+        architecture_defaults_[architecture].is_object()) {
+        return architecture_defaults_[architecture];
+    }
+    return json::object();
 }
 
 static void save_user_json(const std::string& save_path, const json& to_save) {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -360,9 +360,12 @@ void Router::load_model(const std::string& model_name,
     json backend_json = tentative.get_option(backend_option);
     const std::string backend = backend_json.is_string() ? backend_json.get<std::string>() : "";
 
-    // Second pass: rebuild defaults using the resolved backend
+    // Second pass: rebuild defaults using the resolved backend.
+    // Per-architecture defaults sit between global config and model-level recipe_options.
     RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options(backend));
-    RecipeOptions effective_options = options.inherit(model_info.recipe_options.inherit(default_opt));
+    RecipeOptions arch_opts(model_info.recipe,
+                            model_manager_->get_architecture_defaults(model_info.gguf.architecture));
+    RecipeOptions effective_options = options.inherit(model_info.recipe_options.inherit(arch_opts.inherit(default_opt)));
 
     // LOAD SERIALIZATION STRATEGY (from spec: point #2 in Additional Considerations)
     std::unique_lock<std::mutex> lock(load_mutex_);


### PR DESCRIPTION
Closes #2480.

adds per-architecture `recipe_options` that automatically apply recommended llamacpp (or potentially other) settings unless overridden by per-model `recipe_options`.