### PR TITLE
fix(ui): preserve user-configured custom connection URLs in prototype

### DIFF
--- a/prototype/ui-redesign/src/api.ts
+++ b/prototype/ui-redesign/src/api.ts
@@ -560,12 +560,13 @@ class LemonadeAPI {
 
   get baseUrl(): string {
     try {
+      const hasExplicitUrl = Boolean(this._hostBaseUrl || safeGetLocalStorage(LS_BASE_URL));
       const raw = normalizeBaseUrl(this._hostBaseUrl || safeGetLocalStorage(LS_BASE_URL) || DEFAULT_BASE_URL);
       // On mobile, window.location.hostname is the PC's LAN IP (e.g. 192.168.3.35).
       // Substitute it when the configured host is localhost/127.0.0.1 so that all
       // API calls and WebSocket connections resolve to the serving machine, not the phone.
       const parsed = new URL(raw);
-      if ((parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') && typeof window !== 'undefined') {
+      if (!hasExplicitUrl && (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') && typeof window !== 'undefined') {
         const winHost = window.location.hostname;
         if (winHost && winHost !== 'localhost' && winHost !== '[::1]' && winHost !== '::1') {
           parsed.hostname = winHost;


### PR DESCRIPTION
This PR ensures that connection settings manually configured by the user via the Connect tab are preserved and not dynamically rewritten.

Currently, the mobile LAN hostname substitution check runs unconditionally on any resolved `localhost` or `127.0.0.1` address. When visiting a hosted deployment such as https://lemonade-taupe.vercel.app/#/connect and attempting to manually input a local Lemonade API server at `localhost`, the hostname is dynamically hijacked and rewritten to `lemonade-taupe.vercel.app`, breaking the connection.

This change checks if a custom URL is stored in `_hostBaseUrl` or `localStorage` (`lemonade_base_url`), and bypasses the mobile LAN hostname rewrite if the user has explicitly saved their settings.