### PR TITLE
fix(server): forward ctx_size to auto-loaded models

### DIFF
--- a/src/cpp/include/lemon/ollama_api.h
+++ b/src/cpp/include/lemon/ollama_api.h
@@ -41,7 +41,8 @@ private:
     void register_anthropic_routes(httplib::Server& server, const std::shared_ptr<OllamaApi>& self);
 
     // Helpers
-    void auto_load_model(const std::string& model);
+    void auto_load_model(const std::string& model, const json& request_options = json::object());
+    static json extract_auto_load_options(const json& request);
     std::string normalize_model_name(const std::string& name);
     json build_ollama_model_entry(const std::string& id, const ModelInfo& info);
     json convert_openai_chat_to_ollama(const json& openai_response, const std::string& model);

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -248,17 +248,10 @@ private:
                                   httplib::Response& res,
                                   nlohmann::json& out);
 
-    // Helper function for auto-loading models (eliminates code duplication and race conditions)
-    // Optionally accepts per-request override options (e.g. ctx_size) that are applied only on
-    // the very first load.  If the model is already loaded these are silently ignored so as not
-    // to overturn options that were set by a prior explicit /v1/load call.
-    //
-    // Callers MUST extract only load-level options via extract_auto_load_options() before
-    // passing them here — never pass the raw inference request body.  This prevents
-    // request-scoped fields (temperature, max_tokens, messages, steps, etc.) from leaking
-    // into recipe options that would affect subsequent requests.  Currently only ctx_size
-    // is allowlisted; pinned, eviction settings, *_args, and image params are excluded.
-    // (They can be forwarded via /v1/load when needed.)
+    // Auto-load a model on first use. request_options are applied only on the first load;
+    // if the model is already loaded they are ignored so explicit /v1/load settings win.
+    // Callers must pass only load-level options from extract_auto_load_options() — never
+    // the raw request body — to keep request-scoped fields out of persistent recipe options.
     void auto_load_model_if_needed(const std::string& model_name,
                                    const json& request_options = json::object());
 
@@ -342,11 +335,8 @@ private:
     // Set to true after check_for_model_updates() completes at startup.
     std::atomic<bool> update_check_done_{false};
 
-    // Extract only load-level options from an inference request body.  Returns a new json
-    // containing a small, explicit allowlist of fields that are safe to forward to the
-    // RecipeOptions constructor during auto-load.  All other request-scoped fields
-    // (temperature, max_tokens, messages, steps, cfg_scale, etc.) are deliberately excluded
-    // so they cannot accidentally influence persistent model-load settings.
+    // Extract load-level options from an inference request body. Currently only ctx_size
+    // is forwarded; request-scoped fields are excluded so they cannot leak into recipe options.
     static json extract_auto_load_options(const json& request);
 };
 

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -249,7 +249,18 @@ private:
                                   nlohmann::json& out);
 
     // Helper function for auto-loading models (eliminates code duplication and race conditions)
-    void auto_load_model_if_needed(const std::string& model_name);
+    // Optionally accepts per-request override options (e.g. ctx_size) that are applied only on
+    // the very first load.  If the model is already loaded these are silently ignored so as not
+    // to overturn options that were set by a prior explicit /v1/load call.
+    //
+    // Callers MUST extract only load-level options via extract_auto_load_options() before
+    // passing them here — never pass the raw inference request body.  This prevents
+    // request-scoped fields (temperature, max_tokens, messages, steps, etc.) from leaking
+    // into recipe options that would affect subsequent requests.  Currently only ctx_size
+    // is allowlisted; pinned, eviction settings, *_args, and image params are excluded.
+    // (They can be forwarded via /v1/load when needed.)
+    void auto_load_model_if_needed(const std::string& model_name,
+                                   const json& request_options = json::object());
 
     // Helper: persist the registry's installed-providers list into config.json
     // by overlaying onto the current runtime-config snapshot. Called after
@@ -330,6 +341,13 @@ private:
 
     // Set to true after check_for_model_updates() completes at startup.
     std::atomic<bool> update_check_done_{false};
+
+    // Extract only load-level options from an inference request body.  Returns a new json
+    // containing a small, explicit allowlist of fields that are safe to forward to the
+    // RecipeOptions constructor during auto-load.  All other request-scoped fields
+    // (temperature, max_tokens, messages, steps, cfg_scale, etc.) are deliberately excluded
+    // so they cannot accidentally influence persistent model-load settings.
+    static json extract_auto_load_options(const json& request);
 };
 
 } // namespace lemon

