### PR TITLE
fix(security): move WebSocket API key from query string to Sec-WebSoc…

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -716,6 +716,9 @@ jobs:
           echo "Running WebSocket idle test (31s regression)..."
           .venv/bin/python test/test_websocket_idle.py
           echo "WebSocket idle test PASSED!"
+          echo "Running WebSocket auth tests..."
+          .venv/bin/python test/server_websocket_auth.py
+          echo "WebSocket auth tests PASSED!"
 
       - name: Run web-app path traversal tests (unsigned path)
         if: steps.check_signing.outputs.has_signing != 'true'
@@ -2077,6 +2080,9 @@ jobs:
           echo "Running WebSocket idle test..."
           .venv/bin/python test/test_websocket_idle.py
           echo "WebSocket idle test PASSED!"
+          echo "Running WebSocket auth tests..."
+          .venv/bin/python test/server_websocket_auth.py
+          echo "WebSocket auth tests PASSED!"
 
       # The full smoke test can be added to a different GPU equipped pipeline
       # as well if needed, but it would significantly add to the pipeline runtime.
@@ -2205,6 +2211,9 @@ jobs:
             echo "Running WebSocket idle test..."
             $VENV_PYTHON test/test_websocket_idle.py
             echo "WebSocket idle test PASSED!"
+            echo "Running WebSocket auth tests..."
+            $VENV_PYTHON test/server_websocket_auth.py
+            echo "WebSocket auth tests PASSED!"
           elif [ "${{ matrix.test_type }}" = "ollama" ]; then
             echo "Running Ollama API tests..."
             $VENV_PYTHON test/test_ollama.py --cli-binary "$CLI_BINARY"

