### PR TITLE
test: relax streaming response length assertions from >5 to >0

### DIFF
--- a/test/server_llm.py
+++ b/test/server_llm.py
@@ -168,7 +168,7 @@ class LLMTests(ServerTestBase):
         self.assertGreater(
             chunk_count, 2, f"Should have multiple chunks, got {chunk_count}"
         )
-        self.assertGreater(len(complete_response), 5, "Response should have content")
+        self.assertGreater(len(complete_response), 0, "Response should have content")
 
     @skip_if_unsupported("chat_completions_async")
     def test_003_chat_completions_streaming_async(self):
@@ -199,7 +199,7 @@ class LLMTests(ServerTestBase):
 
             print()
             self.assertGreater(chunk_count, 2)
-            self.assertGreater(len(complete_response), 5)
+            self.assertGreater(len(complete_response), 0)
 
         asyncio.run(_run())
 
@@ -221,7 +221,7 @@ class LLMTests(ServerTestBase):
         )
 
         print(f"Response: {completion.choices[0].text}")
-        self.assertGreater(len(completion.choices[0].text), 5)
+        self.assertGreater(len(completion.choices[0].text), 0)
 
         # Check usage fields
         self.assertGreater(completion.usage.prompt_tokens, 0)
@@ -251,7 +251,7 @@ class LLMTests(ServerTestBase):
 
         print()
         self.assertGreater(chunk_count, 2)
-        self.assertGreater(len(complete_response), 5)
+        self.assertGreater(len(complete_response), 0)
 
     @skip_if_unsupported("completions_async")
     def test_006_completions_streaming_async(self):
@@ -278,7 +278,7 @@ class LLMTests(ServerTestBase):
 
             print()
             self.assertGreater(chunk_count, 2)
-            self.assertGreater(len(complete_response), 5)
+            self.assertGreater(len(complete_response), 0)
 
         asyncio.run(_run())
 
@@ -301,7 +301,7 @@ class LLMTests(ServerTestBase):
         )
 
         print(f"Response: {response.output[0].content[0].text}")
-        self.assertGreater(len(response.output[0].content[0].text), 5)
+        self.assertGreater(len(response.output[0].content[0].text), 0)
 
     @skip_if_unsupported("responses_api_streaming")
     def test_008_responses_api_streaming(self):
@@ -343,7 +343,7 @@ class LLMTests(ServerTestBase):
 
         print()
         self.assertEqual(last_event_type, "response.completed")
-        self.assertGreater(len(complete_response), 5)
+        self.assertGreater(len(complete_response), 0)
 
     # =========================================================================
     # PARAMETER TESTS


### PR DESCRIPTION
## Summary

Relaxes `assertGreater(len(response), 5)` to `assertGreater(len(response), 0)` across 7 tests in `test/server_llm.py` that use `max_tokens=10`.

## Problem

The streaming/completion tests assert `len(complete_response) > 5`, but with `max_tokens=10` on small test models, 10 tokens can produce ≤5 characters. This was observed failing in CI:

```
test_006_completions_streaming_async
AssertionError: 5 not greater than 5
```

The model returned `" (ਹਾ"` — 5 bytes across 10 tokens due to multibyte UTF-8.

## Fix

Changed `> 5` to `> 0` in all affected tests. These tests verify **streaming mechanics** (multiple chunks arrive, content is non-empty), not model output quality. The meaningful assertion is `chunk_count > 2`, which proves the stream produces multiple chunks.

## Affected tests

| Test | Line |
|------|------|
| `test_002_chat_completions_streaming` | 171 |
| `test_003_chat_completions_streaming_async` | 202 |
| `test_004_completions_non_streaming` | 224 |
| `test_005_completions_streaming` | 254 |
| `test_006_completions_streaming_async` | 281 |
| `test_007_responses_api` | 304 |
| `test_008_responses_api_streaming` | 346 |