### PR TITLE
feat(rocm): detect externally-installed ROCm on Windows

### DIFF
--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -129,7 +129,7 @@ On the stable channel Lemonade normally downloads its own ROCm runtime (TheRock)
 `ROCM_PATH` and `rocm-sdk` work on both platforms. When the runtime is found via one of them, a `major.minor` version match is accepted (and a runtime with no version file is accepted as-is), so a patch-level difference won't trigger a second download. To force Lemonade to use a specific ROCm, set `ROCM_PATH` before starting the server:
 
 ```bash
-# Linux / macOS
+# Linux
 export ROCM_PATH=/path/to/rocm
 ```
 

--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -118,18 +118,24 @@ After changing channels, you'll need to reinstall the ROCm backend:
 lemonade backends install llamacpp:rocm
 ```
 
-### Reusing a System-Installed ROCm (Linux)
+### Reusing a System-Installed ROCm (Windows and Linux)
 
-On the stable channel Lemonade normally downloads its own ROCm runtime (TheRock). If you already have ROCm installed system-wide, Lemonade reuses it instead of downloading a second copy when it can find a matching version. It locates the install root in this order, using the first directory that contains `lib{,64}/libamdhip64.so`:
+On the stable channel Lemonade normally downloads its own ROCm runtime (TheRock). If you already have ROCm installed system-wide, Lemonade reuses it instead of downloading a second copy when it can find a matching version. It locates the install root in this order, using the first directory that contains the HIP runtime (`bin\amdhip64.dll` on Windows, `lib{,64}/libamdhip64.so` on Linux):
 
 1. The `ROCM_PATH` environment variable
 2. `rocm-sdk path --root`, when `rocm-sdk` is on your `PATH` (e.g. a ROCm installed from the TheRock pip wheels)
-3. `/opt/rocm`
+3. The platform default: `HIP_PATH` (set by the AMD HIP SDK installer) on Windows, `/opt/rocm` on Linux
 
-When the runtime is found via `ROCM_PATH` or `rocm-sdk`, a `major.minor` version match is accepted (and a runtime with no version file is accepted as-is), so a patch-level difference won't trigger a second download. To force Lemonade to use a specific ROCm, export `ROCM_PATH` before starting the server:
+`ROCM_PATH` and `rocm-sdk` work on both platforms. When the runtime is found via one of them, a `major.minor` version match is accepted (and a runtime with no version file is accepted as-is), so a patch-level difference won't trigger a second download. To force Lemonade to use a specific ROCm, set `ROCM_PATH` before starting the server:
 
 ```bash
+# Linux / macOS
 export ROCM_PATH=/path/to/rocm
