### PR TITLE
fix: model update startup behavior in offline mode

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1284,6 +1284,11 @@ std::map<std::string, ModelInfo> ModelManager::get_supported_models() {
 }
 
 void ModelManager::check_for_model_updates() {
+    if (auto* cfg = RuntimeConfig::global(); cfg && cfg->offline()) {
+        LOG(DEBUG, "ModelManager")
+            << "Offline mode enabled, skipping model update check" << std::endl;
+        return;
+    }
     // Collect (model_name, repo_id, cached_sha) for downloaded models,
     // deduplicated by repo_id so we only fetch HF API once per repo.
     // All model variants sharing a repo are marked together.
@@ -1633,13 +1638,27 @@ void ModelManager::build_cache() {
     // its own downloaded status. Precedence: server/user/extra models win, so we
     // emplace (don't overwrite). Failures are handled inside each backend's ops.
     {
+        const bool offline = [] {
+            auto* cfg = RuntimeConfig::global();
+            return cfg && cfg->offline();
+        }();
+
         backends::BackendOpsContext octx;
         octx.model_manager = this;
         octx.cloud_registry = cloud_registry_;
+
         for (const auto* desc : backends::all_descriptors()) {
             if (!desc->dynamic_models) {
                 continue;
             }
+
+            if (offline && desc->recipe == "cloud") {
+                LOG(DEBUG, "ModelManager")
+                    << "Offline mode enabled, skipping cloud model discovery"
+                    << std::endl;
+                continue;
+            }
+
             for (auto& m : backends::ops_for(desc->recipe)->discover_models(octx)) {
                 all_models.emplace(m.model_name, std::move(m));
             }


### PR DESCRIPTION
## Summary

Addresses the offline-mode startup behavior from #2608.

- Skip downloaded-model update checks when `offline=true`
- Skip cloud model discovery during model-cache warmup when `offline=true`
- Keep local dynamic discovery, such as FLM, intact

## Why

lemonade config set offline=true should prevent automatic startup network activity. The server currently still performs background update/discovery work during model-cache warmup, including Hugging Face model update checks and cloud-provider discovery.

This PR keeps the fix intentionally small and focused on the startup/offline bug.

## Testing

- Set lemonade config set offline=true
- Start lemond
- Verify the model update check is skipped
- Verify cloud model discovery is skipped
- Verify local models and local dynamic discovery still work
- Set offline=false
- Verify normal update/discovery behavior still works

**## Follow-up**

A broader strict-offline mode could be added separately if desired, should we do it? @superm1  @ramkrishna2910. This is out of scope for this PR and would need larger changes around cloud requests, pull/variant lookup, also newly added telemetry, and potentially other user-initiated network paths.