### PR TITLE
fix(installer): add missing architecture_defaults.json to MSI

### DIFF
--- a/src/cpp/installer/Product.wxs.in
+++ b/src/cpp/installer/Product.wxs.in
@@ -208,6 +208,10 @@
         <File Id="toolDefinitions.json" Source="$(var.BuildDir)\Release\resources\toolDefinitions.json" KeyPath="yes" />
       </Component>
 
+      <Component Id="ArchitectureDefaultsJson" Directory="ResourcesDir" Guid="f04a62d1-8b3e-4c2a-9f5d-7e1b8c3a0d4e">
+        <File Id="architecture_defaults.json" Source="$(var.BuildDir)\Release\resources\architecture_defaults.json" KeyPath="yes" />
+      </Component>
+
       <Component Id="FaviconIco" Directory="StaticDir" Guid="c0d1e2f3-a4b5-4c6d-7e8f-9a0b1c2d3e4f">
         <File Id="favicon.ico" Source="$(var.BuildDir)\Release\resources\static\favicon.ico" KeyPath="yes" />
       </Component>


### PR DESCRIPTION
The resource file `architecture_defaults.json` exists in the source tree and in the build output, but was not listed in the WiX `Product.wxs.in` component group. The MSI therefore never copies it to the install directory, causing a warning on every server startup:

Warn (ModelManager) Could not load architecture_defaults.json: Failed to open file: ...\resources/architecture_defaults.json

Add the missing component to the WiX installer.

Closes #2522.