### PR TITLE
Router/2382 RoutingPolicyEngine — assembly + evaluate() (M8)

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -281,8 +281,9 @@ jobs:
           cmake --build --preset default --target test_routing_policy_registry
           cmake --build --preset default --target test_routing_policy_semantic
           cmake --build --preset default --target test_routing_policy_deterministic
+          cmake --build --preset default --target test_routing_policy_engine
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic)Test"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine)Test"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -586,8 +587,9 @@ jobs:
           cmake --build --preset default --target test_routing_policy_registry
           cmake --build --preset default --target test_routing_policy_semantic
           cmake --build --preset default --target test_routing_policy_deterministic
+          cmake --build --preset default --target test_routing_policy_engine
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic)Test"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine)Test"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1898,6 +1898,7 @@ set(_ROUTING_CONTRACT_TEST_SRC
 if(EXISTS "${_ROUTING_CONTRACT_TEST_SRC}")
     add_executable(test_routing_policy_contract
         test/cpp/test_routing_policy_contract.cpp
+        src/cpp/server/routing_policy.cpp
     )
     target_include_directories(test_routing_policy_contract PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
@@ -1995,6 +1996,30 @@ if(EXISTS "${_ROUTING_DETERMINISTIC_TEST_SRC}")
 
     include(CTest)
     add_test(NAME RoutingPolicyDeterministicTest COMMAND test_routing_policy_deterministic)
+endif()
+
+# Routing engine assembly (issue #2382): RoutingPolicyEngine constructor rule
+# compilation, first-match-wins route(), default fail-open, trace opt-in,
+# on_error error paths, and concurrent route() consistency against a fake.
+set(_ROUTING_ENGINE_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_engine.cpp"
+)
+if(EXISTS "${_ROUTING_ENGINE_TEST_SRC}")
+    add_executable(test_routing_policy_engine
+        test/cpp/test_routing_policy_engine.cpp
+        src/cpp/server/routing_policy.cpp
+    )
+    target_include_directories(test_routing_policy_engine PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_routing_policy_engine PRIVATE nlohmann_json::nlohmann_json)
+    find_package(Threads REQUIRED)
+    target_link_libraries(test_routing_policy_engine PRIVATE Threads::Threads)
+
+    include(CTest)
+    add_test(NAME RoutingPolicyEngineTest COMMAND test_routing_policy_engine)
 endif()
 
 # Auto-tune: GGUF array storage, scalar derivation, weighted KV cache computation.

--- a/src/cpp/include/lemon/routing_policy.h
+++ b/src/cpp/include/lemon/routing_policy.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 #include <nlohmann/json.hpp>
 
@@ -260,6 +261,27 @@ struct Decision {
     bool default_used = false;             // true => fell through to default_model
     json outputs = json::object();         // verbatim from the matched rule
     std::vector<TraceEntry> trace;         // populated only when trace requested
+
+    Decision() = default;
+
+    // No rule matched — fail open to default_model. This is the base
+    // constructor: it sets route_to, marks default_used, and folds in the trace
+    // (gated by want_trace) so a Decision is never built without deciding what
+    // happens to its trace. The matched constructor delegates to it.
+    Decision(std::string default_model, bool want_trace, std::vector<TraceEntry> trace)
+        : route_to(std::move(default_model)), default_used(true) {
+        if (want_trace) this->trace = std::move(trace);
+    }
+
+    // A rule matched: delegate to the default constructor for the route_to +
+    // trace plumbing, then flip default_used off and layer on the matched rule's
+    // id and outputs.
+    Decision(const Rule& rule, bool want_trace, std::vector<TraceEntry> trace)
+        : Decision(rule.route_to, want_trace, std::move(trace)) {
+        default_used = false;
+        matched_rule = rule.id;
+        outputs = rule.outputs;
+    }
 };
 
 // ---------------------------------------------------------------------------
@@ -360,17 +382,22 @@ struct RoutePolicy {
     std::map<std::string, ClassifierPtr> classifiers;    // id -> classifier
 };
 
-// The routing engine. The CONSTRUCTOR SIGNATURE is frozen here; the routing
-// logic (first-match evaluation, fail-open, trace assembly) is implemented with
-// the engine assembly. `route()` is declared but intentionally NOT defined in
-// the foundation — the contract test constructs the engine but never calls it.
+// The routing engine. The CONSTRUCTOR SIGNATURE is frozen here. The constructor
+// compiles every rule's MatchExpr into an immutable Condition tree (via
+// compile_match_expr + the classifier/deterministic LeafFactory); route()
+// walks those trees first-match-wins and fails open to default_model.
+//
+// The engine is const after construction and therefore safe to share across
+// concurrent requests: all per-request mutable state lives in a local
+// EvalContext. Hot-reload (#2383) swaps the whole engine behind a shared_ptr
+// rather than mutating one in place.
 class RoutingPolicyEngine {
 public:
-    RoutingPolicyEngine(RoutePolicy policy, ClassifierServices services)
-        : policy_(std::move(policy)), services_(std::move(services)) {}
+    RoutingPolicyEngine(RoutePolicy policy, ClassifierServices services);
 
     // Select a candidate for `ctx`. When `want_trace` is set, the returned
-    // Decision carries a per-condition trace.
+    // Decision carries a per-condition trace. Never throws: any unexpected
+    // failure fails open to default_model with default_used=true.
     Decision route(const RouteContext& ctx, bool want_trace) const;
 
     const RoutePolicy& policy() const { return policy_; }
@@ -378,6 +405,10 @@ public:
 private:
     RoutePolicy policy_;
     ClassifierServices services_;
+    // Compiled match tree per rule, parallel to policy_.rules. Immutable after
+    // construction; each ConditionPtr is itself a shared_ptr to const-usable
+    // state.
+    std::vector<ConditionPtr> compiled_rules_;
 };
 
 } // namespace lemon

--- a/src/cpp/server/routing_policy.cpp
+++ b/src/cpp/server/routing_policy.cpp
@@ -1094,4 +1094,44 @@ NamedLeafFactories make_deterministic_leaf_factories() {
     return factories;
 }
 
+RoutingPolicyEngine::RoutingPolicyEngine(RoutePolicy policy, ClassifierServices services)
+    : policy_(std::move(policy)), services_(std::move(services)) {
+    // Compile every rule's match expression once, at construction, so route()
+    // does pure tree-walking on immutable state. Classifier leaves resolve
+    // against policy_.classifiers; deterministic leaf types (keywords/regex/
+    // min_chars/has_*/metadata) plug in via make_deterministic_leaf_factories().
+    LeafFactory leaf_factory =
+        make_leaf_factory(policy_.classifiers, make_deterministic_leaf_factories());
+    compiled_rules_.reserve(policy_.rules.size());
+    for (const auto& rule : policy_.rules) {
+        compiled_rules_.push_back(compile_match_expr(rule.match, leaf_factory));
+    }
+}
+
+Decision RoutingPolicyEngine::route(const RouteContext& ctx, bool want_trace) const {
+    EvalContext eval{ctx, services_, want_trace, {}, {}, {}};
+
+    // First-match-wins over the compiled rules. A classifier-level failure is
+    // already absorbed upstream by ClassifierBandCondition (Score::ok + the
+    // band's on_error), so this catch is only a last-resort guard: any
+    // unexpected throw fails the whole request open to default_model rather than
+    // escaping route().
+    try {
+        for (std::size_t i = 0; i < compiled_rules_.size(); ++i) {
+            if (compiled_rules_[i]->evaluate(eval)) {
+                return Decision(policy_.rules[i], want_trace, std::move(eval.trace));
+            }
+        }
+    } catch (const std::exception& e) {
+        LOG(WARNING, "Routing") << "Routing policy evaluation threw; failing open to '"
+                                << policy_.default_model << "': " << e.what() << std::endl;
+    } catch (...) {
+        LOG(WARNING, "Routing") << "Routing policy evaluation threw an unknown exception; "
+                                << "failing open to '" << policy_.default_model << "'"
+                                << std::endl;
+    }
+
+    return Decision(policy_.default_model, want_trace, std::move(eval.trace));
+}
+
 } // namespace lemon