--- a/src/cpp/server/anthropic_api.cpp
+++ b/src/cpp/server/anthropic_api.cpp
@@ -889,7 +889,7 @@ void OllamaApi::handle_anthropic_messages(const httplib::Request& req, httplib::
         auto openai_req = convert_anthropic_to_openai_chat(request_json, warnings);
 
         try {
-            auto_load_model(model);
+            auto_load_model(model, extract_auto_load_options(request_json));
         } catch (const std::exception&) {
             res.status = 404;
             json error = {

--- a/src/cpp/server/ollama_api.cpp
+++ b/src/cpp/server/ollama_api.cpp
@@ -252,17 +252,21 @@ void OllamaApi::auto_load_model(const std::string& model, const json& request_op
 }
 
 // ============================================================================
-// Extract load-level options from request body for auto-load
-// Only forwards explicit allowlist (currently only ctx_size)
+// Forward load-level options only so request-scoped fields can't leak
 // ============================================================================
 nlohmann::json OllamaApi::extract_auto_load_options(const json& request) {
     nlohmann::json result = json::object();
-    auto extract_if_present = [&request, &result](const std::string& key) {
-        if (request.contains(key)) {
-            result[key] = request[key];
-        }
-    };
-    extract_if_present("ctx_size");
+
+    if (request.contains("options") && request["options"].is_object() &&
+        request["options"].contains("num_ctx")) {
+        result["ctx_size"] = request["options"]["num_ctx"];
+    }
+
+    // Top-level wins over options.num_ctx, matching map_ollama_options precedence.
+    if (request.contains("ctx_size")) {
+        result["ctx_size"] = request["ctx_size"];
+    }
+
     return result;
 }
 

--- a/src/cpp/server/ollama_api.cpp
+++ b/src/cpp/server/ollama_api.cpp
@@ -224,7 +224,7 @@ std::string OllamaApi::normalize_model_name(const std::string& name) {
 // ============================================================================
 // auto-load model if needed (mirrors Server::auto_load_model_if_needed)
 // ============================================================================
-void OllamaApi::auto_load_model(const std::string& model) {
+void OllamaApi::auto_load_model(const std::string& model, const json& request_options) {
     std::string name = normalize_model_name(model);
 
     if (router_->is_model_loaded(name)) {
@@ -247,8 +247,23 @@ void OllamaApi::auto_load_model(const std::string& model) {
         info = model_manager_->get_model_info(name);
     }
 
-    router_->load_model(name, info, RecipeOptions(info.recipe, json::object()), true);
+    router_->load_model(name, info, RecipeOptions(info.recipe, request_options), true);
     LOG(INFO, "OllamaApi") << "Model loaded: " << name << std::endl;
+}
+
+// ============================================================================
+// Extract load-level options from request body for auto-load
+// Only forwards explicit allowlist (currently only ctx_size)
+// ============================================================================
+nlohmann::json OllamaApi::extract_auto_load_options(const json& request) {
+    nlohmann::json result = json::object();
+    auto extract_if_present = [&request, &result](const std::string& key) {
+        if (request.contains(key)) {
+            result[key] = request[key];
+        }
+    };
+    extract_if_present("ctx_size");
+    return result;
 }
 
 // build Ollama model entry from ModelInfo
@@ -704,7 +719,7 @@ void OllamaApi::handle_chat(const httplib::Request& req, httplib::Response& res)
 
         // Auto-load the model
         try {
-            auto_load_model(model);
+            auto_load_model(model, extract_auto_load_options(request_json));
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found, try pulling it first"}};
@@ -836,7 +851,7 @@ void OllamaApi::handle_generate(const httplib::Request& req, httplib::Response& 
         }
 
         try {
-            auto_load_model(model);
+            auto_load_model(model, extract_auto_load_options(request_json));
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found, try pulling it first"}};
@@ -1273,7 +1288,7 @@ void OllamaApi::handle_embed(const httplib::Request& req, httplib::Response& res
         }
 
         try {
-            auto_load_model(model);
+            auto_load_model(model, extract_auto_load_options(request_json));
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found"}};
@@ -1340,7 +1355,7 @@ void OllamaApi::handle_embeddings(const httplib::Request& req, httplib::Response
         }
 
         try {
-            auto_load_model(model);
+            auto_load_model(model, extract_auto_load_options(request_json));
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found"}};

--- a/src/cpp/server/ollama_api.cpp
+++ b/src/cpp/server/ollama_api.cpp
@@ -228,6 +228,13 @@ void OllamaApi::auto_load_model(const std::string& model, const json& request_op
     std::string name = normalize_model_name(model);
 
     if (router_->is_model_loaded(name)) {
+        if (request_options.contains("ctx_size")) {
+            auto loaded_ctx = router_->get_model_recipe_options(name).get_option("ctx_size");
+            LOG(DEBUG, "OllamaApi")
+                << "Ignoring requested ctx_size=" << request_options["ctx_size"]
+                << " for already-loaded " << name
+                << " (loaded ctx_size=" << loaded_ctx << ")" << std::endl;
+        }
         return;
     }
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1871,6 +1871,14 @@ void Server::auto_load_model_if_needed(const std::string& requested_model,
     // Check if this specific model is already loaded (multi-model aware)
     if (router_->is_model_loaded(requested_model)) {
         LOG(DEBUG, "Server") << "Model already loaded: " << requested_model << std::endl;
+        if (request_options.contains("ctx_size")) {
+            auto loaded_ctx = router_->get_model_recipe_options(requested_model)
+                                  .get_option("ctx_size");
+            LOG(DEBUG, "Server")
+                << "Ignoring requested ctx_size=" << request_options["ctx_size"]
+                << " for already-loaded " << requested_model
+                << " (loaded ctx_size=" << loaded_ctx << ")" << std::endl;
+        }
         return;
     }
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1852,7 +1852,28 @@ nlohmann::json Server::create_model_error(const std::string& requested_model, co
 //   3. If model is downloaded: Use cached version (don't check HuggingFace for updates)
 //
 // Note: Only the /pull endpoint checks HuggingFace for updates (do_not_upgrade=false)
-void Server::auto_load_model_if_needed(const std::string& requested_model) {
+
+// Extract only load-level options from an inference request body.  Returns a new json
+// containing an explicit allowlist of fields that are safe to forward to the
+// RecipeOptions constructor during auto-load.  All other request-scoped fields
+// (temperature, max_tokens, messages, steps, cfg_scale, etc.) are deliberately excluded
+// so they cannot accidentally influence persistent model-load settings.
+//
+// Currently only ctx_size is allowlisted.  Other fields (pinned, eviction settings,
+// *_args) can be added here later with corresponding regression tests.
+nlohmann::json Server::extract_auto_load_options(const json& request) {
+    nlohmann::json result = json::object();
+    auto extract_if_present = [&request, &result](const std::string& key) {
+        if (request.contains(key)) {
+            result[key] = request[key];
+        }
+    };
+    extract_if_present("ctx_size");
+    return result;
+}
+
+void Server::auto_load_model_if_needed(const std::string& requested_model,
+                                        const json& request_options) {
     // Check if this specific model is already loaded (multi-model aware)
     if (router_->is_model_loaded(requested_model)) {
         LOG(DEBUG, "Server") << "Model already loaded: " << requested_model << std::endl;
@@ -1893,10 +1914,10 @@ void Server::auto_load_model_if_needed(const std::string& requested_model) {
         info = model_manager_->get_model_info(requested_model);
     }
 
-    // Load model with do_not_upgrade=true
+    // Load model with do_not_upgrade=true, applying per-request options on first load.
     // For FLM models: FastFlowLMServer will handle download internally if needed
     // For non-FLM models: Model should already be cached at this point
-    router_->load_model(requested_model, info, RecipeOptions(info.recipe, json::object()), true);
+    router_->load_model(requested_model, info, RecipeOptions(info.recipe, request_options), true);
     LOG(INFO, "Server") << "Model loaded successfully: " << requested_model << std::endl;
 }
 
@@ -2381,7 +2402,7 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
         // Handle model loading/switching
         if (request_json.contains("model")) {
             try {
-                auto_load_model_if_needed(requested_model);
+                auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
                 if (span) {
                     span->cancel();
                 }
@@ -2618,7 +2639,7 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
         // Handle model loading/switching (same logic as chat_completions)
         if (request_json.contains("model")) {
             try {
-                auto_load_model_if_needed(requested_model);
+                auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
                 if (span) {
                     span->cancel();
                 }
@@ -2824,7 +2845,7 @@ void Server::handle_embeddings(const httplib::Request& req, httplib::Response& r
         // Handle model loading/switching using helper function
         if (request_json.contains("model")) {
             try {
-                auto_load_model_if_needed(requested_model);
+                auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
                 if (span) {
                     span->cancel();
                 }
@@ -2879,7 +2900,7 @@ void Server::handle_reranking(const httplib::Request& req, httplib::Response& re
         // Handle model loading/switching using helper function
         if (request_json.contains("model")) {
             try {
-                auto_load_model_if_needed(requested_model);
+                auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
                 if (span) {
                     span->cancel();
                 }
@@ -3122,7 +3143,7 @@ void Server::handle_audio_transcriptions(const httplib::Request& req, httplib::R
         if (request_json.contains("model")) {
             std::string requested_model = request_json["model"];
             try {
-                auto_load_model_if_needed(requested_model);
+                auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
             } catch (const std::exception& e) {
                 LOG(ERROR, "Server") << "Failed to load audio model: " << e.what() << std::endl;
                 auto error_response = create_model_error(requested_model, e.what());
@@ -3171,7 +3192,7 @@ void Server::handle_audio_speech(const httplib::Request& req, httplib::Response&
         if (request_json.contains("model")) {
             std::string requested_model = request_json["model"];
             try {
-                auto_load_model_if_needed(requested_model);
+                auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
             } catch (const std::exception& e) {
                 LOG(ERROR, "Server") << "Failed to load text-to-speech model: " << e.what() << std::endl;
                 auto error_response = create_model_error(requested_model, e.what());
@@ -3382,7 +3403,7 @@ void Server::handle_audio_generations(const httplib::Request& req, httplib::Resp
 
         std::string requested_model = request_json["model"];
         try {
-            auto_load_model_if_needed(requested_model);
+            auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
         } catch (const std::exception& e) {
             LOG(ERROR, "Server") << "Failed to load audio-generation model: " << e.what() << std::endl;
             auto error_response = create_model_error(requested_model, e.what());
@@ -3505,7 +3526,7 @@ void Server::handle_3d_generations(const httplib::Request& req, httplib::Respons
 
         std::string requested_model = request_json["model"];
         try {
-            auto_load_model_if_needed(requested_model);
+            auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
         } catch (const std::exception& e) {
             LOG(ERROR, "Server") << "Failed to load 3D-generation model: " << e.what() << std::endl;
             auto error_response = create_model_error(requested_model, e.what());
@@ -3557,7 +3578,7 @@ void Server::handle_image_generations(const httplib::Request& req, httplib::Resp
         std::string requested_model = request_json["model"];
 
         try {
-            auto_load_model_if_needed(requested_model);
+            auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
         } catch (const std::exception& e) {
             LOG(ERROR, "Server") << "Failed to load image model: " << e.what() << std::endl;
             auto error_response = create_model_error(requested_model, e.what());
@@ -3659,7 +3680,7 @@ bool Server::load_image_model(const nlohmann::json& request_json, httplib::Respo
     }
     std::string requested_model = request_json["model"];
     try {
-        auto_load_model_if_needed(requested_model);
+        auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
     } catch (const std::exception& e) {
         LOG(ERROR, "Server") << "Failed to load image model: " << e.what() << std::endl;
         auto error_response = create_model_error(requested_model, e.what());
@@ -4059,7 +4080,7 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
         if (request_json.contains("model")) {
             std::string requested_model = request_json["model"];
             try {
-                auto_load_model_if_needed(requested_model);
+                auto_load_model_if_needed(requested_model, extract_auto_load_options(request_json));
             } catch (const std::exception& e) {
                 LOG(ERROR, "Server") << "Failed to load model: " << e.what() << std::endl;
                 auto error_response = create_model_error(requested_model, e.what());

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1866,8 +1866,8 @@ nlohmann::json Server::extract_auto_load_options(const json& request) {
     return result;
 }
 
-void Server::auto_load_model_if_needed(const std::string& requested_model,
-                                        const json& request_options) {
+void Server::auto_load_model_if_needed(
+    const std::string& requested_model, const json& request_options) {
     // Check if this specific model is already loaded (multi-model aware)
     if (router_->is_model_loaded(requested_model)) {
         LOG(DEBUG, "Server") << "Model already loaded: " << requested_model << std::endl;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1853,14 +1853,8 @@ nlohmann::json Server::create_model_error(const std::string& requested_model, co
 //
 // Note: Only the /pull endpoint checks HuggingFace for updates (do_not_upgrade=false)
 
-// Extract only load-level options from an inference request body.  Returns a new json
-// containing an explicit allowlist of fields that are safe to forward to the
-// RecipeOptions constructor during auto-load.  All other request-scoped fields
-// (temperature, max_tokens, messages, steps, cfg_scale, etc.) are deliberately excluded
-// so they cannot accidentally influence persistent model-load settings.
-//
-// Currently only ctx_size is allowlisted.  Other fields (pinned, eviction settings,
-// *_args) can be added here later with corresponding regression tests.
+// Load-level options that may be forwarded to RecipeOptions during auto-load.
+// Keep this an explicit allowlist so request-scoped fields don't leak into recipe options.
 nlohmann::json Server::extract_auto_load_options(const json& request) {
     nlohmann::json result = json::object();
     auto extract_if_present = [&request, &result](const std::string& key) {

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -759,8 +759,8 @@ class EndpointTests(ServerTestBase):
           2. Call /v1/chat/completions with a large mix of request-scoped params
              AND a custom ctx_size.
           3. Auto-load should only apply ctx_size.
-          4. Verify recipe_options on the loaded model contains ctx_size but NOT
-             temperature, max_tokens, stream, or messages."""
+          4. Verify recipe_options on the loaded model contains ctx_size but
+             none of the request-scoped or recipe-level fields sent alongside."""
         # Ensure clean slate
         requests.post(
             f"{self.base_url}/unload",
@@ -768,104 +768,105 @@ class EndpointTests(ServerTestBase):
             timeout=TIMEOUT_DEFAULT,
         )
 
-        # Send an inference request with both load-level and request-scoped params.
-        # Only ctx_size should be forwarded to the RecipeOptions constructor.
-        custom_ctx_size = 8192
-        inference_response = requests.post(
-            f"{self.base_url}/chat/completions",
-            json={
-                "model": ENDPOINT_TEST_MODEL,
-                "messages": [{"role": "user", "content": "Hello, world!"}],
-                "max_tokens": 12345,
-                "temperature": 0.99,
-                "top_p": 0.88,
-                "top_k": 77,
-                "stream": True,
-                "presence_penalty": -0.5,
-                "frequency_penalty": 1.2,
-                "seed": 42,
-                "response_format": {"type": "json_object"},
-                "tools": [{"type": "function", "function": {"name": "test"}}],
-                "tool_choice": "required",
-                "pinned": True,
-                "llamacpp_args": "--foo-bar",
-                "auto_evict": True,
-                "evict_idle_timeout": 1,
-                "ctx_size": custom_ctx_size,
-                "max_completion_tokens": 999,
-            },
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        self.assertEqual(
-            inference_response.status_code,
-            200,
-            f"Chat completions should succeed: {inference_response.text[:500]}",
-        )
-
-        # Verify the loaded model's recipe_options
-        health_response = requests.get(
-            f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
-        )
-        health_data = health_response.json()
-
-        loaded_model = None
-        for m in health_data.get("all_models_loaded", []):
-            if m["model_name"] == ENDPOINT_TEST_MODEL:
-                loaded_model = m
-                break
-
-        self.assertIsNotNone(
-            loaded_model,
-            f"Model {ENDPOINT_TEST_MODEL} should be loaded after auto-load",
-        )
-
-        recipe_options = loaded_model.get("recipe_options", {})
-
-        # ---- Allowlisted: ctx_size MUST be present ----
-        self.assertIn(
-            "ctx_size",
-            recipe_options,
-            "ctx_size from inference request should be forwarded to recipe_options",
-        )
-        self.assertEqual(
-            recipe_options["ctx_size"],
-            custom_ctx_size,
-            f"ctx_size should match request value {custom_ctx_size}",
-        )
-
-        # ---- Denied: request-scoped params must NOT be in recipe_options ----
-        forbidden = [
-            "temperature",
-            "max_tokens",
-            "stream",
-            "messages",
-            "top_p",
-            "top_k",
-            "presence_penalty",
-            "frequency_penalty",
-            "seed",
-            "response_format",
-            "tools",
-            "tool_choice",
-            "max_completion_tokens",
-            "model",
-            "pinned",
-            "llamacpp_args",
-            "auto_evict",
-            "evict_idle_timeout",
-        ]
-        for field in forbidden:
-            self.assertNotIn(
-                field,
-                recipe_options,
-                f"Request-scoped field '{field}' must NOT leak into recipe_options "
-                f"on auto-load (found: {recipe_options.get(field)})",
+        try:
+            # Send an inference request with both load-level and request-scoped params.
+            # Only ctx_size should be forwarded to the RecipeOptions constructor.
+            custom_ctx_size = 8192
+            inference_response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": ENDPOINT_TEST_MODEL,
+                    "messages": [{"role": "user", "content": "Hello, world!"}],
+                    "max_tokens": 5,
+                    "temperature": 0.99,
+                    "top_p": 0.88,
+                    "top_k": 77,
+                    "stream": False,
+                    "presence_penalty": -0.5,
+                    "frequency_penalty": 1.2,
+                    "seed": 42,
+                    "pinned": True,
+                    "llamacpp_args": "--foo-bar",
+                    "auto_evict": True,
+                    "evict_idle_timeout": 1,
+                    "ctx_size": custom_ctx_size,
+                    "max_completion_tokens": 10,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(
+                inference_response.status_code,
+                200,
+                f"Chat completions should succeed: {inference_response.text[:500]}",
             )
 
-        print(
-            f"[OK] Auto-load forwarded only ctx_size={custom_ctx_size}; "
-            f"request-scoped params correctly excluded"
-        )
+            # Verify the loaded model's recipe_options
+            health_response = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            )
+            health_data = health_response.json()
+
+            loaded_model = None
+            for m in health_data.get("all_models_loaded", []):
+                if m["model_name"] == ENDPOINT_TEST_MODEL:
+                    loaded_model = m
+                    break
+
+            self.assertIsNotNone(
+                loaded_model,
+                f"Model {ENDPOINT_TEST_MODEL} should be loaded after auto-load",
+            )
+
+            recipe_options = loaded_model.get("recipe_options", {})
+
+            # ---- Allowlisted: ctx_size MUST be present ----
+            self.assertIn(
+                "ctx_size",
+                recipe_options,
+                "ctx_size from inference request should be forwarded to recipe_options",
+            )
+            self.assertEqual(
+                recipe_options["ctx_size"],
+                custom_ctx_size,
+                f"ctx_size should match request value {custom_ctx_size}",
+            )
+
+            # ---- Denied: request-scoped params must NOT be in recipe_options ----
+            forbidden = [
+                "temperature",
+                "max_tokens",
+                "stream",
+                "messages",
+                "top_p",
+                "top_k",
+                "presence_penalty",
+                "frequency_penalty",
+                "seed",
+                "max_completion_tokens",
+                "model",
+                "pinned",
+                "llamacpp_args",
+                "auto_evict",
+                "evict_idle_timeout",
+            ]
+            for field in forbidden:
+                self.assertNotIn(
+                    field,
+                    recipe_options,
+                    f"Request-scoped field '{field}' must NOT leak into recipe_options "
+                    f"on auto-load (found: {recipe_options.get(field)})",
+                )
+
+            print(
+                f"[OK] Auto-load forwarded only ctx_size={custom_ctx_size}; "
+                f"request-scoped params correctly excluded"
+            )
+        finally:
+            requests.post(
+                f"{self.base_url}/unload",
+                json={"model_name": ENDPOINT_TEST_MODEL},
+                timeout=TIMEOUT_DEFAULT,
+            )
 
     def _start_mock_cloud_provider(
         self, upstream_ids, chat_handler=None, sse_chunks=None

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -744,6 +744,121 @@ class EndpointTests(ServerTestBase):
             f"{loaded_after['pid']}"
         )
 
+    def test_013_auto_load_forwards_only_allowlisted_options(self):
+        """Regression for #2663 / PR #2664 review: request-scoped params must NOT leak
+        into recipe_options on auto-load.
+
+        When the server auto-loads a model via an inference endpoint (e.g.
+        /v1/chat/completions) it must only forward an explicit allowlist
+        of load-level fields (currently only ctx_size).  Request-scoped
+        fields like temperature, max_tokens, stream, messages, model, etc. must
+        remain invisible to RecipeOptions so they cannot affect subsequent requests.
+
+        Steps:
+          1. Unload the test model.
+          2. Call /v1/chat/completions with a large mix of request-scoped params
+             AND a custom ctx_size.
+          3. Auto-load should only apply ctx_size.
+          4. Verify recipe_options on the loaded model contains ctx_size but NOT
+             temperature, max_tokens, stream, or messages."""
+        # Ensure clean slate
+        requests.post(
+            f"{self.base_url}/unload",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        # Send an inference request with both load-level and request-scoped params.
+        # Only ctx_size should be forwarded to the RecipeOptions constructor.
+        custom_ctx_size = 8192
+        inference_response = requests.post(
+            f"{self.base_url}/chat/completions",
+            json={
+                "model": ENDPOINT_TEST_MODEL,
+                "messages": [{"role": "user", "content": "Hello, world!"}],
+                "max_tokens": 12345,
+                "temperature": 0.99,
+                "top_p": 0.88,
+                "top_k": 77,
+                "stream": True,
+                "presence_penalty": -0.5,
+                "frequency_penalty": 1.2,
+                "seed": 42,
+                "response_format": {"type": "json_object"},
+                "tools": [{"type": "function", "function": {"name": "test"}}],
+                "tool_choice": "required",
+                "ctx_size": custom_ctx_size,
+                "max_completion_tokens": 999,
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(
+            inference_response.status_code,
+            200,
+            f"Chat completions should succeed: {inference_response.text[:500]}",
+        )
+
+        # Verify the loaded model's recipe_options
+        health_response = requests.get(
+            f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+        )
+        health_data = health_response.json()
+
+        loaded_model = None
+        for m in health_data.get("all_models_loaded", []):
+            if m["model_name"] == ENDPOINT_TEST_MODEL:
+                loaded_model = m
+                break
+
+        self.assertIsNotNone(
+            loaded_model,
+            f"Model {ENDPOINT_TEST_MODEL} should be loaded after auto-load",
+        )
+
+        recipe_options = loaded_model.get("recipe_options", {})
+
+        # ---- Allowlisted: ctx_size MUST be present ----
+        self.assertIn(
+            "ctx_size",
+            recipe_options,
+            "ctx_size from inference request should be forwarded to recipe_options",
+        )
+        self.assertEqual(
+            recipe_options["ctx_size"],
+            custom_ctx_size,
+            f"ctx_size should match request value {custom_ctx_size}",
+        )
+
+        # ---- Denied: request-scoped params must NOT be in recipe_options ----
+        forbidden = [
+            "temperature",
+            "max_tokens",
+            "stream",
+            "messages",
+            "top_p",
+            "top_k",
+            "presence_penalty",
+            "frequency_penalty",
+            "seed",
+            "response_format",
+            "tools",
+            "tool_choice",
+            "max_completion_tokens",
+            "model",
+        ]
+        for field in forbidden:
+            self.assertNotIn(
+                field,
+                recipe_options,
+                f"Request-scoped field '{field}' must NOT leak into recipe_options "
+                f"on auto-load (found: {recipe_options.get(field)})",
+            )
+
+        print(
+            f"[OK] Auto-load forwarded only ctx_size={custom_ctx_size}; "
+            f"request-scoped params correctly excluded"
+        )
+
     def _start_mock_cloud_provider(
         self, upstream_ids, chat_handler=None, sse_chunks=None
     ):
@@ -2921,7 +3036,9 @@ class EndpointTests(ServerTestBase):
             self.assertEqual(default_route.get("default_used"), True)
             self.assertEqual(default_route.get("outputs"), {})
             self.assertNotIn("trace", default_route)
-            self.assertEqual(default_response.headers.get("x-lemonade-route"), "default")
+            self.assertEqual(
+                default_response.headers.get("x-lemonade-route"), "default"
+            )
             print(f"[OK] collection.router dispatched {public_name} -> completion")
         finally:
             try:
@@ -2960,7 +3077,9 @@ class EndpointTests(ServerTestBase):
             ],
         }
         try:
-            pull_response = self._pull_router_collection(canonical_name, routing=routing)
+            pull_response = self._pull_router_collection(
+                canonical_name, routing=routing
+            )
             self.assertEqual(pull_response.status_code, 200, pull_response.text)
             self.assertEqual(pull_response.json()["status"], "success")
 
@@ -3058,7 +3177,9 @@ class EndpointTests(ServerTestBase):
 
     def _assert_stream_route_decision(self, resp, endpoint_name):
         if resp.status_code != 200:
-            self.fail(f"streaming {endpoint_name} returned {resp.status_code}: {resp.text}")
+            self.fail(
+                f"streaming {endpoint_name} returned {resp.status_code}: {resp.text}"
+            )
         self.assertEqual(resp.headers.get("x-lemonade-route"), "code-to-test-model")
         data_events = self._collect_sse_data_events(resp)
         self.assertTrue(

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -787,6 +787,10 @@ class EndpointTests(ServerTestBase):
                 "response_format": {"type": "json_object"},
                 "tools": [{"type": "function", "function": {"name": "test"}}],
                 "tool_choice": "required",
+                "pinned": True,
+                "llamacpp_args": "--foo-bar",
+                "auto_evict": True,
+                "evict_idle_timeout": 1,
                 "ctx_size": custom_ctx_size,
                 "max_completion_tokens": 999,
             },
@@ -845,6 +849,10 @@ class EndpointTests(ServerTestBase):
             "tool_choice",
             "max_completion_tokens",
             "model",
+            "pinned",
+            "llamacpp_args",
+            "auto_evict",
+            "evict_idle_timeout",
         ]
         for field in forbidden:
             self.assertNotIn(

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -544,63 +544,66 @@ class OllamaTests(ServerTestBase):
         response = unload_all_models()
         self.assertIn(response.status_code, (200, 404), response.text)
 
-        custom_ctx_size = 8192
-        response = requests.post(
-            f"{OLLAMA_BASE_URL}/api/chat",
-            json={
-                "model": ENDPOINT_TEST_MODEL,
-                "messages": [{"role": "user", "content": "Hi"}],
-                "stream": False,
-                "options": {
-                    "num_ctx": custom_ctx_size,
-                    "num_predict": 10,
-                    "temperature": 0.7,
-                    "top_p": 0.9,
-                    "pinned": True,
-                    "llamacpp_args": "--foo-bar",
-                    "auto_evict": True,
-                    "evict_idle_timeout": 1,
+        try:
+            custom_ctx_size = 8192
+            response = requests.post(
+                f"{OLLAMA_BASE_URL}/api/chat",
+                json={
+                    "model": ENDPOINT_TEST_MODEL,
+                    "messages": [{"role": "user", "content": "Hi"}],
+                    "stream": False,
+                    "options": {
+                        "num_ctx": custom_ctx_size,
+                        "num_predict": 10,
+                        "temperature": 0.7,
+                        "top_p": 0.9,
+                        "pinned": True,
+                        "llamacpp_args": "--foo-bar",
+                        "auto_evict": True,
+                        "evict_idle_timeout": 1,
+                    },
                 },
-            },
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        self.assertEqual(response.status_code, 200, response.text)
-
-        # Verify ctx_size was applied and request-scoped options did not leak
-        # by inspecting the runtime recipe_options from /health.
-        health_response = requests.get(
-            f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
-        )
-        self.assertEqual(health_response.status_code, 200)
-        loaded_model = None
-        for m in health_response.json().get("all_models_loaded", []):
-            if m["model_name"] == ENDPOINT_TEST_MODEL:
-                loaded_model = m
-                break
-        self.assertIsNotNone(
-            loaded_model,
-            f"{ENDPOINT_TEST_MODEL} should be loaded after auto-load",
-        )
-        recipe_options = loaded_model.get("recipe_options", {})
-        self.assertEqual(
-            recipe_options.get("ctx_size"),
-            custom_ctx_size,
-            "ctx_size should be present in recipe_options",
-        )
-        for field in (
-            "temperature",
-            "top_p",
-            "num_predict",
-            "pinned",
-            "llamacpp_args",
-            "auto_evict",
-            "evict_idle_timeout",
-        ):
-            self.assertNotIn(
-                field,
-                recipe_options,
-                f"Request-scoped field '{field}' must not leak into recipe_options",
+                timeout=TIMEOUT_MODEL_OPERATION,
             )
+            self.assertEqual(response.status_code, 200, response.text)
+
+            # Verify ctx_size was applied and request-scoped options did not leak
+            # by inspecting the runtime recipe_options from /health.
+            health_response = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            )
+            self.assertEqual(health_response.status_code, 200)
+            loaded_model = None
+            for m in health_response.json().get("all_models_loaded", []):
+                if m["model_name"] == ENDPOINT_TEST_MODEL:
+                    loaded_model = m
+                    break
+            self.assertIsNotNone(
+                loaded_model,
+                f"{ENDPOINT_TEST_MODEL} should be loaded after auto-load",
+            )
+            recipe_options = loaded_model.get("recipe_options", {})
+            self.assertEqual(
+                recipe_options.get("ctx_size"),
+                custom_ctx_size,
+                "ctx_size should be present in recipe_options",
+            )
+            for field in (
+                "temperature",
+                "top_p",
+                "num_predict",
+                "pinned",
+                "llamacpp_args",
+                "auto_evict",
+                "evict_idle_timeout",
+            ):
+                self.assertNotIn(
+                    field,
+                    recipe_options,
+                    f"Request-scoped field '{field}' must not leak into recipe_options",
+                )
+        finally:
+            unload_all_models()
 
     # ========================================================================
     # 501 stubs

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -556,6 +556,10 @@ class OllamaTests(ServerTestBase):
                     "num_predict": 10,
                     "temperature": 0.7,
                     "top_p": 0.9,
+                    "pinned": True,
+                    "llamacpp_args": "--foo-bar",
+                    "auto_evict": True,
+                    "evict_idle_timeout": 1,
                 },
             },
             timeout=TIMEOUT_MODEL_OPERATION,
@@ -583,7 +587,15 @@ class OllamaTests(ServerTestBase):
             custom_ctx_size,
             "ctx_size should be present in recipe_options",
         )
-        for field in ("temperature", "top_p", "num_predict"):
+        for field in (
+            "temperature",
+            "top_p",
+            "num_predict",
+            "pinned",
+            "llamacpp_args",
+            "auto_evict",
+            "evict_idle_timeout",
+        ):
             self.assertNotIn(
                 field,
                 recipe_options,

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -551,8 +551,8 @@ class OllamaTests(ServerTestBase):
                 "model": ENDPOINT_TEST_MODEL,
                 "messages": [{"role": "user", "content": "Hi"}],
                 "stream": False,
-                "ctx_size": custom_ctx_size,
                 "options": {
+                    "num_ctx": custom_ctx_size,
                     "num_predict": 10,
                     "temperature": 0.7,
                     "top_p": 0.9,

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -534,6 +534,62 @@ class OllamaTests(ServerTestBase):
         last_chunk = chunks[-1]
         self.assertTrue(last_chunk.get("done", False))
 
+    def test_015a_auto_load_forwards_only_ctx_size(self):
+        """Regression: Ollama auto-load must forward only ctx_size to recipe_options.
+
+        Request-scoped fields (temperature, top_p, num_predict, etc.) must not leak
+        into persistent model-load settings."""
+        self.ensure_model_pulled()
+
+        response = unload_all_models()
+        self.assertIn(response.status_code, (200, 404), response.text)
+
+        custom_ctx_size = 8192
+        response = requests.post(
+            f"{OLLAMA_BASE_URL}/api/chat",
+            json={
+                "model": ENDPOINT_TEST_MODEL,
+                "messages": [{"role": "user", "content": "Hi"}],
+                "stream": False,
+                "ctx_size": custom_ctx_size,
+                "options": {
+                    "num_predict": 10,
+                    "temperature": 0.7,
+                    "top_p": 0.9,
+                },
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+        # Verify ctx_size was applied and request-scoped options did not leak
+        # by inspecting the runtime recipe_options from /health.
+        health_response = requests.get(
+            f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(health_response.status_code, 200)
+        loaded_model = None
+        for m in health_response.json().get("all_models_loaded", []):
+            if m["model_name"] == ENDPOINT_TEST_MODEL:
+                loaded_model = m
+                break
+        self.assertIsNotNone(
+            loaded_model,
+            f"{ENDPOINT_TEST_MODEL} should be loaded after auto-load",
+        )
+        recipe_options = loaded_model.get("recipe_options", {})
+        self.assertEqual(
+            recipe_options.get("ctx_size"),
+            custom_ctx_size,
+            "ctx_size should be present in recipe_options",
+        )
+        for field in ("temperature", "top_p", "num_predict"):
+            self.assertNotIn(
+                field,
+                recipe_options,
+                f"Request-scoped field '{field}' must not leak into recipe_options",
+            )
+
     # ========================================================================
     # 501 stubs
     # ========================================================================


### PR DESCRIPTION
## Problem

When the server auto-loads a model via an inference endpoint, it ignores the `ctx_size` in the request body. The model loads with `recipe_options.json` defaults (usually 4096), regardless of what the client requests.

This affects the OpenAI-compatible REST endpoints (`/v1/chat/completions`, `/v1/completions`, etc.) and the Ollama-compatible layer (`/api/chat`, `/api/generate`, `/api/embed`, `/api/embeddings`, plus the Anthropic-compatible `/v1/messages` handler inside `OllamaApi`). Ollama clients set context size via the standard `options.num_ctx` field, which the auto-load path did not read.

## Root Cause

Both `Server::auto_load_model_if_needed()` and `OllamaApi::auto_load_model()` hardcoded an empty JSON object when constructing `RecipeOptions`:

```cpp
// Before
router_->load_model(requested_model, info, RecipeOptions(info.recipe, json::object()), true);
```

All recipe defaults are used; no per-request overrides are forwarded. The `/v1/load` endpoint, by contrast, passes the request body to `RecipeOptions`.

## Fix

1. Add an optional `request_options` parameter to both auto-load helpers (default `json::object()` for backward compatibility).

2. Introduce `extract_auto_load_options()` in both `Server` and `OllamaApi`. It allowlists `ctx_size` only; request-scoped fields (`temperature`, `max_tokens`, `messages`, `top_p`, `steps`, etc.) are excluded so they cannot leak into persistent model-load settings. The Ollama copy also maps `options.num_ctx` to `ctx_size`, with top-level `ctx_size` winning (matching `map_ollama_options` precedence).

3. Update all REST inference endpoints (11 call sites) and all Ollama inference endpoints (4 call sites) to pass the extracted options. The Anthropic `/v1/messages` handler, which routes through `OllamaApi`, is updated too.

4. The already-loaded early-return is unchanged, so options from subsequent auto-load requests are ignored. This preserves the invariant that explicit `/v1/load` options cannot be overturned by auto-load. A DEBUG log now reports the ignored requested `ctx_size` alongside the loaded model's current value when a request carries `ctx_size` against an already-loaded model.

## Files Changed

- `src/cpp/include/lemon/server.h` — `auto_load_model_if_needed()` signature, `extract_auto_load_options()` declaration
- `src/cpp/server/server.cpp` — REST inference endpoints; DEBUG log on already-loaded ctx_size mismatch
- `src/cpp/include/lemon/ollama_api.h` — `auto_load_model()` signature, `extract_auto_load_options()` declaration
- `src/cpp/server/ollama_api.cpp` — Ollama inference endpoints; `options.num_ctx` → `ctx_size` mapping; DEBUG log
- `src/cpp/server/anthropic_api.cpp` — Anthropic messages handler
- `test/server_endpoints.py` — REST regression test
- `test/test_ollama.py` — Ollama regression test

## Testing

Built locally with `cmake --build --preset default`; zero errors or warnings. Both regression tests run end-to-end against a live `lemond` (CPU llama-server) on Linux (Fedora 42) and pass:

- **REST** (`test_013_auto_load_forwards_only_allowlisted_options`): non-streaming chat completion with `ctx_size=8192` plus request-scoped params (`temperature`, `max_tokens`, `top_p`, `seed`, …) and valid llamacpp recipe-level fields (`pinned`, `llamacpp_args`, `auto_evict`, `evict_idle_timeout`). Verifies `recipe_options` contains `ctx_size=8192` and none of the others. The recipe-level assertions are the real boundary the allowlist closes, since `RecipeOptions` already discards non-recipe keys. `try`/`finally` unloads the model.

- **Ollama** (`test_015a_auto_load_forwards_only_ctx_size`): `/api/chat` with the standard `options.num_ctx=8192` plus `options.num_predict`, `temperature`, `top_p`, and the same recipe-level fields. Verifies `recipe_options` contains `ctx_size=8192` and that `temperature`, `top_p`, `num_predict`, and the recipe-level fields do not leak.

Untested locally: Windows, macOS, and GPU backends (Vulkan/ROCm/CUDA). The change is platform-agnostic C++ with no platform guards, so cross-platform risk is minimal.

Lambda callbacks (MCP gateway, `CollectionOrchestrator`) retain the default parameter and are unaffected by design.

## Related

Fixes: #2663.