### PR TITLE
feat: autoopt-required backend changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ All core endpoints are registered under **4 path prefixes**:
 - `/v0/` — Legacy short
 - `/v1/` — OpenAI SDK / LiteLLM compatibility
 
-**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `load`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`
+**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `load`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`, `backends/llamacpp/fit-params`, `backends/llamacpp/bench` (SSE)
 
 **Ollama-compatible endpoints** (under `/api/` without version prefix): `chat`, `generate`, `tags`, `show`, `delete`, `pull`, `embed`, `embeddings`, `ps`, `version`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2195,6 +2195,22 @@ if(EXISTS "${_AUTO_TUNE_TEST_SRC}")
     add_test(NAME AutoTuneTest COMMAND test_auto_tune)
 endif()
 
+# llama.cpp tool-output parsers (llama-fit-params / llama-bench, header-only).
+set(_LLAMACPP_TOOLS_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_llamacpp_tools.cpp"
+)
+if(EXISTS "${_LLAMACPP_TOOLS_TEST_SRC}")
+    add_executable(test_llamacpp_tools
+        test/cpp/test_llamacpp_tools.cpp
+    )
+    target_include_directories(test_llamacpp_tools PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_llamacpp_tools PRIVATE nlohmann_json::nlohmann_json)
+    add_test(NAME LlamaCppToolsTest COMMAND test_llamacpp_tools)
+endif()
+
 set(_TELEMETRY_HELPERS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_telemetry_helpers.cpp")
 if(EXISTS "${_TELEMETRY_HELPERS_TEST_SRC}")
     add_executable(test_telemetry_helpers test/cpp/test_telemetry_helpers.cpp)

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -156,6 +156,24 @@ namespace lemon::backends {
         /** Get the path to the backend's binary. Gives precedence to the path set through environment variables, if set. Throws if not found. */
         static std::string get_backend_binary_path(const BackendSpec& spec, const std::string& backend);
 
+        /**
+         * Path to a sibling tool shipped in the same install dir as the backend's
+         * main binary (e.g. llama-bench / llama-fit-params next to llama-server).
+         * Empty string when the tool is not present.
+         */
+        static std::string get_backend_tool_path(const BackendSpec& spec, const std::string& backend,
+                                                 const std::string& tool);
+
+        /**
+         * Platform environment (LD_LIBRARY_PATH / PATH / OCL_SET_SVM_SIZE) needed to
+         * launch any binary from a llama.cpp backend install dir — ROCm needs its
+         * bundled/TheRock libraries resolvable, CUDA its bundled runtime. Device
+         * selection env (CUDA_VISIBLE_DEVICES etc.) is NOT included; callers that
+         * need it use apply_cuda_env_vars.
+         */
+        static std::vector<std::pair<std::string, std::string>> get_backend_env(
+            const std::string& llamacpp_backend, const std::string& executable);
+
         /** Get the path where the version indicator is installed. Does not check existence. */
         static std::string get_installed_version_file(const BackendSpec& spec, const std::string& backend);
 

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp.h
@@ -29,6 +29,8 @@ inline const BackendDescriptor descriptor = {
          "Comma-separated list of accelerator devices to use (e.g. Vulkan0)", "Llama.cpp Backend Options"},
         {"llamacpp_args", "--llamacpp-args", "", "ARGS",
          "Custom arguments to pass to llama-server", "Llama.cpp Backend Options"},
+        {"mmproj_enabled", "--mmproj-enabled", true, "BOOL",
+         "Load the multimodal projector of vision models (false frees its memory for context)", "Llama.cpp Backend Options"},
     },
     /*support*/ {
         {"system", {"linux"}, {{"cpu", {"x86_64", "arm64"}}}, "x86_64/ARM64 CPU, GPU"},

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp_tools.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp_tools.h
@@ -1,0 +1,186 @@
+// llama.cpp auxiliary tools (llama-fit-params, llama-bench) exposed as
+// standalone server queries. Parsers are inline so the test binary needs no
+// linking; the runners live in llamacpp_tools.cpp.
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <atomic>
+#include <functional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace lemon {
+namespace backends {
+namespace llamacpp {
+
+using json = nlohmann::ordered_json;
+using CancelFlag = std::atomic<bool>;
+using ProgressFn = std::function<bool(const std::string& detail)>;
+
+struct FitEstimate {
+    std::string backend;
+    int fit_target_mib = 1024;
+    std::string extra_args;           // probe variant, e.g. "-ctk q8_0 -ctv q8_0" or "--no-mmproj"
+    std::string fitted_args;          // stdout line 1, e.g. "-c 32768 -ngl -1"
+    int fitted_ctx = 0;
+    int fitted_ngl = -1;              // -1 = full offload
+    int fitted_ncmoe = 0;
+    struct DeviceMem {
+        std::string device;
+        int model_mib = 0, ctx_mib = 0, compute_mib = 0;
+    };
+    std::vector<DeviceMem> devices;
+    bool fits_fully = false;
+    bool ok = false;
+    std::string error;
+
+    int total_mib() const {
+        int t = 0;
+        for (const auto& d : devices)
+            if (d.device.rfind("Host", 0) != 0) t += d.model_mib + d.ctx_mib + d.compute_mib;
+        return t;
+    }
+
+    json to_json() const {
+        json devs = json::array();
+        for (const auto& d : devices)
+            devs.push_back({{"device", d.device}, {"model_mib", d.model_mib},
+                            {"ctx_mib", d.ctx_mib}, {"compute_mib", d.compute_mib}});
+        return {{"backend", backend}, {"fit_target_mib", fit_target_mib},
+                {"extra_args", extra_args}, {"fitted_args", fitted_args},
+                {"fitted_ctx", fitted_ctx}, {"fitted_ngl", fitted_ngl},
+                {"fitted_ncmoe", fitted_ncmoe}, {"devices", devs},
+                {"fits_fully", fits_fully}, {"ok", ok}, {"error", error}};
+    }
+};
+
+struct BenchPoint {
+    std::string backend;
+    json params;                      // varied flags, e.g. {"d":30000,"b":2048,"ub":2048}
+    double pp_avg_ts = 0;
+    double tg_avg_ts = 0;
+    int n_depth = 0;
+    bool ok = false;
+    std::string error;
+
+    json to_json() const {
+        return {{"backend", backend}, {"params", params}, {"pp_avg_ts", pp_avg_ts},
+                {"tg_avg_ts", tg_avg_ts}, {"n_depth", n_depth}, {"ok", ok}, {"error", error}};
+    }
+};
+
+// llama-fit-params stdout: the first line starting with '-' carries the fitted
+// args ("-c 32768 -ngl -1"); with -fitp on, subsequent "<dev> <model> <ctx>
+// <compute>" rows follow (MiB). Anything else is log noise.
+inline FitEstimate parse_fit_params_output(const std::string& output) {
+    FitEstimate fit;
+    std::istringstream in(output);
+    std::string line;
+    while (std::getline(in, line)) {
+        while (!line.empty() && (line.back() == '\r' || line.back() == ' ')) line.pop_back();
+        if (line.empty()) continue;
+        if (fit.fitted_args.empty() && line[0] == '-') {
+            fit.fitted_args = line;
+            std::istringstream args(line);
+            std::string tok;
+            while (args >> tok) {
+                if (tok == "-c" || tok == "--ctx-size") args >> fit.fitted_ctx;
+                else if (tok == "-ngl" || tok == "--n-gpu-layers") args >> fit.fitted_ngl;
+                else if (tok == "-ncmoe" || tok == "--n-cpu-moe") args >> fit.fitted_ncmoe;
+            }
+            continue;
+        }
+        FitEstimate::DeviceMem d;
+        char dev[128] = {};
+        if (std::sscanf(line.c_str(), "%127s %d %d %d", dev, &d.model_mib, &d.ctx_mib,
+                        &d.compute_mib) == 4 && d.model_mib >= 0) {
+            d.device = dev;
+            fit.devices.push_back(d);
+        }
+    }
+    // The tool prints the args line only when it had to ADJUST something; a
+    // bare memory table means everything fits at the requested (or model
+    // default, i.e. full trained) settings. fitted_ctx stays 0 = "no cap".
+    fit.ok = !fit.fitted_args.empty() || !fit.devices.empty();
+    fit.fits_fully = fit.ok && fit.fitted_ngl == -1 && fit.fitted_ncmoe == 0;
+    if (!fit.ok) fit.error = "no fitted-args line or memory table in llama-fit-params output";
+    return fit;
+}
+
+// llama-bench -o json: array of test objects. Rows with n_prompt>0/n_gen==0
+// are prompt-processing, n_gen>0/n_prompt==0 are generation; keyed by n_depth.
+// The captured stream interleaves stderr logs (subprocess pipes are merged),
+// so the JSON array is extracted between the bare "[" and "]" lines first.
+inline std::vector<BenchPoint> parse_llama_bench_json(const std::string& output,
+                                                      const std::string& backend) {
+    std::vector<BenchPoint> points;
+    std::string json_text;
+    {
+        std::istringstream in(output);
+        std::string line;
+        bool inside = false;
+        while (std::getline(in, line)) {
+            std::string trimmed = line;
+            while (!trimmed.empty() && (trimmed.back() == '\r' || trimmed.back() == ' '))
+                trimmed.pop_back();
+            if (!inside && trimmed == "[") inside = true;
+            if (inside) json_text += line + "\n";
+            if (inside && trimmed == "]") break;
+        }
+        if (json_text.empty()) json_text = output;
+    }
+    json tests;
+    try {
+        tests = json::parse(json_text);
+    } catch (const std::exception& e) {
+        BenchPoint p;
+        p.backend = backend;
+        p.error = std::string("llama-bench JSON parse failed: ") + e.what();
+        points.push_back(p);
+        return points;
+    }
+    if (!tests.is_array()) return points;
+
+    auto point_for_depth = [&points, &backend](int depth) -> BenchPoint& {
+        for (auto& p : points)
+            if (p.n_depth == depth) return p;
+        BenchPoint p;
+        p.backend = backend;
+        p.n_depth = depth;
+        p.params = {{"d", depth}};
+        points.push_back(p);
+        return points.back();
+    };
+
+    for (const auto& t : tests) {
+        if (!t.is_object()) continue;
+        const int depth = t.value("n_depth", 0);
+        const int n_prompt = t.value("n_prompt", 0);
+        const int n_gen = t.value("n_gen", 0);
+        const double avg = t.value("avg_ts", 0.0);
+        BenchPoint& p = point_for_depth(depth);
+        if (n_prompt > 0 && n_gen == 0) p.pp_avg_ts = avg;
+        else if (n_gen > 0 && n_prompt == 0) p.tg_avg_ts = avg;
+        p.ok = p.pp_avg_ts > 0 || p.tg_avg_ts > 0;
+    }
+    return points;
+}
+
+// Runs llama-fit-params for `backend` against a local GGUF. Soft-fails into
+// the returned struct (ok=false + error); never throws.
+FitEstimate run_fit_params(const std::string& backend, const std::string& gguf_path,
+                           const std::vector<std::string>& extra_args, int fit_target_mib,
+                           CancelFlag& cancel);
+
+// One llama-bench invocation; `params` may carry {"d": int|[ints]}, {"b": N,
+// "ub": N}, {"ctk": "q8_0", "ctv": "q8_0"}. Returns one BenchPoint per depth.
+// `progress` receives raw tool progress lines; returning false cancels.
+std::vector<BenchPoint> run_llama_bench(const std::string& backend,
+                                        const std::string& gguf_path, const json& params,
+                                        CancelFlag& cancel, ProgressFn progress);
+
+}  // namespace llamacpp
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp_tools.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp_tools.h
@@ -6,7 +6,9 @@
 #include <nlohmann/json.hpp>
 
 #include <atomic>
+#include <cctype>
 #include <functional>
+#include <set>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -166,6 +168,116 @@ inline std::vector<BenchPoint> parse_llama_bench_json(const std::string& output,
         p.ok = p.pp_avg_ts > 0 || p.tg_avg_ts > 0;
     }
     return points;
+}
+
+// ── Request validation ─────────────────────────────────────────────────
+//
+// Both tool endpoints take a small, closed parameter set; requests are
+// validated exhaustively (unknown keys, types, ranges) before anything
+// reaches a subprocess command line. Validators return "" when the body is
+// valid, else a client-facing error message.
+
+namespace tools_detail {
+
+inline const std::set<std::string>& kv_cache_types() {
+    static const std::set<std::string> types = {"f32",  "f16",  "bf16", "q8_0",   "q5_1",
+                                                "q5_0", "q4_1", "q4_0", "iq4_nl"};
+    return types;
+}
+
+inline bool valid_backend_name(const std::string& name) {
+    if (name.empty() || name.size() > 64) return false;
+    for (char c : name) {
+        if (!std::isalnum(static_cast<unsigned char>(c)) && c != '-' && c != '_') return false;
+    }
+    return true;
+}
+
+inline std::string check_common(const json& body, const std::set<std::string>& allowed) {
+    if (!body.is_object()) return "request body must be a JSON object";
+    for (const auto& [key, value] : body.items()) {
+        (void)value;
+        if (!allowed.count(key)) {
+            std::string keys;
+            for (const auto& k : allowed) keys += (keys.empty() ? "" : ", ") + k;
+            return "unexpected field '" + key + "'; allowed fields: " + keys;
+        }
+    }
+    if (!body.contains("model") || !body["model"].is_string()
+        || body["model"].get<std::string>().empty()) {
+        return "'model' is required and must be a non-empty string";
+    }
+    if (!body.contains("backend") || !body["backend"].is_string()
+        || !valid_backend_name(body["backend"].get<std::string>())) {
+        return "'backend' is required and must be an installed llamacpp backend name";
+    }
+    return "";
+}
+
+inline bool int_in_range(const json& v, long long lo, long long hi) {
+    if (!v.is_number_integer()) return false;
+    const long long n = v.get<long long>();
+    return n >= lo && n <= hi;
+}
+
+}  // namespace tools_detail
+
+inline std::string validate_fit_params_request(const json& body) {
+    static const std::set<std::string> allowed = {"model", "backend", "args", "fit_target_mib"};
+    std::string err = tools_detail::check_common(body, allowed);
+    if (!err.empty()) return err;
+    if (body.contains("args")) {
+        const auto& args = body["args"];
+        if (args.is_array()) {
+            for (const auto& a : args)
+                if (!a.is_string()) return "'args' array entries must be strings";
+        } else if (!args.is_string()) {
+            return "'args' must be a string or an array of strings";
+        }
+    }
+    if (body.contains("fit_target_mib")
+        && !tools_detail::int_in_range(body["fit_target_mib"], 0, 10000000)) {
+        return "'fit_target_mib' must be an integer between 0 and 10000000";
+    }
+    return "";
+}
+
+inline std::string validate_bench_request(const json& body) {
+    static const std::set<std::string> allowed = {"model", "backend", "d", "b", "ub",
+                                                  "ctk",   "ctv"};
+    std::string err = tools_detail::check_common(body, allowed);
+    if (!err.empty()) return err;
+    if (body.contains("d")) {
+        const auto& d = body["d"];
+        if (d.is_array()) {
+            if (d.empty()) return "'d' array must not be empty";
+            for (const auto& v : d)
+                if (!tools_detail::int_in_range(v, 0, 4194304))
+                    return "'d' entries must be integers between 0 and 4194304";
+        } else if (!tools_detail::int_in_range(d, 0, 4194304)) {
+            return "'d' must be an integer between 0 and 4194304 or an array of such";
+        }
+    }
+    for (const char* key : {"b", "ub"}) {
+        if (body.contains(key) && !tools_detail::int_in_range(body[key], 1, 65536))
+            return std::string("'") + key + "' must be an integer between 1 and 65536";
+    }
+    if (body.contains("ub") && !body.contains("b")) {
+        return "'ub' requires 'b'";
+    }
+    for (const char* key : {"ctk", "ctv"}) {
+        if (!body.contains(key)) continue;
+        if (!body[key].is_string() || !tools_detail::kv_cache_types().count(body[key].get<std::string>())) {
+            std::string types;
+            for (const auto& t : tools_detail::kv_cache_types())
+                types += (types.empty() ? "" : ", ") + t;
+            return std::string("'") + key + "' must be one of: " + types;
+        }
+    }
+    if (body.contains("ctv") && !body.contains("ctk")) {
+        return "'ctv' requires 'ctk'";
+    }
+    return "";
 }
 
 // Runs llama-fit-params for `backend` against a local GGUF. Soft-fails into

--- a/src/cpp/include/lemon/gguf_reader.h
+++ b/src/cpp/include/lemon/gguf_reader.h
@@ -40,6 +40,9 @@ struct GgufMetadata {
     int64_t key_length_swa = 0;      // SWA-reduced key length (Gemma4, etc.)
     int64_t swa_layer_count = 0;     // layers with sliding-window attention (derived)
     int64_t full_attention_interval = 0; // every Nth layer does full attention (Qwen SSM)
+    int64_t expert_count = 0;        // MoE expert count (0 = dense)
+    std::string base_model_repo;     // general.base_model.0.repo_url (quant repos point at the source model)
+    std::string base_model_name;     // general.base_model.0.name
     GgufCapabilities caps;
 
     // ── Raw per-layer arrays (stored as read from GGUF) ───────────────
@@ -227,6 +230,15 @@ inline bool read_gguf_metadata(GgufMetadata& out, const std::string& path) {
             continue;
         }
 
+        if (key == "general.base_model.0.repo_url" && type == 8) {
+            if (!read_gguf_string(in, out.base_model_repo)) return false;
+            continue;
+        }
+        if (key == "general.base_model.0.name" && type == 8) {
+            if (!read_gguf_string(in, out.base_model_name)) return false;
+            continue;
+        }
+
         // Context length
         const bool context_key = !out.architecture.empty()
                                  && key == out.architecture + ".context_length";
@@ -296,6 +308,12 @@ inline bool read_gguf_metadata(GgufMetadata& out, const std::string& path) {
                 int64_t value = 0;
                 if (read_gguf_integer_value(in, type, value) && value > 0)
                     out.full_attention_interval = value;
+                continue;
+            }
+            if (key == out.architecture + ".expert_count") {
+                int64_t value = 0;
+                if (read_gguf_integer_value(in, type, value) && value > 0)
+                    out.expert_count = value;
                 continue;
             }
         }

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -151,6 +151,8 @@ private:
     void handle_metrics(const httplib::Request& req, httplib::Response& res);
     void handle_stats(const httplib::Request& req, httplib::Response& res);
     void handle_system_info(const httplib::Request& req, httplib::Response& res);
+    void handle_llamacpp_fit_params(const httplib::Request& req, httplib::Response& res);
+    void handle_llamacpp_bench(const httplib::Request& req, httplib::Response& res);
     void handle_system_stats(const httplib::Request& req, httplib::Response& res);
     void handle_log_level(const httplib::Request& req, httplib::Response& res);
     void handle_shutdown(const httplib::Request& req, httplib::Response& res);
@@ -309,6 +311,10 @@ private:
 
     std::mutex downloads_mutex_;
     std::map<std::string, std::shared_ptr<DownloadJob>> download_jobs_;
+
+    // Serializes llama-fit-params / llama-bench tool queries: concurrent GPU
+    // measurements would contend for memory and corrupt each other's numbers.
+    std::atomic<bool> llamacpp_tool_busy_{false};
 
     bool running_;
     bool startup_failed_ = false;

--- a/src/cpp/include/lemon/utils/process_manager.h
+++ b/src/cpp/include/lemon/utils/process_manager.h
@@ -33,7 +33,8 @@ public:
         OutputLineCallback on_line,
         const std::string& working_dir = "",
         int timeout_seconds = -1,
-        bool capture_stderr = true);
+        bool capture_stderr = true,
+        const std::vector<std::pair<std::string, std::string>>& env_vars = {});
 
     static void stop_process(ProcessHandle handle);
 

