### PR TITLE
feat(ui): implement Files tab with model file listing (#2428)

### DIFF
--- a/prototype/ui-redesign/src/api.ts
+++ b/prototype/ui-redesign/src/api.ts
@@ -134,6 +134,20 @@ export interface ModelsData {
   data: ModelInfo[];
 }
 
+/** One physical file backing a model (from GET /api/v1/models/{id}/files). */
+export interface ModelFileInfo {
+  name: string;
+  role: string;
+  size_bytes: number;
+  exists: boolean;
+}
+
+/** Response shape of GET /api/v1/models/{id}/files. */
+export interface ModelFilesResponse {
+  model_id: string;
+  files: ModelFileInfo[];
+}
+
 /** Real disk usage for the model-storage drive (bytes). */
 export interface StorageInfo {
   usedBytes: number;
@@ -943,6 +957,23 @@ class LemonadeAPI {
 
   async modelDetail(id: string): Promise<ModelInfo> {
     return this._json<ModelInfo>(`/api/v1/models/${encodeURIComponent(id)}`);
+  }
+
+  /**
+   * List the physical files backing a model (main weights, mmproj, tokenizer, …).
+   * Returns null when the endpoint is unreachable or the model is unknown, so the
+   * UI can fall back to an empty/error state instead of throwing.
+   */
+  async getModelFiles(id: string): Promise<ModelFilesResponse | null> {
+    try {
+      const data = await this._json<ModelFilesResponse>(
+        `/api/v1/models/${encodeURIComponent(id)}/files`,
+      );
+      if (!data || !Array.isArray(data.files)) return null;
+      return data;
+    } catch {
+      return null;
+    }
   }
 
   async loadModel(modelName: string, recipeOptions?: Record<string, unknown>, modelInfo?: ModelInfo | null): Promise<unknown> {

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -7,7 +7,8 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import MarkdownIt from 'markdown-it';
 import DOMPurify from 'dompurify';
-import type { ModelInfo, LoadedModel } from '../api';
+import type { ModelInfo, LoadedModel, ModelFileInfo } from '../api';
+import api from '../api';
 import { capabilityFromModelInfo, capabilityLabel } from '../modelCapabilities';
 import {
   DEFAULT_PRESET, PRESET_STORE_EVENT, Preset, PresetChangeKind,
@@ -447,15 +448,124 @@ const ModelPresetsTab: React.FC<{
   );
 };
 
-/* ── Files tab stub ──────────────────────────────────────────── */
+/* ── Files tab ───────────────────────────────────────────────── */
 
-const ModelFilesTab: React.FC = () => (
-  <div className="detail-tab-content detail-files detail-files--stub">
-    <Icon name="hard-drive" size={28} aria-hidden="true" />
-    <p>Files tab — coming in a future update.</p>
-    <small>Requires a <code>GET /api/v1/models/&#123;id&#125;/files</code> endpoint in lemond.</small>
-  </div>
-);
+/** Human-readable byte size (B / KB / MB / GB) using binary units. */
+function fmtBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  const decimals = unit === 0 ? 0 : value >= 100 ? 0 : value >= 10 ? 1 : 2;
+  return `${value.toFixed(decimals)} ${units[unit]}`;
+}
+
+/** Title-case a role slug for display (e.g. "mmproj" → "Mmproj", "main" → "Main"). */
+function roleLabel(role: string): string {
+  const r = String(role || '').trim();
+  if (!r) return 'File';
+  return r.charAt(0).toUpperCase() + r.slice(1);
+}
+
+const ModelFilesTab: React.FC<{ model: ModelInfo | null | undefined; isActive: boolean }> = ({ model, isActive }) => {
+  const modelId = model ? String(model.id || '') : '';
+  const [files, setFiles] = useState<ModelFileInfo[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!isActive) return;
+    if (!modelId) { setFiles([]); return; }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+    api.getModelFiles(modelId)
+      .then(resp => {
+        if (cancelled) return;
+        if (!resp) { setError(true); setFiles(null); return; }
+        setFiles(resp.files);
+      })
+      .catch(() => { if (!cancelled) { setError(true); setFiles(null); } })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [modelId, isActive]);
+
+  if (loading) {
+    return (
+      <div className="detail-tab-content detail-files detail-files--loading" aria-live="polite" aria-busy="true">
+        <span>Loading files…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="detail-tab-content detail-files detail-files--empty">
+        <Icon name="hard-drive" size={32} aria-hidden="true" />
+        <p>Unable to load files for this model.</p>
+      </div>
+    );
+  }
+
+  if (!files || files.length === 0) {
+    return (
+      <div className="detail-tab-content detail-files detail-files--empty">
+        <Icon name="hard-drive" size={32} aria-hidden="true" />
+        <p>No files found for this model.</p>
+        <small>Files appear here once the model has been downloaded.</small>
+      </div>
+    );
+  }
+
+  return (
+    <div className="detail-tab-content detail-files">
+      <table className="detail-files__table">
+        <caption className="sr-only">Files backing {mdName(model) || modelId}</caption>
+        <thead>
+          <tr>
+            <th scope="col">File</th>
+            <th scope="col">Role</th>
+            <th scope="col" className="detail-files__col-size">Size</th>
+            <th scope="col">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {files.map((file, idx) => (
+            <tr key={`${file.name}-${idx}`}>
+              <td className="detail-files__name">
+                <Icon name="file" size={14} aria-hidden="true" />
+                <span title={file.name}>{file.name}</span>
+              </td>
+              <td>
+                <span className="detail-files__role-badge">{roleLabel(file.role)}</span>
+              </td>
+              <td className="detail-files__col-size">{fmtBytes(file.size_bytes)}</td>
+              <td>
+                {file.exists ? (
+                  <span className="detail-files__status detail-files__status--present">
+                    <Icon name="check" size={14} aria-hidden="true" />
+                    <span>Downloaded</span>
+                  </span>
+                ) : (
+                  <span className="detail-files__status detail-files__status--missing">
+                    <Icon name="download" size={14} aria-hidden="true" />
+                    <span>Not downloaded</span>
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
 
 /* ── ModelDetailPanel ────────────────────────────────────────── */
 
@@ -926,7 +1036,9 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
           {tab.id === 'presets' && (
             <ModelPresetsTab model={model} isActive={activeTab === 'presets'} />
           )}
-          {tab.id === 'files' && <ModelFilesTab />}
+          {tab.id === 'files' && (
+            <ModelFilesTab model={model} isActive={activeTab === 'files'} />
+          )}
         </div>
       ))}
     </div>

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -9001,22 +9001,91 @@ input, textarea {
   margin: 0;
 }
 
-/* ── Files tab stub ───────────────────────────────────────────── */
+/* ── Files tab ────────────────────────────────────────────────── */
 
-.detail-files--stub {
+.detail-files {
   flex: 1;
+  overflow-y: auto;
+  padding: var(--space-5);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.detail-files--loading,
+.detail-files--empty {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: var(--space-3);
   color: var(--text-tertiary);
-  font-size: var(--text-sm);
   text-align: center;
-  padding: var(--space-6);
+  min-height: 160px;
 }
 
-.detail-files--stub small { font-size: var(--text-xs); }
+.detail-files--empty small { font-size: var(--text-xs); }
+
+.detail-files__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.detail-files__table th,
+.detail-files__table td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+  vertical-align: middle;
+}
+
+.detail-files__table th {
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  border-bottom: 1px solid var(--border-strong);
+}
+
+.detail-files__table tbody tr:last-child td { border-bottom: none; }
+
+.detail-files__col-size { text-align: right; white-space: nowrap; }
+th.detail-files__col-size { text-align: right; }
+
+.detail-files__name {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.88em;
+  color: var(--text-primary);
+  word-break: break-all;
+}
+
+.detail-files__name svg { flex-shrink: 0; color: var(--text-tertiary); }
+
+.detail-files__role-badge {
+  display: inline-block;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.detail-files__status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
+.detail-files__status--present { color: var(--success, var(--accent-fg)); }
+.detail-files__status--missing { color: var(--text-tertiary); }
 
 /* ── btn size helpers ─────────────────────────────────────────── */
 

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -9037,6 +9037,8 @@ input, textarea {
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border-subtle);
   vertical-align: middle;
+  height: 40px;
+  box-sizing: border-box;
 }
 
 .detail-files__table th {
@@ -9046,12 +9048,12 @@ input, textarea {
   text-transform: uppercase;
   letter-spacing: 0.03em;
   border-bottom: 1px solid var(--border-strong);
+  height: 32px;
 }
 
 .detail-files__table tbody tr:last-child td { border-bottom: none; }
 
-.detail-files__col-size { text-align: right; white-space: nowrap; }
-th.detail-files__col-size { text-align: right; }
+.detail-files__col-size { text-align: left; white-space: nowrap; }
 
 .detail-files__name {
   display: flex;
@@ -9061,6 +9063,9 @@ th.detail-files__col-size { text-align: right; }
   font-size: 0.88em;
   color: var(--text-primary);
   word-break: break-all;
+  max-width: 320px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .detail-files__name svg { flex-shrink: 0; color: var(--text-tertiary); }

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -3705,3 +3705,115 @@ test.describe('Accessibility — update preset while loaded (#2356)', () => {
     await expect(unload).toBeFocused();
   });
 });
+
+// ─── 29. Model-detail Files tab — model file listing (#2428 Slice 2) ──────────
+//
+// Slice 2 wires the Files tab to the new GET /api/v1/models/{id}/files endpoint
+// (PR #2437). The tab renders the physical files backing a model — filename,
+// role badge, human-readable size, and download status — in an accessible
+// <table> with column headers and a caption. Empty/error/loading states are
+// covered too. Range: A180–A184.
+
+test.describe('Accessibility — model-detail Files tab (#2428)', () => {
+  const SAMPLE_FILES = [
+    { name: 'Llama-3.1-8B-Q4_K_M.gguf', role: 'main', size_bytes: 4294967296, exists: true },
+    { name: 'mmproj-Llama-3.1-8B.gguf', role: 'mmproj', size_bytes: 524288000, exists: true },
+    { name: 'tokenizer.json', role: 'tokenizer', size_bytes: 0, exists: false },
+  ];
+
+  async function goToFilesTab(
+    page: Page,
+    opts: { files?: Array<Record<string, unknown>>; filesStatus?: number } = {},
+  ): Promise<void> {
+    const files = opts.files ?? SAMPLE_FILES;
+    const filesStatus = opts.filesStatus ?? 200;
+
+    await page.route('**/api/v1/health', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'test', all_models_loaded: [] }),
+      }),
+    );
+    await page.route('**/api/v1/models**', async route =>
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            { id: 'Llama-3.1-8B', name: 'Llama-3.1-8B', labels: ['llm'], recipe: 'llamacpp', downloaded: true },
+          ],
+        }),
+      }),
+    );
+    // Registered AFTER the generic /models** route so this more specific handler
+    // wins (Playwright matches routes in reverse registration order).
+    await page.route('**/api/v1/models/*/files', async route =>
+      route.fulfill({
+        status: filesStatus,
+        contentType: 'application/json',
+        body: JSON.stringify({ model_id: 'Llama-3.1-8B', files }),
+      }),
+    );
+
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await navigateToView(page, 'Models');
+    await page.waitForSelector('.manager--detail');
+    await page.waitForSelector('.model-list-item', { timeout: 5000 }).catch(() => {});
+    await page.locator('.model-list-item').first().click();
+    await page.waitForTimeout(150);
+    await page.locator('[role="tab"]').filter({ hasText: /Files/i }).click();
+    await page.waitForTimeout(200);
+  }
+
+  test('A180 — Files tab renders a table with accessible column headers', async ({ page }) => {
+    await goToFilesTab(page);
+    const table = page.locator('.detail-files__table');
+    await expect(table).toBeVisible();
+    // Column headers expose scope="col" so screen readers announce them.
+    const headers = table.locator('th[scope="col"]');
+    expect(await headers.count()).toBe(4);
+    await expect(table.locator('caption')).toHaveText(/Files backing/i);
+    // One body row per file returned by the endpoint.
+    await expect(table.locator('tbody tr')).toHaveCount(SAMPLE_FILES.length);
+  });
+
+  test('A181 — file rows show name, role badge, size, and download status', async ({ page }) => {
+    await goToFilesTab(page);
+    const firstRow = page.locator('.detail-files__table tbody tr').first();
+    await expect(firstRow.locator('.detail-files__name')).toContainText('Llama-3.1-8B-Q4_K_M.gguf');
+    await expect(firstRow.locator('.detail-files__role-badge')).toHaveText(/Main/i);
+    // 4294967296 bytes == 4.00 GB (binary units).
+    await expect(firstRow.locator('.detail-files__col-size')).toContainText('GB');
+    await expect(firstRow.locator('.detail-files__status--present')).toContainText(/Downloaded/i);
+
+    // A not-yet-downloaded file surfaces the missing state (not by color alone).
+    const missingRow = page.locator('.detail-files__table tbody tr').last();
+    await expect(missingRow.locator('.detail-files__status--missing')).toContainText(/Not downloaded/i);
+  });
+
+  test('A182 — empty file list shows an accessible empty state', async ({ page }) => {
+    await goToFilesTab(page, { files: [] });
+    await expect(page.locator('.detail-files__table')).toHaveCount(0);
+    const empty = page.locator('.detail-files--empty');
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText(/No files found/i);
+  });
+
+  test('A183 — a failed files request shows an error state, not a broken table', async ({ page }) => {
+    await goToFilesTab(page, { filesStatus: 500 });
+    await expect(page.locator('.detail-files__table')).toHaveCount(0);
+    await expect(page.locator('.detail-files--empty')).toContainText(/Unable to load files/i);
+  });
+
+  test('A184 — the Files tab passes a WCAG 2.1 AA axe-core scan', async ({ page }) => {
+    await goToFilesTab(page);
+    await expect(page.locator('.detail-files__table')).toBeVisible();
+    const results = await new AxeBuilder({ page })
+      .withTags([...WCAG_TAGS])
+      .analyze();
+    const critical = results.violations.filter(
+      v => v.impact === 'critical' || v.impact === 'serious',
+    );
+    expect(critical, formatViolations(critical)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the **Files tab** in the Model Detail Panel, completing Slice 2 of #2428.

### What it does
- Calls the new `GET /api/v1/models/{id}/files` endpoint (merged in #2437)
- Displays an accessible table showing each model file's name, role, size (human-readable), and download status
- Handles loading, empty, and error states gracefully
- Storage meter was already wired - confirmed working end-to-end against a live `lemond` build from this branch

### Changes (4 files)
| File | Change |
|------|--------|
| `src/api.ts` | Added `ModelFileInfo`, `ModelFilesResponse` interfaces + `getModelFiles(id)` method |
| `src/components/ModelDetailPanel.tsx` | Replaced Files tab stub with real component (fetch, table, states) |
| `src/styles/styles.css` | Dark-theme table/badge/status styles for the Files tab |
| `tests/a11y.spec.ts` | 5 new tests (A180-A184): table semantics, content, empty, error, axe scan |

### Testing
- **Built lemond.exe from this branch** and confirmed:
  - `GET /api/v1/models/Qwen3.6-35B-A3B-GGUF/files` returns files with roles (main, mmproj)
  - `GET /api/v1/system-info` returns `model_storage` with real disk stats
- **Playwright**: 191 passed, 7 skipped, 3 pre-existing failures (unrelated to this PR)
- **TypeScript**: `tsc --noEmit` clean

### Accessibility
- Semantic table with caption, scope=col headers
- Status conveyed via text (not color-only): Downloaded / Not downloaded
- aria-live=polite + aria-busy on loading state
- Passes axe-core WCAG 2.1 AA scan (test A184)

Closes progress on #2428. @fl0rianr - ready for your review.
