### PR TITLE
fix: set SO_REUSEADDR in find_free_port to avoid TIME_WAIT false posi…

### DIFF
--- a/src/app/src-tauri/Cargo.lock
+++ b/src/app/src-tauri/Cargo.lock
@@ -1812,7 +1812,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2228,6 +2228,7 @@ dependencies = [
  "objc2-web-kit",
  "serde",
  "serde_json",
+ "socket2 0.5.10",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
@@ -3808,6 +3809,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -4502,7 +4513,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5461,6 +5472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/src/app/src-tauri/Cargo.toml
+++ b/src/app/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1", features = ["full"] }
 dirs = "5"
 url = "2"
 log = "0.4"
+socket2 = "0.5"
 env_logger = "0.11"
 
 # webview_shim.rs hooks the platform-native webview to:

--- a/src/app/src-tauri/src/beacon.rs
+++ b/src/app/src-tauri/src/beacon.rs
@@ -14,7 +14,7 @@
 
 use crate::events;
 use serde::Deserialize;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::OnceLock;
 use tauri::{AppHandle, Emitter};
@@ -22,6 +22,20 @@ use tokio::net::UdpSocket;
 use tokio::time::Duration;
 
 pub(crate) const BEACON_PORT: u16 = 13305;
+
+async fn create_reusable_socket(addr: SocketAddr) -> Result<UdpSocket, std::io::Error> {
+    let socket = socket2::Socket::new(
+        socket2::Domain::IPV4,
+        socket2::Type::DGRAM,
+        None,
+    )?;
+    socket.set_reuse_address(true)?;
+    socket.set_broadcast(true)?;
+    let socket_addr: socket2::SockAddr = addr.into();
+    socket.bind(&socket_addr)?;
+    socket.set_nonblocking(true)?;
+    Ok(tokio::net::UdpSocket::from_std(std::net::UdpSocket::from(socket))?)
+}
 
 static CACHED_SERVER_PORT: AtomicU16 = AtomicU16::new(BEACON_PORT);
 
@@ -90,7 +104,7 @@ pub(crate) async fn run_beacon_listener(app: AppHandle) {
             continue;
         }
 
-        let socket = match UdpSocket::bind(("0.0.0.0", BEACON_PORT)).await {
+        let socket = match create_reusable_socket(SocketAddr::from((Ipv4Addr::UNSPECIFIED, BEACON_PORT))).await {
             Ok(s) => s,
             Err(err) => {
                 log::error!("Beacon listener bind failed: {err}, retrying in 10s");
@@ -98,7 +112,6 @@ pub(crate) async fn run_beacon_listener(app: AppHandle) {
                 continue;
             }
         };
-        let _ = socket.set_broadcast(true);
         log::info!("Beacon listener started on 0.0.0.0:{BEACON_PORT}");
 
         let mut buf = vec![0u8; 2048];

--- a/src/cpp/server/utils/network_beacon.cpp
+++ b/src/cpp/server/utils/network_beacon.cpp
@@ -62,6 +62,16 @@ void NetworkBeacon::createSocket() {
     if (_socket == INVALID_SOCKET_NB) {
         throw std::runtime_error("Could not create socket");
     }
+
+    // Set SO_REUSEADDR so the broadcast socket can rebind after TIME_WAIT
+    // when the server is restarted.
+#ifdef _WIN32
+    int opt = 1;
+    setsockopt(_socket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&opt), sizeof(opt));
+#else
+    int opt = 1;
+    setsockopt(_socket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+#endif
 }
 
 std::string NetworkBeacon::getLocalHostname() {

--- a/src/cpp/server/utils/platform/process_macos.cpp
+++ b/src/cpp/server/utils/platform/process_macos.cpp
@@ -606,6 +606,10 @@ int MacOSProcessPlatform::find_free_port(int start_port) {
             continue;
         }
 
+        // Set SO_REUSEADDR to avoid falsely reporting TIME_WAIT ports as "in use".
+        int opt = 1;
+        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
         sockaddr_in addr;
         addr.sin_family = AF_INET;
         addr.sin_port = htons(port);

--- a/src/cpp/server/utils/platform/process_unix.cpp
+++ b/src/cpp/server/utils/platform/process_unix.cpp
@@ -642,6 +642,10 @@ int UnixProcessPlatform::find_free_port(int start_port) {
             continue;
         }
 
+        // Set SO_REUSEADDR to avoid falsely reporting TIME_WAIT ports as "in use".
+        int opt = 1;
+        setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
         sockaddr_in addr;
         addr.sin_family = AF_INET;
         addr.sin_port = htons(port);

--- a/src/cpp/server/utils/platform/process_windows.cpp
+++ b/src/cpp/server/utils/platform/process_windows.cpp
@@ -638,6 +638,10 @@ public:
                 continue;
             }
 
+            // Set SO_REUSEADDR to avoid falsely reporting TIME_WAIT ports as "in use".
+            int opt = 1;
+            setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&opt), sizeof(opt));
+
             sockaddr_in addr;
             addr.sin_family = AF_INET;
             addr.sin_port = htons(port);


### PR DESCRIPTION
…tives

The find_free_port function on all platforms (Linux, macOS, Windows) binds a test socket to check if a port is available. Without SO_REUSEADDR set, bind() fails with EADDRINUSE for ports in TIME_WAIT state — TCP sockets that were recently connected and are still in the kernel's TIME_WAIT recovery period (~60s on Linux).

This causes the port scanner to incorrectly report such ports as "in use" even though nothing is actively listening on them.

The fix: set SO_REUSEADDR on the test socket before binding. This is standard practice for port scanning and allows binding to TIME_WAIT ports.

On Windows, setsockopt takes a const char* pointer (not int*), so the argument is cast accordingly.