### PR TITLE
feat(telemetry): reduce verbosity of telemetry logging

### DIFF
--- a/src/cpp/include/lemon/streaming_proxy.h
+++ b/src/cpp/include/lemon/streaming_proxy.h
@@ -20,17 +20,23 @@ public:
         double time_to_first_token = 0.0;
         double tokens_per_second = 0.0;
         std::string error_message = "";
+        std::string model_name = "";
 
         void print() const {
             if (input_tokens > 0 || output_tokens > 0) {
-                LOG(INFO, "Telemetry") << "=== Telemetry ===" << std::endl;
-                LOG(INFO, "Telemetry") << "Input tokens:  " << input_tokens << std::endl;
-                LOG(INFO, "Telemetry") << "Output tokens: " << output_tokens << std::endl;
-                LOG(INFO, "Telemetry") << "TTFT (s):      " << std::fixed << std::setprecision(3)
-                          << time_to_first_token << std::endl;
-                LOG(INFO, "Telemetry") << "TPS:           " << std::fixed << std::setprecision(2)
-                          << tokens_per_second << std::endl;
-                LOG(INFO, "Telemetry") << "=================" << std::endl;
+                LOG(INFO, "Telemetry") << "Inference completed: model=" << model_name
+                                       << ", tokens=" << (input_tokens + output_tokens)
+                                       << " (in=" << input_tokens << ", out=" << output_tokens << ")"
+                                       << ", ttft=" << std::fixed << std::setprecision(3) << time_to_first_token << "s"
+                                       << ", tps=" << std::fixed << std::setprecision(2) << tokens_per_second << std::endl;
+
+                LOG(DEBUG, "Telemetry") << "=== Telemetry ===\n"
+                                        << "Model:         " << model_name << "\n"
+                                        << "Input tokens:  " << input_tokens << "\n"
+                                        << "Output tokens: " << output_tokens << "\n"
+                                        << "TTFT (s):      " << std::fixed << std::setprecision(3) << time_to_first_token << "\n"
+                                        << "TPS:           " << std::fixed << std::setprecision(2) << tokens_per_second << "\n"
+                                        << "=================" << std::endl;
             }
         }
     };

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2379,29 +2379,36 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 double ttft_seconds = 0.0;
                 double tps = 0.0;
 
-                LOG(INFO, "Telemetry") << "=== Telemetry ===" << std::endl;
                 if (timings.contains("prompt_n")) {
                     input_tokens = timings["prompt_n"].get<int>();
-                    LOG(INFO, "Telemetry") << "Input tokens:  " << input_tokens << std::endl;
                 }
                 if (timings.contains("predicted_n")) {
                     output_tokens = timings["predicted_n"].get<int>();
-                    LOG(INFO, "Telemetry") << "Output tokens: " << output_tokens << std::endl;
                 }
                 if (timings.contains("prompt_ms")) {
                     ttft_seconds = timings["prompt_ms"].get<double>() / 1000.0;
-                    LOG(INFO, "Telemetry") << "TTFT (s):      " << std::fixed << std::setprecision(2)
-                             << ttft_seconds << std::endl;
                 }
                 if (timings.contains("predicted_per_second")) {
                     tps = timings["predicted_per_second"].get<double>();
-                    LOG(INFO, "Telemetry") << "TPS:           " << std::fixed << std::setprecision(2)
-                             << tps << std::endl;
                 }
-                LOG(INFO, "Telemetry") << "=================" << std::endl;
+
+                std::string model_name = request_json.value("model", "");
+                LOG(INFO, "Telemetry") << "Inference completed: model=" << model_name
+                                       << ", tokens=" << (input_tokens + output_tokens)
+                                       << " (in=" << input_tokens << ", out=" << output_tokens << ")"
+                                       << ", ttft=" << std::fixed << std::setprecision(2) << ttft_seconds << "s"
+                                       << ", tps=" << tps << std::endl;
+
+                LOG(DEBUG, "Telemetry") << "=== Telemetry ===\n"
+                                        << "Model:         " << model_name << "\n"
+                                        << "Input tokens:  " << input_tokens << "\n"
+                                        << "Output tokens: " << output_tokens << "\n"
+                                        << "TTFT (s):      " << std::fixed << std::setprecision(2) << ttft_seconds << "\n"
+                                        << "TPS:           " << std::fixed << std::setprecision(2) << tps << "\n"
+                                        << "=================" << std::endl;
 
                 // Save telemetry to router
