### PR TITLE
feat: add musl (Alpine Linux) support and packaging

### DIFF
--- a/.github/workflows/alpine_apk_build.yml
+++ b/.github/workflows/alpine_apk_build.yml
@@ -1,0 +1,157 @@
+name: Alpine musl APK 🏔️
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  # No paths filter here: the required "Alpine APK builds" check has to report
+  # on every PR, and a workflow that never triggers leaves it pending forever.
+  # `labeled` is here so the ci:distros escape hatch takes effect without a
+  # push. Adding `types` replaces the defaults, so the three default activity
+  # types have to be listed explicitly.
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build-apk:
+    name: Build .apk (${{ matrix.arch }})
+    # Label a PR `ci:distros` to opt it back in.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:distros')
+    runs-on: ${{ matrix.runs-on }}
+    permissions:
+      # Needed by the release-upload step on tag pushes.
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runs-on: ubuntu-latest
+          - arch: aarch64
+            runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          clean: true
+
+      # The job runs on the glibc host so the JS actions (checkout, upload,
+      # release) work; only the musl build itself runs inside Alpine via docker.
+      # The arm64 runner is native, so the arm64 alpine image needs no QEMU.
+      - name: Build APK
+        run: |
+          docker run --rm -v "$PWD:/src" -w /src alpine:latest \
+            sh packaging/alpine/build-apk.sh
+
+      - name: Smoke test the package
+        run: |
+          docker run --rm -v "$PWD:/src" -w /src alpine:latest sh -eux -c '
+            apk add --allow-untrusted ./dist/lemonade-server-*.apk
+            lemond --version
+            lemonade --version
+
+            export XDG_RUNTIME_DIR=/tmp/xdg-runtime
+            mkdir -p "$XDG_RUNTIME_DIR" && chmod 700 "$XDG_RUNTIME_DIR"
+
+            lemond --port 13305 > /tmp/lemond.log 2>&1 &
+            for i in $(seq 1 30); do
+              if wget -q -O - http://localhost:13305/live >/dev/null 2>&1; then
+                echo "Server is up"; exit 0
+              fi
+              sleep 2
+            done
+            echo "ERROR: server did not become healthy"
+            cat /tmp/lemond.log || true
+            exit 1
+          '
+
+      - name: Smoke test the OpenRC service
+        run: |
+          # Exercises the documented `rc-service lemonade-server start` path (not
+          # just a hand-exported `lemond`): the initd must export XDG_RUNTIME_DIR
+          # itself, or lemond refuses to start. --nodeps because a bare container
+          # has no running `net` service to depend on.
+          docker run --rm -v "$PWD:/src" -w /src alpine:latest sh -eux -c '
+            apk add --allow-untrusted ./dist/lemonade-server-*.apk
+
+            # Minimal OpenRC bootstrap for a non-init container.
+            mkdir -p /run/openrc
+            touch /run/openrc/softlevel
+
+            rc-service --nodeps lemonade-server start
+            for i in $(seq 1 30); do
+              if wget -q -O - http://localhost:13305/live >/dev/null 2>&1; then
+                echo "Service is up"
+                rc-service --nodeps lemonade-server stop || true
+                exit 0
+              fi
+              sleep 2
+            done
+            echo "ERROR: service did not become healthy"
+            cat /var/log/lemonade/lemonade.log || true
+            rc-service --nodeps lemonade-server stop || true
+            exit 1
+          '
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: lemonade-server-apk-${{ matrix.arch }}
+          path: dist/*.apk
+          if-no-files-found: error
+
+      # abuild names both arches lemonade-server-<ver>-r<rel>.apk, so give the
+      # release asset an arch suffix to avoid overwriting the other leg's upload.
+      - name: Stage release asset
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -eux
+          mkdir -p release-assets
+          orig=$(ls dist/lemonade-server-*.apk | head -1)
+          cp "$orig" "release-assets/$(basename "${orig%.apk}")-${{ matrix.arch }}.apk"
+
+      - name: Upload to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release-assets/*.apk
+          fail_on_unmatched_files: true
+
+  # Gate job that ensures: 1. in the merge queue, all jobs in `needs:` ran
+  # successfully (otherwise the merge is blocked), and 2. these jobs do not need
+  # to run on ordinary pull request pushes.
+  alpine-gate:
+    name: Alpine APK builds
+    needs: [build-apk]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check gated jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          # $NEEDS: {"job-id": {"result": "success|failure|skipped|cancelled"}, ...}
+          # Fail if any job broke. In the merge queue, also fail if any never ran.
+          echo "$NEEDS"
+          broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
+          if [ -n "$broke" ]; then
+            echo "FAILED: $broke"
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            absent=$(jq -r 'to_entries[]|select(.value.result!="success")|.key' <<<"$NEEDS")
+            if [ -n "$absent" ]; then
+              echo "DID NOT RUN IN MERGE QUEUE: $absent"
+              exit 1
+            fi
+          fi

--- a/.github/workflows/docker-build-smoke-test-alpine.yml
+++ b/.github/workflows/docker-build-smoke-test-alpine.yml
@@ -1,0 +1,100 @@
+name: Docker Build Smoke Test (Alpine/musl)
+
+on:
+  pull_request:
+    paths:
+      - "Dockerfile.alpine"
+      - ".dockerignore"
+      - "src/cpp/**"
+      - "include/**"
+      - "resources/**"
+      - "CMakeLists.txt"
+      - "CMakePresets.json"
+      - "setup.sh"
+      - "packaging/alpine/**"
+      - ".github/workflows/docker-build-smoke-test-alpine.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-smoke-test-alpine:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Build Docker image
+        run: |
+          # Temporary: the musl backend assets still live in a fork, so point
+          # backend downloads there explicitly. Drop this build-arg once the
+          # companion asset PRs land in lemonade-sdk/*.
+          docker build -f Dockerfile.alpine \
+            --build-arg LEMONADE_BACKEND_REPO_OWNER=clemperorpenguin \
+            -t lemonade-alpine:test .
+
+      - name: Run container
+        run: |
+          docker run -d \
+            --name lemonade-alpine-test \
+            -p 13305:13305 \
+            lemonade-alpine:test
+
+      - name: Wait for server to be ready
+        run: |
+          echo "Waiting for Lemonade to start..."
+          for i in {1..30}; do
+            if curl -sf http://localhost:13305/live > /dev/null; then
+              echo "Server is up"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Server did not start in time"
+          docker logs lemonade-alpine-test
+          exit 1
+
+      - name: CLI on PATH regression check
+        run: |
+          # Regression guard: the lemonade/lemond binaries must be callable by
+          # name via `docker exec` (i.e. on PATH), not just by absolute path.
+          # Non-login shell so the container's ENV PATH (/opt/lemonade) is used;
+          # Alpine's /etc/profile hard-resets PATH and would hide the binaries.
+          docker exec lemonade-alpine-test sh -c 'command -v lemonade && command -v lemond'
+          docker exec lemonade-alpine-test sh -c 'lemonade status'
+
+      - name: Load model
+        run: |
+          # Exercises the musl llama.cpp backend download path: on musl the
+          # backend asset is fetched from the fork release (LEMONADE_BACKEND_REPO_OWNER
+          # is baked into Dockerfile.alpine) and run under swrast Vulkan / CPU.
+          curl -X POST http://localhost:13305/api/v1/load \
+            -H "Content-Type: application/json" \
+            -d '{"model_name": "Qwen3-0.6B-GGUF"}'
+
+      - name: Chat completion smoke test
+        run: |
+          RESPONSE=$(curl -s http://localhost:13305/api/v1/chat/completions \
+            -H "Content-Type: application/json" \
+            -d '{
+              "model": "Qwen3-0.6B-GGUF",
+              "messages": [
+                { "role": "user", "content": "Hello, Lemonade!" }
+              ]
+            }')
+
+          echo "Response:"
+          echo "$RESPONSE"
+
+          echo "$RESPONSE" | grep -q '"choices"' || exit 1
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker logs lemonade-alpine-test || true
+          docker rm -f lemonade-alpine-test || true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2336,6 +2336,26 @@ if(EXISTS "${_INSTALL_ATOMICITY_TEST_SRC}")
     add_cpp_ci_test(InstallAtomicityTest CI OFF COMMAND test_install_atomicity)
 endif()
 
+# musl backend asset resolution (lemon::backends::musl::*). Header-only, pure
+# logic: asserts a musl host never resolves a glibc ("ubuntu") asset and that
+# GPU backends with no musl build throw. Arch is a parameter, so it runs on any
+# libc — no need to build under musl.
+set(_MUSL_INSTALL_PARAMS_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_musl_install_params.cpp"
+)
+if(EXISTS "${_MUSL_INSTALL_PARAMS_TEST_SRC}")
+    add_executable(test_musl_install_params
+        test/cpp/test_musl_install_params.cpp
+    )
+    target_include_directories(test_musl_install_params PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+
+    include(CTest)
+    add_cpp_ci_test(MuslInstallParamsTest CI ON COMMAND test_musl_install_params)
+endif()
+
 # Routing engine contract surface (issue #2407). Header-only foundation: the
 # shared types/interfaces in routing_policy.h plus the fake ClassifierServices.
 # The test loads the L0a-L3 fixtures from the source tree via ROUTING_FIXTURE_DIR.

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,88 @@
+# ==============================================================
+# Alpine / musl build of lemonade (lemond + lemonade CLI + web-app).
+#
+# Mirrors the glibc Dockerfile but on musl. NPU backends (FLM/RyzenAI) are not
+# available on musl and are intentionally omitted. GPU backends (Vulkan) require
+# a Vulkan driver in the container/host at runtime.
+# ==============================================================
+FROM alpine:latest AS builder
+
+# Build dependencies. Alpine has no systemd, so libsystemd is absent by design;
+# the build must not require it on musl.
+RUN apk add --no-cache \
+    build-base \
+    cmake \
+    samurai \
+    git \
+    linux-headers \
+    nodejs \
+    npm \
+    pkgconf \
+    openssl-dev \
+    curl-dev \
+    zlib-dev \
+    libdrm-dev \
+    libcap-dev \
+    libwebsockets-dev
+
+COPY . /app
+WORKDIR /app
+
+RUN rm -rf build && \
+    cmake --preset default && \
+    cmake --build --preset default web-app
+
+# # ============================================================
+# # Runtime stage — small musl image
+# # ============================================================
+FROM alpine:latest
+
+# Runtime dependencies. libstdc++/libgcc back the C++ binaries; vulkan-loader +
+# a Mesa driver enable the Vulkan backends; ca-certificates lets lemond fetch
+# backends/models over HTTPS.
+RUN apk add --no-cache \
+    libstdc++ \
+    libgcc \
+    curl \
+    openssl \
+    zlib \
+    libdrm \
+    libcap \
+    libwebsockets \
+    vulkan-loader \
+    mesa-vulkan-swrast \
+    ca-certificates \
+    unzip \
+    jq
+
+WORKDIR /opt/lemonade
+
+# Provide a private runtime directory so lemond can use get_runtime_dir()
+RUN mkdir -p /run/lemonade && chmod 700 /run/lemonade
+ENV XDG_RUNTIME_DIR=/run/lemonade
+
+# Official images resolve backend assets from lemonade-sdk/* (empty default).
+# While the musl assets still live in a fork, CI passes the fork owner
+# explicitly (--build-arg LEMONADE_BACKEND_REPO_OWNER=...); remove that once the
+# companion asset PRs land upstream.
+ARG LEMONADE_BACKEND_REPO_OWNER=
+ENV LEMONADE_BACKEND_REPO_OWNER=${LEMONADE_BACKEND_REPO_OWNER}
+
+COPY --from=builder /app/build/lemond ./lemond
+COPY --from=builder /app/build/lemonade ./lemonade
+COPY --from=builder /app/build/resources ./resources
+
+RUN chmod +x ./lemond ./lemonade
+
+ENV PATH="/opt/lemonade:${PATH}"
+
+RUN mkdir -p /opt/lemonade/llama/cpu \
+    /opt/lemonade/llama/vulkan \
+    /root/.cache/huggingface
+
+EXPOSE 13305
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:13305/live || exit 1
+
+CMD ["./lemond", "--host", "0.0.0.0"]

--- a/packaging/alpine/APKBUILD
+++ b/packaging/alpine/APKBUILD
@@ -1,0 +1,59 @@
+# Maintainer: Lemonade <lemonade@amd.com>
+pkgname=lemonade-server
+pkgver=10.9.0
+pkgrel=0
+pkgdesc="Local LLM server with GPU/NPU acceleration (musl build)"
+url="https://lemonade-server.ai"
+arch="x86_64 aarch64"
+license="Apache-2.0"
+# build-base/git/samurai come from alpine-sdk when building via build-apk.sh,
+# but list them so `abuild -r` can resolve a minimal environment too.
+makedepends="
+	build-base
+	cmake
+	samurai
+	git
+	nodejs
+	npm
+	pkgconf
+	linux-headers
+	openssl-dev
+	curl-dev
+	zlib-dev
+	libdrm-dev
+	libcap-dev
+	libwebsockets-dev
+	"
+# Shared-library deps of lemond/lemonade are auto-detected by abuild's tracedeps.
+# These are the runtime helpers it can't infer: TLS roots and the unzip binary
+# lemond shells out to when extracting .zip backend archives (stable-diffusion).
+depends="ca-certificates unzip onnxruntime openrc"
+install="$pkgname.pre-install $pkgname.post-install"
+source="$pkgname-$pkgver.tar.gz"
+builddir="$srcdir/$pkgname-$pkgver"
+options="!check"
+
+build() {
+	cmake -B build -G Ninja \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_INSTALL_PREFIX=/usr
+	cmake --build build
+	# Stages the browser UI into build/resources so it's picked up by install.
+	cmake --build build --target web-app
+}
+
+package() {
+	DESTDIR="$pkgdir" cmake --install build
+
+	# Alpine has no systemd; drop the units and sysusers.d snippet the Linux
+	# install rules emit and ship an OpenRC service instead.
+	rm -rf "$pkgdir"/usr/lib/systemd "$pkgdir"/usr/lib/sysusers.d
+
+	# abuild rejects uncompressed man pages; the Linux install rules ship them
+	# plain. Keep everything in one package (so the OpenRC service ships with the
+	# binaries) rather than splitting a -doc subpackage, and just gzip them.
+	gzip -9 "$pkgdir"/usr/share/man/man1/*.1
+
+	install -Dm755 "$builddir"/packaging/alpine/lemonade-server.initd \
+		"$pkgdir"/etc/init.d/lemonade-server
+}

--- a/packaging/alpine/README.md
+++ b/packaging/alpine/README.md
@@ -1,0 +1,52 @@
+# Alpine / musl packaging
+
+Builds an installable `lemonade-server` `.apk` (lemond + lemonade CLI + web app)
+for musl-based Linux. NPU backends (FastFlowLM/RyzenAI) are not available on musl
+and are excluded; GPU (Vulkan) backends work if a Vulkan driver is present at
+runtime.
+
+## Build
+
+From the repo root, in an `alpine:latest` container:
+
+```sh
+docker run --rm -v "$PWD:/src" -w /src alpine:latest \
+    sh packaging/alpine/build-apk.sh
+```
+
+The `.apk` lands in `./dist/`. `build-apk.sh` snapshots the working tree, drives
+`abuild` with a throwaway signing key, and copies out the result. Set `OUTDIR` to
+change the destination.
+
+CI builds both `x86_64` and `aarch64` packages via
+`.github/workflows/alpine_apk_build.yml` (runs the same script inside an
+`alpine:latest` container, smoke-tests the install, and uploads the `.apk` as a
+workflow artifact).
+
+## Install & run
+
+```sh
+apk add --allow-untrusted ./dist/lemonade-server-*.apk
+rc-service lemonade-server start        # or run `lemond` directly
+```
+
+Web UI: <http://localhost:13305/app>
+
+The service runs as the unprivileged `lemonade` user (state in
+`/var/lib/lemonade`). Env vars (`HF_TOKEN`, `LEMONADE_API_KEY`, …) go in
+`/etc/lemonade/conf.d/*.conf`, mirroring the systemd drop-in on glibc distros.
+
+## musl backend assets
+
+The backends (llama.cpp, whisper.cpp, stable-diffusion.cpp, Kokoro, Moonshine)
+publish musl (`-linux-musl-` / `-Linux-musl-`) release assets from a fork until
+they land in `lemonade-sdk/*`. Until then, point backend downloads at that fork:
+
+```sh
+export LEMONADE_BACKEND_REPO_OWNER=clemperorpenguin
+```
+
+Only `lemonade-sdk/*` repos are remapped; upstream repos (`ggml-org`, `leejet`)
+are untouched. Without this, `lemond` resolves `lemonade-sdk/*` musl assets that
+do not exist yet and the download 404s. Drop it in `/etc/lemonade/conf.d/*.conf`
+to make it persistent for the service.

--- a/packaging/alpine/build-apk.sh
+++ b/packaging/alpine/build-apk.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Build a lemonade-server .apk for musl/Alpine.
+#
+# Run inside an alpine:latest container from the repo root, e.g.:
+#
+#   docker run --rm -v "$PWD:/src" -w /src alpine:latest \
+#       sh packaging/alpine/build-apk.sh
+#
+# Produces the .apk(s) under ./dist/ (override with OUTDIR=/path).
+set -eux
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+OUTDIR=${OUTDIR:-"$REPO_ROOT/dist"}
+
+# Keep the packaged version in lockstep with the CMake project version.
+VERSION=$(sed -n 's/^project(lemon_cpp VERSION \([0-9.]*\)).*/\1/p' "$REPO_ROOT/CMakeLists.txt")
+[ -n "$VERSION" ] || { echo "could not parse project version from CMakeLists.txt" >&2; exit 1; }
+
+# Populate the on-disk package index so abuild's own `apk add` (for makedepends)
+# can resolve packages. `apk add --no-cache` fetches the index to memory only and
+# leaves nothing on disk, which makes the later builddeps step fail.
+apk update
+
+# alpine-sdk brings abuild + build-base + git; abuild -r installs makedepends.
+apk add alpine-sdk
+
+# We run as root in the CI container, so force abuild to use apk directly for
+# installing makedepends instead of its default doas/sudo escalation (the base
+# alpine image ships neither).
+export SUDO_APK="apk"
+
+# abuild refuses to run without a signing key. Generate a throwaway one.
+# Don't use `-i`: that shells out to doas to copy the pubkey into
+# /etc/apk/keys, which fails in the bare image — we're root, so cp it ourselves.
+if ! ls "$HOME"/.abuild/*.rsa >/dev/null 2>&1; then
+	abuild-keygen -a -n
+fi
+cp "$HOME"/.abuild/*.rsa.pub /etc/apk/keys/
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Snapshot the working tree (includes uncommitted changes) minus build output.
+STAGE="$WORK/src/lemonade-server-$VERSION"
+mkdir -p "$STAGE"
+cp -a "$REPO_ROOT"/. "$STAGE"/
+rm -rf "$STAGE"/build "$STAGE"/build-* "$STAGE"/.git "$STAGE"/dist
+
+BUILDDIR="$WORK/abuild"
+mkdir -p "$BUILDDIR"
+cp "$REPO_ROOT"/packaging/alpine/APKBUILD "$BUILDDIR"/
+cp "$REPO_ROOT"/packaging/alpine/lemonade-server.pre-install "$BUILDDIR"/
+cp "$REPO_ROOT"/packaging/alpine/lemonade-server.post-install "$BUILDDIR"/
+sed -i "s/^pkgver=.*/pkgver=$VERSION/" "$BUILDDIR"/APKBUILD
+
+tar -czf "$BUILDDIR/lemonade-server-$VERSION.tar.gz" -C "$WORK/src" "lemonade-server-$VERSION"
+
+cd "$BUILDDIR"
+abuild -F checksum
+abuild -F -r
+
+mkdir -p "$OUTDIR"
+find "$HOME"/packages -name '*.apk' -exec cp -v {} "$OUTDIR"/ \;
+echo "APK(s) written to $OUTDIR"

