### PR TITLE
docs: add Telemetry guide to mkdocs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
       - vLLM: guide/configuration/vllm.md
       - Moonshine: guide/configuration/moonshine.md
       - Cloud Offload: guide/configuration/cloud.md
+    - Telemetry: guide/telemetry.md
     - FAQ: guide/faq.md
   - Development:
     - Overview: dev/README.md


### PR DESCRIPTION
The `docs/guide/telemetry.md` page (added in #2330) was never linked in the site navigation. This adds it under **User Guide**, after Cloud Offload and before FAQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)