### PR TITLE
feat(ui): expand funnel filter options

### DIFF
--- a/prototype/ui-redesign/src/components/Icon.tsx
+++ b/prototype/ui-redesign/src/components/Icon.tsx
@@ -7,7 +7,7 @@ export type IconName =
   | 'sun' | 'moon' | 'paperclip' | 'mic' | 'send' | 'stop' | 'copy' | 'check'
   | 'x' | 'tools' | 'chat' | 'omni' | 'image' | 'audio' | 'tts' | 'embedding'
   | 'reranking' | 'model' | 'globe' | 'file' | 'code' | 'vision' | 'logs'
-  | 'search' | 'search-check' | 'edit' | 'download' | 'play' | 'pause' | 'trash' | 'rotate-ccw' | 'chevron-down' | 'chevron-right' | 'plug' | 'box' | 'alert' | 'clock'
+  | 'search' | 'search-check' | 'eye' | 'eye-off' | 'plus' | 'edit' | 'download' | 'play' | 'pause' | 'trash' | 'rotate-ccw' | 'chevron-down' | 'chevron-right' | 'plug' | 'box' | 'alert' | 'clock'
   | 'citrus' | 'scale' | 'scan-eye' | 'gem' | 'gauge' | 'timer' | 'pen-line' | 'library'
   | 'hard-drive' | 'sliders-horizontal' | 'flame' | 'wrench' | 'brain' | 'rocket' | 'pin'
   | 'star' | 'hugging-face'
@@ -56,6 +56,9 @@ export const Icon: React.FC<IconProps> = ({ name, size = 16, className, title })
       case 'search': return <><circle cx="11" cy="11" r="7" /><path d="M20 20l-4-4" /></>;
       case 'scan-eye': return <><path d="M3 7V5a2 2 0 012-2h2" /><path d="M17 3h2a2 2 0 012 2v2" /><path d="M21 17v2a2 2 0 01-2 2h-2" /><path d="M7 21H5a2 2 0 01-2-2v-2" /><circle cx="12" cy="12" r="1" /><path d="M18.944 12.33a1 1 0 000-.66 7.5 7.5 0 00-13.888 0 1 1 0 000 .66 7.5 7.5 0 0013.888 0" /></>;
       case 'search-check': return <><path d="m8 11 2 2 4-4" /><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></>;
