### PR TITLE
Add server-side MCP client host foundation

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -178,6 +178,19 @@ jobs:
           if ($failures.Count -gt 0) { exit 1 }
           Write-Host "Build and packaging successful!" -ForegroundColor Green
 
+      - name: Run MCP client unit test on Windows
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          # Exercise the Windows-only process, quoting, environment-block, and
+          # pipe/handle paths that Linux and macOS cannot cover.
+          cmake --build build --config Release --target test_mcp_client_config
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          ctest --test-dir build -C Release --output-on-failure -R "^mcp_client_config$"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Upload Lemonade Server Installers
         id: upload-unsigned-msi
         uses: actions/upload-artifact@v7

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -287,8 +287,9 @@ jobs:
           cmake --build --preset default --target test_model_manager_collection_validation
           cmake --build --preset default --target test_routing_classifier_services
           cmake --build --preset default --target test_network_utils
+          cmake --build --preset default --target test_mcp_client_config
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -598,8 +599,9 @@ jobs:
           cmake --build --preset default --target test_model_manager_collection_validation
           cmake --build --preset default --target test_routing_classifier_services
           cmake --build --preset default --target test_network_utils
+          cmake --build --preset default --target test_mcp_client_config
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,6 +655,7 @@ set(SOURCES_CORE
     src/cpp/server/backend_manager.cpp
     src/cpp/server/ollama_api.cpp
     src/cpp/server/anthropic_api.cpp
+    src/cpp/server/mcp_client.cpp
     src/cpp/server/mcp_server.cpp
     src/cpp/server/streaming_audio_buffer.cpp
     src/cpp/server/vad.cpp
@@ -817,6 +818,33 @@ if(BUILD_TESTING AND EXISTS "${VLLM_ARG_RESOLVER_TEST_SOURCE}")
     )
     target_link_libraries(test_vllm_arg_resolver PRIVATE nlohmann_json::nlohmann_json)
     add_test(NAME vllm_arg_resolver COMMAND test_vllm_arg_resolver)
+endif()
+
+set(MCP_CLIENT_CONFIG_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_mcp_client_config.cpp")
+if(BUILD_TESTING AND EXISTS "${MCP_CLIENT_CONFIG_TEST_SOURCE}")
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    find_package(Threads REQUIRED)
+
+    add_executable(test_mcp_client_config
+        ${MCP_CLIENT_CONFIG_TEST_SOURCE}
+        src/cpp/server/mcp_client.cpp
+    )
+    target_link_libraries(test_mcp_client_config PRIVATE nlohmann_json::nlohmann_json Threads::Threads)
+    if(USE_SYSTEM_HTTPLIB)
+        target_link_libraries(test_mcp_client_config PRIVATE lemonade-httplib)
+    else()
+        target_link_libraries(test_mcp_client_config PRIVATE httplib::httplib)
+    endif()
+
+    if(Python3_Interpreter_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/fixtures/mock_mcp_stdio_server.py")
+        file(TO_CMAKE_PATH "${Python3_EXECUTABLE}" LEMONADE_TEST_PYTHON_PATH)
+        file(TO_CMAKE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/test/fixtures/mock_mcp_stdio_server.py" LEMONADE_TEST_MCP_STDIO_SERVER_PATH)
+        target_compile_definitions(test_mcp_client_config PRIVATE
+            "LEMONADE_TEST_PYTHON=\"${LEMONADE_TEST_PYTHON_PATH}\""
+            "LEMONADE_TEST_MCP_STDIO_SERVER=\"${LEMONADE_TEST_MCP_STDIO_SERVER_PATH}\"")
+    endif()
+
+    add_test(NAME mcp_client_config COMMAND test_mcp_client_config)
 endif()
 
 # libwebsockets for the realtime and log-stream WebSocket server

--- a/src/cpp/include/lemon/mcp_client.h
+++ b/src/cpp/include/lemon/mcp_client.h
@@ -15,20 +15,17 @@ using json = nlohmann::json;
 
 // Server-side MCP client host for external MCP servers.
 //
-// PR1 scope:
-//   - stdio transport only
-//   - config persistence under the Lemonade cache directory
-//   - internal/admin HTTP endpoints for config, connect/disconnect, tool discovery,
-//     and raw tools/call execution
-//
-// Chat-loop integration intentionally stays out of this class. PR2 can consume
-// /internal/mcp/tools and /internal/mcp/servers/{id}/tools/call from GUI3/web UI.
+// This foundation intentionally provides only stdio transport, persistent server
+// configuration, explicit connect/disconnect, tool discovery, and raw tool calls.
+// Chat-loop orchestration and GUI selection remain separate follow-up work.
 struct McpServerConfig {
     std::string id;
     std::string name;
     std::string transport = "stdio";
     std::string command;
     std::vector<std::string> args;
+    // Values must be environment references in the form ${VARIABLE}. Raw values
+    // are rejected so credentials can never be persisted in mcp_servers.json.
     std::map<std::string, std::string> env;
     std::string working_dir;
     bool enabled = true;
@@ -46,16 +43,13 @@ public:
     void register_routes(httplib::Server& server);
     void stop_all();
 
-    // Public for small unit tests and PR2 mapping code.
     static McpServerConfig parse_server_config_json(const json& value,
-                                                    bool allow_missing_id = false);
-    static json config_to_json(const McpServerConfig& config, bool include_env_values = false);
+                                                     bool allow_missing_id = false);
+    static json config_to_json(const McpServerConfig& config,
+                               bool include_env_values = false);
     static std::string make_chat_tool_name(const std::string& server_id,
                                            const std::string& tool_name);
 
-    // Service methods used by the HTTP routes, unit tests, and the future chat-loop
-    // integration. They intentionally return JSON matching the REST responses so
-    // PR2 can reuse the same implementation without going through HTTP internally.
     json list_servers_json() const;
     json list_tools_json() const;
     json upsert_server_json(const json& body);
@@ -72,7 +66,8 @@ private:
     McpServerConfig config_for_id(const std::string& id) const;
 
     void load_config_file();
-    void save_config_file_locked() const;
+    void save_config_file_locked(
+        const std::map<std::string, McpServerConfig>& configs) const;
     std::string next_id_locked(const std::string& seed) const;
 
     std::string cache_dir_;
@@ -83,9 +78,7 @@ private:
     std::map<std::string, std::shared_ptr<Runtime>> runtimes_;
 };
 
-// Route hook used by server.cpp. The implementation keeps one manager per cache
-// directory alive for the process lifetime, so Server does not need a new member
-// just to expose the foundation endpoints.
-void register_mcp_client_routes(httplib::Server& server, const std::string& cache_dir);
+void register_mcp_client_routes(httplib::Server& server,
+                                const std::string& cache_dir);
 
 }  // namespace lemon

--- a/src/cpp/include/lemon/mcp_client.h
+++ b/src/cpp/include/lemon/mcp_client.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+namespace lemon {
+
+using json = nlohmann::json;
+
+// Server-side MCP client host for external MCP servers.
+//
+// PR1 scope:
+//   - stdio transport only
+//   - config persistence under the Lemonade cache directory
+//   - internal/admin HTTP endpoints for config, connect/disconnect, tool discovery,
+//     and raw tools/call execution
+//
+// Chat-loop integration intentionally stays out of this class. PR2 can consume
+// /internal/mcp/tools and /internal/mcp/servers/{id}/tools/call from GUI3/web UI.
+struct McpServerConfig {
+    std::string id;
+    std::string name;
+    std::string transport = "stdio";
+    std::string command;
+    std::vector<std::string> args;
+    std::map<std::string, std::string> env;
+    std::string working_dir;
+    bool enabled = true;
+    int timeout_ms = 30000;
+};
+
+class McpClientManager : public std::enable_shared_from_this<McpClientManager> {
+public:
+    explicit McpClientManager(std::string cache_dir);
+    ~McpClientManager();
+
+    McpClientManager(const McpClientManager&) = delete;
+    McpClientManager& operator=(const McpClientManager&) = delete;
+
+    void register_routes(httplib::Server& server);
+    void stop_all();
+
+    // Public for small unit tests and PR2 mapping code.
+    static McpServerConfig parse_server_config_json(const json& value,
+                                                    bool allow_missing_id = false);
+    static json config_to_json(const McpServerConfig& config, bool include_env_values = false);
+    static std::string make_chat_tool_name(const std::string& server_id,
+                                           const std::string& tool_name);
+
+    // Service methods used by the HTTP routes, unit tests, and the future chat-loop
+    // integration. They intentionally return JSON matching the REST responses so
+    // PR2 can reuse the same implementation without going through HTTP internally.
+    json list_servers_json() const;
+    json list_tools_json() const;
+    json upsert_server_json(const json& body);
+    json remove_server_json(const std::string& id);
+    json connect_server_json(const std::string& id);
+    json disconnect_server_json(const std::string& id);
+    json refresh_tools_json(const std::string& id);
+    json call_tool_json(const std::string& id, const json& body);
+
+private:
+    struct Runtime;
+
+    std::shared_ptr<Runtime> runtime_for_locked(const McpServerConfig& config);
+    McpServerConfig config_for_id(const std::string& id) const;
+
+    void load_config_file();
+    void save_config_file_locked() const;
+    std::string next_id_locked(const std::string& seed) const;
+
+    std::string cache_dir_;
+    std::string config_path_;
+
+    mutable std::mutex mutex_;
+    std::map<std::string, McpServerConfig> configs_;
+    std::map<std::string, std::shared_ptr<Runtime>> runtimes_;
+};
+
+// Route hook used by server.cpp. The implementation keeps one manager per cache
+// directory alive for the process lifetime, so Server does not need a new member
+// just to expose the foundation endpoints.
+void register_mcp_client_routes(httplib::Server& server, const std::string& cache_dir);
+
+}  // namespace lemon

--- a/src/cpp/include/lemon/mcp_client.h
+++ b/src/cpp/include/lemon/mcp_client.h
@@ -68,7 +68,7 @@ public:
 private:
     struct Runtime;
 
-    std::shared_ptr<Runtime> runtime_for_locked(const McpServerConfig& config);
+    std::shared_ptr<Runtime> get_or_create_runtime(const McpServerConfig& config);
     McpServerConfig config_for_id(const std::string& id) const;
 
     void load_config_file();

--- a/src/cpp/server/mcp_client.cpp
+++ b/src/cpp/server/mcp_client.cpp
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <chrono>
 #include <condition_variable>
-#include <cctype>
 #include <cstdint>
 #include <cstdlib>
 #include <cwchar>
@@ -1166,8 +1166,8 @@ private:
             if (read == 0) break;
             if (!consume_bytes(line, buffer.data(), read, callback)) return false;
         }
-        if (!line.empty()) callback(line);
-        return true;
+        return line.empty() ||
+               consume_bytes(line, "\n", 1, callback);
     }
 #else
     int stdout_read_handle() const { return stdout_read_; }
@@ -1189,8 +1189,8 @@ private:
                 return !running_.load(std::memory_order_acquire);
             }
         }
-        if (!line.empty()) callback(line);
-        return true;
+        return line.empty() ||
+               consume_bytes(line, "\n", 1, callback);
     }
 #endif
 

