### PR TITLE
fix: normalize gfx arch tokens to family wildcards in identify_rocm_arch_from_name (#2319)

### DIFF
--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1747,6 +1747,25 @@ std::string identify_cuda_arch_from_name(const std::string& device_name) {
     return "";
 }
 
+// Map a specific gfx arch token to its family wildcard where ROCm backend assets
+// are published under the family name instead of per-arch. Specific archs that
+// have their own published assets (gfx1150, gfx1151, gfx1152, gfx942, gfx90a, etc.)
+// remain unchanged.
+static std::string gfx_to_family_wildcard(const std::string& gfx_arch) {
+    // RDNA4 (gfx120X) — RX 9000 series
+    if (gfx_arch == "gfx1200" || gfx_arch == "gfx1201") return "gfx120X";
+    // RDNA3 (gfx110X) — RX 7000 series
+    if (gfx_arch == "gfx1100" || gfx_arch == "gfx1101" ||
+        gfx_arch == "gfx1102" || gfx_arch == "gfx1103") return "gfx110X";
+    // RDNA2 (gfx103X) — RX 6000 series
+    if (gfx_arch == "gfx1030" || gfx_arch == "gfx1031" ||
+        gfx_arch == "gfx1032" || gfx_arch == "gfx1033" ||
+        gfx_arch == "gfx1034" || gfx_arch == "gfx1035" ||
+        gfx_arch == "gfx1036") return "gfx103X";
+    // Not mappable to a family wildcard — return as-is
+    return gfx_arch;
+}
+
 // Helper to identify ROCm architecture from GPU name.
 std::string identify_rocm_arch_from_name(const std::string& device_name) {
     std::string device_lower = device_name;
@@ -1754,8 +1773,10 @@ std::string identify_rocm_arch_from_name(const std::string& device_name) {
 
     std::smatch gfx_match;
     // Match 3- or 4-digit gfx tokens; the trailing nibble can be hex (e.g. gfx90a).
+    // Map to family wildcard where applicable (e.g. gfx1201 → gfx120X for RDNA4)
+    // so that ROCm backend asset URLs and support matrix checks use family names.
     if (std::regex_search(device_lower, gfx_match, std::regex(R"((gfx[0-9a-f]{3,4}))"))) {
-        return gfx_match[1].str();
+        return gfx_to_family_wildcard(gfx_match[1].str());
     }
 
     // Linux will pass the ISA from KFD, transform it to what the rest of lemonade expects
@@ -1774,7 +1795,7 @@ std::string identify_rocm_arch_from_name(const std::string& device_name) {
 
         char buf[16];
         std::snprintf(buf, sizeof(buf), "gfx%d%x%x", major, minor, step);
-        return std::string(buf);
+        return gfx_to_family_wildcard(std::string(buf));
     }
 
     if (device_lower.find("radeon") == std::string::npos &&


### PR DESCRIPTION
## What

Map specific gfx arch tokens to their family wildcards where ROCm backend assets are published under the family name instead of per-arch. Specific archs that have their own published assets (gfx1150, gfx1151, gfx1152, gfx942, gfx90a, etc.) remain unchanged.

## Why

`identify_rocm_arch_from_name` returns the exact gfx token (e.g. `gfx1201`, `gfx1102`) but ROCm backend assets are published under family wildcards (`gfx120X`, `gfx110X`). This mismatch means:
- Backend asset URLs resolve incorrectly
- Support matrix checks fail even for supported GPUs
- Users get "unsupported GPU" errors on hardware that works fine

## How

Adds a `gfx_to_family_wildcard()` helper that maps:
- RDNA4: `gfx1200`/`gfx1201` → `gfx120X`
- RDNA3: `gfx1100`–`gfx1103` → `gfx110X`
- RDNA2: `gfx1030`–`gfx1036` → `gfx103X`
- All others: passed through unchanged

Called from both the regex match path and the KFD ISA path in `identify_rocm_arch_from_name`.

## Tested

- [ ] RDNA3 GPU (gfx1102 → gfx110X resolution)
- [ ] Non-matching archs pass through unchanged

Fixes #2319