### PR TITLE
Bundle the Lemonade Nexus sidecar

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,7 +8,7 @@
       "name": "lemonade-base",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_PROJECT_TOP_LEVEL_INCLUDES": "${sourceDir}/cmake/LemonadeNexus.cmake"
+        "CMAKE_PROJECT_lemon_cpp_INCLUDE": "${sourceDir}/cmake/LemonadeNexus.cmake"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,7 +5,15 @@
   },
   "configurePresets": [
     {
+      "name": "lemonade-base",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_PROJECT_TOP_LEVEL_INCLUDES": "${sourceDir}/cmake/LemonadeNexus.cmake"
+      }
+    },
+    {
       "name": "default",
+      "inherits": "lemonade-base",
       "displayName": "Default (Ninja)",
       "description": "Build with Ninja generator",
       "generator": "Ninja",
@@ -16,6 +24,7 @@
     },
     {
       "name": "windows",
+      "inherits": "lemonade-base",
       "displayName": "Windows (Visual Studio 2022)",
       "description": "Build with Visual Studio 2022 generator on Windows",
       "generator": "Visual Studio 17 2022",
@@ -24,6 +33,7 @@
     },
     {
       "name": "vs18",
+      "inherits": "lemonade-base",
       "displayName": "Windows (Visual Studio 2026)",
       "description": "Build with Visual Studio 2026 generator on Windows",
       "generator": "Visual Studio 18 2026",
@@ -32,6 +42,7 @@
     },
     {
       "name": "debug",
+      "inherits": "lemonade-base",
       "displayName": "Debug (Ninja)",
       "description": "Build with Ninja generator in Debug mode",
       "generator": "Ninja",
@@ -42,6 +53,7 @@
     },
     {
       "name": "release",
+      "inherits": "lemonade-base",
       "displayName": "Release (Ninja)",
       "description": "Build with Ninja generator in Release mode",
       "generator": "Ninja",
@@ -50,6 +62,36 @@
         "CMAKE_BUILD_TYPE": "Release"
       },
       "hidden": true
+    },
+    {
+      "name": "nexus",
+      "inherits": "default",
+      "displayName": "Default with Nexus sidecar",
+      "description": "Build Lemonade and the bundled Nexus sidecar with Ninja",
+      "binaryDir": "${sourceDir}/build-nexus",
+      "cacheVariables": {
+        "LEMONADE_BUNDLE_NEXUS": "ON"
+      }
+    },
+    {
+      "name": "nexus-windows",
+      "inherits": "windows",
+      "displayName": "Windows with Nexus sidecar",
+      "description": "Build Lemonade and the bundled Nexus sidecar with Visual Studio 2022",
+      "binaryDir": "${sourceDir}/build-nexus-windows",
+      "cacheVariables": {
+        "LEMONADE_BUNDLE_NEXUS": "ON"
+      }
+    },
+    {
+      "name": "nexus-vs18",
+      "inherits": "vs18",
+      "displayName": "Windows VS 2026 with Nexus sidecar",
+      "description": "Build Lemonade and the bundled Nexus sidecar with Visual Studio 2026",
+      "binaryDir": "${sourceDir}/build-nexus-vs18",
+      "cacheVariables": {
+        "LEMONADE_BUNDLE_NEXUS": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -74,6 +116,20 @@
     {
       "name": "release",
       "configurePreset": "release"
+    },
+    {
+      "name": "nexus",
+      "configurePreset": "nexus"
+    },
+    {
+      "name": "nexus-windows",
+      "configurePreset": "nexus-windows",
+      "configuration": "Release"
+    },
+    {
+      "name": "nexus-vs18",
+      "configurePreset": "nexus-vs18",
+      "configuration": "Release"
     }
   ]
 }

--- a/cmake/LemonadeNexus.cmake
+++ b/cmake/LemonadeNexus.cmake
@@ -14,7 +14,6 @@ endif()
 
 include(ExternalProject)
 include(FetchContent)
