### PR TITLE
Router/2386 decision trace response

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -638,6 +638,7 @@ set(SOURCES_CORE
     src/cpp/server/routing_policy.cpp
     src/cpp/server/routing_policy_parser.cpp
     src/cpp/server/routing_policy_store.cpp
+    src/cpp/server/route_decision_response.cpp
     src/cpp/server/runtime_config.cpp
     src/cpp/server/telemetry.cpp
     src/cpp/server/logging_config.cpp
@@ -2089,6 +2090,29 @@ if(EXISTS "${_ROUTING_STORE_TEST_SRC}")
 
     include(CTest)
     add_test(NAME RoutingPolicyStoreTest COMMAND test_routing_policy_store)
+endif()
+
+set(_ROUTE_DECISION_RESPONSE_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_route_decision_response.cpp"
+)
+if(EXISTS "${_ROUTE_DECISION_RESPONSE_TEST_SRC}")
+    add_executable(test_route_decision_response
+        test/cpp/test_route_decision_response.cpp
+        src/cpp/server/route_decision_response.cpp
+    )
+    target_include_directories(test_route_decision_response PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_route_decision_response PRIVATE nlohmann_json::nlohmann_json)
+    if(USE_SYSTEM_HTTPLIB)
+        target_link_libraries(test_route_decision_response PRIVATE lemonade-httplib)
+    else()
+        target_link_libraries(test_route_decision_response PRIVATE httplib::httplib)
+    endif()
+
+    include(CTest)
+    add_test(NAME RouteDecisionResponseTest COMMAND test_route_decision_response)
 endif()
 
 # ModelManager collection validation for collection.router registration:

--- a/src/cpp/include/lemon/route_decision_response.h
+++ b/src/cpp/include/lemon/route_decision_response.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "routing_policy.h"
+
+#include <httplib.h>
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace lemon {
+
+json route_decision_to_json(const Decision& decision);
+
+std::string route_decision_header_value(const Decision& decision);
+
+void attach_route_header(httplib::Response& res, const Decision& decision);
+
+std::string attach_route_decision_to_sse_event(const std::string& event,
+                                               const json& route_decision_json,
+                                               bool& attached);
+
+class RouteDecisionSseSink {
+public:
+    RouteDecisionSseSink(httplib::DataSink& inner, json route_decision_json);
+
+    bool write(const char* data, size_t length);
+    void done();
+    void done_with_trailer(const httplib::Headers& trailer);
+    bool is_writable() const;
+
+private:
+    void flush();
+
+    httplib::DataSink& inner_;
+    json route_decision_json_;
+    bool attached_ = false;
+    std::string buffer_;
+};
+
+template <typename StreamFn>
+void stream_with_route_decision(httplib::DataSink& sink,
+                                json route_decision_json,
+                                StreamFn&& stream_fn) {
+    if (route_decision_json.is_null()) {
+        stream_fn(sink);
+        return;
+    }
+
+    RouteDecisionSseSink route_sink_wrapper(sink, std::move(route_decision_json));
+    httplib::DataSink route_sink;
+    route_sink.write = [&route_sink_wrapper](const char* data, size_t len) {
+        return route_sink_wrapper.write(data, len);
+    };
+    route_sink.done = [&route_sink_wrapper]() { route_sink_wrapper.done(); };
+    route_sink.done_with_trailer = [&route_sink_wrapper](
+        const httplib::Headers& trailer) {
+        route_sink_wrapper.done_with_trailer(trailer);
+    };
+    route_sink.is_writable = [&route_sink_wrapper]() {
+        return route_sink_wrapper.is_writable();
+    };
+    stream_fn(route_sink);
+}
+
+} // namespace lemon

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -18,6 +18,7 @@
 #include <httplib.h>
 #include "runtime_config.h"
 #include "router.h"
+#include "routing_policy.h"
 #include "model_manager.h"
 #include "backend_manager.h"
 #include "cloud_provider_registry.h"
@@ -30,6 +31,12 @@ namespace lemon {
 
 // Forward declaration
 class SystemMetricsPlatform;
+
+struct RouterDispatchResult {
+    std::string requested_model;
+    std::string selected_model;
+    Decision decision;
+};
 
 class Server {
 public:
@@ -100,13 +107,16 @@ private:
                                             const ModelInfo& collection_info,
                                             httplib::Response& res);
     // Run a collection.router model's routing engine and return the selected
-    // candidate model. Returns std::nullopt when routing did not engage (no
-    // parsed policy), so callers leave the request's model field untouched.
-    std::optional<std::string> route_collection_request(const nlohmann::json& request_json,
-                                                        const ModelInfo& collection_info);
+    // candidate plus the full Decision. Returns std::nullopt when routing did
+    // not engage (no parsed policy), so callers leave the request untouched.
+    std::optional<RouterDispatchResult> route_collection_request(
+        const nlohmann::json& request_json,
+        const ModelInfo& collection_info);
     // If request_json addresses a collection.router model, rewrite its "model"
-    // field in place to the engine-selected candidate. No-op otherwise.
-    void apply_router_collection_dispatch(nlohmann::json& request_json);
+    // field in place to the engine-selected candidate and return the Decision.
+    // No-op otherwise.
+    std::optional<RouterDispatchResult> apply_router_collection_dispatch(
+        nlohmann::json& request_json);
     void handle_completions(const httplib::Request& req, httplib::Response& res);
     void handle_embeddings(const httplib::Request& req, httplib::Response& res);
     void handle_reranking(const httplib::Request& req, httplib::Response& res);

--- a/src/cpp/resources/schemas/decision.schema.json
+++ b/src/cpp/resources/schemas/decision.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://lemonade-sdk.github.io/schemas/decision.schema.json",
   "title": "Lemonade route decision (x_lemonade_route)",
-  "description": "The decision object the engine emits, attached additively to the chat response body as `x_lemonade_route`. Pure model selection — no verdict/route-category/action in core; those are trust-customer concerns read off `outputs`. The scalar matched_rule is also surfaced in the `x-lemonade-route` response header.",
+  "description": "The decision object the engine emits, attached additively to the chat response body as `x_lemonade_route`. Pure model selection — no verdict/route-category/action in core; those are trust-customer concerns read off `outputs`. The `x-lemonade-route` response header carries the matched rule id, or `default` when the request routed through default_model.",
   "type": "object",
   "required": ["version", "route_to", "matched_rule", "default_used"],
   "properties": {

--- a/src/cpp/resources/schemas/route_policy.schema.json
+++ b/src/cpp/resources/schemas/route_policy.schema.json
@@ -125,7 +125,11 @@
       "type": "object",
       "required": ["id", "match", "route_to"],
       "properties": {
-        "id": { "type": "string" },
+        "id": {
+          "description": "Safe rule token surfaced in the x-lemonade-route header when matched.",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9._-]+$"
+        },
         "match": { "$ref": "#/$defs/match_expr" },
         "route_to": {
           "description": "Must name a candidate. The local/private/cloud route category is derived from the chosen component's recipe.",

--- a/src/cpp/resources/schemas/schema-lock.json
+++ b/src/cpp/resources/schemas/schema-lock.json
@@ -1,10 +1,10 @@
 {
   "route_policy.schema.json": {
-    "sha256": "bce2a2968cd5b5e24ead0e503cf282186e89fc88db2eafe76cbc120805ab21dd",
+    "sha256": "855dd69b2e5dbd8f861cefdc886422d73aa20843517ea437f9d99d571e292951",
     "released": false
   },
   "decision.schema.json": {
-    "sha256": "bcbc6c56c6e8f1426a774d3318b3409042ad8447d64a553b0b191335b7599150",
+    "sha256": "6c35970798f5007ffa29cbc42ae2ed04b2f335923f5c7962dd352675088314ce",
     "released": false
   },
   "request.schema.json": {

--- a/src/cpp/server/route_decision_response.cpp
+++ b/src/cpp/server/route_decision_response.cpp
@@ -1,0 +1,180 @@
+#include "lemon/route_decision_response.h"
+
+#include <utility>
+
+namespace lemon {
+namespace {
+
+struct EventBoundary {
+    std::size_t pos = std::string::npos;
+    std::size_t len = 0;
+};
+
+std::optional<EventBoundary> find_sse_event_boundary(const std::string& buffer) {
+    for (std::size_t i = 0; i < buffer.size(); ++i) {
+        if (buffer[i] != '\r' && buffer[i] != '\n') {
+            continue;
+        }
+
+        std::size_t first_len = 1;
+        if (buffer[i] == '\r') {
+            if (i + 1 >= buffer.size()) {
+                return std::nullopt;
+            }
+            if (buffer[i + 1] == '\n') {
+                first_len = 2;
+            }
+        }
+
+        const std::size_t second = i + first_len;
+        if (second >= buffer.size()) {
+            return std::nullopt;
+        }
+        if (buffer[second] == '\n') {
+            return EventBoundary{i, first_len + 1};
+        }
+        if (buffer[second] == '\r') {
+            if (second + 1 < buffer.size() && buffer[second + 1] == '\n') {
+                return EventBoundary{i, first_len + 2};
+            }
+            if (first_len == 2 && second + 1 >= buffer.size()) {
+                return std::nullopt;
+            }
+            return EventBoundary{i, first_len + 1};
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+json route_decision_to_json(const Decision& decision) {
+    json out = {
+        {"version", "1"},
+        {"route_to", decision.route_to},
+        {"matched_rule", decision.matched_rule},
+        {"default_used", decision.default_used},
+        {"outputs", decision.outputs.is_object() ? decision.outputs : json::object()},
+    };
+    if (!decision.trace.empty()) {
+        out["trace"] = json::array();
+        for (const auto& entry : decision.trace) {
+            json trace_entry = {
+                {"condition", entry.condition},
+                {"result", entry.result},
+            };
+            if (entry.score.has_value()) {
+                trace_entry["score"] = *entry.score;
+            }
+            out["trace"].push_back(std::move(trace_entry));
+        }
+    }
+    return out;
+}
+
+std::string route_decision_header_value(const Decision& decision) {
+    return decision.matched_rule.empty() ? "default" : decision.matched_rule;
+}
+
+void attach_route_header(httplib::Response& res, const Decision& decision) {
+    res.set_header("x-lemonade-route", route_decision_header_value(decision));
+}
+
+std::string attach_route_decision_to_sse_event(
+    const std::string& event,
+    const json& route_decision_json,
+    bool& attached) {
+    if (attached || route_decision_json.is_null()) {
+        return event;
+    }
+
+    const std::string prefix = "data:";
+    std::size_t pos = event.find(prefix);
+    if (pos == std::string::npos) {
+        return event;
+    }
+    std::size_t payload_start = pos + prefix.size();
+    while (payload_start < event.size() &&
+           (event[payload_start] == ' ' || event[payload_start] == '\t')) {
+        ++payload_start;
+    }
+    std::size_t payload_end = event.find('\n', payload_start);
+    if (payload_end == std::string::npos) {
+        payload_end = event.size();
+    }
+    while (payload_end > payload_start &&
+           (event[payload_end - 1] == '\r' || event[payload_end - 1] == ' ' ||
+            event[payload_end - 1] == '\t')) {
+        --payload_end;
+    }
+
+    std::string payload = event.substr(payload_start, payload_end - payload_start);
+    if (payload.empty() || payload == "[DONE]") {
+        return event;
+    }
+
+    json parsed = json::parse(payload, nullptr, /*allow_exceptions=*/false);
+    if (!parsed.is_object()) {
+        return event;
+    }
+    parsed["x_lemonade_route"] = route_decision_json;
+    attached = true;
+
+    std::string out = event.substr(0, payload_start);
+    out += parsed.dump();
+    out += event.substr(payload_end);
+    return out;
+}
+
+RouteDecisionSseSink::RouteDecisionSseSink(httplib::DataSink& inner,
+                                           json route_decision_json)
+    : inner_(inner), route_decision_json_(std::move(route_decision_json)) {}
+
+bool RouteDecisionSseSink::write(const char* data, size_t length) {
+    buffer_.append(data, length);
+    while (true) {
+        std::optional<EventBoundary> boundary = find_sse_event_boundary(buffer_);
+        if (!boundary.has_value()) {
+            break;
+        }
+        std::string event = buffer_.substr(0, boundary->pos + boundary->len);
+        buffer_.erase(0, boundary->pos + boundary->len);
+        event = attach_route_decision_to_sse_event(
+            event, route_decision_json_, attached_);
+        if (!inner_.write(event.c_str(), event.size())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void RouteDecisionSseSink::done() {
+    flush();
+    if (inner_.done) {
+        inner_.done();
+    }
+}
+
+void RouteDecisionSseSink::done_with_trailer(const httplib::Headers& trailer) {
+    flush();
+    if (inner_.done_with_trailer) {
+        inner_.done_with_trailer(trailer);
+    } else if (inner_.done) {
+        inner_.done();
+    }
+}
+
+bool RouteDecisionSseSink::is_writable() const {
+    return !inner_.is_writable || inner_.is_writable();
+}
+
+void RouteDecisionSseSink::flush() {
+    if (!buffer_.empty()) {
+        std::string event = attach_route_decision_to_sse_event(
+            buffer_, route_decision_json_, attached_);
+        inner_.write(event.c_str(), event.size());
+        buffer_.clear();
+    }
+}
+
+} // namespace lemon

--- a/src/cpp/server/routing_policy_parser.cpp
+++ b/src/cpp/server/routing_policy_parser.cpp
@@ -62,6 +62,30 @@ std::string optional_string(const json& value,
     return value.at(key).get<std::string>();
 }
 
+bool is_safe_rule_id(const std::string& id) {
+    for (char ch : id) {
+        const bool ok = (ch >= 'A' && ch <= 'Z') ||
+                        (ch >= 'a' && ch <= 'z') ||
+                        (ch >= '0' && ch <= '9') ||
+                        ch == '.' || ch == '_' || ch == '-';
+        if (!ok) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::string required_rule_id(const json& value,
+                             const std::string& key,
+                             const std::string& path) {
+    std::string id = required_string(value, key, path);
+    if (!is_safe_rule_id(id)) {
+        throw std::invalid_argument(
+            path + "." + key + " must match [A-Za-z0-9._-]");
+    }
+    return id;
+}
+
 std::string schema_major(const std::string& version) {
     const auto dot = version.find('.');
     return dot == std::string::npos ? version : version.substr(0, dot);
@@ -443,7 +467,7 @@ std::vector<Rule> parse_rules(const json& routing,
         reject_unknown_keys(rule_json, routing_rule_keys(), path);
 
         Rule rule;
-        rule.id = required_string(rule_json, "id", path);
+        rule.id = required_rule_id(rule_json, "id", path);
         if (!ids.insert(rule.id).second) {
             throw std::invalid_argument(path + ".id duplicates rule id '" + rule.id + "'");
         }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -188,6 +188,172 @@ void set_error_response(const json& response, httplib::Response& res,
     res.set_content(response.dump(), "application/json");
 }
 
+json route_decision_to_json(const Decision& decision) {
+    json out = {
+        {"version", "1"},
+        {"route_to", decision.route_to},
+        {"matched_rule", decision.matched_rule},
+        {"default_used", decision.default_used},
+        {"outputs", decision.outputs.is_object() ? decision.outputs : json::object()},
+    };
+    if (!decision.trace.empty()) {
+        out["trace"] = json::array();
+        for (const auto& entry : decision.trace) {
+            json trace_entry = {
+                {"condition", entry.condition},
+                {"result", entry.result},
+            };
+            if (entry.score.has_value()) {
+                trace_entry["score"] = *entry.score;
+            }
+            out["trace"].push_back(std::move(trace_entry));
+        }
+    }
+    return out;
+}
+
+void attach_route_header(httplib::Response& res, const Decision& decision) {
+    if (!decision.matched_rule.empty()) {
+        res.set_header("x-lemonade-route", decision.matched_rule);
+    }
+}
+
+void attach_route_decision(json& response, httplib::Response& res,
+                           const std::optional<RouterDispatchResult>& dispatch) {
+    if (!dispatch.has_value()) {
+        return;
+    }
+    response["x_lemonade_route"] = route_decision_to_json(dispatch->decision);
+    attach_route_header(res, dispatch->decision);
+}
+
+std::string attach_route_decision_to_sse_event(
+    const std::string& event,
+    const json& route_decision_json,
+    bool& attached) {
+    if (attached || route_decision_json.is_null()) {
+        return event;
+    }
+
+    const std::string prefix = "data:";
+    std::size_t pos = event.find(prefix);
+    if (pos == std::string::npos) {
+        return event;
+    }
+    std::size_t payload_start = pos + prefix.size();
+    while (payload_start < event.size() &&
+           (event[payload_start] == ' ' || event[payload_start] == '\t')) {
+        ++payload_start;
+    }
+    std::size_t payload_end = event.find('\n', payload_start);
+    if (payload_end == std::string::npos) {
+        payload_end = event.size();
+    }
+    while (payload_end > payload_start &&
+           (event[payload_end - 1] == '\r' || event[payload_end - 1] == ' ' ||
+            event[payload_end - 1] == '\t')) {
+        --payload_end;
+    }
+
+    std::string payload = event.substr(payload_start, payload_end - payload_start);
+    if (payload.empty() || payload == "[DONE]") {
+        return event;
+    }
+
+    json parsed = json::parse(payload, nullptr, /*allow_exceptions=*/false);
+    if (!parsed.is_object()) {
+        return event;
+    }
+    parsed["x_lemonade_route"] = route_decision_json;
+    attached = true;
+
+    std::string out = event.substr(0, payload_start);
+    out += parsed.dump();
+    out += event.substr(payload_end);
+    return out;
+}
+
+class RouteDecisionSseSink {
+public:
+    RouteDecisionSseSink(httplib::DataSink& inner, json route_decision_json)
+        : inner_(inner), route_decision_json_(std::move(route_decision_json)) {}
+
+    bool write(const char* data, size_t length) {
+        buffer_.append(data, length);
+        std::size_t event_end = std::string::npos;
+        while ((event_end = buffer_.find("\n\n")) != std::string::npos) {
+            std::string event = buffer_.substr(0, event_end + 2);
+            buffer_.erase(0, event_end + 2);
+            event = attach_route_decision_to_sse_event(
+                event, route_decision_json_, attached_);
+            if (!inner_.write(event.c_str(), event.size())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void done() {
+        flush();
+        if (inner_.done) {
+            inner_.done();
+        }
+    }
+
+    void done_with_trailer(const httplib::Headers& trailer) {
+        flush();
+        if (inner_.done_with_trailer) {
+            inner_.done_with_trailer(trailer);
+        } else if (inner_.done) {
+            inner_.done();
+        }
+    }
+
+    bool is_writable() const {
+        return !inner_.is_writable || inner_.is_writable();
+    }
+
+private:
+    void flush() {
+        if (!buffer_.empty()) {
+            std::string event = attach_route_decision_to_sse_event(
+                buffer_, route_decision_json_, attached_);
+            inner_.write(event.c_str(), event.size());
+            buffer_.clear();
+        }
+    }
+
+    httplib::DataSink& inner_;
+    json route_decision_json_;
+    bool attached_ = false;
+    std::string buffer_;
+};
+
+template <typename StreamFn>
+void stream_with_route_decision(httplib::DataSink& sink,
+                                json route_decision_json,
+                                StreamFn&& stream_fn) {
+    if (route_decision_json.is_null()) {
+        stream_fn(sink);
+        return;
+    }
+
+    RouteDecisionSseSink route_sink_wrapper(sink, std::move(route_decision_json));
+    httplib::DataSink route_sink;
+    route_sink.write = [&route_sink_wrapper](const char* data, size_t len) {
+        return route_sink_wrapper.write(data, len);
+    };
+    route_sink.done = [&route_sink_wrapper]() { route_sink_wrapper.done(); };
+    route_sink.done_with_trailer = [&route_sink_wrapper](
+        const httplib::Headers& trailer) {
+        route_sink_wrapper.done_with_trailer(trailer);
+    };
+    route_sink.is_writable = [&route_sink_wrapper]() {
+        return route_sink_wrapper.is_writable();
+    };
+    stream_fn(route_sink);
+}
+
 int get_http_status_from_error(const std::string& error_code) {
     if (error_code == "slots_pinned_error") {
         return 409;
@@ -2189,8 +2355,9 @@ void Server::handle_collection_chat_completions(const nlohmann::json& request_js
     res.set_content(response.dump(), "application/json");
 }
 
-std::optional<std::string> Server::route_collection_request(const nlohmann::json& request_json,
-                                             const ModelInfo& collection_info) {
+std::optional<RouterDispatchResult> Server::route_collection_request(
+    const nlohmann::json& request_json,
+    const ModelInfo& collection_info) {
     // The policy is parsed once when the models cache is built (ModelManager),
     // so dispatch just reads it here. A missing policy means the collection
     // failed to parse at cache-build time; return nullopt so the caller leaves
@@ -2210,34 +2377,44 @@ std::optional<std::string> Server::route_collection_request(const nlohmann::json
     RoutingPolicyEngine engine(std::move(policy), std::move(services));
 
     RouteContext ctx = build_route_context(request_json, collection_info.model_name);
-    Decision decision = engine.route(ctx, /*want_trace=*/false);
-    return decision.route_to;
+    const bool want_trace = request_json.value("route_trace", false);
+    Decision decision = engine.route(ctx, want_trace);
+    RouterDispatchResult result;
+    result.requested_model = collection_info.model_name;
+    result.selected_model = decision.route_to;
+    result.decision = std::move(decision);
+    return result;
 }
 
-void Server::apply_router_collection_dispatch(nlohmann::json& request_json) {
+std::optional<RouterDispatchResult> Server::apply_router_collection_dispatch(
+    nlohmann::json& request_json) {
     if (!request_json.contains("model") || !request_json["model"].is_string()) {
-        return;
+        return std::nullopt;
     }
     const std::string requested_model = request_json["model"].get<std::string>();
     try {
         if (!model_manager_->model_exists(requested_model)) {
-            return;
+            return std::nullopt;
         }
         ModelInfo info = model_manager_->get_model_info(requested_model);
         if (!is_router_collection_recipe(info.recipe)) {
-            return;
+            return std::nullopt;
         }
-        std::optional<std::string> selected = route_collection_request(request_json, info);
-        if (!selected) {
-            return;
+        auto dispatch = route_collection_request(request_json, info);
+        if (!dispatch) {
+            return std::nullopt;
         }
+        dispatch->requested_model = requested_model;
         LOG(INFO, "Server") << "Router collection '" << requested_model << "' -> '"
-                            << *selected << "'" << std::endl;
-        request_json["model"] = *selected;
+                            << dispatch->selected_model << "'" << std::endl;
+        request_json["model"] = dispatch->selected_model;
+        request_json.erase("route_trace");
+        return dispatch;
     } catch (const std::exception& e) {
         LOG(WARNING, "Server") << "Router collection dispatch failed for '"
                                << requested_model << "': " << e.what() << std::endl;
     }
+    return std::nullopt;
 }
 
 void Server::handle_chat_completions(const httplib::Request& req, httplib::Response& res) {
@@ -2259,6 +2436,7 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
         }
 
         bool request_modified = false;
+        std::optional<RouterDispatchResult> route_dispatch;
 
         // Omni "collection" models run a server-side tool-calling loop instead of a
         // plain completion. Branch before auto-load/LLM-type checks: the collection
@@ -2276,12 +2454,13 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                         // The recipe is the trigger (no "auto", no /v1/route): run the
                         // routing engine and rewrite the model to the selected
                         // candidate, then fall through to normal completion handling.
-                        std::optional<std::string> selected =
-                            route_collection_request(request_json, info);
-                        if (selected) {
+                        route_dispatch = route_collection_request(request_json, info);
+                        if (route_dispatch) {
+                            route_dispatch->requested_model = requested_model;
                             LOG(INFO, "Server") << "Router collection '" << requested_model
-                                                << "' -> '" << *selected << "'" << std::endl;
-                            request_json["model"] = *selected;
+                                                << "' -> '" << route_dispatch->selected_model << "'" << std::endl;
+                            request_json["model"] = route_dispatch->selected_model;
+                            request_json.erase("route_trace");
                         }
                     }
                 }
@@ -2372,18 +2551,29 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 res.set_header("Cache-Control", "no-cache");
                 res.set_header("Connection", "keep-alive");
                 res.set_header("X-Accel-Buffering", "no"); // Disable nginx buffering
+                if (route_dispatch) {
+                    attach_route_header(res, route_dispatch->decision);
+                }
 
                 // Use cpp-httplib's chunked content provider for SSE streaming
+                json route_decision_json = route_dispatch
+                    ? route_decision_to_json(route_dispatch->decision)
+                    : json(nullptr);
                 res.set_chunked_content_provider(
                     "text/event-stream",
-                    [this, request_body](size_t offset, httplib::DataSink& sink) {
+                    [this, request_body, route_decision_json](size_t offset, httplib::DataSink& sink) {
                         // For chunked responses, offset tracks bytes sent so far
                         // We only want to stream once when offset is 0
                         if (offset > 0) {
                             return false; // We're done after the first call
                         }
 
-                        router_->chat_completion_stream(request_body, sink);
+                        stream_with_route_decision(
+                            sink,
+                            route_decision_json,
+                            [this, &request_body](httplib::DataSink& route_sink) {
+                                router_->chat_completion_stream(request_body, route_sink);
+                            });
                         return false;
                     }
                 );
@@ -2404,6 +2594,7 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 return;
             }
 
+            attach_route_decision(response, res, route_dispatch);
             // Debug: Check if response contains tool_calls
             if (response.contains("choices") && response["choices"].is_array() && !response["choices"].empty()) {
                 auto& first_choice = response["choices"][0];
@@ -2536,7 +2727,8 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
 
         // A collection.router model flips this endpoint into engine mode: pick a
         // candidate and rewrite the model before the usual load/forward logic.
-        apply_router_collection_dispatch(request_json);
+        std::optional<RouterDispatchResult> route_dispatch =
+            apply_router_collection_dispatch(request_json);
 
         std::string requested_model;
         if (request_json.contains("model") && request_json["model"].is_string()) {
@@ -2605,16 +2797,27 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
                 res.set_header("Cache-Control", "no-cache");
                 res.set_header("Connection", "keep-alive");
                 res.set_header("X-Accel-Buffering", "no");
+                if (route_dispatch) {
+                    attach_route_header(res, route_dispatch->decision);
+                }
 
+                json route_decision_json = route_dispatch
+                    ? route_decision_to_json(route_dispatch->decision)
+                    : json(nullptr);
                 res.set_chunked_content_provider(
                     "text/event-stream",
-                    [this, request_body](size_t offset, httplib::DataSink& sink) {
+                    [this, request_body, route_decision_json](size_t offset, httplib::DataSink& sink) {
                         if (offset > 0) {
                             return false; // Already sent everything
                         }
 
                         // Use unified Router path for streaming
-                        router_->completion_stream(request_body, sink);
+                        stream_with_route_decision(
+                            sink,
+                            route_decision_json,
+                            [this, &request_body](httplib::DataSink& route_sink) {
+                                router_->completion_stream(request_body, route_sink);
+                            });
 
                         return false;
                     }
@@ -2649,6 +2852,7 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
                 return;
             }
 
+            attach_route_decision(response, res, route_dispatch);
             res.set_content(response.dump(), "application/json");
 
             // Print and save telemetry for non-streaming completions
@@ -3982,7 +4186,8 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
 
         // A collection.router model flips this endpoint into engine mode: pick a
         // candidate and rewrite the model before the usual load/forward logic.
-        apply_router_collection_dispatch(request_json);
+        std::optional<RouterDispatchResult> route_dispatch =
+            apply_router_collection_dispatch(request_json);
 
         // Handle model loading/switching using helper function
         if (request_json.contains("model")) {
@@ -4019,17 +4224,28 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
                 res.set_header("Cache-Control", "no-cache");
                 res.set_header("Connection", "keep-alive");
                 res.set_header("X-Accel-Buffering", "no");
+                if (route_dispatch) {
+                    attach_route_header(res, route_dispatch->decision);
+                }
 
                 // Use cpp-httplib's chunked content provider for SSE streaming
+                json route_decision_json = route_dispatch
+                    ? route_decision_to_json(route_dispatch->decision)
+                    : json(nullptr);
                 res.set_chunked_content_provider(
                     "text/event-stream",
-                    [this, request_body](size_t offset, httplib::DataSink& sink) {
+                    [this, request_body, route_decision_json](size_t offset, httplib::DataSink& sink) {
                         if (offset > 0) {
                             return false; // Only stream once
                         }
 
                         // Use unified Router path for streaming
-                        router_->responses_stream(request_body, sink);
+                        stream_with_route_decision(
+                            sink,
+                            route_decision_json,
+                            [this, &request_body](httplib::DataSink& route_sink) {
+                                router_->responses_stream(request_body, route_sink);
+                            });
 
                         return false;
                     }
@@ -4050,6 +4266,7 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
                 return;
             }
 
+            attach_route_decision(response, res, route_dispatch);
             LOG(INFO, "Server") << "200 OK" << std::endl;
             res.set_content(response.dump(), "application/json");
         }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2,6 +2,7 @@
 #include <optional>
 #include "lemon/collection_orchestrator.h"
 #include "lemon/hf_variants.h"
+#include "lemon/route_decision_response.h"
 #include "lemon/routing_classifier_services.h"
 #include "lemon/routing_policy.h"
 #include "lemon/config_file.h"
@@ -188,36 +189,6 @@ void set_error_response(const json& response, httplib::Response& res,
     res.set_content(response.dump(), "application/json");
 }
 
-json route_decision_to_json(const Decision& decision) {
-    json out = {
-        {"version", "1"},
-        {"route_to", decision.route_to},
-        {"matched_rule", decision.matched_rule},
-        {"default_used", decision.default_used},
-        {"outputs", decision.outputs.is_object() ? decision.outputs : json::object()},
-    };
-    if (!decision.trace.empty()) {
-        out["trace"] = json::array();
-        for (const auto& entry : decision.trace) {
-            json trace_entry = {
-                {"condition", entry.condition},
-                {"result", entry.result},
-            };
-            if (entry.score.has_value()) {
-                trace_entry["score"] = *entry.score;
-            }
-            out["trace"].push_back(std::move(trace_entry));
-        }
-    }
-    return out;
-}
-
-void attach_route_header(httplib::Response& res, const Decision& decision) {
-    if (!decision.matched_rule.empty()) {
-        res.set_header("x-lemonade-route", decision.matched_rule);
-    }
-}
-
 void attach_route_decision(json& response, httplib::Response& res,
                            const std::optional<RouterDispatchResult>& dispatch) {
     if (!dispatch.has_value()) {
@@ -227,131 +198,39 @@ void attach_route_decision(json& response, httplib::Response& res,
     attach_route_header(res, dispatch->decision);
 }
 
-std::string attach_route_decision_to_sse_event(
-    const std::string& event,
-    const json& route_decision_json,
-    bool& attached) {
-    if (attached || route_decision_json.is_null()) {
-        return event;
+template <typename StreamFn>
+void set_route_decision_sse_content_provider(
+    httplib::Response& res,
+    const std::optional<RouterDispatchResult>& dispatch,
+    std::string request_body,
+    StreamFn stream_fn) {
+    res.set_header("Cache-Control", "no-cache");
+    res.set_header("Connection", "keep-alive");
+    res.set_header("X-Accel-Buffering", "no");
+    if (dispatch) {
+        attach_route_header(res, dispatch->decision);
     }
 
-    const std::string prefix = "data:";
-    std::size_t pos = event.find(prefix);
-    if (pos == std::string::npos) {
-        return event;
-    }
-    std::size_t payload_start = pos + prefix.size();
-    while (payload_start < event.size() &&
-           (event[payload_start] == ' ' || event[payload_start] == '\t')) {
-        ++payload_start;
-    }
-    std::size_t payload_end = event.find('\n', payload_start);
-    if (payload_end == std::string::npos) {
-        payload_end = event.size();
-    }
-    while (payload_end > payload_start &&
-           (event[payload_end - 1] == '\r' || event[payload_end - 1] == ' ' ||
-            event[payload_end - 1] == '\t')) {
-        --payload_end;
-    }
-
-    std::string payload = event.substr(payload_start, payload_end - payload_start);
-    if (payload.empty() || payload == "[DONE]") {
-        return event;
-    }
-
-    json parsed = json::parse(payload, nullptr, /*allow_exceptions=*/false);
-    if (!parsed.is_object()) {
-        return event;
-    }
-    parsed["x_lemonade_route"] = route_decision_json;
-    attached = true;
-
-    std::string out = event.substr(0, payload_start);
-    out += parsed.dump();
-    out += event.substr(payload_end);
-    return out;
-}
-
-class RouteDecisionSseSink {
-public:
-    RouteDecisionSseSink(httplib::DataSink& inner, json route_decision_json)
-        : inner_(inner), route_decision_json_(std::move(route_decision_json)) {}
-
-    bool write(const char* data, size_t length) {
-        buffer_.append(data, length);
-        std::size_t event_end = std::string::npos;
-        while ((event_end = buffer_.find("\n\n")) != std::string::npos) {
-            std::string event = buffer_.substr(0, event_end + 2);
-            buffer_.erase(0, event_end + 2);
-            event = attach_route_decision_to_sse_event(
-                event, route_decision_json_, attached_);
-            if (!inner_.write(event.c_str(), event.size())) {
+    json route_decision_json = dispatch
+        ? route_decision_to_json(dispatch->decision)
+        : json(nullptr);
+    res.set_chunked_content_provider(
+        "text/event-stream",
+        [request_body = std::move(request_body),
+         route_decision_json = std::move(route_decision_json),
+         stream_fn = std::move(stream_fn)](size_t offset, httplib::DataSink& sink) {
+            if (offset > 0) {
                 return false;
             }
-        }
-        return true;
-    }
 
-    void done() {
-        flush();
-        if (inner_.done) {
-            inner_.done();
-        }
-    }
-
-    void done_with_trailer(const httplib::Headers& trailer) {
-        flush();
-        if (inner_.done_with_trailer) {
-            inner_.done_with_trailer(trailer);
-        } else if (inner_.done) {
-            inner_.done();
-        }
-    }
-
-    bool is_writable() const {
-        return !inner_.is_writable || inner_.is_writable();
-    }
-
-private:
-    void flush() {
-        if (!buffer_.empty()) {
-            std::string event = attach_route_decision_to_sse_event(
-                buffer_, route_decision_json_, attached_);
-            inner_.write(event.c_str(), event.size());
-            buffer_.clear();
-        }
-    }
-
-    httplib::DataSink& inner_;
-    json route_decision_json_;
-    bool attached_ = false;
-    std::string buffer_;
-};
-
-template <typename StreamFn>
-void stream_with_route_decision(httplib::DataSink& sink,
-                                json route_decision_json,
-                                StreamFn&& stream_fn) {
-    if (route_decision_json.is_null()) {
-        stream_fn(sink);
-        return;
-    }
-
-    RouteDecisionSseSink route_sink_wrapper(sink, std::move(route_decision_json));
-    httplib::DataSink route_sink;
-    route_sink.write = [&route_sink_wrapper](const char* data, size_t len) {
-        return route_sink_wrapper.write(data, len);
-    };
-    route_sink.done = [&route_sink_wrapper]() { route_sink_wrapper.done(); };
-    route_sink.done_with_trailer = [&route_sink_wrapper](
-        const httplib::Headers& trailer) {
-        route_sink_wrapper.done_with_trailer(trailer);
-    };
-    route_sink.is_writable = [&route_sink_wrapper]() {
-        return route_sink_wrapper.is_writable();
-    };
-    stream_fn(route_sink);
+            stream_with_route_decision(
+                sink,
+                route_decision_json,
+                [&request_body, &stream_fn](httplib::DataSink& route_sink) {
+                    stream_fn(request_body, route_sink);
+                });
+            return false;
+        });
 }
 
 int get_http_status_from_error(const std::string& error_code) {
@@ -2547,36 +2426,13 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                 // Log the HTTP request
                 LOG(INFO, "Server") << "POST /api/v1/chat/completions - Streaming" << std::endl;
 
-                // Set up streaming response with SSE headers
-                res.set_header("Cache-Control", "no-cache");
-                res.set_header("Connection", "keep-alive");
-                res.set_header("X-Accel-Buffering", "no"); // Disable nginx buffering
-                if (route_dispatch) {
-                    attach_route_header(res, route_dispatch->decision);
-                }
-
-                // Use cpp-httplib's chunked content provider for SSE streaming
-                json route_decision_json = route_dispatch
-                    ? route_decision_to_json(route_dispatch->decision)
-                    : json(nullptr);
-                res.set_chunked_content_provider(
-                    "text/event-stream",
-                    [this, request_body, route_decision_json](size_t offset, httplib::DataSink& sink) {
-                        // For chunked responses, offset tracks bytes sent so far
-                        // We only want to stream once when offset is 0
-                        if (offset > 0) {
-                            return false; // We're done after the first call
-                        }
-
-                        stream_with_route_decision(
-                            sink,
-                            route_decision_json,
-                            [this, &request_body](httplib::DataSink& route_sink) {
-                                router_->chat_completion_stream(request_body, route_sink);
-                            });
-                        return false;
-                    }
-                );
+                set_route_decision_sse_content_provider(
+                    res,
+                    route_dispatch,
+                    request_body,
+                    [this](const std::string& body, httplib::DataSink& sink) {
+                        router_->chat_completion_stream(body, sink);
+                    });
             } catch (const std::exception& e) {
                 LOG(ERROR, "Server") << "Streaming failed: " << e.what() << std::endl;
                 res.status = 500;
@@ -2793,35 +2649,13 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
                 // Log the HTTP request
                 LOG(INFO, "Server") << "POST /api/v1/completions - Streaming" << std::endl;
 
-                // Set up SSE headers
-                res.set_header("Cache-Control", "no-cache");
-                res.set_header("Connection", "keep-alive");
-                res.set_header("X-Accel-Buffering", "no");
-                if (route_dispatch) {
-                    attach_route_header(res, route_dispatch->decision);
-                }
-
-                json route_decision_json = route_dispatch
-                    ? route_decision_to_json(route_dispatch->decision)
-                    : json(nullptr);
-                res.set_chunked_content_provider(
-                    "text/event-stream",
-                    [this, request_body, route_decision_json](size_t offset, httplib::DataSink& sink) {
-                        if (offset > 0) {
-                            return false; // Already sent everything
-                        }
-
-                        // Use unified Router path for streaming
-                        stream_with_route_decision(
-                            sink,
-                            route_decision_json,
-                            [this, &request_body](httplib::DataSink& route_sink) {
-                                router_->completion_stream(request_body, route_sink);
-                            });
-
-                        return false;
-                    }
-                );
+                set_route_decision_sse_content_provider(
+                    res,
+                    route_dispatch,
+                    request_body,
+                    [this](const std::string& body, httplib::DataSink& sink) {
+                        router_->completion_stream(body, sink);
+                    });
 
                 LOG(INFO, "Server") << "Streaming completed - 200 OK" << std::endl;
                 return;
@@ -4220,36 +4054,13 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
             try {
                 LOG(INFO, "Server") << "POST /api/v1/responses - Streaming" << std::endl;
 
-                // Set up streaming response with SSE headers
-                res.set_header("Cache-Control", "no-cache");
-                res.set_header("Connection", "keep-alive");
-                res.set_header("X-Accel-Buffering", "no");
-                if (route_dispatch) {
-                    attach_route_header(res, route_dispatch->decision);
-                }
-
-                // Use cpp-httplib's chunked content provider for SSE streaming
-                json route_decision_json = route_dispatch
-                    ? route_decision_to_json(route_dispatch->decision)
-                    : json(nullptr);
-                res.set_chunked_content_provider(
-                    "text/event-stream",
-                    [this, request_body, route_decision_json](size_t offset, httplib::DataSink& sink) {
-                        if (offset > 0) {
-                            return false; // Only stream once
-                        }
-
-                        // Use unified Router path for streaming
-                        stream_with_route_decision(
-                            sink,
-                            route_decision_json,
-                            [this, &request_body](httplib::DataSink& route_sink) {
-                                router_->responses_stream(request_body, route_sink);
-                            });
-
-                        return false;
-                    }
-                );
+                set_route_decision_sse_content_provider(
+                    res,
+                    route_dispatch,
+                    request_body,
+                    [this](const std::string& body, httplib::DataSink& sink) {
+                        router_->responses_stream(body, sink);
+                    });
             } catch (const std::exception& e) {
                 LOG(ERROR, "Server") << "Streaming failed: " << e.what() << std::endl;
                 res.status = 500;

--- a/test/cpp/test_route_decision_response.cpp
+++ b/test/cpp/test_route_decision_response.cpp
@@ -1,0 +1,130 @@
+#include "lemon/route_decision_response.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using lemon::Decision;
+using lemon::RouteDecisionSseSink;
+using lemon::json;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static json decision_json() {
+    Decision decision;
+    decision.route_to = "Tiny-Test-Model-GGUF";
+    decision.matched_rule = "code-to-test-model";
+    return lemon::route_decision_to_json(decision);
+}
+
+struct SinkCapture {
+    httplib::DataSink inner;
+    std::string body;
+    bool done = false;
+
+    SinkCapture() {
+        inner.write = [this](const char* data, size_t len) {
+            body.append(data, len);
+            return true;
+        };
+        inner.done = [this]() { done = true; };
+        inner.is_writable = []() { return true; };
+    }
+};
+
+static bool output_contains_route(const std::string& body) {
+    return body.find("\"x_lemonade_route\"") != std::string::npos &&
+           body.find("\"route_to\":\"Tiny-Test-Model-GGUF\"") != std::string::npos;
+}
+
+static void test_lf_event_is_injected() {
+    SinkCapture capture;
+    RouteDecisionSseSink sink(capture.inner, decision_json());
+
+    const std::string event = "data: {\"id\":\"one\"}\n\n";
+    check("LF write succeeds", sink.write(event.data(), event.size()));
+    check("LF event flushes before done", output_contains_route(capture.body));
+    check("LF event does not call done early", !capture.done);
+
+    sink.done();
+    check("LF done forwarded", capture.done);
+}
+
+static void test_crlf_split_event_is_injected_before_done() {
+    SinkCapture capture;
+    RouteDecisionSseSink sink(capture.inner, decision_json());
+
+    const std::vector<std::string> chunks = {
+        "da",
+        "ta: {\"id\":\"two\"}\r",
+        "\n\r",
+        "\n",
+    };
+    for (std::size_t i = 0; i < chunks.size(); ++i) {
+        check("CRLF split write succeeds", sink.write(chunks[i].data(), chunks[i].size()));
+        if (i + 1 < chunks.size()) {
+            check("CRLF split waits for full record separator", capture.body.empty());
+        }
+    }
+
+    check("CRLF split event flushes before done", output_contains_route(capture.body));
+    check("CRLF output preserves CRLF framing", capture.body.find("\r\n\r\n") != std::string::npos);
+    check("CRLF event does not call done early", !capture.done);
+}
+
+static void test_cr_event_is_injected() {
+    SinkCapture capture;
+    RouteDecisionSseSink sink(capture.inner, decision_json());
+
+    const std::string event = "data: {\"id\":\"three\"}\r\r";
+    check("CR write succeeds", sink.write(event.data(), event.size()));
+    check("CR event flushes before done", output_contains_route(capture.body));
+    check("CR output preserves CR framing", capture.body.find("\r\r") != std::string::npos);
+}
+
+static void test_only_first_json_event_gets_route() {
+    SinkCapture capture;
+    RouteDecisionSseSink sink(capture.inner, decision_json());
+
+    const std::string events =
+        "data: {\"id\":\"first\"}\n\n"
+        "data: {\"id\":\"second\"}\n\n";
+    check("multi-event write succeeds", sink.write(events.data(), events.size()));
+
+    const std::size_t first = capture.body.find("\"x_lemonade_route\"");
+    check("first event receives route", first != std::string::npos);
+    check("route attached only once",
+          first == capture.body.rfind("\"x_lemonade_route\""));
+}
+
+static void test_route_header_default_value() {
+    Decision matched;
+    matched.matched_rule = "safe-rule_1.2";
+    check("matched rule header uses rule id",
+          lemon::route_decision_header_value(matched) == "safe-rule_1.2");
+
+    Decision defaulted;
+    defaulted.default_used = true;
+    check("default route header is explicit",
+          lemon::route_decision_header_value(defaulted) == "default");
+}
+
+int main() {
+    test_lf_event_is_injected();
+    test_crlf_split_event_is_injected_before_done();
+    test_cr_event_is_injected();
+    test_only_first_json_event_gets_route();
+    test_route_header_default_value();
+
+    if (g_failures == 0) {
+        std::printf("All route decision response tests passed.\n");
+    } else {
+        std::printf("%d route decision response test(s) failed.\n", g_failures);
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_routing_policy_parser.cpp
+++ b/test/cpp/test_routing_policy_parser.cpp
@@ -153,6 +153,11 @@ static void test_validation_errors_are_clear() {
     check("malformed score band rejected",
           throws_with(bad_band, "min_score greater than max_score"));
 
+    json unsafe_rule_id = fixture("l1_keywords.json");
+    unsafe_rule_id["routing"]["rules"][0]["id"] = "bad rule\r\nx-header";
+    check("unsafe rule id rejected",
+          throws_with(unsafe_rule_id, "must match [A-Za-z0-9._-]"));
+
     json router_sugar = fixture("l0a_llm_router.json");
     check("routing.router is recognized but deferred to #2405",
           throws_with(router_sugar, "routing.router desugaring"));

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -2921,7 +2921,7 @@ class EndpointTests(ServerTestBase):
             self.assertEqual(default_route.get("default_used"), True)
             self.assertEqual(default_route.get("outputs"), {})
             self.assertNotIn("trace", default_route)
-            self.assertIsNone(default_response.headers.get("x-lemonade-route"))
+            self.assertEqual(default_response.headers.get("x-lemonade-route"), "default")
             print(f"[OK] collection.router dispatched {public_name} -> completion")
         finally:
             try:
@@ -3046,6 +3046,112 @@ class EndpointTests(ServerTestBase):
             except Exception:
                 pass
 
+    def _collect_sse_data_events(self, resp):
+        data_events = []
+        for raw_line in resp.iter_lines():
+            if not raw_line:
+                continue
+            line = raw_line.decode("utf-8", errors="replace")
+            if line.startswith("data:"):
+                data_events.append(line[len("data:") :].strip())
+        return data_events
+
+    def _assert_stream_route_decision(self, resp, endpoint_name):
+        if resp.status_code != 200:
+            self.fail(f"streaming {endpoint_name} returned {resp.status_code}: {resp.text}")
+        self.assertEqual(resp.headers.get("x-lemonade-route"), "code-to-test-model")
+        data_events = self._collect_sse_data_events(resp)
+        self.assertTrue(
+            data_events,
+            f"streaming {endpoint_name} must emit at least one SSE data event",
+        )
+        blob = "\n".join(data_events)
+        self.assertNotIn(
+            '"error"',
+            blob,
+            f"streaming {endpoint_name} must not error: {blob[:500]}",
+        )
+        route_chunks = []
+        for event in data_events:
+            if event == "[DONE]":
+                continue
+            try:
+                payload = json.loads(event)
+            except Exception:
+                continue
+            route = payload.get("x_lemonade_route")
+            if route:
+                route_chunks.append(route)
+        self.assertTrue(
+            route_chunks,
+            f"streaming {endpoint_name} must attach x_lemonade_route to a chunk",
+        )
+        route = route_chunks[0]
+        self.assertEqual(route.get("route_to"), ENDPOINT_TEST_MODEL)
+        self.assertEqual(route.get("matched_rule"), "code-to-test-model")
+        self.assertIsInstance(route.get("trace"), list)
+        return data_events
+
+    def test_021zj_router_collection_chat_streaming_route_decision(self):
+        """/chat/completions streaming attaches additive route metadata."""
+        suffix = uuid.uuid4().hex[:8]
+        canonical_name = f"user.RouterChatStream-{suffix}"
+        public_name = canonical_name[5:]
+        try:
+            pull_response = self._pull_router_collection(canonical_name)
+            self.assertEqual(pull_response.status_code, 200, pull_response.text)
+            self.assertEqual(pull_response.json()["status"], "success")
+
+            with requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": public_name,
+                    "messages": [
+                        {"role": "user", "content": "Please write code for me"}
+                    ],
+                    "max_tokens": 8,
+                    "stream": True,
+                    "route_trace": True,
+                },
+                stream=True,
+                timeout=TIMEOUT_MODEL_OPERATION,
+            ) as resp:
+                self._assert_stream_route_decision(resp, "/chat/completions")
+            print(
+                f"[OK] collection.router /chat/completions (streaming) attached route decision"
+            )
+        finally:
+            self._cleanup_router_collection(canonical_name)
+
+    def test_021zk_router_collection_completions_streaming_route_decision(self):
+        """/completions streaming attaches additive route metadata."""
+        suffix = uuid.uuid4().hex[:8]
+        canonical_name = f"user.RouterComplStream-{suffix}"
+        public_name = canonical_name[5:]
+        try:
+            pull_response = self._pull_router_collection(canonical_name)
+            self.assertEqual(pull_response.status_code, 200, pull_response.text)
+            self.assertEqual(pull_response.json()["status"], "success")
+
+            with requests.post(
+                f"{self.base_url}/completions",
+                json={
+                    "model": public_name,
+                    "prompt": "Please write code for me",
+                    "max_tokens": 8,
+                    "stream": True,
+                    "route_trace": True,
+                },
+                stream=True,
+                timeout=TIMEOUT_MODEL_OPERATION,
+            ) as resp:
+                self._assert_stream_route_decision(resp, "/completions")
+            print(
+                f"[OK] collection.router /completions (streaming) attached route decision"
+            )
+        finally:
+            self._cleanup_router_collection(canonical_name)
+
     def test_021za_router_collection_completions_dispatch(self):
         """/completions dispatches a collection.router request to the
         engine-selected candidate (#2385), same as /chat/completions."""
@@ -3137,44 +3243,7 @@ class EndpointTests(ServerTestBase):
                 stream=True,
                 timeout=TIMEOUT_MODEL_OPERATION,
             ) as resp:
-                self.assertEqual(resp.status_code, 200, resp.text)
-                self.assertEqual(resp.headers.get("x-lemonade-route"), "code-to-test-model")
-                data_events = []
-                for raw_line in resp.iter_lines():
-                    if not raw_line:
-                        continue
-                    line = raw_line.decode("utf-8", errors="replace")
-                    if line.startswith("data:"):
-                        data_events.append(line[len("data:") :].strip())
-            self.assertTrue(
-                data_events,
-                "streaming /responses must emit at least one SSE data event",
-            )
-            blob = "\n".join(data_events)
-            self.assertNotIn(
-                '"error"',
-                blob,
-                f"streaming /responses must not error: {blob[:500]}",
-            )
-            route_chunks = []
-            for event in data_events:
-                if event == "[DONE]":
-                    continue
-                try:
-                    payload = json.loads(event)
-                except Exception:
-                    continue
-                route = payload.get("x_lemonade_route")
-                if route:
-                    route_chunks.append(route)
-            self.assertTrue(
-                route_chunks,
-                "streaming /responses must attach x_lemonade_route to a chunk",
-            )
-            route = route_chunks[0]
-            self.assertEqual(route.get("route_to"), ENDPOINT_TEST_MODEL)
-            self.assertEqual(route.get("matched_rule"), "code-to-test-model")
-            self.assertIsInstance(route.get("trace"), list)
+                self._assert_stream_route_decision(resp, "/responses")
             print(
                 f"[OK] collection.router /responses (streaming) dispatched {public_name}"
             )

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -2890,6 +2890,38 @@ class EndpointTests(ServerTestBase):
                 public_name,
                 "response model must be the routed candidate, not the router alias",
             )
+            route = body.get("x_lemonade_route")
+            self.assertIsInstance(route, dict)
+            self.assertEqual(route.get("version"), "1")
+            self.assertEqual(route.get("route_to"), ENDPOINT_TEST_MODEL)
+            self.assertEqual(route.get("matched_rule"), "code-to-test-model")
+            self.assertEqual(route.get("default_used"), False)
+            self.assertEqual(route.get("outputs"), {})
+            self.assertNotIn("trace", route, "trace must be opt-in via route_trace")
+            self.assertEqual(
+                chat_response.headers.get("x-lemonade-route"),
+                "code-to-test-model",
+            )
+
+            default_response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": public_name,
+                    "messages": [{"role": "user", "content": "Hello there"}],
+                    "max_tokens": 8,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(default_response.status_code, 200, default_response.text)
+            default_body = default_response.json()
+            default_route = default_body.get("x_lemonade_route")
+            self.assertIsInstance(default_route, dict)
+            self.assertEqual(default_route.get("route_to"), ENDPOINT_TEST_MODEL)
+            self.assertEqual(default_route.get("matched_rule"), "")
+            self.assertEqual(default_route.get("default_used"), True)
+            self.assertEqual(default_route.get("outputs"), {})
+            self.assertNotIn("trace", default_route)
+            self.assertIsNone(default_response.headers.get("x-lemonade-route"))
             print(f"[OK] collection.router dispatched {public_name} -> completion")
         finally:
             try:
@@ -2908,6 +2940,66 @@ class EndpointTests(ServerTestBase):
                 )
             except Exception:
                 pass
+
+    def test_021zi_router_collection_trace_and_outputs(self):
+        """route_trace=true returns the full Decision trace and copies rule
+        outputs verbatim without interpreting them (#2386)."""
+        suffix = uuid.uuid4().hex[:8]
+        canonical_name = f"user.RouterTrace-{suffix}"
+        public_name = canonical_name[5:]
+        routing = {
+            "candidates": [ENDPOINT_TEST_MODEL],
+            "default_model": ENDPOINT_TEST_MODEL,
+            "rules": [
+                {
+                    "id": "code-to-test-model",
+                    "match": {"keywords_any": ["code", "def "]},
+                    "route_to": ENDPOINT_TEST_MODEL,
+                    "outputs": {"verdict": "warn"},
+                }
+            ],
+        }
+        try:
+            pull_response = self._pull_router_collection(canonical_name, routing=routing)
+            self.assertEqual(pull_response.status_code, 200, pull_response.text)
+            self.assertEqual(pull_response.json()["status"], "success")
+
+            chat_response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": public_name,
+                    "messages": [
+                        {"role": "user", "content": "Please write code for me"}
+                    ],
+                    "route_trace": True,
+                    "max_tokens": 8,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(chat_response.status_code, 200, chat_response.text)
+            body = chat_response.json()
+            self.assertIn("choices", body)
+            route = body.get("x_lemonade_route")
+            self.assertIsInstance(route, dict)
+            self.assertEqual(route.get("outputs"), {"verdict": "warn"})
+            self.assertEqual(route.get("matched_rule"), "code-to-test-model")
+            trace = route.get("trace")
+            self.assertIsInstance(trace, list)
+            self.assertTrue(trace)
+            self.assertTrue(
+                any(
+                    entry.get("condition") == "keywords_any"
+                    and entry.get("result") is True
+                    for entry in trace
+                ),
+                f"route trace must include the matched keywords condition: {trace}",
+            )
+            # Core must not interpret trust outputs as content-filter behavior.
+            choice = body["choices"][0]
+            self.assertNotEqual(choice.get("finish_reason"), "content_filter")
+            print(f"[OK] collection.router route_trace returned Decision trace")
+        finally:
+            self._cleanup_router_collection(canonical_name)
 
     def _pull_router_collection(self, canonical_name, routing=None, overrides=None):
         """Register a collection.router whose single candidate is
@@ -3040,11 +3132,13 @@ class EndpointTests(ServerTestBase):
                     "input": "Please write code for me",
                     "max_output_tokens": 16,
                     "stream": True,
+                    "route_trace": True,
                 },
                 stream=True,
                 timeout=TIMEOUT_MODEL_OPERATION,
             ) as resp:
                 self.assertEqual(resp.status_code, 200, resp.text)
+                self.assertEqual(resp.headers.get("x-lemonade-route"), "code-to-test-model")
                 data_events = []
                 for raw_line in resp.iter_lines():
                     if not raw_line:
@@ -3062,6 +3156,25 @@ class EndpointTests(ServerTestBase):
                 blob,
                 f"streaming /responses must not error: {blob[:500]}",
             )
+            route_chunks = []
+            for event in data_events:
+                if event == "[DONE]":
+                    continue
+                try:
+                    payload = json.loads(event)
+                except Exception:
+                    continue
+                route = payload.get("x_lemonade_route")
+                if route:
+                    route_chunks.append(route)
+            self.assertTrue(
+                route_chunks,
+                "streaming /responses must attach x_lemonade_route to a chunk",
+            )
+            route = route_chunks[0]
+            self.assertEqual(route.get("route_to"), ENDPOINT_TEST_MODEL)
+            self.assertEqual(route.get("matched_rule"), "code-to-test-model")
+            self.assertIsInstance(route.get("trace"), list)
             print(
                 f"[OK] collection.router /responses (streaming) dispatched {public_name}"
             )


### PR DESCRIPTION
## Summary

  Closes #2386.

  This PR exposes the router `Decision` from `collection.router` dispatch as additive response metadata. Routing already
  selected the concrete backend model in #2385; this change carries the full decision through the server layer and returns it to
  clients under `x_lemonade_route`.

  The decision includes:

  - `version`
  - `route_to`
  - `matched_rule`
  - `default_used`
  - `outputs`
  - optional `trace` when the request sets `route_trace: true`

  For routed streaming responses, the same decision metadata is injected into the first JSON SSE event, and the matched rule is
  also surfaced via the `x-lemonade-route` response header when a rule matched.

  ## Details

  - Adds `RouterDispatchResult` so server dispatch keeps both the selected model and the full `Decision`.
  - Attaches `x_lemonade_route` to non-streaming `/chat/completions`, `/completions`, and `/responses` responses.
  - Injects `x_lemonade_route` into routed SSE streams without changing non-router streaming behavior.
  - Preserves `outputs` as opaque pass-through data; the server does not interpret trust/customer-specific fields.
  - Keeps trace opt-in only via `route_trace: true`.
  - Strips `route_trace` before forwarding requests to the selected backend model.
  - Adds endpoint coverage for matched-rule decisions, default-route decisions, trace output, `outputs`, and streaming response metadata.

  ## Testing

  ```bash
  git diff --check

  PATH=/tmp/lemonade-cmake-venv/bin:$PATH cmake --build --preset default --target lemond

  PATH=/tmp/lemonade-cmake-venv/bin:$PATH ctest --test-dir build --output-on-failure -R "RoutingPolicy(Contract|Evaluator|
  Registry|Semantic|Deterministic|Engine|Parser|Store)Test|RoutingClassifierServicesTest|ModelManagerCollectionValidationTest"

  python3 -m py_compile test/server_endpoints.py

  Also ran focused endpoint tests against this branch’s built lemond on port 13306:

  LEMONADE_TEST_PORT=13306 PYTHONPATH=. /tmp/lemonade-cmake-venv/bin/python -m unittest \
    server_endpoints.EndpointTests.test_021z_router_collection_chat_dispatch \
    server_endpoints.EndpointTests.test_021zi_router_collection_trace_and_outputs \
    server_endpoints.EndpointTests.test_021za_router_collection_completions_dispatch \
    server_endpoints.EndpointTests.test_021zb_router_collection_responses_dispatch \
    server_endpoints.EndpointTests.test_021zc_router_collection_responses_streaming_dispatch

  Result:

  Ran 5 tests in 22.863s

  OK