### PR TITLE
fix(macos): drop dangerous Hardened Runtime entitlements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1657,9 +1657,6 @@ if(APPLE)
             <plist version=\"1.0\">
             <dict>
                 <key>com.apple.security.cs.allow-jit</key><true/>
-                <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
-                <key>com.apple.security.cs.disable-library-validation</key><true/>
-                <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
             </dict>
             </plist>")
     endif()

--- a/src/cpp/server/entitlements.plist
+++ b/src/cpp/server/entitlements.plist
@@ -4,11 +4,5 @@
 <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Remove disable-library-validation, allow-dyld-environment-variables, and allow-unsigned-executable-memory from the codesign entitlements, keeping only allow-jit. The first two together let a process influencing the daemon environment inject DYLD_INSERT_LIBRARIES into a signed, notarised binary — a Gatekeeper-bypass LPE primitive (SWSPLAT-24222, CWE-426/250).

Bundled .dylibs must now be signed with the same Team ID to load.