### PR TITLE
fix: quote /MANIFESTINPUT path and detect RX 7600 as gfx110X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -768,9 +768,10 @@ if(WIN32)
             /NXCOMPAT         # Data Execution Prevention (DEP)
             /GUARD:CF         # Control Flow Guard
         )
-        # Embed manifest file
+        # Embed manifest file. /MANIFESTINPUT's path must be quoted; unquoted,
+        # a path containing a space breaks the linker with LNK1181.
         set_target_properties(${EXECUTABLE_NAME} PROPERTIES
-            LINK_FLAGS "/MANIFEST:EMBED /MANIFESTINPUT:${CMAKE_CURRENT_BINARY_DIR}/server/lemonade.manifest"
+            LINK_FLAGS "/MANIFEST:EMBED /MANIFESTINPUT:\"${CMAKE_CURRENT_BINARY_DIR}/server/lemonade.manifest\""
         )
     endif()
 endif()

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -1867,7 +1867,13 @@ std::string identify_rocm_arch_from_name(const std::string& device_name) {
         return "gfx120X";
     }
 
-    if (device_lower.find("7700") != std::string::npos ||
+    // "7600" alone is not product-specific enough: it also matches names like
+    // "AMD Radeon HD 7600M Series" (a GCN1 card from 2012, not RDNA3). Match
+    // the actual product family instead.
+    if (device_lower.find("rx 7600") != std::string::npos ||
+        device_lower.find("rx7600") != std::string::npos ||
+        device_lower.find("pro w7600") != std::string::npos ||
+        device_lower.find("7700") != std::string::npos ||
         device_lower.find("7800") != std::string::npos ||
         device_lower.find("7900") != std::string::npos ||
         device_lower.find("v710") != std::string::npos) {


### PR DESCRIPTION
Two independent Windows/ROCm fixes:

- The /MANIFESTINPUT linker flag's path was unquoted, so a build tree under a directory containing a space fails to link with LNK1181 (the path is silently truncated at the space). Quote it.

- identify_rocm_arch_from_name() matched 7700/7800/7900/v710 but not the RX 7600, so a machine with an RX 7600 reported no gfx110X family and every ROCm backend (llamacpp included) showed as unsupported on it. Add 7600 to the existing gfx110X substring check.