### PR TITLE
fix: readme and gen_backend_boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,39 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows, Linux</td>
     </tr>
     <tr>
+      <td rowspan="6"><strong>Audio generation</strong></td>
+      <td rowspan="3"><code>thinksound</code> (experimental)</td>
+      <td><code>rocm</code></td>
+      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>cuda</code></td>
+      <td>NVIDIA GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>vulkan</code></td>
+      <td>Vulkan-capable GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td rowspan="3"><code>acestep</code> (experimental)</td>
+      <td><code>rocm</code></td>
+      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>cuda</code></td>
+      <td>NVIDIA GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>vulkan</code></td>
+      <td>Vulkan-capable GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
       <td rowspan="5"><strong>Image generation</strong></td>
       <td rowspan="5"><code>sd-cpp</code></td>
       <td><code>rocm</code></td>
@@ -272,6 +305,23 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td><code>metal</code></td>
       <td>Apple Silicon GPU</td>
       <td>macOS</td>
+    </tr>
+    <tr>
+      <td rowspan="3"><strong>3D generation</strong></td>
+      <td rowspan="3"><code>trellis</code> (experimental)</td>
+      <td><code>rocm</code></td>
+      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>cuda</code></td>
+      <td>NVIDIA GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>vulkan</code></td>
+      <td>Vulkan-capable GPUs</td>
+      <td>Windows, Linux</td>
     </tr>
   </tbody>
 </table>

--- a/docs/tools/gen_backend_boilerplate.py
+++ b/docs/tools/gen_backend_boilerplate.py
@@ -124,11 +124,15 @@ def md_escape(text: str) -> str:
     return str(text).replace("|", "\\|")
 
 
+# Preferred README ordering, not an allow-list. Modalities not listed here are
+# appended deterministically so future backends cannot be silently omitted.
 MODALITY_ORDER = [
     "Text generation",
     "Speech-to-text",
     "Text-to-speech",
+    "Audio generation",
     "Image generation",
+    "3D generation",
 ]
 OS_LABEL = {"windows": "Windows", "linux": "Linux", "macos": "macOS"}
 OS_ORDER = ["windows", "linux", "macos"]
@@ -150,17 +154,31 @@ def _ordered(recipes: dict) -> list:
     return sorted(recipes.items(), key=lambda kv: kv[1].get("order", 999))
 
 
+def _ordered_modalities(by_mod: dict[str, list]) -> list[str]:
+    """Return known modalities first, then future modalities deterministically."""
+    preferred = [mod for mod in MODALITY_ORDER if mod in by_mod]
+    additional = sorted(set(by_mod) - set(MODALITY_ORDER))
+    return preferred + additional
+
+
 def render_readme_matrix(recipes: dict) -> str:
     # Group descriptor-backed recipes by modality, in descriptor registry order.
-    by_mod: dict[str, list] = {m: [] for m in MODALITY_ORDER}
+    # MODALITY_ORDER controls presentation only; it must never filter recipes.
+    by_mod: dict[str, list] = {}
     for recipe, info in _ordered(recipes):
-        mod = info.get("modality")
-        if not mod or mod not in by_mod:
+        support_rows = info.get("support", [])
+        if not support_rows:
             continue
+        mod = info.get("modality")
+        if not mod:
+            sys.exit(
+                f"Backend '{recipe}' has support rows but no documentation modality"
+            )
+
         # Merge support rows sharing a (backend, device summary); union their OS.
         merged: list[dict] = []
         seen: dict[tuple, dict] = {}
-        for row in info.get("support", []):
+        for row in support_rows:
             key = (row["backend"], row.get("device_summary", ""))
             if key in seen:
                 seen[key]["os"] |= set(row.get("os", []))
@@ -173,7 +191,7 @@ def render_readme_matrix(recipes: dict) -> str:
                 seen[key] = d
                 merged.append(d)
         if merged:
-            by_mod[mod].append((recipe, info, merged))
+            by_mod.setdefault(mod, []).append((recipe, info, merged))
 
     out = [
         "<table>",
@@ -188,11 +206,9 @@ def render_readme_matrix(recipes: dict) -> str:
         "  </thead>",
         "  <tbody>",
     ]
-    for mod in MODALITY_ORDER:
+    for mod in _ordered_modalities(by_mod):
         recipes_in = by_mod[mod]
-        if not recipes_in:
-            continue
-        mod_span = sum(len(m) for _, _, m in recipes_in)
+        mod_span = sum(len(merged) for _, _, merged in recipes_in)
         first_mod = True
         for recipe, info, merged in recipes_in:
             engine = f"<code>{recipe}</code>" + (


### PR DESCRIPTION
## Summary

Fix the generated README backend matrix so new modalities are not silently omitted.

## Changes

* Add Audio generation and 3D generation to the preferred modality order.
* Treat the modality list as ordering only, not an allow-list.
* Automatically include future modalities.
* Fail clearly when a backend has support entries but no modality.

## Result

ThinkSound, ACE-Step, OpenMOSS, and TRELLIS are now represented correctly in the generated backend documentation.
