### PR TITLE
Fix: GUI3, model, backend, and chat panel usability issues

### DIFF
--- a/prototype/ui-redesign/src/components/BackendManager.tsx
+++ b/prototype/ui-redesign/src/components/BackendManager.tsx
@@ -341,17 +341,10 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     window.setTimeout(() => setToastMsg(null), 3500);
   }, []);
 
-  const handleInstall = useCallback(async (recipe: string, backend: string, isUpdate = false, skipConfirm = false) => {
+  const handleInstall = useCallback(async (recipe: string, backend: string, isUpdate = false) => {
     const key = backendKey(recipe, backend);
     const actionLabel = isUpdate ? 'Updating' : 'Installing';
     const doneLabel = isUpdate ? 'updated' : 'installed';
-    // GUI2-style behavior for backend updates: the Update click itself is consent.
-    // Keep the install confirmation because that can add a new runtime, but do not
-    // show the alarming local-files confirmation for ordinary updates (#2569).
-    if (!skipConfirm && !isUpdate) {
-      const ok = window.confirm(`Install ${RECIPE_LABELS[recipe] || recipe} · ${backend}? This adds local Lemonade runtime files.`);
-      if (!ok) return;
-    }
     setInstalling(key);
     toast(`${actionLabel} ${RECIPE_LABELS[recipe] || recipe} · ${backend}…`);
     const downloadName = backendDownloadName(recipe, backend);
@@ -425,8 +418,6 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
   }, [fetchInfo, toast]);
 
   const handleUninstall = useCallback(async (recipe: string, backend: string) => {
-    const ok = window.confirm(`Uninstall ${RECIPE_LABELS[recipe] || recipe} · ${backend}? This removes local backend runtime files.`);
-    if (!ok) return;
     try {
       setInstalling(backendKey(recipe, backend));
       await api.uninstallBackend(recipe, backend);
@@ -449,7 +440,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     }
     if (updates.length === 0) return;
     for (const { recipe, backend } of updates) {
-      await handleInstall(recipe, backend, true, true);
+      await handleInstall(recipe, backend, true);
     }
   }, [sysInfo, handleInstall]);
 

--- a/prototype/ui-redesign/src/components/BackendManager.tsx
+++ b/prototype/ui-redesign/src/components/BackendManager.tsx
@@ -274,6 +274,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showTech, setShowTech] = useState(false);
+  const [showUnsupported, setShowUnsupported] = useState(false);
   const [installing, setInstalling] = useState<string | null>(null); // "recipe:backend"
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const [userPresets, setUserPresets] = useState<Preset[]>(loadUserPresets);
@@ -344,9 +345,11 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     const key = backendKey(recipe, backend);
     const actionLabel = isUpdate ? 'Updating' : 'Installing';
     const doneLabel = isUpdate ? 'updated' : 'installed';
-    if (!skipConfirm) {
-      const verb = isUpdate ? 'update' : 'install';
-      const ok = window.confirm(`${actionLabel} ${RECIPE_LABELS[recipe] || recipe} · ${backend} can change local Lemonade runtime files. Continue with this ${verb}?`);
+    // GUI2-style behavior for backend updates: the Update click itself is consent.
+    // Keep the install confirmation because that can add a new runtime, but do not
+    // show the alarming local-files confirmation for ordinary updates (#2569).
+    if (!skipConfirm && !isUpdate) {
+      const ok = window.confirm(`Install ${RECIPE_LABELS[recipe] || recipe} · ${backend}? This adds local Lemonade runtime files.`);
       if (!ok) return;
     }
     setInstalling(key);
@@ -445,8 +448,6 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
       }
     }
     if (updates.length === 0) return;
-    const ok = window.confirm(`Update ${updates.length} backend${updates.length > 1 ? 's' : ''}? This can change local Lemonade runtime files.`);
-    if (!ok) return;
     for (const { recipe, backend } of updates) {
       await handleInstall(recipe, backend, true, true);
     }
@@ -476,6 +477,29 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     for (const [recipe, recipeInfo] of Object.entries(sysInfo.recipes)) {
       const cap = (RECIPE_CAPABILITY[recipe] || 'LLM') as CapabilityCol;
       for (const [backend, backendInfo] of Object.entries(recipeInfo.backends)) {
+        // Match GUI2: unsupported backends are not useful actions/statuses for
+        // the current system and should not take matrix space (#2568).
+        if (backendInfo.state === 'unsupported') continue;
+        for (const device of devicesForBackend(recipe, backend, backendInfo)) {
+          const key = `${device}:${cap}`;
+          if (!cells.has(key)) cells.set(key, []);
+          cells.get(key)!.push({ recipe, backend, info: backendInfo });
+        }
+      }
+    }
+    return cells;
+  }, [sysInfo]);
+
+  const unsupportedMatrixCells = useMemo(() => {
+    if (!sysInfo?.recipes) return new Map<string, CellEntry[]>();
+    const cells = new Map<string, CellEntry[]>();
+
+    for (const [recipe, recipeInfo] of Object.entries(sysInfo.recipes)) {
+      const cap = (RECIPE_CAPABILITY[recipe] || 'LLM') as CapabilityCol;
+      for (const [backend, backendInfo] of Object.entries(recipeInfo.backends)) {
+        // Keep unsupported backends out of the primary matrix (#2568), but retain
+        // a collapsed same-shape matrix for debugging and technical-detail reasons.
+        if (backendInfo.state !== 'unsupported') continue;
         for (const device of devicesForBackend(recipe, backend, backendInfo)) {
           const key = `${device}:${cap}`;
           if (!cells.has(key)) cells.set(key, []);
@@ -494,6 +518,23 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     }
     return DEVICE_ORDER.filter(d => detectedDevices.includes(d) || referenced.has(d));
   }, [detectedDevices, matrixCells]);
+
+  const unsupportedMatrixRows = useMemo(() => {
+    const referenced = new Set<DeviceKey>();
+    for (const key of unsupportedMatrixCells.keys()) {
+      const device = key.split(':')[0] as DeviceKey;
+      if (DEVICE_ORDER.includes(device)) referenced.add(device);
+    }
+    return DEVICE_ORDER.filter(d => referenced.has(d));
+  }, [unsupportedMatrixCells]);
+
+  const unsupportedBackendCount = useMemo(() => {
+    const keys = new Set<string>();
+    for (const entries of unsupportedMatrixCells.values()) {
+      for (const { recipe, backend } of entries) keys.add(backendKey(recipe, backend));
+    }
+    return keys.size;
+  }, [unsupportedMatrixCells]);
 
   // Keep the matrix skeleton mounted even when /system-info is unavailable.
   // This preserves navigation/test affordances while the cells truthfully show
@@ -539,6 +580,85 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
       default: return '';
     }
   }, [sysInfo]);
