### PR TITLE
Support gfx950, using the same path as gfx942

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2226,3 +2226,13 @@ if(EXISTS "${_VLLM_CDNA_TEST_SRC}")
     target_link_libraries(test_vllm_cdna_gating PRIVATE lemonade-server-core)
     add_test(NAME VllmCdnaGatingTest COMMAND test_vllm_cdna_gating)
 endif()
+
+# llamacpp gfx950 (MI350) install gate: only the Linux + stable-channel asset is
+# published, so the shared Windows/Linux support row must not advertise Windows
+# or nightly installs for gfx950.
+set(_LLAMACPP_GFX950_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_llamacpp_gfx950_gating.cpp")
+if(EXISTS "${_LLAMACPP_GFX950_TEST_SRC}")
+    add_executable(test_llamacpp_gfx950_gating test/cpp/test_llamacpp_gfx950_gating.cpp)
+    target_link_libraries(test_llamacpp_gfx950_gating PRIVATE lemonade-server-core)
+    add_test(NAME LlamacppGfx950GatingTest COMMAND test_llamacpp_gfx950_gating)
+endif()

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     </tr>
     <tr>
       <td><code>rocm</code></td>
-      <td>Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942) and MI350X (gfx950)*</td>
+      <td>Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942) and MI350X (gfx950, Linux + stable only)*</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     </tr>
     <tr>
       <td><code>rocm</code></td>
-      <td>Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942)*</td>
+      <td>Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942) and MI350X (gfx950)*</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -38,7 +38,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `llamacpp` | metal | macos | metal |
 | `llamacpp` | cuda | linux, windows | nvidia_gpu (sm_100, sm_120, sm_121, sm_75, sm_80, sm_86, sm_89, sm_90) |
 | `llamacpp` | vulkan | linux, windows | amd_gpu; cpu (arm64, x86_64) |
-| `llamacpp` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X, gfx942) |
+| `llamacpp` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X, gfx942, gfx950) |
 | `llamacpp` | cpu | linux, windows | cpu (arm64, x86_64) |
 | `moonshine` | cpu | windows | cpu (x86_64) |
 | `moonshine` | cpu | linux | cpu (arm64, x86_64) |

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -66,6 +66,13 @@ the generator instead. Prose outside the markers is preserved. -->
 | `whispercpp` | metal | macos | metal |
 <!-- END GENERATED: backends-matrix -->
 
+> **Note:** The `llamacpp` `rocm` row lists `linux, windows` for the family as a
+> whole, but MI350X (`gfx950`) is currently gated to **Linux + stable channel
+> only** — the Windows TheRock distribution and the ROCm nightly build for
+> gfx950 are not yet published, so `gfx950` installs are rejected on Windows and
+> on the nightly channel. The OS column reflects the row's overall reach; the
+> per-architecture restriction is enforced by the backend's install gate.
+
 ## Recipe options
 
 <!-- BEGIN GENERATED: backend-options -->

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
@@ -37,7 +37,10 @@ inline const BackendDescriptor descriptor = {
          {{"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120", "sm_121"}}}, "NVIDIA GPUs (Turing or newer)**"},
         {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64", "arm64"}}, {"amd_gpu", {}}}, "x86_64 CPU, AMD iGPU, AMD dGPU; ARM64 CPU/GPU (Linux)"},
         {"rocm", {"windows", "linux"},
-         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X", "gfx942", "gfx950"}}}, "Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942) and MI350X (gfx950)*"},
+         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X", "gfx942", "gfx950"}}}, "Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942) and MI350X (gfx950)*",
+         // gfx950 (MI350) only ships a Linux + stable-channel asset so far; the
+         // Windows TheRock dist and the nightly build aren't published yet.
+         {{"gfx950", {/*os*/ {"linux"}, /*channels*/ {"stable"}}}}},
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64", "arm64"}}}, "x86_64 CPU; ARM64 CPU (Linux)"},
     },
     /*default_labels*/  {},

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
@@ -37,7 +37,7 @@ inline const BackendDescriptor descriptor = {
          {{"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120", "sm_121"}}}, "NVIDIA GPUs (Turing or newer)**"},
         {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64", "arm64"}}, {"amd_gpu", {}}}, "x86_64 CPU, AMD iGPU, AMD dGPU; ARM64 CPU/GPU (Linux)"},
         {"rocm", {"windows", "linux"},
-         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X", "gfx942"}}}, "Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942)*"},
+         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X", "gfx942", "gfx950"}}}, "Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942) and MI350X (gfx950)*"},
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64", "arm64"}}}, "x86_64 CPU; ARM64 CPU (Linux)"},
     },
     /*default_labels*/  {},

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
@@ -37,7 +37,7 @@ inline const BackendDescriptor descriptor = {
          {{"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120", "sm_121"}}}, "NVIDIA GPUs (Turing or newer)**"},
         {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64", "arm64"}}, {"amd_gpu", {}}}, "x86_64 CPU, AMD iGPU, AMD dGPU; ARM64 CPU/GPU (Linux)"},
         {"rocm", {"windows", "linux"},
-         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X", "gfx942", "gfx950"}}}, "Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942) and MI350X (gfx950)*",
+         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X", "gfx942", "gfx950"}}}, "Supported AMD ROCm iGPU/dGPU families, incl. AMD Instinct MI300X (gfx942) and MI350X (gfx950, Linux + stable only)*",
          // gfx950 (MI350) only ships a Linux + stable-channel asset so far; the
          // Windows TheRock dist and the nightly build aren't published yet.
          {{"gfx950", {/*os*/ {"linux"}, /*channels*/ {"stable"}}}}},