-                router_->update_telemetry(request_json.value("model", ""), input_tokens, output_tokens,
+                router_->update_telemetry(model_name, input_tokens, output_tokens,
                                           ttft_seconds, tps);
             } else if (response.contains("usage")) {
                 // OpenAI format uses "usage" field
@@ -2411,31 +2418,38 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 double ttft_seconds = 0.0;
                 double tps = 0.0;
 
-                LOG(INFO, "Telemetry") << "=== Telemetry ===" << std::endl;
                 if (usage.contains("prompt_tokens")) {
                     input_tokens = usage["prompt_tokens"].get<int>();
-                    LOG(INFO, "Telemetry") << "Input tokens:  " << input_tokens << std::endl;
                 }
                 if (usage.contains("completion_tokens")) {
                     output_tokens = usage["completion_tokens"].get<int>();
-                    LOG(INFO, "Telemetry") << "Output tokens: " << output_tokens << std::endl;
                 }
 
                 // FLM format may include timing data
                 if (usage.contains("prefill_duration_ttft")) {
                     ttft_seconds = usage["prefill_duration_ttft"].get<double>();
-                    LOG(INFO, "Telemetry") << "TTFT (s):      " << std::fixed << std::setprecision(2)
-                             << ttft_seconds << std::endl;
                 }
                 if (usage.contains("decoding_speed_tps")) {
                     tps = usage["decoding_speed_tps"].get<double>();
-                    LOG(INFO, "Telemetry") << "TPS:           " << std::fixed << std::setprecision(2)
-                             << tps << std::endl;
                 }
-                LOG(INFO, "Telemetry") << "=================" << std::endl;
+
+                std::string model_name = request_json.value("model", "");
+                LOG(INFO, "Telemetry") << "Inference completed: model=" << model_name
+                                       << ", tokens=" << (input_tokens + output_tokens)
+                                       << " (in=" << input_tokens << ", out=" << output_tokens << ")"
+                                       << ", ttft=" << std::fixed << std::setprecision(2) << ttft_seconds << "s"
+                                       << ", tps=" << tps << std::endl;
+
+                LOG(DEBUG, "Telemetry") << "=== Telemetry ===\n"
+                                        << "Model:         " << model_name << "\n"
+                                        << "Input tokens:  " << input_tokens << "\n"
+                                        << "Output tokens: " << output_tokens << "\n"
+                                        << "TTFT (s):      " << std::fixed << std::setprecision(2) << ttft_seconds << "\n"
+                                        << "TPS:           " << std::fixed << std::setprecision(2) << tps << "\n"
+                                        << "=================" << std::endl;
 
                 // Save telemetry to router
-                router_->update_telemetry(request_json.value("model", ""), input_tokens, output_tokens,
+                router_->update_telemetry(model_name, input_tokens, output_tokens,
                                           ttft_seconds, tps);
             }
 
@@ -2589,29 +2603,36 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
                 double ttft_seconds = 0.0;
                 double tps = 0.0;
 
-                LOG(INFO, "Telemetry") << "=== Telemetry ===" << std::endl;
                 if (timings.contains("prompt_n")) {
                     input_tokens = timings["prompt_n"].get<int>();
-                    LOG(INFO, "Telemetry") << "Input tokens:  " << input_tokens << std::endl;
                 }
                 if (timings.contains("predicted_n")) {
                     output_tokens = timings["predicted_n"].get<int>();
-                    LOG(INFO, "Telemetry") << "Output tokens: " << output_tokens << std::endl;
                 }
                 if (timings.contains("prompt_ms")) {
                     ttft_seconds = timings["prompt_ms"].get<double>() / 1000.0;
-                    LOG(INFO, "Telemetry") << "TTFT (s):      " << std::fixed << std::setprecision(2)
-                             << ttft_seconds << std::endl;
                 }
                 if (timings.contains("predicted_per_second")) {
                     tps = timings["predicted_per_second"].get<double>();
-                    LOG(INFO, "Telemetry") << "TPS:           " << std::fixed << std::setprecision(2)
-                             << tps << std::endl;
                 }
-                LOG(INFO, "Telemetry") << "=================" << std::endl;
+
+                std::string model_name = request_json.value("model", "");
+                LOG(INFO, "Telemetry") << "Inference completed: model=" << model_name
+                                       << ", tokens=" << (input_tokens + output_tokens)
+                                       << " (in=" << input_tokens << ", out=" << output_tokens << ")"
+                                       << ", ttft=" << std::fixed << std::setprecision(2) << ttft_seconds << "s"
+                                       << ", tps=" << tps << std::endl;
+
+                LOG(DEBUG, "Telemetry") << "=== Telemetry ===\n"
+                                        << "Model:         " << model_name << "\n"
+                                        << "Input tokens:  " << input_tokens << "\n"
+                                        << "Output tokens: " << output_tokens << "\n"
+                                        << "TTFT (s):      " << std::fixed << std::setprecision(2) << ttft_seconds << "\n"
+                                        << "TPS:           " << std::fixed << std::setprecision(2) << tps << "\n"
+                                        << "=================" << std::endl;
 
                 // Save telemetry to router
-                router_->update_telemetry(request_json.value("model", ""), input_tokens, output_tokens,
+                router_->update_telemetry(model_name, input_tokens, output_tokens,
                                           ttft_seconds, tps);
             } else if (response.contains("usage")) {
                 auto usage = response["usage"];
@@ -2620,31 +2641,38 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
                 double ttft_seconds = 0.0;
                 double tps = 0.0;
 
-                LOG(INFO, "Telemetry") << "=== Telemetry ===" << std::endl;
                 if (usage.contains("prompt_tokens")) {
                     input_tokens = usage["prompt_tokens"].get<int>();
-                    LOG(INFO, "Telemetry") << "Input tokens:  " << input_tokens << std::endl;
                 }
                 if (usage.contains("completion_tokens")) {
                     output_tokens = usage["completion_tokens"].get<int>();
-                    LOG(INFO, "Telemetry") << "Output tokens: " << output_tokens << std::endl;
                 }
 
                 // FLM format may include timing data
                 if (usage.contains("prefill_duration_ttft")) {
                     ttft_seconds = usage["prefill_duration_ttft"].get<double>();
-                    LOG(INFO, "Telemetry") << "TTFT (s):      " << std::fixed << std::setprecision(2)
-                             << ttft_seconds << std::endl;
                 }
                 if (usage.contains("decoding_speed_tps")) {
                     tps = usage["decoding_speed_tps"].get<double>();
-                    LOG(INFO, "Telemetry") << "TPS:           " << std::fixed << std::setprecision(2)
-                             << tps << std::endl;
                 }
-                LOG(INFO, "Telemetry") << "=================" << std::endl;
+
+                std::string model_name = request_json.value("model", "");
+                LOG(INFO, "Telemetry") << "Inference completed: model=" << model_name
+                                       << ", tokens=" << (input_tokens + output_tokens)
+                                       << " (in=" << input_tokens << ", out=" << output_tokens << ")"
+                                       << ", ttft=" << std::fixed << std::setprecision(2) << ttft_seconds << "s"
+                                       << ", tps=" << tps << std::endl;
+
+                LOG(DEBUG, "Telemetry") << "=== Telemetry ===\n"
+                                        << "Model:         " << model_name << "\n"
+                                        << "Input tokens:  " << input_tokens << "\n"
+                                        << "Output tokens: " << output_tokens << "\n"
+                                        << "TTFT (s):      " << std::fixed << std::setprecision(2) << ttft_seconds << "\n"
+                                        << "TPS:           " << std::fixed << std::setprecision(2) << tps << "\n"
+                                        << "=================" << std::endl;
 
                 // Save telemetry to router
-                router_->update_telemetry(request_json.value("model", ""), input_tokens, output_tokens,
+                router_->update_telemetry(model_name, input_tokens, output_tokens,
                                           ttft_seconds, tps);
             }
 

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -73,6 +73,12 @@ void StreamingProxy::forward_sse_stream(
     std::function<void()> on_chunk) {
 
     TelemetryData telemetry;
+    try {
+        auto req_json = json::parse(request_body);
+        if (req_json.contains("model") && req_json["model"].is_string()) {
+            telemetry.model_name = req_json["model"].get<std::string>();
+        }
+    } catch (...) {}
     std::string line_buffer;
     bool stream_error = false;
     bool has_done_marker = false;

--- a/src/cpp/server/telemetry.cpp
+++ b/src/cpp/server/telemetry.cpp
@@ -524,7 +524,7 @@ private:
                                 ++it;
                             }
                         }
-                        LOG(INFO, "Telemetry") << "Flush requested. Exporting batch of "
+                        LOG(DEBUG, "Telemetry") << "Flush requested. Exporting batch of "
                                                << batch_spans.size() << " spans..." << std::endl;
                         break;
                     }