+      case 'eye': return <><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12z" /><circle cx="12" cy="12" r="3" /></>;
+      case 'eye-off': return <><path d="M3 3l18 18" /><path d="M10.6 10.6A3 3 0 0012 15a3 3 0 002.4-1.2" /><path d="M9.9 4.2A10.7 10.7 0 0112 4c6.5 0 10 8 10 8a15.4 15.4 0 01-3.1 4.1" /><path d="M6.1 6.1A15.4 15.4 0 002 12s3.5 6 10 6a10.7 10.7 0 004-.8" /></>;
+      case 'plus': return <><path d="M12 5v14" /><path d="M5 12h14" /></>;
       case 'edit': return <><path d="M4 20h4l10.5-10.5a2.1 2.1 0 00-3-3L5 17v3z" /><path d="M14 7l3 3" /></>;
       case 'download': return <><path d="M12 3v12" /><path d="M7 10l5 5 5-5" /><path d="M5 21h14" /></>;
       case 'play': return <path d="M8 5.5v13l11-6.5-11-6.5z" />;

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -100,7 +100,7 @@ interface FilterPopoverStyle extends React.CSSProperties {
 }
 
 const TEXT_FILTER_FIELDS: Array<{ key: TextFilterField; label: string }> = [
-  { key: 'any', label: 'Any text' },
+  { key: 'any', label: 'All text' },
   { key: 'name', label: 'Name' },
   { key: 'backend', label: 'Backend' },
   { key: 'type', label: 'Type' },
@@ -109,10 +109,6 @@ const TEXT_FILTER_FIELDS: Array<{ key: TextFilterField; label: string }> = [
   { key: 'status', label: 'Status' },
 ];
 
-const TEXT_FILTER_MODES: Array<{ key: TextFilterMode; label: string }> = [
-  { key: 'include', label: 'contains' },
-  { key: 'exclude', label: 'does not contain' },
-];
 
 let textFilterRuleCounter = 0;
 
@@ -489,8 +485,8 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
     const maxUsableWidth = Math.max(320, viewportWidth - viewportPadding * 2);
-    const width = Math.min(560, maxUsableWidth);
-    const top = Math.max(viewportPadding, buttonRect.bottom + 6);
+    const width = Math.min(440, maxUsableWidth);
+    const top = Math.max(viewportPadding, buttonRect.bottom + 4);
 
     let left = buttonRect.right - width;
     if (left < viewportPadding) left = viewportPadding;
@@ -655,7 +651,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
               aria-modal="false"
             >
               <div className="model-list-panel__filter-popover-head">
-                <span>Model filters</span>
+                <span>Filters</span>
                 <button
                   type="button"
                   className="model-list-panel__filter-popover-close"
@@ -692,20 +688,18 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
 
               <div className="model-list-panel__filter-section">
                 <div className="model-list-panel__filter-section-head">
-                  <span className="model-list-panel__filter-section-title">Custom text rules</span>
+                  <span className="model-list-panel__filter-section-title">Text</span>
                   <button
                     type="button"
                     className="model-list-panel__filter-add"
                     onClick={addTextFilter}
                   >
-                    + Add
+                    <Icon name="plus" size={13} aria-hidden="true" />
+                    <span>Add</span>
                   </button>
                 </div>
 
                 <div className="model-list-panel__text-filters" role="group" aria-label="Custom text filters">
-                  {textFilters.length === 0 && (
-                    <span className="model-list-panel__filter-empty">Add a text rule, for example “does not contain qwen”.</span>
-                  )}
                   {textFilters.map((rule, index) => (
                     <div key={rule.id} className="model-list-panel__text-filter">
                       <label className="sr-only" htmlFor={`${rule.id}-field`}>Filter field</label>
@@ -721,18 +715,32 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                         ))}
                       </select>
 
-                      <label className="sr-only" htmlFor={`${rule.id}-mode`}>Filter mode</label>
-                      <select
-                        id={`${rule.id}-mode`}
+                      <div
                         className="model-list-panel__text-filter-mode"
-                        value={rule.mode}
-                        onChange={e => updateTextFilter(rule.id, { mode: e.target.value as TextFilterMode })}
+                        role="group"
                         aria-label={`Filter ${index + 1} mode`}
                       >
-                        {TEXT_FILTER_MODES.map(mode => (
-                          <option key={mode.key} value={mode.key}>{mode.label}</option>
-                        ))}
-                      </select>
+                        <button
+                          type="button"
+                          className={`model-list-panel__text-filter-mode-btn${rule.mode === 'include' ? ' model-list-panel__text-filter-mode-btn--active' : ''}`}
+                          onClick={() => updateTextFilter(rule.id, { mode: 'include' })}
+                          aria-label={`Filter ${index + 1}: include matching models`}
+                          aria-pressed={rule.mode === 'include'}
+                          title="Include matches"
+                        >
+                          <Icon name="eye" size={13} aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          className={`model-list-panel__text-filter-mode-btn${rule.mode === 'exclude' ? ' model-list-panel__text-filter-mode-btn--active' : ''}`}
+                          onClick={() => updateTextFilter(rule.id, { mode: 'exclude' })}
+                          aria-label={`Filter ${index + 1}: exclude matching models`}
+                          aria-pressed={rule.mode === 'exclude'}
+                          title="Exclude matches"
+                        >
+                          <Icon name="eye-off" size={13} aria-hidden="true" />
+                        </button>
+                      </div>
 
                       <label className="sr-only" htmlFor={`${rule.id}-value`}>Filter text</label>
                       <input
@@ -741,7 +749,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                         type="text"
                         value={rule.value}
                         onChange={e => updateTextFilter(rule.id, { value: e.target.value })}
-                        placeholder={rule.mode === 'exclude' ? 'e.g. qwen' : 'e.g. llama'}
+                        placeholder="e.g. qwen"
                         aria-label={`Filter ${index + 1} text`}
                         autoComplete="off"
                       />
@@ -752,14 +760,10 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                         onClick={() => removeTextFilter(rule.id)}
                         aria-label={`Remove filter ${index + 1}`}
                       >
-                        ×
+                        <Icon name="x" size={13} aria-hidden="true" />
                       </button>
                     </div>
                   ))}
-                </div>
-
-                <div className="model-list-panel__filter-help">
-                  Rules are combined with AND. “Does not contain qwen” hides Qwen models.
                 </div>
               </div>
 
@@ -769,7 +773,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                   className="model-list-panel__filter-clear"
                   onClick={clearAllFilters}
                 >
-                  Clear all filters
+                  Clear
                 </button>
               )}
             </div>

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -4,7 +4,7 @@
  *
  * Part of the master-detail layout introduced in #2355 Slice 1.
  */
-import React, { useCallback, useRef, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useMemo, useState } from 'react';
 import type { ModelInfo, LoadedModel } from '../api';
 import {
   capabilityFromModelInfo,
@@ -81,6 +81,118 @@ const FILTER_TABS: Array<{ key: FilterTab; label: string; iconName: IconName }> 
   { key: 'tts', label: 'TTS', iconName: 'tts' },
   { key: 'embedding', label: 'Embed', iconName: 'embedding' },
 ];
