### PR TITLE
fix(rocm): detect version-suffixed HIP runtime on Windows (ROCm 7.x)

### DIFF
--- a/docs/guide/configuration/llamacpp.md
+++ b/docs/guide/configuration/llamacpp.md
@@ -120,7 +120,7 @@ lemonade backends install llamacpp:rocm
 
 ### Reusing a System-Installed ROCm (Windows and Linux)
 
-On the stable channel Lemonade normally downloads its own ROCm runtime (TheRock). If you already have ROCm installed system-wide, Lemonade reuses it instead of downloading a second copy when it can find a matching version. It locates the install root in this order, using the first directory that contains the HIP runtime (`bin\amdhip64.dll` on Windows, `lib{,64}/libamdhip64.so` on Linux):
+On the stable channel Lemonade normally downloads its own ROCm runtime (TheRock). If you already have ROCm installed system-wide, Lemonade reuses it instead of downloading a second copy when it can find a matching version. It locates the install root in this order, using the first directory that contains the HIP runtime (`bin\amdhip64.dll` or `bin\amdhip64_<version>.dll` on Windows, `lib{,64}/libamdhip64.so` on Linux):
 
 1. The `ROCM_PATH` environment variable
 2. `rocm-sdk path --root`, when `rocm-sdk` is on your `PATH` (e.g. a ROCm installed from the TheRock pip wheels)

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -110,8 +110,9 @@ namespace lemon::backends {
         /**
          * Resolve the ROCm install root, honoring an externally-installed ROCm
          * before the bundled default. Resolution order, returning the first root
-         * that contains the HIP runtime (Windows: bin\amdhip64.dll or
-         * lib\amdhip64.dll; Linux: lib{,64}/libamdhip64.so):
+         * that contains the HIP runtime (Windows: amdhip64.dll or
+         * amdhip64_<version>.dll under bin\ or lib\; Linux:
+         * lib{,64}/libamdhip64.so):
          *   1. ROCM_PATH environment variable
          *   2. `rocm-sdk path --root` (when rocm-sdk is on PATH)
          *   3. Platform default (Windows: HIP_PATH set by the AMD HIP SDK;

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -829,15 +829,32 @@ namespace lemon::backends {
             }
 #ifdef _WIN32
             // ROCm 5.x/6.x ship bin\amdhip64.dll; ROCm 7.x version-suffixes it
-            // (bin\amdhip64_7.dll), so match the amdhip64*.dll prefix.
+            // (bin\amdhip64_7.dll). Accept amdhip64.dll or amdhip64_<digits>.dll,
+            // not arbitrary suffixes like amdhip64_backup.dll.
+            const auto is_hip_runtime = [](const std::string& name) {
+                if (name == "amdhip64.dll") {
+                    return true;
+                }
+                static const std::string prefix = "amdhip64_";
+                static const std::string suffix = ".dll";
+                if (name.size() <= prefix.size() + suffix.size() ||
+                    name.compare(0, prefix.size(), prefix) != 0 ||
+                    name.compare(name.size() - suffix.size(), suffix.size(), suffix) != 0) {
+                    return false;
+                }
+                const auto digits = name.substr(
+                    prefix.size(), name.size() - prefix.size() - suffix.size());
+                return std::all_of(digits.begin(), digits.end(),
+                                   [](unsigned char c) { return std::isdigit(c); });
+            };
             for (const char* subdir : {"bin", "lib"}) {
                 const fs::path dir = root / subdir;
                 if (!fs::is_directory(dir, ec)) {
                     continue;
                 }
                 for (fs::directory_iterator it(dir, ec), end; it != end && !ec; it.increment(ec)) {
-                    const std::string name = it->path().filename().string();
-                    if (name.rfind("amdhip64", 0) == 0 && it->path().extension() == ".dll") {
+                    if (it->is_regular_file(ec) &&
+                        is_hip_runtime(it->path().filename().string())) {
                         return root;
                     }
                 }

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -828,9 +828,18 @@ namespace lemon::backends {
                 return std::nullopt;
             }
 #ifdef _WIN32
+            // ROCm 5.x/6.x ship bin\amdhip64.dll; ROCm 7.x version-suffixes it
+            // (bin\amdhip64_7.dll), so match the amdhip64*.dll prefix.
             for (const char* subdir : {"bin", "lib"}) {
-                if (fs::exists(root / subdir / "amdhip64.dll", ec)) {
-                    return root;
+                const fs::path dir = root / subdir;
+                if (!fs::is_directory(dir, ec)) {
+                    continue;
+                }
+                for (fs::directory_iterator it(dir, ec), end; it != end && !ec; it.increment(ec)) {
+                    const std::string name = it->path().filename().string();
+                    if (name.rfind("amdhip64", 0) == 0 && it->path().extension() == ".dll") {
+                        return root;
+                    }
                 }
             }
 #else

--- a/test/cpp/test_rocm_root_resolution.cpp
+++ b/test/cpp/test_rocm_root_resolution.cpp
@@ -95,6 +95,13 @@ int main() {
     const fs::path invalid_root = tmp / "invalid";
     fs::create_directories(invalid_root / "lib");  // no HIP runtime
 
+#ifdef _WIN32
+    // ROCm 7.x version-suffixes the runtime (bin\amdhip64_7.dll) instead of the
+    // plain bin\amdhip64.dll used by 5.x/6.x.
+    const fs::path valid_root_versioned = tmp / "valid_versioned";
+    write_stub(valid_root_versioned / "bin" / "amdhip64_7.dll");
+#endif
+
     // pick_rocm_root_candidates: pure selection of absolute-path lines from
     // `rocm-sdk path --root` output, whose stdout may be interleaved with the
     // child's stderr (warnings). No filesystem access.
@@ -146,6 +153,16 @@ int main() {
         check(explicit_source, "ROCM_PATH (fallback subdir) is marked explicit");
     }
 
+#ifdef _WIN32
+    {
+        bool explicit_source = false;
+        set_rocm_path(valid_root_versioned.string());
+        auto root = BackendUtils::resolve_rocm_root(&explicit_source);
+        check(root.has_value() && fs::equivalent(*root, valid_root_versioned),
+              "ROCM_PATH with version-suffixed amdhip64_7.dll resolves");
+    }
+#endif
+
     // A ROCM_PATH missing the HIP runtime must fall through, never resolve to
     // itself, and never be reported as explicit.
     {
@@ -162,9 +179,11 @@ int main() {
     // A non-existent ROCM_PATH must fall through without the fs probes throwing.
     {
         bool explicit_source = false;
-        set_rocm_path((tmp / "does-not-exist").string());
+        const fs::path missing = tmp / "does-not-exist";
+        set_rocm_path(missing.string());
         auto root = BackendUtils::resolve_rocm_root(&explicit_source);
-        check(!root.has_value() || !fs::equivalent(*root, tmp / "does-not-exist"),
+        std::error_code ec;
+        check(!root.has_value() || !fs::equivalent(*root, missing, ec),
               "non-existent ROCM_PATH falls through without throwing");
         if (!root.has_value()) {
             check(!explicit_source,

--- a/test/cpp/test_rocm_root_resolution.cpp
+++ b/test/cpp/test_rocm_root_resolution.cpp
@@ -100,6 +100,10 @@ int main() {
     // plain bin\amdhip64.dll used by 5.x/6.x.
     const fs::path valid_root_versioned = tmp / "valid_versioned";
     write_stub(valid_root_versioned / "bin" / "amdhip64_7.dll");
+
+    // A non-version suffix must not be mistaken for the HIP runtime.
+    const fs::path bogus_suffix_root = tmp / "bogus_suffix";
+    write_stub(bogus_suffix_root / "bin" / "amdhip64_backup.dll");
 #endif
 
     // pick_rocm_root_candidates: pure selection of absolute-path lines from
@@ -160,6 +164,16 @@ int main() {
         auto root = BackendUtils::resolve_rocm_root(&explicit_source);
         check(root.has_value() && fs::equivalent(*root, valid_root_versioned),
               "ROCM_PATH with version-suffixed amdhip64_7.dll resolves");
+        check(explicit_source,
+              "ROCM_PATH with version-suffixed amdhip64_7.dll is marked explicit");
+    }
+
+    {
+        set_rocm_path(bogus_suffix_root.string());
+        std::error_code ec;
+        auto root = BackendUtils::resolve_rocm_root(nullptr);
+        check(!root.has_value() || !fs::equivalent(*root, bogus_suffix_root, ec),
+              "ROCM_PATH with amdhip64_backup.dll does not resolve to itself");
     }
 #endif
 


### PR DESCRIPTION
Follow-up to #2508. Windows system-ROCm detection probes for `bin\amdhip64.dll`, but ROCm 7.x version-suffixes the HIP runtime to `bin\amdhip64_7.dll`. So a system ROCm 7.x install (via `HIP_PATH`/`ROCM_PATH`) went undetected and TheRock was downloaded anyway — the feature no-ops on current ROCm.

Fix: match the `amdhip64*.dll` prefix under `bin`/`lib` (still covers plain `amdhip64.dll` for 5.x/6.x).

Verified on a real ROCm 7.1 Windows host: `resolve_rocm_root` now returns `C:\Program Files\AMD\ROCm\7.1\` where it previously returned `nullopt`. Added a regression test for the version-suffixed runtime, and fixed a latent throwing `fs::equivalent` in the test that only triggered once a host root actually resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