--- a/src/app/src/renderer/utils/logWebSocketClient.ts
+++ b/src/app/src/renderer/utils/logWebSocketClient.ts
@@ -1,4 +1,4 @@
-import { buildWebSocketUrl } from './serverConfig';
+import { buildWebSocketUrl, webSocketProtocols } from './serverConfig';
 
 export interface LogEntry {
   seq: number;
@@ -24,8 +24,9 @@ export async function connectLogStream(
   afterSeq: number | null,
   callbacks: LogStreamCallbacks,
 ): Promise<LogStreamHandle> {
+  const protocols = await webSocketProtocols();
   const wsUrl = buildWebSocketUrl('/logs/stream');
-  const socket = new WebSocket(wsUrl);
+  const socket = new WebSocket(wsUrl, protocols);
 
   socket.addEventListener('open', () => {
     socket.send(JSON.stringify({

--- a/src/app/src/renderer/utils/serverConfig.ts
+++ b/src/app/src/renderer/utils/serverConfig.ts
@@ -361,6 +361,39 @@ class ServerConfig {
 // Export singleton instance
 export const serverConfig = new ServerConfig();
 
+/**
+ * Registered application subprotocol. The server advertises only this protocol,
+ * so the client must offer it for libwebsockets to negotiate the upgrade and
+ * echo a subprotocol back (browsers fail the socket otherwise).
+ */
+export const WS_APP_PROTOCOL = 'lemonade-realtime';
+
+function base64UrlEncode(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Build the Sec-WebSocket-Protocol list for an authenticated WebSocket upgrade,
+ * shared by the realtime and log-stream clients. Offers the registered
+ * application protocol plus a base64url-encoded credential (base64url keeps the
+ * key within the token characters a subprotocol value permits). Awaits config
+ * initialization so the API key is populated before it is read. Returns
+ * undefined when no API key is configured, leaving the upgrade unauthenticated.
+ */
+export async function webSocketProtocols(): Promise<string[] | undefined> {
+  await serverConfig.waitForInit();
+  const apiKey = serverConfig.getAPIKey();
+  if (!apiKey) {
+    return undefined;
+  }
+  return [WS_APP_PROTOCOL, `bearer.${base64UrlEncode(apiKey)}`];
+}
+
 // Export convenience functions
 export const getApiBaseUrl = () => serverConfig.getApiBaseUrl();
 export const getServerBaseUrl = () => serverConfig.getServerBaseUrl();

--- a/src/app/src/renderer/utils/serverConfig.ts
+++ b/src/app/src/renderer/utils/serverConfig.ts
@@ -163,7 +163,8 @@ class ServerConfig {
    * accepts WebSocket upgrades for /realtime and /logs/stream). Going through
    * URL rather than string concat is what makes this correct for IPv6
    * literals — URL.host preserves the brackets that hostname does not. The
-   * configured API key is appended automatically when set.
+   * API key is NOT included in the URL — the caller should pass it via
+   * Sec-WebSocket-Protocol instead (see websocketClient.ts).
    */
   buildWebSocketUrl(path: string, wsPort?: number, query?: URLSearchParams): string {
     const url = new URL(this.getServerBaseUrl());
@@ -173,12 +174,9 @@ class ServerConfig {
     }
     url.pathname = url.pathname.replace(/\/$/, '') + path;
 
-    const params = new URLSearchParams(query);
-    const apiKey = this.getAPIKey();
-    if (apiKey) {
-      params.set('api_key', apiKey);
+    if (query) {
+      url.search = query.toString();
     }
-    url.search = params.toString();
     return url.toString();
   }
 

--- a/src/app/src/renderer/utils/websocketClient.ts
+++ b/src/app/src/renderer/utils/websocketClient.ts
@@ -2,7 +2,7 @@
  * WebSocket client for realtime transcription.
  * Uses a raw WebSocket with OpenAI Realtime API message format.
  */
-import { buildWebSocketUrl, serverFetch } from './serverConfig';
+import { buildWebSocketUrl, getAPIKey, serverFetch } from './serverConfig';
 
 export interface TranscriptionCallbacks {
   /** Called with transcription text. isFinal=false for interim results that replace previous interim. */
@@ -25,13 +25,16 @@ export class TranscriptionWebSocket {
    * Create a new TranscriptionWebSocket.
    * Use the static connect() method instead of calling this directly.
    */
-  private constructor(wsUrl: string, model: string, callbacks: TranscriptionCallbacks) {
+  private constructor(wsUrl: string, model: string, callbacks: TranscriptionCallbacks, apiKey?: string) {
     this.wsUrl = wsUrl;
 
-    console.log('[WebSocket] Connecting to:', wsUrl);
+    const redactedUrl = wsUrl.replace(/\?.*/, '?<redacted>');
+    console.log('[WebSocket] Connecting to:', redactedUrl);
 
-    // Use raw WebSocket without subprotocols
-    this.socket = new WebSocket(wsUrl);
+    // Send API key via Sec-WebSocket-Protocol header (bearer.{apiKey} format)
+    // rather than in the query string to prevent it from appearing in logs
+    const protocols = apiKey ? [`bearer.${apiKey}`] : undefined;
+    this.socket = new WebSocket(wsUrl, protocols);
 
     this.socket.addEventListener('open', () => {
       console.log('[WebSocket] Connection opened');
@@ -111,10 +114,11 @@ export class TranscriptionWebSocket {
     wsUrl: string,
     model: string,
     callbacks: TranscriptionCallbacks,
+    apiKey?: string,
     timeoutMs = 5000,
   ): Promise<TranscriptionWebSocket> {
     return new Promise((resolve, reject) => {
-      const client = new TranscriptionWebSocket(wsUrl, model, callbacks);
+      const client = new TranscriptionWebSocket(wsUrl, model, callbacks, apiKey);
       const timer = setTimeout(() => {
         client.socket.close();
         reject(new Error(`WebSocket connect timeout: ${wsUrl}`));
@@ -143,10 +147,11 @@ export class TranscriptionWebSocket {
     callbacks: TranscriptionCallbacks,
   ): Promise<TranscriptionWebSocket> {
     const query = new URLSearchParams({ model });
+    const apiKey = getAPIKey();
 
     const mainUrl = buildWebSocketUrl('/v1/realtime', undefined, query);
     try {
-      return await TranscriptionWebSocket.openSocket(mainUrl, model, callbacks);
+      return await TranscriptionWebSocket.openSocket(mainUrl, model, callbacks, apiKey);
     } catch (err) {
       console.warn('[WebSocket] Main-port connect failed, falling back to websocket_port:', err);
     }
@@ -163,7 +168,7 @@ export class TranscriptionWebSocket {
     }
 
     const legacyUrl = buildWebSocketUrl('/realtime', wsPort, query);
-    return TranscriptionWebSocket.openSocket(legacyUrl, model, callbacks);
+    return TranscriptionWebSocket.openSocket(legacyUrl, model, callbacks, apiKey);
   }
 
   private send(msg: object) {

--- a/src/app/src/renderer/utils/websocketClient.ts
+++ b/src/app/src/renderer/utils/websocketClient.ts
@@ -2,7 +2,7 @@
  * WebSocket client for realtime transcription.
  * Uses a raw WebSocket with OpenAI Realtime API message format.
  */
-import { buildWebSocketUrl, getAPIKey, serverFetch } from './serverConfig';
+import { buildWebSocketUrl, serverFetch, webSocketProtocols } from './serverConfig';
 
 export interface TranscriptionCallbacks {
   /** Called with transcription text. isFinal=false for interim results that replace previous interim. */
@@ -25,15 +25,12 @@ export class TranscriptionWebSocket {
    * Create a new TranscriptionWebSocket.
    * Use the static connect() method instead of calling this directly.
    */
-  private constructor(wsUrl: string, model: string, callbacks: TranscriptionCallbacks, apiKey?: string) {
+  private constructor(wsUrl: string, model: string, callbacks: TranscriptionCallbacks, protocols?: string[]) {
     this.wsUrl = wsUrl;
 
     const redactedUrl = wsUrl.replace(/\?.*/, '?<redacted>');
     console.log('[WebSocket] Connecting to:', redactedUrl);
 
-    // Send API key via Sec-WebSocket-Protocol header (bearer.{apiKey} format)
-    // rather than in the query string to prevent it from appearing in logs
-    const protocols = apiKey ? [`bearer.${apiKey}`] : undefined;
     this.socket = new WebSocket(wsUrl, protocols);
 
     this.socket.addEventListener('open', () => {
@@ -114,11 +111,11 @@ export class TranscriptionWebSocket {
     wsUrl: string,
     model: string,
     callbacks: TranscriptionCallbacks,
-    apiKey?: string,
+    protocols?: string[],
     timeoutMs = 5000,
   ): Promise<TranscriptionWebSocket> {
     return new Promise((resolve, reject) => {
-      const client = new TranscriptionWebSocket(wsUrl, model, callbacks, apiKey);
+      const client = new TranscriptionWebSocket(wsUrl, model, callbacks, protocols);
       const timer = setTimeout(() => {
         client.socket.close();
         reject(new Error(`WebSocket connect timeout: ${wsUrl}`));
@@ -147,11 +144,11 @@ export class TranscriptionWebSocket {
     callbacks: TranscriptionCallbacks,
   ): Promise<TranscriptionWebSocket> {
     const query = new URLSearchParams({ model });
-    const apiKey = getAPIKey();
+    const protocols = await webSocketProtocols();
 
     const mainUrl = buildWebSocketUrl('/v1/realtime', undefined, query);
     try {
-      return await TranscriptionWebSocket.openSocket(mainUrl, model, callbacks, apiKey);
+      return await TranscriptionWebSocket.openSocket(mainUrl, model, callbacks, protocols);
     } catch (err) {
       console.warn('[WebSocket] Main-port connect failed, falling back to websocket_port:', err);
     }
@@ -168,7 +165,7 @@ export class TranscriptionWebSocket {
     }
 
     const legacyUrl = buildWebSocketUrl('/realtime', wsPort, query);
-    return TranscriptionWebSocket.openSocket(legacyUrl, model, callbacks, apiKey);
+    return TranscriptionWebSocket.openSocket(legacyUrl, model, callbacks, protocols);
   }
 
   private send(msg: object) {

--- a/src/cpp/include/lemon/websocket_server.h
+++ b/src/cpp/include/lemon/websocket_server.h
@@ -136,9 +136,6 @@ private:
     std::unordered_map<std::string, std::string> receive_buffers_;
     std::mutex connections_mutex_;
     bool telemetry_listener_registered_{false};
-    // Temporary map to store protocols during handshake (keyed by socket fd)
-    mutable std::unordered_map<int, std::string> pending_protocols_;
-    mutable std::mutex protocols_mutex_;
 
     // Handle new WebSocket connection
     void handle_connection(const std::string& connection_id, struct lws* wsi);
@@ -152,8 +149,9 @@ private:
     // Handle writable callback — flush message queue
     void handle_writable(const std::string& connection_id, struct lws* wsi);
 
-    bool authenticate_connection(struct lws* wsi, const char* protocol) const;
+    bool authenticate_connection(struct lws* wsi) const;
     static std::optional<std::string> get_header(struct lws* wsi, enum lws_token_indexes token);
+    static std::optional<std::string> get_protocol_credential(struct lws* wsi);
     static std::optional<std::string> get_url_arg(struct lws* wsi, const char* name);
     static std::string get_request_path(struct lws* wsi);
     std::string strip_bearer_prefix(const std::string& token) const;

--- a/src/cpp/include/lemon/websocket_server.h
+++ b/src/cpp/include/lemon/websocket_server.h
@@ -136,6 +136,9 @@ private:
     std::unordered_map<std::string, std::string> receive_buffers_;
     std::mutex connections_mutex_;
     bool telemetry_listener_registered_{false};
+    // Temporary map to store protocols during handshake (keyed by socket fd)
+    mutable std::unordered_map<int, std::string> pending_protocols_;
+    mutable std::mutex protocols_mutex_;
 
     // Handle new WebSocket connection
     void handle_connection(const std::string& connection_id, struct lws* wsi);
@@ -149,7 +152,7 @@ private:
     // Handle writable callback — flush message queue
     void handle_writable(const std::string& connection_id, struct lws* wsi);
 
-    bool authenticate_connection(struct lws* wsi) const;
+    bool authenticate_connection(struct lws* wsi, const char* protocol) const;
     static std::optional<std::string> get_header(struct lws* wsi, enum lws_token_indexes token);
     static std::optional<std::string> get_url_arg(struct lws* wsi, const char* name);
     static std::string get_request_path(struct lws* wsi);

--- a/src/cpp/server/websocket_server.cpp
+++ b/src/cpp/server/websocket_server.cpp
@@ -1,4 +1,5 @@
 #include "lemon/router.h"
+#include "lemon/utils/json_utils.h"
 #include "lemon/utils/process_manager.h"
 #include "lemon/websocket_server.h"
 #include "telemetry.h"
@@ -130,14 +131,8 @@ int WebSocketServer::ws_callback(struct lws* wsi,
             if (classify_path(path) == ConnectionKind::invalid) {
                 return 1;
             }
-            const char* protocol = static_cast<const char*>(in);
-            if (!server->authenticate_connection(wsi, protocol)) {
+            if (!server->authenticate_connection(wsi)) {
                 return 1;
-            }
-            if (protocol && std::strlen(protocol) > 0) {
-                int fd = static_cast<int>(lws_get_socket_fd(wsi));
-                std::lock_guard<std::mutex> lock(server->protocols_mutex_);
-                server->pending_protocols_[fd] = std::string(protocol);
             }
             break;
         }
@@ -391,20 +386,12 @@ std::string WebSocketServer::extract_token_from_wsi(struct lws* wsi) const {
         token = get_url_arg(wsi, "api_key");
     }
     if (!token) {
-        int fd = static_cast<int>(lws_get_socket_fd(wsi));
-        std::lock_guard<std::mutex> lock(protocols_mutex_);
-        auto it = pending_protocols_.find(fd);
-        if (it != pending_protocols_.end()) {
-            const std::string& protocol = it->second;
-            if (protocol.find("bearer.") == 0) {
-                return protocol.substr(7);
-            }
-        }
+        token = get_protocol_credential(wsi);
     }
     return token ? strip_bearer_prefix(*token) : "";
 }
 
-bool WebSocketServer::authenticate_connection(struct lws* wsi, const char* protocol) const {
+bool WebSocketServer::authenticate_connection(struct lws* wsi) const {
     if (api_key_.empty()) {
         return true;
     }
@@ -413,11 +400,8 @@ bool WebSocketServer::authenticate_connection(struct lws* wsi, const char* proto
     if (!token) {
         token = get_url_arg(wsi, "api_key");
     }
-    if (!token && protocol && std::strlen(protocol) > 0) {
-        std::string protocol_str(protocol);
-        if (protocol_str.find("bearer.") == 0) {
-            token = protocol_str.substr(7);
-        }
+    if (!token) {
+        token = get_protocol_credential(wsi);
     }
 
     if (!token) {
@@ -448,12 +432,6 @@ void WebSocketServer::handle_connection(const std::string& connection_id, struct
     std::string token_str = extract_token_from_wsi(wsi);
     auto client_session_id_opt = get_url_arg(wsi, "client_session_id");
     std::string client_session_id = client_session_id_opt ? *client_session_id_opt : "";
-
-    {
-        int fd = static_cast<int>(lws_get_socket_fd(wsi));
-        std::lock_guard<std::mutex> lock(protocols_mutex_);
-        pending_protocols_.erase(fd);
-    }
 
     {
         std::lock_guard<std::mutex> lock(connections_mutex_);
@@ -734,6 +712,38 @@ std::optional<std::string> WebSocketServer::get_header(struct lws* wsi, enum lws
     }
 
     return std::string(buffer, static_cast<size_t>(copied));
+}
+
+std::optional<std::string> WebSocketServer::get_protocol_credential(struct lws* wsi) {
+    static constexpr char credential_prefix[] = "bearer.";
+    static constexpr size_t prefix_len = sizeof(credential_prefix) - 1;
+
+    auto header = get_header(wsi, WSI_TOKEN_PROTOCOL);
+    if (!header) {
+        return std::nullopt;
+    }
+
+    // The credential rides in Sec-WebSocket-Protocol alongside the registered
+    // application protocol. The encoding is base64url, so the value contains
+    // only token characters and ends at the next list separator.
+    const std::string& value = *header;
+    size_t pos = value.find(credential_prefix);
+    if (pos == std::string::npos) {
+        return std::nullopt;
+    }
+    size_t begin = pos + prefix_len;
+    size_t end = value.find_first_of(", \t", begin);
+    std::string encoded = value.substr(begin, end == std::string::npos ? std::string::npos : end - begin);
+
+    // Translate base64url back to standard base64 before decoding.
+    for (char& c : encoded) {
+        if (c == '-') {
+            c = '+';
+        } else if (c == '_') {
+            c = '/';
+        }
+    }
+    return utils::JsonUtils::base64_decode(encoded);
 }
 
 std::optional<std::string> WebSocketServer::get_url_arg(struct lws* wsi, const char* name) {

--- a/src/cpp/server/websocket_server.cpp
+++ b/src/cpp/server/websocket_server.cpp
@@ -130,8 +130,14 @@ int WebSocketServer::ws_callback(struct lws* wsi,
             if (classify_path(path) == ConnectionKind::invalid) {
                 return 1;
             }
-            if (!server->authenticate_connection(wsi)) {
+            const char* protocol = static_cast<const char*>(in);
+            if (!server->authenticate_connection(wsi, protocol)) {
                 return 1;
+            }
+            if (protocol && std::strlen(protocol) > 0) {
+                int fd = static_cast<int>(lws_get_socket_fd(wsi));
+                std::lock_guard<std::mutex> lock(server->protocols_mutex_);
+                server->pending_protocols_[fd] = std::string(protocol);
             }
             break;
         }
@@ -384,10 +390,21 @@ std::string WebSocketServer::extract_token_from_wsi(struct lws* wsi) const {
     if (!token) {
         token = get_url_arg(wsi, "api_key");
     }
+    if (!token) {
+        int fd = static_cast<int>(lws_get_socket_fd(wsi));
+        std::lock_guard<std::mutex> lock(protocols_mutex_);
+        auto it = pending_protocols_.find(fd);
+        if (it != pending_protocols_.end()) {
+            const std::string& protocol = it->second;
+            if (protocol.find("bearer.") == 0) {
+                return protocol.substr(7);
+            }
+        }
+    }
     return token ? strip_bearer_prefix(*token) : "";
 }
 
-bool WebSocketServer::authenticate_connection(struct lws* wsi) const {
+bool WebSocketServer::authenticate_connection(struct lws* wsi, const char* protocol) const {
     if (api_key_.empty()) {
         return true;
     }
@@ -395,6 +412,12 @@ bool WebSocketServer::authenticate_connection(struct lws* wsi) const {
     auto token = get_header(wsi, WSI_TOKEN_HTTP_AUTHORIZATION);
     if (!token) {
         token = get_url_arg(wsi, "api_key");
+    }
+    if (!token && protocol && std::strlen(protocol) > 0) {
+        std::string protocol_str(protocol);
+        if (protocol_str.find("bearer.") == 0) {
+            token = protocol_str.substr(7);
+        }
     }
 
     if (!token) {
@@ -425,6 +448,12 @@ void WebSocketServer::handle_connection(const std::string& connection_id, struct
     std::string token_str = extract_token_from_wsi(wsi);
     auto client_session_id_opt = get_url_arg(wsi, "client_session_id");
     std::string client_session_id = client_session_id_opt ? *client_session_id_opt : "";
+
+    {
+        int fd = static_cast<int>(lws_get_socket_fd(wsi));
+        std::lock_guard<std::mutex> lock(protocols_mutex_);
+        pending_protocols_.erase(fd);
+    }
 
     {
         std::lock_guard<std::mutex> lock(connections_mutex_);

--- a/test/server_websocket_auth.py
+++ b/test/server_websocket_auth.py
@@ -55,8 +55,9 @@ class WebSocketAuthTests(unittest.TestCase):
     def setUpClass(cls):
         cls.lemond_bin = get_default_lemond_binary()
         if not os.path.exists(cls.lemond_bin):
-            raise RuntimeError(
-                f"lemond binary not found at {cls.lemond_bin}. Build it first."
+            raise unittest.SkipTest(
+                f"lemond binary not found at {cls.lemond_bin}; "
+                "skipping (source-build only)"
             )
         cls.temp_dir = tempfile.mkdtemp(prefix="lemond_ws_auth_")
         cls.port = find_free_port()

--- a/test/server_websocket_auth.py
+++ b/test/server_websocket_auth.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Integration tests for WebSocket API-key authentication via the
+Sec-WebSocket-Protocol header.
+
+Clients that cannot set request headers (browsers) authenticate by offering the
+registered application subprotocol ("lemonade-realtime") alongside a base64url
+credential subprotocol ("bearer.<base64url(api_key)>"). These tests exercise
+that path for both /realtime and /logs/stream, on the dedicated WebSocket port
+and the main HTTP port, plus the backward-compatible api_key query parameter.
+"""
+
+import asyncio
+import base64
+import json
+import os
+import sys
+import socket
+import time
+import tempfile
+import subprocess
+import unittest
+
+import requests
+import websockets
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from utils.test_models import get_default_lemond_binary
+
+API_KEY = "secret_key"
+APP_PROTOCOL = "lemonade-realtime"
+
+
+def find_free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+def credential_protocol(api_key):
+    encoded = base64.urlsafe_b64encode(api_key.encode()).decode().rstrip("=")
+    return f"bearer.{encoded}"
+
+
+def auth_subprotocols(api_key):
+    return [APP_PROTOCOL, credential_protocol(api_key)]
+
+
+class WebSocketAuthTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.lemond_bin = get_default_lemond_binary()
+        if not os.path.exists(cls.lemond_bin):
+            raise RuntimeError(
+                f"lemond binary not found at {cls.lemond_bin}. Build it first."
+            )
+        cls.temp_dir = tempfile.mkdtemp(prefix="lemond_ws_auth_")
+        cls.port = find_free_port()
+
+        env = os.environ.copy()
+        env.pop("LEMONADE_ADMIN_API_KEY", None)
+        env["LEMONADE_API_KEY"] = API_KEY
+
+        cls.log_path = os.path.join(cls.temp_dir, "lemond.log")
+        cls.log_file = open(cls.log_path, "w")
+        cls.proc = subprocess.Popen(
+            [cls.lemond_bin, cls.temp_dir, "--port", str(cls.port)],
+            stdout=cls.log_file,
+            stderr=cls.log_file,
+            env=env,
+        )
+
+        cls.ws_port = None
+        for _ in range(60):
+            try:
+                res = requests.get(f"http://localhost:{cls.port}/live", timeout=0.2)
+                if res.status_code == 200:
+                    health = requests.get(
+                        f"http://localhost:{cls.port}/api/v1/health",
+                        headers={"Authorization": f"Bearer {API_KEY}"},
+                        timeout=0.5,
+                    )
+                    cls.ws_port = health.json().get("websocket_port")
+                    break
+            except Exception:
+                pass
+            time.sleep(0.05)
+
+        if cls.ws_port is None:
+            cls.tearDownClass()
+            raise RuntimeError("Failed to start lemond server for WebSocket auth tests")
+
+    @classmethod
+    def tearDownClass(cls):
+        proc = getattr(cls, "proc", None)
+        if proc and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=3)
+            except Exception:
+                proc.kill()
+                proc.wait()
+        log_file = getattr(cls, "log_file", None)
+        if log_file:
+            log_file.close()
+        temp_dir = getattr(cls, "temp_dir", None)
+        if temp_dir:
+            import shutil
+
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    # --- realtime -----------------------------------------------------------
+
+    def test_001_realtime_subprotocol_auth_ws_port(self):
+        """Valid subprotocol credential upgrades /realtime on the WS port."""
+
+        async def run():
+            uri = f"ws://localhost:{self.ws_port}/realtime"
+            async with websockets.connect(
+                uri, subprotocols=auth_subprotocols(API_KEY)
+            ) as ws:
+                self.assertEqual(ws.subprotocol, APP_PROTOCOL)
+                msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=3.0))
+                self.assertEqual(msg.get("type"), "session.created")
+
+        asyncio.run(run())
+
+    def test_002_realtime_subprotocol_auth_main_port(self):
+        """Valid subprotocol credential upgrades /v1/realtime on the main port."""
+
+        async def run():
+            uri = f"ws://localhost:{self.port}/v1/realtime"
+            async with websockets.connect(
+                uri, subprotocols=auth_subprotocols(API_KEY)
+            ) as ws:
+                self.assertEqual(ws.subprotocol, APP_PROTOCOL)
+                msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=3.0))
+                self.assertEqual(msg.get("type"), "session.created")
+
+        asyncio.run(run())
+
+    def test_003_realtime_wrong_key_rejected(self):
+        """A subprotocol credential with the wrong key is rejected."""
+
+        async def run():
+            uri = f"ws://localhost:{self.ws_port}/realtime"
+            with self.assertRaises(
+                (
+                    websockets.exceptions.InvalidStatus,
+                    websockets.exceptions.InvalidHandshake,
+                )
+            ):
+                async with websockets.connect(
+                    uri, subprotocols=auth_subprotocols("wrong_key")
+                ):
+                    pass
+
+        asyncio.run(run())
+
+    def test_004_realtime_query_param_backward_compat(self):
+        """The legacy api_key query parameter still authenticates /realtime."""
+
+        async def run():
+            uri = f"ws://localhost:{self.ws_port}/realtime?api_key={API_KEY}"
+            async with websockets.connect(uri) as ws:
+                msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=3.0))
+                self.assertEqual(msg.get("type"), "session.created")
+
+        asyncio.run(run())
+
+    # --- logs ---------------------------------------------------------------
+
+    def test_005_logs_subprotocol_auth_ws_port(self):
+        """Valid subprotocol credential upgrades /logs/stream on the WS port."""
+
+        async def run():
+            uri = f"ws://localhost:{self.ws_port}/logs/stream"
+            async with websockets.connect(
+                uri, subprotocols=auth_subprotocols(API_KEY)
+            ) as ws:
+                self.assertEqual(ws.subprotocol, APP_PROTOCOL)
+                await ws.send(json.dumps({"type": "logs.subscribe", "after_seq": None}))
+                msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=3.0))
+                self.assertEqual(msg.get("type"), "logs.snapshot")
+
+        asyncio.run(run())
+
+    def test_006_logs_subprotocol_auth_main_port(self):
+        """Valid subprotocol credential upgrades /logs/stream on the main port."""
+
+        async def run():
+            uri = f"ws://localhost:{self.port}/logs/stream"
+            async with websockets.connect(
+                uri, subprotocols=auth_subprotocols(API_KEY)
+            ) as ws:
+                self.assertEqual(ws.subprotocol, APP_PROTOCOL)
+                await ws.send(json.dumps({"type": "logs.subscribe", "after_seq": None}))
+                msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=3.0))
+                self.assertEqual(msg.get("type"), "logs.snapshot")
+
+        asyncio.run(run())
+
+    def test_007_logs_wrong_key_rejected(self):
+        """A subprotocol credential with the wrong key is rejected for logs."""
+
+        async def run():
+            uri = f"ws://localhost:{self.ws_port}/logs/stream"
+            with self.assertRaises(
+                (
+                    websockets.exceptions.InvalidStatus,
+                    websockets.exceptions.InvalidHandshake,
+                )
+            ):
+                async with websockets.connect(
+                    uri, subprotocols=auth_subprotocols("wrong_key")
+                ):
+                    pass
+
+        asyncio.run(run())
+
+    def test_008_logs_missing_credentials_rejected(self):
+        """No credentials at all is rejected for /logs/stream."""
+
+        async def run():
+            uri = f"ws://localhost:{self.ws_port}/logs/stream"
+            with self.assertRaises(
+                (
+                    websockets.exceptions.InvalidStatus,
+                    websockets.exceptions.InvalidHandshake,
+                )
+            ):
+                async with websockets.connect(uri):
+                    pass
+
+        asyncio.run(run())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The realtime transcription WebSocket sent the API key in the URL query string (`ws://host:port/realtime?api_key=...`) and logged the full URL, exposing the key in server access logs, libwebsockets handshake logs, browser history (web-app mode), and to on-path observers over cleartext `ws://`.

The credential now rides in the `Sec-WebSocket-Protocol` header. Because libwebsockets rejects unregistered subprotocols during negotiation (before the auth callback runs), the client must also offer the registered application protocol — otherwise the upgrade fails whenever `LEMONADE_API_KEY` is set.

Client (TypeScript):
- Remove the API key from the WebSocket URL (`buildWebSocketUrl` no longer appends `api_key`).
- Add a shared `webSocketProtocols()` helper offering `[lemonade-realtime, bearer.<base64url(key)>]`; base64url keeps the key within the subprotocol token charset, and awaiting config init fixes a race where the key was read before async init finished.
- Both the realtime (`websocketClient.ts`) and log-stream (`logWebSocketClient.ts`) clients pass these protocols to `new WebSocket()`; previously `/logs/stream` sent no credential at all.
- Redact query parameters from console logs.

Server (C++):
- `get_protocol_credential()` reads the full `Sec-WebSocket-Protocol` header, extracts the `bearer.` credential, and base64url-decodes it.
- Wired into both `extract_token_from_wsi()` and `authenticate_connection()`, after the `Authorization` header and `api_key` query param (backward compatible).

Tests:
- New `test/server_websocket_auth.py` covers authenticated `/v1/realtime` and `/logs/stream` on both the dedicated WebSocket port and the main HTTP port.

The fix applies to both the Tauri desktop app and the web app, which share the same renderer code.
