### PR TITLE
fix(macos): reduce log directory permissions to prevent privilege esc…

### DIFF
--- a/src/cpp/postinst-full-mac
+++ b/src/cpp/postinst-full-mac
@@ -84,9 +84,8 @@ mkdir -p "$CONFIG_DIR"
 chmod 755 "$CONFIG_DIR"
 
 # Log Directory (Critical: Service crashes if missing)
-# Permissions 777 so both the root daemon and user-level tray agent can write logs
 mkdir -p "$LOG_DIR"
-chmod 777 "$LOG_DIR"
+chmod 755 "$LOG_DIR"
 chown root:wheel "$LOG_DIR"
 
 # Share Directory


### PR DESCRIPTION
…alation

The macOS post-install script created /var/log/lemonade with world-writable permissions (0777), allowing any local user to create a symlink before the LaunchDaemon starts. Since launchd opens log files as root without O_NOFOLLOW, an attacker could redirect writes to arbitrary files (e.g., /etc/sudoers.d/).

Changed permissions from 0777 to 0755. The root-owned daemon (com.lemonade.server) can still write logs, while preventing unauthorized users from manipulating the directory contents. The tray agent logs to /Users/Shared/, not this directory.

Fixes SWSPLAT-24190