### PR TITLE
Fix: Update CUDA version for llama.cpp

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -4,7 +4,7 @@
     "vulkan": "b9747",
     "rocm-stable": "b9752",
     "rocm-nightly": "b1292",
-    "cuda": "b9752",
+    "cuda": "b9851",
     "metal": "b9747",
     "cpu": "b9747"
   },


### PR DESCRIPTION
Simply updates cuda backend for llama.cpp

Relates to ##2492 as quickfix for the upcoming release.

Problem: Windows artifacts for cuda where not build for the currently linked release.