### PR TITLE
feat(ui): simplify custom model and Omni collection management

### DIFF
--- a/prototype/ui-redesign/src/components/Icon.tsx
+++ b/prototype/ui-redesign/src/components/Icon.tsx
@@ -10,7 +10,7 @@ export type IconName =
   | 'search' | 'search-check' | 'eye' | 'eye-off' | 'plus' | 'edit' | 'download' | 'play' | 'pause' | 'trash' | 'rotate-ccw' | 'chevron-down' | 'chevron-up' | 'chevron-right' | 'plug' | 'box' | 'alert' | 'clock'
   | 'citrus' | 'scale' | 'scan-eye' | 'gem' | 'gauge' | 'timer' | 'pen-line' | 'library'
   | 'hard-drive' | 'sliders-horizontal' | 'flame' | 'wrench' | 'brain' | 'rocket' | 'pin'
-  | 'star' | 'hugging-face'
+  | 'star' | 'hugging-face' | 'user-round-cog'
   | 'speech' | 'book-open' | 'newspaper' | 'github' | 'discord' | 'funnel' | 'info';
 
 interface IconProps {
@@ -89,6 +89,7 @@ export const Icon: React.FC<IconProps> = ({ name, size = 16, className, title })
       case 'pin': return <><path d="M12 17v5" /><path d="M5 17h14v-2l-4-4V5l2-2V2H7v1l2 2v6l-4 4v2z" /></>;
       case 'star': return <path d="M12 2.5l2.9 6.1 6.6.7-4.9 4.5 1.3 6.5L12 17.8 6.1 20.8l1.3-6.5-4.9-4.5 6.6-.7z" />;
       case 'hugging-face': return <><circle cx="12" cy="12" r="9" /><path d="M8.5 14a4 4 0 007 0" /><path d="M9 10h.01" /><path d="M15 10h.01" /></>;
+      case 'user-round-cog': return <><path d="M2 21a8 8 0 0 1 10.434-7.62" /><circle cx="10" cy="8" r="5" /><circle cx="18" cy="18" r="3" /><path d="m19.5 14.3-.4.9m-2.2 5.6-.4.9m5.2-.4-.9-.4m-5.6-2.2-.9-.4m7.4 0-.9.4m-5.6 2.2-.9.4m5.2 2.2-.4-.9m-2.2-5.6-.4-.9" /></>;
       case 'speech': return <><path d="M21 15a4 4 0 01-4 4H8l-5 3V7a4 4 0 014-4h10a4 4 0 014 4z" /><path d="M8 9h8" /><path d="M8 13h5" /></>;
       case 'book-open': return <><path d="M12 7v14" /><path d="M3 5.5A2.5 2.5 0 015.5 3H12v18H5.5A2.5 2.5 0 013 18.5z" /><path d="M21 5.5A2.5 2.5 0 0018.5 3H12v18h6.5a2.5 2.5 0 002.5-2.5z" /></>;
       case 'newspaper': return <><path d="M4 5h13a3 3 0 013 3v11H7a3 3 0 01-3-3z" /><path d="M4 16a3 3 0 003 3" /><path d="M8 8h6" /><path d="M8 12h8" /><path d="M8 15h5" /></>;

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -21,6 +21,7 @@ import {
   type RecipeOptions, type SamplingParams,
 } from '../presetStore';
 import { Icon, CapabilityIcon, PresetIcon } from './Icon';
+import { getCollectionComponents, isCollectionModel } from '../features/collections/collectionModels';
 
 /* ── Helpers (local copies to keep component self-contained) ──── */
 
@@ -1378,6 +1379,69 @@ const ModelFilesTab: React.FC<{ model: ModelInfo | null | undefined; isActive: b
   );
 };
 