--- a/src/cpp/server/mcp_client.cpp
+++ b/src/cpp/server/mcp_client.cpp
@@ -1,0 +1,1320 @@
+#include "lemon/mcp_client.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cctype>
+#include <cstdint>
+#include <cstdlib>
+#include <cwchar>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
+#include <lemon/utils/aixlog.hpp>
+
+#ifdef _WIN32
+    #define NOMINMAX
+    #include <windows.h>
+#else
+    #include <cerrno>
+    #include <csignal>
+    #include <cstring>
+    #include <fcntl.h>
+    #include <sys/types.h>
+    #include <sys/wait.h>
+    #include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace lemon {
+namespace {
+
+constexpr const char* kProtocolVersion = "2025-06-18";
+constexpr const char* kProtocolVersion20250326 = "2025-03-26";
+constexpr const char* kProtocolVersion20241105 = "2024-11-05";
+constexpr const char* kConfigFileName = "mcp_servers.json";
+constexpr int kDefaultTimeoutMs = 30000;
+constexpr int kMinTimeoutMs = 1000;
+constexpr int kMaxTimeoutMs = 300000;
+constexpr int kMaxToolListPages = 32;
+
+json make_error(const std::string& message, int status_code = 400,
+                const std::string& type = "mcp_client_error") {
+    return json{{"error", json{{"message", message}, {"type", type}, {"status_code", status_code}}}};
+}
+
+void set_json(httplib::Response& res, const json& body, int status = 200) {
+    res.status = status;
+    res.set_content(body.dump(), "application/json");
+}
+
+void set_error(httplib::Response& res, const std::string& message, int status = 400,
+               const std::string& type = "mcp_client_error") {
+    set_json(res, make_error(message, status, type), status);
+}
+
+bool parse_json_body(const httplib::Request& req, httplib::Response& res, json& out,
+                     bool required = true) {
+    if (req.body.empty()) {
+        if (required) {
+            set_error(res, "Request body must be a JSON object", 400);
+            return false;
+        }
+        out = json::object();
+        return true;
+    }
+    try {
+        out = json::parse(req.body);
+    } catch (const std::exception& e) {
+        set_error(res, std::string("Invalid JSON body: ") + e.what(), 400);
+        return false;
+    }
+    if (!out.is_object()) {
+        set_error(res, "Request body must be a JSON object", 400);
+        return false;
+    }
+    return true;
+}
+
+bool has_control_char(const std::string& value) {
+    return std::any_of(value.begin(), value.end(), [](unsigned char c) {
+        return c < 0x20 || c == 0x7f;
+    });
+}
+
+std::string trim(std::string value) {
+    auto not_space = [](unsigned char c) { return !std::isspace(c); };
+    value.erase(value.begin(), std::find_if(value.begin(), value.end(), not_space));
+    value.erase(std::find_if(value.rbegin(), value.rend(), not_space).base(), value.end());
+    return value;
+}
+
+bool valid_id(const std::string& id) {
+    if (id.empty() || id.size() > 96) return false;
+    return std::all_of(id.begin(), id.end(), [](unsigned char c) {
+        return std::isalnum(c) || c == '-' || c == '_' || c == '.';
+    });
+}
+
+std::string sanitize_id_seed(const std::string& seed) {
+    std::string out;
+    out.reserve(seed.size());
+    bool last_dash = false;
+    for (unsigned char c : seed) {
+        const bool ok = std::isalnum(c) || c == '_' || c == '.';
+        if (ok) {
+            out.push_back(static_cast<char>(std::tolower(c)));
+            last_dash = false;
+        } else if (!last_dash) {
+            out.push_back('-');
+            last_dash = true;
+        }
+    }
+    while (!out.empty() && out.front() == '-') out.erase(out.begin());
+    while (!out.empty() && out.back() == '-') out.pop_back();
+    if (out.empty()) out = "mcp-server";
+    if (out.size() > 64) out.resize(64);
+    return out;
+}
+
+std::string basename_like(const std::string& command) {
+    size_t pos = command.find_last_of("/\\");
+    if (pos == std::string::npos) return command;
+    return command.substr(pos + 1);
+}
+
+bool valid_env_name(const std::string& name) {
+    if (name.empty()) return false;
+    unsigned char first = static_cast<unsigned char>(name[0]);
+    if (!(std::isalpha(first) || first == '_')) return false;
+    return std::all_of(name.begin() + 1, name.end(), [](unsigned char c) {
+        return std::isalnum(c) || c == '_';
+    });
+}
+
+int clamp_timeout_ms(int timeout_ms) {
+    return std::max(kMinTimeoutMs, std::min(kMaxTimeoutMs, timeout_ms));
+}
+
+bool supported_protocol_version(const std::string& version) {
+    // The PR1 stdio foundation only uses initialize, tools/list and tools/call.
+    // Those are stable across the recent protocol revisions that existing MCP
+    // servers commonly advertise. Unknown future/ancient versions are rejected
+    // so we do not silently run with incompatible semantics.
+    return version == kProtocolVersion ||
+           version == kProtocolVersion20250326 ||
+           version == kProtocolVersion20241105;
+}
+
+std::string fnv1a_hex8(const std::string& value) {
+    std::uint32_t hash = 2166136261u;
+    for (unsigned char c : value) {
+        hash ^= c;
+        hash *= 16777619u;
+    }
+    std::ostringstream oss;
+    oss << std::hex << std::setw(8) << std::setfill('0') << hash;
+    return oss.str();
+}
+
+json json_rpc_request(int id, const std::string& method, json params = json::object()) {
+    json msg{{"jsonrpc", "2.0"}, {"id", id}, {"method", method}};
+    if (!params.is_null()) msg["params"] = std::move(params);
+    return msg;
+}
+
+json json_rpc_notification(const std::string& method, json params = json::object()) {
+    json msg{{"jsonrpc", "2.0"}, {"method", method}};
+    if (!params.is_null()) msg["params"] = std::move(params);
+    return msg;
+}
+
+json json_rpc_method_not_found(const json& id, const std::string& method) {
+    return json{{"jsonrpc", "2.0"},
+                {"id", id},
+                {"error", json{{"code", -32601}, {"message", "Unsupported MCP client request: " + method}}}};
+}
+
+std::string json_rpc_error_message(const json& response) {
+    if (!response.contains("error")) return "";
+    const auto& err = response["error"];
+    if (err.is_object()) {
+        return err.value("message", err.dump());
+    }
+    if (err.is_string()) return err.get<std::string>();
+    return err.dump();
+}
+
+#ifdef _WIN32
+std::wstring utf8_to_wide(const std::string& value) {
+    if (value.empty()) return std::wstring();
+    int len = MultiByteToWideChar(CP_UTF8, 0, value.data(), static_cast<int>(value.size()), nullptr, 0);
+    if (len <= 0) throw std::runtime_error("Failed to convert UTF-8 to UTF-16");
+    std::wstring out(static_cast<size_t>(len), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, value.data(), static_cast<int>(value.size()), out.data(), len);
+    return out;
+}
+
+std::wstring quote_windows_arg(const std::wstring& arg) {
+    if (arg.empty()) return L"\"\"";
+    const bool needs_quotes = arg.find_first_of(L" \t\n\v\"") != std::wstring::npos;
+    if (!needs_quotes) return arg;
+
+    std::wstring out = L"\"";
+    size_t backslashes = 0;
+    for (wchar_t ch : arg) {
+        if (ch == L'\\') {
+            ++backslashes;
+        } else if (ch == L'\"') {
+            out.append(backslashes * 2 + 1, L'\\');
+            out.push_back(ch);
+            backslashes = 0;
+        } else {
+            out.append(backslashes, L'\\');
+            backslashes = 0;
+            out.push_back(ch);
+        }
+    }
+    out.append(backslashes * 2, L'\\');
+    out.push_back(L'\"');
+    return out;
+}
+
+std::wstring build_windows_command_line(const std::string& command, const std::vector<std::string>& args) {
+    std::wstring cmd = quote_windows_arg(utf8_to_wide(command));
+    for (const auto& arg : args) {
+        cmd.push_back(L' ');
+        cmd += quote_windows_arg(utf8_to_wide(arg));
+    }
+    return cmd;
+}
+
+struct CaseInsensitiveWideLess {
+    bool operator()(const std::wstring& a, const std::wstring& b) const {
+        return _wcsicmp(a.c_str(), b.c_str()) < 0;
+    }
+};
+
+std::vector<wchar_t> build_windows_environment_block(const std::map<std::string, std::string>& overrides) {
+    std::vector<std::wstring> hidden_entries;
+    std::map<std::wstring, std::wstring, CaseInsensitiveWideLess> entries;
+
+    LPWCH raw = GetEnvironmentStringsW();
+    if (raw) {
+        for (LPWCH p = raw; *p; ) {
+            std::wstring entry(p);
+            p += entry.size() + 1;
+            if (!entry.empty() && entry[0] == L'=') {
+                hidden_entries.push_back(entry);
+                continue;
+            }
+            size_t eq = entry.find(L'=');
+            if (eq != std::wstring::npos) {
+                entries[entry.substr(0, eq)] = entry;
+            }
+        }
+        FreeEnvironmentStringsW(raw);
+    }
+
+    for (const auto& [key, value] : overrides) {
+        std::wstring wkey = utf8_to_wide(key);
+        entries[wkey] = wkey + L"=" + utf8_to_wide(value);
+    }
+
+    std::vector<wchar_t> block;
+    for (const auto& entry : hidden_entries) {
+        block.insert(block.end(), entry.begin(), entry.end());
+        block.push_back(L'\0');
+    }
+    for (const auto& [_, entry] : entries) {
+        block.insert(block.end(), entry.begin(), entry.end());
+        block.push_back(L'\0');
+    }
+    block.push_back(L'\0');
+    return block;
+}
+#endif
+
+class StdioProcess {
+public:
+    using LineCallback = std::function<void(const std::string&)>;
+
+    StdioProcess() = default;
+    ~StdioProcess() { stop(); }
+
+    StdioProcess(const StdioProcess&) = delete;
+    StdioProcess& operator=(const StdioProcess&) = delete;
+
+    void start(const McpServerConfig& config, LineCallback on_stdout_line, LineCallback on_stderr_line) {
+        stop();
+        on_stdout_line_ = std::move(on_stdout_line);
+        on_stderr_line_ = std::move(on_stderr_line);
+
+        if (!config.working_dir.empty()) {
+            std::error_code ec;
+            if (!fs::is_directory(fs::path(config.working_dir), ec) || ec) {
+                throw std::runtime_error("MCP working_dir is not a readable directory: " + config.working_dir);
+            }
+        }
+
+#ifdef _WIN32
+        start_windows(config);
+#else
+        start_posix(config);
+#endif
+        running_.store(true, std::memory_order_release);
+        stdout_thread_ = std::thread([this] { read_loop_stdout(); });
+        stderr_thread_ = std::thread([this] { read_loop_stderr(); });
+    }
+
+    bool write_line(const std::string& line) {
+        std::lock_guard<std::mutex> lock(write_mutex_);
+        if (!running_.load(std::memory_order_acquire)) return false;
+        std::string payload = line;
+        payload.push_back('\n');
+#ifdef _WIN32
+        DWORD total = 0;
+        const char* data = payload.data();
+        DWORD remaining = static_cast<DWORD>(payload.size());
+        while (remaining > 0) {
+            DWORD written = 0;
+            if (!WriteFile(stdin_write_, data + total, remaining, &written, nullptr) || written == 0) {
+                return false;
+            }
+            total += written;
+            remaining -= written;
+        }
+        FlushFileBuffers(stdin_write_);
+        return true;
+#else
+        const char* data = payload.data();
+        size_t remaining = payload.size();
+        while (remaining > 0) {
+            ssize_t written = ::write(stdin_write_, data, remaining);
+            if (written < 0) {
+                if (errno == EINTR) continue;
+                return false;
+            }
+            if (written == 0) return false;
+            data += written;
+            remaining -= static_cast<size_t>(written);
+        }
+        return true;
+#endif
+    }
+
+    void stop() {
+        if (!started_) return;
+        running_.store(false, std::memory_order_release);
+
+#ifdef _WIN32
+        if (stdin_write_ != INVALID_HANDLE_VALUE) {
+            CloseHandle(stdin_write_);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+        }
+        if (process_info_.hProcess) {
+            DWORD wait = WaitForSingleObject(process_info_.hProcess, 1000);
+            if (wait == WAIT_TIMEOUT) {
+                TerminateProcess(process_info_.hProcess, 1);
+                WaitForSingleObject(process_info_.hProcess, 1000);
+            }
+        }
+#else
+        if (stdin_write_ >= 0) {
+            ::close(stdin_write_);
+            stdin_write_ = -1;
+        }
+        if (pid_ > 0) {
+            int status = 0;
+            auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+            while (std::chrono::steady_clock::now() < deadline) {
+                pid_t r = ::waitpid(pid_, &status, WNOHANG);
+                if (r == pid_) break;
+                if (r < 0 && errno == ECHILD) break;
+                std::this_thread::sleep_for(std::chrono::milliseconds(25));
+            }
+            if (::waitpid(pid_, &status, WNOHANG) == 0) {
+                ::kill(pid_, SIGTERM);
+                deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+                while (std::chrono::steady_clock::now() < deadline) {
+                    pid_t r = ::waitpid(pid_, &status, WNOHANG);
+                    if (r == pid_) break;
+                    if (r < 0 && errno == ECHILD) break;
+                    std::this_thread::sleep_for(std::chrono::milliseconds(25));
+                }
+                if (::waitpid(pid_, &status, WNOHANG) == 0) {
+                    ::kill(pid_, SIGKILL);
+                    ::waitpid(pid_, &status, 0);
+                }
+            }
+        }
+        if (stdout_read_ >= 0) {
+            ::close(stdout_read_);
+            stdout_read_ = -1;
+        }
+        if (stderr_read_ >= 0) {
+            ::close(stderr_read_);
+            stderr_read_ = -1;
+        }
+#endif
+
+        if (stdout_thread_.joinable()) stdout_thread_.join();
+        if (stderr_thread_.joinable()) stderr_thread_.join();
+
+#ifdef _WIN32
+        if (process_info_.hThread) {
+            CloseHandle(process_info_.hThread);
+            process_info_.hThread = nullptr;
+        }
+        if (process_info_.hProcess) {
+            CloseHandle(process_info_.hProcess);
+            process_info_.hProcess = nullptr;
+        }
+        if (stdout_read_ != INVALID_HANDLE_VALUE) {
+            CloseHandle(stdout_read_);
+            stdout_read_ = INVALID_HANDLE_VALUE;
+        }
+        if (stderr_read_ != INVALID_HANDLE_VALUE) {
+            CloseHandle(stderr_read_);
+            stderr_read_ = INVALID_HANDLE_VALUE;
+        }
+#else
+        pid_ = -1;
+#endif
+        started_ = false;
+    }
+
+private:
+#ifdef _WIN32
+    void start_windows(const McpServerConfig& config) {
+        SECURITY_ATTRIBUTES sa{};
+        sa.nLength = sizeof(sa);
+        sa.bInheritHandle = TRUE;
+        sa.lpSecurityDescriptor = nullptr;
+
+        HANDLE stdin_read = INVALID_HANDLE_VALUE;
+        HANDLE stdout_write = INVALID_HANDLE_VALUE;
+        HANDLE stderr_write = INVALID_HANDLE_VALUE;
+
+        if (!CreatePipe(&stdin_read, &stdin_write_, &sa, 0)) {
+            throw std::runtime_error("CreatePipe(stdin) failed");
+        }
+        if (!CreatePipe(&stdout_read_, &stdout_write, &sa, 0)) {
+            CloseHandle(stdin_read);
+            CloseHandle(stdin_write_);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error("CreatePipe(stdout) failed");
+        }
+        if (!CreatePipe(&stderr_read_, &stderr_write, &sa, 0)) {
+            CloseHandle(stdin_read);
+            CloseHandle(stdin_write_);
+            CloseHandle(stdout_read_);
+            CloseHandle(stdout_write);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            stdout_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error("CreatePipe(stderr) failed");
+        }
+
+        SetHandleInformation(stdin_write_, HANDLE_FLAG_INHERIT, 0);
+        SetHandleInformation(stdout_read_, HANDLE_FLAG_INHERIT, 0);
+        SetHandleInformation(stderr_read_, HANDLE_FLAG_INHERIT, 0);
+
+        STARTUPINFOW si{};
+        si.cb = sizeof(si);
+        si.dwFlags = STARTF_USESTDHANDLES;
+        si.hStdInput = stdin_read;
+        si.hStdOutput = stdout_write;
+        si.hStdError = stderr_write;
+
+        std::wstring cmdline = build_windows_command_line(config.command, config.args);
+        std::vector<wchar_t> mutable_cmdline(cmdline.begin(), cmdline.end());
+        mutable_cmdline.push_back(L'\0');
+        std::wstring cwd = config.working_dir.empty() ? std::wstring() : utf8_to_wide(config.working_dir);
+        std::vector<wchar_t> env_block = build_windows_environment_block(config.env);
+
+        PROCESS_INFORMATION pi{};
+        BOOL ok = CreateProcessW(
+            nullptr,
+            mutable_cmdline.data(),
+            nullptr,
+            nullptr,
+            TRUE,
+            CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT,
+            env_block.empty() ? nullptr : env_block.data(),
+            cwd.empty() ? nullptr : cwd.c_str(),
+            &si,
+            &pi);
+
+        CloseHandle(stdin_read);
+        CloseHandle(stdout_write);
+        CloseHandle(stderr_write);
+
+        if (!ok) {
+            DWORD err = GetLastError();
+            CloseHandle(stdin_write_);
+            CloseHandle(stdout_read_);
+            CloseHandle(stderr_read_);
+            stdin_write_ = stdout_read_ = stderr_read_ = INVALID_HANDLE_VALUE;
+            std::ostringstream oss;
+            oss << "CreateProcess failed for MCP server '" << config.command << "' (GetLastError=" << err << ")";
+            throw std::runtime_error(oss.str());
+        }
+
+        process_info_ = pi;
+        started_ = true;
+    }
+#else
+    void start_posix(const McpServerConfig& config) {
+        int stdin_pipe[2] = {-1, -1};
+        int stdout_pipe[2] = {-1, -1};
+        int stderr_pipe[2] = {-1, -1};
+        auto close_pair = [](int pair[2]) {
+            if (pair[0] >= 0) ::close(pair[0]);
+            if (pair[1] >= 0) ::close(pair[1]);
+        };
+        if (::pipe(stdin_pipe) != 0 || ::pipe(stdout_pipe) != 0 || ::pipe(stderr_pipe) != 0) {
+            int err = errno;
+            close_pair(stdin_pipe);
+            close_pair(stdout_pipe);
+            close_pair(stderr_pipe);
+            throw std::runtime_error(std::string("pipe failed: ") + std::strerror(err));
+        }
+
+        pid_t pid = ::fork();
+        if (pid < 0) {
+            int err = errno;
+            ::close(stdin_pipe[0]); ::close(stdin_pipe[1]);
+            ::close(stdout_pipe[0]); ::close(stdout_pipe[1]);
+            ::close(stderr_pipe[0]); ::close(stderr_pipe[1]);
+            throw std::runtime_error(std::string("fork failed: ") + std::strerror(err));
+        }
+
+        if (pid == 0) {
+            ::dup2(stdin_pipe[0], STDIN_FILENO);
+            ::dup2(stdout_pipe[1], STDOUT_FILENO);
+            ::dup2(stderr_pipe[1], STDERR_FILENO);
+
+            ::close(stdin_pipe[0]);
+            ::close(stdin_pipe[1]);
+            ::close(stdout_pipe[0]);
+            ::close(stdout_pipe[1]);
+            ::close(stderr_pipe[0]);
+            ::close(stderr_pipe[1]);
+
+            if (!config.working_dir.empty()) {
+                ::chdir(config.working_dir.c_str());
+            }
+            for (const auto& [key, value] : config.env) {
+                ::setenv(key.c_str(), value.c_str(), 1);
+            }
+
+            std::vector<std::string> argv_strings;
+            argv_strings.reserve(config.args.size() + 1);
+            argv_strings.push_back(config.command);
+            for (const auto& arg : config.args) argv_strings.push_back(arg);
+
+            std::vector<char*> argv;
+            argv.reserve(argv_strings.size() + 1);
+            for (auto& value : argv_strings) argv.push_back(value.data());
+            argv.push_back(nullptr);
+
+            ::execvp(config.command.c_str(), argv.data());
+            _exit(127);
+        }
+
+        ::close(stdin_pipe[0]);
+        ::close(stdout_pipe[1]);
+        ::close(stderr_pipe[1]);
+
+        pid_ = pid;
+        stdin_write_ = stdin_pipe[1];
+        stdout_read_ = stdout_pipe[0];
+        stderr_read_ = stderr_pipe[0];
+        started_ = true;
+    }
+#endif
+
+    void read_loop_stdout() { read_loop(stdout_read_handle(), on_stdout_line_); }
+    void read_loop_stderr() { read_loop(stderr_read_handle(), on_stderr_line_); }
+
+#ifdef _WIN32
+    HANDLE stdout_read_handle() const { return stdout_read_; }
+    HANDLE stderr_read_handle() const { return stderr_read_; }
+
+    void read_loop(HANDLE handle, const LineCallback& cb) {
+        std::string line;
+        char ch = 0;
+        DWORD n = 0;
+        while (handle != INVALID_HANDLE_VALUE && ReadFile(handle, &ch, 1, &n, nullptr) && n == 1) {
+            if (ch == '\n') {
+                if (!line.empty() && line.back() == '\r') line.pop_back();
+                if (!line.empty()) cb(line);
+                line.clear();
+            } else {
+                line.push_back(ch);
+            }
+        }
+        if (!line.empty()) cb(line);
+    }
+#else
+    int stdout_read_handle() const { return stdout_read_; }
+    int stderr_read_handle() const { return stderr_read_; }
+
+    void read_loop(int fd, const LineCallback& cb) {
+        std::string line;
+        char ch = 0;
+        while (fd >= 0) {
+            ssize_t n = ::read(fd, &ch, 1);
+            if (n == 1) {
+                if (ch == '\n') {
+                    if (!line.empty() && line.back() == '\r') line.pop_back();
+                    if (!line.empty()) cb(line);
+                    line.clear();
+                } else {
+                    line.push_back(ch);
+                }
+            } else if (n == 0) {
+                break;
+            } else if (errno != EINTR) {
+                break;
+            }
+        }
+        if (!line.empty()) cb(line);
+    }
+#endif
+
+    bool started_ = false;
+    std::atomic<bool> running_{false};
+    std::mutex write_mutex_;
+    std::thread stdout_thread_;
+    std::thread stderr_thread_;
+    LineCallback on_stdout_line_;
+    LineCallback on_stderr_line_;
+
+#ifdef _WIN32
+    PROCESS_INFORMATION process_info_{};
+    HANDLE stdin_write_ = INVALID_HANDLE_VALUE;
+    HANDLE stdout_read_ = INVALID_HANDLE_VALUE;
+    HANDLE stderr_read_ = INVALID_HANDLE_VALUE;
+#else
+    pid_t pid_ = -1;
+    int stdin_write_ = -1;
+    int stdout_read_ = -1;
+    int stderr_read_ = -1;
+#endif
+};
+
+json openai_tool_from_mcp_tool(const McpServerConfig& config, const json& tool) {
+    const std::string tool_name = tool.value("name", std::string());
+    const std::string chat_name = McpClientManager::make_chat_tool_name(config.id, tool_name);
+    std::string description = tool.value("description", std::string());
+    if (description.empty()) description = tool.value("title", std::string());
+    if (description.empty()) description = "MCP tool " + tool_name + " from " + config.name;
+    description = "[" + config.name + "] " + description;
+
+    json parameters = tool.value("inputSchema", json::object());
+    if (!parameters.is_object() || parameters.empty()) {
+        parameters = json{{"type", "object"}, {"properties", json::object()}};
+    }
+
+    return json{{"type", "function"},
+                {"function", json{{"name", chat_name},
+                                  {"description", description},
+                                  {"parameters", parameters}}}};
+}
+
+}  // namespace
+
+struct McpClientManager::Runtime {
+    explicit Runtime(McpServerConfig cfg) : config(std::move(cfg)) {}
+    ~Runtime() { disconnect(); }
+
+    struct Waiter {
+        std::mutex mutex;
+        std::condition_variable cv;
+        bool done = false;
+        json response;
+    };
+
+    McpServerConfig config;
+    mutable std::mutex mutex;
+    bool connected = false;
+    std::string last_error;
+    json server_info = json::object();
+    json server_capabilities = json::object();
+    std::string negotiated_protocol_version;
+    json tools = json::array();
+
+    std::unique_ptr<StdioProcess> process;
+    std::atomic<int> next_request_id{1};
+
+    std::mutex waiters_mutex;
+    std::map<int, std::shared_ptr<Waiter>> waiters;
+
+    void connect(const McpServerConfig& new_config) {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (connected) return;
+        config = new_config;
+        last_error.clear();
+        server_info = json::object();
+        server_capabilities = json::object();
+        negotiated_protocol_version.clear();
+        tools = json::array();
+
+        process = std::make_unique<StdioProcess>();
+        try {
+            process->start(
+                config,
+                [this](const std::string& line) { handle_stdout_line(line); },
+                [this](const std::string& line) { handle_stderr_line(line); });
+
+            json init = request(
+                "initialize",
+                json{{"protocolVersion", kProtocolVersion},
+                     {"capabilities", json::object()},
+                     {"clientInfo", json{{"name", "lemonade-mcp-client"},
+                                           {"title", "Lemonade MCP Client Host"},
+                                           {"version", "pr1"}}}},
+                config.timeout_ms);
+            if (init.contains("error")) {
+                throw std::runtime_error("initialize failed: " + json_rpc_error_message(init));
+            }
+            const json result = init.value("result", json::object());
+            negotiated_protocol_version = result.value("protocolVersion", std::string(kProtocolVersion));
+            if (!supported_protocol_version(negotiated_protocol_version)) {
+                throw std::runtime_error("MCP server negotiated unsupported protocol version: " +
+                                         negotiated_protocol_version);
+            }
+            server_info = result.value("serverInfo", json::object());
+            server_capabilities = result.value("capabilities", json::object());
+            notify("notifications/initialized", json::object());
+            connected = true;
+            refresh_tools_locked();
+        } catch (const std::exception& e) {
+            last_error = e.what();
+            connected = false;
+            if (process) process->stop();
+            process.reset();
+            throw;
+        }
+    }
+
+    void disconnect() {
+        std::lock_guard<std::mutex> lock(mutex);
+        connected = false;
+        {
+            std::lock_guard<std::mutex> wlock(waiters_mutex);
+            for (auto& [_, waiter] : waiters) {
+                std::lock_guard<std::mutex> lk(waiter->mutex);
+                waiter->response = make_error("MCP server disconnected", 499);
+                waiter->done = true;
+                waiter->cv.notify_all();
+            }
+            waiters.clear();
+        }
+        if (process) {
+            process->stop();
+            process.reset();
+        }
+    }
+
+    void refresh_tools() {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (!connected) throw std::runtime_error("MCP server is not connected");
+        refresh_tools_locked();
+    }
+
+    json call_tool(const std::string& name, const json& arguments, int timeout_ms) {
+        std::lock_guard<std::mutex> lock(mutex);
+        if (!connected) throw std::runtime_error("MCP server is not connected");
+        json params{{"name", name}, {"arguments", arguments.is_object() ? arguments : json::object()}};
+        json response = request("tools/call", std::move(params), timeout_ms > 0 ? timeout_ms : config.timeout_ms);
+        if (response.contains("error")) {
+            throw std::runtime_error(json_rpc_error_message(response));
+        }
+        return response.value("result", json::object());
+    }
+
+    json snapshot(bool include_env_values = false) const {
+        std::lock_guard<std::mutex> lock(mutex);
+        json out = McpClientManager::config_to_json(config, include_env_values);
+        out["status"] = connected ? "connected" : "disconnected";
+        out["connected"] = connected;
+        out["last_error"] = last_error;
+        out["protocol_version"] = negotiated_protocol_version;
+        out["server_info"] = server_info;
+        out["capabilities"] = server_capabilities;
+        out["tools"] = tools;
+        return out;
+    }
+
+private:
+    json request(const std::string& method, json params, int timeout_ms) {
+        int id = next_request_id.fetch_add(1, std::memory_order_relaxed);
+        auto waiter = std::make_shared<Waiter>();
+        {
+            std::lock_guard<std::mutex> lock(waiters_mutex);
+            waiters[id] = waiter;
+        }
+
+        json msg = json_rpc_request(id, method, std::move(params));
+        if (!process || !process->write_line(msg.dump())) {
+            std::lock_guard<std::mutex> lock(waiters_mutex);
+            waiters.erase(id);
+            throw std::runtime_error("Failed to write JSON-RPC request to MCP server");
+        }
+
+        const auto timeout = std::chrono::milliseconds(clamp_timeout_ms(timeout_ms));
+        std::unique_lock<std::mutex> lock(waiter->mutex);
+        if (!waiter->cv.wait_for(lock, timeout, [&] { return waiter->done; })) {
+            {
+                std::lock_guard<std::mutex> wlock(waiters_mutex);
+                waiters.erase(id);
+            }
+            notify("notifications/cancelled", json{{"requestId", id}, {"reason", "timeout"}});
+            throw std::runtime_error("MCP request timed out: " + method);
+        }
+        return waiter->response;
+    }
+
+    void notify(const std::string& method, json params) {
+        if (!process) return;
+        json msg = json_rpc_notification(method, std::move(params));
+        process->write_line(msg.dump());
+    }
+
+    void refresh_tools_locked() {
+        json collected = json::array();
+        std::string cursor;
+        for (int page = 0; page < kMaxToolListPages; ++page) {
+            json params = json::object();
+            if (!cursor.empty()) params["cursor"] = cursor;
+            json response = request("tools/list", params, config.timeout_ms);
+            if (response.contains("error")) {
+                throw std::runtime_error("tools/list failed: " + json_rpc_error_message(response));
+            }
+            const json result = response.value("result", json::object());
+            if (result.contains("tools") && result["tools"].is_array()) {
+                for (const auto& tool : result["tools"]) {
+                    if (tool.is_object() && tool.contains("name") && tool["name"].is_string()) {
+                        collected.push_back(tool);
+                    }
+                }
+            }
+            cursor = result.value("nextCursor", std::string());
+            if (cursor.empty()) break;
+        }
+        tools = std::move(collected);
+    }
+
+    void handle_stdout_line(const std::string& line) {
+        json msg;
+        try {
+            msg = json::parse(line);
+        } catch (const std::exception& e) {
+            LOG(WARNING, "McpClient") << "Ignoring non-JSON MCP stdout from " << config.id
+                                      << ": " << e.what() << std::endl;
+            return;
+        }
+
+        if (msg.contains("id") && (msg.contains("result") || msg.contains("error"))) {
+            int id = -1;
+            if (msg["id"].is_number_integer()) {
+                id = msg["id"].get<int>();
+            } else if (msg["id"].is_string()) {
+                try { id = std::stoi(msg["id"].get<std::string>()); } catch (...) { id = -1; }
+            }
+            if (id >= 0) {
+                std::shared_ptr<Waiter> waiter;
+                {
+                    std::lock_guard<std::mutex> lock(waiters_mutex);
+                    auto it = waiters.find(id);
+                    if (it != waiters.end()) {
+                        waiter = it->second;
+                        waiters.erase(it);
+                    }
+                }
+                if (waiter) {
+                    std::lock_guard<std::mutex> lock(waiter->mutex);
+                    waiter->response = std::move(msg);
+                    waiter->done = true;
+                    waiter->cv.notify_all();
+                }
+            }
+            return;
+        }
+
+        // PR1 does not expose client-side capabilities such as sampling/roots.
+        // Return a JSON-RPC method-not-found response for server-initiated requests
+        // so a server does not hang forever waiting for a reply.
+        if (msg.contains("method") && msg["method"].is_string() && msg.contains("id")) {
+            const std::string method = msg["method"].get<std::string>();
+            if (process) process->write_line(json_rpc_method_not_found(msg["id"], method).dump());
+            return;
+        }
+
+        if (msg.contains("method") && msg["method"].is_string()) {
+            LOG(DEBUG, "McpClient") << "MCP notification from " << config.id << ": "
+                                    << msg["method"].get<std::string>() << std::endl;
+        }
+    }
+
+    void handle_stderr_line(const std::string& line) {
+        LOG(DEBUG, "McpClient") << "[" << config.id << " stderr] " << line << std::endl;
+    }
+};
+
+McpClientManager::McpClientManager(std::string cache_dir) : cache_dir_(std::move(cache_dir)) {
+    if (cache_dir_.empty()) cache_dir_ = ".";
+    fs::path path = fs::path(cache_dir_) / kConfigFileName;
+    config_path_ = path.string();
+    load_config_file();
+}
+
+McpClientManager::~McpClientManager() {
+    stop_all();
+}
+
+void McpClientManager::register_routes(httplib::Server& server) {
+    auto self = shared_from_this();
+
+    server.Get("/internal/mcp/servers", [self](const httplib::Request&, httplib::Response& res) {
+        set_json(res, self->list_servers_json());
+    });
+
+    server.Get("/internal/mcp/tools", [self](const httplib::Request&, httplib::Response& res) {
+        set_json(res, self->list_tools_json());
+    });
+
+    server.Post("/internal/mcp/servers", [self](const httplib::Request& req, httplib::Response& res) {
+        json body;
+        if (!parse_json_body(req, res, body)) return;
+        try {
+            set_json(res, self->upsert_server_json(body));
+        } catch (const std::exception& e) {
+            set_error(res, e.what(), 400);
+        }
+    });
+
+    server.Delete(R"(/internal/mcp/servers/([A-Za-z0-9_.-]+))",
+        [self](const httplib::Request& req, httplib::Response& res) {
+            try {
+                set_json(res, self->remove_server_json(req.matches[1].str()));
+            } catch (const std::exception& e) {
+                set_error(res, e.what(), 404);
+            }
+        });
+
+    server.Post(R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/connect)",
+        [self](const httplib::Request& req, httplib::Response& res) {
+            try {
+                set_json(res, self->connect_server_json(req.matches[1].str()));
+            } catch (const std::exception& e) {
+                set_error(res, e.what(), 500);
+            }
+        });
+
+    server.Post(R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/disconnect)",
+        [self](const httplib::Request& req, httplib::Response& res) {
+            try {
+                set_json(res, self->disconnect_server_json(req.matches[1].str()));
+            } catch (const std::exception& e) {
+                set_error(res, e.what(), 404);
+            }
+        });
+
+    server.Post(R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/refresh-tools)",
+        [self](const httplib::Request& req, httplib::Response& res) {
+            try {
+                set_json(res, self->refresh_tools_json(req.matches[1].str()));
+            } catch (const std::exception& e) {
+                set_error(res, e.what(), 500);
+            }
+        });
+
+    server.Post(R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/tools/call)",
+        [self](const httplib::Request& req, httplib::Response& res) {
+            json body;
+            if (!parse_json_body(req, res, body)) return;
+            try {
+                set_json(res, self->call_tool_json(req.matches[1].str(), body));
+            } catch (const std::exception& e) {
+                set_error(res, e.what(), 500);
+            }
+        });
+}
+
+void McpClientManager::stop_all() {
+    std::map<std::string, std::shared_ptr<Runtime>> runtimes;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        runtimes = runtimes_;
+    }
+    for (auto& [_, runtime] : runtimes) {
+        if (runtime) runtime->disconnect();
+    }
+}
+
+McpServerConfig McpClientManager::parse_server_config_json(const json& value,
+                                                           bool allow_missing_id) {
+    if (!value.is_object()) throw std::runtime_error("MCP server config must be an object");
+
+    McpServerConfig cfg;
+    cfg.id = trim(value.value("id", std::string()));
+    cfg.name = trim(value.value("name", std::string()));
+    cfg.transport = trim(value.value("transport", std::string("stdio")));
+    cfg.command = trim(value.value("command", std::string()));
+    cfg.working_dir = trim(value.value("working_dir", value.value("workingDir", std::string())));
+    cfg.enabled = value.value("enabled", true);
+    cfg.timeout_ms = clamp_timeout_ms(value.value("timeout_ms", value.value("timeoutMs", kDefaultTimeoutMs)));
+
+    if (allow_missing_id && cfg.id.empty()) {
+        cfg.id = sanitize_id_seed(!cfg.name.empty() ? cfg.name : basename_like(cfg.command));
+    }
+    if (!valid_id(cfg.id)) throw std::runtime_error("MCP server id must match [A-Za-z0-9_.-]+ and be at most 96 chars");
+    if (cfg.name.empty()) cfg.name = cfg.id;
+    if (has_control_char(cfg.name)) throw std::runtime_error("MCP server name must not contain control characters");
+    if (cfg.transport != "stdio") throw std::runtime_error("PR1 supports only MCP stdio transport");
+    if (cfg.command.empty()) throw std::runtime_error("MCP stdio server config requires command");
+    if (has_control_char(cfg.command)) throw std::runtime_error("MCP command must not contain control characters");
+    if (has_control_char(cfg.working_dir)) throw std::runtime_error("MCP working_dir must not contain control characters");
+
+    if (value.contains("args")) {
+        if (!value["args"].is_array()) throw std::runtime_error("MCP args must be an array of strings");
+        for (const auto& arg : value["args"]) {
+            if (!arg.is_string()) throw std::runtime_error("MCP args must be an array of strings");
+            std::string s = arg.get<std::string>();
+            if (s.find('\0') != std::string::npos) throw std::runtime_error("MCP args must not contain NUL");
+            cfg.args.push_back(std::move(s));
+        }
+    }
+
+    if (value.contains("env")) {
+        if (!value["env"].is_object()) throw std::runtime_error("MCP env must be an object of string values");
+        for (auto it = value["env"].begin(); it != value["env"].end(); ++it) {
+            if (!valid_env_name(it.key())) throw std::runtime_error("Invalid MCP env var name: " + it.key());
+            if (!it.value().is_string()) throw std::runtime_error("MCP env values must be strings");
+            std::string v = it.value().get<std::string>();
+            if (v.find('\0') != std::string::npos) throw std::runtime_error("MCP env values must not contain NUL");
+            cfg.env[it.key()] = std::move(v);
+        }
+    }
+
+    return cfg;
+}
+
+json McpClientManager::config_to_json(const McpServerConfig& config, bool include_env_values) {
+    json env = json::object();
+    for (const auto& [key, value] : config.env) {
+        env[key] = include_env_values ? value : "***";
+    }
+    return json{{"id", config.id},
+                {"name", config.name},
+                {"transport", config.transport},
+                {"command", config.command},
+                {"args", config.args},
+                {"env", env},
+                {"working_dir", config.working_dir},
+                {"enabled", config.enabled},
+                {"timeout_ms", config.timeout_ms}};
+}
+
+std::string McpClientManager::make_chat_tool_name(const std::string& server_id,
+                                                  const std::string& tool_name) {
+    auto clean = [](const std::string& s) {
+        std::string out;
+        out.reserve(s.size());
+        for (unsigned char c : s) {
+            if (std::isalnum(c) || c == '_' || c == '-') out.push_back(static_cast<char>(c));
+            else out.push_back('_');
+        }
+        while (!out.empty() && out.front() == '_') out.erase(out.begin());
+        while (!out.empty() && out.back() == '_') out.pop_back();
+        if (out.empty()) out = "tool";
+        return out;
+    };
+    const std::string raw = server_id + "\n" + tool_name;
+    const std::string suffix = "_" + fnv1a_hex8(raw);
+    std::string name = "mcp_" + clean(server_id) + "__" + clean(tool_name);
+    if (name.size() > 64) {
+        // OpenAI-compatible function names are commonly limited to 64 chars.
+        // Preserve readability while keeping a stable hash suffix so two long
+        // MCP tool names do not collapse to the same truncated function name.
+        const size_t keep = 64 - suffix.size();
+        name.resize(keep);
+        while (!name.empty() && (name.back() == '_' || name.back() == '-')) name.pop_back();
+        name += suffix;
+    }
+    return name.empty() ? "mcp_tool" : name;
+}
+
+json McpClientManager::list_servers_json() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    json servers = json::array();
+    for (const auto& [id, cfg] : configs_) {
+        auto it = runtimes_.find(id);
+        if (it != runtimes_.end() && it->second) {
+            servers.push_back(it->second->snapshot(false));
+        } else {
+            json s = config_to_json(cfg, false);
+            s["status"] = "disconnected";
+            s["connected"] = false;
+            s["last_error"] = "";
+            s["tools"] = json::array();
+            servers.push_back(std::move(s));
+        }
+    }
+    return json{{"servers", servers}};
+}
+
+json McpClientManager::list_tools_json() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    json tools = json::array();
+    for (const auto& [id, runtime] : runtimes_) {
+        if (!runtime) continue;
+        json snap = runtime->snapshot(false);
+        if (!snap.value("connected", false)) continue;
+        const auto& cfg = configs_.at(id);
+        for (const auto& tool : snap.value("tools", json::array())) {
+            if (!tool.is_object() || !tool.contains("name") || !tool["name"].is_string()) continue;
+            const std::string tool_name = tool["name"].get<std::string>();
+            tools.push_back(json{{"server_id", id},
+                                 {"server_name", cfg.name},
+                                 {"name", tool_name},
+                                 {"chat_name", make_chat_tool_name(id, tool_name)},
+                                 {"title", tool.value("title", std::string())},
+                                 {"description", tool.value("description", std::string())},
+                                 {"inputSchema", tool.value("inputSchema", json::object())},
+                                 {"tool", tool},
+                                 {"openai_tool", openai_tool_from_mcp_tool(cfg, tool)}});
+        }
+    }
+    return json{{"tools", tools}};
+}
+
+json McpClientManager::upsert_server_json(const json& body) {
+    const json& raw = body.contains("server") && body["server"].is_object() ? body["server"] : body;
+    McpServerConfig cfg = parse_server_config_json(raw, true);
+
+    std::shared_ptr<Runtime> old_runtime;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (raw.value("id", std::string()).empty()) {
+            cfg.id = next_id_locked(cfg.id);
+        }
+        configs_[cfg.id] = cfg;
+        auto it = runtimes_.find(cfg.id);
+        if (it != runtimes_.end()) {
+            old_runtime = it->second;
+            runtimes_.erase(it);
+        }
+        save_config_file_locked();
+    }
+    if (old_runtime) old_runtime->disconnect();
+
+    return json{{"server", config_to_json(cfg, false)}};
+}
+
+json McpClientManager::remove_server_json(const std::string& id) {
+    std::shared_ptr<Runtime> runtime;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!configs_.count(id)) throw std::runtime_error("Unknown MCP server: " + id);
+        configs_.erase(id);
+        auto it = runtimes_.find(id);
+        if (it != runtimes_.end()) {
+            runtime = it->second;
+            runtimes_.erase(it);
+        }
+        save_config_file_locked();
+    }
+    if (runtime) runtime->disconnect();
+    return json{{"removed", id}};
+}
+
+json McpClientManager::connect_server_json(const std::string& id) {
+    McpServerConfig cfg = config_for_id(id);
+    if (!cfg.enabled) throw std::runtime_error("MCP server is disabled: " + id);
+    auto runtime = runtime_for_locked(cfg);
+    runtime->connect(cfg);
+    return json{{"server", runtime->snapshot(false)}};
+}
+
+json McpClientManager::disconnect_server_json(const std::string& id) {
+    std::shared_ptr<Runtime> runtime;
+    McpServerConfig cfg;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto cfg_it = configs_.find(id);
+        if (cfg_it == configs_.end()) throw std::runtime_error("Unknown MCP server: " + id);
+        cfg = cfg_it->second;
+        auto it = runtimes_.find(id);
+        if (it != runtimes_.end()) runtime = it->second;
+    }
+    if (runtime) runtime->disconnect();
+    json out = config_to_json(cfg, false);
+    out["status"] = "disconnected";
+    out["connected"] = false;
+    out["tools"] = json::array();
+    return json{{"server", out}};
+}
+
+json McpClientManager::refresh_tools_json(const std::string& id) {
+    McpServerConfig cfg = config_for_id(id);
+    if (!cfg.enabled) throw std::runtime_error("MCP server is disabled: " + id);
+    auto runtime = runtime_for_locked(cfg);
+    runtime->connect(cfg);
+    runtime->refresh_tools();
+    return json{{"server", runtime->snapshot(false)}};
+}
+
+json McpClientManager::call_tool_json(const std::string& id, const json& body) {
+    if (!body.contains("name") || !body["name"].is_string()) {
+        throw std::runtime_error("tools/call body requires string field `name`");
+    }
+    McpServerConfig cfg = config_for_id(id);
+    if (!cfg.enabled) throw std::runtime_error("MCP server is disabled: " + id);
+    auto runtime = runtime_for_locked(cfg);
+    runtime->connect(cfg);
+
+    const std::string name = body["name"].get<std::string>();
+    json arguments = body.value("arguments", json::object());
+    if (!arguments.is_object()) arguments = json::object();
+    int timeout_ms = clamp_timeout_ms(body.value("timeout_ms", body.value("timeoutMs", cfg.timeout_ms)));
+    json result = runtime->call_tool(name, arguments, timeout_ms);
+    return json{{"server_id", id}, {"tool", name}, {"result", result}};
+}
+
+std::shared_ptr<McpClientManager::Runtime> McpClientManager::runtime_for_locked(const McpServerConfig& config) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = runtimes_.find(config.id);
+    if (it != runtimes_.end() && it->second) return it->second;
+    auto runtime = std::make_shared<Runtime>(config);
+    runtimes_[config.id] = runtime;
+    return runtime;
+}
+
+McpServerConfig McpClientManager::config_for_id(const std::string& id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = configs_.find(id);
+    if (it == configs_.end()) throw std::runtime_error("Unknown MCP server: " + id);
+    return it->second;
+}
+
+void McpClientManager::load_config_file() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    configs_.clear();
+    std::ifstream in(config_path_);
+    if (!in.good()) return;
+    try {
+        json doc = json::parse(in);
+        const json servers = doc.contains("servers") ? doc["servers"] : json::array();
+        if (!servers.is_array()) return;
+        for (const auto& entry : servers) {
+            try {
+                McpServerConfig cfg = parse_server_config_json(entry, false);
+                configs_[cfg.id] = std::move(cfg);
+            } catch (const std::exception& e) {
+                LOG(WARNING, "McpClient") << "Skipping invalid MCP server config: " << e.what() << std::endl;
+            }
+        }
+    } catch (const std::exception& e) {
+        LOG(WARNING, "McpClient") << "Failed to read MCP config " << config_path_ << ": " << e.what() << std::endl;
+    }
+}
+
+void McpClientManager::save_config_file_locked() const {
+    fs::path path(config_path_);
+    std::error_code ec;
+    fs::create_directories(path.parent_path(), ec);
+    if (ec) throw std::runtime_error("Failed to create MCP config directory: " + ec.message());
+
+    json servers = json::array();
+    for (const auto& [_, cfg] : configs_) servers.push_back(config_to_json(cfg, true));
+    json doc{{"version", 1}, {"servers", servers}};
+
+    std::ofstream out(config_path_, std::ios::trunc);
+    if (!out.good()) throw std::runtime_error("Failed to open MCP config for writing: " + config_path_);
+    out << std::setw(2) << doc << std::endl;
+}
+
+std::string McpClientManager::next_id_locked(const std::string& seed) const {
+    std::string base = sanitize_id_seed(seed);
+    std::string id = base;
+    for (int i = 2; configs_.count(id); ++i) {
+        id = base + "-" + std::to_string(i);
+    }
+    return id;
+}
+
+void register_mcp_client_routes(httplib::Server& server, const std::string& cache_dir) {
+    static std::mutex managers_mutex;
+    static std::map<std::string, std::weak_ptr<McpClientManager>> managers;
+
+    std::shared_ptr<McpClientManager> manager;
+    {
+        std::lock_guard<std::mutex> lock(managers_mutex);
+        auto it = managers.find(cache_dir);
+        if (it != managers.end()) manager = it->second.lock();
+        if (!manager) {
+            manager = std::make_shared<McpClientManager>(cache_dir);
+            managers[cache_dir] = manager;
+        }
+    }
+    manager->register_routes(server);
+}
+
+}  // namespace lemon