-include(GNUInstallDirs)
 
 if(LEMONADE_NEXUS_SOURCE_DIR)
     get_filename_component(_lemonade_nexus_source_dir
@@ -92,16 +91,22 @@ ExternalProject_Add(lemonade_nexus_external
     USES_TERMINAL_BUILD TRUE
 )
 
+if(WIN32)
+    set(_lemonade_nexus_executable_suffix ".exe")
+else()
+    set(_lemonade_nexus_executable_suffix "")
+endif()
+
 if(CMAKE_CONFIGURATION_TYPES)
     set(_lemonade_nexus_sidecar
-        "${_lemonade_nexus_binary_dir}/projects/LemonadeNexusSidecar/$<CONFIG>/lemonade-nexus-sidecar${CMAKE_EXECUTABLE_SUFFIX}")
+        "${_lemonade_nexus_binary_dir}/projects/LemonadeNexusSidecar/$<CONFIG>/lemonade-nexus-sidecar${_lemonade_nexus_executable_suffix}")
 else()
     set(_lemonade_nexus_sidecar
-        "${_lemonade_nexus_binary_dir}/projects/LemonadeNexusSidecar/lemonade-nexus-sidecar${CMAKE_EXECUTABLE_SUFFIX}")
+        "${_lemonade_nexus_binary_dir}/projects/LemonadeNexusSidecar/lemonade-nexus-sidecar${_lemonade_nexus_executable_suffix}")
 endif()
 
 install(PROGRAMS "${_lemonade_nexus_sidecar}"
-    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    DESTINATION bin
     COMPONENT Runtime)
 
 function(_lemonade_nexus_finalize_targets)

