### PR TITLE
Document ARM64 archive names and normalize Linux names to x86_64

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -149,7 +149,7 @@ runs:
           echo ""
           echo "| Platform | Download |"
           echo "|----------|----------|"
-          echo "| **Ubuntu x64** | [lemonade-embeddable-${VERSION}-ubuntu-x64.tar.gz](https://github.com/$REPO/releases/download/$TAG_NAME/lemonade-embeddable-${VERSION}-ubuntu-x64.tar.gz) |"
+          echo "| **Ubuntu x86_64** | [lemonade-embeddable-${VERSION}-ubuntu-x86_64.tar.gz](https://github.com/$REPO/releases/download/$TAG_NAME/lemonade-embeddable-${VERSION}-ubuntu-x86_64.tar.gz) |"
           echo "| **Windows x64** | [lemonade-embeddable-${VERSION}-windows-x64.zip](https://github.com/$REPO/releases/download/$TAG_NAME/lemonade-embeddable-${VERSION}-windows-x64.zip) |"
           echo "| **macOS arm64** | [lemonade-embeddable-${VERSION}-macos-arm64.tar.gz](https://github.com/$REPO/releases/download/$TAG_NAME/lemonade-embeddable-${VERSION}-macos-arm64.tar.gz) |"
           echo ""

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -870,7 +870,7 @@ jobs:
         include:
           - arch-name: X86_64
             runs-on: ubuntu-latest
-            platform: ubuntu-x64
+            platform: ubuntu-x86_64
             artifact-suffix: x86_64
             job-suffix: ""
           - arch-name: ARM64
@@ -1605,7 +1605,7 @@ jobs:
         include:
           - label: Linux
             os: ubuntu-latest
-            platform: ubuntu-x64
+            platform: ubuntu-x86_64
             artifact: lemonade-embeddable-linux-x86_64
           - label: Linux ARM64
             os: ubuntu-24.04-arm
@@ -2639,7 +2639,7 @@ jobs:
           ls -lh lemonade-server_${LEMONADE_VERSION}-debian13_amd64.deb
           ls -lh lemonade-server_${LEMONADE_VERSION}-debian13_arm64.deb
           ls -lh *.pkg
-          ls -lh lemonade-embeddable-${LEMONADE_VERSION}-ubuntu-x64.tar.gz
+          ls -lh lemonade-embeddable-${LEMONADE_VERSION}-ubuntu-x86_64.tar.gz
           ls -lh lemonade-embeddable-${LEMONADE_VERSION}-ubuntu-arm64.tar.gz
           ls -lh lemonade-embeddable-${LEMONADE_VERSION}-windows-x64.zip
           ls -lh lemonade-embeddable-${LEMONADE_VERSION}-macos-arm64.tar.gz
@@ -2665,7 +2665,7 @@ jobs:
             lemonade-server_${{ env.LEMONADE_VERSION }}-debian13_amd64.deb
             lemonade-server_${{ env.LEMONADE_VERSION }}-debian13_arm64.deb
             *.pkg
-            lemonade-embeddable-${{ env.LEMONADE_VERSION }}-ubuntu-x64.tar.gz
+            lemonade-embeddable-${{ env.LEMONADE_VERSION }}-ubuntu-x86_64.tar.gz
             lemonade-embeddable-${{ env.LEMONADE_VERSION }}-ubuntu-arm64.tar.gz
             lemonade-embeddable-${{ env.LEMONADE_VERSION }}-windows-x64.zip
             lemonade-embeddable-${{ env.LEMONADE_VERSION }}-macos-arm64.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1741,7 +1741,7 @@ else()
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
         set(EMBEDDABLE_PLATFORM "ubuntu-arm64")
     else()
-        set(EMBEDDABLE_PLATFORM "ubuntu-x64")
+        set(EMBEDDABLE_PLATFORM "ubuntu-x86_64")
     endif()
 endif()
 