+
+type TextFilterField = 'any' | 'name' | 'backend' | 'type' | 'capability' | 'label' | 'status';
+type TextFilterMode = 'include' | 'exclude';
+
+interface TextFilterRule {
+  id: string;
+  field: TextFilterField;
+  mode: TextFilterMode;
+  value: string;
+}
+
+interface FilterPopoverStyle extends React.CSSProperties {
+  left: number;
+  top: number;
+  width: number;
+  maxHeight: number;
+}
+
+const TEXT_FILTER_FIELDS: Array<{ key: TextFilterField; label: string }> = [
+  { key: 'any', label: 'Any text' },
+  { key: 'name', label: 'Name' },
+  { key: 'backend', label: 'Backend' },
+  { key: 'type', label: 'Type' },
+  { key: 'capability', label: 'Capability' },
+  { key: 'label', label: 'Label' },
+  { key: 'status', label: 'Status' },
+];
+
+const TEXT_FILTER_MODES: Array<{ key: TextFilterMode; label: string }> = [
+  { key: 'include', label: 'contains' },
+  { key: 'exclude', label: 'does not contain' },
+];
+
+let textFilterRuleCounter = 0;
+
+function createTextFilterRule(overrides: Partial<TextFilterRule> = {}): TextFilterRule {
+  textFilterRuleCounter += 1;
+  return {
+    id: `text-filter-${textFilterRuleCounter}`,
+    field: 'any',
+    mode: 'include',
+    value: '',
+    ...overrides,
+  };
+}
+
+function normalizeFilterText(value: unknown): string {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function compactTextFilters(filters: TextFilterRule[]): TextFilterRule[] {
+  return filters.filter(rule => normalizeFilterText(rule.value).length > 0);
+}
+
+function listCapabilityLabelText(m: ModelInfo): string {
+  return modelCapabilityTags(m).map(tag => CAPABILITY_TAG_LABELS[tag]).join(' ');
+}
+
+function listModelTypeText(m: ModelInfo): string {
+  const cap = capabilityFromModelInfo(m);
+  if (cap === 'chat' || cap === 'unknown') return 'llm chat text';
+  if (cap === 'audio') return 'audio transcription speech-to-text asr stt';
+  if (cap === 'tts') return 'tts speech text-to-speech';
+  if (cap === 'image') return 'image diffusion image-generation';
+  if (cap === 'embedding') return 'embedding embed';
+  if (cap === 'reranking') return 'reranking reranker';
+  return String(cap);
+}
+
+function listModelStatusText(status: ModelStatus): string {
+  switch (status) {
+    case 'running': return 'running loaded active';
+    case 'downloaded': return 'downloaded local ready';
+    case 'downloading': return 'downloading pulling download';
+    case 'available':
+    default: return 'available remote';
+  }
+}
+
+function modelTextFilterTarget(m: ModelInfo, status: ModelStatus, field: TextFilterField): string {
+  const nameText = `${listModelName(m)} ${m.display_name || ''}`;
+  const recipe = String((m as any).recipe || '');
+  const backendText = recipe ? `${recipe} ${listRecipeBadgeText(recipe)}` : '';
+  const typeText = listModelTypeText(m);
+  const labelText = (m.labels || []).join(' ');
+  const capabilityText = `${listCapabilityLabelText(m)} ${modelCapabilityTags(m).join(' ')}`;
+  const statusText = listModelStatusText(status);
+
+  switch (field) {
+    case 'name': return nameText;
+    case 'backend': return backendText;
+    case 'type': return typeText;
+    case 'capability': return capabilityText;
+    case 'label': return labelText;
+    case 'status': return statusText;
+    case 'any':
+    default:
+      return `${nameText} ${backendText} ${typeText} ${labelText} ${capabilityText} ${statusText}`;
+  }
+}
+
+function modelMatchesTextFilters(m: ModelInfo, status: ModelStatus, filters: TextFilterRule[]): boolean {
+  for (const rule of filters) {
+    const needle = normalizeFilterText(rule.value);
+    if (!needle) continue;
+    const haystack = modelTextFilterTarget(m, status, rule.field).toLowerCase();
+    const matches = haystack.includes(needle);
+    if (rule.mode === 'include' && !matches) return false;
+    if (rule.mode === 'exclude' && matches) return false;
+  }
+  return true;
+}
 
 export function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
   if (filter === 'all') return true;
@@ -226,12 +338,15 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   favoriteNames,
 }) => {
   const [filterOpen, setFilterOpen] = useState(false);
+  const [filterPopoverStyle, setFilterPopoverStyle] = useState<FilterPopoverStyle | null>(null);
   const [sortBy, setSortBy] = useState<SortBy>('name');
+  const [textFilters, setTextFilters] = useState<TextFilterRule[]>(() => [createTextFilterRule()]);
   const filterBtnRef = useRef<HTMLButtonElement>(null);
   const filterPopoverRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const defaultSearchRef = useRef<HTMLInputElement>(null);
   const inputRef = (searchInputRef ?? defaultSearchRef) as React.RefObject<HTMLInputElement>;
+  const activeTextFilters = useMemo(() => compactTextFilters(textFilters), [textFilters]);
 
   // Build flat list filtered by search + type; sort based on sortBy
   const flatList = useMemo((): FlatModelEntry[] => {
@@ -253,12 +368,6 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
       // Funnel: functional capability tags (multi-select). Empty = no filter.
       if (!modelMatchesCapabilityTags(m, capabilityFilter ?? new Set())) continue;
 
-      // Filter by search
-      if (q) {
-        const haystack = `${mName} ${m.display_name || ''} ${(m as any).recipe || ''} ${(m.labels || []).join(' ')}`.toLowerCase();
-        if (!haystack.includes(q)) continue;
-      }
-
       const activeDownload = activeDownloadForModel(downloadItems, mName);
       const pullPct = activeDownload?.percent ?? pulling[mName];
 
@@ -271,6 +380,15 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
         status = 'downloaded';
       } else {
         status = 'available';
+      }
+
+      // Funnel: custom text rules. All active rules are combined with AND.
+      if (!modelMatchesTextFilters(m, status, activeTextFilters)) continue;
+
+      // Filter by search
+      if (q) {
+        const haystack = `${mName} ${m.display_name || ''} ${(m as any).recipe || ''} ${(m.labels || []).join(' ')}`.toLowerCase();
+        if (!haystack.includes(q)) continue;
       }
 
       result.push({ model: m, status, downloadPct: pullPct, pinned: pinnedNames?.has(mName.toLowerCase()) ?? false });
@@ -321,7 +439,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
     }
 
     return result;
-  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy, pinnedNames, favoriteNames, primaryFilter, backendFilter, tagFilter, capabilityFilter]);
+  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy, pinnedNames, favoriteNames, primaryFilter, backendFilter, tagFilter, capabilityFilter, activeTextFilters]);
 
   // Funnel options: the union of functional capability tags present across the
   // models, in canonical order. Derived client-side from the model labels —
