### PR TITLE
dev: change base image to Ubuntu 24.04 in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/cpp:1-debian-12
+FROM mcr.microsoft.com/devcontainers/cpp:1-ubuntu-24.04
 
 ARG REINSTALL_CMAKE_VERSION_FROM_SOURCE="3.22.2"
 


### PR DESCRIPTION
## Why

Currently Debian 12 is used. Those system libs and packages are quite old causing problems.

## Reasoning

Switching to one of the newest OS in the dev-containter might conceal a package or similar we have with our oldest supported OS.
Hence switching to our oldest supported Linux OS makes most sense considering those arguments.