--- a/docs/embeddable/README.md
+++ b/docs/embeddable/README.md
@@ -26,7 +26,7 @@ Embeddable Lemonade is an zip/tarball artifact shipped in Lemonade releases.
 | Platform | GitHub Actions artifact | Archive |
 |----------|--------------------------|---------|
 | Windows x64 | `lemonade-embeddable-windows` | `lemonade-embeddable-{VERSION}-windows-x64.zip` |
-| Linux x86_64 | `lemonade-embeddable-linux-x86_64` | `lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz` |
+| Linux x86_64 | `lemonade-embeddable-linux-x86_64` | `lemonade-embeddable-{VERSION}-ubuntu-x86_64.tar.gz` |
 | Linux ARM64 | `lemonade-embeddable-linux-arm64` | `lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz` |
 | macOS ARM64 | `lemonade-embeddable-macos` | `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz` |
 

--- a/docs/embeddable/README.md
+++ b/docs/embeddable/README.md
@@ -23,9 +23,10 @@ Use Embeddable Lemonade instead of a global Lemonade Service when you want a coh
 
 Embeddable Lemonade is an zip/tarball artifact shipped in Lemonade releases.
 
-- Windows: `lemonade-embeddable-10.1.0-windows-x64.zip`
-- Ubuntu: `lemonade-embeddable-10.1.0-ubuntu-x64.tar.gz`
-- macOS: `lemonade-embeddable-10.1.0-macos-arm64.tar.gz`
+- Windows x64: `lemonade-embeddable-{VERSION}-windows-x64.zip`
+- Linux x86_64: `lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz`
+- Linux ARM64: `lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz`
+- macOS ARM64: `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz`
 
 > Note: see the [Building from Source](./building.md) for instructions for building your own embeddable Lemonade from source, including for other Linux distros.
 

--- a/docs/embeddable/README.md
+++ b/docs/embeddable/README.md
@@ -28,7 +28,7 @@ Embeddable Lemonade is an zip/tarball artifact shipped in Lemonade releases.
 | Windows x64 | `lemonade-embeddable-windows` | `lemonade-embeddable-{VERSION}-windows-x64.zip` |
 | Linux x86_64 | `lemonade-embeddable-linux-x86_64` | `lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz` |
 | Linux ARM64 | `lemonade-embeddable-linux-arm64` | `lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz` |
-| macOS ARM64 | `lemonade-embeddable-macos` | `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz` |`
+| macOS ARM64 | `lemonade-embeddable-macos` | `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz` |
 
 > Note: see the [Building from Source](./building.md) for instructions for building your own embeddable Lemonade from source, including for other Linux distros.
 

--- a/docs/embeddable/README.md
+++ b/docs/embeddable/README.md
@@ -23,10 +23,12 @@ Use Embeddable Lemonade instead of a global Lemonade Service when you want a coh
 
 Embeddable Lemonade is an zip/tarball artifact shipped in Lemonade releases.
 
-- Windows x64: `lemonade-embeddable-{VERSION}-windows-x64.zip`
-- Linux x86_64: `lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz`
-- Linux ARM64: `lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz`
-- macOS ARM64: `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz`
+| Platform | GitHub Actions artifact | Archive |
+|----------|--------------------------|---------|
+| Windows x64 | `lemonade-embeddable-windows` | `lemonade-embeddable-{VERSION}-windows-x64.zip` |
+| Linux x86_64 | `lemonade-embeddable-linux-x86_64` | `lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz` |
+| Linux ARM64 | `lemonade-embeddable-linux-arm64` | `lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz` |
+| macOS ARM64 | `lemonade-embeddable-macos` | `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz` |`
 
 > Note: see the [Building from Source](./building.md) for instructions for building your own embeddable Lemonade from source, including for other Linux distros.
 

