### PR TITLE
security(renderer): redact API key values from console logs

### DIFF
--- a/src/app/src/renderer/utils/serverConfig.ts
+++ b/src/app/src/renderer/utils/serverConfig.ts
@@ -207,7 +207,7 @@ class ServerConfig {
 
   private setUpdatedAPIKey(apiKey: string) {
     if (this.apiKey != apiKey) {
-      console.log(`API Key updated: ${this.apiKey} -> ${apiKey}`);
+      console.log('API Key updated');
       this.apiKey = apiKey;
       this.notifyPortListeners();
       this.notifyUrlListeners();


### PR DESCRIPTION
Remove cleartext API key logging in setUpdatedAPIKey() to prevent credential disclosure via renderer console output forwarded to log files.