### PR TITLE
chore: normalize the tree with pre-commit run --all-files

### DIFF
--- a/.github/scripts/auto_label.py
+++ b/.github/scripts/auto_label.py
@@ -256,6 +256,7 @@ def has_write_access(login, repo):
         return False
     return data.get("permission") in WRITE_PERMISSIONS
 
+
 def is_bot_user(user):
     """Return True for GitHub bot accounts.
     Bot activity should not count as community engagement for priority labels.
@@ -265,6 +266,7 @@ def is_bot_user(user):
     login = user.get("login") or ""
     user_type = user.get("type") or ""
     return user_type == "Bot" or login.lower().endswith("[bot]")
+
 
 def _add_community_user(users, user, author_association, repo):
     if not user:

--- a/.github/scripts/render_sdcpp_pr_body.py
+++ b/.github/scripts/render_sdcpp_pr_body.py
@@ -16,7 +16,6 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-
 DEFAULT_VALIDATED_LABELS = ("cpu", "vulkan", "rocm-stable")
 
 
@@ -115,12 +114,16 @@ def seconds(row: dict[str, Any]) -> float:
 
 
 def image_url(repository: str, image_ref: str, path: str) -> str:
-    quoted_path = "/".join(part.replace("#", "%23").replace(" ", "%20") for part in path.split("/"))
+    quoted_path = "/".join(
+        part.replace("#", "%23").replace(" ", "%20") for part in path.split("/")
+    )
     quoted_ref = image_ref.replace("#", "%23").replace(" ", "%20")
     return f"https://raw.githubusercontent.com/{repository}/{quoted_ref}/{quoted_path}"
 
 
-def group_summary(records: list[dict[str, Any]], labels: list[str]) -> dict[str, dict[str, Any]]:
+def group_summary(
+    records: list[dict[str, Any]], labels: list[str]
+) -> dict[str, dict[str, Any]]:
     summary: dict[str, dict[str, Any]] = {}
     for label in labels:
         summary[label] = {"total": 0, "passed": 0, "elapsed": 0.0}
@@ -134,7 +137,12 @@ def group_summary(records: list[dict[str, Any]], labels: list[str]) -> dict[str,
     return summary
 
 
-def assert_expected_images(records: list[dict[str, Any]], labels: list[str], models: list[str], sizes: list[str]) -> None:
+def assert_expected_images(
+    records: list[dict[str, Any]],
+    labels: list[str],
+    models: list[str],
+    sizes: list[str],
+) -> None:
     """Fail if any expected backend/model/size image is missing or failed."""
     if not models:
         raise SystemExit("No expected validation models were provided")
@@ -143,7 +151,11 @@ def assert_expected_images(records: list[dict[str, Any]], labels: list[str], mod
 
     rows: dict[tuple[str, str, str], dict[str, Any]] = {}
     for row in records:
-        key = (str(row.get("label", "")), str(row.get("model", "")), str(row.get("size", "")))
+        key = (
+            str(row.get("label", "")),
+            str(row.get("model", "")),
+            str(row.get("size", "")),
+        )
         rows[key] = row
 
     missing: list[str] = []
@@ -169,11 +181,17 @@ def assert_expected_images(records: list[dict[str, Any]], labels: list[str], mod
         if failed:
             details.append("Failed validation records:\n  - " + "\n  - ".join(failed))
         if missing_image:
-            details.append("Missing copied validation images:\n  - " + "\n  - ".join(missing_image))
-        raise SystemExit("Expected validation image evidence is incomplete.\n" + "\n".join(details))
+            details.append(
+                "Missing copied validation images:\n  - " + "\n  - ".join(missing_image)
+            )
+        raise SystemExit(
+            "Expected validation image evidence is incomplete.\n" + "\n".join(details)
+        )
 
 
-def render_body(args: argparse.Namespace, records: list[dict[str, Any]], copied: int) -> str:
+def render_body(
+    args: argparse.Namespace, records: list[dict[str, Any]], copied: int
+) -> str:
     base_backends = parse_csv(args.base_update_backends)
     cuda_backends = parse_csv(args.cuda_update_backends)
     updated = base_backends + cuda_backends
@@ -194,7 +212,8 @@ def render_body(args: argparse.Namespace, records: list[dict[str, Any]], copied:
         f"- Updated base pins: `{', '.join(base_backends)}` -> `{args.base_release}`",
         f"- Updated CUDA pins: `{', '.join(cuda_backends)}` -> `{args.cuda_release}`",
         f"- Validated backends: `{', '.join(labels)}`",
-        "- Updated but not validated here: " + (f"`{', '.join(unvalidated)}`" if unvalidated else "none"),
+        "- Updated but not validated here: "
+        + (f"`{', '.join(unvalidated)}`" if unvalidated else "none"),
         f"- Timing: `{timing_scope}`; per-image timings are listed below.",
         "",
         "CUDA assets are resolved independently from the Lemonade fork. They do not need to share the same tag as the upstream leejet release.",
@@ -212,13 +231,17 @@ def render_body(args: argparse.Namespace, records: list[dict[str, Any]], copied:
 
     for label in labels:
         item = summary.get(label, {"total": 0, "passed": 0, "elapsed": 0.0})
-        result = f"{item['passed']}/{item['total']} images" if item["total"] else "missing"
+        result = (
+            f"{item['passed']}/{item['total']} images" if item["total"] else "missing"
+        )
         elapsed = f"{item['elapsed']:.1f}s" if item["total"] else "-"
         lines.append(f"| {label} | {result} | {elapsed} | `sdcpp-validation-{label}` |")
 
     if unvalidated:
         lines.append("")
-        lines.append("Unvalidated pins are intentionally updated but not exercised in this workflow run.")
+        lines.append(
+            "Unvalidated pins are intentionally updated but not exercised in this workflow run."
+        )
 
     lines += [
         "",
@@ -228,7 +251,14 @@ def render_body(args: argparse.Namespace, records: list[dict[str, Any]], copied:
         "|---|---|---:|---:|---|",
     ]
 
-    for row in sorted(records, key=lambda r: (str(r.get("label", "")), str(r.get("model", "")), str(r.get("size", "")))):
+    for row in sorted(
+        records,
+        key=lambda r: (
+            str(r.get("label", "")),
+            str(r.get("model", "")),
+            str(r.get("size", "")),
+        ),
+    ):
         label = str(row.get("label", ""))
         model = str(row.get("model", ""))
         size = str(row.get("size", ""))
@@ -259,9 +289,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--cuda-release", required=True)
     parser.add_argument("--base-update-backends", required=True)
     parser.add_argument("--cuda-update-backends", required=True)
-    parser.add_argument("--validated-labels", default=",".join(DEFAULT_VALIDATED_LABELS))
-    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", "lemonade-sdk/lemonade"))
-    parser.add_argument("--image-ref", required=True, help="Branch or commit ref that will contain committed evidence images")
+    parser.add_argument(
+        "--validated-labels", default=",".join(DEFAULT_VALIDATED_LABELS)
+    )
+    parser.add_argument(
+        "--repository",
+        default=os.environ.get("GITHUB_REPOSITORY", "lemonade-sdk/lemonade"),
+    )
+    parser.add_argument(
+        "--image-ref",
+        required=True,
+        help="Branch or commit ref that will contain committed evidence images",
+    )
     parser.add_argument("--evidence-dir", required=True)
     parser.add_argument("--output", default="pr_body.md")
     parser.add_argument("--prompt", default=os.environ.get("SDCPP_TEST_PROMPT", ""))
@@ -279,7 +318,9 @@ def main() -> int:
     evidence_dir = Path(args.evidence_dir)
     copied = copy_images(records, evidence_dir)
 
-    assert_expected_images(records, labels, parse_csv(args.models), parse_csv(args.sizes))
+    assert_expected_images(
+        records, labels, parse_csv(args.models), parse_csv(args.sizes)
+    )
 
     body = render_body(args, records, copied)
     Path(args.output).write_text(body, encoding="utf-8")

--- a/.github/scripts/triage_dashboard.py
+++ b/.github/scripts/triage_dashboard.py
@@ -32,7 +32,9 @@ COMPONENT_LABELS = {"cpp", "app", "web ui", "audio"}
 
 def gh_api_pages(path):
     cmd = ["gh", "api", "--paginate", "--slurp", path]
-    out = subprocess.run(cmd, check=True, capture_output=True, text=True, encoding="utf-8").stdout
+    out = subprocess.run(
+        cmd, check=True, capture_output=True, text=True, encoding="utf-8"
+    ).stdout
     pages = json.loads(out)
     return [item for page in pages for item in page]
 
@@ -46,7 +48,9 @@ def fetch_items(repo):
             "url": it["html_url"],
             "author": (it.get("user") or {}).get("login", "?"),
             "labels": [lbl["name"] for lbl in it.get("labels", [])],
-            "assignees": [a["login"] for a in it.get("assignees", []) if a and a.get("login")],
+            "assignees": [
+                a["login"] for a in it.get("assignees", []) if a and a.get("login")
+            ],
             "comments": it.get("comments", 0),
             "is_pr": it.get("pull_request") is not None,
             "created_at": it["created_at"],
@@ -470,8 +474,7 @@ def main():
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     html = (
-        HTML_TEMPLATE
-        .replace("__REPO__", args.repo)
+        HTML_TEMPLATE.replace("__REPO__", args.repo)
         .replace("__GENERATED_AT__", now)
         .replace("__DATA__", script_safe_json(items))
     )

--- a/.github/scripts/update_sdcpp_versions.py
+++ b/.github/scripts/update_sdcpp_versions.py
@@ -15,7 +15,6 @@ import re
 from pathlib import Path
 from typing import Iterable
 
-
 SDCPP_RELEASE_RE = re.compile(r"^master-[0-9]+-[0-9a-f]{7,40}$")
 DEFAULT_BACKENDS = ("cpu", "vulkan", "rocm-stable", "metal", "cuda")
 FORBIDDEN_BACKENDS = {"rocm-nightly"}
@@ -52,7 +51,9 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def validate_backends(requested: Iterable[str], section: dict[str, object]) -> list[str]:
+def validate_backends(
+    requested: Iterable[str], section: dict[str, object]
+) -> list[str]:
     keys: list[str] = []
     seen: set[str] = set()
     for key in requested:

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -5,7 +5,7 @@
 #      area::*, runtime::*, component, and type labels. Runs once per
 #      newly opened issue/PR.
 #   2. Deterministic priority::warm / priority::hot from community
-#      engagement counts (author + commenters + supporting reactions, 
+#      engagement counts (author + commenters + supporting reactions,
 #      excluding bots and write-access users). Refreshed on every new
 #      comment (engagement event) and via a daily cron (to pick up
 #      reaction-only changes, which don't fire webhook events).

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -381,7 +381,7 @@ static double get_collection_component_size(const json& model) {
     if (model.contains("recipe") && model["recipe"].is_string() && model["recipe"].get<std::string>() == "cloud") {
         return UNKNOWN_MODEL_SIZE;
     }
-    if (model.contains("size") && 
+    if (model.contains("size") &&
             model["size"].is_number()) {
         return model["size"].get<double>();
     }

--- a/src/cpp/include/lemon/global_vram_monitor.h
+++ b/src/cpp/include/lemon/global_vram_monitor.h
@@ -41,7 +41,7 @@ private:
     std::atomic<bool> running_;
     int poll_interval_ms_;
     std::thread monitor_thread_;
-    
+
     std::mutex callback_mutex_;
     VramPressureCallback pressure_callback_;
 };

--- a/test/server_eviction.py
+++ b/test/server_eviction.py
@@ -84,7 +84,11 @@ class EvictionTests(ServerTestBase):
 
         requests.post(
             f"{self.base_url.replace('/api/v1', '')}/internal/set",
-            json={"auto_evict": True, "auto_evict_threshold_pct": 0.90,"max_loaded_models": 2},
+            json={
+                "auto_evict": True,
+                "auto_evict_threshold_pct": 0.90,
+                "max_loaded_models": 2,
+            },
             headers=headers,
         )
 
@@ -188,7 +192,11 @@ class EvictionTests(ServerTestBase):
 
         requests.post(
             f"{self.base_url.replace('/api/v1', '')}/internal/set",
-            json={"auto_evict": True, "auto_evict_threshold_pct": 0.90, "max_loaded_models" : 2},
+            json={
+                "auto_evict": True,
+                "auto_evict_threshold_pct": 0.90,
+                "max_loaded_models": 2,
+            },
             headers=headers,
         )
 

--- a/test/server_watchdog_lifecycle.py
+++ b/test/server_watchdog_lifecycle.py
@@ -27,13 +27,18 @@ import unittest
 
 import requests
 
-from utils.capabilities import get_current_config, set_current_config, skip_if_unsupported
+from utils.capabilities import (
+    get_current_config,
+    set_current_config,
+    skip_if_unsupported,
+)
 from utils.server_base import ServerTestBase, run_server_tests
 from utils.test_models import PORT, TIMEOUT_DEFAULT, TIMEOUT_MODEL_OPERATION
 
-
 WATCHDOG_WAIT_SECONDS = int(os.environ.get("LEMONADE_TEST_WATCHDOG_WAIT_SECONDS", "60"))
-POLL_SECONDS = float(os.environ.get("LEMONADE_TEST_WATCHDOG_ASSERT_POLL_SECONDS", "0.5"))
+POLL_SECONDS = float(
+    os.environ.get("LEMONADE_TEST_WATCHDOG_ASSERT_POLL_SECONDS", "0.5")
+)
 
 
 def _headers():
@@ -43,7 +48,9 @@ def _headers():
     return {}
 
 
-@unittest.skipIf(os.name == "nt", "POSIX zombie/reap assertion is not meaningful on Windows")
+@unittest.skipIf(
+    os.name == "nt", "POSIX zombie/reap assertion is not meaningful on Windows"
+)
 class WatchdogLifecycleTests(ServerTestBase):
     """Crash/reap/reload coverage for wrapped backend watchdog lifecycle."""
 
@@ -100,7 +107,9 @@ class WatchdogLifecycleTests(ServerTestBase):
         )
         response.raise_for_status()
         entry = self._wait_for_loaded_model(model_name)
-        self.assertGreater(entry.get("pid", 0), 0, f"/health did not expose a backend pid: {entry}")
+        self.assertGreater(
+            entry.get("pid", 0), 0, f"/health did not expose a backend pid: {entry}"
+        )
         return entry
 
     def _wait_for_loaded_model(self, model_name, timeout=WATCHDOG_WAIT_SECONDS):
@@ -112,9 +121,13 @@ class WatchdogLifecycleTests(ServerTestBase):
                 if model.get("model_name") == model_name and model.get("loaded", True):
                     return model
             time.sleep(POLL_SECONDS)
-        self.fail(f"Timed out waiting for {model_name!r} to be loaded. Last health={last_health}")
+        self.fail(
+            f"Timed out waiting for {model_name!r} to be loaded. Last health={last_health}"
+        )
 
-    def _wait_for_model_absent_from_health(self, model_name, timeout=WATCHDOG_WAIT_SECONDS):
+    def _wait_for_model_absent_from_health(
+        self, model_name, timeout=WATCHDOG_WAIT_SECONDS
+    ):
         deadline = time.time() + timeout
         last_health = None
         while time.time() < deadline:
@@ -199,7 +212,9 @@ class WatchdogLifecycleTests(ServerTestBase):
             f"{self.base_url}/chat/completions",
             json={
                 "model": model_name,
-                "messages": [{"role": "user", "content": "Say OK in one short sentence."}],
+                "messages": [
+                    {"role": "user", "content": "Say OK in one short sentence."}
+                ],
                 "max_tokens": 8,
                 "stream": True,
             },
@@ -293,7 +308,9 @@ class WatchdogLifecycleTests(ServerTestBase):
         self._stream_chat_completion(model_name)
         self._wait_for_pid_reaped(old_pid)
         new_pid = self._assert_fresh_backend_pid(model_name, old_pid)
-        print(f"[OK] Streaming request reloaded {model_name}: pid {old_pid} -> {new_pid}")
+        print(
+            f"[OK] Streaming request reloaded {model_name}: pid {old_pid} -> {new_pid}"
+        )
 
     @skip_if_unsupported("chat_completions")
     def test_active_non_streaming_request_reloads_and_replays_after_backend_crash(self):
@@ -315,7 +332,9 @@ class WatchdogLifecycleTests(ServerTestBase):
         def run_request():
             try:
                 result["payload"] = self._non_streaming_chat_completion(model_name)
-            except Exception as exc:  # noqa: BLE001 - preserve assertion details across thread boundary
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 - preserve assertion details across thread boundary
                 result["error"] = exc
 
         worker = threading.Thread(target=run_request, daemon=True)
@@ -324,12 +343,20 @@ class WatchdogLifecycleTests(ServerTestBase):
         # Kill shortly after the request is issued. If the backend dies before it
         # receives the request, this still exercises the demand-driven reload path;
         # if it dies mid-request, it exercises the retry-after-reset path.
-        time.sleep(float(os.environ.get("LEMONADE_TEST_WATCHDOG_ACTIVE_KILL_DELAY_SECONDS", "0.05")))
+        time.sleep(
+            float(
+                os.environ.get(
+                    "LEMONADE_TEST_WATCHDOG_ACTIVE_KILL_DELAY_SECONDS", "0.05"
+                )
+            )
+        )
         self._kill_backend_process(old_pid)
         print(f"[TEST] Sent SIGKILL to active backend pid {old_pid}")
 
         worker.join(TIMEOUT_MODEL_OPERATION + WATCHDOG_WAIT_SECONDS)
-        self.assertFalse(worker.is_alive(), "Recovered non-streaming request did not finish")
+        self.assertFalse(
+            worker.is_alive(), "Recovered non-streaming request did not finish"
+        )
         if "error" in result:
             raise result["error"]
 
@@ -339,7 +366,9 @@ class WatchdogLifecycleTests(ServerTestBase):
         # Prove the reloaded model is not merely visible in /health but actually
         # usable for another completion after the recovered in-flight request.
         self._non_streaming_chat_completion(model_name)
-        print(f"[OK] Active non-streaming request reloaded {model_name}: pid {old_pid} -> {new_pid}")
+        print(
+            f"[OK] Active non-streaming request reloaded {model_name}: pid {old_pid} -> {new_pid}"
+        )
 
     @skip_if_unsupported("chat_completions")
     def test_next_non_streaming_request_reaps_reloads_and_returns_completion(self):
@@ -357,7 +386,9 @@ class WatchdogLifecycleTests(ServerTestBase):
         print(f"[SETUP] Loaded {model_name} with backend pid {old_pid}")
 
         self._kill_backend_process(old_pid)
-        print(f"[TEST] Sent SIGKILL to backend pid {old_pid} before non-streaming request")
+        print(
+            f"[TEST] Sent SIGKILL to backend pid {old_pid} before non-streaming request"
+        )
 
         self._non_streaming_chat_completion(model_name)
         self._wait_for_pid_reaped(old_pid)
@@ -366,7 +397,9 @@ class WatchdogLifecycleTests(ServerTestBase):
         # A second call verifies the replacement backend remains reachable after
         # the transparent replay completed.
         self._non_streaming_chat_completion(model_name)
-        print(f"[OK] Non-streaming downtime request reloaded {model_name}: pid {old_pid} -> {new_pid}")
+        print(
+            f"[OK] Non-streaming downtime request reloaded {model_name}: pid {old_pid} -> {new_pid}"
+        )
 
     @skip_if_unsupported("chat_completions")
     def test_concurrent_non_streaming_request_during_reload_also_completes(self):
@@ -384,14 +417,20 @@ class WatchdogLifecycleTests(ServerTestBase):
         print(f"[SETUP] Loaded {model_name} with backend pid {old_pid}")
 
         self._kill_backend_process(old_pid)
-        print(f"[TEST] Sent SIGKILL to backend pid {old_pid} before concurrent requests")
+        print(
+            f"[TEST] Sent SIGKILL to backend pid {old_pid} before concurrent requests"
+        )
 
         results = [{}, {}]
 
         def run_request(index):
             try:
-                results[index]["payload"] = self._non_streaming_chat_completion(model_name)
-            except Exception as exc:  # noqa: BLE001 - preserve assertion details across thread boundary
+                results[index]["payload"] = self._non_streaming_chat_completion(
+                    model_name
+                )
+            except (
+                Exception
+            ) as exc:  # noqa: BLE001 - preserve assertion details across thread boundary
                 results[index]["error"] = exc
 
         workers = [
@@ -400,12 +439,21 @@ class WatchdogLifecycleTests(ServerTestBase):
         ]
 
         workers[0].start()
-        time.sleep(float(os.environ.get("LEMONADE_TEST_WATCHDOG_CONCURRENT_REQUEST_GAP_SECONDS", "0.05")))
+        time.sleep(
+            float(
+                os.environ.get(
+                    "LEMONADE_TEST_WATCHDOG_CONCURRENT_REQUEST_GAP_SECONDS", "0.05"
+                )
+            )
+        )
         workers[1].start()
 
         for worker in workers:
             worker.join(TIMEOUT_MODEL_OPERATION + WATCHDOG_WAIT_SECONDS)
-            self.assertFalse(worker.is_alive(), "Concurrent recovered non-streaming request did not finish")
+            self.assertFalse(
+                worker.is_alive(),
+                "Concurrent recovered non-streaming request did not finish",
+            )
 
         for result in results:
             if "error" in result:
@@ -414,7 +462,9 @@ class WatchdogLifecycleTests(ServerTestBase):
 
         self._wait_for_pid_reaped(old_pid)
         new_pid = self._assert_fresh_backend_pid(model_name, old_pid)
-        print(f"[OK] Concurrent non-streaming reload preserved both requests: pid {old_pid} -> {new_pid}")
+        print(
+            f"[OK] Concurrent non-streaming reload preserved both requests: pid {old_pid} -> {new_pid}"
+        )
 
 
 if __name__ == "__main__":

--- a/test/server_whisper.py
+++ b/test/server_whisper.py
@@ -552,10 +552,7 @@ class WhisperTests(ServerTestBase):
                 if event_type == "error":
                     self.fail(f"Realtime transcription returned error: {event}")
 
-                if (
-                    event_type
-                    == "conversation.item.input_audio_transcription.delta"
-                ):
+                if event_type == "conversation.item.input_audio_transcription.delta":
                     delta = self._event_text(event, "delta", "transcript", "text")
                     if delta:
                         transcript_parts.append(delta)

--- a/test/test_device_family_matching.py
+++ b/test/test_device_family_matching.py
@@ -12,6 +12,7 @@ import unittest
 # Python replica of system_info.cpp::device_matches_constraint()
 # ---------------------------------------------------------------------------
 
+
 def device_matches_constraint(device_family: str, allowed_families: set) -> bool:
     if not allowed_families:
         return True  # Empty = all families allowed
@@ -20,16 +21,18 @@ def device_matches_constraint(device_family: str, allowed_families: set) -> bool
         return True
 
     for af in allowed_families:
-        if len(af) > 1 and af.endswith('X'):
+        if len(af) > 1 and af.endswith("X"):
             prefix = af[:-1]
             if device_family.startswith(prefix):
                 return True
 
     return False
 
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 class TestDeviceFamilyMatching(unittest.TestCase):
     def test_wildcard_matching(self):
@@ -57,6 +60,7 @@ class TestDeviceFamilyMatching(unittest.TestCase):
         self.assertTrue(device_matches_constraint("gfx1103", {"gfx103X", "gfx110X"}))
         self.assertTrue(device_matches_constraint("gfx1201", {"gfx110X", "gfx120X"}))
         self.assertFalse(device_matches_constraint("gfx1151", {"gfx103X", "gfx110X"}))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/utils/reset_server_state.py
+++ b/test/utils/reset_server_state.py
@@ -20,7 +20,6 @@ import requests
 
 from .test_models import PORT, TIMEOUT_DEFAULT
 
-
 HOST_CANDIDATES = ("127.0.0.1", "localhost")
 
 

--- a/test/validate_sdcpp.py
+++ b/test/validate_sdcpp.py
@@ -22,7 +22,6 @@ from typing import Any
 
 import requests
 
-
 DEFAULT_PORT = int(os.environ.get("LEMONADE_PORT", "13305"))
 DEFAULT_TIMEOUT = int(os.environ.get("LEMONADE_VALIDATE_SD_TIMEOUT", "3600"))
 DEFAULT_STEPS = int(os.environ.get("LEMONADE_VALIDATE_SD_STEPS", "4"))
@@ -208,7 +207,9 @@ def record_failure(
         "seed": args.seed,
         "pass": False,
         "warmup": args.warmup,
-        "timing_scope": "request_wall_s_after_warmup" if args.warmup else "request_wall_s_cold",
+        "timing_scope": (
+            "request_wall_s_after_warmup" if args.warmup else "request_wall_s_cold"
+        ),
         "error": str(exc),
         "request_elapsed_s": round(time.monotonic() - started, 3),
         # Backward-compatible alias for older PR body renderers.
@@ -261,7 +262,9 @@ def main() -> int:
 
     print(f"[INFO] Waiting for Lemonade server at {base_url}")
     wait_for_server(base_url)
-    print(f"[INFO] Configuring sd-cpp backend={args.backend} channel={args.channel or ''}")
+    print(
+        f"[INFO] Configuring sd-cpp backend={args.backend} channel={args.channel or ''}"
+    )
     configure_backend(base_url, args.backend, args.channel)
 
     for model in models:
@@ -281,7 +284,9 @@ def main() -> int:
                 overall_pass = False
                 print(f"[FAIL] warmup {model} on {label}: {exc}", file=sys.stderr)
                 for size in sizes:
-                    results.append(record_failure(args, label, model, size, time.monotonic(), exc))
+                    results.append(
+                        record_failure(args, label, model, size, time.monotonic(), exc)
+                    )
                 continue
 
         for width, height in sizes:
@@ -297,8 +302,16 @@ def main() -> int:
                 "seed": args.seed,
                 "pass": False,
                 "warmup": args.warmup,
-                "warmup_elapsed_s": round(warmup_elapsed_by_model.get(model, 0.0), 3) if args.warmup else 0.0,
-                "timing_scope": "request_wall_s_after_warmup" if args.warmup else "request_wall_s_cold",
+                "warmup_elapsed_s": (
+                    round(warmup_elapsed_by_model.get(model, 0.0), 3)
+                    if args.warmup
+                    else 0.0
+                ),
+                "timing_scope": (
+                    "request_wall_s_after_warmup"
+                    if args.warmup
+                    else "request_wall_s_cold"
+                ),
             }
             try:
                 print(f"[INFO] Generating {model} {width}x{height} on {label}")
@@ -316,7 +329,10 @@ def main() -> int:
                     raise AssertionError(
                         f"PNG dimensions are {actual_width}x{actual_height}, expected {width}x{height}"
                     )
-                image_path = images_dir / f"sdcpp-{label}-{safe_slug(model)}-{width}x{height}.png"
+                image_path = (
+                    images_dir
+                    / f"sdcpp-{label}-{safe_slug(model)}-{width}x{height}.png"
+                )
                 image_path.write_bytes(image)
                 record.update(
                     {


### PR DESCRIPTION
Follow-up to #2689, per @superm1's suggestion there: clean the tree so a pre-commit CI job can check *everything* rather than only the files a contributor happened to touch.

Pure tool output — `pre-commit run --all-files` with the pinned hooks. No hand edits.

- 10 Python files reformatted by Black (pinned 26.1.0), under `test/` and `.github/scripts/`
- 3 one-line trailing-whitespace fixes (2 C++, 1 YAML)

After this, `pre-commit run --all-files` is green on the whole tree, so #2689 can drop its changed-files scoping.

### It is behaviour-preserving, and mechanically so

Rather than ask anyone to read 182 lines of reformatting:

- **All 10 reformatted `.py` files are AST-identical** before and after — `ast.parse` → `ast.dump` compares equal for every one.
- **The 3 non-Python changes are whitespace-only** — `git diff -w` is empty.

So there is nothing here to review line by line.

Not tested: nothing to test — no behaviour changed. CI is the check.