--- a/docs/embeddable/building.md
+++ b/docs/embeddable/building.md
@@ -73,12 +73,12 @@ If you want the embeddable build to include the browser UI assets under `resourc
 
 The `embeddable` target produces a single archive in `build/`:
 
-| Platform | Archive |
-|----------|---------|
-| Linux x86_64 | `lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz` |
-| Linux ARM64 | `lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz` |
-| Windows x64 | `lemonade-embeddable-{VERSION}-windows-x64.zip` |
-| macOS ARM64 | `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz` |
+| Platform | GitHub Actions artifact | Archive |
+|----------|--------------------------|---------|
+| Linux x86_64 | `lemonade-embeddable-linux-x86_64` | `lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz` |
+| Linux ARM64 | `lemonade-embeddable-linux-arm64` | `lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz` |
+| Windows x64 | `lemonade-embeddable-windows` | `lemonade-embeddable-{VERSION}-windows-x64.zip` |
+| macOS ARM64 | `lemonade-embeddable-macos` | `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz` |
 
 Each archive contains:
 

--- a/docs/embeddable/building.md
+++ b/docs/embeddable/building.md
@@ -32,7 +32,7 @@ The `embeddable` CMake target builds the server, CLI, and required resource file
     cmake --build --preset default --target embeddable
     ```
 
-    This produces `build/lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz`.
+    This produces `build/lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz` on x86_64 Linux and `build/lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz` on ARM64 Linux.
 
 === "macOS (bash)"
 
@@ -75,9 +75,10 @@ The `embeddable` target produces a single archive in `build/`:
 
 | Platform | Archive |
 |----------|---------|
-| Linux    | `lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz` |
-| Windows  | `lemonade-embeddable-{VERSION}-windows-x64.zip` |
-| macOS    | `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz` |
+| Linux x86_64 | `lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz` |
+| Linux ARM64 | `lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz` |
+| Windows x64 | `lemonade-embeddable-{VERSION}-windows-x64.zip` |
+| macOS ARM64 | `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz` |
 
 Each archive contains:
 

--- a/docs/embeddable/building.md
+++ b/docs/embeddable/building.md
@@ -32,7 +32,7 @@ The `embeddable` CMake target builds the server, CLI, and required resource file
     cmake --build --preset default --target embeddable
     ```
 
-    This produces `build/lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz` on x86_64 Linux and `build/lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz` on ARM64 Linux.
+    This produces `build/lemonade-embeddable-{VERSION}-ubuntu-x86_64.tar.gz` on x86_64 Linux and `build/lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz` on ARM64 Linux.
 
 === "macOS (bash)"
 
@@ -75,7 +75,7 @@ The `embeddable` target produces a single archive in `build/`:
 
 | Platform | GitHub Actions artifact | Archive |
 |----------|--------------------------|---------|
-| Linux x86_64 | `lemonade-embeddable-linux-x86_64` | `lemonade-embeddable-{VERSION}-ubuntu-x64.tar.gz` |
+| Linux x86_64 | `lemonade-embeddable-linux-x86_64` | `lemonade-embeddable-{VERSION}-ubuntu-x86_64.tar.gz` |
 | Linux ARM64 | `lemonade-embeddable-linux-arm64` | `lemonade-embeddable-{VERSION}-ubuntu-arm64.tar.gz` |
 | Windows x64 | `lemonade-embeddable-windows` | `lemonade-embeddable-{VERSION}-windows-x64.zip` |
 | macOS ARM64 | `lemonade-embeddable-macos` | `lemonade-embeddable-{VERSION}-macos-arm64.tar.gz` |


### PR DESCRIPTION
Fixes #2501.

Updates embeddable naming after #2430:

- documents GitHub Actions artifact names separately from archive filenames
- adds Linux ARM64 embeddable documentation
- renames the Linux x86_64 embeddable release archive from `ubuntu-x64` to `ubuntu-x86_64`
- updates CMake, release workflow verification/upload paths, generated release notes, and docs