--- a/cmake/LemonadeNexus.cmake
+++ b/cmake/LemonadeNexus.cmake
@@ -1,0 +1,118 @@
+option(LEMONADE_BUNDLE_NEXUS "Build and package the Lemonade Nexus sidecar" OFF)
+set(LEMONADE_NEXUS_SOURCE_DIR "" CACHE PATH "Use a local lemonade-nexus checkout instead of fetching it")
+set(LEMONADE_NEXUS_GIT_TAG
+    "f1b44e1585578d43c2f108135705019569ee84dc"
+    CACHE STRING "Pinned lemonade-nexus commit")
+
+if(NOT LEMONADE_BUNDLE_NEXUS)
+    return()
+endif()
+
+if(CMAKE_VERSION VERSION_LESS 3.25.1)
+    message(FATAL_ERROR "LEMONADE_BUNDLE_NEXUS requires CMake 3.25.1 or newer")
+endif()
+
+include(ExternalProject)
+include(FetchContent)
+include(GNUInstallDirs)
+
+if(LEMONADE_NEXUS_SOURCE_DIR)
+    get_filename_component(_lemonade_nexus_source_dir
+        "${LEMONADE_NEXUS_SOURCE_DIR}" ABSOLUTE)
+    if(NOT EXISTS "${_lemonade_nexus_source_dir}/CMakeLists.txt")
+        message(FATAL_ERROR
+            "LEMONADE_NEXUS_SOURCE_DIR does not contain a CMakeLists.txt: "
+            "${_lemonade_nexus_source_dir}")
+    endif()
+else()
+    FetchContent_Declare(lemonade_nexus_source
+        GIT_REPOSITORY https://github.com/lemonade-sdk/lemonade-nexus.git
+        GIT_TAG ${LEMONADE_NEXUS_GIT_TAG}
+        GIT_SHALLOW FALSE
+        GIT_PROGRESS TRUE
+        SOURCE_SUBDIR cmake/fetch-only
+        EXCLUDE_FROM_ALL
+    )
+    FetchContent_MakeAvailable(lemonade_nexus_source)
+    set(_lemonade_nexus_source_dir "${lemonade_nexus_source_SOURCE_DIR}")
+endif()
+
+set(_lemonade_nexus_binary_dir
+    "${CMAKE_BINARY_DIR}/_deps/lemonade-nexus-build")
+set(_lemonade_nexus_cmake_args
+    "-DBUILD_TESTING=OFF"
+    "-DLEMONADE_NEXUS_MINIMAL_DEPS=ON"
+)
+
+if(NOT LEMONADE_NEXUS_SOURCE_DIR)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DNEXUS_GIT_COMMIT_OVERRIDE=${LEMONADE_NEXUS_GIT_TAG}")
+endif()
+if(CMAKE_BUILD_TYPE)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
+endif()
+if(CMAKE_TOOLCHAIN_FILE)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+endif()
+if(VCPKG_TARGET_TRIPLET)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}")
+endif()
+if(OPENSSL_ROOT_DIR)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}"
+        "-DOPENSSL_USE_STATIC_LIBS=ON")
+endif()
+if(CMAKE_OSX_ARCHITECTURES)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
+endif()
+if(APPLE)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DOPENSSL_FORCE_BUNDLED=ON")
+endif()
+
+# Keep Nexus in an isolated CMake build because both projects currently declare
+# overlapping third-party targets and cache variables.
+ExternalProject_Add(lemonade_nexus_external
+    SOURCE_DIR "${_lemonade_nexus_source_dir}"
+    BINARY_DIR "${_lemonade_nexus_binary_dir}"
+    DOWNLOAD_COMMAND ""
+    UPDATE_COMMAND ""
+    INSTALL_COMMAND ""
+    CMAKE_ARGS ${_lemonade_nexus_cmake_args}
+    BUILD_COMMAND
+        ${CMAKE_COMMAND} --build <BINARY_DIR>
+        --config $<CONFIG>
+        --target LemonadeNexusSidecar
+        --parallel
+    USES_TERMINAL_CONFIGURE TRUE
+    USES_TERMINAL_BUILD TRUE
+)
+
+if(CMAKE_CONFIGURATION_TYPES)
+    set(_lemonade_nexus_sidecar
+        "${_lemonade_nexus_binary_dir}/projects/LemonadeNexusSidecar/$<CONFIG>/lemonade-nexus-sidecar${CMAKE_EXECUTABLE_SUFFIX}")
+else()
+    set(_lemonade_nexus_sidecar
+        "${_lemonade_nexus_binary_dir}/projects/LemonadeNexusSidecar/lemonade-nexus-sidecar${CMAKE_EXECUTABLE_SUFFIX}")
+endif()
+
+install(PROGRAMS "${_lemonade_nexus_sidecar}"
+    DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    COMPONENT Runtime)
+
+function(_lemonade_nexus_finalize_targets)
+    foreach(_package_target wix_installer_minimal wix_installer_full package-macos)
+        if(TARGET ${_package_target})
+            add_dependencies(${_package_target} lemonade_nexus_external)
+        endif()
+    endforeach()
+endfunction()
+
+cmake_language(DEFER CALL _lemonade_nexus_finalize_targets)
+
+message(STATUS
+    "Lemonade Nexus sidecar enabled from ${_lemonade_nexus_source_dir}")

--- a/cmake/LemonadeNexus.cmake
+++ b/cmake/LemonadeNexus.cmake
@@ -1,7 +1,7 @@
 option(LEMONADE_BUNDLE_NEXUS "Build and package the Lemonade Nexus sidecar" OFF)
 set(LEMONADE_NEXUS_SOURCE_DIR "" CACHE PATH "Use a local lemonade-nexus checkout instead of fetching it")
 set(LEMONADE_NEXUS_GIT_TAG
-    "f1b44e1585578d43c2f108135705019569ee84dc"
+    "427dc33841f4a2a21fbdc5b6d57325b682a66673"
     CACHE STRING "Pinned lemonade-nexus commit")
 
 if(NOT LEMONADE_BUNDLE_NEXUS)
@@ -18,15 +18,15 @@ include(FetchContent)
 if(LEMONADE_NEXUS_SOURCE_DIR)
     get_filename_component(_lemonade_nexus_source_dir
         "${LEMONADE_NEXUS_SOURCE_DIR}" ABSOLUTE)
