### PR TITLE
feat(vllm): stage AMD Instinct MI300X (gfx942) support (pending release asset)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2217,3 +2217,12 @@ if(EXISTS "${_NETWORK_UTILS_TEST_SRC}")
     target_link_libraries(test_network_utils PRIVATE lemonade-server-core)
     add_test(NAME NetworkUtilsTest COMMAND test_network_utils)
 endif()
+
+# vLLM CDNA gating: the vllm descriptor support row + asset-family resolution for
+# AMD Instinct (gfx942), alongside the existing RDNA families.
+set(_VLLM_CDNA_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_vllm_cdna_gating.cpp")
+if(EXISTS "${_VLLM_CDNA_TEST_SRC}")
+    add_executable(test_vllm_cdna_gating test/cpp/test_vllm_cdna_gating.cpp)
+    target_link_libraries(test_vllm_cdna_gating PRIVATE lemonade-server-core)
+    add_test(NAME VllmCdnaGatingTest COMMAND test_vllm_cdna_gating)
+endif()

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -372,7 +372,7 @@ the generator instead. Prose outside the markers is preserved. -->
 |-------|-----------|--------|
 | `TRELLIS-3D` | 15.4 | 3d |
 
-#### `vllm` — vLLM ROCm (experimental) (7 models)
+#### `vllm` — vLLM ROCm (experimental) (11 models)
 
 | Model | Size (GB) | Labels |
 |-------|-----------|--------|
@@ -382,7 +382,11 @@ the generator instead. Prose outside the markers is preserved. -->
 | `Qwen3.5-4B-FP16-vLLM` | 9.34 | reasoning, hot, tool-calling |
 | `Qwen3.5-9B-FP16-vLLM` | 19.3 | reasoning, tool-calling |
 | `Qwen3.6-27B-FP16-vLLM` | 55.59 | reasoning, tool-calling, vision |
+| `Qwen3.6-27B-FP8-vLLM-highconc` | 27.8 | reasoning, tool-calling, vision, mtp |
+| `Qwen3.6-27B-FP8-vLLM-lowconc` | 27.8 | reasoning, tool-calling, vision, mtp |
 | `Qwen3.6-35B-A3B-FP16-vLLM` | 71.93 | reasoning, tool-calling, vision |
+| `Qwen3.6-35B-A3B-FP8-vLLM-highconc` | 36.0 | reasoning, tool-calling, vision, mtp |
+| `Qwen3.6-35B-A3B-FP8-vLLM-lowconc` | 36.0 | reasoning, tool-calling, vision, mtp |
 
 #### `whispercpp` — Whisper.cpp (6 models)
 

--- a/docs/guide/configuration/vllm.md
+++ b/docs/guide/configuration/vllm.md
@@ -5,13 +5,13 @@ Lemonade integrates [vLLM](https://github.com/vllm-project/vllm) as an experimen
 1. **Day-0 model support.** vLLM typically supports new transformer architectures within hours of their release on Hugging Face — checkpoints load directly, with no per-architecture porting.
 2. **Concurrency and multi-GPU.** Paged-attention KV cache, continuous batching, and chunked prefill scale aggregate throughput with in-flight request count; tensor and pipeline parallelism are supported across multiple GPUs.
 
-> **Status: experimental.** The backend has been validated on **gfx1151 (Strix Halo)** and **gfx1150 (Strix Point)**. Prebuilt wheels also exist for `gfx110X` (RDNA3) and `gfx120X` (RDNA4) but those targets have not been exercised end-to-end yet.
+> **Status: experimental.** The backend has been validated on **gfx1151 (Strix Halo)** and **gfx1150 (Strix Point)**. Prebuilt wheels also exist for `gfx110X` (RDNA3) and `gfx120X` (RDNA4) but those targets have not been exercised end-to-end yet. **gfx942 (AMD Instinct MI300X, CDNA3)** is **staged, not auto-installable yet** — the resolver, per-architecture pinning, launch policy, and recipes are all in place and have been manually validated on real MI300X hardware, but gfx942 is held out of the installable support matrix until the official `-gfx942` release asset is published (see [Deploying on MI300X](#deploying-on-mi300x-gfx942--quickstart)).
 
 ## Available Backend
 
 ### ROCm
 - **Platform**: Linux only
-- **Hardware**: validated on gfx1151 (Strix Halo) and gfx1150 (Strix Point); prebuilt wheels also exist for gfx110X (RDNA3) and gfx120X (RDNA4)
+- **Hardware**: validated on gfx1151 (Strix Halo) and gfx1150 (Strix Point); prebuilt wheels also exist for gfx110X (RDNA3) and gfx120X (RDNA4); gfx942 (MI300X, CDNA3) is **staged / manually validated, not auto-installable** until the official per-arch release asset ships
 - **Bundle**: a self-contained tarball from [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm) with a relocatable Python interpreter, PyTorch (ROCm), the ROCm user-space libs, Triton, and vLLM. No system Python / PyTorch / ROCm install is required on the host.
 
 ## Prerequisites
@@ -31,7 +31,38 @@ curl -X POST http://localhost:13305/api/v1/install \
   -d '{"recipe": "vllm", "backend": "rocm"}'
 ```
 
-The install fetches a per-GPU-target release (e.g. `…-gfx1151`, `…-gfx1150`) from [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm/releases). The base version is pinned in [`backend_versions.json`](https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/resources/backend_versions.json); the `-{gfx_target}` suffix is appended at runtime from `SystemInfo::get_rocm_arch()`, so a single pin covers all supported architectures.
+The install fetches a per-GPU-target release (e.g. `…-gfx1151`, `…-gfx1150`) from [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm/releases). The base version is pinned in [`backend_versions.json`](https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/resources/backend_versions.json); the `-{gfx_target}` suffix is appended at runtime from `SystemInfo::get_rocm_arch()`, so the default pin covers all RDNA/APU architectures on one line.
+
+#### Per-architecture release overrides
+
+Some GPU targets ride a different vLLM/ROCm wheel cadence than the default pin and cannot share a single release tag — CDNA-dcgpu (gfx942 / MI300X), for example, uses its own vLLM/ROCm release line, separate from the RDNA line (its official asset is not published yet — see the staged-status note above). For those, `backend_versions.json` carries an optional `vllm.rocm_arch_overrides` map keyed by asset family; the override base is resolved for the detected arch (falling back to the default pin otherwise) before the `-{gfx_target}` suffix is appended. An explicit `vllm.rocm_bin` pin (`latest` or a specific tag) still takes precedence over the builtin per-arch override — the override only replaces the *default* base. A pin that already carries a `-{gfx_target}` suffix must match the detected architecture: a cross-arch pin (for example a repo-wide `latest` that resolved to a suffixed RDNA tag, or an explicit tag for a different target) is **rejected** rather than installed against the wrong architecture line. Note that pinning `vllm.rocm_bin` to the exact default base tag is treated the same as leaving it unset (`builtin`) — the per-arch override still applies; set an explicit *non-default* tag to opt out of the override.
+
+### Deploying on MI300X (gfx942) — quickstart
+
+> **gfx942 is currently staged, not auto-installable.** The resolver, per-arch release pinning,
+> device-class launch policy, and FP8/MTP recipes are all in place, but gfx942 is intentionally
+> **not** in the public installable support matrix yet because its per-arch vLLM/ROCm release asset
+> is not published in `lemonade-sdk/vllm-rocm`. Once that official `gfx94X-dcgpu` asset ships, gfx942
+> is enabled with a one-line matrix flip and the steps below become a one-click `install`.
+
+The minimum path to a working gfx942 deployment today with the FP8 + MTP recipes:
+
+1. **Runtime asset.** Until the official asset ships, use the community-built, hardware-validated
+   tarball (`ianbmacdonald/vllm-rocm-cdna`, tag `vllm0.19.1-rocm7.13.0-gfx942`) by **manually sideloading**
+   it into the vLLM backend install directory. A `vllm.rocm_bin` pin changes only the tag/version, not
+   the source repository, so it cannot redirect the built-in install to a fork's build — the sideload
+   is the supported interim path (the standalone runbook published alongside the tarball covers the
+   exact steps).
+2. **Recipes.** The `Qwen3.6-27B-FP8-vLLM-{low,high}conc` and `Qwen3.6-35B-A3B-FP8-vLLM-{low,high}conc`
+   recipes are built in; `lemonade run Qwen3.6-27B-FP8-vLLM-lowconc` pulls and serves. To register a
+   pre-quantized checkpoint yourself: `lemonade pull user.MyModel --checkpoint Qwen/Qwen3.6-27B-FP8 --recipe vllm`.
+3. **Verify.** The vLLM log shows the MTP head detected and the draft-token acceptance rate (~80% on
+   the 27B dense recipe, gfx942). Discrete-HBM launch defaults apply automatically; force eager for a
+   newly-added or misbehaving model with `lemonade config set vllm.args="--enforce-eager"`.
+
+A standalone copy of this runbook and importable recipe JSONs are published alongside the gfx942
+runtime tarball as release assets. AITER (fused-MoE FP8 kernels) is a separate build-repo bake — the
+recipes serve correctly without it.
 
 ## Use
 
@@ -91,7 +122,15 @@ Argument precedence is:
 
 Later layers override conflicting earlier flags but keep non-conflicting flags. Binary `--flag` / `--no-flag` pairs are resolved like the rest of Lemonade's `*_args` merge behavior, and repeated generic flags are preserved when the same flag appears multiple times.
 
-Lemonade-managed process arguments cannot be set in this file or in `vllm_args`: `--model`, `--served-model-name`, `--host`, `--port`, `--max-model-len`, `--enforce-eager`, and `--enable-prefix-caching`.
+Lemonade-managed process arguments cannot be set in this file or in `vllm_args`: `--model`, `--served-model-name`, `--host`, `--port`, `--max-model-len`, and `--enable-prefix-caching`.
+
+`--enforce-eager` is a special case: it is normally managed by Lemonade (discrete-HBM GPUs such as MI300X default to CUDA-graph capture, while every other GPU — shared-memory APUs and consumer discrete dGPUs alike — defaults to eager), but you **may** pass `--enforce-eager` in `vllm_args` as a managed *intent* to force eager mode on a discrete-HBM GPU — either when bringing up a newly-added / not-yet-fully-supported model, or when an existing model's CUDA-graph capture misbehaves. Lemonade detects it and re-emits it exactly once (it is not passed through as a raw duplicate flag).
+
+## Speculative decoding (MTP)
+
+Some FP8 Qwen3.6 recipes enable **Multi-Token Prediction (MTP)** speculative decoding through a structured `speculative_config` object in [`vllm_model_config.json`](https://github.com/lemonade-sdk/lemonade/blob/main/src/cpp/resources/vllm_model_config.json) (`{"method": "mtp", "num_speculative_tokens": 1}`). It is configured as an object rather than a `vllm_args` string because the space-delimited `vllm_args` tokenizer would corrupt inline JSON; Lemonade serializes it to a single `--speculative-config` argument.
+
+**Validation scope.** MTP was verified on gfx942 / MI300X (`vllm0.19.1-rocm7.13.0`): vLLM detects the model's MTP head, and the dense `Qwen3.6-27B-FP8` recipe reached ~80% draft-token acceptance. The `Qwen3.6-35B-A3B-FP8` MoE recipes were throughput-benched on the same GPU with the MTP head active. The recipes are **not** arch-restricted, so an RDNA host with enough VRAM can load them against the default RDNA pin (`vllm0.20.1-rocm7.12.0`); that pin is newer than the gfx942 line and exposes the same method, but MTP on RDNA has not been independently serve-validated.
 
 ## Tuning
 

--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -182,7 +182,7 @@
    Yes! Lemonade supports multiple execution modes:
 
    - **AMD Ryzen 7000/8000/200 series**: GPU acceleration via llama.cpp + Vulkan backend
-   - **AMD Ryzen AI MAX+ (Strix Halo) on Linux**: in addition to the above, the experimental `vllm:rocm` backend is supported on gfx1151 (see [vLLM configuration](configuration/vllm.md))
+   - **AMD Ryzen AI MAX+ (Strix Halo) on Linux**: in addition to the above, the experimental `vllm:rocm` backend is supported on gfx1151; AMD Instinct MI300X (gfx942, CDNA3) support is **staged — manually validated, not auto-installable yet** — pending the official per-architecture release asset (see [vLLM configuration](configuration/vllm.md))
    - **Systems with Radeon GPUs**: Yes
    - **Any x86 CPU**: Yes
    - **Intel/NVIDIA systems**: CPU inference, with GPU support via the llama.cpp + Vulkan backend

--- a/src/cpp/include/lemon/backends/vllm/vllm.h
+++ b/src/cpp/include/lemon/backends/vllm/vllm.h
@@ -25,6 +25,8 @@ inline const BackendDescriptor descriptor = {
          "Custom arguments to pass to vllm-server", "vLLM Options"},
     },
     /*support*/ {
+        // gfx942 omitted until its vLLM/ROCm asset ships in lemonade-sdk/vllm-rocm;
+        // everything else is wired, so re-add it here once that lands.
         {"rocm", {"linux"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx110X", "gfx120X"}}}, "Strix Halo iGPU (gfx1151)"},
     },
     /*default_labels*/  {},

--- a/src/cpp/include/lemon/backends/vllm/vllm_arg_resolver.h
+++ b/src/cpp/include/lemon/backends/vllm/vllm_arg_resolver.h
@@ -13,14 +13,35 @@ struct VLLMArgResolution {
     // True when the user/family already supplied --dtype, so backend code
     // should not force its own (e.g. the AWQ float16 default).
     bool has_dtype_arg = false;
+    // True when the user asked for eager. The resolver has already removed the flag from
+    // `args` — load() re-emits it from the launch policy.
+    bool has_enforce_eager = false;
     bool has_quantization_arg = false;
     std::string quantization_arg;
+    // Structured rather than a passthrough flag: the `vllm_args` tokenizer strips quotes
+    // and would corrupt inline JSON. The backend re-serializes it.
+    std::string speculative_config;
 };
 
 VLLMArgResolution resolve_vllm_args(const std::string& model_name,
                                     const std::string& checkpoint,
                                     const nlohmann::json& config,
                                     const std::string& user_vllm_args);
+
+// Discrete-HBM datacenter GPUs (AMD Instinct, gfx9xx) get vLLM's native memory budgeting
+// and graph capture; APUs and consumer GPUs keep the conservative launch defaults. This
+// predicate is the seam a future memory planner replaces.
+bool is_discrete_hbm_arch(const std::string& arch);
+
+struct DeviceClassLaunchPolicy {
+    bool enforce_eager;     // push --enforce-eager (disables CUDA-graph capture)
+    bool force_awq_kernel;  // force the 'awq' kernel (+ float16) for AWQ models
+    bool cap_kv_cache;      // push the fixed --kv-cache-memory-bytes cap
+};
+
+DeviceClassLaunchPolicy device_class_launch_policy(const std::string& arch,
+                                                   bool has_memory_budget_arg,
+                                                   bool has_enforce_eager = false);
 
 } // namespace backends
 } // namespace lemon

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -108,11 +108,21 @@ public:
     static std::string get_rocm_arch();
     static std::string get_cuda_arch();
 
+    // Picks the ROCm compute target from an "amd_gpu" device array: a discrete GPU wins
+    // over an integrated one on a hybrid host (e.g. Strix Halo APU + MI300X dGPU).
+    static std::string select_rocm_arch(const json& amd_gpu_devices);
+
     // Collapse a concrete ROCm ISA (e.g. gfx1201) to the family target name the
     // GitHub release repos publish their assets under (e.g. gfx120X), per the
     // rocm_asset_families map in backend_versions.json. ISAs absent from the map
     // (and values already in family form) are returned unchanged.
     static std::string rocm_asset_family(const std::string& arch);
+
+    // AMD ships CDNA-dcgpu (gfx942) vLLM wheels on a different cadence than RDNA, so no
+    // single tag covers both; returns vllm.rocm_arch_overrides[family], or empty for the
+    // default pin. Beware: vLLM release tags use the raw ISA (gfx942), unlike
+    // therock.url_mapping, which maps it to gfx94X-dcgpu.
+    static std::string vllm_rocm_version_override(const std::string& asset_family);
 
     // When set non-empty on the calling thread, get_rocm_arch() returns this
     // value instead of probing hardware, so backend asset URLs can be resolved

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -90,7 +90,11 @@
     "metal": "b17"
   },
   "vllm": {
-    "rocm": "vllm0.20.1-rocm7.12.0"
+    "comment": "'rocm' is the default (RDNA) pin. 'rocm_arch_overrides' pins per detected asset family (rocm_asset_family output) where AMD's vLLM/ROCm wheel cadence diverges: CDNA-dcgpu (gfx942) shares no release tag with the RDNA line, so it pins its own version. Review each override at release time - feature/fix parity across arch lines lags until bumped.",
+    "rocm": "vllm0.20.1-rocm7.12.0",
+    "rocm_arch_overrides": {
+      "gfx942": "vllm0.19.1-rocm7.13.0"
+    }
   },
   "rocm_asset_families": {
     "comment": "Maps a concrete ROCm ISA (as detected on the device) to the family target name the GitHub release repos publish assets under. ISAs not listed here (e.g. gfx908, gfx90a, which ship as individual assets) are used verbatim. Add a new GPU's ISA here when its release asset is published under a family name.",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1746,6 +1746,30 @@
         ],
         "size": 55.59
     },
+    "Qwen3.6-27B-FP8-vLLM-lowconc": {
+        "checkpoint": "Qwen/Qwen3.6-27B-FP8",
+        "recipe": "vllm",
+        "suggested": false,
+        "labels": [
+            "reasoning",
+            "tool-calling",
+            "vision",
+            "mtp"
+        ],
+        "size": 27.8
+    },
+    "Qwen3.6-27B-FP8-vLLM-highconc": {
+        "checkpoint": "Qwen/Qwen3.6-27B-FP8",
+        "recipe": "vllm",
+        "suggested": false,
+        "labels": [
+            "reasoning",
+            "tool-calling",
+            "vision",
+            "mtp"
+        ],
+        "size": 27.8
+    },
     "Qwen3.6-35B-A3B-FP16-vLLM": {
         "checkpoint": "Qwen/Qwen3.6-35B-A3B",
         "recipe": "vllm",
@@ -1756,6 +1780,30 @@
             "vision"
         ],
         "size": 71.93
+    },
+    "Qwen3.6-35B-A3B-FP8-vLLM-lowconc": {
+        "checkpoint": "Qwen/Qwen3.6-35B-A3B-FP8",
+        "recipe": "vllm",
+        "suggested": false,
+        "labels": [
+            "reasoning",
+            "tool-calling",
+            "vision",
+            "mtp"
+        ],
+        "size": 36.0
+    },
+    "Qwen3.6-35B-A3B-FP8-vLLM-highconc": {
+        "checkpoint": "Qwen/Qwen3.6-35B-A3B-FP8",
+        "recipe": "vllm",
+        "suggested": false,
+        "labels": [
+            "reasoning",
+            "tool-calling",
+            "vision",
+            "mtp"
+        ],
+        "size": 36.0
     },
     "GLM-4.7-Flash-FP16-vLLM": {
         "checkpoint": "zai-org/GLM-4.7-Flash",

--- a/src/cpp/resources/vllm_model_config.json
+++ b/src/cpp/resources/vllm_model_config.json
@@ -35,8 +35,28 @@
     "Qwen3.6-27B-FP16-vLLM": {
       "family": "qwen3."
     },
+    "Qwen3.6-27B-FP8-vLLM-lowconc": {
+      "family": "qwen3.",
+      "args": "--max-num-seqs 8",
+      "speculative_config": { "method": "mtp", "num_speculative_tokens": 1 }
+    },
+    "Qwen3.6-27B-FP8-vLLM-highconc": {
+      "family": "qwen3.",
+      "args": "--max-num-seqs 256",
+      "speculative_config": { "method": "mtp", "num_speculative_tokens": 1 }
+    },
     "Qwen3.6-35B-A3B-FP16-vLLM": {
       "family": "qwen3."
+    },
+    "Qwen3.6-35B-A3B-FP8-vLLM-lowconc": {
+      "family": "qwen3.",
+      "args": "--max-num-seqs 8",
+      "speculative_config": { "method": "mtp", "num_speculative_tokens": 1 }
+    },
+    "Qwen3.6-35B-A3B-FP8-vLLM-highconc": {
+      "family": "qwen3.",
+      "args": "--max-num-seqs 256",
+      "speculative_config": { "method": "mtp", "num_speculative_tokens": 1 }
     },
     "GLM-4.7-Flash-FP16-vLLM": {
       "family": "glm4.7"

--- a/src/cpp/server/backends/vllm/vllm_arg_resolver.cpp
+++ b/src/cpp/server/backends/vllm/vllm_arg_resolver.cpp
@@ -20,9 +20,10 @@ struct ParsedArg {
 constexpr const char* MEMORY_BUDGET_CONFLICT_KEY = "memory_budget";
 
 const std::set<std::string>& protected_flags() {
+    // --enforce-eager is deliberately absent: it must reach the resolver, which manages
+    // it (see resolve_vllm_args), rather than being rejected here as a process-shape flag.
     static const std::set<std::string> flags = {
         "--enable-prefix-caching",
-        "--enforce-eager",
         "--host",
         "--max-model-len",
         "--model",
@@ -238,6 +239,11 @@ bool has_dtype_arg(const std::vector<ParsedArg>& args) {
                        [](const ParsedArg& arg) { return arg.flag == "--dtype"; });
 }
 
+bool has_enforce_eager_arg(const std::vector<ParsedArg>& args) {
+    return std::any_of(args.begin(), args.end(),
+                       [](const ParsedArg& arg) { return arg.flag == "--enforce-eager"; });
+}
+
 const ParsedArg* find_arg(const std::vector<ParsedArg>& args, const std::string& flag) {
     auto it = std::find_if(args.begin(), args.end(),
                            [&](const ParsedArg& arg) { return arg.flag == flag; });
@@ -288,17 +294,65 @@ VLLMArgResolution resolve_vllm_args(const std::string& model_name,
 
     merge_layer(resolved, parse_args(user_vllm_args, "vllm_args"));
 
+    // Managed, not passthrough: load() re-emits --enforce-eager from the device-class
+    // launch policy, so detect it here and strip it to avoid a duplicate on the vLLM
+    // command line. Detection lets an explicit request override the graph default.
+    const bool has_enforce_eager = has_enforce_eager_arg(resolved);
+    resolved.erase(std::remove_if(resolved.begin(), resolved.end(),
+                                  [](const ParsedArg& arg) {
+                                      return arg.flag == "--enforce-eager";
+                                  }),
+                   resolved.end());
+
     const ParsedArg* quantization_arg = find_arg(resolved, "--quantization");
     std::string quantization_value = quantization_arg && !quantization_arg->values.empty()
         ? quantization_arg->values.front()
         : "";
 
+    // A structured JSON knob (e.g. MTP) that cannot ride the args string, so it is read
+    // as an object (family first, model wins) and re-serialized for the backend. A
+    // scalar/array is rejected loudly rather than dumped as something vLLM cannot parse.
+    std::string speculative_config;
+    auto take_speculative_config = [&speculative_config](const nlohmann::json* src,
+                                                         const char* scope) {
+        if (!src || !src->contains("speculative_config")) {
+            return;
+        }
+        const nlohmann::json& sc = (*src)["speculative_config"];
+        if (!sc.is_object()) {
+            throw std::runtime_error(std::string("speculative_config in the ") + scope +
+                                     " entry must be a JSON object, got " + sc.type_name());
+        }
+        speculative_config = sc.dump();
+    };
+    take_speculative_config(family, "family");
+    take_speculative_config(model_entry, "model");
+
     return {
         flatten_args(resolved),
         has_memory_budget_arg(resolved),
         has_dtype_arg(resolved),
+        has_enforce_eager,
         quantization_arg != nullptr,
-        quantization_value
+        quantization_value,
+        speculative_config
+    };
+}
+
+bool is_discrete_hbm_arch(const std::string& arch) {
+    // gfx9* covers every CDNA generation plus Vega20 — all HBM discrete parts, no RDNA
+    // (gfx10xx-gfx12xx). Vega20's inclusion is inert: the support gate rejects it first.
+    return arch.rfind("gfx9", 0) == 0;
+}
+
+DeviceClassLaunchPolicy device_class_launch_policy(const std::string& arch,
+                                                   bool has_memory_budget_arg,
+                                                   bool has_enforce_eager) {
+    const bool discrete_hbm = is_discrete_hbm_arch(arch);
+    return {
+        /*enforce_eager*/    !discrete_hbm || has_enforce_eager,
+        /*force_awq_kernel*/ !discrete_hbm,
+        /*cap_kv_cache*/     !discrete_hbm && !has_memory_budget_arg,
     };
 }
 

--- a/src/cpp/server/backends/vllm/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm/vllm_server.cpp
@@ -17,6 +17,7 @@
 #include <filesystem>
 #include <fstream>
 #include <random>
+#include <regex>
 #include <sstream>
 
 namespace fs = std::filesystem;
@@ -280,9 +281,32 @@ InstallParams VLLMServer::get_install_params(const std::string& backend, const s
             );
         }
 #ifdef __linux__
-        // One release per GPU target since 0.19.1: release tag is
-        // {version}-{target_arch}, e.g. vllm0.20.1-rocm7.12.0-gfx1151.
-        std::string release_tag = version + "-" + target_arch;
+        // The per-arch override replaces ONLY the builtin default base, so an explicit
+        // vllm.rocm_bin pin is not silently clobbered on an MI300X host.
+        std::string arch_override = SystemInfo::vllm_rocm_version_override(target_arch);
+        std::string default_pin = BackendUtils::get_backend_version("vllm", "rocm");
+        const bool on_builtin_default = version.empty() || version == default_pin;
+        const std::string& effective_version =
+            (!arch_override.empty() && on_builtin_default) ? arch_override : version;
+        // One release per GPU target since 0.19.1 (vllm0.20.1-rocm7.12.0-gfx1151): a bare
+        // base gets the detected suffix appended. An already-suffixed pin is rejected
+        // unless it matches, so a cross-arch pin cannot install against the wrong line.
+        static const std::regex arch_suffix_re("-(gfx[0-9a-fA-FxX]+)$");
+        std::smatch arch_suffix_match;
+        std::string release_tag;
+        if (std::regex_search(effective_version, arch_suffix_match, arch_suffix_re)) {
+            const std::string pinned_arch = arch_suffix_match[1].str();
+            if (pinned_arch != target_arch) {
+                throw std::runtime_error(
+                    "vLLM ROCm pin '" + effective_version + "' targets " + pinned_arch +
+                    " but this host is " + target_arch +
+                    "; pin a " + target_arch +
+                    " release (vllm.rocm_bin) or unset it to use the default.");
+            }
+            release_tag = effective_version;
+        } else {
+            release_tag = effective_version + "-" + target_arch;
+        }
         params.version_override = release_tag;
         params.filename = release_tag + "-x64.tar.gz";
 #else
@@ -348,7 +372,13 @@ void VLLMServer::load(const std::string& model_name,
     args.push_back("--served-model-name");
     args.push_back(model_name);
     // Keep eager execution for consumer GPU inference; leave dtype selection to vLLM.
-    args.push_back("--enforce-eager");
+    // Discrete-HBM parts skip it: eager costs decode throughput for no stability gain.
+    const DeviceClassLaunchPolicy launch_policy = device_class_launch_policy(
+        SystemInfo::get_rocm_arch(), resolved_vllm_args.has_memory_budget_arg,
+        resolved_vllm_args.has_enforce_eager);
+    if (launch_policy.enforce_eager) {
+        args.push_back("--enforce-eager");
+    }
     // Pass ctx_size through to vllm-server's --max-model-len. Trust the
     // user's value verbatim; the global default lives in defaults.json
     // (same as llamacpp). Larger values raise KV-cache memory and Triton
@@ -361,7 +391,7 @@ void VLLMServer::load(const std::string& model_name,
     // For AWQ specifically we force the 'awq' kernel because vLLM's default
     // awq_marlin is very slow on consumer GPUs (2 tok/s -> 12 tok/s).
     std::string quant_method = detect_quant_method(model_id);
-    if (quant_method == "awq") {
+    if (quant_method == "awq" && launch_policy.force_awq_kernel) {
         if (!resolved_vllm_args.has_quantization_arg) {
             LOG(DEBUG, "vLLM") << "Detected AWQ; forcing --quantization awq" << std::endl;
             args.push_back("--quantization");
@@ -391,9 +421,19 @@ void VLLMServer::load(const std::string& model_name,
 
     // Avoid vLLM's default gpu_memory_utilization=0.92 on shared-memory systems.
     // Keep this overridable through vllm_args for users that want another limit.
-    if (!resolved_vllm_args.has_memory_budget_arg) {
+    // Discrete-HBM GPUs get vLLM's native budgeting instead of a fixed cap.
+    if (launch_policy.cap_kv_cache) {
         args.push_back("--kv-cache-memory-bytes");
         args.push_back("4G");
+    }
+
+    // Emitted as its own argv element, never through vllm_args: that tokenizer strips quotes
+    // and would corrupt the JSON.
+    if (!resolved_vllm_args.speculative_config.empty()) {
+        LOG(DEBUG, "vLLM") << "Enabling speculative decoding: "
+                           << resolved_vllm_args.speculative_config << std::endl;
+        args.push_back("--speculative-config");
+        args.push_back(resolved_vllm_args.speculative_config);
     }
 
     if (!resolved_vllm_args.args.empty()) {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -794,7 +794,21 @@ static std::string get_expected_backend_version(const std::string& recipe, const
     if (!recipe_config.contains(resolved_backend) || !recipe_config[resolved_backend].is_string()) {
         return "";
     }
-    return recipe_config[resolved_backend].get<std::string>();
+    std::string base_version = recipe_config[resolved_backend].get<std::string>();
+
+    // The expected version must resolve the SAME per-arch override that install used,
+    // or these GPUs report update_required forever: versions_match tolerates the
+    // "-{family}" suffix but not a different base.
+    if (recipe == "vllm" && resolved_backend == "rocm") {
+        std::string asset_family = SystemInfo::rocm_asset_family(SystemInfo::get_rocm_arch());
+        if (!asset_family.empty()) {
+            std::string override_version = SystemInfo::vllm_rocm_version_override(asset_family);
+            if (!override_version.empty()) {
+                return override_version;
+            }
+        }
+    }
+    return base_version;
 }
 
 // ============================================================================
@@ -859,7 +873,8 @@ json SystemInfo::get_device_dict() {
         if (amd_igpu.available) {
             json gpu_json = {
                 {"name", amd_igpu.name},
-                {"available", amd_igpu.available}
+                {"available", amd_igpu.available},
+                {"integrated", true}
             };
             if (amd_igpu.vram_gb > 0) {
                 gpu_json["vram_gb"] = amd_igpu.vram_gb;
@@ -879,7 +894,8 @@ json SystemInfo::get_device_dict() {
             if (gpu.available) {
                 json gpu_json = {
                     {"name", gpu.name},
-                    {"available", gpu.available}
+                    {"available", gpu.available},
+                    {"integrated", false}
                 };
                 if (gpu.vram_gb > 0) {
                     gpu_json["vram_gb"] = gpu.vram_gb;
@@ -2096,9 +2112,59 @@ std::string SystemInfo::rocm_asset_family(const std::string& arch) {
     return arch;
 }
 
+std::string SystemInfo::vllm_rocm_version_override(const std::string& asset_family) {
+    static const json overrides = []() -> json {
+        try {
+            std::string config_path = utils::get_resource_path("resources/backend_versions.json");
+            std::ifstream file(config_path);
+            if (!file.is_open()) {
+                return json::object();
+            }
+            json vllm = json::parse(file).value("vllm", json::object());
+            return vllm.value("rocm_arch_overrides", json::object());
+        } catch (...) {
+            return json::object();
+        }
+    }();
+
+    if (auto it = overrides.find(asset_family); it != overrides.end() && it->is_string()) {
+        return it->get<std::string>();
+    }
+    return "";
+}
+
+std::string SystemInfo::select_rocm_arch(const json& amd_gpu_devices) {
+    if (!amd_gpu_devices.is_array()) {
+        return "";
+    }
+    // The device array is iGPU-first, so taking the first supported match would pick the
+    // APU on a hybrid host. Prefer a discrete GPU; fall back to integrated.
+    std::string integrated_fallback;
+    for (const auto& gpu : amd_gpu_devices) {
+        if (!gpu.value("available", false)) {
+            continue;
+        }
+        // The "family" field is identify_rocm_arch_from_name(name) captured at
+        // detection time; fall back to re-deriving from the name if it is absent.
+        std::string arch = gpu.value("family", "");
+        if (arch.empty()) {
+            arch = identify_rocm_arch_from_name(gpu.value("name", ""));
+        }
+        if (arch.empty()) {
+            continue;
+        }
+        if (gpu.value("integrated", false)) {
+            if (integrated_fallback.empty()) {
+                integrated_fallback = arch;
+            }
+            continue;
+        }
+        return arch;  // discrete GPU wins
+    }
+    return integrated_fallback;  // empty if no supported AMD GPU found
+}
+
 std::string SystemInfo::get_rocm_arch() {
-    // Returns the ROCm architecture for the best available AMD GPU on this system
-    // Checks iGPU first, then dGPUs. Returns empty string if no compatible GPU found.
     if (!g_rocm_arch_override.empty()) {
         return g_rocm_arch_override;
     }
@@ -2111,20 +2177,8 @@ std::string SystemInfo::get_rocm_arch() {
         }
 
         const auto& devices = system_info["devices"];
-
-        // Check AMD GPUs
-        if (devices.contains("amd_gpu") && devices["amd_gpu"].is_array()) {
-            for (const auto& gpu : devices["amd_gpu"]) {
-                if (gpu.value("available", false)) {
-                    std::string name = gpu.value("name", "");
-                    if (!name.empty()) {
-                        std::string arch = identify_rocm_arch_from_name(name);
-                        if (!arch.empty()) {
-                            return arch;
-                        }
-                    }
-                }
-            }
+        if (devices.contains("amd_gpu")) {
+            return select_rocm_arch(devices["amd_gpu"]);
         }
     } catch (...) {
         // Detection failed

--- a/test/cpp/test_vllm_cdna_gating.cpp
+++ b/test/cpp/test_vllm_cdna_gating.cpp
@@ -1,0 +1,229 @@
+#include <algorithm>
+#include <iostream>
+#include <regex>
+#include <stdexcept>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include "lemon/backends/vllm/vllm_arg_resolver.h"
+#include "lemon/system_info.h"
+
+using lemon::SystemInfo;
+using lemon::backends::device_class_launch_policy;
+using lemon::backends::is_discrete_hbm_arch;
+using lemon::backends::resolve_vllm_args;
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const std::string& label) {
+    if (condition) {
+        std::cout << "PASS: " << label << std::endl;
+    } else {
+        std::cout << "FAIL: " << label << std::endl;
+        ++failures;
+    }
+}
+
+}  // namespace
+
+int main() {
+    // gfx942 is not in the installable matrix until its asset ships, though everything
+    // below it is wired and tested.
+    expect(!SystemInfo::backend_supports_arch("vllm", "rocm", "gfx942"),
+           "vllm:rocm gfx942 is NOT advertised installable yet (asset pending; infra staged)");
+
+    expect(SystemInfo::backend_supports_arch("vllm", "rocm", "gfx1100"),
+           "vllm:rocm still supports gfx1100 via gfx110X wildcard");
+    expect(SystemInfo::backend_supports_arch("vllm", "rocm", "gfx1151"),
+           "vllm:rocm still supports gfx1151 (Strix Halo)");
+
+    expect(!SystemInfo::backend_supports_arch("vllm", "rocm", "gfx906"),
+           "vllm:rocm does not support gfx906 (not published)");
+    expect(!SystemInfo::backend_supports_arch("vllm", "rocm", "gfx1036"),
+           "vllm:rocm does not support gfx1036 (iGPU, not published)");
+
+    expect(is_discrete_hbm_arch("gfx942"), "gfx942 is discrete-HBM class");
+    expect(is_discrete_hbm_arch("gfx950"), "gfx950 is discrete-HBM class");
+    expect(is_discrete_hbm_arch("gfx90a"), "gfx90a is discrete-HBM class");
+    expect(!is_discrete_hbm_arch("gfx1151"), "gfx1151 (Strix Halo APU) is not discrete-HBM");
+    expect(!is_discrete_hbm_arch("gfx1100"), "gfx1100 (consumer dGPU) keeps conservative defaults");
+    expect(!is_discrete_hbm_arch("gfx1201"), "gfx1201 (RDNA4) keeps conservative defaults");
+    expect(!is_discrete_hbm_arch(""), "empty arch is not discrete-HBM");
+
+    expect(SystemInfo::rocm_asset_family("gfx942") == "gfx942",
+           "rocm_asset_family passes gfx942 through unchanged (release tag arch)");
+    expect(SystemInfo::rocm_asset_family("gfx1100") == "gfx110X",
+           "rocm_asset_family collapses gfx1100 to gfx110X");
+
+    // Per-arch version override: gfx942 (CDNA-dcgpu) pins a distinct vLLM/ROCm
+    // release line from the RDNA default, since no single tag carries both.
+    expect(SystemInfo::vllm_rocm_version_override("gfx942") == "vllm0.19.1-rocm7.13.0",
+           "vllm gfx942 overrides to its own dcgpu release line");
+    expect(SystemInfo::vllm_rocm_version_override("gfx110X").empty(),
+           "vllm RDNA families use the default pin (no override)");
+    expect(SystemInfo::vllm_rocm_version_override("gfx1151").empty(),
+           "vllm gfx1151 uses the default pin (no override)");
+
+    // The discrete-HBM vs conservative-default wiring that VLLMServer::load() applies.
+    auto apu = device_class_launch_policy("gfx1151", false);
+    expect(apu.enforce_eager && apu.cap_kv_cache && apu.force_awq_kernel,
+           "gfx1151 (Strix Halo APU) keeps conservative defaults: eager + kv-cap + awq-force");
+    auto cdna = device_class_launch_policy("gfx942", false);
+    expect(!cdna.enforce_eager && !cdna.cap_kv_cache && !cdna.force_awq_kernel,
+           "gfx942 (MI300X) gets vLLM-native budgeting: no eager, no kv-cap, no awq-force");
+    auto cdna_budget = device_class_launch_policy("gfx942", true);
+    expect(!cdna_budget.cap_kv_cache,
+           "explicit user memory budget suppresses the kv-cap on discrete-HBM");
+    auto rdna_dgpu = device_class_launch_policy("gfx1100", false);
+    expect(rdna_dgpu.enforce_eager && rdna_dgpu.cap_kv_cache && rdna_dgpu.force_awq_kernel,
+           "gfx1100 (consumer dGPU) keeps conservative defaults");
+
+    // An explicit --enforce-eager forces eager even on discrete-HBM, leaving the other
+    // discrete-HBM defaults intact.
+    auto cdna_eager = device_class_launch_policy("gfx942", false, /*has_enforce_eager=*/true);
+    expect(cdna_eager.enforce_eager,
+           "explicit --enforce-eager overrides the discrete-HBM graph default on gfx942");
+    expect(!cdna_eager.cap_kv_cache && !cdna_eager.force_awq_kernel,
+           "the eager escape hatch does not disturb the other gfx942 defaults");
+
+    // Reachability: the policy above only matters if --enforce-eager survives the
+    // resolver — not rejected as protected, reported as intent, stripped from passthrough.
+    {
+        auto eager = resolve_vllm_args("m", "some/checkpoint", nlohmann::json::object(), "--enforce-eager");
+        expect(eager.has_enforce_eager,
+               "resolve_vllm_args accepts --enforce-eager and records it as a managed intent");
+        bool leaked = std::find(eager.args.begin(), eager.args.end(), "--enforce-eager") != eager.args.end();
+        expect(!leaked,
+               "resolve_vllm_args strips --enforce-eager from passthrough args (no duplicate flag)");
+    }
+    {
+        auto plain = resolve_vllm_args("m", "some/checkpoint", nlohmann::json::object(), "");
+        expect(!plain.has_enforce_eager,
+               "resolve_vllm_args without --enforce-eager reports has_enforce_eager=false");
+    }
+
+    // speculative_config (e.g. MTP) is read as an object and serialized for the backend.
+    {
+        nlohmann::json cfg;
+        cfg["models"]["M"]["speculative_config"] = {{"method", "mtp"}, {"num_speculative_tokens", 1}};
+        auto res = resolve_vllm_args("M", "cp", cfg, "");
+        expect(!res.speculative_config.empty(),
+               "resolve_vllm_args surfaces model speculative_config");
+        expect(res.speculative_config.find("mtp") != std::string::npos &&
+               res.speculative_config.find("num_speculative_tokens") != std::string::npos,
+               "speculative_config serializes the MTP JSON for --speculative-config");
+        auto none = resolve_vllm_args("M", "cp", nlohmann::json::object(), "");
+        expect(none.speculative_config.empty(),
+               "speculative_config is empty when the model config does not set it");
+    }
+
+    // speculative_config resolves family-first then model (model wins).
+    {
+        nlohmann::json cfg;
+        cfg["families"]["fam"]["speculative_config"] = {{"method", "mtp"}, {"num_speculative_tokens", 2}};
+        cfg["models"]["FM"]["family"] = "fam";
+        auto fam = resolve_vllm_args("FM", "cp", cfg, "");
+        expect(fam.speculative_config.find("\"num_speculative_tokens\":2") != std::string::npos,
+               "family-level speculative_config is applied when the model sets none");
+        cfg["models"]["FM"]["speculative_config"] = {{"method", "mtp"}, {"num_speculative_tokens", 1}};
+        auto model_wins = resolve_vllm_args("FM", "cp", cfg, "");
+        expect(model_wins.speculative_config.find("\"num_speculative_tokens\":1") != std::string::npos,
+               "model-level speculative_config overrides the family-level one");
+    }
+
+    // speculative_config must be a JSON object — a scalar/array is a config mistake,
+    // rejected with a clear error rather than silently dumped (fl0rianr review).
+    {
+        nlohmann::json cfg;
+        cfg["models"]["M"]["speculative_config"] = "mtp";  // wrong: a string, not an object
+        bool threw = false;
+        try {
+            resolve_vllm_args("M", "cp", cfg, "");
+        } catch (const std::runtime_error&) {
+            threw = true;
+        }
+        expect(threw, "a non-object speculative_config is rejected with a clear error");
+    }
+
+    // Release tags: a bare base gains the -{arch} suffix, a matching pin is used verbatim,
+    // and a cross-arch pin is rejected rather than installed against the wrong line.
+    {
+        auto release_tag = [](const std::string& v, const std::string& arch) -> std::string {
+            static const std::regex re("-(gfx[0-9a-fA-FxX]+)$");
+            std::smatch match;
+            if (std::regex_search(v, match, re)) {
+                if (match[1].str() != arch) {
+                    throw std::runtime_error("vLLM ROCm pin '" + v + "' targets " +
+                                             match[1].str() + " but this host is " + arch);
+                }
+                return v;
+            }
+            return v + "-" + arch;
+        };
+        expect(release_tag("vllm0.19.1-rocm7.13.0", "gfx942") == "vllm0.19.1-rocm7.13.0-gfx942",
+               "a bare base version gets the -gfx942 target suffix");
+        expect(release_tag("vllm0.19.1-rocm7.13.0-gfx942", "gfx942") == "vllm0.19.1-rocm7.13.0-gfx942",
+               "a full -gfx942 pin matching the host is used verbatim (no ...-gfx942-gfx942 double suffix)");
+        bool cross_arch_rejected = false;
+        try {
+            release_tag("vllm0.20.1-rocm7.12.0-gfx110X", "gfx942");
+        } catch (const std::runtime_error&) {
+            cross_arch_rejected = true;
+        }
+        expect(cross_arch_rejected,
+               "a cross-arch pin (gfx110X on a gfx942 host) is REJECTED, not installed against the wrong arch");
+    }
+
+    // The device list is iGPU-first, so a hybrid host (gfx1151 APU + gfx942 dGPU) must
+    // still resolve gfx942.
+    {
+        nlohmann::json hybrid = nlohmann::json::array();
+        hybrid.push_back({{"name", "AMD Radeon 8060S"}, {"family", "gfx1151"}, {"integrated", true}, {"available", true}});
+        hybrid.push_back({{"name", "AMD Instinct MI300X"}, {"family", "gfx942"}, {"integrated", false}, {"available", true}});
+        expect(SystemInfo::select_rocm_arch(hybrid) == "gfx942",
+               "hybrid iGPU(gfx1151)+dGPU(gfx942): the discrete MI300X wins over the iGPU");
+
+        nlohmann::json igpu_only = nlohmann::json::array();
+        igpu_only.push_back({{"name", "AMD Radeon 8060S"}, {"family", "gfx1151"}, {"integrated", true}, {"available", true}});
+        expect(SystemInfo::select_rocm_arch(igpu_only) == "gfx1151",
+               "iGPU-only (Strix Halo) still resolves its integrated arch");
+
+        nlohmann::json dgpu_only = nlohmann::json::array();
+        dgpu_only.push_back({{"name", "AMD Instinct MI300X"}, {"family", "gfx942"}, {"integrated", false}, {"available", true}});
+        expect(SystemInfo::select_rocm_arch(dgpu_only) == "gfx942",
+               "dGPU-only resolves the discrete arch");
+
+        nlohmann::json unavailable_dgpu = nlohmann::json::array();
+        unavailable_dgpu.push_back({{"name", "AMD Radeon 8060S"}, {"family", "gfx1151"}, {"integrated", true}, {"available", true}});
+        unavailable_dgpu.push_back({{"name", "AMD Instinct MI300X"}, {"family", "gfx942"}, {"integrated", false}, {"available", false}});
+        expect(SystemInfo::select_rocm_arch(unavailable_dgpu) == "gfx1151",
+               "an unavailable discrete GPU falls back to the available iGPU");
+    }
+
+    // Status must resolve the SAME per-arch override install writes, or gfx942 reads
+    // update_required forever (the RDNA pin cannot prefix-match the dcgpu base).
+    {
+        std::string family = SystemInfo::rocm_asset_family("gfx942");
+        std::string override_base = SystemInfo::vllm_rocm_version_override(family);
+        std::string installed = override_base + "-" + family;  // what get_install_params writes
+        auto prefix_match = [](const std::string& inst, const std::string& exp) {
+            return inst == exp || (exp.size() < inst.size() &&
+                                   inst.compare(0, exp.size() + 1, exp + "-") == 0);
+        };
+        expect(!override_base.empty(), "gfx942 pins a per-arch expected override line for status");
+        expect(prefix_match(installed, override_base),
+               "gfx942 install tag matches its per-arch expected version (fix: status resolves the override)");
+        expect(!prefix_match(installed, "vllm0.20.1-rocm7.12.0"),
+               "gfx942 install tag does NOT match the default RDNA base (why per-arch status resolution is required)");
+    }
+
+    if (failures != 0) {
+        std::cout << failures << " assertion(s) failed" << std::endl;
+        return 1;
+    }
+    std::cout << "All vllm CDNA gating assertions passed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Extends the experimental vLLM ROCm backend from RDNA to AMD Instinct CDNA (gfx942 / MI300X). gfx942 is **staged out of the installable matrix** until an official `vllm0.19.1-rocm7.13.0-gfx942` asset ships in `lemonade-sdk/vllm-rocm` (lemonade-sdk/vllm-rocm#25) — everything else lands now, so enabling it is a one-line flip once the asset exists.

**What changed**
- gfx942 added to the vllm descriptor's ROCm support row (currently gated out; see above).
- Per-arch release pinning: `vllm.rocm_arch_overrides` in `backend_versions.json`, resolved via the shared `rocm_asset_family()` — gfx942 rides its own vLLM/ROCm line (RDNA can't share the tag); RDNA falls through to the default pin, unchanged.
- Device-class launch defaults: discrete-HBM (Instinct) gets vLLM-native budgeting + CUDA-graph capture; APUs/consumer dGPUs keep the conservative defaults. `--enforce-eager` stays a user-overridable escape hatch.
- FP8 + MTP recipes for Qwen3.6-27B and 35B-A3B.

**Validation** — MI300X (gfx942; Hot Aisle VM, Ubuntu 24.04, kernel 6.8, ROCm 7.13 bundled): served vLLM end-to-end (Qwen2.5-0.5B 306–511 tok/s warm; FP8/MTP recipes 45–126 tok/s single-stream, MTP ~80% draft acceptance). RDNA fall-through validated on RX 7900 XT (gfx1100). `test_vllm_cdna_gating` covers gating, per-arch override, and fall-through. **Not tested:** Windows, other CDNA (gfx90a/gfx908), and the official gfx942 asset — which doesn't exist yet (the resolver is validated to construct the exact tag/URL against a community build).

The device-class launch predicate is an MVP that could fold into a #2235-style memory planner later — happy to reshape or hand the branch over; discussion in #2546.
