### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 <!--
 Before submitting this PR, please read:
 - docs/dev/contribute.md
+- docs/dev/philosophy.md
 - AGENTS.md if you used an AI coding agent or AI-assisted workflow
 - docs/dev/documentation.md if this PR changes user-facing or developer-facing documentation
 -->
@@ -13,6 +14,8 @@ For bug fixes, link the related issue and/or include exact reproduction steps.
 For new features, explain how the feature works and what use case it supports.
 -->
 
+Fixes #<!-- issue number -->
+
 ## Scope
 
 - [ ] This PR addresses one clear issue or change.
@@ -22,14 +25,27 @@ For new features, explain how the feature works and what use case it supports.
 
 ## Testing
 
+- [ ] Code builds without errors locally.
 - [ ] I tested this change locally.
 - [ ] I described the testing performed below.
 
+<!-- Describe what you tested, commands run, and results -->
+_Testing details:_
+
 ## Documentation
+
+<!-- Select ONE of the following -->
 
 - [ ] Documentation is not affected by this change.
 - [ ] Documentation is affected and has been updated.
 - [ ] Documentation is affected but will be handled in a separate PR or issue.
+
+## Breaking Changes
+
+- [ ] This PR introduces breaking changes.
+- [ ] This PR does not introduce breaking changes.
+
+<!-- If breaking changes, describe them and migration path -->
 
 ## AI-assisted contribution
 
@@ -39,6 +55,8 @@ Please select one:
 - [ ] I did not use AI tools for this PR.
 
 If AI tools were used:
+
+<!-- Only complete this section if you checked "I used AI tools for this PR" above -->
 
 - [ ] I verified that I understand the changes.
 - [ ] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+<!--
+Before submitting this PR, please read:
+- docs/dev/contribute.md
+- AGENTS.md if you used an AI coding agent or AI-assisted workflow
+- docs/dev/documentation.md if this PR changes user-facing or developer-facing documentation
+-->
+
+## Summary
+
+<!-- What does this PR change? Keep it short and specific. -->
+
+## Scope
+
+- [ ] This PR addresses one clear issue or change.
+- [ ] I reviewed the full diff myself before submitting.
+- [ ] I removed unrelated local changes.
+- [ ] I kept refactoring separate unless it is required for this change.
+
+## Testing
+
+- [ ] I tested this change locally.
+- [ ] I described the testing performed below.
+
+## Documentation
+
+- [ ] Documentation is not affected by this change.
+- [ ] Documentation is affected and has been updated.
+- [ ] Documentation is affected but will be handled in a separate PR or issue.
+
+## AI-assisted contribution
+
+Please select one:
+
+- [ ] I used AI tools for this PR.
+- [ ] I did not use AI tools for this PR.
+
+If AI tools were used:
+
+- [ ] I verified that I understand the changes.
+- [ ] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,11 @@ Before submitting this PR, please read:
 
 ## Summary
 
-<!-- What does this PR change? Keep it short and specific. -->
+<!--
+What does this PR change? Keep it short and specific.
+For bug fixes, link the related issue and/or include exact reproduction steps.
+For new features, explain how the feature works and what use case it supports.
+-->
 
 ## Scope
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ Pass `DEPENDS` only when the CI build needs targets beyond the `COMMAND` executa
 
 **Never write comments that explain WHAT the code does** — well-named identifiers already do that. Don't reference the current task, fix, or callers ("used by X", "added for the Y flow", "handles the case from issue #123") — those belong in the PR description and rot as the codebase evolves.
 
-**PR descriptions should be concise.** 1-3 sentences for the summary. No essays. The diff shows what changed; the description explains why and any non-obvious context. Bullet points over paragraphs.
+**PR descriptions should be concise.** 1-3 sentences for the summary. No essays. The diff shows what changed; the description explains why and any non-obvious context. Bullet points over paragraphs. When creating a PR, use `.github/pull_request_template.md` and fill every section — Summary (with `Fixes #` link), Scope, Testing (confirm build + describe what was tested), Documentation (select one), Breaking Changes (select one), and AI-assisted contribution.
 
 ### C++
 - C++17, `lemon::` namespace
@@ -244,3 +244,4 @@ These MUST be maintained in all changes:
 - UI/frontend changes are handled by core maintainers only
 - Python formatting with Black is required
 - PRs trigger CI for linting, formatting, and integration tests
+- Use `.github/pull_request_template.md` for all PRs and fill every section


### PR DESCRIPTION
This PR adds a default GitHub pull request template for Lemonade.

The template encourages contributors to keep PRs focused, review the full diff, describe testing, clarify documentation impact, and disclose AI-assisted workflows where applicable.

## Why

This should make PRs easier to review, especially for new contributors and AI-assisted workflows.

The template makes expectations around scope, testing, documentation impact, and contributor responsibility more explicit. It should reduce the chance that documentation updates are missed and help improve the quality of AI-assisted PRs before they reach review.

It also makes PR descriptions more consistent across the repo.

## Review notes

I’d like reviewers to check the wording, tone, so we can align on the final PR template before merging.