+```
+
+```powershell
+# Windows (PowerShell)
+$env:ROCM_PATH = "C:\path\to\rocm"
 ```
 
 ### Pinning to a Specific Version Tag

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -119,9 +119,6 @@ namespace lemon::backends {
          * Returns std::nullopt when none validate. When resolved_explicitly is
          * non-null, it is set to true when the root came from ROCM_PATH or
          * rocm-sdk (a user-selected ROCm) and false for the platform default.
-         *
-         * Meaningful on Windows and Linux; on other platforms callers reach it
-         * solely behind is_rocm_installed_system_wide(), which returns false.
          */
         static std::optional<fs::path> resolve_rocm_root(bool* resolved_explicitly = nullptr);
 
@@ -133,7 +130,7 @@ namespace lemon::backends {
          */
         static std::string read_rocm_version_from_root(const fs::path& root);
 
-        /** Check if ROCm libraries are installed system-wide (Windows and Linux) */
+        /** Check if a system-wide ROCm install can be located (see resolve_rocm_root) */
         static bool is_rocm_installed_system_wide();
 
         /** Get TheRock installation directory for a specific architecture and version */

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -123,15 +123,21 @@ namespace lemon::backends {
         static std::optional<fs::path> resolve_rocm_root(bool* resolved_explicitly = nullptr);
 
         /**
+         * Trim each line and keep those that name an absolute path, preserving
+         * order. `rocm-sdk path --root`'s stdout can be interleaved with the
+         * child's stderr (warnings), so the wanted path is not necessarily the
+         * first line. Pure string logic; the caller validates each candidate.
+         */
+        static std::vector<std::string> pick_rocm_root_candidates(
+            const std::vector<std::string>& lines);
+
+        /**
          * Read the ROCm version string from a resolved install root, probing the
          * known version-file locations ({root}/.info/version,
          * {root}/share/rocm/version, {root}/version). Returns the trimmed first
          * line of the first file found, or "" when none exist.
          */
         static std::string read_rocm_version_from_root(const fs::path& root);
-
-        /** Check if a system-wide ROCm install can be located (see resolve_rocm_root) */
-        static bool is_rocm_installed_system_wide();
 
         /** Get TheRock installation directory for a specific architecture and version */
         static std::string get_therock_install_dir(const std::string& arch, const std::string& version);

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -110,17 +110,18 @@ namespace lemon::backends {
         /**
          * Resolve the ROCm install root, honoring an externally-installed ROCm
          * before the bundled default. Resolution order, returning the first root
-         * that contains lib{,64}/libamdhip64.so:
+         * that contains the HIP runtime (Windows: bin\amdhip64.dll or
+         * lib\amdhip64.dll; Linux: lib{,64}/libamdhip64.so):
          *   1. ROCM_PATH environment variable
          *   2. `rocm-sdk path --root` (when rocm-sdk is on PATH)
-         *   3. /opt/rocm
+         *   3. Platform default (Windows: HIP_PATH set by the AMD HIP SDK;
+         *      Linux: /opt/rocm)
          * Returns std::nullopt when none validate. When resolved_explicitly is
          * non-null, it is set to true when the root came from ROCM_PATH or
-         * rocm-sdk (a user-selected ROCm) and false for the /opt/rocm fallback.
+         * rocm-sdk (a user-selected ROCm) and false for the platform default.
          *
-         * Probes Linux HIP runtime artifacts (lib{,64}/libamdhip64.so, /opt/rocm)
-         * and is only meaningful on Linux; current callers reach it solely behind
-         * is_rocm_installed_system_wide() (Linux-gated).
+         * Meaningful on Windows and Linux; on other platforms callers reach it
+         * solely behind is_rocm_installed_system_wide(), which returns false.
          */
         static std::optional<fs::path> resolve_rocm_root(bool* resolved_explicitly = nullptr);
 
@@ -132,7 +133,7 @@ namespace lemon::backends {
          */
         static std::string read_rocm_version_from_root(const fs::path& root);
 
-        /** Check if ROCm libraries are installed system-wide (Linux only) */
+        /** Check if ROCm libraries are installed system-wide (Windows and Linux) */
         static bool is_rocm_installed_system_wide();
 
         /** Get TheRock installation directory for a specific architecture and version */

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -167,15 +167,10 @@ bool github_download_service_reachable() {
     return utils::HttpClient::is_reachable("https://github.com/", 2);
 }
 
-bool has_matching_system_rocm_runtime(const std::string& expected_runtime_version) {
-    bool resolved_explicitly = false;
-    const auto rocm_root = backends::BackendUtils::resolve_rocm_root(&resolved_explicitly);
-    if (!rocm_root) {
-        return false;
-    }
-
+bool has_matching_system_rocm_runtime(const fs::path& rocm_root, bool resolved_explicitly,
+                                      const std::string& expected_runtime_version) {
     const std::string system_version =
-        backends::BackendUtils::read_rocm_version_from_root(*rocm_root);
+        backends::BackendUtils::read_rocm_version_from_root(rocm_root);
 
     if (resolved_explicitly) {
         // The user deliberately installed this ROCm (via ROCM_PATH or rocm-sdk).
@@ -183,7 +178,7 @@ bool has_matching_system_rocm_runtime(const std::string& expected_runtime_versio
         // major.minor match, and accept outright when no version file is present.
         if (system_version.empty()) {
             LOG(INFO, "BackendManager")
-                << "Using explicitly-selected system ROCm at " << rocm_root->string()
+                << "Using explicitly-selected system ROCm at " << rocm_root.string()
                 << " (no version file; skipping version gate)" << std::endl;
             return true;
         }
@@ -192,7 +187,7 @@ bool has_matching_system_rocm_runtime(const std::string& expected_runtime_versio
             runtime_version_major_minor(system_version) ==
                 runtime_version_major_minor(expected_runtime_version);
         LOG(matches ? DEBUG : INFO, "BackendManager")
-            << "Explicitly-selected system ROCm at " << rocm_root->string()
+            << "Explicitly-selected system ROCm at " << rocm_root.string()
             << " version '" << system_version << "' vs expected '"
             << expected_runtime_version << "' -> "
             << (matches ? "match" : "mismatch") << std::endl;
@@ -202,7 +197,7 @@ bool has_matching_system_rocm_runtime(const std::string& expected_runtime_versio
     const bool matches =
         runtime_version_matches_expected(system_version, expected_runtime_version);
     LOG(DEBUG, "BackendManager")
-        << "System ROCm at " << rocm_root->string() << " version '" << system_version
+        << "System ROCm at " << rocm_root.string() << " version '" << system_version
         << "' vs expected '" << expected_runtime_version << "' -> "
         << (matches ? "match" : "mismatch") << std::endl;
     return matches;
@@ -236,9 +231,12 @@ bool will_install_therock(const std::string& os, const json& backend_versions) {
     std::string therock_version = backend_versions["therock"]["version"].get<std::string>();
     std::string expected_rocm_version = normalize_runtime_version(therock_version);
 
-    // Check if system ROCm matches TheRock version - if so, don't need TheRock
-    if (backends::BackendUtils::is_rocm_installed_system_wide() &&
-        has_matching_system_rocm_runtime(expected_rocm_version)) {
+    // Check if system ROCm matches TheRock version - if so, don't need TheRock.
+    // Resolve once here and thread it through, avoiding a second rocm-sdk spawn.
+    bool resolved_explicitly = false;
+    const auto rocm_root = backends::BackendUtils::resolve_rocm_root(&resolved_explicitly);
+    if (rocm_root &&
+        has_matching_system_rocm_runtime(*rocm_root, resolved_explicitly, expected_rocm_version)) {
         LOG(DEBUG, "BackendManager")
             << "System ROCm " << expected_rocm_version
             << " matches TheRock version, skipping TheRock installation" << std::endl;

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -820,16 +820,32 @@ namespace lemon::backends {
             if (root.empty() || !fs::exists(root, ec)) {
                 return std::nullopt;
             }
+#ifdef _WIN32
+            for (const char* subdir : {"bin", "lib"}) {
+                if (fs::exists(root / subdir / "amdhip64.dll", ec)) {
+                    return root;
+                }
+            }
+#else
             for (const char* lib_subdir : {"lib", "lib64"}) {
                 if (fs::exists(root / lib_subdir / "libamdhip64.so", ec)) {
                     return root;
                 }
             }
+#endif
             return std::nullopt;
         }
 
         std::optional<fs::path> query_rocm_sdk_root() {
-            if (utils::find_executable_in_path("rocm-sdk").empty()) {
+#ifdef _WIN32
+            // SearchPathA (used by find_executable_in_path) does not append a
+            // default extension, so the console-script shim must be named
+            // explicitly. CreateProcess resolves the .exe for the spawn itself.
+            const char* rocm_sdk_exe = "rocm-sdk.exe";
+#else
+            const char* rocm_sdk_exe = "rocm-sdk";
+#endif
+            if (utils::find_executable_in_path(rocm_sdk_exe).empty()) {
                 return std::nullopt;
             }
 
@@ -874,7 +890,7 @@ namespace lemon::backends {
                 return root;
             }
             LOG(DEBUG, "BackendUtils") << "ROCM_PATH=" << env
-                      << " has no lib{,64}/libamdhip64.so; trying other sources" << std::endl;
+                      << " has no HIP runtime; trying other sources" << std::endl;
         }
 
         if (auto sdk_root = query_rocm_sdk_root()) {
@@ -887,13 +903,25 @@ namespace lemon::backends {
                 return root;
             }
             LOG(DEBUG, "BackendUtils") << "rocm-sdk reported " << sdk_root->string()
-                      << " but it has no lib{,64}/libamdhip64.so; trying /opt/rocm" << std::endl;
+                      << " but it has no HIP runtime; trying platform default" << std::endl;
         }
 
+#ifdef _WIN32
+        // The AMD HIP SDK installer sets HIP_PATH; treat it as the platform
+        // default (like /opt/rocm on Linux), not a user selection.
+        if (const char* hip = std::getenv("HIP_PATH"); hip && *hip != '\0') {
+            if (auto root = validate_rocm_root(fs::path(hip))) {
+                LOG(DEBUG, "BackendUtils") << "Resolved ROCm root at default HIP_PATH: "
+                          << root->string() << std::endl;
+                return root;
+            }
+        }
+#else
         if (auto root = validate_rocm_root("/opt/rocm")) {
             LOG(DEBUG, "BackendUtils") << "Resolved ROCm root at default /opt/rocm" << std::endl;
             return root;
         }
+#endif
 
         return std::nullopt;
     }
@@ -926,18 +954,19 @@ namespace lemon::backends {
     }
 
     bool BackendUtils::is_rocm_installed_system_wide() {
-#ifndef __linux__
+#if !defined(__linux__) && !defined(_WIN32)
         return false;
 #else
         auto rocm_root_opt = resolve_rocm_root();
         if (!rocm_root_opt) {
             LOG(DEBUG, "BackendUtils")
-                << "No ROCm installation detected (ROCM_PATH, rocm-sdk, /opt/rocm)" << std::endl;
+                << "No ROCm installation detected (ROCM_PATH, rocm-sdk, platform default)"
+                << std::endl;
             return false;
         }
         const fs::path& rocm_root = *rocm_root_opt;
 
-        // resolve_rocm_root already verified libamdhip64.so. The version file is
+        // resolve_rocm_root already verified the HIP runtime. The version file is
         // best-effort: accept the install even when it ships none.
         const std::string version = read_rocm_version_from_root(rocm_root);
         if (!version.empty()) {

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -954,9 +954,6 @@ namespace lemon::backends {
     }
 
     bool BackendUtils::is_rocm_installed_system_wide() {
-#if !defined(__linux__) && !defined(_WIN32)
-        return false;
-#else
         auto rocm_root_opt = resolve_rocm_root();
         if (!rocm_root_opt) {
             LOG(DEBUG, "BackendUtils")
@@ -977,7 +974,6 @@ namespace lemon::backends {
                       << " (no version file found)" << std::endl;
         }
         return true;
-#endif
     }
 
     std::string BackendUtils::get_therock_install_dir(const std::string& arch, const std::string& version) {

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <lemon/utils/aixlog.hpp>
 #include <algorithm>
 #include <system_error>
@@ -849,11 +850,13 @@ namespace lemon::backends {
                 return std::nullopt;
             }
 
-            std::string captured;
-            auto on_line = [&captured](const std::string& line) {
-                if (captured.empty()) {
-                    captured = line;
-                }
+            // run_process_with_output merges the child's stderr into stdout, and
+            // rocm-sdk is a Python console script that may emit warnings there.
+            // Collect every line and pick the first that validates, rather than
+            // trusting the first line (which could be a warning).
+            std::vector<std::string> lines;
+            auto on_line = [&lines](const std::string& line) {
+                lines.push_back(line);
                 return true;
             };
 
@@ -866,12 +869,12 @@ namespace lemon::backends {
                 return std::nullopt;
             }
 
-            const auto first = captured.find_first_not_of(" \t\r\n");
-            if (first == std::string::npos) {
-                return std::nullopt;
+            for (const auto& candidate : BackendUtils::pick_rocm_root_candidates(lines)) {
+                if (auto root = validate_rocm_root(fs::path(candidate))) {
+                    return root;
+                }
             }
-            const auto last = captured.find_last_not_of(" \t\r\n");
-            return fs::path(captured.substr(first, last - first + 1));
+            return std::nullopt;
         }
     }  // namespace
 
@@ -894,16 +897,12 @@ namespace lemon::backends {
         }
 
         if (auto sdk_root = query_rocm_sdk_root()) {
-            if (auto root = validate_rocm_root(*sdk_root)) {
-                if (resolved_explicitly) {
-                    *resolved_explicitly = true;
-                }
-                LOG(DEBUG, "BackendUtils") << "Resolved ROCm root from rocm-sdk: "
-                          << root->string() << std::endl;
-                return root;
+            if (resolved_explicitly) {
+                *resolved_explicitly = true;
             }
-            LOG(DEBUG, "BackendUtils") << "rocm-sdk reported " << sdk_root->string()
-                      << " but it has no HIP runtime; trying platform default" << std::endl;
+            LOG(DEBUG, "BackendUtils") << "Resolved ROCm root from rocm-sdk: "
+                      << sdk_root->string() << std::endl;
+            return *sdk_root;
         }
 
 #ifdef _WIN32
@@ -924,6 +923,23 @@ namespace lemon::backends {
 #endif
 
         return std::nullopt;
+    }
+
+    std::vector<std::string> BackendUtils::pick_rocm_root_candidates(
+        const std::vector<std::string>& lines) {
+        std::vector<std::string> candidates;
+        for (const auto& line : lines) {
+            const auto first = line.find_first_not_of(" \t\r\n");
+            if (first == std::string::npos) {
+                continue;
+            }
+            const auto last = line.find_last_not_of(" \t\r\n");
+            std::string trimmed = line.substr(first, last - first + 1);
+            if (fs::path(trimmed).is_absolute()) {
+                candidates.push_back(std::move(trimmed));
+            }
+        }
+        return candidates;
     }
 
     std::string BackendUtils::read_rocm_version_from_root(const fs::path& root) {
@@ -951,29 +967,6 @@ namespace lemon::backends {
             return line.substr(first, last - first + 1);
         }
         return "";
-    }
-
-    bool BackendUtils::is_rocm_installed_system_wide() {
-        auto rocm_root_opt = resolve_rocm_root();
-        if (!rocm_root_opt) {
-            LOG(DEBUG, "BackendUtils")
-                << "No ROCm installation detected (ROCM_PATH, rocm-sdk, platform default)"
-                << std::endl;
-            return false;
-        }
-        const fs::path& rocm_root = *rocm_root_opt;
-
-        // resolve_rocm_root already verified the HIP runtime. The version file is
-        // best-effort: accept the install even when it ships none.
-        const std::string version = read_rocm_version_from_root(rocm_root);
-        if (!version.empty()) {
-            LOG(DEBUG, "BackendUtils") << "Found system ROCm at " << rocm_root.string()
-                      << " with version " << version << std::endl;
-        } else {
-            LOG(DEBUG, "BackendUtils") << "Found ROCm libraries at " << rocm_root.string()
-                      << " (no version file found)" << std::endl;
-        }
-        return true;
     }
 
     std::string BackendUtils::get_therock_install_dir(const std::string& arch, const std::string& version) {

--- a/test/cpp/test_rocm_root_resolution.cpp
+++ b/test/cpp/test_rocm_root_resolution.cpp
@@ -1,10 +1,12 @@
-// Unit tests for lemon::backends::BackendUtils::resolve_rocm_root().
+// Unit tests for lemon::backends::BackendUtils::resolve_rocm_root() and its
+// pure line-selection helper pick_rocm_root_candidates().
 //
 // The rocm-sdk and platform-default branches are host-dependent and can't be
 // driven deterministically, so these tests exercise the ROCM_PATH branch with a
 // temp dir containing a fake HIP runtime (amdhip64.dll on Windows,
 // libamdhip64.so elsewhere) and otherwise assert only invariants that hold
-// regardless of host state.
+// regardless of host state. pick_rocm_root_candidates is pure, so its line
+// selection is tested directly.
 
 #include <cstdlib>
 #include <filesystem>
@@ -92,6 +94,37 @@ int main() {
 
     const fs::path invalid_root = tmp / "invalid";
     fs::create_directories(invalid_root / "lib");  // no HIP runtime
+
+    // pick_rocm_root_candidates: pure selection of absolute-path lines from
+    // `rocm-sdk path --root` output, whose stdout may be interleaved with the
+    // child's stderr (warnings). No filesystem access.
+    {
+#ifdef _WIN32
+        const std::string abs_path = "C:\\opt\\rocm";
+        const std::string abs_path_crlf = "C:\\opt\\rocm\r";
+#else
+        const std::string abs_path = "/opt/rocm";
+        const std::string abs_path_crlf = "/opt/rocm\r";
+#endif
+        const auto warn_then_path =
+            BackendUtils::pick_rocm_root_candidates({"WARNING deprecated", abs_path});
+        check(warn_then_path.size() == 1 && warn_then_path.front() == abs_path,
+              "pick_rocm_root_candidates skips a leading stderr warning");
+
+        const auto with_blanks =
+            BackendUtils::pick_rocm_root_candidates({"", "   ", abs_path});
+        check(with_blanks.size() == 1 && with_blanks.front() == abs_path,
+              "pick_rocm_root_candidates skips blank lines");
+
+        const auto none =
+            BackendUtils::pick_rocm_root_candidates({"WARNING deprecated", "relative/dir"});
+        check(none.empty(),
+              "pick_rocm_root_candidates returns empty when no line is an absolute path");
+
+        const auto crlf = BackendUtils::pick_rocm_root_candidates({abs_path_crlf});
+        check(crlf.size() == 1 && crlf.front() == abs_path,
+              "pick_rocm_root_candidates trims trailing CR");
+    }
 
     {
         bool explicit_source = false;

--- a/test/cpp/test_rocm_root_resolution.cpp
+++ b/test/cpp/test_rocm_root_resolution.cpp
@@ -1,9 +1,10 @@
 // Unit tests for lemon::backends::BackendUtils::resolve_rocm_root().
 //
-// The rocm-sdk and /opt/rocm branches are host-dependent and can't be driven
-// deterministically, so these tests exercise the ROCM_PATH branch with a temp
-// dir containing a fake libamdhip64.so and otherwise assert only invariants
-// that hold regardless of host state.
+// The rocm-sdk and platform-default branches are host-dependent and can't be
+// driven deterministically, so these tests exercise the ROCM_PATH branch with a
+// temp dir containing a fake HIP runtime (amdhip64.dll on Windows,
+// libamdhip64.so elsewhere) and otherwise assert only invariants that hold
+// regardless of host state.
 
 #include <cstdlib>
 #include <filesystem>
@@ -59,6 +60,16 @@ void write_stub(const fs::path& p) {
     std::ofstream(p) << "stub";
 }
 
+// Write a fake HIP runtime where resolve_rocm_root probes. `primary` picks the
+// first probed subdir, otherwise the fallback one.
+void write_hip_runtime_stub(const fs::path& root, bool primary) {
+#ifdef _WIN32
+    write_stub(root / (primary ? "bin" : "lib") / "amdhip64.dll");
+#else
+    write_stub(root / (primary ? "lib" : "lib64") / "libamdhip64.so");
+#endif
+}
+
 }  // namespace
 
 int main() {
@@ -74,35 +85,35 @@ int main() {
     fs::create_directories(tmp);
 
     const fs::path valid_root = tmp / "valid";
-    write_stub(valid_root / "lib" / "libamdhip64.so");
+    write_hip_runtime_stub(valid_root, /*primary=*/true);
 
-    const fs::path valid_root_lib64 = tmp / "valid64";
-    write_stub(valid_root_lib64 / "lib64" / "libamdhip64.so");
+    const fs::path valid_root_alt = tmp / "valid_alt";
+    write_hip_runtime_stub(valid_root_alt, /*primary=*/false);
 
     const fs::path invalid_root = tmp / "invalid";
-    fs::create_directories(invalid_root / "lib");  // no libamdhip64.so
+    fs::create_directories(invalid_root / "lib");  // no HIP runtime
 
     {
         bool explicit_source = false;
         set_rocm_path(valid_root.string());
         auto root = BackendUtils::resolve_rocm_root(&explicit_source);
-        check(root.has_value(), "ROCM_PATH (lib/) resolves");
+        check(root.has_value(), "ROCM_PATH (primary subdir) resolves");
         check(root.has_value() && fs::equivalent(*root, valid_root),
-              "ROCM_PATH (lib/) resolves to the given root");
-        check(explicit_source, "ROCM_PATH (lib/) is marked explicit");
+              "ROCM_PATH (primary subdir) resolves to the given root");
+        check(explicit_source, "ROCM_PATH (primary subdir) is marked explicit");
     }
 
     {
         bool explicit_source = false;
-        set_rocm_path(valid_root_lib64.string());
+        set_rocm_path(valid_root_alt.string());
         auto root = BackendUtils::resolve_rocm_root(&explicit_source);
-        check(root.has_value(), "ROCM_PATH (lib64/) resolves");
-        check(root.has_value() && fs::equivalent(*root, valid_root_lib64),
-              "ROCM_PATH (lib64/) resolves to the given root");
-        check(explicit_source, "ROCM_PATH (lib64/) is marked explicit");
+        check(root.has_value(), "ROCM_PATH (fallback subdir) resolves");
+        check(root.has_value() && fs::equivalent(*root, valid_root_alt),
+              "ROCM_PATH (fallback subdir) resolves to the given root");
+        check(explicit_source, "ROCM_PATH (fallback subdir) is marked explicit");
     }
 
-    // A ROCM_PATH missing libamdhip64.so must fall through, never resolve to
+    // A ROCM_PATH missing the HIP runtime must fall through, never resolve to
     // itself, and never be reported as explicit.
     {
         bool explicit_source = false;


### PR DESCRIPTION
Extends system-ROCm reuse (previously Linux-only, #2498) to Windows: probes `bin\amdhip64.dll`/`lib\amdhip64.dll`, uses `rocm-sdk.exe` for the PATH presence check, and treats `HIP_PATH` (set by the AMD HIP SDK installer) as the platform default. Docs and unit test updated to match.