### PR TITLE
log: reduce verbosity of model already loaded and websocket connection logs

### DIFF
--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -439,7 +439,7 @@ void Router::load_model(const std::string& model_name,
                 evict_server(existing);
                 // Fall through to create and load with new options
             } else {
-                LOG(INFO, "Router") << "Model already loaded, updating access time and pinned status" << std::endl;
+                LOG(DEBUG, "Router") << "Model already loaded, updating access time and pinned status" << std::endl;
                 existing->set_pinned(final_pinned);
                 existing->update_access_time();
                 is_loading_ = false;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1783,7 +1783,7 @@ nlohmann::json Server::create_model_error(const std::string& requested_model, co
 void Server::auto_load_model_if_needed(const std::string& requested_model) {
     // Check if this specific model is already loaded (multi-model aware)
     if (router_->is_model_loaded(requested_model)) {
-        LOG(INFO, "Server") << "Model already loaded: " << requested_model << std::endl;
+        LOG(DEBUG, "Server") << "Model already loaded: " << requested_model << std::endl;
         return;
     }
 
@@ -1836,7 +1836,7 @@ void Server::ensure_collection_loaded(const ModelInfo& info) {
             continue;
         }
         if (router_->is_model_loaded(component)) {
-            LOG(INFO, "Server") << "Component already loaded: " << component << std::endl;
+            LOG(DEBUG, "Server") << "Component already loaded: " << component << std::endl;
             continue;
         }
         auto comp_info = model_manager_->get_model_info(component);

--- a/src/cpp/server/websocket_server.cpp
+++ b/src/cpp/server/websocket_server.cpp
@@ -146,7 +146,7 @@ int WebSocketServer::ws_callback(struct lws* wsi,
                 LOG(DEBUG, "WebSocket") << "Transient connection closed before handshake (id: "
                                        << pss->connection_id << ")" << std::endl;
             } else {
-                LOG(INFO, "WebSocket") << "New connection from: " << ip
+                LOG(DEBUG, "WebSocket") << "New connection from: " << ip
                                        << " (id: " << pss->connection_id << ")" << std::endl;
             }
 


### PR DESCRIPTION
This pull request makes minor changes to logging levels throughout the server codebase. Specifically, several log statements that previously used the `INFO` level have been changed to use the more verbose `DEBUG` level, which helps reduce noise in production logs and makes these messages available primarily during debugging sessions.

Logging level adjustments:

* Changed log level from `INFO` to `DEBUG` for model loading status messages in `Router::load_model` in `router.cpp`
* Changed log level from `INFO` to `DEBUG` for model already loaded messages in `Server::auto_load_model_if_needed` in `server.cpp`
* Changed log level from `INFO` to `DEBUG` for component already loaded messages in `Server::ensure_collection_loaded` in `server.cpp`
* Changed log level from `INFO` to `DEBUG` for new WebSocket connection messages in `WebSocketServer::ws_callback` in `websocket_server.cpp`