@@ -336,12 +454,93 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   }, [allModels]);
 
   const capabilityFilterSize = capabilityFilter?.size ?? 0;
+  const activeFilterCount = capabilityFilterSize + activeTextFilters.length;
+
   const toggleCapability = useCallback((tag: CapabilityTag) => {
     if (!onCapabilityFilterChange) return;
     const next = new Set(capabilityFilter ?? new Set<string>());
     if (next.has(tag)) next.delete(tag); else next.add(tag);
     onCapabilityFilterChange(next);
   }, [capabilityFilter, onCapabilityFilterChange]);
+
+  const addTextFilter = useCallback(() => {
+    setTextFilters(prev => [...prev, createTextFilterRule()]);
+  }, []);
+
+  const updateTextFilter = useCallback((id: string, patch: Partial<TextFilterRule>) => {
+    setTextFilters(prev => prev.map(rule => rule.id === id ? { ...rule, ...patch } : rule));
+  }, []);
+
+  const removeTextFilter = useCallback((id: string) => {
+    setTextFilters(prev => prev.filter(rule => rule.id !== id));
+  }, []);
+
+  const clearAllFilters = useCallback(() => {
+    onCapabilityFilterChange?.(new Set());
+    setTextFilters([createTextFilterRule()]);
+  }, [onCapabilityFilterChange]);
+
+  const updateFilterPopoverPosition = useCallback(() => {
+    const button = filterBtnRef.current;
+    if (!button) return;
+
+    const buttonRect = button.getBoundingClientRect();
+    const viewportPadding = 12;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const maxUsableWidth = Math.max(320, viewportWidth - viewportPadding * 2);
+    const width = Math.min(560, maxUsableWidth);
+    const top = Math.max(viewportPadding, buttonRect.bottom + 6);
+
+    let left = buttonRect.right - width;
+    if (left < viewportPadding) left = viewportPadding;
+    if (left + width > viewportWidth - viewportPadding) {
+      left = viewportWidth - viewportPadding - width;
+    }
+
+    setFilterPopoverStyle({
+      left,
+      top,
+      width,
+      maxHeight: Math.max(220, viewportHeight - top - viewportPadding),
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!filterOpen) return;
+
+    updateFilterPopoverPosition();
+    window.addEventListener('resize', updateFilterPopoverPosition);
+    window.addEventListener('scroll', updateFilterPopoverPosition, true);
+
+    return () => {
+      window.removeEventListener('resize', updateFilterPopoverPosition);
+      window.removeEventListener('scroll', updateFilterPopoverPosition, true);
+    };
+  }, [filterOpen, updateFilterPopoverPosition]);
+
+  useEffect(() => {
+    if (!filterOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (filterBtnRef.current?.contains(target)) return;
+      if (filterPopoverRef.current?.contains(target)) return;
+      setFilterOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setFilterOpen(false);
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [filterOpen]);
 
   // Keyboard navigation on the list (ArrowUp/Down/Home/End)
   const handleListKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -437,9 +636,9 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
           <button
             ref={filterBtnRef}
             type="button"
-            className={`model-list-panel__filter-btn${filterOpen ? ' model-list-panel__filter-btn--open' : ''}${capabilityFilterSize > 0 ? ' model-list-panel__filter-btn--active' : ''}`}
+            className={`model-list-panel__filter-btn${filterOpen ? ' model-list-panel__filter-btn--open' : ''}${activeFilterCount > 0 ? ' model-list-panel__filter-btn--active' : ''}`}
             onClick={handleFilterBtnClick}
-            aria-label={capabilityFilterSize > 0 ? `Filter models by capability (${capabilityFilterSize} active)` : 'Filter models by capability'}
+            aria-label={activeFilterCount > 0 ? `Filter models (${activeFilterCount} active)` : 'Filter models'}
             aria-expanded={filterOpen}
             aria-haspopup="dialog"
           >
@@ -450,12 +649,13 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
             <div
               ref={filterPopoverRef}
               className="model-list-panel__filter-popover"
+              style={filterPopoverStyle ?? undefined}
               role="dialog"
               aria-label="Model filters"
               aria-modal="false"
             >
               <div className="model-list-panel__filter-popover-head">
-                <span>Filter by capability</span>
+                <span>Model filters</span>
                 <button
                   type="button"
                   className="model-list-panel__filter-popover-close"
@@ -465,35 +665,113 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                   <Icon name="x" size={13} />
                 </button>
               </div>
-              <div className="model-list-panel__filter-options" role="group" aria-label="Model capability filter">
-                {availableCapabilityTags.length === 0 && (
-                  <span className="model-list-panel__filter-empty">No capabilities available</span>
-                )}
-                {availableCapabilityTags.map(tag => {
-                  const active = capabilityFilter?.has(tag) ?? false;
-                  return (
-                    <button
-                      key={tag}
-                      type="button"
-                      className={`model-list-panel__filter-option${active ? ' model-list-panel__filter-option--active' : ''}`}
-                      onClick={() => toggleCapability(tag)}
-                      aria-pressed={active}
-                    >
-                      <CapabilityIcon capability={capabilityTagIconTarget(tag) as any} size={12} aria-hidden="true" />
-                      {CAPABILITY_TAG_LABELS[tag]}
-                    </button>
-                  );
-                })}
-                {capabilityFilterSize > 0 && (
+
+              <div className="model-list-panel__filter-section">
+                <div className="model-list-panel__filter-section-title">Capabilities</div>
+                <div className="model-list-panel__filter-options" role="group" aria-label="Model capability filter">
+                  {availableCapabilityTags.length === 0 && (
+                    <span className="model-list-panel__filter-empty">No capabilities available</span>
+                  )}
+                  {availableCapabilityTags.map(tag => {
+                    const active = capabilityFilter?.has(tag) ?? false;
+                    return (
+                      <button
+                        key={tag}
+                        type="button"
+                        className={`model-list-panel__filter-option${active ? ' model-list-panel__filter-option--active' : ''}`}
+                        onClick={() => toggleCapability(tag)}
+                        aria-pressed={active}
+                      >
+                        <CapabilityIcon capability={capabilityTagIconTarget(tag) as any} size={12} aria-hidden="true" />
+                        {CAPABILITY_TAG_LABELS[tag]}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="model-list-panel__filter-section">
+                <div className="model-list-panel__filter-section-head">
+                  <span className="model-list-panel__filter-section-title">Custom text rules</span>
                   <button
                     type="button"
-                    className="model-list-panel__filter-clear"
-                    onClick={() => onCapabilityFilterChange?.(new Set())}
+                    className="model-list-panel__filter-add"
+                    onClick={addTextFilter}
                   >
-                    Clear all
+                    + Add
                   </button>
-                )}
+                </div>
+
+                <div className="model-list-panel__text-filters" role="group" aria-label="Custom text filters">
+                  {textFilters.length === 0 && (
+                    <span className="model-list-panel__filter-empty">Add a text rule, for example “does not contain qwen”.</span>
+                  )}
+                  {textFilters.map((rule, index) => (
+                    <div key={rule.id} className="model-list-panel__text-filter">
+                      <label className="sr-only" htmlFor={`${rule.id}-field`}>Filter field</label>
+                      <select
+                        id={`${rule.id}-field`}
+                        className="model-list-panel__text-filter-field"
+                        value={rule.field}
+                        onChange={e => updateTextFilter(rule.id, { field: e.target.value as TextFilterField })}
+                        aria-label={`Filter ${index + 1} field`}
+                      >
+                        {TEXT_FILTER_FIELDS.map(field => (
+                          <option key={field.key} value={field.key}>{field.label}</option>
+                        ))}
+                      </select>
+
+                      <label className="sr-only" htmlFor={`${rule.id}-mode`}>Filter mode</label>
+                      <select
+                        id={`${rule.id}-mode`}
+                        className="model-list-panel__text-filter-mode"
+                        value={rule.mode}
+                        onChange={e => updateTextFilter(rule.id, { mode: e.target.value as TextFilterMode })}
+                        aria-label={`Filter ${index + 1} mode`}
+                      >
+                        {TEXT_FILTER_MODES.map(mode => (
+                          <option key={mode.key} value={mode.key}>{mode.label}</option>
+                        ))}
+                      </select>
+
+                      <label className="sr-only" htmlFor={`${rule.id}-value`}>Filter text</label>
+                      <input
+                        id={`${rule.id}-value`}
+                        className="model-list-panel__text-filter-input"
+                        type="text"
+                        value={rule.value}
+                        onChange={e => updateTextFilter(rule.id, { value: e.target.value })}
+                        placeholder={rule.mode === 'exclude' ? 'e.g. qwen' : 'e.g. llama'}
+                        aria-label={`Filter ${index + 1} text`}
+                        autoComplete="off"
+                      />
+
+                      <button
+                        type="button"
+                        className="model-list-panel__text-filter-remove"
+                        onClick={() => removeTextFilter(rule.id)}
+                        aria-label={`Remove filter ${index + 1}`}
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="model-list-panel__filter-help">
+                  Rules are combined with AND. “Does not contain qwen” hides Qwen models.
+                </div>
               </div>
+
+              {activeFilterCount > 0 && (
+                <button
+                  type="button"
+                  className="model-list-panel__filter-clear"
+                  onClick={clearAllFilters}
+                >
+                  Clear all filters
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -1697,7 +1697,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
       const builtinToolNames = new Set(['generate_image', 'edit_image', 'text_to_speech', 'transcribe_audio', 'analyze_image']);
       const seenCustomToolNames = new Set<string>();
       const customTools = isOmniCollection
-        ? customDraft.omniCustomTools.map((tool, index) => {
+        ? customDraft.omniCustomTools.map((tool, index): CustomOmniToolDefinition | null => {
           const hasAnyValue = [tool.name, tool.description, tool.targetModel, tool.systemPrompt, tool.promptTemplate, tool.parametersJson, tool.maxTokens].some(value => String(value || '').trim());
           if (!hasAnyValue) return null;
           const name = sanitizeOmniToolName(tool.name);
@@ -1728,7 +1728,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
             parameters,
             max_tokens: Number.isFinite(maxTokens) && maxTokens > 0 ? Math.floor(maxTokens) : undefined,
           };
-        }).filter((tool): tool is CustomOmniToolDefinition => Boolean(tool))
+        }).filter((tool): tool is CustomOmniToolDefinition => tool !== null)
         : [];
       const componentRoles = {
         llm: customDraft.llmComponent,

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -8290,15 +8290,11 @@ input, textarea {
 .model-list-panel__filter-popover {
   position: fixed;
   z-index: 160;
-  /* Solid, opaque surface so list content behind the popover does not bleed
-     through (the previous `--surface-overlay` token is undefined → transparent).
-     Fixed positioning lets the dialog sit above the nav rail and expand across
-     the available viewport instead of being clipped by the middle list pane. */
   background: var(--surface-3);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  padding: var(--space-3);
-  min-width: min(360px, calc(100vw - 24px));
+  padding: var(--space-2);
+  min-width: min(320px, calc(100vw - 24px));
   max-width: calc(100vw - 24px);
   overflow: auto;
   box-shadow: 0 12px 32px rgba(0,0,0,0.38);
@@ -8308,32 +8304,41 @@ input, textarea {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-1) var(--space-2) var(--space-2);
+  gap: var(--space-2);
+  min-height: 24px;
+  padding: 0 0 var(--space-1);
   font-size: var(--text-xs);
-  color: var(--text-tertiary);
+  font-weight: 600;
+  color: var(--text-secondary);
 }
 
 .model-list-panel__filter-popover-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
   background: none;
-  border: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
   color: var(--text-tertiary);
   cursor: pointer;
-  padding: 2px;
-  display: inline-flex;
 }
 
-.model-list-panel__filter-popover-close:hover { color: var(--text-primary); }
-.model-list-panel__filter-popover-close:focus-visible { outline: 2px solid var(--accent-focus); border-radius: 2px; }
+.model-list-panel__filter-popover-close:hover { color: var(--text-primary); background: var(--surface-2); border-color: var(--border-subtle); }
+.model-list-panel__filter-popover-close:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
 
 .model-list-panel__filter-section {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: var(--space-1);
   padding: var(--space-2) 0;
   border-top: 1px solid var(--border-subtle);
 }
 
-.model-list-panel__filter-section:first-of-type { border-top: none; padding-top: 0; }
+.model-list-panel__filter-section:first-of-type { border-top: none; padding-top: var(--space-1); }
+.model-list-panel__filter-section:last-of-type { padding-bottom: var(--space-1); }
 
 .model-list-panel__filter-section-head {
   display: flex;
@@ -8343,16 +8348,18 @@ input, textarea {
 }
 
 .model-list-panel__filter-section-title {
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .model-list-panel__filter-add {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 3px;
   min-height: 24px;
   padding: 0 var(--space-2);
   border: 1px solid var(--border-subtle);
@@ -8368,69 +8375,72 @@ input, textarea {
 
 .model-list-panel__filter-options {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
 .model-list-panel__filter-option {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-1) var(--space-2);
-  background: none;
-  border: none;
-  border-radius: var(--radius-sm);
+  gap: 4px;
+  min-height: 24px;
+  padding: 0 var(--space-2);
+  background: var(--surface-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
   color: var(--text-secondary);
   font-size: var(--text-xs);
   cursor: pointer;
   text-align: left;
 }
 
-.model-list-panel__filter-option:hover { background: var(--surface-2); color: var(--text-primary); }
+.model-list-panel__filter-option:hover { background: var(--surface-2); color: var(--text-primary); border-color: var(--border-strong); }
 .model-list-panel__filter-option:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
-.model-list-panel__filter-option--active { color: var(--accent-fg); font-weight: 600; }
-.model-list-panel__filter-option[aria-pressed="true"] { background: var(--surface-2); }
+.model-list-panel__filter-option--active,
+.model-list-panel__filter-option[aria-pressed="true"] { color: var(--accent-fg); border-color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 12%, transparent); }
 
 .model-list-panel__filter-empty {
-  padding: var(--space-1) var(--space-2);
+  padding: var(--space-1) 0;
   color: var(--text-tertiary);
   font-size: var(--text-xs);
 }
 
 .model-list-panel__filter-clear {
-  margin-top: var(--space-1);
-  padding: var(--space-1) var(--space-2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-end;
+  min-height: 24px;
+  margin-top: 0;
+  padding: 0 var(--space-2);
   background: none;
-  border: none;
-  border-top: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
   color: var(--accent-fg);
   font-size: var(--text-xs);
   cursor: pointer;
-  text-align: left;
-  border-radius: var(--radius-sm);
 }
-.model-list-panel__filter-clear:hover { background: var(--surface-2); }
+.model-list-panel__filter-clear:hover { background: var(--surface-2); border-color: var(--border-strong); }
 .model-list-panel__filter-clear:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
 
 .model-list-panel__text-filters {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 4px;
 }
 
 .model-list-panel__text-filter {
   display: grid;
-  grid-template-columns: minmax(92px, 0.9fr) minmax(118px, 1.05fr) minmax(112px, 1fr) 26px;
-  gap: var(--space-1);
+  grid-template-columns: minmax(92px, 0.75fr) 56px minmax(112px, 1fr) 24px;
+  gap: 4px;
   align-items: center;
 }
 
 .model-list-panel__text-filter-field,
-.model-list-panel__text-filter-mode,
 .model-list-panel__text-filter-input {
   width: 100%;
   min-width: 0;
-  height: 28px;
+  height: 26px;
   padding: 0 var(--space-2);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
@@ -8441,25 +8451,53 @@ input, textarea {
 }
 
 .model-list-panel__text-filter-field:focus,
-.model-list-panel__text-filter-mode:focus,
 .model-list-panel__text-filter-input:focus {
   outline: 2px solid var(--accent-focus);
   outline-offset: 0;
   border-color: transparent;
 }
 
+.model-list-panel__text-filter-mode {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  height: 26px;
+  padding: 2px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-base);
+}
+
+.model-list-panel__text-filter-mode-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: calc(var(--radius-sm) - 2px);
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+.model-list-panel__text-filter-mode-btn:hover { color: var(--text-primary); background: var(--surface-2); }
+.model-list-panel__text-filter-mode-btn:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+.model-list-panel__text-filter-mode-btn--active,
+.model-list-panel__text-filter-mode-btn[aria-pressed="true"] { color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 14%, transparent); border-color: color-mix(in srgb, var(--accent-fg) 35%, transparent); }
+
 .model-list-panel__text-filter-remove {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   background: none;
   color: var(--text-tertiary);
   cursor: pointer;
-  font-size: 16px;
   line-height: 1;
 }
 
@@ -8470,15 +8508,10 @@ input, textarea {
 }
 .model-list-panel__text-filter-remove:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
 
-.model-list-panel__filter-help {
-  color: var(--text-tertiary);
-  font-size: var(--text-xs);
-  line-height: var(--leading-normal);
-}
-
-@media (max-width: 720px) {
-  .model-list-panel__text-filter { grid-template-columns: 1fr 1fr 26px; }
-  .model-list-panel__text-filter-input { grid-column: 1 / 3; }
+@media (max-width: 560px) {
+  .model-list-panel__filter-popover { padding: var(--space-2); }
+  .model-list-panel__text-filter { grid-template-columns: minmax(86px, 1fr) 56px 24px; }
+  .model-list-panel__text-filter-input { grid-column: 1 / 4; }
 }
 
 /* Capability icons on a model row — one per functional capability tag (#2424). */

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -8288,18 +8288,20 @@ input, textarea {
 
 /* Filter popover */
 .model-list-panel__filter-popover {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  z-index: 50;
+  position: fixed;
+  z-index: 160;
   /* Solid, opaque surface so list content behind the popover does not bleed
-     through (the previous `--surface-overlay` token is undefined → transparent). */
+     through (the previous `--surface-overlay` token is undefined → transparent).
+     Fixed positioning lets the dialog sit above the nav rail and expand across
+     the available viewport instead of being clipped by the middle list pane. */
   background: var(--surface-3);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  padding: var(--space-2);
-  min-width: 160px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+  padding: var(--space-3);
+  min-width: min(360px, calc(100vw - 24px));
+  max-width: calc(100vw - 24px);
+  overflow: auto;
+  box-shadow: 0 12px 32px rgba(0,0,0,0.38);
 }
 
 .model-list-panel__filter-popover-head {
@@ -8322,6 +8324,47 @@ input, textarea {
 
 .model-list-panel__filter-popover-close:hover { color: var(--text-primary); }
 .model-list-panel__filter-popover-close:focus-visible { outline: 2px solid var(--accent-focus); border-radius: 2px; }
+
+.model-list-panel__filter-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.model-list-panel__filter-section:first-of-type { border-top: none; padding-top: 0; }
+
+.model-list-panel__filter-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.model-list-panel__filter-section-title {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.model-list-panel__filter-add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 24px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.model-list-panel__filter-add:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.model-list-panel__filter-add:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
 
 .model-list-panel__filter-options {
   display: flex;
@@ -8368,6 +8411,75 @@ input, textarea {
 }
 .model-list-panel__filter-clear:hover { background: var(--surface-2); }
 .model-list-panel__filter-clear:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+
+.model-list-panel__text-filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.model-list-panel__text-filter {
+  display: grid;
+  grid-template-columns: minmax(92px, 0.9fr) minmax(118px, 1.05fr) minmax(112px, 1fr) 26px;
+  gap: var(--space-1);
+  align-items: center;
+}
+
+.model-list-panel__text-filter-field,
+.model-list-panel__text-filter-mode,
+.model-list-panel__text-filter-input {
+  width: 100%;
+  min-width: 0;
+  height: 28px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  box-sizing: border-box;
+}
+
+.model-list-panel__text-filter-field:focus,
+.model-list-panel__text-filter-mode:focus,
+.model-list-panel__text-filter-input:focus {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 0;
+  border-color: transparent;
+}
+
+.model-list-panel__text-filter-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.model-list-panel__text-filter-remove:hover {
+  background: var(--surface-2);
+  color: var(--text-primary);
+  border-color: var(--border-subtle);
+}
+.model-list-panel__text-filter-remove:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+
+.model-list-panel__filter-help {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+@media (max-width: 720px) {
+  .model-list-panel__text-filter { grid-template-columns: 1fr 1fr 26px; }
+  .model-list-panel__text-filter-input { grid-column: 1 / 3; }
+}
 
 /* Capability icons on a model row — one per functional capability tag (#2424). */
 .model-list-item__caps {


### PR DESCRIPTION
## Summary

Adds compact custom filtering to the Models tab funnel menu in the GUI3 prototype.

## Why

The model list is growing, so users need a quick way to find or hide model groups without relying only on predefined capability filters. This is especially useful for excluding models by keyword, for example hiding all models containing `qwen`.

## Changes

- Adds custom text filter rules to the Models tab.
- Supports combining multiple filter rules.
- Supports include and exclude matching through compact icon toggles.
- Allows filtering by:
  - any searchable text
  - model name
  - backend
  - type
  - capability
  - label
  - status
- Keeps existing capability filters intact.
- Moves the popover into an overlay position so it can expand beyond the rail instead of being clipped.


## Testing

- Verified `npm run build` succeeds
- `npm test` yields  7 skipped 195 passed
- locally checked and tested for function

<img width="498" height="424" alt="image" src="https://github.com/user-attachments/assets/b417bb7a-ce0e-4da4-9158-cb013f338b04" />