--- a/packaging/alpine/lemonade-server.initd
+++ b/packaging/alpine/lemonade-server.initd
@@ -1,0 +1,39 @@
+#!/sbin/openrc-run
+
+name="Lemonade Server"
+description="Local LLM server with GPU/NPU acceleration"
+
+command="/usr/bin/lemond"
+command_user="lemonade:lemonade"
+command_background=true
+pidfile="/run/lemonade/lemonade-server.pid"
+directory="/var/lib/lemonade"
+output_log="/var/log/lemonade/lemonade.log"
+error_log="/var/log/lemonade/lemonade.log"
+
+export HOME="/var/lib/lemonade"
+
+# lemond resolves its runtime dir from XDG_RUNTIME_DIR (or RUNTIME_DIRECTORY);
+# without one it refuses to start. start_pre creates this dir 0700 lemonade:lemonade.
+export XDG_RUNTIME_DIR="/run/lemonade"
+
+depend() {
+	need net
+	after firewall
+}
+
+start_pre() {
+	checkpath -d -m 0700 -o lemonade:lemonade /run/lemonade
+	checkpath -d -m 0750 -o lemonade:lemonade /var/lib/lemonade
+	checkpath -d -m 0750 -o lemonade:lemonade /var/log/lemonade
+
+	# Mirror the systemd EnvironmentFile drop-in: load HF_TOKEN,
+	# LEMONADE_API_KEY, etc. from /etc/lemonade/conf.d/*.conf.
+	if [ -d /etc/lemonade/conf.d ]; then
+		set -a
+		for f in /etc/lemonade/conf.d/*.conf; do
+			[ -f "$f" ] && . "$f"
+		done
+		set +a
+	fi
+}

--- a/packaging/alpine/lemonade-server.post-install
+++ b/packaging/alpine/lemonade-server.post-install
@@ -1,0 +1,16 @@
+#!/bin/sh
+mkdir -p /var/lib/lemonade
+chown lemonade:lemonade /var/lib/lemonade
+chmod 0750 /var/lib/lemonade
+
+cat <<'EOF'
+
+lemonade-server installed.
+
+Start it now:   rc-service lemonade-server start
+Enable at boot: rc-update add lemonade-server default
+
+The web UI is served at http://localhost:13305/app
+EOF
+
+exit 0

--- a/packaging/alpine/lemonade-server.pre-install
+++ b/packaging/alpine/lemonade-server.pre-install
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Create the unprivileged 'lemonade' system user the service runs as,
+# matching the systemd sysusers.d definition (home /var/lib/lemonade).
+
+addgroup -S lemonade 2>/dev/null || true
+adduser -S -D -H -h /var/lib/lemonade -s /sbin/nologin -G lemonade \
+	-g "Lemonade Server" lemonade 2>/dev/null || true
+
+exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -120,6 +120,8 @@ else
             missing_packages+=("pre-commit")
         elif [ "$OS" = "linux" ] && command_exists zypper; then
             missing_packages+=("python313-pre-commit")
+        elif [ "$OS" = "linux" ] && command_exists apk; then
+            missing_packages+=("pre-commit")
         elif [ "$OS" = "macos" ] && command_exists brew; then
             missing_packages+=("pre-commit")
         elif command_exists pip || command_exists pip3; then
@@ -160,6 +162,8 @@ if [ ${#missing_tools[@]} -gt 0 ]; then
             missing_packages+=("git" "cmake" "ninja-build" "gcc" "gcc-c++" "make")
         elif command_exists zypper; then
             missing_packages+=("git" "cmake" "ninja" "gcc" "gcc-c++" "make")
+        elif command_exists apk; then
+            missing_packages+=("git" "cmake" "samurai" "build-base")
         fi
     elif [ "$OS" = "macos" ]; then
         missing_packages+=("git" "cmake" "ninja")
@@ -252,6 +256,21 @@ if command_exists pkg-config; then
                         libwebsockets) missing_packages+=("libwebsockets-devel") ;;
                     esac
                 done
+            elif command_exists apk; then
+                # Map pkg-config names to Alpine (musl) packages. Alpine has no
+                # systemd, so libsystemd is skipped — the build must not require
+                # it on musl.
+                for lib in "${missing_libs[@]}"; do
+                    case "$lib" in
+                        libcurl) missing_packages+=("curl-dev") ;;
+                        openssl) missing_packages+=("openssl-dev") ;;
+                        zlib) missing_packages+=("zlib-dev") ;;
+                        libsystemd) : ;;
+                        libdrm) missing_packages+=("libdrm-dev") ;;
+                        libcap) missing_packages+=("libcap-dev") ;;
+                        libwebsockets) missing_packages+=("libwebsockets-dev") ;;
+                    esac
+                done
             fi
         elif [ "$OS" = "macos" ]; then
             # macOS typically has these via Xcode Command Line Tools
@@ -278,6 +297,8 @@ else
             missing_packages+=("pkgconfig" "libcurl-devel" "openssl-devel" "zlib-devel" "systemd-devel" "libdrm-devel" "libcap-devel" "libwebsockets-devel")
         elif command_exists zypper; then
             missing_packages+=("pkg-config" "libcurl-devel" "libopenssl-devel" "zlib-devel" "systemd-devel" "libdrm-devel" "libcap-devel" "libwebsockets-devel")
+        elif command_exists apk; then
+            missing_packages+=("pkgconf" "curl-dev" "openssl-dev" "zlib-dev" "libdrm-dev" "libcap-dev" "libwebsockets-dev")
         fi
     elif [ "$OS" = "macos" ]; then
         missing_packages+=("pkg-config" "curl" "openssl" "zlib")
@@ -603,6 +624,12 @@ if [ ${#missing_packages[@]} -gt 0 ]; then
             else
                 install_cmd="sudo zypper install -y --replacefiles --force-resolution ${missing_packages[*]}"
             fi
+        elif command_exists apk; then
+            if is_root; then
+                install_cmd="apk add ${missing_packages[*]}"
+            else
+                install_cmd="sudo apk add ${missing_packages[*]}"
+            fi
         fi
     elif [ "$OS" = "macos" ]; then
         install_cmd="brew install ${missing_packages[*]}"
@@ -649,6 +676,8 @@ if [ ${#missing_packages[@]} -gt 0 ]; then
             maybe_sudo dnf install -y ${missing_packages[@]}
         elif command_exists zypper; then
             maybe_sudo zypper install -y --replacefiles --force-resolution ${missing_packages[@]}
+        elif command_exists apk; then
+            maybe_sudo apk add ${missing_packages[@]}
         fi
     elif [ "$OS" = "macos" ]; then
         brew install ${missing_packages[@]}

--- a/src/cpp/include/lemon/backends/kokoro/kokoro.h
+++ b/src/cpp/include/lemon/backends/kokoro/kokoro.h
@@ -25,7 +25,12 @@ inline const BackendDescriptor descriptor = {
     /*options*/ {},
     /*support*/ {
         {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
+#ifndef LEMON_LINUX_MUSL
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
+#else
+        // musl publishes both x86_64 and aarch64 CPU assets.
+        {"cpu", {"linux"}, {{"cpu", {"x86_64", "arm64"}}}, "x86_64/ARM64 CPU"},
+#endif
     },
     /*default_labels*/  {"tts"},  // kokoro only does TTS; declare it so a label-less
                                    // user model is typed TTS, not LLM (catalog models

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
@@ -33,14 +33,20 @@ inline const BackendDescriptor descriptor = {
     /*support*/ {
         {"system", {"linux"}, {{"cpu", {"x86_64", "arm64"}}}, "x86_64/ARM64 CPU, GPU"},
         {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
+        // No musl cuda/rocm builds exist (glibc-only assets); omit on musl so a
+        // musl host never selects a backend it cannot download.
+#ifndef LEMON_LINUX_MUSL
         {"cuda", {"windows", "linux"},
          {{"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120", "sm_121"}}}, "NVIDIA GPUs (Turing or newer)**"},
+#endif
         {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64", "arm64"}}, {"amd_gpu", {}}}, "x86_64 CPU, AMD iGPU, AMD dGPU; ARM64 CPU/GPU (Linux)"},
+#ifndef LEMON_LINUX_MUSL
         {"rocm", {"windows", "linux"},
          {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X", "gfx942", "gfx950"}}}, "Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942) and MI350X (gfx950, Linux + stable only)*",
          // gfx950 (MI350) only ships a Linux + stable-channel asset so far; the
          // Windows TheRock dist and the nightly build aren't published yet.
          {{"gfx950", {/*os*/ {"linux"}, /*channels*/ {"stable"}}}}},
+#endif
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64", "arm64"}}}, "x86_64 CPU; ARM64 CPU (Linux)"},
     },
     /*default_labels*/  {},

--- a/src/cpp/include/lemon/backends/musl_assets.h
+++ b/src/cpp/include/lemon/backends/musl_assets.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+// Pure musl backend asset resolution. A musl build of lemond must never resolve a
+// glibc ("ubuntu"/"Ubuntu") release asset, and the GPU backends that only ship
+// glibc binaries (llamacpp cuda/rocm, whispercpp rocm) have no musl build at all.
+// These helpers encode exactly which musl assets exist, throwing for variants that
+// don't, so the selection layer (descriptor support rows) and the install layer
+// agree and the logic stays unit-testable off musl.
+//
+// Kept dependency-free (no SystemInfo, no I/O, no json) on purpose. Repos stay as
+// lemonade-sdk/* here; apply_repo_owner_override() remaps them downstream.
+namespace lemon::backends::musl {
+
+enum class Arch { X86_64, Aarch64 };
+
+struct Asset {
+    std::string repo;      // GitHub "org/repo"
+    std::string filename;  // Release asset filename
+};
+
+// Host architecture as an Arch. Backends pass this so the resolvers below stay
+// pure and testable for either arch regardless of the build host.
+inline Arch host_arch() {
+#if defined(__aarch64__) || defined(_M_ARM64)
+    return Arch::Aarch64;
+#else
+    return Arch::X86_64;
+#endif
+}
+
+inline Asset llamacpp(const std::string& backend, const std::string& version, Arch arch) {
+    const std::string a = (arch == Arch::Aarch64) ? "arm64" : "x64";
+    if (backend == "cpu") {
+        return {"lemonade-sdk/llama.cpp", "llama-" + version + "-bin-linux-musl-" + a + ".tar.gz"};
+    }
+    if (backend == "vulkan") {
+        return {"lemonade-sdk/llama.cpp", "llama-" + version + "-bin-linux-musl-vulkan-" + a + ".tar.gz"};
+    }
+    throw std::runtime_error("llamacpp backend '" + backend + "' has no musl build");
+}
+
+inline Asset whispercpp(const std::string& backend, const std::string& version, Arch arch) {
+    const std::string a = (arch == Arch::Aarch64) ? "aarch64" : "x86_64";
+    if (backend == "cpu") {
+        return {"lemonade-sdk/whisper.cpp-rocm", "whisper-" + version + "-linux-musl-cpu-" + a + ".tar.gz"};
+    }
+    if (backend == "vulkan") {
+        return {"lemonade-sdk/whisper.cpp-rocm", "whisper-" + version + "-linux-musl-vulkan-" + a + ".tar.gz"};
+    }
+    throw std::runtime_error("whispercpp backend '" + backend + "' has no musl build");
+}
+
+// sd.cpp ships only CPU and Vulkan on musl; load() coerces any GPU backend to one
+// of those, and an explicit cuda/rocm request maps to the CPU asset here (never a
+// glibc one). short_version is the asset-name form (see SDServer::get_install_params).
+inline Asset sdcpp(const std::string& backend, const std::string& short_version, Arch arch) {
+    const std::string a = (arch == Arch::Aarch64) ? "aarch64" : "x86_64";
+    const std::string variant = (backend == "vulkan") ? "-vulkan-" : "-";
+    return {"lemonade-sdk/stable-diffusion.cpp",
+            "sd-" + short_version + "-bin-Linux-musl" + variant + a + ".zip"};
+}
+
+inline Asset kokoro(const std::string& backend, Arch arch) {
+    const std::string a = (arch == Arch::Aarch64) ? "arm64" : "x86_64";
+    if (backend == "cpu") {
+        return {"lemonade-sdk/Kokoros", "kokoros-linux-musl-" + a + ".tar.gz"};
+    }
+    throw std::runtime_error("kokoro backend '" + backend + "' has no musl build");
+}
+
+inline Asset moonshine(const std::string& version, Arch arch) {
+    const std::string a = (arch == Arch::Aarch64) ? "arm64" : "x64";
+    return {"lemonade-sdk/moonshine-server-rocm",
+            "moonshine-server-" + version + "-linux-musl-" + a + ".tar.gz"};
+}
+
+}  // namespace lemon::backends::musl

--- a/src/cpp/include/lemon/backends/sdcpp/sdcpp.h
+++ b/src/cpp/include/lemon/backends/sdcpp/sdcpp.h
@@ -37,12 +37,19 @@ inline const BackendDescriptor descriptor = {
     },
     /*support*/ {
         {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
+        // No musl rocm/cuda builds exist (glibc-only assets); omit on musl.
+#ifndef LEMON_LINUX_MUSL
         {"cuda", {"windows", "linux"},
          {{"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120", "sm_121"}}}, "NVIDIA GPUs (Turing or newer)**"},
         {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
         {"rocm", {"windows", "linux"},
          {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families*"},
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
+#else
+        // musl publishes both x86_64 and aarch64 CPU/Vulkan assets.
+        {"vulkan", {"linux"}, {{"cpu", {"x86_64", "arm64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
+        {"cpu", {"linux"}, {{"cpu", {"x86_64", "arm64"}}}, "x86_64/ARM64 CPU"},
+#endif
     },
     /*default_labels*/  {"image"},
     /*required_checkpoints*/ {"main"},  // flux text_encoder+vae validated together in load()

--- a/src/cpp/include/lemon/backends/whispercpp/whispercpp.h
+++ b/src/cpp/include/lemon/backends/whispercpp/whispercpp.h
@@ -31,10 +31,17 @@ inline const BackendDescriptor descriptor = {
     /*support*/ {
         {"npu", {"windows"}, {{"amd_npu", {"XDNA2"}}}, "XDNA2 NPU"},
         {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
+        // No musl rocm build exists (glibc-only asset); omit on musl.
+#ifndef LEMON_LINUX_MUSL
         {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}}, "x86_64 CPU"},
         {"rocm", {"windows", "linux"},
          {{"amd_gpu", {"gfx1150", "gfx1151", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families*"},
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
+#else
+        // musl publishes both x86_64 and aarch64 CPU/Vulkan assets.
+        {"vulkan", {"linux"}, {{"cpu", {"x86_64", "arm64"}}, {"amd_gpu", {}}}, "x86_64/ARM64 CPU"},
+        {"cpu", {"linux"}, {{"cpu", {"x86_64", "arm64"}}}, "x86_64/ARM64 CPU"},
+#endif
     },
     /*default_labels*/  {"transcription", "realtime-transcription"},
     /*required_checkpoints*/ {"main"},  // npu_cache validated in load() (npu variant only)

--- a/src/cpp/include/lemon/platform.h
+++ b/src/cpp/include/lemon/platform.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Compile-time libc detection.
+//
+// glibc defines __GLIBC__ (exposed via <features.h>); musl defines no libc
+// identification macro, so on Linux its absence means musl. A lemond built
+// against musl only ever runs on musl, so this compile-time signal is
+// sufficient to select musl-specific backend release assets.
+#ifdef __linux__
+#include <features.h>
+#if !defined(__GLIBC__)
+#define LEMON_LINUX_MUSL 1
+#endif
+#endif

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -9,6 +9,7 @@
 #include "lemon/utils/path_utils.h"
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -24,6 +25,21 @@ namespace fs = std::filesystem;
 namespace lemon {
 
 namespace {
+
+// Testing hook: redirect backend downloads from the production lemonade-sdk/*
+// release repos to a fork owner that publishes work-in-progress assets (e.g. a
+// personal fork cutting musl releases). Set LEMONADE_BACKEND_REPO_OWNER to the
+// fork owner. Only lemonade-sdk/* repos are remapped; upstream repos
+// (ggml-org, leejet, ...) are left untouched so their assets still resolve.
+std::string apply_repo_owner_override(const std::string& repo) {
+    const char* owner = std::getenv("LEMONADE_BACKEND_REPO_OWNER");
+    if (!owner || !*owner) return repo;
+    const std::string prefix = "lemonade-sdk/";
+    if (repo.rfind(prefix, 0) == 0) {
+        return std::string(owner) + "/" + repo.substr(prefix.size());
+    }
+    return repo;
+}
 
 std::string get_current_os() {
 #ifdef _WIN32
@@ -496,7 +512,8 @@ std::string BackendManager::get_or_resolve_latest_tag(const std::string& recipe,
         // First call extracts the repo for this (recipe, backend); filename
         // templating is discarded.
         auto pinned_params = spec->install_params_fn(resolved_backend, pinned);
-        return fetch_latest_github_tag(pinned_params.repo, /*throw_on_failure=*/false);
+        return fetch_latest_github_tag(apply_repo_owner_override(pinned_params.repo),
+                                       /*throw_on_failure=*/false);
     } catch (const std::exception& e) {
         LOG(WARNING, "BackendManager") << "get_or_resolve_latest_tag(" << recipe
                                        << ":" << backend << ") failed: " << e.what() << std::endl;
@@ -520,9 +537,11 @@ BackendManager::InstallParams BackendManager::get_install_params(const std::stri
     // Two-pass: first call gets the repo for resolve_user_version (filename
     // discarded); second call templates the resolved tag into the real filename.
     auto pinned_params = spec->install_params_fn(resolved_backend, pinned);
+    pinned_params.repo = apply_repo_owner_override(pinned_params.repo);
     std::string resolved_version = resolve_user_version(
         recipe, resolved_backend, pinned, pinned_params.repo);
     auto final_params = spec->install_params_fn(resolved_backend, resolved_version);
+    final_params.repo = apply_repo_owner_override(final_params.repo);
     // Allow backends to override the release tag (e.g. per-GPU-target releases)
     std::string release_version = final_params.version_override.empty()
                                       ? resolved_version

--- a/src/cpp/server/backends/kokoro/kokoro_server.cpp
+++ b/src/cpp/server/backends/kokoro/kokoro_server.cpp
@@ -4,7 +4,9 @@
 #include "lemon/backends/backend_ops.h"
 #include "lemon/backends/backend_utils.h"
 #include "lemon/backends/hf_cache_util.h"
+#include "lemon/backends/musl_assets.h"
 #include "lemon/model_manager.h"
+#include "lemon/platform.h"
 #include "lemon/utils/path_utils.h"
 #include <filesystem>
 #include "lemon/backend_manager.h"
@@ -42,10 +44,19 @@ std::string default_kokoro_backend() {
 
 InstallParams KokoroServer::get_install_params(const std::string& backend, const std::string& version) {
     InstallParams params;
+
+#ifdef LEMON_LINUX_MUSL
+    // musl ships only a CPU build; other backends have none (helper throws).
+    const auto musl_asset = musl::kokoro(backend, musl::host_arch());
+    params.repo = musl_asset.repo;
+    params.filename = musl_asset.filename;
+    return params;
+#endif
+
     params.repo = "lemonade-sdk/Kokoros";
 
     if (backend == "cpu") {
-#ifdef _WIN32
+#if defined(_WIN32)
         params.filename = "kokoros-windows-x86_64.tar.gz";
 #elif defined(__linux__)
         params.filename = "kokoros-linux-x86_64.tar.gz";

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -5,9 +5,11 @@
 #include "lemon/backends/backend_registry.h"
 #include "lemon/backends/backend_ops.h"
 #include "lemon/backends/backend_utils.h"
+#include "lemon/backends/musl_assets.h"
 #include "lemon/gguf_capabilities.h"
 #include "lemon/gguf_reader.h"
 #include "lemon/model_manager.h"
+#include "lemon/platform.h"
 #include <algorithm>
 #include <filesystem>
 #include <regex>
@@ -170,6 +172,14 @@ InstallParams LlamaCppServer::get_install_params(const std::string& backend, con
     if (resolved_backend == "system") {
         return params; // Return empty params for system backend
     }
+
+#ifdef LEMON_LINUX_MUSL
+    // musl ships only CPU and Vulkan; cuda/rocm have no musl build (helper throws).
+    const auto musl_asset = musl::llamacpp(resolved_backend, version, musl::host_arch());
+    params.repo = musl_asset.repo;
+    params.filename = musl_asset.filename;
+    return params;
+#endif
 
     if (resolved_backend == "rocm-stable") {
         params.repo = "lemonade-sdk/llama.cpp";

--- a/src/cpp/server/backends/moonshine/moonshine_server.cpp
+++ b/src/cpp/server/backends/moonshine/moonshine_server.cpp
@@ -2,7 +2,9 @@
 #include "lemon/backends/moonshine/moonshine.h"
 #include "lemon/backends/backend_registry.h"
 #include "lemon/backends/backend_utils.h"
+#include "lemon/backends/musl_assets.h"
 #include "lemon/backend_manager.h"
+#include "lemon/platform.h"
 #include "lemon/runtime_config.h"
 #include "lemon/utils/custom_args.h"
 #include "lemon/utils/http_client.h"
@@ -32,6 +34,15 @@ namespace backends {
 InstallParams MoonshineServer::get_install_params(const std::string& backend, const std::string& version) {
     (void)backend;  // moonshine is CPU-only
     InstallParams params;
+
+#ifdef LEMON_LINUX_MUSL
+    // Upstream PyInstaller bundles are glibc-only; musl builds come from the fork.
+    const auto musl_asset = musl::moonshine(version, musl::host_arch());
+    params.repo = musl_asset.repo;
+    params.filename = musl_asset.filename;
+    return params;
+#endif
+
     params.repo = "lemonade-sdk/moonshine-server-rocm";
 
     // Self-contained PyInstaller bundles built by the lemonade-sdk/moonshine-server-rocm

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -2,7 +2,9 @@
 #include "lemon/backends/sdcpp/sdcpp.h"
 #include "lemon/backends/backend_registry.h"
 #include "lemon/backends/backend_utils.h"
+#include "lemon/backends/musl_assets.h"
 #include "lemon/backend_manager.h"
+#include "lemon/platform.h"
 #include "lemon/runtime_config.h"
 #include "lemon/utils/custom_args.h"
 #include "lemon/utils/http_client.h"
@@ -12,6 +14,7 @@
 #include "lemon/error_types.h"
 #include "lemon/system_info.h"
 #include <httplib.h>
+#include <algorithm>
 #include <iostream>
 #include <filesystem>
 #include <fstream>
@@ -114,6 +117,15 @@ InstallParams SDServer::get_install_params(const std::string& backend, const std
         }
     }
 
+#ifdef LEMON_LINUX_MUSL
+    // musl ships only CPU and Vulkan; load() maps any GPU backend to one of those,
+    // and cuda/rocm map to the CPU asset here — never a glibc/ubuntu asset.
+    const auto musl_asset = musl::sdcpp(resolved_backend, short_version, musl::host_arch());
+    params.repo = musl_asset.repo;
+    params.filename = musl_asset.filename;
+    return params;
+#endif
+
     if (resolved_backend == "metal") {
 #if defined(__APPLE__)
         params.filename = "sd-" + short_version + "-bin-Darwin-macOS-*-arm64.zip";
@@ -163,7 +175,7 @@ InstallParams SDServer::get_install_params(const std::string& backend, const std
 #endif
     } else {
         // CPU build (default)
-    #ifdef _WIN32
+#if defined(_WIN32)
         params.filename = "sd-" + short_version + "-bin-win-avx2-x64.zip";
 #elif defined(__linux__)
         params.filename = "sd-" + short_version + "-bin-Linux-Ubuntu-24.04-x86_64.zip";
@@ -198,6 +210,18 @@ void SDServer::load(const std::string& model_name,
         auto supported = SystemInfo::get_supported_backends("sd-cpp");
         backend = supported.backends.empty() ? "cpu" : supported.backends[0];
     }
+#ifdef LEMON_LINUX_MUSL
+    // musl builds ship only CPU and Vulkan; there is no musl rocm/cuda asset, so
+    // route any GPU backend through Vulkan when the platform reports it, else
+    // fall back to CPU (keeps device/args/binary dir and validation aligned).
+    if (backend != "vulkan" && backend != "cpu") {
+        auto musl_supported = SystemInfo::get_supported_backends("sd-cpp");
+        bool vulkan_ok = std::find(musl_supported.backends.begin(),
+                                   musl_supported.backends.end(),
+                                   "vulkan") != musl_supported.backends.end();
+        backend = vulkan_ok ? "vulkan" : "cpu";
+    }
+#endif
     std::string resolved_backend = resolve_sdcpp_backend(backend);
     std::string sdcpp_args = options.get_option("sdcpp_args");
 

--- a/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
+++ b/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
@@ -4,8 +4,10 @@
 #include "lemon/backends/backend_ops.h"
 #include "lemon/backends/backend_utils.h"
 #include "lemon/backends/hf_cache_util.h"
+#include "lemon/backends/musl_assets.h"
 #include "lemon/model_manager.h"
 #include "lemon/backend_manager.h"
+#include "lemon/platform.h"
 #include "lemon/runtime_config.h"
 #include "lemon/system_info.h"
 #include "lemon/audio_types.h"
@@ -81,6 +83,14 @@ WhisperServer::~WhisperServer() {
 InstallParams WhisperServer::get_install_params(const std::string& backend, const std::string& version) {
     InstallParams params;
 
+#ifdef LEMON_LINUX_MUSL
+    // musl ships only CPU and Vulkan; rocm/npu have no musl build (helper throws).
+    const auto musl_asset = musl::whispercpp(backend, version, musl::host_arch());
+    params.repo = musl_asset.repo;
+    params.filename = musl_asset.filename;
+    return params;
+#endif
+
     params.repo = "lemonade-sdk/whisper.cpp-rocm";
 
     if (backend == "npu") {
@@ -90,7 +100,7 @@ InstallParams WhisperServer::get_install_params(const std::string& backend, cons
         throw std::runtime_error("NPU whisper.cpp only supported on Windows");
 #endif
     } else if (backend == "cpu") {
-#ifdef _WIN32
+#if defined(_WIN32)
         params.filename = "whisper-" + version + "-windows-cpu-x64.zip";
 #elif defined(__linux__)
         params.filename = "whisper-" + version + "-linux-cpu-x86_64.tar.gz";
@@ -111,7 +121,7 @@ InstallParams WhisperServer::get_install_params(const std::string& backend, cons
         throw std::runtime_error("ROCm whisper.cpp backend is only supported on Windows and Linux");
 #endif
     } else if (backend == "vulkan") {
-#ifdef _WIN32
+#if defined(_WIN32)
         params.filename = "whisper-" + version + "-windows-vulkan-x64.zip";
 #elif defined(__linux__)
         params.filename = "whisper-" + version + "-linux-vulkan-x86_64.tar.gz";

--- a/test/cpp/test_musl_install_params.cpp
+++ b/test/cpp/test_musl_install_params.cpp
@@ -1,0 +1,131 @@
+// Standalone unit tests for the pure musl backend asset resolvers
+// (lemon::backends::musl::*). A musl build of lemond must never resolve a glibc
+// ("ubuntu"/"Ubuntu") release asset, and the GPU backends that only ship glibc
+// binaries (llamacpp cuda/rocm, whispercpp rocm) have no musl build at all — the
+// resolver must throw rather than fall through to a glibc name. Regression
+// coverage for the musl backend-selection gating.
+//
+// The resolvers are pure and dependency-free, so these assertions run on any
+// host regardless of libc (they take the target arch as a parameter).
+//
+// Checks use an explicit pass/fail counter (not assert()) so the test stays
+// effective under the Release build the CI `default` preset uses, where -DNDEBUG
+// would compile assert() to a no-op.
+//
+// Compile with:
+//   g++ -std=c++17 -I src/cpp/include \
+//       test/cpp/test_musl_install_params.cpp -o musl_install_params_test
+//
+// Run with:
+//   ./musl_install_params_test
+
+#include <cstdio>
+#include <functional>
+#include <string>
+
+#include <lemon/backends/musl_assets.h>
+
+namespace musl = lemon::backends::musl;
+
+struct TestResult {
+    int passed = 0;
+    int failed = 0;
+
+    void check(bool cond, const std::string& name) {
+        if (cond) {
+            printf("[PASS] %s\n", name.c_str());
+            ++passed;
+        } else {
+            printf("[FAIL] %s\n", name.c_str());
+            ++failed;
+        }
+    }
+};
+
+static bool contains(const std::string& s, const std::string& sub) {
+    return s.find(sub) != std::string::npos;
+}
+
+// A musl asset name must name musl and must never carry a glibc or foreign-OS
+// token. This is the core invariant the whole gating change exists to guarantee.
+static void check_is_musl_asset(TestResult& r, const std::string& label,
+                                const musl::Asset& asset) {
+    r.check(contains(asset.filename, "musl"), label + ": names musl");
+    r.check(!contains(asset.filename, "ubuntu"), label + ": no lowercase ubuntu");
+    r.check(!contains(asset.filename, "Ubuntu"), label + ": no capital Ubuntu");
+    r.check(!contains(asset.filename, "windows"), label + ": no windows");
+    r.check(!contains(asset.filename, "darwin"), label + ": no darwin");
+    r.check(!contains(asset.filename, "macos"), label + ": no macos");
+    r.check(asset.repo.rfind("lemonade-sdk/", 0) == 0, label + ": lemonade-sdk repo");
+}
+
+static void check_throws(TestResult& r, const std::string& label,
+                         const std::function<void()>& fn) {
+    bool threw = false;
+    try {
+        fn();
+    } catch (const std::exception&) {
+        threw = true;
+    }
+    r.check(threw, label + ": no musl build -> throws");
+}
+
+int main() {
+    TestResult r;
+    const std::string v = "b9700";       // llama/whisper/moonshine version form
+    const std::string sd_v = "master-1f9ee88";  // sd short_version form
+
+    printf("=== musl install-param resolver Unit Tests ===\n\n");
+
+    for (musl::Arch arch : {musl::Arch::X86_64, musl::Arch::Aarch64}) {
+        const std::string a = (arch == musl::Arch::Aarch64) ? "[aarch64]" : "[x86_64]";
+
+        // llama.cpp: only cpu and vulkan have musl builds; cuda/rocm must throw.
+        check_is_musl_asset(r, a + " llamacpp cpu", musl::llamacpp("cpu", v, arch));
+        check_is_musl_asset(r, a + " llamacpp vulkan", musl::llamacpp("vulkan", v, arch));
+        check_throws(r, a + " llamacpp cuda", [&] { musl::llamacpp("cuda", v, arch); });
+        check_throws(r, a + " llamacpp rocm-stable", [&] { musl::llamacpp("rocm-stable", v, arch); });
+        check_throws(r, a + " llamacpp rocm-nightly", [&] { musl::llamacpp("rocm-nightly", v, arch); });
+
+        // whisper.cpp: only cpu and vulkan; rocm/npu must throw.
+        check_is_musl_asset(r, a + " whispercpp cpu", musl::whispercpp("cpu", v, arch));
+        check_is_musl_asset(r, a + " whispercpp vulkan", musl::whispercpp("vulkan", v, arch));
+        check_throws(r, a + " whispercpp rocm", [&] { musl::whispercpp("rocm", v, arch); });
+        check_throws(r, a + " whispercpp npu", [&] { musl::whispercpp("npu", v, arch); });
+
+        // sd.cpp remaps every backend to a musl CPU/Vulkan asset (never throws,
+        // never glibc): an explicit cuda/rocm request must not leak an ubuntu name.
+        check_is_musl_asset(r, a + " sdcpp cpu", musl::sdcpp("cpu", sd_v, arch));
+        check_is_musl_asset(r, a + " sdcpp vulkan", musl::sdcpp("vulkan", sd_v, arch));
+        check_is_musl_asset(r, a + " sdcpp rocm", musl::sdcpp("rocm", sd_v, arch));
+        check_is_musl_asset(r, a + " sdcpp cuda", musl::sdcpp("cuda", sd_v, arch));
+
+        // kokoro: only cpu; metal must throw.
+        check_is_musl_asset(r, a + " kokoro cpu", musl::kokoro("cpu", arch));
+        check_throws(r, a + " kokoro metal", [&] { musl::kokoro("metal", arch); });
+
+        // moonshine: cpu-only bundle, always a musl asset.
+        check_is_musl_asset(r, a + " moonshine", musl::moonshine(v, arch));
+    }
+
+    // Spot-check the exact asset shapes so a rename on either side (fork CI vs.
+    // this resolver) is caught, not just the "contains musl" invariant.
+    r.check(musl::llamacpp("vulkan", v, musl::Arch::X86_64).filename ==
+                "llama-b9700-bin-linux-musl-vulkan-x64.tar.gz",
+            "llamacpp vulkan x86_64 exact name");
+    r.check(musl::whispercpp("cpu", v, musl::Arch::Aarch64).filename ==
+                "whisper-b9700-linux-musl-cpu-aarch64.tar.gz",
+            "whispercpp cpu aarch64 exact name");
+    r.check(musl::sdcpp("vulkan", sd_v, musl::Arch::X86_64).filename ==
+                "sd-master-1f9ee88-bin-Linux-musl-vulkan-x86_64.zip",
+            "sdcpp vulkan x86_64 exact name");
+    r.check(musl::kokoro("cpu", musl::Arch::Aarch64).filename ==
+                "kokoros-linux-musl-arm64.tar.gz",
+            "kokoro cpu aarch64 exact name");
+    r.check(musl::moonshine(v, musl::Arch::X86_64).filename ==
+                "moonshine-server-b9700-linux-musl-x64.tar.gz",
+            "moonshine x86_64 exact name");
+
+    printf("\n=== %d passed, %d failed ===\n", r.passed, r.failed);
+    return r.failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
This PR adds support for building and running lemonade on musl-based Linux (Alpine), covering both the C++ server and native packaging. llama.cpp (CPU + Vulkan) is verified working on Alpine; the remaining backends are in progress.

**What's included:**
- Compile-time libc detection (platform.h): defines LEMON_LINUX_MUSL on __linux__ && !__GLIBC__, which drives backend asset selection.
- Per-backend musl asset selection (llama.cpp, stable-diffusion.cpp, whisper.cpp, Kokoro, moonshine): musl builds fetch dedicated …-musl-… assets, never a glibc binary.
- Alpine packaging (packaging/alpine/): APKBUILD (OpenRC instead of systemd), install scripts, build-apk.sh; adds onnxruntime runtime dep for the ONNX audio backends.
- CI (alpine_apk_build.yml): builds + smoke-tests the .apk for x86_64 and aarch64.
- setup.sh: apk branches at each package-manager choke point.
- Dockerfile.alpine and a LEMONADE_BACKEND_REPO_OWNER testing hook (no-op when unset).
 
**Depends on:**
Companion changes to the backend release repos publish the …-musl-… assets (separate PRs). backend_versions.json intentionally unchanged.

**Status:**
llama.cpp CPU + Vulkan verified on Alpine; sd.cpp / whisper / Kokoro / moonshine in progress.

**Cross-platform safety:**
All C++ changes are #ifdef LEMON_LINUX_MUSL-guarded; shell changes are apk-only. glibc / Windows / macOS unchanged.