### PR TITLE
server: add explicit preset profiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,6 +634,7 @@ set(SOURCES_CORE
     src/cpp/server/telemetry.cpp
     src/cpp/server/logging_config.cpp
     src/cpp/server/log_stream.cpp
+    src/cpp/server/preset_store.cpp
     src/cpp/server/prometheus_metrics.cpp
     src/cpp/server/utils/http_client.cpp
     src/cpp/server/utils/json_utils.cpp

--- a/src/cpp/include/lemon/preset_store.h
+++ b/src/cpp/include/lemon/preset_store.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <mutex>
+#include <optional>
+#include <string>
+#include <nlohmann/json.hpp>
+
+namespace lemon {
+
+using json = nlohmann::json;
+
+// Server-side storage for task/application presets.
+//
+// This is intentionally separate from recipe_options:
+// - recipe_options stay model/load/backend parameters.
+// - presets are global user-facing profiles and may include behavior metadata
+//   such as system prompts and tool defaults.
+// - system prompts are stored as direct text, not as prompt IDs whose meaning can
+//   drift when the frontend starter prompt catalog changes.
+class PresetStore {
+public:
+    explicit PresetStore(std::string cache_dir);
+
+    json list_presets() const;
+    std::optional<json> get_preset(const std::string& id) const;
+    json upsert_preset(json preset);
+    bool delete_preset(const std::string& id);
+
+    json export_store() const;
+    json import_store(const json& payload);
+
+    static std::string requested_preset_id(const json& request);
+    static void merge_missing(json& target, const json& defaults);
+    static std::string selected_system_prompt_text(const json& preset);
+
+private:
+    json load_user_store_unlocked() const;
+    void save_user_store_unlocked(const json& store) const;
+
+    static json empty_user_store();
+    static json builtin_presets();
+    static json sanitize_preset(json preset, bool force_starter);
+    static bool is_builtin_id(const std::string& id);
+    static bool is_valid_id(const std::string& id);
+
+    std::string cache_dir_;
+    mutable std::mutex mutex_;
+};
+
+} // namespace lemon

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -20,6 +20,7 @@
 #include "model_manager.h"
 #include "backend_manager.h"
 #include "cloud_provider_registry.h"
+#include "preset_store.h"
 #include "upgradable_http_server.h"
 #include "websocket_server.h"
 #include "lemon/utils/network_beacon.h"
@@ -74,6 +75,15 @@ private:
     void handle_config_set(const httplib::Request& req, httplib::Response& res);
     void handle_config_get(const httplib::Request& req, httplib::Response& res);
     void handle_config_defaults_get(const httplib::Request& req, httplib::Response& res);
+    void handle_presets_list(const httplib::Request& req, httplib::Response& res);
+    void handle_preset_get(const httplib::Request& req, httplib::Response& res);
+    void handle_preset_upsert(const httplib::Request& req, httplib::Response& res);
+    void handle_preset_delete(const httplib::Request& req, httplib::Response& res);
+    void handle_presets_export(const httplib::Request& req, httplib::Response& res);
+    void handle_presets_import(const httplib::Request& req, httplib::Response& res);
+    bool apply_preset_to_load_request(nlohmann::json& request_json, httplib::Response& res);
+    bool apply_preset_to_chat_request(nlohmann::json& request_json, httplib::Response& res,
+                                      nlohmann::json& preset_recipe_options);
 
     // Side-effect callback for RuntimeConfig::set(). Receives a nested JSON
     // mirroring the input shape, containing only entries that actually changed.
@@ -217,7 +227,8 @@ private:
                                   nlohmann::json& out);
 
     // Helper function for auto-loading models (eliminates code duplication and race conditions)
-    void auto_load_model_if_needed(const std::string& model_name);
+    void auto_load_model_if_needed(const std::string& model_name,
+                                   const nlohmann::json& load_options = nlohmann::json::object());
 
     // Helper: persist the registry's installed-providers list into config.json
     // by overlaying onto the current runtime-config snapshot. Called after
@@ -268,6 +279,7 @@ private:
     std::unique_ptr<ModelManager> model_manager_;
     std::unique_ptr<BackendManager> backend_manager_;
     std::unique_ptr<CloudProviderRegistry> cloud_registry_;
+    std::unique_ptr<PresetStore> preset_store_;
     std::unique_ptr<WebSocketServer> websocket_server_;
 
     std::mutex downloads_mutex_;

