### PR TITLE
fix: support nested schemas and handle client disconnects in responses telemetry

### DIFF
--- a/src/cpp/include/lemon/streaming_proxy.h
+++ b/src/cpp/include/lemon/streaming_proxy.h
@@ -54,8 +54,11 @@ public:
 
     static void process_sse_lines(std::string& line_buffer, std::function<void(const std::string&)> line_callback);
 
-private:
     static TelemetryData parse_telemetry(const std::string& buffer);
+
+    static void accumulate_responses_delta(const nlohmann::json& parsed, std::string& accumulated_text);
+
+private:
 };
 
 } // namespace lemon

--- a/src/cpp/server/backends/cloud/cloud_server.cpp
+++ b/src/cpp/server/backends/cloud/cloud_server.cpp
@@ -11,6 +11,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
+#include <curl/curl.h>
 #include <string_view>
 #include <utility>
 #include <lemon/utils/aixlog.hpp>
@@ -634,6 +635,22 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
                 timeout_seconds
             );
 
+            if (result.curl_code != CURLE_OK) {
+                if (result.curl_code == CURLE_WRITE_ERROR) {
+                    LOG(WARNING, "Cloud") << "Client disconnected during stream: CURL error: " << result.curl_error << std::endl;
+                    if (telemetry_callback) {
+                        telemetry_callback(0, 0, 0.0, 0.0, "Client disconnected during stream");
+                    }
+                    return;
+                } else if (result.curl_code == CURLE_PARTIAL_FILE || result.curl_code == CURLE_RECV_ERROR) {
+                    if (!has_done_marker) {
+                        throw std::runtime_error("backend connection failed during SSE stream before DONE: CURL error: " + result.curl_error);
+                    }
+                } else {
+                    throw std::runtime_error("SSE stream failed: CURL error: " + result.curl_error);
+                }
+            }
+
             if (result.status_code != 200) {
                 LOG(ERROR, "Cloud") << "Provider returned status " << result.status_code
                                     << ", body: " << body_buffer.substr(0, 200) << std::endl;
@@ -671,7 +688,7 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
                 telemetry_callback(input_tokens, output_tokens, time_to_first_token, tokens_per_second, "");
             }
         } else {
-            auto result = utils::HttpClient::post_stream(
+            utils::HttpResponse result = utils::HttpClient::post_stream(
                 url,
                 forwarded_body,
                 [&sink](const char* data, size_t length) {
@@ -680,6 +697,17 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
                 headers,
                 timeout_seconds
             );
+            if (result.curl_code != CURLE_OK) {
+                if (result.curl_code == CURLE_WRITE_ERROR) {
+                    LOG(WARNING, "Cloud") << "Client disconnected during stream: CURL error: " << result.curl_error << std::endl;
+                    if (telemetry_callback) {
+                        telemetry_callback(0, 0, 0.0, 0.0, "Client disconnected during stream");
+                    }
+                    return;
+                } else {
+                    throw std::runtime_error("Request failed: CURL error: " + result.curl_error);
+                }
+            }
             if (result.status_code != 200) {
                 LOG(ERROR, "Cloud") << "Provider returned status " << result.status_code << std::endl;
                 if (telemetry_callback) {

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -1088,10 +1088,18 @@ json Router::chat_completion(const json& request) {
             } else {
                 nlohmann::json usage_payload = nlohmann::json::object();
                 std::string text_output = "";
-                if (response.contains("usage")) {
+                if (response.contains("usage") && response["usage"].is_object()) {
                     auto usage = response["usage"];
-                    if (usage.contains("prompt_tokens")) usage_payload["prompt_tokens"] = usage["prompt_tokens"].get<int>();
-                    if (usage.contains("completion_tokens")) usage_payload["completion_tokens"] = usage["completion_tokens"].get<int>();
+                    if (usage.contains("prompt_tokens")) {
+                        usage_payload["prompt_tokens"] = usage["prompt_tokens"].get<int>();
+                    } else if (usage.contains("input_tokens")) {
+                        usage_payload["prompt_tokens"] = usage["input_tokens"].get<int>();
+                    }
+                    if (usage.contains("completion_tokens")) {
+                        usage_payload["completion_tokens"] = usage["completion_tokens"].get<int>();
+                    } else if (usage.contains("output_tokens")) {
+                        usage_payload["completion_tokens"] = usage["output_tokens"].get<int>();
+                    }
                 }
                 if (response.contains("timings")) {
                     auto timings = response["timings"];
@@ -1179,10 +1187,18 @@ json Router::completion(const json& request) {
             } else {
                 nlohmann::json usage_payload = nlohmann::json::object();
                 std::string text_output = "";
-                if (response.contains("usage")) {
+                if (response.contains("usage") && response["usage"].is_object()) {
                     auto usage = response["usage"];
-                    if (usage.contains("prompt_tokens")) usage_payload["prompt_tokens"] = usage["prompt_tokens"].get<int>();
-                    if (usage.contains("completion_tokens")) usage_payload["completion_tokens"] = usage["completion_tokens"].get<int>();
+                    if (usage.contains("prompt_tokens")) {
+                        usage_payload["prompt_tokens"] = usage["prompt_tokens"].get<int>();
+                    } else if (usage.contains("input_tokens")) {
+                        usage_payload["prompt_tokens"] = usage["input_tokens"].get<int>();
+                    }
+                    if (usage.contains("completion_tokens")) {
+                        usage_payload["completion_tokens"] = usage["completion_tokens"].get<int>();
+                    } else if (usage.contains("output_tokens")) {
+                        usage_payload["completion_tokens"] = usage["output_tokens"].get<int>();
+                    }
                 }
 
                 if (response.contains("choices") && response["choices"].is_array() && !response["choices"].empty()) {
@@ -1239,9 +1255,13 @@ json Router::embeddings(const json& request) {
                 span->end_with_error(error_msg);
             } else {
                 nlohmann::json usage_payload = nlohmann::json::object();
-                if (response.contains("usage")) {
+                if (response.contains("usage") && response["usage"].is_object()) {
                     auto usage = response["usage"];
-                    if (usage.contains("prompt_tokens")) usage_payload["prompt_tokens"] = usage["prompt_tokens"].get<int>();
+                    if (usage.contains("prompt_tokens")) {
+                        usage_payload["prompt_tokens"] = usage["prompt_tokens"].get<int>();
+                    } else if (usage.contains("input_tokens")) {
+                        usage_payload["prompt_tokens"] = usage["input_tokens"].get<int>();
+                    }
                     if (usage.contains("total_tokens")) usage_payload["total_tokens"] = usage["total_tokens"].get<int>();
                 }
                 std::string output_dump = "";
@@ -1291,9 +1311,13 @@ json Router::reranking(const json& request) {
                 span->end_with_error(error_msg);
             } else {
                 nlohmann::json usage_payload = nlohmann::json::object();
-                if (response.contains("usage")) {
+                if (response.contains("usage") && response["usage"].is_object()) {
                     auto usage = response["usage"];
-                    if (usage.contains("prompt_tokens")) usage_payload["prompt_tokens"] = usage["prompt_tokens"].get<int>();
+                    if (usage.contains("prompt_tokens")) {
+                        usage_payload["prompt_tokens"] = usage["prompt_tokens"].get<int>();
+                    } else if (usage.contains("input_tokens")) {
+                        usage_payload["prompt_tokens"] = usage["input_tokens"].get<int>();
+                    }
                     if (usage.contains("total_tokens")) usage_payload["total_tokens"] = usage["total_tokens"].get<int>();
                 }
                 span->end_with_success(usage_payload, response.dump());
@@ -1943,15 +1967,7 @@ void Router::responses_stream(const std::string& request_body, httplib::DataSink
                     try {
                         auto parsed = json::parse(json_str);
                         if (!hide_outputs) {
-                            if (parsed.contains("choices") && parsed["choices"].is_array() && !parsed["choices"].empty()) {
-                                auto delta = parsed["choices"][0]["delta"];
-                                if (delta.contains("content") && delta["content"].is_string()) {
-                                    *accumulated_text += delta["content"].get<std::string>();
-                                }
-                            }
-                            if (parsed.contains("response") && parsed["response"].is_string()) {
-                                *accumulated_text += parsed["response"].get<std::string>();
-                            }
+                            StreamingProxy::accumulate_responses_delta(parsed, *accumulated_text);
                         }
                     } catch (...) {}
                 }

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -9,6 +9,61 @@
 
 namespace lemon {
 
+namespace {
+
+void extract_telemetry_from_chunk(const nlohmann::json& chunk, StreamingProxy::TelemetryData& telemetry) {
+    nlohmann::json usage;
+    if (chunk.contains("usage")) {
+        usage = chunk["usage"];
+    } else if (chunk.contains("response") && chunk["response"].is_object() && chunk["response"].contains("usage")) {
+        usage = chunk["response"]["usage"];
+    }
+
+    if (usage.is_object()) {
+        if (usage.contains("prompt_tokens")) {
+            telemetry.input_tokens = usage["prompt_tokens"].get<int>();
+        } else if (usage.contains("input_tokens")) {
+            telemetry.input_tokens = usage["input_tokens"].get<int>();
+        }
+        if (usage.contains("completion_tokens")) {
+            telemetry.output_tokens = usage["completion_tokens"].get<int>();
+        } else if (usage.contains("output_tokens")) {
+            telemetry.output_tokens = usage["output_tokens"].get<int>();
+        }
+        if (usage.contains("prefill_duration_ttft")) {
+            telemetry.time_to_first_token = usage["prefill_duration_ttft"].get<double>();
+        }
+        if (usage.contains("decoding_speed_tps")) {
+            telemetry.tokens_per_second = usage["decoding_speed_tps"].get<double>();
+        }
+    }
+
+    nlohmann::json timings;
+    if (chunk.contains("timings")) {
+        timings = chunk["timings"];
+    } else if (chunk.contains("response") && chunk["response"].is_object() && chunk["response"].contains("timings")) {
+        timings = chunk["response"]["timings"];
+    }
+
+    if (timings.is_object()) {
+        if (timings.contains("prompt_n")) {
+            telemetry.input_tokens = timings["prompt_n"].get<int>();
+        }
+        if (timings.contains("predicted_n")) {
+            telemetry.output_tokens = timings["predicted_n"].get<int>();
+        }
+        if (timings.contains("prompt_ms")) {
+            telemetry.time_to_first_token = timings["prompt_ms"].get<double>() / 1000.0;
+        }
+        if (timings.contains("predicted_per_second")) {
+            telemetry.tokens_per_second = timings["predicted_per_second"].get<double>();
+        }
+    }
+}
+
+} // namespace
+
+
 void StreamingProxy::forward_sse_stream(
     const std::string& backend_url,
     const std::string& request_body,
@@ -35,41 +90,12 @@ void StreamingProxy::forward_sse_stream(
         if (!json_str.empty() && json_str != "[DONE]") {
             try {
                 auto chunk = json::parse(json_str);
-                if (chunk.contains("usage")) {
-                    auto usage = chunk["usage"];
-                    if (usage.contains("prompt_tokens")) {
-                        telemetry.input_tokens = usage["prompt_tokens"].get<int>();
-                    }
-                    if (usage.contains("completion_tokens")) {
-                        telemetry.output_tokens = usage["completion_tokens"].get<int>();
-                    }
-                    if (usage.contains("prefill_duration_ttft")) {
-                        telemetry.time_to_first_token = usage["prefill_duration_ttft"].get<double>();
-                    }
-                    if (usage.contains("decoding_speed_tps")) {
-                        telemetry.tokens_per_second = usage["decoding_speed_tps"].get<double>();
-                    }
-                }
-                if (chunk.contains("timings")) {
-                    auto timings = chunk["timings"];
-                    if (timings.contains("prompt_n")) {
-                        telemetry.input_tokens = timings["prompt_n"].get<int>();
-                    }
-                    if (timings.contains("predicted_n")) {
-                        telemetry.output_tokens = timings["predicted_n"].get<int>();
-                    }
-                    if (timings.contains("prompt_ms")) {
-                        telemetry.time_to_first_token = timings["prompt_ms"].get<double>() / 1000.0;
-                    }
-                    if (timings.contains("predicted_per_second")) {
-                        telemetry.tokens_per_second = timings["predicted_per_second"].get<double>();
-                    }
-                }
+                extract_telemetry_from_chunk(chunk, telemetry);
             } catch (...) {}
         }
     };
 
-    auto result = utils::HttpClient::post_stream(
+    utils::HttpResponse result = utils::HttpClient::post_stream(
         backend_url,
         request_body,
         [&sink, &line_buffer, &has_done_marker, &has_first_token,
@@ -105,21 +131,32 @@ void StreamingProxy::forward_sse_stream(
     const bool transport_interrupted =
         result.curl_code == CURLE_PARTIAL_FILE || result.curl_code == CURLE_RECV_ERROR;
 
+    if (result.curl_code != CURLE_OK) {
+        if (result.curl_code == CURLE_WRITE_ERROR) {
+            stream_error = true;
+            LOG(WARNING, "StreamingProxy") << "Client disconnected during SSE stream (CURL error: " << result.curl_error << ")" << std::endl;
+            telemetry.error_message = "Client disconnected during stream";
+        } else if (transport_interrupted) {
+            if (!has_done_marker) {
+                // This is the important crash path: HTTP headers may have been sent and
+                // some bytes may even have reached the client, but the SSE protocol never
+                // completed. Do not synthesize [DONE], because that hides backend crashes
+                // from the router and leaves stale loaded-model state behind.
+                throw std::runtime_error(
+                    "backend connection failed during SSE stream before DONE: CURL error: " +
+                    result.curl_error);
+            }
+        } else {
+            stream_error = true;
+            LOG(ERROR, "StreamingProxy") << "SSE stream failed: CURL error: " << result.curl_error << std::endl;
+            telemetry.error_message = "SSE stream failed: CURL error: " + result.curl_error;
+        }
+    }
+
     if (result.status_code != 200) {
         stream_error = true;
         LOG(ERROR, "StreamingProxy") << "Backend returned error: " << result.status_code << std::endl;
         telemetry.error_message = "Backend returned error status code: " + std::to_string(result.status_code);
-    }
-
-    if (transport_interrupted && !has_done_marker) {
-        // This is the important crash path: HTTP headers may have been sent and
-        // some bytes may even have reached the client, but the SSE protocol never
-        // completed. Do not synthesize [DONE], because that hides backend crashes
-        // from the router and leaves stale loaded-model state behind.
-        stream_error = true;
-        throw std::runtime_error(
-            "backend connection failed during SSE stream before DONE: CURL error: " +
-            result.curl_error);
     }
 
     if (!stream_error) {
@@ -176,7 +213,7 @@ void StreamingProxy::forward_byte_stream(
 
     bool stream_error = false;
 
-    auto result = utils::HttpClient::post_stream(
+    utils::HttpResponse result = utils::HttpClient::post_stream(
         backend_url,
         request_body,
         [&sink, &on_chunk](const char* data, size_t length) {
@@ -197,19 +234,25 @@ void StreamingProxy::forward_byte_stream(
     const bool transport_interrupted =
         result.curl_code == CURLE_PARTIAL_FILE || result.curl_code == CURLE_RECV_ERROR;
 
+    if (result.curl_code != CURLE_OK) {
+        stream_error = true;
+        if (result.curl_code == CURLE_WRITE_ERROR) {
+            LOG(WARNING, "StreamingProxy") << "Client disconnected during byte stream (CURL error: " << result.curl_error << ")" << std::endl;
+        } else if (transport_interrupted) {
+            // Keep byte streams consistent with SSE: an interrupted transport is a
+            // backend failure, not a clean stream completion. The caller will mark
+            // the backend unavailable and reload after the current response unwinds.
+            throw std::runtime_error(
+                "backend connection failed during byte stream: CURL error: " +
+                result.curl_error);
+        } else {
+            LOG(ERROR, "StreamingProxy") << "Byte stream failed: CURL error: " << result.curl_error << std::endl;
+        }
+    }
+
     if (result.status_code != 200) {
         stream_error = true;
         LOG(ERROR, "StreamingProxy") << "Backend returned error: " << result.status_code << std::endl;
-    }
-
-    if (transport_interrupted) {
-        // Keep byte streams consistent with SSE: an interrupted transport is a
-        // backend failure, not a clean stream completion. The caller will mark
-        // the backend unavailable and reload after the current response unwinds.
-        stream_error = true;
-        throw std::runtime_error(
-            "backend connection failed during byte stream: CURL error: " +
-            result.curl_error);
     }
 
     if (!stream_error) {
@@ -228,67 +271,30 @@ StreamingProxy::TelemetryData StreamingProxy::parse_telemetry(const std::string&
     json last_chunk_with_usage;
 
     while (std::getline(stream, line)) {
-        // Handle SSE format (data: ...)
         std::string json_str;
         if (line.find("data: ") == 0) {
-            json_str = line.substr(6); // Remove "data: " prefix
+            json_str = line.substr(6);
         } else if (line.find("ChatCompletionChunk: ") == 0) {
-            // FLM debug format
-            json_str = line.substr(21); // Remove "ChatCompletionChunk: " prefix
+            json_str = line.substr(21);
         }
 
         if (!json_str.empty() && json_str != "[DONE]") {
             try {
                 auto chunk = json::parse(json_str);
-                // Look for usage or timings in the chunk
-                if (chunk.contains("usage") || chunk.contains("timings")) {
+                bool has_usage = chunk.contains("usage") || chunk.contains("timings");
+                if (!has_usage && chunk.contains("response") && chunk["response"].is_object()) {
+                    has_usage = chunk["response"].contains("usage") || chunk["response"].contains("timings");
+                }
+                if (has_usage) {
                     last_chunk_with_usage = chunk;
                 }
-            } catch (...) {
-                // Skip invalid JSON
-            }
+            } catch (...) {}
         }
     }
 
-    // Extract telemetry from the last chunk with usage data
     if (!last_chunk_with_usage.empty()) {
         try {
-            if (last_chunk_with_usage.contains("usage")) {
-                auto usage = last_chunk_with_usage["usage"];
-
-                if (usage.contains("prompt_tokens")) {
-                    telemetry.input_tokens = usage["prompt_tokens"].get<int>();
-                }
-                if (usage.contains("completion_tokens")) {
-                    telemetry.output_tokens = usage["completion_tokens"].get<int>();
-                }
-
-                // FLM format
-                if (usage.contains("prefill_duration_ttft")) {
-                    telemetry.time_to_first_token = usage["prefill_duration_ttft"].get<double>();
-                }
-                if (usage.contains("decoding_speed_tps")) {
-                    telemetry.tokens_per_second = usage["decoding_speed_tps"].get<double>();
-                }
-            }
-
-            // Alternative format (timings)
-            if (last_chunk_with_usage.contains("timings")) {
-                auto timings = last_chunk_with_usage["timings"];
-
-                if (timings.contains("prompt_n")) {
-                    telemetry.input_tokens = timings["prompt_n"].get<int>();
-                }
-                if (timings.contains("predicted_n")) {
-                    telemetry.output_tokens = timings["predicted_n"].get<int>();
-                }
-                if (timings.contains("prompt_ms")) {
-                    telemetry.time_to_first_token = timings["prompt_ms"].get<double>() / 1000.0;
-                }
-                if (timings.contains("predicted_per_second")) {
-                    telemetry.tokens_per_second = timings["predicted_per_second"].get<double>();
-                }
-            }
+            extract_telemetry_from_chunk(last_chunk_with_usage, telemetry);
         } catch (const std::exception& e) {
             LOG(ERROR, "StreamingProxy") << "Error parsing telemetry: " << e.what() << std::endl;
         }
@@ -306,6 +312,35 @@ void StreamingProxy::process_sse_lines(std::string& line_buffer, std::function<v
             line.pop_back();
         }
         line_callback(line);
+    }
+}
+
+void StreamingProxy::accumulate_responses_delta(const nlohmann::json& parsed, std::string& accumulated_text) {
+    if (parsed.contains("choices") && parsed["choices"].is_array() && !parsed["choices"].empty()) {
+        auto choice = parsed["choices"][0];
+        if (choice.is_object() && choice.contains("delta")) {
+            auto delta = choice["delta"];
+            if (delta.is_object() && delta.contains("content") && delta["content"].is_string()) {
+                accumulated_text += delta["content"].get<std::string>();
+            }
+        }
+    }
+    if (parsed.contains("response") && parsed["response"].is_string()) {
+        accumulated_text += parsed["response"].get<std::string>();
+    }
+    // Supports Responses API type-restricted delta vs. backward compatible fallback.
+    if (parsed.contains("delta")) {
+        bool should_extract_delta = true;
+        if (parsed.contains("type")) {
+            should_extract_delta = (parsed["type"] == "response.output_text.delta");
+        }
+        if (should_extract_delta) {
+            if (parsed["delta"].is_string()) {
+                accumulated_text += parsed["delta"].get<std::string>();
+            } else if (parsed["delta"].is_object() && parsed["delta"].contains("text") && parsed["delta"]["text"].is_string()) {
+                accumulated_text += parsed["delta"]["text"].get<std::string>();
+            }
+        }
     }
 }
 

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -611,7 +611,7 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     // layer knows whether it saw the protocol-level [DONE] marker. It will treat
     // the same transport code as success after [DONE] and as backend failure
     // before [DONE]. Other CURL errors are still exceptional.
-    if (res != CURLE_OK && res != CURLE_PARTIAL_FILE && res != CURLE_RECV_ERROR) {
+    if (res != CURLE_OK && res != CURLE_PARTIAL_FILE && res != CURLE_RECV_ERROR && res != CURLE_WRITE_ERROR) {
         std::string error = "CURL error: " + response.curl_error;
         LOG(ERROR, "HttpClient") << "" << error << std::endl;
         curl_slist_free_all(header_list);

--- a/test/cpp/test_telemetry_helpers.cpp
+++ b/test/cpp/test_telemetry_helpers.cpp
@@ -1,10 +1,14 @@
-#include <cstdio>
-#include <string>
-#include <vector>
 #include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <cstdio>
+#include <httplib.h>
 #include <map>
+#include <string>
+#include <thread>
+#include <vector>
 #include "lemon/backends/vllm/vllm_server.h"
+#include "lemon/streaming_proxy.h"
 
 namespace lemon::telemetry {
     std::string standardize_thinking(const std::string& text);
@@ -150,6 +154,212 @@ int main() {
         bool wait_missing = (it_wait == res.end());
         std::printf("[%s] parse_vllm_metrics_text malformed: num_requests_waiting (abc) is skipped\n", wait_missing ? "PASS" : "FAIL");
         if (!wait_missing) ++g_failures;
+    }
+
+    // --- parse_telemetry tests ---
+    std::printf("===========================================\n");
+    {
+        auto check_int = [](const char* name, int actual, int expected) {
+            bool ok = (actual == expected);
+            std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+            if (!ok) {
+                std::printf("      Expected: %d\n", expected);
+                std::printf("      Actual:   %d\n", actual);
+                ++g_failures;
+            }
+        };
+
+        auto check_double_val = [](const char* name, double actual, double expected) {
+            bool ok = (std::abs(actual - expected) < 1e-6);
+            std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+            if (!ok) {
+                std::printf("      Expected: %f\n", expected);
+                std::printf("      Actual:   %f\n", actual);
+                ++g_failures;
+            }
+        };
+
+        // 1. Root level usage
+        {
+            std::string buffer = "data: {\"usage\": {\"prompt_tokens\": 10, \"completion_tokens\": 20}}\n";
+            auto tel = lemon::StreamingProxy::parse_telemetry(buffer);
+            check_int("parse_telemetry: root usage prompt_tokens", tel.input_tokens, 10);
+            check_int("parse_telemetry: root usage completion_tokens", tel.output_tokens, 20);
+        }
+
+        // 2. Nested usage under response (OpenAI keys)
+        {
+            std::string buffer = "data: {\"response\": {\"usage\": {\"prompt_tokens\": 30, \"completion_tokens\": 40, \"prefill_duration_ttft\": 0.15, \"decoding_speed_tps\": 45.2}}}\n";
+            auto tel = lemon::StreamingProxy::parse_telemetry(buffer);
+            check_int("parse_telemetry: nested usage prompt_tokens", tel.input_tokens, 30);
+            check_int("parse_telemetry: nested usage completion_tokens", tel.output_tokens, 40);
+            check_double_val("parse_telemetry: nested usage prefill_duration_ttft", tel.time_to_first_token, 0.15);
+            check_double_val("parse_telemetry: nested usage decoding_speed_tps", tel.tokens_per_second, 45.2);
+        }
+
+        // 2b. Nested usage under response (Responses API keys)
+        {
+            std::string buffer = "data: {\"response\": {\"usage\": {\"input_tokens\": 35, \"output_tokens\": 45, \"prefill_duration_ttft\": 0.18, \"decoding_speed_tps\": 50.0}}}\n";
+            auto tel = lemon::StreamingProxy::parse_telemetry(buffer);
+            check_int("parse_telemetry: nested usage input_tokens", tel.input_tokens, 35);
+            check_int("parse_telemetry: nested usage output_tokens", tel.output_tokens, 45);
+            check_double_val("parse_telemetry: nested usage input prefill_duration_ttft", tel.time_to_first_token, 0.18);
+            check_double_val("parse_telemetry: nested usage input decoding_speed_tps", tel.tokens_per_second, 50.0);
+        }
+
+        // 3. Root level timings
+        {
+            std::string buffer = "data: {\"timings\": {\"prompt_n\": 50, \"predicted_n\": 60, \"prompt_ms\": 1500.0, \"predicted_per_second\": 25.5}}\n";
+            auto tel = lemon::StreamingProxy::parse_telemetry(buffer);
+            check_int("parse_telemetry: root timings prompt_tokens", tel.input_tokens, 50);
+            check_int("parse_telemetry: root timings completion_tokens", tel.output_tokens, 60);
+            check_double_val("parse_telemetry: root timings prompt_ms", tel.time_to_first_token, 1.5);
+            check_double_val("parse_telemetry: root timings predicted_per_second", tel.tokens_per_second, 25.5);
+        }
+
+        // 4. Nested timings under response
+        {
+            std::string buffer = "data: {\"response\": {\"timings\": {\"prompt_n\": 70, \"predicted_n\": 80, \"prompt_ms\": 2000.0, \"predicted_per_second\": 30.0}}}\n";
+            auto tel = lemon::StreamingProxy::parse_telemetry(buffer);
+            check_int("parse_telemetry: nested timings prompt_tokens", tel.input_tokens, 70);
+            check_int("parse_telemetry: nested timings completion_tokens", tel.output_tokens, 80);
+            check_double_val("parse_telemetry: nested timings prompt_ms", tel.time_to_first_token, 2.0);
+            check_double_val("parse_telemetry: nested timings predicted_per_second", tel.tokens_per_second, 30.0);
+        }
+    }
+
+    // --- accumulate_responses_delta tests ---
+    std::printf("===========================================\n");
+    {
+        // a) Verify that chunk type "response.output_text.delta" with string delta contributes to accumulated_text.
+        {
+            std::string acc = "";
+            nlohmann::json chunk = {
+                {"type", "response.output_text.delta"},
+                {"delta", "hello"}
+            };
+            lemon::StreamingProxy::accumulate_responses_delta(chunk, acc);
+            check_eq("accumulate_responses_delta: type output_text.delta + string delta", acc, "hello");
+        }
+
+        // b) Verify that chunk type "response.output_text.delta" with object delta (text field) contributes to accumulated_text.
+        {
+            std::string acc = "";
+            nlohmann::json chunk = {
+                {"type", "response.output_text.delta"},
+                {"delta", {{"text", " world"}}}
+            };
+            lemon::StreamingProxy::accumulate_responses_delta(chunk, acc);
+            check_eq("accumulate_responses_delta: type output_text.delta + object delta", acc, " world");
+        }
+
+        // c) Verify that a non-text event (e.g., type == "response.audio.delta" or type == "response.tool.delta") does NOT contribute to accumulated_text.
+        {
+            std::string acc = "";
+            nlohmann::json audio_chunk = {
+                {"type", "response.audio.delta"},
+                {"delta", "audio_data"}
+            };
+            lemon::StreamingProxy::accumulate_responses_delta(audio_chunk, acc);
+            check_eq("accumulate_responses_delta: non-text type response.audio.delta (string)", acc, "");
+
+            nlohmann::json tool_chunk = {
+                {"type", "response.tool.delta"},
+                {"delta", {{"text", "tool_data"}}}
+            };
+            lemon::StreamingProxy::accumulate_responses_delta(tool_chunk, acc);
+            check_eq("accumulate_responses_delta: non-text type response.tool.delta (object)", acc, "");
+        }
+
+        // d) Verify that chunks without 'type' (fallback/OpenAI chat completion chunks) still contribute to accumulated_text.
+        {
+            std::string acc = "";
+            nlohmann::json chunk_no_type_string = {
+                {"delta", "fallback string"}
+            };
+            lemon::StreamingProxy::accumulate_responses_delta(chunk_no_type_string, acc);
+            check_eq("accumulate_responses_delta: no type + string delta", acc, "fallback string");
+
+            acc = "";
+            nlohmann::json chunk_no_type_obj = {
+                {"delta", {{"text", "fallback object"}}}
+            };
+            lemon::StreamingProxy::accumulate_responses_delta(chunk_no_type_obj, acc);
+            check_eq("accumulate_responses_delta: no type + object delta", acc, "fallback object");
+
+            acc = "";
+            nlohmann::json chunk_openai = {
+                {"choices", nlohmann::json::array({{{"delta", {{"content", "OpenAI content"}}}}})}
+            };
+            lemon::StreamingProxy::accumulate_responses_delta(chunk_openai, acc);
+            check_eq("accumulate_responses_delta: no type + choices array delta", acc, "OpenAI content");
+        }
+    }
+
+    // --- Client disconnect telemetry error handling tests ---
+    std::printf("===========================================\n");
+    {
+        httplib::Server svr;
+        svr.Post("/stream", [](const httplib::Request& req, httplib::Response& res) {
+            res.set_content_provider(
+                "text/event-stream",
+                [](size_t offset, httplib::DataSink& sink) {
+                    sink.write("data: hello\n\n", 13);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                    sink.write("data: [DONE]\n\n", 14);
+                    sink.done();
+                    return true;
+                }
+            );
+        });
+
+        int port = svr.bind_to_any_port("127.0.0.1");
+        if (port < 0) {
+            std::printf("[FAIL] Failed to bind httplib::Server to any port\n");
+            ++g_failures;
+        } else {
+            std::thread server_thread([&svr]() {
+                svr.listen_after_bind();
+            });
+            svr.wait_until_ready();
+
+            httplib::DataSink sink;
+            sink.write = [](const char* data, size_t len) {
+                // Abort the stream by returning false
+                return false;
+            };
+            sink.done = []() {};
+
+            bool callback_called = false;
+            std::string error_msg = "";
+
+            std::string backend_url = "http://127.0.0.1:" + std::to_string(port) + "/stream";
+
+            lemon::StreamingProxy::forward_sse_stream(
+                backend_url,
+                "{}",
+                sink,
+                [&callback_called, &error_msg](const lemon::StreamingProxy::TelemetryData& tel) {
+                    callback_called = true;
+                    error_msg = tel.error_message;
+                },
+                5 // 5 seconds timeout
+            );
+
+            svr.stop();
+            if (server_thread.joinable()) {
+                server_thread.join();
+            }
+
+            if (callback_called) {
+                std::printf("[PASS] forward_sse_stream abort: callback was called\n");
+            } else {
+                std::printf("[FAIL] forward_sse_stream abort: callback was NOT called\n");
+                ++g_failures;
+            }
+
+            check_eq("Client disconnected error message check", error_msg, "Client disconnected during stream");
+        }
     }
 
     std::printf("===========================================\n");


### PR DESCRIPTION
### Problem
1. **Empty Output & Zero Token Counts:** Telemetry traces for requests using the OpenAI-compatible `/v1/responses` endpoint showed empty generation outputs and `0` token usage statistics on Arize Phoenix. This occurred because:
   * Streaming text chunks were formatted with a top-level `delta` object/string instead of a `choices` array.
   * Usage statistics and timings were nested inside a top-level `response` object instead of being placed at the JSON root.
   * The Responses API chunk usage payload specifies `"input_tokens"` and `"output_tokens"` instead of standard OpenAI `"prompt_tokens"` and `"completion_tokens"`.
2. **Aborted Streams Reported as OK:** When a client disconnected prematurely (e.g. due to client-side timeouts during long parallel prompt processing), the write callback failed (`CURLE_WRITE_ERROR`). The proxy code didn't flag this curl error as a stream failure, resulting in the server synthesizing `[DONE]` and completing the span with an `OK` status despite the output being truncated.

### Solution
* **Top-Level Delta Parsing:** Updated `Router::responses_stream` to parse top-level `delta` strings and objects, extracting text changes correctly.
* **Nested Telemetry Parsing:** Updated `StreamingProxy::forward_sse_stream` and `StreamingProxy::parse_telemetry` to look for `usage` and `timings` both at the root of the chunk and nested inside the `response` object.
* **Key Fallbacks:** Parsed both `"prompt_tokens"`/`"completion_tokens"` (OpenAI) and `"input_tokens"`/`"output_tokens"` (Responses API) key schemas in both streaming (`StreamingProxy`) and non-streaming (`Router::chat_completion`, `Router::completion`, `Router::embeddings`, `Router::reranking`) handlers.
* **Client Disconnect Capture:** Updated the SSE and byte stream forwarders to explicitly check if `result.curl_code != CURLE_OK`.
  * If the client disconnects (`CURLE_WRITE_ERROR`), the telemetry span is ended with an `ERROR` status indicating a client disconnect, preventing cut-off spans from appearing as successful `OK` runs.
  * We avoid throwing a C++ exception for `CURLE_WRITE_ERROR` so we don't trigger false-positive model resets or evictions on the server when a client simply closes their socket.

### Testing
* Added C++ unit tests to `test_telemetry_helpers.cpp` validating `StreamingProxy::parse_telemetry` against root-level and nested telemetry schemas with standard and fallback key names.
* Built and verified that all C++ unit tests pass cleanly:
  ```bash
  cmake --build --preset default
  ./build/test_telemetry_helpers