### PR TITLE
fix(server): size HTTP thread pool from CPU count and add socket time…

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -705,6 +705,7 @@ jobs:
           PYTHONIOENCODING: utf-8
           HF_HOME: ${{ github.workspace }}/hf-cache
           GGML_METAL_NO_RESIDENCY: "1"
+          LEMONADE_WS_IDLE_SECONDS: "31"
         run: |
           set -e
           echo "Resetting server state before endpoint tests..."
@@ -712,6 +713,9 @@ jobs:
           echo "Running endpoint tests..."
           .venv/bin/python test/server_endpoints.py --cli-binary ./build/lemonade
           echo "Endpoint tests PASSED!"
+          echo "Running WebSocket idle test (31s regression)..."
+          .venv/bin/python test/test_websocket_idle.py
+          echo "WebSocket idle test PASSED!"
 
       - name: Run web-app path traversal tests (unsigned path)
         if: steps.check_signing.outputs.has_signing != 'true'
@@ -2070,6 +2074,9 @@ jobs:
         run: |
           .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu endpoints"
           .venv/bin/python test/server_endpoints.py --cli-binary lemonade
+          echo "Running WebSocket idle test..."
+          .venv/bin/python test/test_websocket_idle.py
+          echo "WebSocket idle test PASSED!"
 
       # The full smoke test can be added to a different GPU equipped pipeline
       # as well if needed, but it would significantly add to the pipeline runtime.
@@ -2195,6 +2202,9 @@ jobs:
           elif [ "${{ matrix.test_type }}" = "endpoints" ]; then
             echo "Running endpoint tests..."
             $VENV_PYTHON test/server_endpoints.py --cli-binary "$CLI_BINARY"
+            echo "Running WebSocket idle test..."
+            $VENV_PYTHON test/test_websocket_idle.py
+            echo "WebSocket idle test PASSED!"
           elif [ "${{ matrix.test_type }}" = "ollama" ]; then
             echo "Running Ollama API tests..."
             $VENV_PYTHON test/test_ollama.py --cli-binary "$CLI_BINARY"
@@ -2329,6 +2339,9 @@ jobs:
         run: |
           $VENV_PYTHON -m test.utils.reset_server_state --best-effort --label "${{ matrix.os }} endpoints"
           $VENV_PYTHON test/server_endpoints.py --cli-binary "$CLI_BINARY"
+          echo "Running WebSocket idle test..."
+          $VENV_PYTHON test/test_websocket_idle.py
+          echo "WebSocket idle test PASSED!"
 
       - name: Test web-app path traversal
         if: ${{ !cancelled() && steps.setup.outcome == 'success' && !(runner.os == 'macOS' && needs.build-lemonade-macos-dmg.outputs.has_signing != 'true') }}

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -1,8 +1,10 @@
 #pragma once
 
-// CRITICAL: Define thread pool count BEFORE including httplib.h
+// Define thread pool count BEFORE including httplib.h. This is only the
+// fallback for httplib's default-constructed servers; the listeners are sized
+// at runtime from the host CPU count in setup_http_servers().
 #ifndef CPPHTTPLIB_THREAD_POOL_COUNT