+
+  const renderBackendCell = useCallback(({ recipe, backend, info }: CellEntry) => {
+    const badge = stateBadge(info.state);
+    const cellKey = backendKey(recipe, backend);
+    const isInstalling = installing === cellKey;
+    const backendDownload = downloadItems.find(download => backendDownloadMatches(download, recipe, backend));
+    const showBackendProgress = Boolean(backendDownload && (isDownloadActive(backendDownload) || backendDownload.status === 'paused'));
+    const assignedPreset = assignedPresetForBackendKey(cellKey);
+
+    return (
+      <div className="cell" key={`${recipe}-${backend}`} data-cell={cellKey}>
+        <span className="cell__name">
+          {RECIPE_LABELS[recipe] || recipe}
+          {backend !== 'cpu' && backend !== 'npu' && ` · ${backend}`}
+        </span>
+        <span className={`cell__badge ${badge.cls}`}>{badge.label}</span>
+        {showTech && info.version && <span className="cell__sha">{info.version}</span>}
+        {/* #2432: read-only display of an assigned backend preset. Assignment
+            happens in the global Presets view, not here. Absent when none. */}
+        {assignedPreset && (
+          <span className="cell__preset" data-cell-preset title="Backend preset assigned in the Presets view (applies globally)">
+            <PresetIcon preset={assignedPreset} /> {assignedPreset.name}
+          </span>
+        )}
+        {showTech && info.message && <span className="cell__message">{info.message}</span>}
+        <div className="cell__actions" onClick={e => e.stopPropagation()}>
+          {(info.state === 'installable') && (
+            <button
+              className="cell__swap"
+              disabled={isInstalling}
+              aria-label={`Install ${RECIPE_LABELS[recipe] || recipe} (${backend})`}
+              onClick={() => handleInstall(recipe, backend)}>
+              {isInstalling ? 'Installing…' : 'Install'}
+            </button>
+          )}
+          {(info.state === 'update_required' || info.state === 'update_available') && (
+            <button
+              className="cell__swap"
+              disabled={isInstalling}
+              aria-label={`Update ${RECIPE_LABELS[recipe] || recipe} (${backend})`}
+              onClick={() => handleInstall(recipe, backend, true)}>
+              {isInstalling ? 'Updating…' : 'Update'}
+            </button>
+          )}
+          {info.state === 'action_required' && info.action && (
+            <button
+              className="cell__swap"
+              aria-label={`Setup guide for ${RECIPE_LABELS[recipe] || recipe} (${backend})`}
+              onClick={() => handleAction(info.action)}>
+              Setup guide ▸
+            </button>
+          )}
+          {canShowUninstall(info) && (
+            <button
+              className="cell__swap cell__swap--danger"
+              disabled={isInstalling}
+              aria-label={`Uninstall ${RECIPE_LABELS[recipe] || recipe} (${backend})`}
+              onClick={() => handleUninstall(recipe, backend)}>
+              {isInstalling ? 'Working…' : 'Uninstall'}
+            </button>
+          )}
+        </div>
+        {showBackendProgress && backendDownload && (
+          <div className="cell__download-progress" aria-label={`${backendProgressPercent(backendDownload).toFixed(0)}%`}>
+            <div className="cell__download-progress-track">
+              <div
+                className="cell__download-progress-fill"
+                style={{ width: `${backendProgressPercent(backendDownload)}%` }}
+              />
+            </div>
+            <span className="cell__download-progress-text">{backendProgressPercent(backendDownload).toFixed(0)}%</span>
+          </div>
+        )}
+        {backendDownload?.status === 'error' && backendDownload.error && (
+          <span className="cell__download-error">{backendDownload.error}</span>
+        )}
+      </div>
+    );
+  }, [assignedPresetForBackendKey, downloadItems, handleAction, handleInstall, handleUninstall, installing, showTech]);
 
 
   /* ── Render ───────────────────────────────────────────── */
@@ -639,84 +759,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
                     }
                     return (
                       <td key={cap}>
-                        {entries.map(({ recipe, backend, info }) => {
-                          const badge = stateBadge(info.state);
-                          const cellKey = backendKey(recipe, backend);
-                          const isInstalling = installing === cellKey;
-                          const backendDownload = downloadItems.find(download => backendDownloadMatches(download, recipe, backend));
-                          const showBackendProgress = Boolean(backendDownload && (isDownloadActive(backendDownload) || backendDownload.status === 'paused'));
-                          const assignedPreset = assignedPresetForBackendKey(cellKey);
-                          return (
-                            <div className="cell" key={`${recipe}-${backend}`}
-                              data-cell={cellKey}>
-                              <span className="cell__name">
-                                {RECIPE_LABELS[recipe] || recipe}
-                                {backend !== 'cpu' && backend !== 'npu' && ` · ${backend}`}
-                              </span>
-                              <span className={`cell__badge ${badge.cls}`}>{badge.label}</span>
-                              {showTech && info.version && <span className="cell__sha">{info.version}</span>}
-                              {/* #2432: read-only display of an assigned backend preset. Assignment
-                                  happens in the global Presets view, not here. Absent when none. */}
-                              {assignedPreset && (
-                                <span className="cell__preset" data-cell-preset title="Backend preset assigned in the Presets view (applies globally)">
-                                  <PresetIcon preset={assignedPreset} /> {assignedPreset.name}
-                                </span>
-                              )}
-                              {showTech && info.message && <span className="cell__message">{info.message}</span>}
-                              <div className="cell__actions" onClick={e => e.stopPropagation()}>
-                                {(info.state === 'installable') && (
-                                  <button
-                                    className="cell__swap"
-                                    disabled={isInstalling}
-                                    aria-label={`Install ${RECIPE_LABELS[recipe] || recipe} (${backend})`}
-                                    onClick={() => handleInstall(recipe, backend)}>
-                                    {isInstalling ? 'Installing…' : 'Install'}
-                                  </button>
-                                )}
-                                {(info.state === 'update_required' || info.state === 'update_available') && (
-                                  <button
-                                    className="cell__swap"
-                                    disabled={isInstalling}
-                                    aria-label={`Update ${RECIPE_LABELS[recipe] || recipe} (${backend})`}
-                                    onClick={() => handleInstall(recipe, backend, true)}>
-                                    {isInstalling ? 'Updating…' : 'Update'}
-                                  </button>
-                                )}
-                                {info.state === 'action_required' && info.action && (
-                                  <button
-                                    className="cell__swap"
-                                    aria-label={`Setup guide for ${RECIPE_LABELS[recipe] || recipe} (${backend})`}
-                                    onClick={() => handleAction(info.action)}>
-                                    Setup guide ▸
-                                  </button>
-                                )}
-                                {canShowUninstall(info) && (
-                                  <button
-                                    className="cell__swap cell__swap--danger"
-                                    disabled={isInstalling}
-                                    aria-label={`Uninstall ${RECIPE_LABELS[recipe] || recipe} (${backend})`}
-                                    onClick={() => handleUninstall(recipe, backend)}>
-                                    {isInstalling ? 'Working…' : 'Uninstall'}
-                                  </button>
-                                )}
-                              </div>
-                              {showBackendProgress && backendDownload && (
-                                <div className="cell__download-progress" aria-label={`${backendProgressPercent(backendDownload).toFixed(0)}%`}>
-                                  <div className="cell__download-progress-track">
-                                    <div
-                                      className="cell__download-progress-fill"
-                                      style={{ width: `${backendProgressPercent(backendDownload)}%` }}
-                                    />
-                                  </div>
-                                  <span className="cell__download-progress-text">{backendProgressPercent(backendDownload).toFixed(0)}%</span>
-                                </div>
-                              )}
-                              {backendDownload?.status === 'error' && backendDownload.error && (
-                                <span className="cell__download-error">{backendDownload.error}</span>
-                              )}
-                            </div>
-                          );
-                        })}
+                        {entries.map(renderBackendCell)}
                       </td>
                     );
                   })}
