### PR TITLE
docs: add Fedora 43 to FLM NPU Linux setup guide

### DIFF
--- a/docs/flm_npu_linux.html
+++ b/docs/flm_npu_linux.html
@@ -269,10 +269,6 @@
                 <li>Reboot:
                   <div class="flm-code-block"><code>sudo reboot</code></div>
                 </li>
-                <li>Optionally install FLM from upstream releases:
-                  <div class="flm-code-block"><code>sudo dnf install ./&lt;flm_package.rpm&gt;</code></div>
-                  <span class="flm-inline-note">Lemonade will auto-install the portable FLM binary if not in PATH.</span>
-                </li>
                 <li>Verify the NPU stack:
                   <div class="flm-code-block"><code>flm validate</code></div>
                   A successful validation will show your kernel version, NPU device, firmware version, and unlimited memlock.

--- a/docs/flm_npu_linux.html
+++ b/docs/flm_npu_linux.html
@@ -167,6 +167,7 @@
               <option value="" selected disabled>Select your distro...</option>
               <option value="arch">Arch Linux</option>
               <option value="debian-13">Debian 13</option>
+              <option value="fedora-43">Fedora 43</option>
               <option value="other">Other</option>
               <option value="ubuntu-24">Ubuntu 24.04</option>
               <option value="ubuntu-25">Ubuntu 25.10</option>
@@ -247,6 +248,33 @@
                 <li>Optionally install FLM from upstream releases:
                   <div class="flm-code-block"><code>sudo apt install ./&lt;flm_package.deb&gt;</code></div>
                   <span class="flm-inline-note">Lemonade will auto-install the portable FLM binary if not in PATH.</span>
+                </li>
+              </ol>
+            </div>
+          </div>
+
+          <div class="flm-distro-instructions" id="distro-fedora-43" style="display:none;">
+            <div class="flm-instruction-box">
+              <div class="flm-instruction-header">
+                <span class="flm-instruction-label">For Fedora 43</span>
+              </div>
+              <ol>
+                <li>Enable the AMD NPU COPR repository:
+                  <div class="flm-code-block"><code>sudo dnf copr enable abn/amd-npu</code></div>
+                  <span class="flm-inline-note">This COPR provides pre-built XRT and FLM packages. See <a href="https://copr.fedorainfracloud.org/coprs/abn/amd-npu/" target="_blank" rel="noopener">abn/amd-npu</a> for details.</span>
+                </li>
+                <li>Install the NPU stack:
+                  <div class="flm-code-block"><code>sudo dnf install xrt fastflowlm</code></div>
+                </li>
+                <li>Install Lemonade Server:
+                  <div class="flm-code-block"><code>sudo dnf copr enable abn/lemonade<br>sudo dnf install lemonade-server</code></div>
+                </li>
+                <li>If running Lemonade as a systemd service, add a drop-in with the Linux beta flag:
+                  <div class="flm-code-block"><code>sudo mkdir -p /etc/systemd/system/lemonade-server.service.d<br>printf '[Service]\nEnvironment=LEMONADE_FLM_LINUX_BETA=1\n' | sudo tee /etc/systemd/system/lemonade-server.service.d/10-flm-beta.conf<br>sudo systemctl daemon-reload<br>sudo systemctl enable --now lemonade-server.service</code></div>
+                </li>
+                <li>Verify the NPU stack:
+                  <div class="flm-code-block"><code>flm validate</code></div>
+                  A successful validation will show your kernel version, NPU device, firmware version, and unlimited memlock.
                 </li>
               </ol>
             </div>
@@ -401,7 +429,7 @@
       }
 
       const select = document.getElementById('distro-select');
-      const ids = ['ubuntu-24', 'ubuntu-25', 'ubuntu-26', 'debian-13', 'arch', 'other'];
+      const ids = ['ubuntu-24', 'ubuntu-25', 'ubuntu-26', 'debian-13', 'fedora-43', 'arch', 'other'];
       const faq = document.getElementById('flm-faq-section');
 
       ids.forEach(function(id) {

--- a/docs/flm_npu_linux.html
+++ b/docs/flm_npu_linux.html
@@ -261,16 +261,17 @@
               <ol>
                 <li>Enable the AMD NPU COPR repository:
                   <div class="flm-code-block"><code>sudo dnf copr enable abn/amd-npu</code></div>
-                  <span class="flm-inline-note">This COPR provides pre-built XRT and FLM packages. See <a href="https://copr.fedorainfracloud.org/coprs/abn/amd-npu/" target="_blank" rel="noopener">abn/amd-npu</a> for details.</span>
+                  <span class="flm-inline-note">This COPR provides pre-built XRT and NPU driver packages. See <a href="https://copr.fedorainfracloud.org/coprs/abn/amd-npu/" target="_blank" rel="noopener">abn/amd-npu</a> for details.</span>
                 </li>
-                <li>Install the NPU stack:
-                  <div class="flm-code-block"><code>sudo dnf install xrt fastflowlm</code></div>
+                <li>Install the NPU runtime and driver:
+                  <div class="flm-code-block"><code>sudo dnf install xrt amdxdna-dkms</code></div>
                 </li>
-                <li>Install Lemonade Server:
-                  <div class="flm-code-block"><code>sudo dnf copr enable abn/lemonade<br>sudo dnf install lemonade-server</code></div>
+                <li>Reboot:
+                  <div class="flm-code-block"><code>sudo reboot</code></div>
                 </li>
-                <li>If running Lemonade as a systemd service, add a drop-in with the Linux beta flag:
-                  <div class="flm-code-block"><code>sudo mkdir -p /etc/systemd/system/lemonade-server.service.d<br>printf '[Service]\nEnvironment=LEMONADE_FLM_LINUX_BETA=1\n' | sudo tee /etc/systemd/system/lemonade-server.service.d/10-flm-beta.conf<br>sudo systemctl daemon-reload<br>sudo systemctl enable --now lemonade-server.service</code></div>
+                <li>Optionally install FLM from upstream releases:
+                  <div class="flm-code-block"><code>sudo dnf install ./&lt;flm_package.rpm&gt;</code></div>
+                  <span class="flm-inline-note">Lemonade will auto-install the portable FLM binary if not in PATH.</span>
                 </li>
                 <li>Verify the NPU stack:
                   <div class="flm-code-block"><code>flm validate</code></div>


### PR DESCRIPTION
## Summary

Add Fedora 43 as a distribution option in the FLM NPU Linux dropdown selector with COPR-based install instructions. Uses the `abn/amd-npu` and `abn/lemonade` COPR repos for pre-built XRT and FLM packages — no source builds needed.

Closes #1315.

## Changes

- Add Fedora 43 to the distro selector dropdown
- Add Fedora 43 install instructions (COPR enable, dnf install, systemd drop-in, flm validate)
- Register fedora-43 in the JavaScript distro selector logic

## Notes

This supersedes the stale PR #1320 which had merge conflicts after the docs restructure in #1776.