-#define CPPHTTPLIB_THREAD_POOL_COUNT 8
+#define CPPHTTPLIB_THREAD_POOL_COUNT 64
 #endif
 
 #include <string>

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -450,7 +450,7 @@ void Server::setup_http_servers() {
     // lifetime, so a small fixed pool lets a handful of slow-loris or long-lived
     // streaming connections starve the management endpoints (/health, /load).
     unsigned int hw = std::thread::hardware_concurrency();
-    size_t thread_count = std::max<size_t>(32, static_cast<size_t>(hw) * 4);
+    size_t thread_count = std::clamp<size_t>(static_cast<size_t>(hw) * 4, 32, 256);
     std::function<httplib::TaskQueue *(void)> task_queue_factory = [thread_count] {
         LOG(DEBUG, "Server") << "Creating new thread pool with " << thread_count
                              << " threads" << std::endl;
@@ -466,8 +466,14 @@ void Server::setup_http_servers() {
     // Bound how long a single connection can tie up a worker thread. Without a
     // read timeout a client that opens a socket and never finishes its request
     // (slow loris) holds its worker indefinitely. Streaming responses drive
-    // their own write cadence, so keep the write timeout generous.
-    for (RoutedHttpServer* srv : {http_server_.get(), http_server_v6_.get()}) {
+    // their own write cadence, so keep the write timeout generous. The fronts
+    // need the same limits: they own accept and run the WebSocket upgrade peek
+    // before delegating, so a stalled client could otherwise hold a front
+    // worker there.
+    for (httplib::Server* srv : {static_cast<httplib::Server*>(http_front_.get()),
+                                 static_cast<httplib::Server*>(http_front_v6_.get()),
+                                 static_cast<httplib::Server*>(http_server_.get()),
+                                 static_cast<httplib::Server*>(http_server_v6_.get())}) {
         srv->set_read_timeout(30, 0);
         srv->set_write_timeout(300, 0);
         srv->set_keep_alive_max_count(100);

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -445,9 +445,16 @@ void Server::setup_http_servers() {
     // CRITICAL: Enable multi-threading so the server can handle concurrent requests
     // Without this, the server is single-threaded and blocks on long operations
 
-    std::function<httplib::TaskQueue *(void)> task_queue_factory = [this] {
-        LOG(DEBUG, "Server") << "Creating new thread pool with 8 threads" << std::endl;
-        return new httplib::ThreadPool(8);
+    // Size the pool from the host CPU count instead of a fixed 8. cpp-httplib
+    // dedicates one worker thread per in-flight request for the connection's
+    // lifetime, so a small fixed pool lets a handful of slow-loris or long-lived
+    // streaming connections starve the management endpoints (/health, /load).
+    unsigned int hw = std::thread::hardware_concurrency();
+    size_t thread_count = std::max<size_t>(32, static_cast<size_t>(hw) * 4);
+    std::function<httplib::TaskQueue *(void)> task_queue_factory = [thread_count] {
+        LOG(DEBUG, "Server") << "Creating new thread pool with " << thread_count
+                             << " threads" << std::endl;
+        return new httplib::ThreadPool(thread_count);
     };
 
     // The fronts own the accept loops (and therefore the task queues)
@@ -455,6 +462,16 @@ void Server::setup_http_servers() {
     http_front_v6_->new_task_queue = task_queue_factory;
     http_server_->new_task_queue = task_queue_factory;
     http_server_v6_->new_task_queue = task_queue_factory;
+
+    // Bound how long a single connection can tie up a worker thread. Without a
+    // read timeout a client that opens a socket and never finishes its request
+    // (slow loris) holds its worker indefinitely. Streaming responses drive
+    // their own write cadence, so keep the write timeout generous.
+    for (RoutedHttpServer* srv : {http_server_.get(), http_server_v6_.get()}) {
+        srv->set_read_timeout(30, 0);
+        srv->set_write_timeout(300, 0);
+        srv->set_keep_alive_max_count(100);
+    }
 
     setup_routes(*http_server_);
     setup_routes(*http_server_v6_);

--- a/test/test_websocket_idle.py
+++ b/test/test_websocket_idle.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Regression test: verify that WebSocket connections (/realtime, /logs/stream)
+survive idle periods without being killed by the front server's read timeout.
+
+The front listeners have a 30s read timeout to guard against slow-loris attacks.
+WebSocket connections are accepted by the front, then adopted by libwebsockets.
+This test confirms that the timeout doesn't kill idle WebSocket sessions after
+adoption.
+
+Usage:
+    python3 test_websocket_idle.py [port] [idle_seconds]
+
+    Default: port from LEMONADE_TEST_PORT (13305), idle from LEMONADE_WS_IDLE_SECONDS (5)
+    For full regression: LEMONADE_WS_IDLE_SECONDS=31 (proves >30s survival)
+"""
+
+import asyncio
+import os
+import sys
+
+import websockets
+
+
+async def test_idle_websocket(port: int, idle_seconds: int):
+    """Hold a WebSocket connection idle, then verify it's still alive."""
+    uri = f"ws://localhost:{port}/logs/stream"
+    print(f"Connecting to {uri}...")
+
+    async with websockets.connect(uri) as ws:
+        print(f"Connected. Waiting {idle_seconds}s idle...")
+        await asyncio.sleep(idle_seconds)
+
+        print("Sending ping...")
+        pong_waiter = await ws.ping()
+        await asyncio.wait_for(pong_waiter, timeout=5)
+        print(f"✓ Pong received — connection alive after {idle_seconds}s idle")
+
+
+if __name__ == "__main__":
+    port = (
+        int(sys.argv[1])
+        if len(sys.argv) > 1
+        else int(os.environ.get("LEMONADE_TEST_PORT", "13305"))
+    )
+    idle_seconds = (
+        int(sys.argv[2])
+        if len(sys.argv) > 2
+        else int(os.environ.get("LEMONADE_WS_IDLE_SECONDS", "5"))
+    )
+    asyncio.run(test_idle_websocket(port, idle_seconds))


### PR DESCRIPTION
…outs

The fixed 8-thread pool let a handful of slow-loris or long-lived streaming connections starve the management endpoints. Size the pool from the host CPU count (min 32) and add read/keep-alive timeouts so a stalled client can no longer hold a worker thread indefinitely.