@@ -725,6 +768,68 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
             </tbody>
           </table>
         </div>
+
+        {unsupportedBackendCount > 0 && (
+          <section className="backends__unsupported" data-backends-unsupported>
+            <button
+              type="button"
+              className="backends__unsupported-toggle"
+              aria-expanded={showUnsupported}
+              aria-controls="backends-unsupported-matrix"
+              onClick={() => setShowUnsupported(open => !open)}>
+              <span className="backends__unsupported-title">
+                <Icon name={showUnsupported ? 'chevron-down' : 'chevron-right'} size={14} aria-hidden="true" />
+                Unsupported backends
+              </span>
+              <span className="backends__unsupported-meta">
+                {unsupportedBackendCount} hidden from the main table
+              </span>
+            </button>
+
+            {showUnsupported && (
+              <div className="matrix matrix--unsupported" id="backends-unsupported-matrix" data-backends-unsupported-matrix>
+                <table>
+                  <thead>
+                    <tr>
+                      <th scope="col">Device</th>
+                      {CAPABILITY_COLS.map(c => (
+                        <th scope="col" key={c}>{c}</th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {unsupportedMatrixRows.map(deviceKey => (
+                      <tr key={deviceKey}>
+                        <th scope="row">
+                          {DEVICE_LABELS[deviceKey]}
+                          {showTech && (
+                            <div className="cell__device-detail">{deviceDetail(deviceKey) || 'reported by backend metadata'}</div>
+                          )}
+                        </th>
+                        {CAPABILITY_COLS.map(cap => {
+                          const key = `${deviceKey}:${cap}`;
+                          const entries = unsupportedMatrixCells.get(key);
+                          if (!entries || entries.length === 0) {
+                            return (
+                              <td className="matrix__empty" key={cap}>
+                                <span aria-hidden="true">—</span>
+                              </td>
+                            );
+                          }
+                          return (
+                            <td key={cap}>
+                              {entries.map(renderBackendCell)}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        )}
 
       {/* #2351: always-present polite live region so NVDA announces toast messages */}
       <div role="status" aria-live="polite" aria-atomic="true" className="sr-only" data-backends-toast-live>

--- a/prototype/ui-redesign/src/components/ChatView.tsx
+++ b/prototype/ui-redesign/src/components/ChatView.tsx
@@ -59,6 +59,33 @@ const ACTIVE_KEY = 'active_conversation';
 const PERSIST_KEY = 'persist_conversations';
 const STORAGE_VERSION = 3;
 
+const CHAT_LOGS_WIDTH_KEY = 'chat_logs_panel_width';
+const CHAT_LOGS_DEFAULT_WIDTH = 520;
+const CHAT_LOGS_MIN_WIDTH = 340;
+const CHAT_LOGS_MAX_WIDTH = 920;
+
+function maxChatLogsWidthForViewport(railExpanded = true): number {
+  if (typeof window === 'undefined') return CHAT_LOGS_MAX_WIDTH;
+  const railWidth = railExpanded ? 280 : 56;
+  const viewportMax = window.innerWidth - railWidth - 380;
+  return Math.max(CHAT_LOGS_MIN_WIDTH, Math.min(CHAT_LOGS_MAX_WIDTH, viewportMax));
+}
+
+function clampChatLogsWidth(width: number, railExpanded = true): number {
+  return Math.max(CHAT_LOGS_MIN_WIDTH, Math.min(maxChatLogsWidthForViewport(railExpanded), Math.round(width)));
+}
+
+function loadChatLogsWidth(scope: string): number {
+  if (typeof window === 'undefined') return CHAT_LOGS_DEFAULT_WIDTH;
+  try {
+    const stored = Number(window.localStorage.getItem(scopedKey(scope, CHAT_LOGS_WIDTH_KEY)));
+    const width = Number.isFinite(stored) ? stored : CHAT_LOGS_DEFAULT_WIDTH;
+    return clampChatLogsWidth(width, true);
+  } catch {
+    return clampChatLogsWidth(CHAT_LOGS_DEFAULT_WIDTH, true);
+  }
+}
+
 function generateId(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
 }
@@ -578,6 +605,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel, loadedModels, onModel
   });
   const presetToolsSeedRef = useRef('');
   const [showInlineLogs, setShowInlineLogs] = useState(false);
+  const [chatLogsWidth, setChatLogsWidth] = useState(() => loadChatLogsWidth(storageScope));
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
   const [modelPickerQuery, setModelPickerQuery] = useState('');
   const [modelPickerLoading, setModelPickerLoading] = useState<string | null>(null);
@@ -601,6 +629,65 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel, loadedModels, onModel
   const liveFinalizeTimerRef = useRef<number | null>(null);
   const audioLevelRef = useRef(0);
   const autoSpeechRef = useRef<{ audio: HTMLAudioElement; url: string } | null>(null);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(scopedKey(storageScope, CHAT_LOGS_WIDTH_KEY), String(chatLogsWidth));
+    } catch {
+      // Non-critical: inline log width persistence is best-effort only.
+    }
+  }, [chatLogsWidth, storageScope]);
+
+  const chatLayoutStyle = useMemo(() => ({
+    '--chat-logs-width': `${chatLogsWidth}px`,
+  } as React.CSSProperties), [chatLogsWidth]);
+
+  const handleChatLogsResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (window.innerWidth <= 980) return;
+    event.preventDefault();
+
+    const startX = event.clientX;
+    const startWidth = chatLogsWidth;
+    const handle = event.currentTarget;
+    try { handle.setPointerCapture(event.pointerId); } catch { /* ignore */ }
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      // The handle sits on the left edge of the logs panel: dragging left makes
+      // the panel wider, dragging right makes it narrower.
+      const nextWidth = clampChatLogsWidth(startWidth - (moveEvent.clientX - startX), railExpanded);
+      setChatLogsWidth(nextWidth);
+    };
+
+    const stopResize = () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', stopResize);
+      window.removeEventListener('pointercancel', stopResize);
+      document.body.classList.remove('is-resizing-chat-logs');
+      try { handle.releasePointerCapture(event.pointerId); } catch { /* ignore */ }
+    };
+
+    document.body.classList.add('is-resizing-chat-logs');
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', stopResize, { once: true });
+    window.addEventListener('pointercancel', stopResize, { once: true });
+  }, [chatLogsWidth, railExpanded]);
+
+  const handleChatLogsResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    const step = event.shiftKey ? 48 : 20;
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      setChatLogsWidth(width => clampChatLogsWidth(width + step, railExpanded));
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      setChatLogsWidth(width => clampChatLogsWidth(width - step, railExpanded));
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      setChatLogsWidth(CHAT_LOGS_MIN_WIDTH);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      setChatLogsWidth(clampChatLogsWidth(CHAT_LOGS_MAX_WIDTH, railExpanded));
+    }
+  }, [railExpanded]);
 
   const currentLoadedModel = useMemo(
     () => loadedModels.find(m => m.model_name === currentModel) || null,
@@ -1868,7 +1955,10 @@ ${finalText}`
 
   return (
     <>
-      <div className={`chat ${railExpanded ? 'rail-expanded' : ''}${showInlineLogs ? ' chat--with-logs' : ''}`}>
+      <div
+        className={`chat ${railExpanded ? 'rail-expanded' : ''}${showInlineLogs ? ' chat--with-logs' : ''}`}
+        style={showInlineLogs ? chatLayoutStyle : undefined}
+      >
       {/* Conversation rail */}
       <aside className="rail">
         <div className="rail__head">
@@ -2121,6 +2211,18 @@ ${finalText}`
 
       {showInlineLogs && (
         <aside className="chat__logs" aria-label="Lemonade logs next to chat">
+          <div
+            className="chat__logs-resizer"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize logs panel"
+            aria-valuemin={CHAT_LOGS_MIN_WIDTH}
+            aria-valuemax={CHAT_LOGS_MAX_WIDTH}
+            aria-valuenow={chatLogsWidth}
+            tabIndex={0}
+            onPointerDown={handleChatLogsResizeStart}
+            onKeyDown={handleChatLogsResizeKeyDown}
+          />
           <LogViewer />
         </aside>
       )}

--- a/prototype/ui-redesign/src/components/ChatView.tsx
+++ b/prototype/ui-redesign/src/components/ChatView.tsx
@@ -28,7 +28,21 @@ import { customModelToModelInfo, loadCustomModels } from '../features/customMode
 import { findModelInfoByName, getAudioTranscriptionComponent, getPrimaryChatComponent, getVisionChatComponent, isCollectionModel } from '../features/collections/collectionModels';
 import { LEMONADE_TOOLS, executeTool } from '../tools/lemonadeTools';
 import { buildOmniToolRuntime } from '../tools/omniTools';
-import { PRESET_STORE_EVENT, activePresetForModel, systemPromptTextForPreset, systemPromptNameForPreset } from '../presetStore';
+import {
+  DEFAULT_PRESET,
+  PRESET_STORE_EVENT,
+  type Preset,
+  activePresetForModel,
+  allStoredPresets,
+  isCompatible,
+  loadApplied,
+  saveApplied,
+  classifyPresetChange,
+  runningPresetIdForModel,
+  setRunningPreset,
+  systemPromptTextForPreset,
+  systemPromptNameForPreset,
+} from '../presetStore';
 import { TTS_SETTINGS_EVENT, loadTtsPlaybackSettings, ttsVoiceFromRecipeOptions } from '../features/audio/ttsSettings';
 
 interface Message {
@@ -610,10 +624,15 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel, loadedModels, onModel
   const [modelPickerQuery, setModelPickerQuery] = useState('');
   const [modelPickerLoading, setModelPickerLoading] = useState<string | null>(null);
   const [modelPickerError, setModelPickerError] = useState<string | null>(null);
+  const [presetPickerOpen, setPresetPickerOpen] = useState(false);
+  const [presetPickerQuery, setPresetPickerQuery] = useState('');
+  const [presetPickerApplying, setPresetPickerApplying] = useState<string | null>(null);
+  const [presetPickerError, setPresetPickerError] = useState<string | null>(null);
   const threadRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const modelPickerRef = useRef<HTMLDivElement>(null);
+  const presetPickerRef = useRef<HTMLDivElement>(null);
   const thinkingContentRef = useRef<HTMLDivElement>(null);
   const thinkingSticky = useRef(true);
   const scrollRafRef = useRef<number>(0);
@@ -754,6 +773,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel, loadedModels, onModel
     return () => window.removeEventListener(TTS_SETTINGS_EVENT, reloadTtsSettings);
   }, [storageScope]);
 