-    if(NOT EXISTS "${_lemonade_nexus_source_dir}/CMakeLists.txt")
+    if(NOT EXISTS "${_lemonade_nexus_source_dir}/projects/LemonadeNexusSidecar/CMakeLists.txt")
         message(FATAL_ERROR
-            "LEMONADE_NEXUS_SOURCE_DIR does not contain a CMakeLists.txt: "
+            "LEMONADE_NEXUS_SOURCE_DIR is not a bundling-capable lemonade-nexus checkout: "
             "${_lemonade_nexus_source_dir}")
     endif()
 else()
     FetchContent_Declare(lemonade_nexus_source
         GIT_REPOSITORY https://github.com/lemonade-sdk/lemonade-nexus.git
-        GIT_TAG ${LEMONADE_NEXUS_GIT_TAG}
+        GIT_TAG "${LEMONADE_NEXUS_GIT_TAG}"
         GIT_SHALLOW FALSE
         GIT_PROGRESS TRUE
         SOURCE_SUBDIR cmake/fetch-only
@@ -38,58 +38,6 @@ endif()
 
 set(_lemonade_nexus_binary_dir
     "${CMAKE_BINARY_DIR}/_deps/lemonade-nexus-build")
-set(_lemonade_nexus_cmake_args
-    "-DBUILD_TESTING=OFF"
-    "-DLEMONADE_NEXUS_MINIMAL_DEPS=ON"
-)
-
-if(NOT LEMONADE_NEXUS_SOURCE_DIR)
-    list(APPEND _lemonade_nexus_cmake_args
-        "-DNEXUS_GIT_COMMIT_OVERRIDE=${LEMONADE_NEXUS_GIT_TAG}")
-endif()
-if(CMAKE_BUILD_TYPE)
-    list(APPEND _lemonade_nexus_cmake_args
-        "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}")
-endif()
-if(CMAKE_TOOLCHAIN_FILE)
-    list(APPEND _lemonade_nexus_cmake_args
-        "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
-endif()
-if(VCPKG_TARGET_TRIPLET)
-    list(APPEND _lemonade_nexus_cmake_args
-        "-DVCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}")
-endif()
-if(OPENSSL_ROOT_DIR)
-    list(APPEND _lemonade_nexus_cmake_args
-        "-DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}"
-        "-DOPENSSL_USE_STATIC_LIBS=ON")
-endif()
-if(CMAKE_OSX_ARCHITECTURES)
-    list(APPEND _lemonade_nexus_cmake_args
-        "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
-endif()
-if(APPLE)
-    list(APPEND _lemonade_nexus_cmake_args
-        "-DOPENSSL_FORCE_BUNDLED=ON")
-endif()
-
-# Keep Nexus in an isolated CMake build because both projects currently declare
-# overlapping third-party targets and cache variables.
-ExternalProject_Add(lemonade_nexus_external
-    SOURCE_DIR "${_lemonade_nexus_source_dir}"
-    BINARY_DIR "${_lemonade_nexus_binary_dir}"
-    DOWNLOAD_COMMAND ""
-    UPDATE_COMMAND ""
-    INSTALL_COMMAND ""
-    CMAKE_ARGS ${_lemonade_nexus_cmake_args}
-    BUILD_COMMAND
-        ${CMAKE_COMMAND} --build <BINARY_DIR>
-        --config $<CONFIG>
-        --target LemonadeNexusSidecar
-        --parallel
-    USES_TERMINAL_CONFIGURE TRUE
-    USES_TERMINAL_BUILD TRUE
-)
 
 if(WIN32)
     set(_lemonade_nexus_executable_suffix ".exe")
@@ -105,12 +53,82 @@ else()
         "${_lemonade_nexus_binary_dir}/projects/LemonadeNexusSidecar/lemonade-nexus-sidecar${_lemonade_nexus_executable_suffix}")
 endif()
 
+set(_lemonade_nexus_cmake_args
+    "-DBUILD_TESTING:BOOL=OFF"
+    "-DLEMONADE_NEXUS_MINIMAL_DEPS:BOOL=ON"
+)
+
+if(NOT LEMONADE_NEXUS_SOURCE_DIR)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DNEXUS_GIT_COMMIT_OVERRIDE:STRING=${LEMONADE_NEXUS_GIT_TAG}")
+endif()
+if(CMAKE_BUILD_TYPE)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}")
+endif()
+if(CMAKE_TOOLCHAIN_FILE)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_TOOLCHAIN_FILE}")
+endif()
+if(VCPKG_TARGET_TRIPLET)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DVCPKG_TARGET_TRIPLET:STRING=${VCPKG_TARGET_TRIPLET}")
+endif()
+if(OPENSSL_ROOT_DIR)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DOPENSSL_ROOT_DIR:PATH=${OPENSSL_ROOT_DIR}"
+        "-DOPENSSL_USE_STATIC_LIBS:BOOL=ON")
+endif()
+if(CMAKE_OSX_ARCHITECTURES)
+    string(REPLACE ";" "|" _lemonade_nexus_osx_architectures
+        "${CMAKE_OSX_ARCHITECTURES}")
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DCMAKE_OSX_ARCHITECTURES:STRING=${_lemonade_nexus_osx_architectures}")
+endif()
+if(CMAKE_OSX_DEPLOYMENT_TARGET)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+endif()
+if(CMAKE_OSX_SYSROOT)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DCMAKE_OSX_SYSROOT:PATH=${CMAKE_OSX_SYSROOT}")
+endif()
+if(APPLE)
+    list(APPEND _lemonade_nexus_cmake_args
+        "-DOPENSSL_FORCE_BUNDLED:BOOL=ON")
+endif()
+
+# Keep Nexus in an isolated CMake build because both projects currently declare
+# overlapping third-party targets and cache variables.
+ExternalProject_Add(lemonade_nexus_external
+    SOURCE_DIR "${_lemonade_nexus_source_dir}"
+    BINARY_DIR "${_lemonade_nexus_binary_dir}"
+    DOWNLOAD_COMMAND ""
+    UPDATE_COMMAND ""
+    INSTALL_COMMAND ""
+    LIST_SEPARATOR "|"
+    CMAKE_ARGS ${_lemonade_nexus_cmake_args}
+    BUILD_COMMAND
+        ${CMAKE_COMMAND} --build <BINARY_DIR>
+        --config $<CONFIG>
+        --target LemonadeNexusSidecar
+        --parallel
+    BUILD_BYPRODUCTS "${_lemonade_nexus_sidecar}"
+    USES_TERMINAL_CONFIGURE TRUE
+    USES_TERMINAL_BUILD TRUE
+)
+
 install(PROGRAMS "${_lemonade_nexus_sidecar}"
     DESTINATION bin
     COMPONENT Runtime)
 
 function(_lemonade_nexus_finalize_targets)
-    foreach(_package_target wix_installer_minimal wix_installer_full package-macos)
+    foreach(_package_target
+            package
+            wix_installers
+            wix_installer_minimal
+            wix_installer_full
+            package-macos)
         if(TARGET ${_package_target})
             add_dependencies(${_package_target} lemonade_nexus_external)
         endif()


### PR DESCRIPTION
## Summary

Bundles the pinned `lemonade-nexus-sidecar` as an opt-in Lemonade build component.

- Fetches Nexus at merged commit `427dc33841f4a2a21fbdc5b6d57325b682a66673`, or accepts a local checkout override.
- Builds Nexus in an isolated CMake sub-build to avoid dependency target and cache collisions.
- Installs the sidecar with Lemonade and wires it into Linux, Windows, and macOS package targets.
- Adds opt-in Ninja and Visual Studio presets; existing builds remain unchanged by default.

## Scope

This PR covers build and packaging only. It does not start Nexus, expose runtime APIs, manage configuration, or add UI.

## Testing

- Validated preset parsing with CMake 3.31.6.
- Validated Single-Config and Multi-Config configure, build dependency, and component install behavior with a local mock Nexus project.
- Normal Lemonade CI was green before the final Nexus pin and CMake hardening updates; the refreshed head is awaiting CI.