### PR TITLE
Router/2383 policy parser hot reload

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -282,8 +282,11 @@ jobs:
           cmake --build --preset default --target test_routing_policy_semantic
           cmake --build --preset default --target test_routing_policy_deterministic
           cmake --build --preset default --target test_routing_policy_engine
+          cmake --build --preset default --target test_routing_policy_parser
+          cmake --build --preset default --target test_routing_policy_store
+          cmake --build --preset default --target test_model_manager_collection_validation
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine)Test"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -588,8 +591,11 @@ jobs:
           cmake --build --preset default --target test_routing_policy_semantic
           cmake --build --preset default --target test_routing_policy_deterministic
           cmake --build --preset default --target test_routing_policy_engine
+          cmake --build --preset default --target test_routing_policy_parser
+          cmake --build --preset default --target test_routing_policy_store
+          cmake --build --preset default --target test_model_manager_collection_validation
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine)Test"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,8 @@ set(SOURCES_CORE
     src/cpp/server/system_info.cpp
     src/cpp/server/recipe_options.cpp
     src/cpp/server/routing_policy.cpp
+    src/cpp/server/routing_policy_parser.cpp
+    src/cpp/server/routing_policy_store.cpp
     src/cpp/server/runtime_config.cpp
     src/cpp/server/telemetry.cpp
     src/cpp/server/logging_config.cpp
@@ -2023,6 +2025,78 @@ if(EXISTS "${_ROUTING_ENGINE_TEST_SRC}")
 
     include(CTest)
     add_test(NAME RoutingPolicyEngineTest COMMAND test_routing_policy_engine)
+endif()
+
+# Routing policy parser (issue #2383): collection.router JSON -> RoutePolicy,
+# schema/parser key parity, component resolution, and validation errors.
+set(_ROUTING_PARSER_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_parser.cpp"
+)
+if(EXISTS "${_ROUTING_PARSER_TEST_SRC}")
+    add_executable(test_routing_policy_parser
+        test/cpp/test_routing_policy_parser.cpp
+        src/cpp/server/routing_policy.cpp
+        src/cpp/server/routing_policy_parser.cpp
+    )
+    target_include_directories(test_routing_policy_parser PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_routing_policy_parser PRIVATE nlohmann_json::nlohmann_json)
+    target_compile_definitions(test_routing_policy_parser PRIVATE
+        ROUTING_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/fixtures/routing"
+        ROUTING_SCHEMA_FILE="${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/resources/schemas/route_policy.schema.json"
+    )
+
+    include(CTest)
+    add_test(NAME RoutingPolicyParserTest COMMAND test_routing_policy_parser)
+endif()
+
+# Routing policy store (issue #2383): directory-backed policy loading and
+# DirectoryWatcher-triggered shared_ptr snapshot swaps.
+set(_ROUTING_STORE_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_store.cpp"
+)
+if(EXISTS "${_ROUTING_STORE_TEST_SRC}")
+    add_executable(test_routing_policy_store
+        test/cpp/test_routing_policy_store.cpp
+        src/cpp/server/routing_policy.cpp
+        src/cpp/server/routing_policy_parser.cpp
+        src/cpp/server/routing_policy_store.cpp
+        src/cpp/server/directory_watcher.cpp
+    )
+    target_include_directories(test_routing_policy_store PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/test/cpp
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_routing_policy_store PRIVATE nlohmann_json::nlohmann_json)
+    find_package(Threads REQUIRED)
+    target_link_libraries(test_routing_policy_store PRIVATE Threads::Threads)
+    target_compile_definitions(test_routing_policy_store PRIVATE
+        ROUTING_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/fixtures/routing"
+    )
+
+    include(CTest)
+    add_test(NAME RoutingPolicyStoreTest COMMAND test_routing_policy_store)
+endif()
+
+# ModelManager collection validation for collection.router registration:
+# /pull-style validation rejects malformed routing and preserves the routing
+# block in ModelInfo::extras after user-model registration.
+set(_MODEL_MANAGER_COLLECTION_VALIDATION_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_model_manager_collection_validation.cpp"
+)
+if(EXISTS "${_MODEL_MANAGER_COLLECTION_VALIDATION_TEST_SRC}")
+    add_executable(test_model_manager_collection_validation
+        test/cpp/test_model_manager_collection_validation.cpp
+    )
+    target_link_libraries(test_model_manager_collection_validation PRIVATE lemonade-server-core)
+    add_dependencies(test_model_manager_collection_validation copy_resources)
+
+    include(CTest)
+    add_test(NAME ModelManagerCollectionValidationTest COMMAND test_model_manager_collection_validation)
 endif()
 
 # Auto-tune: GGUF array storage, scalar derivation, weighted KV cache computation.

--- a/src/app/src/renderer/utils/modelData.ts
+++ b/src/app/src/renderer/utils/modelData.ts
@@ -1,4 +1,4 @@
-import { isCollectionRecipe } from './recipeNames';
+import { isModelCollectionRecipe } from './recipeNames';
 
 export const USER_MODEL_PREFIX = 'user.';
 
@@ -36,6 +36,9 @@ export interface ModelInfo {
   // global default in toolDefinitions.json when set. Keeps {tool_list} and
   // {tool_guidance} placeholders so runtime substitution still works.
   system_prompt?: string;
+  // collection.router policies. Kept opaque in the general model catalog; router
+  // authoring tools validate against the routing schema.
+  routing?: unknown;
   [key: string]: unknown;
 }
 
