### PR TITLE
fix: bump openmoss to v0.1.3 (fixes progressive audio degradation past 10 s)

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -127,9 +127,9 @@
     "cuda": "v0.1.5"
   },
   "openmoss": {
-    "vulkan": "v0.1.2",
-    "rocm-stable": "v0.1.2",
-    "cuda": "v0.1.2"
+    "vulkan": "v0.1.3",
+    "rocm-stable": "v0.1.3",
+    "cuda": "v0.1.3"
   },
   "clear_bin_if_lemonade_below": "9.4.0"
 }


### PR DESCRIPTION
OpenMOSS' codec uses a sliding window attention of 10s instead of full attention. Since the port used full attention, quality degraded after 10s.