### PR TITLE
Detect externally-installed ROCm before downloading TheRock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2015,3 +2015,12 @@ if(EXISTS "${_CONFIG_TELEMETRY_TEST_SRC}")
     target_link_libraries(test_config_telemetry PRIVATE lemonade-server-core)
     add_test(NAME ConfigTelemetryTest COMMAND test_config_telemetry)
 endif()
+
+# ROCm root resolution (ROCM_PATH / rocm-sdk / /opt/rocm priority): covers the
+# external-ROCm detection that lets Lemonade skip the bundled TheRock download.
+set(_ROCM_ROOT_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_rocm_root_resolution.cpp")
+if(EXISTS "${_ROCM_ROOT_TEST_SRC}")
+    add_executable(test_rocm_root_resolution test/cpp/test_rocm_root_resolution.cpp)
+    target_link_libraries(test_rocm_root_resolution PRIVATE lemonade-server-core)
+    add_test(NAME RocmRootResolutionTest COMMAND test_rocm_root_resolution)
+endif()

--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -118,6 +118,20 @@ After changing channels, you'll need to reinstall the ROCm backend:
 lemonade backends install llamacpp:rocm
 ```
 
+### Reusing a System-Installed ROCm (Linux)
+
+On the stable channel Lemonade normally downloads its own ROCm runtime (TheRock). If you already have ROCm installed system-wide, Lemonade reuses it instead of downloading a second copy when it can find a matching version. It locates the install root in this order, using the first directory that contains `lib{,64}/libamdhip64.so`:
+
+1. The `ROCM_PATH` environment variable
+2. `rocm-sdk path --root`, when `rocm-sdk` is on your `PATH` (e.g. a ROCm installed from the TheRock pip wheels)
+3. `/opt/rocm`
+
+When the runtime is found via `ROCM_PATH` or `rocm-sdk`, a `major.minor` version match is accepted (and a runtime with no version file is accepted as-is), so a patch-level difference won't trigger a second download. To force Lemonade to use a specific ROCm, export `ROCM_PATH` before starting the server:
+
+```bash
+export ROCM_PATH=/path/to/rocm
+```
+
 ### Pinning to a Specific Version Tag
 
 You can pin `llamacpp.rocm_bin` to a specific release tag instead of using `"builtin"` or `"latest"`. **Each channel downloads from a different GitHub repository, so you must set the correct channel before setting a specific tag.**

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <functional>
 #include <filesystem>
+#include <optional>
 #include <utility>
 #include <vector>
 #include "lemon/backends/backend_descriptor.h"
@@ -105,6 +106,31 @@ namespace lemon::backends {
 
         /** Get the latest version number for the given recipe/backend */
         static std::string get_backend_version(const std::string& recipe, const std::string& backend);
+
+        /**
+         * Resolve the ROCm install root, honoring an externally-installed ROCm
+         * before the bundled default. Resolution order, returning the first root
+         * that contains lib{,64}/libamdhip64.so:
+         *   1. ROCM_PATH environment variable
+         *   2. `rocm-sdk path --root` (when rocm-sdk is on PATH)
+         *   3. /opt/rocm
+         * Returns std::nullopt when none validate. When resolved_explicitly is
+         * non-null, it is set to true when the root came from ROCM_PATH or
+         * rocm-sdk (a user-selected ROCm) and false for the /opt/rocm fallback.
+         *
+         * Probes Linux HIP runtime artifacts (lib{,64}/libamdhip64.so, /opt/rocm)
+         * and is only meaningful on Linux; current callers reach it solely behind
+         * is_rocm_installed_system_wide() (Linux-gated).
+         */
+        static std::optional<fs::path> resolve_rocm_root(bool* resolved_explicitly = nullptr);
+
+        /**
+         * Read the ROCm version string from a resolved install root, probing the
+         * known version-file locations ({root}/.info/version,
+         * {root}/share/rocm/version, {root}/version). Returns the trimmed first
+         * line of the first file found, or "" when none exist.
+         */
+        static std::string read_rocm_version_from_root(const fs::path& root);
 
         /** Check if ROCm libraries are installed system-wide (Linux only) */
         static bool is_rocm_installed_system_wide();

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -11,11 +11,12 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <functional>
+#include <iostream>
 #include <map>
-#include <vector>
+#include <optional>
 #include <thread>
+#include <vector>
 #include <lemon/utils/aixlog.hpp>
 
 namespace fs = std::filesystem;
@@ -101,6 +102,19 @@ bool runtime_version_matches_expected(const std::string& discovered_version,
     return discovered.rfind(expected + ".", 0) == 0;
 }
 
+std::string runtime_version_major_minor(const std::string& version) {
+    const std::string normalized = normalize_runtime_version(version);
+    const auto first_dot = normalized.find('.');
+    if (first_dot == std::string::npos) {
+        return normalized;
+    }
+    const auto second_dot = normalized.find('.', first_dot + 1);
+    if (second_dot == std::string::npos) {
+        return normalized;
+    }
+    return normalized.substr(0, second_dot);
+}
+
 std::string read_version_file(const fs::path& version_file) {
     if (!fs::exists(version_file)) {
         return "";
@@ -154,9 +168,44 @@ bool github_download_service_reachable() {
 }
 
 bool has_matching_system_rocm_runtime(const std::string& expected_runtime_version) {
-    const fs::path version_file = "/opt/rocm/.info/version";
-    const std::string system_version = read_version_file(version_file);
-    return runtime_version_matches_expected(system_version, expected_runtime_version);
+    bool resolved_explicitly = false;
+    const auto rocm_root = backends::BackendUtils::resolve_rocm_root(&resolved_explicitly);
+    if (!rocm_root) {
+        return false;
+    }
+
+    const std::string system_version =
+        backends::BackendUtils::read_rocm_version_from_root(*rocm_root);
+
+    if (resolved_explicitly) {
+        // The user deliberately installed this ROCm (via ROCM_PATH or rocm-sdk).
+        // Don't re-download TheRock over a patch-level difference: accept a
+        // major.minor match, and accept outright when no version file is present.
+        if (system_version.empty()) {
+            LOG(INFO, "BackendManager")
+                << "Using explicitly-selected system ROCm at " << rocm_root->string()
+                << " (no version file; skipping version gate)" << std::endl;
+            return true;
+        }
+        const bool matches =
+            runtime_version_matches_expected(system_version, expected_runtime_version) ||
+            runtime_version_major_minor(system_version) ==
+                runtime_version_major_minor(expected_runtime_version);
+        LOG(matches ? DEBUG : INFO, "BackendManager")
+            << "Explicitly-selected system ROCm at " << rocm_root->string()
+            << " version '" << system_version << "' vs expected '"
+            << expected_runtime_version << "' -> "
+            << (matches ? "match" : "mismatch") << std::endl;
+        return matches;
+    }
+
+    const bool matches =
+        runtime_version_matches_expected(system_version, expected_runtime_version);
+    LOG(DEBUG, "BackendManager")
+        << "System ROCm at " << rocm_root->string() << " version '" << system_version
+        << "' vs expected '" << expected_runtime_version << "' -> "
+        << (matches ? "match" : "mismatch") << std::endl;
+    return matches;
 }
 
 

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -813,9 +813,8 @@ namespace lemon::backends {
         }
     }
     namespace {
-        // A directory qualifies as a ROCm root only if it ships the HIP runtime
-        // (lib{,64}/libamdhip64.so). Uses the non-throwing fs overloads so a
-        // bogus user-supplied path reports "not a root" instead of throwing.
+        // Non-throwing fs overloads so a bogus user-supplied path reports
+        // "not a root" instead of throwing.
         std::optional<fs::path> validate_rocm_root(const fs::path& root) {
             std::error_code ec;
             if (root.empty() || !fs::exists(root, ec)) {
@@ -829,8 +828,6 @@ namespace lemon::backends {
             return std::nullopt;
         }
 
-        // Query `rocm-sdk path --root` when rocm-sdk is on PATH. Returns the
-        // first non-empty line of output (the install root) or nullopt.
         std::optional<fs::path> query_rocm_sdk_root() {
             if (utils::find_executable_in_path("rocm-sdk").empty()) {
                 return std::nullopt;
@@ -867,7 +864,6 @@ namespace lemon::backends {
             *resolved_explicitly = false;
         }
 
-        // 1. ROCM_PATH env var (e.g. exported by an external ROCm installer).
         if (const char* env = std::getenv("ROCM_PATH"); env && *env != '\0') {
             if (auto root = validate_rocm_root(fs::path(env))) {
                 if (resolved_explicitly) {
@@ -881,7 +877,6 @@ namespace lemon::backends {
                       << " has no lib{,64}/libamdhip64.so; trying other sources" << std::endl;
         }
 
-        // 2. rocm-sdk on PATH.
         if (auto sdk_root = query_rocm_sdk_root()) {
             if (auto root = validate_rocm_root(*sdk_root)) {
                 if (resolved_explicitly) {
@@ -895,7 +890,6 @@ namespace lemon::backends {
                       << " but it has no lib{,64}/libamdhip64.so; trying /opt/rocm" << std::endl;
         }
 
-        // 3. /opt/rocm (historical default).
         if (auto root = validate_rocm_root("/opt/rocm")) {
             LOG(DEBUG, "BackendUtils") << "Resolved ROCm root at default /opt/rocm" << std::endl;
             return root;

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -812,48 +812,147 @@ namespace lemon::backends {
             }
         }
     }
+    namespace {
+        // A directory qualifies as a ROCm root only if it ships the HIP runtime
+        // (lib{,64}/libamdhip64.so). Uses the non-throwing fs overloads so a
+        // bogus user-supplied path reports "not a root" instead of throwing.
+        std::optional<fs::path> validate_rocm_root(const fs::path& root) {
+            std::error_code ec;
+            if (root.empty() || !fs::exists(root, ec)) {
+                return std::nullopt;
+            }
+            for (const char* lib_subdir : {"lib", "lib64"}) {
+                if (fs::exists(root / lib_subdir / "libamdhip64.so", ec)) {
+                    return root;
+                }
+            }
+            return std::nullopt;
+        }
+
+        // Query `rocm-sdk path --root` when rocm-sdk is on PATH. Returns the
+        // first non-empty line of output (the install root) or nullopt.
+        std::optional<fs::path> query_rocm_sdk_root() {
+            if (utils::find_executable_in_path("rocm-sdk").empty()) {
+                return std::nullopt;
+            }
+
+            std::string captured;
+            auto on_line = [&captured](const std::string& line) {
+                if (captured.empty()) {
+                    captured = line;
+                }
+                return true;
+            };
+
+            int rc = utils::ProcessManager::run_process_with_output(
+                "rocm-sdk", {"path", "--root"}, on_line, /*working_dir=*/"",
+                /*timeout_seconds=*/5);
+            if (rc != 0) {
+                LOG(DEBUG, "BackendUtils") << "rocm-sdk path --root exited with " << rc
+                          << "; ignoring" << std::endl;
+                return std::nullopt;
+            }
+
+            const auto first = captured.find_first_not_of(" \t\r\n");
+            if (first == std::string::npos) {
+                return std::nullopt;
+            }
+            const auto last = captured.find_last_not_of(" \t\r\n");
+            return fs::path(captured.substr(first, last - first + 1));
+        }
+    }  // namespace
+
+    std::optional<fs::path> BackendUtils::resolve_rocm_root(bool* resolved_explicitly) {
+        if (resolved_explicitly) {
+            *resolved_explicitly = false;
+        }
+
+        // 1. ROCM_PATH env var (e.g. exported by an external ROCm installer).
+        if (const char* env = std::getenv("ROCM_PATH"); env && *env != '\0') {
+            if (auto root = validate_rocm_root(fs::path(env))) {
+                if (resolved_explicitly) {
+                    *resolved_explicitly = true;
+                }
+                LOG(DEBUG, "BackendUtils") << "Resolved ROCm root from ROCM_PATH: "
+                          << root->string() << std::endl;
+                return root;
+            }
+            LOG(DEBUG, "BackendUtils") << "ROCM_PATH=" << env
+                      << " has no lib{,64}/libamdhip64.so; trying other sources" << std::endl;
+        }
+
+        // 2. rocm-sdk on PATH.
+        if (auto sdk_root = query_rocm_sdk_root()) {
+            if (auto root = validate_rocm_root(*sdk_root)) {
+                if (resolved_explicitly) {
+                    *resolved_explicitly = true;
+                }
+                LOG(DEBUG, "BackendUtils") << "Resolved ROCm root from rocm-sdk: "
+                          << root->string() << std::endl;
+                return root;
+            }
+            LOG(DEBUG, "BackendUtils") << "rocm-sdk reported " << sdk_root->string()
+                      << " but it has no lib{,64}/libamdhip64.so; trying /opt/rocm" << std::endl;
+        }
+
+        // 3. /opt/rocm (historical default).
+        if (auto root = validate_rocm_root("/opt/rocm")) {
+            LOG(DEBUG, "BackendUtils") << "Resolved ROCm root at default /opt/rocm" << std::endl;
+            return root;
+        }
+
+        return std::nullopt;
+    }
+
+    std::string BackendUtils::read_rocm_version_from_root(const fs::path& root) {
+        const std::vector<fs::path> version_paths = {
+            root / ".info" / "version",
+            root / "share" / "rocm" / "version",
+            root / "version"
+        };
+        for (const auto& version_path : version_paths) {
+            std::error_code ec;
+            if (!fs::exists(version_path, ec)) {
+                continue;
+            }
+            std::ifstream file(version_path);
+            if (!file.is_open()) {
+                continue;
+            }
+            std::string line;
+            std::getline(file, line);
+            const auto first = line.find_first_not_of(" \t\r\n");
+            if (first == std::string::npos) {
+                continue;
+            }
+            const auto last = line.find_last_not_of(" \t\r\n");
+            return line.substr(first, last - first + 1);
+        }
+        return "";
+    }
+
     bool BackendUtils::is_rocm_installed_system_wide() {
 #ifndef __linux__
         return false;
 #else
-        // Only check /opt/rocm for system-wide installation
-        // (/usr is handled by the system backend separately)
-        fs::path rocm_root("/opt/rocm");
-
-        // Check for libamdhip64.so in lib directories
-        std::vector<std::string> lib_subdirs = {"lib", "lib64"};
-        bool found_lib = false;
-
-        for (const auto& lib_subdir : lib_subdirs) {
-            fs::path lib_path = rocm_root / lib_subdir / "libamdhip64.so";
-            if (fs::exists(lib_path)) {
-                found_lib = true;
-                break;
-            }
-        }
-
-        if (!found_lib) {
-            LOG(DEBUG, "BackendUtils") << "No system-wide ROCm installation detected at /opt/rocm" << std::endl;
+        auto rocm_root_opt = resolve_rocm_root();
+        if (!rocm_root_opt) {
+            LOG(DEBUG, "BackendUtils")
+                << "No ROCm installation detected (ROCM_PATH, rocm-sdk, /opt/rocm)" << std::endl;
             return false;
         }
+        const fs::path& rocm_root = *rocm_root_opt;
 
-        // Verify with version file
-        std::vector<std::string> version_paths = {
-            (rocm_root / ".info" / "version").string(),
-            (rocm_root / "share" / "rocm" / "version").string(),
-            (rocm_root / "version").string()
-        };
-
-        for (const auto& version_path : version_paths) {
-            if (fs::exists(version_path)) {
-                LOG(DEBUG, "BackendUtils") << "Found system ROCm at /opt/rocm with version file: "
-                          << version_path << std::endl;
-                return true;
-            }
+        // resolve_rocm_root already verified libamdhip64.so. The version file is
+        // best-effort: accept the install even when it ships none.
+        const std::string version = read_rocm_version_from_root(rocm_root);
+        if (!version.empty()) {
+            LOG(DEBUG, "BackendUtils") << "Found system ROCm at " << rocm_root.string()
+                      << " with version " << version << std::endl;
+        } else {
+            LOG(DEBUG, "BackendUtils") << "Found ROCm libraries at " << rocm_root.string()
+                      << " (no version file found)" << std::endl;
         }
-
-        // If we found the lib but no version file, log a warning but still accept it
-        LOG(DEBUG, "BackendUtils") << "Found ROCm libraries at /opt/rocm (no version file found)" << std::endl;
         return true;
 #endif
     }

--- a/test/cpp/test_rocm_root_resolution.cpp
+++ b/test/cpp/test_rocm_root_resolution.cpp
@@ -1,14 +1,9 @@
 // Unit tests for lemon::backends::BackendUtils::resolve_rocm_root().
 //
-// resolve_rocm_root() lets Lemonade reuse an externally-installed ROCm instead
-// of downloading its own TheRock runtime. It resolves the install root in
-// priority order: ROCM_PATH -> `rocm-sdk path --root` -> /opt/rocm, returning
-// the first directory that ships lib{,64}/libamdhip64.so.
-//
-// These tests drive the ROCM_PATH and fallback paths with temp dirs containing
-// a fake libamdhip64.so. They cannot deterministically exercise the rocm-sdk
-// or /opt/rocm branches (host-dependent), so they only assert invariants that
-// hold regardless of host state.
+// The rocm-sdk and /opt/rocm branches are host-dependent and can't be driven
+// deterministically, so these tests exercise the ROCM_PATH branch with a temp
+// dir containing a fake libamdhip64.so and otherwise assert only invariants
+// that hold regardless of host state.
 
 #include <cstdlib>
 #include <filesystem>
@@ -87,7 +82,6 @@ int main() {
     const fs::path invalid_root = tmp / "invalid";
     fs::create_directories(invalid_root / "lib");  // no libamdhip64.so
 
-    // Case 1: ROCM_PATH points at a valid root (lib/) -> resolves it, explicit.
     {
         bool explicit_source = false;
         set_rocm_path(valid_root.string());
@@ -98,7 +92,6 @@ int main() {
         check(explicit_source, "ROCM_PATH (lib/) is marked explicit");
     }
 
-    // Case 2: ROCM_PATH points at a valid root (lib64/) -> resolves it.
     {
         bool explicit_source = false;
         set_rocm_path(valid_root_lib64.string());
@@ -109,22 +102,20 @@ int main() {
         check(explicit_source, "ROCM_PATH (lib64/) is marked explicit");
     }
 
-    // Case 3: ROCM_PATH set but missing libamdhip64.so -> must NOT return that
-    // path; falls through to rocm-sdk / /opt/rocm (host-dependent, may be none).
+    // A ROCM_PATH missing libamdhip64.so must fall through, never resolve to
+    // itself, and never be reported as explicit.
     {
         bool explicit_source = false;
         set_rocm_path(invalid_root.string());
         auto root = BackendUtils::resolve_rocm_root(&explicit_source);
         check(!root.has_value() || !fs::equivalent(*root, invalid_root),
               "invalid ROCM_PATH does not resolve to itself");
-        // The invalid path itself must never be reported as an explicit match.
         if (!root.has_value()) {
             check(!explicit_source, "invalid ROCM_PATH does not mark explicit");
         }
     }
 
-    // Case 4: ROCM_PATH set to a non-existent path -> same fall-through, no
-    // throw from the non-throwing filesystem probes.
+    // A non-existent ROCM_PATH must fall through without the fs probes throwing.
     {
         bool explicit_source = false;
         set_rocm_path((tmp / "does-not-exist").string());
@@ -137,17 +128,14 @@ int main() {
         }
     }
 
-    // Case 5: nullptr out-param is accepted.
     {
         set_rocm_path(valid_root.string());
         auto root = BackendUtils::resolve_rocm_root(nullptr);
         check(root.has_value(), "nullptr resolved_explicitly is accepted");
     }
 
-    // Case 6: no ROCM_PATH and (assuming) no rocm-sdk/opt-rocm on this host ->
-    // resolver is well-behaved (returns a value only if the host genuinely has
-    // ROCm at /opt/rocm or via rocm-sdk). We only assert it does not throw and,
-    // if it resolves, the result is not explicit unless rocm-sdk supplied it.
+    // With no ROCM_PATH the result is host-dependent; only assert the no-ROCm
+    // host resolves to nullopt and clears the explicit flag.
     {
         clear_rocm_path();
         bool explicit_source = true;  // sentinel; must be overwritten to false

--- a/test/cpp/test_rocm_root_resolution.cpp
+++ b/test/cpp/test_rocm_root_resolution.cpp
@@ -1,0 +1,173 @@
+// Unit tests for lemon::backends::BackendUtils::resolve_rocm_root().
+//
+// resolve_rocm_root() lets Lemonade reuse an externally-installed ROCm instead
+// of downloading its own TheRock runtime. It resolves the install root in
+// priority order: ROCM_PATH -> `rocm-sdk path --root` -> /opt/rocm, returning
+// the first directory that ships lib{,64}/libamdhip64.so.
+//
+// These tests drive the ROCM_PATH and fallback paths with temp dirs containing
+// a fake libamdhip64.so. They cannot deterministically exercise the rocm-sdk
+// or /opt/rocm branches (host-dependent), so they only assert invariants that
+// hold regardless of host state.
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#include <lemon/backends/backend_utils.h>
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+using lemon::backends::BackendUtils;
+
+namespace {
+
+int g_failures = 0;
+
+// assert() is compiled out under NDEBUG (the default Release preset), so these
+// tests use an explicit checker that records failures and drives the exit code,
+// matching the sibling tests in this directory.
+void check(bool cond, const char* msg) {
+    if (cond) {
+        std::cout << "[ok] " << msg << std::endl;
+    } else {
+        std::cerr << "[FAIL] " << msg << std::endl;
+        ++g_failures;
+    }
+}
+
+void set_rocm_path(const std::string& value) {
+#ifdef _WIN32
+    _putenv_s("ROCM_PATH", value.c_str());
+#else
+    setenv("ROCM_PATH", value.c_str(), /*overwrite=*/1);
+#endif
+}
+
+void clear_rocm_path() {
+#ifdef _WIN32
+    _putenv("ROCM_PATH=");  // "name=" removes the variable on Windows
+#else
+    unsetenv("ROCM_PATH");
+#endif
+}
+
+void write_stub(const fs::path& p) {
+    fs::create_directories(p.parent_path());
+    std::ofstream(p) << "stub";
+}
+
+}  // namespace
+
+int main() {
+    fs::path tmp = fs::temp_directory_path() /
+                   ("lemon_rocm_root_test_" + std::to_string(
+#ifdef _WIN32
+                        _getpid()
+#else
+                        getpid()
+#endif
+                        ));
+    fs::remove_all(tmp);
+    fs::create_directories(tmp);
+
+    const fs::path valid_root = tmp / "valid";
+    write_stub(valid_root / "lib" / "libamdhip64.so");
+
+    const fs::path valid_root_lib64 = tmp / "valid64";
+    write_stub(valid_root_lib64 / "lib64" / "libamdhip64.so");
+
+    const fs::path invalid_root = tmp / "invalid";
+    fs::create_directories(invalid_root / "lib");  // no libamdhip64.so
+
+    // Case 1: ROCM_PATH points at a valid root (lib/) -> resolves it, explicit.
+    {
+        bool explicit_source = false;
+        set_rocm_path(valid_root.string());
+        auto root = BackendUtils::resolve_rocm_root(&explicit_source);
+        check(root.has_value(), "ROCM_PATH (lib/) resolves");
+        check(root.has_value() && fs::equivalent(*root, valid_root),
+              "ROCM_PATH (lib/) resolves to the given root");
+        check(explicit_source, "ROCM_PATH (lib/) is marked explicit");
+    }
+
+    // Case 2: ROCM_PATH points at a valid root (lib64/) -> resolves it.
+    {
+        bool explicit_source = false;
+        set_rocm_path(valid_root_lib64.string());
+        auto root = BackendUtils::resolve_rocm_root(&explicit_source);
+        check(root.has_value(), "ROCM_PATH (lib64/) resolves");
+        check(root.has_value() && fs::equivalent(*root, valid_root_lib64),
+              "ROCM_PATH (lib64/) resolves to the given root");
+        check(explicit_source, "ROCM_PATH (lib64/) is marked explicit");
+    }
+
+    // Case 3: ROCM_PATH set but missing libamdhip64.so -> must NOT return that
+    // path; falls through to rocm-sdk / /opt/rocm (host-dependent, may be none).
+    {
+        bool explicit_source = false;
+        set_rocm_path(invalid_root.string());
+        auto root = BackendUtils::resolve_rocm_root(&explicit_source);
+        check(!root.has_value() || !fs::equivalent(*root, invalid_root),
+              "invalid ROCM_PATH does not resolve to itself");
+        // The invalid path itself must never be reported as an explicit match.
+        if (!root.has_value()) {
+            check(!explicit_source, "invalid ROCM_PATH does not mark explicit");
+        }
+    }
+
+    // Case 4: ROCM_PATH set to a non-existent path -> same fall-through, no
+    // throw from the non-throwing filesystem probes.
+    {
+        bool explicit_source = false;
+        set_rocm_path((tmp / "does-not-exist").string());
+        auto root = BackendUtils::resolve_rocm_root(&explicit_source);
+        check(!root.has_value() || !fs::equivalent(*root, tmp / "does-not-exist"),
+              "non-existent ROCM_PATH falls through without throwing");
+        if (!root.has_value()) {
+            check(!explicit_source,
+                  "non-existent ROCM_PATH does not mark explicit");
+        }
+    }
+
+    // Case 5: nullptr out-param is accepted.
+    {
+        set_rocm_path(valid_root.string());
+        auto root = BackendUtils::resolve_rocm_root(nullptr);
+        check(root.has_value(), "nullptr resolved_explicitly is accepted");
+    }
+
+    // Case 6: no ROCM_PATH and (assuming) no rocm-sdk/opt-rocm on this host ->
+    // resolver is well-behaved (returns a value only if the host genuinely has
+    // ROCm at /opt/rocm or via rocm-sdk). We only assert it does not throw and,
+    // if it resolves, the result is not explicit unless rocm-sdk supplied it.
+    {
+        clear_rocm_path();
+        bool explicit_source = true;  // sentinel; must be overwritten to false
+        auto root = BackendUtils::resolve_rocm_root(&explicit_source);
+        if (!root.has_value()) {
+            check(!explicit_source,
+                  "no ROCM_PATH and no host ROCm -> nullopt, not explicit");
+        } else {
+            std::cout << "[skip] host has ROCm at " << root->string()
+                      << "; fallback branch not isolatable" << std::endl;
+        }
+    }
+
+    clear_rocm_path();
+    fs::remove_all(tmp);
+    if (g_failures == 0) {
+        std::cout << "All rocm_root_resolution tests passed" << std::endl;
+    } else {
+        std::cerr << g_failures << " rocm_root_resolution test(s) failed"
+                  << std::endl;
+    }
+    return g_failures ? 1 : 0;
+}


### PR DESCRIPTION
Closes #2497

## Summary
Lemonade hardcoded `/opt/rocm` when checking for a system ROCm, so installs that live elsewhere (e.g. TheRock pip wheels via rocm-cli) were never found and Lemonade downloaded its own runtime — the "two runtimes" problem.

This resolves the ROCm root in priority order — `ROCM_PATH` → `rocm-sdk path --root` → `/opt/rocm` — validating each by probing `lib{,64}/libamdhip64.so`. When the user explicitly selects a ROCm (`ROCM_PATH`/`rocm-sdk`), the version gate is relaxed to major.minor and accepts the install when it ships no version file.

## Notes
- Linux-only in practice (gated behind the existing Linux check).
- Adds a unit test for the resolver (`RocmRootResolutionTest`).
- Follow-up (not in this PR): `load_hsa_runtime` in `system_info.cpp` still falls back to a hardcoded `/opt/rocm` for the WSL2 HSA path.