### PR TITLE
fix(router): capture load duration before std::move to prevent null deref

### DIFF
--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -622,11 +622,12 @@ void Router::load_model(const std::string& model_name,
                 lock.lock();
 
                 retry_server->set_state(ModelState::READY);
+                const auto retry_duration_ms = retry_server->get_load_duration_ms();
                 loaded_servers_.push_back(std::move(retry_server));
                 is_loading_ = false;
                 load_cv_.notify_all();
 
-                LOG(DEBUG, "Router") << "Retry successful in " << retry_server->get_load_duration_ms() << "ms!" << std::endl;
+                LOG(DEBUG, "Router") << "Retry successful in " << retry_duration_ms << "ms!" << std::endl;
             } catch (const std::exception& retry_error) {
                 lock.lock();
                 is_loading_ = false;


### PR DESCRIPTION
## Summary

Fixes a use-after-move null pointer dereference in `Router::load_model` that causes `lemond` to crash with `SIGSEGV` (`SEGV_MAPERR`) when debug logging is enabled.

Fixes #2554.

## Root Cause

In the model load retry path (triggered when the initial load fails with a non-file-not-found error, causing the "nuclear option" eviction of all models before retrying):

```cpp
// router.cpp — retry path
retry_server->set_state(ModelState::READY);
loaded_servers_.push_back(std::move(retry_server));  // ← retry_server is now null
is_loading_ = false;
load_cv_.notify_all();

LOG(DEBUG, "Router") << "Retry successful in "
    << retry_server->get_load_duration_ms()            // ← SIGSEGV: deref null
    << "ms!" << std::endl;
```

`std::move(retry_server)` on line 625 transfers ownership into `loaded_servers_`, leaving `retry_server` as a null `unique_ptr`. Line 629 then calls `retry_server->get_load_duration_ms()`, dereferencing the null pointer.

## Disassembly Confirmation

Crash address `lemond + 0x28cd43` corresponds to:

```asm
28cd33:  lea  "Retry successful in ",%rsi    # load string literal
28cd3d:  call ostream_insert                  # ostream << "Retry successful in "
28cd43:  mov  0x1c8(%r14),%rsi               # CRASH: read load_duration_ms_ from r14=null
28cd4d:  call ostream::_M_insert<long>        # ostream << (long)value
```

`r14` holds `retry_server.get()` which is `nullptr` after the `std::move`.

## Trigger Conditions

1. Model load fails with a non-file-not-found error (e.g. GPU OOM during multi-model operation)
2. "Nuclear option" evicts all loaded models and retries (line 602)
3. Retry **succeeds** (reaching line 625)
4. Log level is `debug` (the offending line is `LOG(DEBUG, ...)`)

This makes it highly correlated with rapid model switching under GPU memory pressure — loading a new model fails, triggers full eviction, the retry succeeds on freed memory, and the debug log crashes.

**Note:** The crash only occurs when log level is `debug`. Production builds with default logging would not hit this code path.

## Fix

Capture `get_load_duration_ms()` into a local variable before the `std::move`, then use the saved value in the log statement.

## Testing

- Verified the crash reproduces consistently on v10.9.0 with `log_level: debug` during multi-model load/evict cycles
- Confirmed the fix resolves the crash by eliminating the post-move dereference