+  const allPresets = useMemo(() => allStoredPresets(), [presetVersion]);
   const currentPreset = useMemo(() => currentModel ? activePresetForModel(currentModel) : null, [currentModel, presetVersion]);
 
   useEffect(() => {
@@ -874,6 +894,101 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel, loadedModels, onModel
     return filtered.slice(0, 80);
   }, [capabilityForLoaded, knownModelInfos, modelPickerQuery, selectableModels]);
 
+
+  const presetPickerTarget = currentKnownModelInfo || currentCustomModelInfo || currentModel || null;
+  const presetPickerOptions = useMemo(() => {
+    if (!currentModel) return [];
+    const q = presetPickerQuery.trim().toLowerCase();
+    return allPresets
+      .filter(preset => isCompatible(preset, presetPickerTarget))
+      .filter(preset => {
+        if (!q) return true;
+        return [
+          preset.name,
+          preset.description,
+          preset.applies_to.join(' '),
+          systemPromptNameForPreset(preset),
+          preset.tools_enabled === false ? 'tools off' : 'tools on',
+        ].join(' ').toLowerCase().includes(q);
+      })
+      .slice(0, 80);
+  }, [allPresets, currentModel, presetPickerQuery, presetPickerTarget]);
+
+  const handlePresetPickerSelect = useCallback(async (preset: Preset) => {
+    if (!currentModel || presetPickerApplying) return;
+
+    const targetName = currentModel;
+    const previousApplied = loadApplied();
+    const previouslyLinkedPreset = currentPreset || activePresetForModel(targetName);
+    const runId = runningPresetIdForModel(targetName);
+    const runningPreset = runId
+      ? (allStoredPresets().find(p => p.id === runId) ?? previouslyLinkedPreset)
+      : previouslyLinkedPreset;
+    const changeKind = currentLoadedModel
+      ? classifyPresetChange(runningPreset, preset)
+      : 'none';
+
+    const nextApplied = { ...previousApplied };
+    if (preset.id === DEFAULT_PRESET.id) delete nextApplied[targetName];
+    else nextApplied[targetName] = preset.id;
+
+    setPresetPickerApplying(preset.id);
+    setPresetPickerError(null);
+    saveApplied(nextApplied);
+
+    const nextTools = preset.tools_enabled !== false;
+    setUseTools(nextTools);
+    try { localStorage.setItem(scopedKey(storageScope, TOOLS_KEY), String(nextTools)); } catch { /* ignore */ }
+
+    // Choosing a preset from the Chat composer is an explicit user action, just
+    // like choosing a different model. Apply the target state immediately: live
+    // request-time changes take effect on the next request; load-time changes
+    // trigger a reload so the running backend is actually using the selected
+    // preset instead of merely linking it for later.
+    try {
+      if (currentCapability === 'image') {
+        imageSettingsTouchedRef.current = false;
+        imageSettingsCommittedRef.current = false;
+        setImageSettings(imageDefaultsForModel(
+          currentLoadedModel,
+          currentKnownModelInfo,
+          preset.recipe_options as Record<string, unknown> | undefined,
+        ));
+        setImageMode('generate');
+      }
+
+      if (currentLoadedModel && changeKind === 'reload') {
+        await api.reloadModel(
+          targetName,
+          Object.keys(preset.recipe_options || {}).length > 0
+            ? preset.recipe_options as Record<string, unknown>
+            : undefined,
+          currentKnownModelInfo || currentCustomModelInfo || null,
+        );
+        await Promise.resolve(onRefresh());
+      }
+
+      if (currentLoadedModel) setRunningPreset(targetName, preset.id);
+      setPresetPickerOpen(false);
+      setPresetPickerQuery('');
+    } catch (err) {
+      setPresetPickerOpen(true);
+      setPresetPickerError(friendlyErrorMessage(err));
+    } finally {
+      setPresetPickerApplying(null);
+    }
+  }, [
+    currentCapability,
+    currentCustomModelInfo,
+    currentKnownModelInfo,
+    currentLoadedModel,
+    currentModel,
+    currentPreset,
+    onRefresh,
+    presetPickerApplying,
+    storageScope,
+  ]);
+
   const modeSupportsChatCompletions = currentCapability === 'chat' || currentCapability === 'omni';
   const modeSupportsTools = modeSupportsChatCompletions;
   const canUseAudioInput = currentCapability === 'omni' || currentCapability === 'audio' || supportsRealtimeAudio;
