### PR TITLE
fix(security): replace system() with ProcessManager in archive extrac…

### DIFF
--- a/src/cpp/include/lemon/utils/process_manager.h
+++ b/src/cpp/include/lemon/utils/process_manager.h
@@ -32,7 +32,8 @@ public:
         const std::vector<std::string>& args,
         OutputLineCallback on_line,
         const std::string& working_dir = "",
-        int timeout_seconds = -1);
+        int timeout_seconds = -1,
+        bool capture_stderr = true);
 
     static void stop_process(ProcessHandle handle);
 

--- a/src/cpp/include/lemon/utils/process_platform.h
+++ b/src/cpp/include/lemon/utils/process_platform.h
@@ -43,7 +43,8 @@ public:
         const std::vector<std::string>& args,
         OutputLineCallback on_line,
         const std::string& working_dir,
-        int timeout_seconds) = 0;
+        int timeout_seconds,
+        bool capture_stderr = true) = 0;
 
     // Utility functions
     virtual int find_free_port(int start_port) = 0;

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -232,7 +232,6 @@ namespace lemon::backends {
     bool BackendUtils::extract_seven_zip(const std::string& archive_path, const std::string& dest_dir, const std::string& backend_name) {
         // CUDA Windows release assets are .7z and use the existing native tar.exe path.
         // Linux CUDA assets are .tar.xz, so Linux should not require bsdtar/7z/p7zip.
-        std::string command;
         fs::create_directories(dest_dir);
         LOG(DEBUG, backend_name) << "Extracting 7z to " << dest_dir << std::endl;
 #ifdef _WIN32
@@ -247,9 +246,14 @@ namespace lemon::backends {
         }
         {
             std::string tar_path = platform->get_native_tar_path();
-            std::string probe_cmd = tar_path + " --list -f \"" + archive_path + "\" >nul 2>&1";
-            std::string unused;
-            if (lemon::utils::ProcessManager::run_command(probe_cmd, unused, 10) != 0) {
+            int probe_result = lemon::utils::ProcessManager::run_process_with_output(
+                tar_path,
+                {"--list", "-f", archive_path},
+                [](const std::string&) { return true; },
+                "",
+                10
+            );
+            if (probe_result != 0) {
                 LOG(ERROR, backend_name) << "Error: tar.exe cannot read this .7z archive. Windows 11 22H2+ (bsdtar/libarchive) required." << std::endl;
                 return false;
             }
@@ -257,19 +261,27 @@ namespace lemon::backends {
         // Note: do NOT use --strip-components=1 here. The CUDA .7z archives from
         // lemonade-sdk/llama.cpp have no top-level directory — files sit at the
         // archive root. Stripping would discard every entry and produce an empty dir.
-        command = platform->get_native_tar_path() + " -xf \"" + archive_path + "\" -C \"" + dest_dir + "\"";
-#else
-        LOG(ERROR, backend_name) << "Error: .7z backend archives are only expected on Windows. Linux CUDA assets should be .tar.xz." << std::endl;
-        return false;
-#endif
         std::string output;
-        int result = lemon::utils::ProcessManager::run_command(command, output, 300);
+        int result = lemon::utils::ProcessManager::run_process_with_output(
+            platform->get_native_tar_path(),
+            {"-xf", archive_path, "-C", dest_dir},
+            [&output](const std::string& line) {
+                output += line + "\n";
+                return true;
+            },
+            "",
+            300
+        );
         if (result != 0) {
             LOG(ERROR, backend_name) << "Extraction failed with code: " << result
                                      << (output.empty() ? "" : " - " + output) << std::endl;
             return false;
         }
         return true;
+#else
+        LOG(ERROR, backend_name) << "Error: .7z backend archives are only expected on Windows. Linux CUDA assets should be .tar.xz." << std::endl;
+        return false;
+#endif
     }
 
     static fs::path get_backend_download_cache_dir() {

--- a/src/cpp/server/utils/platform/archive_unix.cpp
+++ b/src/cpp/server/utils/platform/archive_unix.cpp
@@ -1,4 +1,5 @@
 #include <lemon/utils/archive_platform.h>
+#include <lemon/utils/process_manager.h>
 #include <lemon/utils/aixlog.hpp>
 #include <cstdio>
 #include <filesystem>
@@ -18,12 +19,21 @@ public:
         fs::create_directories(dest_dir);
         LOG(DEBUG, backend_name) << "Extracting zip to " << dest_dir << std::endl;
 
-        std::string command = "unzip -o -q \"" + zip_path + "\" -d \"" + dest_dir + "\"";
-        int result = system(command.c_str());
+        std::string output;
+        int result = ProcessManager::run_process_with_output(
+            "unzip",
+            {"-o", "-q", zip_path, "-d", dest_dir},
+            [&output](const std::string& line) {
+                output += line + "\n";
+                return true;
+            },
+            "",
+            30
+        );
 
         if (result != 0) {
             LOG(ERROR, backend_name) << "Extraction failed. Ensure 'unzip' is installed. Code: "
-                                    << result << std::endl;
+                                    << result << (output.empty() ? "" : " - " + output) << std::endl;
             return false;
         }
         return true;
@@ -35,30 +45,43 @@ public:
         fs::create_directories(dest_dir);
         LOG(DEBUG, backend_name) << "Extracting tarball to " << dest_dir << std::endl;
 
-        auto list_output = [](const std::string& cmd) -> std::string {
-            std::string result;
-            std::unique_ptr<FILE, int(*)(FILE*)> pipe(popen(cmd.c_str(), "r"), pclose);
-            if (!pipe) return "";
-            char buf[4096];
-            while (fgets(buf, sizeof(buf), pipe.get())) {
-                result += buf;
-            }
-            return result;
-        };
+        std::string entries;
+        int list_result = ProcessManager::run_process_with_output(
+            "tar",
+            {"-tf", tarball_path},
+            [&entries](const std::string& line) {
+                entries += line + "\n";
+                return true;
+            },
+            "",
+            30,
+            false
+        );
 
-        std::string entries = list_output(
-            "tar -tf \"" + tarball_path + "\" 2>/dev/null || true");
-        int strip = compute_tarball_strip_components(entries);
+        int strip = 0;
+        if (list_result == 0) {
+            strip = compute_tarball_strip_components(entries);
+            LOG(DEBUG, backend_name) << "Tarball strip-components: " << strip << std::endl;
+        } else {
+            LOG(DEBUG, backend_name) << "Could not list tarball contents, using strip=0" << std::endl;
+        }
 
-        LOG(DEBUG, backend_name) << "Tarball strip-components: " << strip << std::endl;
+        std::string output;
+        int result = ProcessManager::run_process_with_output(
+            "tar",
+            {"-xf", tarball_path, "-C", dest_dir,
+             "--strip-components=" + std::to_string(strip), "--no-same-owner"},
+            [&output](const std::string& line) {
+                output += line + "\n";
+                return true;
+            },
+            "",
+            300
+        );
 
-        std::string command = "tar -xf \"" + tarball_path + "\" -C \"" + dest_dir +
-                            "\" --strip-components=" + std::to_string(strip) +
-                            " --no-same-owner";
-
-        int result = system(command.c_str());
         if (result != 0) {
-            LOG(ERROR, backend_name) << "Extraction failed with code: " << result << std::endl;
+            LOG(ERROR, backend_name) << "Extraction failed with code: " << result
+                                    << (output.empty() ? "" : " - " + output) << std::endl;
             return false;
         }
         return true;
@@ -69,7 +92,17 @@ public:
     }
 
     bool is_native_tar_available() override {
-        return system("tar --version >/dev/null 2>&1") == 0;
+        try {
+            return ProcessManager::run_process_with_output(
+                "tar",
+                {"--version"},
+                [](const std::string&) { return true; },
+                "",
+                5
+            ) == 0;
+        } catch (const std::exception&) {
+            return false;
+        }
     }
 };
 

--- a/src/cpp/server/utils/platform/archive_windows.cpp
+++ b/src/cpp/server/utils/platform/archive_windows.cpp
@@ -11,6 +11,21 @@ namespace fs = std::filesystem;
 
 namespace lemon::utils {
 
+namespace {
+std::string escape_powershell_literal(const std::string& value) {
+    std::string escaped;
+    escaped.reserve(value.size());
+    for (char c : value) {
+        if (c == '\'') {
+            escaped += "''";
+        } else {
+            escaped += c;
+        }
+    }
+    return escaped;
+}
+} // namespace
+
 class WindowsArchivePlatform : public ArchivePlatform {
 public:
     std::string get_native_tar_path() override {
@@ -23,19 +38,37 @@ public:
 
     bool is_native_tar_available() override {
         std::string tar_path = get_native_tar_path();
-        std::string command = tar_path + " --version >nul 2>&1";
-        std::string unused;
-        return ProcessManager::run_command(command, unused) == 0;
+        try {
+            return ProcessManager::run_process_with_output(
+                tar_path,
+                {"--version"},
+                [](const std::string&) { return true; },
+                "",
+                5
+            ) == 0;
+        } catch (const std::exception&) {
+            return false;
+        }
     }
     bool extract_zip(const std::string& zip_path,
                     const std::string& dest_dir,
                     const std::string& backend_name) override {
-        std::string command;
         fs::create_directories(dest_dir);
+        std::string output;
+        int result;
 
         if (is_native_tar_available()) {
             LOG(DEBUG, backend_name) << "Extracting ZIP with native tar to " << dest_dir << std::endl;
-            command = get_native_tar_path() + " -xf \"" + zip_path + "\" -C \"" + dest_dir + "\"";
+            result = ProcessManager::run_process_with_output(
+                get_native_tar_path(),
+                {"-xf", zip_path, "-C", dest_dir},
+                [&output](const std::string& line) {
+                    output += line + "\n";
+                    return true;
+                },
+                "",
+                300
+            );
         } else {
             LOG(DEBUG, backend_name) << "Extracting ZIP via PowerShell to " << dest_dir << std::endl;
             std::string powershell_path = "powershell";
@@ -43,13 +76,22 @@ public:
             if (system_root) {
                 powershell_path = std::string(system_root) + "\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
             }
-            command = powershell_path + " -Command \"Expand-Archive -Path '" + zip_path +
-                     "' -DestinationPath '" + dest_dir + "' -Force\"";
+            result = ProcessManager::run_process_with_output(
+                powershell_path,
+                {"-Command", "Expand-Archive -LiteralPath '" + escape_powershell_literal(zip_path) +
+                 "' -DestinationPath '" + escape_powershell_literal(dest_dir) + "' -Force"},
+                [&output](const std::string& line) {
+                    output += line + "\n";
+                    return true;
+                },
+                "",
+                300
+            );
         }
 
-        int result = system(command.c_str());
         if (result != 0) {
-            LOG(ERROR, backend_name) << "Extraction failed with code: " << result << std::endl;
+            LOG(ERROR, backend_name) << "Extraction failed with code: " << result
+                                    << (output.empty() ? "" : " - " + output) << std::endl;
             return false;
         }
         return true;
@@ -66,30 +108,43 @@ public:
             return false;
         }
 
-        auto list_output = [](const std::string& cmd) -> std::string {
-            std::string result;
-            std::unique_ptr<FILE, int(*)(FILE*)> pipe(_popen(cmd.c_str(), "r"), _pclose);
-            if (!pipe) return "";
-            char buf[4096];
-            while (fgets(buf, sizeof(buf), pipe.get())) {
-                result += buf;
-            }
-            return result;
-        };
+        std::string entries;
+        int list_result = ProcessManager::run_process_with_output(
+            get_native_tar_path(),
+            {"-tf", tarball_path},
+            [&entries](const std::string& line) {
+                entries += line + "\n";
+                return true;
+            },
+            "",
+            30,
+            false
+        );
 
-        std::string entries = list_output(
-            get_native_tar_path() + " -tf \"" + tarball_path + "\" 2>nul");
-        int strip = compute_tarball_strip_components(entries);
+        int strip = 0;
+        if (list_result == 0) {
+            strip = compute_tarball_strip_components(entries);
+            LOG(DEBUG, backend_name) << "Tarball strip-components: " << strip << std::endl;
+        } else {
+            LOG(DEBUG, backend_name) << "Could not list tarball contents, using strip=0" << std::endl;
+        }
 
-        LOG(DEBUG, backend_name) << "Tarball strip-components: " << strip << std::endl;
+        std::string output;
+        int result = ProcessManager::run_process_with_output(
+            get_native_tar_path(),
+            {"-xf", tarball_path, "-C", dest_dir,
+             "--strip-components=" + std::to_string(strip), "--no-same-owner"},
+            [&output](const std::string& line) {
+                output += line + "\n";
+                return true;
+            },
+            "",
+            300
+        );
 
-        std::string command = get_native_tar_path() + " -xf \"" + tarball_path +
-                            "\" -C \"" + dest_dir + "\" --strip-components=" +
-                            std::to_string(strip) + " --no-same-owner";
-
-        int result = system(command.c_str());
         if (result != 0) {
-            LOG(ERROR, backend_name) << "Extraction failed with code: " << result << std::endl;
+            LOG(ERROR, backend_name) << "Extraction failed with code: " << result
+                                    << (output.empty() ? "" : " - " + output) << std::endl;
             return false;
         }
         return true;

--- a/src/cpp/server/utils/platform/process_macos.cpp
+++ b/src/cpp/server/utils/platform/process_macos.cpp
@@ -74,7 +74,8 @@ public:
         const std::vector<std::string>& args,
         OutputLineCallback on_line,
         const std::string& working_dir,
-        int timeout_seconds) override;
+        int timeout_seconds,
+        bool capture_stderr = true) override;
 
     int find_free_port(int start_port) override;
     int run_command(const std::string& command, std::string& output, int timeout_seconds) override;
@@ -455,7 +456,8 @@ int MacOSProcessPlatform::run_with_output(
     const std::vector<std::string>& args,
     OutputLineCallback on_line,
     const std::string& working_dir,
-    int timeout_seconds) {
+    int timeout_seconds,
+    bool capture_stderr) {
 
     // For simplicity, reuse fork/exec for run_with_output on macOS
     // (This is a less critical path than spawn)
@@ -476,7 +478,9 @@ int MacOSProcessPlatform::run_with_output(
     if (pid == 0) {
         close(stdout_pipe[0]);
         dup2(stdout_pipe[1], STDOUT_FILENO);
-        dup2(stdout_pipe[1], STDERR_FILENO);
+        if (capture_stderr) {
+            dup2(stdout_pipe[1], STDERR_FILENO);
+        }
         close(stdout_pipe[1]);
 
         if (!working_dir.empty()) {

--- a/src/cpp/server/utils/platform/process_unix.cpp
+++ b/src/cpp/server/utils/platform/process_unix.cpp
@@ -105,7 +105,8 @@ public:
         const std::vector<std::string>& args,
         OutputLineCallback on_line,
         const std::string& working_dir,
-        int timeout_seconds) override;
+        int timeout_seconds,
+        bool capture_stderr = true) override;
 
     int find_free_port(int start_port) override;
     int run_command(const std::string& command, std::string& output, int timeout_seconds) override;
@@ -483,7 +484,8 @@ int UnixProcessPlatform::run_with_output(
     const std::vector<std::string>& args,
     OutputLineCallback on_line,
     const std::string& working_dir,
-    int timeout_seconds) {
+    int timeout_seconds,
+    bool capture_stderr) {
 
     int stdout_pipe[2];
 
@@ -507,7 +509,9 @@ int UnixProcessPlatform::run_with_output(
         close(stdout_pipe[0]);
 
         dup2(stdout_pipe[1], STDOUT_FILENO);
-        dup2(stdout_pipe[1], STDERR_FILENO);
+        if (capture_stderr) {
+            dup2(stdout_pipe[1], STDERR_FILENO);
+        }
         close(stdout_pipe[1]);
 
         if (!working_dir.empty()) {

--- a/src/cpp/server/utils/platform/process_windows.cpp
+++ b/src/cpp/server/utils/platform/process_windows.cpp
@@ -454,7 +454,8 @@ public:
         const std::vector<std::string>& args,
         OutputLineCallback on_line,
         const std::string& working_dir,
-        int timeout_seconds) override {
+        int timeout_seconds,
+        bool capture_stderr = true) override {
 
         std::string cmdline = escape_windows_arg(executable);
         for (const auto& arg : args) {
@@ -484,7 +485,7 @@ public:
         si.dwFlags = STARTF_USESTDHANDLES;
         si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
         si.hStdOutput = stdout_write;
-        si.hStdError = stdout_write;  // Merge stderr into stdout
+        si.hStdError = capture_stderr ? stdout_write : GetStdHandle(STD_ERROR_HANDLE);
         ZeroMemory(&pi, sizeof(pi));
 
         BOOL success = CreateProcessA(

--- a/src/cpp/server/utils/process_manager.cpp
+++ b/src/cpp/server/utils/process_manager.cpp
@@ -52,10 +52,11 @@ int ProcessManager::run_process_with_output(
     const std::vector<std::string>& args,
     OutputLineCallback on_line,
     const std::string& working_dir,
-    int timeout_seconds) {
+    int timeout_seconds,
+    bool capture_stderr) {
 
     auto platform = create_process_platform();
-    return platform->run_with_output(executable, args, on_line, working_dir, timeout_seconds);
+    return platform->run_with_output(executable, args, on_line, working_dir, timeout_seconds, capture_stderr);
 }
 
 void ProcessManager::kill_process(ProcessHandle handle) {


### PR DESCRIPTION
…tion

Fixes shell command injection vulnerability in extract_zip(), extract_tarball(), and extract_seven_zip() by replacing system() calls with ProcessManager::run_process_with_output() using proper argument vectors instead of string concatenation.

Changes:
- archive_unix.cpp: Use ProcessManager with argv for unzip and tar
- archive_windows.cpp: Use ProcessManager with argv for tar and PowerShell
- backend_utils.cpp: Use ProcessManager with argv in extract_seven_zip()

This prevents arbitrary shell command execution via crafted archive paths (e.g., paths containing "; touch /tmp/pwned;").