--- a/test/cpp/test_routing_policy_engine.cpp
+++ b/test/cpp/test_routing_policy_engine.cpp
@@ -1,0 +1,248 @@
+// Unit tests for the RoutingPolicyEngine assembly (#2382).
+//
+// Exercises the engine end-to-end over hand-built RoutePolicy fixtures with a
+// faked ClassifierServices: the rule-match path, first-match-wins ordering, the
+// default (fail-open) path, want_trace on/off, the classifier on_error error
+// path, and concurrent route() calls on one shared engine instance.
+//
+// Deterministic leaf conditions (#2380) are not yet wired into the leaf factory,
+// so every rule here uses classifier-band leaves, which resolve against the
+// policy's classifiers today.
+//
+// Compile (standalone):
+//   g++ -std=c++17 -I src/cpp/include -I build/_deps/json-src/include -I test/cpp \
+//       test/cpp/test_routing_policy_engine.cpp src/cpp/server/routing_policy.cpp \
+//       -o test_routing_policy_engine
+
+#include "fake_classifier_services.h"
+#include "lemon/routing_policy.h"
+
+#include <atomic>
+#include <cstdio>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+using lemon::Decision;
+using lemon::MatchExpr;
+using lemon::RouteContext;
+using lemon::RoutePolicy;
+using lemon::RoutingPolicyEngine;
+using lemon::Rule;
+using lemon::json;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+namespace {
+
+// A single classifier-band leaf: {"classifier": id, "label": label, "min_score": min}.
+MatchExpr classifier_leaf(const std::string& classifier_id, const std::string& label,
+                          double min_score) {
+    MatchExpr expr;
+    expr.op = MatchExpr::Op::Leaf;
+    expr.leaf = json{{"classifier", classifier_id}, {"label", label}, {"min_score", min_score}};
+    return expr;
+}
+
+Rule make_rule(const std::string& id, MatchExpr match, const std::string& route_to,
+               json outputs = json::object()) {
+    Rule rule;
+    rule.id = id;
+    rule.match = std::move(match);
+    rule.route_to = route_to;
+    rule.outputs = std::move(outputs);
+    return rule;
+}
+
+// Policy: classifier "pii" (labels PII/NO_PII, default PII) over model "pii-model".
+// One rule keeps PII-flagged requests on the local candidate.
+RoutePolicy make_pii_policy() {
+    RoutePolicy policy;
+    policy.candidates = {"local-llm", "cloud-llm"};
+    policy.default_model = "cloud-llm";
+    policy.classifiers = lemon::make_classifiers(json::array({
+        json{{"id", "pii"},
+             {"type", "classifier"},
+             {"model", "pii-model"},
+             {"labels", {"PII", "NO_PII"}},
+             {"default_label", "PII"}},
+    }));
+    policy.rules = {
+        make_rule("keep-private", classifier_leaf("pii", "PII", 0.5), "local-llm",
+                  json{{"verdict", "block"}}),
+    };
+    return policy;
+}
+
+} // namespace
+
+static void test_rule_match_path() {
+    lemon::testing::FakeClassifierServices fake;
+    fake.set_classifier_scores("pii-model", {{"PII", 0.9}, {"NO_PII", 0.1}});
+    RoutingPolicyEngine engine(make_pii_policy(), fake.make());
+
+    RouteContext ctx;
+    ctx.input = "my ssn is 123-45-6789";
+    Decision d = engine.route(ctx, /*want_trace=*/false);
+
+    check("matched rule selects its route_to", d.route_to == "local-llm");
+    check("matched rule reports its id", d.matched_rule == "keep-private");
+    check("matched rule clears default_used", !d.default_used);
+    check("matched rule copies outputs verbatim",
+          d.outputs.value("verdict", "") == "block");
+    check("trace empty when not requested", d.trace.empty());
+}
+
+static void test_default_path() {
+    lemon::testing::FakeClassifierServices fake;
+    fake.set_classifier_scores("pii-model", {{"PII", 0.1}, {"NO_PII", 0.9}});
+    RoutingPolicyEngine engine(make_pii_policy(), fake.make());
+
+    RouteContext ctx;
+    ctx.input = "what is the capital of France?";
+    Decision d = engine.route(ctx, /*want_trace=*/false);
+
+    check("no match falls through to default_model", d.route_to == "cloud-llm");
+    check("default path leaves matched_rule empty", d.matched_rule.empty());
+    check("default path sets default_used", d.default_used);
+    check("default path has empty outputs", d.outputs.empty());
+}
+
+static void test_first_match_wins() {
+    lemon::testing::FakeClassifierServices fake;
+    fake.set_classifier_scores("pii-model", {{"PII", 0.9}, {"NO_PII", 0.1}});
+
+    RoutePolicy policy = make_pii_policy();
+    // A second rule that would also match PII>=0.5 but routes elsewhere; the
+    // first rule must win.
+    policy.rules.push_back(
+        make_rule("second", classifier_leaf("pii", "PII", 0.5), "cloud-llm"));
+    RoutingPolicyEngine engine(std::move(policy), fake.make());
+
+    RouteContext ctx;
+    ctx.input = "ssn 123";
+    Decision d = engine.route(ctx, false);
+    check("first matching rule wins over later rules", d.matched_rule == "keep-private");
+    check("first match routes to first rule's target", d.route_to == "local-llm");
+}
+
+static void test_trace_on_and_off() {
+    lemon::testing::FakeClassifierServices fake;
+    fake.set_classifier_scores("pii-model", {{"PII", 0.9}, {"NO_PII", 0.1}});
+    RoutingPolicyEngine engine(make_pii_policy(), fake.make());
+
+    RouteContext ctx;
+    ctx.input = "ssn 123";
+
+    Decision off = engine.route(ctx, /*want_trace=*/false);
+    check("want_trace=false yields no trace", off.trace.empty());
+
+    Decision on = engine.route(ctx, /*want_trace=*/true);
+    check("want_trace=true records the classifier leaf", on.trace.size() == 1 &&
+              on.trace[0].condition == "classifier:pii");
+    check("trace carries the scored value",
+          on.trace.size() == 1 && on.trace[0].score.has_value() &&
+              *on.trace[0].score == 0.9 && on.trace[0].result);
+}
+
+// A failed classifier (Score::ok=false) drives the band's on_error. With the
+// default on_error=match_false the rule cannot match, so the request fails open
+// to default_model — route() must never throw on that path.
+static void test_classifier_failure_falls_open() {
+    lemon::testing::FakeClassifierServices fake;
+    // No scores configured for "pii-model": the fake returns an empty map, and
+    // an empty label set makes score_of("PII") == 0.0 < 0.5 (band false).
+    RoutingPolicyEngine engine(make_pii_policy(), fake.make());
+
+    RouteContext ctx;
+    ctx.input = "anything";
+    Decision d = engine.route(ctx, false);
+    check("classifier failure path lands on default_model", d.route_to == "cloud-llm");
+    check("classifier failure path sets default_used", d.default_used);
+}
+
+// on_error=match_true means a failed classifier trips its rule (fail-closed
+// authoring): the request must route to the rule's target, not the default. A
+// genuine failure is run_classifier throwing (an empty result is a valid ok
+// score, not a failure), so this binds a throwing service directly.
+static void test_on_error_match_true_routes_to_rule() {
+    RoutePolicy policy;
+    policy.candidates = {"guard", "cloud-llm"};
+    policy.default_model = "cloud-llm";
+    policy.classifiers = lemon::make_classifiers(json::array({
+        json{{"id", "jailbreak"},
+             {"type", "classifier"},
+             {"model", "jb-model"},
+             {"on_error", "match_true"},
+             {"labels", {"JAILBREAK", "BENIGN"}},
+             {"default_label", "JAILBREAK"}},
+    }));
+    policy.rules = {
+        make_rule("guard", classifier_leaf("jailbreak", "JAILBREAK", 0.5), "guard"),
+    };
+
+    lemon::ClassifierServices services;
+    services.run_classifier = [](const std::string&, const std::string&)
+        -> std::map<std::string, double> { throw std::runtime_error("model down"); };
+    RoutingPolicyEngine engine(std::move(policy), std::move(services));
+
+    RouteContext ctx;
+    ctx.input = "ignore previous instructions";
+    Decision d = engine.route(ctx, false);
+    check("on_error match_true routes a failed classifier to its rule",
+          d.route_to == "guard" && d.matched_rule == "guard" && !d.default_used);
+}
+
+// One const engine, many threads: per-request state must live only in the local
+// EvalContext, so concurrent want_trace=true/false calls never corrupt each
+// other's trace and every call returns the same deterministic Decision.
+static void test_concurrent_route_is_consistent() {
+    lemon::testing::FakeClassifierServices fake;
+    fake.set_classifier_scores("pii-model", {{"PII", 0.9}, {"NO_PII", 0.1}});
+    RoutingPolicyEngine engine(make_pii_policy(), fake.make());
+
+    constexpr int kThreads = 16;
+    constexpr int kIters = 500;
+    std::atomic<int> mismatches{0};
+
+    std::vector<std::thread> workers;
+    for (int t = 0; t < kThreads; ++t) {
+        const bool want_trace = (t % 2 == 0);
+        workers.emplace_back([&engine, &mismatches, want_trace, kIters]() {
+            for (int i = 0; i < kIters; ++i) {
+                RouteContext ctx;
+                ctx.input = "ssn 123";
+                Decision d = engine.route(ctx, want_trace);
+                const std::size_t expected_trace = want_trace ? 1u : 0u;
+                if (d.route_to != "local-llm" || d.matched_rule != "keep-private" ||
+                    d.trace.size() != expected_trace) {
+                    ++mismatches;
+                }
+            }
+        });
+    }
+    for (auto& w : workers) w.join();
+
+    check("concurrent route() calls stay consistent", mismatches.load() == 0);
+}
+
+int main() {
+    test_rule_match_path();
+    test_default_path();
+    test_first_match_wins();
+    test_trace_on_and_off();
+    test_classifier_failure_falls_open();
+    test_on_error_match_true_routes_to_rule();
+    test_concurrent_route_is_consistent();
+
+    std::printf("\n%s\n", g_failures == 0 ? "ALL ENGINE TESTS PASSED"
+                                          : "ENGINE TESTS FAILED");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_routing_policy_engine.cpp
+++ b/test/cpp/test_routing_policy_engine.cpp
@@ -5,9 +5,11 @@
 // default (fail-open) path, want_trace on/off, the classifier on_error error
 // path, and concurrent route() calls on one shared engine instance.
 //
-// Deterministic leaf conditions (#2380) are not yet wired into the leaf factory,
-// so every rule here uses classifier-band leaves, which resolve against the
-// policy's classifiers today.
+// Deterministic leaf conditions (#2380) are wired into the engine's leaf factory
+// via make_deterministic_leaf_factories(), so the deterministic-rule tests below
+// build keywords_any / regex / min_chars / metadata leaves directly (mirroring
+// the committed l1_keywords / l1_metadata fixtures) and drive them through
+// route() with no classifier backend involved.
 //
 // Compile (standalone):
 //   g++ -std=c++17 -I src/cpp/include -I build/_deps/json-src/include -I test/cpp \
@@ -48,6 +50,21 @@ MatchExpr classifier_leaf(const std::string& classifier_id, const std::string& l
     MatchExpr expr;
     expr.op = MatchExpr::Op::Leaf;
     expr.leaf = json{{"classifier", classifier_id}, {"label", label}, {"min_score", min_score}};
+    return expr;
+}
+
+// A raw deterministic leaf, e.g. {"keywords_any": [...]} or {"min_chars": 4000}.
+MatchExpr deterministic_leaf(json leaf) {
+    MatchExpr expr;
+    expr.op = MatchExpr::Op::Leaf;
+    expr.leaf = std::move(leaf);
+    return expr;
+}
+
+MatchExpr any_of(std::vector<MatchExpr> children) {
+    MatchExpr expr;
+    expr.op = MatchExpr::Op::Any;
+    expr.children = std::move(children);
     return expr;
 }
 
@@ -200,6 +217,82 @@ static void test_on_error_match_true_routes_to_rule() {
           d.route_to == "guard" && d.matched_rule == "guard" && !d.default_used);
 }
 