--- a/src/cpp/include/lemon/backends/vllm/vllm.h
+++ b/src/cpp/include/lemon/backends/vllm/vllm.h
@@ -25,8 +25,8 @@ inline const BackendDescriptor descriptor = {
          "Custom arguments to pass to vllm-server", "vLLM Options"},
     },
     /*support*/ {
-        // gfx942 omitted until its vLLM/ROCm asset ships in lemonade-sdk/vllm-rocm;
-        // everything else is wired, so re-add it here once that lands.
+        // gfx942/gfx950 (CDNA) omitted until their vLLM/ROCm assets ship in lemonade-sdk/vllm-rocm;
+        // everything else is wired (incl. the rocm_arch_overrides pins), so re-add them here once that lands.
         {"rocm", {"linux"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx110X", "gfx120X"}}}, "Strix Halo iGPU (gfx1151)"},
     },
     /*default_labels*/  {},

--- a/src/cpp/include/lemon/recipe_backend_def.h
+++ b/src/cpp/include/lemon/recipe_backend_def.h
@@ -9,6 +9,19 @@ namespace lemon {
 // Device constraints: device_type -> set of allowed families (empty = all families)
 using DeviceConstraints = std::map<std::string, std::set<std::string>>;
 
+// Optional per-arch restriction, tighter than the owning support row. Used when
+// a single family/ISA is installable on only a subset of the row's OSes or ROCm
+// channels because the upstream assets for the others aren't published yet
+// (e.g. gfx950 / MI350: only the Linux + stable asset exists so far). An arch
+// absent from the row's gate map inherits the row's full OS/channel reach.
+struct ArchInstallGate {
+    std::set<std::string> os;        // if non-empty, arch installable only on these OSes
+    std::set<std::string> channels;  // if non-empty, arch installable only on these ROCm channels
+};
+
+// arch token (as written in the support row, e.g. "gfx950") -> its extra gate.
+using ArchInstallGates = std::map<std::string, ArchInstallGate>;
+
 // A single recipe/backend support row: which OS and device families a given
 // (recipe, backend) pair runs on. The canonical support matrix is assembled by
 // collecting these rows from every backend descriptor (see BackendDescriptor::support).
@@ -24,6 +37,7 @@ struct RecipeBackendDef {
     // Human-friendly device description for the generated support matrix (README).
     // May contain footnote markers (e.g. "*") whose text lives as prose in the doc.
     std::string device_summary = "";
+    ArchInstallGates arch_gates;
 };
 
 // A backend descriptor's support row, without the recipe (it's always the
@@ -34,6 +48,7 @@ struct BackendSupport {
     std::set<std::string> supported_os;
     DeviceConstraints devices;
     std::string device_summary = "";
+    ArchInstallGates arch_gates;
 };
 
 } // namespace lemon

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -28,6 +28,7 @@
       "gfx908",
       "gfx90a",
       "gfx942",
+      "gfx950",
       "gfx1100",
       "gfx1101",
       "gfx1102",
@@ -55,6 +56,7 @@
       "gfx908": "gfx90X-dcgpu",
       "gfx90a": "gfx90X-dcgpu",
       "gfx942": "gfx94X-dcgpu",
+      "gfx950": "gfx950-dcgpu",
       "gfx103X": "gfx103X-all",
       "gfx110X": "gfx110X-all",
       "gfx120X": "gfx120X-all",
@@ -90,10 +92,11 @@
     "metal": "b17"
   },
   "vllm": {
-    "comment": "'rocm' is the default (RDNA) pin. 'rocm_arch_overrides' pins per detected asset family (rocm_asset_family output) where AMD's vLLM/ROCm wheel cadence diverges: CDNA-dcgpu (gfx942) shares no release tag with the RDNA line, so it pins its own version. Review each override at release time - feature/fix parity across arch lines lags until bumped.",
+    "comment": "'rocm' is the default (RDNA) pin. 'rocm_arch_overrides' pins per detected asset family (rocm_asset_family output) where AMD's vLLM/ROCm wheel cadence diverges: CDNA-dcgpu (gfx942, gfx950) shares no release tag with the RDNA line, so it pins its own version. gfx950 (CDNA4) rides the same CDNA vLLM/ROCm line as gfx942 (CDNA3). Review each override at release time - feature/fix parity across arch lines lags until bumped.",
     "rocm": "vllm0.20.1-rocm7.12.0",
     "rocm_arch_overrides": {
-      "gfx942": "vllm0.19.1-rocm7.13.0"
+      "gfx942": "vllm0.19.1-rocm7.13.0",
+      "gfx950": "vllm0.19.1-rocm7.13.0"
     }
   },
   "rocm_asset_families": {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -479,7 +479,8 @@ static const std::vector<RecipeBackendDef>& recipe_defs() {
         std::vector<RecipeBackendDef> v;
         for (const auto* desc : lemon::backends::all_descriptors()) {
             for (const auto& row : desc->support) {
-                v.push_back({desc->recipe, row.backend, row.supported_os, row.devices, row.device_summary});
+                v.push_back({desc->recipe, row.backend, row.supported_os, row.devices,
+                             row.device_summary, row.arch_gates});
             }
         }
         return v;
@@ -629,18 +630,57 @@ static bool device_matches_constraint(const std::string& device_family,
     return false;
 }
 
+// Find the install gate that applies to `arch` in a support row, honoring the
+// same trailing-X wildcard the device matrix uses. Returns nullptr when the arch
+// has no extra gate (inherits the row's full OS/channel reach).
+static const ArchInstallGate* find_arch_gate(const ArchInstallGates& gates,
+                                             const std::string& arch) {
+    auto exact = gates.find(arch);
+    if (exact != gates.end()) {
+        return &exact->second;
+    }
+    for (const auto& [token, gate] : gates) {
+        if (device_matches_constraint(arch, {token})) {
+            return &gate;
+        }
+    }
+    return nullptr;
+}
+
+// True if `arch` clears a support row's per-arch gate for the given OS/channel.
+// An empty channel means "channel-agnostic" (e.g. the availability matrix asks
+// about the bare "rocm" backend) and only the OS half of the gate is enforced.
+static bool arch_gate_allows(const ArchInstallGates& gates, const std::string& arch,
+                             const std::string& os, const std::string& channel) {
+    const ArchInstallGate* gate = find_arch_gate(gates, arch);
+    if (!gate) {
+        return true;
+    }
+    if (!gate->os.empty() && gate->os.count(os) == 0) {
+        return false;
+    }
+    if (!channel.empty() && !gate->channels.empty() && gate->channels.count(channel) == 0) {
+        return false;
+    }
+    return true;
+}
+
 // True if (recipe, backend) is published for the given ROCm family/ISA, per the
 // support matrix assembled from backend descriptors. The matrix keys ROCm rows
 // under "rocm", so a channel-qualified backend (rocm-stable/rocm-nightly) is
-// normalized before lookup. `arch` may be a concrete ISA or a family token; the
-// trailing-X wildcard in the matrix handles ISA-to-family matching.
+// normalized before lookup — the channel it carries is still honored against any
+// per-arch gate. `arch` may be a concrete ISA or a family token; the trailing-X
+// wildcard in the matrix handles ISA-to-family matching.
 bool SystemInfo::backend_supports_arch(const std::string& recipe,
                                        const std::string& backend,
                                        const std::string& arch) {
     std::string matrix_backend = backend;
+    std::string channel;
     if (matrix_backend.rfind("rocm-", 0) == 0) {
+        channel = matrix_backend.substr(std::string("rocm-").size());
         matrix_backend = "rocm";
     }
+    const std::string current_os = get_current_os();
     for (const auto& def : recipe_defs()) {
         if (def.recipe != recipe || def.backend != matrix_backend) {
             continue;
@@ -649,7 +689,10 @@ bool SystemInfo::backend_supports_arch(const std::string& recipe,
         if (it == def.devices.end()) {
             return false;
         }
-        return device_matches_constraint(arch, it->second);
+        if (!device_matches_constraint(arch, it->second)) {
+            return false;
+        }
+        return arch_gate_allows(def.arch_gates, arch, current_os, channel);
     }
     return false;
 }
@@ -1297,6 +1340,17 @@ json SystemInfo::build_recipes_info(const json& devices) {
         std::vector<std::pair<std::string, std::set<std::string>>> missing_devices;  // Device types not present
         std::vector<std::pair<std::string, std::set<std::string>>> wrong_family;     // Device present but wrong family
 
+        // Resolve the ROCm channel this recipe is configured for, so per-arch gates
+        // (e.g. gfx950 is stable-only) can be enforced against the active channel.
+        std::string row_channel;
+        if (!def.arch_gates.empty() && def.backend == "rocm" &&
+            backends::recipe_has_rocm_channels(def.recipe)) {
+            row_channel = "stable";
+            if (auto* cfg = RuntimeConfig::global()) {
+                row_channel = cfg->rocm_channel_for_recipe(def.recipe);
+            }
+        }
+
         for (const auto& [required_device_type, required_families] : def.devices) {
             bool device_type_found = false;
             bool family_matched = false;
@@ -1304,7 +1358,8 @@ json SystemInfo::build_recipes_info(const json& devices) {
             for (const auto& detected : detected_devices) {
                 if (detected.type == required_device_type) {
                     device_type_found = true;
-                    if (device_matches_constraint(detected.family, required_families)) {
+                    if (device_matches_constraint(detected.family, required_families) &&
+                        arch_gate_allows(def.arch_gates, detected.family, current_os, row_channel)) {
                         matching_devices.push_back(detected.type);
                         family_matched = true;
                     }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -506,6 +506,7 @@ static const std::map<std::string, std::string> DEVICE_FAMILY_NAMES = {
     {"gfx110X", "Radeon RX 7000 series (RDNA3)"},
     {"gfx120X", "Radeon RX 9000 series (RDNA4)"},
     {"gfx942", "AMD Instinct MI300X / MI300A (CDNA3)"},
+    {"gfx950", "AMD Instinct MI350X / MI355X (CDNA4)"},
 
     // NVIDIA GPU compute capabilities (CUDA)
     {"sm_75",  "GeForce RTX 20 / GTX 16 series (Turing)"},

--- a/test/cpp/test_llamacpp_gfx950_gating.cpp
+++ b/test/cpp/test_llamacpp_gfx950_gating.cpp
@@ -1,0 +1,60 @@
+// Verifies the per-arch install gate on the llamacpp:rocm support row: gfx950
+// (MI350) only has a Linux + stable-channel asset published so far, so it must
+// not be advertised installable on Windows or on the nightly channel, while the
+// established RDNA families and gfx942 keep their full reach.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "lemon/system_info.h"
+
+using lemon::SystemInfo;
+
+namespace {
+
+int failures = 0;
+
+void expect(bool cond, const std::string& msg) {
+    if (!cond) {
+        std::cerr << "FAIL: " << msg << std::endl;
+        ++failures;
+    } else {
+        std::cout << "ok: " << msg << std::endl;
+    }
+}
+
+}  // namespace
+
+int main() {
+#if defined(_WIN32)
+    const bool on_linux = false;
+#elif defined(__linux__)
+    const bool on_linux = true;
+#else
+    const bool on_linux = false;
+#endif
+
+    // RDNA families are unchanged: installable on every OS and channel.
+    expect(SystemInfo::backend_supports_arch("llamacpp", "rocm-stable", "gfx1151"),
+           "llamacpp gfx1151 stable stays installable");
+    expect(SystemInfo::backend_supports_arch("llamacpp", "rocm-nightly", "gfx1151"),
+           "llamacpp gfx1151 nightly stays installable");
+
+    // gfx950 (MI350) is gated to Linux + stable until the other assets ship.
+    expect(SystemInfo::backend_supports_arch("llamacpp", "rocm-stable", "gfx950") == on_linux,
+           "llamacpp gfx950 stable is installable on Linux only");
+    expect(!SystemInfo::backend_supports_arch("llamacpp", "rocm-nightly", "gfx950"),
+           "llamacpp gfx950 nightly is never advertised (asset not published)");
+    expect(SystemInfo::backend_supports_arch("llamacpp", "rocm", "gfx950") == on_linux,
+           "llamacpp gfx950 (bare rocm) honors the Linux-only OS gate");
+
+    // gfx942 carries no gate, so its behavior is untouched by this change.
+    expect(SystemInfo::backend_supports_arch("llamacpp", "rocm-stable", "gfx942"),
+           "llamacpp gfx942 stable is unaffected by the gfx950 gate");
+
+    if (failures == 0) {
+        std::cout << "All llamacpp gfx950 gating assertions passed" << std::endl;
+    }
+    return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/cpp/test_vllm_cdna_gating.cpp
+++ b/test/cpp/test_vllm_cdna_gating.cpp
@@ -62,6 +62,8 @@ int main() {
     // release line from the RDNA default, since no single tag carries both.
     expect(SystemInfo::vllm_rocm_version_override("gfx942") == "vllm0.19.1-rocm7.13.0",
            "vllm gfx942 overrides to its own dcgpu release line");
+    expect(SystemInfo::vllm_rocm_version_override("gfx950") == "vllm0.19.1-rocm7.13.0",
+           "vllm gfx950 (CDNA4) rides the same CDNA release line as gfx942");
     expect(SystemInfo::vllm_rocm_version_override("gfx110X").empty(),
            "vllm RDNA families use the default pin (no override)");
     expect(SystemInfo::vllm_rocm_version_override("gfx1151").empty(),

--- a/test/cpp/test_vllm_cdna_gating.cpp
+++ b/test/cpp/test_vllm_cdna_gating.cpp
@@ -34,6 +34,8 @@ int main() {
     // below it is wired and tested.
     expect(!SystemInfo::backend_supports_arch("vllm", "rocm", "gfx942"),
            "vllm:rocm gfx942 is NOT advertised installable yet (asset pending; infra staged)");
+    expect(!SystemInfo::backend_supports_arch("vllm", "rocm", "gfx950"),
+           "vllm:rocm gfx950 is NOT advertised installable yet (asset pending; infra staged)");
 
     expect(SystemInfo::backend_supports_arch("vllm", "rocm", "gfx1100"),
            "vllm:rocm still supports gfx1100 via gfx110X wildcard");


### PR DESCRIPTION
Routes `gfx950` (MI350) through the same code path as `gfx942`.
Verified the `llama.cpp` backend runs correctly on MI350 hardware.

This addresses (at least partially) issue https://github.com/lemonade-sdk/lemonade/issues/2686