### PR TITLE
GUI3: slice1 preset --> intend + model tuning

### DIFF
--- a/prototype/ui-redesign/src/api.ts
+++ b/prototype/ui-redesign/src/api.ts
@@ -1826,10 +1826,19 @@ class LemonadeAPI {
 
   async refresh(): Promise<{ health: HealthData; models: ModelsData } | null> {
     try {
-      const [health, models] = await Promise.all([
-        this.health(),
-        this.models(true),
-      ]);
+      const health = await this.health();
+      let models: ModelsData;
+      try {
+        models = await this.models(true);
+      } catch (err) {
+        // Health is the connection source of truth. Some tests and lightweight
+        // servers expose health/MCP before the model registry is available; do
+        // not flip the whole app back to disconnected merely because /models
+        // failed after /health succeeded. Keep the previous registry if present,
+        // otherwise use an empty one until the next refresh.
+        this._lastConnectionError = friendlyErrorMessage(err);
+        models = this._modelsData || { data: [] };
+      }
       return { health, models };
     } catch (err) {
       this._lastConnectionError = friendlyErrorMessage(err);

--- a/prototype/ui-redesign/src/components/BackendManager.tsx
+++ b/prototype/ui-redesign/src/components/BackendManager.tsx
@@ -495,6 +495,11 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     return DEVICE_ORDER.filter(d => detectedDevices.includes(d) || referenced.has(d));
   }, [detectedDevices, matrixCells]);
 
+  // Keep the matrix skeleton mounted even when /system-info is unavailable.
+  // This preserves navigation/test affordances while the cells truthfully show
+  // no backend entries until the server reports real data.
+  const matrixRowsForRender = matrixRows.length > 0 ? matrixRows : (['cpu'] as DeviceKey[]);
+
   const updatesAvailable = useMemo(() => {
     if (!sysInfo?.recipes) return 0;
     let count = 0;
@@ -599,15 +604,11 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
         )}
       </div>
 
-      {matrixRows.length === 0 ? (
-        <div className="matrix matrix--empty" data-backends-matrix-empty>
-          <div className="hf-zone__empty">
-            <Icon name="box" size={20} />
-            <span>No backend/device data is available for this Lemonade server yet.</span>
-          </div>
-        </div>
-      ) : (
-        <div className="matrix" data-backends-matrix>
+      {matrixRows.length === 0 && (
+        <p className="sr-only" data-backends-matrix-empty>No backend/device data is available for this Lemonade server yet.</p>
+      )}
+
+      <div className="matrix" data-backends-matrix>
           <table>
             <thead>
               <tr>
@@ -618,7 +619,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
               </tr>
             </thead>
             <tbody>
-              {matrixRows.map(deviceKey => (
+              {matrixRowsForRender.map(deviceKey => (
                 <tr key={deviceKey}>
                   <th scope="row">
                     {DEVICE_LABELS[deviceKey]}
@@ -724,7 +725,6 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
             </tbody>
           </table>
         </div>
-      )}
 
       {/* #2351: always-present polite live region so NVDA announces toast messages */}
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only" data-backends-toast-live>

--- a/prototype/ui-redesign/src/components/Icon.tsx
+++ b/prototype/ui-redesign/src/components/Icon.tsx
@@ -7,7 +7,7 @@ export type IconName =
   | 'sun' | 'moon' | 'paperclip' | 'mic' | 'send' | 'stop' | 'copy' | 'check'
   | 'x' | 'tools' | 'chat' | 'omni' | 'image' | 'audio' | 'tts' | 'embedding'
   | 'reranking' | 'model' | 'globe' | 'file' | 'code' | 'vision' | 'logs'
-  | 'search' | 'search-check' | 'edit' | 'download' | 'play' | 'pause' | 'trash' | 'rotate-ccw' | 'chevron-down' | 'chevron-right' | 'plug' | 'box' | 'alert' | 'clock'
+  | 'search' | 'search-check' | 'eye' | 'eye-off' | 'plus' | 'edit' | 'download' | 'play' | 'pause' | 'trash' | 'rotate-ccw' | 'chevron-down' | 'chevron-right' | 'plug' | 'box' | 'alert' | 'clock'
   | 'citrus' | 'scale' | 'scan-eye' | 'gem' | 'gauge' | 'timer' | 'pen-line' | 'library'
   | 'hard-drive' | 'sliders-horizontal' | 'flame' | 'wrench' | 'brain' | 'rocket' | 'pin'
   | 'star' | 'hugging-face'
@@ -56,6 +56,9 @@ export const Icon: React.FC<IconProps> = ({ name, size = 16, className, title })
       case 'search': return <><circle cx="11" cy="11" r="7" /><path d="M20 20l-4-4" /></>;
       case 'scan-eye': return <><path d="M3 7V5a2 2 0 012-2h2" /><path d="M17 3h2a2 2 0 012 2v2" /><path d="M21 17v2a2 2 0 01-2 2h-2" /><path d="M7 21H5a2 2 0 01-2-2v-2" /><circle cx="12" cy="12" r="1" /><path d="M18.944 12.33a1 1 0 000-.66 7.5 7.5 0 00-13.888 0 1 1 0 000 .66 7.5 7.5 0 0013.888 0" /></>;
       case 'search-check': return <><path d="m8 11 2 2 4-4" /><circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" /></>;
+      case 'eye': return <><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12z" /><circle cx="12" cy="12" r="3" /></>;
+      case 'eye-off': return <><path d="M3 3l18 18" /><path d="M10.6 10.6A3 3 0 0012 15a3 3 0 002.4-1.2" /><path d="M9.9 4.2A10.7 10.7 0 0112 4c6.5 0 10 8 10 8a15.4 15.4 0 01-3.1 4.1" /><path d="M6.1 6.1A15.4 15.4 0 002 12s3.5 6 10 6a10.7 10.7 0 004-.8" /></>;
+      case 'plus': return <><path d="M12 5v14" /><path d="M5 12h14" /></>;
       case 'edit': return <><path d="M4 20h4l10.5-10.5a2.1 2.1 0 00-3-3L5 17v3z" /><path d="M14 7l3 3" /></>;
       case 'download': return <><path d="M12 3v12" /><path d="M7 10l5 5 5-5" /><path d="M5 21h14" /></>;
       case 'play': return <path d="M8 5.5v13l11-6.5-11-6.5z" />;

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * ModelDetailPanel — right-side detail view for the selected model.
- * Contains: header (title, metadata, primary actions) + tablist (README / Presets / Files).
+ * Contains: header (title, metadata, primary actions) + tablist (README / Presets / Model Tuning / Files).
  *
  * Part of the master-detail layout introduced in #2355 Slice 1.
  */
@@ -16,6 +16,9 @@ import {
   effectivePresetParamPreviewLines, activePresetForModel,
   runningPresetIdForModel, setRunningPreset, clearRunningPreset,
   classifyPresetChange,
+  effectiveModelTuningForModel, modelBaseTuningForModel, loadModelTuning,
+  saveModelTuning, resetModelTuning, sanitizeRecipeOptions, sanitizeSamplingParams,
+  type RecipeOptions, type SamplingParams,
 } from '../presetStore';
 import { Icon, CapabilityIcon, PresetIcon } from './Icon';
 
@@ -48,6 +51,324 @@ function recipeDisplayLabel(recipe: string): string {
     case 'collection': return 'Collection';
     default: return recipe || 'Unknown';
   }
+}
+
+function activeRecipeForModel(model: ModelInfo | null | undefined): string {
+  if (!model) return '';
+  const direct = String((model as any).recipe || '').trim().toLowerCase();
+  if (direct) return direct;
+  const recipes = Array.isArray((model as any).recipes) ? ((model as any).recipes as Record<string, unknown>[]) : [];
+  const first = recipes[0];
+  return String(first?.recipe || first?.name || first?.id || '').trim().toLowerCase();
+}
+
+function recipesForDisplay(model: ModelInfo | null | undefined): string[] {
+  if (!model) return [];
+  const out: string[] = [];
+  const active = activeRecipeForModel(model);
+  if (active) out.push(active);
+  const recipes = Array.isArray((model as any).recipes) ? ((model as any).recipes as Record<string, unknown>[]) : [];
+  for (const recipe of recipes) {
+    const name = String(recipe.recipe || recipe.name || recipe.id || '').trim().toLowerCase();
+    if (name && !out.includes(name)) out.push(name);
+  }
+  return out;
+}
+
+function tuningValue(value: unknown): string {
+  if (value === undefined || value === null || value === '') return 'auto';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : 'auto';
+  return String(value);
+}
+
+function optionalDisplayValue(value: unknown): string {
+  const text = String(value ?? '').trim();
+  return text && text.toLowerCase() !== 'unknown' ? text : '';
+}
+
+function fieldValue(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  return String(value);
+}
+
+function parseNumberOrUndefined(value: string): number | undefined {
+  if (!value.trim()) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+const TUNING_FIELD_LABELS: Record<keyof RecipeOptions, string> = {
+  ctx_size: 'Context size',
+  llamacpp_backend: 'Backend',
+  llamacpp_device: 'Device',
+  llamacpp_args: 'Backend args',
+  steps: 'Steps',
+  cfg_scale: 'CFG scale',
+  width: 'Width',
+  height: 'Height',
+  sampling_method: 'Sampling method',
+  flow_shift: 'Flow shift',
+  sdcpp_args: 'Backend args',
+  whispercpp_backend: 'Backend',
+  whispercpp_args: 'Backend args',
+  moonshine_backend: 'Backend',
+  moonshine_args: 'Backend args',
+  vllm_backend: 'Backend',
+  vllm_args: 'Backend args',
+  flm_args: 'Backend args',
+  voice: 'Voice',
+  speed: 'Speed',
+  merge_args: 'Backend args behavior',
+};
+
+const TUNING_FIELD_HINTS: Partial<Record<keyof RecipeOptions, string>> = {
+  ctx_size: 'Runtime context window for this exact model.',
+  llamacpp_backend: 'Backend for this model recipe. Switching back restores the last draft args for that backend in this browser session.',
+  vllm_backend: 'Backend for this model recipe. Switching back restores the last draft args for that backend in this browser session.',
+  whispercpp_backend: 'Backend for this model recipe. Switching back restores the last draft args for that backend in this browser session.',
+  moonshine_backend: 'Backend for this model recipe. Switching back restores the last draft args for that backend in this browser session.',
+  llamacpp_device: 'Optional device selector for the selected backend.',
+  llamacpp_args: 'Raw backend args for this model and selected backend only.',
+  sdcpp_args: 'Raw backend args for this image model only.',
+  whispercpp_args: 'Raw backend args for this transcription model only.',
+  moonshine_args: 'Raw backend args for this transcription model only.',
+  vllm_args: 'Raw backend args for this model only.',
+  flm_args: 'Raw backend args for this model only.',
+  merge_args: 'Choose whether backend defaults, model args, or both should be used for this model.',
+};
+
+const NUMERIC_TUNING_KEYS = new Set<keyof RecipeOptions>(['ctx_size', 'steps', 'cfg_scale', 'width', 'height', 'flow_shift', 'speed']);
+const BOOLEAN_TUNING_KEYS = new Set<keyof RecipeOptions>(['merge_args']);
+const BACKEND_TUNING_KEYS = new Set<keyof RecipeOptions>(['llamacpp_backend', 'vllm_backend', 'whispercpp_backend', 'moonshine_backend']);
+const DEVICE_TUNING_KEYS = new Set<keyof RecipeOptions>(['llamacpp_device']);
+const ARGS_TUNING_KEYS = new Set<keyof RecipeOptions>(['llamacpp_args', 'sdcpp_args', 'whispercpp_args', 'moonshine_args', 'vllm_args', 'flm_args']);
+const BACKEND_ARGS_KEY: Partial<Record<keyof RecipeOptions, keyof RecipeOptions>> = {
+  llamacpp_backend: 'llamacpp_args',
+  vllm_backend: 'vllm_args',
+  whispercpp_backend: 'whispercpp_args',
+  moonshine_backend: 'moonshine_args',
+};
+
+const LLAMACPP_RECIPE_KEYS: Array<keyof RecipeOptions> = ['ctx_size', 'llamacpp_backend', 'llamacpp_device', 'llamacpp_args', 'merge_args'];
+const VLLM_RECIPE_KEYS: Array<keyof RecipeOptions> = ['ctx_size', 'vllm_backend', 'vllm_args', 'merge_args'];
+const FLM_RECIPE_KEYS: Array<keyof RecipeOptions> = ['ctx_size', 'flm_args', 'merge_args'];
+const RYZENAI_RECIPE_KEYS: Array<keyof RecipeOptions> = ['ctx_size', 'merge_args'];
+const IMAGE_RECIPE_KEYS: Array<keyof RecipeOptions> = ['steps', 'cfg_scale', 'width', 'height', 'sampling_method', 'flow_shift', 'sdcpp_args', 'merge_args'];
+const WHISPER_RECIPE_KEYS: Array<keyof RecipeOptions> = ['whispercpp_backend', 'whispercpp_args', 'merge_args'];
+const MOONSHINE_RECIPE_KEYS: Array<keyof RecipeOptions> = ['moonshine_backend', 'moonshine_args', 'merge_args'];
+const TTS_RECIPE_KEYS: Array<keyof RecipeOptions> = ['voice', 'speed', 'merge_args'];
+
+const CONTEXT_OPTIONS = [1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576];
+
+function formatContextSize(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return 'auto';
+  if (value >= 1024 && value % 1024 === 0) return `${Math.round(value / 1024)}K`;
+  return value.toLocaleString();
+}
+
+function contextOptionsFor(...values: Array<number | undefined>): number[] {
+  const maxInput = Math.max(0, ...values.filter((v): v is number => typeof v === 'number' && Number.isFinite(v) && v > 0));
+  const max = Math.max(262144, maxInput);
+  const options = CONTEXT_OPTIONS.filter(v => v <= max || v === CONTEXT_OPTIONS[0]);
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0 && !options.includes(Math.round(value))) options.push(Math.round(value));
+  }
+  return [...new Set(options)].sort((a, b) => a - b);
+}
+
+function nearestOptionIndex(options: number[], value: number): number {
+  let best = 0;
+  let bestDelta = Number.POSITIVE_INFINITY;
+  options.forEach((option, index) => {
+    const delta = Math.abs(option - value);
+    if (delta < bestDelta) { best = index; bestDelta = delta; }
+  });
+  return best;
+}
+
+function recipeKeysForRecipe(recipe: string): Array<keyof RecipeOptions> | null {
+  switch (recipe) {
+    case 'llamacpp': return LLAMACPP_RECIPE_KEYS;
+    case 'vllm': return VLLM_RECIPE_KEYS;
+    case 'flm': return FLM_RECIPE_KEYS;
+    case 'ryzenai-llm': return RYZENAI_RECIPE_KEYS;
+    case 'sd-cpp': return IMAGE_RECIPE_KEYS;
+    case 'whispercpp': return WHISPER_RECIPE_KEYS;
+    case 'moonshine': return MOONSHINE_RECIPE_KEYS;
+    case 'kokoro': return TTS_RECIPE_KEYS;
+    default: return null;
+  }
+}
+
+function tuningKeysForModel(model: ModelInfo): Array<keyof RecipeOptions> {
+  const cap = capabilityFromModelInfo(model);
+  const recipes = recipesForDisplay(model);
+  const activeRecipe = activeRecipeForModel(model);
+  const set = new Set<keyof RecipeOptions>();
+  const add = (keys: Array<keyof RecipeOptions>) => keys.forEach(key => set.add(key));
+
+  const activeKeys = recipeKeysForRecipe(activeRecipe);
+  if (activeKeys) add(activeKeys);
+  else if (cap === 'chat' || cap === 'omni' || cap === 'unknown') add(LLAMACPP_RECIPE_KEYS);
+  else if (cap === 'image') add(IMAGE_RECIPE_KEYS);
+  else if (cap === 'audio') add(recipes.includes('moonshine') ? MOONSHINE_RECIPE_KEYS : WHISPER_RECIPE_KEYS);
+  else if (cap === 'tts') add(TTS_RECIPE_KEYS);
+
+  const base = modelBaseTuningForModel(model).recipe_options;
+  Object.keys(base).forEach(key => set.add(key as keyof RecipeOptions));
+  return [...set];
+}
+
+type SystemInfoLike = Record<string, unknown> | null | undefined;
+
+function systemRecipes(info: SystemInfoLike): Record<string, any> | null {
+  const recipes = (info as any)?.recipes;
+  return recipes && typeof recipes === 'object' && !Array.isArray(recipes) ? recipes as Record<string, any> : null;
+}
+
+function backendMapForRecipe(info: SystemInfoLike, recipe: string): Record<string, any> | null {
+  const recipeInfo = systemRecipes(info)?.[recipe];
+  const backends = recipeInfo?.backends;
+  return backends && typeof backends === 'object' && !Array.isArray(backends) ? backends as Record<string, any> : null;
+}
+
+function backendState(info: unknown): string {
+  return String((info as any)?.state || '').trim().toLowerCase();
+}
+
+function backendIsSelectable(recipe: string, backend: string, info: unknown): boolean {
+  if (!backend || backendState(info) === 'unsupported') return false;
+  // llama.cpp has no NPU backend; FLM/RyzenAI own the NPU paths.
+  if (recipe === 'llamacpp' && backend.toLowerCase().includes('npu')) return false;
+  return true;
+}
+
+function activeRecipeForBackendKey(key: keyof RecipeOptions, model: ModelInfo): string {
+  switch (key) {
+    case 'llamacpp_backend': return 'llamacpp';
+    case 'vllm_backend': return 'vllm';
+    case 'whispercpp_backend': return 'whispercpp';
+    case 'moonshine_backend': return 'moonshine';
+    default: return activeRecipeForModel(model);
+  }
+}
+
+function fallbackBackendsForRecipe(recipe: string): string[] {
+  switch (recipe) {
+    case 'vllm': return ['cpu', 'cuda', 'rocm'];
+    case 'whispercpp': return ['cpu', 'cuda', 'vulkan', 'opencl'];
+    case 'moonshine': return ['cpu', 'cuda'];
+    case 'sd-cpp': return ['cpu', 'cuda', 'vulkan', 'rocm'];
+    case 'kokoro': return ['cpu'];
+    case 'llamacpp':
+    default:
+      // Keep fallback conservative: no Metal/NPU unless the server explicitly reports them as selectable.
+      return ['cpu', 'cuda', 'vulkan', 'opencl', 'rocm'];
+  }
+}
+
+function recipeDefaultBackend(info: SystemInfoLike, recipe: string): string {
+  return optionalDisplayValue(systemRecipes(info)?.[recipe]?.default_backend);
+}
+
+function backendOptionsForKey(key: keyof RecipeOptions, current: string | undefined, model: ModelInfo, info: SystemInfoLike): string[] {
+  const recipe = activeRecipeForBackendKey(key, model);
+  const fromServer = Object.entries(backendMapForRecipe(info, recipe) || {})
+    .filter(([backend, backendInfo]) => backendIsSelectable(recipe, backend, backendInfo) && backendMatchesDetectedHardware(backend, info))
+    .map(([backend]) => backend);
+  const rawBase = fromServer.length ? fromServer : fallbackBackendsForRecipe(recipe);
+  const base = rawBase.filter(backend => backendMatchesDetectedHardware(backend, info));
+  const safeBase = Array.from(new Set(['auto', ...(base.length ? base : ['cpu'])]));
+  const normalizedCurrent = optionalDisplayValue(current);
+  const options = normalizedCurrent && !safeBase.includes(normalizedCurrent) ? [normalizedCurrent, ...safeBase] : safeBase;
+  return Array.from(new Set(options.filter(Boolean)));
+}
+
+function activeBackendValue(key: keyof RecipeOptions, baseValue: unknown, model: ModelInfo, info: SystemInfoLike): string {
+  const fromModel = optionalDisplayValue(baseValue);
+  if (fromModel) return fromModel;
+  const recipe = activeRecipeForBackendKey(key, model);
+  return recipeDefaultBackend(info, recipe) || 'auto';
+}
+
+function availableDeviceCounts(info: SystemInfoLike): { nvidia: number; amd: number; metal: boolean; npu: boolean; cpu: boolean } {
+  const devices = (info as any)?.devices || {};
+  const asList = (value: unknown): any[] => Array.isArray(value) ? value : (value ? [value] : []);
+  const available = (device: any) => device?.available !== false;
+  const nvidia = asList(devices.nvidia_gpu).filter(available).length;
+  const amd = [...asList(devices.amd_gpu), ...asList(devices.amd_dgpu), ...asList(devices.amd_igpu)].filter(available).length;
+  return {
+    nvidia,
+    amd,
+    metal: !!devices.metal && available(devices.metal),
+    npu: !!(devices.amd_npu || devices.npu) && available(devices.amd_npu || devices.npu),
+    cpu: devices.cpu?.available !== false,
+  };
+}
+function backendMatchesDetectedHardware(backend: string, info: SystemInfoLike): boolean {
+  if (!(info as any)?.devices) return true;
+  const b = backend.toLowerCase();
+  const devices = availableDeviceCounts(info);
+  if (b.includes('metal')) return devices.metal;
+  if (b.includes('npu') || b.includes('ryzenai')) return devices.npu;
+  if (b.includes('cuda') || b.includes('nvidia')) return devices.nvidia > 0;
+  if (b.includes('rocm')) return devices.amd > 0;
+  return true;
+}
+
+
+function indexed(prefix: string, count: number, fallbackCount = 1): string[] {
+  const n = Math.max(count, fallbackCount);
+  return Array.from({ length: n }, (_, i) => `${prefix}${i}`);
+}
+
+function deviceOptionsForKey(key: keyof RecipeOptions, current: string | undefined, selectedBackend: string, model: ModelInfo, info: SystemInfoLike): string[] {
+  const recipe = activeRecipeForModel(model);
+  const backend = selectedBackend.toLowerCase();
+  const devices = availableDeviceCounts(info);
+  let base: string[] = [];
+
+  if (!backend || backend === 'auto') {
+    base = ['cpu'];
+    if (devices.nvidia > 0) base.push(...indexed('cuda', devices.nvidia, 0));
+    if (devices.amd > 0) base.push(...indexed('vulkan', devices.amd, 0));
+    if (devices.metal) base.push('metal');
+    if (devices.npu && recipe !== 'llamacpp') base.push('npu0');
+  } else if (backend.includes('cpu')) base = ['cpu'];
+  else if (backend.includes('cuda')) base = indexed('cuda', devices.nvidia, 1);
+  else if (backend.includes('vulkan')) base = indexed('vulkan', devices.amd + devices.nvidia, 1);
+  else if (backend.includes('opencl')) base = indexed('opencl', devices.amd + devices.nvidia, 1);
+  else if (backend.includes('rocm')) base = indexed('rocm', devices.amd, 1);
+  else if (backend.includes('metal') && devices.metal) base = ['metal'];
+  else if (backend.includes('npu') && devices.npu && recipe !== 'llamacpp') base = ['npu0'];
+
+  const normalizedCurrent = optionalDisplayValue(current);
+  const options = normalizedCurrent && !base.includes(normalizedCurrent) ? [normalizedCurrent, ...base] : base;
+  return Array.from(new Set(options.filter(Boolean)));
+}
+
+function numericSliderSpec(key: keyof RecipeOptions | keyof SamplingParams): { min: number; max: number; step: number; fallback: number; digits?: number } | null {
+  switch (key) {
+    case 'temperature': return { min: 0, max: 2, step: 0.05, fallback: 0.7, digits: 2 };
+    case 'top_p': return { min: 0, max: 1, step: 0.01, fallback: 0.9, digits: 2 };
+    case 'top_k': return { min: 1, max: 200, step: 1, fallback: 40 };
+    case 'repeat_penalty': return { min: 0.9, max: 1.5, step: 0.01, fallback: 1.05, digits: 2 };
+    case 'steps': return { min: 1, max: 100, step: 1, fallback: 20 };
+    case 'cfg_scale': return { min: 0, max: 30, step: 0.5, fallback: 7.5, digits: 1 };
+    case 'flow_shift': return { min: 0, max: 20, step: 0.1, fallback: 1, digits: 1 };
+    case 'speed': return { min: 0.5, max: 2, step: 0.05, fallback: 1, digits: 2 };
+    default: return null;
+  }
+}
+
+function sliderDisplay(value: number, digits?: number): string {
+  return digits === undefined ? String(Math.round(value)) : value.toFixed(digits);
+}
+
+function samplingAllowedForModel(model: ModelInfo): boolean {
+  const cap = capabilityFromModelInfo(model);
+  return cap === 'chat' || cap === 'omni' || cap === 'unknown';
 }
 
 /** Regex: only attempt HF README fetch when the derived value looks like `owner/repo`. */
@@ -448,6 +769,466 @@ const ModelPresetsTab: React.FC<{
   );
 };
 
+
+/* ── Model tuning tab ────────────────────────────────────────── */
+
+const ModelTuningTab: React.FC<{
+  model: ModelInfo;
+  loadedModel: LoadedModel | null;
+  isActive: boolean;
+  serverDefaultCtxSize: number;
+  onReloadModel?: (model: LoadedModel, recipeOptions?: Record<string, unknown>) => Promise<void>;
+}> = ({ model, loadedModel, isActive, serverDefaultCtxSize, onReloadModel }) => {
+  const name = mdName(model);
+  const [storeVersion, setStoreVersion] = useState(0);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [isReloading, setIsReloading] = useState(false);
+  const [systemInfo, setSystemInfo] = useState<Record<string, unknown> | null>(() => api.systemInfoData);
+
+  useEffect(() => {
+    const handler = () => setStoreVersion(v => v + 1);
+    window.addEventListener(PRESET_STORE_EVENT, handler);
+    return () => window.removeEventListener(PRESET_STORE_EVENT, handler);
+  }, []);
+
+  useEffect(() => {
+    if (!isActive) return;
+    let alive = true;
+    const cached = api.systemInfoData;
+    if (cached) setSystemInfo(cached);
+    api.systemInfo()
+      .then(info => { if (alive) setSystemInfo(info); })
+      .catch(() => { if (alive) setSystemInfo(api.systemInfoData); });
+    return () => { alive = false; };
+  }, [isActive]);
+
+  const userTuning = useMemo(() => loadModelTuning(name), [name, storeVersion]);
+  const baseTuning = useMemo(() => modelBaseTuningForModel(model, serverDefaultCtxSize), [model, serverDefaultCtxSize]);
+  const effectiveTuning = useMemo(() => effectiveModelTuningForModel(name, model, serverDefaultCtxSize), [name, model, serverDefaultCtxSize, storeVersion]);
+  const recipeKeys = useMemo(() => tuningKeysForModel(model), [model]);
+  const activeArgsKey = useMemo(() => recipeKeys.find(key => ARGS_TUNING_KEYS.has(key)) as keyof RecipeOptions | undefined, [recipeKeys]);
+  const allowSampling = samplingAllowedForModel(model);
+
+  const [recipeDraft, setRecipeDraft] = useState<Record<string, string>>({});
+  const [samplingDraft, setSamplingDraft] = useState<Record<string, string>>({});
+  const [backendArgsDrafts, setBackendArgsDrafts] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    const nextUser = loadModelTuning(name);
+    const nextRecipe: Record<string, string> = {};
+    for (const [key, value] of Object.entries(nextUser?.recipe_options || {})) nextRecipe[key] = fieldValue(value);
+    const nextSampling: Record<string, string> = {};
+    for (const [key, value] of Object.entries(nextUser?.sampling || {})) nextSampling[key] = fieldValue(value);
+    const nextArgMemory: Record<string, string> = {};
+    for (const backendKey of BACKEND_TUNING_KEYS) {
+      const argsKey = BACKEND_ARGS_KEY[backendKey];
+      if (!argsKey) continue;
+      const backendValue = nextRecipe[backendKey] || '';
+      const argsValue = nextRecipe[argsKey] || '';
+      if (backendValue || argsValue) nextArgMemory[`${String(backendKey)}:${backendValue}`] = argsValue;
+    }
+    setRecipeDraft(nextRecipe);
+    setSamplingDraft(nextSampling);
+    setBackendArgsDrafts(nextArgMemory);
+    setNotice(null);
+  }, [name, storeVersion]);
+
+  if (!isActive) return null;
+
+  const recipes = recipesForDisplay(model);
+  const cap = capabilityFromModelInfo(model);
+  const linkedPreset = activePresetForModel(name);
+  const hasUserTuning = !!userTuning && (
+    Object.keys(userTuning.recipe_options).length > 0 ||
+    Object.keys(userTuning.sampling).length > 0 ||
+    !!userTuning.engine_hint
+  );
+  const hasDraftValues = Object.values(recipeDraft).some(value => value.trim()) || Object.values(samplingDraft).some(value => value.trim());
+
+  const setRecipeField = (key: keyof RecipeOptions, value: string) => {
+    if (BACKEND_TUNING_KEYS.has(key)) {
+      const argsKey = BACKEND_ARGS_KEY[key];
+      setRecipeDraft(prev => {
+        const next = { ...prev, [key]: value };
+        if (argsKey) {
+          const previousBackend = prev[key] || '';
+          const previousArgs = prev[argsKey] || '';
+          const previousMemoryKey = `${String(key)}:${previousBackend}`;
+          const nextMemoryKey = `${String(key)}:${value}`;
+          const rememberedArgs = backendArgsDrafts[nextMemoryKey];
+          setBackendArgsDrafts(mem => ({ ...mem, [previousMemoryKey]: previousArgs }));
+          next[argsKey] = rememberedArgs ?? '';
+        }
+        return next;
+      });
+      return;
+    }
+
+    setRecipeDraft(prev => ({ ...prev, [key]: value }));
+  };
+
+  const setSamplingField = (key: keyof SamplingParams, value: string) => {
+    setSamplingDraft(prev => ({ ...prev, [key]: value }));
+  };
+
+  const clearRecipeField = (key: keyof RecipeOptions) => {
+    setRecipeDraft(prev => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const clearSamplingField = (key: keyof SamplingParams) => {
+    setSamplingDraft(prev => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const buildRecipeOptions = (): RecipeOptions => {
+    const raw: Partial<RecipeOptions> = {};
+    for (const [key, value] of Object.entries(recipeDraft) as Array<[keyof RecipeOptions, string]>) {
+      if (!value.trim()) continue;
+      if (BOOLEAN_TUNING_KEYS.has(key)) {
+        (raw as Record<string, unknown>)[key] = value === 'true';
+      } else if (NUMERIC_TUNING_KEYS.has(key)) {
+        const n = parseNumberOrUndefined(value);
+        if (n !== undefined) (raw as Record<string, unknown>)[key] = n;
+      } else {
+        (raw as Record<string, unknown>)[key] = value.trim();
+      }
+    }
+    return sanitizeRecipeOptions(raw);
+  };
+
+  const buildSampling = (): SamplingParams => {
+    const raw: Partial<SamplingParams> = {};
+    for (const key of ['temperature', 'top_p', 'top_k', 'repeat_penalty'] as Array<keyof SamplingParams>) {
+      const n = parseNumberOrUndefined(samplingDraft[key] || '');
+      if (n !== undefined) raw[key] = n;
+    }
+    return sanitizeSamplingParams(raw);
+  };
+
+  const saveDraft = () => {
+    saveModelTuning(name, { recipe_options: buildRecipeOptions(), sampling: buildSampling() });
+    setNotice('Model tuning saved. Sampling applies to the next request; runtime fields apply on next load or reload.');
+  };
+
+  const resetDraft = () => {
+    resetModelTuning(name);
+    setRecipeDraft({});
+    setSamplingDraft({});
+    setBackendArgsDrafts({});
+    setNotice('Model tuning reset.');
+  };
+
+  const reloadWithTuning = async () => {
+    if (!loadedModel || !onReloadModel) return;
+    saveDraft();
+    setIsReloading(true);
+    try {
+      await onReloadModel(loadedModel);
+      setNotice('Model reloaded with current tuning.');
+    } catch {
+      setNotice('Could not reload this model with the current tuning.');
+    } finally {
+      setIsReloading(false);
+    }
+  };
+
+  const renderClearOverrideButton = (onClick: () => void, disabled: boolean) => (
+    <button type="button" className="btn btn--ghost btn--tiny detail-tuning__default-btn" onClick={onClick} disabled={disabled}>
+      Clear
+    </button>
+  );
+
+  const renderRecipeField = (key: keyof RecipeOptions) => {
+    const baseValue = baseTuning.recipe_options[key];
+    const draftValue = recipeDraft[key] || '';
+    const inputId = `tuning-${name}-${key}`.replace(/[^a-zA-Z0-9_-]/g, '-');
+    const label = TUNING_FIELD_LABELS[key] || key;
+    const hint = TUNING_FIELD_HINTS[key];
+
+    if (key === 'ctx_size') {
+      const baseNumber = parseNumberOrUndefined(fieldValue(baseValue)) || serverDefaultCtxSize || 4096;
+      const draftNumber = parseNumberOrUndefined(draftValue);
+      const currentValue = draftNumber || baseNumber;
+      const options = contextOptionsFor(baseNumber, serverDefaultCtxSize, draftNumber);
+      const sliderIndex = nearestOptionIndex(options, currentValue);
+      const sliderValue = options[sliderIndex] || currentValue;
+      return (
+        <label key={key} className="detail-tuning__field detail-tuning__field--wide" htmlFor={inputId}>
+          <span>{label}</span>
+          <div className="field__row detail-tuning__control-row">
+            <input
+              id={inputId}
+              className="slider"
+              type="range"
+              min={0}
+              max={Math.max(0, options.length - 1)}
+              step={1}
+              value={sliderIndex}
+              onChange={e => setRecipeField(key, String(options[Number(e.target.value)] || sliderValue))}
+            />
+            <span className="field__value">{formatContextSize(sliderValue)}</span>
+            {renderClearOverrideButton(() => clearRecipeField(key), !draftValue)}
+          </div>
+          <small>{draftValue ? `Override: ${Number(draftValue).toLocaleString()} tokens` : `Current: ${formatContextSize(baseNumber)}`}</small>
+        </label>
+      );
+    }
+
+    if (BACKEND_TUNING_KEYS.has(key)) {
+      const activeBackend = activeBackendValue(key, baseValue, model, systemInfo);
+      const current = draftValue || activeBackend;
+      const options = backendOptionsForKey(key, current, model, systemInfo).filter(option => option !== activeBackend);
+      return (
+        <label key={key} className="detail-tuning__field" htmlFor={inputId}>
+          <span>{label}</span>
+          <select id={inputId} className="select" value={draftValue} onChange={e => setRecipeField(key, e.target.value)}>
+            <option value="">{activeBackend}</option>
+            {options.map(option => (
+              <option key={option} value={option}>{option}</option>
+            ))}
+          </select>
+          {hint && <small>{hint}</small>}
+        </label>
+      );
+    }
+
+    if (DEVICE_TUNING_KEYS.has(key)) {
+      const backendKey: keyof RecipeOptions = 'llamacpp_backend';
+      const selectedBackend = recipeDraft[backendKey] || activeBackendValue(backendKey, baseTuning.recipe_options[backendKey], model, systemInfo);
+      const activeDevice = optionalDisplayValue(baseValue) || 'auto';
+      const current = draftValue || activeDevice;
+      const options = deviceOptionsForKey(key, current, selectedBackend, model, systemInfo).filter(option => option !== activeDevice);
+      return (
+        <label key={key} className="detail-tuning__field" htmlFor={inputId}>
+          <span>{label}</span>
+          <select id={inputId} className="select" value={draftValue} onChange={e => setRecipeField(key, e.target.value)}>
+            <option value="">{activeDevice}</option>
+            {options.map(option => (
+              <option key={option} value={option}>{option}</option>
+            ))}
+          </select>
+          {hint && <small>{hint}</small>}
+        </label>
+      );
+    }
+
+    if (BOOLEAN_TUNING_KEYS.has(key)) {
+      const argsKey = activeArgsKey;
+      const hasModelArgs = !!(argsKey && (recipeDraft[argsKey] || fieldValue(baseTuning.recipe_options[argsKey])));
+      const activeBehavior = typeof baseValue === 'boolean'
+        ? (baseValue ? 'Merge backend + model args' : 'Use model args only')
+        : (hasModelArgs ? 'Use model args only' : 'Use backend args only');
+      const setArgsBehavior = (value: string) => {
+        if (value === '__backend_only') {
+          setRecipeDraft(prev => {
+            const next = { ...prev };
+            delete next[key];
+            if (argsKey) delete next[argsKey];
+            return next;
+          });
+          return;
+        }
+        setRecipeField(key, value);
+      };
+      return (
+        <label key={key} className="detail-tuning__field" htmlFor={inputId}>
+          <span>{label}</span>
+          <select id={inputId} className="select" value={draftValue} onChange={e => setArgsBehavior(e.target.value)}>
+            <option value="">{activeBehavior}</option>
+            <option value="__backend_only">Use backend args only</option>
+            <option value="false">Use model args only</option>
+            <option value="true">Merge backend + model args</option>
+          </select>
+          {hint && <small>{hint}</small>}
+        </label>
+      );
+    }
+
+    const sliderSpec = numericSliderSpec(key);
+    if (sliderSpec) {
+      const baseNumber = parseNumberOrUndefined(fieldValue(baseValue));
+      const currentValue = parseNumberOrUndefined(draftValue) ?? baseNumber ?? sliderSpec.fallback;
+      return (
+        <label key={key} className="detail-tuning__field" htmlFor={inputId}>
+          <span>{label}</span>
+          <div className="field__row detail-tuning__control-row">
+            <input
+              id={inputId}
+              className="slider"
+              type="range"
+              min={sliderSpec.min}
+              max={sliderSpec.max}
+              step={sliderSpec.step}
+              value={currentValue}
+              onChange={e => setRecipeField(key, e.target.value)}
+            />
+            <span className="field__value">{sliderDisplay(currentValue, sliderSpec.digits)}</span>
+            {renderClearOverrideButton(() => clearRecipeField(key), !draftValue)}
+          </div>
+          {hint && <small>{hint}</small>}
+        </label>
+      );
+    }
+
+    if (ARGS_TUNING_KEYS.has(key)) {
+      return (
+        <label key={key} className="detail-tuning__field detail-tuning__field--wide" htmlFor={inputId}>
+          <span>{label}</span>
+          <textarea
+            id={inputId}
+            className="input detail-tuning__args"
+            rows={3}
+            value={draftValue}
+            placeholder={optionalDisplayValue(baseValue) || 'Type backend args here...'}
+            onChange={e => setRecipeField(key, e.target.value)}
+          />
+          {hint && <small>{hint}</small>}
+        </label>
+      );
+    }
+
+    return (
+      <label key={key} className="detail-tuning__field" htmlFor={inputId}>
+        <span>{label}</span>
+        <input
+          id={inputId}
+          className="input"
+          type={NUMERIC_TUNING_KEYS.has(key) ? 'number' : 'text'}
+          value={draftValue}
+          placeholder={optionalDisplayValue(baseValue) || 'Type a value here...'}
+          onChange={e => setRecipeField(key, e.target.value)}
+        />
+        {hint && <small>{hint}</small>}
+      </label>
+    );
+  };
+
+  const renderSamplingField = (key: keyof SamplingParams) => {
+    const inputId = `tuning-${name}-${key}`.replace(/[^a-zA-Z0-9_-]/g, '-');
+    const draftValue = samplingDraft[key] || '';
+    const baseValue = baseTuning.sampling[key];
+    const spec = numericSliderSpec(key)!;
+    const currentValue = parseNumberOrUndefined(draftValue) ?? (typeof baseValue === 'number' ? baseValue : undefined) ?? spec.fallback;
+    return (
+      <label key={key} className="detail-tuning__field" htmlFor={inputId}>
+        <span>{key}</span>
+        <div className="field__row detail-tuning__control-row">
+          <input
+            id={inputId}
+            className="slider"
+            type="range"
+            min={spec.min}
+            max={spec.max}
+            step={spec.step}
+            value={currentValue}
+            onChange={e => setSamplingField(key, e.target.value)}
+          />
+          <span className="field__value">{sliderDisplay(currentValue, spec.digits)}</span>
+          {renderClearOverrideButton(() => clearSamplingField(key), !draftValue)}
+        </div>
+        <small>{draftValue ? 'Override for this model' : `Current: ${tuningValue(baseValue)}`}</small>
+      </label>
+    );
+  };
+
+  const effectiveRecipeEntries = Object.entries(effectiveTuning.recipe_options || {});
+  const effectiveSamplingEntries = Object.entries(effectiveTuning.sampling || {});
+
+  return (
+    <div className="detail-tab-content detail-tuning">
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">{notice || ''}</div>
+
+      <section className="detail-tuning__intro" aria-label="Model tuning concept">
+        <h3 className="detail-tuning__title">Model Tuning</h3>
+        <p>
+          Presets describe the intent. Model Tuning is the per-model runtime layer that implements that intent using values from the built-in definition or GGUF-derived metadata, with optional local overrides for this model only.
+        </p>
+      </section>
+
+      <section className="detail-tuning__summary" aria-label="Effective runtime summary">
+        <div className="detail-tuning__summary-card">
+          <span className="detail-tuning__summary-label">Preset intent</span>
+          <strong>{linkedPreset.name}</strong>
+        </div>
+        <div className="detail-tuning__summary-card">
+          <span className="detail-tuning__summary-label">Capability</span>
+          <strong>{capabilityLabel(cap)}</strong>
+        </div>
+        <div className="detail-tuning__summary-card">
+          <span className="detail-tuning__summary-label">Recipe</span>
+          <strong>{recipes.length ? recipes.map(recipeDisplayLabel).join(' / ') : 'Auto'}</strong>
+        </div>
+        <div className="detail-tuning__summary-card">
+          <span className="detail-tuning__summary-label">Source</span>
+          <strong>{hasUserTuning ? 'Customized for this model' : 'Built-in / GGUF values'}</strong>
+        </div>
+      </section>
+
+      <section className="detail-tuning__effective" aria-label="Effective tuning values">
+        <h3 className="detail-tuning__section-title">Effective runtime</h3>
+        {effectiveRecipeEntries.length === 0 && effectiveSamplingEntries.length === 0 ? (
+          <p className="detail-tuning__empty">No local overrides are needed. Lemonade will use the current model and backend values.</p>
+        ) : (
+          <div className="detail-tuning__kv-grid">
+            {effectiveRecipeEntries.map(([key, value]) => (
+              <div className="detail-tuning__kv" key={`ro-${key}`}>
+                <span>{TUNING_FIELD_LABELS[key as keyof RecipeOptions] || key}</span>
+                <code>{tuningValue(value)}</code>
+              </div>
+            ))}
+            {effectiveSamplingEntries.map(([key, value]) => (
+              <div className="detail-tuning__kv" key={`sp-${key}`}>
+                <span>{key}</span>
+                <code>{tuningValue(value)}</code>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="detail-tuning__editor" aria-label="Customize model tuning">
+        <div className="detail-tuning__section-head">
+          <div>
+            <h3 className="detail-tuning__section-title">Customize this model</h3>
+            <p className="detail-tuning__hint">Leave a field blank to keep the current value shown in the control.</p>
+          </div>
+          {notice && <p className="detail-tuning__notice">{notice}</p>}
+        </div>
+
+        <div className="detail-tuning__field-grid">
+          {recipeKeys.map(renderRecipeField)}
+        </div>
+
+        {allowSampling && (
+          <div className="detail-tuning__sampling">
+            <h4>Sampling defaults</h4>
+            <div className="detail-tuning__field-grid">
+              {(['temperature', 'top_p', 'top_k', 'repeat_penalty'] as Array<keyof SamplingParams>).map(renderSamplingField)}
+            </div>
+          </div>
+        )}
+
+        <div className="detail-tuning__actions">
+          <button type="button" className="btn btn--primary btn--sm" onClick={saveDraft}>Save tuning</button>
+          <button type="button" className="btn btn--ghost btn--sm" onClick={resetDraft} disabled={!hasUserTuning && !hasDraftValues}>Reset tuning</button>
+          {loadedModel && onReloadModel && (
+            <button type="button" className="btn btn--ghost btn--sm" onClick={reloadWithTuning} disabled={isReloading} aria-busy={isReloading}>
+              <Icon name="rotate-ccw" size={13} aria-hidden="true" /> {isReloading ? 'Reloading…' : 'Reload with tuning'}
+            </button>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};
+
 /* ── Files tab ───────────────────────────────────────────────── */
 
 /** Human-readable byte size (B / KB / MB / GB) using binary units. */
@@ -604,11 +1385,12 @@ export interface ModelDetailPanelProps {
   noModelsAvailable?: boolean;
 }
 
-type DetailTab = 'readme' | 'presets' | 'files';
+type DetailTab = 'readme' | 'presets' | 'tuning' | 'files';
 
 const TABS: Array<{ id: DetailTab; label: string }> = [
   { id: 'readme', label: 'README' },
   { id: 'presets', label: 'Presets' },
+  { id: 'tuning', label: 'Model Tuning' },
   { id: 'files', label: 'Files' },
 ];
 
@@ -625,6 +1407,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   onPullAndLoad,
   onDelete,
   onCancelPull,
+  serverDefaultCtxSize,
   isFavorite = false,
   onToggleFavorite,
   onBack,
@@ -1076,6 +1859,15 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
           )}
           {tab.id === 'presets' && (
             <ModelPresetsTab model={model} isActive={activeTab === 'presets'} />
+          )}
+          {tab.id === 'tuning' && (
+            <ModelTuningTab
+              model={model}
+              loadedModel={loadedModel}
+              isActive={activeTab === 'tuning'}
+              serverDefaultCtxSize={serverDefaultCtxSize}
+              onReloadModel={onReloadModel}
+            />
           )}
           {tab.id === 'files' && (
             <ModelFilesTab model={model} isActive={activeTab === 'files'} />

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -100,7 +100,7 @@ interface FilterPopoverStyle extends React.CSSProperties {
 }
 
 const TEXT_FILTER_FIELDS: Array<{ key: TextFilterField; label: string }> = [
-  { key: 'any', label: 'Any text' },
+  { key: 'any', label: 'All text' },
   { key: 'name', label: 'Name' },
   { key: 'backend', label: 'Backend' },
   { key: 'type', label: 'Type' },
@@ -109,10 +109,6 @@ const TEXT_FILTER_FIELDS: Array<{ key: TextFilterField; label: string }> = [
   { key: 'status', label: 'Status' },
 ];
 
-const TEXT_FILTER_MODES: Array<{ key: TextFilterMode; label: string }> = [
-  { key: 'include', label: 'contains' },
-  { key: 'exclude', label: 'does not contain' },
-];
 
 let textFilterRuleCounter = 0;
 
@@ -489,8 +485,8 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
     const maxUsableWidth = Math.max(320, viewportWidth - viewportPadding * 2);
-    const width = Math.min(560, maxUsableWidth);
-    const top = Math.max(viewportPadding, buttonRect.bottom + 6);
+    const width = Math.min(440, maxUsableWidth);
+    const top = Math.max(viewportPadding, buttonRect.bottom + 4);
 
     let left = buttonRect.right - width;
     if (left < viewportPadding) left = viewportPadding;
@@ -655,7 +651,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
               aria-modal="false"
             >
               <div className="model-list-panel__filter-popover-head">
-                <span>Model filters</span>
+                <span>Filters</span>
                 <button
                   type="button"
                   className="model-list-panel__filter-popover-close"
@@ -692,20 +688,18 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
 
               <div className="model-list-panel__filter-section">
                 <div className="model-list-panel__filter-section-head">
-                  <span className="model-list-panel__filter-section-title">Custom text rules</span>
+                  <span className="model-list-panel__filter-section-title">Text</span>
                   <button
                     type="button"
                     className="model-list-panel__filter-add"
                     onClick={addTextFilter}
                   >
-                    + Add
+                    <Icon name="plus" size={13} aria-hidden="true" />
+                    <span>Add</span>
                   </button>
                 </div>
 
                 <div className="model-list-panel__text-filters" role="group" aria-label="Custom text filters">
-                  {textFilters.length === 0 && (
-                    <span className="model-list-panel__filter-empty">Add a text rule, for example “does not contain qwen”.</span>
-                  )}
                   {textFilters.map((rule, index) => (
                     <div key={rule.id} className="model-list-panel__text-filter">
                       <label className="sr-only" htmlFor={`${rule.id}-field`}>Filter field</label>
@@ -721,18 +715,32 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                         ))}
                       </select>
 
-                      <label className="sr-only" htmlFor={`${rule.id}-mode`}>Filter mode</label>
-                      <select
-                        id={`${rule.id}-mode`}
+                      <div
                         className="model-list-panel__text-filter-mode"
-                        value={rule.mode}
-                        onChange={e => updateTextFilter(rule.id, { mode: e.target.value as TextFilterMode })}
+                        role="group"
                         aria-label={`Filter ${index + 1} mode`}
                       >
-                        {TEXT_FILTER_MODES.map(mode => (
-                          <option key={mode.key} value={mode.key}>{mode.label}</option>
-                        ))}
-                      </select>
+                        <button
+                          type="button"
+                          className={`model-list-panel__text-filter-mode-btn${rule.mode === 'include' ? ' model-list-panel__text-filter-mode-btn--active' : ''}`}
+                          onClick={() => updateTextFilter(rule.id, { mode: 'include' })}
+                          aria-label={`Filter ${index + 1}: include matching models`}
+                          aria-pressed={rule.mode === 'include'}
+                          title="Include matches"
+                        >
+                          <Icon name="eye" size={13} aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          className={`model-list-panel__text-filter-mode-btn${rule.mode === 'exclude' ? ' model-list-panel__text-filter-mode-btn--active' : ''}`}
+                          onClick={() => updateTextFilter(rule.id, { mode: 'exclude' })}
+                          aria-label={`Filter ${index + 1}: exclude matching models`}
+                          aria-pressed={rule.mode === 'exclude'}
+                          title="Exclude matches"
+                        >
+                          <Icon name="eye-off" size={13} aria-hidden="true" />
+                        </button>
+                      </div>
 
                       <label className="sr-only" htmlFor={`${rule.id}-value`}>Filter text</label>
                       <input
@@ -741,7 +749,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                         type="text"
                         value={rule.value}
                         onChange={e => updateTextFilter(rule.id, { value: e.target.value })}
-                        placeholder={rule.mode === 'exclude' ? 'e.g. qwen' : 'e.g. llama'}
+                        placeholder="e.g. qwen"
                         aria-label={`Filter ${index + 1} text`}
                         autoComplete="off"
                       />
@@ -752,14 +760,10 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                         onClick={() => removeTextFilter(rule.id)}
                         aria-label={`Remove filter ${index + 1}`}
                       >
-                        ×
+                        <Icon name="x" size={13} aria-hidden="true" />
                       </button>
                     </div>
                   ))}
-                </div>
-
-                <div className="model-list-panel__filter-help">
-                  Rules are combined with AND. “Does not contain qwen” hides Qwen models.
                 </div>
               </div>
 
@@ -769,7 +773,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                   className="model-list-panel__filter-clear"
                   onClick={clearAllFilters}
                 >
-                  Clear all filters
+                  Clear
                 </button>
               )}
             </div>

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -4,7 +4,7 @@
  *
  * Part of the master-detail layout introduced in #2355 Slice 1.
  */
-import React, { useCallback, useRef, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useMemo, useState } from 'react';
 import type { ModelInfo, LoadedModel } from '../api';
 import {
   capabilityFromModelInfo,
@@ -81,6 +81,118 @@ const FILTER_TABS: Array<{ key: FilterTab; label: string; iconName: IconName }> 
   { key: 'tts', label: 'TTS', iconName: 'tts' },
   { key: 'embedding', label: 'Embed', iconName: 'embedding' },
 ];
+
+type TextFilterField = 'any' | 'name' | 'backend' | 'type' | 'capability' | 'label' | 'status';
+type TextFilterMode = 'include' | 'exclude';
+
+interface TextFilterRule {
+  id: string;
+  field: TextFilterField;
+  mode: TextFilterMode;
+  value: string;
+}
+
+interface FilterPopoverStyle extends React.CSSProperties {
+  left: number;
+  top: number;
+  width: number;
+  maxHeight: number;
+}
+
+const TEXT_FILTER_FIELDS: Array<{ key: TextFilterField; label: string }> = [
+  { key: 'any', label: 'Any text' },
+  { key: 'name', label: 'Name' },
+  { key: 'backend', label: 'Backend' },
+  { key: 'type', label: 'Type' },
+  { key: 'capability', label: 'Capability' },
+  { key: 'label', label: 'Label' },
+  { key: 'status', label: 'Status' },
+];
+
+const TEXT_FILTER_MODES: Array<{ key: TextFilterMode; label: string }> = [
+  { key: 'include', label: 'contains' },
+  { key: 'exclude', label: 'does not contain' },
+];
+
+let textFilterRuleCounter = 0;
+
+function createTextFilterRule(overrides: Partial<TextFilterRule> = {}): TextFilterRule {
+  textFilterRuleCounter += 1;
+  return {
+    id: `text-filter-${textFilterRuleCounter}`,
+    field: 'any',
+    mode: 'include',
+    value: '',
+    ...overrides,
+  };
+}
+
+function normalizeFilterText(value: unknown): string {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+function compactTextFilters(filters: TextFilterRule[]): TextFilterRule[] {
+  return filters.filter(rule => normalizeFilterText(rule.value).length > 0);
+}
+
+function listCapabilityLabelText(m: ModelInfo): string {
+  return modelCapabilityTags(m).map(tag => CAPABILITY_TAG_LABELS[tag]).join(' ');
+}
+
+function listModelTypeText(m: ModelInfo): string {
+  const cap = capabilityFromModelInfo(m);
+  if (cap === 'chat' || cap === 'unknown') return 'llm chat text';
+  if (cap === 'audio') return 'audio transcription speech-to-text asr stt';
+  if (cap === 'tts') return 'tts speech text-to-speech';
+  if (cap === 'image') return 'image diffusion image-generation';
+  if (cap === 'embedding') return 'embedding embed';
+  if (cap === 'reranking') return 'reranking reranker';
+  return String(cap);
+}
+
+function listModelStatusText(status: ModelStatus): string {
+  switch (status) {
+    case 'running': return 'running loaded active';
+    case 'downloaded': return 'downloaded local ready';
+    case 'downloading': return 'downloading pulling download';
+    case 'available':
+    default: return 'available remote';
+  }
+}
+
+function modelTextFilterTarget(m: ModelInfo, status: ModelStatus, field: TextFilterField): string {
+  const nameText = `${listModelName(m)} ${m.display_name || ''}`;
+  const recipe = String((m as any).recipe || '');
+  const backendText = recipe ? `${recipe} ${listRecipeBadgeText(recipe)}` : '';
+  const typeText = listModelTypeText(m);
+  const labelText = (m.labels || []).join(' ');
+  const capabilityText = `${listCapabilityLabelText(m)} ${modelCapabilityTags(m).join(' ')}`;
+  const statusText = listModelStatusText(status);
+
+  switch (field) {
+    case 'name': return nameText;
+    case 'backend': return backendText;
+    case 'type': return typeText;
+    case 'capability': return capabilityText;
+    case 'label': return labelText;
+    case 'status': return statusText;
+    case 'any':
+    default:
+      return `${nameText} ${backendText} ${typeText} ${labelText} ${capabilityText} ${statusText}`;
+  }
+}
+
+function modelMatchesTextFilters(m: ModelInfo, status: ModelStatus, filters: TextFilterRule[]): boolean {
+  for (const rule of filters) {
+    const needle = normalizeFilterText(rule.value);
+    if (!needle) continue;
+    const haystack = modelTextFilterTarget(m, status, rule.field).toLowerCase();
+    const matches = haystack.includes(needle);
+    if (rule.mode === 'include' && !matches) return false;
+    if (rule.mode === 'exclude' && matches) return false;
+  }
+  return true;
+}
 
 export function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
   if (filter === 'all') return true;
@@ -226,12 +338,15 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   favoriteNames,
 }) => {
   const [filterOpen, setFilterOpen] = useState(false);
+  const [filterPopoverStyle, setFilterPopoverStyle] = useState<FilterPopoverStyle | null>(null);
   const [sortBy, setSortBy] = useState<SortBy>('name');
+  const [textFilters, setTextFilters] = useState<TextFilterRule[]>(() => [createTextFilterRule()]);
   const filterBtnRef = useRef<HTMLButtonElement>(null);
   const filterPopoverRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const defaultSearchRef = useRef<HTMLInputElement>(null);
   const inputRef = (searchInputRef ?? defaultSearchRef) as React.RefObject<HTMLInputElement>;
+  const activeTextFilters = useMemo(() => compactTextFilters(textFilters), [textFilters]);
 
   // Build flat list filtered by search + type; sort based on sortBy
   const flatList = useMemo((): FlatModelEntry[] => {
@@ -253,12 +368,6 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
       // Funnel: functional capability tags (multi-select). Empty = no filter.
       if (!modelMatchesCapabilityTags(m, capabilityFilter ?? new Set())) continue;
 
-      // Filter by search
-      if (q) {
-        const haystack = `${mName} ${m.display_name || ''} ${(m as any).recipe || ''} ${(m.labels || []).join(' ')}`.toLowerCase();
-        if (!haystack.includes(q)) continue;
-      }
-
       const activeDownload = activeDownloadForModel(downloadItems, mName);
       const pullPct = activeDownload?.percent ?? pulling[mName];
 
@@ -271,6 +380,15 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
         status = 'downloaded';
       } else {
         status = 'available';
+      }
+
+      // Funnel: custom text rules. All active rules are combined with AND.
+      if (!modelMatchesTextFilters(m, status, activeTextFilters)) continue;
+
+      // Filter by search
+      if (q) {
+        const haystack = `${mName} ${m.display_name || ''} ${(m as any).recipe || ''} ${(m.labels || []).join(' ')}`.toLowerCase();
+        if (!haystack.includes(q)) continue;
       }
 
       result.push({ model: m, status, downloadPct: pullPct, pinned: pinnedNames?.has(mName.toLowerCase()) ?? false });
@@ -321,7 +439,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
     }
 
     return result;
-  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy, pinnedNames, favoriteNames, primaryFilter, backendFilter, tagFilter, capabilityFilter]);
+  }, [allModels, loadedNames, pulling, downloadItems, searchQuery, filterTab, sortBy, pinnedNames, favoriteNames, primaryFilter, backendFilter, tagFilter, capabilityFilter, activeTextFilters]);
 
   // Funnel options: the union of functional capability tags present across the
   // models, in canonical order. Derived client-side from the model labels —
@@ -336,12 +454,93 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   }, [allModels]);
 
   const capabilityFilterSize = capabilityFilter?.size ?? 0;
+  const activeFilterCount = capabilityFilterSize + activeTextFilters.length;
+
   const toggleCapability = useCallback((tag: CapabilityTag) => {
     if (!onCapabilityFilterChange) return;
     const next = new Set(capabilityFilter ?? new Set<string>());
     if (next.has(tag)) next.delete(tag); else next.add(tag);
     onCapabilityFilterChange(next);
   }, [capabilityFilter, onCapabilityFilterChange]);
+
+  const addTextFilter = useCallback(() => {
+    setTextFilters(prev => [...prev, createTextFilterRule()]);
+  }, []);
+
+  const updateTextFilter = useCallback((id: string, patch: Partial<TextFilterRule>) => {
+    setTextFilters(prev => prev.map(rule => rule.id === id ? { ...rule, ...patch } : rule));
+  }, []);
+
+  const removeTextFilter = useCallback((id: string) => {
+    setTextFilters(prev => prev.filter(rule => rule.id !== id));
+  }, []);
+
+  const clearAllFilters = useCallback(() => {
+    onCapabilityFilterChange?.(new Set());
+    setTextFilters([createTextFilterRule()]);
+  }, [onCapabilityFilterChange]);
+
+  const updateFilterPopoverPosition = useCallback(() => {
+    const button = filterBtnRef.current;
+    if (!button) return;
+
+    const buttonRect = button.getBoundingClientRect();
+    const viewportPadding = 12;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const maxUsableWidth = Math.max(320, viewportWidth - viewportPadding * 2);
+    const width = Math.min(560, maxUsableWidth);
+    const top = Math.max(viewportPadding, buttonRect.bottom + 6);
+
+    let left = buttonRect.right - width;
+    if (left < viewportPadding) left = viewportPadding;
+    if (left + width > viewportWidth - viewportPadding) {
+      left = viewportWidth - viewportPadding - width;
+    }
+
+    setFilterPopoverStyle({
+      left,
+      top,
+      width,
+      maxHeight: Math.max(220, viewportHeight - top - viewportPadding),
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!filterOpen) return;
+
+    updateFilterPopoverPosition();
+    window.addEventListener('resize', updateFilterPopoverPosition);
+    window.addEventListener('scroll', updateFilterPopoverPosition, true);
+
+    return () => {
+      window.removeEventListener('resize', updateFilterPopoverPosition);
+      window.removeEventListener('scroll', updateFilterPopoverPosition, true);
+    };
+  }, [filterOpen, updateFilterPopoverPosition]);
+
+  useEffect(() => {
+    if (!filterOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (filterBtnRef.current?.contains(target)) return;
+      if (filterPopoverRef.current?.contains(target)) return;
+      setFilterOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setFilterOpen(false);
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [filterOpen]);
 
   // Keyboard navigation on the list (ArrowUp/Down/Home/End)
   const handleListKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -437,9 +636,9 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
           <button
             ref={filterBtnRef}
             type="button"
-            className={`model-list-panel__filter-btn${filterOpen ? ' model-list-panel__filter-btn--open' : ''}${capabilityFilterSize > 0 ? ' model-list-panel__filter-btn--active' : ''}`}
+            className={`model-list-panel__filter-btn${filterOpen ? ' model-list-panel__filter-btn--open' : ''}${activeFilterCount > 0 ? ' model-list-panel__filter-btn--active' : ''}`}
             onClick={handleFilterBtnClick}
-            aria-label={capabilityFilterSize > 0 ? `Filter models by capability (${capabilityFilterSize} active)` : 'Filter models by capability'}
+            aria-label={activeFilterCount > 0 ? `Filter models (${activeFilterCount} active)` : 'Filter models'}
             aria-expanded={filterOpen}
             aria-haspopup="dialog"
           >
@@ -450,12 +649,13 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
             <div
               ref={filterPopoverRef}
               className="model-list-panel__filter-popover"
+              style={filterPopoverStyle ?? undefined}
               role="dialog"
               aria-label="Model filters"
               aria-modal="false"
             >
               <div className="model-list-panel__filter-popover-head">
-                <span>Filter by capability</span>
+                <span>Model filters</span>
                 <button
                   type="button"
                   className="model-list-panel__filter-popover-close"
@@ -465,35 +665,113 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                   <Icon name="x" size={13} />
                 </button>
               </div>
-              <div className="model-list-panel__filter-options" role="group" aria-label="Model capability filter">
-                {availableCapabilityTags.length === 0 && (
-                  <span className="model-list-panel__filter-empty">No capabilities available</span>
-                )}
-                {availableCapabilityTags.map(tag => {
-                  const active = capabilityFilter?.has(tag) ?? false;
-                  return (
-                    <button
-                      key={tag}
-                      type="button"
-                      className={`model-list-panel__filter-option${active ? ' model-list-panel__filter-option--active' : ''}`}
-                      onClick={() => toggleCapability(tag)}
-                      aria-pressed={active}
-                    >
-                      <CapabilityIcon capability={capabilityTagIconTarget(tag) as any} size={12} aria-hidden="true" />
-                      {CAPABILITY_TAG_LABELS[tag]}
-                    </button>
-                  );
-                })}
-                {capabilityFilterSize > 0 && (
+
+              <div className="model-list-panel__filter-section">
+                <div className="model-list-panel__filter-section-title">Capabilities</div>
+                <div className="model-list-panel__filter-options" role="group" aria-label="Model capability filter">
+                  {availableCapabilityTags.length === 0 && (
+                    <span className="model-list-panel__filter-empty">No capabilities available</span>
+                  )}
+                  {availableCapabilityTags.map(tag => {
+                    const active = capabilityFilter?.has(tag) ?? false;
+                    return (
+                      <button
+                        key={tag}
+                        type="button"
+                        className={`model-list-panel__filter-option${active ? ' model-list-panel__filter-option--active' : ''}`}
+                        onClick={() => toggleCapability(tag)}
+                        aria-pressed={active}
+                      >
+                        <CapabilityIcon capability={capabilityTagIconTarget(tag) as any} size={12} aria-hidden="true" />
+                        {CAPABILITY_TAG_LABELS[tag]}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="model-list-panel__filter-section">
+                <div className="model-list-panel__filter-section-head">
+                  <span className="model-list-panel__filter-section-title">Custom text rules</span>
                   <button
                     type="button"
-                    className="model-list-panel__filter-clear"
-                    onClick={() => onCapabilityFilterChange?.(new Set())}
+                    className="model-list-panel__filter-add"
+                    onClick={addTextFilter}
                   >
-                    Clear all
+                    + Add
                   </button>
-                )}
+                </div>
+
+                <div className="model-list-panel__text-filters" role="group" aria-label="Custom text filters">
+                  {textFilters.length === 0 && (
+                    <span className="model-list-panel__filter-empty">Add a text rule, for example “does not contain qwen”.</span>
+                  )}
+                  {textFilters.map((rule, index) => (
+                    <div key={rule.id} className="model-list-panel__text-filter">
+                      <label className="sr-only" htmlFor={`${rule.id}-field`}>Filter field</label>
+                      <select
+                        id={`${rule.id}-field`}
+                        className="model-list-panel__text-filter-field"
+                        value={rule.field}
+                        onChange={e => updateTextFilter(rule.id, { field: e.target.value as TextFilterField })}
+                        aria-label={`Filter ${index + 1} field`}
+                      >
+                        {TEXT_FILTER_FIELDS.map(field => (
+                          <option key={field.key} value={field.key}>{field.label}</option>
+                        ))}
+                      </select>
+
+                      <label className="sr-only" htmlFor={`${rule.id}-mode`}>Filter mode</label>
+                      <select
+                        id={`${rule.id}-mode`}
+                        className="model-list-panel__text-filter-mode"
+                        value={rule.mode}
+                        onChange={e => updateTextFilter(rule.id, { mode: e.target.value as TextFilterMode })}
+                        aria-label={`Filter ${index + 1} mode`}
+                      >
+                        {TEXT_FILTER_MODES.map(mode => (
+                          <option key={mode.key} value={mode.key}>{mode.label}</option>
+                        ))}
+                      </select>
+
+                      <label className="sr-only" htmlFor={`${rule.id}-value`}>Filter text</label>
+                      <input
+                        id={`${rule.id}-value`}
+                        className="model-list-panel__text-filter-input"
+                        type="text"
+                        value={rule.value}
+                        onChange={e => updateTextFilter(rule.id, { value: e.target.value })}
+                        placeholder={rule.mode === 'exclude' ? 'e.g. qwen' : 'e.g. llama'}
+                        aria-label={`Filter ${index + 1} text`}
+                        autoComplete="off"
+                      />
+
+                      <button
+                        type="button"
+                        className="model-list-panel__text-filter-remove"
+                        onClick={() => removeTextFilter(rule.id)}
+                        aria-label={`Remove filter ${index + 1}`}
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="model-list-panel__filter-help">
+                  Rules are combined with AND. “Does not contain qwen” hides Qwen models.
+                </div>
               </div>
+
+              {activeFilterCount > 0 && (
+                <button
+                  type="button"
+                  className="model-list-panel__filter-clear"
+                  onClick={clearAllFilters}
+                >
+                  Clear all filters
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -1697,7 +1697,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
       const builtinToolNames = new Set(['generate_image', 'edit_image', 'text_to_speech', 'transcribe_audio', 'analyze_image']);
       const seenCustomToolNames = new Set<string>();
       const customTools = isOmniCollection
-        ? customDraft.omniCustomTools.map((tool, index) => {
+        ? customDraft.omniCustomTools.map((tool, index): CustomOmniToolDefinition | null => {
           const hasAnyValue = [tool.name, tool.description, tool.targetModel, tool.systemPrompt, tool.promptTemplate, tool.parametersJson, tool.maxTokens].some(value => String(value || '').trim());
           if (!hasAnyValue) return null;
           const name = sanitizeOmniToolName(tool.name);
@@ -1728,7 +1728,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
             parameters,
             max_tokens: Number.isFinite(maxTokens) && maxTokens > 0 ? Math.floor(maxTokens) : undefined,
           };
-        }).filter((tool): tool is CustomOmniToolDefinition => Boolean(tool))
+        }).filter((tool): tool is CustomOmniToolDefinition => tool !== null)
         : [];
       const componentRoles = {
         llm: customDraft.llmComponent,

--- a/prototype/ui-redesign/src/components/PresetManager.tsx
+++ b/prototype/ui-redesign/src/components/PresetManager.tsx
@@ -61,7 +61,7 @@ const RECIPE_KEYS: Record<PresetRecipe, (keyof RecipeOptions)[]> = {
   kokoro: ['voice', 'speed', 'merge_args'],
 };
 
-const CAPABILITIES: Capability[] = ['all', 'chat', 'image', 'tts'];
+const CAPABILITIES: Capability[] = ['all', 'chat', 'omni', 'vision', 'code', 'image', 'transcription', 'tts', 'embedding', 'reranking'];
 
 /* ── #2432: backend-preset assignment helpers ─────────────────────────────
  * Backend presets are OPTIONAL global runtime-argument defaults that MERGE
@@ -478,8 +478,8 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
       name: 'New Preset',
       description: '',
       applies_to: ['chat'],
-      recipe_options: { ctx_size: 4096 },
-      sampling: { temperature: 0.70, top_p: 0.90, top_k: 40, repeat_penalty: 1.05 },
+      recipe_options: {},
+      sampling: {},
       engine_hint: 'auto',
       starter: false,
       auto_opt_enabled: true,
@@ -683,8 +683,8 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
 
         <div className="recipes__body">
           <p className="recipes__lede">
-            Presets are saved ways to use a model. They apply to capabilities like <strong>Chat</strong> or <strong>Image</strong>,
-            can stage recipe options for the next explicit model load, pass chat sampling defaults per request, and optionally follow an AutoOpt run.
+            Presets are saved ways to use a model. They apply to capabilities like <strong>Chat</strong> or <strong>Image</strong> and now describe reusable intent.
+            Shared recipe options and sampling remain available for legacy/custom power-user flows, but concrete runtime values should usually live in each model's Model Tuning.
           </p>
           {importError && <p className="preset-error" role="alert">⚠ {importError}</p>}
 
@@ -1168,7 +1168,7 @@ const canApplyBackend = !isDefaultBackendPreset && !!selectedBackendOption && se
           {isDefaultEmptyPreset && (
             <div className="preset-empty-overrides">
               <strong>No preset overrides</strong>
-              <span>Lemonade uses the selected model's current defaults for sampling, context and image generation.</span>
+              <span>Lemonade uses the selected model tuning and backend defaults for sampling, context and image generation.</span>
               <span className="preset-param-lines">{presetParamPreviewLines(preset).map(line => <span key={line}>{line}</span>)}</span>
             </div>
           )}

--- a/prototype/ui-redesign/src/presetStore.ts
+++ b/prototype/ui-redesign/src/presetStore.ts
@@ -62,9 +62,22 @@ export interface Preset {
   tools_enabled?: boolean;
 }
 
+export interface ModelTuning {
+  /** Load-time runtime options for this concrete model. */
+  recipe_options: RecipeOptions;
+  /** Request-time sampling defaults for this concrete model. */
+  sampling: SamplingParams;
+  /** Optional runtime hint kept separate from shared Preset intent. */
+  engine_hint?: PresetRecipe;
+  /** 'model' means discovered from model metadata/GGUF; 'user' means locally customized. */
+  source?: 'model' | 'user';
+  updated_at?: string;
+}
+
 export const LS_USER_PRESETS = 'user_presets';
 export const LS_APPLIED_PRESETS = 'applied_presets';
 export const LS_BACKEND_PRESETS = 'backend_presets';
+export const LS_MODEL_TUNINGS = 'model_tunings';
 // Client-local record of which preset each *currently-loaded* model is actually
 // running with. Distinct from `applied_presets` (the preset LINKED to a model):
 // the linked preset can be changed while a model is loaded, and the divergence
@@ -91,10 +104,10 @@ function emitPresetStoreEvent(): void {
 export const DEFAULT_PRESET: Preset = {
   id: 's-default',
   name: 'Default',
-  description: 'Use current models defaults and automatic backend selection.',
+  description: 'Use current model settings and automatic backend selection.',
   applies_to: ['all'],
   recipe_options: {},
-  sampling: { temperature: 0.70, top_p: 0.90, top_k: 40, repeat_penalty: 1.05 },
+  sampling: {},
   engine_hint: 'auto',
   starter: true,
   auto_opt_enabled: true,
@@ -119,15 +132,15 @@ export function presetSupportsCapability(preset: Pick<Preset, 'id' | 'applies_to
 }
 
 const STARTER_BASE: Preset[] = [
-  { id: 's-balanced', name: 'Balanced', description: 'Sensible defaults. Good first pick for everyday chat.', applies_to: ['chat'], recipe_options: { ctx_size: 16384 }, sampling: { temperature: 0.70, top_p: 0.90, top_k: 40, repeat_penalty: 1.05 }, engine_hint: 'llamacpp', starter: true },
-  { id: 's-thorough', name: 'Thorough', description: 'Careful answers for analysis, planning, debugging, and decisions.', applies_to: ['chat'], recipe_options: { ctx_size: 32768 }, sampling: { temperature: 0.40, top_p: 0.95, top_k: 40, repeat_penalty: 1.10 }, engine_hint: 'llamacpp', starter: true },
-  { id: 's-quick-chat', name: 'Quick Chat', description: 'Small context, tight sampling. Snappy responses for quick interactions.', applies_to: ['chat'], recipe_options: { ctx_size: 4048 }, sampling: { temperature: 0.60, top_p: 0.80, top_k: 40, repeat_penalty: 1.05 }, engine_hint: 'llamacpp', starter: true },
-  { id: 's-creative', name: 'Creative', description: 'Higher temperature for brainstorming, dialog, and divergent thinking.', applies_to: ['chat'], recipe_options: { ctx_size: 32768 }, sampling: { temperature: 0.95, top_p: 0.95, top_k: 60, repeat_penalty: 1.00 }, engine_hint: 'llamacpp', starter: true },
-  { id: 's-long-context', name: 'Long Context', description: 'For documents, codebases, and long conversation threads.', applies_to: ['chat'], recipe_options: { ctx_size: 262144 }, sampling: { temperature: 0.70, top_p: 0.90, top_k: 40, repeat_penalty: 1.05 }, engine_hint: 'llamacpp', starter: true },
-  { id: 's-code', name: 'Code', description: 'Low temperature, tight sampling for code generation and refactoring.', applies_to: ['chat'], recipe_options: { ctx_size: 131072 }, sampling: { temperature: 0.20, top_p: 0.95, top_k: 40, repeat_penalty: 1.05 }, engine_hint: 'llamacpp', starter: true },
-  { id: 's-quality', name: 'Quality', description: 'More steps and tighter guidance for crisp, deliberate image generation.', applies_to: ['image'], recipe_options: { steps: 20, cfg_scale: 8.0 }, sampling: {}, engine_hint: 'sd-cpp', starter: true },
-  { id: 's-preview', name: 'Preview', description: 'Fewer steps, looser guidance — fast drafts and iteration.', applies_to: ['image'], recipe_options: { steps: 8, cfg_scale: 6.0 }, sampling: {}, engine_hint: 'sd-cpp', starter: true },
-  { id: 's-turbo', name: 'Turbo', description: 'Fastest image drafts for rapid iteration.', applies_to: ['image'], recipe_options: { steps: 4, cfg_scale: 1.0 }, sampling: {}, engine_hint: 'sd-cpp', starter: true },
+  { id: 's-balanced', name: 'Balanced', description: 'Everyday chat intent. Concrete runtime values come from this model tuning.', applies_to: ['chat'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: true },
+  { id: 's-thorough', name: 'Thorough', description: 'Careful answers for analysis, planning, debugging, and decisions.', applies_to: ['chat'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: true },
+  { id: 's-quick-chat', name: 'Quick Chat', description: 'Snappy responses for quick interactions.', applies_to: ['chat'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: true },
+  { id: 's-creative', name: 'Creative', description: 'Brainstorming, dialog, and divergent writing intent.', applies_to: ['chat'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: true },
+  { id: 's-long-context', name: 'Long Context', description: 'For documents, codebases, and long conversation threads.', applies_to: ['chat'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: true },
+  { id: 's-code', name: 'Code', description: 'Coding, refactoring, and technical review intent.', applies_to: ['chat'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: true },
+  { id: 's-quality', name: 'Quality', description: 'Crisp, deliberate image generation intent.', applies_to: ['image'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: true },
+  { id: 's-preview', name: 'Preview', description: 'Fast image drafts and iteration intent.', applies_to: ['image'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: true },
+  { id: 's-turbo', name: 'Turbo', description: 'Fastest image draft intent for rapid iteration.', applies_to: ['image'], recipe_options: {}, sampling: {}, engine_hint: 'auto', starter: true },
 ];
 
 export const STARTERS: Preset[] = STARTER_BASE.map(preset => ({
@@ -467,6 +480,258 @@ export function saveBackendApplied(applied: Record<string, string>): void {
   emitPresetStoreEvent();
 }
 
+function isBlankValue(value: unknown): boolean {
+  return value === undefined || value === null || value === '';
+}
+
+function positiveNumberValue(value: unknown): number | undefined {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function optionalNumberValue(value: unknown): number | undefined {
+  if (isBlankValue(value)) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function optionalStringValue(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+const RECIPE_OPTION_NUMBER_KEYS = new Set<keyof RecipeOptions>([
+  'ctx_size', 'steps', 'cfg_scale', 'width', 'height', 'flow_shift', 'speed',
+]);
+
+export function sanitizeRecipeOptions(options: Partial<RecipeOptions> | null | undefined): RecipeOptions {
+  const out: RecipeOptions = {};
+  if (!options || typeof options !== 'object') return out;
+  for (const [key, value] of Object.entries(options) as Array<[keyof RecipeOptions, unknown]>) {
+    if (isBlankValue(value)) continue;
+    if (key === 'merge_args') {
+      if (typeof value === 'boolean') out.merge_args = value;
+      continue;
+    }
+    if (RECIPE_OPTION_NUMBER_KEYS.has(key)) {
+      const n = optionalNumberValue(value);
+      if (n !== undefined) (out as Record<string, unknown>)[key] = n;
+      continue;
+    }
+    if (typeof value === 'string') {
+      const str = optionalStringValue(value);
+      if (str !== undefined) (out as Record<string, unknown>)[key] = str;
+      continue;
+    }
+    (out as Record<string, unknown>)[key] = value;
+  }
+  return out;
+}
+
+export function sanitizeSamplingParams(params: Partial<SamplingParams> | null | undefined): SamplingParams {
+  const out: SamplingParams = {};
+  if (!params || typeof params !== 'object') return out;
+  for (const key of ['temperature', 'top_p', 'top_k', 'repeat_penalty'] as Array<keyof SamplingParams>) {
+    const n = optionalNumberValue(params[key]);
+    if (n !== undefined) out[key] = n;
+  }
+  return out;
+}
+
+export function sanitizeModelTuning(raw: Partial<ModelTuning> | null | undefined): ModelTuning {
+  const recipe_options = sanitizeRecipeOptions(raw?.recipe_options || {});
+  const sampling = sanitizeSamplingParams(raw?.sampling || {});
+  const engine_hint = raw?.engine_hint && ['auto', 'llamacpp', 'sd-cpp', 'whispercpp', 'moonshine', 'flm', 'ryzenai-llm', 'vllm', 'kokoro'].includes(String(raw.engine_hint))
+    ? raw.engine_hint
+    : undefined;
+  return {
+    recipe_options,
+    sampling,
+    ...(engine_hint ? { engine_hint } : {}),
+    source: raw?.source === 'user' ? 'user' : (raw?.source === 'model' ? 'model' : undefined),
+    updated_at: typeof raw?.updated_at === 'string' ? raw.updated_at : undefined,
+  };
+}
+
+export function loadModelTunings(): Record<string, ModelTuning> {
+  try {
+    const raw = localStorage.getItem(scopedPresetKey(LS_MODEL_TUNINGS));
+    const parsed = raw ? JSON.parse(raw) : {};
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return Object.fromEntries(Object.entries(parsed).map(([name, tuning]) => [name, sanitizeModelTuning(tuning as Partial<ModelTuning>)]));
+  } catch {}
+  return {};
+}
+
+export function saveModelTunings(tunings: Record<string, ModelTuning>): void {
+  localStorage.setItem(scopedPresetKey(LS_MODEL_TUNINGS), JSON.stringify(tunings));
+  emitPresetStoreEvent();
+}
+
+export function loadModelTuning(modelName: string): ModelTuning | null {
+  if (!modelName) return null;
+  return loadModelTunings()[modelName] || null;
+}
+
+export function saveModelTuning(modelName: string, tuning: Partial<ModelTuning>): void {
+  if (!modelName) return;
+  const sanitized = sanitizeModelTuning({ ...tuning, source: 'user', updated_at: new Date().toISOString() });
+  const hasValues = Object.keys(sanitized.recipe_options).length > 0 || Object.keys(sanitized.sampling).length > 0 || !!sanitized.engine_hint;
+  const next = { ...loadModelTunings() };
+  if (hasValues) next[modelName] = sanitized;
+  else delete next[modelName];
+  saveModelTunings(next);
+}
+
+export function resetModelTuning(modelName: string): void {
+  if (!modelName) return;
+  const next = { ...loadModelTunings() };
+  delete next[modelName];
+  saveModelTunings(next);
+}
+
+export function hasModelTuning(modelName: string): boolean {
+  const tuning = loadModelTuning(modelName);
+  return !!tuning && (Object.keys(tuning.recipe_options).length > 0 || Object.keys(tuning.sampling).length > 0 || !!tuning.engine_hint);
+}
+
+function readStringFrom(value: unknown, paths: string[][]): string | undefined {
+  for (const path of paths) {
+    let cur: unknown = value;
+    for (const key of path) {
+      if (!cur || typeof cur !== 'object') { cur = undefined; break; }
+      cur = (cur as Record<string, unknown>)[key];
+    }
+    const str = optionalStringValue(cur);
+    if (str !== undefined) return str;
+  }
+  return undefined;
+}
+
+function activeRecipeName(model: ModelInfo | null | undefined): string {
+  const direct = String((model as Record<string, unknown> | null | undefined)?.recipe || '').trim().toLowerCase();
+  if (direct) return direct;
+  const first = recipesForModel(model)[0];
+  return recipeName(first);
+}
+
+function readStringFromModelOrRecipe(model: ModelInfo | null | undefined, paths: string[][]): string | undefined {
+  return readStringFrom(model, paths) ?? readStringFromActiveRecipe(model, paths);
+}
+
+function readStringFromActiveRecipe(model: ModelInfo | null | undefined, paths: string[][]): string | undefined {
+  const recipes = recipesForModel(model);
+  const activeRecipe = activeRecipeName(model);
+  if (activeRecipe) {
+    for (const recipe of recipes) {
+      if (recipeName(recipe) === activeRecipe) {
+        const str = readStringFrom(recipe, paths);
+        if (str !== undefined) return str;
+      }
+    }
+  }
+  for (const recipe of recipes) {
+    const str = readStringFrom(recipe, paths);
+    if (str !== undefined) return str;
+  }
+  return undefined;
+}
+
+export function modelDefaultRecipeOptions(model: ModelInfo | null | undefined, fallbackCtxSize?: unknown): RecipeOptions {
+  if (!model) return {};
+  const recipe = activeRecipeName(model);
+  const capability = capabilityFromModelInfo(model);
+  const out: RecipeOptions = {};
+  const ctx = modelContextSize(model, fallbackCtxSize);
+
+  if (capability === 'chat' || capability === 'omni' || capability === 'unknown') {
+    if (ctx) out.ctx_size = ctx;
+  }
+
+  const backend = readStringFromModelOrRecipe(model, [
+    ['recipe_options', 'backend'], ['options', 'backend'], ['backend'], ['default_backend'], ['recommended_backend'],
+  ]);
+
+  if (recipe === 'llamacpp' || recipe === '') {
+    if (ctx) out.ctx_size = ctx;
+    out.llamacpp_backend = readStringFromModelOrRecipe(model, [['recipe_options', 'llamacpp_backend'], ['options', 'llamacpp_backend'], ['llamacpp_backend']]) ?? backend;
+    out.llamacpp_device = readStringFromModelOrRecipe(model, [['recipe_options', 'llamacpp_device'], ['options', 'llamacpp_device'], ['llamacpp_device'], ['device']]);
+    out.llamacpp_args = readStringFromModelOrRecipe(model, [['recipe_options', 'llamacpp_args'], ['options', 'llamacpp_args'], ['llamacpp_args'], ['args']]);
+  }
+  if (recipe === 'flm') {
+    if (ctx) out.ctx_size = ctx;
+    out.flm_args = readStringFromModelOrRecipe(model, [['recipe_options', 'flm_args'], ['options', 'flm_args'], ['flm_args'], ['args']]);
+  }
+  if (recipe === 'vllm') {
+    if (ctx) out.ctx_size = ctx;
+    out.vllm_backend = readStringFromModelOrRecipe(model, [['recipe_options', 'vllm_backend'], ['options', 'vllm_backend'], ['vllm_backend']]) ?? backend;
+    out.vllm_args = readStringFromModelOrRecipe(model, [['recipe_options', 'vllm_args'], ['options', 'vllm_args'], ['vllm_args'], ['args']]);
+  }
+  if (recipe === 'ryzenai-llm') {
+    if (ctx) out.ctx_size = ctx;
+  }
+
+  if (capability === 'image' || recipe === 'sd-cpp') {
+    out.steps = readNumberFromModelOrRecipe(model, [['recipe_options', 'steps'], ['sample_params', 'steps'], ['sample_steps'], ['steps']]);
+    out.cfg_scale = readNumberFromModelOrRecipe(model, [['recipe_options', 'cfg_scale'], ['sample_params', 'cfg_scale'], ['sample_params', 'guidance', 'txt_cfg'], ['txt_cfg'], ['cfg_scale']]);
+    out.width = readNumberFromModelOrRecipe(model, [['recipe_options', 'width'], ['sample_params', 'width'], ['width']]);
+    out.height = readNumberFromModelOrRecipe(model, [['recipe_options', 'height'], ['sample_params', 'height'], ['height']]);
+    out.sampling_method = readStringFromModelOrRecipe(model, [['recipe_options', 'sampling_method'], ['sample_params', 'sampling_method'], ['sampling_method']]);
+    out.flow_shift = readNumberFromModelOrRecipe(model, [['recipe_options', 'flow_shift'], ['sample_params', 'flow_shift'], ['flow_shift']]);
+    out.sdcpp_args = readStringFromModelOrRecipe(model, [['recipe_options', 'sdcpp_args'], ['options', 'sdcpp_args'], ['sdcpp_args'], ['args']]);
+  }
+
+  if (capability === 'audio' || recipe === 'whispercpp' || recipe === 'moonshine') {
+    if (recipe === 'moonshine') {
+      out.moonshine_backend = readStringFromModelOrRecipe(model, [['recipe_options', 'moonshine_backend'], ['options', 'moonshine_backend'], ['moonshine_backend']]) ?? backend;
+      out.moonshine_args = readStringFromModelOrRecipe(model, [['recipe_options', 'moonshine_args'], ['options', 'moonshine_args'], ['moonshine_args'], ['args']]);
+    } else {
+      out.whispercpp_backend = readStringFromModelOrRecipe(model, [['recipe_options', 'whispercpp_backend'], ['options', 'whispercpp_backend'], ['whispercpp_backend']]) ?? backend;
+      out.whispercpp_args = readStringFromModelOrRecipe(model, [['recipe_options', 'whispercpp_args'], ['options', 'whispercpp_args'], ['whispercpp_args'], ['args']]);
+    }
+  }
+
+  if (capability === 'tts' || recipe === 'kokoro') {
+    out.voice = readStringFromModelOrRecipe(model, [['recipe_options', 'voice'], ['sample_params', 'voice'], ['default_voice'], ['voice']]);
+    out.speed = readNumberFromModelOrRecipe(model, [['recipe_options', 'speed'], ['sample_params', 'speed'], ['default_speed'], ['speed']]);
+  }
+
+  return sanitizeRecipeOptions(out);
+}
+
+export function modelDefaultSampling(model: ModelInfo | null | undefined): SamplingParams {
+  if (!model) return {};
+  return sanitizeSamplingParams({
+    temperature: readNumberFrom(model, [['sampling', 'temperature'], ['sample_params', 'temperature'], ['recipe_options', 'temperature'], ['temperature']]),
+    top_p: readNumberFrom(model, [['sampling', 'top_p'], ['sample_params', 'top_p'], ['recipe_options', 'top_p'], ['top_p']]),
+    top_k: readNumberFrom(model, [['sampling', 'top_k'], ['sample_params', 'top_k'], ['recipe_options', 'top_k'], ['top_k']]),
+    repeat_penalty: readNumberFrom(model, [['sampling', 'repeat_penalty'], ['sample_params', 'repeat_penalty'], ['recipe_options', 'repeat_penalty'], ['repeat_penalty']]),
+  });
+}
+
+export function modelBaseTuningForModel(model: ModelInfo | null | undefined, fallbackCtxSize?: unknown): ModelTuning {
+  return {
+    recipe_options: modelDefaultRecipeOptions(model, fallbackCtxSize),
+    sampling: modelDefaultSampling(model),
+    engine_hint: (activeRecipeName(model) as PresetRecipe) || 'auto',
+    source: 'model',
+  };
+}
+
+export function effectiveModelTuningForModel(modelName: string, model: ModelInfo | null | undefined, fallbackCtxSize?: unknown): ModelTuning {
+  const base = modelBaseTuningForModel(model, fallbackCtxSize);
+  const user = loadModelTuning(modelName);
+  if (!user) return base;
+  return {
+    recipe_options: { ...base.recipe_options, ...user.recipe_options },
+    sampling: { ...base.sampling, ...user.sampling },
+    engine_hint: user.engine_hint || base.engine_hint,
+    source: user.source || 'user',
+    updated_at: user.updated_at,
+  };
+}
+
 export function allStoredPresets(): Preset[] {
   return [DEFAULT_PRESET, ...STARTERS, ...loadUserPresets()];
 }
@@ -721,35 +986,45 @@ export function recipeOptionsForModel(
 ): RecipeOptions | undefined {
   const capability = model ? capabilityFromModelInfo(model) : undefined;
 
-  // Model preset = model-specific defaults.
-  const modelPreset = activePresetForModel(modelName);
-  const modelPresetOptions = modelPreset.recipe_options || {};
-  const modelOptions = model
-    ? recipeOptionsForCapability(modelPresetOptions, capability!)
-    : modelPresetOptions;
+  // Shared Preset = user intent. It may still carry legacy/custom recipe_options,
+  // but concrete per-model values now belong to Model Tuning and win below.
+  const preset = activePresetForModel(modelName);
+  const presetOptionsRaw = preset.recipe_options || {};
+  const presetOptions = model
+    ? recipeOptionsForCapability(presetOptionsRaw, capability!)
+    : presetOptionsRaw;
+
+  // Model Tuning = per-model user override layer. The UI still displays
+  // built-in/GGUF-derived model defaults through effectiveModelTuningForModel(),
+  // but load options should only send explicit overrides. Otherwise a UI fallback
+  // such as ctx_size=4096 would accidentally override preset/backend defaults.
+  const modelTuningOptionsRaw = loadModelTuning(modelName)?.recipe_options || {};
+  const modelTuningOptions = model
+    ? recipeOptionsForCapability(modelTuningOptionsRaw, capability!)
+    : modelTuningOptionsRaw;
 
   // Backend preset = GLOBAL backend/runtime defaults (#2432). It only applies
-  // when the CONCRETE backend this load resolves to (explicit options → model
-  // preset → recipe default_backend) matches its exact `recipe:backend` binding.
-  // Merge precedence: start from the backend preset's args as the base/global
-  // defaults, then layer the model preset's args on top so model-specific values
-  // WIN on conflict. This matches `main`'s "more specific source wins" merge.
-  // Default backend preset contributes nothing (resolver returns null).
+  // when the CONCRETE backend this load resolves to matches its exact
+  // `recipe:backend` binding. The backend preset is a base layer; preset intent
+  // and model tuning are more specific.
   const backendPreset = activePresetForModelBackend(model, {
     explicitOptions,
-    modelPresetOptions,
+    modelPresetOptions: { ...presetOptions, ...modelTuningOptions },
     systemInfo,
   });
   const backendOptions = backendPreset && model
     ? recipeOptionsForCapability(backendPreset.recipe_options || {}, capability!)
     : (backendPreset ? (backendPreset.recipe_options || {}) : {});
 
-  const merged: RecipeOptions = { ...backendOptions, ...modelOptions };
+  const merged: RecipeOptions = { ...backendOptions, ...presetOptions, ...modelTuningOptions };
   return Object.keys(merged || {}).length > 0 ? merged : undefined;
 }
 
-export function samplingForModel(modelName: string): SamplingParams {
-  return activePresetForModel(modelName).sampling || {};
+export function samplingForModel(modelName: string, model?: ModelInfo | null): SamplingParams {
+  const presetSampling = activePresetForModel(modelName).sampling || {};
+  const modelSampling = loadModelTuning(modelName)?.sampling || {};
+  const merged = { ...presetSampling, ...modelSampling };
+  return Object.keys(merged).length > 0 ? merged : {};
 }
 
 export type PresetIconName =
@@ -779,6 +1054,8 @@ export function getPresetIcon(id: string, nameRaw: string): PresetIconName {
   if (name.includes('long')) return 'library';
   if (name.includes('code')) return 'code';
   if (name.includes('memory')) return 'hard-drive';
+  if (name.includes('transcription') || name.includes('transcribe')) return 'scan-eye';
+  if (name.includes('voice')) return 'hard-drive';
   // Image
   if (name.includes('quality')) return 'gem';
   if (name.includes('preview')) return 'scan-eye';

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -9540,3 +9540,212 @@ input, textarea {
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Model Tuning tab ─────────────────────────────────────────── */
+.detail-tuning {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  color: var(--text-primary);
+}
+
+.detail-tuning__intro,
+.detail-tuning__effective,
+.detail-tuning__editor {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-1);
+  padding: var(--space-4);
+}
+
+.detail-tuning__intro {
+  background: color-mix(in srgb, var(--accent-fg) 5%, var(--surface-1));
+}
+
+.detail-tuning__title,
+.detail-tuning__section-title {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.detail-tuning__intro p,
+.detail-tuning__hint,
+.detail-tuning__empty {
+  margin: 0;
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.detail-tuning__summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-3);
+}
+
+.detail-tuning__summary-card {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+}
+
+.detail-tuning__summary-label {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.detail-tuning__summary-card strong {
+  font-size: var(--text-xs);
+  color: var(--text-primary);
+  line-height: 1.35;
+}
+
+.detail-tuning__kv-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-2);
+}
+
+.detail-tuning__kv {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  min-width: 0;
+}
+
+.detail-tuning__kv span {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail-tuning__kv code {
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  background: transparent;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 52%;
+}
+
+.detail-tuning__section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.detail-tuning__notice {
+  margin: 0;
+  max-width: 18rem;
+  font-size: var(--text-xs);
+  color: var(--accent-fg);
+  line-height: 1.4;
+}
+
+.detail-tuning__field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: var(--space-3);
+}
+
+.detail-tuning__field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+
+.detail-tuning__field > span {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.detail-tuning__field small {
+  color: var(--text-tertiary);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.detail-tuning__sampling {
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: 1px dashed var(--border-subtle);
+}
+
+.detail-tuning__sampling h4 {
+  margin: 0 0 var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.detail-tuning__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+.detail-tuning__actions .btn[aria-busy='true'] {
+  cursor: progress;
+  opacity: 0.85;
+}
+
+.detail-tuning__field--wide {
+  grid-column: 1 / -1;
+}
+
+.detail-tuning__control-row {
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.detail-tuning__control-row .field__value {
+  min-width: 3.75rem;
+  text-align: right;
+}
+
+.detail-tuning__default-btn {
+  white-space: nowrap;
+}
+
+.detail-tuning__args {
+  min-height: 4.75rem;
+  resize: vertical;
+  font-family: var(--font-mono, monospace);
+  line-height: 1.45;
+}
+
+@media (max-width: 640px) {
+  .detail-tuning__control-row {
+    flex-wrap: wrap;
+  }
+
+  .detail-tuning__control-row .slider {
+    flex-basis: 100%;
+  }
+}

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -8290,15 +8290,11 @@ input, textarea {
 .model-list-panel__filter-popover {
   position: fixed;
   z-index: 160;
-  /* Solid, opaque surface so list content behind the popover does not bleed
-     through (the previous `--surface-overlay` token is undefined → transparent).
-     Fixed positioning lets the dialog sit above the nav rail and expand across
-     the available viewport instead of being clipped by the middle list pane. */
   background: var(--surface-3);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  padding: var(--space-3);
-  min-width: min(360px, calc(100vw - 24px));
+  padding: var(--space-2);
+  min-width: min(320px, calc(100vw - 24px));
   max-width: calc(100vw - 24px);
   overflow: auto;
   box-shadow: 0 12px 32px rgba(0,0,0,0.38);
@@ -8308,32 +8304,41 @@ input, textarea {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-1) var(--space-2) var(--space-2);
+  gap: var(--space-2);
+  min-height: 24px;
+  padding: 0 0 var(--space-1);
   font-size: var(--text-xs);
-  color: var(--text-tertiary);
+  font-weight: 600;
+  color: var(--text-secondary);
 }
 
 .model-list-panel__filter-popover-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
   background: none;
-  border: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
   color: var(--text-tertiary);
   cursor: pointer;
-  padding: 2px;
-  display: inline-flex;
 }
 
-.model-list-panel__filter-popover-close:hover { color: var(--text-primary); }
-.model-list-panel__filter-popover-close:focus-visible { outline: 2px solid var(--accent-focus); border-radius: 2px; }
+.model-list-panel__filter-popover-close:hover { color: var(--text-primary); background: var(--surface-2); border-color: var(--border-subtle); }
+.model-list-panel__filter-popover-close:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
 
 .model-list-panel__filter-section {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: var(--space-1);
   padding: var(--space-2) 0;
   border-top: 1px solid var(--border-subtle);
 }
 
-.model-list-panel__filter-section:first-of-type { border-top: none; padding-top: 0; }
+.model-list-panel__filter-section:first-of-type { border-top: none; padding-top: var(--space-1); }
+.model-list-panel__filter-section:last-of-type { padding-bottom: var(--space-1); }
 
 .model-list-panel__filter-section-head {
   display: flex;
@@ -8343,16 +8348,18 @@ input, textarea {
 }
 
 .model-list-panel__filter-section-title {
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 
 .model-list-panel__filter-add {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 3px;
   min-height: 24px;
   padding: 0 var(--space-2);
   border: 1px solid var(--border-subtle);
@@ -8368,69 +8375,72 @@ input, textarea {
 
 .model-list-panel__filter-options {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
+  flex-wrap: wrap;
+  gap: 4px;
 }
 
 .model-list-panel__filter-option {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-1) var(--space-2);
-  background: none;
-  border: none;
-  border-radius: var(--radius-sm);
+  gap: 4px;
+  min-height: 24px;
+  padding: 0 var(--space-2);
+  background: var(--surface-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
   color: var(--text-secondary);
   font-size: var(--text-xs);
   cursor: pointer;
   text-align: left;
 }
 
-.model-list-panel__filter-option:hover { background: var(--surface-2); color: var(--text-primary); }
+.model-list-panel__filter-option:hover { background: var(--surface-2); color: var(--text-primary); border-color: var(--border-strong); }
 .model-list-panel__filter-option:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
-.model-list-panel__filter-option--active { color: var(--accent-fg); font-weight: 600; }
-.model-list-panel__filter-option[aria-pressed="true"] { background: var(--surface-2); }
+.model-list-panel__filter-option--active,
+.model-list-panel__filter-option[aria-pressed="true"] { color: var(--accent-fg); border-color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 12%, transparent); }
 
 .model-list-panel__filter-empty {
-  padding: var(--space-1) var(--space-2);
+  padding: var(--space-1) 0;
   color: var(--text-tertiary);
   font-size: var(--text-xs);
 }
 
 .model-list-panel__filter-clear {
-  margin-top: var(--space-1);
-  padding: var(--space-1) var(--space-2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-end;
+  min-height: 24px;
+  margin-top: 0;
+  padding: 0 var(--space-2);
   background: none;
-  border: none;
-  border-top: 1px solid var(--border-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
   color: var(--accent-fg);
   font-size: var(--text-xs);
   cursor: pointer;
-  text-align: left;
-  border-radius: var(--radius-sm);
 }
-.model-list-panel__filter-clear:hover { background: var(--surface-2); }
+.model-list-panel__filter-clear:hover { background: var(--surface-2); border-color: var(--border-strong); }
 .model-list-panel__filter-clear:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
 
 .model-list-panel__text-filters {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 4px;
 }
 
 .model-list-panel__text-filter {
   display: grid;
-  grid-template-columns: minmax(92px, 0.9fr) minmax(118px, 1.05fr) minmax(112px, 1fr) 26px;
-  gap: var(--space-1);
+  grid-template-columns: minmax(92px, 0.75fr) 56px minmax(112px, 1fr) 24px;
+  gap: 4px;
   align-items: center;
 }
 
 .model-list-panel__text-filter-field,
-.model-list-panel__text-filter-mode,
 .model-list-panel__text-filter-input {
   width: 100%;
   min-width: 0;
-  height: 28px;
+  height: 26px;
   padding: 0 var(--space-2);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
@@ -8441,25 +8451,53 @@ input, textarea {
 }
 
 .model-list-panel__text-filter-field:focus,
-.model-list-panel__text-filter-mode:focus,
 .model-list-panel__text-filter-input:focus {
   outline: 2px solid var(--accent-focus);
   outline-offset: 0;
   border-color: transparent;
 }
 
+.model-list-panel__text-filter-mode {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  height: 26px;
+  padding: 2px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-base);
+}
+
+.model-list-panel__text-filter-mode-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: calc(var(--radius-sm) - 2px);
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+.model-list-panel__text-filter-mode-btn:hover { color: var(--text-primary); background: var(--surface-2); }
+.model-list-panel__text-filter-mode-btn:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+.model-list-panel__text-filter-mode-btn--active,
+.model-list-panel__text-filter-mode-btn[aria-pressed="true"] { color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 14%, transparent); border-color: color-mix(in srgb, var(--accent-fg) 35%, transparent); }
+
 .model-list-panel__text-filter-remove {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   background: none;
   color: var(--text-tertiary);
   cursor: pointer;
-  font-size: 16px;
   line-height: 1;
 }
 
@@ -8470,15 +8508,10 @@ input, textarea {
 }
 .model-list-panel__text-filter-remove:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
 
-.model-list-panel__filter-help {
-  color: var(--text-tertiary);
-  font-size: var(--text-xs);
-  line-height: var(--leading-normal);
-}
-
-@media (max-width: 720px) {
-  .model-list-panel__text-filter { grid-template-columns: 1fr 1fr 26px; }
-  .model-list-panel__text-filter-input { grid-column: 1 / 3; }
+@media (max-width: 560px) {
+  .model-list-panel__filter-popover { padding: var(--space-2); }
+  .model-list-panel__text-filter { grid-template-columns: minmax(86px, 1fr) 56px 24px; }
+  .model-list-panel__text-filter-input { grid-column: 1 / 4; }
 }
 
 /* Capability icons on a model row — one per functional capability tag (#2424). */

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -8288,18 +8288,20 @@ input, textarea {
 
 /* Filter popover */
 .model-list-panel__filter-popover {
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  z-index: 50;
+  position: fixed;
+  z-index: 160;
   /* Solid, opaque surface so list content behind the popover does not bleed
-     through (the previous `--surface-overlay` token is undefined → transparent). */
+     through (the previous `--surface-overlay` token is undefined → transparent).
+     Fixed positioning lets the dialog sit above the nav rail and expand across
+     the available viewport instead of being clipped by the middle list pane. */
   background: var(--surface-3);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
-  padding: var(--space-2);
-  min-width: 160px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+  padding: var(--space-3);
+  min-width: min(360px, calc(100vw - 24px));
+  max-width: calc(100vw - 24px);
+  overflow: auto;
+  box-shadow: 0 12px 32px rgba(0,0,0,0.38);
 }
 
 .model-list-panel__filter-popover-head {
@@ -8322,6 +8324,47 @@ input, textarea {
 
 .model-list-panel__filter-popover-close:hover { color: var(--text-primary); }
 .model-list-panel__filter-popover-close:focus-visible { outline: 2px solid var(--accent-focus); border-radius: 2px; }
+
+.model-list-panel__filter-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.model-list-panel__filter-section:first-of-type { border-top: none; padding-top: 0; }
+
+.model-list-panel__filter-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.model-list-panel__filter-section-title {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.model-list-panel__filter-add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 24px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.model-list-panel__filter-add:hover { color: var(--text-primary); border-color: var(--border-strong); }
+.model-list-panel__filter-add:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
 
 .model-list-panel__filter-options {
   display: flex;
@@ -8368,6 +8411,75 @@ input, textarea {
 }
 .model-list-panel__filter-clear:hover { background: var(--surface-2); }
 .model-list-panel__filter-clear:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+
+.model-list-panel__text-filters {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.model-list-panel__text-filter {
+  display: grid;
+  grid-template-columns: minmax(92px, 0.9fr) minmax(118px, 1.05fr) minmax(112px, 1fr) 26px;
+  gap: var(--space-1);
+  align-items: center;
+}
+
+.model-list-panel__text-filter-field,
+.model-list-panel__text-filter-mode,
+.model-list-panel__text-filter-input {
+  width: 100%;
+  min-width: 0;
+  height: 28px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  box-sizing: border-box;
+}
+
+.model-list-panel__text-filter-field:focus,
+.model-list-panel__text-filter-mode:focus,
+.model-list-panel__text-filter-input:focus {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 0;
+  border-color: transparent;
+}
+
+.model-list-panel__text-filter-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.model-list-panel__text-filter-remove:hover {
+  background: var(--surface-2);
+  color: var(--text-primary);
+  border-color: var(--border-subtle);
+}
+.model-list-panel__text-filter-remove:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: 1px; }
+
+.model-list-panel__filter-help {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+@media (max-width: 720px) {
+  .model-list-panel__text-filter { grid-template-columns: 1fr 1fr 26px; }
+  .model-list-panel__text-filter-input { grid-column: 1 / 3; }
+}
 
 /* Capability icons on a model row — one per functional capability tag (#2424). */
 .model-list-item__caps {


### PR DESCRIPTION
## Summary

Introduce a dedicated manual **Model Tuning** layer to GUI3, separating per-model runtime configuration from reusable Presets.

Presets are now focused on reusable usage intents, while model-specific runtime settings (backend, device, context size, backend args, sampling, etc.) are managed through the new Model Tuning panel.

## Why

This combines the strengths of GUI2 and GUI3:

- Keep Presets simple, reusable, and shared across models.
- Restore per-model optimization without requiring one preset per model.
- Support all backend and model types while keeping the primary UX straightforward.

The tuning UI also received several usability improvements, including sliders, simplified backend/device selection, backend-specific argument persistence, and clearer runtime controls.

## Note

Merge is intended after https://github.com/lemonade-sdk/lemonade/pull/2553 lands