### PR TITLE
feat(router): wire classifier services to router calls

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -285,8 +285,9 @@ jobs:
           cmake --build --preset default --target test_routing_policy_parser
           cmake --build --preset default --target test_routing_policy_store
           cmake --build --preset default --target test_model_manager_collection_validation
+          cmake --build --preset default --target test_routing_classifier_services
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -594,8 +595,9 @@ jobs:
           cmake --build --preset default --target test_routing_policy_parser
           cmake --build --preset default --target test_routing_policy_store
           cmake --build --preset default --target test_model_manager_collection_validation
+          cmake --build --preset default --target test_routing_classifier_services
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -631,6 +631,8 @@ set(SOURCES_CORE
     src/cpp/server/streaming_proxy.cpp
     src/cpp/server/system_info.cpp
     src/cpp/server/recipe_options.cpp
+    src/cpp/server/routing_classifier_services.cpp
+    src/cpp/server/routing_classifier_services_router.cpp
     src/cpp/server/routing_policy.cpp
     src/cpp/server/routing_policy_parser.cpp
     src/cpp/server/routing_policy_store.cpp
@@ -2099,6 +2101,27 @@ if(EXISTS "${_MODEL_MANAGER_COLLECTION_VALIDATION_TEST_SRC}")
 
     include(CTest)
     add_test(NAME ModelManagerCollectionValidationTest COMMAND test_model_manager_collection_validation)
+endif()
+
+# Router-backed ClassifierServices wiring (issue #2384): binds the pure engine's
+# embed/run_classifier/chat lambdas to Router-style JSON calls.
+set(_ROUTING_CLASSIFIER_SERVICES_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_classifier_services.cpp"
+)
+if(EXISTS "${_ROUTING_CLASSIFIER_SERVICES_TEST_SRC}")
+    add_executable(test_routing_classifier_services
+        test/cpp/test_routing_classifier_services.cpp
+        src/cpp/server/routing_classifier_services.cpp
+        src/cpp/server/routing_policy.cpp
+    )
+    target_include_directories(test_routing_classifier_services PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_routing_classifier_services PRIVATE nlohmann_json::nlohmann_json)
+
+    include(CTest)
+    add_test(NAME RoutingClassifierServicesTest COMMAND test_routing_classifier_services)
 endif()
 
 # Auto-tune: GGUF array storage, scalar derivation, weighted KV cache computation.

--- a/src/cpp/include/lemon/routing_classifier_services.h
+++ b/src/cpp/include/lemon/routing_classifier_services.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "lemon/routing_policy.h"
+
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace lemon {
+
+class Router;
+
+using EnsureClassifierModelLoaded = std::function<void(const std::string& model)>;
+using RouterJsonCall = std::function<json(const json& request)>;
+
+ClassifierServices make_router_classifier_services(
+    Router& router,
+    EnsureClassifierModelLoaded ensure_loaded = {});
+
+// Testable adapter seam: production binds these calls to Router::embeddings and
+// Router::chat_completion; unit tests bind them to fake Router-like functions.
+ClassifierServices make_classifier_services_from_router_calls(
+    RouterJsonCall embeddings,
+    RouterJsonCall chat_completion,
+    EnsureClassifierModelLoaded ensure_loaded = {});
+
+std::vector<float> parse_embedding_vector(const json& response);
+std::map<std::string, double> parse_classifier_scores(const json& response);
+std::string extract_chat_text(const json& response);
+
+} // namespace lemon

--- a/src/cpp/server/routing_classifier_services.cpp
+++ b/src/cpp/server/routing_classifier_services.cpp
@@ -1,6 +1,8 @@
 #include "lemon/routing_classifier_services.h"
 
+#include <cmath>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 
@@ -95,6 +97,40 @@ json parse_json_text(const std::string& text) {
     return parsed.is_discarded() ? json(nullptr) : parsed;
 }
 
+void validate_score_range(const std::map<std::string, double>& scores) {
+    for (const auto& [label, score] : scores) {
+        if (!std::isfinite(score) || score < 0.0 || score > 1.0) {
+            throw std::runtime_error(
+                "classifier score for label '" + label + "' must be in [0, 1]");
+        }
+    }
+}
+
+std::optional<std::string> try_extract_chat_text(const json& response) {
+    if (response.is_object() && response.contains("choices") &&
+        response["choices"].is_array() && !response["choices"].empty()) {
+        const json& choice = response["choices"].front();
+        if (choice.is_object()) {
+            if (choice.contains("message") && choice["message"].is_object()) {
+                const json& message = choice["message"];
+                if (message.contains("content") && message["content"].is_string()) {
+                    return message["content"].get<std::string>();
+                }
+            }
+            if (choice.contains("text") && choice["text"].is_string()) {
+                return choice["text"].get<std::string>();
+            }
+        }
+    }
+
+    if (response.is_object() && response.contains("content") &&
+        response["content"].is_string()) {
+        return response["content"].get<std::string>();
+    }
+
+    return std::nullopt;
+}
+
 } // namespace
 
 std::vector<float> parse_embedding_vector(const json& response) {
@@ -132,25 +168,8 @@ std::vector<float> parse_embedding_vector(const json& response) {
 std::string extract_chat_text(const json& response) {
     throw_if_error_response(response, "chat completion request");
 
-    if (response.is_object() && response.contains("choices") &&
-        response["choices"].is_array() && !response["choices"].empty()) {
-        const json& choice = response["choices"].front();
-        if (choice.is_object()) {
-            if (choice.contains("message") && choice["message"].is_object()) {
-                const json& message = choice["message"];
-                if (message.contains("content") && message["content"].is_string()) {
-                    return message["content"].get<std::string>();
-                }
-            }
-            if (choice.contains("text") && choice["text"].is_string()) {
-                return choice["text"].get<std::string>();
-            }
-        }
-    }
-
-    if (response.is_object() && response.contains("content") &&
-        response["content"].is_string()) {
-        return response["content"].get<std::string>();
+    if (auto text = try_extract_chat_text(response)) {
+        return *text;
     }
 
     throw std::runtime_error("chat completion response did not contain text content");
@@ -159,10 +178,20 @@ std::string extract_chat_text(const json& response) {
 std::map<std::string, double> parse_classifier_scores(const json& response) {
     throw_if_error_response(response, "classifier request");
 
-    const std::string content = extract_chat_text(response);
-    json parsed = parse_json_text(content);
-    auto scores = parse_scores_payload(parsed);
+    if (auto content = try_extract_chat_text(response)) {
+        json parsed = parse_json_text(*content);
+        auto scores = parse_scores_payload(parsed);
+        if (!scores.empty()) {
+            validate_score_range(scores);
+            return scores;
+        }
+        throw std::runtime_error(
+            "classifier chat content did not contain label scores");
+    }
+
+    auto scores = parse_scores_payload(response);
     if (!scores.empty()) {
+        validate_score_range(scores);
         return scores;
     }
 

--- a/src/cpp/server/routing_classifier_services.cpp
+++ b/src/cpp/server/routing_classifier_services.cpp
@@ -159,14 +159,9 @@ std::string extract_chat_text(const json& response) {
 std::map<std::string, double> parse_classifier_scores(const json& response) {
     throw_if_error_response(response, "classifier request");
 
-    auto scores = parse_scores_payload(response);
-    if (!scores.empty()) {
-        return scores;
-    }
-
     const std::string content = extract_chat_text(response);
     json parsed = parse_json_text(content);
-    scores = parse_scores_payload(parsed);
+    auto scores = parse_scores_payload(parsed);
     if (!scores.empty()) {
         return scores;
     }

--- a/src/cpp/server/routing_classifier_services.cpp
+++ b/src/cpp/server/routing_classifier_services.cpp
@@ -1,0 +1,249 @@
+#include "lemon/routing_classifier_services.h"
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+namespace lemon {
+namespace {
+
+void throw_if_error_response(const json& response, const std::string& context) {
+    if (!response.is_object() || !response.contains("error")) {
+        return;
+    }
+    std::string message = context + " failed";
+    const json& error = response["error"];
+    if (error.is_object() && error.contains("message") && error["message"].is_string()) {
+        message += ": " + error["message"].get<std::string>();
+    }
+    throw std::runtime_error(message);
+}
+
+void ensure_model(const EnsureClassifierModelLoaded& ensure_loaded,
+                  const std::string& model) {
+    if (ensure_loaded) {
+        ensure_loaded(model);
+    }
+}
+
+std::map<std::string, double> scores_from_object(const json& obj) {
+    std::map<std::string, double> scores;
+    if (!obj.is_object()) {
+        return scores;
+    }
+    for (auto it = obj.begin(); it != obj.end(); ++it) {
+        if (it.value().is_number()) {
+            scores[it.key()] = it.value().get<double>();
+        }
+    }
+    return scores;
+}
+
+std::map<std::string, double> scores_from_label_score_array(const json& arr) {
+    std::map<std::string, double> scores;
+    if (!arr.is_array()) {
+        return scores;
+    }
+    for (const auto& item : arr) {
+        if (!item.is_object() ||
+            !item.contains("label") || !item["label"].is_string() ||
+            !item.contains("score") || !item["score"].is_number()) {
+            continue;
+        }
+        scores[item["label"].get<std::string>()] = item["score"].get<double>();
+    }
+    return scores;
+}
+
+std::map<std::string, double> parse_scores_payload(const json& payload) {
+    if (payload.is_array()) {
+        return scores_from_label_score_array(payload);
+    }
+    if (!payload.is_object()) {
+        return {};
+    }
+
+    for (const char* key : {"labels", "scores", "classification", "classifications"}) {
+        if (!payload.contains(key)) {
+            continue;
+        }
+        if (payload[key].is_object()) {
+            auto scores = scores_from_object(payload[key]);
+            if (!scores.empty()) return scores;
+        }
+        if (payload[key].is_array()) {
+            auto scores = scores_from_label_score_array(payload[key]);
+            if (!scores.empty()) return scores;
+        }
+    }
+
+    if (payload.contains("label") && payload["label"].is_string() &&
+        payload.contains("score") && payload["score"].is_number()) {
+        return {{payload["label"].get<std::string>(), payload["score"].get<double>()}};
+    }
+
+    if (payload.contains("data") && payload["data"].is_array()) {
+        auto scores = scores_from_label_score_array(payload["data"]);
+        if (!scores.empty()) return scores;
+    }
+
+    return scores_from_object(payload);
+}
+
+json parse_json_text(const std::string& text) {
+    json parsed = json::parse(text, nullptr, /*allow_exceptions=*/false);
+    return parsed.is_discarded() ? json(nullptr) : parsed;
+}
+
+} // namespace
+
+std::vector<float> parse_embedding_vector(const json& response) {
+    throw_if_error_response(response, "embedding request");
+
+    const json* embedding = nullptr;
+    if (response.is_object() && response.contains("data") &&
+        response["data"].is_array() && !response["data"].empty()) {
+        const json& first = response["data"].front();
+        if (first.is_object() && first.contains("embedding")) {
+            embedding = &first["embedding"];
+        }
+    }
+    if (!embedding && response.is_object() && response.contains("embedding")) {
+        embedding = &response["embedding"];
+    }
+    if (!embedding || !embedding->is_array()) {
+        throw std::runtime_error("embedding response did not contain an embedding array");
+    }
+
+    std::vector<float> result;
+    result.reserve(embedding->size());
+    for (const auto& value : *embedding) {
+        if (!value.is_number()) {
+            throw std::runtime_error("embedding response contained a non-numeric value");
+        }
+        result.push_back(value.get<float>());
+    }
+    if (result.empty()) {
+        throw std::runtime_error("embedding response contained an empty embedding");
+    }
+    return result;
+}
+
+std::string extract_chat_text(const json& response) {
+    throw_if_error_response(response, "chat completion request");
+
+    if (response.is_object() && response.contains("choices") &&
+        response["choices"].is_array() && !response["choices"].empty()) {
+        const json& choice = response["choices"].front();
+        if (choice.is_object()) {
+            if (choice.contains("message") && choice["message"].is_object()) {
+                const json& message = choice["message"];
+                if (message.contains("content") && message["content"].is_string()) {
+                    return message["content"].get<std::string>();
+                }
+            }
+            if (choice.contains("text") && choice["text"].is_string()) {
+                return choice["text"].get<std::string>();
+            }
+        }
+    }
+
+    if (response.is_object() && response.contains("content") &&
+        response["content"].is_string()) {
+        return response["content"].get<std::string>();
+    }
+
+    throw std::runtime_error("chat completion response did not contain text content");
+}
+
+std::map<std::string, double> parse_classifier_scores(const json& response) {
+    throw_if_error_response(response, "classifier request");
+
+    auto scores = parse_scores_payload(response);
+    if (!scores.empty()) {
+        return scores;
+    }
+
+    const std::string content = extract_chat_text(response);
+    json parsed = parse_json_text(content);
+    scores = parse_scores_payload(parsed);
+    if (!scores.empty()) {
+        return scores;
+    }
+
+    throw std::runtime_error("classifier response did not contain label scores");
+}
+
+ClassifierServices make_classifier_services_from_router_calls(
+    RouterJsonCall embeddings,
+    RouterJsonCall chat_completion,
+    EnsureClassifierModelLoaded ensure_loaded) {
+    ClassifierServices services;
+    auto embeddings_call = std::make_shared<RouterJsonCall>(std::move(embeddings));
+    auto chat_completion_call =
+        std::make_shared<RouterJsonCall>(std::move(chat_completion));
+
+    services.embed = [embeddings_call,
+                      ensure_loaded](const std::string& model,
+                                     const std::string& text) -> std::vector<float> {
+        if (!*embeddings_call) {
+            throw std::runtime_error("Router embeddings call is not configured");
+        }
+        ensure_model(ensure_loaded, model);
+        json request = {
+            {"model", model},
+            {"input", text},
+        };
+        return parse_embedding_vector((*embeddings_call)(request));
+    };
+
+    services.run_classifier = [chat_completion_call,
+                               ensure_loaded](const std::string& model,
+                                              const std::string& input)
+        -> std::map<std::string, double> {
+        if (!*chat_completion_call) {
+            throw std::runtime_error("Router chat_completion call is not configured");
+        }
+        ensure_model(ensure_loaded, model);
+        json request = {
+            {"model", model},
+            {"stream", false},
+            {"temperature", 0.0},
+            {"messages", json::array({
+                {
+                    {"role", "system"},
+                    {"content", "Classify the user input. Return only JSON mapping label names to numeric scores."},
+                },
+                {
+                    {"role", "user"},
+                    {"content", input},
+                },
+            })},
+        };
+        return parse_classifier_scores((*chat_completion_call)(request));
+    };
+
+    services.chat = [chat_completion_call,
+                     ensure_loaded](const std::string& model,
+                                    const std::string& prompt,
+                                    const std::string& input) -> std::string {
+        if (!*chat_completion_call) {
+            throw std::runtime_error("Router chat_completion call is not configured");
+        }
+        ensure_model(ensure_loaded, model);
+        json request = {
+            {"model", model},
+            {"stream", false},
+            {"temperature", 0.0},
+            {"messages", json::array({
+                {{"role", "system"}, {"content", prompt}},
+                {{"role", "user"}, {"content", input}},
+            })},
+        };
+        return extract_chat_text((*chat_completion_call)(request));
+    };
+
+    return services;
+}
+
+} // namespace lemon

--- a/src/cpp/server/routing_classifier_services_router.cpp
+++ b/src/cpp/server/routing_classifier_services_router.cpp
@@ -1,0 +1,18 @@
+#include "lemon/routing_classifier_services.h"
+
+#include "lemon/router.h"
+
+#include <utility>
+
+namespace lemon {
+
+ClassifierServices make_router_classifier_services(
+    Router& router,
+    EnsureClassifierModelLoaded ensure_loaded) {
+    return make_classifier_services_from_router_calls(
+        [&router](const json& request) { return router.embeddings(request); },
+        [&router](const json& request) { return router.chat_completion(request); },
+        std::move(ensure_loaded));
+}
+
+} // namespace lemon

--- a/test/cpp/test_routing_classifier_services.cpp
+++ b/test/cpp/test_routing_classifier_services.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <map>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -73,6 +74,17 @@ static ClassifierPtr make_model_classifier() {
         {"model", "pii-model"},
         {"labels", {"PII", "NO_PII"}},
         {"default_label", "PII"},
+    });
+}
+
+static ClassifierPtr make_fail_closed_model_classifier() {
+    return lemon::make_classifier(json{
+        {"id", "pii"},
+        {"type", "classifier"},
+        {"model", "pii-model"},
+        {"labels", {"PII", "NO_PII"}},
+        {"default_label", "PII"},
+        {"on_error", "match_true"},
     });
 }
 
@@ -177,6 +189,58 @@ static void test_run_classifier_ignores_openai_metadata() {
           near(scores.at("NO_PII"), 0.1));
 }
 
+static void test_direct_score_payload_is_supported() {
+    auto scores = lemon::parse_classifier_scores(json{
+        {"PII", 0.7},
+        {"NO_PII", 0.3},
+    });
+    check("direct classifier score maps are supported",
+          scores.size() == 2 && near(scores.at("PII"), 0.7) &&
+          near(scores.at("NO_PII"), 0.3));
+}
+
+static void test_out_of_range_scores_are_rejected() {
+    bool high_threw = false;
+    try {
+        lemon::parse_classifier_scores(json{{"PII", 999.0}});
+    } catch (const std::runtime_error&) {
+        high_threw = true;
+    }
+    check("classifier scores above 1 are rejected", high_threw);
+
+    bool negative_threw = false;
+    try {
+        lemon::parse_classifier_scores(json{{"choices", json::array({
+            json{{"message", {{"content", R"({"PII":-1.0})"}}}}
+        })}});
+    } catch (const std::runtime_error&) {
+        negative_threw = true;
+    }
+    check("classifier scores below 0 are rejected", negative_threw);
+}
+
+static void test_out_of_range_scores_drive_on_error() {
+    auto services = lemon::make_classifier_services_from_router_calls(
+        [](const json&) { return json::object(); },
+        [](const json&) {
+            return json{{"choices", json::array({
+                json{{"message", {{"content", R"({"PII":999.0})"}}}}
+            })}};
+        });
+
+    RoutePolicy policy;
+    policy.candidates = {"local", "cloud"};
+    policy.default_model = "cloud";
+    policy.classifiers["pii"] = make_fail_closed_model_classifier();
+    policy.rules = {
+        rule("keep-private", leaf(json{{"classifier", "pii"}, {"min_score", 0.5}}), "local"),
+    };
+
+    RoutingPolicyEngine engine(std::move(policy), services);
+    Decision decision = engine.route(route_context("my ssn is 123"), false);
+    check("out-of-range model scores become classifier failure and apply on_error",
+          decision.route_to == "local" && decision.matched_rule == "keep-private");
+}
 
 static void test_model_classifier_routes_with_router_services() {
     auto services = lemon::make_classifier_services_from_router_calls(
@@ -224,6 +288,9 @@ int main() {
     test_semantic_similarity_loops_through_router_embeddings();
     test_run_classifier_uses_router_chat_completion();
     test_run_classifier_ignores_openai_metadata();
+    test_direct_score_payload_is_supported();
+    test_out_of_range_scores_are_rejected();
+    test_out_of_range_scores_drive_on_error();
     test_model_classifier_routes_with_router_services();
     test_chat_service_extracts_text();
 

--- a/test/cpp/test_routing_classifier_services.cpp
+++ b/test/cpp/test_routing_classifier_services.cpp
@@ -1,0 +1,203 @@
+// Unit tests for Router-backed ClassifierServices wiring (#2384).
+
+#include "lemon/routing_classifier_services.h"
+
+#include <cmath>
+#include <cstdio>
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using lemon::ClassifierContext;
+using lemon::ClassifierPtr;
+using lemon::Decision;
+using lemon::MatchExpr;
+using lemon::RouteContext;
+using lemon::RoutePolicy;
+using lemon::RoutingPolicyEngine;
+using lemon::Rule;
+using lemon::Score;
+using lemon::json;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static bool near(double a, double b, double eps = 1e-9) {
+    return std::fabs(a - b) <= eps;
+}
+
+static RouteContext route_context(const std::string& input) {
+    RouteContext ctx;
+    ctx.input = input;
+    ctx.params.chars = input.size();
+    return ctx;
+}
+
+static MatchExpr leaf(json value) {
+    MatchExpr expr;
+    expr.op = MatchExpr::Op::Leaf;
+    expr.leaf = std::move(value);
+    return expr;
+}
+
+static Rule rule(const std::string& id, MatchExpr match, const std::string& route_to) {
+    Rule out;
+    out.id = id;
+    out.match = std::move(match);
+    out.route_to = route_to;
+    return out;
+}
+
+static ClassifierPtr make_semantic_classifier() {
+    return lemon::make_classifier(json{
+        {"id", "topic"},
+        {"type", "semantic_similarity"},
+        {"model", "embedder"},
+        {"reference_phrases", {
+            {"coding", {"write code"}},
+            {"math", {"integral"}},
+        }},
+    });
+}
+
+static ClassifierPtr make_model_classifier() {
+    return lemon::make_classifier(json{
+        {"id", "pii"},
+        {"type", "classifier"},
+        {"model", "pii-model"},
+        {"labels", {"PII", "NO_PII"}},
+        {"default_label", "PII"},
+    });
+}
+
+static void test_embed_uses_router_embeddings_shape() {
+    std::vector<std::string> loaded;
+    json seen_request;
+    auto services = lemon::make_classifier_services_from_router_calls(
+        [&](const json& request) {
+            seen_request = request;
+            return json{{"data", json::array({json{{"embedding", {1.0, 2.0, 3.0}}}})}};
+        },
+        [](const json&) { return json::object(); },
+        [&](const std::string& model) { loaded.push_back(model); });
+
+    auto vec = services.embed("embedder", "hello");
+    check("embed ensure_loaded is called", loaded == std::vector<std::string>{"embedder"});
+    check("embed forwards model and input",
+          seen_request.value("model", "") == "embedder" &&
+          seen_request.value("input", "") == "hello");
+    check("embed parses OpenAI embedding response",
+          vec.size() == 3 && vec[0] == 1.0f && vec[2] == 3.0f);
+}
+
+static void test_semantic_similarity_loops_through_router_embeddings() {
+    std::map<std::string, std::vector<float>> vectors = {
+        {"write code", {1.0f, 0.0f}},
+        {"integral", {0.0f, 1.0f}},
+        {"fix bug", {1.0f, 0.0f}},
+    };
+    int embedding_calls = 0;
+    auto services = lemon::make_classifier_services_from_router_calls(
+        [&](const json& request) {
+            ++embedding_calls;
+            const std::string text = request.value("input", "");
+            return json{{"data", json::array({json{{"embedding", vectors.at(text)}}})}};
+        },
+        [](const json&) { return json::object(); });
+
+    auto classifier = make_semantic_classifier();
+    Score score = classifier->evaluate(ClassifierContext{
+        route_context("fix bug"),
+        services,
+    });
+
+    check("semantic_similarity returns scores through Router embeddings",
+          score.ok && near(score.score_of("coding"), 1.0) &&
+          near(score.score_of("math"), 0.0));
+    check("semantic_similarity embeds references plus input", embedding_calls == 3);
+}
+
+static void test_run_classifier_uses_router_chat_completion() {
+    std::vector<std::string> loaded;
+    json seen_request;
+    auto services = lemon::make_classifier_services_from_router_calls(
+        [](const json&) { return json::object(); },
+        [&](const json& request) {
+            seen_request = request;
+            return json{{"choices", json::array({
+                json{{"message", {{"content", R"({"PII":0.85,"NO_PII":0.15})"}}}}
+            })}};
+        },
+        [&](const std::string& model) { loaded.push_back(model); });
+
+    auto scores = services.run_classifier("pii-model", "my ssn is 123");
+    check("run_classifier ensure_loaded is called",
+          loaded == std::vector<std::string>{"pii-model"});
+    check("run_classifier forwards model and user input",
+          seen_request.value("model", "") == "pii-model" &&
+          seen_request["messages"][1].value("content", "") == "my ssn is 123");
+    check("run_classifier parses chat JSON label scores",
+          near(scores.at("PII"), 0.85) && near(scores.at("NO_PII"), 0.15));
+}
+
+static void test_model_classifier_routes_with_router_services() {
+    auto services = lemon::make_classifier_services_from_router_calls(
+        [](const json&) { return json::object(); },
+        [](const json&) {
+            return json{{"choices", json::array({
+                json{{"message", {{"content", R"({"PII":0.9,"NO_PII":0.1})"}}}}
+            })}};
+        });
+
+    RoutePolicy policy;
+    policy.candidates = {"local", "cloud"};
+    policy.default_model = "cloud";
+    policy.classifiers["pii"] = make_model_classifier();
+    policy.rules = {
+        rule("keep-private", leaf(json{{"classifier", "pii"}, {"min_score", 0.5}}), "local"),
+    };
+
+    RoutingPolicyEngine engine(std::move(policy), services);
+    Decision decision = engine.route(route_context("my ssn is 123"), true);
+    check("model-backed classifier routes through Router services",
+          decision.route_to == "local" && decision.matched_rule == "keep-private");
+    check("model-backed classifier trace carries score",
+          decision.trace.size() == 1 && decision.trace[0].score.has_value() &&
+          near(*decision.trace[0].score, 0.9));
+}
+
+static void test_chat_service_extracts_text() {
+    auto services = lemon::make_classifier_services_from_router_calls(
+        [](const json&) { return json::object(); },
+        [](const json& request) {
+            check("chat forwards system prompt",
+                  request["messages"][0].value("content", "") == "route this");
+            return json{{"choices", json::array({
+                json{{"message", {{"content", "large-model"}}}}
+            })}};
+        });
+
+    check("chat extracts assistant content",
+          services.chat("router-model", "route this", "hard problem") == "large-model");
+}
+
+int main() {
+    test_embed_uses_router_embeddings_shape();
+    test_semantic_similarity_loops_through_router_embeddings();
+    test_run_classifier_uses_router_chat_completion();
+    test_model_classifier_routes_with_router_services();
+    test_chat_service_extracts_text();
+
+    if (g_failures == 0) {
+        std::printf("All routing classifier service tests passed.\n");
+    } else {
+        std::printf("%d routing classifier service test(s) failed.\n", g_failures);
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_routing_classifier_services.cpp
+++ b/test/cpp/test_routing_classifier_services.cpp
@@ -146,6 +146,38 @@ static void test_run_classifier_uses_router_chat_completion() {
           near(scores.at("PII"), 0.85) && near(scores.at("NO_PII"), 0.15));
 }
 
+static void test_run_classifier_ignores_openai_metadata() {
+    auto services = lemon::make_classifier_services_from_router_calls(
+        [](const json&) { return json::object(); },
+        [](const json&) {
+            return json{
+                {"id", "chatcmpl-abc123"},
+                {"object", "chat.completion"},
+                {"created", 1742927481},
+                {"model", "pii-model"},
+                {"choices", json::array({
+                    json{
+                        {"index", 0},
+                        {"finish_reason", "stop"},
+                        {"message", {{"role", "assistant"},
+                                     {"content", R"({"PII":0.9,"NO_PII":0.1})"}}},
+                    }
+                })},
+                {"usage", {{"prompt_tokens", 12}, {"completion_tokens", 8},
+                           {"total_tokens", 20}}},
+            };
+        });
+
+    auto scores = services.run_classifier("pii-model", "my ssn is 123");
+    check("run_classifier ignores OpenAI metadata fields",
+          scores.find("created") == scores.end() &&
+          scores.find("prompt_tokens") == scores.end());
+    check("run_classifier reads scores from message content",
+          scores.size() == 2 && near(scores.at("PII"), 0.9) &&
+          near(scores.at("NO_PII"), 0.1));
+}
+
+
 static void test_model_classifier_routes_with_router_services() {
     auto services = lemon::make_classifier_services_from_router_calls(
         [](const json&) { return json::object(); },
@@ -191,6 +223,7 @@ int main() {
     test_embed_uses_router_embeddings_shape();
     test_semantic_similarity_loops_through_router_embeddings();
     test_run_classifier_uses_router_chat_completion();
+    test_run_classifier_ignores_openai_metadata();
     test_model_classifier_routes_with_router_services();
     test_chat_service_extracts_text();
 


### PR DESCRIPTION
## Summary

Part of #2384

  Implements the Lemonade Router `ClassifierServices` wiring layer. This bridges the pure routing engine to Router-style backend calls while keeping  `routing_policy.h` backend-free.

  The new adapter lets router policies evaluate:

  - `semantic_similarity` through `Router::embeddings(json)`
  - model-backed `classifier` conditions through Router-style chat completion returning label scores
  - future L0a `llm` router calls through Router-style chat completion text extraction

  ## What Changed

  - Added `routing_classifier_services`:
    - `make_router_classifier_services(Router&, ensure_loaded)` binds the pure engine’s `ClassifierServices` lambdas to live `Router` calls
    - `make_classifier_services_from_router_calls(...)` provides a deterministic test seam using Router-shaped JSON call functions
    - `embed()` builds an embeddings request and parses OpenAI-style embedding responses
    - `run_classifier()` builds a classifier chat request, invokes the Router-style chat call, and parses label/score output
    - `chat()` builds a prompt + user input chat request and extracts assistant text for future `routing.router` / L0a work

  - Added robust response parsing:
    - OpenAI embeddings shape: `data[0].embedding`
    - direct score maps: `{ "PII": 0.9 }`
    - nested score maps: `{ "labels": { "PII": 0.9 } }`
    - label-score arrays: `[{"label":"PII","score":0.9}]`
    - chat JSON content: `choices[0].message.content = "{\"PII\":0.9}"`

  - Added focused tests:
    - verifies `ensure_loaded` is called before Router-style service calls
    - verifies embedding request shape and vector parsing
    - verifies `semantic_similarity` scores through Router-style embeddings
    - verifies model-backed classifier routing through Router-style chat completion
    - verifies `chat()` extracts assistant content for future L0a use

  - Added CMake and CI wiring for `RoutingClassifierServicesTest`.

  ## Notes

  The pure engine still touches backends only through `ClassifierServices`; no backend or `Router` headers were added to `routing_policy.h`.

  The tests use Router-shaped JSON call adapters rather than real backend subprocesses. This verifies the `ClassifierServices` ↔ Router request/response contract deterministically. Live model-backed E2E should be covered in #2388 once `collection.router` dispatch is wired in #2385.

  This PR does not implement:

  - `collection.router` request dispatch (#2385)
  - `routing.router` / L0a desugaring (#2405)
  - live backend E2E docs/tests (#2388)

  ## Validation

  Ran locally:

  ```bash
  cmake --preset default
  cmake --build --preset default --target test_routing_classifier_services
  ctest --test-dir build --output-on-failure -R "RoutingClassifierServicesTest"
  ctest --test-dir build --output-on-failure -R "RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine)Test|RoutingClassifierServicesTest"
  cmake --build --preset default --target lemond
  git diff --check