@@ -575,7 +575,7 @@ private:
                             }
                         }
 
-                        LOG(INFO, "Telemetry") << "Batch target size reached or timeout elapsed. Exporting batch of "
+                        LOG(DEBUG, "Telemetry") << "Batch target size reached or timeout elapsed. Exporting batch of "
                                                << batch_spans.size() << " spans..." << std::endl;
                         break;
                     } else {
@@ -618,7 +618,7 @@ private:
                     auto response = utils::HttpClient::post(batch_endpoint, payload, batch_headers, 3);
                     if (response.status_code >= 200 && response.status_code < 300) {
                         success = true;
-                        LOG(INFO, "Telemetry") << "Successfully sent telemetry batch." << std::endl;
+                        LOG(DEBUG, "Telemetry") << "Successfully sent telemetry batch." << std::endl;
                         {
                             std::unique_lock<std::mutex> lock(mutex_);
                             endpoint_unreachable_ = false;
@@ -660,7 +660,7 @@ private:
                     std::uniform_real_distribution<double> dist(0.5, 1.5);
                     double delay_with_jitter = delay * dist(gen);
 
-                    LOG(INFO, "Telemetry") << "Retrying batch in " << delay_with_jitter << " seconds (with jitter, attempt " << retries << " of " << max_retries << ")..." << std::endl;
+                    LOG(DEBUG, "Telemetry") << "Retrying batch in " << delay_with_jitter << " seconds (with jitter, attempt " << retries << " of " << max_retries << ")..." << std::endl;
 
                     bool local_shutdown = false;
                     bool local_flush_requested = false;
@@ -671,11 +671,11 @@ private:
                         local_flush_requested = flush_requested_;
                     }
                     if (local_shutdown) {
-                        LOG(INFO, "Telemetry") << "Shutdown requested during retry sleep. Aborting." << std::endl;
+                        LOG(DEBUG, "Telemetry") << "Shutdown requested during retry sleep. Aborting." << std::endl;
                         return;
                     }
                     if (local_flush_requested) {
-                        LOG(INFO, "Telemetry") << "Flush requested during retry sleep. Aborting retries for this batch." << std::endl;
+                        LOG(DEBUG, "Telemetry") << "Flush requested during retry sleep. Aborting retries for this batch." << std::endl;
                         break;
                     }
                 } else {
@@ -758,7 +758,7 @@ public:
         if (auto* config = RuntimeConfig::global()) {
             batch_size = config->telemetry_otlp_send_batch_size();
         }
-        LOG(INFO, "Telemetry") << "Accumulating span to batch (size " << (queue_.size() + 1) << "/" << batch_size << ")..." << std::endl;
+        LOG(DEBUG, "Telemetry") << "Accumulating span to batch (size " << (queue_.size() + 1) << "/" << batch_size << ")..." << std::endl;
 
         queue_.push_back({std::move(span_details), std::move(endpoint), std::move(headers), std::move(protocol), std::chrono::steady_clock::now()});
         cv_.notify_one();


### PR DESCRIPTION
This change reduces the verbosity of the telemetry logging system at the default `INFO` log level to keep server console logs clean. Background batching/export logs are downgraded to `DEBUG`, and per-request multi-line timing statistics are replaced by a single-line summary including the model name.

### Changes
* **Exporters**: Downgraded span accumulation, batch transmission success/timeout, retries, and shutdown exporter logs in `telemetry.cpp` to `DEBUG`.
* **Inference Logs**: Replaced 6-line timing boxes in `server.cpp` and `streaming_proxy.h` with a single `INFO` line detailing the `model`, `tokens` (in/out/total), `ttft`, and `tps`.
* **Debug Mode**: Preserves detailed multi-line formatted statistics under the `DEBUG` log level for verbose analysis when needed.