### PR TITLE
fix(acestep): music without lyrics isn't the greatest

### DIFF
--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -703,12 +703,25 @@ This endpoint is not part of the OpenAI API (OpenAI's audio endpoints cover spee
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `model` | Yes | The audio-generation model to use (e.g., `ThinkSound-SFX`, `ACE-Step-Music`). |
-| `prompt` | Yes | Text description of the music or sound effect to generate. |
+| `prompt` | Yes | Text description of the music or sound effect to generate. For music, this is the style description: genre, mood, tempo, instruments, and voice. |
+| `lyrics` | No | Lyrics to sing (ACE-Step only). When present and not empty, the track is generated with vocals singing these lyrics. Omitting the field, an empty string, or the sentinel `[Instrumental]` (any case) produces an instrumental track. See [Lyrics](#lyrics) below for the expected format. |
+| `vocal_language` | No | BCP-47 language code of the lyrics, e.g. `en`, `fr`, `ja` (ACE-Step only). Default: `en`. |
 | `duration` | No | Length of the clip in seconds. Defaults to the backend's native default. |
 | `steps` | No | Number of inference steps. Lower is faster, higher can improve quality. |
 | `cfg` | No | Classifier-free guidance strength (ThinkSound only). |
 | `seed` | No | Random seed for reproducibility. |
 | `response_format` | No | Output encoding. Only formats the backend natively produces are accepted (currently `wav`); other values are rejected with `400 Bad Request`. Default: `wav`. |
+
+### Lyrics
+
+ACE-Step vocals are a two-stage pipeline inside the backend: a language model first turns the style description and lyrics into audio codes, then the diffusion synthesizer renders those codes into audio. The instrumental path skips the language-model stage entirely, which also means lyrics embedded in the `prompt` field are treated as style text — they are never sung. Vocal generations take noticeably longer than instrumental ones of the same duration because of the extra language-model pass.
+
+Format the `lyrics` value the way the ACE-Step authors recommend:
+
+- Mark each song section with a structure tag on its own line: `[verse]`, `[chorus]`, `[bridge]`, `[intro]`, `[outro]`.
+- Write one sung phrase per line and separate sections with a blank line.
+- Describe the voice ("gentle female vocals", "raspy male baritone") in `prompt`, not in the lyrics.
+- Lyrics may be in any supported language; set `vocal_language` to match.
 
 ### Response
 
@@ -726,6 +739,20 @@ curl -X POST http://localhost:13305/v1/audio/generations \
         "seed": 42
       }' \
   --output clip.wav
+```
+
+### Example request (music with vocals)
+
+```bash
+curl -X POST http://localhost:13305/v1/audio/generations \
+  -H "Content-Type: application/json" \
+  -d '{
+        "model": "ACE-Step-Music",
+        "prompt": "warm acoustic folk ballad, fingerpicked guitar, gentle female vocals",
+        "lyrics": "[verse]\nMoonlight spills across the floor\nShadows dancing by the door\n\n[chorus]\nWe sing until the morning light\nCarried on the wind tonight",
+        "duration": 60
+      }' \
+  --output song.wav
 ```
 
 ## `POST /v1/3d/generations`

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -28,7 +28,7 @@ the generator instead. Prose outside the markers is preserved. -->
 <!-- BEGIN GENERATED: backends-matrix -->
 | Recipe | Backend | OS | Device families |
 |--------|---------|----|-----------------|
-| `acestep` | rocm | linux, windows | amd_gpu |
+| `acestep` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `acestep` | cuda | linux, windows | nvidia_gpu |
 | `acestep` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
 | `flm` | npu | linux, windows | amd_npu (XDNA2) |
@@ -52,10 +52,10 @@ the generator instead. Prose outside the markers is preserved. -->
 | `sd-cpp` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
 | `sd-cpp` | cpu | linux, windows | cpu (x86_64) |
 | `sd-cpp` | metal | macos | metal |
-| `thinksound` | rocm | linux, windows | amd_gpu |
+| `thinksound` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `thinksound` | cuda | linux, windows | nvidia_gpu |
 | `thinksound` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
-| `trellis` | rocm | linux, windows | amd_gpu |
+| `trellis` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `trellis` | cuda | linux, windows | nvidia_gpu |
 | `trellis` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
 | `vllm` | rocm | linux | amd_gpu (gfx110X, gfx1150, gfx1151, gfx120X) |
@@ -395,3 +395,21 @@ the generator instead. Prose outside the markers is preserved. -->
 | `Whisper-Small` | 0.488 | transcription, realtime-transcription |
 | `Whisper-Tiny` | 0.075 | transcription, realtime-transcription |
 <!-- END GENERATED: backend-models -->
+
+## Implementation notes
+
+### ACE-Step (`acestep`)
+
+`ace-server` exposes an asynchronous job API: `POST /lm` or `POST /synth` returns a job id immediately, `GET /job?id=N` polls the status, and `GET /job?id=N&result=1` fetches the finished result. `AceStepServer::run_job` wraps this submit/poll/fetch cycle with a ceiling of roughly 20 minutes per stage at a 1-second poll cadence. Synth results arrive as `multipart/mixed` (an audio part plus a latent part); Lemonade extracts the first audio part.
+
+Vocals are a two-stage pipeline. `POST /lm` with `lm_mode: "generate"` runs the ACE-Step language model, which turns the caption and lyrics into audio codes plus LM-filled metadata, returned as a JSON array of enriched requests. That array is accepted by `POST /synth` verbatim, so Lemonade feeds it through unchanged. `POST /synth` on its own is the DiT-only instrumental path — it has no language model and cannot sing, so a `lyrics` value (other than the sentinel below) is what routes a request through `/lm` first.
+
+`[Instrumental]` — any case, surrounding whitespace ignored — is ACE-Step's sentinel for the no-vocals path, matching the Python reference implementation. Instrumental requests send the sentinel explicitly rather than an empty string because the synth stage also feeds the lyrics text into its conditioning.
+
+Errors from `audio_generations` are written into the response sink as a JSON error payload; the endpoint handler turns that into an HTTP error instead of shipping it as audio.
+
+The model download fetches the DiT checkpoint variant plus three companions when present in the repo: the language model (`acestep-5Hz-lm-4B-Q8_0.gguf`, required for vocals and auto-lyrics), the Qwen3 text encoder, and the VAE. The checkpoint path handed to `--models` is the directory of GGUFs; `ace-server` scans it by architecture, and `--keep-loaded` keeps models resident across requests.
+
+### Backend auto-selection
+
+When a recipe's backend is not pinned in `config.json` (the `backend` key is absent or `"auto"`), the default backend reported in `system-info` — and used by `RecipeOptions` when resolving `*_backend` options — is chosen as follows: the first supported backend in `RECIPE_DEFS` preference order wins, unless a later supported backend is already locally installed (state `installed`, `update_available`, or `update_required`) while the earlier candidates are merely installable. In that case the first installed one wins. This makes explicitly installing a variant (e.g. the Vulkan build of a GPU backend) an effective override: auto-selection uses what is on disk instead of downloading the preference-order winner. An explicit `backend` value in `config.json` always takes precedence over both rules. The llamacpp `system` variant is never auto-selected unless `prefer_system` is set.

--- a/src/app/src/renderer/components/panels/AudioGenerationPanel.tsx
+++ b/src/app/src/renderer/components/panels/AudioGenerationPanel.tsx
@@ -46,6 +46,7 @@ const AudioGenerationPanel: React.FC<AudioGenerationPanelProps> = ({
 
   const [prompt, setPrompt] = useState('');
   const [lyrics, setLyrics] = useState('');
+  const [vocalLanguage, setVocalLanguage] = useState('en');
   const [showLyricsHelp, setShowLyricsHelp] = useState(false);
   const [duration, setDuration] = useState(10);
   const [clips, setClips] = useState<GeneratedClip[]>([]);
@@ -75,7 +76,9 @@ const AudioGenerationPanel: React.FC<AudioGenerationPanelProps> = ({
           model: selectedModel,
           prompt,
           duration,
-          ...(isMusic && trimmedLyrics ? { lyrics } : {}),
+          ...(isMusic && trimmedLyrics
+            ? { lyrics, vocal_language: vocalLanguage.trim() || 'en' }
+            : {}),
         }),
       });
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
@@ -123,14 +126,26 @@ const AudioGenerationPanel: React.FC<AudioGenerationPanelProps> = ({
         <div className="chat-input-wrapper">
           {isMusic ? (
             <>
-              <input
-                type="text"
-                className="chat-input"
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="Style description — genre, mood, tempo, instruments, voice..."
-              />
+              <div className="style-input-row">
+                <input
+                  type="text"
+                  className="chat-input"
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Style description — genre, mood, tempo, instruments, voice..."
+                />
+                <label className="vocal-language-label" title="Vocal language (BCP-47 code, e.g. en, fr, ja)">
+                  Lang
+                  <input
+                    type="text"
+                    value={vocalLanguage}
+                    onChange={(e) => setVocalLanguage(e.target.value)}
+                    maxLength={8}
+                    disabled={isBusy}
+                  />
+                </label>
+              </div>
               <div className="lyrics-input-row">
                 <textarea
                   className="chat-input lyrics-input"

--- a/src/app/src/renderer/components/panels/AudioGenerationPanel.tsx
+++ b/src/app/src/renderer/components/panels/AudioGenerationPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { useModels } from '../../hooks/useModels';
 import { Modality } from '../../hooks/useInferenceState';
 import { ModelsData } from '../../utils/modelData';
@@ -24,12 +25,28 @@ interface GeneratedClip {
   prompt: string;
 }
 
+const LYRICS_EXAMPLE = `[verse]
+Moonlight spills across the floor
+Shadows dancing by the door
+
+[chorus]
+We sing until the morning light
+Carried on the wind tonight
+
+[bridge]
+Hold the note and let it soar
+
+[outro]
+Fading softly, nothing more`;
+
 const AudioGenerationPanel: React.FC<AudioGenerationPanelProps> = ({
   isBusy, isPreFlight, isInferring, activeModality, runPreFlight, reset, showError,
 }) => {
   const { selectedModel, modelsData } = useModels();
 
   const [prompt, setPrompt] = useState('');
+  const [lyrics, setLyrics] = useState('');
+  const [showLyricsHelp, setShowLyricsHelp] = useState(false);
   const [duration, setDuration] = useState(10);
   const [clips, setClips] = useState<GeneratedClip[]>([]);
   const clipsRef = useRef<GeneratedClip[]>([]);
@@ -37,11 +54,10 @@ const AudioGenerationPanel: React.FC<AudioGenerationPanelProps> = ({
 
   useEffect(() => () => { clipsRef.current.forEach(c => URL.revokeObjectURL(c.url)); }, []);
 
-  // Music (ACE-Step) is long-form, so default to a full clip; SFX (ThinkSound)
-  // stays short. Resets to the model's default when the selected model changes.
   const audioRecipe = modelsData?.[selectedModel]?.recipe || '';
+  const isMusic = audioRecipe === 'acestep';
   useEffect(() => {
-    setDuration(audioRecipe === 'acestep' ? 150 : 10);
+    setDuration(isMusic ? 150 : 10);
   }, [audioRecipe]);
 
   const handleGenerate = async () => {
@@ -51,10 +67,16 @@ const AudioGenerationPanel: React.FC<AudioGenerationPanelProps> = ({
     if (!ready) return;
 
     try {
+      const trimmedLyrics = lyrics.trim();
       const response = await serverFetch('/audio/generations', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: selectedModel, prompt, duration }),
+        body: JSON.stringify({
+          model: selectedModel,
+          prompt,
+          duration,
+          ...(isMusic && trimmedLyrics ? { lyrics } : {}),
+        }),
       });
       if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
       const blob = await response.blob();
@@ -99,14 +121,41 @@ const AudioGenerationPanel: React.FC<AudioGenerationPanelProps> = ({
 
       <div className="chat-input-container">
         <div className="chat-input-wrapper">
-          <textarea
-            className="chat-input"
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Describe the music or sound effect to generate..."
-            rows={1}
-          />
+          {isMusic ? (
+            <>
+              <input
+                type="text"
+                className="chat-input"
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Style description — genre, mood, tempo, instruments, voice..."
+              />
+              <div className="lyrics-input-row">
+                <textarea
+                  className="chat-input lyrics-input"
+                  value={lyrics}
+                  onChange={(e) => setLyrics(e.target.value)}
+                  placeholder="Lyrics (optional) — leave empty for an instrumental track"
+                  rows={4}
+                />
+                <button
+                  className="lyrics-help-button"
+                  title="Lyrics syntax guide"
+                  onClick={() => setShowLyricsHelp(true)}
+                >?</button>
+              </div>
+            </>
+          ) : (
+            <textarea
+              className="chat-input"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Describe the music or sound effect to generate..."
+              rows={1}
+            />
+          )}
           <InferenceControls
             isBusy={isBusy}
             isInferring={isInferring}
@@ -131,6 +180,40 @@ const AudioGenerationPanel: React.FC<AudioGenerationPanelProps> = ({
           />
         </div>
       </div>
+
+      {showLyricsHelp && createPortal(
+        <div
+          className="settings-overlay"
+          onMouseDown={(e: React.MouseEvent<HTMLDivElement>) => { if (e.target === e.currentTarget) setShowLyricsHelp(false); }}
+        >
+          <div className="settings-modal" onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}>
+            <div className="settings-header">
+              <h3>Lyrics syntax</h3>
+              <button className="settings-close-button" onClick={() => setShowLyricsHelp(false)} title="Close">
+                <svg width="14" height="14" viewBox="0 0 14 14">
+                  <path d="M 1,1 L 13,13 M 13,1 L 1,13" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                </svg>
+              </button>
+            </div>
+            <div className="settings-content lyrics-help-content">
+              <p>
+                Mark each song section with a structure tag on its own line:{' '}
+                <code>[verse]</code>, <code>[chorus]</code>, <code>[bridge]</code>,{' '}
+                <code>[intro]</code>, <code>[outro]</code>.
+              </p>
+              <ul>
+                <li>Write one sung phrase per line and separate sections with a blank line.</li>
+                <li>Leave the lyrics field empty (or write <code>[instrumental]</code>) for a track without vocals.</li>
+                <li>Describe the voice in the style field (e.g. &quot;gentle female vocals&quot;, &quot;raspy male baritone&quot;), not in the lyrics.</li>
+                <li>Lyrics don&apos;t have to be English; write them in the language they should be sung in.</li>
+              </ul>
+              <p>Example:</p>
+              <pre>{LYRICS_EXAMPLE}</pre>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
     </>
   );
 };

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -3627,6 +3627,72 @@ input::-webkit-calendar-picker-indicator {
     cursor: not-allowed;
 }
 
+.lyrics-input-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    border-top: 1px solid var(--border-tertiary);
+    margin-top: 8px;
+    padding-top: 8px;
+}
+
+.lyrics-input {
+    overflow-y: auto;
+    max-height: 160px;
+}
+
+.lyrics-help-button {
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 1px solid var(--border-secondary);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.lyrics-help-button:hover {
+    color: var(--text-primary);
+    background: var(--bg-alpha-1);
+}
+
+.lyrics-help-content {
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    gap: 12px;
+}
+
+.lyrics-help-content p {
+    margin: 0;
+}
+
+.lyrics-help-content ul {
+    margin: 0;
+    padding-left: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.lyrics-help-content code {
+    background: var(--bg-tertiary);
+    border-radius: 4px;
+    padding: 1px 5px;
+}
+
+.lyrics-help-content pre {
+    background: var(--bg-tertiary);
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin: 0;
+    white-space: pre-wrap;
+    font-size: 0.85rem;
+}
+
 .chat-controls {
     display: flex;
     align-items: center;

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -3627,6 +3627,49 @@ input::-webkit-calendar-picker-indicator {
     cursor: not-allowed;
 }
 
+.style-input-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.style-input-row .chat-input {
+    flex: 1;
+    width: auto;
+}
+
+.vocal-language-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+    font-size: 0.85em;
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
+.vocal-language-label input {
+    -webkit-appearance: none;
+    appearance: none;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-primary);
+    border-radius: 4px;
+    color: var(--text-primary);
+    padding: 4px 6px;
+    font-size: 13px;
+    width: 40px;
+}
+
+.vocal-language-label input:focus {
+    outline: none;
+    border-color: var(--border-5);
+}
+
+.vocal-language-label input:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .lyrics-input-row {
     display: flex;
     align-items: flex-start;

--- a/src/cpp/include/lemon/backends/acestep/acestep.h
+++ b/src/cpp/include/lemon/backends/acestep/acestep.h
@@ -23,7 +23,7 @@ inline const BackendDescriptor descriptor = {
          "ACE-Step backend to use", "Audio Generation Options"},
     },
     /*support*/ {
-        {"rocm", {"linux", "windows"}, {{"amd_gpu", {}}}, "AMD GPUs (ROCm via TheRock)"},
+        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
         {"cuda", {"linux", "windows"}, {{"nvidia_gpu", {}}}, "NVIDIA GPUs"},
         {"vulkan", {"linux", "windows"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
     },

--- a/src/cpp/include/lemon/backends/acestep/acestep_server.h
+++ b/src/cpp/include/lemon/backends/acestep/acestep_server.h
@@ -34,6 +34,8 @@ public:
 
 private:
     std::string resolve_binary_path(const std::string& backend);
+    bool run_job(const std::string& path, const std::string& body,
+                 std::string& result, std::string& error);
 };
 
 namespace acestep {

--- a/src/cpp/include/lemon/backends/thinksound/thinksound.h
+++ b/src/cpp/include/lemon/backends/thinksound/thinksound.h
@@ -23,7 +23,7 @@ inline const BackendDescriptor descriptor = {
          "ThinkSound backend to use", "Audio Generation Options"},
     },
     /*support*/ {
-        {"rocm", {"linux", "windows"}, {{"amd_gpu", {}}}, "AMD GPUs (ROCm via TheRock)"},
+        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
         {"cuda", {"linux", "windows"}, {{"nvidia_gpu", {}}}, "NVIDIA GPUs"},
         {"vulkan", {"linux", "windows"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
     },

--- a/src/cpp/include/lemon/backends/trellis/trellis.h
+++ b/src/cpp/include/lemon/backends/trellis/trellis.h
@@ -21,7 +21,7 @@ inline const BackendDescriptor descriptor = {
          "Trellis backend to use", "3D Generation Options"},
     },
     /*support*/ {
-        {"rocm", {"linux", "windows"}, {{"amd_gpu", {}}}, "AMD GPUs (ROCm via TheRock)"},
+        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
         {"cuda", {"linux", "windows"}, {{"nvidia_gpu", {}}}, "NVIDIA GPUs"},
         {"vulkan", {"linux", "windows"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
     },

--- a/src/cpp/server/backends/acestep/acestep_server.cpp
+++ b/src/cpp/server/backends/acestep/acestep_server.cpp
@@ -14,6 +14,7 @@
 #include "lemon/utils/process_manager.h"
 #include <lemon/utils/aixlog.hpp>
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
@@ -40,6 +41,16 @@ std::string extract_multipart_audio(const std::string& body) {
     size_t bend = body.find("\r\n--ace-batch-boundary", bstart);
     if (bend == std::string::npos) return "";
     return body.substr(bstart, bend - bstart);
+}
+
+bool is_instrumental_sentinel(const std::string& lyrics) {
+    size_t b = lyrics.find_first_not_of(" \t\r\n");
+    if (b == std::string::npos) return true;
+    size_t e = lyrics.find_last_not_of(" \t\r\n");
+    std::string t = lyrics.substr(b, e - b + 1);
+    std::transform(t.begin(), t.end(), t.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return t == "[instrumental]";
 }
 }  // namespace
 
@@ -172,16 +183,62 @@ void AceStepServer::unload() {
     }
 }
 
+bool AceStepServer::run_job(const std::string& path, const std::string& body,
+                            std::string& result, std::string& error) {
+    const std::string stage = path.substr(1);
+    const std::string base = get_base_url();
+    auto submit = utils::HttpClient::post(base + path, body,
+                                          {{"Content-Type", "application/json"}}, 60);
+    if (submit.status_code != 200) {
+        LOG(ERROR, "acestep-server") << stage << " submit failed (HTTP " << submit.status_code
+                                     << "): " << submit.body << std::endl;
+        error = stage + " submit failed (HTTP " + std::to_string(submit.status_code) + ")";
+        return false;
+    }
+    std::string job_id = json::parse(submit.body).value("id", std::string());
+    if (job_id.empty()) {
+        LOG(ERROR, "acestep-server") << stage << " submit returned no job id: " << submit.body << std::endl;
+        error = stage + " submit returned no job id";
+        return false;
+    }
+
+    const std::string job_url = base + "/job?id=" + job_id;
+    std::string status;
+    for (int i = 0; i < 1200; ++i) {
+        auto poll = utils::HttpClient::get(job_url, {}, 30);
+        if (poll.status_code == 200) {
+            try { status = json::parse(poll.body).value("status", std::string()); }
+            catch (...) { status.clear(); }
+        }
+        if (status == "done" || status == "failed" || status == "cancelled") break;
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    if (status != "done") {
+        LOG(ERROR, "acestep-server") << stage << " job " << job_id << " ended with status '"
+                                     << status << "'" << std::endl;
+        error = stage + " job ended with status '" + status + "'";
+        return false;
+    }
+
+    auto fetched = utils::HttpClient::get(job_url + "&result=1", {}, 120);
+    if (fetched.status_code != 200) {
+        LOG(ERROR, "acestep-server") << "fetching " << stage << " job result failed (HTTP "
+                                     << fetched.status_code << ")" << std::endl;
+        error = "fetching " + stage + " job result failed (HTTP " +
+                std::to_string(fetched.status_code) + ")";
+        return false;
+    }
+    result = std::move(fetched.body);
+    return true;
+}
+
 void AceStepServer::audio_generations(const json& request, httplib::DataSink& sink) {
-    // Failures write an error payload into the sink; the endpoint handler turns
-    // it into an HTTP error instead of shipping it as audio.
     auto fail = [&sink](const std::string& message) {
         const std::string payload =
             json{{"error", {{"message", message}, {"type", "backend_error"}}}}.dump();
         sink.write(payload.data(), payload.size());
     };
     try {
-        // Map the Lemonade request onto ace-server's /synth (instrumental, DiT-only).
         json synth;
         synth["caption"] = request.value("prompt", std::string());
         synth["synth_model"] = "";
@@ -190,47 +247,38 @@ void AceStepServer::audio_generations(const json& request, httplib::DataSink& si
         if (request.contains("seed"))     synth["seed"]     = request["seed"];
         if (request.contains("steps"))    synth["inference_steps"] = request["steps"];
 
-        const std::string base = get_base_url();
-        auto submit = utils::HttpClient::post(base + "/synth", synth.dump(),
-                                              {{"Content-Type", "application/json"}}, 60);
-        if (submit.status_code != 200) {
-            LOG(ERROR, "acestep-server") << "synth submit failed (HTTP " << submit.status_code
-                                         << "): " << submit.body << std::endl;
-            fail("synth submit failed (HTTP " + std::to_string(submit.status_code) + ")");
-            return;
+        std::string lyrics;
+        if (request.contains("lyrics") && request["lyrics"].is_string()) {
+            lyrics = request["lyrics"].get<std::string>();
         }
-        std::string job_id = json::parse(submit.body).value("id", std::string());
-        if (job_id.empty()) {
-            LOG(ERROR, "acestep-server") << "synth submit returned no job id: " << submit.body << std::endl;
-            fail("synth submit returned no job id");
-            return;
-        }
+        const bool vocal = !is_instrumental_sentinel(lyrics);
 
-        // Poll until the job finishes (music generation: seconds to a few minutes).
-        const std::string job_url = base + "/job?id=" + job_id;
-        std::string status;
-        for (int i = 0; i < 1200; ++i) {  // ~20 min ceiling at 1s cadence
-            auto poll = utils::HttpClient::get(job_url, {}, 30);
-            if (poll.status_code == 200) {
-                try { status = json::parse(poll.body).value("status", std::string()); }
-                catch (...) { status.clear(); }
+        std::string error;
+        std::string synth_body;
+        if (vocal) {
+            synth["lyrics"] = lyrics;
+            synth["lm_mode"] = "generate";
+            std::string language = "en";
+            if (request.contains("vocal_language") && request["vocal_language"].is_string()) {
+                language = request["vocal_language"].get<std::string>();
             }
-            if (status == "done" || status == "failed" || status == "cancelled") break;
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-        }
-        if (status != "done") {
-            LOG(ERROR, "acestep-server") << "synth job " << job_id << " ended with status '" << status << "'" << std::endl;
-            fail("synth job ended with status '" + status + "'");
-            return;
+            synth["vocal_language"] = language;
+
+            if (!run_job("/lm", synth.dump(), synth_body, error)) {
+                fail(error);
+                return;
+            }
+        } else {
+            synth["lyrics"] = "[Instrumental]";
+            synth_body = synth.dump();
         }
 
-        auto result = utils::HttpClient::get(job_url + "&result=1", {}, 120);
-        if (result.status_code != 200) {
-            LOG(ERROR, "acestep-server") << "fetching job result failed (HTTP " << result.status_code << ")" << std::endl;
-            fail("fetching job result failed (HTTP " + std::to_string(result.status_code) + ")");
+        std::string result;
+        if (!run_job("/synth", synth_body, result, error)) {
+            fail(error);
             return;
         }
-        std::string audio = extract_multipart_audio(result.body);
+        std::string audio = extract_multipart_audio(result);
         if (audio.empty()) {
             LOG(ERROR, "acestep-server") << "no audio part in multipart result" << std::endl;
             fail("no audio part in synth result");

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3370,6 +3370,15 @@ void Server::handle_audio_generations(const httplib::Request& req, httplib::Resp
                 {"type", "invalid_request_error"}}}}.dump(), "application/json");
             return;
         }
+        for (const auto* field : {"lyrics", "vocal_language"}) {
+            if (request_json.contains(field) && !request_json[field].is_string()) {
+                res.status = 400;
+                res.set_content(nlohmann::json{{"error", {
+                    {"message", "'" + std::string(field) + "' must be a string"},
+                    {"type", "invalid_request_error"}}}}.dump(), "application/json");
+                return;
+            }
+        }
 
         std::string requested_model = request_json["model"];
         try {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1147,6 +1147,7 @@ json SystemInfo::build_recipes_info(const json& devices) {
     static constexpr int kNonUnsupportedPriority = 2;
 
     std::map<std::pair<std::string, std::string>, int> backend_status_priority;
+    std::set<std::string> default_backend_installed;
 
     auto set_backend_status = [&recipes, &backend_status_priority](
                                 const std::string& recipe,
@@ -1484,12 +1485,21 @@ json SystemInfo::build_recipes_info(const json& devices) {
             continue;
         }
 
-        // First supported backend in RECIPE_DEFS order becomes the default when
-        // the recipe backend is auto-selected. Skip 'system' backend unless
-        // explicitly preferred via env var.
         bool skip_as_default = (def.backend == "system" && !prefer_llamacpp_system);
-        if (supported && !skip_as_default && !recipes[def.recipe].contains("default_backend")) {
-            recipes[def.recipe]["default_backend"] = def.backend;
+        if (supported && !skip_as_default) {
+            const std::string effective_state =
+                recipes[def.recipe]["backends"][def.backend].value("state", "unsupported");
+            const bool locally_installed = effective_state == "installed"
+                || effective_state == "update_available"
+                || effective_state == "update_required";
+            const bool overrides_uninstalled_default =
+                locally_installed && default_backend_installed.count(def.recipe) == 0;
+            if (!recipes[def.recipe].contains("default_backend") || overrides_uninstalled_default) {
+                recipes[def.recipe]["default_backend"] = def.backend;
+                if (locally_installed) {
+                    default_backend_installed.insert(def.recipe);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I was so focused on generating *instrumental* music I completely forgot to wire the actual lyrics pipeline :) now you can have lyrics as well in your music (+ added syntax guide for the AceStep lyrics prompting).

Also fixes for #2623 since this touches the AceStep engine:
- Backend auto-selection prefers an installed variant over downloading the preference-order winner (#2623).
- Gate acestep/thinksound/trellis ROCm rows to the GPU families the engine releases are built for (#2623).