### PR TITLE
fix: strip mtp label for GLM-4 architecture to prevent MTP crash (#2451)

### DIFF
--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -765,6 +765,20 @@ public:
         // reclassify the model away from its endpoint type.
         if (info.type == ModelType::LLM) {
             apply_gguf_capability_labels(info.labels, info.gguf.caps);
+            // GLM-4 MoE models crash with MTP speculative decoding because the
+            // GGUF conversion doesn't include multimodal metadata the graph
+            // builder expects when constructing the draft context. Strip the
+            // mtp label so these models run without speculative decoding until
+            // upstream llama.cpp fixes the GLM-4 MoE draft context construction.
+            // See: https://github.com/lemonade-sdk/lemonade/issues/2451
+            std::string arch_lower = info.gguf.architecture;
+            std::transform(arch_lower.begin(), arch_lower.end(), arch_lower.begin(), ::tolower);
+            if (arch_lower.find("glm4") == 0) {
+                auto it = std::remove(info.labels.begin(), info.labels.end(), "mtp");
+                if (it != info.labels.end()) {
+                    info.labels.erase(it, info.labels.end());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Problem
GLM-4 MoE models (e.g., GLM-4.5-Air-UD-Q4K-XL-GGUF) embed MTP layers (`nextn_predict_layers > 0`) in the GGUF, which causes lemonade to enable speculative decoding (`--spec-type draft-mtp`). When llama.cpp's GLM-4 MoE graph builder constructs the MTP draft context, it asserts:

```
glm4-moe.cpp:149: This GGUF does not support multimodal. Please reconvert it.
```

This crashes llama-server on the first prompt, rendering the model unusable.

## Fix
After `apply_gguf_capability_labels()` runs, check if the GGUF architecture starts with "glm4" (case-insensitive). If so, strip the `mtp` label so the model runs without speculative decoding. The model loads and runs correctly — just without the MTP performance optimization.

## Testing
- GLM-4.5-Air-UD-Q4K-XL-GGUF should now load and respond to prompts without crashing
- Non-GLM-4 MTP models (e.g., Qwen3.6 MTP) should still get speculative decoding

Fixes #2451