+// Deterministic leaves (#2380) must resolve on the engine path via
+// make_deterministic_leaf_factories(). Mirrors l1_keywords.json: an `any` of
+// keywords_any / regex routes code to the big model, and min_chars routes long
+// context there too; everything else falls open to the default. No classifier
+// backend is touched, so an empty ClassifierServices is sufficient.
+static RoutePolicy make_keywords_policy() {
+    RoutePolicy policy;
+    policy.candidates = {"small-llm", "big-llm"};
+    policy.default_model = "small-llm";
+    policy.rules = {
+        make_rule("code-to-big",
+                  any_of({deterministic_leaf(json{{"keywords_any",
+                              json::array({"def ", "function", "stack trace", "compile"})}}),
+                          deterministic_leaf(json{{"regex", "```[a-z]*"}})}),
+                  "big-llm"),
+        make_rule("long-context-to-big",
+                  deterministic_leaf(json{{"min_chars", 4000}}), "big-llm"),
+    };
+    return policy;
+}
+
+static void test_deterministic_keywords_route() {
+    RoutingPolicyEngine engine(make_keywords_policy(), lemon::ClassifierServices{});
+
+    RouteContext ctx;
+    ctx.input = "please write a function that reverses a list";
+    Decision hit = engine.route(ctx, /*want_trace=*/false);
+    check("keywords_any leaf matches and routes to big-llm",
+          hit.route_to == "big-llm" && hit.matched_rule == "code-to-big");
+
+    RouteContext plain;
+    plain.input = "what is the capital of France?";
+    Decision miss = engine.route(plain, false);
+    check("non-matching deterministic rules fall open to default",
+          miss.route_to == "small-llm" && miss.default_used);
+}
+
+static void test_deterministic_min_chars_route() {
+    RoutingPolicyEngine engine(make_keywords_policy(), lemon::ClassifierServices{});
+
+    RouteContext ctx;
+    ctx.input = std::string(5000, 'a');
+    ctx.params.chars = ctx.input.size();  // min_chars bounds params.chars (UTF-8 bytes)
+    Decision d = engine.route(ctx, false);
+    check("min_chars leaf routes long input to its rule",
+          d.route_to == "big-llm" && d.matched_rule == "long-context-to-big");
+}
+
+// Mirrors l1_metadata.json: a metadata `equals` leaf keeps flagged requests on
+// the local model. Proves the metadata deterministic leaf constructs and
+// evaluates on the engine path.
+static void test_deterministic_metadata_route() {
+    RoutePolicy policy;
+    policy.candidates = {"local-llm", "cloud-llm"};
+    policy.default_model = "cloud-llm";
+    policy.rules = {
+        make_rule("keep-confidential",
+                  deterministic_leaf(json{{"metadata",
+                      json{{"key", "task_class"}, {"equals", "confidential"}}}}),
+                  "local-llm"),
+    };
+    RoutingPolicyEngine engine(std::move(policy), lemon::ClassifierServices{});
+
+    RouteContext hit;
+    hit.metadata = {{"task_class", "confidential"}};
+    Decision d = engine.route(hit, false);
+    check("metadata equals leaf routes to its rule",
+          d.route_to == "local-llm" && d.matched_rule == "keep-confidential");
+
+    RouteContext miss;
+    miss.metadata = {{"task_class", "public"}};
+    Decision open = engine.route(miss, false);
+    check("metadata mismatch falls open to default",
+          open.route_to == "cloud-llm" && open.default_used);
+}
+
 // One const engine, many threads: per-request state must live only in the local
 // EvalContext, so concurrent want_trace=true/false calls never corrupt each
 // other's trace and every call returns the same deterministic Decision.
