### PR TITLE
feat(models): add RPG-HaloTales-V1 omni collection

### DIFF
--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -100,13 +100,14 @@ the generator instead. Prose outside the markers is preserved. -->
 ## Models
 
 <!-- BEGIN GENERATED: backend-models -->
-#### `collection.omni` — collection.omni (4 models)
+#### `collection.omni` — collection.omni (5 models)
 
 | Model | Size (GB) | Labels |
 |-------|-----------|--------|
 | `LMX-Omni-5.5B-Lite` | 9.3 | — |
 | `LMX-Omni-52B-Halo` | 44.77 | — |
 | `Lite Collection` |  | — |
+| `RPG-HaloTales-V1` | 39.77 | — |
 | `Ultra Collection` |  | — |
 
 #### `kokoro` — Kokoro (1 models)

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1614,6 +1614,12 @@
             "kokoro-v1"
         ]
     },
+    "RPG-HaloTales-V1": {
+        "checkpoint": "lemonade-sdk/RPG-HaloTales-V1",
+        "recipe": "collection.omni",
+        "suggested": true,
+        "size": 39.77
+    },
     "kokoro-v1": {
         "checkpoint": "mikkoph/kokoro-onnx",
         "recipe": "kokoro",


### PR DESCRIPTION
Registers [`lemonade-sdk/RPG-HaloTales-V1`](https://huggingface.co/lemonade-sdk/RPG-HaloTales-V1) in the model registry, placed after the existing `collection.omni` models.

- A turn-based illustrated and voiced RPG storyteller packaged as a Lemonade Omni collection.
- `checkpoint`/`recipe`/`size` mirror the sibling `LMX-Omni-*` entries; components and system prompt ship in the repo's `RPG-HaloTales-V1.json` manifest (downloaded on pull), so no inline `components` array is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)