--- a/src/cpp/server/mcp_client.cpp
+++ b/src/cpp/server/mcp_client.cpp
@@ -145,6 +145,42 @@ bool valid_env_name(const std::string& name) {
     });
 }
 
+
+std::optional<std::string> env_reference_name(const std::string& value) {
+    if (value.size() < 4 || value.rfind("${", 0) != 0 || value.back() != '}') {
+        return std::nullopt;
+    }
+    std::string name = value.substr(2, value.size() - 3);
+    if (!valid_env_name(name)) return std::nullopt;
+    return name;
+}
+
+McpServerConfig resolve_env_references(McpServerConfig config) {
+    for (auto& [key, value] : config.env) {
+        auto ref = env_reference_name(value);
+        if (!ref) continue;
+        const char* env_value = std::getenv(ref->c_str());
+        value = env_value ? std::string(env_value) : std::string();
+    }
+    return config;
+}
+
+json config_to_persisted_json(const McpServerConfig& config) {
+    json out = McpClientManager::config_to_json(config, true);
+    json env = json::object();
+    for (const auto& [key, value] : config.env) {
+        if (env_reference_name(value)) {
+            env[key] = value;
+        } else {
+            // MCP env values commonly contain tokens. Do not write raw secrets to
+            // the cache file; persist an environment-variable reference instead.
+            env[key] = "${" + key + "}";
+        }
+    }
+    out["env"] = std::move(env);
+    return out;
+}
+
 int clamp_timeout_ms(int timeout_ms) {
     return std::max(kMinTimeoutMs, std::min(kMaxTimeoutMs, timeout_ms));
 }
@@ -303,17 +339,19 @@ public:
         on_stdout_line_ = std::move(on_stdout_line);
         on_stderr_line_ = std::move(on_stderr_line);
 
-        if (!config.working_dir.empty()) {
+        McpServerConfig process_config = resolve_env_references(config);
+
+        if (!process_config.working_dir.empty()) {
             std::error_code ec;
-            if (!fs::is_directory(fs::path(config.working_dir), ec) || ec) {
-                throw std::runtime_error("MCP working_dir is not a readable directory: " + config.working_dir);
+            if (!fs::is_directory(fs::path(process_config.working_dir), ec) || ec) {
+                throw std::runtime_error("MCP working_dir is not a readable directory: " + process_config.working_dir);
             }
         }
 
 #ifdef _WIN32
-        start_windows(config);
+        start_windows(process_config);
 #else
-        start_posix(config);
+        start_posix(process_config);
 #endif
         running_.store(true, std::memory_order_release);
         stdout_thread_ = std::thread([this] { read_loop_stdout(); });
@@ -401,14 +439,8 @@ public:
                 }
             }
         }
-        if (stdout_read_ >= 0) {
-            ::close(stdout_read_);
-            stdout_read_ = -1;
-        }
-        if (stderr_read_ >= 0) {
-            ::close(stderr_read_);
-            stderr_read_ = -1;
-        }
+        // Reader fds are closed after joining reader threads. Closing an fd
+        // while another thread is blocked in read() can race with fd reuse.
 #endif
 
         if (stdout_thread_.joinable()) stdout_thread_.join();
@@ -432,6 +464,14 @@ public:
             stderr_read_ = INVALID_HANDLE_VALUE;
         }
 #else
+        if (stdout_read_ >= 0) {
+            ::close(stdout_read_);
+            stdout_read_ = -1;
+        }
+        if (stderr_read_ >= 0) {
+            ::close(stderr_read_);
+            stderr_read_ = -1;
+        }
         pid_ = -1;
 #endif
         started_ = false;
@@ -1102,12 +1142,22 @@ std::string McpClientManager::make_chat_tool_name(const std::string& server_id,
 }
 
 json McpClientManager::list_servers_json() const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::pair<McpServerConfig, std::shared_ptr<Runtime>>> entries;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        entries.reserve(configs_.size());
+        for (const auto& [id, cfg] : configs_) {
+            std::shared_ptr<Runtime> runtime;
+            auto it = runtimes_.find(id);
+            if (it != runtimes_.end()) runtime = it->second;
+            entries.push_back({cfg, runtime});
+        }
+    }
+
     json servers = json::array();