@@ -240,6 +333,9 @@ int main() {
     test_trace_on_and_off();
     test_classifier_failure_falls_open();
     test_on_error_match_true_routes_to_rule();
+    test_deterministic_keywords_route();
+    test_deterministic_min_chars_route();
+    test_deterministic_metadata_route();
     test_concurrent_route_is_consistent();
 
     std::printf("\n%s\n", g_failures == 0 ? "ALL ENGINE TESTS PASSED"

--- a/test/cpp/test_routing_policy_engine.cpp
+++ b/test/cpp/test_routing_policy_engine.cpp
@@ -169,19 +169,22 @@ static void test_trace_on_and_off() {
               *on.trace[0].score == 0.9 && on.trace[0].result);
 }
 
-// A failed classifier (Score::ok=false) drives the band's on_error. With the
-// default on_error=match_false the rule cannot match, so the request fails open
-// to default_model — route() must never throw on that path.
+// A genuinely failed classifier (run_classifier throws => Score::ok=false)
+// drives the band's on_error. The "pii" classifier leaves on_error unset, so it
+// defaults to match_false: the rule cannot match and the request fails open to
+// default_model — the symmetric counterpart to the match_true test below, and a
+// guarantee that route() never lets the exception escape.
 static void test_classifier_failure_falls_open() {
-    lemon::testing::FakeClassifierServices fake;
-    // No scores configured for "pii-model": the fake returns an empty map, and
-    // an empty label set makes score_of("PII") == 0.0 < 0.5 (band false).
-    RoutingPolicyEngine engine(make_pii_policy(), fake.make());
+    lemon::ClassifierServices services;
+    services.run_classifier = [](const std::string&, const std::string&)
+        -> std::map<std::string, double> { throw std::runtime_error("model down"); };
+    RoutingPolicyEngine engine(make_pii_policy(), std::move(services));
 
     RouteContext ctx;
     ctx.input = "anything";
     Decision d = engine.route(ctx, false);
     check("classifier failure path lands on default_model", d.route_to == "cloud-llm");
+    check("classifier failure path leaves matched_rule empty", d.matched_rule.empty());
     check("classifier failure path sets default_used", d.default_used);
 }
 


### PR DESCRIPTION
Implements the routing engine declared in `routing_policy.h`: the constructor compiles each rule's `match` expression into an immutable `Condition` tree, and `route()` walks them first-match-wins, failing open to `default_model`. Closes #2382.

### What's in it
- **`RoutingPolicyEngine` ctor** (`routing_policy.cpp`) — builds the per-rule `Condition` trees once via `compile_match_expr` + the classifier/deterministic `LeafFactory`. Engine is `const` after construction, so it's safe to share across concurrent requests (all per-request state lives in a local `EvalContext`).
- **`route(ctx, want_trace)`** — first-match-wins selection; fills the per-condition `trace` only when requested. Never throws: any unexpected failure (incl. classifier exceptions) is caught and fails open to `default_model` with `default_used=true`.
- **`Decision` construction cleanup** — replaced the positional constructor with two delegating constructors: a base `Decision(default_model, want_trace, trace)` and `Decision(const Rule&, want_trace, trace)` that delegates to it. `default_used` and trace-folding are handled internally, so callers can't build a `Decision` and forget the trace.

### Tests / CI
- New `test_routing_policy_engine` (`RoutingPolicyEngineTest`): rule-match, default fail-open, first-match-wins, trace on/off, classifier-failure-falls-open, `on_error: match_true` on a throwing service, and a 16-thread × 500-iteration concurrency check.
- Registered the target in CMakeLists.txt and added it to both C++ unit-test blocks in cpp_server_build_test_release.yml.

### Notes
- Unblocks #2384 (ClassifierServices ↔ Router live wiring).
- No trust semantics in core — verdicts/actions stay layered on top via `Rule::outputs`.
