### PR TITLE
chore(rocm): bump llama.cpp rocm-nightly to b1295 (ROCWMMA_FATTN=OFF)

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -1,9 +1,9 @@
 {
-  "comment": "This configuration file controls which llama.cpp, whisper.cpp, sd.cpp, ryzenai-llm, and FLM versions are downloaded for each backend. You can modify these values to pin specific versions without rebuilding the application.",
+  "comment": "This configuration file controls which llama.cpp, whisper.cpp, sd.cpp, ryzenai-llm, and FLM versions are downloaded for each backend. You can modify these values to pin specific versions without rebuilding the application.\n\nROCm builds: upstream ggml-org/llama.cpp defaults GGML_HIP_ROCWMMA_FATTN to OFF in cmake (b9752+).\nlemonade-sdk/llamacpp-rocm builds also set -DGGML_HIP_ROCWMMA_FATTN=OFF. ROCWMMA_FATTN=ON can improve\nshort-context prefill but hurts long-context (4× slower on Strix Halo with 30K context).\nIf shipping both ON/OFF variants in future, select based on expected context length / GPU type.",
   "llamacpp": {
     "vulkan": "b9747",
     "rocm-stable": "b9752",
-    "rocm-nightly": "b1292",
+    "rocm-nightly": "b1295",
     "cuda": "b9851",
     "metal": "b9747",
     "cpu": "b9747"


### PR DESCRIPTION
Updates rocm-nightly from b1292 (Jun 25) to b1295 (Jul 9), which was built with `-DGGML_HIP_ROCWMMA_FATTN=OFF`.

- Upstream cmake default for GGML_HIP_ROCWMMA_FATTN is OFF since b9752+ (ggml/CMakeLists.txt:219)
- ROCWMMA_FATTN=ON helps short-context prefill but causes **4x slowdown** on long-context (30K tokens) on Strix Halo
- b1295 confirmed built with OFF by the llamacpp-rocm CI

Refs #2624