### PR TITLE
fix(backends): enable sd-cpp CUDA support on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td><code>cuda</code></td>
       <td>NVIDIA GPUs (Turing or newer)**</td>
-      <td>Linux</td>
+      <td>Windows, Linux</td>
     </tr>
     <tr>
       <td><code>vulkan</code></td>

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -47,7 +47,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `openmoss` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
 | `ryzenai-llm` | npu | windows | amd_npu (XDNA2) |
 | `sd-cpp` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
-| `sd-cpp` | cuda | linux | nvidia_gpu (sm_100, sm_120, sm_121, sm_75, sm_80, sm_86, sm_89, sm_90) |
+| `sd-cpp` | cuda | linux, windows | nvidia_gpu (sm_100, sm_120, sm_121, sm_75, sm_80, sm_86, sm_89, sm_90) |
 | `sd-cpp` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
 | `sd-cpp` | cpu | linux, windows | cpu (x86_64) |
 | `sd-cpp` | metal | macos | metal |

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -97,6 +97,8 @@ Values set in the user's `config.json` always take precedence over these seeded 
     "cfg_scale": 7.0,
     "cpu_args": "",
     "cpu_bin": "builtin",
+    "cuda_args": "",
+    "cuda_bin": "builtin",
     "height": 512,
     "rocm_args": "",
     "rocm_bin": "builtin",

--- a/src/cpp/include/lemon/backends/sdcpp/sdcpp.h
+++ b/src/cpp/include/lemon/backends/sdcpp/sdcpp.h
@@ -38,7 +38,7 @@ inline const BackendDescriptor descriptor = {
     /*support*/ {
         {"rocm", {"windows", "linux"},
          {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families*"},
-        {"cuda", {"linux"},
+        {"cuda", {"windows", "linux"},
          {{"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120", "sm_121"}}}, "NVIDIA GPUs (Turing or newer)**"},
         {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
@@ -55,8 +55,8 @@ inline const BackendDescriptor descriptor = {
     /*version_policy*/  VersionPolicy::Exact,
     /*self_manages_downloads*/ false,
     /*takes_args*/      true,
-    /*arg_variants*/    {"cpu", "rocm", "vulkan"},
-    /*bin_variants*/    {"cpu", "rocm", "vulkan"},
+    /*arg_variants*/    {"cpu", "rocm", "vulkan", "cuda"},
+    /*bin_variants*/    {"cpu", "rocm", "vulkan", "cuda"},
     /*config_extra*/    {{"steps", 20}, {"cfg_scale", 7.0}, {"width", 512}, {"height", 512}},
 };
 

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -62,6 +62,8 @@
     "cfg_scale": 7.0,
     "cpu_args": "",
     "cpu_bin": "builtin",
+    "cuda_args": "",
+    "cuda_bin": "builtin",
     "height": 512,
     "rocm_args": "",
     "rocm_bin": "builtin",


### PR DESCRIPTION
## What

sd-cpp's `cuda` variant was restricted to Linux-only in the backend descriptor, even though the Windows CUDA download/runtime path in `sdcpp_server.cpp` is already implemented and the upstream `stable-diffusion.cpp` release still publishes a `windows-cuda` asset (validated by `validate_sdcpp.yml`). llama.cpp's descriptor already lists `cuda` for both Windows and Linux, so this brings sd-cpp in line.

- `src/cpp/include/lemon/backends/sdcpp/sdcpp.h` — add `"windows"` back to the cuda `support` row; add `cuda` to `arg_variants`/`bin_variants` so `config.json` gets `cuda_args`/`cuda_bin` defaults.
- Regenerated `src/cpp/resources/defaults.json` and docs (`README.md`, `docs/dev/backends-reference.md`, `docs/guide/configuration/README.md`) via `docs/tools/gen_backend_boilerplate.py`.

## Note

Windows CUDA support for sd-cpp was deliberately disabled in #2174 ("sd-cpp's CUDA backend is not supported on Windows"), with no linked issue explaining the underlying failure. This PR re-enables it since the asset and download plumbing exist and are still CI-validated for asset presence. 

## Test plan

- [x] Verify sd-cpp cuda now appears as an available backend option in `lemonade backends` / system-info on Windows
- [x] Install and load an sd-cpp model with `--sdcpp cuda` on a Windows machine with an NVIDIA GPU (Turing or newer) and confirm image generation actually works (not just that the binary launches)
- [x] Confirm Linux sd-cpp cuda behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)