### PR TITLE
feat: support HF_ENDPOINT env var for Hugging Face mirror configuration (#2579)

### DIFF
--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -10,6 +10,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <lemon/utils/path_utils.h>
+
 namespace lemon_cli {
 
 namespace {
@@ -140,9 +142,15 @@ std::string normalize_user_model_name(std::string name) {
 }
 
 std::string strip_huggingface_url_prefix(const std::string& arg) {
-    static const std::string prefix = "https://huggingface.co/";
-    if (arg.rfind(prefix, 0) == 0) {
-        return arg.substr(prefix.size());
+    std::string endpoint = lemon::utils::get_hf_endpoint();
+    // Try stripping configured mirror prefix first, then known default
+    std::string endpoint_prefix = endpoint + "/";
+    if (arg.rfind(endpoint_prefix, 0) == 0) {
+        return arg.substr(endpoint_prefix.size());
+    }
+    static const std::string default_prefix = "https://huggingface.co/";
+    if (endpoint_prefix != default_prefix && arg.rfind(default_prefix, 0) == 0) {
+        return arg.substr(default_prefix.size());
     }
     return arg;
 }

--- a/src/cpp/include/lemon/utils/path_utils.h
+++ b/src/cpp/include/lemon/utils/path_utils.h
@@ -101,6 +101,14 @@ std::string get_hf_cache_dir();
 std::string get_runtime_dir();
 
 /**
+ * Get the Hugging Face Hub endpoint base URL.
+ * Reads the HF_ENDPOINT environment variable, falls back to
+ * https://huggingface.co when unset or empty.
+ * Trailing slashes are stripped.
+ */
+std::string get_hf_endpoint();
+
+/**
  * Get the directory where backend executables will be downloaded.
  * This is in the user's cache directory (~/.cache/lemonade/bin on all platforms)
  * to support All Users installations where the install directory may be read-only.

--- a/src/cpp/server/backends/vllm/vllm_server.cpp
+++ b/src/cpp/server/backends/vllm/vllm_server.cpp
@@ -153,7 +153,7 @@ static std::string detect_quant_method(const std::string& model_id) {
     }
 
     // 2. Fetch directly from HF
-    std::string url = "https://huggingface.co/" + model_id + "/resolve/main/config.json";
+    std::string url = lemon::utils::get_hf_endpoint() + "/" + model_id + "/resolve/main/config.json";
     auto resp = HttpClient::get(url);
     if (resp.status_code == 200) {
         return parse_quant_method(resp.body);

--- a/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
+++ b/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
@@ -189,7 +189,7 @@ void WhisperServer::download_npu_compiled_cache(const std::string& model_path,
     }
 
     try {
-        std::string hf_url = "https://huggingface.co/" + cache_repo + "/resolve/main/" + cache_filename;
+        std::string hf_url = get_hf_endpoint() + "/" + cache_repo + "/resolve/main/" + cache_filename;
 
         LOG(INFO, "WhisperServer") << "Downloading from: " << hf_url << std::endl;
 

--- a/src/cpp/server/hf_variants.cpp
+++ b/src/cpp/server/hf_variants.cpp
@@ -11,6 +11,7 @@
 #include "lemon/model_types.h"
 #include "lemon/utils/http_client.h"
 #include "lemon/utils/json_utils.h"
+#include "lemon/utils/path_utils.h"
 
 namespace lemon {
 
@@ -209,7 +210,7 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
 
     // `?blobs=true` makes HF include per-file `size` in each siblings entry,
     // which we forward to the variant set so the CLI menu can show real sizes.
-    std::string url = "https://huggingface.co/api/models/" + checkpoint + "?blobs=true";
+    std::string url = lemon::utils::get_hf_endpoint() + "/api/models/" + checkpoint + "?blobs=true";
     auto response = HttpClient::get(url, headers);
     // HuggingFace returns 401 (not 404) for nonexistent public repos to mimic
     // the behavior of gated repos. Treat both as "not found" from the user's
@@ -308,7 +309,7 @@ nlohmann::json fetch_pull_variants(const std::string& checkpoint, bool& not_foun
         }
 
         std::string manifest_url =
-            "https://huggingface.co/" + checkpoint + "/resolve/main/" + manifest_filename;
+            lemon::utils::get_hf_endpoint() + "/" + checkpoint + "/resolve/main/" + manifest_filename;
         auto manifest_response = HttpClient::get(manifest_url, headers);
         if (manifest_response.status_code != 200) {
             throw std::runtime_error(

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1335,7 +1335,7 @@ void ModelManager::check_for_model_updates() {
 
         try {
             LOG(DEBUG, "ModelManager") << "Checking for updates: " << repo_id << std::endl;
-            std::string api_url = "https://huggingface.co/api/models/" + repo_id;
+            std::string api_url = lemon::utils::get_hf_endpoint() + "/api/models/" + repo_id;
             auto response = HttpClient::get(api_url, headers, 10);
 
             if (response.status_code != 200) {
@@ -3201,7 +3201,7 @@ static std::map<std::string, HfFileMetadata> fetch_hf_file_metadata_for_ref(
     }
 
     for (const auto& subdir : subdirs_to_fetch) {
-        std::string tree_url = "https://huggingface.co/api/models/" + repo_id + "/tree/" + ref;
+        std::string tree_url = lemon::utils::get_hf_endpoint() + "/api/models/" + repo_id + "/tree/" + ref;
         if (!subdir.empty()) {
             tree_url += "/" + subdir;
         }
@@ -3647,7 +3647,7 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
     // NOTE: This API call happens EVERY time this function is called, regardless of
     // whether files are cached. The do_not_upgrade check should happen in the caller
     // (download_model) to avoid this API call when using cached models.
-    std::string api_url = "https://huggingface.co/api/models/" + main_repo_id;
+    std::string api_url = lemon::utils::get_hf_endpoint() + "/api/models/" + main_repo_id;
 
     LOG(INFO, "ModelManager") << "Fetching repository file list from Hugging Face..." << std::endl;
     auto response = HttpClient::get(api_url, headers);
@@ -3809,7 +3809,7 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
         if (repo_id == main_repo_id || files.empty()) continue;
 
         // Query HF API for this repo's commit hash
-        std::string other_api_url = "https://huggingface.co/api/models/" + repo_id;
+        std::string other_api_url = lemon::utils::get_hf_endpoint() + "/api/models/" + repo_id;
         auto other_response = HttpClient::get(other_api_url, headers);
 
         std::string other_hash = "main";
@@ -3892,7 +3892,7 @@ void ModelManager::download_from_huggingface(const ModelInfo& info,
             std::string size_key = repo_id + ':' + filename;
             file_entry["name"] = filename;
             std::string repo_commit = repo_commit_hashes.count(repo_id) ? repo_commit_hashes[repo_id] : "main";
-            file_entry["url"] = "https://huggingface.co/" + repo_id + "/resolve/" + repo_commit + "/" + filename;
+            file_entry["url"] = lemon::utils::get_hf_endpoint() + "/" + repo_id + "/resolve/" + repo_commit + "/" + filename;
             file_entry["size"] = file_sizes.count(size_key) ? file_sizes[size_key] : 0;
             file_entry["download_path"] = repo_download_paths[repo_id];
             if (file_hashes.count(size_key)) {

--- a/src/cpp/server/utils/path_utils.cpp
+++ b/src/cpp/server/utils/path_utils.cpp
@@ -212,6 +212,20 @@ std::string get_runtime_dir() {
     return platform()->get_runtime_dir();
 }
 
+std::string get_hf_endpoint() {
+    static const std::string default_endpoint = "https://huggingface.co";
+    std::string env = get_environment_variable_utf8("HF_ENDPOINT");
+    if (env.empty()) {
+        return default_endpoint;
+    }
+    // Strip trailing slashes
+    while (env.size() > 1 && env.back() == '/') {
+        env.pop_back();
+    }
+    return env;
+}
+
+
 std::string get_downloaded_bin_dir() {
     // Use cache directory on all platforms for consistent multi-user support
     // This is important for All Users installs on Windows where Program Files is read-only


### PR DESCRIPTION
## Summary

Adds `get_hf_endpoint()` helper that reads the `HF_ENDPOINT` environment variable at runtime and falls back to `https://huggingface.co` when unset. Trailing slashes are automatically stripped.

Replaces all 11 hardcoded `https://huggingface.co` URL constructions across 6 source files with calls to `get_hf_endpoint()`.

Closes #2579

## Changes

| File | Change |
|------|--------|
| `path_utils.h` | `get_hf_endpoint()` declaration |
| `path_utils.cpp` | `get_hf_endpoint()` implementation |
| `model_manager.cpp` | 5 API URLs → `get_hf_endpoint()` |
| `hf_variants.cpp` | 2 URLs + `path_utils.h` include |
| `vllm_server.cpp` | 1 URL for `config.json` fetch |
| `whispercpp_server.cpp` | 1 URL for NPU cache download |
| `hf_pull.cpp` | `strip_huggingface_url_prefix()` recognizes mirror + default |

## Testing

- [x] Compiles clean on Strix Halo (gfx1151, ROCm)
- [x] Unset `HF_ENDPOINT` → default `https://huggingface.co` used
- [x] Trailing slashes stripped (`https://hf-mirror.com/` → `https://hf-mirror.com`)
- [x] Custom endpoint passes through as-is