-    for (const auto& [id, cfg] : configs_) {
-        auto it = runtimes_.find(id);
-        if (it != runtimes_.end() && it->second) {
-            servers.push_back(it->second->snapshot(false));
+    for (const auto& [cfg, runtime] : entries) {
+        if (runtime) {
+            servers.push_back(runtime->snapshot(false));
         } else {
             json s = config_to_json(cfg, false);
             s["status"] = "disconnected";
@@ -1121,20 +1171,29 @@ json McpClientManager::list_servers_json() const {
 }
 
 json McpClientManager::list_tools_json() const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::pair<McpServerConfig, std::shared_ptr<Runtime>>> entries;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        entries.reserve(runtimes_.size());
+        for (const auto& [id, runtime] : runtimes_) {
+            if (!runtime) continue;
+            auto cfg_it = configs_.find(id);
+            if (cfg_it == configs_.end()) continue;
+            entries.push_back({cfg_it->second, runtime});
+        }
+    }
+
     json tools = json::array();
-    for (const auto& [id, runtime] : runtimes_) {
-        if (!runtime) continue;
+    for (const auto& [cfg, runtime] : entries) {
         json snap = runtime->snapshot(false);
         if (!snap.value("connected", false)) continue;
-        const auto& cfg = configs_.at(id);
         for (const auto& tool : snap.value("tools", json::array())) {
             if (!tool.is_object() || !tool.contains("name") || !tool["name"].is_string()) continue;
             const std::string tool_name = tool["name"].get<std::string>();
-            tools.push_back(json{{"server_id", id},
+            tools.push_back(json{{"server_id", cfg.id},
                                  {"server_name", cfg.name},
                                  {"name", tool_name},
-                                 {"chat_name", make_chat_tool_name(id, tool_name)},
+                                 {"chat_name", make_chat_tool_name(cfg.id, tool_name)},
                                  {"title", tool.value("title", std::string())},
                                  {"description", tool.value("description", std::string())},
                                  {"inputSchema", tool.value("inputSchema", json::object())},
@@ -1188,7 +1247,7 @@ json McpClientManager::remove_server_json(const std::string& id) {
 json McpClientManager::connect_server_json(const std::string& id) {
     McpServerConfig cfg = config_for_id(id);
     if (!cfg.enabled) throw std::runtime_error("MCP server is disabled: " + id);
-    auto runtime = runtime_for_locked(cfg);
+    auto runtime = get_or_create_runtime(cfg);
     runtime->connect(cfg);
     return json{{"server", runtime->snapshot(false)}};
 }
@@ -1215,7 +1274,7 @@ json McpClientManager::disconnect_server_json(const std::string& id) {
 json McpClientManager::refresh_tools_json(const std::string& id) {
     McpServerConfig cfg = config_for_id(id);
     if (!cfg.enabled) throw std::runtime_error("MCP server is disabled: " + id);
-    auto runtime = runtime_for_locked(cfg);
+    auto runtime = get_or_create_runtime(cfg);
     runtime->connect(cfg);
     runtime->refresh_tools();
     return json{{"server", runtime->snapshot(false)}};
@@ -1227,7 +1286,7 @@ json McpClientManager::call_tool_json(const std::string& id, const json& body) {
     }
     McpServerConfig cfg = config_for_id(id);
     if (!cfg.enabled) throw std::runtime_error("MCP server is disabled: " + id);
-    auto runtime = runtime_for_locked(cfg);
+    auto runtime = get_or_create_runtime(cfg);
     runtime->connect(cfg);
 
     const std::string name = body["name"].get<std::string>();
@@ -1238,7 +1297,7 @@ json McpClientManager::call_tool_json(const std::string& id, const json& body) {
     return json{{"server_id", id}, {"tool", name}, {"result", result}};
 }
 
-std::shared_ptr<McpClientManager::Runtime> McpClientManager::runtime_for_locked(const McpServerConfig& config) {
+std::shared_ptr<McpClientManager::Runtime> McpClientManager::get_or_create_runtime(const McpServerConfig& config) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = runtimes_.find(config.id);
     if (it != runtimes_.end() && it->second) return it->second;
@@ -1283,7 +1342,7 @@ void McpClientManager::save_config_file_locked() const {
     if (ec) throw std::runtime_error("Failed to create MCP config directory: " + ec.message());
 
     json servers = json::array();
-    for (const auto& [_, cfg] : configs_) servers.push_back(config_to_json(cfg, true));
+    for (const auto& [_, cfg] : configs_) servers.push_back(config_to_persisted_json(cfg));
     json doc{{"version", 1}, {"servers", servers}};
 
     std::ofstream out(config_path_, std::ios::trunc);

--- a/src/cpp/server/mcp_client.cpp
+++ b/src/cpp/server/mcp_client.cpp
@@ -13,6 +13,7 @@
 #include <functional>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -21,6 +22,7 @@
 #include <stdexcept>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include <lemon/utils/aixlog.hpp>
 
@@ -32,9 +34,13 @@
     #include <csignal>
     #include <cstring>
     #include <fcntl.h>
+    #include <pthread.h>
+    #include <sys/stat.h>
     #include <sys/types.h>
     #include <sys/wait.h>
     #include <unistd.h>
+
+extern char** environ;
 #endif
 
 namespace fs = std::filesystem;
@@ -42,7 +48,8 @@ namespace fs = std::filesystem;
 namespace lemon {
 namespace {
 
-constexpr const char* kProtocolVersion = "2025-06-18";
+constexpr const char* kProtocolVersion = "2025-11-25";
+constexpr const char* kProtocolVersion20250618 = "2025-06-18";
 constexpr const char* kProtocolVersion20250326 = "2025-03-26";
 constexpr const char* kProtocolVersion20241105 = "2024-11-05";
 constexpr const char* kConfigFileName = "mcp_servers.json";
@@ -50,10 +57,14 @@ constexpr int kDefaultTimeoutMs = 30000;
 constexpr int kMinTimeoutMs = 1000;
 constexpr int kMaxTimeoutMs = 300000;
 constexpr int kMaxToolListPages = 32;
+constexpr std::size_t kReadBufferBytes = 8192;
+constexpr std::size_t kMaxMessageBytes = 64U * 1024U * 1024U;
 
 json make_error(const std::string& message, int status_code = 400,
                 const std::string& type = "mcp_client_error") {
-    return json{{"error", json{{"message", message}, {"type", type}, {"status_code", status_code}}}};
+    return json{{"error", json{{"message", message},
+                                {"type", type},
+                                {"status_code", status_code}}}};
 }
 
 void set_json(httplib::Response& res, const json& body, int status = 200) {
@@ -61,13 +72,14 @@ void set_json(httplib::Response& res, const json& body, int status = 200) {
     res.set_content(body.dump(), "application/json");
 }
 
-void set_error(httplib::Response& res, const std::string& message, int status = 400,
+void set_error(httplib::Response& res, const std::string& message,
+               int status = 400,
                const std::string& type = "mcp_client_error") {
     set_json(res, make_error(message, status, type), status);
 }
 
-bool parse_json_body(const httplib::Request& req, httplib::Response& res, json& out,
-                     bool required = true) {
+bool parse_json_body(const httplib::Request& req, httplib::Response& res,
+                     json& out, bool required = true) {
     if (req.body.empty()) {
         if (required) {
             set_error(res, "Request body must be a JSON object", 400);
@@ -89,6 +101,25 @@ bool parse_json_body(const httplib::Request& req, httplib::Response& res, json& 
     return true;
 }
 
+bool ascii_is_alpha(unsigned char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
+
+bool ascii_is_digit(unsigned char c) {
+    return c >= '0' && c <= '9';
+}
+
+bool ascii_is_alnum(unsigned char c) {
+    return ascii_is_alpha(c) || ascii_is_digit(c);
+}
+
+char ascii_to_lower(unsigned char c) {
+    if (c >= 'A' && c <= 'Z') {
+        return static_cast<char>(c - 'A' + 'a');
+    }
+    return static_cast<char>(c);
+}
+
 bool has_control_char(const std::string& value) {
     return std::any_of(value.begin(), value.end(), [](unsigned char c) {
         return c < 0x20 || c == 0x7f;
@@ -97,15 +128,17 @@ bool has_control_char(const std::string& value) {
 
 std::string trim(std::string value) {
     auto not_space = [](unsigned char c) { return !std::isspace(c); };
-    value.erase(value.begin(), std::find_if(value.begin(), value.end(), not_space));
-    value.erase(std::find_if(value.rbegin(), value.rend(), not_space).base(), value.end());
+    value.erase(value.begin(),
+                std::find_if(value.begin(), value.end(), not_space));
+    value.erase(std::find_if(value.rbegin(), value.rend(), not_space).base(),
+                value.end());
     return value;
 }
 
 bool valid_id(const std::string& id) {
     if (id.empty() || id.size() > 96) return false;
     return std::all_of(id.begin(), id.end(), [](unsigned char c) {
-        return std::isalnum(c) || c == '-' || c == '_' || c == '.';
+        return ascii_is_alnum(c) || c == '-' || c == '_' || c == '.';
     });
 }
 
@@ -114,9 +147,9 @@ std::string sanitize_id_seed(const std::string& seed) {
     out.reserve(seed.size());
     bool last_dash = false;
     for (unsigned char c : seed) {
-        const bool ok = std::isalnum(c) || c == '_' || c == '.';
+        const bool ok = ascii_is_alnum(c) || c == '_' || c == '.';
         if (ok) {
-            out.push_back(static_cast<char>(std::tolower(c)));
+            out.push_back(ascii_to_lower(c));
             last_dash = false;
         } else if (!last_dash) {
             out.push_back('-');
@@ -131,23 +164,23 @@ std::string sanitize_id_seed(const std::string& seed) {
 }
 
 std::string basename_like(const std::string& command) {
-    size_t pos = command.find_last_of("/\\");
+    const std::size_t pos = command.find_last_of("/\\");
     if (pos == std::string::npos) return command;
     return command.substr(pos + 1);
 }
 
 bool valid_env_name(const std::string& name) {
     if (name.empty()) return false;
-    unsigned char first = static_cast<unsigned char>(name[0]);
-    if (!(std::isalpha(first) || first == '_')) return false;
+    const unsigned char first = static_cast<unsigned char>(name.front());
+    if (!(ascii_is_alpha(first) || first == '_')) return false;
     return std::all_of(name.begin() + 1, name.end(), [](unsigned char c) {
-        return std::isalnum(c) || c == '_';
+        return ascii_is_alnum(c) || c == '_';
     });
 }
 
-
 std::optional<std::string> env_reference_name(const std::string& value) {
-    if (value.size() < 4 || value.rfind("${", 0) != 0 || value.back() != '}') {
+    if (value.size() < 4 || value.rfind("${", 0) != 0 ||
+        value.back() != '}') {
         return std::nullopt;
     }
     std::string name = value.substr(2, value.size() - 3);
@@ -155,30 +188,38 @@ std::optional<std::string> env_reference_name(const std::string& value) {
     return name;
 }
 
+void validate_env_references(const McpServerConfig& config) {
+    for (const auto& [key, value] : config.env) {
+        if (!env_reference_name(value)) {
+            throw std::runtime_error(
+                "MCP env value for '" + key +
+                "' must be an environment reference such as ${" + key +
+                "}; raw values are not persisted");
+        }
+    }
+}
+
 McpServerConfig resolve_env_references(McpServerConfig config) {
     for (auto& [key, value] : config.env) {
-        auto ref = env_reference_name(value);
-        if (!ref) continue;
+        const auto ref = env_reference_name(value);
+        if (!ref) {
+            throw std::runtime_error(
+                "MCP env value for '" + key +
+                "' is not a valid ${VARIABLE} reference");
+        }
         const char* env_value = std::getenv(ref->c_str());
-        value = env_value ? std::string(env_value) : std::string();
+        if (!env_value) {
+            throw std::runtime_error(
+                "Required MCP environment variable is not set: " + *ref);
+        }
+        value = env_value;
     }
     return config;
 }
 
 json config_to_persisted_json(const McpServerConfig& config) {
-    json out = McpClientManager::config_to_json(config, true);
-    json env = json::object();
-    for (const auto& [key, value] : config.env) {
-        if (env_reference_name(value)) {
-            env[key] = value;
-        } else {
-            // MCP env values commonly contain tokens. Do not write raw secrets to
-            // the cache file; persist an environment-variable reference instead.
-            env[key] = "${" + key + "}";
-        }
-    }
-    out["env"] = std::move(env);
-    return out;
+    validate_env_references(config);
+    return McpClientManager::config_to_json(config, true);
 }
 
 int clamp_timeout_ms(int timeout_ms) {
@@ -186,33 +227,32 @@ int clamp_timeout_ms(int timeout_ms) {
 }
 
 bool supported_protocol_version(const std::string& version) {
-    // The PR1 stdio foundation only uses initialize, tools/list and tools/call.
-    // Those are stable across the recent protocol revisions that existing MCP
-    // servers commonly advertise. Unknown future/ancient versions are rejected
-    // so we do not silently run with incompatible semantics.
     return version == kProtocolVersion ||
+           version == kProtocolVersion20250618 ||
            version == kProtocolVersion20250326 ||
            version == kProtocolVersion20241105;
 }
 
-std::string fnv1a_hex8(const std::string& value) {
-    std::uint32_t hash = 2166136261u;
+std::string fnv1a_hex16(const std::string& value) {
+    std::uint64_t hash = 14695981039346656037ULL;
     for (unsigned char c : value) {
         hash ^= c;
-        hash *= 16777619u;
+        hash *= 1099511628211ULL;
     }
     std::ostringstream oss;
-    oss << std::hex << std::setw(8) << std::setfill('0') << hash;
+    oss << std::hex << std::setw(16) << std::setfill('0') << hash;
     return oss.str();
 }
 
-json json_rpc_request(int id, const std::string& method, json params = json::object()) {
+json json_rpc_request(std::int64_t id, const std::string& method,
+                      json params = json::object()) {
     json msg{{"jsonrpc", "2.0"}, {"id", id}, {"method", method}};
     if (!params.is_null()) msg["params"] = std::move(params);
     return msg;
 }
 
-json json_rpc_notification(const std::string& method, json params = json::object()) {
+json json_rpc_notification(const std::string& method,
+                           json params = json::object()) {
     json msg{{"jsonrpc", "2.0"}, {"method", method}};
     if (!params.is_null()) msg["params"] = std::move(params);
     return msg;
@@ -221,15 +261,15 @@ json json_rpc_notification(const std::string& method, json params = json::object
 json json_rpc_method_not_found(const json& id, const std::string& method) {
     return json{{"jsonrpc", "2.0"},
                 {"id", id},
-                {"error", json{{"code", -32601}, {"message", "Unsupported MCP client request: " + method}}}};
+                {"error", json{{"code", -32601},
+                                {"message",
+                                 "Unsupported MCP client request: " + method}}}};
 }
 
 std::string json_rpc_error_message(const json& response) {
     if (!response.contains("error")) return "";
     const auto& err = response["error"];
-    if (err.is_object()) {
-        return err.value("message", err.dump());
-    }
+    if (err.is_object()) return err.value("message", err.dump());
     if (err.is_string()) return err.get<std::string>();
     return err.dump();
 }
@@ -237,20 +277,28 @@ std::string json_rpc_error_message(const json& response) {
 #ifdef _WIN32
 std::wstring utf8_to_wide(const std::string& value) {
     if (value.empty()) return std::wstring();
-    int len = MultiByteToWideChar(CP_UTF8, 0, value.data(), static_cast<int>(value.size()), nullptr, 0);
-    if (len <= 0) throw std::runtime_error("Failed to convert UTF-8 to UTF-16");
-    std::wstring out(static_cast<size_t>(len), L'\0');
-    MultiByteToWideChar(CP_UTF8, 0, value.data(), static_cast<int>(value.size()), out.data(), len);
+    const int len = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                        value.data(),
+                                        static_cast<int>(value.size()), nullptr, 0);
+    if (len <= 0) {
+        throw std::runtime_error("Failed to convert UTF-8 to UTF-16");
+    }
+    std::wstring out(static_cast<std::size_t>(len), L'\0');
+    if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(),
+                            static_cast<int>(value.size()), out.data(), len) <= 0) {
+        throw std::runtime_error("Failed to convert UTF-8 to UTF-16");
+    }
     return out;
 }
 
 std::wstring quote_windows_arg(const std::wstring& arg) {
     if (arg.empty()) return L"\"\"";
-    const bool needs_quotes = arg.find_first_of(L" \t\n\v\"") != std::wstring::npos;
+    const bool needs_quotes =
+        arg.find_first_of(L" \t\n\v\"") != std::wstring::npos;
     if (!needs_quotes) return arg;
 
     std::wstring out = L"\"";
-    size_t backslashes = 0;
+    std::size_t backslashes = 0;
     for (wchar_t ch : arg) {
         if (ch == L'\\') {
             ++backslashes;
@@ -269,7 +317,8 @@ std::wstring quote_windows_arg(const std::wstring& arg) {
     return out;
 }
 
-std::wstring build_windows_command_line(const std::string& command, const std::vector<std::string>& args) {
+std::wstring build_windows_command_line(
+    const std::string& command, const std::vector<std::string>& args) {
     std::wstring cmd = quote_windows_arg(utf8_to_wide(command));
     for (const auto& arg : args) {
         cmd.push_back(L' ');
@@ -284,26 +333,28 @@ struct CaseInsensitiveWideLess {
     }
 };
 
-std::vector<wchar_t> build_windows_environment_block(const std::map<std::string, std::string>& overrides) {
+std::vector<wchar_t> build_windows_environment_block(
+    const std::map<std::string, std::string>& overrides) {
     std::vector<std::wstring> hidden_entries;
     std::map<std::wstring, std::wstring, CaseInsensitiveWideLess> entries;
 
     LPWCH raw = GetEnvironmentStringsW();
-    if (raw) {
-        for (LPWCH p = raw; *p; ) {
-            std::wstring entry(p);
-            p += entry.size() + 1;
-            if (!entry.empty() && entry[0] == L'=') {
-                hidden_entries.push_back(entry);
-                continue;
-            }
-            size_t eq = entry.find(L'=');
-            if (eq != std::wstring::npos) {
-                entries[entry.substr(0, eq)] = entry;
-            }
-        }
-        FreeEnvironmentStringsW(raw);
+    if (!raw) {
+        throw std::runtime_error("GetEnvironmentStringsW failed");
     }
+    for (LPWCH p = raw; *p;) {
+        std::wstring entry(p);
+        p += entry.size() + 1;
+        if (!entry.empty() && entry.front() == L'=') {
+            hidden_entries.push_back(entry);
+            continue;
+        }
+        const std::size_t eq = entry.find(L'=');
+        if (eq != std::wstring::npos) {
+            entries[entry.substr(0, eq)] = entry;
+        }
+    }
+    FreeEnvironmentStringsW(raw);
 
     for (const auto& [key, value] : overrides) {
         std::wstring wkey = utf8_to_wide(key);
@@ -322,11 +373,103 @@ std::vector<wchar_t> build_windows_environment_block(const std::map<std::string,
     block.push_back(L'\0');
     return block;
 }
+#else
+std::map<std::string, std::string> current_environment() {
+    std::map<std::string, std::string> env;
+    if (!environ) return env;
+    for (char** entry = environ; *entry; ++entry) {
+        const std::string value(*entry);
+        const std::size_t eq = value.find('=');
+        if (eq == std::string::npos || eq == 0) continue;
+        env[value.substr(0, eq)] = value.substr(eq + 1);
+    }
+    return env;
+}
+
+std::string resolve_executable(
+    const McpServerConfig& config,
+    const std::map<std::string, std::string>& environment) {
+    if (config.command.find('/') != std::string::npos) {
+        return config.command;
+    }
+
+    auto path_it = environment.find("PATH");
+    const std::string path_value =
+        path_it == environment.end() ? "/usr/local/bin:/usr/bin:/bin"
+                                     : path_it->second;
+
+    std::size_t begin = 0;
+    while (begin <= path_value.size()) {
+        const std::size_t end = path_value.find(':', begin);
+        std::string directory = path_value.substr(
+            begin, end == std::string::npos ? std::string::npos : end - begin);
+        if (directory.empty()) directory = ".";
+
+        fs::path candidate(directory);
+        if (candidate.is_relative() && !config.working_dir.empty()) {
+            candidate = fs::path(config.working_dir) / candidate;
+        }
+        candidate /= config.command;
+
+        std::error_code ec;
+        fs::path absolute = fs::absolute(candidate, ec);
+        const std::string candidate_string =
+            ec ? candidate.string() : absolute.string();
+        if (::access(candidate_string.c_str(), X_OK) == 0) {
+            return candidate_string;
+        }
+
+        if (end == std::string::npos) break;
+        begin = end + 1;
+    }
+
+    throw std::runtime_error("MCP command was not found on PATH: " +
+                             config.command);
+}
+
+ssize_t write_without_sigpipe(int fd, const void* data, std::size_t size) {
+    sigset_t blocked;
+    sigset_t previous;
+    sigemptyset(&blocked);
+    sigaddset(&blocked, SIGPIPE);
+
+    const int mask_result = pthread_sigmask(SIG_BLOCK, &blocked, &previous);
+    if (mask_result != 0) {
+        errno = mask_result;
+        return -1;
+    }
+
+    sigset_t pending;
+    bool already_pending = false;
+    if (sigpending(&pending) == 0) {
+        already_pending = sigismember(&pending, SIGPIPE) == 1;
+    }
+
+    ssize_t result;
+    do {
+        result = ::write(fd, data, size);
+    } while (result < 0 && errno == EINTR);
+    const int saved_errno = errno;
+
+    if (result < 0 && saved_errno == EPIPE && !already_pending) {
+        sigset_t pending_after;
+        if (sigpending(&pending_after) == 0 &&
+            sigismember(&pending_after, SIGPIPE) == 1) {
+            int consumed_signal = 0;
+            (void)sigwait(&blocked, &consumed_signal);
+        }
+    }
+
+    pthread_sigmask(SIG_SETMASK, &previous, nullptr);
+    errno = saved_errno;
+    return result;
+}
 #endif
 
 class StdioProcess {
 public:
     using LineCallback = std::function<void(const std::string&)>;
+    using ExitCallback = std::function<void()>;
 
     StdioProcess() = default;
     ~StdioProcess() { stop(); }
@@ -334,17 +477,27 @@ public:
     StdioProcess(const StdioProcess&) = delete;
     StdioProcess& operator=(const StdioProcess&) = delete;
 
-    void start(const McpServerConfig& config, LineCallback on_stdout_line, LineCallback on_stderr_line) {
-        stop();
+    void start(const McpServerConfig& config, LineCallback on_stdout_line,
+               LineCallback on_stderr_line, ExitCallback on_exit) {
+        std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+        stop_locked();
+
         on_stdout_line_ = std::move(on_stdout_line);
         on_stderr_line_ = std::move(on_stderr_line);
+        {
+            std::lock_guard<std::mutex> callback_lock(callback_mutex_);
+            on_exit_ = std::move(on_exit);
+        }
+        exit_notified_.store(false, std::memory_order_release);
 
-        McpServerConfig process_config = resolve_env_references(config);
-
+        const McpServerConfig process_config = resolve_env_references(config);
         if (!process_config.working_dir.empty()) {
             std::error_code ec;
-            if (!fs::is_directory(fs::path(process_config.working_dir), ec) || ec) {
-                throw std::runtime_error("MCP working_dir is not a readable directory: " + process_config.working_dir);
+            if (!fs::is_directory(fs::path(process_config.working_dir), ec) ||
+                ec) {
+                throw std::runtime_error(
+                    "MCP working_dir is not a readable directory: " +
+                    process_config.working_dir);
             }
         }
 
@@ -353,94 +506,147 @@ public:
 #else
         start_posix(process_config);
 #endif
+
         running_.store(true, std::memory_order_release);
-        stdout_thread_ = std::thread([this] { read_loop_stdout(); });
-        stderr_thread_ = std::thread([this] { read_loop_stderr(); });
+        try {
+            stdout_thread_ = std::thread([this] { read_loop_stdout(); });
+            stderr_thread_ = std::thread([this] { read_loop_stderr(); });
+        } catch (...) {
+            running_.store(false, std::memory_order_release);
+            stop_locked();
+            throw;
+        }
     }
 
     bool write_line(const std::string& line) {
-        std::lock_guard<std::mutex> lock(write_mutex_);
-        if (!running_.load(std::memory_order_acquire)) return false;
-        std::string payload = line;
-        payload.push_back('\n');
+        bool failed = false;
+        {
+            std::lock_guard<std::mutex> write_lock(write_mutex_);
+            if (!running_.load(std::memory_order_acquire)) return false;
+
+            std::string payload = line;
+            payload.push_back('\n');
 #ifdef _WIN32
-        DWORD total = 0;
-        const char* data = payload.data();
-        DWORD remaining = static_cast<DWORD>(payload.size());
-        while (remaining > 0) {
-            DWORD written = 0;
-            if (!WriteFile(stdin_write_, data + total, remaining, &written, nullptr) || written == 0) {
-                return false;
+            const char* data = payload.data();
+            std::size_t remaining = payload.size();
+            while (remaining > 0) {
+                const DWORD chunk = static_cast<DWORD>(std::min<std::size_t>(
+                    remaining, std::numeric_limits<DWORD>::max()));
+                DWORD written = 0;
+                if (!WriteFile(stdin_write_, data, chunk, &written, nullptr) ||
+                    written == 0) {
+                    failed = true;
+                    break;
+                }
+                data += written;
+                remaining -= written;
             }
-            total += written;
-            remaining -= written;
-        }
-        FlushFileBuffers(stdin_write_);
-        return true;
 #else
-        const char* data = payload.data();
-        size_t remaining = payload.size();
-        while (remaining > 0) {
-            ssize_t written = ::write(stdin_write_, data, remaining);
-            if (written < 0) {
-                if (errno == EINTR) continue;
-                return false;
+            const char* data = payload.data();
+            std::size_t remaining = payload.size();
+            while (remaining > 0) {
+                const ssize_t written =
+                    write_without_sigpipe(stdin_write_, data, remaining);
+                if (written <= 0) {
+                    failed = true;
+                    break;
+                }
+                data += written;
+                remaining -= static_cast<std::size_t>(written);
             }
-            if (written == 0) return false;
-            data += written;
-            remaining -= static_cast<size_t>(written);
-        }
-        return true;
 #endif
+            if (failed) {
+                running_.store(false, std::memory_order_release);
+            }
+        }
+
+        if (failed) notify_exit_once();
+        return !failed;
     }
 
     void stop() {
+        std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+        stop_locked();
+    }
+
+private:
+    void stop_locked() {
         if (!started_) return;
         running_.store(false, std::memory_order_release);
 
+        {
+            std::lock_guard<std::mutex> write_lock(write_mutex_);
 #ifdef _WIN32
-        if (stdin_write_ != INVALID_HANDLE_VALUE) {
-            CloseHandle(stdin_write_);
-            stdin_write_ = INVALID_HANDLE_VALUE;
+            if (stdin_write_ != INVALID_HANDLE_VALUE) {
+                CloseHandle(stdin_write_);
+                stdin_write_ = INVALID_HANDLE_VALUE;
+            }
+#else
+            if (stdin_write_ >= 0) {
+                ::close(stdin_write_);
+                stdin_write_ = -1;
+            }
+#endif
         }
+
+#ifdef _WIN32
         if (process_info_.hProcess) {
             DWORD wait = WaitForSingleObject(process_info_.hProcess, 1000);
             if (wait == WAIT_TIMEOUT) {
-                TerminateProcess(process_info_.hProcess, 1);
+                if (job_ != nullptr) {
+                    TerminateJobObject(job_, 1);
+                } else {
+                    TerminateProcess(process_info_.hProcess, 1);
+                }
                 WaitForSingleObject(process_info_.hProcess, 1000);
+            } else if (job_ != nullptr) {
+                // The main process may exit while descendants still hold the pipe
+                // handles. Terminating the job prevents reader-thread shutdown
+                // from hanging on inherited handles.
+                TerminateJobObject(job_, 0);
             }
         }
 #else
-        if (stdin_write_ >= 0) {
-            ::close(stdin_write_);
-            stdin_write_ = -1;
-        }
         if (pid_ > 0) {
             int status = 0;
-            auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+            bool reaped = false;
+            auto deadline = std::chrono::steady_clock::now() +
+                            std::chrono::seconds(1);
             while (std::chrono::steady_clock::now() < deadline) {
-                pid_t r = ::waitpid(pid_, &status, WNOHANG);
-                if (r == pid_) break;
-                if (r < 0 && errno == ECHILD) break;
+                const pid_t result = ::waitpid(pid_, &status, WNOHANG);
+                if (result == pid_ || (result < 0 && errno == ECHILD)) {
+                    reaped = true;
+                    break;
+                }
                 std::this_thread::sleep_for(std::chrono::milliseconds(25));
             }
-            if (::waitpid(pid_, &status, WNOHANG) == 0) {
-                ::kill(pid_, SIGTERM);
-                deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+            if (!reaped) {
+                ::kill(-pid_, SIGTERM);
+                deadline = std::chrono::steady_clock::now() +
+                           std::chrono::seconds(1);
                 while (std::chrono::steady_clock::now() < deadline) {
-                    pid_t r = ::waitpid(pid_, &status, WNOHANG);
-                    if (r == pid_) break;
-                    if (r < 0 && errno == ECHILD) break;
-                    std::this_thread::sleep_for(std::chrono::milliseconds(25));
-                }
-                if (::waitpid(pid_, &status, WNOHANG) == 0) {
-                    ::kill(pid_, SIGKILL);
-                    ::waitpid(pid_, &status, 0);
+                    const pid_t result = ::waitpid(pid_, &status, WNOHANG);
+                    if (result == pid_ ||
+                        (result < 0 && errno == ECHILD)) {
+                        reaped = true;
+                        break;
+                    }
+                    std::this_thread::sleep_for(
+                        std::chrono::milliseconds(25));
                 }
             }
+            if (!reaped) {
+                ::kill(-pid_, SIGKILL);
+                while (::waitpid(pid_, &status, 0) < 0 && errno == EINTR) {
+                }
+            } else {
+                // Clean up descendants in the process group even when the direct
+                // child exited after stdin was closed.
+                ::kill(-pid_, SIGTERM);
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                ::kill(-pid_, SIGKILL);
+            }
         }
-        // Reader fds are closed after joining reader threads. Closing an fd
-        // while another thread is blocked in read() can race with fd reuse.
 #endif
 
         if (stdout_thread_.joinable()) stdout_thread_.join();
@@ -454,6 +660,10 @@ public:
         if (process_info_.hProcess) {
             CloseHandle(process_info_.hProcess);
             process_info_.hProcess = nullptr;
+        }
+        if (job_ != nullptr) {
+            CloseHandle(job_);
+            job_ = nullptr;
         }
         if (stdout_read_ != INVALID_HANDLE_VALUE) {
             CloseHandle(stdout_read_);
@@ -474,152 +684,412 @@ public:
         }
         pid_ = -1;
 #endif
+
         started_ = false;
+        on_stdout_line_ = nullptr;
+        on_stderr_line_ = nullptr;
+        {
+            std::lock_guard<std::mutex> callback_lock(callback_mutex_);
+            on_exit_ = nullptr;
+        }
     }
 
-private:
 #ifdef _WIN32
     void start_windows(const McpServerConfig& config) {
+        std::wstring command_line =
+            build_windows_command_line(config.command, config.args);
+        std::vector<wchar_t> mutable_command_line(command_line.begin(),
+                                                   command_line.end());
+        mutable_command_line.push_back(L'\0');
+        const std::wstring cwd = config.working_dir.empty()
+                                     ? std::wstring()
+                                     : utf8_to_wide(config.working_dir);
+        std::vector<wchar_t> environment =
+            build_windows_environment_block(config.env);
+
         SECURITY_ATTRIBUTES sa{};
         sa.nLength = sizeof(sa);
         sa.bInheritHandle = TRUE;
-        sa.lpSecurityDescriptor = nullptr;
 
         HANDLE stdin_read = INVALID_HANDLE_VALUE;
         HANDLE stdout_write = INVALID_HANDLE_VALUE;
         HANDLE stderr_write = INVALID_HANDLE_VALUE;
 
-        if (!CreatePipe(&stdin_read, &stdin_write_, &sa, 0)) {
-            throw std::runtime_error("CreatePipe(stdin) failed");
-        }
-        if (!CreatePipe(&stdout_read_, &stdout_write, &sa, 0)) {
-            CloseHandle(stdin_read);
-            CloseHandle(stdin_write_);
-            stdin_write_ = INVALID_HANDLE_VALUE;
-            throw std::runtime_error("CreatePipe(stdout) failed");
-        }
-        if (!CreatePipe(&stderr_read_, &stderr_write, &sa, 0)) {
-            CloseHandle(stdin_read);
-            CloseHandle(stdin_write_);
-            CloseHandle(stdout_read_);
-            CloseHandle(stdout_write);
+        auto close_if_valid = [](HANDLE handle) {
+            if (handle != INVALID_HANDLE_VALUE && handle != nullptr) {
+                CloseHandle(handle);
+            }
+        };
+
+        if (!CreatePipe(&stdin_read, &stdin_write_, &sa, 0) ||
+            !CreatePipe(&stdout_read_, &stdout_write, &sa, 0) ||
+            !CreatePipe(&stderr_read_, &stderr_write, &sa, 0)) {
+            const DWORD error = GetLastError();
+            close_if_valid(stdin_read);
+            close_if_valid(stdin_write_);
+            close_if_valid(stdout_read_);
+            close_if_valid(stdout_write);
+            close_if_valid(stderr_read_);
+            close_if_valid(stderr_write);
             stdin_write_ = INVALID_HANDLE_VALUE;
             stdout_read_ = INVALID_HANDLE_VALUE;
-            throw std::runtime_error("CreatePipe(stderr) failed");
+            stderr_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error(
+                "CreatePipe failed for MCP server (GetLastError=" +
+                std::to_string(error) + ")");
         }
 
-        SetHandleInformation(stdin_write_, HANDLE_FLAG_INHERIT, 0);
-        SetHandleInformation(stdout_read_, HANDLE_FLAG_INHERIT, 0);
-        SetHandleInformation(stderr_read_, HANDLE_FLAG_INHERIT, 0);
-
-        STARTUPINFOW si{};
-        si.cb = sizeof(si);
-        si.dwFlags = STARTF_USESTDHANDLES;
-        si.hStdInput = stdin_read;
-        si.hStdOutput = stdout_write;
-        si.hStdError = stderr_write;
-
-        std::wstring cmdline = build_windows_command_line(config.command, config.args);
-        std::vector<wchar_t> mutable_cmdline(cmdline.begin(), cmdline.end());
-        mutable_cmdline.push_back(L'\0');
-        std::wstring cwd = config.working_dir.empty() ? std::wstring() : utf8_to_wide(config.working_dir);
-        std::vector<wchar_t> env_block = build_windows_environment_block(config.env);
-
-        PROCESS_INFORMATION pi{};
-        BOOL ok = CreateProcessW(
-            nullptr,
-            mutable_cmdline.data(),
-            nullptr,
-            nullptr,
-            TRUE,
-            CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT,
-            env_block.empty() ? nullptr : env_block.data(),
-            cwd.empty() ? nullptr : cwd.c_str(),
-            &si,
-            &pi);
-
-        CloseHandle(stdin_read);
-        CloseHandle(stdout_write);
-        CloseHandle(stderr_write);
-
-        if (!ok) {
-            DWORD err = GetLastError();
-            CloseHandle(stdin_write_);
-            CloseHandle(stdout_read_);
-            CloseHandle(stderr_read_);
-            stdin_write_ = stdout_read_ = stderr_read_ = INVALID_HANDLE_VALUE;
-            std::ostringstream oss;
-            oss << "CreateProcess failed for MCP server '" << config.command << "' (GetLastError=" << err << ")";
-            throw std::runtime_error(oss.str());
+        if (!SetHandleInformation(stdin_write_, HANDLE_FLAG_INHERIT, 0) ||
+            !SetHandleInformation(stdout_read_, HANDLE_FLAG_INHERIT, 0) ||
+            !SetHandleInformation(stderr_read_, HANDLE_FLAG_INHERIT, 0)) {
+            const DWORD error = GetLastError();
+            close_if_valid(stdin_read);
+            close_if_valid(stdin_write_);
+            close_if_valid(stdout_read_);
+            close_if_valid(stdout_write);
+            close_if_valid(stderr_read_);
+            close_if_valid(stderr_write);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            stdout_read_ = INVALID_HANDLE_VALUE;
+            stderr_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error(
+                "SetHandleInformation failed for MCP server (GetLastError=" +
+                std::to_string(error) + ")");
         }
 
-        process_info_ = pi;
+        struct AttributeListGuard {
+            LPPROC_THREAD_ATTRIBUTE_LIST list = nullptr;
+            ~AttributeListGuard() {
+                if (list) DeleteProcThreadAttributeList(list);
+            }
+        } attribute_guard;
+
+        STARTUPINFOEXW startup{};
+        startup.StartupInfo.cb = sizeof(startup);
+        startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+        startup.StartupInfo.hStdInput = stdin_read;
+        startup.StartupInfo.hStdOutput = stdout_write;
+        startup.StartupInfo.hStdError = stderr_write;
+
+        SIZE_T attribute_bytes = 0;
+        InitializeProcThreadAttributeList(nullptr, 1, 0,
+                                          &attribute_bytes);
+        if (attribute_bytes == 0) {
+            const DWORD error = GetLastError();
+            close_if_valid(stdin_read);
+            close_if_valid(stdin_write_);
+            close_if_valid(stdout_read_);
+            close_if_valid(stdout_write);
+            close_if_valid(stderr_read_);
+            close_if_valid(stderr_write);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            stdout_read_ = INVALID_HANDLE_VALUE;
+            stderr_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error(
+                "Failed to size Windows process attribute list (GetLastError=" +
+                std::to_string(error) + ")");
+        }
+        std::vector<unsigned char> attribute_storage(attribute_bytes);
+        startup.lpAttributeList =
+            reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(
+                attribute_storage.data());
+        if (!InitializeProcThreadAttributeList(startup.lpAttributeList, 1, 0,
+                                               &attribute_bytes)) {
+            const DWORD error = GetLastError();
+            close_if_valid(stdin_read);
+            close_if_valid(stdin_write_);
+            close_if_valid(stdout_read_);
+            close_if_valid(stdout_write);
+            close_if_valid(stderr_read_);
+            close_if_valid(stderr_write);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            stdout_read_ = INVALID_HANDLE_VALUE;
+            stderr_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error(
+                "InitializeProcThreadAttributeList failed (GetLastError=" +
+                std::to_string(error) + ")");
+        }
+        attribute_guard.list = startup.lpAttributeList;
+        HANDLE inherited_handles[] = {stdin_read, stdout_write, stderr_write};
+        if (!UpdateProcThreadAttribute(
+                startup.lpAttributeList, 0,
+                PROC_THREAD_ATTRIBUTE_HANDLE_LIST, inherited_handles,
+                sizeof(inherited_handles), nullptr, nullptr)) {
+            const DWORD error = GetLastError();
+            close_if_valid(stdin_read);
+            close_if_valid(stdin_write_);
+            close_if_valid(stdout_read_);
+            close_if_valid(stdout_write);
+            close_if_valid(stderr_read_);
+            close_if_valid(stderr_write);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            stdout_read_ = INVALID_HANDLE_VALUE;
+            stderr_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error(
+                "UpdateProcThreadAttribute failed (GetLastError=" +
+                std::to_string(error) + ")");
+        }
+
+        job_ = CreateJobObjectW(nullptr, nullptr);
+        if (!job_) {
+            const DWORD error = GetLastError();
+            close_if_valid(stdin_read);
+            close_if_valid(stdin_write_);
+            close_if_valid(stdout_read_);
+            close_if_valid(stdout_write);
+            close_if_valid(stderr_read_);
+            close_if_valid(stderr_write);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            stdout_read_ = INVALID_HANDLE_VALUE;
+            stderr_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error(
+                "CreateJobObjectW failed for MCP server (GetLastError=" +
+                std::to_string(error) + ")");
+        }
+
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_info{};
+        job_info.BasicLimitInformation.LimitFlags =
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        if (!SetInformationJobObject(job_, JobObjectExtendedLimitInformation,
+                                     &job_info, sizeof(job_info))) {
+            const DWORD error = GetLastError();
+            CloseHandle(job_);
+            job_ = nullptr;
+            close_if_valid(stdin_read);
+            close_if_valid(stdin_write_);
+            close_if_valid(stdout_read_);
+            close_if_valid(stdout_write);
+            close_if_valid(stderr_read_);
+            close_if_valid(stderr_write);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            stdout_read_ = INVALID_HANDLE_VALUE;
+            stderr_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error(
+                "SetInformationJobObject failed for MCP server (GetLastError=" +
+                std::to_string(error) + ")");
+        }
+
+        PROCESS_INFORMATION process{};
+        const BOOL created = CreateProcessW(
+            nullptr, mutable_command_line.data(), nullptr, nullptr, TRUE,
+            CREATE_NO_WINDOW | CREATE_UNICODE_ENVIRONMENT | CREATE_SUSPENDED |
+                EXTENDED_STARTUPINFO_PRESENT,
+            environment.data(), cwd.empty() ? nullptr : cwd.c_str(),
+            &startup.StartupInfo, &process);
+
+        close_if_valid(stdin_read);
+        close_if_valid(stdout_write);
+        close_if_valid(stderr_write);
+
+        if (!created) {
+            const DWORD error = GetLastError();
+            CloseHandle(job_);
+            job_ = nullptr;
+            close_if_valid(stdin_write_);
+            close_if_valid(stdout_read_);
+            close_if_valid(stderr_read_);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            stdout_read_ = INVALID_HANDLE_VALUE;
+            stderr_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error(
+                "CreateProcessW failed for MCP server '" + config.command +
+                "' (GetLastError=" + std::to_string(error) + ")");
+        }
+
+        if (!AssignProcessToJobObject(job_, process.hProcess)) {
+            const DWORD error = GetLastError();
+            TerminateProcess(process.hProcess, 1);
+            CloseHandle(process.hThread);
+            CloseHandle(process.hProcess);
+            CloseHandle(job_);
+            job_ = nullptr;
+            close_if_valid(stdin_write_);
+            close_if_valid(stdout_read_);
+            close_if_valid(stderr_read_);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            stdout_read_ = INVALID_HANDLE_VALUE;
+            stderr_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error(
+                "AssignProcessToJobObject failed for MCP server (GetLastError=" +
+                std::to_string(error) + ")");
+        }
+
+        if (ResumeThread(process.hThread) == static_cast<DWORD>(-1)) {
+            const DWORD error = GetLastError();
+            TerminateJobObject(job_, 1);
+            CloseHandle(process.hThread);
+            CloseHandle(process.hProcess);
+            CloseHandle(job_);
+            job_ = nullptr;
+            close_if_valid(stdin_write_);
+            close_if_valid(stdout_read_);
+            close_if_valid(stderr_read_);
+            stdin_write_ = INVALID_HANDLE_VALUE;
+            stdout_read_ = INVALID_HANDLE_VALUE;
+            stderr_read_ = INVALID_HANDLE_VALUE;
+            throw std::runtime_error(
+                "ResumeThread failed for MCP server (GetLastError=" +
+                std::to_string(error) + ")");
+        }
+
+        process_info_ = process;
         started_ = true;
     }
 #else
+    static bool set_close_on_exec(int fd) {
+        const int flags = ::fcntl(fd, F_GETFD);
+        return flags >= 0 && ::fcntl(fd, F_SETFD, flags | FD_CLOEXEC) == 0;
+    }
+
+    static int create_cloexec_pipe(int fds[2]) {
+#ifdef __linux__
+        return ::pipe2(fds, O_CLOEXEC);
+#else
+        if (::pipe(fds) != 0) return -1;
+        if (set_close_on_exec(fds[0]) && set_close_on_exec(fds[1])) {
+            return 0;
+        }
+        const int saved_errno = errno;
+        ::close(fds[0]);
+        ::close(fds[1]);
+        fds[0] = fds[1] = -1;
+        errno = saved_errno;
+        return -1;
+#endif
+    }
+
     void start_posix(const McpServerConfig& config) {
+        std::map<std::string, std::string> environment = current_environment();
+        for (const auto& [key, value] : config.env) environment[key] = value;
+        const std::string executable = resolve_executable(config, environment);
+
+        std::vector<std::string> argv_strings;
+        argv_strings.reserve(config.args.size() + 1);
+        argv_strings.push_back(config.command);
+        argv_strings.insert(argv_strings.end(), config.args.begin(),
+                            config.args.end());
+        std::vector<char*> argv;
+        argv.reserve(argv_strings.size() + 1);
+        for (auto& value : argv_strings) argv.push_back(value.data());
+        argv.push_back(nullptr);
+
+        std::vector<std::string> env_strings;
+        env_strings.reserve(environment.size());
+        for (const auto& [key, value] : environment) {
+            env_strings.push_back(key + "=" + value);
+        }
+        std::vector<char*> envp;
+        envp.reserve(env_strings.size() + 1);
+        for (auto& value : env_strings) envp.push_back(value.data());
+        envp.push_back(nullptr);
+
         int stdin_pipe[2] = {-1, -1};
         int stdout_pipe[2] = {-1, -1};
         int stderr_pipe[2] = {-1, -1};
+        int exec_error_pipe[2] = {-1, -1};
         auto close_pair = [](int pair[2]) {
             if (pair[0] >= 0) ::close(pair[0]);
             if (pair[1] >= 0) ::close(pair[1]);
+            pair[0] = pair[1] = -1;
         };
-        if (::pipe(stdin_pipe) != 0 || ::pipe(stdout_pipe) != 0 || ::pipe(stderr_pipe) != 0) {
-            int err = errno;
+
+        if (create_cloexec_pipe(stdin_pipe) != 0 ||
+            create_cloexec_pipe(stdout_pipe) != 0 ||
+            create_cloexec_pipe(stderr_pipe) != 0 ||
+            create_cloexec_pipe(exec_error_pipe) != 0) {
+            const int error = errno;
             close_pair(stdin_pipe);
             close_pair(stdout_pipe);
             close_pair(stderr_pipe);
-            throw std::runtime_error(std::string("pipe failed: ") + std::strerror(err));
+            close_pair(exec_error_pipe);
+            throw std::runtime_error(
+                std::string("pipe creation failed: ") +
+                std::strerror(error));
         }
 
-        pid_t pid = ::fork();
-        if (pid < 0) {
-            int err = errno;
-            ::close(stdin_pipe[0]); ::close(stdin_pipe[1]);
-            ::close(stdout_pipe[0]); ::close(stdout_pipe[1]);
-            ::close(stderr_pipe[0]); ::close(stderr_pipe[1]);
-            throw std::runtime_error(std::string("fork failed: ") + std::strerror(err));
+        const pid_t child = ::fork();
+        if (child < 0) {
+            const int error = errno;
+            close_pair(stdin_pipe);
+            close_pair(stdout_pipe);
+            close_pair(stderr_pipe);
+            close_pair(exec_error_pipe);
+            throw std::runtime_error(std::string("fork failed: ") +
+                                     std::strerror(error));
         }
 
-        if (pid == 0) {
-            ::dup2(stdin_pipe[0], STDIN_FILENO);
-            ::dup2(stdout_pipe[1], STDOUT_FILENO);
-            ::dup2(stderr_pipe[1], STDERR_FILENO);
-
-            ::close(stdin_pipe[0]);
+        if (child == 0) {
             ::close(stdin_pipe[1]);
             ::close(stdout_pipe[0]);
-            ::close(stdout_pipe[1]);
             ::close(stderr_pipe[0]);
+            ::close(exec_error_pipe[0]);
+
+            auto child_fail = [&](int error) {
+                const int saved = error;
+                while (::write(exec_error_pipe[1], &saved, sizeof(saved)) < 0 &&
+                       errno == EINTR) {
+                }
+                _exit(127);
+            };
+
+            if (::setpgid(0, 0) != 0) child_fail(errno);
+            if (!config.working_dir.empty() &&
+                ::chdir(config.working_dir.c_str()) != 0) {
+                child_fail(errno);
+            }
+            if (::dup2(stdin_pipe[0], STDIN_FILENO) < 0 ||
+                ::dup2(stdout_pipe[1], STDOUT_FILENO) < 0 ||
+                ::dup2(stderr_pipe[1], STDERR_FILENO) < 0) {
+                child_fail(errno);
+            }
+
+            ::close(stdin_pipe[0]);
+            ::close(stdout_pipe[1]);
             ::close(stderr_pipe[1]);
-
-            if (!config.working_dir.empty()) {
-                ::chdir(config.working_dir.c_str());
-            }
-            for (const auto& [key, value] : config.env) {
-                ::setenv(key.c_str(), value.c_str(), 1);
-            }
-
-            std::vector<std::string> argv_strings;
-            argv_strings.reserve(config.args.size() + 1);
-            argv_strings.push_back(config.command);
-            for (const auto& arg : config.args) argv_strings.push_back(arg);
-
-            std::vector<char*> argv;
-            argv.reserve(argv_strings.size() + 1);
-            for (auto& value : argv_strings) argv.push_back(value.data());
-            argv.push_back(nullptr);
-
-            ::execvp(config.command.c_str(), argv.data());
-            _exit(127);
+            ::execve(executable.c_str(), argv.data(), envp.data());
+            child_fail(errno);
         }
 
+        ::setpgid(child, child);
         ::close(stdin_pipe[0]);
         ::close(stdout_pipe[1]);
         ::close(stderr_pipe[1]);
+        ::close(exec_error_pipe[1]);
 
-        pid_ = pid;
+        int exec_error = 0;
+        ssize_t bytes = 0;
+        do {
+            bytes = ::read(exec_error_pipe[0], &exec_error,
+                           sizeof(exec_error));
+        } while (bytes < 0 && errno == EINTR);
+        ::close(exec_error_pipe[0]);
+
+        if (bytes > 0) {
+            int status = 0;
+            while (::waitpid(child, &status, 0) < 0 && errno == EINTR) {
+            }
+            ::close(stdin_pipe[1]);
+            ::close(stdout_pipe[0]);
+            ::close(stderr_pipe[0]);
+            throw std::runtime_error(
+                "Failed to launch MCP server '" + config.command + "': " +
+                std::strerror(exec_error));
+        }
+        if (bytes < 0) {
+            const int error = errno;
+            ::kill(-child, SIGKILL);
+            int status = 0;
+            while (::waitpid(child, &status, 0) < 0 && errno == EINTR) {
+            }
+            ::close(stdin_pipe[1]);
+            ::close(stdout_pipe[0]);
+            ::close(stderr_pipe[0]);
+            throw std::runtime_error(
+                std::string("Failed to verify MCP exec: ") +
+                std::strerror(error));
+        }
+
+        pid_ = child;
         stdin_write_ = stdin_pipe[1];
         stdout_read_ = stdout_pipe[0];
         stderr_read_ = stderr_pipe[0];
@@ -627,65 +1097,132 @@ private:
     }
 #endif
 
-    void read_loop_stdout() { read_loop(stdout_read_handle(), on_stdout_line_); }
-    void read_loop_stderr() { read_loop(stderr_read_handle(), on_stderr_line_); }
+    bool consume_bytes(std::string& line, const char* data, std::size_t count,
+                       const LineCallback& callback) {
+        for (std::size_t i = 0; i < count; ++i) {
+            const char ch = data[i];
+            if (ch == '\n') {
+                if (!line.empty() && line.back() == '\r') line.pop_back();
+                if (!line.empty()) {
+                    try {
+                        callback(line);
+                    } catch (const std::exception& e) {
+                        if (on_stderr_line_) {
+                            on_stderr_line_(
+                                std::string("MCP stdout callback failed: ") +
+                                e.what());
+                        }
+                        return false;
+                    } catch (...) {
+                        if (on_stderr_line_) {
+                            on_stderr_line_(
+                                "MCP stdout callback failed with unknown error");
+                        }
+                        return false;
+                    }
+                }
+                line.clear();
+            } else {
+                if (line.size() >= kMaxMessageBytes) {
+                    if (on_stderr_line_) {
+                        on_stderr_line_(
+                            "MCP message exceeded the 64 MiB safety limit");
+                    }
+                    return false;
+                }
+                line.push_back(ch);
+            }
+        }
+        return true;
+    }
+
+    void read_loop_stdout() {
+        const bool clean = read_loop(stdout_read_handle(), on_stdout_line_);
+        const bool was_running =
+            running_.exchange(false, std::memory_order_acq_rel);
+        if (was_running || !clean) notify_exit_once();
+    }
+
+    void read_loop_stderr() {
+        read_loop(stderr_read_handle(), on_stderr_line_);
+    }
 
 #ifdef _WIN32
     HANDLE stdout_read_handle() const { return stdout_read_; }
     HANDLE stderr_read_handle() const { return stderr_read_; }
 
-    void read_loop(HANDLE handle, const LineCallback& cb) {
+    bool read_loop(HANDLE handle, const LineCallback& callback) {
         std::string line;
-        char ch = 0;
-        DWORD n = 0;
-        while (handle != INVALID_HANDLE_VALUE && ReadFile(handle, &ch, 1, &n, nullptr) && n == 1) {
-            if (ch == '\n') {
-                if (!line.empty() && line.back() == '\r') line.pop_back();
-                if (!line.empty()) cb(line);
-                line.clear();
-            } else {
-                line.push_back(ch);
+        std::vector<char> buffer(kReadBufferBytes);
+        while (handle != INVALID_HANDLE_VALUE) {
+            DWORD read = 0;
+            if (!ReadFile(handle, buffer.data(),
+                          static_cast<DWORD>(buffer.size()), &read, nullptr)) {
+                const DWORD error = GetLastError();
+                return error == ERROR_BROKEN_PIPE ||
+                       error == ERROR_HANDLE_EOF ||
+                       !running_.load(std::memory_order_acquire);
             }
+            if (read == 0) break;
+            if (!consume_bytes(line, buffer.data(), read, callback)) return false;
         }
-        if (!line.empty()) cb(line);
+        if (!line.empty()) callback(line);
+        return true;
     }
 #else
     int stdout_read_handle() const { return stdout_read_; }
     int stderr_read_handle() const { return stderr_read_; }
 
-    void read_loop(int fd, const LineCallback& cb) {
+    bool read_loop(int fd, const LineCallback& callback) {
         std::string line;
-        char ch = 0;
+        std::vector<char> buffer(kReadBufferBytes);
         while (fd >= 0) {
-            ssize_t n = ::read(fd, &ch, 1);
-            if (n == 1) {
-                if (ch == '\n') {
-                    if (!line.empty() && line.back() == '\r') line.pop_back();
-                    if (!line.empty()) cb(line);
-                    line.clear();
-                } else {
-                    line.push_back(ch);
+            const ssize_t read = ::read(fd, buffer.data(), buffer.size());
+            if (read > 0) {
+                if (!consume_bytes(line, buffer.data(),
+                                   static_cast<std::size_t>(read), callback)) {
+                    return false;
                 }
-            } else if (n == 0) {
+            } else if (read == 0) {
                 break;
             } else if (errno != EINTR) {
-                break;
+                return !running_.load(std::memory_order_acquire);
             }
         }
-        if (!line.empty()) cb(line);
+        if (!line.empty()) callback(line);
+        return true;
     }
 #endif
 
+    void notify_exit_once() {
+        if (exit_notified_.exchange(true, std::memory_order_acq_rel)) return;
+        ExitCallback callback;
+        {
+            std::lock_guard<std::mutex> callback_lock(callback_mutex_);
+            callback = on_exit_;
+        }
+        if (!callback) return;
+        try {
+            callback();
+        } catch (...) {
+        }
+    }
+
+    std::mutex lifecycle_mutex_;
+    std::mutex write_mutex_;
+    std::mutex callback_mutex_;
     bool started_ = false;
     std::atomic<bool> running_{false};
-    std::mutex write_mutex_;
+    std::atomic<bool> exit_notified_{false};
     std::thread stdout_thread_;
     std::thread stderr_thread_;
     LineCallback on_stdout_line_;
     LineCallback on_stderr_line_;
+    ExitCallback on_exit_;
 
 #ifdef _WIN32
     PROCESS_INFORMATION process_info_{};
+    HANDLE job_ = nullptr;
     HANDLE stdin_write_ = INVALID_HANDLE_VALUE;
     HANDLE stdout_read_ = INVALID_HANDLE_VALUE;
     HANDLE stderr_read_ = INVALID_HANDLE_VALUE;
@@ -697,17 +1234,22 @@ private:
 #endif
 };
 
-json openai_tool_from_mcp_tool(const McpServerConfig& config, const json& tool) {
+json openai_tool_from_mcp_tool(const McpServerConfig& config,
+                               const json& tool) {
     const std::string tool_name = tool.value("name", std::string());
-    const std::string chat_name = McpClientManager::make_chat_tool_name(config.id, tool_name);
+    const std::string chat_name =
+        McpClientManager::make_chat_tool_name(config.id, tool_name);
     std::string description = tool.value("description", std::string());
     if (description.empty()) description = tool.value("title", std::string());
-    if (description.empty()) description = "MCP tool " + tool_name + " from " + config.name;
+    if (description.empty()) {
+        description = "MCP tool " + tool_name + " from " + config.name;
+    }
     description = "[" + config.name + "] " + description;
 
     json parameters = tool.value("inputSchema", json::object());
     if (!parameters.is_object() || parameters.empty()) {
-        parameters = json{{"type", "object"}, {"properties", json::object()}};
+        parameters =
+            json{{"type", "object"}, {"properties", json::object()}};
     }
 
     return json{{"type", "function"},
@@ -727,110 +1269,265 @@ struct McpClientManager::Runtime {
         std::condition_variable cv;
         bool done = false;
         json response;
+        std::weak_ptr<StdioProcess> owner;
     };
 
     McpServerConfig config;
-    mutable std::mutex mutex;
+    mutable std::mutex state_mutex;
+    std::mutex connect_mutex;
+    std::mutex lifecycle_mutex;
+    std::uint64_t lifecycle_generation = 0;
     bool connected = false;
     std::string last_error;
     json server_info = json::object();
     json server_capabilities = json::object();
     std::string negotiated_protocol_version;
     json tools = json::array();
+    std::shared_ptr<StdioProcess> process;
 
-    std::unique_ptr<StdioProcess> process;
-    std::atomic<int> next_request_id{1};
-
+    std::atomic<std::int64_t> next_request_id{1};
     std::mutex waiters_mutex;
-    std::map<int, std::shared_ptr<Waiter>> waiters;
+    std::map<std::int64_t, std::shared_ptr<Waiter>> waiters;
 
     void connect(const McpServerConfig& new_config) {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (connected) return;
-        config = new_config;
-        last_error.clear();
-        server_info = json::object();
-        server_capabilities = json::object();
-        negotiated_protocol_version.clear();
-        tools = json::array();
+        // Capture the generation before waiting for the connect serializer. A
+        // disconnect that happens while this call is queued therefore cancels
+        // it instead of allowing it to reconnect after disconnect returns.
+        std::uint64_t connect_generation = 0;
+        {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            connect_generation = lifecycle_generation;
+        }
 
-        process = std::make_unique<StdioProcess>();
+        std::lock_guard<std::mutex> connect_lock(connect_mutex);
+
+        // Dispose of a process that exited or failed protocol validation before
+        // installing a replacement. This work is outside state_mutex so status
+        // snapshots never wait on process teardown.
+        std::shared_ptr<StdioProcess> stale_process;
+        {
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            if (lifecycle_generation != connect_generation) {
+                throw std::runtime_error(
+                    "MCP connection was cancelled before initialization");
+            }
+            {
+                std::lock_guard<std::mutex> state_lock(state_mutex);
+                if (connected) return;
+                stale_process = std::move(process);
+                connected = false;
+                tools = json::array();
+            }
+            if (stale_process) {
+                cancel_waiters_for(stale_process,
+                                   "MCP server connection was replaced", 499);
+            }
+        }
+        if (stale_process) stale_process->stop();
+
+        auto candidate = std::make_shared<StdioProcess>();
         try {
-            process->start(
-                config,
-                [this](const std::string& line) { handle_stdout_line(line); },
-                [this](const std::string& line) { handle_stderr_line(line); });
+            {
+                // Installing and starting the candidate under lifecycle_mutex
+                // closes the small race where disconnect could detach it before
+                // StdioProcess::start has initialized its handles.
+                std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+                if (lifecycle_generation != connect_generation) {
+                    throw std::runtime_error(
+                        "MCP connection was cancelled before process start");
+                }
+                {
+                    std::lock_guard<std::mutex> state_lock(state_mutex);
+                    config = new_config;
+                    connected = false;
+                    last_error.clear();
+                    server_info = json::object();
+                    server_capabilities = json::object();
+                    negotiated_protocol_version.clear();
+                    tools = json::array();
+                    process = candidate;
+                }
 
-            json init = request(
-                "initialize",
+                std::weak_ptr<StdioProcess> weak_candidate(candidate);
+                candidate->start(
+                    new_config,
+                    [this, weak_candidate](const std::string& line) {
+                        if (auto source = weak_candidate.lock()) {
+                            handle_stdout_line(source, line);
+                        }
+                    },
+                    [this](const std::string& line) {
+                        handle_stderr_line(line);
+                    },
+                    [this, weak_candidate] {
+                        if (auto source = weak_candidate.lock()) {
+                            handle_process_exit(source);
+                        }
+                    });
+            }
+
+            const json init = request(
+                candidate, "initialize",
                 json{{"protocolVersion", kProtocolVersion},
                      {"capabilities", json::object()},
-                     {"clientInfo", json{{"name", "lemonade-mcp-client"},
-                                           {"title", "Lemonade MCP Client Host"},
-                                           {"version", "pr1"}}}},
-                config.timeout_ms);
+                     {"clientInfo",
+                      json{{"name", "lemonade-mcp-client"},
+                           {"title", "Lemonade MCP Client Host"},
+                           {"version", "1"}}}},
+                new_config.timeout_ms);
             if (init.contains("error")) {
-                throw std::runtime_error("initialize failed: " + json_rpc_error_message(init));
+                throw std::runtime_error(
+                    "initialize failed: " + json_rpc_error_message(init));
             }
-            const json result = init.value("result", json::object());
-            negotiated_protocol_version = result.value("protocolVersion", std::string(kProtocolVersion));
-            if (!supported_protocol_version(negotiated_protocol_version)) {
-                throw std::runtime_error("MCP server negotiated unsupported protocol version: " +
-                                         negotiated_protocol_version);
+            if (!init.contains("result") || !init["result"].is_object()) {
+                throw std::runtime_error(
+                    "MCP initialize response is missing an object result");
             }
-            server_info = result.value("serverInfo", json::object());
-            server_capabilities = result.value("capabilities", json::object());
-            notify("notifications/initialized", json::object());
-            connected = true;
-            refresh_tools_locked();
+
+            const json result = init["result"];
+            if (!result.contains("protocolVersion") ||
+                !result["protocolVersion"].is_string()) {
+                throw std::runtime_error(
+                    "MCP initialize result is missing protocolVersion");
+            }
+            const std::string protocol_version =
+                result["protocolVersion"].get<std::string>();
+            if (!supported_protocol_version(protocol_version)) {
+                throw std::runtime_error(
+                    "MCP server negotiated unsupported protocol version: " +
+                    protocol_version);
+            }
+
+            const json info = result.value("serverInfo", json::object());
+            const json capabilities =
+                result.value("capabilities", json::object());
+            if (!info.is_object() || !capabilities.is_object()) {
+                throw std::runtime_error(
+                    "MCP initialize result contains invalid server metadata");
+            }
+
+            notify(candidate, "notifications/initialized", json::object(),
+                   true);
+
+            json discovered_tools = json::array();
+            if (capabilities.contains("tools")) {
+                if (!capabilities["tools"].is_object()) {
+                    throw std::runtime_error(
+                        "MCP tools capability must be an object");
+                }
+                discovered_tools =
+                    fetch_tools(candidate, new_config.timeout_ms);
+            }
+
+            {
+                std::lock_guard<std::mutex> state_lock(state_mutex);
+                if (process != candidate) {
+                    throw std::runtime_error(
+                        "MCP connection was cancelled during initialization");
+                }
+                config = new_config;
+                negotiated_protocol_version = protocol_version;
+                server_info = info;
+                server_capabilities = capabilities;
+                tools = std::move(discovered_tools);
+                connected = true;
+                last_error.clear();
+            }
         } catch (const std::exception& e) {
-            last_error = e.what();
-            connected = false;
-            if (process) process->stop();
-            process.reset();
+            fail_candidate(candidate, e.what());
+            throw;
+        } catch (...) {
+            fail_candidate(candidate, "Unknown MCP connection failure");
             throw;
         }
     }
 
     void disconnect() {
-        std::lock_guard<std::mutex> lock(mutex);
-        connected = false;
+        std::shared_ptr<StdioProcess> old_process;
         {
-            std::lock_guard<std::mutex> wlock(waiters_mutex);
-            for (auto& [_, waiter] : waiters) {
-                std::lock_guard<std::mutex> lk(waiter->mutex);
-                waiter->response = make_error("MCP server disconnected", 499);
-                waiter->done = true;
-                waiter->cv.notify_all();
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            ++lifecycle_generation;
+            {
+                std::lock_guard<std::mutex> state_lock(state_mutex);
+                old_process = std::move(process);
+                connected = false;
+                last_error.clear();
+                server_info = json::object();
+                server_capabilities = json::object();
+                negotiated_protocol_version.clear();
+                tools = json::array();
             }
-            waiters.clear();
+            if (old_process) {
+                cancel_waiters_for(old_process, "MCP server disconnected", 499);
+            }
         }
-        if (process) {
-            process->stop();
-            process.reset();
-        }
+        if (old_process) old_process->stop();
     }
 
     void refresh_tools() {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!connected) throw std::runtime_error("MCP server is not connected");
-        refresh_tools_locked();
+        std::shared_ptr<StdioProcess> source;
+        int timeout_ms = kDefaultTimeoutMs;
+        {
+            std::lock_guard<std::mutex> state_lock(state_mutex);
+            if (!connected || !process) {
+                throw std::runtime_error("MCP server is not connected");
+            }
+            source = process;
+            timeout_ms = config.timeout_ms;
+            if (!server_capabilities.contains("tools")) {
+                tools = json::array();
+                return;
+            }
+        }
+
+        json discovered = fetch_tools(source, timeout_ms);
+        {
+            std::lock_guard<std::mutex> state_lock(state_mutex);
+            if (!connected || process != source) {
+                throw std::runtime_error(
+                    "MCP server disconnected while refreshing tools");
+            }
+            tools = std::move(discovered);
+        }
     }
 
-    json call_tool(const std::string& name, const json& arguments, int timeout_ms) {
-        std::lock_guard<std::mutex> lock(mutex);
-        if (!connected) throw std::runtime_error("MCP server is not connected");
-        json params{{"name", name}, {"arguments", arguments.is_object() ? arguments : json::object()}};
-        json response = request("tools/call", std::move(params), timeout_ms > 0 ? timeout_ms : config.timeout_ms);
+    json call_tool(const std::string& name, const json& arguments,
+                   int timeout_ms) {
+        std::shared_ptr<StdioProcess> source;
+        int configured_timeout = kDefaultTimeoutMs;
+        {
+            std::lock_guard<std::mutex> state_lock(state_mutex);
+            if (!connected || !process) {
+                throw std::runtime_error("MCP server is not connected");
+            }
+            source = process;
+            configured_timeout = config.timeout_ms;
+            if (!server_capabilities.contains("tools")) {
+                throw std::runtime_error(
+                    "MCP server did not advertise the tools capability");
+            }
+        }
+
+        json params{{"name", name},
+                    {"arguments",
+                     arguments.is_object() ? arguments : json::object()}};
+        const json response = request(
+            source, "tools/call", std::move(params),
+            timeout_ms > 0 ? timeout_ms : configured_timeout);
         if (response.contains("error")) {
             throw std::runtime_error(json_rpc_error_message(response));
         }
-        return response.value("result", json::object());
+        if (!response.contains("result")) {
+            throw std::runtime_error(
+                "MCP tools/call response is missing result");
+        }
+        return response["result"];
     }
 
     json snapshot(bool include_env_values = false) const {
-        std::lock_guard<std::mutex> lock(mutex);
-        json out = McpClientManager::config_to_json(config, include_env_values);
+        std::lock_guard<std::mutex> state_lock(state_mutex);
+        json out =
+            McpClientManager::config_to_json(config, include_env_values);
         out["status"] = connected ? "connected" : "disconnected";
         out["connected"] = connected;
         out["last_error"] = last_error;
@@ -842,197 +1539,417 @@ struct McpClientManager::Runtime {
     }
 
 private:
-    json request(const std::string& method, json params, int timeout_ms) {
-        int id = next_request_id.fetch_add(1, std::memory_order_relaxed);
-        auto waiter = std::make_shared<Waiter>();
+    bool is_current_process(
+        const std::shared_ptr<StdioProcess>& source) const {
+        std::lock_guard<std::mutex> state_lock(state_mutex);
+        return process == source;
+    }
+
+    void fail_candidate(const std::shared_ptr<StdioProcess>& candidate,
+                        const std::string& message) {
+        bool owned = false;
         {
-            std::lock_guard<std::mutex> lock(waiters_mutex);
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            {
+                std::lock_guard<std::mutex> state_lock(state_mutex);
+                if (process == candidate) {
+                    process.reset();
+                    connected = false;
+                    last_error = message;
+                    server_info = json::object();
+                    server_capabilities = json::object();
+                    negotiated_protocol_version.clear();
+                    tools = json::array();
+                    owned = true;
+                }
+            }
+            cancel_waiters_for(candidate, message, 502);
+        }
+        if (owned) candidate->stop();
+    }
+
+    std::int64_t allocate_request_id() {
+        const std::int64_t id =
+            next_request_id.fetch_add(1, std::memory_order_relaxed);
+        if (id <= 0 || id == std::numeric_limits<std::int64_t>::max()) {
+            throw std::runtime_error("MCP request id space exhausted");
+        }
+        return id;
+    }
+
+    json request(const std::shared_ptr<StdioProcess>& source,
+                 const std::string& method, json params, int timeout_ms) {
+        const std::int64_t id = allocate_request_id();
+        auto waiter = std::make_shared<Waiter>();
+        waiter->owner = source;
+
+        {
+            // Registering under lifecycle_mutex ensures disconnect cannot cancel
+            // the old set and then miss a waiter added for the detached process.
+            std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex);
+            if (!is_current_process(source)) {
+                throw std::runtime_error("MCP server is disconnected");
+            }
+            std::lock_guard<std::mutex> waiters_lock(waiters_mutex);
             waiters[id] = waiter;
         }
 
-        json msg = json_rpc_request(id, method, std::move(params));
-        if (!process || !process->write_line(msg.dump())) {
-            std::lock_guard<std::mutex> lock(waiters_mutex);
-            waiters.erase(id);
-            throw std::runtime_error("Failed to write JSON-RPC request to MCP server");
+        const json message =
+            json_rpc_request(id, method, std::move(params));
+        if (!source->write_line(message.dump())) {
+            remove_waiter(id, waiter);
+            throw std::runtime_error(
+                "Failed to write JSON-RPC request to MCP server");
         }
 
-        const auto timeout = std::chrono::milliseconds(clamp_timeout_ms(timeout_ms));
-        std::unique_lock<std::mutex> lock(waiter->mutex);
-        if (!waiter->cv.wait_for(lock, timeout, [&] { return waiter->done; })) {
-            {
-                std::lock_guard<std::mutex> wlock(waiters_mutex);
-                waiters.erase(id);
+        const auto timeout =
+            std::chrono::milliseconds(clamp_timeout_ms(timeout_ms));
+        std::unique_lock<std::mutex> waiter_lock(waiter->mutex);
+        if (!waiter->cv.wait_for(waiter_lock, timeout,
+                                 [&] { return waiter->done; })) {
+            waiter_lock.unlock();
+            const bool removed = remove_waiter(id, waiter);
+            if (removed) {
+                notify(source, "notifications/cancelled",
+                       json{{"requestId", id}, {"reason", "timeout"}},
+                       false);
             }
-            notify("notifications/cancelled", json{{"requestId", id}, {"reason", "timeout"}});
             throw std::runtime_error("MCP request timed out: " + method);
         }
         return waiter->response;
     }
 
-    void notify(const std::string& method, json params) {
-        if (!process) return;
-        json msg = json_rpc_notification(method, std::move(params));
-        process->write_line(msg.dump());
+    bool remove_waiter(std::int64_t id,
+                       const std::shared_ptr<Waiter>& expected) {
+        std::lock_guard<std::mutex> waiters_lock(waiters_mutex);
+        const auto it = waiters.find(id);
+        if (it == waiters.end() || it->second != expected) return false;
+        waiters.erase(it);
+        return true;
     }
 
-    void refresh_tools_locked() {
+    void cancel_waiters_for(const std::shared_ptr<StdioProcess>& owner,
+                            const std::string& message, int status) {
+        std::vector<std::shared_ptr<Waiter>> cancelled;
+        {
+            std::lock_guard<std::mutex> waiters_lock(waiters_mutex);
+            for (auto it = waiters.begin(); it != waiters.end();) {
+                if (it->second->owner.lock() == owner) {
+                    cancelled.push_back(it->second);
+                    it = waiters.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+        }
+
+        for (const auto& waiter : cancelled) {
+            std::lock_guard<std::mutex> waiter_lock(waiter->mutex);
+            if (waiter->done) continue;
+            waiter->response = make_error(message, status);
+            waiter->done = true;
+            waiter->cv.notify_all();
+        }
+    }
+
+    void notify(const std::shared_ptr<StdioProcess>& source,
+                const std::string& method, json params, bool required) {
+        if (!source || !is_current_process(source)) {
+            if (required) {
+                throw std::runtime_error("MCP server is disconnected");
+            }
+            return;
+        }
+        const json message =
+            json_rpc_notification(method, std::move(params));
+        if (!source->write_line(message.dump()) && required) {
+            throw std::runtime_error(
+                "Failed to write MCP notification: " + method);
+        }
+    }
+
+    json fetch_tools(const std::shared_ptr<StdioProcess>& source,
+                     int timeout_ms) {
         json collected = json::array();
         std::string cursor;
         for (int page = 0; page < kMaxToolListPages; ++page) {
             json params = json::object();
             if (!cursor.empty()) params["cursor"] = cursor;
-            json response = request("tools/list", params, config.timeout_ms);
+
+            const json response =
+                request(source, "tools/list", std::move(params), timeout_ms);
             if (response.contains("error")) {
-                throw std::runtime_error("tools/list failed: " + json_rpc_error_message(response));
+                throw std::runtime_error(
+                    "tools/list failed: " +
+                    json_rpc_error_message(response));
             }
-            const json result = response.value("result", json::object());
-            if (result.contains("tools") && result["tools"].is_array()) {
+            if (!response.contains("result") ||
+                !response["result"].is_object()) {
+                throw std::runtime_error(
+                    "MCP tools/list response is missing an object result");
+            }
+
+            const json& result = response["result"];
+            if (result.contains("tools")) {
+                if (!result["tools"].is_array()) {
+                    throw std::runtime_error(
+                        "MCP tools/list result.tools must be an array");
+                }
                 for (const auto& tool : result["tools"]) {
-                    if (tool.is_object() && tool.contains("name") && tool["name"].is_string()) {
-                        collected.push_back(tool);
+                    if (!tool.is_object() || !tool.contains("name") ||
+                        !tool["name"].is_string() ||
+                        tool["name"].get<std::string>().empty()) {
+                        throw std::runtime_error(
+                            "MCP tools/list returned an invalid tool entry");
                     }
+                    collected.push_back(tool);
                 }
             }
-            cursor = result.value("nextCursor", std::string());
-            if (cursor.empty()) break;
+
+            cursor.clear();
+            if (result.contains("nextCursor") &&
+                !result["nextCursor"].is_null()) {
+                if (!result["nextCursor"].is_string()) {
+                    throw std::runtime_error(
+                        "MCP tools/list nextCursor must be a string");
+                }
+                cursor = result["nextCursor"].get<std::string>();
+            }
+            if (cursor.empty()) return collected;
         }
-        tools = std::move(collected);
+
+        throw std::runtime_error(
+            "MCP tools/list exceeded the 32-page safety limit");
     }
 
-    void handle_stdout_line(const std::string& line) {
-        json msg;
+    void handle_stdout_line(
+        const std::shared_ptr<StdioProcess>& source,
+        const std::string& line) {
+        json message;
         try {
-            msg = json::parse(line);
+            message = json::parse(line);
         } catch (const std::exception& e) {
-            LOG(WARNING, "McpClient") << "Ignoring non-JSON MCP stdout from " << config.id
-                                      << ": " << e.what() << std::endl;
+            protocol_failure(source,
+                             std::string("Invalid JSON on MCP stdout: ") +
+                                 e.what());
             return;
         }
 
-        if (msg.contains("id") && (msg.contains("result") || msg.contains("error"))) {
-            int id = -1;
-            if (msg["id"].is_number_integer()) {
-                id = msg["id"].get<int>();
-            } else if (msg["id"].is_string()) {
-                try { id = std::stoi(msg["id"].get<std::string>()); } catch (...) { id = -1; }
-            }
-            if (id >= 0) {
-                std::shared_ptr<Waiter> waiter;
-                {
-                    std::lock_guard<std::mutex> lock(waiters_mutex);
-                    auto it = waiters.find(id);
-                    if (it != waiters.end()) {
-                        waiter = it->second;
-                        waiters.erase(it);
-                    }
+        if (!message.is_object() ||
+            message.value("jsonrpc", std::string()) != "2.0") {
+            protocol_failure(source,
+                             "MCP stdout message is not valid JSON-RPC 2.0");
+            return;
+        }
+
+        if (message.contains("id") &&
+            (message.contains("result") || message.contains("error"))) {
+            std::optional<std::int64_t> id;
+            if (message["id"].is_number_integer()) {
+                id = message["id"].get<std::int64_t>();
+            } else if (message["id"].is_number_unsigned()) {
+                const auto unsigned_id =
+                    message["id"].get<std::uint64_t>();
+                if (unsigned_id <= static_cast<std::uint64_t>(
+                                       std::numeric_limits<std::int64_t>::max())) {
+                    id = static_cast<std::int64_t>(unsigned_id);
                 }
-                if (waiter) {
-                    std::lock_guard<std::mutex> lock(waiter->mutex);
-                    waiter->response = std::move(msg);
-                    waiter->done = true;
-                    waiter->cv.notify_all();
+            } else if (message["id"].is_string()) {
+                try {
+                    std::size_t parsed = 0;
+                    const std::string text =
+                        message["id"].get<std::string>();
+                    const std::int64_t parsed_id = std::stoll(text, &parsed);
+                    if (parsed == text.size()) id = parsed_id;
+                } catch (...) {
                 }
+            }
+
+            if (!id || *id < 0) {
+                protocol_failure(source,
+                                 "MCP response contains an invalid id");
+                return;
+            }
+
+            std::shared_ptr<Waiter> waiter;
+            {
+                std::lock_guard<std::mutex> waiters_lock(waiters_mutex);
+                const auto it = waiters.find(*id);
+                if (it != waiters.end() &&
+                    it->second->owner.lock() == source) {
+                    waiter = it->second;
+                    waiters.erase(it);
+                }
+            }
+            if (waiter) {
+                std::lock_guard<std::mutex> waiter_lock(waiter->mutex);
+                waiter->response = std::move(message);
+                waiter->done = true;
+                waiter->cv.notify_all();
             }
             return;
         }
 
-        // PR1 does not expose client-side capabilities such as sampling/roots.
-        // Return a JSON-RPC method-not-found response for server-initiated requests
-        // so a server does not hang forever waiting for a reply.
-        if (msg.contains("method") && msg["method"].is_string() && msg.contains("id")) {
-            const std::string method = msg["method"].get<std::string>();
-            if (process) process->write_line(json_rpc_method_not_found(msg["id"], method).dump());
+        if (message.contains("method") && message["method"].is_string() &&
+            message.contains("id")) {
+            const std::string method =
+                message["method"].get<std::string>();
+            source->write_line(
+                json_rpc_method_not_found(message["id"], method).dump());
             return;
         }
 
-        if (msg.contains("method") && msg["method"].is_string()) {
-            LOG(DEBUG, "McpClient") << "MCP notification from " << config.id << ": "
-                                    << msg["method"].get<std::string>() << std::endl;
+        if (message.contains("method") && message["method"].is_string()) {
+            LOG(DEBUG, "McpClient")
+                << "MCP notification from " << server_id() << ": "
+                << message["method"].get<std::string>() << std::endl;
+            return;
         }
+
+        protocol_failure(source,
+                         "MCP stdout message is neither a response, request, nor notification");
     }
 
     void handle_stderr_line(const std::string& line) {
-        LOG(DEBUG, "McpClient") << "[" << config.id << " stderr] " << line << std::endl;
+        LOG(DEBUG, "McpClient")
+            << "[" << server_id() << " stderr] " << line << std::endl;
+    }
+
+    void handle_process_exit(
+        const std::shared_ptr<StdioProcess>& source) {
+        bool current = false;
+        {
+            std::lock_guard<std::mutex> state_lock(state_mutex);
+            if (process == source) {
+                connected = false;
+                last_error = "MCP server process exited";
+                server_info = json::object();
+                server_capabilities = json::object();
+                negotiated_protocol_version.clear();
+                tools = json::array();
+                current = true;
+            }
+        }
+        if (current) {
+            cancel_waiters_for(source, "MCP server process exited", 502);
+            std::thread([source] { source->stop(); }).detach();
+        }
+    }
+
+    void protocol_failure(const std::shared_ptr<StdioProcess>& source,
+                          const std::string& message) {
+        bool current = false;
+        {
+            std::lock_guard<std::mutex> state_lock(state_mutex);
+            if (process == source) {
+                connected = false;
+                last_error = message;
+                server_info = json::object();
+                server_capabilities = json::object();
+                negotiated_protocol_version.clear();
+                tools = json::array();
+                current = true;
+            }
+        }
+        if (current) {
+            cancel_waiters_for(source, message, 502);
+            std::thread([source] { source->stop(); }).detach();
+        }
+    }
+
+    std::string server_id() const {
+        std::lock_guard<std::mutex> state_lock(state_mutex);
+        return config.id;
     }
 };
 
-McpClientManager::McpClientManager(std::string cache_dir) : cache_dir_(std::move(cache_dir)) {
+McpClientManager::McpClientManager(std::string cache_dir)
+    : cache_dir_(std::move(cache_dir)) {
     if (cache_dir_.empty()) cache_dir_ = ".";
-    fs::path path = fs::path(cache_dir_) / kConfigFileName;
-    config_path_ = path.string();
+    config_path_ = (fs::path(cache_dir_) / kConfigFileName).string();
     load_config_file();
 }
 
-McpClientManager::~McpClientManager() {
-    stop_all();
-}
+McpClientManager::~McpClientManager() { stop_all(); }
 
 void McpClientManager::register_routes(httplib::Server& server) {
     auto self = shared_from_this();
 
-    server.Get("/internal/mcp/servers", [self](const httplib::Request&, httplib::Response& res) {
-        set_json(res, self->list_servers_json());
-    });
+    server.Get("/internal/mcp/servers",
+               [self](const httplib::Request&, httplib::Response& res) {
+                   set_json(res, self->list_servers_json());
+               });
+    server.Get("/internal/mcp/tools",
+               [self](const httplib::Request&, httplib::Response& res) {
+                   set_json(res, self->list_tools_json());
+               });
 
-    server.Get("/internal/mcp/tools", [self](const httplib::Request&, httplib::Response& res) {
-        set_json(res, self->list_tools_json());
-    });
+    server.Post("/internal/mcp/servers",
+                [self](const httplib::Request& req,
+                       httplib::Response& res) {
+                    json body;
+                    if (!parse_json_body(req, res, body)) return;
+                    try {
+                        set_json(res, self->upsert_server_json(body));
+                    } catch (const std::exception& e) {
+                        set_error(res, e.what(), 400);
+                    }
+                });
 
-    server.Post("/internal/mcp/servers", [self](const httplib::Request& req, httplib::Response& res) {
-        json body;
-        if (!parse_json_body(req, res, body)) return;
-        try {
-            set_json(res, self->upsert_server_json(body));
-        } catch (const std::exception& e) {
-            set_error(res, e.what(), 400);
-        }
-    });
-
-    server.Delete(R"(/internal/mcp/servers/([A-Za-z0-9_.-]+))",
+    server.Delete(
+        R"(/internal/mcp/servers/([A-Za-z0-9_.-]+))",
         [self](const httplib::Request& req, httplib::Response& res) {
             try {
-                set_json(res, self->remove_server_json(req.matches[1].str()));
+                set_json(res,
+                         self->remove_server_json(req.matches[1].str()));
             } catch (const std::exception& e) {
                 set_error(res, e.what(), 404);
             }
         });
 
-    server.Post(R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/connect)",
+    server.Post(
+        R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/connect)",
         [self](const httplib::Request& req, httplib::Response& res) {
             try {
-                set_json(res, self->connect_server_json(req.matches[1].str()));
+                set_json(res,
+                         self->connect_server_json(req.matches[1].str()));
             } catch (const std::exception& e) {
-                set_error(res, e.what(), 500);
+                set_error(res, e.what(), 502);
             }
         });
 
-    server.Post(R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/disconnect)",
+    server.Post(
+        R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/disconnect)",
         [self](const httplib::Request& req, httplib::Response& res) {
             try {
-                set_json(res, self->disconnect_server_json(req.matches[1].str()));
+                set_json(res,
+                         self->disconnect_server_json(req.matches[1].str()));
             } catch (const std::exception& e) {
                 set_error(res, e.what(), 404);
             }
         });
 
-    server.Post(R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/refresh-tools)",
+    server.Post(
+        R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/refresh-tools)",
         [self](const httplib::Request& req, httplib::Response& res) {
             try {
-                set_json(res, self->refresh_tools_json(req.matches[1].str()));
+                set_json(res,
+                         self->refresh_tools_json(req.matches[1].str()));
             } catch (const std::exception& e) {
-                set_error(res, e.what(), 500);
+                set_error(res, e.what(), 502);
             }
         });
 
-    server.Post(R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/tools/call)",
+    server.Post(
+        R"(/internal/mcp/servers/([A-Za-z0-9_.-]+)/tools/call)",
         [self](const httplib::Request& req, httplib::Response& res) {
             json body;
             if (!parse_json_body(req, res, body)) return;
             try {
-                set_json(res, self->call_tool_json(req.matches[1].str(), body));
+                set_json(res,
+                         self->call_tool_json(req.matches[1].str(), body));
             } catch (const std::exception& e) {
-                set_error(res, e.what(), 500);
+                set_error(res, e.what(), 502);
             }
         });
 }
@@ -1041,65 +1958,157 @@ void McpClientManager::stop_all() {
     std::map<std::string, std::shared_ptr<Runtime>> runtimes;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        runtimes = runtimes_;
+        runtimes.swap(runtimes_);
     }
     for (auto& [_, runtime] : runtimes) {
         if (runtime) runtime->disconnect();
     }
 }
 
-McpServerConfig McpClientManager::parse_server_config_json(const json& value,
-                                                           bool allow_missing_id) {
-    if (!value.is_object()) throw std::runtime_error("MCP server config must be an object");
-
-    McpServerConfig cfg;
-    cfg.id = trim(value.value("id", std::string()));
-    cfg.name = trim(value.value("name", std::string()));
-    cfg.transport = trim(value.value("transport", std::string("stdio")));
-    cfg.command = trim(value.value("command", std::string()));
-    cfg.working_dir = trim(value.value("working_dir", value.value("workingDir", std::string())));
-    cfg.enabled = value.value("enabled", true);
-    cfg.timeout_ms = clamp_timeout_ms(value.value("timeout_ms", value.value("timeoutMs", kDefaultTimeoutMs)));
-
-    if (allow_missing_id && cfg.id.empty()) {
-        cfg.id = sanitize_id_seed(!cfg.name.empty() ? cfg.name : basename_like(cfg.command));
+McpServerConfig McpClientManager::parse_server_config_json(
+    const json& value, bool allow_missing_id) {
+    if (!value.is_object()) {
+        throw std::runtime_error("MCP server config must be an object");
     }
-    if (!valid_id(cfg.id)) throw std::runtime_error("MCP server id must match [A-Za-z0-9_.-]+ and be at most 96 chars");
-    if (cfg.name.empty()) cfg.name = cfg.id;
-    if (has_control_char(cfg.name)) throw std::runtime_error("MCP server name must not contain control characters");
-    if (cfg.transport != "stdio") throw std::runtime_error("PR1 supports only MCP stdio transport");
-    if (cfg.command.empty()) throw std::runtime_error("MCP stdio server config requires command");
-    if (has_control_char(cfg.command)) throw std::runtime_error("MCP command must not contain control characters");
-    if (has_control_char(cfg.working_dir)) throw std::runtime_error("MCP working_dir must not contain control characters");
+
+    auto read_string = [&value](const char* field,
+                                const std::string& fallback = std::string()) {
+        if (!value.contains(field)) return fallback;
+        if (!value[field].is_string()) {
+            throw std::runtime_error(std::string("MCP ") + field +
+                                     " must be a string");
+        }
+        return value[field].get<std::string>();
+    };
+
+    McpServerConfig config;
+    config.id = trim(read_string("id"));
+    config.name = trim(read_string("name"));
+    config.transport = trim(read_string("transport", "stdio"));
+    config.command = trim(read_string("command"));
+
+    if (value.contains("working_dir") && value.contains("workingDir")) {
+        throw std::runtime_error(
+            "Use only one of working_dir or workingDir");
+    }
+    config.working_dir = trim(value.contains("working_dir")
+                                  ? read_string("working_dir")
+                                  : read_string("workingDir"));
+
+    if (value.contains("enabled")) {
+        if (!value["enabled"].is_boolean()) {
+            throw std::runtime_error("MCP enabled must be a boolean");
+        }
+        config.enabled = value["enabled"].get<bool>();
+    }
+
+    if (value.contains("timeout_ms") && value.contains("timeoutMs")) {
+        throw std::runtime_error("Use only one of timeout_ms or timeoutMs");
+    }
+    const char* timeout_field = value.contains("timeout_ms")
+                                    ? "timeout_ms"
+                                    : "timeoutMs";
+    if (value.contains(timeout_field)) {
+        if (!value[timeout_field].is_number_integer()) {
+            throw std::runtime_error("MCP timeout must be an integer");
+        }
+        const auto timeout = value[timeout_field].get<long long>();
+        if (timeout < kMinTimeoutMs || timeout > kMaxTimeoutMs) {
+            throw std::runtime_error(
+                "MCP timeout must be between 1000 and 300000 ms");
+        }
+        config.timeout_ms = static_cast<int>(timeout);
+    }
 
     if (value.contains("args")) {
-        if (!value["args"].is_array()) throw std::runtime_error("MCP args must be an array of strings");
+        if (!value["args"].is_array()) {
+            throw std::runtime_error(
+                "MCP args must be an array of strings");
+        }
         for (const auto& arg : value["args"]) {
-            if (!arg.is_string()) throw std::runtime_error("MCP args must be an array of strings");
-            std::string s = arg.get<std::string>();
-            if (s.find('\0') != std::string::npos) throw std::runtime_error("MCP args must not contain NUL");
-            cfg.args.push_back(std::move(s));
+            if (!arg.is_string()) {
+                throw std::runtime_error(
+                    "MCP args must be an array of strings");
+            }
+            std::string text = arg.get<std::string>();
+            if (text.find('\0') != std::string::npos) {
+                throw std::runtime_error("MCP args must not contain NUL");
+            }
+            config.args.push_back(std::move(text));
         }
     }
 
     if (value.contains("env")) {
-        if (!value["env"].is_object()) throw std::runtime_error("MCP env must be an object of string values");
-        for (auto it = value["env"].begin(); it != value["env"].end(); ++it) {
-            if (!valid_env_name(it.key())) throw std::runtime_error("Invalid MCP env var name: " + it.key());
-            if (!it.value().is_string()) throw std::runtime_error("MCP env values must be strings");
-            std::string v = it.value().get<std::string>();
-            if (v.find('\0') != std::string::npos) throw std::runtime_error("MCP env values must not contain NUL");
-            cfg.env[it.key()] = std::move(v);
+        if (!value["env"].is_object()) {
+            throw std::runtime_error(
+                "MCP env must be an object of string references");
+        }
+        for (auto it = value["env"].begin(); it != value["env"].end();
+             ++it) {
+            if (!valid_env_name(it.key())) {
+                throw std::runtime_error("Invalid MCP env var name: " +
+                                         it.key());
+            }
+            if (!it.value().is_string()) {
+                throw std::runtime_error(
+                    "MCP env values must be strings");
+            }
+            std::string reference = it.value().get<std::string>();
+            if (!env_reference_name(reference)) {
+                throw std::runtime_error(
+                    "MCP env value for '" + it.key() +
+                    "' must be a ${VARIABLE} reference; raw values are rejected");
+            }
+            config.env[it.key()] = std::move(reference);
         }
     }
 
-    return cfg;
+    if (allow_missing_id && config.id.empty()) {
+        config.id = sanitize_id_seed(
+            !config.name.empty() ? config.name
+                                 : basename_like(config.command));
+    }
+    if (!valid_id(config.id)) {
+        throw std::runtime_error(
+            "MCP server id must match [A-Za-z0-9_.-]+ and be at most 96 chars");
+    }
+    if (config.name.empty()) config.name = config.id;
+    if (has_control_char(config.name)) {
+        throw std::runtime_error(
+            "MCP server name must not contain control characters");
+    }
+    if (config.transport != "stdio") {
+        throw std::runtime_error(
+            "This MCP client host supports only stdio transport");
+    }
+    if (config.command.empty()) {
+        throw std::runtime_error(
+            "MCP stdio server config requires command");
+    }
+    if (config.command.find('\0') != std::string::npos ||
+        has_control_char(config.command)) {
+        throw std::runtime_error(
+            "MCP command must not contain control characters");
+    }
+    if (config.working_dir.find('\0') != std::string::npos ||
+        has_control_char(config.working_dir)) {
+        throw std::runtime_error(
+            "MCP working_dir must not contain control characters");
+    }
+
+    validate_env_references(config);
+    return config;
 }
 
-json McpClientManager::config_to_json(const McpServerConfig& config, bool include_env_values) {
+json McpClientManager::config_to_json(const McpServerConfig& config,
+                                      bool include_env_values) {
     json env = json::object();
     for (const auto& [key, value] : config.env) {
-        env[key] = include_env_values ? value : "***";
+        // A persisted config contains references only. Returning the reference is
+        // safe and useful to clients; a legacy in-memory raw value stays masked.
+        env[key] = (include_env_values || env_reference_name(value))
+                       ? value
+                       : "***";
     }
     return json{{"id", config.id},
                 {"name", config.name},
@@ -1112,33 +2121,44 @@ json McpClientManager::config_to_json(const McpServerConfig& config, bool includ
                 {"timeout_ms", config.timeout_ms}};
 }
 
-std::string McpClientManager::make_chat_tool_name(const std::string& server_id,
-                                                  const std::string& tool_name) {
-    auto clean = [](const std::string& s) {
-        std::string out;
-        out.reserve(s.size());
-        for (unsigned char c : s) {
-            if (std::isalnum(c) || c == '_' || c == '-') out.push_back(static_cast<char>(c));
-            else out.push_back('_');
+std::string McpClientManager::make_chat_tool_name(
+    const std::string& server_id, const std::string& tool_name) {
+    auto clean = [](const std::string& input) {
+        std::string output;
+        output.reserve(input.size());
+        for (unsigned char c : input) {
+            output.push_back(ascii_is_alnum(c) || c == '_' || c == '-'
+                                 ? static_cast<char>(c)
+                                 : '_');
         }
-        while (!out.empty() && out.front() == '_') out.erase(out.begin());
-        while (!out.empty() && out.back() == '_') out.pop_back();
-        if (out.empty()) out = "tool";
-        return out;
+        while (!output.empty() && output.front() == '_') {
+            output.erase(output.begin());
+        }
+        while (!output.empty() && output.back() == '_') output.pop_back();
+        return output.empty() ? std::string("tool") : output;
     };
+
+    const std::string clean_server = clean(server_id);
+    const std::string clean_tool = clean(tool_name);
     const std::string raw = server_id + "\n" + tool_name;
-    const std::string suffix = "_" + fnv1a_hex8(raw);
-    std::string name = "mcp_" + clean(server_id) + "__" + clean(tool_name);
+    const std::string hash_suffix = "_" + fnv1a_hex16(raw);
+    std::string name = "mcp_" + clean_server + "__" + clean_tool;
+
+    const bool lossy = clean_server != server_id || clean_tool != tool_name;
+    const bool ambiguous_separator =
+        clean_server.find("__") != std::string::npos ||
+        clean_tool.find("__") != std::string::npos;
+    if (lossy || ambiguous_separator) name += hash_suffix;
     if (name.size() > 64) {
-        // OpenAI-compatible function names are commonly limited to 64 chars.
-        // Preserve readability while keeping a stable hash suffix so two long
-        // MCP tool names do not collapse to the same truncated function name.
-        const size_t keep = 64 - suffix.size();
+        const std::size_t keep = 64 - hash_suffix.size();
         name.resize(keep);
-        while (!name.empty() && (name.back() == '_' || name.back() == '-')) name.pop_back();
-        name += suffix;
+        while (!name.empty() &&
+               (name.back() == '_' || name.back() == '-')) {
+            name.pop_back();
+        }
+        name += hash_suffix;
     }
-    return name.empty() ? "mcp_tool" : name;
+    return name;
 }
 
 json McpClientManager::list_servers_json() const {
@@ -1146,28 +2166,32 @@ json McpClientManager::list_servers_json() const {
     {
         std::lock_guard<std::mutex> lock(mutex_);
         entries.reserve(configs_.size());
-        for (const auto& [id, cfg] : configs_) {
-            std::shared_ptr<Runtime> runtime;
-            auto it = runtimes_.find(id);
-            if (it != runtimes_.end()) runtime = it->second;
-            entries.push_back({cfg, runtime});
+        for (const auto& [id, config] : configs_) {
+            const auto runtime_it = runtimes_.find(id);
+            entries.emplace_back(
+                config, runtime_it == runtimes_.end()
+                            ? nullptr
+                            : runtime_it->second);
         }
     }
 
     json servers = json::array();
-    for (const auto& [cfg, runtime] : entries) {
+    for (const auto& [config, runtime] : entries) {
         if (runtime) {
             servers.push_back(runtime->snapshot(false));
-        } else {
-            json s = config_to_json(cfg, false);
-            s["status"] = "disconnected";
-            s["connected"] = false;
-            s["last_error"] = "";
-            s["tools"] = json::array();
-            servers.push_back(std::move(s));
+            continue;
         }
+        json item = config_to_json(config, false);
+        item["status"] = "disconnected";
+        item["connected"] = false;
+        item["last_error"] = "";
+        item["protocol_version"] = "";
+        item["server_info"] = json::object();
+        item["capabilities"] = json::object();
+        item["tools"] = json::array();
+        servers.push_back(std::move(item));
     }
-    return json{{"servers", servers}};
+    return json{{"servers", std::move(servers)}};
 }
 
 json McpClientManager::list_tools_json() const {
@@ -1176,197 +2200,334 @@ json McpClientManager::list_tools_json() const {
         std::lock_guard<std::mutex> lock(mutex_);
         entries.reserve(runtimes_.size());
         for (const auto& [id, runtime] : runtimes_) {
-            if (!runtime) continue;
-            auto cfg_it = configs_.find(id);
-            if (cfg_it == configs_.end()) continue;
-            entries.push_back({cfg_it->second, runtime});
+            const auto config_it = configs_.find(id);
+            if (runtime && config_it != configs_.end()) {
+                entries.emplace_back(config_it->second, runtime);
+            }
         }
     }
 
-    json tools = json::array();
-    for (const auto& [cfg, runtime] : entries) {
-        json snap = runtime->snapshot(false);
-        if (!snap.value("connected", false)) continue;
-        for (const auto& tool : snap.value("tools", json::array())) {
-            if (!tool.is_object() || !tool.contains("name") || !tool["name"].is_string()) continue;
-            const std::string tool_name = tool["name"].get<std::string>();
-            tools.push_back(json{{"server_id", cfg.id},
-                                 {"server_name", cfg.name},
-                                 {"name", tool_name},
-                                 {"chat_name", make_chat_tool_name(cfg.id, tool_name)},
-                                 {"title", tool.value("title", std::string())},
-                                 {"description", tool.value("description", std::string())},
-                                 {"inputSchema", tool.value("inputSchema", json::object())},
-                                 {"tool", tool},
-                                 {"openai_tool", openai_tool_from_mcp_tool(cfg, tool)}});
+    json tools_json = json::array();
+    for (const auto& [config, runtime] : entries) {
+        const json state = runtime->snapshot(false);
+        if (!state.value("connected", false)) continue;
+        const json available = state.value("tools", json::array());
+        if (!available.is_array()) continue;
+        for (const auto& tool : available) {
+            if (!tool.is_object() || !tool.contains("name") ||
+                !tool["name"].is_string()) {
+                continue;
+            }
+            const std::string name = tool["name"].get<std::string>();
+            tools_json.push_back(
+                json{{"server_id", config.id},
+                     {"server_name", config.name},
+                     {"name", name},
+                     {"chat_name", make_chat_tool_name(config.id, name)},
+                     {"title", tool.value("title", std::string())},
+                     {"description",
+                      tool.value("description", std::string())},
+                     {"inputSchema",
+                      tool.value("inputSchema", json::object())},
+                     {"tool", tool},
+                     {"openai_tool",
+                      openai_tool_from_mcp_tool(config, tool)}});
         }
     }
-    return json{{"tools", tools}};
+    return json{{"tools", std::move(tools_json)}};
 }
 
 json McpClientManager::upsert_server_json(const json& body) {
-    const json& raw = body.contains("server") && body["server"].is_object() ? body["server"] : body;
-    McpServerConfig cfg = parse_server_config_json(raw, true);
+    const json& raw = body.contains("server") && body["server"].is_object()
+                          ? body["server"]
+                          : body;
+    McpServerConfig config = parse_server_config_json(raw, true);
 
     std::shared_ptr<Runtime> old_runtime;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        if (raw.value("id", std::string()).empty()) {
-            cfg.id = next_id_locked(cfg.id);
+        if (!raw.contains("id") ||
+            (raw["id"].is_string() &&
+             trim(raw["id"].get<std::string>()).empty())) {
+            config.id = next_id_locked(config.id);
         }
-        configs_[cfg.id] = cfg;
-        auto it = runtimes_.find(cfg.id);
-        if (it != runtimes_.end()) {
-            old_runtime = it->second;
-            runtimes_.erase(it);
+
+        auto next_configs = configs_;
+        next_configs[config.id] = config;
+        save_config_file_locked(next_configs);
+        configs_.swap(next_configs);
+
+        const auto runtime_it = runtimes_.find(config.id);
+        if (runtime_it != runtimes_.end()) {
+            old_runtime = runtime_it->second;
+            runtimes_.erase(runtime_it);
         }
-        save_config_file_locked();
     }
     if (old_runtime) old_runtime->disconnect();
-
-    return json{{"server", config_to_json(cfg, false)}};
+    return json{{"server", config_to_json(config, false)}};
 }
 
 json McpClientManager::remove_server_json(const std::string& id) {
     std::shared_ptr<Runtime> runtime;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        if (!configs_.count(id)) throw std::runtime_error("Unknown MCP server: " + id);
-        configs_.erase(id);
-        auto it = runtimes_.find(id);
-        if (it != runtimes_.end()) {
-            runtime = it->second;
-            runtimes_.erase(it);
+        if (!configs_.count(id)) {
+            throw std::runtime_error("Unknown MCP server: " + id);
         }
-        save_config_file_locked();
+        auto next_configs = configs_;
+        next_configs.erase(id);
+        save_config_file_locked(next_configs);
+        configs_.swap(next_configs);
+
+        const auto runtime_it = runtimes_.find(id);
+        if (runtime_it != runtimes_.end()) {
+            runtime = runtime_it->second;
+            runtimes_.erase(runtime_it);
+        }
     }
     if (runtime) runtime->disconnect();
     return json{{"removed", id}};
 }
 
 json McpClientManager::connect_server_json(const std::string& id) {
-    McpServerConfig cfg = config_for_id(id);
-    if (!cfg.enabled) throw std::runtime_error("MCP server is disabled: " + id);
-    auto runtime = get_or_create_runtime(cfg);
-    runtime->connect(cfg);
+    const McpServerConfig config = config_for_id(id);
+    if (!config.enabled) {
+        throw std::runtime_error("MCP server is disabled: " + id);
+    }
+    const auto runtime = get_or_create_runtime(config);
+    runtime->connect(config);
     return json{{"server", runtime->snapshot(false)}};
 }
 
 json McpClientManager::disconnect_server_json(const std::string& id) {
+    McpServerConfig config;
     std::shared_ptr<Runtime> runtime;
-    McpServerConfig cfg;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto cfg_it = configs_.find(id);
-        if (cfg_it == configs_.end()) throw std::runtime_error("Unknown MCP server: " + id);
-        cfg = cfg_it->second;
-        auto it = runtimes_.find(id);
-        if (it != runtimes_.end()) runtime = it->second;
+        const auto config_it = configs_.find(id);
+        if (config_it == configs_.end()) {
+            throw std::runtime_error("Unknown MCP server: " + id);
+        }
+        config = config_it->second;
+        const auto runtime_it = runtimes_.find(id);
+        if (runtime_it != runtimes_.end()) runtime = runtime_it->second;
     }
     if (runtime) runtime->disconnect();
-    json out = config_to_json(cfg, false);
-    out["status"] = "disconnected";
-    out["connected"] = false;
-    out["tools"] = json::array();
-    return json{{"server", out}};
+
+    json state = config_to_json(config, false);
+    state["status"] = "disconnected";
+    state["connected"] = false;
+    state["last_error"] = "";
+    state["protocol_version"] = "";
+    state["server_info"] = json::object();
+    state["capabilities"] = json::object();
+    state["tools"] = json::array();
+    return json{{"server", std::move(state)}};
 }
 
 json McpClientManager::refresh_tools_json(const std::string& id) {
-    McpServerConfig cfg = config_for_id(id);
-    if (!cfg.enabled) throw std::runtime_error("MCP server is disabled: " + id);
-    auto runtime = get_or_create_runtime(cfg);
-    runtime->connect(cfg);
+    const McpServerConfig config = config_for_id(id);
+    if (!config.enabled) {
+        throw std::runtime_error("MCP server is disabled: " + id);
+    }
+    const auto runtime = get_or_create_runtime(config);
+    runtime->connect(config);
     runtime->refresh_tools();
     return json{{"server", runtime->snapshot(false)}};
 }
 
-json McpClientManager::call_tool_json(const std::string& id, const json& body) {
-    if (!body.contains("name") || !body["name"].is_string()) {
-        throw std::runtime_error("tools/call body requires string field `name`");
+json McpClientManager::call_tool_json(const std::string& id,
+                                      const json& body) {
+    if (!body.contains("name") || !body["name"].is_string() ||
+        body["name"].get<std::string>().empty()) {
+        throw std::runtime_error(
+            "tools/call body requires non-empty string field `name`");
     }
-    McpServerConfig cfg = config_for_id(id);
-    if (!cfg.enabled) throw std::runtime_error("MCP server is disabled: " + id);
-    auto runtime = get_or_create_runtime(cfg);
-    runtime->connect(cfg);
+    if (body.contains("arguments") && !body["arguments"].is_object()) {
+        throw std::runtime_error(
+            "tools/call field `arguments` must be an object");
+    }
+
+    const McpServerConfig config = config_for_id(id);
+    if (!config.enabled) {
+        throw std::runtime_error("MCP server is disabled: " + id);
+    }
+    const auto runtime = get_or_create_runtime(config);
+    runtime->connect(config);
+
+    int timeout_ms = config.timeout_ms;
+    if (body.contains("timeout_ms") && body.contains("timeoutMs")) {
+        throw std::runtime_error("Use only one of timeout_ms or timeoutMs");
+    }
+    const char* timeout_field = body.contains("timeout_ms")
+                                    ? "timeout_ms"
+                                    : "timeoutMs";
+    if (body.contains(timeout_field)) {
+        if (!body[timeout_field].is_number_integer()) {
+            throw std::runtime_error("tools/call timeout must be an integer");
+        }
+        const auto timeout = body[timeout_field].get<long long>();
+        if (timeout < kMinTimeoutMs || timeout > kMaxTimeoutMs) {
+            throw std::runtime_error(
+                "tools/call timeout must be between 1000 and 300000 ms");
+        }
+        timeout_ms = static_cast<int>(timeout);
+    }
 
     const std::string name = body["name"].get<std::string>();
-    json arguments = body.value("arguments", json::object());
-    if (!arguments.is_object()) arguments = json::object();
-    int timeout_ms = clamp_timeout_ms(body.value("timeout_ms", body.value("timeoutMs", cfg.timeout_ms)));
-    json result = runtime->call_tool(name, arguments, timeout_ms);
+    const json arguments = body.value("arguments", json::object());
+    const json result = runtime->call_tool(name, arguments, timeout_ms);
     return json{{"server_id", id}, {"tool", name}, {"result", result}};
 }
 
-std::shared_ptr<McpClientManager::Runtime> McpClientManager::get_or_create_runtime(const McpServerConfig& config) {
+std::shared_ptr<McpClientManager::Runtime>
+McpClientManager::get_or_create_runtime(const McpServerConfig& config) {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto it = runtimes_.find(config.id);
+    const auto it = runtimes_.find(config.id);
     if (it != runtimes_.end() && it->second) return it->second;
     auto runtime = std::make_shared<Runtime>(config);
     runtimes_[config.id] = runtime;
     return runtime;
 }
 
-McpServerConfig McpClientManager::config_for_id(const std::string& id) const {
+McpServerConfig McpClientManager::config_for_id(
+    const std::string& id) const {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto it = configs_.find(id);
-    if (it == configs_.end()) throw std::runtime_error("Unknown MCP server: " + id);
+    const auto it = configs_.find(id);
+    if (it == configs_.end()) {
+        throw std::runtime_error("Unknown MCP server: " + id);
+    }
     return it->second;
 }
 
 void McpClientManager::load_config_file() {
     std::lock_guard<std::mutex> lock(mutex_);
     configs_.clear();
-    std::ifstream in(config_path_);
-    if (!in.good()) return;
+
+    std::ifstream input(config_path_);
+    if (!input.good()) return;
     try {
-        json doc = json::parse(in);
-        const json servers = doc.contains("servers") ? doc["servers"] : json::array();
-        if (!servers.is_array()) return;
+        const json document = json::parse(input);
+        if (!document.is_object()) {
+            throw std::runtime_error("root must be an object");
+        }
+        const json servers = document.value("servers", json::array());
+        if (!servers.is_array()) {
+            throw std::runtime_error("servers must be an array");
+        }
         for (const auto& entry : servers) {
             try {
-                McpServerConfig cfg = parse_server_config_json(entry, false);
-                configs_[cfg.id] = std::move(cfg);
+                McpServerConfig config =
+                    parse_server_config_json(entry, false);
+                if (configs_.count(config.id)) {
+                    LOG(WARNING, "McpClient")
+                        << "Ignoring duplicate MCP server id in config: "
+                        << config.id << std::endl;
+                    continue;
+                }
+                configs_.emplace(config.id, std::move(config));
             } catch (const std::exception& e) {
-                LOG(WARNING, "McpClient") << "Skipping invalid MCP server config: " << e.what() << std::endl;
+                LOG(WARNING, "McpClient")
+                    << "Skipping invalid MCP server config: " << e.what()
+                    << std::endl;
             }
         }
     } catch (const std::exception& e) {
-        LOG(WARNING, "McpClient") << "Failed to read MCP config " << config_path_ << ": " << e.what() << std::endl;
+        LOG(WARNING, "McpClient")
+            << "Failed to read MCP config " << config_path_ << ": "
+            << e.what() << std::endl;
     }
 }
 
-void McpClientManager::save_config_file_locked() const {
-    fs::path path(config_path_);
-    std::error_code ec;
-    fs::create_directories(path.parent_path(), ec);
-    if (ec) throw std::runtime_error("Failed to create MCP config directory: " + ec.message());
+void McpClientManager::save_config_file_locked(
+    const std::map<std::string, McpServerConfig>& configs) const {
+    const fs::path path(config_path_);
+    std::error_code error;
+    fs::create_directories(path.parent_path(), error);
+    if (error) {
+        throw std::runtime_error(
+            "Failed to create MCP config directory: " + error.message());
+    }
 
     json servers = json::array();
-    for (const auto& [_, cfg] : configs_) servers.push_back(config_to_persisted_json(cfg));
-    json doc{{"version", 1}, {"servers", servers}};
+    for (const auto& [_, config] : configs) {
+        servers.push_back(config_to_persisted_json(config));
+    }
+    const json document{{"version", 1}, {"servers", std::move(servers)}};
 
-    std::ofstream out(config_path_, std::ios::trunc);
-    if (!out.good()) throw std::runtime_error("Failed to open MCP config for writing: " + config_path_);
-    out << std::setw(2) << doc << std::endl;
+    const fs::path temporary = path.string() + ".tmp";
+    {
+        std::ofstream output(temporary,
+                             std::ios::binary | std::ios::trunc);
+        if (!output.good()) {
+            throw std::runtime_error(
+                "Failed to open MCP config for writing: " +
+                temporary.string());
+        }
+        output << std::setw(2) << document << '\n';
+        output.flush();
+        if (!output.good()) {
+            output.close();
+            std::error_code ignored;
+            fs::remove(temporary, ignored);
+            throw std::runtime_error(
+                "Failed to write MCP config: " + temporary.string());
+        }
+    }
+
+#ifndef _WIN32
+    if (::chmod(temporary.c_str(), S_IRUSR | S_IWUSR) != 0) {
+        const int saved_errno = errno;
+        std::error_code ignored;
+        fs::remove(temporary, ignored);
+        throw std::runtime_error(
+            std::string("Failed to secure MCP config permissions: ") +
+            std::strerror(saved_errno));
+    }
+#endif
+
+#ifdef _WIN32
+    const std::wstring source = utf8_to_wide(temporary.string());
+    const std::wstring destination = utf8_to_wide(path.string());
+    if (!MoveFileExW(source.c_str(), destination.c_str(),
+                     MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        const DWORD move_error = GetLastError();
+        DeleteFileW(source.c_str());
+        throw std::runtime_error(
+            "Failed to replace MCP config atomically (GetLastError=" +
+            std::to_string(move_error) + ")");
+    }
+#else
+    if (::rename(temporary.c_str(), path.c_str()) != 0) {
+        const int saved_errno = errno;
+        std::error_code ignored;
+        fs::remove(temporary, ignored);
+        throw std::runtime_error(
+            std::string("Failed to replace MCP config atomically: ") +
+            std::strerror(saved_errno));
+    }
+#endif
 }
 
-std::string McpClientManager::next_id_locked(const std::string& seed) const {
-    std::string base = sanitize_id_seed(seed);
+std::string McpClientManager::next_id_locked(
+    const std::string& seed) const {
+    const std::string base = sanitize_id_seed(seed);
     std::string id = base;
-    for (int i = 2; configs_.count(id); ++i) {
-        id = base + "-" + std::to_string(i);
+    for (int suffix = 2; configs_.count(id); ++suffix) {
+        id = base + "-" + std::to_string(suffix);
     }
     return id;
 }
 
-void register_mcp_client_routes(httplib::Server& server, const std::string& cache_dir) {
+void register_mcp_client_routes(httplib::Server& server,
+                                const std::string& cache_dir) {
     static std::mutex managers_mutex;
     static std::map<std::string, std::weak_ptr<McpClientManager>> managers;
 
     std::shared_ptr<McpClientManager> manager;
     {
         std::lock_guard<std::mutex> lock(managers_mutex);
-        auto it = managers.find(cache_dir);
+        const auto it = managers.find(cache_dir);
         if (it != managers.end()) manager = it->second.lock();
         if (!manager) {
             manager = std::make_shared<McpClientManager>(cache_dir);

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -6,6 +6,7 @@
 #include "lemon/routing_policy.h"
 #include "lemon/config_file.h"
 #include "lemon/mcp_server.h"
+#include "lemon/mcp_client.h"
 #include "lemon/ollama_api.h"
 #include "lemon/backends/cloud/cloud_server.h"
 #include "lemon/backends/sdcpp/sdcpp_server.h"
@@ -840,6 +841,11 @@ void Server::setup_routes(httplib::Server &web_server) {
     web_server.Post("/internal/simulate-vram-pressure", [this](const httplib::Request& req, httplib::Response& res) {
         handle_simulate_vram_pressure(req, res);
     });
+
+    // Server-side MCP client host foundation (admin-gated through the existing
+    // /internal/* pre-routing auth). GUI3 and the web UI can both use these
+    // endpoints via the normal Lemonade server connection.
+    register_mcp_client_routes(web_server, cache_dir_);
 
     // Cloud auth: register quad-prefix POST and a parameterized DELETE.
     //   POST /v1/cloud/auth        body: {provider, api_key}

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -599,7 +599,9 @@ httplib::Server::HandlerResponse Server::authenticate_request(const httplib::Req
     //   when LEMONADE_ADMIN_API_KEY is unset, admin_api_key_ == api_key_, so the
     //   regular key also authenticates against /internal/*.
     // - If api_key_ is empty, the regular endpoints require no authentication.
-    // - If admin_api_key_ is empty (neither key set), /internal/* requires none.
+    // - If admin_api_key_ is empty (neither key set), legacy /internal/* routes
+    //   require no authentication. The MCP process-launch surface is deliberately
+    //   fail-closed and requires an explicitly configured admin key.
 
     // Safely extract bearer token, guarding against malformed Authorization headers
     std::string auth_token;
@@ -618,7 +620,23 @@ httplib::Server::HandlerResponse Server::authenticate_request(const httplib::Req
 
     telemetry::g_current_auth_token = auth_token;
 
+    const bool is_mcp_internal_route =
+        req.path == "/internal/mcp" ||
+        req.path.rfind("/internal/mcp/", 0) == 0;
+
     if (is_internal_route) {
+        // MCP server registration can launch arbitrary local processes. Do not
+        // expose that capability on a keyless server, even on loopback: permissive
+        // CORS would otherwise let an unrelated web page drive these endpoints.
+        // Apply this to OPTIONS as well so a browser preflight fails closed.
+        if (is_mcp_internal_route && admin_api_key_.empty()) {
+            res.status = 403;
+            res.set_content(
+                "{\"error\": \"MCP administration requires LEMONADE_ADMIN_API_KEY or LEMONADE_API_KEY\"}",
+                "application/json");
+            return httplib::Server::HandlerResponse::Handled;
+        }
+
         // Internal routes require admin key authentication
         if (!admin_api_key_.empty() && req.method != "OPTIONS") {
             if (auth_token != admin_api_key_) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1530,9 +1530,10 @@ void Server::run() {
             LOG(WARNING, "Server")
                 << "Serving on non-loopback host '" << bound_host
                 << "' without an API key. All endpoints, including the /internal/* "
-                   "control endpoints, are reachable from other machines "
-                   "unauthenticated. Set LEMONADE_API_KEY to secure all endpoints; "
-                   "LEMONADE_ADMIN_API_KEY on its own only secures the /internal/* "
+                   "control endpoints and the /internal/mcp/* process-launch endpoints, "
+                   "are reachable from other machines unauthenticated. Set "
+                   "LEMONADE_API_KEY to secure all endpoints; LEMONADE_ADMIN_API_KEY "
+                   "on its own only secures the /internal/* "
                    "control endpoints." << std::endl;
         } else if (api_key_.empty()) {
             LOG(WARNING, "Server")

--- a/test/cpp/test_mcp_client_config.cpp
+++ b/test/cpp/test_mcp_client_config.cpp
@@ -5,10 +5,11 @@
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
-#include <functional>
 #include <fstream>
+#include <functional>
 #include <future>
 #include <iostream>
+#include <iterator>
 #include <string>
 #include <thread>
 #include <vector>
@@ -47,9 +48,16 @@ bool throws(const std::function<void()>& operation) {
     return false;
 }
 
-}  // namespace
+void remove_test_directory(const fs::path& path) noexcept {
+    std::error_code ec;
+    fs::remove_all(path, ec);
+    if (ec) {
+        std::cerr << "warning: failed to remove MCP test directory '"
+                  << path.string() << "': " << ec.message() << '\n';
+    }
+}
 
-int main() {
+int run_tests() {
     using lemon::McpClientManager;
     using lemon::json;
 
@@ -144,11 +152,18 @@ int main() {
         assert(!id.empty());
 
         const fs::path persisted_path = cache_dir / "mcp_servers.json";
-        std::ifstream persisted_input(persisted_path);
-        assert(persisted_input.good());
-        const std::string persisted(
-            (std::istreambuf_iterator<char>(persisted_input)),
-            std::istreambuf_iterator<char>());
+        std::string persisted;
+        {
+            std::ifstream persisted_input(persisted_path);
+            if (!persisted_input) {
+                throw std::runtime_error(
+                    "failed to open persisted MCP configuration: " +
+                    persisted_path.string());
+            }
+            persisted.assign(
+                std::istreambuf_iterator<char>(persisted_input),
+                std::istreambuf_iterator<char>());
+        }
         assert(persisted.find("super-secret-value") == std::string::npos);
         assert(persisted.find("${LEMONADE_MCP_TEST_SECRET}") !=
                std::string::npos);
@@ -185,7 +200,8 @@ int main() {
             }));
         }
         for (int i = 0; i < 16; ++i) {
-            const json parallel = parallel_calls[static_cast<std::size_t>(i)].get();
+            const json parallel =
+                parallel_calls[static_cast<std::size_t>(i)].get();
             assert(parallel.at("result").at("content").at(0).at("text") ==
                    "parallel-" + std::to_string(i));
         }
@@ -273,13 +289,13 @@ int main() {
     } catch (...) {
         unset_test_env("LEMONADE_MCP_TEST_SECRET");
         unset_test_env("LEMONADE_MCP_INIT_DELAY");
-        fs::remove_all(cache_dir);
+        remove_test_directory(cache_dir);
         throw;
     }
 
     unset_test_env("LEMONADE_MCP_TEST_SECRET");
     unset_test_env("LEMONADE_MCP_INIT_DELAY");
-    fs::remove_all(cache_dir);
+    remove_test_directory(cache_dir);
 #else
     std::cout
         << "mock stdio integration test skipped: Python fixture not configured\n";
@@ -287,4 +303,18 @@ int main() {
 
     std::cout << "mcp client config tests passed\n";
     return 0;
+}
+
+}  // namespace
+
+int main() {
+    try {
+        return run_tests();
+    } catch (const std::exception& e) {
+        std::cerr << "mcp_client_config failed: " << e.what() << '\n';
+        return 1;
+    } catch (...) {
+        std::cerr << "mcp_client_config failed with unknown exception\n";
+        return 1;
+    }
 }

--- a/test/cpp/test_mcp_client_config.cpp
+++ b/test/cpp/test_mcp_client_config.cpp
@@ -2,13 +2,52 @@
 
 #include <cassert>
 #include <chrono>
+#include <cstdlib>
 #include <exception>
 #include <filesystem>
+#include <functional>
 #include <fstream>
+#include <future>
 #include <iostream>
 #include <string>
+#include <thread>
+#include <vector>
 
 namespace fs = std::filesystem;
+using namespace std::chrono_literals;
+
+namespace {
+
+void set_test_env(const std::string& name, const std::string& value) {
+#ifdef _WIN32
+    if (_putenv_s(name.c_str(), value.c_str()) != 0) {
+        throw std::runtime_error("failed to set test environment variable");
+    }
+#else
+    if (::setenv(name.c_str(), value.c_str(), 1) != 0) {
+        throw std::runtime_error("failed to set test environment variable");
+    }
+#endif
+}
+
+void unset_test_env(const std::string& name) {
+#ifdef _WIN32
+    _putenv_s(name.c_str(), "");
+#else
+    ::unsetenv(name.c_str());
+#endif
+}
+
+bool throws(const std::function<void()>& operation) {
+    try {
+        operation();
+    } catch (const std::exception&) {
+        return true;
+    }
+    return false;
+}
+
+}  // namespace
 
 int main() {
     using lemon::McpClientManager;
@@ -20,96 +59,230 @@ int main() {
         {"transport", "stdio"},
         {"command", "python"},
         {"args", json::array({"-m", "revit_mcp_bridge"})},
-        {"env", json{{"REVIT_PROFILE", "default"}}},
+        {"env", json{{"REVIT_PROFILE", "${REVIT_PROFILE}"}}},
         {"working_dir", ""},
         {"enabled", true},
         {"timeout_ms", 5000},
     };
 
-    auto cfg = McpClientManager::parse_server_config_json(raw);
-    assert(cfg.id == "revit");
-    assert(cfg.name == "Revit MCP");
-    assert(cfg.transport == "stdio");
-    assert(cfg.command == "python");
-    assert(cfg.args.size() == 2);
-    assert(cfg.env.at("REVIT_PROFILE") == "default");
-    assert(cfg.timeout_ms == 5000);
+    const auto config = McpClientManager::parse_server_config_json(raw);
+    assert(config.id == "revit");
+    assert(config.name == "Revit MCP");
+    assert(config.transport == "stdio");
+    assert(config.command == "python");
+    assert(config.args.size() == 2);
+    assert(config.env.at("REVIT_PROFILE") == "${REVIT_PROFILE}");
+    assert(config.timeout_ms == 5000);
 
-    const json masked = McpClientManager::config_to_json(cfg, false);
-    assert(masked.at("env").at("REVIT_PROFILE") == "***");
-    const json unmasked = McpClientManager::config_to_json(cfg, true);
-    assert(unmasked.at("env").at("REVIT_PROFILE") == "default");
+    const json public_config = McpClientManager::config_to_json(config, false);
+    assert(public_config.at("env").at("REVIT_PROFILE") == "${REVIT_PROFILE}");
 
-    const std::string chat_name = McpClientManager::make_chat_tool_name("revit", "list elements!");
-    assert(chat_name == "mcp_revit__list_elements");
+    assert(throws([] {
+        McpClientManager::parse_server_config_json(
+            json{{"id", "raw-secret"},
+                 {"command", "python"},
+                 {"env", json{{"TOKEN", "plaintext-secret"}}}});
+    }));
+    assert(throws([] {
+        McpClientManager::parse_server_config_json(
+            json{{"id", "bad id"}, {"command", "python"}});
+    }));
+    assert(throws([] {
+        McpClientManager::parse_server_config_json(
+            json{{"id", "bad-timeout"},
+                 {"command", "python"},
+                 {"timeout_ms", 1}});
+    }));
 
-    bool rejected = false;
-    try {
-        McpClientManager::parse_server_config_json(json{{"id", "bad id"}, {"command", "python"}});
-    } catch (const std::exception&) {
-        rejected = true;
-    }
-    assert(rejected);
-
-    auto generated = McpClientManager::parse_server_config_json(
-        json{{"name", "My Server"}, {"command", "node"}, {"args", json::array({"server.js"})}},
+    const auto generated = McpClientManager::parse_server_config_json(
+        json{{"name", "My Server"},
+             {"command", "node"},
+             {"args", json::array({"server.js"})}},
         true);
     assert(generated.id == "my-server");
 
+    const std::string lossy_a =
+        McpClientManager::make_chat_tool_name("server", "a b");
+    const std::string lossy_b =
+        McpClientManager::make_chat_tool_name("server", "a@b");
+    assert(lossy_a != lossy_b);
+    assert(lossy_a.size() <= 64);
+    assert(lossy_b.size() <= 64);
+    const std::string separator_a =
+        McpClientManager::make_chat_tool_name("a", "b__c");
+    const std::string separator_b =
+        McpClientManager::make_chat_tool_name("a__b", "c");
+    assert(separator_a != separator_b);
+
 #if defined(LEMONADE_TEST_PYTHON) && defined(LEMONADE_TEST_MCP_STDIO_SERVER)
     const auto unique = std::chrono::duration_cast<std::chrono::microseconds>(
-        std::chrono::steady_clock::now().time_since_epoch()).count();
+                            std::chrono::steady_clock::now().time_since_epoch())
+                            .count();
     const fs::path cache_dir = fs::temp_directory_path() /
-        ("lemonade_mcp_client_test_" + std::to_string(unique));
+                               ("lemonade_mcp_client_test_" +
+                                std::to_string(unique));
     fs::create_directories(cache_dir);
+    set_test_env("LEMONADE_MCP_TEST_SECRET", "super-secret-value");
+    set_test_env("LEMONADE_MCP_INIT_DELAY", "0");
 
-    {
+    try {
         McpClientManager manager(cache_dir.string());
-        const json created = manager.upsert_server_json(json{
-            {"name", "Mock MCP"},
-            {"transport", "stdio"},
-            {"command", std::string(LEMONADE_TEST_PYTHON)},
-            {"args", json::array({std::string(LEMONADE_TEST_MCP_STDIO_SERVER)})},
-            {"env", json{{"LEMONADE_MCP_TEST_SECRET", "super-secret-value"}}},
-            {"timeout_ms", 5000},
-        });
+        const json created = manager.upsert_server_json(
+            json{{"name", "Mock MCP"},
+                 {"transport", "stdio"},
+                 {"command", std::string(LEMONADE_TEST_PYTHON)},
+                 {"args",
+                  json::array(
+                      {std::string(LEMONADE_TEST_MCP_STDIO_SERVER)})},
+                 {"env",
+                  json{{"LEMONADE_MCP_TEST_SECRET",
+                        "${LEMONADE_MCP_TEST_SECRET}"}}},
+                 {"timeout_ms", 5000}});
 
-        const std::string id = created.at("server").at("id").get<std::string>();
+        const std::string id =
+            created.at("server").at("id").get<std::string>();
         assert(!id.empty());
 
         const fs::path persisted_path = cache_dir / "mcp_servers.json";
-        std::ifstream persisted_in(persisted_path);
-        assert(persisted_in.good());
+        std::ifstream persisted_input(persisted_path);
+        assert(persisted_input.good());
         const std::string persisted(
-            (std::istreambuf_iterator<char>(persisted_in)),
+            (std::istreambuf_iterator<char>(persisted_input)),
             std::istreambuf_iterator<char>());
         assert(persisted.find("super-secret-value") == std::string::npos);
-        assert(persisted.find("${LEMONADE_MCP_TEST_SECRET}") != std::string::npos);
+        assert(persisted.find("${LEMONADE_MCP_TEST_SECRET}") !=
+               std::string::npos);
 
         const json connected = manager.connect_server_json(id);
         assert(connected.at("server").value("connected", false));
+        assert(connected.at("server").at("protocol_version") ==
+               "2025-11-25");
         assert(connected.at("server").at("tools").is_array());
-        assert(connected.at("server").at("tools").size() == 1);
-        assert(connected.at("server").at("tools").at(0).at("name") == "echo");
+        assert(connected.at("server").at("tools").size() == 3);
 
-        const json listed = manager.list_tools_json();
-        assert(listed.at("tools").is_array());
-        assert(listed.at("tools").size() == 1);
-        assert(listed.at("tools").at(0).at("chat_name").get<std::string>().find("mcp_") == 0);
+        const json call = manager.call_tool_json(
+            id, json{{"name", "echo"},
+                     {"arguments",
+                      json{{"message", "hello from lemonade"}}},
+                     {"timeout_ms", 5000}});
+        assert(call.at("result").at("content").at(0).at("text") ==
+               "hello from lemonade");
+        assert(call.at("result")
+                   .at("structuredContent")
+                   .at("secret_seen") == true);
 
-        const json call = manager.call_tool_json(id, json{
-            {"name", "echo"},
-            {"arguments", json{{"message", "hello from lemonade"}}},
-            {"timeout_ms", 5000},
+        // Multiple in-flight JSON-RPC requests must be correlated by ID without
+        // serializing the full request/response wait under the runtime lock.
+        std::vector<std::future<json>> parallel_calls;
+        for (int i = 0; i < 16; ++i) {
+            parallel_calls.push_back(std::async(std::launch::async, [&, i] {
+                return manager.call_tool_json(
+                    id, json{{"name", "echo"},
+                             {"arguments",
+                              json{{"message", "parallel-" +
+                                                   std::to_string(i)}}},
+                             {"timeout_ms", 5000}});
+            }));
+        }
+        for (int i = 0; i < 16; ++i) {
+            const json parallel = parallel_calls[static_cast<std::size_t>(i)].get();
+            assert(parallel.at("result").at("content").at(0).at("text") ==
+                   "parallel-" + std::to_string(i));
+        }
+
+        // A slow tool call must not block status snapshots or disconnect. The
+        // original PR held Runtime::mutex while waiting for the response.
+        auto slow_call = std::async(std::launch::async, [&] {
+            return manager.call_tool_json(
+                id, json{{"name", "sleep"},
+                         {"arguments", json{{"seconds", 10.0}}},
+                         {"timeout_ms", 30000}});
         });
-        assert(call.at("result").at("content").at(0).at("text") == "hello from lemonade");
+        std::this_thread::sleep_for(250ms);
 
+        const auto status_start = std::chrono::steady_clock::now();
+        const json listed = manager.list_servers_json();
+        const auto status_elapsed =
+            std::chrono::steady_clock::now() - status_start;
+        assert(status_elapsed < 1s);
+        assert(listed.at("servers").is_array());
+
+        const auto disconnect_start = std::chrono::steady_clock::now();
         manager.disconnect_server_json(id);
+        const auto disconnect_elapsed =
+            std::chrono::steady_clock::now() - disconnect_start;
+        assert(disconnect_elapsed < 4s);
+        assert(slow_call.wait_for(2s) == std::future_status::ready);
+        assert(throws([&] { (void)slow_call.get(); }));
+
+        // Reconnect and verify that a child process exiting without a response
+        // wakes the request immediately rather than waiting for its full timeout.
+        manager.connect_server_json(id);
+        const auto exit_start = std::chrono::steady_clock::now();
+        assert(throws([&] {
+            manager.call_tool_json(
+                id, json{{"name", "exit"},
+                         {"arguments", json::object()},
+                         {"timeout_ms", 10000}});
+        }));
+        const auto exit_elapsed =
+            std::chrono::steady_clock::now() - exit_start;
+        assert(exit_elapsed < 5s);
+
         manager.remove_server_json(id);
+
+        // Disconnect must also cancel initialization in progress. This covers a
+        // race where disconnect could previously return before connect installed
+        // its child, allowing the connection to become live afterwards.
+        set_test_env("LEMONADE_MCP_INIT_DELAY", "10");
+        const json delayed = manager.upsert_server_json(
+            json{{"name", "Delayed MCP"},
+                 {"transport", "stdio"},
+                 {"command", std::string(LEMONADE_TEST_PYTHON)},
+                 {"args",
+                  json::array(
+                      {std::string(LEMONADE_TEST_MCP_STDIO_SERVER)})},
+                 {"env",
+                  json{{"LEMONADE_MCP_INIT_DELAY",
+                        "${LEMONADE_MCP_INIT_DELAY}"}}},
+                 {"timeout_ms", 30000}});
+        const std::string delayed_id =
+            delayed.at("server").at("id").get<std::string>();
+
+        auto connecting = std::async(std::launch::async, [&] {
+            return manager.connect_server_json(delayed_id);
+        });
+        std::this_thread::sleep_for(250ms);
+        const auto cancel_connect_start = std::chrono::steady_clock::now();
+        manager.disconnect_server_json(delayed_id);
+        const auto cancel_connect_elapsed =
+            std::chrono::steady_clock::now() - cancel_connect_start;
+        assert(cancel_connect_elapsed < 4s);
+        assert(connecting.wait_for(2s) == std::future_status::ready);
+        assert(throws([&] { (void)connecting.get(); }));
+        const json delayed_state = manager.list_servers_json();
+        bool found_delayed_disconnected = false;
+        for (const auto& server : delayed_state.at("servers")) {
+            if (server.at("id") == delayed_id) {
+                found_delayed_disconnected =
+                    !server.value("connected", true);
+            }
+        }
+        assert(found_delayed_disconnected);
+        manager.remove_server_json(delayed_id);
+    } catch (...) {
+        unset_test_env("LEMONADE_MCP_TEST_SECRET");
+        unset_test_env("LEMONADE_MCP_INIT_DELAY");
+        fs::remove_all(cache_dir);
+        throw;
     }
+
+    unset_test_env("LEMONADE_MCP_TEST_SECRET");
+    unset_test_env("LEMONADE_MCP_INIT_DELAY");
     fs::remove_all(cache_dir);
 #else
-    std::cout << "mock stdio integration test skipped: Python fixture not configured\n";
+    std::cout
+        << "mock stdio integration test skipped: Python fixture not configured\n";
 #endif
 
     std::cout << "mcp client config tests passed\n";

--- a/test/cpp/test_mcp_client_config.cpp
+++ b/test/cpp/test_mcp_client_config.cpp
@@ -1,0 +1,106 @@
+#include "lemon/mcp_client.h"
+
+#include <cassert>
+#include <chrono>
+#include <exception>
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+int main() {
+    using lemon::McpClientManager;
+    using lemon::json;
+
+    const json raw = {
+        {"id", "revit"},
+        {"name", "Revit MCP"},
+        {"transport", "stdio"},
+        {"command", "python"},
+        {"args", json::array({"-m", "revit_mcp_bridge"})},
+        {"env", json{{"REVIT_PROFILE", "default"}}},
+        {"working_dir", ""},
+        {"enabled", true},
+        {"timeout_ms", 5000},
+    };
+
+    auto cfg = McpClientManager::parse_server_config_json(raw);
+    assert(cfg.id == "revit");
+    assert(cfg.name == "Revit MCP");
+    assert(cfg.transport == "stdio");
+    assert(cfg.command == "python");
+    assert(cfg.args.size() == 2);
+    assert(cfg.env.at("REVIT_PROFILE") == "default");
+    assert(cfg.timeout_ms == 5000);
+
+    const json masked = McpClientManager::config_to_json(cfg, false);
+    assert(masked.at("env").at("REVIT_PROFILE") == "***");
+    const json unmasked = McpClientManager::config_to_json(cfg, true);
+    assert(unmasked.at("env").at("REVIT_PROFILE") == "default");
+
+    const std::string chat_name = McpClientManager::make_chat_tool_name("revit", "list elements!");
+    assert(chat_name == "mcp_revit__list_elements");
+
+    bool rejected = false;
+    try {
+        McpClientManager::parse_server_config_json(json{{"id", "bad id"}, {"command", "python"}});
+    } catch (const std::exception&) {
+        rejected = true;
+    }
+    assert(rejected);
+
+    auto generated = McpClientManager::parse_server_config_json(
+        json{{"name", "My Server"}, {"command", "node"}, {"args", json::array({"server.js"})}},
+        true);
+    assert(generated.id == "my-server");
+
+#if defined(LEMONADE_TEST_PYTHON) && defined(LEMONADE_TEST_MCP_STDIO_SERVER)
+    const auto unique = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+    const fs::path cache_dir = fs::temp_directory_path() /
+        ("lemonade_mcp_client_test_" + std::to_string(unique));
+    fs::create_directories(cache_dir);
+
+    {
+        McpClientManager manager(cache_dir.string());
+        const json created = manager.upsert_server_json(json{
+            {"name", "Mock MCP"},
+            {"transport", "stdio"},
+            {"command", std::string(LEMONADE_TEST_PYTHON)},
+            {"args", json::array({std::string(LEMONADE_TEST_MCP_STDIO_SERVER)})},
+            {"timeout_ms", 5000},
+        });
+
+        const std::string id = created.at("server").at("id").get<std::string>();
+        assert(!id.empty());
+
+        const json connected = manager.connect_server_json(id);
+        assert(connected.at("server").value("connected", false));
+        assert(connected.at("server").at("tools").is_array());
+        assert(connected.at("server").at("tools").size() == 1);
+        assert(connected.at("server").at("tools").at(0).at("name") == "echo");
+
+        const json listed = manager.list_tools_json();
+        assert(listed.at("tools").is_array());
+        assert(listed.at("tools").size() == 1);
+        assert(listed.at("tools").at(0).at("chat_name").get<std::string>().find("mcp_") == 0);
+
+        const json call = manager.call_tool_json(id, json{
+            {"name", "echo"},
+            {"arguments", json{{"message", "hello from lemonade"}}},
+            {"timeout_ms", 5000},
+        });
+        assert(call.at("result").at("content").at(0).at("text") == "hello from lemonade");
+
+        manager.disconnect_server_json(id);
+        manager.remove_server_json(id);
+    }
+    fs::remove_all(cache_dir);
+#else
+    std::cout << "mock stdio integration test skipped: Python fixture not configured\n";
+#endif
+
+    std::cout << "mcp client config tests passed\n";
+    return 0;
+}

--- a/test/cpp/test_mcp_client_config.cpp
+++ b/test/cpp/test_mcp_client_config.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <exception>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -69,11 +70,21 @@ int main() {
             {"transport", "stdio"},
             {"command", std::string(LEMONADE_TEST_PYTHON)},
             {"args", json::array({std::string(LEMONADE_TEST_MCP_STDIO_SERVER)})},
+            {"env", json{{"LEMONADE_MCP_TEST_SECRET", "super-secret-value"}}},
             {"timeout_ms", 5000},
         });
 
         const std::string id = created.at("server").at("id").get<std::string>();
         assert(!id.empty());
+
+        const fs::path persisted_path = cache_dir / "mcp_servers.json";
+        std::ifstream persisted_in(persisted_path);
+        assert(persisted_in.good());
+        const std::string persisted(
+            (std::istreambuf_iterator<char>(persisted_in)),
+            std::istreambuf_iterator<char>());
+        assert(persisted.find("super-secret-value") == std::string::npos);
+        assert(persisted.find("${LEMONADE_MCP_TEST_SECRET}") != std::string::npos);
 
         const json connected = manager.connect_server_json(id);
         assert(connected.at("server").value("connected", false));

--- a/test/fixtures/mock_mcp_stdio_server.py
+++ b/test/fixtures/mock_mcp_stdio_server.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
-"""Tiny MCP stdio server for manual PR1 smoke testing."""
+"""Deterministic stdio MCP fixture for the Lemonade MCP client tests."""
+
 import json
+import os
 import sys
+import time
+
+PROTOCOL_VERSION = "2025-11-25"
 
 TOOLS = [
     {
@@ -13,53 +18,112 @@ TOOLS = [
             "properties": {"message": {"type": "string"}},
             "required": ["message"],
         },
-    }
+    },
+    {
+        "name": "sleep",
+        "title": "Sleep",
+        "description": "Sleep long enough to exercise cancellation",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"seconds": {"type": "number"}},
+        },
+    },
+    {
+        "name": "exit",
+        "title": "Exit",
+        "description": "Exit without a response to exercise process death",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
 ]
 
 
-def send(obj):
-    sys.stdout.write(json.dumps(obj, separators=(",", ":")) + "\n")
+def send(message):
+    sys.stdout.write(json.dumps(message, separators=(",", ":")) + "\n")
     sys.stdout.flush()
+
+
+def reply(request_id, result):
+    send({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+def error(request_id, code, message):
+    send(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }
+    )
 
 
 for line in sys.stdin:
     if not line.strip():
         continue
-    msg = json.loads(line)
-    method = msg.get("method")
-    mid = msg.get("id")
+
+    try:
+        message = json.loads(line)
+    except json.JSONDecodeError as exc:
+        print(f"invalid request JSON: {exc}", file=sys.stderr, flush=True)
+        continue
+
+    method = message.get("method")
+    request_id = message.get("id")
+
     if method == "initialize":
-        send({
-            "jsonrpc": "2.0",
-            "id": mid,
-            "result": {
-                "protocolVersion": msg.get("params", {}).get("protocolVersion", "2025-06-18"),
+        delay = float(os.environ.get("LEMONADE_MCP_INIT_DELAY", "0"))
+        if delay > 0:
+            time.sleep(min(delay, 60.0))
+        requested = message.get("params", {}).get("protocolVersion")
+        negotiated = requested if requested == PROTOCOL_VERSION else PROTOCOL_VERSION
+        reply(
+            request_id,
+            {
+                "protocolVersion": negotiated,
                 "capabilities": {"tools": {"listChanged": False}},
-                "serverInfo": {"name": "mock-mcp", "version": "0.1"},
+                "serverInfo": {"name": "mock-mcp", "version": "0.2"},
             },
-        })
+        )
     elif method == "notifications/initialized":
-        pass
+        continue
+    elif method == "notifications/cancelled":
+        continue
     elif method == "tools/list":
-        send({"jsonrpc": "2.0", "id": mid, "result": {"tools": TOOLS}})
+        reply(request_id, {"tools": TOOLS})
     elif method == "tools/call":
-        params = msg.get("params", {})
-        if params.get("name") == "echo":
-            text = params.get("arguments", {}).get("message", "")
-            send({
-                "jsonrpc": "2.0",
-                "id": mid,
-                "result": {"content": [{"type": "text", "text": text}], "isError": False},
-            })
+        params = message.get("params", {})
+        name = params.get("name")
+        arguments = params.get("arguments", {})
+
+        if name == "echo":
+            text = arguments.get("message", "")
+            secret = os.environ.get("LEMONADE_MCP_TEST_SECRET", "")
+            reply(
+                request_id,
+                {
+                    "content": [{"type": "text", "text": text}],
+                    "structuredContent": {"secret_seen": bool(secret)},
+                    "isError": False,
+                },
+            )
+        elif name == "sleep":
+            seconds = float(arguments.get("seconds", 10.0))
+            time.sleep(max(0.0, min(seconds, 60.0)))
+            reply(
+                request_id,
+                {
+                    "content": [{"type": "text", "text": "finished"}],
+                    "isError": False,
+                },
+            )
+        elif name == "exit":
+            sys.exit(0)
         else:
-            send({
-                "jsonrpc": "2.0",
-                "id": mid,
-                "result": {"content": [{"type": "text", "text": "unknown tool"}], "isError": True},
-            })
-    elif mid is not None:
-        send({
-            "jsonrpc": "2.0",
-            "id": mid,
-            "error": {"code": -32601, "message": f"Unknown method: {method}"},
-        })
+            reply(
+                request_id,
+                {
+                    "content": [{"type": "text", "text": "unknown tool"}],
+                    "isError": True,
+                },
+            )
+    elif request_id is not None:
+        error(request_id, -32601, f"Unknown method: {method}")

--- a/test/fixtures/mock_mcp_stdio_server.py
+++ b/test/fixtures/mock_mcp_stdio_server.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tiny MCP stdio server for manual PR1 smoke testing."""
+import json
+import sys
+
+TOOLS = [
+    {
+        "name": "echo",
+        "title": "Echo",
+        "description": "Echo back a message",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"message": {"type": "string"}},
+            "required": ["message"],
+        },
+    }
+]
+
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+for line in sys.stdin:
+    if not line.strip():
+        continue
+    msg = json.loads(line)
+    method = msg.get("method")
+    mid = msg.get("id")
+    if method == "initialize":
+        send({
+            "jsonrpc": "2.0",
+            "id": mid,
+            "result": {
+                "protocolVersion": msg.get("params", {}).get("protocolVersion", "2025-06-18"),
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "mock-mcp", "version": "0.1"},
+            },
+        })
+    elif method == "notifications/initialized":
+        pass
+    elif method == "tools/list":
+        send({"jsonrpc": "2.0", "id": mid, "result": {"tools": TOOLS}})
+    elif method == "tools/call":
+        params = msg.get("params", {})
+        if params.get("name") == "echo":
+            text = params.get("arguments", {}).get("message", "")
+            send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {"content": [{"type": "text", "text": text}], "isError": False},
+            })
+        else:
+            send({
+                "jsonrpc": "2.0",
+                "id": mid,
+                "result": {"content": [{"type": "text", "text": "unknown tool"}], "isError": True},
+            })
+    elif mid is not None:
+        send({
+            "jsonrpc": "2.0",
+            "id": mid,
+            "error": {"code": -32601, "message": f"Unknown method: {method}"},
+        })


### PR DESCRIPTION
## Summary

Partly addresses #2596.

Adds the server-side foundation for an MCP client host in Lemonade. This introduces internal/admin endpoints for configuring stdio MCP servers, connecting/disconnecting them, discovering available tools, and calling tools through JSON-RPC.

This PR intentionally keeps the GUI integration and automatic chat-loop tool orchestration out of scope. Those can build on the `/internal/mcp/*` endpoints in a follow-up.

## Scope

* Add McpClientManager for server-side MCP client hosting.
* Support stdio MCP server configs persisted under the Lemonade cache directory.
* Add `/internal/mcp/servers` and `/internal/mcp/tools` endpoints.
* Add connect, disconnect, refresh-tools, remove-server, and raw tools/call endpoints.
* Expose discovered MCP tools in an OpenAI-compatible tool metadata shape for future chat integration.
* Add a mock stdio MCP server fixture.
* Add a C++ test covering config parsing, env masking, stdio initialize, tool discovery, and tools/call roundtrip.
* Wire the new C++ test into CI.

## Out of Scope

* GUI settings UI for adding/removing MCP servers.
* Per-chat MCP server/tool selection.
* Automatic model tool-calling orchestration in chat completions.
* HTTP/SSE MCP transport support.

MCP env values are not persisted as raw secrets. Persisted configs store ${VAR}
references; users should provide secrets through the process environment.

## Testing

* `cmake --build --preset default --target test_mcp_client_config`
* `ctest --test-dir build -R mcp_client_config --output-on-failure`
* `cmake --build --preset default --target lemond`

The local MCP client test passes and now exercises the stdio mock server path
