### PR TITLE
feat(ui): add build-time LEMONADE_BASE_URL override for prototype

### DIFF
--- a/prototype/ui-redesign/src/api.ts
+++ b/prototype/ui-redesign/src/api.ts
@@ -20,7 +20,7 @@ function detectDefaultBaseUrl(): string {
   return 'http://127.0.0.1:13305';
 }
 
-const DEFAULT_BASE_URL = detectDefaultBaseUrl();
+const DEFAULT_BASE_URL = process.env.LEMONADE_BASE_URL || detectDefaultBaseUrl();
 const LS_BASE_URL = 'lemonade_base_url';
 const LS_API_KEY = 'lemonade_api_key';
 
@@ -566,9 +566,10 @@ class LemonadeAPI {
       // Substitute it when the configured host is localhost/127.0.0.1 so that all
       // API calls and WebSocket connections resolve to the serving machine, not the phone.
       const parsed = new URL(raw);
-      if (!hasExplicitUrl && (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') && typeof window !== 'undefined') {
+      const hasBuildTimeOverride = Boolean(process.env.LEMONADE_BASE_URL);
+      if (!hasExplicitUrl && !hasBuildTimeOverride && (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') && typeof window !== 'undefined') {
         const winHost = window.location.hostname;
-        if (winHost && winHost !== 'localhost' && winHost !== '[::1]' && winHost !== '::1') {
+        if (winHost && winHost !== 'localhost' && winHost !== '127.0.0.1' && winHost !== '[::1]' && winHost !== '::1') {
           parsed.hostname = winHost;
         }
       }

--- a/prototype/ui-redesign/webpack.config.js
+++ b/prototype/ui-redesign/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = (env, argv) => ({
   mode: argv.mode || 'development',
@@ -60,6 +61,9 @@ module.exports = (env, argv) => ({
     new HtmlWebpackPlugin({
       template: './src/index.html',
       filename: 'index.html',
+    }),
+    new webpack.DefinePlugin({
+      'process.env.LEMONADE_BASE_URL': JSON.stringify(process.env.LEMONADE_BASE_URL || ''),
     }),
   ],
   devServer: {


### PR DESCRIPTION
This PR adds support for a build-time connection URL override in the Lemonade UI redesign prototype.

When deploying the UI prototype to a public static host like https://lemonade-taupe.vercel.app/, the dynamic hostname rewrite logic hijacks any `localhost`/`127.0.0.1` connection addresses and rewrites them to the deployment domain. By introducing a build-time `LEMONADE_BASE_URL` environment variable and injecting it via Webpack's `DefinePlugin`, we allow hosted deployments to explicitly specify a default connect address (such as `http://localhost:13305`) and bypass dynamic hostname replacement.