@@ -918,6 +1033,17 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel, loadedModels, onModel
     window.addEventListener('pointerdown', onPointerDown);
     return () => window.removeEventListener('pointerdown', onPointerDown);
   }, [modelPickerOpen]);
+
+  useEffect(() => {
+    if (!presetPickerOpen) return;
+    const onPointerDown = (event: PointerEvent) => {
+      const root = presetPickerRef.current;
+      if (!root || root.contains(event.target as Node)) return;
+      setPresetPickerOpen(false);
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    return () => window.removeEventListener('pointerdown', onPointerDown);
+  }, [presetPickerOpen]);
 
   useEffect(() => {
     const currentStillUsable = currentModel && loadedModels.some(m => m.model_name === currentModel && canSelectInComposer(m));
@@ -2236,7 +2362,7 @@ ${finalText}`
               <button
                 type="button"
                 className="composer__model-button"
-                onClick={() => { setModelPickerOpen(v => !v); setModelPickerError(null); }}
+                onClick={() => { setModelPickerOpen(v => !v); setPresetPickerOpen(false); setModelPickerError(null); }}
                 aria-haspopup="listbox"
                 aria-expanded={modelPickerOpen}
               >
@@ -2284,18 +2410,66 @@ ${finalText}`
           <button
             type="button"
             className={`composer__mode-badge composer__mode-badge--${capabilityBadge(currentCapability)} composer__mode-badge--interactive`}
-            onClick={() => setModelPickerOpen(true)}
+            onClick={() => { setModelPickerOpen(true); setPresetPickerOpen(false); }}
             title="Mode follows the selected model. Open model search to change it."
           >
             <CapabilityIcon capability={currentCapability} size={13} /> {supportsRealtimeAudio && modeSupportsChatCompletions ? 'Chat + Audio' : capabilityLabel(currentCapability)} mode
           </button>
-          {currentPreset && (
-            <span className="composer__preset-badge" title={`Active preset for this model. Prompt: ${systemPromptNameForPreset(currentPreset)}. Tools start ${currentPreset.tools_enabled === false ? 'OFF' : 'ON'}.`}>
-              <PresetIcon preset={currentPreset} /> Preset: {currentPreset.name}
-            </span>
+          {currentPreset && currentModel && (
+            <div className="composer__preset-picker" ref={presetPickerRef}>
+              <button
+                type="button"
+                className="composer__preset-badge composer__preset-badge--interactive"
+                onClick={() => { setPresetPickerOpen(v => !v); setModelPickerOpen(false); }}
+                title={`Active preset for this model. Prompt: ${systemPromptNameForPreset(currentPreset)}. Tools start ${currentPreset.tools_enabled === false ? 'OFF' : 'ON'}. Click to change preset.`}
+                aria-haspopup="listbox"
+                aria-expanded={presetPickerOpen}
+              >
+                <PresetIcon preset={currentPreset} /> Preset: {currentPreset.name}
+                <span className="composer__model-button-caret">▾</span>
+              </button>
+              {presetPickerOpen && (
+                <div className="composer__model-menu composer__preset-menu" role="dialog" aria-label="Search presets">
+                  <label className="composer__model-search">
+                    <Icon name="search" size={14} />
+                    <input
+                      autoFocus
+                      value={presetPickerQuery}
+                      placeholder="Search presets…"
+                      onChange={e => setPresetPickerQuery(e.target.value)}
+                    />
+                  </label>
+                  <div className="composer__model-results" role="listbox">
+                    {presetPickerOptions.map(preset => {
+                      const isActive = preset.id === currentPreset.id;
+                      return (
+                        <button
+                          type="button"
+                          key={preset.id}
+                          className={`composer__model-option${isActive ? ' is-active' : ''}`}
+                          onClick={() => handlePresetPickerSelect(preset)}
+                          disabled={!!presetPickerApplying}
+                          role="option"
+                          aria-selected={isActive}
+                        >
+                          <PresetIcon preset={preset} />
+                          <span className="composer__model-option-text">
+                            <strong>{preset.name}</strong>
+                            <span>{preset.description || 'No description'} · Prompt: {systemPromptNameForPreset(preset)} · Tools {preset.tools_enabled === false ? 'OFF' : 'ON'}</span>
+                          </span>
+                          {presetPickerApplying === preset.id && <span className="composer__model-option-loading">Applying…</span>}
+                        </button>
+                      );
+                    })}
+                    {presetPickerOptions.length === 0 && <div className="composer__model-empty">No matching presets</div>}
+                  </div>
+                  {presetPickerError && <div className="composer__model-error">{presetPickerError}</div>}
+                </div>
+              )}
+            </div>
           )}
           <button
-            className={`composer__tools-toggle ${useTools ? 'composer__tools-toggle--active' : ''}`}
+            className={`composer__tools-toggle ${useTools && modeSupportsTools ? 'composer__tools-toggle--active' : ''}`}
             onClick={() => {
               const next = !useTools;
               setUseTools(next);

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -847,6 +847,25 @@ const OMNI_COMPONENT_ROLE_CONFIG: Record<OmniComponentRole, { label: string; pla
 
 const NON_PLANNER_LABELS = new Set(['image', 'image-generation', 'edit', 'upscaling', 'speech', 'tts', 'text-to-speech', 'transcription', 'embeddings', 'embedding', 'reranking', 'reranker']);
 
+const MODEL_LIST_WIDTH_KEY = 'model_list_panel_width';
+const MODEL_LIST_DEFAULT_WIDTH = 360;
+const MODEL_LIST_MIN_WIDTH = 300;
+const MODEL_LIST_MAX_WIDTH = 620;
+
+function clampModelListWidth(width: number): number {
+  return Math.max(MODEL_LIST_MIN_WIDTH, Math.min(MODEL_LIST_MAX_WIDTH, Math.round(width)));
+}
+
+function loadModelListWidth(): number {
+  if (typeof window === 'undefined') return MODEL_LIST_DEFAULT_WIDTH;
+  try {
+    const stored = Number(window.localStorage.getItem(MODEL_LIST_WIDTH_KEY));
+    return Number.isFinite(stored) ? clampModelListWidth(stored) : MODEL_LIST_DEFAULT_WIDTH;
+  } catch {
+    return MODEL_LIST_DEFAULT_WIDTH;
+  }
+}
+
 function lowerLabels(m: ModelInfo): string[] {
   return (m.labels || []).map(label => label.toLowerCase().trim()).filter(Boolean);
 }
@@ -1079,6 +1098,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   const [backendFilter, setBackendFilter] = useState<string>('all');
   const [tagFilter, setTagFilter] = useState<string | null>(null);
   const [navRailOpen, setNavRailOpen] = useState(false);
+  const [modelListWidth, setModelListWidth] = useState(loadModelListWidth);
   const [showAllAvailable, setShowAllAvailable] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -1115,6 +1135,70 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   const hasVisibleModelsRef = useRef(false);
   const modelsSnapshotRef = useRef<string>('');
   const loadedSnapshotRef = useRef<string>('');
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(MODEL_LIST_WIDTH_KEY, String(modelListWidth));
+    } catch {
+      // Non-critical: width persistence is best-effort only.
+    }
+  }, [modelListWidth]);
+
+  const modelDetailLayoutStyle = useMemo(() => ({
+    '--model-list-panel-width': `${modelListWidth}px`,
+  } as React.CSSProperties), [modelListWidth]);
+
+  const handleModelListResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (window.innerWidth <= 700) return;
+    event.preventDefault();
+
+    const startX = event.clientX;
+    const startWidth = modelListWidth;
+    const handle = event.currentTarget;
+    try { handle.setPointerCapture(event.pointerId); } catch { /* ignore */ }
+
+    const maxWidthForViewport = () => {
+      // Keep a usable detail pane even on medium desktops. The fixed rail is
+      // 232px in the desktop grid; the detail pane should keep at least ~420px.
+      const viewportMax = window.innerWidth - 232 - 420;
+      return Math.max(MODEL_LIST_MIN_WIDTH, Math.min(MODEL_LIST_MAX_WIDTH, viewportMax));
+    };
+
+    const handlePointerMove = (moveEvent: PointerEvent) => {
+      const nextWidth = clampModelListWidth(Math.min(maxWidthForViewport(), startWidth + moveEvent.clientX - startX));
+      setModelListWidth(nextWidth);
+    };
+
+    const stopResize = () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', stopResize);
+      window.removeEventListener('pointercancel', stopResize);
+      document.body.classList.remove('is-resizing-model-list');
+      try { handle.releasePointerCapture(event.pointerId); } catch { /* ignore */ }
+    };
+
+    document.body.classList.add('is-resizing-model-list');
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', stopResize, { once: true });
+    window.addEventListener('pointercancel', stopResize, { once: true });
+  }, [modelListWidth]);
+
+  const handleModelListResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    const largeStep = event.shiftKey ? 40 : 16;
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      setModelListWidth(width => clampModelListWidth(width - largeStep));
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      setModelListWidth(width => clampModelListWidth(width + largeStep));
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      setModelListWidth(MODEL_LIST_MIN_WIDTH);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      setModelListWidth(MODEL_LIST_MAX_WIDTH);
+    }
+  }, []);
 
 
   useEffect(() => {
@@ -2676,7 +2760,10 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     </section>
   );
   return (
-    <div className={`manager manager--detail${mobileDetailOpen ? ' manager--detail-mobile-open' : ''}${navRailOpen ? ' manager--nav-open' : ''}`}>
+    <div
+      className={`manager manager--detail${mobileDetailOpen ? ' manager--detail-mobile-open' : ''}${navRailOpen ? ' manager--nav-open' : ''}`}
+      style={modelDetailLayoutStyle}
+    >
       {/* Responsive: toggle the left nav rail on narrow viewports */}
       <button
         type="button"
@@ -2734,6 +2821,19 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         pinnedNames={pinnedNameSet}
         onTogglePin={togglePinnedModel}
         favoriteNames={favoriteNameSet}
+      />
+
+      <div
+        className="manager__model-list-resizer"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize model list panel"
+        aria-valuemin={MODEL_LIST_MIN_WIDTH}
+        aria-valuemax={MODEL_LIST_MAX_WIDTH}
+        aria-valuenow={modelListWidth}
+        tabIndex={0}
+        onPointerDown={handleModelListResizeStart}
+        onKeyDown={handleModelListResizeKeyDown}
       />
 
       {/* Right panel: custom form overlay OR model detail */}

--- a/prototype/ui-redesign/src/inspectStore.ts
+++ b/prototype/ui-redesign/src/inspectStore.ts
@@ -148,6 +148,7 @@ class InspectStoreClass {
   private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
   private currentWsUrl: string = '';
   private autoSelectNextTrace = false;
+  private connectionGeneration = 0;
 
   constructor() {
     this.loadFromLocalStorage();
@@ -273,17 +274,23 @@ class InspectStoreClass {
       }
     }
 
-    // If capturing changed, persist to localStorage
-    if (next.capturing !== undefined && next.capturing !== prevState.capturing) {
-      safeSetLocalStorage(LOCAL_STORAGE_CAPTURING_KEY, String(next.capturing));
-      if (next.capturing) {
-        this.state.captureReady = 'connecting';
-        api.sessionHeadersEnabled = false;
+    // If capturing changed, persist to localStorage and start/stop capture.
+    // If callers set capturing=true while it is already true, still repair a missing
+    // socket. This keeps tests and recovery paths deterministic after a dropped WS.
+    if (next.capturing !== undefined) {
+      if (next.capturing !== prevState.capturing) {
+        safeSetLocalStorage(LOCAL_STORAGE_CAPTURING_KEY, String(next.capturing));
+        if (next.capturing) {
+          this.state.captureReady = 'connecting';
+          api.sessionHeadersEnabled = false;
+          this.connect();
+        } else {
+          this.state.captureReady = 'disconnected';
+          api.sessionHeadersEnabled = false;
+          this.disconnect();
+        }
+      } else if (next.capturing && !this.hasActiveSocket()) {
         this.connect();
-      } else {
-        this.state.captureReady = 'disconnected';
-        api.sessionHeadersEnabled = false;
-        this.disconnect();
       }
     }
 
@@ -344,11 +351,20 @@ class InspectStoreClass {
   }
 
   // WebSocket Connection
-  private connect() {
-    clearTimeout(this.reconnectTimeout);
+  private hasActiveSocket() {
+    return !!this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING);
+  }
+
+  private connect(force = false) {
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = null;
+    }
+
     if (!this.state.capturing) {
       return;
     }
+
     const baseUrl = api.baseUrl;
     const apiKey = api.apiKey;
 
@@ -358,12 +374,14 @@ class InspectStoreClass {
     params.set('client_session_id', api.clientSessionId);
     wsUrl += `?${params.toString()}`;
 
-    // Skip redundant connection attempts
-    if (this.ws && this.currentWsUrl === wsUrl && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+    // Skip redundant automatic connection attempts, but allow explicit reconnect()
+    // to replace the socket even if the current socket is still open.
+    if (!force && this.ws && this.currentWsUrl === wsUrl && this.hasActiveSocket()) {
       return;
     }
 
     this.currentWsUrl = wsUrl;
+    const generation = ++this.connectionGeneration;
 
     if (this.ws) {
       try {
@@ -373,22 +391,34 @@ class InspectStoreClass {
         this.ws.onerror = null;
         this.ws.close();
       } catch {}
+      this.ws = null;
     }
 
     try {
-      this.ws = new WebSocket(wsUrl);
+      const socket = new WebSocket(wsUrl);
+      this.ws = socket;
 
-      this.ws.onopen = () => {
-        if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-          this.ws.send(JSON.stringify({
+      const isCurrentSocket = () => this.ws === socket && this.connectionGeneration === generation;
+
+      socket.onopen = () => {
+        if (!isCurrentSocket()) return;
+        if (socket.readyState !== WebSocket.OPEN) return;
+        try {
+          socket.send(JSON.stringify({
             type: 'auth',
             token: apiKey,
             client_session_id: api.clientSessionId
           }));
+        } catch (err) {
+          console.error('Failed to authenticate inspect WebSocket:', err);
+          try {
+            socket.close();
+          } catch {}
         }
       };
 
-      this.ws.onmessage = (event) => {
+      socket.onmessage = (event) => {
+        if (!isCurrentSocket()) return;
         try {
           const raw = JSON.parse(event.data);
           if (raw && raw.type === 'error') {
@@ -410,31 +440,44 @@ class InspectStoreClass {
         }
       };
 
-      this.ws.onclose = () => {
+      socket.onclose = () => {
+        if (!isCurrentSocket()) return;
+        this.ws = null;
         if (!this.state.capturing) return;
         if (this.state.captureReady !== 'unsupported') {
           this.setState({ captureReady: 'connecting' });
         }
         api.sessionHeadersEnabled = false;
-        // Retry connection after 5 seconds
-        clearTimeout(this.reconnectTimeout);
+        if (this.reconnectTimeout) {
+          clearTimeout(this.reconnectTimeout);
+        }
         this.reconnectTimeout = setTimeout(() => this.connect(), 5000);
       };
 
-      this.ws.onerror = () => {
-        if (this.ws) this.ws.close();
+      socket.onerror = () => {
+        if (!isCurrentSocket()) return;
+        try {
+          socket.close();
+        } catch {}
       };
     } catch (err) {
       console.error('Failed to instantiate inspect WebSocket:', err);
       if (!this.state.capturing) return;
-      clearTimeout(this.reconnectTimeout);
+      this.ws = null;
+      if (this.reconnectTimeout) {
+        clearTimeout(this.reconnectTimeout);
+      }
       this.reconnectTimeout = setTimeout(() => this.connect(), 5000);
     }
   }
 
   disconnect() {
-    clearTimeout(this.reconnectTimeout);
-    this.reconnectTimeout = null;
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = null;
+    }
+    this.connectionGeneration++;
+    this.currentWsUrl = '';
     this.setState({ captureReady: 'disconnected' });
     api.sessionHeadersEnabled = false;
     if (this.ws) {
@@ -451,7 +494,7 @@ class InspectStoreClass {
 
   // Force reconnect when settings change (e.g. key changed)
   reconnect() {
-    this.connect();
+    this.connect(true);
   }
 }
 

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -3125,6 +3125,64 @@ input, textarea {
   font-size: var(--text-xs);
 }
 
+.backends__unsupported {
+  margin: 0 var(--space-8) var(--space-5);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-1);
+  overflow: hidden;
+}
+
+.backends__unsupported-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface-base);
+  color: var(--text-secondary);
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out);
+}
+
+.backends__unsupported-toggle:hover,
+.backends__unsupported-toggle:focus-visible {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}
+
+.backends__unsupported-toggle:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: -2px;
+}
+
+.backends__unsupported-title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+}
+
+.backends__unsupported-meta {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}
+
+.matrix--unsupported {
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--border-subtle);
+  border-radius: 0;
+  flex: none;
+  max-width: none;
+  max-height: min(42vh, 460px);
+}
+
 /* Cell within matrix */
 .cell {
   display: flex;
@@ -3818,6 +3876,9 @@ input, textarea {
   .backends__head { padding: var(--space-5) var(--space-4) var(--space-3); }
   .backends__title { flex-direction: column; gap: var(--space-2); }
   .matrix { margin: var(--space-3) var(--space-4); }
+  .backends__unsupported { margin: 0 var(--space-4) var(--space-3); }
+  .matrix--unsupported { margin: 0; }
+  .backends__unsupported-toggle { align-items: flex-start; flex-direction: column; }
   .matrix th, .matrix td { padding: var(--space-3); }
 }
 
@@ -6225,22 +6286,62 @@ input, textarea {
 }
 
 .chat--with-logs {
-  grid-template-columns: var(--rail-collapsed) minmax(0, 1fr) minmax(340px, 34vw);
+  grid-template-columns: var(--rail-collapsed) minmax(320px, 1fr) minmax(340px, var(--chat-logs-width, 34vw));
   grid-template-areas:
     "rail main logs"
     "rail composer logs";
 }
 
 .chat--with-logs.rail-expanded {
-  grid-template-columns: var(--rail-expanded) minmax(0, 1fr) minmax(360px, 34vw);
+  grid-template-columns: var(--rail-expanded) minmax(320px, 1fr) minmax(360px, var(--chat-logs-width, 34vw));
 }
 
 .chat__logs {
   grid-area: logs;
+  position: relative;
   min-width: 0;
   border-left: 1px solid var(--border-subtle);
   background: color-mix(in srgb, var(--surface-1) 90%, transparent);
   overflow: hidden;
+}
+
+.chat__logs-resizer {
+  position: absolute;
+  left: -5px;
+  top: 0;
+  bottom: 0;
+  width: 10px;
+  cursor: col-resize;
+  z-index: 5;
+  touch-action: none;
+}
+
+.chat__logs-resizer::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: var(--space-3);
+  bottom: var(--space-3);
+  width: 2px;
+  border-radius: 999px;
+  background: transparent;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.chat__logs-resizer:hover::after,
+.chat__logs-resizer:focus-visible::after,
+.is-resizing-chat-logs .chat__logs-resizer::after {
+  background: var(--accent-fg);
+}
+
+.chat__logs-resizer:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: -2px;
+}
+
+.is-resizing-chat-logs {
+  cursor: col-resize;
+  user-select: none;
 }
 
 .chat__logs .logs-view {
@@ -6392,6 +6493,29 @@ input, textarea {
   display: inline-flex;
   align-items: center;
   gap: 5px;
+  cursor: pointer;
+  border-style: solid;
+}
+
+.composer__mode-badge--interactive:hover,
+.composer__mode-badge--interactive:focus-visible,
+.composer__tools-toggle:hover,
+.composer__tools-toggle:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-fg) 18%, transparent);
+}
+
+.composer__tools-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+  box-shadow: none;
+}
+
+.composer__preset-badge {
+  cursor: default;
+  opacity: 0.88;
 }
 
 .composer__bar {
@@ -6530,6 +6654,10 @@ input, textarea {
     min-height: 280px;
     border-left: 0;
     border-top: 1px solid var(--border-subtle);
+  }
+
+  .chat__logs-resizer {
+    display: none;
   }
 
   .composer__model-button {
@@ -7351,6 +7479,21 @@ input, textarea {
   overflow: auto;
 }
 
+.logs-virtual {
+  min-width: max-content;
+}
+
+.logs-virtual > div {
+  right: auto !important;
+  min-width: 100%;
+  width: max-content;
+}
+
+.logs-line {
+  min-width: 100%;
+  width: max-content;
+}
+
 .logs-line--continuation .logs-line__time,
 .logs-line--continuation .logs-line__badge {
   opacity: 0.45;
@@ -7366,8 +7509,9 @@ input, textarea {
 .logs-line__text {
   white-space: pre;
   word-break: normal;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  overflow: visible;
+  text-overflow: clip;
+  flex: 0 0 auto;
 }
 
 .detail__tts-playback {
@@ -7976,7 +8120,7 @@ input, textarea {
 
 .manager--detail {
   display: grid;
-  grid-template-columns: 232px 280px minmax(0, 1fr);
+  grid-template-columns: 232px var(--model-list-panel-width, 360px) minmax(0, 1fr);
   /* Override the `auto 1fr` rows inherited from `.manager` so the panes are
      constrained to the viewport height. Without this, the panes land in the
      `auto` row and grow to content height — making the left rail (categories,
@@ -7987,6 +8131,46 @@ input, textarea {
   height: 100%;
   min-height: 0;
   overflow: hidden;
+  position: relative;
+}
+
+.manager__model-list-resizer {
+  position: absolute;
+  left: calc(232px + var(--model-list-panel-width, 360px) - 5px);
+  top: 0;
+  bottom: 0;
+  width: 10px;
+  cursor: col-resize;
+  z-index: 6;
+  touch-action: none;
+}
+
+.manager__model-list-resizer::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: var(--space-3);
+  bottom: var(--space-3);
+  width: 2px;
+  border-radius: 999px;
+  background: transparent;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.manager__model-list-resizer:hover::after,
+.manager__model-list-resizer:focus-visible::after,
+.is-resizing-model-list .manager__model-list-resizer::after {
+  background: var(--accent-fg);
+}
+
+.manager__model-list-resizer:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: -2px;
+}
+
+.is-resizing-model-list {
+  cursor: col-resize;
+  user-select: none;
 }
 
 /* Responsive nav-rail toggle — hidden on wide viewports (rail always shown) */
@@ -9288,6 +9472,8 @@ input, textarea {
 
 /* ── Responsive: list-first → tap-to-detail on narrow viewports ── */
 @media (max-width: 700px) {
+  .manager__model-list-resizer { display: none; }
+
   /* Remove grid; each panel takes full width/height */
   .manager--detail {
     display: block;
@@ -11813,4 +11999,11 @@ input, textarea {
   background: var(--accent-soft);
   color: var(--accent);
   font-weight: var(--weight-bold);
+}
+
+/* Keep the optional unsupported backend matrix aligned with the main backend matrix. */
+.matrix.matrix--unsupported {
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
 }

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -3945,7 +3945,8 @@ input, textarea {
   .composer__toolbar { max-width: 100%; }
 
   /* ── Model selector: truncate aggressively so bar doesn't overflow ── */
-  .composer__model-button {
+  .composer__model-button,
+  .composer__preset-badge {
     max-width: 40vw;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -3954,6 +3955,7 @@ input, textarea {
 
   /* ── Prevent iOS Safari auto-zoom on input focus (requires font-size >= 16px) ── */
   .composer__model-search input,
+  .composer__preset-menu input,
   .composer__input,
   input, textarea, select {
     font-size: 16px !important;
@@ -4053,7 +4055,8 @@ input, textarea {
   }
 
   /* ── Model selector in composer: cap width more aggressively ── */
-  .composer__model-button {
+  .composer__model-button,
+  .composer__preset-badge {
     max-width: 50vw;
   }
 
@@ -6357,7 +6360,8 @@ input, textarea {
   flex-wrap: wrap;
 }
 
-.composer__model-picker {
+.composer__model-picker,
+.composer__preset-picker {
   position: relative;
 }
 
@@ -6406,6 +6410,10 @@ input, textarea {
   box-shadow: var(--shadow-lg);
   -webkit-backdrop-filter: blur(24px) saturate(160%);
   backdrop-filter: blur(24px) saturate(160%);
+}
+
+.composer__preset-menu {
+  width: min(460px, 90vw);
 }
 
 .composer__model-search {
@@ -6499,6 +6507,9 @@ input, textarea {
 
 .composer__mode-badge--interactive:hover,
 .composer__mode-badge--interactive:focus-visible,
+.composer__preset-badge--interactive:hover,
+.composer__preset-badge--interactive:focus-visible,
+.composer__preset-badge--interactive[aria-expanded="true"],
 .composer__tools-toggle:hover,
 .composer__tools-toggle:focus-visible {
   transform: translateY(-1px);
@@ -6516,6 +6527,11 @@ input, textarea {
 .composer__preset-badge {
   cursor: default;
   opacity: 0.88;
+}
+
+.composer__preset-badge--interactive {
+  cursor: pointer;
+  opacity: 1;
 }
 
 .composer__bar {
@@ -6660,7 +6676,8 @@ input, textarea {
     display: none;
   }
 
-  .composer__model-button {
+  .composer__model-button,
+  .composer__preset-badge {
     max-width: 72vw;
   }
 }
@@ -6677,7 +6694,8 @@ input, textarea {
   }
 
   /* Composer model button: tighter on phone */
-  .composer__model-button {
+  .composer__model-button,
+  .composer__preset-badge {
     max-width: 50vw;
   }
 }


### PR DESCRIPTION
## Summary

Fixes several GUI3 usability issues on the Backends, Models, and Chat pages.

## Changes

- Make the Models list wider by default and horizontally resizable.
- Hide unsupported backends from the main backend matrix.
- Add a collapsible unsupported backend debug matrix below the main table.
- Keep technical details available for unsupported backends.
- Remove the scary confirmation dialog for backend updates.
- Make inline Chat logs resizable and readable with horizontal scrolling.
- Visually distinguish clickable Chat model-row pills from static info pills.
- Align unsupported backend matrix sizing/scroll behavior with the main matrix.

## Testing

- manual ui testing
- npm test 199 passed, 9 skipped

Closes #2565
Closes #2568
Closes #2569
Closes #2570
Closes #2571