+const COLLECTION_ROLE_LABELS: Record<string, string> = {
+  llm: 'Planner LLM',
+  vision: 'Vision',
+  image: 'Image generation',
+  edit: 'Image editing',
+  transcription: 'Transcription',
+  speech: 'Text to speech',
+};
+
+const CustomCollectionSettingsTab: React.FC<{ model: ModelInfo; onEdit?: (model: ModelInfo) => void }> = ({ model, onEdit }) => {
+  const roles = ((model as any).component_roles || {}) as Record<string, string>;
+  const components = getCollectionComponents(model);
+  const displayRoles: Record<string, string> = { ...roles, llm: roles.llm || components[0] || '' };
+  const assigned = new Set(Object.values(displayRoles).filter(Boolean));
+  const unassigned = components.filter(component => !assigned.has(component));
+  const tools = Array.isArray((model as any).custom_tools) ? (model as any).custom_tools as Array<Record<string, unknown>> : [];
+  const hasCustomPrompt = Boolean(String((model as any).system_prompt || '').trim());
+
+  return (
+    <div className="detail-tab-content custom-collection-settings">
+      <div className="custom-collection-settings__intro">
+        <div>
+          <h3>Collection settings</h3>
+          <p>Components stay editable after the collection has been saved or downloaded.</p>
+        </div>
+        {onEdit && (
+          <button type="button" className="btn btn--primary btn--sm" onClick={() => onEdit(model)}>
+            <Icon name="edit" size={13} /> Edit settings
+          </button>
+        )}
+      </div>
+
+      <section className="custom-collection-settings__section" aria-label="Collection components">
+        <h4>Components</h4>
+        <div className="custom-collection-settings__components">
+          {Object.entries(COLLECTION_ROLE_LABELS).map(([role, label]) => (
+            <div className="custom-collection-settings__component" key={role}>
+              <span>{label}</span>
+              <strong>{displayRoles[role] || 'Not set'}</strong>
+            </div>
+          ))}
+          {unassigned.map(component => (
+            <div className="custom-collection-settings__component" key={component}>
+              <span>Tool model</span>
+              <strong>{component}</strong>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="custom-collection-settings__section" aria-label="Advanced collection settings summary">
+        <h4>Advanced</h4>
+        <div className="custom-collection-settings__summary">
+          <span>System prompt</span>
+          <strong>{hasCustomPrompt ? 'Customized' : 'Default'}</strong>
+          <span>Custom LLM tools</span>
+          <strong>{tools.length}</strong>
+        </div>
+      </section>
+    </div>
+  );
+};
+
 /* ── ModelDetailPanel ────────────────────────────────────────── */
 
 export interface ModelDetailPanelProps {
@@ -1408,6 +1472,8 @@ export interface ModelDetailPanelProps {
   isFavorite?: boolean;
   /** Toggle this model's favorite/pin state. Receives the model name. */
   onToggleFavorite?: (name: string) => void;
+  /** Open the persistent settings editor for a saved custom Omni collection. */
+  onEditCustomCollection?: (model: ModelInfo) => void;
   /** Called when the "Back to models" button is clicked (narrow viewports). */
   onBack?: () => void;
   /** True when the registry has no models at all (empty state guidance differs
@@ -1415,12 +1481,17 @@ export interface ModelDetailPanelProps {
   noModelsAvailable?: boolean;
 }
 
-type DetailTab = 'readme' | 'presets' | 'tuning' | 'files';
+type DetailTab = 'settings' | 'readme' | 'presets' | 'tuning' | 'files';
 
 const TABS: Array<{ id: DetailTab; label: string }> = [
   { id: 'readme', label: 'README' },
   { id: 'presets', label: 'Presets' },
   { id: 'tuning', label: 'Model Tuning' },
+  { id: 'files', label: 'Files' },
+];
+
+const CUSTOM_COLLECTION_TABS: Array<{ id: DetailTab; label: string }> = [
+  { id: 'settings', label: 'Settings' },
   { id: 'files', label: 'Files' },
 ];
 
@@ -1440,6 +1511,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   serverDefaultCtxSize,
   isFavorite = false,
   onToggleFavorite,
+  onEditCustomCollection,
   onBack,
   noModelsAvailable = false,
 }) => {
@@ -1459,11 +1531,14 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
 
   const detailName = model ? mdName(model) : '';
   const detailLoaded = !!loadedModel;
+  const isCustomCollection = Boolean(model && (model as any).custom && isCollectionModel(model));
+  const detailTabs = isCustomCollection ? CUSTOM_COLLECTION_TABS : TABS;
 
   // Move focus to heading when model changes
   useEffect(() => {
     if (model) panelHeadingRef.current?.focus();
-  }, [model?.id]);
+    setActiveTab(isCustomCollection ? 'settings' : 'readme');
+  }, [detailName, isCustomCollection]);
 
   // Re-render when the preset store changes (applied/running/user presets).
   useEffect(() => {
@@ -1487,7 +1562,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   }, [detailName, detailLoaded, storeTick]);
 
   // Reset transient update feedback when the selected model changes.
-  useEffect(() => { setUpdateStatus({ phase: 'idle', msg: '' }); }, [model?.id]);
+  useEffect(() => { setUpdateStatus({ phase: 'idle', msg: '' }); }, [detailName]);
 
   // Auto-dismiss terminal update messages so the live region settles.
   useEffect(() => {
@@ -1575,14 +1650,14 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
 
   // Roving tabindex: keyboard navigation across tabs
   const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
-    const count = TABS.length;
+    const count = detailTabs.length;
     let next = -1;
     if (e.key === 'ArrowRight') { e.preventDefault(); next = (index + 1) % count; }
     else if (e.key === 'ArrowLeft') { e.preventDefault(); next = (index - 1 + count) % count; }
     else if (e.key === 'Home') { e.preventDefault(); next = 0; }
     else if (e.key === 'End') { e.preventDefault(); next = count - 1; }
     if (next >= 0) {
-      setActiveTab(TABS[next].id);
+      setActiveTab(detailTabs[next].id);
       tabRefs.current[next]?.focus();
     }
   };
@@ -1856,7 +1931,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
         aria-label="Model details sections"
         aria-labelledby="detail-panel-heading"
       >
-        {TABS.map((tab, i) => (
+        {detailTabs.map((tab, i) => (
           <button
             key={tab.id}
             ref={el => { tabRefs.current[i] = el; }}
@@ -1875,7 +1950,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
       </div>
 
       {/* Tab panels */}
-      {TABS.map(tab => (
+      {detailTabs.map(tab => (
         <div
           key={tab.id}
           id={`detail-panel-${tab.id}`}
@@ -1884,6 +1959,9 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
           className={`detail-tabs__panel${activeTab === tab.id ? ' detail-tabs__panel--active' : ''}`}
           hidden={activeTab !== tab.id}
         >
+          {tab.id === 'settings' && model && (
+            <CustomCollectionSettingsTab model={model} onEdit={onEditCustomCollection} />
+          )}
           {tab.id === 'readme' && (
             <ModelReadmeTab model={model} isActive={activeTab === 'readme'} />
           )}

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -308,8 +308,7 @@ export interface ModelListPanelProps {
   /** Active tag chip from the left rail (null = no tag filter). */
   tagFilter?: string | null;
   searchInputRef?: React.RefObject<HTMLInputElement | null>;
-  onAddCustomModel?: () => void;
-  onAddOmniCollection?: () => void;
+  onOpenCustomModels?: () => void;
   /** Lowercased set of pinned model names. Pinned rows float to the top. Client-local. */
   pinnedNames?: Set<string>;
   /** Toggle a model's pinned state. Receives the model name. */
@@ -337,8 +336,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   backendFilter = 'all',
   tagFilter = null,
   searchInputRef,
-  onAddCustomModel,
-  onAddOmniCollection,
+  onOpenCustomModels,
   pinnedNames,
   onTogglePin,
   favoriteNames,
@@ -584,32 +582,18 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
       {/* Title */}
       <div className="model-list-panel__title manager__title">
         <h1>Models</h1>
+        {onOpenCustomModels && (
+          <button
+            type="button"
+            className="model-list-panel__custom-menu-btn"
+            onClick={onOpenCustomModels}
+            aria-label="Open custom models"
+            title="Manage custom models"
+          >
+            <Icon name="user-round-cog" size={19} aria-hidden="true" />
+          </button>
+        )}
       </div>
-
-      {/* Custom model / Omni collection actions — grounded button group at the
-          top of the list area (moved from the bottom per fl0rianr). */}
-      {(onAddCustomModel || onAddOmniCollection) && (
-        <div className="model-list-panel__add-group" role="group" aria-label="Add custom models">
-          {onAddCustomModel && (
-            <button
-              type="button"
-              className="btn btn--ghost btn--tiny model-list-panel__add-btn manager__custom-btn"
-              onClick={onAddCustomModel}
-            >
-              + Custom model
-            </button>
-          )}
-          {onAddOmniCollection && (
-            <button
-              type="button"
-              className="btn btn--ghost btn--tiny model-list-panel__add-btn manager__custom-btn manager__custom-btn--omni"
-              onClick={onAddOmniCollection}
-            >
-              + Omni collection
-            </button>
-          )}
-        </div>
-      )}
 
       {/* Search bar */}
       <div className="model-list-panel__search-row">

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -473,12 +473,10 @@ const CUSTOM_RECIPE_SUGGESTIONS: Record<string, CustomRecipeSuggestion> = {
   },
 };
 
-const CheckpointExampleCard: React.FC<{ title: string; checkpoint: string; note?: string }> = ({ title, checkpoint, note }) => (
-  <div className="custom-model-form__checkpoint-example" aria-label={title}>
-    <strong>{title}</strong>
-    <span><code title={checkpoint}>{checkpoint}</code></span>
-    {note ? <small>{note}</small> : <small aria-hidden="true">&nbsp;</small>}
-  </div>
+const InlineCheckpointExample: React.FC<{ checkpoint: string; note?: string }> = ({ checkpoint, note }) => (
+  <span className="custom-model-form__inline-example" title={note || checkpoint}>
+    Example: <code>{checkpoint}</code>
+  </span>
 );
 
 function optionValue(recipe: string, backend?: string): string {
@@ -842,6 +840,46 @@ function createEmptyCustomDraft(mode: CustomFormMode = 'model'): CustomModelDraf
   };
 }
 
+function customDraftFromModel(model: ModelInfo): CustomModelDraftState {
+  const checkpoints = objectRecord((model as any).checkpoints);
+  const roles = objectRecord((model as any).component_roles);
+  const rawTools = Array.isArray((model as any).custom_tools) ? (model as any).custom_tools as CustomOmniToolDefinition[] : [];
+  const components = getCollectionComponents(model);
+  const capability = String((model as any).type || 'chat') as CustomModelCapability;
+  const collection = isCollectionModel(model);
+  const structuralLabels = new Set(['custom', 'omni', 'multimodal', 'vision-language']);
+  return {
+    name: modelName(model),
+    displayName: String(model.display_name || modelName(model)),
+    checkpoint: String((model as any).checkpoint || checkpoints.main || ''),
+    mmproj: String((model as any).mmproj || checkpoints.mmproj || ''),
+    imageTextEncoder: String(checkpoints.text_encoder || ''),
+    imageVae: String(checkpoints.vae || ''),
+    recipe: String((model as any).recipe || (collection ? 'collection.omni' : 'llamacpp')),
+    capability,
+    maxContextWindow: String((model as any).max_context_window || ''),
+    labels: modelLabels(model).filter(label => !structuralLabels.has(label.toLowerCase())).join(', '),
+    omniSource: collection ? 'collection' : 'single',
+    llmComponent: String(roles.llm || components[0] || ''),
+    visionComponent: String(roles.vision || ''),
+    imageComponent: String(roles.image || ''),
+    editComponent: String(roles.edit || ''),
+    transcriptionComponent: String(roles.transcription || ''),
+    speechComponent: String(roles.speech || ''),
+    omniSystemPrompt: String((model as any).system_prompt || DEFAULT_OMNI_SYSTEM_PROMPT_TEMPLATE),
+    omniCustomTools: rawTools.map((tool, index) => ({
+      id: String(tool.id || `custom-tool-${index + 1}`),
+      name: String(tool.name || ''),
+      description: String(tool.description || ''),
+      targetModel: String(tool.target_model || ''),
+      systemPrompt: String(tool.system_prompt || ''),
+      promptTemplate: String(tool.prompt_template || ''),
+      parametersJson: JSON.stringify(tool.parameters || DEFAULT_CUSTOM_LLM_TOOL_PARAMETERS, null, 2),
+      maxTokens: tool.max_tokens ? String(tool.max_tokens) : '',
+    })),
+  };
+}
+
 function loadedIsVirtualOmniCollection(model: LoadedModel): boolean {
   const recipe = String(model.recipe || '').toLowerCase();
   const components = model.recipe_options?.components;
@@ -1126,7 +1164,6 @@ const OmniComponentPicker: React.FC<OmniComponentPickerProps> = ({ role, value, 
           </div>
         )}
       </div>
-      <div className="omni-component-picker__help">{selected ? selected.detail : config.help}</div>
     </div>
   );
 };
@@ -1175,6 +1212,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
 
   const [customModels, setCustomModels] = useState<ModelInfo[]>(() => loadCustomModels(accountSession.storageScope).map(customModelToModelInfo));
   const [showCustomForm, setShowCustomForm] = useState(false);
+  const [editingCustomModelName, setEditingCustomModelName] = useState<string | null>(null);
   const [customError, setCustomError] = useState<string | null>(null);
   const [customJsonNotice, setCustomJsonNotice] = useState<string | null>(null);
   const [customDraft, setCustomDraft] = useState<CustomModelDraftState>(() => createEmptyCustomDraft());
@@ -1708,7 +1746,16 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   };
 
   const openCustomForm = (mode: CustomFormMode = 'model') => {
+    setEditingCustomModelName(null);
     setCustomDraft(createEmptyCustomDraft(mode));
+    setCustomError(null);
+    setShowCustomForm(true);
+    void refreshCustomRecipeAvailability();
+  };
+
+  const openCustomCollectionEditor = (model: ModelInfo) => {
+    setEditingCustomModelName(modelName(model));
+    setCustomDraft(customDraftFromModel(model));
     setCustomError(null);
     setShowCustomForm(true);
     void refreshCustomRecipeAvailability();
@@ -1716,6 +1763,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
 
   const closeCustomForm = () => {
     setShowCustomForm(false);
+    setEditingCustomModelName(null);
     setCustomError(null);
   };
 
@@ -1909,7 +1957,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         ? { main: checkpoint, ...extraCheckpoints }
         : undefined;
       const saved = upsertCustomModel(accountSession.storageScope, {
-        name: implicitCustomModelName(customDraft.displayName, customDraft.checkpoint, customDraft.capability === 'omni' ? 'omni-model' : 'custom-model'),
+        name: editingCustomModelName || implicitCustomModelName(customDraft.displayName, customDraft.checkpoint, customDraft.capability === 'omni' ? 'omni-model' : 'custom-model'),
         displayName: customDraft.displayName,
         checkpoint,
         checkpoints,
@@ -1928,7 +1976,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
       });
       reloadCustomModels();
       setShowCustomForm(false);
-      setSearchQuery(saved.display_name || saved.name);
+      setEditingCustomModelName(null);
+      setPrimaryFilter('my-models');
+      setSearchQuery('');
+      setSelectedDetailModelId(saved.name);
+      setMobileDetailOpen(true);
       setCustomDraft(createEmptyCustomDraft());
     } catch (err) {
       setCustomError(err instanceof Error ? err.message : 'Could not save custom model.');
@@ -2162,6 +2214,22 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   // the normal local registry.
   const hfMode = primaryFilter === 'huggingface' && hfSearchActive;
   const listModels = hfMode ? hfModelInfos : allModels;
+  const selectedDetailModel = selectedDetailModelId
+    ? (allModels.find(m => modelName(m) === selectedDetailModelId) ?? null)
+    : null;
+  const selectedDetailIsCustom = Boolean(selectedDetailModel && (selectedDetailModel as any).custom);
+  const showCustomEditor = showCustomForm || (primaryFilter === 'my-models' && !selectedDetailIsCustom);
+
+  const handlePrimaryFilterChange = (next: PrimaryFilter) => {
+    setPrimaryFilter(next);
+    setNavRailOpen(false);
+    if (next === 'my-models') {
+      if (!selectedDetailIsCustom) openCustomForm('model');
+      else closeCustomForm();
+      return;
+    }
+    closeCustomForm();
+  };
 
   /* ── Toggle detail ───────────────────────────────────────── */
   const toggleDetail = (name: string) => {
@@ -2734,7 +2802,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     && visibleFilteredAvailable.length === 0
     && !hasHuggingFaceActivity;
   const isCustomOmniCollectionDraft = customDraft.capability === 'omni' && customDraft.omniSource === 'collection';
-  const customFormTitle = isCustomOmniCollectionDraft ? 'Custom Omni collection' : 'Custom model';
+  const customFormTitle = editingCustomModelName ? 'Edit Omni collection' : (isCustomOmniCollectionDraft ? 'Custom Omni collection' : 'Custom model');
   const customRecipeOptions = recipeOptionsForDraft(customDraft.capability, customDraft.omniSource);
   const selectedCustomRecipe = customRecipeOptions.find(option => option.value === customDraft.recipe) || customRecipeOptions[0];
   const selectedCustomRecipeName = selectedCustomRecipe?.recipe || optionRecipe(customDraft.recipe);
@@ -2844,7 +2912,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         pinnedNames={pinnedNameSet}
         favoriteNames={favoriteNameSet}
         primaryFilter={primaryFilter}
-        onPrimaryFilterChange={(f) => { setPrimaryFilter(f); setNavRailOpen(false); }}
+        onPrimaryFilterChange={handlePrimaryFilterChange}
         categoryFilter={filterTab}
         onCategoryFilterChange={(f) => { setFilterTab(f); setNavRailOpen(false); }}
         backendFilter={backendFilter}
@@ -2877,8 +2945,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         backendFilter={hfMode ? 'all' : backendFilter}
         tagFilter={hfMode ? null : tagFilter}
         searchInputRef={searchRef}
-        onAddCustomModel={() => (showCustomForm && !isCustomOmniCollectionDraft) ? closeCustomForm() : openCustomForm('model')}
-        onAddOmniCollection={() => openCustomForm('omni-collection')}
+        onOpenCustomModels={() => openCustomForm('model')}
         pinnedNames={pinnedNameSet}
         onTogglePin={togglePinnedModel}
         favoriteNames={favoriteNameSet}
@@ -2898,9 +2965,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
       />
 
       {/* Right panel: custom form overlay OR model detail */}
-      {showCustomForm ? (
+      {showCustomEditor ? (
         <div className="manager__detail-form-panel">
-          <section className="zone custom-model-form" aria-label={`Add ${customFormTitle}`}>
+          <section className="zone custom-model-form" aria-label={customFormTitle}>
             <div className="zone__head">
               <span className="zone__dot zone__dot--available" />
               <span className="zone__title">{customFormTitle}</span>
@@ -2908,122 +2975,125 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
               <span className="zone__rule" />
             </div>
             <div className="custom-model-form__toolbar">
-              <button className="btn btn--ghost btn--tiny" type="button" onClick={handleExportCustomModels}>Export JSON</button>
-              <button className="btn btn--ghost btn--tiny" type="button" onClick={() => customJsonInputRef.current?.click()}>Import JSON</button>
+              {editingCustomModelName ? (
+                <span className="custom-model-form__editing-badge">Editing saved collection</span>
+              ) : (
+                <div className="custom-model-form__mode-switch" role="group" aria-label="Custom model type">
+                  <button
+                    type="button"
+                    className={!isCustomOmniCollectionDraft ? 'is-active' : ''}
+                    aria-pressed={!isCustomOmniCollectionDraft}
+                    onClick={() => openCustomForm('model')}
+                  >
+                    Custom model
+                  </button>
+                  <button
+                    type="button"
+                    className={isCustomOmniCollectionDraft ? 'is-active' : ''}
+                    aria-pressed={isCustomOmniCollectionDraft}
+                    onClick={() => openCustomForm('omni-collection')}
+                  >
+                    Omni collection
+                  </button>
+                </div>
+              )}
+              <div className="custom-model-form__io-actions">
+                <button className="btn btn--ghost btn--tiny" type="button" onClick={handleExportCustomModels}>Export JSON</button>
+                <button className="btn btn--ghost btn--tiny" type="button" onClick={() => customJsonInputRef.current?.click()}>Import JSON</button>
+              </div>
             </div>
             <form className="custom-model-form__grid" onSubmit={handleSaveCustomModel}>
               <label className="custom-model-form__field">Name
-                <input value={customDraft.displayName} onChange={e => handleCustomDraftChange({ displayName: e.target.value })} placeholder="My custom model" />
-                <span className="custom-model-form__field-hint">Display name for the registered user model.</span>
-              </label>
-              <label className="custom-model-form__field">Capability
-                <select value={customDraft.capability} onChange={e => {
-                  const nextCapability = e.target.value as CustomModelCapability;
-                  handleCustomDraftChange({
-                    capability: nextCapability,
-                    omniSource: nextCapability === 'omni' ? customDraft.omniSource : 'single',
-                    recipe: defaultRecipeForCapability(nextCapability, nextCapability === 'omni' ? customDraft.omniSource : 'single'),
-                  });
-                }}>
-                  {CUSTOM_CAPABILITIES.map(c => <option key={c.value} value={c.value}>{c.label} — {c.hint}</option>)}
-                </select>
-                <span className="custom-model-form__field-hint">Determines which compatible recipe/backend options are shown.</span>
-              </label>
-              <label className="custom-model-form__field">Recipe/backend
-                <select value={selectedCustomRecipe?.value || ''} onChange={e => handleCustomDraftChange({ recipe: e.target.value })} disabled={customRecipeOptions.length === 0}>
-                  {customRecipeOptions.length === 0
-                    ? <option value="">No compatible recipe/backend available</option>
-                    : customRecipeOptions.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
-                </select>
-                <span className="custom-model-form__field-hint">{selectedCustomRecipe?.hint || 'Backend used to register and download this custom model.'}</span>
+                <input
+                  value={customDraft.displayName}
+                  onChange={e => handleCustomDraftChange({ displayName: e.target.value })}
+                  placeholder={isCustomOmniCollectionDraft ? 'My Omni collection' : 'My custom model'}
+                />
               </label>
               <label className="custom-model-form__field">Extra labels
                 <input value={customDraft.labels} onChange={e => handleCustomDraftChange({ labels: e.target.value })} placeholder="tool-calling, reasoning" />
-                <span className="custom-model-form__field-hint">Optional comma-separated tags added to the model.</span>
               </label>
-              {customDraft.capability === 'omni' && (
+
+              {!isCustomOmniCollectionDraft && (
                 <>
-                  <label className="custom-model-form__field">Omni type
-                    <select value={customDraft.omniSource} onChange={e => {
-                      const omniSource = e.target.value as 'single' | 'collection';
-                      handleCustomDraftChange({ omniSource, recipe: defaultRecipeForCapability('omni', omniSource) });
+                  <label className="custom-model-form__field">Capability
+                    <select value={customDraft.capability} onChange={e => {
+                      const nextCapability = e.target.value as CustomModelCapability;
+                      handleCustomDraftChange({
+                        capability: nextCapability,
+                        omniSource: 'single',
+                        recipe: defaultRecipeForCapability(nextCapability, 'single'),
+                      });
                     }}>
-                      <option value="single">Single multimodal checkpoint</option>
-                      <option value="collection">Collection wrapper from existing components</option>
+                      {CUSTOM_CAPABILITIES.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
                     </select>
-                    <span className="custom-model-form__field-hint">Choose a direct checkpoint or a wrapper around component models.</span>
                   </label>
-                  <div className="custom-model-form__field-spacer" aria-hidden="true" />
+                  <label className="custom-model-form__field">Recipe/backend
+                    <select value={selectedCustomRecipe?.value || ''} onChange={e => handleCustomDraftChange({ recipe: e.target.value })} disabled={customRecipeOptions.length === 0}>
+                      {customRecipeOptions.length === 0
+                        ? <option value="">No compatible backend available</option>
+                        : customRecipeOptions.map(option => <option key={option.value} value={option.value}>{option.label}</option>)}
+                    </select>
+                  </label>
+                  <label className="custom-model-form__field custom-model-form__wide">Checkpoint, Hugging Face repo, or local path
+                    {selectedCustomRecipeSuggestion && (
+                      <InlineCheckpointExample
+                        checkpoint={selectedCustomRecipeSuggestion.checkpoint}
+                        note={selectedCustomRecipeSuggestion.note}
+                      />
+                    )}
+                    <input
+                      value={customDraft.checkpoint}
+                      onChange={e => handleCustomDraftChange({ checkpoint: e.target.value })}
+                      placeholder={primaryCheckpointPlaceholder}
+                    />
+                  </label>
+                  {showLlamacppMmprojField && (
+                    <label className="custom-model-form__field custom-model-form__wide">Vision projector (mmproj)
+                      <InlineCheckpointExample
+                        checkpoint={mmprojCheckpointExample?.checkpoint || 'repo/model:mmproj-model-f16.gguf'}
+                        note={mmprojCheckpointExample?.note}
+                      />
+                      <input
+                        value={customDraft.mmproj}
+                        onChange={e => handleCustomDraftChange({ mmproj: e.target.value })}
+                        placeholder="Optional"
+                      />
+                    </label>
+                  )}
+                  {showImageExtraCheckpointFields && (
+                    <>
+                      <label className="custom-model-form__field">Text encoder checkpoint
+                        <InlineCheckpointExample
+                          checkpoint={textEncoderCheckpointExample?.checkpoint || 'repo/text-encoder:model.safetensors'}
+                          note={textEncoderCheckpointExample?.note}
+                        />
+                        <input
+                          value={customDraft.imageTextEncoder}
+                          onChange={e => handleCustomDraftChange({ imageTextEncoder: e.target.value })}
+                          placeholder="Optional"
+                        />
+                      </label>
+                      <label className="custom-model-form__field">VAE checkpoint
+                        <InlineCheckpointExample
+                          checkpoint={vaeCheckpointExample?.checkpoint || 'repo/vae:model.safetensors'}
+                          note={vaeCheckpointExample?.note}
+                        />
+                        <input
+                          value={customDraft.imageVae}
+                          onChange={e => handleCustomDraftChange({ imageVae: e.target.value })}
+                          placeholder="Optional"
+                        />
+                      </label>
+                    </>
+                  )}
                 </>
               )}
-              <label className="custom-model-form__field">{isCustomOmniCollectionDraft ? 'Optional collection checkpoint/alias' : 'Checkpoint, HF repo, or local path'}
-                <input
-                  value={customDraft.checkpoint}
-                  onChange={e => handleCustomDraftChange({ checkpoint: e.target.value })}
-                  placeholder={isCustomOmniCollectionDraft ? 'Optional; first component is used when left empty' : primaryCheckpointPlaceholder}
-                />
-                <span className="custom-model-form__field-hint">{isCustomOmniCollectionDraft ? 'Optional alias for collection wrappers.' : 'Hugging Face id, quantized variant, or absolute local path.'}</span>
-              </label>
-              {isCustomOmniCollectionDraft ? (
-                <div className="custom-model-form__field-spacer" aria-hidden="true" />
-              ) : selectedCustomRecipeSuggestion && (
-                <CheckpointExampleCard
-                  title={`${recipeLabel(selectedCustomRecipeName)} checkpoint format example`}
-                  checkpoint={selectedCustomRecipeSuggestion.checkpoint}
-                  note={selectedCustomRecipeSuggestion.note}
-                />
-              )}
-              {showLlamacppMmprojField && (
-                <>
-                  <label className="custom-model-form__field">Vision projector (mmproj)
-                    <input
-                      value={customDraft.mmproj}
-                      onChange={e => handleCustomDraftChange({ mmproj: e.target.value })}
-                      placeholder={mmprojCheckpointExample?.checkpoint || 'repo/model:mmproj-model-f16.gguf'}
-                    />
-                    <span className="custom-model-form__field-hint">Optional extra checkpoint for llama.cpp vision models; leave empty for text-only models.</span>
-                  </label>
-                  <CheckpointExampleCard
-                    title="Vision projector checkpoint format example"
-                    checkpoint={mmprojCheckpointExample?.checkpoint || 'repo/model:mmproj-model-f16.gguf'}
-                    note={mmprojCheckpointExample?.note}
-                  />
-                </>
-              )}
-              {showImageExtraCheckpointFields && (
-                <>
-                  <label className="custom-model-form__field">Text encoder checkpoint
-                    <input
-                      value={customDraft.imageTextEncoder}
-                      onChange={e => handleCustomDraftChange({ imageTextEncoder: e.target.value })}
-                      placeholder={textEncoderCheckpointExample?.checkpoint || 'repo/text-encoder:model.safetensors'}
-                    />
-                    <span className="custom-model-form__field-hint">Optional for image pipelines that split text encoder weights from the main checkpoint.</span>
-                  </label>
-                  <CheckpointExampleCard
-                    title="Text encoder checkpoint format example"
-                    checkpoint={textEncoderCheckpointExample?.checkpoint || 'repo/text-encoder:model.safetensors'}
-                    note={textEncoderCheckpointExample?.note}
-                  />
-                  <label className="custom-model-form__field">VAE checkpoint
-                    <input
-                      value={customDraft.imageVae}
-                      onChange={e => handleCustomDraftChange({ imageVae: e.target.value })}
-                      placeholder={vaeCheckpointExample?.checkpoint || 'repo/vae:model.safetensors'}
-                    />
-                    <span className="custom-model-form__field-hint">Optional for image pipelines that split VAE weights from the main checkpoint.</span>
-                  </label>
-                  <CheckpointExampleCard
-                    title="VAE checkpoint format example"
-                    checkpoint={vaeCheckpointExample?.checkpoint || 'repo/vae:model.safetensors'}
-                    note={vaeCheckpointExample?.note}
-                  />
-                </>
-              )}
-              {customDraft.capability === 'omni' && customDraft.omniSource === 'collection' && (
+
+              {isCustomOmniCollectionDraft && (
                 <>
                   <div className="custom-model-form__hint custom-model-form__wide">
-                    Build a visible Omni collection from downloaded, registered, or custom models. Pick components from the searchable dropdowns; use the HuggingFace zone to download/register new components before selecting them here.
+                    Choose the models that make up this collection. Only the planner LLM is required.
                   </div>
                   <OmniComponentPicker role="llm" value={customDraft.llmComponent} options={omniComponentOptions.llm} onChange={value => updateOmniComponent('llm', value)} onHuggingFaceSearch={searchHuggingFaceFromPicker} />
                   <OmniComponentPicker role="vision" value={customDraft.visionComponent} options={omniComponentOptions.vision} onChange={value => updateOmniComponent('vision', value)} onHuggingFaceSearch={searchHuggingFaceFromPicker} />
@@ -3031,111 +3101,110 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
                   <OmniComponentPicker role="edit" value={customDraft.editComponent} options={omniComponentOptions.edit} onChange={value => updateOmniComponent('edit', value)} onHuggingFaceSearch={searchHuggingFaceFromPicker} />
                   <OmniComponentPicker role="transcription" value={customDraft.transcriptionComponent} options={omniComponentOptions.transcription} onChange={value => updateOmniComponent('transcription', value)} onHuggingFaceSearch={searchHuggingFaceFromPicker} />
                   <OmniComponentPicker role="speech" value={customDraft.speechComponent} options={omniComponentOptions.speech} onChange={value => updateOmniComponent('speech', value)} onHuggingFaceSearch={searchHuggingFaceFromPicker} />
-                  <label className="custom-model-form__field custom-model-form__wide custom-model-form__textarea-field">Omni tool system prompt
-                    <textarea
-                      value={customDraft.omniSystemPrompt}
-                      onChange={e => handleCustomDraftChange({ omniSystemPrompt: e.target.value })}
-                      rows={10}
-                      spellCheck={false}
-                    />
-                    <span className="custom-model-form__field-hint custom-model-form__field-hint--wrap">Optional planner prompt template. Keep {'{tool_list}'} and {'{tool_guidance}'} to insert the active Omni tools and runtime guidance automatically.</span>
-                  </label>
-                  <div className="custom-model-form__prompt-actions custom-model-form__wide">
-                    <button className="btn btn--ghost btn--tiny" type="button" onClick={() => handleCustomDraftChange({ omniSystemPrompt: DEFAULT_OMNI_SYSTEM_PROMPT_TEMPLATE })}>Reset to default</button>
-                    <span>{customDraft.omniSystemPrompt.trim() === DEFAULT_OMNI_SYSTEM_PROMPT_TEMPLATE ? 'Default prompt will be used.' : 'Custom prompt override will be saved with this collection.'}</span>
-                  </div>
-                  <div className="custom-model-form__tools custom-model-form__wide">
-                    <div className="custom-model-form__section-head">
-                      <div>
-                        <strong>Custom LLM tools</strong>
-                        <span>Expose other local LLMs as planner-callable tools, e.g. coder/reviewer helper models.</span>
+
+                  <details className="custom-model-form__advanced custom-model-form__wide">
+                    <summary>
+                      <span>Advanced settings</span>
+                      <small>System prompt and custom LLM tools</small>
+                    </summary>
+                    <div className="custom-model-form__advanced-body">
+                      <label className="custom-model-form__field custom-model-form__wide custom-model-form__textarea-field">Omni tool system prompt
+                        <textarea
+                          value={customDraft.omniSystemPrompt}
+                          onChange={e => handleCustomDraftChange({ omniSystemPrompt: e.target.value })}
+                          rows={8}
+                          spellCheck={false}
+                        />
+                      </label>
+                      <div className="custom-model-form__prompt-actions custom-model-form__wide">
+                        <button className="btn btn--ghost btn--tiny" type="button" onClick={() => handleCustomDraftChange({ omniSystemPrompt: DEFAULT_OMNI_SYSTEM_PROMPT_TEMPLATE })}>Reset to default</button>
                       </div>
-                      <div className="custom-model-form__section-actions">
-                        <button className="btn btn--ghost btn--tiny" type="button" onClick={() => addOmniCustomTool('generic')}>+ LLM tool</button>
-                        <button className="btn btn--ghost btn--tiny" type="button" onClick={addCoderReviewerPair}>+ Coder/reviewer pair</button>
+                      <div className="custom-model-form__tools custom-model-form__wide">
+                        <div className="custom-model-form__section-head">
+                          <div>
+                            <strong>Custom LLM tools</strong>
+                            <span>Optional planner-callable helper models.</span>
+                          </div>
+                          <div className="custom-model-form__section-actions">
+                            <button className="btn btn--ghost btn--tiny" type="button" onClick={() => addOmniCustomTool('generic')}>+ LLM tool</button>
+                            <button className="btn btn--ghost btn--tiny" type="button" onClick={addCoderReviewerPair}>+ Coder/reviewer pair</button>
+                          </div>
+                        </div>
+                        {customDraft.omniCustomTools.length === 0 ? (
+                          <div className="custom-model-form__empty-tools">No custom LLM tools configured.</div>
+                        ) : customDraft.omniCustomTools.map((tool, index) => {
+                          const targetListId = `omni-custom-tool-targets-${tool.id}`;
+                          return (
+                            <div className="custom-model-form__tool-card" key={tool.id}>
+                              <div className="custom-model-form__tool-card-head">
+                                <strong>Tool {index + 1}</strong>
+                                <button className="btn btn--ghost btn--tiny" type="button" onClick={() => removeOmniCustomTool(tool.id)}>Remove</button>
+                              </div>
+                              <label className="custom-model-form__field">Tool name
+                                <input
+                                  value={tool.name}
+                                  onChange={e => updateOmniCustomTool(tool.id, { name: sanitizeOmniToolName(e.target.value) })}
+                                  placeholder="ask_coder"
+                                />
+                              </label>
+                              <label className="custom-model-form__field">Target LLM
+                                <input
+                                  value={tool.targetModel}
+                                  list={targetListId}
+                                  onChange={e => updateOmniCustomTool(tool.id, { targetModel: e.target.value })}
+                                  placeholder="Select or type a model id"
+                                />
+                                <datalist id={targetListId}>
+                                  {omniComponentOptions.llm.map(option => (
+                                    <option key={option.id} value={option.id}>{option.label}</option>
+                                  ))}
+                                </datalist>
+                              </label>
+                              <label className="custom-model-form__field custom-model-form__wide">Description
+                                <input
+                                  value={tool.description}
+                                  onChange={e => updateOmniCustomTool(tool.id, { description: e.target.value })}
+                                  placeholder="When should the planner use this tool?"
+                                />
+                              </label>
+                              <label className="custom-model-form__field custom-model-form__wide custom-model-form__textarea-field custom-model-form__textarea-field--compact">Tool system prompt
+                                <textarea
+                                  value={tool.systemPrompt}
+                                  onChange={e => updateOmniCustomTool(tool.id, { systemPrompt: e.target.value })}
+                                  rows={4}
+                                  spellCheck={false}
+                                />
+                              </label>
+                              <label className="custom-model-form__field custom-model-form__wide custom-model-form__textarea-field custom-model-form__textarea-field--compact">User prompt template
+                                <textarea
+                                  value={tool.promptTemplate}
+                                  onChange={e => updateOmniCustomTool(tool.id, { promptTemplate: e.target.value })}
+                                  rows={4}
+                                  spellCheck={false}
+                                />
+                              </label>
+                              <label className="custom-model-form__field custom-model-form__wide custom-model-form__textarea-field custom-model-form__textarea-field--compact">Tool argument schema JSON
+                                <textarea
+                                  value={tool.parametersJson}
+                                  onChange={e => updateOmniCustomTool(tool.id, { parametersJson: e.target.value })}
+                                  rows={5}
+                                  spellCheck={false}
+                                />
+                              </label>
+                              <label className="custom-model-form__field">Max tokens
+                                <input
+                                  value={tool.maxTokens}
+                                  inputMode="numeric"
+                                  onChange={e => updateOmniCustomTool(tool.id, { maxTokens: e.target.value.replace(/[^0-9]/g, '') })}
+                                  placeholder="Optional"
+                                />
+                              </label>
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
-                    {customDraft.omniCustomTools.length === 0 ? (
-                      <div className="custom-model-form__empty-tools">No custom LLM tools configured. Built-in media/audio tools still come from the selected components.</div>
-                    ) : customDraft.omniCustomTools.map((tool, index) => {
-                      const targetListId = `omni-custom-tool-targets-${tool.id}`;
-                      return (
-                        <div className="custom-model-form__tool-card" key={tool.id}>
-                          <div className="custom-model-form__tool-card-head">
-                            <strong>Tool {index + 1}</strong>
-                            <button className="btn btn--ghost btn--tiny" type="button" onClick={() => removeOmniCustomTool(tool.id)}>Remove</button>
-                          </div>
-                          <label className="custom-model-form__field">Tool name
-                            <input
-                              value={tool.name}
-                              onChange={e => updateOmniCustomTool(tool.id, { name: sanitizeOmniToolName(e.target.value) })}
-                              placeholder="ask_coder"
-                            />
-                            <span className="custom-model-form__field-hint">Function name exposed to the planner. Use letters, numbers, underscores, or hyphens.</span>
-                          </label>
-                          <label className="custom-model-form__field">Target LLM
-                            <input
-                              value={tool.targetModel}
-                              list={targetListId}
-                              onChange={e => updateOmniCustomTool(tool.id, { targetModel: e.target.value })}
-                              placeholder="Select or type a model id"
-                            />
-                            <datalist id={targetListId}>
-                              {omniComponentOptions.llm.map(option => (
-                                <option key={option.id} value={option.id}>{option.label}</option>
-                              ))}
-                            </datalist>
-                            <span className="custom-model-form__field-hint">The model called when this tool runs. Tool calls are plain chat completions, no recursive tools.</span>
-                          </label>
-                          <label className="custom-model-form__field custom-model-form__wide">Description
-                            <input
-                              value={tool.description}
-                              onChange={e => updateOmniCustomTool(tool.id, { description: e.target.value })}
-                              placeholder="Delegate a focused implementation task to a coding model."
-                            />
-                            <span className="custom-model-form__field-hint">Tell the planner when to call this tool.</span>
-                          </label>
-                          <label className="custom-model-form__field custom-model-form__wide custom-model-form__textarea-field custom-model-form__textarea-field--compact">Tool system prompt
-                            <textarea
-                              value={tool.systemPrompt}
-                              onChange={e => updateOmniCustomTool(tool.id, { systemPrompt: e.target.value })}
-                              rows={4}
-                              spellCheck={false}
-                            />
-                            <span className="custom-model-form__field-hint custom-model-form__field-hint--wrap">Role prompt for the target LLM.</span>
-                          </label>
-                          <label className="custom-model-form__field custom-model-form__wide custom-model-form__textarea-field custom-model-form__textarea-field--compact">User prompt template
-                            <textarea
-                              value={tool.promptTemplate}
-                              onChange={e => updateOmniCustomTool(tool.id, { promptTemplate: e.target.value })}
-                              rows={4}
-                              spellCheck={false}
-                            />
-                            <span className="custom-model-form__field-hint custom-model-form__field-hint--wrap">Supports {'{arguments}'} plus argument placeholders like {'{task}'} and {'{context}'}.</span>
-                          </label>
-                          <label className="custom-model-form__field custom-model-form__wide custom-model-form__textarea-field custom-model-form__textarea-field--compact">Tool argument schema JSON
-                            <textarea
-                              value={tool.parametersJson}
-                              onChange={e => updateOmniCustomTool(tool.id, { parametersJson: e.target.value })}
-                              rows={5}
-                              spellCheck={false}
-                            />
-                            <span className="custom-model-form__field-hint custom-model-form__field-hint--wrap">OpenAI function parameters schema. Default exposes task and context.</span>
-                          </label>
-                          <label className="custom-model-form__field">Max tokens
-                            <input
-                              value={tool.maxTokens}
-                              inputMode="numeric"
-                              onChange={e => updateOmniCustomTool(tool.id, { maxTokens: e.target.value.replace(/[^0-9]/g, '') })}
-                              placeholder="Optional"
-                            />
-                            <span className="custom-model-form__field-hint">Optional output cap for this tool call.</span>
-                          </label>
-                          <div className="custom-model-form__field-spacer" aria-hidden="true" />
-                        </div>
-                      );
-                    })}
-                  </div>
+                  </details>
                 </>
               )}
               {customError && <div className="custom-model-form__error"><Icon name="alert" size={14} /> {customError}</div>}
@@ -3156,9 +3225,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         </div>
       ) : (
         <ModelDetailPanel
-          model={selectedDetailModelId
-            ? (listModels.find(m => modelName(m) === selectedDetailModelId) ?? null)
-            : null}
+          model={selectedDetailModel}
           loadedModel={selectedDetailModelId
             ? (displayLoadedModels.find(m => m.model_name === selectedDetailModelId) ?? null)
             : null}
@@ -3175,6 +3242,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
           serverDefaultCtxSize={serverDefaultCtxSize}
           isFavorite={selectedDetailModelId ? favoriteNameSet.has(selectedDetailModelId.toLowerCase()) : false}
           onToggleFavorite={toggleFavoriteModel}
+          onEditCustomCollection={openCustomCollectionEditor}
           noModelsAvailable={allModels.length === 0}
           onBack={() => {
             setMobileDetailOpen(false);

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -12266,3 +12266,287 @@ input, textarea {
 }
 .cap-chip--audio-generation { --cap-color: #2dd4bf; }
 .cap-chip--model3d { --cap-color: #818cf8; }
+
+/* ── Simplified custom model management ─────────────────────── */
+.model-list-panel__title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.model-list-panel__custom-menu-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-out), background var(--duration-fast) var(--ease-out), border-color var(--duration-fast) var(--ease-out);
+}
+
+.model-list-panel__custom-menu-btn:hover,
+.model-list-panel__custom-menu-btn:focus-visible {
+  border-color: var(--border-subtle);
+  background: var(--surface-2);
+  color: var(--accent-fg);
+  outline: none;
+}
+
+.custom-model-form__toolbar {
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.custom-model-form__io-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: auto;
+}
+
+.custom-model-form__mode-switch {
+  display: inline-flex;
+  padding: 3px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+}
+
+.custom-model-form__mode-switch button {
+  min-height: 30px;
+  padding: 0 var(--space-3);
+  border: 0;
+  border-radius: calc(var(--radius-md) - 3px);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+}
+
+.custom-model-form__mode-switch button:hover {
+  color: var(--text-primary);
+}
+
+.custom-model-form__mode-switch button.is-active {
+  background: var(--surface-raised);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.custom-model-form__editing-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 var(--space-3);
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-fg);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+}
+
+.custom-model-form__grid label,
+.custom-model-form__field,
+.custom-model-form__textarea-field,
+.custom-model-form__textarea-field--compact {
+  grid-template-rows: none;
+  align-content: start;
+}
+
+.custom-model-form__inline-example {
+  display: none;
+  min-width: 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+}
+
+.custom-model-form__field:focus-within > .custom-model-form__inline-example {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.custom-model-form__inline-example code {
+  overflow: hidden;
+  color: var(--accent-fg);
+  font-family: var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.custom-model-form__advanced {
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-1);
+}
+
+.custom-model-form__advanced > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  color: var(--text-primary);
+  cursor: pointer;
+  list-style: none;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+}
+
+.custom-model-form__advanced > summary::-webkit-details-marker {
+  display: none;
+}
+
+.custom-model-form__advanced > summary::after {
+  content: '+';
+  color: var(--text-tertiary);
+  font-size: var(--text-lg);
+  font-weight: 400;
+}
+
+.custom-model-form__advanced[open] > summary::after {
+  content: '−';
+}
+
+.custom-model-form__advanced > summary small {
+  margin-left: auto;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  font-weight: 400;
+}
+
+.custom-model-form__advanced-body {
+  display: grid;
+  gap: var(--space-3);
+  padding: 0 var(--space-3) var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.custom-model-form__advanced-body > :first-child {
+  margin-top: var(--space-3);
+}
+
+.custom-model-form__prompt-actions {
+  justify-content: flex-start;
+  padding: 0;
+}
+
+/* Saved custom collections intentionally expose Settings + Files only. */
+.custom-collection-settings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+}
+
+.custom-collection-settings__intro {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.custom-collection-settings__intro h3,
+.custom-collection-settings__section h4 {
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.custom-collection-settings__intro p {
+  margin: var(--space-1) 0 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+}
+
+.custom-collection-settings__section {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.custom-collection-settings__components {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.custom-collection-settings__component,
+.custom-collection-settings__summary {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+}
+
+.custom-collection-settings__component {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  padding: var(--space-3);
+}
+
+.custom-collection-settings__component span,
+.custom-collection-settings__summary span {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}
+
+.custom-collection-settings__component strong {
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.custom-collection-settings__summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-2) var(--space-4);
+  padding: var(--space-3);
+}
+
+.custom-collection-settings__summary strong {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+@media (max-width: 720px) {
+  .custom-model-form__toolbar,
+  .custom-collection-settings__intro {
+    align-items: stretch;
+  }
+
+  .custom-model-form__mode-switch,
+  .custom-model-form__io-actions {
+    width: 100%;
+  }
+
+  .custom-model-form__mode-switch button,
+  .custom-model-form__io-actions .btn {
+    flex: 1;
+  }
+
+  .custom-model-form__advanced > summary small {
+    display: none;
+  }
+
+  .custom-collection-settings__intro {
+    flex-direction: column;
+  }
+
+  .custom-collection-settings__components {
+    grid-template-columns: 1fr;
+  }
+}

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -33,6 +33,23 @@ async function navigateToView(page: Page, label: string): Promise<void> {
   await page.waitForTimeout(300);
 }
 
+/** Open the custom-model editor through the Models heading action. */
+async function openCustomModelEditor(
+  page: Page,
+  mode: 'model' | 'omni-collection' = 'model',
+): Promise<void> {
+  await page.goto('/');
+  await navigateToView(page, 'Models');
+  await page.waitForSelector('.manager');
+
+  await page.getByRole('button', { name: 'Open custom models' }).click();
+  await page.waitForSelector('.custom-model-form');
+
+  if (mode === 'omni-collection') {
+    await page.getByRole('button', { name: 'Omni collection', exact: true }).click();
+  }
+}
+
 /** Format axe violations into a readable string for assertion failure messages. */
 function formatViolations(
   violations: Array<{ id: string; description: string; impact?: string | null }>,
@@ -1732,10 +1749,7 @@ test.describe('Accessibility — account menu dialog', () => {
 
 test.describe('Accessibility — Omni picker combobox semantics (#2347)', () => {
   async function openOmniCollectionForm(page: Page): Promise<void> {
-    await page.goto('/');
-    await navigateToView(page, 'Models');
-    await page.waitForSelector('.manager');
-    await page.getByText('+ Omni collection').click();
+    await openCustomModelEditor(page, 'omni-collection');
     await page.waitForSelector('.omni-component-picker');
   }
 
@@ -1847,10 +1861,7 @@ test.describe('Accessibility — icon-button accessible names (#2353)', () => {
   });
 
   test('A79 — Omni picker clear button has aria-label naming target', async ({ page }) => {
-    await page.goto('/');
-    await navigateToView(page, 'Models');
-    await page.waitForSelector('.manager');
-    await page.getByText('+ Omni collection').click();
+    await openCustomModelEditor(page, 'omni-collection');
     await page.waitForSelector('.omni-component-picker');
 
     const clearBtns = page.locator('.omni-component-picker__clear');
@@ -2379,17 +2390,25 @@ test.describe('Accessibility — master-detail model view (#2355 Slice 1)', () =
     expect(labelledBy).toBeTruthy();
   });
 
-  // ── Custom model / Omni collection buttons ────────────────────────────────────
+  // ── Custom model management ───────────────────────────────────────────────────
 
-  test('A104 — "+ Custom model" and "+ Omni collection" buttons are visible and keyboard-accessible', async ({ page }) => {
+  test('A104 — custom-model heading action opens an accessible model-type switch', async ({ page }) => {
     await goToModels(page);
-    const customBtn = page.getByText('+ Custom model');
-    const omniBtn = page.getByText('+ Omni collection');
+
+    const openCustomModels = page.getByRole('button', { name: 'Open custom models' });
+    await expect(openCustomModels).toBeVisible();
+    await expect(openCustomModels).toHaveRole('button');
+    await openCustomModels.click();
+
+    const typeGroup = page.getByRole('group', { name: 'Custom model type' });
+    const customBtn = typeGroup.getByRole('button', { name: 'Custom model', exact: true });
+    const omniBtn = typeGroup.getByRole('button', { name: 'Omni collection', exact: true });
+    await expect(typeGroup).toBeVisible();
     await expect(customBtn).toBeVisible();
     await expect(omniBtn).toBeVisible();
-    // Both should be real buttons
     await expect(customBtn).toHaveRole('button');
     await expect(omniBtn).toHaveRole('button');
+    await expect(customBtn).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('A105 — master-detail Models view passes WCAG 2.1 AA axe-core scan with mock data', async ({ page }) => {
@@ -3049,22 +3068,27 @@ test.describe('Accessibility — left navigation rail (#2355 three-pane)', () =>
     expect((await bar.getAttribute('aria-label')) ?? '').not.toBe('');
   });
 
-  // ── Custom-model buttons (moved to TOP) ──────────────────────────────────
+  // ── Custom-model heading action ───────────────────────────────────────────
 
-  test('A133 — custom-model buttons are a grounded group at the top and keyboard reachable', async ({ page }) => {
+  test('A133 — custom-model action is grouped with the Models heading and keyboard reachable', async ({ page }) => {
     await goToModelsWithNavMock(page);
-    const group = page.locator('.model-list-panel__add-group');
-    await expect(group).toBeVisible();
-    const customBtn = group.getByRole('button', { name: /custom model/i });
-    const omniBtn = group.getByRole('button', { name: /omni collection/i });
-    await expect(customBtn).toBeVisible();
-    await expect(omniBtn).toBeVisible();
-    await customBtn.focus();
-    await expect(customBtn).toBeFocused();
-    // The group sits above the model list in DOM order (top of the area).
-    const groupBox = await group.boundingBox();
+
+    const title = page.locator('.model-list-panel__title');
+    const heading = title.getByRole('heading', { name: 'Models' });
+    const customModelsBtn = title.getByRole('button', { name: 'Open custom models' });
+    await expect(title).toBeVisible();
+    await expect(heading).toBeVisible();
+    await expect(customModelsBtn).toBeVisible();
+
+    await customModelsBtn.focus();
+    await expect(customModelsBtn).toBeFocused();
+    await page.keyboard.press('Enter');
+    await expect(page.locator('.custom-model-form')).toBeVisible();
+
+    // The heading action remains grounded above the model list.
+    const titleBox = await title.boundingBox();
     const listBox = await page.locator('.model-list-panel__list').boundingBox();
-    expect(groupBox && listBox && groupBox.y < listBox.y).toBeTruthy();
+    expect(titleBox && listBox && titleBox.y < listBox.y).toBeTruthy();
   });
 
   // ── Responsive nav toggle ────────────────────────────────────────────────


### PR DESCRIPTION
## GUI3: simplify custom model and Omni collection management

### Summary

* replace the bulky custom-model actions with an accessible settings icon next to the Models heading
* provide a unified editor for custom models and Omni collections
* simplify Omni collection setup and move tools and the system prompt under Advanced settings
* keep saved collections editable with focused Settings and Files views
* update accessibility tests for the new navigation and editor structure

### Testing

* local ui testing
* all npm test passed

Closes #2563
