### PR TITLE
chore(release): bump version to v10.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
-project(lemon_cpp VERSION 10.8.1)
+project(lemon_cpp VERSION 10.9.0)
 
 include(CTest)
 


### PR DESCRIPTION
Bumps the project version from 10.8.1 to 10.9.0 in `CMakeLists.txt`.