@@ -76,7 +79,7 @@ const normalizeModelInfo = (info: unknown): ModelInfo | null => {
   const checkpoint = typeof info['checkpoint'] === 'string' ? info['checkpoint'] : '';
   const recipe = typeof info['recipe'] === 'string' ? info['recipe'] : '';
 
-  if (!recipe || (!checkpoint && !isCollectionRecipe(recipe))) {
+  if (!recipe || (!checkpoint && !isModelCollectionRecipe(recipe))) {
     return null;
   }
 
@@ -140,6 +143,10 @@ const normalizeModelInfo = (info: unknown): ModelInfo | null => {
   const systemPrompt = info['system_prompt'];
   if (typeof systemPrompt === 'string' && systemPrompt) {
     normalized.system_prompt = systemPrompt;
+  }
+
+  if (isRecord(info['routing'])) {
+    normalized.routing = info['routing'];
   }
 
   const vision = info['vision'];
@@ -234,6 +241,10 @@ const fetchBuiltInModelsFromAPI = async (): Promise<ModelsData> => {
         modelInfo.system_prompt = model.system_prompt;
       }
 
+      if (model.routing && typeof model.routing === 'object' && !Array.isArray(model.routing)) {
+        modelInfo.routing = model.routing;
+      }
+
       // cloud_provider distinguishes per-provider buckets in the Model
       // Manager grouping (recipe="cloud" alone collapses all providers
       // into a single sub-heading).
@@ -289,6 +300,7 @@ const EXPORT_KNOWN_KEYS = new Set([
   'labels',
   'recipe',
   'recipe_options',
+  'routing',
   'size',
   'system_prompt',
 ]);
@@ -323,7 +335,7 @@ export const normalizeModelExportPayload = (
   const name = typeof payload.model_name === 'string' && payload.model_name ? payload.model_name : fallbackId;
   payload.model_name = name.startsWith(USER_MODEL_PREFIX) ? name : `${USER_MODEL_PREFIX}${name}`;
 
-  if (isCollectionRecipe(typeof payload.recipe === 'string' ? payload.recipe : undefined)) {
+  if (isModelCollectionRecipe(typeof payload.recipe === 'string' ? payload.recipe : undefined)) {
     // Normalize each embedded component with the same transform. Components
     // are leaf models: drop their (empty) collection fields and keep bare
     // names — the server decides `user.` prefixing when registering them.

--- a/src/app/src/renderer/utils/recipeNames.ts
+++ b/src/app/src/renderer/utils/recipeNames.ts
@@ -1,7 +1,12 @@
 export const COLLECTION_OMNI_MODEL_RECIPE = 'collection.omni';
+export const COLLECTION_ROUTER_MODEL_RECIPE = 'collection.router';
 
 export const isCollectionRecipe = (recipe?: string): boolean => {
   return recipe === COLLECTION_OMNI_MODEL_RECIPE;
+};
+
+export const isModelCollectionRecipe = (recipe?: string): boolean => {
+  return recipe === COLLECTION_OMNI_MODEL_RECIPE || recipe === COLLECTION_ROUTER_MODEL_RECIPE;
 };
 
 // Recipe display names. Hardware-backend names (llamacpp, whispercpp, sd-cpp, …)
@@ -12,6 +17,7 @@ export const isCollectionRecipe = (recipe?: string): boolean => {
 // no local support rows).
 export const RECIPE_DISPLAY_NAMES: Record<string, string> = {
   [COLLECTION_OMNI_MODEL_RECIPE]: 'Lemonade',
+  [COLLECTION_ROUTER_MODEL_RECIPE]: 'Router',
   'cloud': 'Cloud',
 };
 

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -1271,7 +1271,7 @@ int main(int argc, char* argv[]) {
         ->type_name("TYPE CHECKPOINT")
         ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     pull_cmd->add_option("--recipe", config.recipe,
-        "Recipe for the custom user.* model (e.g., llamacpp, flm, sd-cpp, whispercpp, collection.omni)")
+        "Recipe for the custom user.* model (e.g., llamacpp, flm, sd-cpp, whispercpp, collection.omni, collection.router)")
         ->group("Manual Configuration Options")
         ->type_name("RECIPE")
         ->default_val(config.recipe);

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -361,7 +361,7 @@ static bool has_manual_pull_options(const CliConfig& config) {
 
 static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig& config) {
     if (has_manual_pull_options(config)) {
-        if (lemon::is_collection_recipe(config.recipe)) {
+        if (lemon::is_omni_collection_recipe(config.recipe)) {
             if (config.components.empty()) {
                 std::cerr << "Error: omni pull requires --components MODEL [MODEL ...]."
                           << std::endl;

--- a/src/cpp/cli/recipe_import.cpp
+++ b/src/cpp/cli/recipe_import.cpp
@@ -30,6 +30,7 @@ const std::vector<std::string> kKnownKeys = {
     "labels",
     "recipe",
     "recipe_options",
+    "routing",
     "size",
     "system_prompt"
 };
@@ -244,7 +245,7 @@ bool validate_and_transform_model_json(nlohmann::json& model_data) {
         return false;
     }
 
-    bool is_collection = lemon::is_collection_recipe(model_data["recipe"].get<std::string>());
+    bool is_collection = lemon::is_model_collection_recipe(model_data["recipe"].get<std::string>());
 
     bool has_checkpoints = model_data.contains("checkpoints") && model_data["checkpoints"].is_object();
     bool has_checkpoint = model_data.contains("checkpoint") && model_data["checkpoint"].is_string();

--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -7,9 +7,18 @@
 namespace lemon {
 
 constexpr const char* COLLECTION_OMNI_MODEL_RECIPE = "collection.omni";
+constexpr const char* COLLECTION_ROUTER_MODEL_RECIPE = "collection.router";
 
 inline bool is_collection_recipe(const std::string& recipe) {
     return recipe == COLLECTION_OMNI_MODEL_RECIPE;
+}
+
+inline bool is_router_collection_recipe(const std::string& recipe) {
+    return recipe == COLLECTION_ROUTER_MODEL_RECIPE;
+}
+
+inline bool is_model_collection_recipe(const std::string& recipe) {
+    return is_collection_recipe(recipe) || is_router_collection_recipe(recipe);
 }
 
 enum class ModelState {

--- a/src/cpp/include/lemon/model_types.h
+++ b/src/cpp/include/lemon/model_types.h
@@ -9,7 +9,7 @@ namespace lemon {
 constexpr const char* COLLECTION_OMNI_MODEL_RECIPE = "collection.omni";
 constexpr const char* COLLECTION_ROUTER_MODEL_RECIPE = "collection.router";
 
-inline bool is_collection_recipe(const std::string& recipe) {
+inline bool is_omni_collection_recipe(const std::string& recipe) {
     return recipe == COLLECTION_OMNI_MODEL_RECIPE;
 }
 
@@ -18,7 +18,7 @@ inline bool is_router_collection_recipe(const std::string& recipe) {
 }
 
 inline bool is_model_collection_recipe(const std::string& recipe) {
-    return is_collection_recipe(recipe) || is_router_collection_recipe(recipe);
+    return is_omni_collection_recipe(recipe) || is_router_collection_recipe(recipe);
 }
 
 enum class ModelState {

--- a/src/cpp/include/lemon/routing_policy_parser.h
+++ b/src/cpp/include/lemon/routing_policy_parser.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "lemon/routing_policy.h"
+
+#include <functional>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace lemon {
+
+// Resolves a component name from collection JSON into the name the engine should
+// route to. Server integration can bind this to ModelManager::resolve_model_name;
+// pure parser tests use the identity resolver.
+using RoutingComponentResolver =
+    std::function<std::optional<std::string>(const std::string& component)>;
+
+struct RoutingPolicyParseOptions {
+    RoutingComponentResolver resolve_component;
+    bool require_declared_components = true;
+};
+
+// Parser key registries. The parser rejects any key outside these sets; the
+// schema-parity test compares them to route_policy.schema.json so parser and
+// schema vocabulary cannot drift silently.
+const std::set<std::string>& routing_policy_root_keys();
+const std::set<std::string>& routing_block_keys();
+const std::set<std::string>& routing_router_keys();
+const std::set<std::string>& routing_classifier_keys();
+const std::set<std::string>& routing_rule_keys();
+const std::set<std::string>& routing_match_expr_keys();
+const std::set<std::string>& routing_metadata_match_keys();
+
+// Parse a full collection.router document into engine-ready policy state.
+// Throws std::invalid_argument with a user-facing message on validation errors.
+RoutePolicy parse_route_policy_collection(
+    const json& collection_json,
+    const RoutingPolicyParseOptions& options = RoutingPolicyParseOptions{});
+
+} // namespace lemon

--- a/src/cpp/include/lemon/routing_policy_store.h
+++ b/src/cpp/include/lemon/routing_policy_store.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "lemon/directory_watcher.h"
+#include "lemon/routing_policy.h"
+#include "lemon/routing_policy_parser.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace lemon {
+
+// Directory-backed cache of compiled collection.router engines. A reload builds
+// a complete immutable snapshot and atomically swaps the shared_ptr, so readers
+// either see the old valid set or the new valid set.
+//
+// This is the module-level hot-reload implementation for #2383. It is not wired
+// into Server request dispatch yet: #2385 owns attaching a store/registry to the
+// live server lifecycle and using its engines to route OpenAI requests.
+class RoutingPolicyStore {
+public:
+    struct Snapshot {
+        std::map<std::string, std::shared_ptr<const RoutingPolicyEngine>> engines;
+        std::map<std::string, std::string> errors;
+    };
+
+    RoutingPolicyStore(std::string directory,
+                       ClassifierServices services,
+                       RoutingPolicyParseOptions parse_options = {});
+    ~RoutingPolicyStore();
+
+    std::shared_ptr<const Snapshot> reload();
+    void start_watching();
+    void stop_watching();
+
+    std::shared_ptr<const RoutingPolicyEngine> get_engine(const std::string& model_name) const;
+    std::shared_ptr<const Snapshot> snapshot() const;
+
+private:
+    std::shared_ptr<const Snapshot> load_directory() const;
+
+    std::string directory_;
+    ClassifierServices services_;
+    RoutingPolicyParseOptions parse_options_;
+    std::unique_ptr<DirectoryWatcher> watcher_;
+    std::shared_ptr<const Snapshot> snapshot_;
+};
+
+} // namespace lemon

--- a/src/cpp/include/lemon/routing_policy_store.h
+++ b/src/cpp/include/lemon/routing_policy_store.h
@@ -43,6 +43,8 @@ private:
     ClassifierServices services_;
     RoutingPolicyParseOptions parse_options_;
     std::unique_ptr<DirectoryWatcher> watcher_;
+    // TODO(C++20): replace std::atomic_load/store free functions with a
+    // std::atomic<std::shared_ptr<const Snapshot>> member (deprecated in C++20).
     std::shared_ptr<const Snapshot> snapshot_;
 };
 

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -323,7 +323,7 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
             manifest = nlohmann::json();
         }
         bool valid_manifest = manifest.is_object() &&
-            is_collection_recipe(manifest.value("recipe", std::string())) &&
+            is_omni_collection_recipe(manifest.value("recipe", std::string())) &&
             manifest.contains("components") && manifest["components"].is_array() &&
             !manifest["components"].empty() &&
             manifest.contains("models") && manifest["models"].is_array();

--- a/src/cpp/server/mcp_server.cpp
+++ b/src/cpp/server/mcp_server.cpp
@@ -818,7 +818,7 @@ json McpServer::tool_omni(const json& arguments) {
         model = arguments["model"].get<std::string>();
     } else {
         for (const auto& [name, info] : model_manager_->get_downloaded_models()) {
-            if (is_collection_recipe(info.recipe)) {
+            if (is_omni_collection_recipe(info.recipe)) {
                 model = name;
                 break;
             }
@@ -851,7 +851,7 @@ json McpServer::tool_omni(const json& arguments) {
     }
 
     ModelInfo info = model_manager_->get_model_info(model);
-    if (!is_collection_recipe(info.recipe)) {
+    if (!is_omni_collection_recipe(info.recipe)) {
         return json{
             {"content", json::array({text_content_block(
                 "Model '" + model + "' is not an Omni collection (recipe='" +

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1,6 +1,7 @@
 #include <lemon/model_manager.h>
 #include <lemon/runtime_config.h>
 #include <lemon/hf_variants.h>
+#include <lemon/routing_policy_parser.h>
 #include <lemon/utils/json_utils.h>
 #include <lemon/utils/http_client.h>
 #include <lemon/utils/process_manager.h>
@@ -109,7 +110,7 @@ static constexpr auto safe_dir_options = fs::directory_options::none;
 namespace lemon {
 
 // Properties which are defined by the user for model registration.
-static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults", "components", "recipe_options", "system_prompt"};
+static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults", "components", "recipe_options", "routing", "system_prompt"};
 
 static constexpr const char USER_MODEL_PREFIX[] = "user.";
 static constexpr size_t USER_MODEL_PREFIX_LEN = sizeof(USER_MODEL_PREFIX) - 1;
@@ -1092,7 +1093,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
 
 std::string ModelManager::resolve_model_path(const ModelInfo& info, const std::string& type, const std::string& checkpoint) const {
     // Collections are virtual entries with no direct checkpoint to resolve.
-    if (is_collection_recipe(info.recipe)) {
+    if (is_model_collection_recipe(info.recipe)) {
         return "";
     }
 
@@ -1277,7 +1278,7 @@ void ModelManager::check_for_model_updates() {
         }
         for (const auto& [name, info] : models_cache_) {
             if (!info.downloaded) continue;
-            if (is_collection_recipe(info.recipe)) continue;
+            if (is_model_collection_recipe(info.recipe)) continue;
             if (info.recipe == "flm" || info.recipe == "cloud") continue;
 
             std::string main_cp = info.checkpoint("main");
@@ -1504,7 +1505,7 @@ void ModelManager::build_cache() {
         // a previous version may have persisted are ignored/self-healed). A
         // pure inline collection has no checkpoint pointer; it keeps its
         // authored components and only falls back to the cache when empty.
-        if (is_collection_recipe(info.recipe) &&
+        if (is_model_collection_recipe(info.recipe) &&
             (info.components.empty() || !info.checkpoint().empty())) {
             info.components.clear();
             populate_collection_components_from_cache_locked(info);
@@ -1557,7 +1558,7 @@ void ModelManager::build_cache() {
         // so a refreshed manifest is reflected and no stale list can shadow it.
         // A pure inline user collection has no checkpoint pointer and keeps its
         // authored components, falling back to the cache only when empty.
-        if (is_collection_recipe(info.recipe) &&
+        if (is_model_collection_recipe(info.recipe) &&
             (info.components.empty() || !info.checkpoint().empty())) {
             info.components.clear();
             populate_collection_components_from_cache_locked(info);
@@ -1643,7 +1644,7 @@ void ModelManager::build_cache() {
     int downloaded_count = 0;
     // First pass: determine download status for non-collection models
     for (auto& [name, info] : all_models) {
-        if (is_collection_recipe(info.recipe)) {
+        if (is_model_collection_recipe(info.recipe)) {
             continue;  // Handled in second pass after components are resolved
         }
         const auto* desc = backends::descriptor_for(info.recipe);
@@ -1659,7 +1660,7 @@ void ModelManager::build_cache() {
     // Second pass: determine download status for collection models
     // (must happen after components have their downloaded status set)
     for (auto& [name, info] : all_models) {
-        if (!is_collection_recipe(info.recipe)) continue;
+        if (!is_model_collection_recipe(info.recipe)) continue;
         info.downloaded = check_component_downloaded(info, all_models);
         if (info.downloaded) {
             downloaded_count++;
@@ -1748,7 +1749,7 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
 
     // Check download status (collections aggregate their components; everyone
     // else asks its backend ops).
-    if (is_collection_recipe(info.recipe)) {
+    if (is_model_collection_recipe(info.recipe)) {
         info.downloaded = check_component_downloaded(info, models_cache_);
     } else {
         backends::BackendOpsContext octx;
@@ -1834,7 +1835,7 @@ void ModelManager::update_model_in_cache(const std::string& model_name, bool dow
         // depend on this model, so the collection reflects component changes
         // without requiring a full cache rebuild.
         for (auto& [name, entry] : models_cache_) {
-            if (!is_collection_recipe(entry.recipe)) continue;
+            if (!is_model_collection_recipe(entry.recipe)) continue;
             if (std::find(entry.components.begin(), entry.components.end(),
                           model_name) == entry.components.end()) {
                 continue;
@@ -2085,7 +2086,7 @@ std::map<std::string, ModelInfo> ModelManager::filter_models_by_backend(
 
         // Collections are UI-level entries that orchestrate components.
         // They should always be visible if present in the registry.
-        if (is_collection_recipe(recipe)) {
+        if (is_model_collection_recipe(recipe)) {
             filtered[name] = info;
             continue;
         }
@@ -2333,7 +2334,7 @@ void ModelManager::register_user_model(const std::string& model_name,
     // repo pointer (checkpoint). Persisting `components` here would let a stale
     // local copy shadow a refreshed manifest. A pure inline collection has no
     // checkpoint pointer and keeps its authored components.
-    if (is_collection_recipe(recipe)) {
+    if (is_model_collection_recipe(recipe)) {
         std::string pointer = model_entry.value("checkpoint", std::string());
         if (pointer.empty() && model_entry.contains("checkpoints") &&
             model_entry["checkpoints"].is_object()) {
@@ -2502,7 +2503,7 @@ static json read_cached_collection_manifest(const fs::path& cache_dir) {
             continue;
         }
         if (candidate.is_object() &&
-            is_collection_recipe(JsonUtils::get_or_default<std::string>(candidate, "recipe", ""))) {
+            is_model_collection_recipe(JsonUtils::get_or_default<std::string>(candidate, "recipe", ""))) {
             return candidate;
         }
     }
@@ -2632,9 +2633,9 @@ std::vector<std::string> ModelManager::register_components(const json& component
         // Components must be regular models, not collections (backstop for the
         // HF-manifest path, which does not go through validate_collection_request).
         bool def_is_collection =
-            def.is_object() && is_collection_recipe(def.value("recipe", std::string()));
+            def.is_object() && is_model_collection_recipe(def.value("recipe", std::string()));
         if (def_is_collection ||
-            (model_exists(name) && is_collection_recipe(get_model_info(name).recipe))) {
+            (model_exists(name) && is_model_collection_recipe(get_model_info(name).recipe))) {
             throw std::runtime_error(
                 "Collection components must be regular models, not collections: '" + name + "'");
         }
@@ -2801,11 +2802,11 @@ void ModelManager::download_model(const std::string& model_name,
             );
         }
 
-        if (is_collection_recipe(actual_recipe)) {
+        if (is_model_collection_recipe(actual_recipe)) {
             if (auto err = validate_collection_request(model_name, model_data)) {
                 throw std::runtime_error(*err);
             }
-            LOG(INFO, "ModelManager") << "Registering new omni collection: " << model_name << std::endl;
+            LOG(INFO, "ModelManager") << "Registering new collection: " << model_name << std::endl;
         } else {
             // Check that required arguments are provided
             if (actual_checkpoint.empty() || actual_recipe.empty()) {
@@ -2830,7 +2831,7 @@ void ModelManager::download_model(const std::string& model_name,
         // otherwise overwrite registration. Collections have no checkpoint, so
         // the "components in request" flag distinguishes a real overwrite from
         // a cascade pull that should reuse the registered components.
-        bool is_collection_overwrite = is_collection_recipe(actual_recipe) &&
+        bool is_collection_overwrite = is_model_collection_recipe(actual_recipe) &&
                                         model_data.contains("components");
         if (is_collection_overwrite) {
             if (auto err = validate_collection_request(model_name, model_data)) {
@@ -2862,7 +2863,7 @@ void ModelManager::download_model(const std::string& model_name,
     // Track that this call created the registration so component-resolution
     // failures can roll it back instead of leaving a broken entry behind.
     bool collection_registered_this_call = false;
-    if (is_collection_recipe(actual_recipe) && is_user_model_name(model_name) && !model_registered) {
+    if (is_model_collection_recipe(actual_recipe) && is_user_model_name(model_name) && !model_registered) {
         register_user_model(model_name, model_data);
         model_registered = true;
         collection_registered_this_call = true;
@@ -2878,7 +2879,7 @@ void ModelManager::download_model(const std::string& model_name,
     // its `checkpoint` pointer, with the component list rebuilt from the cached
     // manifest (fetched). The one exception: a fetched manifest registers its
     // components as user models so they're routable.
-    if (is_collection_recipe(actual_recipe)) {
+    if (is_model_collection_recipe(actual_recipe)) {
         // Cycle guard: re-entering the same collection on the current call
         // chain means the user registered a circular reference (e.g. user.A
         // includes user.B which includes user.A). Without this, the fan-out
@@ -4217,7 +4218,7 @@ std::optional<std::string> ModelManager::validate_collection_request(
         if (!checkpoint_pointer.empty()) {
             return std::nullopt;  // pointer-only HF-backed collection
         }
-        return std::string("recipe='collection.omni' requires a non-empty 'components' array");
+        return std::string("Collection recipe requires a non-empty 'components' array");
     }
     // An inline collection import carries its component definitions in a `models`
     // array. Every component must be *resolvable*: either it is already
@@ -4262,8 +4263,8 @@ std::optional<std::string> ModelManager::validate_collection_request(
         const json* def = find_inline_def(bare);
         bool is_collection_component =
             (def != nullptr && def->is_object() &&
-             is_collection_recipe(def->value("recipe", std::string()))) ||
-            (model_exists(bare) && is_collection_recipe(get_model_info(bare).recipe));
+             is_model_collection_recipe(def->value("recipe", std::string()))) ||
+            (model_exists(bare) && is_model_collection_recipe(get_model_info(bare).recipe));
         if (is_collection_component) {
             return "Collection components must be regular models, not collections: '" +
                    component_name + "'";
@@ -4289,6 +4290,25 @@ std::optional<std::string> ModelManager::validate_collection_request(
         } else if (!model_exists(component_name)) {
             return "Collection component not registered: '" + component_name +
                    "'. Pull or register it before referencing it in a collection.";
+        }
+    }
+    if (is_router_collection_recipe(model_data.value("recipe", std::string()))) {
+        RoutingPolicyParseOptions options;
+        options.resolve_component = [this](const std::string& name) -> std::optional<std::string> {
+            try {
+                return resolve_model_name(name);
+            } catch (...) {
+                // Inline collection imports may reference components that are
+                // defined in the same JSON but not registered yet. Keep those
+                // names stable so parser component-role validation can still
+                // compare them against the authored components array.
+                return name;
+            }
+        };
+        try {
+            parse_route_policy_collection(model_data, options);
+        } catch (const std::exception& e) {
+            return std::string("Invalid collection.router routing policy: ") + e.what();
         }
     }
     return std::nullopt;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -4306,7 +4306,8 @@ std::optional<std::string> ModelManager::validate_collection_request(
             }
         };
         try {
-            parse_route_policy_collection(model_data, options);
+            RoutePolicy policy = parse_route_policy_collection(model_data, options);
+            RoutingPolicyEngine(std::move(policy), ClassifierServices{});
         } catch (const std::exception& e) {
             return std::string("Invalid collection.router routing policy: ") + e.what();
         }

--- a/src/cpp/server/routing_policy_parser.cpp
+++ b/src/cpp/server/routing_policy_parser.cpp
@@ -1,0 +1,540 @@
+#include "lemon/routing_policy_parser.h"
+
+#include "lemon/model_types.h"
+
+#include <algorithm>
+#include <set>
+#include <stdexcept>
+#include <utility>
+
+namespace lemon {
+namespace {
+
+std::string path_index(const std::string& path, std::size_t i) {
+    return path + "[" + std::to_string(i) + "]";
+}
+
+void require_object(const json& value, const std::string& path) {
+    if (!value.is_object()) {
+        throw std::invalid_argument(path + " must be an object");
+    }
+}
+
+void reject_unknown_keys(const json& value,
+                         const std::set<std::string>& accepted,
+                         const std::string& path) {
+    require_object(value, path);
+    for (const auto& [key, _] : value.items()) {
+        if (accepted.count(key) == 0) {
+            throw std::invalid_argument(path + " contains unknown key '" + key + "'");
+        }
+    }
+}
+
+const json& required_field(const json& value,
+                           const std::string& key,
+                           const std::string& path) {
+    if (!value.contains(key)) {
+        throw std::invalid_argument(path + " is missing required key '" + key + "'");
+    }
+    return value.at(key);
+}
+
+std::string required_string(const json& value,
+                            const std::string& key,
+                            const std::string& path) {
+    const json& field = required_field(value, key, path);
+    if (!field.is_string() || field.get<std::string>().empty()) {
+        throw std::invalid_argument(path + "." + key + " must be a non-empty string");
+    }
+    return field.get<std::string>();
+}
+
+std::string optional_string(const json& value,
+                            const std::string& key,
+                            const std::string& path) {
+    if (!value.contains(key)) {
+        return "";
+    }
+    if (!value.at(key).is_string() || value.at(key).get<std::string>().empty()) {
+        throw std::invalid_argument(path + "." + key + " must be a non-empty string");
+    }
+    return value.at(key).get<std::string>();
+}
+
+std::string schema_major(const std::string& version) {
+    const auto dot = version.find('.');
+    return dot == std::string::npos ? version : version.substr(0, dot);
+}
+
+void validate_version_1(const json& collection_json) {
+    const std::string version = required_string(collection_json, "version", "collection");
+    const std::string major = schema_major(version);
+    if (major != "1") {
+        throw std::invalid_argument(
+            "Unsupported collection.router schema major '" + major +
+            "' from version '" + version + "'; supported major is '1'");
+    }
+    if (version != "1") {
+        throw std::invalid_argument(
+            "Unsupported collection.router schema version '" + version +
+            "'; this parser implements version '1'");
+    }
+}
+
+std::string resolve_component(const std::string& component,
+                              const RoutingPolicyParseOptions& options,
+                              const std::string& path) {
+    std::optional<std::string> resolved =
+        options.resolve_component ? options.resolve_component(component)
+                                  : std::optional<std::string>(component);
+    if (!resolved.has_value() || resolved->empty()) {
+        throw std::invalid_argument(path + " references unknown component '" + component + "'");
+    }
+    return *resolved;
+}
+
+std::set<std::string> parse_declared_components(const json& collection_json,
+                                                const RoutingPolicyParseOptions& options) {
+    std::set<std::string> components;
+    if (!collection_json.contains("components")) {
+        if (options.require_declared_components) {
+            throw std::invalid_argument("collection.router requires a non-empty components array");
+        }
+        return components;
+    }
+    const json& value = collection_json.at("components");
+    if (!value.is_array() || value.empty()) {
+        if (options.require_declared_components) {
+            throw std::invalid_argument("collection.components must be a non-empty array");
+        }
+        return components;
+    }
+    for (std::size_t i = 0; i < value.size(); ++i) {
+        if (!value[i].is_string() || value[i].get<std::string>().empty()) {
+            throw std::invalid_argument(path_index("collection.components", i) +
+                                        " must be a non-empty string");
+        }
+        std::string resolved = resolve_component(value[i].get<std::string>(), options,
+                                                 path_index("collection.components", i));
+        components.insert(std::move(resolved));
+    }
+    return components;
+}
+
+void require_declared(const std::string& resolved,
+                      const std::string& original,
+                      const std::set<std::string>& declared,
+                      const RoutingPolicyParseOptions& options,
+                      const std::string& path) {
+    if (!options.require_declared_components) {
+        return;
+    }
+    if (declared.count(resolved) == 0) {
+        throw std::invalid_argument(path + " references component '" + original +
+                                    "' that is not declared in collection.components");
+    }
+}
+
+std::vector<std::string> parse_candidates(const json& routing,
+                                          const std::set<std::string>& declared,
+                                          const RoutingPolicyParseOptions& options) {
+    const json& value = required_field(routing, "candidates", "routing");
+    if (!value.is_array() || value.empty()) {
+        throw std::invalid_argument("routing.candidates must be a non-empty array");
+    }
+    std::vector<std::string> candidates;
+    std::set<std::string> seen;
+    for (std::size_t i = 0; i < value.size(); ++i) {
+        const std::string path = path_index("routing.candidates", i);
+        if (!value[i].is_string() || value[i].get<std::string>().empty()) {
+            throw std::invalid_argument(path + " must be a non-empty string");
+        }
+        const std::string original = value[i].get<std::string>();
+        std::string resolved = resolve_component(original, options, path);
+        require_declared(resolved, original, declared, options, path);
+        if (!seen.insert(resolved).second) {
+            throw std::invalid_argument(path + " duplicates candidate '" + original + "'");
+        }
+        candidates.push_back(std::move(resolved));
+    }
+    return candidates;
+}
+
+bool contains_string(const std::vector<std::string>& values, const std::string& value) {
+    return std::find(values.begin(), values.end(), value) != values.end();
+}
+
+void validate_score_bound(const json& leaf,
+                          const std::string& key,
+                          std::optional<double>& out,
+                          const std::string& path) {
+    if (!leaf.contains(key)) {
+        return;
+    }
+    if (!leaf.at(key).is_number()) {
+        throw std::invalid_argument(path + "." + key + " must be numeric");
+    }
+    const double value = leaf.at(key).get<double>();
+    if (value < 0.0 || value > 1.0) {
+        throw std::invalid_argument(path + "." + key + " must be in [0, 1]");
+    }
+    out = value;
+}
+
+void validate_string_array(const json& value,
+                           const std::string& path,
+                           bool require_non_empty) {
+    if (!value.is_array() || (require_non_empty && value.empty())) {
+        throw std::invalid_argument(path + " must be a non-empty array");
+    }
+    for (std::size_t i = 0; i < value.size(); ++i) {
+        if (!value[i].is_string() || value[i].get<std::string>().empty()) {
+            throw std::invalid_argument(path_index(path, i) +
+                                        " must be a non-empty string");
+        }
+    }
+}
+
+void validate_metadata_match(const json& spec, const std::string& path) {
+    reject_unknown_keys(spec, routing_metadata_match_keys(), path);
+    required_string(spec, "key", path);
+    const int comparators = static_cast<int>(spec.contains("equals")) +
+                            static_cast<int>(spec.contains("any")) +
+                            static_cast<int>(spec.contains("exists"));
+    if (comparators != 1) {
+        throw std::invalid_argument(
+            path + " must contain exactly one comparator: equals, any, or exists");
+    }
+    if (spec.contains("equals") && !spec.at("equals").is_string()) {
+        throw std::invalid_argument(path + ".equals must be a string");
+    }
+    if (spec.contains("any")) {
+        validate_string_array(spec.at("any"), path + ".any", true);
+    }
+    if (spec.contains("exists") && !spec.at("exists").is_boolean()) {
+        throw std::invalid_argument(path + ".exists must be a boolean");
+    }
+}
+
+void validate_leaf(const json& leaf,
+                   const std::map<std::string, ClassifierPtr>& classifiers,
+                   const std::string& path) {
+    reject_unknown_keys(leaf, routing_match_expr_keys(), path);
+
+    std::size_t condition_count = 0;
+    if (leaf.contains("classifier")) {
+        ++condition_count;
+        const std::string id = required_string(leaf, "classifier", path);
+        auto classifier_it = classifiers.find(id);
+        if (classifier_it == classifiers.end()) {
+            throw std::invalid_argument(path + ".classifier references unknown classifier '" +
+                                        id + "'");
+        }
+
+        const auto& classifier = classifier_it->second;
+        if (leaf.contains("label")) {
+            const std::string label = optional_string(leaf, "label", path);
+            const auto& labels = classifier->labels();
+            if (labels.empty() ||
+                std::find(labels.begin(), labels.end(), label) == labels.end()) {
+                throw std::invalid_argument(path + ".label references unknown label '" +
+                                            label + "' on classifier '" + id + "'");
+            }
+        } else if (!classifier->labels().empty() &&
+                   !classifier->default_label().has_value()) {
+            throw std::invalid_argument(
+                path + " omits label but classifier '" + id +
+                "' has no default_label");
+        }
+
+        std::optional<double> min_score;
+        std::optional<double> max_score;
+        validate_score_bound(leaf, "min_score", min_score, path);
+        validate_score_bound(leaf, "max_score", max_score, path);
+        if (min_score.has_value() && max_score.has_value() && *min_score > *max_score) {
+            throw std::invalid_argument(path + " has min_score greater than max_score");
+        }
+    } else {
+        for (const char* classifier_only : {"label", "min_score", "max_score"}) {
+            if (leaf.contains(classifier_only)) {
+                throw std::invalid_argument(path + "." + classifier_only +
+                                            " requires a classifier condition");
+            }
+        }
+    }
+
+    for (const char* op : {"keywords_any", "keywords_all"}) {
+        if (leaf.contains(op)) {
+            ++condition_count;
+            validate_string_array(leaf.at(op), path + "." + op, true);
+        }
+    }
+    if (leaf.contains("regex")) {
+        ++condition_count;
+        if (!leaf.at("regex").is_string() || leaf.at("regex").get<std::string>().empty()) {
+            throw std::invalid_argument(path + ".regex must be a non-empty string");
+        }
+    }
+    for (const char* op : {"min_chars", "max_chars"}) {
+        if (leaf.contains(op)) {
+            ++condition_count;
+            if (!leaf.at(op).is_number_integer() || leaf.at(op).get<long long>() < 0) {
+                throw std::invalid_argument(path + "." + op +
+                                            " must be a non-negative integer");
+            }
+        }
+    }
+    for (const char* op : {"has_tools", "has_images"}) {
+        if (leaf.contains(op)) {
+            ++condition_count;
+            if (!leaf.at(op).is_boolean()) {
+                throw std::invalid_argument(path + "." + op + " must be a boolean");
+            }
+        }
+    }
+    if (leaf.contains("metadata")) {
+        ++condition_count;
+        validate_metadata_match(leaf.at("metadata"), path + ".metadata");
+    }
+
+    if (condition_count == 0) {
+        throw std::invalid_argument(path + " must contain at least one leaf condition");
+    }
+}
+
+MatchExpr parse_match_expr(const json& expr,
+                           const std::map<std::string, ClassifierPtr>& classifiers,
+                           const std::string& path,
+                           std::size_t depth) {
+    if (depth > kMaxMatchExprDepth) {
+        throw std::invalid_argument(path + " exceeds maximum match expression depth");
+    }
+    reject_unknown_keys(expr, routing_match_expr_keys(), path);
+
+    const bool has_any = expr.contains("any");
+    const bool has_all = expr.contains("all");
+    const bool has_not = expr.contains("not");
+    const int logical_count = static_cast<int>(has_any) +
+                              static_cast<int>(has_all) +
+                              static_cast<int>(has_not);
+    if (logical_count > 1) {
+        throw std::invalid_argument(path +
+                                    " must contain only one logical operator");
+    }
+
+    if (logical_count == 1) {
+        if (expr.size() != 1) {
+            throw std::invalid_argument(path +
+                                        " cannot mix logical operators with leaf conditions");
+        }
+        MatchExpr out;
+        if (has_any || has_all) {
+            const char* key = has_any ? "any" : "all";
+            const json& children = expr.at(key);
+            if (!children.is_array() || children.empty()) {
+                throw std::invalid_argument(path + "." + key +
+                                            " must be a non-empty array");
+            }
+            out.op = has_any ? MatchExpr::Op::Any : MatchExpr::Op::All;
+            out.children.reserve(children.size());
+            for (std::size_t i = 0; i < children.size(); ++i) {
+                out.children.push_back(parse_match_expr(
+                    children[i], classifiers, path_index(path + "." + key, i), depth + 1));
+            }
+            return out;
+        }
+
+        out.op = MatchExpr::Op::Not;
+        out.children.push_back(parse_match_expr(
+            expr.at("not"), classifiers, path + ".not", depth + 1));
+        return out;
+    }
+
+    validate_leaf(expr, classifiers, path);
+    MatchExpr out;
+    out.op = MatchExpr::Op::Leaf;
+    out.leaf = expr;
+    return out;
+}
+
+json parse_classifier_configs(const json& routing,
+                              const std::set<std::string>& declared,
+                              const RoutingPolicyParseOptions& options) {
+    if (!routing.contains("classifiers")) {
+        return json::array();
+    }
+    const json& classifiers = routing.at("classifiers");
+    if (!classifiers.is_array()) {
+        throw std::invalid_argument("routing.classifiers must be an array");
+    }
+
+    json resolved = json::array();
+    for (std::size_t i = 0; i < classifiers.size(); ++i) {
+        const std::string path = path_index("routing.classifiers", i);
+        const json& classifier = classifiers[i];
+        reject_unknown_keys(classifier, routing_classifier_keys(), path);
+        required_string(classifier, "id", path);
+        const std::string type = required_string(classifier, "type", path);
+
+        if (classifier.contains("on_error")) {
+            const std::string on_error = optional_string(classifier, "on_error", path);
+            if (on_error != "match_true" && on_error != "match_false") {
+                throw std::invalid_argument(path + ".on_error must be match_true or match_false");
+            }
+        }
+
+        json item = classifier;
+        if (classifier.contains("model")) {
+            const std::string original = optional_string(classifier, "model", path);
+            std::string resolved_model = resolve_component(original, options, path + ".model");
+            require_declared(resolved_model, original, declared, options, path + ".model");
+            item["model"] = std::move(resolved_model);
+        }
+
+        // make_classifier performs the type-specific checks. Keep this local
+        // branch only for clearer errors on reserved-but-not-yet-implemented
+        // router sugar paths handled in #2405.
+        if (type == "llm") {
+            throw std::invalid_argument(
+                path + " uses classifier type 'llm', which is reserved for #2405 "
+                "routing.router desugaring and is not implemented by the M9 parser");
+        }
+        resolved.push_back(std::move(item));
+    }
+    return resolved;
+}
+
+std::string parse_default_model(const json& routing,
+                                const std::vector<std::string>& candidates,
+                                const std::set<std::string>& declared,
+                                const RoutingPolicyParseOptions& options) {
+    const std::string original = required_string(routing, "default_model", "routing");
+    std::string resolved = resolve_component(original, options, "routing.default_model");
+    require_declared(resolved, original, declared, options, "routing.default_model");
+    if (!contains_string(candidates, resolved)) {
+        throw std::invalid_argument(
+            "routing.default_model '" + original + "' must be listed in routing.candidates");
+    }
+    return resolved;
+}
+
+std::vector<Rule> parse_rules(const json& routing,
+                              const std::vector<std::string>& candidates,
+                              const std::map<std::string, ClassifierPtr>& classifiers,
+                              const std::set<std::string>& declared,
+                              const RoutingPolicyParseOptions& options) {
+    if (routing.contains("router")) {
+        reject_unknown_keys(routing.at("router"), routing_router_keys(), "routing.router");
+        throw std::invalid_argument(
+            "routing.router desugaring is reserved for #2405 and is not implemented by the M9 parser");
+    }
+    const json& rules_json = required_field(routing, "rules", "routing");
+    if (!rules_json.is_array() || rules_json.empty()) {
+        throw std::invalid_argument("routing.rules must be a non-empty array");
+    }
+
+    std::vector<Rule> rules;
+    rules.reserve(rules_json.size());
+    std::set<std::string> ids;
+    for (std::size_t i = 0; i < rules_json.size(); ++i) {
+        const std::string path = path_index("routing.rules", i);
+        const json& rule_json = rules_json[i];
+        reject_unknown_keys(rule_json, routing_rule_keys(), path);
+
+        Rule rule;
+        rule.id = required_string(rule_json, "id", path);
+        if (!ids.insert(rule.id).second) {
+            throw std::invalid_argument(path + ".id duplicates rule id '" + rule.id + "'");
+        }
+        rule.match = parse_match_expr(
+            required_field(rule_json, "match", path), classifiers, path + ".match", 0);
+
+        const std::string original_route = required_string(rule_json, "route_to", path);
+        rule.route_to = resolve_component(original_route, options, path + ".route_to");
+        require_declared(rule.route_to, original_route, declared, options, path + ".route_to");
+        if (!contains_string(candidates, rule.route_to)) {
+            throw std::invalid_argument(path + ".route_to '" + original_route +
+                                        "' must be listed in routing.candidates");
+        }
+        if (rule_json.contains("outputs")) {
+            if (!rule_json.at("outputs").is_object()) {
+                throw std::invalid_argument(path + ".outputs must be an object");
+            }
+            rule.outputs = rule_json.at("outputs");
+        }
+        rules.push_back(std::move(rule));
+    }
+    return rules;
+}
+
+} // namespace
+
+const std::set<std::string>& routing_policy_root_keys() {
+    static const std::set<std::string> keys = {
+        "version", "model_name", "recipe", "components", "models", "routing"};
+    return keys;
+}
+
+const std::set<std::string>& routing_block_keys() {
+    static const std::set<std::string> keys = {
+        "candidates", "default_model", "router", "classifiers", "rules"};
+    return keys;
+}
+
+const std::set<std::string>& routing_router_keys() {
+    static const std::set<std::string> keys = {"type", "model", "prompt"};
+    return keys;
+}
+
+const std::set<std::string>& routing_classifier_keys() {
+    static const std::set<std::string> keys = {
+        "id", "type", "model", "prompt", "labels", "default_label",
+        "reference_phrases", "on_error"};
+    return keys;
+}
+
+const std::set<std::string>& routing_rule_keys() {
+    static const std::set<std::string> keys = {"id", "match", "route_to", "outputs"};
+    return keys;
+}
+
+const std::set<std::string>& routing_match_expr_keys() {
+    static const std::set<std::string> keys = {
+        "any", "all", "not", "classifier", "label", "min_score", "max_score",
+        "keywords_any", "keywords_all", "regex", "min_chars", "max_chars",
+        "has_tools", "has_images", "metadata"};
+    return keys;
+}
+
+const std::set<std::string>& routing_metadata_match_keys() {
+    static const std::set<std::string> keys = {"key", "equals", "any", "exists"};
+    return keys;
+}
+
+RoutePolicy parse_route_policy_collection(const json& collection_json,
+                                          const RoutingPolicyParseOptions& options) {
+    reject_unknown_keys(collection_json, routing_policy_root_keys(), "collection");
+    validate_version_1(collection_json);
+
+    const std::string recipe = required_string(collection_json, "recipe", "collection");
+    if (!is_router_collection_recipe(recipe)) {
+        throw std::invalid_argument(
+            "collection.recipe must be 'collection.router' for a routing policy");
+    }
+
+    const std::set<std::string> declared = parse_declared_components(collection_json, options);
+    const json& routing = required_field(collection_json, "routing", "collection");
+    reject_unknown_keys(routing, routing_block_keys(), "routing");
+
+    RoutePolicy policy;
+    policy.candidates = parse_candidates(routing, declared, options);
+    policy.default_model = parse_default_model(routing, policy.candidates, declared, options);
+
+    const json classifier_configs = parse_classifier_configs(routing, declared, options);
+    policy.classifiers = make_classifiers(classifier_configs);
+    policy.rules = parse_rules(routing, policy.candidates, policy.classifiers, declared, options);
+    return policy;
+}
+
+} // namespace lemon

--- a/src/cpp/server/routing_policy_store.cpp
+++ b/src/cpp/server/routing_policy_store.cpp
@@ -1,0 +1,150 @@
+#include "lemon/routing_policy_store.h"
+
+#include "lemon/model_types.h"
+#include "lemon/utils/aixlog.hpp"
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+namespace lemon {
+namespace fs = std::filesystem;
+namespace {
+
+bool is_json_file(const fs::path& path) {
+    return path.has_extension() && path.extension() == ".json";
+}
+
+json load_json_file(const fs::path& path) {
+    std::ifstream in(path);
+    if (!in) {
+        throw std::runtime_error("could not open file");
+    }
+    std::stringstream ss;
+    ss << in.rdbuf();
+    json parsed = json::parse(ss.str(), nullptr, /*allow_exceptions=*/false);
+    if (parsed.is_discarded()) {
+        throw std::runtime_error("invalid JSON");
+    }
+    return parsed;
+}
+
+std::string policy_model_name(const json& doc, const fs::path& path) {
+    if (doc.contains("model_name") && doc["model_name"].is_string() &&
+        !doc["model_name"].get<std::string>().empty()) {
+        return doc["model_name"].get<std::string>();
+    }
+    return path.stem().string();
+}
+
+bool is_router_policy_document(const json& doc) {
+    return doc.is_object() && doc.contains("recipe") && doc["recipe"].is_string() &&
+           is_router_collection_recipe(doc["recipe"].get<std::string>());
+}
+
+} // namespace
+
+RoutingPolicyStore::RoutingPolicyStore(std::string directory,
+                                       ClassifierServices services,
+                                       RoutingPolicyParseOptions parse_options)
+    : directory_(std::move(directory)),
+      services_(std::move(services)),
+      parse_options_(std::move(parse_options)),
+      snapshot_(std::make_shared<Snapshot>()) {}
+
+RoutingPolicyStore::~RoutingPolicyStore() {
+    stop_watching();
+}
+
+std::shared_ptr<const RoutingPolicyStore::Snapshot> RoutingPolicyStore::load_directory() const {
+    auto next = std::make_shared<Snapshot>();
+    if (directory_.empty()) {
+        return next;
+    }
+
+    std::error_code ec;
+    if (!fs::exists(directory_, ec)) {
+        return next;
+    }
+
+    for (fs::recursive_directory_iterator it(directory_, fs::directory_options::skip_permission_denied, ec), end;
+         !ec && it != end; it.increment(ec)) {
+        if (ec || !it->is_regular_file(ec) || !is_json_file(it->path())) {
+            continue;
+        }
+
+        const std::string file = it->path().string();
+        try {
+            json doc = load_json_file(it->path());
+            if (!is_router_policy_document(doc)) {
+                continue;
+            }
+
+            const std::string model_name = policy_model_name(doc, it->path());
+            RoutePolicy policy = parse_route_policy_collection(doc, parse_options_);
+            auto engine = std::make_shared<RoutingPolicyEngine>(std::move(policy), services_);
+            next->engines[model_name] = std::move(engine);
+        } catch (const std::exception& e) {
+            next->errors[file] = e.what();
+        } catch (...) {
+            next->errors[file] = "unknown routing policy load error";
+        }
+    }
+    if (ec) {
+        next->errors[directory_] = ec.message();
+    }
+    return next;
+}
+
+std::shared_ptr<const RoutingPolicyStore::Snapshot> RoutingPolicyStore::reload() {
+    auto next = load_directory();
+    std::atomic_store(&snapshot_, next);
+    return next;
+}
+
+void RoutingPolicyStore::start_watching() {
+    if (watcher_ || directory_.empty()) {
+        return;
+    }
+    reload();
+    watcher_ = std::make_unique<DirectoryWatcher>(directory_);
+    watcher_->set_callback([this]() {
+        try {
+            auto next = reload();
+            if (!next->errors.empty()) {
+                LOG(WARNING, "Routing") << "Routing policy reload completed with "
+                                        << next->errors.size() << " error(s)" << std::endl;
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING, "Routing") << "Routing policy reload failed: "
+                                    << e.what() << std::endl;
+        } catch (...) {
+            LOG(WARNING, "Routing") << "Routing policy reload failed with unknown error"
+                                    << std::endl;
+        }
+    });
+    watcher_->start();
+}
+
+void RoutingPolicyStore::stop_watching() {
+    if (watcher_) {
+        watcher_->stop();
+        watcher_.reset();
+    }
+}
+
+std::shared_ptr<const RoutingPolicyEngine> RoutingPolicyStore::get_engine(
+    const std::string& model_name) const {
+    auto current = snapshot();
+    auto it = current->engines.find(model_name);
+    return it == current->engines.end() ? nullptr : it->second;
+}
+
+std::shared_ptr<const RoutingPolicyStore::Snapshot> RoutingPolicyStore::snapshot() const {
+    return std::atomic_load(&snapshot_);
+}
+
+} // namespace lemon

--- a/src/cpp/server/routing_policy_store.cpp
+++ b/src/cpp/server/routing_policy_store.cpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <filesystem>
 #include <fstream>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <utility>
@@ -70,6 +71,9 @@ std::shared_ptr<const RoutingPolicyStore::Snapshot> RoutingPolicyStore::load_dir
         return next;
     }
 
+    std::map<std::string, std::string> policy_files_by_model;
+    std::set<std::string> duplicate_models;
+
     for (fs::recursive_directory_iterator it(directory_, fs::directory_options::skip_permission_denied, ec), end;
          !ec && it != end; it.increment(ec)) {
         if (ec || !it->is_regular_file(ec) || !is_json_file(it->path())) {
@@ -84,6 +88,27 @@ std::shared_ptr<const RoutingPolicyStore::Snapshot> RoutingPolicyStore::load_dir
             }
 
             const std::string model_name = policy_model_name(doc, it->path());
+            auto [model_file_it, inserted] = policy_files_by_model.emplace(model_name, file);
+            if (!inserted) {
+                duplicate_models.insert(model_name);
+                const std::string first_file = model_file_it->second;
+                next->errors[file] = "duplicate collection.router model_name '" +
+                                     model_name + "' also defined by '" +
+                                     first_file + "'";
+                if (next->errors.count(first_file) == 0) {
+                    next->errors[first_file] =
+                        "duplicate collection.router model_name '" + model_name +
+                        "' also defined by '" + file + "'";
+                }
+                next->engines.erase(model_name);
+                continue;
+            }
+            if (duplicate_models.count(model_name) != 0) {
+                next->errors[file] =
+                    "duplicate collection.router model_name '" + model_name + "'";
+                continue;
+            }
+
             RoutePolicy policy = parse_route_policy_collection(doc, parse_options_);
             auto engine = std::make_shared<RoutingPolicyEngine>(std::move(policy), services_);
             next->engines[model_name] = std::move(engine);

--- a/src/cpp/server/routing_policy_store.cpp
+++ b/src/cpp/server/routing_policy_store.cpp
@@ -3,7 +3,9 @@
 #include "lemon/model_types.h"
 #include "lemon/utils/aixlog.hpp"
 
+#include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <set>
@@ -16,7 +18,10 @@ namespace fs = std::filesystem;
 namespace {
 
 bool is_json_file(const fs::path& path) {
-    return path.has_extension() && path.extension() == ".json";
+    std::string extension = path.extension().string();
+    std::transform(extension.begin(), extension.end(), extension.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return extension == ".json";
 }
 
 json load_json_file(const fs::path& path) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2062,11 +2062,18 @@ nlohmann::json Server::model_info_to_json(const std::string& model_id, const Mod
         model_json["image_defaults"] = img_def;
     }
 
-    // Collections (Omni) additionally embed each component's full model object,
+    if (is_router_collection_recipe(info.recipe)) {
+        auto routing_it = info.extras.find("routing");
+        if (routing_it != info.extras.end() && routing_it->second.is_object()) {
+            model_json["routing"] = routing_it->second;
+        }
+    }
+
+    // Collections additionally embed each component's full model object,
     // in component order, under "models". Embedding is bounded by
     // kMaxCollectionEmbedDepth so nested (or cyclic) collection registrations
     // cannot recurse unboundedly.
-    if (is_collection_recipe(info.recipe) && depth < kMaxCollectionEmbedDepth) {
+    if (is_model_collection_recipe(info.recipe) && depth < kMaxCollectionEmbedDepth) {
         nlohmann::json component_models = nlohmann::json::array();
         for (const auto& component : info.components) {
             if (!model_manager_->model_exists(component)) {
@@ -3828,7 +3835,7 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
             }
         }
 
-        if (is_collection_recipe(recipe)) {
+        if (is_model_collection_recipe(recipe)) {
             if (auto err = model_manager_->validate_collection_request(model_name, request_json)) {
                 bad_request(*err);
                 return;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1826,7 +1826,7 @@ void Server::auto_load_model_if_needed(const std::string& requested_model) {
     auto info = model_manager_->get_model_info(requested_model);
 
     // Collections have no backend of their own — load each component instead.
-    if (is_collection_recipe(info.recipe)) {
+    if (is_omni_collection_recipe(info.recipe)) {
         ensure_collection_loaded(info);
         return;
     }
@@ -2235,7 +2235,7 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
             try {
                 if (model_manager_->model_exists(requested_model)) {
                     ModelInfo info = model_manager_->get_model_info(requested_model);
-                    if (is_collection_recipe(info.recipe)) {
+                    if (is_omni_collection_recipe(info.recipe)) {
                         handle_collection_chat_completions(request_json, info, res);
                         return;
                     }
@@ -4023,14 +4023,14 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
         // Download model if needed (first-time use or missing files). Collections have no
         // checkpoint of their own, so skip the generic HF download path here
         // and let the per-component branch below cascade any missing pieces.
-        if (!model_manager_->is_model_downloaded(model_name) && !is_collection_recipe(info.recipe)) {
+        if (!model_manager_->is_model_downloaded(model_name) && !is_omni_collection_recipe(info.recipe)) {
             LOG(INFO, "Server") << "Model not downloaded, downloading..." << std::endl;
             model_manager_->download_registered_model(info);
             info = model_manager_->get_model_info(model_name);
         }
 
         // Collection models: load each component instead
-        if (is_collection_recipe(info.recipe) && !info.components.empty()) {
+        if (is_omni_collection_recipe(info.recipe) && !info.components.empty()) {
             ensure_collection_loaded(info);
 
             nlohmann::json response = {

--- a/test/app/app-regression/lemonadeTools.test.cjs
+++ b/test/app/app-regression/lemonadeTools.test.cjs
@@ -163,6 +163,23 @@ const tests = [
     },
   },
   {
+    name: 'routing rides through the router collection export/import allowlist',
+    run() {
+      const modelData = readSource('src/app/src/renderer/utils/modelData.ts');
+      assertIncludes(
+        modelData,
+        "'routing',",
+        'EXPORT_KNOWN_KEYS must include routing so collection.router policies round-trip.',
+      );
+      const recipeImport = readSource('src/cpp/cli/recipe_import.cpp');
+      assertIncludes(
+        recipeImport,
+        '"routing"',
+        'kKnownKeys (CLI side) must preserve routing during import/export.',
+      );
+    },
+  },
+  {
     name: 'custom collection draft carries an optional systemPrompt through to the pull request',
     run() {
       const customCollections = readSource('src/app/src/renderer/utils/customCollections.ts');

--- a/test/app/customCollections.test.cjs
+++ b/test/app/customCollections.test.cjs
@@ -181,6 +181,36 @@ defineTest('regular-model export carries no collection fields', () => {
   assert.ok(!('created' in payload));
 });
 
+defineTest('router collection export preserves routing and components', () => {
+  const routing = {
+    candidates: ['local', 'remote'],
+    default_model: 'local',
+    rules: [
+      { id: 'code', match: { keywords_any: ['def '] }, route_to: 'remote' },
+    ],
+  };
+  const raw = {
+    id: 'RouterKit', object: 'model', created: 1234567890, owned_by: 'lemonade',
+    recipe: 'collection.router',
+    checkpoint: '',
+    checkpoints: { main: '' },
+    components: ['local', 'remote'],
+    labels: [],
+    recipe_options: {},
+    routing,
+    suggested: true,
+    downloaded: true,
+  };
+
+  const { filename, payload } = modelDataUtils.normalizeModelExportPayload(raw);
+  assert.equal(filename, 'RouterKit.json');
+  assert.equal(payload.model_name, 'user.RouterKit');
+  assert.deepEqual(payload.components, ['local', 'remote']);
+  assert.deepEqual(payload.routing, routing);
+  assert.ok(!('downloaded' in payload));
+  assert.ok(!('suggested' in payload));
+});
+
 defineTest('DEFAULT_OMNI_SYSTEM_PROMPT is the canonical default from toolDefinitions.json', () => {
   const toolDefinitionsPath = path.join(appRoot, 'src', 'renderer', 'utils', 'toolDefinitions.json');
   const toolDefs = JSON.parse(fs.readFileSync(toolDefinitionsPath, 'utf8'));

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -1,0 +1,129 @@
+// Tests for ModelManager collection registration validation relevant to
+// collection.router policy loading (#2383).
+
+#include "lemon/model_manager.h"
+#include "lemon/utils/path_utils.h"
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace fs = std::filesystem;
+using lemon::ModelManager;
+using lemon::json;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static fs::path make_temp_dir() {
+    fs::path dir = fs::temp_directory_path();
+    dir /= "model_manager_collection_validation_" +
+           std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    fs::create_directories(dir);
+    return dir;
+}
+
+static json component_def(const std::string& name) {
+    return json{
+        {"model_name", name},
+        {"recipe", "llamacpp"},
+        {"checkpoint", "example/" + name + ":Q4_K_M"},
+    };
+}
+
+static json valid_router_collection() {
+    return json{
+        {"model_name", "user.RouterKit"},
+        {"version", "1"},
+        {"recipe", "collection.router"},
+        {"components", {"local", "remote", "pii-detector"}},
+        {"models", {
+            component_def("local"),
+            component_def("remote"),
+            component_def("pii-detector"),
+        }},
+        {"routing", {
+            {"candidates", {"local", "remote"}},
+            {"default_model", "local"},
+            {"classifiers", {{
+                {"id", "pii"},
+                {"type", "classifier"},
+                {"model", "pii-detector"},
+                {"labels", {"PII", "NO_PII"}},
+                {"default_label", "PII"},
+                {"on_error", "match_true"},
+            }}},
+            {"rules", {{
+                {"id", "private-local"},
+                {"match", {{"classifier", "pii"}, {"min_score", 0.5}}},
+                {"route_to", "local"},
+                {"outputs", {{"verdict", "warn"}}},
+            }, {
+                {"id", "code-remote"},
+                {"match", {{"keywords_any", {"def ", "stack trace"}}}},
+                {"route_to", "remote"},
+            }}},
+        }},
+    };
+}
+
+static bool error_contains(const std::optional<std::string>& error,
+                           const std::string& needle) {
+    return error.has_value() && error->find(needle) != std::string::npos;
+}
+
+static void test_accepts_valid_router_policy(ModelManager& manager) {
+    json doc = valid_router_collection();
+    auto err = manager.validate_collection_request("user.RouterKit", doc);
+    check("valid collection.router request passes validation", !err.has_value());
+}
+
+static void test_rejects_bad_routing(ModelManager& manager) {
+    json doc = valid_router_collection();
+    doc["routing"]["rules"][0]["route_to"] = "missing";
+    auto err = manager.validate_collection_request("user.RouterKit", doc);
+    check("invalid route_to in routing is rejected",
+          error_contains(err, "Invalid collection.router routing policy") &&
+          error_contains(err, "not declared in collection.components"));
+
+    json bad_band = valid_router_collection();
+    bad_band["routing"]["rules"][0]["match"]["min_score"] = 0.9;
+    bad_band["routing"]["rules"][0]["match"]["max_score"] = 0.1;
+    err = manager.validate_collection_request("user.RouterKit", bad_band);
+    check("invalid score band is rejected",
+          error_contains(err, "min_score greater than max_score"));
+}
+
+static void test_register_preserves_routing(ModelManager& manager) {
+    json doc = valid_router_collection();
+    manager.register_user_model("user.RouterKit", doc);
+    auto info = manager.get_model_info("user.RouterKit");
+    auto it = info.extras.find("routing");
+    check("registered router collection preserves routing in ModelInfo extras",
+          it != info.extras.end() && it->second == doc["routing"]);
+}
+
+int main() {
+    fs::path temp = make_temp_dir();
+    lemon::utils::set_cache_dir(temp.string());
+
+    ModelManager manager;
+    test_accepts_valid_router_policy(manager);
+    test_rejects_bad_routing(manager);
+    test_register_preserves_routing(manager);
+
+    fs::remove_all(temp);
+
+    if (g_failures == 0) {
+        std::printf("All model manager collection validation tests passed.\n");
+    } else {
+        std::printf("%d model manager collection validation test(s) failed.\n", g_failures);
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -98,6 +98,12 @@ static void test_rejects_bad_routing(ModelManager& manager) {
     err = manager.validate_collection_request("user.RouterKit", bad_band);
     check("invalid score band is rejected",
           error_contains(err, "min_score greater than max_score"));
+
+    json bad_regex = valid_router_collection();
+    bad_regex["routing"]["rules"][1]["match"] = {{"regex", "(a+)+"}};
+    err = manager.validate_collection_request("user.RouterKit", bad_regex);
+    check("compile-time leaf validation rejects catastrophic regex",
+          error_contains(err, "catastrophic backtracking"));
 }
 
 static void test_register_preserves_routing(ModelManager& manager) {

--- a/test/cpp/test_routing_policy_parser.cpp
+++ b/test/cpp/test_routing_policy_parser.cpp
@@ -1,0 +1,198 @@
+// Unit tests for the Lemonade Router policy parser (#2383).
+//
+// Covers JSON -> RoutePolicy parsing, component canonicalization, validation
+// errors, and schema/parser key parity against route_policy.schema.json.
+
+#include "fake_classifier_services.h"
+#include "lemon/routing_policy.h"
+#include "lemon/routing_policy_parser.h"
+
+#include <cstdio>
+#include <fstream>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#ifndef ROUTING_FIXTURE_DIR
+#define ROUTING_FIXTURE_DIR "test/cpp/fixtures/routing"
+#endif
+
+#ifndef ROUTING_SCHEMA_FILE
+#define ROUTING_SCHEMA_FILE "src/cpp/resources/schemas/route_policy.schema.json"
+#endif
+
+using lemon::Decision;
+using lemon::RouteContext;
+using lemon::RoutePolicy;
+using lemon::RoutingPolicyEngine;
+using lemon::RoutingPolicyParseOptions;
+using lemon::json;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static json load_json_file(const std::string& path) {
+    std::ifstream in(path);
+    if (!in) {
+        throw std::runtime_error("could not open " + path);
+    }
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return json::parse(ss.str());
+}
+
+static json fixture(const std::string& name) {
+    return load_json_file(std::string(ROUTING_FIXTURE_DIR) + "/" + name);
+}
+
+static RouteContext request(const std::string& input) {
+    RouteContext ctx;
+    ctx.input = input;
+    ctx.params.chars = input.size();
+    return ctx;
+}
+
+static bool throws_with(const json& doc, const std::string& expected) {
+    try {
+        lemon::parse_route_policy_collection(doc);
+    } catch (const std::invalid_argument& e) {
+        return std::string(e.what()).find(expected) != std::string::npos;
+    } catch (...) {
+        return false;
+    }
+    return false;
+}
+
+static std::set<std::string> schema_property_keys(const json& node) {
+    std::set<std::string> keys;
+    for (const auto& [key, _] : node.items()) {
+        keys.insert(key);
+    }
+    return keys;
+}
+
+static void check_keys(const char* name,
+                       const std::set<std::string>& actual,
+                       const std::set<std::string>& expected) {
+    if (actual == expected) {
+        check(name, true);
+        return;
+    }
+    std::printf("[FAIL] %s\n", name);
+    std::printf("  parser keys:");
+    for (const auto& key : actual) std::printf(" %s", key.c_str());
+    std::printf("\n  schema keys:");
+    for (const auto& key : expected) std::printf(" %s", key.c_str());
+    std::printf("\n");
+    ++g_failures;
+}
+
+static void test_parse_keywords_fixture_and_route() {
+    json doc = fixture("l1_keywords.json");
+    RoutePolicy policy = lemon::parse_route_policy_collection(doc);
+    check("parser reads candidates", policy.candidates.size() == 2);
+    check("parser reads default_model", policy.default_model == "Qwen3-8B-GGUF");
+    check("parser reads rules", policy.rules.size() == 2);
+
+    lemon::testing::FakeClassifierServices fake;
+    RoutingPolicyEngine engine(std::move(policy), fake.make());
+
+    Decision code = engine.route(request("please fix this stack trace"), false);
+    check("parsed deterministic rule routes matching request",
+          code.route_to == "vllm.qwen3-32b" && code.matched_rule == "code-to-big");
+
+    Decision plain = engine.route(request("hello"), false);
+    check("parsed policy falls open to default",
+          plain.route_to == "Qwen3-8B-GGUF" && plain.default_used);
+}
+
+static void test_component_resolver_canonicalizes_policy() {
+    json doc = fixture("l1_keywords.json");
+    RoutingPolicyParseOptions options;
+    options.resolve_component = [](const std::string& name) -> std::optional<std::string> {
+        if (name == "Qwen3-8B-GGUF") return "builtin.Qwen3-8B-GGUF";
+        if (name == "vllm.qwen3-32b") return "user.vllm.qwen3-32b";
+        return std::nullopt;
+    };
+
+    RoutePolicy policy = lemon::parse_route_policy_collection(doc, options);
+    check("resolver canonicalizes candidates",
+          policy.candidates[0] == "builtin.Qwen3-8B-GGUF" &&
+          policy.candidates[1] == "user.vllm.qwen3-32b");
+    check("resolver canonicalizes default_model",
+          policy.default_model == "builtin.Qwen3-8B-GGUF");
+    check("resolver canonicalizes route_to",
+          policy.rules[0].route_to == "user.vllm.qwen3-32b");
+}
+
+static void test_validation_errors_are_clear() {
+    json unknown_version = fixture("l1_keywords.json");
+    unknown_version["version"] = "2";
+    check("unknown schema major rejected clearly",
+          throws_with(unknown_version, "Unsupported collection.router schema major"));
+
+    json bad_route = fixture("l1_keywords.json");
+    bad_route["routing"]["rules"][0]["route_to"] = "missing-model";
+    check("unknown route_to component rejected",
+          throws_with(bad_route, "not declared in collection.components"));
+
+    json dangling_classifier = fixture("l2_semantic.json");
+    dangling_classifier["routing"]["rules"][0]["match"]["classifier"] = "missing";
+    check("dangling classifier reference rejected",
+          throws_with(dangling_classifier, "unknown classifier"));
+
+    json bad_band = fixture("l3_classifier.json");
+    bad_band["routing"]["rules"][0]["match"]["any"][0]["min_score"] = 0.9;
+    bad_band["routing"]["rules"][0]["match"]["any"][0]["max_score"] = 0.1;
+    check("malformed score band rejected",
+          throws_with(bad_band, "min_score greater than max_score"));
+
+    json router_sugar = fixture("l0a_llm_router.json");
+    check("routing.router is recognized but deferred to #2405",
+          throws_with(router_sugar, "routing.router desugaring"));
+}
+
+static void test_schema_parser_key_parity() {
+    json schema = load_json_file(ROUTING_SCHEMA_FILE);
+    check_keys("root keys match schema",
+               lemon::routing_policy_root_keys(),
+               schema_property_keys(schema["properties"]));
+    check_keys("routing keys match schema",
+               lemon::routing_block_keys(),
+               schema_property_keys(schema["$defs"]["routing"]["properties"]));
+    check_keys("router sugar keys match schema",
+               lemon::routing_router_keys(),
+               schema_property_keys(schema["$defs"]["router_sugar"]["properties"]));
+    check_keys("classifier keys match schema",
+               lemon::routing_classifier_keys(),
+               schema_property_keys(schema["$defs"]["classifier"]["properties"]));
+    check_keys("rule keys match schema",
+               lemon::routing_rule_keys(),
+               schema_property_keys(schema["$defs"]["rule"]["properties"]));
+    check_keys("match expr keys match schema",
+               lemon::routing_match_expr_keys(),
+               schema_property_keys(schema["$defs"]["match_expr"]["properties"]));
+    check_keys("metadata keys match schema",
+               lemon::routing_metadata_match_keys(),
+               schema_property_keys(schema["$defs"]["metadata_match"]["properties"]));
+}
+
+int main() {
+    test_parse_keywords_fixture_and_route();
+    test_component_resolver_canonicalizes_policy();
+    test_validation_errors_are_clear();
+    test_schema_parser_key_parity();
+
+    if (g_failures == 0) {
+        std::printf("All routing policy parser tests passed.\n");
+    } else {
+        std::printf("%d routing policy parser test(s) failed.\n", g_failures);
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_routing_policy_store.cpp
+++ b/test/cpp/test_routing_policy_store.cpp
@@ -1,0 +1,155 @@
+// Unit tests for the directory-backed RoutingPolicyStore (#2383).
+
+#include "fake_classifier_services.h"
+#include "lemon/routing_policy_store.h"
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#ifndef ROUTING_FIXTURE_DIR
+#define ROUTING_FIXTURE_DIR "test/cpp/fixtures/routing"
+#endif
+
+namespace fs = std::filesystem;
+using lemon::Decision;
+using lemon::RouteContext;
+using lemon::RoutingPolicyStore;
+using lemon::json;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static json load_fixture(const std::string& name) {
+    std::ifstream in(std::string(ROUTING_FIXTURE_DIR) + "/" + name);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return json::parse(ss.str());
+}
+
+static void write_json(const fs::path& path, const json& doc) {
+    std::ofstream out(path);
+    out << doc.dump(2) << "\n";
+}
+
+static fs::path make_temp_dir() {
+    fs::path dir = fs::temp_directory_path();
+    dir /= "routing_policy_store_test_" +
+           std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    fs::create_directories(dir);
+    return dir;
+}
+
+static RouteContext request(const std::string& input) {
+    RouteContext ctx;
+    ctx.input = input;
+    ctx.params.chars = input.size();
+    return ctx;
+}
+
+static void test_reload_swaps_snapshot() {
+    fs::path dir = make_temp_dir();
+    fs::path policy_path = dir / "router.json";
+    json doc = load_fixture("l1_keywords.json");
+    write_json(policy_path, doc);
+
+    lemon::testing::FakeClassifierServices fake;
+    RoutingPolicyStore store(dir.string(), fake.make());
+    auto first_snapshot = store.reload();
+    auto first_engine = store.get_engine("user.Router-Keywords");
+    check("initial reload loads one engine",
+          first_snapshot->engines.size() == 1 && first_engine != nullptr);
+
+    Decision first = first_engine->route(request("please fix this stack trace"), false);
+    check("initial engine routes with original policy",
+          first.route_to == "vllm.qwen3-32b");
+
+    doc["routing"]["rules"][0]["route_to"] = "Qwen3-8B-GGUF";
+    write_json(policy_path, doc);
+    auto second_snapshot = store.reload();
+    auto second_engine = store.get_engine("user.Router-Keywords");
+
+    check("manual reload swaps engine shared_ptr",
+          second_snapshot->engines.size() == 1 && second_engine != nullptr &&
+          second_engine != first_engine);
+    Decision second = second_engine->route(request("please fix this stack trace"), false);
+    check("reloaded engine uses updated policy",
+          second.route_to == "Qwen3-8B-GGUF");
+
+    fs::remove_all(dir);
+}
+
+static void test_directory_watcher_reload() {
+    fs::path dir = make_temp_dir();
+    fs::path policy_path = dir / "router.json";
+    json doc = load_fixture("l1_keywords.json");
+    write_json(policy_path, doc);
+
+    lemon::testing::FakeClassifierServices fake;
+    RoutingPolicyStore store(dir.string(), fake.make());
+    store.start_watching();
+    auto first_engine = store.get_engine("user.Router-Keywords");
+    check("watcher initial load has engine", first_engine != nullptr);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    doc["routing"]["rules"][0]["route_to"] = "Qwen3-8B-GGUF";
+    write_json(policy_path, doc);
+
+    std::shared_ptr<const lemon::RoutingPolicyEngine> next_engine;
+    for (int i = 0; i < 30; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+        next_engine = store.get_engine("user.Router-Keywords");
+        if (next_engine && next_engine != first_engine) {
+            break;
+        }
+    }
+
+    check("DirectoryWatcher triggers engine swap",
+          next_engine != nullptr && next_engine != first_engine);
+    if (next_engine) {
+        Decision routed = next_engine->route(request("please fix this stack trace"), false);
+        check("watcher-reloaded engine uses updated policy",
+              routed.route_to == "Qwen3-8B-GGUF");
+    }
+    store.stop_watching();
+    fs::remove_all(dir);
+}
+
+static void test_invalid_policy_reports_error() {
+    fs::path dir = make_temp_dir();
+    fs::path policy_path = dir / "bad.json";
+    json doc = load_fixture("l1_keywords.json");
+    doc["routing"]["rules"][0]["route_to"] = "missing-model";
+    write_json(policy_path, doc);
+
+    lemon::testing::FakeClassifierServices fake;
+    RoutingPolicyStore store(dir.string(), fake.make());
+    auto snapshot = store.reload();
+    check("invalid policy does not load an engine", snapshot->engines.empty());
+    check("invalid policy records clear error", !snapshot->errors.empty() &&
+          snapshot->errors.begin()->second.find("not declared") != std::string::npos);
+
+    fs::remove_all(dir);
+}
+
+int main() {
+    test_reload_swaps_snapshot();
+    test_directory_watcher_reload();
+    test_invalid_policy_reports_error();
+
+    if (g_failures == 0) {
+        std::printf("All routing policy store tests passed.\n");
+    } else {
+        std::printf("%d routing policy store test(s) failed.\n", g_failures);
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_routing_policy_store.cpp
+++ b/test/cpp/test_routing_policy_store.cpp
@@ -141,10 +141,31 @@ static void test_invalid_policy_reports_error() {
     fs::remove_all(dir);
 }
 
+static void test_duplicate_policy_model_names_report_errors() {
+    fs::path dir = make_temp_dir();
+    json doc = load_fixture("l1_keywords.json");
+    write_json(dir / "first.json", doc);
+    write_json(dir / "second.json", doc);
+
+    lemon::testing::FakeClassifierServices fake;
+    RoutingPolicyStore store(dir.string(), fake.make());
+    auto snapshot = store.reload();
+
+    check("duplicate policy model names do not load an arbitrary engine",
+          snapshot->engines.empty());
+    check("duplicate policy model names record per-file errors",
+          snapshot->errors.size() == 2 &&
+          snapshot->errors.begin()->second.find("duplicate collection.router model_name") !=
+              std::string::npos);
+
+    fs::remove_all(dir);
+}
+
 int main() {
     test_reload_swaps_snapshot();
     test_directory_watcher_reload();
     test_invalid_policy_reports_error();
+    test_duplicate_policy_model_names_report_errors();
 
     if (g_failures == 0) {
         std::printf("All routing policy store tests passed.\n");

--- a/test/cpp/test_routing_policy_store.cpp
+++ b/test/cpp/test_routing_policy_store.cpp
@@ -141,6 +141,22 @@ static void test_invalid_policy_reports_error() {
     fs::remove_all(dir);
 }
 
+static void test_uppercase_json_extension_loads_policy() {
+    fs::path dir = make_temp_dir();
+    fs::path policy_path = dir / "router.JSON";
+    json doc = load_fixture("l1_keywords.json");
+    write_json(policy_path, doc);
+
+    lemon::testing::FakeClassifierServices fake;
+    RoutingPolicyStore store(dir.string(), fake.make());
+    auto snapshot = store.reload();
+
+    check("uppercase .JSON policy file extension is accepted",
+          snapshot->engines.count("user.Router-Keywords") == 1);
+
+    fs::remove_all(dir);
+}
+
 static void test_duplicate_policy_model_names_report_errors() {
     fs::path dir = make_temp_dir();
     json doc = load_fixture("l1_keywords.json");
@@ -165,6 +181,7 @@ int main() {
     test_reload_swaps_snapshot();
     test_directory_watcher_reload();
     test_invalid_policy_reports_error();
+    test_uppercase_json_extension_loads_policy();
     test_duplicate_policy_model_names_report_errors();
 
     if (g_failures == 0) {


### PR DESCRIPTION
## Summary

  Closes #2383.

  Implements the Lemonade Router M9 policy-loading slice for `collection.router`.

  This adds a backend-free parser that converts validated `collection.router` JSON into `RoutePolicy`, a directory-backed hot-reload store that compiles policies into `RoutingPolicyEngine` instances and atomically swaps snapshots on file changes, and import/export plumbing so router `routing` blocks survive
  round trips.

  ## What Changed

  - Added `routing_policy_parser`:
    - parses `collection.router` JSON into `RoutePolicy`
    - resolves candidates, `default_model`, `route_to`, and classifier model references through an injectable component resolver
    - validates dangling classifier refs, unknown route/default components, malformed score bands, unknown keys, and unsupported schema versions
    - adds parser key registries for schema/parser parity tests
    - explicitly rejects `routing.router` with a clear message, leaving L0a desugaring for #2405

  - Added `routing_policy_store`:
    - loads router policy JSON files from a directory
    - compiles each valid policy into a `RoutingPolicyEngine`
    - tracks per-file load errors without crashing
    - uses `DirectoryWatcher` and atomic `shared_ptr` snapshot swaps for hot reload
    - documents that live server dispatch attachment is owned by #2385

  - Added `collection.router` metadata support:
    - introduces `COLLECTION_ROUTER_MODEL_RECIPE`
    - adds generic collection-recipe handling where registration/cache/export needs to treat both `collection.omni` and `collection.router` as collection metadata
    - preserves `routing` in user model registration
    - surfaces `routing` through `/models/{id}` for router collections
    - adds `routing` to CLI and desktop export/import allowlists

  - Added focused tests and CI coverage:
    - parser behavior and schema/parser key parity
    - directory watcher reload and engine snapshot swap
    - `/pull`-style `ModelManager::validate_collection_request()` checks for router policies
    - registration preserving `routing` in `ModelInfo::extras`
    - app-side allowlist/export regression coverage
    - CI builds and runs the new C++ routing policy tests

  ## Notes

  `routing.router` is intentionally not implemented in this PR. The schema recognizes it, but executing it requires the LLM router classifier and desugaring work tracked separately in #2405. For now, parser validation fails early with a clear message instead of accepting a policy that cannot execute.

  This PR also does not attach the policy store to live request dispatch. The store is the module-level hot-reload implementation for M9; #2385 owns wiring it into the server request path.

  ## Validation

  Ran locally:

  ```bash
  cmake --preset default
  cmake --build --preset default --target test_routing_policy_parser
  cmake --build --preset default --target test_routing_policy_store
  cmake --build --preset default --target test_model_manager_collection_validation
  ctest --test-dir build --output-on-failure -R "RoutingPolicy(Parser|Store)Test"
  ctest --test-dir build --output-on-failure -R "RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest"
  cmake --build --preset default --target lemond
  python test/test_routing_fixtures.py
  python test/test_schema_lock.py
  git diff --check