### PR TITLE
docker: add xz support and validate backend extraction

### DIFF
--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -85,6 +85,21 @@ jobs:
             "lemonade-server:test-${{ matrix.arch }}" \
             lemonade --help
 
+      - name: Verify tar.xz extraction
+        run: |
+          docker run --rm \
+            "lemonade-server:test-${{ matrix.arch }}" \
+            sh -ec '
+              workdir="$(mktemp -d)"
+              printf "ok" > "${workdir}/payload"
+              tar -cJf "${workdir}/test.tar.xz" \
+                -C "${workdir}" payload
+              mkdir "${workdir}/out"
+              tar -xf "${workdir}/test.tar.xz" \
+                -C "${workdir}/out"
+              test "$(cat "${workdir}/out/payload")" = "ok"
+            '
+
       - name: Start server
         run: |
           docker run --detach \
@@ -122,8 +137,13 @@ jobs:
       - name: Export ARM64 image
         if: >-
           matrix.arch == 'arm64' &&
-          github.event_name == 'workflow_dispatch' &&
-          inputs.upload_arm64_artifact
+          (
+            github.event_name == 'pull_request' ||
+            (
+              github.event_name == 'workflow_dispatch' &&
+              inputs.upload_arm64_artifact
+            )
+          )
         shell: bash
         run: |
           set -euo pipefail
@@ -135,8 +155,13 @@ jobs:
       - name: Upload ARM64 test image
         if: >-
           matrix.arch == 'arm64' &&
-          github.event_name == 'workflow_dispatch' &&
-          inputs.upload_arm64_artifact
+          (
+            github.event_name == 'pull_request' ||
+            (
+              github.event_name == 'workflow_dispatch' &&
+              inputs.upload_arm64_artifact
+            )
+          )
         uses: actions/upload-artifact@v4
         with:
           name: lemonade-server-arm64-${{ github.sha }}

--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -85,21 +85,6 @@ jobs:
             "lemonade-server:test-${{ matrix.arch }}" \
             lemonade --help
 
-      - name: Verify tar.xz extraction
-        run: |
-          docker run --rm \
-            "lemonade-server:test-${{ matrix.arch }}" \
-            sh -ec '
-              workdir="$(mktemp -d)"
-              printf "ok" > "${workdir}/payload"
-              tar -cJf "${workdir}/test.tar.xz" \
-                -C "${workdir}" payload
-              mkdir "${workdir}/out"
-              tar -xf "${workdir}/test.tar.xz" \
-                -C "${workdir}/out"
-              test "$(cat "${workdir}/out/payload")" = "ok"
-            '
-
       - name: Start server
         run: |
           docker run --detach \
@@ -137,13 +122,8 @@ jobs:
       - name: Export ARM64 image
         if: >-
           matrix.arch == 'arm64' &&
-          (
-            github.event_name == 'pull_request' ||
-            (
-              github.event_name == 'workflow_dispatch' &&
-              inputs.upload_arm64_artifact
-            )
-          )
+          github.event_name == 'workflow_dispatch' &&
+          inputs.upload_arm64_artifact
         shell: bash
         run: |
           set -euo pipefail
@@ -155,13 +135,8 @@ jobs:
       - name: Upload ARM64 test image
         if: >-
           matrix.arch == 'arm64' &&
-          (
-            github.event_name == 'pull_request' ||
-            (
-              github.event_name == 'workflow_dispatch' &&
-              inputs.upload_arm64_artifact
-            )
-          )
+          github.event_name == 'workflow_dispatch' &&
+          inputs.upload_arm64_artifact
         uses: actions/upload-artifact@v4
         with:
           name: lemonade-server-arm64-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get install -y \
     vulkan-tools \
     libvulkan1 \
     unzip \
+    xz-utils \
     libgomp1 \
     libatomic1 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

Adds `xz-utils` to the container runtime image so Lemonade can extract `.tar.xz` backend archives.

Had an intermediate commit that extended the container smoke test with a real .tar.xz extraction check and temporarily uploaded the ARM64 image artifact on pull request runs for renewed hardware validation. Documented in Testing and comments.

## Why

The first real ARM64 container test successfully verified (see https://github.com/lemonade-sdk/lemonade/pull/2637):

* `linux/arm64` image architecture,
* CLI startup,
* server startup,
* `/live` health check.

Installing the `llamacpp:cuda` backend then failed with:

```text
tar (child): xz: Cannot exec: No such file or directory
```

The downloaded backend archive was valid, but the runtime image contained `tar` without the external `xz` decompressor required for .tar.xz files.

## Changes

* Add xz-utils to the Docker runtime dependencies.

## Testing

* [x] AMD64 container build passes
* [x] ARM64 container build passes
* [x] CLI smoke tests pass
* [x] .tar.xz extraction passes on AMD64 (also confirmed by commit with CI testing this [7774a39](https://github.com/lemonade-sdk/lemonade/pull/2671/commits/7774a39c902ec5044fdc8dd11988305ec5e83563))
* [x] .tar.xz extraction passes on ARM64 (also confirmed by commit with CI testing this [7774a39](https://github.com/lemonade-sdk/lemonade/pull/2671/commits/7774a39c902ec5044fdc8dd11988305ec5e83563))
* [x] Server `/live` health checks pass (comments below)
* [x] Updated ARM64 artifact installs llamacpp:cuda successfully on real hardware (comments below)