--- a/src/cpp/server/preset_store.cpp
+++ b/src/cpp/server/preset_store.cpp
@@ -161,7 +161,7 @@ json PresetStore::builtin_presets() {
         make_preset(
             "s-quick-chat", "Quick Chat",
             "Small context, tight sampling. Snappy responses for quick interactions.",
-            json::array({"chat"}), {{"ctx_size", 4048}},
+            json::array({"chat"}), {{"ctx_size", 4096}},
             {{"temperature", 0.60}, {"top_p", 0.80}, {"top_k", 40}, {"repeat_penalty", 1.05}},
             "llamacpp",
             "Be brief and responsive. Answer the user's direct request with minimal setup.",

--- a/src/cpp/server/preset_store.cpp
+++ b/src/cpp/server/preset_store.cpp
@@ -1,0 +1,543 @@
+#include "lemon/preset_store.h"
+#include "lemon/utils/path_utils.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <stdexcept>
+#include <system_error>
+#include <utility>
+
+#include <lemon/utils/aixlog.hpp>
+
+namespace fs = std::filesystem;
+
+namespace lemon {
+
+namespace {
+
+fs::path store_path_for(const std::string& cache_dir) {
+    return utils::path_from_utf8(cache_dir) / "presets.json";
+}
+
+std::string string_or(const json& object, const std::string& key, const std::string& fallback = "") {
+    if (!object.is_object() || !object.contains(key) || !object[key].is_string()) {
+        return fallback;
+    }
+    return object[key].get<std::string>();
+}
+
+json object_or_empty(const json& value) {
+    return value.is_object() ? value : json::object();
+}
+
+json array_or_empty(const json& value) {
+    return value.is_array() ? value : json::array();
+}
+
+json make_system_prompt(const std::string& id, const std::string& name, const std::string& text, bool built_in) {
+    if (text.empty()) {
+        return json::object();
+    }
+    return {
+        {"id", id},
+        {"name", name},
+        {"text", text},
+        {"built_in", built_in},
+        {"mode", "prepend"}
+    };
+}
+
+json make_system_prompts_array(const std::string& id, const std::string& name, const std::string& text, bool built_in) {
+    if (text.empty()) {
+        return json::array();
+    }
+    return json::array({{
+        {"id", id},
+        {"name", name},
+        {"prompt", text},
+        {"built_in", built_in}
+    }});
+}
+
+json make_preset(const std::string& id,
+                 const std::string& name,
+                 const std::string& description,
+                 json applies_to,
+                 json recipe_options,
+                 json sampling,
+                 const std::string& engine_hint,
+                 const std::string& prompt_text,
+                 bool tools_enabled) {
+    return {
+        {"id", id},
+        {"name", name},
+        {"description", description},
+        {"applies_to", std::move(applies_to)},
+        {"recipe_options", std::move(recipe_options)},
+        {"sampling", std::move(sampling)},
+        {"engine_hint", engine_hint},
+        {"starter", true},
+        {"locked", true},
+        {"tools_enabled", tools_enabled},
+        {"system_prompt_id", prompt_text.empty() ? "none" : "general"},
+        {"system_prompt", make_system_prompt("general", "General", prompt_text, true)},
+        {"system_prompts", make_system_prompts_array("general", "General", prompt_text, true)}
+    };
+}
+
+void throw_invalid_preset(const std::string& message) {
+    throw std::invalid_argument("Invalid preset: " + message);
+}
+
+bool has_nonempty_string(const json& object, const std::string& key) {
+    return object.is_object() && object.contains(key) && object[key].is_string() && !object[key].get<std::string>().empty();
+}
+
+bool bool_or(const json& object, const std::string& key, bool fallback) {
+    if (!object.is_object() || !object.contains(key)) {
+        return fallback;
+    }
+    if (!object[key].is_boolean()) {
+        return fallback;
+    }
+    return object[key].get<bool>();
+}
+
+} // namespace
+
+PresetStore::PresetStore(std::string cache_dir) : cache_dir_(std::move(cache_dir)) {}
+
+json PresetStore::empty_user_store() {
+    return {
+        {"schema_version", 1},
+        {"presets", json::array()}
+    };
+}
+
+bool PresetStore::is_valid_id(const std::string& id) {
+    if (id.empty() || id.size() > 128) {
+        return false;
+    }
+    return std::all_of(id.begin(), id.end(), [](unsigned char c) {
+        return std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == ':';
+    });
+}
+
+bool PresetStore::is_builtin_id(const std::string& id) {
+    for (const auto& preset : builtin_presets()) {
+        if (preset.value("id", "") == id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+json PresetStore::builtin_presets() {
+    static const json presets = json::array({
+        make_preset(
+            "s-default", "Default",
+            "Use current model defaults and automatic backend selection.",
+            json::array({"all"}), json::object(), json::object(),
+            "auto", "", true),
+        make_preset(
+            "s-balanced", "Balanced",
+            "Sensible defaults. Good first pick for everyday chat.",
+            json::array({"chat"}), {{"ctx_size", 16384}},
+            {{"temperature", 0.70}, {"top_p", 0.90}, {"top_k", 40}, {"repeat_penalty", 1.05}},
+            "llamacpp",
+            "Answer directly and practically. Keep responses concise unless the task needs detail, and avoid unnecessary setup.",
+            true),
+        make_preset(
+            "s-thorough", "Thorough",
+            "Careful answers for analysis, planning, debugging, and decisions.",
+            json::array({"chat"}), {{"ctx_size", 32768}},
+            {{"temperature", 0.40}, {"top_p", 0.95}, {"top_k", 40}, {"repeat_penalty", 1.10}},
+            "llamacpp",
+            "Work carefully and systematically. Give the reasoning outcome, tradeoffs, and recommended next step without exposing private chain-of-thought.",
+            true),
+        make_preset(
+            "s-quick-chat", "Quick Chat",
+            "Small context, tight sampling. Snappy responses for quick interactions.",
+            json::array({"chat"}), {{"ctx_size", 4048}},
+            {{"temperature", 0.60}, {"top_p", 0.80}, {"top_k", 40}, {"repeat_penalty", 1.05}},
+            "llamacpp",
+            "Be brief and responsive. Answer the user's direct request with minimal setup.",
+            false),
+        make_preset(
+            "s-creative", "Creative",
+            "Higher temperature for brainstorming, dialog, and divergent thinking.",
+            json::array({"chat"}), {{"ctx_size", 32768}},
+            {{"temperature", 0.95}, {"top_p", 0.95}, {"top_k", 60}, {"repeat_penalty", 1.00}},
+            "llamacpp",
+            "Help the user explore original ideas while staying useful and grounded. Offer variations, not just one answer.",
+            true),
+        make_preset(
+            "s-long-context", "Long Context",
+            "For documents, codebases, and long conversation threads.",
+            json::array({"chat"}), {{"ctx_size", 262144}},
+            {{"temperature", 0.70}, {"top_p", 0.90}, {"top_k", 40}, {"repeat_penalty", 1.05}},
+            "llamacpp",
+            "Handle long inputs by extracting the user's goal, preserving important details, and avoiding unnecessary repetition.",
+            true),
+        make_preset(
+            "s-code", "Code",
+            "Low temperature, tight sampling for code generation and refactoring.",
+            json::array({"chat", "code"}), {{"ctx_size", 131072}},
+            {{"temperature", 0.20}, {"top_p", 0.95}, {"top_k", 40}, {"repeat_penalty", 1.05}},
+            "llamacpp",
+            "Act as a careful coding assistant. Prefer small, maintainable changes, explain the impact, preserve existing style, and keep compatibility in mind.",
+            true),
+        make_preset(
+            "s-quality", "Quality",
+            "More steps and tighter guidance for crisp, deliberate image generation.",
+            json::array({"image"}), {{"steps", 20}, {"cfg_scale", 8.0}}, json::object(),
+            "sd-cpp",
+            "Help produce high-quality image results. Clarify subject, composition, style, lighting, constraints, and negative details only when useful.",
+            false),
+        make_preset(
+            "s-preview", "Preview",
+            "Fewer steps, looser guidance - fast drafts and iteration.",
+            json::array({"image"}), {{"steps", 8}, {"cfg_scale", 6.0}}, json::object(),
+            "sd-cpp",
+            "Optimize for fast image drafts. Keep prompts compact, focus on the main subject, and make iteration easy.",
+            false),
+        make_preset(
+            "s-turbo", "Turbo",
+            "Fastest image drafts for rapid iteration.",
+            json::array({"image"}), {{"steps", 4}, {"cfg_scale", 1.0}}, json::object(),
+            "sd-cpp",
+            "Optimize for the fastest usable image result. Keep instructions minimal and avoid over-specification.",
+            false)
+    });
+    return presets;
+}
+
+json PresetStore::sanitize_preset(json preset, bool force_starter) {
+    if (!preset.is_object()) {
+        throw_invalid_preset("preset must be a JSON object");
+    }
+
+    const std::string id = string_or(preset, "id");
+    if (!is_valid_id(id)) {
+        throw_invalid_preset("id must be non-empty and contain only letters, numbers, '.', '_', '-' or ':'");
+    }
+
+    if (!has_nonempty_string(preset, "name")) {
+        throw_invalid_preset("name must be a non-empty string");
+    }
+
+    json sanitized = preset;
+    sanitized["id"] = id;
+    sanitized["name"] = string_or(preset, "name", "Untitled");
+    sanitized["description"] = string_or(preset, "description");
+
+    json applies_to = array_or_empty(preset.value("applies_to", json::array()));
+    if (applies_to.empty()) {
+        applies_to = json::array({id == "s-default" ? "all" : "chat"});
+    }
+    sanitized["applies_to"] = applies_to;
+    sanitized["recipe_options"] = object_or_empty(preset.value("recipe_options", json::object()));
+    sanitized["sampling"] = object_or_empty(preset.value("sampling", json::object()));
+    sanitized["engine_hint"] = string_or(preset, "engine_hint", "auto");
+    sanitized["starter"] = force_starter || bool_or(preset, "starter", false);
+    sanitized["tools_enabled"] = bool_or(preset, "tools_enabled", true);
+
+    if (!sanitized.contains("system_prompt_id") || !sanitized["system_prompt_id"].is_string()) {
+        sanitized["system_prompt_id"] = selected_system_prompt_text(sanitized).empty() ? "none" : "general";
+    }
+
+    if (sanitized.contains("system_prompts")) {
+        json cleaned = json::array();
+        std::set<std::string> seen;
+        for (const auto& item : array_or_empty(sanitized["system_prompts"])) {
+            if (!item.is_object()) continue;
+            const std::string prompt_id = string_or(item, "id");
+            const std::string prompt_name = string_or(item, "name");
+            const std::string prompt_text = string_or(item, "prompt");
+            if (!is_valid_id(prompt_id) || prompt_name.empty() || prompt_text.empty() || seen.count(prompt_id) > 0) {
+                continue;
+            }
+            seen.insert(prompt_id);
+            cleaned.push_back({
+                {"id", prompt_id},
+                {"name", prompt_name},
+                {"prompt", prompt_text},
+                {"built_in", bool_or(item, "built_in", false)}
+            });
+        }
+        sanitized["system_prompts"] = cleaned;
+    }
+
+    const std::string prompt_text = selected_system_prompt_text(sanitized);
+    if (!prompt_text.empty()) {
+        json current = object_or_empty(sanitized.value("system_prompt", json::object()));
+        // Keep the stable direct-text field in sync with the selected prompt.
+        // This prevents a stale system_prompt.text from overriding a changed
+        // system_prompt_id/system_prompts selection after import or UI edits.
+        current["text"] = prompt_text;
+        if (!current.contains("mode") || !current["mode"].is_string()) {
+            current["mode"] = "prepend";
+        }
+        sanitized["system_prompt"] = current;
+    } else {
+        sanitized.erase("system_prompt");
+    }
+
+    return sanitized;
+}
+
+json PresetStore::load_user_store_unlocked() const {
+    if (cache_dir_.empty()) {
+        return empty_user_store();
+    }
+
+    const fs::path path = store_path_for(cache_dir_);
+    if (!fs::exists(path)) {
+        return empty_user_store();
+    }
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open " + utils::path_to_utf8(path));
+    }
+
+    json loaded;
+    try {
+        loaded = json::parse(file);
+    } catch (const json::parse_error& e) {
+        throw std::runtime_error("Failed to parse " + utils::path_to_utf8(path) + ": " + e.what());
+    }
+
+    json store = empty_user_store();
+    if (loaded.contains("schema_version") && loaded["schema_version"].is_number_integer()) {
+        store["schema_version"] = loaded["schema_version"];
+    }
+    if (loaded.contains("presets") && loaded["presets"].is_array()) {
+        store["presets"] = loaded["presets"];
+    }
+    return store;
+}
+
+void PresetStore::save_user_store_unlocked(const json& store) const {
+    if (cache_dir_.empty()) {
+        throw std::runtime_error("Preset storage is unavailable because cache_dir is empty");
+    }
+
+    const fs::path cache_path = utils::path_from_utf8(cache_dir_);
+    if (!fs::exists(cache_path)) {
+        fs::create_directories(cache_path);
+    }
+
+    const fs::path path = store_path_for(cache_dir_);
+    fs::path temp_path = path;
+    temp_path += ".tmp";
+
+    {
+        std::ofstream file(temp_path);
+        if (!file.is_open()) {
+            throw std::runtime_error("Failed to write " + utils::path_to_utf8(temp_path));
+        }
+        file << store.dump(2) << std::endl;
+    }
+
+    std::error_code ec;
+    fs::rename(temp_path, path, ec);
+    if (ec) {
+        std::error_code copy_ec;
+        fs::copy_file(temp_path, path, fs::copy_options::overwrite_existing, copy_ec);
+        fs::remove(temp_path);
+        if (copy_ec) {
+            throw std::runtime_error("Failed to save " + utils::path_to_utf8(path) + ": " + copy_ec.message());
+        }
+    }
+}
+
+json PresetStore::list_presets() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    json result = builtin_presets();
+    json store = load_user_store_unlocked();
+
+    std::set<std::string> seen;
+    for (const auto& preset : result) {
+        seen.insert(preset.value("id", ""));
+    }
+
+    for (const auto& raw : array_or_empty(store.value("presets", json::array()))) {
+        try {
+            json preset = sanitize_preset(raw, false);
+            const std::string id = preset.value("id", "");
+            if (!seen.count(id)) {
+                result.push_back(std::move(preset));
+                seen.insert(id);
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING, "PresetStore") << "Skipping invalid stored preset: " << e.what() << std::endl;
+        }
+    }
+
+    return result;
+}
+
+std::optional<json> PresetStore::get_preset(const std::string& id) const {
+    for (const auto& preset : list_presets()) {
+        if (preset.value("id", "") == id) {
+            return preset;
+        }
+    }
+    return std::nullopt;
+}
+
+json PresetStore::upsert_preset(json preset) {
+    json sanitized = sanitize_preset(std::move(preset), false);
+    const std::string id = sanitized.value("id", "");
+    if (is_builtin_id(id)) {
+        throw std::invalid_argument("Built-in preset '" + id + "' cannot be overwritten; clone it to a custom id instead");
+    }
+    sanitized["starter"] = false;
+    sanitized["locked"] = false;
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    json store = load_user_store_unlocked();
+    json& presets = store["presets"];
+    bool replaced = false;
+    for (auto& item : presets) {
+        if (item.is_object() && item.value("id", "") == id) {
+            item = sanitized;
+            replaced = true;
+            break;
+        }
+    }
+    if (!replaced) {
+        presets.push_back(sanitized);
+    }
+    save_user_store_unlocked(store);
+    return sanitized;
+}
+
+bool PresetStore::delete_preset(const std::string& id) {
+    if (is_builtin_id(id)) {
+        throw std::invalid_argument("Built-in preset '" + id + "' cannot be deleted");
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    json store = load_user_store_unlocked();
+    json& presets = store["presets"];
+    const size_t before = presets.size();
+    presets.erase(std::remove_if(presets.begin(), presets.end(), [&](const json& item) {
+        return item.is_object() && item.value("id", "") == id;
+    }), presets.end());
+
+    if (presets.size() != before) {
+        save_user_store_unlocked(store);
+        return true;
+    }
+    return false;
+}
+
+json PresetStore::export_store() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    json store = load_user_store_unlocked();
+    store["schema_version"] = 1;
+    store["builtin_presets"] = builtin_presets();
+    return store;
+}
+
+json PresetStore::import_store(const json& payload) {
+    json incoming = payload;
+    if (incoming.contains("presets")) {
+        // already a store-like object
+    } else if (incoming.is_array()) {
+        incoming = {{"schema_version", 1}, {"presets", incoming}};
+    } else {
+        throw std::invalid_argument("Import body must be a preset array or an object with presets");
+    }
+
+    json next = empty_user_store();
+    std::set<std::string> seen;
+    for (const auto& raw : array_or_empty(incoming.value("presets", json::array()))) {
+        json preset = sanitize_preset(raw, false);
+        const std::string id = preset.value("id", "");
+        if (is_builtin_id(id) || seen.count(id)) {
+            continue;
+        }
+        preset["starter"] = false;
+        preset["locked"] = false;
+        next["presets"].push_back(std::move(preset));
+        seen.insert(id);
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    save_user_store_unlocked(next);
+    return next;
+}
+
+std::string PresetStore::requested_preset_id(const json& request) {
+    for (const std::string key : {"preset", "preset_id"}) {
+        if (request.contains(key) && request[key].is_string()) {
+            const std::string value = request[key].get<std::string>();
+            if (!value.empty()) {
+                return value;
+            }
+        }
+    }
+    return "";
+}
+
+void PresetStore::merge_missing(json& target, const json& defaults) {
+    if (!target.is_object() || !defaults.is_object()) {
+        return;
+    }
+    for (const auto& [key, value] : defaults.items()) {
+        if (!target.contains(key)) {
+            target[key] = value;
+        }
+    }
+}
+
+std::string PresetStore::selected_system_prompt_text(const json& preset) {
+    if (!preset.is_object()) {
+        return "";
+    }
+
+    // Prototype/UI compatibility: when a selected prompt id is present, honor the
+    // selected entry first. sanitize_preset() then mirrors that text into the
+    // stable system_prompt.text field for long-term storage.
+    const std::string prompt_id = string_or(preset, "system_prompt_id", "none");
+    if (prompt_id != "none" && !prompt_id.empty()) {
+        for (const auto& prompt : array_or_empty(preset.value("system_prompts", json::array()))) {
+            if (!prompt.is_object() || prompt.value("id", "") != prompt_id) continue;
+            if (prompt.contains("prompt") && prompt["prompt"].is_string()) {
+                return prompt["prompt"].get<std::string>();
+            }
+            if (prompt.contains("text") && prompt["text"].is_string()) {
+                return prompt["text"].get<std::string>();
+            }
+        }
+    }
+
+    // Stable canonical form for server-side presets and imports.
+    if (preset.contains("system_prompt")) {
+        const auto& value = preset["system_prompt"];
+        if (value.is_string()) {
+            return value.get<std::string>();
+        }
+        if (value.is_object()) {
+            if (value.contains("text") && value["text"].is_string()) {
+                return value["text"].get<std::string>();
+            }
+            if (value.contains("content") && value["content"].is_string()) {
+                return value["content"].get<std::string>();
+            }
+            if (value.contains("prompt") && value["prompt"].is_string()) {
+                return value["prompt"].get<std::string>();
+            }
+        }
+    }
+
+    return "";
+}
+
+} // namespace lemon

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3,6 +3,7 @@
 #include "lemon/collection_orchestrator.h"
 #include "lemon/hf_variants.h"
 #include "lemon/config_file.h"
+#include "lemon/preset_store.h"
 #include "lemon/mcp_server.h"
 #include "lemon/ollama_api.h"
 #include "lemon/backends/cloud/cloud_server.h"
@@ -343,6 +344,8 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             cloud_registry_->load_from_config(snap["cloud_providers"]);
         }
     }
+
+    preset_store_ = std::make_unique<PresetStore>(cache_dir_);
 
     model_manager_ = std::make_unique<ModelManager>(config_->extra_models_dir());
     model_manager_->set_cloud_registry(cloud_registry_.get());
@@ -717,6 +720,44 @@ void Server::setup_routes(httplib::Server &web_server) {
         handle_download_control(req, res);
     });
 
+
+
+    // Presets are public profile metadata, stored on the server so the desktop
+    // UI, web UI, CLI and automation clients can share the same named profiles.
+    // They intentionally do not live in recipe_options because profiles are
+    // global/task-oriented while recipe_options are per-model/per-backend load
+    // parameters. No preset is applied unless a request explicitly includes
+    // "preset" or "preset_id".
+    register_get("presets", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_presets_list(req, res);
+    });
+    // Do not use register_post("presets") here: that helper also installs a
+    // GET 405 handler, which would collide with GET /presets above.
+    web_server.Post("/api/v0/presets", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
+    web_server.Post("/api/v1/presets", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
+    web_server.Post("/v0/presets", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
+    web_server.Post("/v1/presets", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
+    register_get("presets/export", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_presets_export(req, res);
+    });
+    // Register import manually too so no generated GET 405 route competes with
+    // the /presets/{id} regex for the reserved id-like segment "import".
+    web_server.Post("/api/v0/presets/import", [this](const httplib::Request& req, httplib::Response& res) { handle_presets_import(req, res); });
+    web_server.Post("/api/v1/presets/import", [this](const httplib::Request& req, httplib::Response& res) { handle_presets_import(req, res); });
+    web_server.Post("/v0/presets/import", [this](const httplib::Request& req, httplib::Response& res) { handle_presets_import(req, res); });
+    web_server.Post("/v1/presets/import", [this](const httplib::Request& req, httplib::Response& res) { handle_presets_import(req, res); });
+    web_server.Get(R"(/api/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_get(req, res); });
+    web_server.Get(R"(/api/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_get(req, res); });
+    web_server.Get(R"(/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_get(req, res); });
+    web_server.Get(R"(/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_get(req, res); });
+    web_server.Put(R"(/api/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
+    web_server.Put(R"(/api/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
+    web_server.Put(R"(/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
+    web_server.Put(R"(/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
+    web_server.Delete(R"(/api/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_delete(req, res); });
+    web_server.Delete(R"(/api/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_delete(req, res); });
+    web_server.Delete(R"(/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_delete(req, res); });
+    web_server.Delete(R"(/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_delete(req, res); });
 
     register_post("load", [this](const httplib::Request& req, httplib::Response& res) {
         handle_load(req, res);
@@ -1793,11 +1834,17 @@ nlohmann::json Server::create_model_error(const std::string& requested_model, co
 //   3. If model is downloaded: Use cached version (don't check HuggingFace for updates)
 //
 // Note: Only the /pull endpoint checks HuggingFace for updates (do_not_upgrade=false)
-void Server::auto_load_model_if_needed(const std::string& requested_model) {
+void Server::auto_load_model_if_needed(const std::string& requested_model,
+                                       const nlohmann::json& load_options) {
+    const bool has_load_options = load_options.is_object() && !load_options.empty();
     // Check if this specific model is already loaded (multi-model aware)
-    if (router_->is_model_loaded(requested_model)) {
+    if (!has_load_options && router_->is_model_loaded(requested_model)) {
         LOG(INFO, "Server") << "Model already loaded: " << requested_model << std::endl;
         return;
+    }
+    if (has_load_options && router_->is_model_loaded(requested_model)) {
+        LOG(INFO, "Server") << "Model already loaded; checking explicit preset load options: "
+                            << requested_model << std::endl;
     }
 
     // Log the auto-loading action
@@ -1837,7 +1884,11 @@ void Server::auto_load_model_if_needed(const std::string& requested_model) {
     // Load model with do_not_upgrade=true
     // For FLM models: FastFlowLMServer will handle download internally if needed
     // For non-FLM models: Model should already be cached at this point
-    router_->load_model(requested_model, info, RecipeOptions(info.recipe, json::object()), true);
+    // When a preset is explicitly requested, use its recipe_options for the
+    // load/reload decision so ctx/backend settings affect CLI/API usage too.
+    router_->load_model(requested_model, info,
+                        RecipeOptions(info.recipe, has_load_options ? load_options : json::object()),
+                        true, /*allow_reload_on_option_change=*/has_load_options);
     LOG(INFO, "Server") << "Model loaded successfully: " << requested_model << std::endl;
 }
 
@@ -2150,6 +2201,8 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
         // Normalize client-provided model names (e.g., strip ":latest" suffix)
         // Must be done before any model_manager/router lookups and before forwarding
         normalize_client_model_name(request_json);
+        nlohmann::json preset_recipe_options = nlohmann::json::object();
+        if (!apply_preset_to_chat_request(request_json, res, preset_recipe_options)) return;
 
         // Debug: Check if tools are present
         if (request_json.contains("tools")) {
@@ -2189,7 +2242,7 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
         // Handle model loading/switching
         if (request_json.contains("model")) {
             try {
-                auto_load_model_if_needed(requested_model);
+                auto_load_model_if_needed(requested_model, preset_recipe_options);
                 if (span) {
                     span->cancel();
                 }
@@ -3887,6 +3940,7 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
 
     nlohmann::json request_json;
     if (!parse_required_json_body(req, res, request_json)) return;
+    if (!apply_preset_to_load_request(request_json, res)) return;
 
     try {
         model_name = request_json["model_name"];
@@ -4733,6 +4787,213 @@ void Server::handle_config_defaults_get(const httplib::Request& /*req*/, httplib
         nlohmann::json error = {{"error", e.what()}};
         res.set_content(error.dump(), "application/json");
     }
+}
+
+
+void Server::handle_presets_list(const httplib::Request& /*req*/, httplib::Response& res) {
+    try {
+        nlohmann::json response = {
+            {"object", "list"},
+            {"data", preset_store_->list_presets()}
+        };
+        res.set_content(response.dump(), "application/json");
+    } catch (const std::exception& e) {
+        res.status = 500;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    }
+}
+
+void Server::handle_preset_get(const httplib::Request& req, httplib::Response& res) {
+    try {
+        const std::string id = req.matches[1].str();
+        auto preset = preset_store_->get_preset(id);
+        if (!preset) {
+            res.status = 404;
+            res.set_content(nlohmann::json{{"error", "Preset not found: " + id}}.dump(), "application/json");
+            return;
+        }
+        res.set_content(preset->dump(), "application/json");
+    } catch (const std::exception& e) {
+        res.status = 500;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    }
+}
+
+void Server::handle_preset_upsert(const httplib::Request& req, httplib::Response& res) {
+    try {
+        nlohmann::json body;
+        if (!parse_required_json_body(req, res, body)) return;
+        if (req.matches.size() > 1) {
+            body["id"] = req.matches[1].str();
+        }
+        nlohmann::json preset = preset_store_->upsert_preset(body);
+        res.set_content(preset.dump(), "application/json");
+    } catch (const std::invalid_argument& e) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    } catch (const std::exception& e) {
+        res.status = 500;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    }
+}
+
+void Server::handle_preset_delete(const httplib::Request& req, httplib::Response& res) {
+    try {
+        const std::string id = req.matches[1].str();
+        if (!preset_store_->delete_preset(id)) {
+            res.status = 404;
+            res.set_content(nlohmann::json{{"error", "Preset not found: " + id}}.dump(), "application/json");
+            return;
+        }
+        res.set_content(nlohmann::json{{"status", "success"}, {"id", id}}.dump(), "application/json");
+    } catch (const std::invalid_argument& e) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    } catch (const std::exception& e) {
+        res.status = 500;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    }
+}
+
+void Server::handle_presets_export(const httplib::Request& /*req*/, httplib::Response& res) {
+    try {
+        res.set_content(preset_store_->export_store().dump(2), "application/json");
+    } catch (const std::exception& e) {
+        res.status = 500;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    }
+}
+
+void Server::handle_presets_import(const httplib::Request& req, httplib::Response& res) {
+    try {
+        nlohmann::json body;
+        if (!parse_required_json_body(req, res, body)) return;
+        res.set_content(preset_store_->import_store(body).dump(2), "application/json");
+    } catch (const std::invalid_argument& e) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    } catch (const std::exception& e) {
+        res.status = 500;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    }
+}
+
+bool Server::apply_preset_to_load_request(nlohmann::json& request_json, httplib::Response& res) {
+    const std::string preset_id = PresetStore::requested_preset_id(request_json);
+    if (preset_id.empty()) {
+        // No implicit preset selection: default /load behavior remains unchanged.
+        return true;
+    }
+    auto preset = preset_store_->get_preset(preset_id);
+    if (!preset) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", "Unknown preset: " + preset_id}}.dump(), "application/json");
+        return false;
+    }
+
+    if (preset->contains("recipe_options") && (*preset)["recipe_options"].is_object()) {
+        PresetStore::merge_missing(request_json, (*preset)["recipe_options"]);
+    }
+
+    request_json.erase("preset");
+    request_json.erase("preset_id");
+    request_json.erase("apply_preset_system_prompt");
+    request_json.erase("system_prompt_policy");
+    return true;
+}
+
+bool Server::apply_preset_to_chat_request(nlohmann::json& request_json,
+                                          httplib::Response& res,
+                                          nlohmann::json& preset_recipe_options) {
+    preset_recipe_options = nlohmann::json::object();
+    const std::string preset_id = PresetStore::requested_preset_id(request_json);
+    if (preset_id.empty()) {
+        // No implicit preset selection: default chat auto-load behavior remains unchanged.
+        return true;
+    }
+
+    auto preset = preset_store_->get_preset(preset_id);
+    if (!preset) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", "Unknown preset: " + preset_id}}.dump(), "application/json");
+        return false;
+    }
+
+    if (preset->contains("recipe_options") && (*preset)["recipe_options"].is_object()) {
+        preset_recipe_options = (*preset)["recipe_options"];
+    }
+    if (preset->contains("sampling") && (*preset)["sampling"].is_object()) {
+        PresetStore::merge_missing(request_json, (*preset)["sampling"]);
+    }
+
+    // tools_enabled is persisted as client/UI metadata in this PR. The server
+    // intentionally does not add or remove tool payloads here, so existing
+    // OpenAI-compatible agent requests are not changed by preset selection.
+    bool apply_prompt = true;
+    if (request_json.contains("apply_preset_system_prompt")) {
+        if (!request_json["apply_preset_system_prompt"].is_boolean()) {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", "apply_preset_system_prompt must be a boolean"}}.dump(), "application/json");
+            return false;
+        }
+        apply_prompt = request_json["apply_preset_system_prompt"].get<bool>();
+    }
+
+    const std::string prompt = PresetStore::selected_system_prompt_text(*preset);
+    if (apply_prompt && !prompt.empty()) {
+        if (!request_json.contains("messages") || !request_json["messages"].is_array()) {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", "Preset system prompts require a messages array"}}.dump(), "application/json");
+            return false;
+        }
+
+        std::string policy = "prepend_if_missing";
+        if (request_json.contains("system_prompt_policy")) {
+            if (!request_json["system_prompt_policy"].is_string()) {
+                res.status = 400;
+                res.set_content(nlohmann::json{{"error", "system_prompt_policy must be a string"}}.dump(), "application/json");
+                return false;
+            }
+            policy = request_json["system_prompt_policy"].get<std::string>();
+        }
+        if (policy != "prepend_if_missing" && policy != "prepend" &&
+            policy != "replace_first" && policy != "skip") {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", "system_prompt_policy must be one of: prepend_if_missing, prepend, replace_first, skip"}}.dump(), "application/json");
+            return false;
+        }
+
+        bool has_system_message = false;
+        for (const auto& message : request_json["messages"]) {
+            if (message.is_object() && message.value("role", "") == "system") {
+                has_system_message = true;
+                break;
+            }
+        }
+
+        nlohmann::json system_message = {{"role", "system"}, {"content", prompt}};
+        bool replaced = false;
+        if (policy == "replace_first") {
+            for (auto& message : request_json["messages"]) {
+                if (message.is_object() && message.value("role", "") == "system") {
+                    message["content"] = prompt;
+                    replaced = true;
+                    break;
+                }
+            }
+        }
+        if (!replaced && policy == "prepend") {
+            request_json["messages"].insert(request_json["messages"].begin(), system_message);
+        } else if (!replaced && policy == "prepend_if_missing" && !has_system_message) {
+            request_json["messages"].insert(request_json["messages"].begin(), system_message);
+        }
+    }
+
+    request_json.erase("preset");
+    request_json.erase("preset_id");
+    request_json.erase("apply_preset_system_prompt");
+    request_json.erase("system_prompt_policy");
+    return true;
 }
 
 void Server::handle_bin_change(const std::string& section,

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -722,6 +722,49 @@ void Server::setup_routes(httplib::Server &web_server) {
 
 
 
+    // Helper for endpoints that intentionally follow the same four public API
+    // prefixes used by the rest of the server: /api/v0, /api/v1, /v0 and /v1.
+    auto register_public_api_paths = [&web_server](
+        const std::string& endpoint,
+        const std::function<void(const std::string&)>& register_one) {
+        const char* prefixes[] = {"/api/v0/", "/api/v1/", "/v0/", "/v1/"};
+        for (const char* prefix : prefixes) {
+            register_one(std::string(prefix) + endpoint);
+        }
+    };
+
+    auto register_post_only = [&web_server, &register_public_api_paths](
+        const std::string& endpoint,
+        std::function<void(const httplib::Request&, httplib::Response&)> handler) {
+        register_public_api_paths(endpoint, [&](const std::string& path) {
+            web_server.Post(path, handler);
+        });
+    };
+
+    auto register_get_regex = [&web_server, &register_public_api_paths](
+        const std::string& endpoint_regex,
+        std::function<void(const httplib::Request&, httplib::Response&)> handler) {
+        register_public_api_paths(endpoint_regex, [&](const std::string& path) {
+            web_server.Get(path, handler);
+        });
+    };
+
+    auto register_put_regex = [&web_server, &register_public_api_paths](
+        const std::string& endpoint_regex,
+        std::function<void(const httplib::Request&, httplib::Response&)> handler) {
+        register_public_api_paths(endpoint_regex, [&](const std::string& path) {
+            web_server.Put(path, handler);
+        });
+    };
+
+    auto register_delete_regex = [&web_server, &register_public_api_paths](
+        const std::string& endpoint_regex,
+        std::function<void(const httplib::Request&, httplib::Response&)> handler) {
+        register_public_api_paths(endpoint_regex, [&](const std::string& path) {
+            web_server.Delete(path, handler);
+        });
+    };
+
     // Presets are public profile metadata, stored on the server so the desktop
     // UI, web UI, CLI and automation clients can share the same named profiles.
     // They intentionally do not live in recipe_options because profiles are
@@ -733,31 +776,28 @@ void Server::setup_routes(httplib::Server &web_server) {
     });
     // Do not use register_post("presets") here: that helper also installs a
     // GET 405 handler, which would collide with GET /presets above.
-    web_server.Post("/api/v0/presets", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
-    web_server.Post("/api/v1/presets", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
-    web_server.Post("/v0/presets", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
-    web_server.Post("/v1/presets", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
+    register_post_only("presets", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_preset_upsert(req, res);
+    });
     register_get("presets/export", [this](const httplib::Request& req, httplib::Response& res) {
         handle_presets_export(req, res);
     });
-    // Register import manually too so no generated GET 405 route competes with
-    // the /presets/{id} regex for the reserved id-like segment "import".
-    web_server.Post("/api/v0/presets/import", [this](const httplib::Request& req, httplib::Response& res) { handle_presets_import(req, res); });
-    web_server.Post("/api/v1/presets/import", [this](const httplib::Request& req, httplib::Response& res) { handle_presets_import(req, res); });
-    web_server.Post("/v0/presets/import", [this](const httplib::Request& req, httplib::Response& res) { handle_presets_import(req, res); });
-    web_server.Post("/v1/presets/import", [this](const httplib::Request& req, httplib::Response& res) { handle_presets_import(req, res); });
-    web_server.Get(R"(/api/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_get(req, res); });
-    web_server.Get(R"(/api/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_get(req, res); });
-    web_server.Get(R"(/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_get(req, res); });
-    web_server.Get(R"(/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_get(req, res); });
-    web_server.Put(R"(/api/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
-    web_server.Put(R"(/api/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
-    web_server.Put(R"(/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
-    web_server.Put(R"(/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_upsert(req, res); });
-    web_server.Delete(R"(/api/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_delete(req, res); });
-    web_server.Delete(R"(/api/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_delete(req, res); });
-    web_server.Delete(R"(/v0/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_delete(req, res); });
-    web_server.Delete(R"(/v1/presets/([A-Za-z0-9._:-]+))", [this](const httplib::Request& req, httplib::Response& res) { handle_preset_delete(req, res); });
+    // Register import without GET 405 routes so the reserved id-like segment
+    // "import" cannot compete with the /presets/{id} regex.
+    register_post_only("presets/import", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_presets_import(req, res);
+    });
+
+    const std::string preset_id_route = R"(presets/([A-Za-z0-9._:-]+))";
+    register_get_regex(preset_id_route, [this](const httplib::Request& req, httplib::Response& res) {
+        handle_preset_get(req, res);
+    });
+    register_put_regex(preset_id_route, [this](const httplib::Request& req, httplib::Response& res) {
+        handle_preset_upsert(req, res);
+    });
+    register_delete_regex(preset_id_route, [this](const httplib::Request& req, httplib::Response& res) {
+        handle_preset_delete(req, res);
+    });
 
     register_post("load", [this](const httplib::Request& req, httplib::Response& res) {
         handle_load(req, res);


### PR DESCRIPTION
Adds a server-side preset/profile store backed by `<cache_dir>/presets.json`, with REST endpoints for list/upsert/delete/import/export.

Presets are separate from per-model recipe_options, but can carry reusable recipe defaults, sampling defaults, UI/client tool metadata, and stable system prompt text.

`/load` and `/chat/completions` can opt into a preset explicitly via `preset`/`preset_id`; explicit request fields still override preset defaults, and preset extension fields are stripped before backend forwarding. Normal model loads and normal chat auto-load behavior remain unchanged when no preset is specified.

Why: This is a preparation for GUI3 on server side so presets are not a GUI only thing and allow TUI use as well.