### PR TITLE
feat(flm): restore validated backend arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1823,6 +1823,27 @@ message(STATUS "  Archive: ${EMBEDDABLE_ARCHIVE_NAME}")
 # ============================================================
 # C++ Unit Tests
 # ============================================================
+
+# FastFlowLM argument validation. Keep this test independent from the server
+set(_FLM_ARG_RESOLVER_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_flm_arg_resolver.cpp"
+)
+set(_FLM_ARG_RESOLVER_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/backends/fastflowlm/flm_arg_resolver.cpp"
+)
+if(EXISTS "${_FLM_ARG_RESOLVER_TEST_SRC}" AND EXISTS "${_FLM_ARG_RESOLVER_SRC}")
+    add_executable(test_flm_arg_resolver
+        test/cpp/test_flm_arg_resolver.cpp
+        src/cpp/server/backends/fastflowlm/flm_arg_resolver.cpp
+    )
+    target_include_directories(test_flm_arg_resolver PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+
+    add_test(NAME FlmArgResolverTest COMMAND test_flm_arg_resolver)
+endif()
+
 set(_DIR_WATCHER_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_directory_watcher.cpp"
 )

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -75,6 +75,13 @@ the generator instead. Prose outside the markers is preserved. -->
 |--------|----------|------|---------|-------------|
 | `acestep_backend` | `--acestep` | BACKEND | "" | ACE-Step backend to use |
 
+#### `flm` — FastFlowLM NPU
+
+| Option | CLI flag | Type | Default | Description |
+|--------|----------|------|---------|-------------|
+| `ctx_size` | `--ctx-size` | SIZE | -1 | Context size for the model |
+| `flm_args` | `--flm-args` | ARGS | "" | Safe flm serve tuning args: --pmode, --prefill-chunk-len, --img-pre-resize, --socket, --q-len, --preemption |
+
 #### `llamacpp` — Llama.cpp GPU
 
 | Option | CLI flag | Type | Default | Description |

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -362,6 +362,7 @@ The following options are available depending on the recipe being used:
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--ctx-size SIZE` | Context size for the model | auto |
+| `--flm-args ARGS` | Safe flm serve tuning args: --pmode, --prefill-chunk-len, --img-pre-resize, --socket, --q-len, --preemption | `""` |
 
 #### Ryzen AI LLM (`ryzenai-llm` recipe)
 

--- a/src/cpp/cli/bench.cpp
+++ b/src/cpp/cli/bench.cpp
@@ -1664,6 +1664,9 @@ CLI::App* register_bench_command(CLI::App& parent,
     cmd->add_option("--llamacpp-args", opts.llamacpp_args, "Custom args for llama-server (e.g. \"-b 2048 -ub 1024\"). Repeat for multiple.")
         ->type_name("ARGS")
         ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
+    cmd->add_option("--flm-args", opts.flm_args, "Safe custom args for flm serve. Repeat for multiple.")
+        ->type_name("ARGS")
+        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     cmd->add_option("--vllm-args", opts.vllm_args, "Custom args for vllm-server. Repeat for multiple.")
         ->type_name("ARGS")
         ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
@@ -1696,6 +1699,7 @@ BenchConfig build_bench_config(const std::string& output_file,
     config.response_log = cli.response_log;
     // Populate backend-specific args map (only non-empty values)
     if (!cli.llamacpp_args.empty()) config.backend_args["llamacpp"] = cli.llamacpp_args;
+    if (!cli.flm_args.empty()) config.backend_args["flm"] = cli.flm_args;
     if (!cli.vllm_args.empty()) config.backend_args["vllm"] = cli.vllm_args;
     if (!cli.sdcpp_args.empty()) config.backend_args["sd-cpp"] = cli.sdcpp_args;
     if (!cli.whispercpp_args.empty()) config.backend_args["whispercpp"] = cli.whispercpp_args;

--- a/src/cpp/include/lemon/backends/fastflowlm/fastflowlm.h
+++ b/src/cpp/include/lemon/backends/fastflowlm/fastflowlm.h
@@ -22,7 +22,12 @@ inline const BackendDescriptor descriptor = {
     /*selectable_backend*/ false,
     /*uses_ctx_size*/   true,
     /*dynamic_models*/  true,  // models come from flm's model_list.json, not server_models.json
-    /*options*/ {},
+    /*options*/ {
+        {"flm_args", "--flm-args", "", "ARGS",
+         "Safe flm serve tuning args: --pmode, --prefill-chunk-len, "
+         "--img-pre-resize, --socket, --q-len, --preemption",
+         "FastFlowLM Options"},
+    },
     /*support*/ {
         {"npu", {"windows", "linux"}, {{"amd_npu", {"XDNA2"}}}, "XDNA2 NPU"},
     },

--- a/src/cpp/include/lemon/backends/fastflowlm/flm_arg_resolver.h
+++ b/src/cpp/include/lemon/backends/fastflowlm/flm_arg_resolver.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace lemon {
+namespace backends {
+
+struct FLMArgResolution {
+    std::vector<std::string> args;
+};
+
+FLMArgResolution resolve_flm_args(const std::string& flm_args, int ctx_size);
+
+} // namespace backends
+} // namespace lemon

--- a/src/cpp/include/lemon_cli/bench.h
+++ b/src/cpp/include/lemon_cli/bench.h
@@ -188,6 +188,7 @@ struct BenchCliOptions {
     std::string response_log;
     // Backend-specific custom args (repeatable for multiple comparisons)
     std::vector<std::string> llamacpp_args;
+    std::vector<std::string> flm_args;
     std::vector<std::string> vllm_args;
     std::vector<std::string> sdcpp_args;
     std::vector<std::string> whispercpp_args;

--- a/src/cpp/server/backends/fastflowlm/fastflowlm_server.cpp
+++ b/src/cpp/server/backends/fastflowlm/fastflowlm_server.cpp
@@ -1,6 +1,7 @@
 #include "lemon/backends/fastflowlm/fastflowlm_server.h"
 #include "lemon/backends/fastflowlm/fastflowlm.h"
 #include "lemon/backends/fastflowlm/fastflowlm_models.h"
+#include "lemon/backends/fastflowlm/flm_arg_resolver.h"
 #include "lemon/backends/backend_registry.h"
 #include "lemon/backends/backend_ops.h"
 #include "lemon/backends/backend_utils.h"
@@ -143,12 +144,14 @@ std::string FastFlowLMServer::download_model(const std::string& checkpoint, bool
 }
 
 void FastFlowLMServer::load(const std::string& model_name,
-                           const ModelInfo& model_info,
-                           const RecipeOptions& options,
-                           bool do_not_upgrade) {
+                            const ModelInfo& model_info,
+                            const RecipeOptions& options,
+                            bool do_not_upgrade) {
     LOG(INFO, "FastFlowLM") << "Loading model: " << model_name << std::endl;
 
     int ctx_size = options.get_option("ctx_size");
+    std::string flm_args = options.get_option("flm_args");
+    FLMArgResolution flm_arg_resolution = resolve_flm_args(flm_args, ctx_size);
 
     std::cout << "[FastFlowLM] Options: ctx_size=" << ctx_size << std::endl;
     // Note: checkpoint_ is set by Router via set_model_metadata() before load() is called
@@ -183,16 +186,14 @@ void FastFlowLMServer::load(const std::string& model_name,
             "serve",
             "--asr", "1",
             "--port", std::to_string(port_),
-            "--host", "127.0.0.1",
-            "--quiet"
+            "--host", "127.0.0.1"
         };
     } else if (model_type_ == ModelType::EMBEDDING) {
         args = {
             "serve",
             "--embed", "1",
             "--port", std::to_string(port_),
-            "--host", "127.0.0.1",
-            "--quiet"
+            "--host", "127.0.0.1"
         };
     } else {
         args = {
@@ -200,10 +201,12 @@ void FastFlowLMServer::load(const std::string& model_name,
             model_info.checkpoint(),
             "--ctx-len", std::to_string(ctx_size),
             "--port", std::to_string(port_),
-            "--host", "127.0.0.1",
-            "--quiet"
+            "--host", "127.0.0.1"
         };
     }
+
+    args.insert(args.end(), flm_arg_resolution.args.begin(), flm_arg_resolution.args.end());
+    args.push_back("--quiet");
 
     LOG(INFO, "FastFlowLM") << "Starting flm-server..." << std::endl;
     LOG(INFO, "ProcessManager") << "Starting process: \"" << flm_path << "\"";

--- a/src/cpp/server/backends/fastflowlm/flm_arg_resolver.cpp
+++ b/src/cpp/server/backends/fastflowlm/flm_arg_resolver.cpp
@@ -1,0 +1,176 @@
+#include "lemon/backends/fastflowlm/flm_arg_resolver.h"
+
+#include <charconv>
+#include <cctype>
+#include <cstddef>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace lemon {
+namespace backends {
+namespace {
+
+constexpr std::size_t MAX_ARGUMENT_STRING_LENGTH = 4096;
+constexpr std::size_t MAX_ARGUMENT_TOKENS = 12;
+constexpr long long MAX_SERVE_CONCURRENCY = 1024;
+
+std::vector<std::string> tokenize(const std::string& input) {
+    if (input.size() > MAX_ARGUMENT_STRING_LENGTH) {
+        throw std::invalid_argument("flm_args exceeds the maximum supported length");
+    }
+
+    std::vector<std::string> tokens;
+    std::string current;
+
+    for (unsigned char c : input) {
+        if (c == '\'' || c == '"' || std::iscntrl(c)) {
+            throw std::invalid_argument(
+                "flm_args accepts only unquoted, space-separated flag/value pairs");
+        }
+
+        if (c == ' ') {
+            if (!current.empty()) {
+                tokens.push_back(current);
+                current.clear();
+            }
+        } else {
+            current.push_back(static_cast<char>(c));
+        }
+    }
+
+    if (!current.empty()) {
+        tokens.push_back(current);
+    }
+
+    if (tokens.size() > MAX_ARGUMENT_TOKENS) {
+        throw std::invalid_argument("flm_args contains too many arguments");
+    }
+
+    return tokens;
+}
+
+long long parse_integer(const std::string& flag, const std::string& value) {
+    long long parsed = 0;
+    const char* begin = value.data();
+    const char* end = begin + value.size();
+    auto result = std::from_chars(begin, end, parsed);
+
+    if (value.empty() || result.ec != std::errc() || result.ptr != end) {
+        throw std::invalid_argument(flag + " requires an integer value");
+    }
+
+    return parsed;
+}
+
+std::string validate_pmode(const std::string& value) {
+    static const std::set<std::string> allowed = {
+        "default",
+        "powersaver",
+        "balanced",
+        "performance",
+        "turbo",
+    };
+
+    if (!allowed.count(value)) {
+        throw std::invalid_argument(
+            "--pmode must be one of: default, powersaver, balanced, performance, turbo");
+    }
+
+    return value;
+}
+
+std::string validate_prefill_chunk_len(const std::string& value, int ctx_size) {
+    long long parsed = parse_integer("--prefill-chunk-len", value);
+    if (parsed != -1 && parsed < 1) {
+        throw std::invalid_argument("--prefill-chunk-len must be -1 or a positive integer");
+    }
+    if (parsed > 0 && ctx_size > 0 && parsed > ctx_size) {
+        throw std::invalid_argument("--prefill-chunk-len cannot exceed ctx_size");
+    }
+    return std::to_string(parsed);
+}
+
+std::string validate_img_pre_resize(const std::string& value) {
+    long long parsed = parse_integer("--img-pre-resize", value);
+    if (parsed < 0 || parsed > 4) {
+        throw std::invalid_argument("--img-pre-resize must be between 0 and 4");
+    }
+    return std::to_string(parsed);
+}
+
+std::string validate_concurrency(const std::string& flag, const std::string& value) {
+    long long parsed = parse_integer(flag, value);
+    if (parsed < 1 || parsed > MAX_SERVE_CONCURRENCY) {
+        throw std::invalid_argument(flag + " must be between 1 and 1024");
+    }
+    return std::to_string(parsed);
+}
+
+std::string validate_preemption(const std::string& value) {
+    if (value == "1" || value == "true") {
+        return "1";
+    }
+    if (value == "0" || value == "false") {
+        return "0";
+    }
+    throw std::invalid_argument("--preemption must be one of: 0, 1, false, true");
+}
+
+std::string validate_value(const std::string& flag, const std::string& value, int ctx_size) {
+    if (flag == "--pmode") {
+        return validate_pmode(value);
+    }
+    if (flag == "--prefill-chunk-len") {
+        return validate_prefill_chunk_len(value, ctx_size);
+    }
+    if (flag == "--img-pre-resize") {
+        return validate_img_pre_resize(value);
+    }
+    if (flag == "--socket" || flag == "--q-len") {
+        return validate_concurrency(flag, value);
+    }
+    if (flag == "--preemption") {
+        return validate_preemption(value);
+    }
+
+    throw std::invalid_argument("flm_args flag is not allowed: " + flag);
+}
+
+} // namespace
+
+FLMArgResolution resolve_flm_args(const std::string& flm_args, int ctx_size) {
+    std::vector<std::string> tokens = tokenize(flm_args);
+    FLMArgResolution resolution;
+    std::set<std::string> seen_flags;
+
+    for (std::size_t i = 0; i < tokens.size();) {
+        const std::string& flag = tokens[i];
+        if (flag.rfind("--", 0) != 0) {
+            throw std::invalid_argument(
+                "flm_args expects canonical long flags beginning with '--': " + flag);
+        }
+        if (flag.find('=') != std::string::npos) {
+            throw std::invalid_argument(
+                "flm_args requires '--flag value' syntax instead of '--flag=value': " + flag);
+        }
+        if (!seen_flags.insert(flag).second) {
+            throw std::invalid_argument("flm_args contains a duplicate flag: " + flag);
+        }
+        if (i + 1 >= tokens.size()) {
+            throw std::invalid_argument("flm_args flag requires a value: " + flag);
+        }
+
+        const std::string canonical_value = validate_value(flag, tokens[i + 1], ctx_size);
+        resolution.args.push_back(flag);
+        resolution.args.push_back(canonical_value);
+        i += 2;
+    }
+
+    return resolution;
+}
+
+} // namespace backends
+} // namespace lemon

--- a/test/cpp/test_flm_arg_resolver.cpp
+++ b/test/cpp/test_flm_arg_resolver.cpp
@@ -1,0 +1,118 @@
+#include "lemon/backends/fastflowlm/flm_arg_resolver.h"
+
+#include <cstdio>
+#include <exception>
+#include <string>
+#include <vector>
+
+using lemon::backends::FLMArgResolution;
+using lemon::backends::resolve_flm_args;
+
+namespace {
+
+std::string join(const std::vector<std::string>& values) {
+    std::string output;
+    for (const auto& value : values) {
+        if (!output.empty()) {
+            output += " ";
+        }
+        output += value;
+    }
+    return output;
+}
+
+bool expect_args(const char* name, const std::string& input, int ctx_size,
+                 const std::string& expected) {
+    try {
+        FLMArgResolution resolution = resolve_flm_args(input, ctx_size);
+        std::string actual = join(resolution.args);
+        bool ok = actual == expected;
+        std::printf("[%s] %s\n  got:  %s\n  want: %s\n",
+                    ok ? "PASS" : "FAIL", name, actual.c_str(), expected.c_str());
+        return ok;
+    } catch (const std::exception& e) {
+        std::printf("[FAIL] %s\n  unexpected error: %s\n", name, e.what());
+        return false;
+    }
+}
+
+bool expect_error(const char* name, const std::string& input, int ctx_size,
+                  const std::string& expected_substring) {
+    try {
+        (void)resolve_flm_args(input, ctx_size);
+    } catch (const std::exception& e) {
+        std::string message = e.what();
+        bool ok = message.find(expected_substring) != std::string::npos;
+        std::printf("[%s] %s\n  error: %s\n",
+                    ok ? "PASS" : "FAIL", name, message.c_str());
+        return ok;
+    }
+
+    std::printf("[FAIL] %s\n  expected error containing: %s\n",
+                name, expected_substring.c_str());
+    return false;
+}
+
+} // namespace
+
+int main() {
+    int failures = 0;
+
+    failures += !expect_args("empty args", "", 8192, "");
+    failures += !expect_args(
+        "all safe args",
+        "--pmode balanced --prefill-chunk-len 4096 --img-pre-resize 3 "
+        "--socket 20 --q-len 15 --preemption true",
+        8192,
+        "--pmode balanced --prefill-chunk-len 4096 --img-pre-resize 3 "
+        "--socket 20 --q-len 15 --preemption 1");
+    failures += !expect_args(
+        "canonicalizes numeric and boolean values",
+        "--socket 0010 --preemption false",
+        8192,
+        "--socket 10 --preemption 0");
+    failures += !expect_args(
+        "prefill auto value",
+        "--prefill-chunk-len -1",
+        8192,
+        "--prefill-chunk-len -1");
+
+    failures += !expect_error("host is blocked", "--host 0.0.0.0", 8192, "not allowed");
+    failures += !expect_error("port is blocked", "--port 8000", 8192, "not allowed");
+    failures += !expect_error("context override is blocked", "--ctx-len 16384", 8192, "not allowed");
+    failures += !expect_error("model mode is blocked", "--asr 1", 8192, "not allowed");
+    failures += !expect_error("embedding mode is blocked", "--embed 1", 8192, "not allowed");
+    failures += !expect_error("quiet is blocked", "--quiet 1", 8192, "not allowed");
+    failures += !expect_error("file input is blocked", "--prompt /etc/passwd", 8192, "not allowed");
+    failures += !expect_error("positional command is blocked", "serve model", 8192, "canonical long flags");
+    failures += !expect_error("short aliases are blocked", "-q 20", 8192, "canonical long flags");
+    failures += !expect_error("equals syntax is blocked", "--q-len=20", 8192, "--flag=value");
+    failures += !expect_error("unknown flag is blocked", "--future-flag 1", 8192, "not allowed");
+    failures += !expect_error("duplicate flag is blocked", "--q-len 10 --q-len 20", 8192, "duplicate");
+    failures += !expect_error("missing value is blocked", "--q-len", 8192, "requires a value");
+    failures += !expect_error("quoted values are blocked", "--pmode \"balanced\"", 8192, "unquoted");
+    failures += !expect_error("control characters are blocked", "--pmode balanced\n", 8192, "unquoted");
+    failures += !expect_error("invalid power mode is blocked", "--pmode maximum", 8192, "must be one of");
+    failures += !expect_error("zero prefill is blocked", "--prefill-chunk-len 0", 8192, "positive integer");
+    failures += !expect_error("prefill over context is blocked", "--prefill-chunk-len 8193", 8192, "ctx_size");
+    failures += !expect_error("negative resize is blocked", "--img-pre-resize -1", 8192, "between 0 and 4");
+    failures += !expect_error("large resize is blocked", "--img-pre-resize 5", 8192, "between 0 and 4");
+    failures += !expect_error("zero sockets are blocked", "--socket 0", 8192, "between 1 and 1024");
+    failures += !expect_error("large queue is blocked", "--q-len 1025", 8192, "between 1 and 1024");
+    failures += !expect_error("non-integer queue is blocked", "--q-len ten", 8192, "integer value");
+    failures += !expect_error("invalid boolean is blocked", "--preemption yes", 8192, "0, 1, false, true");
+    failures += !expect_error(
+        "too many arguments are blocked",
+        "--pmode balanced --prefill-chunk-len 1 --img-pre-resize 1 --socket 1 "
+        "--q-len 1 --preemption 1 --pmode turbo",
+        8192,
+        "too many arguments");
+
+    if (failures != 0) {
+        std::printf("%d FLM argument resolver test(s) failed\n", failures);
+        return 1;
+    }
+
+    std::printf("All FLM argument resolver tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Restore **flm_args** support for FastFlowLM through a strict typed allow-list.

Supported tuning arguments:

* --pmode
* --prefill-chunk-len
* --img-pre-resize
* --socket
* --q-len
* --preemption

Lemonade-managed arguments such as model mode, host, port, context length, and input options remain blocked. The option is available through `load`, `run`, and `bench`.

## Testing

* Built lemonade, lemond, and the new FLM resolver test target
* Ran the complete resolver test suite, including valid values, normalization, duplicates, malformed syntax, blocked arguments, and boundary checks
* Verified successful FLM model loading and inference with gemma4-it-e2b-FLM
* Verified all supported FLM arguments together
* Verified invalid and Lemonade-managed arguments are rejected before FLM startup
* Ran a real bench workflow with FLM arguments across multiple chat scenarios
* Regenerated backend documentation and confirmed generated files are up to date
