### PR TITLE
fix(ci): job-isolated process cleanups and fast installer teardowns

### DIFF
--- a/.github/actions/cleanup-ci-paths-linux/action.yml
+++ b/.github/actions/cleanup-ci-paths-linux/action.yml
@@ -1,0 +1,111 @@
+name: Cleanup Linux CI paths
+
+description: Remove or prune Linux CI directories.
+
+inputs:
+  paths:
+    description: Newline-separated list of paths to remove, or roots to prune when prune-children-older-than-days is set.
+    required: true
+  expected-root:
+    description: Optional root that every deleted path must be under.
+    required: false
+    default: ''
+  prune-children-older-than-days:
+    description: Optional age threshold. When set, delete child directories under each path that are older than this many days instead of deleting the paths themselves.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Cleanup Linux CI paths
+      shell: bash
+      env:
+        CLEANUP_PATHS: ${{ inputs.paths }}
+        EXPECTED_ROOT: ${{ inputs.expected-root }}
+        PRUNE_CHILDREN_OLDER_THAN_DAYS: ${{ inputs.prune-children-older-than-days }}
+      run: |
+        set -euo pipefail
+
+        # Resolve path cleanly
+        get_normalized_fullpath() {
+            local path=$1
+            readlink -f "$path"
+        }
+
+        # Check if path is under expected root
+        test_path_under_root() {
+            local path=$1
+            local expected_root=$2
+
+            if [ -z "$expected_root" ]; then
+                return 0
+            fi
+            if [ -z "$path" ]; then
+                return 1
+            fi
+
+            local full_path
+            full_path=$(get_normalized_fullpath "$path")
+            local full_root
+            full_root=$(get_normalized_fullpath "$expected_root")
+
+            # Check if full_path starts with full_root
+            if [[ "$full_path" == "$full_root"/* ]] || [[ "$full_path" == "$full_root" ]]; then
+                return 0
+            fi
+            return 1
+        }
+
+        # Parse paths input into array
+        IFS=$'\n' read -rd '' -a paths_arr <<< "$CLEANUP_PATHS"$'\n' || true
+
+        prune_days=""
+        if [ -n "$PRUNE_CHILDREN_OLDER_THAN_DAYS" ]; then
+            prune_days="$PRUNE_CHILDREN_OLDER_THAN_DAYS"
+        fi
+
+        if [ -n "$prune_days" ]; then
+            echo "Pruning child directories older than $prune_days days..."
+            for root in "${paths_arr[@]}"; do
+                root=$(echo "$root" | xargs) # trim whitespace
+                if [ -z "$root" ] || [ ! -d "$root" ]; then
+                    continue
+                fi
+
+                if ! test_path_under_root "$root" "$EXPECTED_ROOT"; then
+                    echo "Skipping prune root outside expected root: $root"
+                    continue
+                fi
+
+                echo "Pruning children under root: $root"
+                # Find directories directly under $root that are older than N days
+                # -mindepth 1 -maxdepth 1 limits search to direct children
+                # -type d matches directories only
+                # -mtime +N matches directories modified more than N days ago
+                find "$root" -mindepth 1 -maxdepth 1 -type d -mtime +"$prune_days" | while read -r child; do
+                    if test_path_under_root "$child" "$EXPECTED_ROOT"; then
+                        echo "  Removing: $child"
+                        rm -rf "$child"
+                    else
+                        echo "  Skipping child outside expected root: $child"
+                    fi
+                done
+            done
+        else
+            echo "Removing specified paths..."
+            for path in "${paths_arr[@]}"; do
+                path=$(echo "$path" | xargs) # trim whitespace
+                if [ -z "$path" ] || [ ! -e "$path" ]; then
+                    continue
+                fi
+
+                if ! test_path_under_root "$path" "$EXPECTED_ROOT"; then
+                    echo "Skipping cleanup outside expected root: $path"
+                    continue
+                fi
+
+                echo "Removing path: $path"
+                rm -rf "$path"
+            done
+        fi

--- a/.github/actions/cleanup-ci-paths-windows/action.yml
+++ b/.github/actions/cleanup-ci-paths-windows/action.yml
@@ -74,7 +74,16 @@ runs:
           }
         }
 
-        $paths = @($env:CLEANUP_PATHS -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+        $paths = @($env:CLEANUP_PATHS -split "`r?`n" | ForEach-Object {
+          $trimmed = $_.Trim()
+          if ($trimmed) {
+            $expanded = [System.Environment]::ExpandEnvironmentVariables($trimmed)
+            if ($expanded.StartsWith("~")) {
+              $expanded = Join-Path $env:USERPROFILE $expanded.Substring(1).TrimStart("\/")
+            }
+            $expanded
+          }
+        } | Where-Object { $_ })
         if ($paths.Count -eq 0) {
           Write-Host "No paths provided for cleanup."
           exit 0

--- a/.github/actions/cleanup-processes-linux/action.yml
+++ b/.github/actions/cleanup-processes-linux/action.yml
@@ -10,7 +10,89 @@ runs:
         echo "Cleaning up processes on Linux..."
         echo "========================================"
 
-        # Kill processes aggressively by pattern
+        # Get all descendant PIDs (including target PID) recursively
+        get_process_tree() {
+            local target_pid=$1
+            echo "$target_pid"
+            local children
+            children=$(pgrep -P "$target_pid" 2>/dev/null || true)
+            for child in $children; do
+                get_process_tree "$child"
+            done
+        }
+
+        # Check if the process matches lemond, lemonade, or llama-server
+        is_lemonade_process() {
+            local pid=$1
+            if [ -f "/proc/$pid/cmdline" ]; then
+                local cmdline
+                cmdline=$(cat "/proc/$pid/cmdline" 2>/dev/null | tr '\0' ' ' || true)
+                if [[ "$cmdline" == *"lemond"* ]] || [[ "$cmdline" == *"lemonade"* ]] || [[ "$cmdline" == *"llama-server"* ]]; then
+                    return 0
+                fi
+            fi
+            return 1
+        }
+
+        # Helper to kill a process and all its children recursively with SIGTERM fallback to SIGKILL
+        kill_descendants() {
+            local target_pid=$1
+            if [ -z "$target_pid" ] || ! kill -0 "$target_pid" 2>/dev/null; then
+                return
+            fi
+
+            # Collect the process tree first to handle reparenting safely
+            local tree_pids
+            tree_pids=$(get_process_tree "$target_pid" 2>/dev/null || true)
+
+            echo "  Sending SIGTERM to process tree of PID $target_pid..."
+            for pid in $tree_pids; do
+                kill -15 "$pid" 2>/dev/null || true
+            done
+
+            # Wait for processes to handle SIGTERM
+            sleep 1
+
+            # Fallback to SIGKILL for any survivors
+            local still_alive=()
+            for pid in $tree_pids; do
+                if kill -0 "$pid" 2>/dev/null; then
+                    still_alive+=("$pid")
+                fi
+            done
+
+            if [ ${#still_alive[@]} -gt 0 ]; then
+                echo "  PIDs still alive after SIGTERM, sending SIGKILL: ${still_alive[*]}..."
+                for pid in "${still_alive[@]}"; do
+                    kill -9 "$pid" 2>/dev/null || true
+                done
+            fi
+        }
+
+        # Targeted PID-file based process cleanup
+        TMP_ROOT="${RUNNER_TEMP:-$PWD}"
+        echo "Checking for PID files in $TMP_ROOT..."
+        for pid_file in "$TMP_ROOT"/lemond*.pid "$TMP_ROOT"/lemonade*.pid; do
+            if [ -f "$pid_file" ]; then
+                PID=$(cat "$pid_file" 2>/dev/null || true)
+                if [ -n "$PID" ]; then
+                    echo "Found PID $PID in $pid_file"
+                    if kill -0 "$PID" 2>/dev/null; then
+                        if is_lemonade_process "$PID"; then
+                            echo "Terminating PID $PID and its descendants..."
+                            kill_descendants "$PID"
+                        else
+                            echo "Process $PID is not a lemonade process (PID reused or stale). Skipping."
+                        fi
+                    else
+                        echo "Process $PID is not running."
+                    fi
+                fi
+                rm -f "$pid_file"
+            fi
+        done
+
+        # Kill processes aggressively by pattern with SIGTERM fallback to SIGKILL
         kill_by_pattern() {
             local pattern=$1
             local description=$2
@@ -18,70 +100,139 @@ runs:
             echo ""
             echo "Killing $description processes..."
 
-            # Find and kill in one shot with SIGKILL
-            pkill -9 -f "$pattern" 2>/dev/null && echo "  Killed processes matching: $pattern" || echo "  No $description processes found"
+            if pgrep -f "$pattern" > /dev/null 2>&1; then
+                echo "  Sending SIGTERM to processes matching: $pattern"
+                pkill -15 -f "$pattern" 2>/dev/null || true
+                sleep 1
+                if pgrep -f "$pattern" > /dev/null 2>&1; then
+                    echo "  Sending SIGKILL to remaining processes matching: $pattern"
+                    pkill -9 -f "$pattern" 2>/dev/null || true
+                fi
+            else
+                echo "  No $description processes found"
+            fi
         }
 
-        # Kill by exact name (even more aggressive)
+        # Kill by exact name with SIGTERM fallback to SIGKILL
         kill_by_exact_name() {
             local name=$1
 
             if pgrep -x "$name" > /dev/null 2>&1; then
                 echo "Killing $name (exact match)..."
-                pkill -9 -x "$name"
-                sleep 0.5
+                pkill -15 -x "$name" 2>/dev/null || true
+                sleep 1
                 # Verify it's dead
                 if pgrep -x "$name" > /dev/null 2>&1; then
-                    echo "  WARNING: $name still running after kill!"
+                    echo "  $name still running after SIGTERM, sending SIGKILL..."
+                    pkill -9 -x "$name" 2>/dev/null || true
+                    sleep 0.5
+                    if pgrep -x "$name" > /dev/null 2>&1; then
+                        echo "  WARNING: $name still running after SIGKILL!"
+                    else
+                        echo "  Successfully killed $name"
+                    fi
                 else
                     echo "  Successfully killed $name"
                 fi
             fi
         }
 
-        # Kill llama processes
-        kill_by_pattern "llama-server" "llama-server"
-        kill_by_pattern "llama-cli" "llama-cli"
-        kill_by_pattern "llama-bench" "llama-bench"
+        # Target specific leaked processes by checking if their command line contains a unique string
+        # (like the current workspace path) to avoid concurrency collisions on self-hosted runners.
+        kill_targeted_by_cmdline() {
+            local pattern=$1
+            local match_str=$2
 
-        # Kill everything lemonade-related
-        kill_by_pattern "lemonade" "lemonade"
+            if [ -z "$match_str" ]; then
+                return
+            fi
 
-        # Kill Python processes (this is aggressive - be careful!)
-        kill_by_pattern "python" "Python"
+            echo "Searching for processes matching '$pattern' with '$match_str' in command line..."
+            local pids
+            pids=$(pgrep -x "$pattern" 2>/dev/null || true)
+            for pid in $pids; do
+                if [ -f "/proc/$pid/cmdline" ]; then
+                    local cmdline
+                    cmdline=$(cat "/proc/$pid/cmdline" 2>/dev/null | tr '\0' ' ' || true)
+                    if [[ "$cmdline" == *"$match_str"* ]]; then
+                        echo "  Found matching process PID $pid: $cmdline"
+                        echo "  Sending SIGTERM to PID $pid..."
+                        kill -15 "$pid" 2>/dev/null || true
+                        sleep 0.5
+                        if kill -0 "$pid" 2>/dev/null; then
+                            echo "  PID $pid still alive, sending SIGKILL..."
+                            kill -9 "$pid" 2>/dev/null || true
+                        fi
+                    fi
+                fi
+            done
+        }
 
-        # Additional pass: kill by exact process names
-        echo ""
-        echo "Second pass: killing by exact name..."
-        for proc_name in lemond lemonade-tray llama-server llama-cli llama-bench; do
-            kill_by_exact_name "$proc_name"
-        done
+        # Determine if we are on a self-hosted (shared) runner to prevent concurrent run collisions
+        IS_SELF_HOSTED=false
+        if [ "${RUNNER_ENVIRONMENT:-}" = "self-hosted" ]; then
+            IS_SELF_HOSTED=true
+        elif [[ "${RUNNER_NAME:-}" =~ (stx|rai|selfhost) ]]; then
+            IS_SELF_HOSTED=true
+        fi
 
-        # Wait for processes to die
-        sleep 2
-
-        # FINAL VERIFICATION - show what's still alive
-        echo ""
-        echo "=== Verification: checking for remaining processes ==="
-        if pgrep -f "lemonade|llama" > /dev/null 2>&1; then
-            echo "WARNING: Some processes still alive:"
-            ps aux | grep -E "lemonade|llama" | grep -v grep | grep -v "cleanup-processes" || true
-
-            # NUCLEAR OPTION: Kill them with extreme prejudice
-            echo "Using nuclear option..."
-            pkill -9 -f "llama" 2>/dev/null || true
-            pkill -9 -f "lemonade" 2>/dev/null || true
-            sleep 1
-
-            # Check again
-            if pgrep -f "lemonade|llama" > /dev/null 2>&1; then
-                echo "ERROR: Processes STILL alive after nuclear option!"
-                ps aux | grep -E "lemonade|llama" | grep -v grep || true
-            else
-                echo "Nuclear option successful"
+        if [ "$IS_SELF_HOSTED" = "true" ]; then
+            echo "Running on self-hosted runner (${RUNNER_NAME:-}). Global cleanup bypassed to prevent concurrency collisions."
+            # Targeted cleanup: only kill processes tied to this workspace to prevent resource leaks (like vllm or resource_tracker)
+            if [ -n "${GITHUB_WORKSPACE:-}" ]; then
+                echo "Performing workspace-targeted cleanup for self-hosted runner..."
+                kill_targeted_by_cmdline "vllm|resource_tracker|python[0-9.]*|lemond|lemonade|llama-server" "$GITHUB_WORKSPACE"
             fi
         else
-            echo "All target processes terminated successfully"
+            echo "Running on GitHub-hosted runner. Proceeding with global cleanup fallback..."
+
+            # Kill llama processes
+            kill_by_pattern "llama-server" "llama-server"
+            kill_by_pattern "llama-cli" "llama-cli"
+            kill_by_pattern "llama-bench" "llama-bench"
+
+            # Kill everything lemonade-related
+            kill_by_pattern "lemonade" "lemonade"
+
+            # Kill Python processes (this is aggressive - be careful!)
+            kill_by_pattern "python" "Python"
+
+            # Additional pass: kill by exact process names
+            echo ""
+            echo "Second pass: killing by exact name..."
+            for proc_name in lemond lemonade-tray llama-server llama-cli llama-bench; do
+                kill_by_exact_name "$proc_name"
+            done
+
+            # Wait for processes to die
+            sleep 2
+
+            # FINAL VERIFICATION - show what's still alive
+            echo ""
+            echo "=== Verification: checking for remaining processes ==="
+            if pgrep -f "lemonade|llama" > /dev/null 2>&1; then
+                echo "WARNING: Some processes still alive:"
+                ps aux | grep -E "lemonade|llama" | grep -v grep | grep -v "cleanup-processes" || true
+
+                # NUCLEAR OPTION: Kill them with extreme prejudice
+                echo "Using nuclear option..."
+                pkill -15 -f "llama" 2>/dev/null || true
+                pkill -15 -f "lemonade" 2>/dev/null || true
+                sleep 1
+                pkill -9 -f "llama" 2>/dev/null || true
+                pkill -9 -f "lemonade" 2>/dev/null || true
+                sleep 1
+
+                # Check again
+                if pgrep -f "lemonade|llama" > /dev/null 2>&1; then
+                    echo "ERROR: Processes STILL alive after nuclear option!"
+                    ps aux | grep -E "lemonade|llama" | grep -v grep || true
+                else
+                    echo "Nuclear option successful"
+                fi
+            else
+                echo "All target processes terminated successfully"
+            fi
         fi
 
         echo ""

--- a/.github/actions/cleanup-processes-windows/action.yml
+++ b/.github/actions/cleanup-processes-windows/action.yml
@@ -10,6 +10,48 @@ runs:
         Write-Host "Cleaning up processes on Windows..." -ForegroundColor Cyan
         Write-Host "========================================" -ForegroundColor Cyan
 
+        # Helper function to kill a process and its children recursively
+        function Stop-ProcessAndChildren {
+            param(
+                [int]$ParentPid
+            )
+
+            $children = Get-CimInstance Win32_Process -Filter "ParentProcessId = $ParentPid" -ErrorAction SilentlyContinue
+            foreach ($child in $children) {
+                Stop-ProcessAndChildren -ParentPid $child.ProcessId
+            }
+
+            if (Get-Process -Id $ParentPid -ErrorAction SilentlyContinue) {
+                Write-Host "  Stopping PID $ParentPid..." -ForegroundColor Yellow
+                Stop-Process -Id $ParentPid -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        # Targeted PID-file based process cleanup
+        $tmpRoot = $env:RUNNER_TEMP
+        if (-not $tmpRoot) { $tmpRoot = $PWD }
+        Write-Host "Checking for PID files in $tmpRoot..." -ForegroundColor Yellow
+        $pidFiles = Get-ChildItem (Join-Path $tmpRoot "lemond*.pid"), (Join-Path $tmpRoot "lemonade*.pid") -ErrorAction SilentlyContinue
+        foreach ($file in $pidFiles) {
+            $pidText = Get-Content $file.FullName -Raw -ErrorAction SilentlyContinue
+            $targetPid = 0
+            if ($pidText -and [int]::TryParse($pidText.Trim(), [ref]$targetPid)) {
+                Write-Host "Found PID $targetPid in $($file.Name)" -ForegroundColor Yellow
+                $proc = Get-Process -Id $targetPid -ErrorAction SilentlyContinue
+                if ($proc) {
+                    if ($proc.ProcessName -match "lemond" -or $proc.ProcessName -match "lemonade" -or $proc.ProcessName -match "llama-server") {
+                        Write-Host "Terminating PID $targetPid ($($proc.ProcessName)) and its descendants..." -ForegroundColor Yellow
+                        Stop-ProcessAndChildren -ParentPid $targetPid
+                    } else {
+                        Write-Host "Process $targetPid ($($proc.ProcessName)) is not a lemonade process (PID reused or stale). Skipping." -ForegroundColor Gray
+                    }
+                } else {
+                    Write-Host "Process $targetPid is not running." -ForegroundColor Gray
+                }
+                Remove-Item $file.FullName -Force -ErrorAction SilentlyContinue
+            }
+        }
+
         # Function to safely kill processes by name pattern
         function Stop-ProcessByPattern {
             param(
@@ -39,26 +81,40 @@ runs:
             }
         }
 
-        # Kill llama-server processes
-        Stop-ProcessByPattern -Pattern "llama-server" -Description "llama-server"
-        Stop-ProcessByPattern -Pattern "llama" -Description "llama"
+        # Determine if we are on a self-hosted (shared) runner to prevent concurrent run collisions
+        $isSelfHosted = $false
+        if ($env:RUNNER_ENVIRONMENT -eq "self-hosted") {
+            $isSelfHosted = $true
+        } elseif ($env:RUNNER_NAME -match "(stx|rai|selfhost)") {
+            $isSelfHosted = $true
+        }
 
-        # Kill FLM processes (Windows only)
-        Stop-ProcessByPattern -Pattern "flm" -Description "FLM"
+        if ($isSelfHosted) {
+            Write-Host "Running on self-hosted runner ($($env:RUNNER_NAME)). Global cleanup bypassed to prevent concurrency collisions." -ForegroundColor Cyan
+        } else {
+            Write-Host "Running on GitHub-hosted runner. Proceeding with global cleanup fallback..." -ForegroundColor Cyan
 
-        # Kill backend subprocesses that outlive a force-killed lemond
-        Stop-ProcessByPattern -Pattern "ort-server" -Description "ort-server"
-        Stop-ProcessByPattern -Pattern "moonshine-server" -Description "moonshine-server"
+            # Kill llama-server processes
+            Stop-ProcessByPattern -Pattern "llama-server" -Description "llama-server"
+            Stop-ProcessByPattern -Pattern "llama" -Description "llama"
 
-        # Kill lemonade processes (lemond, lemonade, lemonade-tray, etc.)
-        Stop-ProcessByPattern -Pattern "lemonade" -Description "lemonade"
-        Stop-ProcessByPattern -Pattern "lemond" -Description "lemond"
+            # Kill FLM processes (Windows only)
+            Stop-ProcessByPattern -Pattern "flm" -Description "FLM"
 
-        # Kill Python processes
-        Stop-ProcessByPattern -Pattern "python" -Description "Python"
+            # Kill backend subprocesses that outlive a force-killed lemond
+            Stop-ProcessByPattern -Pattern "ort-server" -Description "ort-server"
+            Stop-ProcessByPattern -Pattern "moonshine-server" -Description "moonshine-server"
 
-        # Kill wscript processes (VBScript launcher used by lemonade)
-        Stop-ProcessByPattern -Pattern "wscript" -Description "wscript"
+            # Kill lemonade processes (lemond, lemonade, lemonade-tray, etc.)
+            Stop-ProcessByPattern -Pattern "lemonade" -Description "lemonade"
+            Stop-ProcessByPattern -Pattern "lemond" -Description "lemond"
+
+            # Kill Python processes
+            Stop-ProcessByPattern -Pattern "python" -Description "Python"
+
+            # Kill wscript processes (VBScript launcher used by lemonade)
+            Stop-ProcessByPattern -Pattern "wscript" -Description "wscript"
+        }
 
         # Wait a moment for processes to fully terminate
         Start-Sleep -Seconds 2
@@ -149,19 +205,37 @@ runs:
         Write-Host "Uninstalling Lemonade Server (MSI)..." -ForegroundColor Magenta
         Write-Host "========================================" -ForegroundColor Magenta
 
-        # Uninstall by Product Code - Attempt to find it first
+        # Uninstall by Product Code - Attempt to find it first using fast registry search
         $productName = "Lemonade Server"
+        Write-Host "Searching for product via registry: $productName" -ForegroundColor Cyan
 
-        Write-Host "Searching for product: $productName" -ForegroundColor Cyan
+        $uninstallPaths = @(
+            "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*",
+            "HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*",
+            "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
+        )
 
-        $product = Get-WmiObject -Class Win32_Product | Where-Object { $_.Name -eq $productName }
+        $productCode = $null
+        $foundProduct = $null
 
-        if ($product) {
-            Write-Host "Found installed product: $($product.Name) (Version: $($product.Version))" -ForegroundColor Green
-            Write-Host "IdentifyingNumber (ProductCode): $($product.IdentifyingNumber)" -ForegroundColor Gray
+        foreach ($path in $uninstallPaths) {
+            $subkeys = Get-ItemProperty $path -ErrorAction SilentlyContinue
+            foreach ($key in $subkeys) {
+                if ($key.DisplayName -eq $productName) {
+                    $foundProduct = $key
+                    $productCode = $key.PSChildName
+                    break
+                }
+            }
+            if ($productCode) { break }
+        }
+
+        if ($productCode) {
+            Write-Host "Found installed product: $($foundProduct.DisplayName) (Version: $($foundProduct.DisplayVersion))" -ForegroundColor Green
+            Write-Host "Product Code: $productCode" -ForegroundColor Gray
 
             Write-Host "Uninstalling..." -ForegroundColor Yellow
-            $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x $($product.IdentifyingNumber) /qn" -Wait -PassThru
+            $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x $productCode /qn" -Wait -PassThru
 
             if ($proc.ExitCode -eq 0) {
                 Write-Host "Uninstall successful!" -ForegroundColor Green
@@ -169,7 +243,7 @@ runs:
                 Write-Host "Uninstall failed with exit code $($proc.ExitCode)" -ForegroundColor Red
             }
         } else {
-            Write-Host "Product '$productName' not found installed via MSI." -ForegroundColor Gray
+            Write-Host "Product '$productName' not found installed via MSI in registry." -ForegroundColor Gray
 
             # Fallback: Check if we can uninstall via the MSI file if it exists in current directory
             if (Test-Path "lemonade-server-minimal.msi") {

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -645,6 +645,7 @@ namespace lemon::backends {
                 utils::DownloadOptions archive_download_opts;
                 archive_download_opts.expected_hash = lookup_expected_asset_hash(
                     spec.recipe, backend, expected_version, repo, filename);
+                archive_download_opts.resume_partial = false;
 
                 auto download_result = utils::HttpClient::download_file(
                     url, zip_path, http_progress_cb, {}, archive_download_opts);
@@ -701,6 +702,7 @@ namespace lemon::backends {
                     utils::DownloadOptions part_download_opts;
                     part_download_opts.expected_hash = lookup_expected_asset_hash(
                         spec.recipe, backend, expected_version, repo, part_filename);
+                    part_download_opts.resume_partial = false;
 
                     auto part_result = utils::HttpClient::download_file(
                         part_url, part_path, part_http_cb, {}, part_download_opts);

--- a/test/server_omni.py
+++ b/test/server_omni.py
@@ -458,7 +458,11 @@ class OmniTests(ServerTestBase):
 
         messages = [{"role": "user", "content": self.MIXED_TOOL_PROMPT}]
         completion = client.chat.completions.create(
-            model=model, messages=messages, tools=self.WEATHER_TOOL, stream=False
+            model=model,
+            messages=messages,
+            tools=self.WEATHER_TOOL,
+            temperature=0.0,
+            stream=False,
         )
         choice = completion.choices[0]
         self._assert_contains(self, choice.message.content, "data:image/", "image")
@@ -495,7 +499,11 @@ class OmniTests(ServerTestBase):
         )
 
         completion = client.chat.completions.create(
-            model=model, messages=messages, tools=self.WEATHER_TOOL, stream=False
+            model=model,
+            messages=messages,
+            tools=self.WEATHER_TOOL,
+            temperature=0.0,
+            stream=False,
         )
         choice = completion.choices[0]
         self._assert_resume_answer(choice.finish_reason, choice.message.content or "")
@@ -514,7 +522,11 @@ class OmniTests(ServerTestBase):
 
         messages = [{"role": "user", "content": self.MIXED_TOOL_PROMPT}]
         stream = client.chat.completions.create(
-            model=model, messages=messages, tools=self.WEATHER_TOOL, stream=True
+            model=model,
+            messages=messages,
+            tools=self.WEATHER_TOOL,
+            temperature=0.0,
+            stream=True,
         )
         content, finish_reason, calls = self._collect_stream(stream)
         self._assert_contains(self, content, "data:image/", "image")
@@ -552,7 +564,11 @@ class OmniTests(ServerTestBase):
         )
 
         stream = client.chat.completions.create(
-            model=model, messages=messages, tools=self.WEATHER_TOOL, stream=True
+            model=model,
+            messages=messages,
+            tools=self.WEATHER_TOOL,
+            temperature=0.0,
+            stream=True,
         )
         content, finish_reason, _ = self._collect_stream(stream)
         self._assert_resume_answer(finish_reason, content)


### PR DESCRIPTION
### Summary
Replaces global name-based process termination on shared runners with job-isolated PID tracking to resolve concurrent build collisions, speeds up Windows teardowns, and prevents backend archive corruption.

### Key Changes
* **Isolated Reaping**: Targets specific PIDs file-tracked under `$RUNNER_TEMP`, using recursive child termination helpers to clean up only the test servers started by the current job.
* **Fast MSI Registry Lookup**: Swaps out the slow `Get-WmiObject` query for direct registry checks under `HKLM`/`HKCU` uninstall subkeys.
* **Corrupted Download Fix**: Disables `resume_partial` on backend releases to prevent corrupted `.part` files in shared `/tmp` folders from breaking extractions.

Relates-to: #2589