--- a/src/cpp/include/lemon/utils/process_platform.h
+++ b/src/cpp/include/lemon/utils/process_platform.h
@@ -44,7 +44,8 @@ public:
         OutputLineCallback on_line,
         const std::string& working_dir,
         int timeout_seconds,
-        bool capture_stderr = true) = 0;
+        bool capture_stderr = true,
+        const std::vector<std::pair<std::string, std::string>>& env_vars = {}) = 0;
 
     // Utility functions
     virtual int find_free_port(int start_port) = 0;

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -1255,4 +1255,110 @@ namespace lemon::backends {
         }
 #endif
     }
+
+    std::string BackendUtils::get_backend_tool_path(const BackendSpec& spec, const std::string& backend,
+                                                    const std::string& tool) {
+        std::string server_bin;
+        try {
+            server_bin = get_backend_binary_path(spec, backend);
+        } catch (const std::exception&) {
+            return "";
+        }
+        fs::path tool_path = fs::path(server_bin).parent_path() / tool;
+#ifdef _WIN32
+        tool_path += ".exe";
+#endif
+        std::error_code ec;
+        if (!fs::exists(tool_path, ec)) return "";
+        return lemon::utils::path_to_utf8(tool_path);
+    }
+
+    std::vector<std::pair<std::string, std::string>> BackendUtils::get_backend_env(
+            const std::string& llamacpp_backend, const std::string& executable) {
+        std::vector<std::pair<std::string, std::string>> env_vars;
+        const bool is_rocm = llamacpp_backend == "rocm-stable" || llamacpp_backend == "rocm-nightly";
+        const bool is_cuda = llamacpp_backend == "cuda";
+#ifndef _WIN32
+        if (is_rocm) {
+            fs::path exe_dir = fs::path(executable).parent_path();
+            std::string lib_path = exe_dir.string();
+
+            if (llamacpp_backend == "rocm-stable") {
+                std::string rocm_arch = SystemInfo::get_rocm_arch();
+                if (!rocm_arch.empty()) {
+                    std::string therock_lib = get_therock_lib_path(rocm_arch);
+                    if (!therock_lib.empty()) {
+                        lib_path = therock_lib + ":" + lib_path;
+                    }
+                }
+            }
+
+            const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
+            if (existing_ld_path && strlen(existing_ld_path) > 0) {
+                lib_path = lib_path + ":" + std::string(existing_ld_path);
+            }
+
+            env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
+            LOG(DEBUG, "BackendUtils") << "Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
+        } else if (is_cuda) {
+            // llama.cpp Linux tarballs ship the bundled CUDA runtime (libcudart.so,
+            // libcublas.so, ...) alongside the binaries.
+            fs::path exe_dir = fs::path(executable).parent_path();
+            std::string lib_path = exe_dir.string();
+
+            const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
+            if (existing_ld_path && strlen(existing_ld_path) > 0) {
+                lib_path = lib_path + ":" + std::string(existing_ld_path);
+            }
+
+            env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
+            LOG(DEBUG, "BackendUtils") << "Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
+        }
+#else
+        if (is_rocm) {
+            std::string new_path;
+
+            if (llamacpp_backend == "rocm-stable") {
+                std::string rocm_arch = SystemInfo::get_rocm_arch();
+                if (!rocm_arch.empty()) {
+                    std::string therock_bin = get_therock_lib_path(rocm_arch);
+                    if (!therock_bin.empty()) {
+                        new_path = lemon::utils::path_to_utf8(
+                            fs::absolute(lemon::utils::path_from_utf8(therock_bin)));
+                    }
+                }
+            }
+
+            if (!new_path.empty()) {
+                const char* existing_path = std::getenv("PATH");
+                if (existing_path && strlen(existing_path) > 0) {
+                    new_path += ";" + std::string(existing_path);
+                }
+                env_vars.push_back({"PATH", new_path});
+            }
+
+            std::string arch = lemon::SystemInfo::get_rocm_arch();
+            if ((arch == "gfx1151") || (arch == "gfx1152")) {
+                // Patch to enable loading larger models on these APUs.
+                env_vars.push_back({"OCL_SET_SVM_SIZE", "262144"});
+                LOG(DEBUG, "BackendUtils") << "Setting OCL_SET_SVM_SIZE=262144 for gfx1151/gfx1152" << std::endl;
+            }
+        } else if (is_cuda) {
+            // CUDA Windows builds bundle cudart64_*.dll etc. next to the binaries;
+            // prepend the executable directory so the loader resolves them first.
+            fs::path exe_dir = fs::absolute(fs::path(executable)).parent_path();
+            std::string new_path = lemon::utils::path_to_utf8(exe_dir);
+
+            const char* existing_path = std::getenv("PATH");
+            if (existing_path && strlen(existing_path) > 0) {
+                new_path += ";" + std::string(existing_path);
+            }
+            env_vars.push_back({"PATH", new_path});
+            LOG(DEBUG, "BackendUtils") << "Prepending CUDA exe dir to PATH: "
+                                       << lemon::utils::path_to_utf8(exe_dir) << std::endl;
+        }
+#endif
+        return env_vars;
+    }
+
 } // namespace lemon::backends

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -352,7 +352,14 @@ void LlamaCppServer::load(const std::string& model_name,
 
     // Add mmproj file if present (for vision models). Skip when hf_load is set —
     // llama-server resolves the mmproj companion itself from the HF repo.
-    if (!mmproj_path.empty() && !model_info.extra<bool>("hf_load", false)) {
+    // mmproj_enabled=false skips (or suppresses, for hf_load) the projector: its
+    // memory goes to context instead when image input is not needed.
+    const json mmproj_opt = options.get_option("mmproj_enabled");
+    const bool mmproj_enabled = !(mmproj_opt.is_boolean() && !mmproj_opt.get<bool>());
+    if (!mmproj_enabled) {
+        LOG(INFO, "LlamaCpp") << "mmproj disabled by option; vision projector not loaded" << std::endl;
+        push_arg(args, reserved_flags, "--no-mmproj");
+    } else if (!mmproj_path.empty() && !model_info.extra<bool>("hf_load", false)) {
         push_arg(args, reserved_flags, "--mmproj", mmproj_path);
         if (!use_gpu) {
             LOG(DEBUG, "LlamaCpp") << "Skipping mmproj argument since GPU mode is not enabled" << std::endl;
@@ -382,6 +389,11 @@ void LlamaCppServer::load(const std::string& model_name,
     // Disable mmap on iGPU
     if (SystemInfo::get_has_igpu()) {
         push_overridable_arg(args, llamacpp_args, "--no-mmap");
+    }
+
+    // mmap is broken on ROCm; direct I/O is the faster of the two workarounds.
+    if (is_llamacpp_rocm_backend(llamacpp_backend)) {
+        push_overridable_arg(args, llamacpp_args, "--direct-io");
     }
 
     // Add embeddings support if the model supports it
@@ -414,91 +426,10 @@ void LlamaCppServer::load(const std::string& model_name,
 
     LOG(INFO, "LlamaCpp") << "Starting llama-server..." << std::endl;
 
-    // For ROCm on Linux, set LD_LIBRARY_PATH to include the ROCm library directory
-    std::vector<std::pair<std::string, std::string>> env_vars;
-#ifndef _WIN32
-    if (is_llamacpp_rocm_backend(llamacpp_backend)) {
-        // Get the directory containing the executable (where ROCm .so files are)
-        fs::path exe_dir = fs::path(executable).parent_path();
-        std::string lib_path = exe_dir.string();
-
-        if (llamacpp_backend == "rocm-stable") {
-            std::string rocm_arch = SystemInfo::get_rocm_arch();
-            if (!rocm_arch.empty()) {
-                std::string therock_lib = BackendUtils::get_therock_lib_path(rocm_arch);
-                if (!therock_lib.empty()) {
-                    lib_path = therock_lib + ":" + lib_path;
-                }
-            }
-        }
-
-        // Preserve existing LD_LIBRARY_PATH if it exists
-        const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
-        if (existing_ld_path && strlen(existing_ld_path) > 0) {
-            lib_path = lib_path + ":" + std::string(existing_ld_path);
-        }
-
-        env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
-        LOG(DEBUG, "LlamaCpp") << "Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
-    } else if (is_llamacpp_cuda_backend(llamacpp_backend)) {
-        // The llama.cpp-builds Linux tarballs ship the bundled CUDA runtime
-        // (libcudart.so, libcublas.so, etc.) alongside llama-server, so add the
-        // executable's directory to LD_LIBRARY_PATH like we do for ROCm.
-        fs::path exe_dir = fs::path(executable).parent_path();
-        std::string lib_path = exe_dir.string();
-
-        const char* existing_ld_path = std::getenv("LD_LIBRARY_PATH");
-        if (existing_ld_path && strlen(existing_ld_path) > 0) {
-            lib_path = lib_path + ":" + std::string(existing_ld_path);
-        }
-
-        env_vars.push_back({"LD_LIBRARY_PATH", lib_path});
-        LOG(DEBUG, "LlamaCpp") << "Setting LD_LIBRARY_PATH=" << lib_path << std::endl;
-    }
-#else
-    // For ROCm on Windows with gfx1151, set OCL_SET_SVMSIZE
-    // This is a patch to enable loading larger models
-    if (is_llamacpp_rocm_backend(llamacpp_backend)) {
-        std::string new_path;
-
-        if (llamacpp_backend == "rocm-stable") {
-            std::string rocm_arch = SystemInfo::get_rocm_arch();
-            if (!rocm_arch.empty()) {
-                std::string therock_bin = BackendUtils::get_therock_lib_path(rocm_arch);
-                if (!therock_bin.empty()) {
-                    new_path = path_to_utf8(fs::absolute(path_from_utf8(therock_bin)));
-                }
-            }
-        }
-
-        if (!new_path.empty()) {
-            const char* existing_path = std::getenv("PATH");
-            if (existing_path && strlen(existing_path) > 0) {
-                new_path += ";" + std::string(existing_path);
-            }
-            env_vars.push_back({"PATH", new_path});
-        }
-
-        std::string arch = lemon::SystemInfo::get_rocm_arch();
-        if ((arch == "gfx1151") || (arch == "gfx1152")){
-            env_vars.push_back({"OCL_SET_SVM_SIZE", "262144"});
-            LOG(DEBUG, "LlamaCpp") << "Setting OCL_SET_SVM_SIZE=262144 for gfx1151/gfx1152 (enables loading larger models)" << std::endl;
-        }
-    } else if (is_llamacpp_cuda_backend(llamacpp_backend)) {
-        // CUDA Windows builds bundle cudart64_*.dll, cublas64_*.dll, etc. next to
-        // llama-server.exe. Prepend the executable directory to PATH so the loader
-        // resolves them before any system-wide CUDA install.
-        fs::path exe_dir = fs::absolute(fs::path(executable)).parent_path();
-        std::string new_path = path_to_utf8(exe_dir);
-
-        const char* existing_path = std::getenv("PATH");
-        if (existing_path && strlen(existing_path) > 0) {
-            new_path += ";" + std::string(existing_path);
-        }
-        env_vars.push_back({"PATH", new_path});
-        LOG(DEBUG, "LlamaCpp") << "Prepending CUDA exe dir to PATH: " << path_to_utf8(exe_dir) << std::endl;
-    }
-#endif
+    // Platform env (LD_LIBRARY_PATH / PATH / OCL_SET_SVM_SIZE) shared with the
+    // other tools launched from the backend install dir (llama-bench, llama-fit-params).
+    std::vector<std::pair<std::string, std::string>> env_vars =
+        BackendUtils::get_backend_env(llamacpp_backend, executable);
 
     if (is_llamacpp_cuda_backend(llamacpp_backend)) {
         const char* existing_llama_device = std::getenv("LLAMA_ARG_DEVICE");

--- a/src/cpp/server/backends/llamacpp/llamacpp_tools.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_tools.cpp
@@ -1,0 +1,154 @@
+#include "lemon/backends/llamacpp/llamacpp_tools.h"
+
+#include "lemon/backends/backend_registry.h"
+#include "lemon/backends/backend_utils.h"
+#include "lemon/utils/path_utils.h"
+#include "lemon/utils/process_manager.h"
+
+#include <algorithm>
+#include <filesystem>
+
+namespace lemon {
+namespace backends {
+namespace llamacpp {
+
+using lemon::backends::BackendUtils;
+using lemon::utils::ProcessManager;
+
+namespace {
+
+std::string tool_path(const std::string& backend, const std::string& tool) {
+    const auto* spec = lemon::backends::spec_for("llamacpp");
+    if (!spec) return "";
+    return BackendUtils::get_backend_tool_path(*spec, backend, tool);
+}
+
+std::vector<std::pair<std::string, std::string>> tool_env(const std::string& backend,
+                                                          const std::string& exe) {
+    return BackendUtils::get_backend_env(backend, exe);
+}
+
+}  // namespace
+
+FitEstimate run_fit_params(const std::string& backend, const std::string& gguf_path,
+                           const std::vector<std::string>& extra_args, int fit_target_mib,
+                           CancelFlag& cancel) {
+    FitEstimate fit;
+    fit.backend = backend;
+    fit.fit_target_mib = fit_target_mib;
+    for (const auto& a : extra_args) fit.extra_args += (fit.extra_args.empty() ? "" : " ") + a;
+
+    const std::string exe = tool_path(backend, "llama-fit-params");
+    if (exe.empty()) {
+        fit.error = "llama-fit-params not found for backend " + backend;
+        return fit;
+    }
+
+    std::vector<std::string> args = {"-m", gguf_path, "-fitp", "on", "--fit-target",
+                                     std::to_string(fit_target_mib)};
+    args.insert(args.end(), extra_args.begin(), extra_args.end());
+
+    std::string output;
+    const int rc = ProcessManager::run_process_with_output(
+        exe, args,
+        [&output, &cancel](const std::string& line) {
+            output += line + "\n";
+            return !cancel.load();
+        },
+        "", 120, /*capture_stderr=*/true, tool_env(backend, exe));
+
+    if (cancel.load()) {
+        fit.error = "cancelled";
+        return fit;
+    }
+    if (rc != 0) {
+        fit.error = "llama-fit-params exited with " + std::to_string(rc);
+        return fit;
+    }
+    FitEstimate parsed = parse_fit_params_output(output);
+    parsed.backend = backend;
+    parsed.fit_target_mib = fit_target_mib;
+    parsed.extra_args = fit.extra_args;
+    return parsed;
+}
+
+std::vector<BenchPoint> run_llama_bench(const std::string& backend,
+                                        const std::string& gguf_path, const json& params,
+                                        CancelFlag& cancel, ProgressFn progress) {
+    const std::string exe = tool_path(backend, "llama-bench");
+    if (exe.empty()) {
+        BenchPoint p;
+        p.backend = backend;
+        p.error = "llama-bench not found for backend " + backend;
+        return {p};
+    }
+
+    std::string depths = "0";
+    if (params.contains("d")) {
+        if (params["d"].is_array()) {
+            depths.clear();
+            for (const auto& d : params["d"])
+                depths += (depths.empty() ? "" : ",") + std::to_string(d.get<int>());
+        } else {
+            depths = std::to_string(params["d"].get<int>());
+        }
+    }
+
+    std::vector<std::string> args = {"-m",   gguf_path, "-fa", "1",  "-r", "2",
+                                     "-o",   "json",    "-oe", "none",     "-p",
+                                     "2048", "-n",      "32",  "-d", depths};
+    if (params.contains("b")) {
+        args.push_back("-b");
+        args.push_back(std::to_string(params["b"].get<int>()));
+        args.push_back("-ub");
+        args.push_back(std::to_string(params.value("ub", params["b"].get<int>())));
+        args[13] = "0";   // -n 0: batch-ladder points only measure prefill
+    }
+    if (params.contains("ctk")) {
+        args.push_back("-ctk");
+        args.push_back(params["ctk"].get<std::string>());
+        args.push_back("-ctv");
+        args.push_back(params.value("ctv", params["ctk"].get<std::string>()));
+    }
+
+    double gb = 0;
+    {
+        std::error_code ec;
+        auto sz = std::filesystem::file_size(lemon::utils::path_from_utf8(gguf_path), ec);
+        if (!ec) gb = (double)sz / (1024.0 * 1024.0 * 1024.0);
+    }
+    const int timeout = std::min(900, 120 + (int)(gb * 30));
+
+    std::string json_out;
+    const int rc = ProcessManager::run_process_with_output(
+        exe, args,
+        [&json_out, &cancel, &progress](const std::string& line) {
+            json_out += line + "\n";
+            if (progress && line.find("main:") != std::string::npos) {
+                if (!progress(line)) return false;
+            }
+            return !cancel.load();
+        },
+        "", timeout, /*capture_stderr=*/true, tool_env(backend, exe));
+
+    if (cancel.load()) return {};
+    if (rc != 0) {
+        BenchPoint p;
+        p.backend = backend;
+        p.error = "llama-bench exited with " + std::to_string(rc);
+        return {p};
+    }
+    auto points = parse_llama_bench_json(json_out, backend);
+    for (auto& p : points) {
+        if (params.contains("b")) {
+            p.params["b"] = params["b"];
+            p.params["ub"] = params.value("ub", params["b"].get<int>());
+        }
+        if (params.contains("ctk")) p.params["ctk"] = params["ctk"];
+    }
+    return points;
+}
+
+}  // namespace llamacpp
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1983,6 +1983,9 @@ void Server::handle_health(const httplib::Request& req, httplib::Response& res) 
     // Add version information
     response["version"] = LEMON_VERSION_STRING;
 
+    // Optional capabilities clients can rely on without probing endpoints.
+    response["features"] = nlohmann::json::array({"llamacpp-tools"});
+
     // Add telemetry state using in-memory runtime configuration
     if (config_) {
         nlohmann::json telemetry_info = {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5804,16 +5804,12 @@ namespace {
 // Validates a llamacpp tool query body ({"model", "backend", ...}) against the
 // registry: the model must be a downloaded llamacpp GGUF. Returns false after
 // writing the error response.
-bool resolve_llamacpp_tool_target(ModelManager& mm, const nlohmann::json& body,
+bool resolve_llamacpp_tool_target(ModelManager& mm,
+                                  const lemon::backends::llamacpp::json& body,
                                   httplib::Response& res, std::string& backend_out,
                                   std::string& gguf_path_out) {
     const std::string model = body.value("model", "");
     backend_out = body.value("backend", "");
-    if (model.empty() || backend_out.empty()) {
-        res.status = 400;
-        res.set_content(R"({"error":"'model' and 'backend' are required"})", "application/json");
-        return false;
-    }
     if (!mm.model_exists(model)) {
         res.status = 404;
         res.set_content(R"({"error":"unknown model"})", "application/json");
@@ -5842,7 +5838,13 @@ bool resolve_llamacpp_tool_target(ModelManager& mm, const nlohmann::json& body,
 void Server::handle_llamacpp_fit_params(const httplib::Request& req, httplib::Response& res) {
     namespace llt = lemon::backends::llamacpp;
     try {
-        const auto body = nlohmann::json::parse(req.body);
+        const auto body = llt::json::parse(req.body);
+        const std::string invalid = llt::validate_fit_params_request(body);
+        if (!invalid.empty()) {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", invalid}}.dump(), "application/json");
+            return;
+        }
         std::string backend, gguf_path;
         if (!resolve_llamacpp_tool_target(*model_manager_, body, res, backend, gguf_path)) {
             return;
@@ -5884,12 +5886,18 @@ void Server::handle_llamacpp_fit_params(const httplib::Request& req, httplib::Re
 
 void Server::handle_llamacpp_bench(const httplib::Request& req, httplib::Response& res) {
     namespace llt = lemon::backends::llamacpp;
-    nlohmann::json body;
+    llt::json body;
     try {
-        body = nlohmann::json::parse(req.body);
+        body = llt::json::parse(req.body);
     } catch (const std::exception& e) {
         res.status = 400;
         res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+        return;
+    }
+    const std::string invalid = llt::validate_bench_request(body);
+    if (!invalid.empty()) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", invalid}}.dump(), "application/json");
         return;
     }
     std::string backend, gguf_path;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -9,6 +9,7 @@
 #include "lemon/mcp_server.h"
 #include "lemon/ollama_api.h"
 #include "lemon/backends/cloud/cloud_server.h"
+#include "lemon/backends/llamacpp/llamacpp_tools.h"
 #include "lemon/backends/sdcpp/sdcpp_server.h"
 #include "lemon/backends/backend_utils.h"
 #include <cstring>
@@ -831,6 +832,15 @@ void Server::setup_routes(httplib::Server &web_server) {
 
     register_post("downloads/control", [this](const httplib::Request& req, httplib::Response& res) {
         handle_download_control(req, res);
+    });
+
+    register_post("backends/llamacpp/fit-params",
+                  [this](const httplib::Request& req, httplib::Response& res) {
+        handle_llamacpp_fit_params(req, res);
+    });
+    register_post("backends/llamacpp/bench",
+                  [this](const httplib::Request& req, httplib::Response& res) {
+        handle_llamacpp_bench(req, res);
     });
 
 
@@ -2121,6 +2131,27 @@ nlohmann::json Server::model_info_to_json(const std::string& model_id, const Mod
         {"components", public_components},
         {"recipe_options", info.recipe_options.to_json()},
     };
+
+    // GGUF facts read at cache-build time; present only for models whose
+    // checkpoint metadata has been parsed (local llamacpp GGUFs).
+    if (!info.gguf.architecture.empty()) {
+        nlohmann::json meta = {
+            {"architecture", info.gguf.architecture},
+            {"context_length", info.gguf.context_length},
+            {"block_count", info.gguf.block_count},
+            {"expert_count", info.gguf.expert_count},
+            {"full_attention_interval", info.gguf.full_attention_interval},
+            {"swa_layer_count", info.gguf.swa_layer_count},
+            {"kv_bytes_per_token", compute_weighted_kv_cache_bytes_per_token(info.gguf)},
+        };
+        if (!info.gguf.base_model_repo.empty()) {
+            meta["base_model_repo"] = info.gguf.base_model_repo;
+        }
+        if (!info.gguf.base_model_name.empty()) {
+            meta["base_model_name"] = info.gguf.base_model_name;
+        }
+        model_json["metadata"] = meta;
+    }
 
     // Surface the cloud provider on cloud entries so the Model Manager can
     // bucket each provider into its own sub-heading. Omitted on local models
@@ -5764,6 +5795,153 @@ void Server::stream_download_operation(
 }
 
 
+
+namespace {
+
+// Validates a llamacpp tool query body ({"model", "backend", ...}) against the
+// registry: the model must be a downloaded llamacpp GGUF. Returns false after
+// writing the error response.
+bool resolve_llamacpp_tool_target(ModelManager& mm, const nlohmann::json& body,
+                                  httplib::Response& res, std::string& backend_out,
+                                  std::string& gguf_path_out) {
+    const std::string model = body.value("model", "");
+    backend_out = body.value("backend", "");
+    if (model.empty() || backend_out.empty()) {
+        res.status = 400;
+        res.set_content(R"({"error":"'model' and 'backend' are required"})", "application/json");
+        return false;
+    }
+    if (!mm.model_exists(model)) {
+        res.status = 404;
+        res.set_content(R"({"error":"unknown model"})", "application/json");
+        return false;
+    }
+    ModelInfo info = mm.get_model_info(model);
+    if (info.recipe != "llamacpp") {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", "model recipe is not llamacpp"},
+                                       {"recipe", info.recipe}}.dump(),
+                        "application/json");
+        return false;
+    }
+    gguf_path_out = info.resolved_path();
+    if (!info.downloaded || gguf_path_out.empty()) {
+        res.status = 400;
+        res.set_content(R"({"error":"model has no local GGUF; download it first"})",
+                        "application/json");
+        return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+void Server::handle_llamacpp_fit_params(const httplib::Request& req, httplib::Response& res) {
+    namespace llt = lemon::backends::llamacpp;
+    try {
+        const auto body = nlohmann::json::parse(req.body);
+        std::string backend, gguf_path;
+        if (!resolve_llamacpp_tool_target(*model_manager_, body, res, backend, gguf_path)) {
+            return;
+        }
+        std::vector<std::string> extra_args;
+        if (body.contains("args")) {
+            if (body["args"].is_string()) {
+                std::istringstream in(body["args"].get<std::string>());
+                for (std::string tok; in >> tok;) extra_args.push_back(tok);
+            } else if (body["args"].is_array()) {
+                for (const auto& a : body["args"])
+                    if (a.is_string()) extra_args.push_back(a.get<std::string>());
+            }
+        }
+        const int fit_target = body.value("fit_target_mib", 1024);
+
+        bool expected = false;
+        if (!llamacpp_tool_busy_.compare_exchange_strong(expected, true)) {
+            res.status = 409;
+            res.set_content(R"({"error":"another fit/bench query is already running"})",
+                            "application/json");
+            return;
+        }
+        llt::CancelFlag cancel{false};
+        llt::FitEstimate fit;
+        try {
+            fit = llt::run_fit_params(backend, gguf_path, extra_args, fit_target, cancel);
+        } catch (...) {
+            llamacpp_tool_busy_ = false;
+            throw;
+        }
+        llamacpp_tool_busy_ = false;
+        res.set_content(fit.to_json().dump(), "application/json");
+    } catch (const std::exception& e) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+    }
+}
+
+void Server::handle_llamacpp_bench(const httplib::Request& req, httplib::Response& res) {
+    namespace llt = lemon::backends::llamacpp;
+    nlohmann::json body;
+    try {
+        body = nlohmann::json::parse(req.body);
+    } catch (const std::exception& e) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", e.what()}}.dump(), "application/json");
+        return;
+    }
+    std::string backend, gguf_path;
+    if (!resolve_llamacpp_tool_target(*model_manager_, body, res, backend, gguf_path)) {
+        return;
+    }
+    llt::json params = llt::json::object();
+    for (const char* key : {"d", "b", "ub", "ctk", "ctv"}) {
+        if (body.contains(key)) params[key] = body[key];
+    }
+
+    bool expected = false;
+    if (!llamacpp_tool_busy_.compare_exchange_strong(expected, true)) {
+        res.status = 409;
+        res.set_content(R"({"error":"another fit/bench query is already running"})",
+                        "application/json");
+        return;
+    }
+    // The chunked provider runs after this handler returns; the busy flag is
+    // released when the provider lambda is destroyed.
+    auto busy_guard = std::shared_ptr<void>(
+        nullptr, [this](void*) { llamacpp_tool_busy_ = false; });
+
+    res.set_header("Cache-Control", "no-cache");
+    res.set_header("Connection", "keep-alive");
+    res.set_header("X-Accel-Buffering", "no");
+    res.set_chunked_content_provider(
+        "text/event-stream",
+        [busy_guard, backend, gguf_path, params](size_t offset, httplib::DataSink& sink) {
+            if (offset > 0) return false;
+            auto write_event = [&sink](const char* event, const nlohmann::json& data) {
+                const std::string s =
+                    "event: " + std::string(event) + "\ndata: " + data.dump() + "\n\n";
+                return sink.write(s.c_str(), s.size());
+            };
+            llt::CancelFlag cancel{false};
+            auto points = llt::run_llama_bench(
+                backend, gguf_path, params, cancel, [&](const std::string& line) {
+                    if (!write_event("progress", {{"detail", line}})) {
+                        LOG(INFO, "Server") << "Client disconnected, cancelling llama-bench"
+                                            << std::endl;
+                        cancel = true;
+                        return false;
+                    }
+                    return true;
+                });
+            if (!cancel.load()) {
+                nlohmann::json arr = nlohmann::json::array();
+                for (const auto& p : points) arr.push_back(nlohmann::json::parse(p.to_json().dump()));
+                write_event("complete", {{"points", arr}});
+            }
+            sink.done();
+            return false;
+        });
+}
 
 void Server::handle_downloads(const httplib::Request&, httplib::Response& res) {
     nlohmann::json response = nlohmann::json::array();

--- a/src/cpp/server/utils/platform/process_macos.cpp
+++ b/src/cpp/server/utils/platform/process_macos.cpp
@@ -75,7 +75,8 @@ public:
         OutputLineCallback on_line,
         const std::string& working_dir,
         int timeout_seconds,
-        bool capture_stderr = true) override;
+        bool capture_stderr = true,
+        const std::vector<std::pair<std::string, std::string>>& env_vars = {}) override;
 
     int find_free_port(int start_port) override;
     int run_command(const std::string& command, std::string& output, int timeout_seconds) override;
@@ -457,7 +458,8 @@ int MacOSProcessPlatform::run_with_output(
     OutputLineCallback on_line,
     const std::string& working_dir,
     int timeout_seconds,
-    bool capture_stderr) {
+    bool capture_stderr,
+    const std::vector<std::pair<std::string, std::string>>& env_vars) {
 
     // For simplicity, reuse fork/exec for run_with_output on macOS
     // (This is a less critical path than spawn)
@@ -485,6 +487,9 @@ int MacOSProcessPlatform::run_with_output(
 
         if (!working_dir.empty()) {
             chdir(working_dir.c_str());
+        }
+        for (const auto& [key, value] : env_vars) {
+            setenv(key.c_str(), value.c_str(), 1);
         }
 
         std::vector<char*> argv_ptrs;

--- a/src/cpp/server/utils/platform/process_unix.cpp
+++ b/src/cpp/server/utils/platform/process_unix.cpp
@@ -106,7 +106,8 @@ public:
         OutputLineCallback on_line,
         const std::string& working_dir,
         int timeout_seconds,
-        bool capture_stderr = true) override;
+        bool capture_stderr = true,
+        const std::vector<std::pair<std::string, std::string>>& env_vars = {}) override;
 
     int find_free_port(int start_port) override;
     int run_command(const std::string& command, std::string& output, int timeout_seconds) override;
@@ -485,7 +486,8 @@ int UnixProcessPlatform::run_with_output(
     OutputLineCallback on_line,
     const std::string& working_dir,
     int timeout_seconds,
-    bool capture_stderr) {
+    bool capture_stderr,
+    const std::vector<std::pair<std::string, std::string>>& env_vars) {
 
     int stdout_pipe[2];
 
@@ -516,6 +518,10 @@ int UnixProcessPlatform::run_with_output(
 
         if (!working_dir.empty()) {
             chdir(working_dir.c_str());
+        }
+
+        for (const auto& [key, value] : env_vars) {
+            setenv(key.c_str(), value.c_str(), 1);
         }
 
 #ifdef HAVE_LIBCAP

--- a/src/cpp/server/utils/platform/process_windows.cpp
+++ b/src/cpp/server/utils/platform/process_windows.cpp
@@ -455,7 +455,8 @@ public:
         OutputLineCallback on_line,
         const std::string& working_dir,
         int timeout_seconds,
-        bool capture_stderr = true) override {
+        bool capture_stderr = true,
+        const std::vector<std::pair<std::string, std::string>>& env_vars = {}) override {
 
         std::string cmdline = escape_windows_arg(executable);
         for (const auto& arg : args) {
@@ -488,6 +489,11 @@ public:
         si.hStdError = capture_stderr ? stdout_write : GetStdHandle(STD_ERROR_HANDLE);
         ZeroMemory(&pi, sizeof(pi));
 
+        std::vector<char> environment_block;
+        if (!env_vars.empty()) {
+            environment_block = build_windows_environment_block(env_vars);
+        }
+
         BOOL success = CreateProcessA(
             nullptr,
             const_cast<char*>(cmdline.c_str()),
@@ -495,7 +501,7 @@ public:
             nullptr,
             TRUE,  // Inherit handles
             CREATE_NO_WINDOW,
-            nullptr,
+            environment_block.empty() ? nullptr : environment_block.data(),
             working_dir.empty() ? nullptr : working_dir.c_str(),
             &si,
             &pi

--- a/src/cpp/server/utils/process_manager.cpp
+++ b/src/cpp/server/utils/process_manager.cpp
@@ -53,10 +53,12 @@ int ProcessManager::run_process_with_output(
     OutputLineCallback on_line,
     const std::string& working_dir,
     int timeout_seconds,
-    bool capture_stderr) {
+    bool capture_stderr,
+    const std::vector<std::pair<std::string, std::string>>& env_vars) {
 
     auto platform = create_process_platform();
-    return platform->run_with_output(executable, args, on_line, working_dir, timeout_seconds, capture_stderr);
+    return platform->run_with_output(executable, args, on_line, working_dir, timeout_seconds,
+                                     capture_stderr, env_vars);
 }
 
 void ProcessManager::kill_process(ProcessHandle handle) {

--- a/test/cpp/test_llamacpp_tools.cpp
+++ b/test/cpp/test_llamacpp_tools.cpp
@@ -56,9 +56,62 @@ static void test_parse_llama_bench() {
     check("bench: parse error surfaces", bad.size() == 1 && !bad[0].ok && !bad[0].error.empty());
 }
 
+static void test_validate_fit_params_request() {
+    auto ok = [](const char* body) { return validate_fit_params_request(json::parse(body)).empty(); };
+    check("vfit: minimal ok", ok(R"({"model":"m","backend":"vulkan"})"));
+    check("vfit: args string ok", ok(R"({"model":"m","backend":"vulkan","args":"-c 4096"})"));
+    check("vfit: args array ok", ok(R"({"model":"m","backend":"vulkan","args":["-c","4096"]})"));
+    check("vfit: fit_target ok", ok(R"({"model":"m","backend":"vulkan","fit_target_mib":2048})"));
+    check("vfit: missing model rejected", !ok(R"({"backend":"vulkan"})"));
+    check("vfit: empty model rejected", !ok(R"({"model":"","backend":"vulkan"})"));
+    check("vfit: missing backend rejected", !ok(R"({"model":"m"})"));
+    check("vfit: backend path chars rejected", !ok(R"({"model":"m","backend":"../evil"})"));
+    check("vfit: unknown key rejected", !ok(R"({"model":"m","backend":"vulkan","bogus":1})"));
+    check("vfit: args number rejected", !ok(R"({"model":"m","backend":"vulkan","args":42})"));
+    check("vfit: args array of numbers rejected",
+          !ok(R"({"model":"m","backend":"vulkan","args":[1,2]})"));
+    check("vfit: fit_target negative rejected",
+          !ok(R"({"model":"m","backend":"vulkan","fit_target_mib":-1})"));
+    check("vfit: fit_target float rejected",
+          !ok(R"({"model":"m","backend":"vulkan","fit_target_mib":1.5})"));
+    check("vfit: non-object rejected", !validate_fit_params_request(json::parse("[1]")).empty());
+    check("vfit: error names field",
+          validate_fit_params_request(json::parse(R"({"model":"m","backend":"vulkan","x":1})"))
+                  .find("'x'") != std::string::npos);
+}
+
+static void test_validate_bench_request() {
+    auto ok = [](const char* body) { return validate_bench_request(json::parse(body)).empty(); };
+    check("vbench: minimal ok", ok(R"({"model":"m","backend":"vulkan"})"));
+    check("vbench: d int ok", ok(R"({"model":"m","backend":"vulkan","d":0})"));
+    check("vbench: d array ok", ok(R"({"model":"m","backend":"vulkan","d":[0,30000]})"));
+    check("vbench: full ok",
+          ok(R"({"model":"m","backend":"vulkan","d":[0],"b":2048,"ub":2048,"ctk":"q8_0","ctv":"q8_0"})"));
+    check("vbench: unknown key rejected", !ok(R"({"model":"m","backend":"vulkan","depth":0})"));
+    check("vbench: d negative rejected", !ok(R"({"model":"m","backend":"vulkan","d":-1})"));
+    check("vbench: d string rejected", !ok(R"({"model":"m","backend":"vulkan","d":"0"})"));
+    check("vbench: d empty array rejected", !ok(R"({"model":"m","backend":"vulkan","d":[]})"));
+    check("vbench: d mixed array rejected", !ok(R"({"model":"m","backend":"vulkan","d":[0,"x"]})"));
+    check("vbench: b zero rejected", !ok(R"({"model":"m","backend":"vulkan","b":0})"));
+    check("vbench: b huge rejected", !ok(R"({"model":"m","backend":"vulkan","b":100000})"));
+    check("vbench: ub without b rejected", !ok(R"({"model":"m","backend":"vulkan","ub":512})"));
+    check("vbench: ctk bogus rejected", !ok(R"({"model":"m","backend":"vulkan","ctk":"q9_9"})"));
+    check("vbench: ctk non-string rejected", !ok(R"({"model":"m","backend":"vulkan","ctk":8})"));
+    check("vbench: ctv without ctk rejected", !ok(R"({"model":"m","backend":"vulkan","ctv":"q8_0"})"));
+    check("vbench: all cache types accepted", [&] {
+        for (const char* t : {"f32", "f16", "bf16", "q8_0", "q5_1", "q5_0", "q4_1", "q4_0", "iq4_nl"}) {
+            json b = {{"model", "m"}, {"backend", "vulkan"}, {"ctk", t}, {"ctv", t}};
+            if (!validate_bench_request(b).empty()) return false;
+        }
+        return true;
+    }());
+}
+
 int main() {
     test_parse_fit_params();
     test_parse_llama_bench();
+    test_validate_fit_params_request();
+    test_validate_bench_request();
     if (g_failures) {
         std::printf("%d FAILURE(S)\n", g_failures);
         return 1;

--- a/test/cpp/test_llamacpp_tools.cpp
+++ b/test/cpp/test_llamacpp_tools.cpp
@@ -1,0 +1,68 @@
+// Standalone test for the llama.cpp tool-output parsers (llama-fit-params /
+// llama-bench), driven entirely by synthetic captured outputs.
+
+#include "lemon/backends/llamacpp/llamacpp_tools.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace lemon::backends::llamacpp;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static void test_parse_fit_params() {
+    const std::string out =
+        "load_backend: loaded RPC backend\n"
+        "-c 32768 -ngl -1\n"
+        "Vulkan0 3147 5760 301\n"
+        "Host 304 0 50\n";
+    FitEstimate f = parse_fit_params_output(out);
+    check("fit: ok", f.ok);
+    check("fit: ctx parsed", f.fitted_ctx == 32768);
+    check("fit: full offload", f.fits_fully && f.fitted_ngl == -1);
+    check("fit: device rows", f.devices.size() == 2 && f.devices[0].ctx_mib == 5760);
+    check("fit: total excludes host", f.total_mib() == 3147 + 5760 + 301);
+
+    FitEstimate bad = parse_fit_params_output("random log noise\n");
+    check("fit: garbage rejected", !bad.ok && !bad.error.empty());
+
+    FitEstimate moe = parse_fit_params_output("-c 16384 -ngl -1 -ncmoe 12\n");
+    check("fit: ncmoe parsed, not full", moe.fitted_ncmoe == 12 && !moe.fits_fully);
+
+    // Table-only output = nothing needed adjusting = full fit at requested ctx.
+    FitEstimate table = parse_fit_params_output("Vulkan0 168 111 513\nHost 120 0 35\n");
+    check("fit: table-only is a full fit", table.ok && table.fits_fully && table.fitted_ctx == 0);
+}
+
+static void test_parse_llama_bench() {
+    const std::string out = R"(0.00.123 I llama_model_loader: loaded meta data
+[
+      {"n_prompt": 2048, "n_gen": 0, "n_depth": 0, "n_batch": 2048, "n_ubatch": 512, "avg_ts": 611.2},
+      {"n_prompt": 0, "n_gen": 32, "n_depth": 0, "n_batch": 2048, "n_ubatch": 512, "avg_ts": 41.8},
+      {"n_prompt": 2048, "n_gen": 0, "n_depth": 30000, "n_batch": 2048, "n_ubatch": 512, "avg_ts": 213.0},
+      {"n_prompt": 0, "n_gen": 32, "n_depth": 30000, "n_batch": 2048, "n_ubatch": 512, "avg_ts": 28.4}
+    ])";
+    auto pts = parse_llama_bench_json(out, "vulkan");
+    check("bench: two depth points", pts.size() == 2);
+    check("bench: d0 pp+tg", pts[0].ok && pts[0].pp_avg_ts == 611.2 && pts[0].tg_avg_ts == 41.8);
+    check("bench: d30000 keyed", pts[1].n_depth == 30000 && pts[1].tg_avg_ts == 28.4);
+
+    auto bad = parse_llama_bench_json("not json", "vulkan");
+    check("bench: parse error surfaces", bad.size() == 1 && !bad[0].ok && !bad[0].error.empty());
+}
+
+int main() {
+    test_parse_fit_params();
+    test_parse_llama_bench();
+    if (g_failures) {
+        std::printf("%d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    std::printf("ALL PASS (0 failures)\n");
+    return 0;
+}

--- a/test/server_llamacpp_tools.py
+++ b/test/server_llamacpp_tools.py
@@ -140,6 +140,77 @@ class LlamaCppToolsEndpointTests(ServerTestBase):
         self.assertIn("expert_count", meta)
         self.assertIn("kv_bytes_per_token", meta)
 
+    def test_005a_schema_validation(self):
+        cases = [
+            ({"model": "m", "backend": "vulkan", "bogus": 1}, "unexpected field"),
+            ({"model": "m"}, "backend"),
+            ({"backend": "vulkan"}, "model"),
+            ({"model": "m", "backend": "../etc"}, "backend"),
+            (
+                {"model": "m", "backend": "vulkan", "fit_target_mib": -5},
+                "fit_target_mib",
+            ),
+            ({"model": "m", "backend": "vulkan", "args": 42}, "args"),
+        ]
+        for body, needle in cases:
+            resp = requests.post(
+                f"{self.base_url}/backends/llamacpp/fit-params",
+                json=body,
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 400, (body, resp.text))
+            self.assertIn(needle, resp.json().get("error", ""), body)
+
+        bench_cases = [
+            ({"model": "m", "backend": "vulkan", "depth": 0}, "unexpected field"),
+            ({"model": "m", "backend": "vulkan", "d": -1}, "'d'"),
+            ({"model": "m", "backend": "vulkan", "b": 0}, "'b'"),
+            ({"model": "m", "backend": "vulkan", "ub": 512}, "'ub' requires"),
+            ({"model": "m", "backend": "vulkan", "ctk": "q9_9"}, "'ctk'"),
+            ({"model": "m", "backend": "vulkan", "ctv": "q8_0"}, "'ctv' requires"),
+        ]
+        for body, needle in bench_cases:
+            resp = requests.post(
+                f"{self.base_url}/backends/llamacpp/bench",
+                json=body,
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 400, (body, resp.text))
+            self.assertIn(needle, resp.json().get("error", ""), body)
+
+        resp = requests.get(
+            f"{self.base_url}/backends/llamacpp/bench", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(resp.status_code, 405)
+
+    def test_005b_busy_returns_409(self):
+        backend = self._installed_backend()
+        if backend is None:
+            self.skipTest("no llamacpp backend installed")
+        self._pull_test_model()
+
+        bench = requests.post(
+            f"{self.base_url}/backends/llamacpp/bench",
+            json={"model": ENDPOINT_TEST_MODEL, "backend": backend, "d": 0},
+            stream=True,
+            timeout=600,
+        )
+        self.assertEqual(bench.status_code, 200)
+        try:
+            got_409 = False
+            for _ in range(20):
+                resp = requests.post(
+                    f"{self.base_url}/backends/llamacpp/fit-params",
+                    json={"model": ENDPOINT_TEST_MODEL, "backend": backend},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+                if resp.status_code == 409:
+                    got_409 = True
+                    break
+            self.assertTrue(got_409, "no 409 while bench stream was active")
+        finally:
+            bench.close()
+
     def test_006_health_advertises_llamacpp_tools(self):
         resp = requests.get(f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT)
         self.assertEqual(resp.status_code, 200)

--- a/test/server_llamacpp_tools.py
+++ b/test/server_llamacpp_tools.py
@@ -1,0 +1,145 @@
+"""llama.cpp tool endpoint tests (backends/llamacpp/fit-params and /bench).
+
+fit-params is a quick estimator (no inference), so the suite works on
+CI-class machines as long as the test model is pulled and a llamacpp
+backend is installed. The bench test streams a real llama-bench run on the
+tiny endpoint-test model.
+"""
+
+import json
+import sys
+import unittest
+
+import requests
+
+sys.path.insert(0, ".")
+sys.path.insert(0, "test")
+
+from utils.server_base import ServerTestBase, TIMEOUT_DEFAULT
+from utils.test_models import ENDPOINT_TEST_MODEL
+
+
+def _sse_events(resp):
+    event, data = None, []
+    for raw in resp.iter_lines(decode_unicode=True):
+        if raw is None:
+            continue
+        if raw.startswith("event: "):
+            event = raw[len("event: ") :]
+        elif raw.startswith("data: "):
+            data.append(raw[len("data: ") :])
+        elif raw == "" and event is not None:
+            yield event, json.loads("\n".join(data)) if data else None
+            event, data = None, []
+
+
+class LlamaCppToolsEndpointTests(ServerTestBase):
+    def _pull_test_model(self):
+        resp = requests.post(
+            f"{self.base_url}/pull",
+            json={"model_name": ENDPOINT_TEST_MODEL},
+            timeout=600,
+        )
+        self.assertIn(resp.status_code, (200, 201))
+
+    def _installed_backend(self):
+        resp = requests.get(f"{self.base_url}/system-info", timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(resp.status_code, 200)
+        backends = (
+            resp.json().get("recipes", {}).get("llamacpp", {}).get("backends", {})
+        )
+        for name, state in backends.items():
+            if state.get("state") in ("installed", "update_available"):
+                return name
+        return None
+
+    def test_001_fit_params_validation(self):
+        resp = requests.post(
+            f"{self.base_url}/backends/llamacpp/fit-params",
+            json={},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(resp.status_code, 400)
+
+        resp = requests.post(
+            f"{self.base_url}/backends/llamacpp/fit-params",
+            json={"model": "no-such-model", "backend": "vulkan"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(resp.status_code, 404)
+
+    def test_002_fit_params_get_is_405(self):
+        resp = requests.get(
+            f"{self.base_url}/backends/llamacpp/fit-params", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(resp.status_code, 405)
+
+    def test_003_fit_params_e2e(self):
+        backend = self._installed_backend()
+        if backend is None:
+            self.skipTest("no llamacpp backend installed")
+        self._pull_test_model()
+
+        resp = requests.post(
+            f"{self.base_url}/backends/llamacpp/fit-params",
+            json={"model": ENDPOINT_TEST_MODEL, "backend": backend},
+            timeout=180,
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        fit = resp.json()
+        self.assertTrue(fit.get("ok"), fit)
+        self.assertEqual(fit.get("backend"), backend)
+        self.assertIsInstance(fit.get("devices"), list)
+
+        resp = requests.post(
+            f"{self.base_url}/backends/llamacpp/fit-params",
+            json={
+                "model": ENDPOINT_TEST_MODEL,
+                "backend": backend,
+                "args": "-c 4096 -ctk q8_0 -ctv q8_0",
+            },
+            timeout=180,
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        self.assertEqual(resp.json().get("extra_args"), "-c 4096 -ctk q8_0 -ctv q8_0")
+
+    def test_004_bench_e2e_streaming(self):
+        backend = self._installed_backend()
+        if backend is None:
+            self.skipTest("no llamacpp backend installed")
+        self._pull_test_model()
+
+        resp = requests.post(
+            f"{self.base_url}/backends/llamacpp/bench",
+            json={"model": ENDPOINT_TEST_MODEL, "backend": backend, "d": 0},
+            stream=True,
+            timeout=600,
+        )
+        self.assertEqual(resp.status_code, 200)
+        complete = None
+        for event, data in _sse_events(resp):
+            if event == "complete":
+                complete = data
+                break
+        self.assertIsNotNone(complete, "no complete event")
+        points = complete.get("points", [])
+        self.assertTrue(points, complete)
+        self.assertTrue(points[0].get("ok"), points)
+        self.assertGreater(points[0].get("tg_avg_ts", 0), 0, points)
+
+    def test_005_models_metadata_block(self):
+        self._pull_test_model()
+        resp = requests.get(
+            f"{self.base_url}/models/{ENDPOINT_TEST_MODEL}", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(resp.status_code, 200)
+        meta = resp.json().get("metadata")
+        self.assertIsInstance(meta, dict, resp.json())
+        self.assertTrue(meta.get("architecture"))
+        self.assertGreater(meta.get("context_length", 0), 0)
+        self.assertIn("expert_count", meta)
+        self.assertIn("kv_bytes_per_token", meta)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/server_llamacpp_tools.py
+++ b/test/server_llamacpp_tools.py
@@ -140,6 +140,11 @@ class LlamaCppToolsEndpointTests(ServerTestBase):
         self.assertIn("expert_count", meta)
         self.assertIn("kv_bytes_per_token", meta)
 
+    def test_006_health_advertises_llamacpp_tools(self):
+        resp = requests.get(f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("llamacpp-tools", resp.json().get("features", []))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
This PR is 1/2 to implement #2613 by adding the necessary backend support - API endpoints for launching `llama-bench` and `llama-fit` for the llamacpp engine to perform diagnostics and performance bencharks to determine optimal setup.