### PR TITLE
feat: autoopt wizard for llama.cpp optimal parameters

### DIFF
--- a/prototype/ui-redesign/package.json
+++ b/prototype/ui-redesign/package.json
@@ -10,7 +10,10 @@
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:a11y": "npx playwright test tests/a11y.spec.ts",
-    "test:preset-intent": "node tests/preset-intent.runtime.cjs"
+    "test:preset-intent": "node tests/preset-intent.runtime.cjs",
+    "test:autoopt-glue": "node tests/autoopt-glue.runtime.cjs",
+    "test:autoopt-synthesize": "node tests/autoopt-synthesize.runtime.cjs",
+    "test:autoopt-store-scope": "node tests/autoopt-store-scope.runtime.cjs"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/prototype/ui-redesign/src/api.ts
+++ b/prototype/ui-redesign/src/api.ts
@@ -355,6 +355,28 @@ export interface SlotTimings {
   predicted_per_second: number;
 }
 
+export type JobStatus = 'queued' | 'running' | 'paused' | 'interrupted' | 'completed' | 'failed';
+
+export interface JobStep {
+  id: string;
+  op: string;
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'skipped' | string;
+  duration_ms?: number;
+  error?: string;
+  output?: unknown;
+}
+
+export interface JobRecord {
+  id: string;
+  name: string;
+  status: JobStatus;
+  inputs?: Record<string, unknown>;
+  context: Record<string, unknown>;
+  cursor?: string;
+  steps: JobStep[];
+  created_at?: string;
+}
+
 export interface SlotData {
   id: number;
   n_ctx: number;
@@ -1562,6 +1584,44 @@ class LemonadeAPI {
     if (Array.isArray(data)) return data as DownloadProgressEvent[];
     if (isObject(data) && Array.isArray(data.downloads)) return data.downloads as DownloadProgressEvent[];
     return [];
+  }
+
+
+  async createJob(name: string, steps: unknown[], inputs: Record<string, unknown> = {}): Promise<{ id: string }> {
+    return this._json<{ id: string }>('/api/v1/jobs', {
+      method: 'POST',
+      body: { name, definition: { steps }, inputs },
+    });
+  }
+
+  async getJob(id: string, signal?: AbortSignal): Promise<JobRecord> {
+    return this._json<JobRecord>(`/api/v1/jobs/${encodeURIComponent(id)}`, {
+      cache: 'no-store',
+      signal,
+    } as LemonadeRequestInit);
+  }
+
+  async listJobs(): Promise<JobRecord[]> {
+    const data = await this._json<unknown>('/api/v1/jobs', { cache: 'no-store' } as LemonadeRequestInit);
+    if (Array.isArray(data)) return data as JobRecord[];
+    if (isObject(data) && Array.isArray(data.jobs)) return data.jobs as JobRecord[];
+    return [];
+  }
+
+  async interruptJob(id: string): Promise<void> {
+    await this._fetch(`/api/v1/jobs/${encodeURIComponent(id)}/interrupt`, { method: 'POST' });
+  }
+
+  async pauseJob(id: string): Promise<void> {
+    await this._fetch(`/api/v1/jobs/${encodeURIComponent(id)}/pause`, { method: 'POST' });
+  }
+
+  async resumeJob(id: string): Promise<void> {
+    await this._fetch(`/api/v1/jobs/${encodeURIComponent(id)}/resume`, { method: 'POST' });
+  }
+
+  async deleteJob(id: string): Promise<void> {
+    await this._fetch(`/api/v1/jobs/${encodeURIComponent(id)}`, { method: 'DELETE' });
   }
 
   async controlDownload(downloadId: string, action: 'pause' | 'cancel' | 'remove'): Promise<unknown> {

--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -136,6 +136,7 @@ const TUNING_FIELD_LABELS: Record<keyof RecipeOptions, string> = {
   voice: 'Voice',
   speed: 'Speed',
   merge_args: 'Backend args behavior',
+  mmproj_enabled: 'Vision projector',
 };
 
 const TUNING_FIELD_HINTS: Partial<Record<keyof RecipeOptions, string>> = {
@@ -156,10 +157,11 @@ const TUNING_FIELD_HINTS: Partial<Record<keyof RecipeOptions, string>> = {
   vllm_args: 'Raw backend args for this model only.',
   flm_args: 'Raw backend args for this model only.',
   merge_args: 'Choose whether backend defaults, model args, or both should be used for this model.',
+  mmproj_enabled: "Off frees the projector's memory for context when image input is not needed.",
 };
 
 const NUMERIC_TUNING_KEYS = new Set<keyof RecipeOptions>(['steps', 'cfg_scale', 'width', 'height', 'flow_shift', 'speed']);
-const BOOLEAN_TUNING_KEYS = new Set<keyof RecipeOptions>(['merge_args']);
+const BOOLEAN_TUNING_KEYS = new Set<keyof RecipeOptions>(['merge_args', 'mmproj_enabled']);
 const BACKEND_TUNING_KEYS = new Set<keyof RecipeOptions>(['llamacpp_backend', 'vllm_backend', 'whispercpp_backend', 'moonshine_backend', 'acestep_backend', 'thinksound_backend', 'openmoss_backend', 'trellis_backend']);
 const DEVICE_TUNING_KEYS = new Set<keyof RecipeOptions>(['llamacpp_device']);
 const ARGS_TUNING_KEYS = new Set<keyof RecipeOptions>(['llamacpp_args', 'sdcpp_args', 'whispercpp_args', 'moonshine_args', 'vllm_args', 'flm_args']);
@@ -170,7 +172,7 @@ const BACKEND_ARGS_KEY: Partial<Record<keyof RecipeOptions, keyof RecipeOptions>
   moonshine_backend: 'moonshine_args',
 };
 
-const LLAMACPP_RECIPE_KEYS: Array<keyof RecipeOptions> = ['llamacpp_backend', 'llamacpp_device', 'llamacpp_args', 'merge_args'];
+const LLAMACPP_RECIPE_KEYS: Array<keyof RecipeOptions> = ['llamacpp_backend', 'llamacpp_device', 'llamacpp_args', 'mmproj_enabled', 'merge_args'];
 const VLLM_RECIPE_KEYS: Array<keyof RecipeOptions> = ['vllm_backend', 'vllm_args', 'merge_args'];
 const FLM_RECIPE_KEYS: Array<keyof RecipeOptions> = ['flm_args', 'merge_args'];
 const RYZENAI_RECIPE_KEYS: Array<keyof RecipeOptions> = ['merge_args'];
@@ -1534,6 +1536,21 @@ const ModelTuningTab: React.FC<{
       );
     }
 
+    if (key === 'mmproj_enabled') {
+      const activeState = typeof baseValue === 'boolean' && !baseValue ? 'Off' : 'On';
+      return (
+        <label key={key} className="detail-tuning__field" htmlFor={inputId}>
+          <span>{label}</span>
+          <select id={inputId} className="select" value={draftValue} onChange={e => setRecipeField(key, e.target.value)}>
+            <option value="">{activeState}</option>
+            <option value="true">On</option>
+            <option value="false">Off</option>
+          </select>
+          {hint && <small>{hint}</small>}
+        </label>
+      );
+    }
+
     if (BOOLEAN_TUNING_KEYS.has(key)) {
       const argsKey = activeArgsKey;
       const hasModelArgs = !!(argsKey && (recipeDraft[argsKey] || fieldValue(baseTuning.recipe_options[argsKey])));
@@ -1697,7 +1714,7 @@ const ModelTuningTab: React.FC<{
         </div>
         <div className="detail-tuning__summary-card">
           <span className="detail-tuning__summary-label">Pair source</span>
-          <strong>{hasUserTuning ? 'Custom tuning' : 'Resolved defaults'}</strong>
+          <strong>{resolvedTuning.tuning.source === 'optimized' ? 'AutoOpt optimized' : (hasUserTuning ? 'Custom tuning' : 'Resolved defaults')}</strong>
         </div>
       </section>
 
@@ -1711,7 +1728,12 @@ const ModelTuningTab: React.FC<{
               <div className="detail-tuning__kv" key={`ro-${key}`}>
                 <span>{TUNING_FIELD_LABELS[key as keyof RecipeOptions] || key}</span>
                 <code>{tuningValue(value)}</code>
-                <small>{tuningSourceLabel(resolvedTuning.sources.recipe_options[key as keyof RecipeOptions])}</small>
+                <small>
+                  {key === 'ctx_size' && selectedPreset.context_hint === 'max'
+                    && resolvedTuning.sources.recipe_options.ctx_size === 'generic'
+                    ? 'Model maximum'
+                    : tuningSourceLabel(resolvedTuning.sources.recipe_options[key as keyof RecipeOptions])}
+                </small>
               </div>
             ))}
             {effectiveSamplingEntries.map(([key, value]) => (

--- a/prototype/ui-redesign/src/components/PresetManager.tsx
+++ b/prototype/ui-redesign/src/components/PresetManager.tsx
@@ -22,6 +22,7 @@ import {
   loadBackendApplied,
   loadUserPresets,
   normalizePresetCapabilities,
+  PRESET_STORE_EVENT,
   presetLabelsFor,
   presetParamPreviewLines,
   presetSupportsCapability,
@@ -34,6 +35,8 @@ import {
 } from '../presetStore';
 import { CapabilityIcon, Icon, PresetIcon, type IconName } from './Icon';
 import { useFocusTrap } from '../hooks/useFocusTrap';
+import AutoOptRail, { openAutoOptRun } from '../features/autoOpt/AutoOptRail';
+import { autoOptStore, type AutoOptState } from '../features/autoOpt/autoOptStore';
 
 const CAPABILITIES: Capability[] = ['all', 'chat', 'omni', 'vision', 'code', 'image', 'transcription', 'audio-generation', 'tts', 'model3d', 'embedding', 'reranking'];
 
@@ -109,54 +112,6 @@ function backendOptionsFromSystemInfo(info: Record<string, unknown> | null): Bac
   }
   return out.sort((a, b) => a.label.localeCompare(b.label));
 }
-
-interface AutoOptRun {
-  id: string;
-  name: string;
-  date: string;
-  lemonadeVersion: string;
-  summary: string;
-  args: string;
-  backends: { name: string; version: string; device: string }[];
-}
-
-const AUTO_OPT_RUNS: AutoOptRun[] = [
-  {
-    id: 'autoopt-1',
-    name: 'AutoOpt #1',
-    date: '2026-06-11',
-    lemonadeVersion: '0.6.0-prototype',
-    summary: 'Balanced local baseline for llama.cpp on mixed CPU/GPU machines.',
-    args: '--threads auto --batch-size 512 --ubatch-size 256 --ctx-size 4096',
-    backends: [
-      { name: 'llama.cpp', version: 'b5412', device: 'CPU baseline' },
-      { name: 'Vulkan', version: '1.3 safe path', device: 'GPU if available' },
-    ],
-  },
-  {
-    id: 'autoopt-2',
-    name: 'AutoOpt #2',
-    date: '2026-06-09',
-    lemonadeVersion: '0.6.0-prototype',
-    summary: 'Low-memory fallback that favors predictable CPU execution.',
-    args: '--threads auto --batch-size 256 --ubatch-size 128 --ctx-size 4096 --n-gpu-layers 0',
-    backends: [
-      { name: 'llama.cpp', version: 'b5408', device: 'CPU' },
-    ],
-  },
-  {
-    id: 'autoopt-3',
-    name: 'AutoOpt #3',
-    date: '2026-06-05',
-    lemonadeVersion: '0.5.9',
-    summary: 'Throughput-oriented llama.cpp draft for larger VRAM systems.',
-    args: '--threads auto --batch-size 1024 --ubatch-size 512 --ctx-size 8192 --n-gpu-layers 99',
-    backends: [
-      { name: 'llama.cpp', version: 'b5389', device: 'GPU preferred' },
-      { name: 'CUDA/Vulkan', version: 'runtime default', device: 'Auto by Lemonade' },
-    ],
-  },
-];
 
 function modelName(model: ModelInfo): string {
   return model.id || model.name || model.display_name || 'unknown';
@@ -267,15 +222,43 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
   const [applyBackendTarget, setApplyBackendTarget] = useState('');
   const [applyBackendSuccess, setApplyBackendSuccess] = useState<string | null>(null);
   const [autoRailCollapsed, setAutoRailCollapsed] = useState(false);
-  const [selectedAutoRunId, setSelectedAutoRunId] = useState(AUTO_OPT_RUNS[0]?.id || '');
-  const [autoOptRuns, setAutoOptRuns] = useState<AutoOptRun[]>(AUTO_OPT_RUNS);
-  const [autoOptRunning, setAutoOptRunning] = useState(false);
+  const [highlightPresetId, setHighlightPresetId] = useState<string | null>(null);
   const slideoverRef = useRef<HTMLElement>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
+  const userPresetsRef = useRef(userPresets);
 
+  useEffect(() => { userPresetsRef.current = userPresets; }, [userPresets]);
   useEffect(() => { saveUserPresets(userPresets); }, [userPresets]);
   useEffect(() => { saveApplied(appliedPresets); }, [appliedPresets]);
   useEffect(() => { saveBackendApplied(backendPresets); }, [backendPresets]);
+
+  useEffect(() => {
+    const onStoreChange = () => {
+      const next = loadUserPresets();
+      if (JSON.stringify(next) !== JSON.stringify(userPresetsRef.current)) {
+        const previousIds = new Set(userPresetsRef.current.map(preset => preset.id));
+        const added = next.find(preset => !previousIds.has(preset.id));
+        setUserPresets(next);
+        if (added) setHighlightPresetId(added.id);
+      }
+      setAppliedPresets(prev => {
+        const nextApplied = loadApplied();
+        return JSON.stringify(nextApplied) === JSON.stringify(prev) ? prev : nextApplied;
+      });
+    };
+    window.addEventListener(PRESET_STORE_EVENT, onStoreChange);
+    return () => window.removeEventListener(PRESET_STORE_EVENT, onStoreChange);
+  }, []);
+
+  useEffect(() => {
+    if (!highlightPresetId) return;
+    requestAnimationFrame(() => {
+      document.querySelector(`[data-recipe-id="${highlightPresetId}"]`)
+        ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+    const timer = window.setTimeout(() => setHighlightPresetId(null), 10000);
+    return () => window.clearTimeout(timer);
+  }, [highlightPresetId]);
 
   useEffect(() => {
     let alive = true;
@@ -301,6 +284,14 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
 
   const appliedModelNames = useMemo(() => Object.keys(appliedPresets), [appliedPresets]);
   const appliedBackendKeys = useMemo(() => Object.keys(backendPresets), [backendPresets]);
+
+  const linkedModelsByPreset = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const [model, presetId] of Object.entries(appliedPresets)) {
+      map.set(presetId, [...(map.get(presetId) || []), model]);
+    }
+    return map;
+  }, [appliedPresets]);
 
   const closeSlideover = useCallback(() => {
     setSelectedPreset(null);
@@ -341,14 +332,14 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
       engine_hint: 'auto',
       starter: false,
       auto_opt_enabled: true,
-      auto_opt_run_id: autoOptRuns[0]?.id || null,
+      auto_opt_run_id: null,
       system_prompt_id: 'general',
       system_prompts: cloneSystemPrompts(CUSTOM_PRESET_PROMPTS),
       tools_enabled: true,
     };
     setUserPresets(prev => [newPreset, ...prev]);
     openSlideover(newPreset);
-  }, [openSlideover, autoOptRuns]);
+  }, [openSlideover]);
 
   const importPresets = useCallback((raw: string) => {
     const data = JSON.parse(raw);
@@ -481,76 +472,14 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
     });
   }, []);
 
-  const handleRunAutoOpt = useCallback(() => {
-    setAutoOptRunning(true);
-    setTimeout(() => {
-      const newRun: AutoOptRun = {
-        id: `autoopt-${Date.now()}`,
-        name: `AutoOpt #${autoOptRuns.length + 1}`,
-        date: new Date().toISOString().split('T')[0],
-        lemonadeVersion: '0.6.0-prototype',
-        summary: 'Fresh optimization based on current system hardware and loaded backends.',
-        args: '--threads auto --batch-size 512 --ubatch-size 256 --ctx-size 4096',
-        backends: [{ name: 'llama.cpp', version: 'latest', device: 'Auto-detected' }],
-      };
-      setAutoOptRuns(prev => [newRun, ...prev]);
-      setSelectedAutoRunId(newRun.id);
-      setAutoOptRunning(false);
-    }, 2000);
-  }, [autoOptRuns.length]);
-
-  const handleDeleteAutoOptRun = useCallback((runId: string) => {
-    setAutoOptRuns(prev => {
-      const next = prev.filter(r => r.id !== runId);
-      if (selectedAutoRunId === runId) {
-        setSelectedAutoRunId(next[0]?.id || '');
-      }
-      return next;
-    });
-  }, [selectedAutoRunId]);
-
-  const selectedAutoRun = autoOptRuns.find(run => run.id === selectedAutoRunId) || autoOptRuns[0];
-
   return (
     <>
       <section className={`recipes recipes--with-rail${autoRailCollapsed ? ' context-rail-collapsed' : ''}`} data-view="presets">
-        <aside className={`context-rail context-rail--autoopt${autoRailCollapsed ? ' is-collapsed' : ''}`} aria-label="AutoOpt runs">
-          <div className="context-rail__head">
-            <button type="button" className="context-rail__toggle" onClick={() => setAutoRailCollapsed(v => !v)} aria-label="Toggle AutoOpt rail">☰</button>
-            <div className="context-rail__title-wrap">
-              <span className="context-rail__eyebrow">Auto Optimizer</span>
-              <strong className="context-rail__title">Runs</strong>
-            </div>
-          </div>
-          <div className="context-rail__body">
-            <p className="context-rail__hint">Select a safe local optimization result and attach it to editable presets. Manual args override AutoOpt.</p>
-            <button type="button" className="btn btn--primary btn--small" style={{ width: '100%', marginBottom: '0.75rem' }} onClick={handleRunAutoOpt} disabled={autoOptRunning}>
-              {autoOptRunning ? '⏳ Running…' : '▶ Run optimizer'}
-            </button>
-            <div className="auto-run-list">
-              {autoOptRuns.map(run => (
-                <article key={run.id} className={`auto-run-card${selectedAutoRunId === run.id ? ' is-active' : ''}`}>
-                  <button type="button" className="auto-run-card__main" onClick={() => setSelectedAutoRunId(run.id)} aria-pressed={selectedAutoRunId === run.id}>
-                    <span className="auto-run-card__icon">⚙️</span>
-                    <span className="auto-run-card__text">
-                      <strong>{run.name}</strong>
-                      <span>{run.date} · Lemonade {run.lemonadeVersion}</span>
-                    </span>
-                  </button>
-                  <details className="auto-run-card__details" onClick={e => e.stopPropagation()}>
-                    <summary>Backend details</summary>
-                    <p>{run.summary}</p>
-                    <code>{run.args}</code>
-                    <ul>
-                      {run.backends.map(backend => <li key={`${run.id}-${backend.name}-${backend.version}`}>{backend.name} {backend.version} · {backend.device}</li>)}
-                    </ul>
-                  </details>
-                  <button type="button" className="btn btn--ghost btn--tiny auto-run-card__delete" onClick={(e) => { e.stopPropagation(); handleDeleteAutoOptRun(run.id); }} aria-label={`Delete ${run.name}`} title="Delete this run">✕</button>
-                </article>
-              ))}
-            </div>
-          </div>
-        </aside>
+        <AutoOptRail
+          loadedModels={loadedModels}
+          collapsed={autoRailCollapsed}
+          onToggleCollapsed={() => setAutoRailCollapsed(v => !v)}
+        />
         <div className="recipes__main">
         <div className="recipes__head">
           <div className="recipes__title">
@@ -577,35 +506,6 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
           </p>
           {importError && <p className="preset-error" role="alert">⚠ {importError}</p>}
 
-
-          {selectedAutoRun && (
-            <div className="autoopt-summary">
-              <div>
-                <span className="autoopt-summary__kicker">Selected AutoOpt result</span>
-                <strong>{selectedAutoRun.name}</strong>
-                <span>{selectedAutoRun.summary}</span>
-              </div>
-              <code>{selectedAutoRun.args}</code>
-            </div>
-          )}
-
-          <div className="zone">
-            <div className="zone__head">
-              <span className="zone__dot zone__dot--ready" />
-              <span className="zone__title">Bundled starters</span>
-              <span className="zone__count">{STARTERS.length + 1}</span>
-              <span className="zone__rule" />
-            </div>
-            <div className="recipe-grid recipe-grid--starters-combined">
-              <PresetCard preset={DEFAULT_PRESET} onClick={() => openSlideover(DEFAULT_PRESET)} onClone={() => handleClone(DEFAULT_PRESET)} />
-              <div className="recipe-grid__contents" data-recipe-grid="starters">
-                {STARTERS.map(preset => (
-                  <PresetCard key={preset.id} preset={preset} onClick={() => openSlideover(preset)} onClone={() => handleClone(preset)} />
-                ))}
-              </div>
-            </div>
-          </div>
-
           <div className="zone">
             <div className="zone__head">
               <span className="zone__dot zone__dot--available" />
@@ -616,7 +516,7 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
             {userPresets.length > 0 ? (
               <div className="recipe-grid" data-recipe-grid="yours">
                 {userPresets.map(preset => (
-                  <PresetCard key={preset.id} preset={preset} onClick={() => openSlideover(preset)} onApply={() => openSlideover(preset)} onExport={() => handleExport(preset)} />
+                  <PresetCard key={preset.id} preset={preset} linkedModels={linkedModelsByPreset.get(preset.id)} highlight={highlightPresetId === preset.id} onClick={() => openSlideover(preset)} onApply={() => openSlideover(preset)} onExport={() => handleExport(preset)} />
                 ))}
               </div>
             ) : (
@@ -700,6 +600,23 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
               </div>
             </div>
           )}
+
+          <div className="zone">
+            <div className="zone__head">
+              <span className="zone__dot zone__dot--ready" />
+              <span className="zone__title">Bundled starters</span>
+              <span className="zone__count">{STARTERS.length + 1}</span>
+              <span className="zone__rule" />
+            </div>
+            <div className="recipe-grid recipe-grid--starters-combined">
+              <PresetCard preset={DEFAULT_PRESET} linkedModels={linkedModelsByPreset.get(DEFAULT_PRESET.id)} onClick={() => openSlideover(DEFAULT_PRESET)} onClone={() => handleClone(DEFAULT_PRESET)} />
+              <div className="recipe-grid__contents" data-recipe-grid="starters">
+                {STARTERS.map(preset => (
+                  <PresetCard key={preset.id} preset={preset} linkedModels={linkedModelsByPreset.get(preset.id)} onClick={() => openSlideover(preset)} onClone={() => handleClone(preset)} />
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
         </div>
       </section>
@@ -717,6 +634,7 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
           <SlideoverContent
             preset={selectedPreset}
             models={allModelOptions}
+            linkedModels={linkedModelsByPreset.get(selectedPreset.id) || []}
             applyTarget={applyTarget}
             onApplyTargetChange={setApplyTarget}
             onApply={handleApply}
@@ -731,7 +649,6 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
             onExport={handleExport}
             onDelete={handleDelete}
             onClose={closeSlideover}
-            autoRuns={autoOptRuns}
           />
         )}
       </aside>
@@ -739,25 +656,32 @@ const PresetManager: React.FC<PresetManagerProps> = ({ loadedModels }) => {
   );
 };
 
+function linkedModelsText(preset: Preset, linkedModels: string[]): string {
+  return `${preset.auto_opt_run_id ? 'Optimized for' : 'Linked to'} ${linkedModels.join(', ')}`;
+}
+
 const PresetCard: React.FC<{
   preset: Preset;
+  linkedModels?: string[];
+  highlight?: boolean;
   onClick: () => void;
   onClone?: () => void;
   onApply?: () => void;
   onExport?: () => void;
-}> = ({ preset, onClick, onClone, onApply, onExport }) => {
+}> = ({ preset, linkedModels, highlight, onClick, onClone, onApply, onExport }) => {
   const descId = `preset-card-desc-${preset.id}`;
   const capLabels = presetLabelsFor(preset).map(c => CAPABILITY_LABELS[c] || c).join(', ');
   const paramLines = paramsPreviewLines(preset);
   const descParts: string[] = [];
   if (preset.starter) descParts.push('Starter');
   descParts.push(`Applies to: ${capLabels}`);
+  if (linkedModels?.length) descParts.push(linkedModelsText(preset, linkedModels));
   if (paramLines.length) descParts.push(`Intent: ${paramLines.join('; ')}`);
   descParts.push(`Prompt: ${promptDisplayText(preset)}`);
   descParts.push(`Tools: ${toolsDisplayText(preset)}`);
   return (
   <article
-    className="recipe-card"
+    className={`recipe-card${highlight ? ' recipe-card--flash' : ''}`}
     data-recipe-id={preset.id}
   >
     {/* Overlay button covers the card for pointer/keyboard activation without nesting interactive roles */}
@@ -772,6 +696,12 @@ const PresetCard: React.FC<{
     {preset.starter && <span className="starter-badge">Starter</span>}
     <div className="recipe-card__head"><PresetIcon preset={preset} /><span className="recipe-card__name">{preset.name}</span></div>
     <p className="recipe-card__desc">{preset.description}</p>
+    {linkedModels && linkedModels.length > 0 && (
+      <p className={`recipe-card__linked${preset.auto_opt_run_id ? ' recipe-card__linked--optimized' : ''}`} data-preset-linked-models aria-hidden="true">
+        <Icon name={preset.auto_opt_run_id ? 'gauge' : 'hard-drive'} size={12} aria-hidden="true" />
+        {linkedModelsText(preset, linkedModels)}
+      </p>
+    )}
     <div className="cap-chip-list cap-chip-list--card" title="Applies to">
       {presetLabelsFor(preset).map(cap => <CapabilityChip key={cap} cap={cap} small />)}
     </div>
@@ -821,6 +751,7 @@ const THINKING_INTENT_OPTIONS: Array<{ value: ThinkingMode; icon: IconName; desc
 const SlideoverContent: React.FC<{
   preset: Preset;
   models: ModelInfo[];
+  linkedModels: string[];
   applyTarget: string;
   onApplyTargetChange: (v: string) => void;
   onApply: (presetId: string, model: ModelInfo) => void;
@@ -835,8 +766,7 @@ const SlideoverContent: React.FC<{
   onExport: (preset: Preset) => void;
   onDelete: (preset: Preset) => void;
   onClose: () => void;
-  autoRuns: AutoOptRun[];
-}> = ({ preset, models, applyTarget, onApplyTargetChange, onApply, applySuccess, backendOptions, applyBackendTarget, onApplyBackendTargetChange, onApplyBackend, applyBackendSuccess, onSave, onClone, onExport, onDelete, onClose }) => {
+}> = ({ preset, models, linkedModels, applyTarget, onApplyTargetChange, onApply, applySuccess, backendOptions, applyBackendTarget, onApplyBackendTargetChange, onApplyBackend, applyBackendSuccess, onSave, onClone, onExport, onDelete, onClose }) => {
   const isReadOnly = preset.starter;
   const [name, setName] = useState(preset.name);
   const [description, setDescription] = useState(preset.description);
@@ -848,8 +778,13 @@ const SlideoverContent: React.FC<{
   const [systemPrompts, setSystemPrompts] = useState<PresetSystemPrompt[]>(cloneSystemPrompts(preset.system_prompts));
   const [toolsEnabled, setToolsEnabled] = useState(preset.tools_enabled !== false);
   const [saved, setSaved] = useState(false);
+  const [autoOptState, setAutoOptState] = useState<AutoOptState>(() => autoOptStore.snapshot());
+  const [missingRunNote, setMissingRunNote] = useState(false);
+
+  useEffect(() => autoOptStore.subscribe(setAutoOptState), []);
 
   useEffect(() => {
+    setMissingRunNote(false);
     setName(preset.name);
     setDescription(preset.description);
     setAppliesTo(normalizePresetCapabilities(preset.id, preset.applies_to));
@@ -976,7 +911,33 @@ const SlideoverContent: React.FC<{
         <div className="slideover__meta-row">
           {normalizedAppliesTo.map(cap => <CapabilityChip key={cap} cap={cap} />)}
           {preset.starter && <span className="recipe-badge recipe-badge--starter" data-recipe-starter-badge>Starter</span>}
+          {preset.auto_opt_run_id && (
+            <button
+              type="button"
+              className="autoopt-preset-chip"
+              onClick={() => {
+                const runId = preset.auto_opt_run_id!;
+                if (autoOptState.runs.some(run => run.id === runId)) {
+                  setMissingRunNote(false);
+                  openAutoOptRun(runId);
+                } else {
+                  setMissingRunNote(true);
+                }
+              }}
+              title="Open the AutoOpt run that produced this preset"
+              data-preset-autoopt-chip
+            >
+              ⚙ Optimized by AutoOpt
+            </button>
+          )}
         </div>
+        {linkedModels.length > 0 && (
+          <p className={`preset-linked-note${preset.auto_opt_run_id ? ' preset-linked-note--optimized' : ''}`} data-preset-editor-linked>
+            <Icon name={preset.auto_opt_run_id ? 'gauge' : 'hard-drive'} size={13} aria-hidden="true" />
+            {linkedModelsText(preset, linkedModels)}
+          </p>
+        )}
+        {missingRunNote && <p className="preset-help" data-preset-autoopt-missing>Run no longer exists on this machine.</p>}
         {isReadOnly ? <p className="slideover__desc" data-recipe-desc>{preset.description}</p> : (
           <textarea className="slideover__desc-input" value={description} onChange={event => setDescription(event.target.value)} placeholder="Description (optional)" rows={2} data-recipe-desc aria-label="Description" />
         )}

--- a/prototype/ui-redesign/src/features/autoOpt/AutoOptRail.tsx
+++ b/prototype/ui-redesign/src/features/autoOpt/AutoOptRail.tsx
@@ -1,0 +1,194 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type { LoadedModel } from '../../api';
+import { autoOptStore, AutoOptState } from './autoOptStore';
+import { AutoOptRunRecord, isAutoOptRunActive } from './autoOptTypes';
+import AutoOptWizard from './AutoOptWizard';
+import AutoOptRunDetail from './AutoOptRunDetail';
+
+export const AUTOOPT_OPEN_RUN_EVENT = 'lemonade:autoopt-open-run';
+
+export function openAutoOptRun(runId: string): void {
+  window.dispatchEvent(new CustomEvent(AUTOOPT_OPEN_RUN_EVENT, { detail: { id: runId } }));
+}
+
+function runDate(run: AutoOptRunRecord): string {
+  const raw = run.finished_at || run.created_at;
+  const parsed = Date.parse(raw || '');
+  if (!Number.isFinite(parsed) || parsed <= 0) return '';
+  return new Date(parsed).toLocaleDateString();
+}
+
+function firstLine(text: string | undefined): string {
+  return String(text || '').split('\n')[0].trim();
+}
+
+function statusChip(run: AutoOptRunRecord): React.ReactNode {
+  switch (run.status) {
+    case 'queued':
+      return <span className="autoopt-status-chip autoopt-status-chip--queued"><span className="autoopt-status-dot" aria-hidden="true" />Queued</span>;
+    case 'running':
+      return (
+        <span className="autoopt-status-chip autoopt-status-chip--running">
+          <span className="autoopt-spinner" aria-hidden="true" />
+          {run.progress
+            ? `${run.progress.stage} · ${run.progress.stage_index + 1}/${run.progress.stage_count}`
+            : 'Running'}
+        </span>
+      );
+    case 'completed':
+      return <span className="autoopt-status-chip autoopt-status-chip--completed">{runDate(run) || 'Completed'}</span>;
+    case 'failed':
+      return (
+        <span className="autoopt-status-chip autoopt-status-chip--failed">
+          <span className="autoopt-status-x" aria-hidden="true">✕</span>
+          {firstLine(run.error) || 'Failed'}
+        </span>
+      );
+    case 'cancelled':
+      return <span className="autoopt-status-chip autoopt-status-chip--cancelled">Cancelled</span>;
+  }
+}
+
+const AutoOptRail: React.FC<{
+  loadedModels: LoadedModel[];
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}> = ({ loadedModels, collapsed, onToggleCollapsed }) => {
+  const [state, setState] = useState<AutoOptState>(() => autoOptStore.snapshot());
+  const [selectedRunId, setSelectedRunId] = useState('');
+  const [wizardOpen, setWizardOpen] = useState(false);
+  const [detailRunId, setDetailRunId] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState('');
+  const previousStatuses = useRef<Map<string, AutoOptRunRecord['status']>>(new Map());
+
+  useEffect(() => autoOptStore.subscribe(setState), []);
+
+  useEffect(() => {
+    const previous = previousStatuses.current;
+    for (const run of state.runs) {
+      const before = previous.get(run.id);
+      if (before && before !== run.status) {
+        if (run.status === 'completed') setAnnouncement(`AutoOpt run for ${run.model} completed.`);
+        else if (run.status === 'failed') setAnnouncement(`AutoOpt run for ${run.model} failed${run.error ? `: ${firstLine(run.error)}` : '.'}`);
+      }
+    }
+    previousStatuses.current = new Map(state.runs.map(run => [run.id, run.status]));
+  }, [state.runs]);
+
+  useEffect(() => {
+    if (!selectedRunId && state.runs.length > 0) setSelectedRunId(state.runs[0].id);
+    else if (selectedRunId && !state.runs.some(run => run.id === selectedRunId)) {
+      setSelectedRunId(state.runs[0]?.id || '');
+    }
+  }, [state.runs, selectedRunId]);
+
+  const openDetail = useCallback((runId: string) => {
+    autoOptStore.setActiveRun(runId);
+    setDetailRunId(runId);
+  }, []);
+
+  const closeDetail = useCallback(() => {
+    autoOptStore.setActiveRun(null);
+    setDetailRunId(null);
+  }, []);
+
+  const deleteRun = useCallback((runId: string) => {
+    const previousSelection = selectedRunId;
+    try {
+      autoOptStore.deleteRun(runId);
+    } catch {
+      setSelectedRunId(previousSelection);
+    }
+  }, [selectedRunId]);
+
+  useEffect(() => {
+    const onOpenRun = (event: Event) => {
+      const id = String((event as CustomEvent).detail?.id || '');
+      if (id) openDetail(id);
+    };
+    window.addEventListener(AUTOOPT_OPEN_RUN_EVENT, onOpenRun as EventListener);
+    return () => window.removeEventListener(AUTOOPT_OPEN_RUN_EVENT, onOpenRun as EventListener);
+  }, [openDetail]);
+
+  return (
+    <>
+      <aside className={`context-rail context-rail--autoopt${collapsed ? ' is-collapsed' : ''}`} aria-label="AutoOpt runs">
+        <div className="context-rail__head">
+          <button type="button" className="context-rail__toggle" onClick={onToggleCollapsed} aria-label="Toggle AutoOpt rail">☰</button>
+          <div className="context-rail__title-wrap">
+            <span className="context-rail__eyebrow">Auto Optimizer</span>
+            <strong className="context-rail__title">Runs</strong>
+          </div>
+        </div>
+        <div className="context-rail__body">
+          <p className="context-rail__hint">Benchmark a model on this machine and turn the winning configuration into a preset. Manual tuning overrides AutoOpt.</p>
+          <button
+            type="button"
+            className="btn btn--primary btn--small"
+            style={{ width: '100%', marginBottom: '0.75rem' }}
+            onClick={() => setWizardOpen(true)}
+            data-autoopt-run-optimizer
+          >
+            ▶ Run optimizer
+          </button>
+          <p className="sr-only" role="status" aria-live="polite" aria-atomic="true" data-autoopt-announcement>{announcement}</p>
+          {state.lastError && (
+            <p className="context-rail__notice preset-error" data-autoopt-rail-error>⚠ {state.lastError}</p>
+          )}
+          <div className="auto-run-list" data-autoopt-run-list>
+            {state.runs.length === 0 && (
+              <p className="context-rail__hint" data-autoopt-empty>No optimization runs yet on this server.</p>
+            )}
+            {state.runs.map(run => {
+              const active = isAutoOptRunActive(run);
+              const cancelling = state.pendingCancel.has(run.id);
+              return (
+                <article key={run.id} className={`auto-run-card auto-run-card--${run.status}${selectedRunId === run.id ? ' is-active' : ''}`} data-autoopt-run={run.id}>
+                  <button type="button" className="auto-run-card__main" onClick={() => setSelectedRunId(run.id)} aria-pressed={selectedRunId === run.id}>
+                    <span className="auto-run-card__icon" aria-hidden="true">⚙️</span>
+                    <span className="auto-run-card__text">
+                      <strong>{run.model || run.id}</strong>
+                      <span data-autoopt-run-status={run.status}>{statusChip(run)}</span>
+                      {run.lemonade_version && <span>Lemonade {run.lemonade_version}</span>}
+                    </span>
+                  </button>
+                  <div className="auto-run-card__actions">
+                    <button type="button" className="btn btn--ghost btn--tiny" onClick={() => openDetail(run.id)} data-autoopt-inspect={run.id}>Inspect</button>
+                    {active ? (
+                      <button
+                        type="button"
+                        className="btn btn--ghost btn--tiny"
+                        disabled={cancelling}
+                        onClick={() => autoOptStore.cancelRun(run.id)}
+                        aria-label={`Cancel AutoOpt run for ${run.model}`}
+                        data-autoopt-cancel={run.id}
+                      >
+                        {cancelling ? 'Cancelling…' : 'Cancel'}
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        className="btn btn--ghost btn--tiny auto-run-card__delete-action"
+                        onClick={() => deleteRun(run.id)}
+                        aria-label={`Delete AutoOpt run for ${run.model}`}
+                        title="Delete this run"
+                        data-autoopt-delete={run.id}
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </aside>
+
+      <AutoOptWizard open={wizardOpen} onClose={() => setWizardOpen(false)} loadedModels={loadedModels} />
+      <AutoOptRunDetail runId={detailRunId} onClose={closeDetail} />
+    </>
+  );
+};
+
+export default AutoOptRail;

--- a/prototype/ui-redesign/src/features/autoOpt/AutoOptRunDetail.tsx
+++ b/prototype/ui-redesign/src/features/autoOpt/AutoOptRunDetail.tsx
@@ -1,0 +1,357 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import api from '../../api';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { autoOptStore, AutoOptState } from './autoOptStore';
+import { createPresetFromRun, applyRunNow } from './presetFromRun';
+import {
+  AutoOptRecommendation,
+  AutoOptRunRecord,
+  AutoOptStage,
+  BenchPoint,
+  isAutoOptRunActive,
+} from './autoOptTypes';
+
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined || !Number.isFinite(ms)) return '';
+  if (ms < 1000) return `${Math.round(ms)} ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)} s`;
+  return `${Math.floor(ms / 60000)}m ${Math.round((ms % 60000) / 1000)}s`;
+}
+
+function formatNumber(value: unknown, digits = 1): string {
+  const n = Number(value);
+  return Number.isFinite(n) ? n.toFixed(digits) : '—';
+}
+
+function stageGlyph(stage: AutoOptStage): string {
+  switch (stage.status) {
+    case 'completed': return '✓';
+    case 'failed': return '✕';
+    case 'running': return '…';
+    case 'skipped': return '·';
+    default: return '○';
+  }
+}
+
+function expectedValue(rec: AutoOptRecommendation, field: 'ttft_ms' | 'tps' | 'vram_gb'): string {
+  const value = rec.expected?.[field];
+  if (value === undefined) return '—';
+  return field === 'vram_gb' ? formatNumber(value, 2) : formatNumber(value);
+}
+
+function benchLadderRows(run: AutoOptRunRecord | undefined): BenchPoint[] {
+  const bench = run?.measurements?.bench || [];
+  return bench.filter(row => row.params?.ladder === true);
+}
+
+function benchDuelRows(run: AutoOptRunRecord | undefined): BenchPoint[] {
+  const bench = run?.measurements?.bench || [];
+  return bench.filter(row => row.params?.ladder !== true && row.params?.spec_n === undefined);
+}
+
+const CopyArgsButton: React.FC<{ text: string }> = ({ text }) => {
+  const [copied, setCopied] = useState(false);
+  const handleClick = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      setCopied(false);
+    }
+  };
+  return (
+    <button
+      type="button"
+      className={`copy-inline${copied ? ' copy-inline--copied' : ''}`}
+      onClick={() => void handleClick()}
+      title={copied ? 'Copied' : 'Copy arguments'}
+      aria-label={copied ? 'Copied' : 'Copy arguments'}
+    >
+      {copied ? '✓' : '⧉'}
+    </button>
+  );
+};
+
+const AutoOptRunDetail: React.FC<{
+  runId: string | null;
+  onClose: () => void;
+}> = ({ runId, onClose }) => {
+  const [storeState, setStoreState] = useState<AutoOptState>(() => autoOptStore.snapshot());
+  const [selectedRecIndex, setSelectedRecIndex] = useState(0);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const slideoverRef = useRef<HTMLElement>(null);
+  const open = !!runId;
+
+  useFocusTrap(slideoverRef, open);
+
+  useEffect(() => autoOptStore.subscribe(setStoreState), []);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedRecIndex(0);
+    setNotice(null);
+    setActionError(null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, runId, onClose]);
+
+  const run = runId ? storeState.runs.find(candidate => candidate.id === runId) : undefined;
+  const result = run?.result;
+
+  const recommendations = useMemo<AutoOptRecommendation[]>(() => {
+    if (!result) return [];
+    return [result.primary, ...(result.alternatives || [])];
+  }, [result]);
+  const selectedRec = recommendations[selectedRecIndex] || recommendations[0];
+  const ladder = benchLadderRows(run);
+  const duel = benchDuelRows(run);
+
+  const modelInfo = useMemo(() => {
+    if (!run) return null;
+    const target = run.model.trim().toLowerCase();
+    return api.allModels.find(model => String((model as Record<string, unknown>).model_name || model.name || model.id || '').trim().toLowerCase() === target) || null;
+  }, [run]);
+
+  const runAction = useCallback(async (action: 'create' | 'create-apply' | 'try') => {
+    if (!run || !selectedRec) return;
+    setActionError(null);
+    setNotice(null);
+    try {
+      if (action === 'create') {
+        const preset = createPresetFromRun(run, selectedRec, modelInfo);
+        setNotice(`Created preset "${preset.name}" and selected it for future loads of ${run.model}.`);
+      } else if (action === 'create-apply') {
+        const preset = createPresetFromRun(run, selectedRec, modelInfo);
+        try {
+          await applyRunNow(run, selectedRec, { save: true });
+        } catch (err) {
+          setActionError(`Preset "${preset.name}" was created and selected, but loading ${run.model} failed: ${err instanceof Error ? err.message : String(err)}`);
+          return;
+        }
+        setNotice(`Created preset "${preset.name}" and applied it to ${run.model}.`);
+      } else {
+        await applyRunNow(run, selectedRec, { save: false });
+        setNotice(`Loaded ${run.model} with the recommended settings (nothing saved).`);
+      }
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Action failed.');
+    }
+  }, [run, selectedRec, modelInfo]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="scrim scrim--autoopt-detail is-open" onClick={onClose} />
+      <aside
+        ref={slideoverRef}
+        className="slideover slideover--wide slideover--autoopt-detail is-open"
+        role="dialog"
+        aria-modal="true"
+        aria-label="AutoOpt run details"
+        data-autoopt-detail
+      >
+        {run && (
+          <>
+            <div className="slideover__head">
+              <div className="slideover__top">
+                <div className="slideover__title-wrap">
+                  <h2 className="slideover__title">AutoOpt · {run.model}</h2>
+                </div>
+                <button className="slideover__close" onClick={onClose} aria-label="Close">✕</button>
+              </div>
+              <p className="slideover__desc">
+                <span className={`autoopt-status-chip autoopt-status-chip--${run.status}`} data-autoopt-detail-status>{run.status}</span>
+                {run.lemonade_version ? ` · Lemonade ${run.lemonade_version}` : ''}
+                {run.summary ? ` · ${run.summary}` : ''}
+              </p>
+            </div>
+
+            <div className="slideover__body autoopt-detail__body">
+              {run.status === 'failed' && run.error && (
+                <p className="preset-error autoopt-detail__error" role="alert" data-autoopt-detail-error>⚠ {run.error}</p>
+              )}
+
+              {run.stages.length > 0 && (
+                <div className="slideover__section">
+                  <h3>Stages</h3>
+                  <ul className="autoopt-stage-list" data-autoopt-detail-stages>
+                    {run.stages.map(stage => (
+                      <li key={stage.name} className={`autoopt-stage autoopt-stage--${stage.status}`}>
+                        <span className="autoopt-stage__marker" aria-hidden="true">{stageGlyph(stage)}</span>
+                        <span className="autoopt-stage__name">{stage.name}</span>
+                        {stage.duration_ms !== undefined && <span className="autoopt-stage__duration">{formatDuration(stage.duration_ms)}</span>}
+                        <span className="autoopt-stage__status">{stage.status}</span>
+                        {stage.error && <span className="autoopt-stage__error">⚠ {stage.error}</span>}
+                        {typeof stage.data?.note === 'string' && <span className="autoopt-stage__note">{stage.data.note}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {run.measurements && (run.measurements.fit.length > 0 || run.measurements.bench.length > 0) && (
+                <div className="slideover__section">
+                  <h3>Measurements</h3>
+                  <p className="preset-help">
+                    {run.measurements.fit.length} heuristic fit estimates · {run.measurements.bench.length} measured configurations
+                  </p>
+                  {duel.length > 0 && (
+                    <div className="autoopt-alt-table-wrap">
+                      <table className="autoopt-alt-table" data-autoopt-bench-duel>
+                        <thead>
+                          <tr><th>Backend</th><th>Depth</th><th>TTFT ms</th><th>tok/s</th><th>VRAM GB</th><th>Status</th></tr>
+                        </thead>
+                        <tbody>
+                          {duel.map((row, index) => (
+                            <tr key={index}>
+                              <td>{row.backend}</td>
+                              <td>{row.params?.d ?? '—'}</td>
+                              <td>{formatNumber(row.ttft_ms)}</td>
+                              <td>{formatNumber(row.tps)}</td>
+                              <td>{row.vram_gb > 0 ? formatNumber(row.vram_gb, 2) : '—'}</td>
+                              <td>{row.ok === false ? (row.error || 'failed') : 'ok'}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                  {ladder.length > 0 && (
+                    <div className="autoopt-alt-table-wrap">
+                      <table className="autoopt-alt-table" data-autoopt-bench-ladder>
+                        <thead>
+                          <tr><th>Backend</th><th>batch</th><th>ubatch</th><th>TTFT ms</th></tr>
+                        </thead>
+                        <tbody>
+                          {ladder.map((row, index) => (
+                            <tr key={index}>
+                              <td>{row.backend}</td>
+                              <td>{row.params?.b ?? '—'}</td>
+                              <td>{row.params?.ub ?? '—'}</td>
+                              <td>{formatNumber(row.ttft_ms)}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {selectedRec && (
+                <div className="slideover__section">
+                  <h3>Recommendation</h3>
+                  <div className="autoopt-rec-card" data-autoopt-recommendation>
+                    <div className="autoopt-rec-card__head">
+                      <strong>{selectedRec.label}</strong>
+                      <div className="autoopt-rec-card__chips">
+                        {selectedRec.llamacpp_backend && <span className="autoopt-chip">{selectedRec.llamacpp_backend}</span>}
+                        {selectedRec.ctx_size > 0 && <span className="autoopt-chip">ctx {selectedRec.ctx_size.toLocaleString()}</span>}
+                        {result?.sampling_defaults?.temperature !== undefined && <span className="autoopt-chip">temp {result.sampling_defaults.temperature}</span>}
+                        {result?.sampling_defaults?.min_p !== undefined && <span className="autoopt-chip">min_p {result.sampling_defaults.min_p}</span>}
+                      </div>
+                    </div>
+                    <div className="autoopt-rec-card__args">
+                      <code data-autoopt-rec-args>{selectedRec.llamacpp_args}</code>
+                      <CopyArgsButton text={selectedRec.llamacpp_args} />
+                    </div>
+                    {selectedRec.rationale.length > 0 && (
+                      <ul className="autoopt-rec-card__rationale">
+                        {selectedRec.rationale.map(line => <li key={line}>{line}</li>)}
+                      </ul>
+                    )}
+                    {selectedRec.tradeoff && <p className="preset-help">{selectedRec.tradeoff}</p>}
+                  </div>
+                </div>
+              )}
+
+              {recommendations.length > 1 && (
+                <div className="slideover__section">
+                  <h3>Alternatives</h3>
+                  <div className="autoopt-alt-table-wrap">
+                    <table className="autoopt-alt-table" data-autoopt-alternatives>
+                      <thead>
+                        <tr>
+                          <th>Option</th>
+                          <th>Backend</th>
+                          <th>Context</th>
+                          <th>TTFT ms</th>
+                          <th>tok/s</th>
+                          <th>VRAM GB</th>
+                          <th />
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {recommendations.map((rec, index) => (
+                          <tr key={rec.label} className={index === selectedRecIndex ? 'is-selected' : ''}>
+                            <td>{rec.label}</td>
+                            <td>{rec.llamacpp_backend || '—'}</td>
+                            <td>{rec.ctx_size !== undefined ? rec.ctx_size.toLocaleString() : '—'}</td>
+                            <td>{expectedValue(rec, 'ttft_ms')}</td>
+                            <td>{expectedValue(rec, 'tps')}</td>
+                            <td>{expectedValue(rec, 'vram_gb')}</td>
+                            <td>
+                              {index === selectedRecIndex
+                                ? <span className="autoopt-chip">Selected</span>
+                                : (
+                                  <button
+                                    type="button"
+                                    className="btn btn--ghost btn--tiny"
+                                    onClick={() => setSelectedRecIndex(index)}
+                                    data-autoopt-use-alternative={rec.label}
+                                  >
+                                    Use this instead
+                                  </button>
+                                )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              <p className="autoopt-detail__notice" role="status" aria-live="polite" aria-atomic="true" data-autoopt-detail-notice>
+                {notice ? `✓ ${notice}` : ''}
+              </p>
+              {actionError && <p className="preset-error" role="alert">⚠ {actionError}</p>}
+            </div>
+
+            {run.status === 'completed' && selectedRec && (
+              <p className="preset-help autoopt-detail__cta-help" data-autoopt-cta-help>
+                &ldquo;Create preset&rdquo; creates the preset and selects it for this model&rsquo;s future loads.
+                &ldquo;Create preset &amp; apply now&rdquo; additionally loads the model with it right away.
+                &ldquo;Try now without saving&rdquo; loads once and saves nothing.
+              </p>
+            )}
+            <div className="slideover__foot">
+              {run.status === 'completed' && selectedRec ? (
+                <>
+                  <button className="btn btn--ghost" onClick={() => void runAction('try')} title="Loads once with the recommended settings and saves nothing" data-autoopt-try-now>Try now without saving</button>
+                  <button className="btn btn--ghost" onClick={() => void runAction('create')} title="Creates the preset and selects it for this model's future loads" data-autoopt-create-preset>Create preset</button>
+                  <button className="btn btn--primary" onClick={() => void runAction('create-apply')} title="Creates the preset, selects it for this model's future loads, and loads the model with it now" data-autoopt-create-apply>Create preset &amp; apply now</button>
+                </>
+              ) : (
+                <>
+                  {isAutoOptRunActive(run) && (
+                    <button className="btn btn--ghost" onClick={() => autoOptStore.cancelRun(run.id)}>Cancel run</button>
+                  )}
+                  <button className="btn btn--primary" onClick={onClose}>Close</button>
+                </>
+              )}
+            </div>
+          </>
+        )}
+      </aside>
+    </>
+  );
+};
+
+export default AutoOptRunDetail;

--- a/prototype/ui-redesign/src/features/autoOpt/AutoOptWizard.tsx
+++ b/prototype/ui-redesign/src/features/autoOpt/AutoOptWizard.tsx
@@ -1,0 +1,412 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import api, { LoadedModel, ModelInfo } from '../../api';
+import { labelsFor } from '../../presetStore';
+import { Icon } from '../../components/Icon';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import {
+  AutoOptBudget,
+  AutoOptKvCacheQuant,
+  AutoOptParallelMode,
+  AutoOptRamHeadroom,
+  AutoOptStartRequest,
+  isAutoOptRunActive,
+} from './autoOptTypes';
+import { autoOptStore, AutoOptState } from './autoOptStore';
+import {
+  BUDGET_LABELS,
+  BUDGET_STEP,
+  KV_QUANT_LABELS,
+  KV_QUANT_STEP,
+  MODEL_STEP,
+  PARALLEL_STEP,
+  RAM_HEADROOM_LABELS,
+  RAM_STEP,
+  REVIEW_STEP,
+  RUNNING_STEP,
+  WIZARD_INTRO,
+  WIZARD_TITLE,
+} from './wizardCopy';
+
+type WizardStep = 'model' | 'parallel' | 'kv' | 'ram' | 'budget' | 'review' | 'running';
+
+function modelName(model: ModelInfo): string {
+  return String((model as Record<string, unknown>).model_name || model.name || model.id || '').trim();
+}
+
+function isEligibleModel(model: ModelInfo): boolean {
+  if ((model as Record<string, unknown>).downloaded !== true) return false;
+  const recipe = String((model as Record<string, unknown>).recipe || '').trim().toLowerCase();
+  if (recipe !== 'llamacpp') return false;
+  const caps = labelsFor(model);
+  return caps.includes('chat') || caps.includes('omni');
+}
+
+function physicalMemoryGb(info: Record<string, unknown> | null): number | null {
+  if (!info) return null;
+  const raw = info['Physical Memory'] ?? (info as Record<string, unknown>).physical_memory ?? (info as Record<string, unknown>).memory_gb;
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string') {
+    const match = /([\d.]+)/.exec(raw);
+    const n = match ? Number(match[1]) : NaN;
+    if (Number.isFinite(n)) return raw.toLowerCase().includes('mb') ? n / 1024 : n;
+  }
+  return null;
+}
+
+function suggestedHeadroom(gb: number): AutoOptRamHeadroom {
+  if (gb >= 64) return 'normal';
+  if (gb >= 32) return 'reduced';
+  if (gb >= 16) return 'minimal';
+  return 'disabled';
+}
+
+const AutoOptWizard: React.FC<{
+  open: boolean;
+  onClose: () => void;
+  loadedModels: LoadedModel[];
+}> = ({ open, onClose, loadedModels }) => {
+  const [step, setStep] = useState<WizardStep>('model');
+  const [models, setModels] = useState<ModelInfo[]>([]);
+  const [selectedModel, setSelectedModel] = useState('');
+  const [parallelMode, setParallelMode] = useState<AutoOptParallelMode>('single');
+  const [slots, setSlots] = useState(2);
+  const [dedicated, setDedicated] = useState(false);
+  const [kvQuant, setKvQuant] = useState<AutoOptKvCacheQuant>('q8_0');
+  const [ramHeadroom, setRamHeadroom] = useState<AutoOptRamHeadroom>('normal');
+  const [ramGb, setRamGb] = useState<number | null>(null);
+  const [budget, setBudget] = useState<AutoOptBudget>('standard');
+  const [allowNetwork, setAllowNetwork] = useState(true);
+  const [consent, setConsent] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [runId, setRunId] = useState<string | null>(null);
+  const [storeState, setStoreState] = useState<AutoOptState>(() => autoOptStore.snapshot());
+  const slideoverRef = useRef<HTMLElement>(null);
+  const ramTouchedRef = useRef(false);
+
+  useFocusTrap(slideoverRef, open);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  useEffect(() => autoOptStore.subscribe(setStoreState), []);
+
+  useEffect(() => {
+    if (!open) return;
+    setStep('model');
+    setSubmitError(null);
+    setRunId(null);
+    setConsent(false);
+    ramTouchedRef.current = false;
+    let alive = true;
+    api.models(true).then(data => { if (alive) setModels((data.data || []).filter(isEligibleModel)); }).catch(() => {
+      if (alive) setModels(api.allModels.filter(isEligibleModel));
+    });
+    const applySuggestion = (info: Record<string, unknown> | null) => {
+      if (!alive) return;
+      const gb = physicalMemoryGb(info);
+      setRamGb(gb);
+      if (gb !== null && !ramTouchedRef.current) setRamHeadroom(suggestedHeadroom(gb));
+    };
+    api.systemInfo().then(applySuggestion).catch(() => applySuggestion(api.systemInfoData));
+    return () => { alive = false; };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || selectedModel) return;
+    const loadedChat = loadedModels.find(model => model.type === 'chat' || model.type === 'omni' || model.type === 'llm')
+      || loadedModels[0];
+    if (loadedChat && models.some(model => modelName(model) === loadedChat.model_name)) {
+      setSelectedModel(loadedChat.model_name);
+    }
+  }, [open, selectedModel, loadedModels, models]);
+
+  const steps = useMemo<WizardStep[]>(() => [
+    'model', 'parallel', 'kv', 'ram', 'budget', 'review',
+  ], []);
+
+  const stepIndex = steps.indexOf(step);
+  const benchmarkTier = budget !== 'quick';
+  const consentRequired = benchmarkTier && loadedModels.length > 0;
+  const canStart = !!selectedModel && (!consentRequired || consent);
+
+  const goBack = useCallback(() => {
+    if (stepIndex > 0) setStep(steps[stepIndex - 1]);
+  }, [stepIndex, steps]);
+
+  const goNext = useCallback(() => {
+    if (stepIndex >= 0 && stepIndex < steps.length - 1) setStep(steps[stepIndex + 1]);
+  }, [stepIndex, steps]);
+
+  const buildRequest = useCallback((): AutoOptStartRequest => ({
+    model: selectedModel,
+    budget,
+    allow_unload: consentRequired ? consent : false,
+    answers: {
+      parallel: parallelMode === 'parallel'
+        ? { mode: 'parallel', slots, dedicated }
+        : { mode: 'single' },
+      kv_cache_quant: kvQuant,
+      ram_headroom: ramHeadroom,
+      allow_network: allowNetwork,
+    },
+  }), [selectedModel, budget, consentRequired, consent, parallelMode, slots, dedicated, kvQuant, ramHeadroom, allowNetwork]);
+
+  const handleStart = useCallback(async () => {
+    setSubmitError(null);
+    try {
+      const id = await autoOptStore.startRun(buildRequest());
+      autoOptStore.setActiveRun(id);
+      setRunId(id);
+      setStep('running');
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Could not start the optimizer.');
+    }
+  }, [buildRequest]);
+
+  const activeRun = runId ? storeState.runs.find(run => run.id === runId) : undefined;
+
+  const renderOptions = <T,>(
+    options: Array<{ value: T; label: string; description: string }>,
+    value: T,
+    setValue: (next: T) => void,
+    dataAttribute: string,
+  ) => (
+    <div className="autoopt-wizard__options">
+      {options.map(option => (
+        <button
+          key={String(option.value)}
+          type="button"
+          className="autoopt-option"
+          aria-pressed={value === option.value}
+          onClick={() => setValue(option.value)}
+          data-autoopt-option={`${dataAttribute}:${String(option.value)}`}
+        >
+          <strong>{option.label}</strong>
+          <span>{option.description}</span>
+        </button>
+      ))}
+    </div>
+  );
+
+  const renderStep = () => {
+    switch (step) {
+      case 'model':
+        return (
+          <fieldset className="preset-intent-fieldset autoopt-wizard__fieldset" data-autoopt-step="model">
+            <legend>{MODEL_STEP.legend}</legend>
+            <p className="preset-help">{MODEL_STEP.help}</p>
+            <p className="preset-help" data-autoopt-model-note>{MODEL_STEP.note}</p>
+            {models.length === 0 ? (
+              <p className="preset-help" data-autoopt-no-models>{MODEL_STEP.empty}</p>
+            ) : (
+              <select
+                className="select"
+                value={selectedModel}
+                onChange={event => setSelectedModel(event.target.value)}
+                aria-label="Model to optimize"
+                data-autoopt-model-select
+              >
+                <option value="">— pick a model —</option>
+                {models.map(model => {
+                  const name = modelName(model);
+                  return <option key={name} value={name}>{name}</option>;
+                })}
+              </select>
+            )}
+          </fieldset>
+        );
+      case 'parallel':
+        return (
+          <fieldset className="preset-intent-fieldset autoopt-wizard__fieldset" data-autoopt-step="parallel">
+            <legend>{PARALLEL_STEP.legend}</legend>
+            {renderOptions(PARALLEL_STEP.options, parallelMode, setParallelMode, 'parallel')}
+            {parallelMode === 'parallel' && (
+              <div className="autoopt-wizard__subfields">
+                <label className="field">
+                  <span className="field__label">{PARALLEL_STEP.slotsLabel}</span>
+                  <input
+                    className="input"
+                    type="number"
+                    min={2}
+                    max={16}
+                    value={slots}
+                    onChange={event => setSlots(Math.max(2, Math.min(16, Math.round(Number(event.target.value) || 2))))}
+                    data-autoopt-slots
+                  />
+                </label>
+                <label className="autoopt-wizard__checkbox">
+                  <input type="checkbox" checked={dedicated} onChange={event => setDedicated(event.target.checked)} data-autoopt-dedicated />
+                  <span>{PARALLEL_STEP.dedicatedLabel}</span>
+                </label>
+              </div>
+            )}
+            <p className="preset-help autoopt-wizard__footnote">{PARALLEL_STEP.footnote}</p>
+          </fieldset>
+        );
+      case 'kv':
+        return (
+          <fieldset className="preset-intent-fieldset autoopt-wizard__fieldset" data-autoopt-step="kv">
+            <legend>{KV_QUANT_STEP.legend}</legend>
+            <p className="preset-help">{KV_QUANT_STEP.help}</p>
+            {renderOptions(KV_QUANT_STEP.options, kvQuant, setKvQuant, 'kv')}
+          </fieldset>
+        );
+      case 'ram':
+        return (
+          <fieldset className="preset-intent-fieldset autoopt-wizard__fieldset" data-autoopt-step="ram">
+            <legend>{RAM_STEP.legend}</legend>
+            <p className="preset-help">{RAM_STEP.help}</p>
+            {ramGb !== null && (
+              <span className="autoopt-suggestion-chip" data-autoopt-ram-suggestion>
+                {RAM_STEP.suggestionChip(Math.round(ramGb))}
+              </span>
+            )}
+            {renderOptions(RAM_STEP.options, ramHeadroom, value => {
+              ramTouchedRef.current = true;
+              setRamHeadroom(value);
+            }, 'ram')}
+          </fieldset>
+        );
+      case 'budget':
+        return (
+          <fieldset className="preset-intent-fieldset autoopt-wizard__fieldset" data-autoopt-step="budget">
+            <legend>{BUDGET_STEP.legend}</legend>
+            {renderOptions(BUDGET_STEP.options, budget, setBudget, 'budget')}
+            <label className="autoopt-wizard__checkbox">
+              <input type="checkbox" checked={allowNetwork} onChange={event => setAllowNetwork(event.target.checked)} data-autoopt-network />
+              <span>{BUDGET_STEP.networkLabel}</span>
+            </label>
+            <p className="preset-help">{BUDGET_STEP.networkHelp}</p>
+            {consentRequired && (
+              <>
+                <label className="autoopt-wizard__checkbox autoopt-wizard__checkbox--consent">
+                  <input type="checkbox" checked={consent} onChange={event => setConsent(event.target.checked)} data-autoopt-consent />
+                  <span>{BUDGET_STEP.consentLabel}</span>
+                </label>
+                <p className="preset-help">{BUDGET_STEP.consentHelp}</p>
+              </>
+            )}
+          </fieldset>
+        );
+      case 'review':
+        return (
+          <fieldset className="preset-intent-fieldset autoopt-wizard__fieldset" data-autoopt-step="review">
+            <legend>{REVIEW_STEP.legend}</legend>
+            <p className="preset-help">{REVIEW_STEP.help}</p>
+            <dl className="autoopt-review">
+              <dt>Model</dt><dd>{selectedModel || '—'}</dd>
+              <dt>Usage</dt><dd>{parallelMode === 'parallel' ? `Parallel · ${slots} slots${dedicated ? ' · dedicated server' : ''}` : 'Single user'}</dd>
+              <dt>KV cache</dt><dd>{KV_QUANT_LABELS[kvQuant]}</dd>
+              <dt>Prompt cache</dt><dd>{RAM_HEADROOM_LABELS[ramHeadroom]}</dd>
+              <dt>Budget</dt><dd>{BUDGET_LABELS[budget]}</dd>
+              <dt>Network</dt><dd>{allowNetwork ? 'Fetch model metadata from Hugging Face' : 'No network access'}</dd>
+              <dt>Unload models</dt><dd>{!benchmarkTier ? 'Not needed for Fast Scan' : (loadedModels.length === 0 ? 'Nothing loaded' : (consent ? 'Allowed' : 'Not allowed'))}</dd>
+            </dl>
+            {consentRequired && !consent && (
+              <p className="preset-error" data-autoopt-consent-gate>Confirm the unload consent on the previous step to start.</p>
+            )}
+            {submitError && <p className="preset-error" role="alert" data-autoopt-submit-error>⚠ {submitError}</p>}
+          </fieldset>
+        );
+      case 'running':
+        return (
+          <div className="autoopt-wizard__running" data-autoopt-step="running">
+            <h3>{activeRun && !isAutoOptRunActive(activeRun) ? 'Run finished' : 'Optimizing…'}</h3>
+            {activeRun?.progress?.detail && (
+              <p className="preset-help" data-autoopt-progress>{activeRun.progress.detail}</p>
+            )}
+            {activeRun && activeRun.stages.length > 0 && (
+              <ul className="autoopt-stage-list" data-autoopt-stage-list>
+                {activeRun.stages.map(stage => (
+                  <li key={stage.name} className={`autoopt-stage autoopt-stage--${stage.status}`}>
+                    <span className="autoopt-stage__marker" aria-hidden="true" />
+                    <span className="autoopt-stage__name">{stage.name}</span>
+                    <span className="autoopt-stage__status">{stage.status}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {activeRun?.status === 'failed' && activeRun.error && (
+              <p className="preset-error" role="alert">⚠ {activeRun.error}</p>
+            )}
+            <p className="preset-help" data-autoopt-close-note>{RUNNING_STEP.closeNote}</p>
+          </div>
+        );
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="scrim scrim--autoopt-wizard is-open" onClick={onClose} />
+      <aside
+        ref={slideoverRef}
+        className="slideover slideover--wide slideover--autoopt-wizard is-open"
+        role="dialog"
+        aria-modal="true"
+        aria-label="AutoOpt wizard"
+        data-autoopt-wizard
+      >
+        <>
+            <div className="slideover__head">
+              <div className="slideover__top">
+                <div className="slideover__title-wrap">
+                  <h2 className="slideover__title">{WIZARD_TITLE}</h2>
+                </div>
+                <button className="slideover__close" onClick={onClose} aria-label="Close">✕</button>
+              </div>
+              <p className="slideover__desc">{WIZARD_INTRO}</p>
+              {step !== 'running' && (
+                <div className="autoopt-wizard__progress" aria-hidden="true">
+                  {steps.map((s, index) => (
+                    <span key={s} className={`autoopt-wizard__dot${index === stepIndex ? ' is-active' : ''}${index < stepIndex ? ' is-done' : ''}`} />
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="slideover__body autoopt-wizard__body">
+              {renderStep()}
+            </div>
+
+            <div className="slideover__foot">
+              {step === 'running' ? (
+                <>
+                  {activeRun && isAutoOptRunActive(activeRun) && runId && (
+                    <button
+                      className="btn btn--ghost"
+                      onClick={() => autoOptStore.cancelRun(runId)}
+                      data-autoopt-cancel-run
+                    >
+                      Cancel run
+                    </button>
+                  )}
+                  <button className="btn btn--primary" onClick={onClose}>Close</button>
+                </>
+              ) : (
+                <>
+                  <button className="btn btn--ghost" onClick={goBack} disabled={stepIndex <= 0} data-autoopt-back>Back</button>
+                  {step === 'review' ? (
+                    <button className="btn btn--primary" onClick={() => void handleStart()} disabled={!canStart} data-autoopt-start>
+                      <Icon name="play" size={14} aria-hidden="true" /> Start optimization
+                    </button>
+                  ) : (
+                    <button className="btn btn--primary" onClick={goNext} disabled={step === 'model' && !selectedModel} data-autoopt-next>Next</button>
+                  )}
+                </>
+              )}
+            </div>
+        </>
+      </aside>
+    </>
+  );
+};
+
+export default AutoOptWizard;

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptController.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptController.ts
@@ -2,7 +2,7 @@ import api, { JobRecord } from '../../api';
 import { buildBenchRecipe } from './autoOptRecipe';
 import {
   NO_GPU_BACKEND_ERROR,
-  availableMib,
+  availableMibForBackend,
   checkpointRepoId,
   computeFitEstimate,
   selectCandidates,
@@ -401,11 +401,10 @@ export async function executeAutoOptRun(
   if (candidates.length === 0) throw new Error(NO_GPU_BACKEND_ERROR);
 
   await runStage('fit_estimate', async () => {
-    const avail = availableMib(hardware);
     for (const backend of candidates) {
       const fit = computeFitEstimate({
         backend,
-        availableMib: avail,
+        availableMib: availableMibForBackend(hardware, backend),
         weightsMib: modelFacts.weights_mib,
         kvBytesPerToken: modelFacts.kv_bytes_per_token,
         blockCount: modelFacts.block_count,
@@ -419,8 +418,6 @@ export async function executeAutoOptRun(
     if (fits.length === 0) throw new Error('no GPU backend available to fit against');
   });
   throwIfAborted();
-
-  const primaryFit = fits.find(f => f.ok && f.backend === candidates[0]) || fits[0] || null;
 
   if (!withBench) {
     cb.stage('bench_job', 'skipped');
@@ -438,7 +435,7 @@ export async function executeAutoOptRun(
     return { result: result!, summary };
   }
 
-  const recipe = buildBenchRecipe(primaryFit, answers, hardware, modelFacts, request.model, request.budget, candidates);
+  const recipe = buildBenchRecipe(fits, answers, hardware, modelFacts, request.model, request.budget, candidates);
   const synth: SynthInputs = {
     hardware, facts: modelFacts, fits, sampling,
     plan: recipe.plan, step_labels: recipe.step_labels,

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptController.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptController.ts
@@ -1,0 +1,471 @@
+import api, { JobRecord } from '../../api';
+import { buildBenchRecipe } from './autoOptRecipe';
+import {
+  NO_GPU_BACKEND_ERROR,
+  availableMib,
+  checkpointRepoId,
+  computeFitEstimate,
+  selectCandidates,
+  synthesize,
+} from './autoOptSynthesize';
+import {
+  AutoOptResult,
+  AutoOptRunRecord,
+  AutoOptStageStatus,
+  AutoOptStartRequest,
+  BenchPlanEntry,
+  BenchPoint,
+  FitEstimate,
+  HardwareSnapshot,
+  ModelFacts,
+  SamplingDefaults,
+  SynthInputs,
+  wizardAnswersFrom,
+} from './autoOptTypes';
+
+export const AUTOOPT_STAGES = [
+  'snapshot', 'model_facts', 'hf_metadata', 'fit_estimate', 'bench_job', 'synthesize',
+] as const;
+
+const JOB_POLL_MS = 1500;
+
+export interface ControllerCallbacks {
+  stage(name: string, status: AutoOptStageStatus, patch?: { duration_ms?: number; error?: string; data?: Record<string, unknown> }): void;
+  progress(detail: string): void;
+  fit(estimate: FitEstimate): void;
+  bench(points: BenchPoint[]): void;
+  jobCreated(jobId: string, synthInputs: SynthInputs): void;
+}
+
+export interface ControllerOutcome {
+  result: AutoOptResult;
+  summary: string;
+}
+
+const RECURRENT_ARCHS = new Set([
+  'mamba', 'mamba2', 'rwkv6', 'rwkv6qwen2', 'rwkv7', 'arwkv7',
+  'jamba', 'falcon-h1', 'granitehybrid', 'nemotron-h', 'lfm2', 'plamo2',
+]);
+
+function isAbort(err: unknown): boolean {
+  return (err as { name?: string } | null)?.name === 'AbortError';
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err || 'Unknown error');
+}
+
+function abortError(): Error {
+  return Object.assign(new Error('cancelled by user'), { name: 'AbortError' });
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) return reject(abortError());
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener('abort', () => { clearTimeout(timer); reject(abortError()); }, { once: true });
+  });
+}
+
+function parseGb(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const match = /([\d.]+)/.exec(value);
+    const n = match ? Number(match[1]) : NaN;
+    if (Number.isFinite(n)) return value.toLowerCase().includes('mb') ? n / 1024 : n;
+  }
+  return 0;
+}
+
+function snapshotFromSystemInfo(info: Record<string, unknown>): HardwareSnapshot {
+  const hw: HardwareSnapshot = {
+    gpus: [],
+    has_igpu: false,
+    ram_is_vram: false,
+    host_ram_gb: parseGb(info['Physical Memory']),
+    installed_backends: [],
+    os: String(info['OS Version'] || ''),
+  };
+  const devices = (info.devices || {}) as Record<string, unknown>;
+  let sharedMemoryGpu = false;
+  const readGpus = (list: unknown, vendor: string) => {
+    if (!Array.isArray(list)) return;
+    for (const raw of list) {
+      const g = raw as Record<string, unknown>;
+      if (g?.available !== true) continue;
+      const virtualGb = Number(g.virtual_mem_gb);
+      const vramGb = Number(g.vram_gb) || 0;
+      const shared = Number.isFinite(virtualGb) && virtualGb > vramGb;
+      hw.gpus.push({
+        vendor,
+        name: String(g.name || ''),
+        family: String(g.family || ''),
+        vram_gb: shared ? virtualGb : vramGb,
+      });
+      if (shared) sharedMemoryGpu = true;
+    }
+  };
+  readGpus(devices.amd_gpu, 'amd');
+  readGpus(devices.nvidia_gpu, 'nvidia');
+  hw.has_igpu = sharedMemoryGpu;
+  hw.ram_is_vram = sharedMemoryGpu && hw.gpus.length === 1;
+
+  const recipes = (info.recipes || {}) as Record<string, { backends?: Record<string, { state?: unknown }> }>;
+  const backends = recipes.llamacpp?.backends || {};
+  for (const [name, backendInfo] of Object.entries(backends)) {
+    const state = String(backendInfo?.state || '');
+    if (state === 'installed' || state === 'update_available') hw.installed_backends.push(name);
+  }
+  return hw;
+}
+
+function factsFromModelDetail(detail: Record<string, unknown>): ModelFacts {
+  const metadata = (detail.metadata && typeof detail.metadata === 'object' && !Array.isArray(detail.metadata))
+    ? detail.metadata as Record<string, unknown>
+    : null;
+  const labels = Array.isArray(detail.labels) ? detail.labels.map(l => String(l).toLowerCase()) : [];
+  const architecture = String(metadata?.architecture || '');
+  const fullAttentionInterval = Number(metadata?.full_attention_interval) || 0;
+  const expertCount = Number(metadata?.expert_count) || 0;
+  const sizeGb = Number(detail.size) || Number(metadata?.file_size_gb) || 0;
+  return {
+    architecture,
+    block_count: Number(metadata?.block_count) || 0,
+    expert_count: expertCount,
+    full_attention_interval: fullAttentionInterval,
+    swa_layer_count: Number(metadata?.swa_layer_count) || 0,
+    n_ctx_train: Number(metadata?.context_length) || Number(detail.max_context_window) || 0,
+    kv_bytes_per_token: Number(metadata?.kv_bytes_per_token) || 0,
+    weights_mib: sizeGb * 1024,
+    is_moe: expertCount > 1,
+    is_hybrid_or_recurrent: fullAttentionInterval > 0 || RECURRENT_ARCHS.has(architecture),
+    has_mtp: labels.includes('mtp'),
+    base_model_repo: String(metadata?.base_model_repo || ''),
+    checkpoint: String(detail.checkpoint || ''),
+    metadata_present: !!metadata,
+  };
+}
+
+function hfRepoIdFromUrl(urlOrId: string): string {
+  const marker = 'huggingface.co/';
+  const pos = urlOrId.indexOf(marker);
+  let id = pos === -1 ? urlOrId : urlOrId.slice(pos + marker.length);
+  while (id.endsWith('/')) id = id.slice(0, -1);
+  return id;
+}
+
+async function fetchHfJson(url: string, signal: AbortSignal): Promise<Record<string, unknown> | null> {
+  const resp = await fetch(url, { signal });
+  if (!resp.ok) return null;
+  try {
+    return await resp.json() as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+async function resolveBaseModelRepo(ggufBaseModelRepo: string, checkpoint: string, signal: AbortSignal): Promise<string> {
+  if (ggufBaseModelRepo) return hfRepoIdFromUrl(ggufBaseModelRepo);
+  const repo = checkpointRepoId(checkpoint);
+  if (!repo) return '';
+  const card = await fetchHfJson(`https://huggingface.co/api/models/${repo}`, signal);
+  const baseModel = (card?.cardData as Record<string, unknown> | undefined)?.base_model;
+  if (typeof baseModel === 'string') return baseModel;
+  if (Array.isArray(baseModel) && typeof baseModel[0] === 'string') return baseModel[0];
+  return '';
+}
+
+function samplingFromConfig(gc: Record<string, unknown>, base: string, file: string): SamplingDefaults {
+  const sd: SamplingDefaults = { source: `hf:${base}/${file}` };
+  if (typeof gc.temperature === 'number') sd.temperature = gc.temperature;
+  if (typeof gc.top_p === 'number') sd.top_p = gc.top_p;
+  if (typeof gc.min_p === 'number') sd.min_p = gc.min_p;
+  if (typeof gc.top_k === 'number') sd.top_k = gc.top_k;
+  return sd;
+}
+
+function hasSamplingValues(sd: SamplingDefaults): boolean {
+  return sd.temperature !== undefined || sd.top_p !== undefined
+    || sd.min_p !== undefined || sd.top_k !== undefined;
+}
+
+async function fetchSamplingDefaults(base: string, signal: AbortSignal): Promise<SamplingDefaults | null> {
+  const gc = await fetchHfJson(`https://huggingface.co/${base}/resolve/main/generation_config.json`, signal);
+  if (gc) {
+    const sd = samplingFromConfig(gc, base, 'generation_config.json');
+    if (hasSamplingValues(sd)) return sd;
+  }
+  const cfg = await fetchHfJson(`https://huggingface.co/${base}/resolve/main/config.json`, signal);
+  if (cfg) {
+    const nested = cfg.generation_config;
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      const sd = samplingFromConfig(nested as Record<string, unknown>, base, 'config.json');
+      if (hasSamplingValues(sd)) return sd;
+    }
+    const top = samplingFromConfig(cfg, base, 'config.json');
+    if (hasSamplingValues(top)) return top;
+  }
+  return null;
+}
+
+function benchPointsFromContext(plan: BenchPlanEntry[], context: Record<string, unknown>): BenchPoint[] {
+  const readMetrics = (ttftKey?: string, tpsKey?: string, vramKey?: string) => {
+    const ttft = ttftKey ? Number(context[ttftKey]) : NaN;
+    const tps = tpsKey ? Number(context[tpsKey]) : NaN;
+    const vram = vramKey ? Number(context[vramKey]) : NaN;
+    const ok = (Number.isFinite(ttft) && ttft > 0) || (Number.isFinite(tps) && tps > 0);
+    return { ttft, tps, vram, ok };
+  };
+  return plan.map(entry => {
+    const primary = readMetrics(entry.ttft_key, entry.tps_key, entry.vram_key);
+    const usedPrimary = primary.ok;
+    const fell = !usedPrimary && entry.fallback_ttft_key !== undefined
+      ? readMetrics(entry.fallback_ttft_key, entry.fallback_tps_key, entry.fallback_vram_key)
+      : null;
+    const m = usedPrimary ? primary : (fell && fell.ok ? fell : primary);
+    const ok = m.ok;
+    const loadedCtx = usedPrimary
+      ? entry.ctx_size
+      : (fell && fell.ok ? (entry.fallback_ctx_size ?? entry.ctx_size) : entry.ctx_size);
+    return {
+      backend: entry.backend,
+      label: entry.label,
+      ctx_size: loadedCtx,
+      llamacpp_args: entry.llamacpp_args,
+      params: entry.params,
+      ttft_ms: ok && Number.isFinite(m.ttft) ? m.ttft : 0,
+      tps: ok && Number.isFinite(m.tps) ? m.tps : 0,
+      vram_gb: Number.isFinite(m.vram) && m.vram > 0 ? m.vram : -1,
+      ok,
+      ...(ok ? {} : { error: 'not measured (config failed or skipped)' }),
+      ...(ok && entry.ctx_probe ? { max_loaded_ctx: loadedCtx } : {}),
+    };
+  });
+}
+
+function jobErrorMessage(job: JobRecord): string {
+  const failed = job.steps.find(step => step.status === 'failed' && step.error);
+  return failed?.error || 'the benchmark job failed on the server';
+}
+
+function isTerminal(status: JobRecord['status']): boolean {
+  return status === 'completed' || status === 'failed' || status === 'interrupted';
+}
+
+async function pollBenchJob(
+  jobId: string,
+  plan: BenchPlanEntry[],
+  stepLabels: Record<string, string>,
+  cb: ControllerCallbacks,
+  signal: AbortSignal,
+): Promise<JobRecord> {
+  while (true) {
+    if (signal.aborted) {
+      throw abortError();
+    }
+    let job: JobRecord;
+    try {
+      job = await api.getJob(jobId, signal);
+    } catch (err) {
+      if (isAbort(err)) {
+        throw abortError();
+      }
+      throw err;
+    }
+    const running = job.steps.find(step => step.status === 'running');
+    if (running) cb.progress(stepLabels[running.id] || `${running.op} · ${running.id}`);
+    cb.bench(benchPointsFromContext(plan, job.context || {}));
+    if (isTerminal(job.status)) return job;
+    await sleep(JOB_POLL_MS, signal);
+  }
+}
+
+async function finishBenchJob(
+  jobId: string,
+  synth: SynthInputs,
+  request: AutoOptStartRequest,
+  cb: ControllerCallbacks,
+  signal: AbortSignal,
+): Promise<ControllerOutcome> {
+  const answers = wizardAnswersFrom(request.answers);
+  const job = await pollBenchJob(jobId, synth.plan, synth.step_labels, cb, signal);
+
+  if (job.status === 'interrupted') throw abortError();
+  if (job.status === 'failed') {
+    cb.stage('bench_job', 'failed', { error: jobErrorMessage(job) });
+    throw new Error(jobErrorMessage(job));
+  }
+  const bench = benchPointsFromContext(synth.plan, job.context || {});
+  cb.bench(bench);
+  if (!bench.some(point => point.ok)) {
+    cb.stage('bench_job', 'failed', { error: 'no configuration produced a measurement' });
+    throw new Error('the benchmark job produced no usable measurements');
+  }
+  cb.stage('bench_job', 'completed');
+
+  let result: AutoOptResult | null = null;
+  cb.stage('synthesize', 'running');
+  try {
+    result = synthesize(synth.hardware, synth.facts, answers, synth.fits, bench, synth.sampling);
+  } catch (err) {
+    cb.stage('synthesize', 'failed', { error: errorMessage(err) });
+    throw new Error('preset synthesis failed');
+  }
+  cb.stage('synthesize', 'completed');
+
+  const summary = `${result.primary.llamacpp_backend} · ctx ${result.primary.ctx_size}`
+    + (result.primary.llamacpp_args ? ` · ${result.primary.llamacpp_args}` : '');
+  return { result, summary };
+}
+
+export async function executeAutoOptRun(
+  request: AutoOptStartRequest,
+  signal: AbortSignal,
+  cb: ControllerCallbacks,
+): Promise<ControllerOutcome> {
+  const answers = wizardAnswersFrom(request.answers);
+  const withBench = request.budget !== 'quick';
+
+  const throwIfAborted = () => { if (signal.aborted) throw abortError(); };
+
+  const runStage = async (name: string, body: () => Promise<void>): Promise<boolean> => {
+    throwIfAborted();
+    cb.stage(name, 'running');
+    const t0 = performance.now();
+    let error = '';
+    let ok = true;
+    try {
+      await body();
+    } catch (err) {
+      if (isAbort(err)) {
+        cb.stage(name, 'failed', { duration_ms: Math.round(performance.now() - t0) });
+        throw err;
+      }
+      ok = false;
+      error = errorMessage(err);
+    }
+    cb.stage(name, ok ? 'completed' : 'failed', {
+      duration_ms: Math.round(performance.now() - t0),
+      ...(error ? { error } : {}),
+    });
+    return ok;
+  };
+
+  let hw: HardwareSnapshot | null = null;
+  let facts: ModelFacts | null = null;
+  let sampling: SamplingDefaults | undefined;
+  const fits: FitEstimate[] = [];
+
+  if (!await runStage('snapshot', async () => {
+    hw = snapshotFromSystemInfo(await api.systemInfo());
+  })) {
+    throw new Error('could not inspect system hardware');
+  }
+
+  if (!await runStage('model_facts', async () => {
+    const detail = await api.modelDetail(request.model) as unknown as Record<string, unknown>;
+    if (String(detail.recipe || '') !== 'llamacpp') throw new Error('model recipe is not llamacpp');
+    if (detail.downloaded !== true) throw new Error('model is not downloaded');
+    facts = factsFromModelDetail(detail);
+    if (!facts.metadata_present) {
+      cb.stage('model_facts', 'running', { data: { note: 'model metadata unavailable — using coarse fit heuristics' } });
+    }
+  })) {
+    throw new Error('could not read model metadata');
+  }
+  const hardware = hw!;
+  const modelFacts = facts!;
+
+  if (answers.allow_network) {
+    await runStage('hf_metadata', async () => {
+      const base = await resolveBaseModelRepo(modelFacts.base_model_repo, modelFacts.checkpoint, signal);
+      if (!base) {
+        cb.stage('hf_metadata', 'running', { data: { note: 'no sampling defaults published (base model not resolvable)' } });
+        return;
+      }
+      const found = await fetchSamplingDefaults(base, signal);
+      if (found) {
+        sampling = found;
+        cb.stage('hf_metadata', 'running', { data: { base_model: base, sampling_source: found.source } });
+      } else {
+        cb.stage('hf_metadata', 'running', { data: { base_model: base, note: 'no sampling defaults published' } });
+      }
+    });
+  } else {
+    cb.stage('hf_metadata', 'skipped');
+  }
+  throwIfAborted();
+
+  const candidates = selectCandidates(hardware, answers);
+  if (candidates.length === 0) throw new Error(NO_GPU_BACKEND_ERROR);
+
+  await runStage('fit_estimate', async () => {
+    const avail = availableMib(hardware);
+    for (const backend of candidates) {
+      const fit = computeFitEstimate({
+        backend,
+        availableMib: avail,
+        weightsMib: modelFacts.weights_mib,
+        kvBytesPerToken: modelFacts.kv_bytes_per_token,
+        blockCount: modelFacts.block_count,
+        isMoe: modelFacts.is_moe,
+        nCtxTrain: modelFacts.n_ctx_train,
+        degraded: !modelFacts.metadata_present,
+      });
+      cb.fit(fit);
+      fits.push(fit);
+    }
+    if (fits.length === 0) throw new Error('no GPU backend available to fit against');
+  });
+  throwIfAborted();
+
+  const primaryFit = fits.find(f => f.ok && f.backend === candidates[0]) || fits[0] || null;
+
+  if (!withBench) {
+    cb.stage('bench_job', 'skipped');
+    let result: AutoOptResult | null = null;
+    if (!await runStage('synthesize', async () => {
+      result = synthesize(hardware, modelFacts, answers, fits, [], sampling);
+    })) {
+      throw new Error('preset synthesis failed');
+    }
+    result!.primary.rationale.push(
+      'Fast Scan: configuration derived from heuristics and not load-validated. '
+      + 'Run a Benchmark to confirm it loads on this hardware.');
+    const summary = `${result!.primary.llamacpp_backend} · ctx ${result!.primary.ctx_size}`
+      + (result!.primary.llamacpp_args ? ` · ${result!.primary.llamacpp_args}` : '');
+    return { result: result!, summary };
+  }
+
+  const recipe = buildBenchRecipe(primaryFit, answers, hardware, modelFacts, request.model, request.budget, candidates);
+  const synth: SynthInputs = {
+    hardware, facts: modelFacts, fits, sampling,
+    plan: recipe.plan, step_labels: recipe.step_labels,
+  };
+
+  cb.stage('bench_job', 'running');
+  throwIfAborted();
+  const { id: jobId } = await api.createJob(`autoopt-${request.model}`, recipe.steps, recipe.inputs);
+  cb.jobCreated(jobId, synth);
+
+  return finishBenchJob(jobId, synth, request, cb, signal);
+}
+
+export async function resumeAutoOptRun(
+  run: AutoOptRunRecord,
+  cb: ControllerCallbacks,
+  signal: AbortSignal,
+): Promise<ControllerOutcome> {
+  if (!run.job_id || !run.synth_inputs) {
+    throw new Error('cannot resume: the run has no server job to re-attach to');
+  }
+  const request: AutoOptStartRequest = {
+    model: run.model,
+    budget: run.budget,
+    allow_unload: run.allow_unload,
+    answers: run.answers,
+  };
+  cb.stage('bench_job', 'running');
+  return finishBenchJob(run.job_id, run.synth_inputs, request, cb, signal);
+}

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptRecipe.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptRecipe.ts
@@ -1,4 +1,4 @@
-import { backendLoadArgs, recommendedCtxSize, roundUpCtx } from './autoOptSynthesize';
+import { backendLoadArgs, recommendedCtxSize } from './autoOptSynthesize';
 import {
   BenchParams,
   BenchPlanEntry,
@@ -19,16 +19,13 @@ const DEPTH_SENTENCE = 'The quick brown fox jumps over the lazy dog. ';
 const DEPTH_TOKENS_PER_SENTENCE = 11;
 const FALLBACK_CTX = 2048;
 const MAX_COMPLETION_TOKENS = 64;
+const DEEP_GEN_MARGIN = 1024;
+const MIN_DEEP_DEPTH = 2048;
 
 function depthPrompt(depthTokens: number): string {
   if (depthTokens <= 0) return 'Reply with a one-word greeting.';
   const repeats = Math.max(1, Math.ceil(depthTokens / DEPTH_TOKENS_PER_SENTENCE));
   return DEPTH_SENTENCE.repeat(repeats) + '\nReply with a one-word summary of the text above.';
-}
-
-function ctxForDepth(depth: number): number {
-  if (depth <= 0) return FALLBACK_CTX;
-  return roundUpCtx(depth + 2048);
 }
 
 interface Measurement {
@@ -57,65 +54,78 @@ export function buildBenchRecipe(
     fits.find(f => f.backend === backend) ?? null;
   const loadArgsFor = (backend: string): string =>
     backendLoadArgs(hardware, backend, fitFor(backend), facts, kv).join(' ').trim();
+  const sanitize = (s: string): string => s.replace(/[^a-zA-Z0-9_]/g, '_');
 
   const measurements: Measurement[] = [];
+  const ladderRungs = budget === 'thorough' ? [512, 1024, 2048, 4096, 8192] : [512, 2048, 8192];
+  const mtpNs = budget === 'thorough' ? [1, 2, 3, 4, 5, 6] : [2, 3, 4];
+  const doLadder = hardware.ram_is_vram && hardware.host_ram_gb >= 32;
 
   for (const backend of candidates) {
+    const bkey = sanitize(backend);
     const recCtx = recommendedCtxSize(fitFor(backend)?.fitted_ctx ?? 0, facts.n_ctx_train, kv);
     const loadArgs = loadArgsFor(backend);
-    const depths: number[] = [0];
-    if (recCtx >= 32768) depths.push(30000);
-    else if (recCtx >= 8192) depths.push(Math.floor(0.8 * recCtx));
-    for (const depth of depths) {
-      const primary = depth <= 0 ? recCtx : ctxForDepth(depth);
-      measurements.push({
-        key: `${backend}_d${depth}`.replace(/[^a-zA-Z0-9_]/g, '_'),
-        label: `Benchmarking ${backend} at depth ${depth}`,
-        backend,
-        ctxPrimary: primary,
-        ctxFallback: depth <= 0 && primary > FALLBACK_CTX ? FALLBACK_CTX : null,
-        ctxProbe: depth <= 0,
-        args: loadArgs,
-        params: { d: depth },
-        depthTokens: depth,
-      });
+
+    measurements.push({
+      key: `${bkey}_d0`,
+      label: `Benchmarking ${backend} at depth 0`,
+      backend,
+      ctxPrimary: recCtx,
+      ctxFallback: recCtx > FALLBACK_CTX ? FALLBACK_CTX : null,
+      ctxProbe: true,
+      args: loadArgs,
+      params: { d: 0 },
+      depthTokens: 0,
+    });
+
+    if (recCtx >= 8192) {
+      const target = recCtx >= 32768 ? 30000 : Math.floor(0.8 * recCtx);
+      const deepDepth = Math.min(target, recCtx - DEEP_GEN_MARGIN);
+      if (deepDepth >= MIN_DEEP_DEPTH) {
+        measurements.push({
+          key: `${bkey}_d${deepDepth}`,
+          label: `Benchmarking ${backend} at depth ${deepDepth}`,
+          backend,
+          ctxPrimary: recCtx,
+          ctxFallback: null,
+          ctxProbe: false,
+          args: loadArgs,
+          params: { d: deepDepth },
+          depthTokens: deepDepth,
+        });
+      }
     }
-  }
 
-  const winner = candidates[0] || 'vulkan';
-  const winnerArgs = loadArgsFor(winner);
-
-  if (hardware.ram_is_vram && hardware.host_ram_gb >= 32) {
-    const rungs = budget === 'thorough' ? [512, 1024, 2048, 4096, 8192] : [512, 2048, 8192];
-    for (const r of rungs) {
-      measurements.push({
-        key: `ladder_b${r}`,
-        label: `Batch ladder -b ${r} on ${winner}`,
-        backend: winner,
-        ctxPrimary: FALLBACK_CTX,
-        ctxFallback: null,
-        ctxProbe: false,
-        args: `${winnerArgs} -b ${r} -ub ${r}`.trim(),
-        params: { ladder: true, b: r, ub: r, d: 0 },
-        depthTokens: 0,
-      });
+    if (doLadder) {
+      for (const r of ladderRungs) {
+        measurements.push({
+          key: `ladder_${bkey}_b${r}`,
+          label: `Batch ladder -b ${r} on ${backend}`,
+          backend,
+          ctxPrimary: FALLBACK_CTX,
+          ctxFallback: null,
+          ctxProbe: false,
+          args: `${loadArgs} -b ${r} -ub ${r}`.trim(),
+          params: { ladder: true, b: r, ub: r, d: 0 },
+          depthTokens: 0,
+        });
+      }
     }
-  }
 
-  if (facts.has_mtp) {
-    const ns = budget === 'thorough' ? [1, 2, 3, 4, 5, 6] : [2, 3, 4];
-    for (const n of ns) {
-      measurements.push({
-        key: `mtp_n${n}`,
-        label: `MTP draft sweep n=${n} on ${winner}`,
-        backend: winner,
-        ctxPrimary: FALLBACK_CTX,
-        ctxFallback: null,
-        ctxProbe: false,
-        args: `${winnerArgs} --spec-type draft-mtp --spec-draft-n-max ${n} --spec-draft-p-min 0.75`.trim(),
-        params: { spec_n: n, d: 0 },
-        depthTokens: 0,
-      });
+    if (facts.has_mtp) {
+      for (const n of mtpNs) {
+        measurements.push({
+          key: `mtp_${bkey}_n${n}`,
+          label: `MTP draft sweep n=${n} on ${backend}`,
+          backend,
+          ctxPrimary: FALLBACK_CTX,
+          ctxFallback: null,
+          ctxProbe: false,
+          args: `${loadArgs} --spec-type draft-mtp --spec-draft-n-max ${n} --spec-draft-p-min 0.75`.trim(),
+          params: { spec_n: n, d: 0 },
+          depthTokens: 0,
+        });
+      }
     }
   }
 

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptRecipe.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptRecipe.ts
@@ -1,4 +1,4 @@
-import { recommendedCtxSize, roundUpCtx } from './autoOptSynthesize';
+import { backendLoadArgs, recommendedCtxSize, roundUpCtx } from './autoOptSynthesize';
 import {
   BenchParams,
   BenchPlanEntry,
@@ -44,7 +44,7 @@ interface Measurement {
 }
 
 export function buildBenchRecipe(
-  fit: FitEstimate | null,
+  fits: FitEstimate[],
   answers: WizardAnswers,
   hardware: HardwareSnapshot,
   facts: ModelFacts,
@@ -53,16 +53,19 @@ export function buildBenchRecipe(
   candidates: string[],
 ): BenchRecipe {
   const kv = answers.kv_cache_quant;
-  const baseArgs = kv !== 'none' ? `-ctk ${kv} -ctv ${kv}` : '';
-  const recCtx = recommendedCtxSize(fit ? fit.fitted_ctx : 0, facts.n_ctx_train, kv);
-
-  const depths: number[] = [0];
-  if (recCtx >= 32768) depths.push(30000);
-  else if (recCtx >= 8192) depths.push(Math.floor(0.8 * recCtx));
+  const fitFor = (backend: string): FitEstimate | null =>
+    fits.find(f => f.backend === backend) ?? null;
+  const loadArgsFor = (backend: string): string =>
+    backendLoadArgs(hardware, backend, fitFor(backend), facts, kv).join(' ').trim();
 
   const measurements: Measurement[] = [];
 
   for (const backend of candidates) {
+    const recCtx = recommendedCtxSize(fitFor(backend)?.fitted_ctx ?? 0, facts.n_ctx_train, kv);
+    const loadArgs = loadArgsFor(backend);
+    const depths: number[] = [0];
+    if (recCtx >= 32768) depths.push(30000);
+    else if (recCtx >= 8192) depths.push(Math.floor(0.8 * recCtx));
     for (const depth of depths) {
       const primary = depth <= 0 ? recCtx : ctxForDepth(depth);
       measurements.push({
@@ -72,7 +75,7 @@ export function buildBenchRecipe(
         ctxPrimary: primary,
         ctxFallback: depth <= 0 && primary > FALLBACK_CTX ? FALLBACK_CTX : null,
         ctxProbe: depth <= 0,
-        args: baseArgs,
+        args: loadArgs,
         params: { d: depth },
         depthTokens: depth,
       });
@@ -80,6 +83,7 @@ export function buildBenchRecipe(
   }
 
   const winner = candidates[0] || 'vulkan';
+  const winnerArgs = loadArgsFor(winner);
 
   if (hardware.ram_is_vram && hardware.host_ram_gb >= 32) {
     const rungs = budget === 'thorough' ? [512, 1024, 2048, 4096, 8192] : [512, 2048, 8192];
@@ -91,7 +95,7 @@ export function buildBenchRecipe(
         ctxPrimary: FALLBACK_CTX,
         ctxFallback: null,
         ctxProbe: false,
-        args: `${baseArgs} -b ${r} -ub ${r}`.trim(),
+        args: `${winnerArgs} -b ${r} -ub ${r}`.trim(),
         params: { ladder: true, b: r, ub: r, d: 0 },
         depthTokens: 0,
       });
@@ -108,7 +112,7 @@ export function buildBenchRecipe(
         ctxPrimary: FALLBACK_CTX,
         ctxFallback: null,
         ctxProbe: false,
-        args: `${baseArgs} --spec-type draft-mtp --spec-draft-n-max ${n} --spec-draft-p-min 0.75`.trim(),
+        args: `${winnerArgs} --spec-type draft-mtp --spec-draft-n-max ${n} --spec-draft-p-min 0.75`.trim(),
         params: { spec_n: n, d: 0 },
         depthTokens: 0,
       });

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptRecipe.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptRecipe.ts
@@ -152,7 +152,6 @@ export function buildBenchRecipe(
     llamacpp_backend: backend,
     ctx_size: ctx,
     llamacpp_args: args,
-    merge_args: false,
     save_options: false,
   });
 

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptRecipe.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptRecipe.ts
@@ -1,0 +1,228 @@
+import { recommendedCtxSize, roundUpCtx } from './autoOptSynthesize';
+import {
+  BenchParams,
+  BenchPlanEntry,
+  FitEstimate,
+  HardwareSnapshot,
+  ModelFacts,
+  WizardAnswers,
+} from './autoOptTypes';
+
+export interface BenchRecipe {
+  steps: Record<string, unknown>[];
+  inputs: Record<string, unknown>;
+  plan: BenchPlanEntry[];
+  step_labels: Record<string, string>;
+}
+
+const DEPTH_SENTENCE = 'The quick brown fox jumps over the lazy dog. ';
+const DEPTH_TOKENS_PER_SENTENCE = 11;
+const FALLBACK_CTX = 2048;
+const MAX_COMPLETION_TOKENS = 64;
+
+function depthPrompt(depthTokens: number): string {
+  if (depthTokens <= 0) return 'Reply with a one-word greeting.';
+  const repeats = Math.max(1, Math.ceil(depthTokens / DEPTH_TOKENS_PER_SENTENCE));
+  return DEPTH_SENTENCE.repeat(repeats) + '\nReply with a one-word summary of the text above.';
+}
+
+function ctxForDepth(depth: number): number {
+  if (depth <= 0) return FALLBACK_CTX;
+  return roundUpCtx(depth + 2048);
+}
+
+interface Measurement {
+  key: string;
+  label: string;
+  backend: string;
+  ctxPrimary: number;
+  ctxFallback: number | null;
+  ctxProbe: boolean;
+  args: string;
+  params: BenchParams;
+  depthTokens: number;
+}
+
+export function buildBenchRecipe(
+  fit: FitEstimate | null,
+  answers: WizardAnswers,
+  hardware: HardwareSnapshot,
+  facts: ModelFacts,
+  model: string,
+  budget: 'quick' | 'standard' | 'thorough',
+  candidates: string[],
+): BenchRecipe {
+  const kv = answers.kv_cache_quant;
+  const baseArgs = kv !== 'none' ? `-ctk ${kv} -ctv ${kv}` : '';
+  const recCtx = recommendedCtxSize(fit ? fit.fitted_ctx : 0, facts.n_ctx_train, kv);
+
+  const depths: number[] = [0];
+  if (recCtx >= 32768) depths.push(30000);
+  else if (recCtx >= 8192) depths.push(Math.floor(0.8 * recCtx));
+
+  const measurements: Measurement[] = [];
+
+  for (const backend of candidates) {
+    for (const depth of depths) {
+      const primary = depth <= 0 ? recCtx : ctxForDepth(depth);
+      measurements.push({
+        key: `${backend}_d${depth}`.replace(/[^a-zA-Z0-9_]/g, '_'),
+        label: `Benchmarking ${backend} at depth ${depth}`,
+        backend,
+        ctxPrimary: primary,
+        ctxFallback: depth <= 0 && primary > FALLBACK_CTX ? FALLBACK_CTX : null,
+        ctxProbe: depth <= 0,
+        args: baseArgs,
+        params: { d: depth },
+        depthTokens: depth,
+      });
+    }
+  }
+
+  const winner = candidates[0] || 'vulkan';
+
+  if (hardware.ram_is_vram && hardware.host_ram_gb >= 32) {
+    const rungs = budget === 'thorough' ? [512, 1024, 2048, 4096, 8192] : [512, 2048, 8192];
+    for (const r of rungs) {
+      measurements.push({
+        key: `ladder_b${r}`,
+        label: `Batch ladder -b ${r} on ${winner}`,
+        backend: winner,
+        ctxPrimary: FALLBACK_CTX,
+        ctxFallback: null,
+        ctxProbe: false,
+        args: `${baseArgs} -b ${r} -ub ${r}`.trim(),
+        params: { ladder: true, b: r, ub: r, d: 0 },
+        depthTokens: 0,
+      });
+    }
+  }
+
+  if (facts.has_mtp) {
+    const ns = budget === 'thorough' ? [1, 2, 3, 4, 5, 6] : [2, 3, 4];
+    for (const n of ns) {
+      measurements.push({
+        key: `mtp_n${n}`,
+        label: `MTP draft sweep n=${n} on ${winner}`,
+        backend: winner,
+        ctxPrimary: FALLBACK_CTX,
+        ctxFallback: null,
+        ctxProbe: false,
+        args: `${baseArgs} --spec-type draft-mtp --spec-draft-n-max ${n} --spec-draft-p-min 0.75`.trim(),
+        params: { spec_n: n, d: 0 },
+        depthTokens: 0,
+      });
+    }
+  }
+
+  const inputs: Record<string, unknown> = { model };
+  const distinctDepths = new Set(measurements.map(m => m.depthTokens));
+  for (const depth of distinctDepths) inputs[`primer_${depth}`] = depthPrompt(depth);
+
+  const steps: Record<string, unknown>[] = [];
+  const plan: BenchPlanEntry[] = [];
+  const stepLabels: Record<string, string> = {};
+
+  const firstStepOf = (index: number): string =>
+    index < measurements.length ? `u_${measurements[index].key}` : 'done';
+
+  const chatParams = (depth: number): Record<string, unknown> => ({
+    model: '${inputs.model}',
+    messages: [{ role: 'user', content: `\${inputs.primer_${depth}}` }],
+    temperature: 0,
+    max_completion_tokens: MAX_COMPLETION_TOKENS,
+  });
+
+  const loadParams = (backend: string, ctx: number, args: string): Record<string, unknown> => ({
+    model: '${inputs.model}',
+    llamacpp_backend: backend,
+    ctx_size: ctx,
+    llamacpp_args: args,
+    merge_args: false,
+    save_options: false,
+  });
+
+  measurements.forEach((m, index) => {
+    const next = firstStepOf(index + 1);
+    const ttftKey = `${m.key}_ttft`;
+    const tpsKey = `${m.key}_tps`;
+    const vramKey = `${m.key}_vram`;
+    stepLabels[`u_${m.key}`] = m.label;
+    stepLabels[`load_${m.key}`] = m.label;
+    stepLabels[`chat_${m.key}`] = m.label;
+    stepLabels[`stats_${m.key}`] = m.label;
+
+    steps.push({ id: `u_${m.key}`, op: 'unload', on_fail: 'continue' });
+    steps.push({
+      id: `load_${m.key}`,
+      op: 'load',
+      params: loadParams(m.backend, m.ctxPrimary, m.args),
+      on_fail: m.ctxFallback !== null ? `loadlo_${m.key}` : next,
+    });
+    steps.push({
+      id: `chat_${m.key}`,
+      op: 'chat',
+      params: chatParams(m.depthTokens),
+      extract: { [ttftKey]: 'timings.prompt_ms', [tpsKey]: 'timings.predicted_per_second' },
+      on_fail: next,
+    });
+    steps.push({
+      id: `stats_${m.key}`,
+      op: 'system_stats',
+      extract: { [vramKey]: 'vram_gb' },
+      on_fail: next,
+      on_done: next,
+    });
+
+    const loTtftKey = `${m.key}_lo_ttft`;
+    const loTpsKey = `${m.key}_lo_tps`;
+    const loVramKey = `${m.key}_lo_vram`;
+
+    if (m.ctxFallback !== null) {
+      stepLabels[`loadlo_${m.key}`] = `${m.label} (fallback ctx ${m.ctxFallback})`;
+      steps.push({
+        id: `loadlo_${m.key}`,
+        op: 'load',
+        params: loadParams(m.backend, m.ctxFallback, m.args),
+        on_fail: next,
+      });
+      steps.push({
+        id: `chatlo_${m.key}`,
+        op: 'chat',
+        params: chatParams(m.depthTokens),
+        extract: { [loTtftKey]: 'timings.prompt_ms', [loTpsKey]: 'timings.predicted_per_second' },
+        on_fail: next,
+      });
+      steps.push({
+        id: `statslo_${m.key}`,
+        op: 'system_stats',
+        extract: { [loVramKey]: 'vram_gb' },
+        on_fail: next,
+        on_done: next,
+      });
+    }
+
+    plan.push({
+      label: m.label,
+      backend: m.backend,
+      ctx_size: m.ctxPrimary,
+      llamacpp_args: m.args,
+      params: m.params,
+      ctx_probe: m.ctxProbe,
+      ttft_key: ttftKey,
+      tps_key: tpsKey,
+      vram_key: vramKey,
+      ...(m.ctxFallback !== null ? {
+        fallback_ctx_size: m.ctxFallback,
+        fallback_ttft_key: loTtftKey,
+        fallback_tps_key: loTpsKey,
+        fallback_vram_key: loVramKey,
+      } : {}),
+    });
+  });
+
+  steps.push({ id: 'done', op: 'unload' });
+  stepLabels.done = 'Finishing up';
+
+  return { steps, inputs, plan, step_labels: stepLabels };
+}

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptStore.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptStore.ts
@@ -1,0 +1,358 @@
+import api from '../../api';
+import {
+  AUTOOPT_STAGES,
+  ControllerOutcome,
+  executeAutoOptRun,
+  resumeAutoOptRun,
+} from './autoOptController';
+import {
+  AutoOptRunRecord,
+  AutoOptStage,
+  AutoOptStartRequest,
+  SynthInputs,
+  isAutoOptRunActive,
+} from './autoOptTypes';
+
+export interface AutoOptState {
+  runs: AutoOptRunRecord[];
+  activeRunId: string | null;
+  lastError: string | null;
+  pendingCancel: Set<string>;
+}
+
+type Listener = (state: AutoOptState) => void;
+
+const STORAGE_PREFIX = 'lemonade_autoopt_runs_v2';
+const MAX_RUNS = 20;
+
+function storageKey(): string {
+  let base = 'default';
+  try { base = api.baseUrl || 'default'; } catch {}
+  const normalized = String(base).toLowerCase().replace(/\/+$/, '');
+  return `${STORAGE_PREFIX}::${normalized}`;
+}
+
+function isoNow(): string {
+  return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function makeRunId(): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const stamp = `${now.getUTCFullYear()}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}`
+    + `-${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}${pad(now.getUTCSeconds())}`;
+  const suffix = Math.floor(Math.random() * 0xffff).toString(16).padStart(4, '0');
+  return `ao-${stamp}-${suffix}`;
+}
+
+function freshStages(): AutoOptStage[] {
+  return AUTOOPT_STAGES.map(name => ({ name, status: 'pending' as const }));
+}
+
+function coerceStoredRun(raw: unknown): AutoOptRunRecord | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const run = raw as AutoOptRunRecord;
+  if (!run.id || typeof run.id !== 'string') return null;
+  const coerced: AutoOptRunRecord = {
+    ...run,
+    stages: Array.isArray(run.stages) ? run.stages : [],
+    measurements: {
+      fit: Array.isArray(run.measurements?.fit) ? run.measurements.fit : [],
+      bench: Array.isArray(run.measurements?.bench) ? run.measurements.bench : [],
+    },
+  };
+  delete coerced.progress;
+
+  if (isAutoOptRunActive(coerced) && !(coerced.job_id && coerced.synth_inputs)) {
+    coerced.status = 'failed';
+    coerced.error = 'interrupted — the page was closed while the run was active';
+    coerced.finished_at = coerced.finished_at || isoNow();
+  }
+  return coerced;
+}
+
+function readStoredRuns(key: string): AutoOptRunRecord[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    const items = Array.isArray(parsed?.runs) ? parsed.runs : [];
+    return items
+      .map(coerceStoredRun)
+      .filter((run: AutoOptRunRecord | null): run is AutoOptRunRecord => !!run)
+      .slice(0, MAX_RUNS);
+  } catch {
+    return [];
+  }
+}
+
+function writeStoredRuns(key: string, runs: AutoOptRunRecord[]): void {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(key, JSON.stringify({ version: 2, runs: runs.slice(0, MAX_RUNS) }));
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err || 'Unknown error');
+}
+
+function runProgress(run: AutoOptRunRecord, detail: string | undefined): AutoOptRunRecord['progress'] {
+  let completed = 0;
+  let current = '';
+  for (const stage of run.stages) {
+    if (stage.status === 'completed' || stage.status === 'skipped') completed++;
+    if (stage.status === 'running') current = stage.name;
+  }
+  return {
+    stage: current || (run.stages.length ? run.stages[run.stages.length - 1].name : ''),
+    stage_index: completed,
+    stage_count: run.stages.length,
+    ...(detail ? { detail } : {}),
+  };
+}
+
+class AutoOptStore {
+  private scopeKey = storageKey();
+  private scopeGeneration = 0;
+  private state: AutoOptState = {
+    runs: readStoredRuns(this.scopeKey),
+    activeRunId: null,
+    lastError: null,
+    pendingCancel: new Set(),
+  };
+  private listeners = new Set<Listener>();
+  private controllers = new Map<string, AbortController>();
+  private progressDetail = new Map<string, string>();
+
+  constructor() {
+    this.reattachActiveRuns();
+    try {
+      api.onStatusChange(() => this.syncStorageScope());
+    } catch {}
+  }
+
+  private syncStorageScope(): void {
+    let key: string;
+    try {
+      key = storageKey();
+    } catch {
+      return;
+    }
+    if (key === this.scopeKey) return;
+    this.scopeKey = key;
+    this.scopeGeneration++;
+    for (const controller of this.controllers.values()) controller.abort();
+    this.controllers.clear();
+    this.progressDetail.clear();
+    this.setState({
+      runs: readStoredRuns(this.scopeKey),
+      activeRunId: null,
+      lastError: null,
+      pendingCancel: new Set(),
+    });
+    this.reattachActiveRuns();
+  }
+
+  private reattachActiveRuns(): void {
+    for (const run of this.state.runs) {
+      if (!isAutoOptRunActive(run) || !run.job_id || !run.synth_inputs) continue;
+      if (this.controllers.has(run.id)) continue;
+      const controller = new AbortController();
+      this.controllers.set(run.id, controller);
+      void this.runController(run.id, controller, cb => resumeAutoOptRun(run, cb, controller.signal));
+    }
+  }
+
+  snapshot(): AutoOptState {
+    return this.state;
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    listener(this.state);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  setActiveRun(id: string | null): void {
+    if (this.state.activeRunId === id) return;
+    this.setState({ activeRunId: id });
+  }
+
+  async startRun(request: AutoOptStartRequest): Promise<string> {
+    if (this.state.runs.some(isAutoOptRunActive)) {
+      throw new Error('an AutoOpt run is already active');
+    }
+    const modelInfo = api.allModels.find(model =>
+      String((model as Record<string, unknown>).model_name || model.name || model.id || '').trim() === request.model);
+    const run: AutoOptRunRecord = {
+      id: makeRunId(),
+      model: request.model,
+      checkpoint: String((modelInfo as Record<string, unknown> | undefined)?.checkpoint || ''),
+      budget: request.budget,
+      answers: request.answers,
+      allow_unload: request.allow_unload,
+      status: 'running',
+      created_at: isoNow(),
+      lemonade_version: api.healthData?.version,
+      stages: freshStages(),
+      measurements: { fit: [], bench: [] },
+    };
+    run.progress = runProgress(run, undefined);
+    this.setState({ runs: [run, ...this.state.runs].slice(0, MAX_RUNS), lastError: null });
+    try {
+      this.persist();
+    } catch {}
+
+    const controller = new AbortController();
+    this.controllers.set(run.id, controller);
+    void this.runController(run.id, controller, cb => executeAutoOptRun(request, controller.signal, cb));
+    return run.id;
+  }
+
+  private async runController(
+    runId: string,
+    controller: AbortController,
+    run: (cb: Parameters<typeof executeAutoOptRun>[2]) => Promise<ControllerOutcome>,
+  ): Promise<void> {
+    const gen = this.scopeGeneration;
+    const alive = () => gen === this.scopeGeneration;
+    const callbacks = {
+      stage: (name: string, status: AutoOptStage['status'], patch?: Partial<AutoOptStage>) => {
+        if (!alive()) return;
+        this.updateRun(runId, r => {
+          const stages = r.stages.some(stage => stage.name === name)
+            ? r.stages.map(stage => stage.name === name
+              ? { ...stage, ...patch, status, ...(patch?.data ? { data: { ...(stage.data || {}), ...patch.data } } : {}) }
+              : stage)
+            : [...r.stages, { name, status, ...patch }];
+          const next = { ...r, stages };
+          next.progress = runProgress(next, this.progressDetail.get(runId));
+          return next;
+        });
+      },
+      progress: (detail: string) => {
+        if (!alive()) return;
+        this.progressDetail.set(runId, detail);
+        this.updateRun(runId, r => ({ ...r, progress: runProgress(r, detail) }), false);
+      },
+      fit: (estimate: AutoOptRunRecord['measurements']['fit'][number]) => {
+        if (!alive()) return;
+        this.updateRun(runId, r => ({
+          ...r,
+          measurements: { ...r.measurements, fit: [...r.measurements.fit, estimate] },
+        }));
+      },
+      bench: (points: AutoOptRunRecord['measurements']['bench']) => {
+        if (!alive()) return;
+        this.updateRun(runId, r => ({
+          ...r,
+          measurements: { ...r.measurements, bench: points },
+        }));
+      },
+      jobCreated: (jobId: string, synthInputs: SynthInputs) => {
+        if (!alive()) return;
+        this.updateRun(runId, r => ({ ...r, job_id: jobId, synth_inputs: synthInputs }));
+      },
+    };
+
+    try {
+      const outcome = await run(callbacks);
+      if (alive()) this.updateRun(runId, run => {
+        const next: AutoOptRunRecord = {
+          ...run,
+          status: controller.signal.aborted ? 'cancelled' : 'completed',
+          finished_at: isoNow(),
+          summary: outcome.summary,
+          result: outcome.result,
+        };
+        delete next.progress;
+        return next;
+      });
+    } catch (err) {
+      const cancelled = controller.signal.aborted || (err as { name?: string } | null)?.name === 'AbortError';
+      if (alive()) this.updateRun(runId, run => {
+        const next: AutoOptRunRecord = {
+          ...run,
+          status: cancelled ? 'cancelled' : 'failed',
+          error: cancelled ? 'cancelled by user' : errorMessage(err),
+          finished_at: isoNow(),
+        };
+        delete next.progress;
+        return next;
+      });
+    } finally {
+      this.controllers.delete(runId);
+      this.progressDetail.delete(runId);
+      if (alive()) {
+        const pendingCancel = new Set(this.state.pendingCancel);
+        if (pendingCancel.delete(runId)) this.setState({ pendingCancel });
+      }
+    }
+  }
+
+  cancelRun(id: string): void {
+    const run = this.state.runs.find(candidate => candidate.id === id);
+    if (run?.job_id) void api.interruptJob(run.job_id).catch(() => {});
+    const controller = this.controllers.get(id);
+    if (!controller) return;
+    const pendingCancel = new Set(this.state.pendingCancel);
+    pendingCancel.add(id);
+    this.setState({ pendingCancel });
+    controller.abort();
+  }
+
+  deleteRun(id: string): void {
+    const run = this.state.runs.find(candidate => candidate.id === id);
+    if (!run) return;
+    if (isAutoOptRunActive(run)) {
+      throw new Error('run is still active — cancel it before deleting');
+    }
+    if (run.job_id) void api.deleteJob(run.job_id).catch(() => {});
+    const previousRuns = this.state.runs;
+    const previousActiveRunId = this.state.activeRunId;
+    this.setState({
+      runs: this.state.runs.filter(candidate => candidate.id !== id),
+      activeRunId: this.state.activeRunId === id ? null : this.state.activeRunId,
+    });
+    try {
+      this.persist();
+    } catch (err) {
+      this.setState({
+        runs: previousRuns,
+        activeRunId: previousActiveRunId,
+        lastError: errorMessage(err),
+      });
+      throw err;
+    }
+  }
+
+  clearError(): void {
+    if (this.state.lastError) this.setState({ lastError: null });
+  }
+
+  private updateRun(id: string, updater: (run: AutoOptRunRecord) => AutoOptRunRecord, persist = true): void {
+    const runs = this.state.runs.map(run => run.id === id ? updater(run) : run);
+    this.setState({ runs });
+    if (persist) {
+      try {
+        this.persist();
+      } catch {
+
+      }
+    }
+  }
+
+  private persist(): void {
+    writeStoredRuns(this.scopeKey, this.state.runs);
+  }
+
+  private setState(patch: Partial<AutoOptState>): void {
+    this.state = { ...this.state, ...patch };
+    this.listeners.forEach(listener => listener(this.state));
+  }
+}
+
+export const autoOptStore = new AutoOptStore();

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptSynthesize.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptSynthesize.ts
@@ -84,6 +84,15 @@ function backendMemoryVendor(hw: HardwareSnapshot, backend: string): 'nvidia' | 
 }
 
 export function availableMibForBackend(hw: HardwareSnapshot, backend: string): number {
+  if (backend === 'vulkan') {
+    const vendors = Array.from(new Set(hw.gpus.map(g => g.vendor)));
+    if (vendors.length > 1) {
+      const pools = vendors
+        .map(v => hw.gpus.filter(g => g.vendor === v).reduce((sum, g) => sum + (g.vram_gb || 0), 0))
+        .filter(gb => gb > 0);
+      if (pools.length > 0) return Math.min(...pools) * 0.92 * 1024;
+    }
+  }
   const vendor = backendMemoryVendor(hw, backend);
   if (vendor === 'apple') return Math.max(1024, hw.host_ram_gb * 0.9 * 1024);
   if (vendor === 'amd' && hw.ram_is_vram) return Math.max(1024, hw.host_ram_gb * 0.9 * 1024);
@@ -397,7 +406,7 @@ export function synthesize(
     let bestN = 3;
     let bestTps = -1;
     for (const bp of bench) {
-      if (!bp.ok || bp.params?.spec_n === undefined) continue;
+      if (!bp.ok || bp.params?.spec_n === undefined || bp.backend !== backend) continue;
       if (bp.tps > bestTps) {
         bestTps = bp.tps;
         bestN = bp.params.spec_n;

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptSynthesize.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptSynthesize.ts
@@ -71,6 +71,31 @@ export function availableMib(hw: HardwareSnapshot): number {
   return Math.max(1024, hw.host_ram_gb * 0.7 * 1024);
 }
 
+function backendMemoryVendor(hw: HardwareSnapshot, backend: string): 'nvidia' | 'amd' | 'apple' | null {
+  if (backend === 'cuda') return 'nvidia';
+  if (backend.startsWith('rocm')) return 'amd';
+  if (backend === 'metal') return 'apple';
+  if (backend === 'vulkan') {
+    if (hw.gpus.some(g => g.vendor === 'amd')) return 'amd';
+    if (hw.gpus.some(g => g.vendor === 'nvidia')) return 'nvidia';
+    return null;
+  }
+  return null;
+}
+
+export function availableMibForBackend(hw: HardwareSnapshot, backend: string): number {
+  const vendor = backendMemoryVendor(hw, backend);
+  if (vendor === 'apple') return Math.max(1024, hw.host_ram_gb * 0.9 * 1024);
+  if (vendor === 'amd' && hw.ram_is_vram) return Math.max(1024, hw.host_ram_gb * 0.9 * 1024);
+  if (vendor) {
+    const groupGb = hw.gpus
+      .filter(g => g.vendor === vendor)
+      .reduce((sum, g) => sum + (g.vram_gb || 0), 0);
+    if (groupGb > 0) return groupGb * 0.92 * 1024;
+  }
+  return Math.max(1024, hw.host_ram_gb * 0.7 * 1024);
+}
+
 export interface FitInputs {
   backend: string;
   availableMib: number;
@@ -142,6 +167,43 @@ export function fitTotalGb(fit: FitEstimate | null | undefined): number {
   return fit ? fit.total_mib / 1024 : 0;
 }
 
+function dualIdenticalNvidia(hw: HardwareSnapshot): boolean {
+  for (let i = 0; i < hw.gpus.length; i++) {
+    for (let j = i + 1; j < hw.gpus.length; j++) {
+      if (hw.gpus[i].vendor === 'nvidia' && hw.gpus[i].family === hw.gpus[j].family) return true;
+    }
+  }
+  return false;
+}
+
+export function backendLoadArgs(
+  hw: HardwareSnapshot,
+  backend: string,
+  fit: FitEstimate | null,
+  mf: ModelFacts,
+  kv: string,
+): string[] {
+  const args: string[] = [];
+  if (backend.startsWith('rocm')) args.push('--direct-io');
+  if (fit && !fit.fits_fully) {
+    if (mf.is_moe && fit.fitted_ncmoe > 0) args.push(`--n-cpu-moe ${fit.fitted_ncmoe}`);
+    else if (mf.is_moe) args.push('--cpu-moe');
+    else if (fit.fitted_ngl >= 0) args.push(`-ngl ${fit.fitted_ngl}`);
+  }
+  if (kv !== 'none') args.push(`-ctk ${kv} -ctv ${kv}`);
+  if (backend === 'cuda' && dualIdenticalNvidia(hw)) args.push('--split-mode tensor');
+  return args;
+}
+
+function isDeepPoint(p: BenchPoint): boolean {
+  return (p.params?.d ?? 0) > 0 && p.params?.ladder !== true && p.params?.spec_n === undefined;
+}
+
+function deepRunFailed(bench: BenchPoint[], backend: string): boolean {
+  const deep = bench.filter(p => p.backend === backend && isDeepPoint(p));
+  return deep.length > 0 && !deep.some(p => p.ok);
+}
+
 function representative(bench: BenchPoint[], backend: string): BenchPoint | null {
   let d0: BenchPoint | null = null;
   let deep: BenchPoint | null = null;
@@ -161,8 +223,10 @@ export function benchScore(tps: number, ttftMs: number, tpsMax: number, ttftMin:
 }
 
 function pickBackend(bench: BenchPoint[], candidates: string[]): { backend: string; rep: BenchPoint | null } {
+  const eligible = candidates.filter(c => !deepRunFailed(bench, c));
+  const pool = eligible.length > 0 ? eligible : candidates;
   const reps: Array<{ backend: string; rep: BenchPoint }> = [];
-  for (const c of candidates) {
+  for (const c of pool) {
     const rep = representative(bench, c);
     if (rep) reps.push({ backend: c, rep });
   }
@@ -236,12 +300,13 @@ export function synthesize(
     }
   }
   p.llamacpp_backend = backend;
-  const isRocm = backend.startsWith('rocm');
   const isCuda = backend === 'cuda';
   const fit = fits.find(f => f.ok && f.backend === backend) || fits.find(f => f.ok) || null;
+  const kv = ans.kv_cache_quant;
 
-  if (isRocm) {
-    args.push('--direct-io');
+  args.push(...backendLoadArgs(hw, backend, fit, mf, kv));
+
+  if (backend.startsWith('rocm')) {
     p.rationale.push('--direct-io: works around broken mmap on ROCm with faster cold loads '
       + 'than --no-mmap.');
   }
@@ -249,31 +314,31 @@ export function synthesize(
   let usedCpuMoe = false;
   if (fit && !fit.fits_fully) {
     if (mf.is_moe && fit.fitted_ncmoe > 0) {
-      args.push(`--n-cpu-moe ${fit.fitted_ncmoe}`);
       usedCpuMoe = true;
       p.rationale.push(`Model exceeds GPU memory: expert tensors of the first ${fit.fitted_ncmoe} `
         + 'layers stay on CPU (--n-cpu-moe) — attention and shared tensors keep GPU speed.');
     } else if (mf.is_moe) {
-      args.push('--cpu-moe');
       usedCpuMoe = true;
       p.rationale.push('Model exceeds GPU memory: all expert tensors on CPU (--cpu-moe); '
         + 'the GPU keeps the non-expert layers.');
     } else if (fit.fitted_ngl >= 0) {
-      args.push(`-ngl ${fit.fitted_ngl}`);
       p.rationale.push(`Model exceeds GPU memory: ${fit.fitted_ngl} of ${mf.block_count} layers `
         + 'offloaded to GPU (-ngl), the rest run on CPU (expect reduced speed).');
     }
   }
 
-  const kv = ans.kv_cache_quant;
   if (kv !== 'none') {
-    args.push(`-ctk ${kv} -ctv ${kv}`);
     const note = kv === 'q8_0'
       ? 'roughly doubles usable context with negligible quality loss'
       : (kv === 'q5_1'
         ? 'about 2.7x context capacity with a slight quality cost'
         : 'about 3.5x context capacity; quality measurably degrades on very long contexts');
     p.rationale.push(`KV cache quantized to ${kv}: ${note}.`);
+  }
+
+  if (isCuda && dualIdenticalNvidia(hw)) {
+    p.rationale.push('Two or more identical NVIDIA GPUs: tensor parallelism speeds up decode '
+      + '(prefill gets slightly slower).');
   }
   let recCtx = recommendedCtxSize(fit ? fit.fitted_ctx : 0, mf.n_ctx_train, kv);
   let loadCeilingHit = false;
@@ -366,20 +431,6 @@ export function synthesize(
       args.push('-b 2048 -ub 2048');
       p.rationale.push('Batch size 2048: unified-memory machines with ample RAM prefill much '
         + 'faster with larger batches (heuristic — run a benchmark pass to measure).');
-    }
-  }
-
-  if (isCuda) {
-    let sameFamily = 0;
-    for (let i = 0; i < hw.gpus.length; i++) {
-      for (let j = i + 1; j < hw.gpus.length; j++) {
-        if (hw.gpus[i].vendor === 'nvidia' && hw.gpus[i].family === hw.gpus[j].family) sameFamily++;
-      }
-    }
-    if (sameFamily > 0) {
-      args.push('--split-mode tensor');
-      p.rationale.push('Two or more identical NVIDIA GPUs: tensor parallelism speeds up decode '
-        + '(prefill gets slightly slower).');
     }
   }
 

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptSynthesize.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptSynthesize.ts
@@ -1,0 +1,456 @@
+import {
+  AutoOptRecommendation,
+  AutoOptResult,
+  BenchPoint,
+  FitEstimate,
+  HardwareSnapshot,
+  ModelFacts,
+  SamplingDefaults,
+  WizardAnswers,
+} from './autoOptTypes';
+
+const CTX_STEPS = [262144, 131072, 98304, 65536, 49152, 32768, 24576, 16384, 12288, 8192, 6144, 4096, 2048];
+
+export function roundDownCtx(ctx: number): number {
+  for (const s of CTX_STEPS) {
+    if (ctx >= s) return s;
+  }
+  return ctx >= 1024 ? Math.floor(ctx) : 1024;
+}
+
+export function roundUpCtx(ctx: number): number {
+  for (let i = CTX_STEPS.length - 1; i >= 0; i--) {
+    if (CTX_STEPS[i] >= ctx) return CTX_STEPS[i];
+  }
+  return CTX_STEPS[0];
+}
+
+export function kvQuantFactor(q: string): number {
+  if (q === 'q8_0') return 0.5;
+  if (q === 'q5_1') return 0.375;
+  if (q === 'q4_0') return 0.28125;
+  return 1.0;
+}
+
+export function recommendedCtxSize(fittedCtx: number, nCtxTrain: number, kv: string): number {
+  let ctx = nCtxTrain > 0 ? nCtxTrain : 32768;
+  if (fittedCtx > 0) {
+    let fitCtx = fittedCtx;
+    if (kv !== 'none') fitCtx = Math.floor(fitCtx / kvQuantFactor(kv));
+    ctx = Math.min(ctx, fitCtx);
+  }
+  let size = roundDownCtx(ctx);
+  if (nCtxTrain > 0 && size >= nCtxTrain) size = nCtxTrain;
+  return size;
+}
+
+const COMPUTE_BASE_MIB = 512;
+const MIN_OFFLOAD_CTX = 4096;
+const DEFAULT_KV_BYTES_PER_TOKEN = 131072;
+
+const NON_GPU_BACKENDS = new Set(['cpu', 'system']);
+
+export const NO_GPU_BACKEND_ERROR =
+  'AutoOpt requires an installed GPU backend (Vulkan, ROCm, or CUDA); '
+  + 'this system reports only CPU inference.';
+
+export function selectCandidates(hw: HardwareSnapshot, ans: WizardAnswers): string[] {
+  const out: string[] = [];
+  for (const b of hw.installed_backends) {
+    if (NON_GPU_BACKENDS.has(b)) continue;
+    if (ans.backends_to_consider.length > 0 && !ans.backends_to_consider.includes(b)) continue;
+    out.push(b);
+  }
+  return out;
+}
+
+export function availableMib(hw: HardwareSnapshot): number {
+  if (hw.ram_is_vram) return Math.max(1024, hw.host_ram_gb * 0.9 * 1024);
+  const gpuGb = hw.gpus.reduce((sum, g) => sum + (g.vram_gb || 0), 0);
+  if (gpuGb > 0) return gpuGb * 0.92 * 1024;
+  return Math.max(1024, hw.host_ram_gb * 0.7 * 1024);
+}
+
+export interface FitInputs {
+  backend: string;
+  availableMib: number;
+  weightsMib: number;
+  kvBytesPerToken: number;
+  blockCount: number;
+  isMoe: boolean;
+  nCtxTrain: number;
+  degraded: boolean;
+}
+
+export function computeFitEstimate(input: FitInputs): FitEstimate {
+  const kvPerTokenMib = (input.kvBytesPerToken || DEFAULT_KV_BYTES_PER_TOKEN) / (1024 * 1024);
+  const compute = COMPUTE_BASE_MIB;
+  const weights = Math.max(0, input.weightsMib);
+  const available = Math.max(1, input.availableMib);
+  const trained = input.nCtxTrain > 0 ? input.nCtxTrain : 32768;
+
+  const base: FitEstimate = {
+    backend: input.backend,
+    fits_fully: false,
+    fitted_ctx: 0,
+    fitted_ngl: -1,
+    fitted_ncmoe: 0,
+    weights_mib: Math.round(weights),
+    kv_mib: 0,
+    compute_mib: compute,
+    total_mib: 0,
+    available_mib: Math.round(available),
+    degraded: input.degraded,
+    ok: true,
+  };
+
+  const minKvMib = kvPerTokenMib * MIN_OFFLOAD_CTX;
+  if (weights + compute + minKvMib > available) {
+    base.fits_fully = false;
+    base.fitted_ctx = MIN_OFFLOAD_CTX;
+    const perLayer = weights / Math.max(1, input.blockCount);
+    const weightsBudget = available - compute - minKvMib;
+    const layersOnGpu = Math.max(0, Math.min(input.blockCount, Math.floor(weightsBudget / Math.max(1, perLayer))));
+    if (input.isMoe) {
+      base.fitted_ngl = -1;
+      base.fitted_ncmoe = Math.max(1, Math.min(input.blockCount, input.blockCount - layersOnGpu));
+    } else {
+      base.fitted_ngl = layersOnGpu;
+      base.fitted_ncmoe = 0;
+    }
+    base.kv_mib = Math.round(minKvMib);
+    base.total_mib = Math.round(available);
+    return base;
+  }
+
+  base.fits_fully = true;
+  const kvFullMib = kvPerTokenMib * trained;
+  if (weights + compute + kvFullMib <= available) {
+    base.fitted_ctx = 0;
+    base.kv_mib = Math.round(kvFullMib);
+    base.total_mib = Math.round(weights + compute + kvFullMib);
+    return base;
+  }
+  const kvBudget = available - weights - compute;
+  base.fitted_ctx = Math.max(MIN_OFFLOAD_CTX, Math.floor(kvBudget / kvPerTokenMib));
+  base.kv_mib = Math.round(kvBudget);
+  base.total_mib = Math.round(available);
+  return base;
+}
+
+export function fitTotalGb(fit: FitEstimate | null | undefined): number {
+  return fit ? fit.total_mib / 1024 : 0;
+}
+
+function representative(bench: BenchPoint[], backend: string): BenchPoint | null {
+  let d0: BenchPoint | null = null;
+  let deep: BenchPoint | null = null;
+  for (const p of bench) {
+    if (!p.ok || p.backend !== backend) continue;
+    if (p.params?.ladder === true || p.params?.spec_n !== undefined) continue;
+    if ((p.params?.d ?? 0) > 0) deep = p;
+    else d0 = p;
+  }
+  return deep || d0;
+}
+
+export function benchScore(tps: number, ttftMs: number, tpsMax: number, ttftMin: number): number {
+  const normTps = tpsMax > 0 ? Math.max(0, tps) / tpsMax : 0;
+  const normTtft = (ttftMs > 0 && ttftMin > 0) ? ttftMin / ttftMs : 0;
+  return 0.7 * normTps + 0.3 * normTtft;
+}
+
+function pickBackend(bench: BenchPoint[], candidates: string[]): { backend: string; rep: BenchPoint | null } {
+  const reps: Array<{ backend: string; rep: BenchPoint }> = [];
+  for (const c of candidates) {
+    const rep = representative(bench, c);
+    if (rep) reps.push({ backend: c, rep });
+  }
+  if (reps.length === 0) return { backend: '', rep: null };
+  const tpsMax = Math.max(...reps.map(r => r.rep.tps), 0);
+  const ttfts = reps.map(r => r.rep.ttft_ms).filter(v => v > 0);
+  const ttftMin = ttfts.length ? Math.min(...ttfts) : 0;
+  let best = reps[0];
+  let bestScore = -1;
+  for (const r of reps) {
+    const score = benchScore(r.rep.tps, r.rep.ttft_ms, tpsMax, ttftMin);
+    if (score > bestScore) {
+      bestScore = score;
+      best = r;
+    }
+  }
+  return { backend: best.backend, rep: best.rep };
+}
+
+export function pickBenchWinner(bench: BenchPoint[], candidates: string[]): string {
+  return pickBackend(bench, candidates).backend;
+}
+
+function fmt1(v: number): string {
+  return v.toFixed(1);
+}
+
+export function checkpointRepoId(checkpoint: string): string {
+  const marker = 'huggingface.co/';
+  const pos = checkpoint.indexOf(marker);
+  let id = pos === -1 ? checkpoint : checkpoint.slice(pos + marker.length);
+  while (id.endsWith('/')) id = id.slice(0, -1);
+  const colon = id.indexOf(':');
+  if (colon !== -1) id = id.slice(0, colon);
+  return id.includes('/') ? id : '';
+}
+
+export function synthesize(
+  hw: HardwareSnapshot,
+  mf: ModelFacts,
+  ans: WizardAnswers,
+  fits: FitEstimate[],
+  bench: BenchPoint[],
+  sampling?: SamplingDefaults,
+): AutoOptResult {
+  const p: AutoOptRecommendation = {
+    label: 'Recommended',
+    llamacpp_backend: '',
+    ctx_size: -1,
+    llamacpp_args: '',
+    rationale: [],
+  };
+  const result: AutoOptResult = { primary: p, alternatives: [] };
+  const args: string[] = [];
+
+  const candidates = selectCandidates(hw, ans);
+  if (candidates.length === 0) throw new Error(NO_GPU_BACKEND_ERROR);
+
+  let backend = candidates[0];
+  if (candidates.length > 1) {
+    const { backend: measured, rep } = pickBackend(bench, candidates);
+    if (measured) backend = measured;
+    if (rep) {
+      const others = candidates.filter(c => c !== backend).join(', ');
+      p.rationale.push(`${backend} chosen over ${others}: best measured throughput/latency balance `
+        + `on this model (${fmt1(rep.tps)} tok/s decode, ${fmt1(rep.ttft_ms)} ms to first token`
+        + `${rep.params?.d ? ` at depth ${rep.params.d}` : ''}).`);
+    } else {
+      p.rationale.push(`${backend} chosen (first installed GPU backend; enable a benchmark `
+        + 'budget to measure alternatives).');
+    }
+  }
+  p.llamacpp_backend = backend;
+  const isRocm = backend.startsWith('rocm');
+  const isCuda = backend === 'cuda';
+  const fit = fits.find(f => f.ok && f.backend === backend) || fits.find(f => f.ok) || null;
+
+  if (isRocm) {
+    args.push('--direct-io');
+    p.rationale.push('--direct-io: works around broken mmap on ROCm with faster cold loads '
+      + 'than --no-mmap.');
+  }
+
+  let usedCpuMoe = false;
+  if (fit && !fit.fits_fully) {
+    if (mf.is_moe && fit.fitted_ncmoe > 0) {
+      args.push(`--n-cpu-moe ${fit.fitted_ncmoe}`);
+      usedCpuMoe = true;
+      p.rationale.push(`Model exceeds GPU memory: expert tensors of the first ${fit.fitted_ncmoe} `
+        + 'layers stay on CPU (--n-cpu-moe) — attention and shared tensors keep GPU speed.');
+    } else if (mf.is_moe) {
+      args.push('--cpu-moe');
+      usedCpuMoe = true;
+      p.rationale.push('Model exceeds GPU memory: all expert tensors on CPU (--cpu-moe); '
+        + 'the GPU keeps the non-expert layers.');
+    } else if (fit.fitted_ngl >= 0) {
+      args.push(`-ngl ${fit.fitted_ngl}`);
+      p.rationale.push(`Model exceeds GPU memory: ${fit.fitted_ngl} of ${mf.block_count} layers `
+        + 'offloaded to GPU (-ngl), the rest run on CPU (expect reduced speed).');
+    }
+  }
+
+  const kv = ans.kv_cache_quant;
+  if (kv !== 'none') {
+    args.push(`-ctk ${kv} -ctv ${kv}`);
+    const note = kv === 'q8_0'
+      ? 'roughly doubles usable context with negligible quality loss'
+      : (kv === 'q5_1'
+        ? 'about 2.7x context capacity with a slight quality cost'
+        : 'about 3.5x context capacity; quality measurably degrades on very long contexts');
+    p.rationale.push(`KV cache quantized to ${kv}: ${note}.`);
+  }
+  let recCtx = recommendedCtxSize(fit ? fit.fitted_ctx : 0, mf.n_ctx_train, kv);
+  let loadCeilingHit = false;
+  for (const bp of bench) {
+    if (!bp.ok || bp.backend !== backend) continue;
+    if (typeof bp.max_loaded_ctx === 'number' && bp.max_loaded_ctx > 0 && bp.max_loaded_ctx < recCtx) {
+      recCtx = bp.max_loaded_ctx;
+      loadCeilingHit = true;
+    }
+  }
+  p.ctx_size = recCtx;
+  if (loadCeilingHit) {
+    p.rationale.push(`Context ${p.ctx_size}: the heuristic estimate did not load on this `
+      + 'hardware during benchmarking; capped to the largest context that actually loaded.');
+  } else if (mf.n_ctx_train > 0 && p.ctx_size >= mf.n_ctx_train) {
+    p.ctx_size = mf.n_ctx_train;
+    p.rationale.push(`Context ${p.ctx_size}: the model's full trained window fits.`);
+  } else {
+    p.rationale.push(`Context ${p.ctx_size}: the largest standard size that fits in memory`
+      + (kv !== 'none' ? ' with the quantized KV cache' : '')
+      + (fit?.degraded ? ' (coarse estimate — model metadata was unavailable).' : '.'));
+  }
+
+  let headroom = ans.ram_headroom;
+  if (mf.is_hybrid_or_recurrent && headroom === 'disabled') {
+    headroom = 'minimal';
+    p.rationale.push('Prompt-cache checkpoints kept at minimal instead of disabled: this '
+      + 'architecture (hybrid/recurrent) must re-process the whole prompt on any cache miss.');
+  }
+  if (headroom === 'reduced') args.push('--cache-ram 4096 -ctxcp 16');
+  else if (headroom === 'minimal') args.push('--cache-ram 2048 -ctxcp 8');
+  else if (headroom === 'disabled') args.push('--cache-ram 0 -ctxcp 0');
+  if (headroom !== 'normal') {
+    p.rationale.push(`Prompt-cache RAM capped (${headroom})`
+      + (hw.ram_is_vram
+        ? ' — on this machine system RAM and GPU memory share one pool.'
+        : ' to keep system RAM free.'));
+  }
+
+  if (ans.parallel && ans.slots > 1) {
+    const np = Math.min(Math.max(ans.slots, 2), 8);
+    if (ans.dedicated_slots) {
+      args.push(`-np ${np} -no-kvu`);
+      p.rationale.push(`${np} parallel slots with dedicated context: each request is `
+        + `guaranteed ${Math.floor(p.ctx_size / np)} tokens (${p.ctx_size} / ${np}).`);
+    } else {
+      args.push(`-np ${np} -kvu`);
+      p.rationale.push(`${np} parallel slots sharing one context pool: long requests can use `
+        + 'most of the window, but concurrent long requests race for it.');
+    }
+  }
+
+  args.push('--spec-default');
+  p.rationale.push('--spec-default: n-gram speculative decoding is effectively free.');
+  if (mf.has_mtp) {
+    let bestN = 3;
+    let bestTps = -1;
+    for (const bp of bench) {
+      if (!bp.ok || bp.params?.spec_n === undefined) continue;
+      if (bp.tps > bestTps) {
+        bestTps = bp.tps;
+        bestN = bp.params.spec_n;
+      }
+    }
+    args.push(`--spec-type draft-mtp --spec-draft-n-max ${bestN}`);
+    p.rationale.push(bestTps > 0
+      ? `MTP draft length ${bestN} measured fastest on this machine (${fmt1(bestTps)} tok/s).`
+      : 'Model has MTP heads: draft-based speculative decoding enabled (default draft length 3).');
+  }
+
+  const bigIgpu = hw.ram_is_vram && hw.host_ram_gb >= 32;
+  {
+    let bestB = 0;
+    let bestTtft = Infinity;
+    let baseTtft = -1;
+    for (const bp of bench) {
+      if (!bp.ok || bp.params?.ladder !== true || bp.backend !== backend) continue;
+      const b = bp.params.b ?? 0;
+      if (b === 512) baseTtft = bp.ttft_ms;
+      if (bp.ttft_ms > 0 && bp.ttft_ms < bestTtft) {
+        bestTtft = bp.ttft_ms;
+        bestB = b;
+      }
+    }
+    if (bestB > 512 && baseTtft > 0 && bestTtft > 0 && baseTtft / bestTtft > 1.05) {
+      args.push(`-b ${bestB} -ub ${bestB}`);
+      p.rationale.push(`Batch size ${bestB} measured ${fmt1((baseTtft / bestTtft - 1) * 100)}% `
+        + 'faster prefill than the default 512 (costs some memory for compute buffers).');
+    } else if (bench.length === 0 && bigIgpu) {
+      args.push('-b 2048 -ub 2048');
+      p.rationale.push('Batch size 2048: unified-memory machines with ample RAM prefill much '
+        + 'faster with larger batches (heuristic — run a benchmark pass to measure).');
+    }
+  }
+
+  if (isCuda) {
+    let sameFamily = 0;
+    for (let i = 0; i < hw.gpus.length; i++) {
+      for (let j = i + 1; j < hw.gpus.length; j++) {
+        if (hw.gpus[i].vendor === 'nvidia' && hw.gpus[i].family === hw.gpus[j].family) sameFamily++;
+      }
+    }
+    if (sameFamily > 0) {
+      args.push('--split-mode tensor');
+      p.rationale.push('Two or more identical NVIDIA GPUs: tensor parallelism speeds up decode '
+        + '(prefill gets slightly slower).');
+    }
+  }
+
+  result.sampling_defaults = sampling;
+  if (sampling) {
+    p.rationale.push('Sampling defaults (temperature/top-p/top-k) taken from the base model\'s '
+      + `generation_config (${sampling.source}).`);
+  }
+
+  const join = (v: string[]) => v.join(' ');
+  p.llamacpp_args = join(args);
+  {
+    const rep = pickBackend(bench, [backend]).rep;
+    const expected: AutoOptRecommendation['expected'] = {};
+    if (fit) expected.vram_gb = Number(fitTotalGb(fit).toFixed(2));
+    if (rep) {
+      if (rep.tps > 0) expected.tps = rep.tps;
+      if (rep.ttft_ms > 0) expected.ttft_ms = rep.ttft_ms;
+    }
+    if (Object.keys(expected).length) p.expected = expected;
+  }
+
+  if (kv !== 'none') {
+    const alt: AutoOptRecommendation = {
+      ...p,
+      label: 'Maximum quality',
+      tradeoff: 'smaller context window',
+      rationale: ['Unquantized f16 KV cache: no quality risk; context shrinks to what fits.'],
+      llamacpp_args: join(args.filter(a => !a.startsWith('-ctk'))),
+      ctx_size: roundDownCtx(Math.max(Math.floor(p.ctx_size * kvQuantFactor(kv)), 4096)),
+      expected: undefined,
+    };
+    result.alternatives.push(alt);
+  }
+  if (kv !== 'q4_0') {
+    const a2: string[] = [];
+    let replaced = false;
+    for (const a of args) {
+      if (a.startsWith('-ctk')) {
+        a2.push('-ctk q4_0 -ctv q4_0');
+        replaced = true;
+      } else {
+        a2.push(a);
+      }
+    }
+    if (!replaced) a2.unshift('-ctk q4_0 -ctv q4_0');
+    const altCtx = Math.floor(p.ctx_size * kvQuantFactor(kv) / kvQuantFactor('q4_0'));
+    const alt: AutoOptRecommendation = {
+      ...p,
+      label: 'Maximum context',
+      tradeoff: 'quality degrades on very long contexts',
+      rationale: ['q4_0 KV cache: about 3.5x the context capacity of f16; noticeable quality '
+        + 'loss past ~32k tokens of active context.'],
+      llamacpp_args: join(a2),
+      ctx_size: roundDownCtx(Math.min(altCtx, mf.n_ctx_train > 0 ? mf.n_ctx_train : altCtx)),
+      expected: undefined,
+    };
+    result.alternatives.push(alt);
+  }
+  if (usedCpuMoe) {
+    const alt: AutoOptRecommendation = {
+      ...p,
+      label: 'Conservative offload',
+      tradeoff: 'slower, but immune to memory pressure',
+      rationale: ['All expert tensors on CPU (--cpu-moe): the safest fit when other '
+        + 'applications compete for GPU memory.'],
+      llamacpp_args: join(args.map(a => a.startsWith('--n-cpu-moe') ? '--cpu-moe' : a)),
+      expected: undefined,
+    };
+    result.alternatives.push(alt);
+  }
+
+  return result;
+}

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptSynthesize.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptSynthesize.ts
@@ -225,6 +225,15 @@ function representative(bench: BenchPoint[], backend: string): BenchPoint | null
   return deep || d0;
 }
 
+function duelPoint(bench: BenchPoint[], backend: string): BenchPoint | null {
+  for (const p of bench) {
+    if (!p.ok || p.backend !== backend) continue;
+    if (p.params?.ladder === true || p.params?.spec_n !== undefined) continue;
+    if ((p.params?.d ?? 0) === 0) return p;
+  }
+  return null;
+}
+
 export function benchScore(tps: number, ttftMs: number, tpsMax: number, ttftMin: number): number {
   const normTps = tpsMax > 0 ? Math.max(0, tps) / tpsMax : 0;
   const normTtft = (ttftMs > 0 && ttftMin > 0) ? ttftMin / ttftMs : 0;
@@ -234,22 +243,23 @@ export function benchScore(tps: number, ttftMs: number, tpsMax: number, ttftMin:
 function pickBackend(bench: BenchPoint[], candidates: string[]): { backend: string; rep: BenchPoint | null } {
   const eligible = candidates.filter(c => !deepRunFailed(bench, c));
   const pool = eligible.length > 0 ? eligible : candidates;
-  const reps: Array<{ backend: string; rep: BenchPoint }> = [];
+  const entries: Array<{ backend: string; duel: BenchPoint; rep: BenchPoint }> = [];
   for (const c of pool) {
-    const rep = representative(bench, c);
-    if (rep) reps.push({ backend: c, rep });
+    const duel = duelPoint(bench, c) || representative(bench, c);
+    if (!duel) continue;
+    entries.push({ backend: c, duel, rep: representative(bench, c) || duel });
   }
-  if (reps.length === 0) return { backend: '', rep: null };
-  const tpsMax = Math.max(...reps.map(r => r.rep.tps), 0);
-  const ttfts = reps.map(r => r.rep.ttft_ms).filter(v => v > 0);
+  if (entries.length === 0) return { backend: '', rep: null };
+  const tpsMax = Math.max(...entries.map(e => e.duel.tps), 0);
+  const ttfts = entries.map(e => e.duel.ttft_ms).filter(v => v > 0);
   const ttftMin = ttfts.length ? Math.min(...ttfts) : 0;
-  let best = reps[0];
+  let best = entries[0];
   let bestScore = -1;
-  for (const r of reps) {
-    const score = benchScore(r.rep.tps, r.rep.ttft_ms, tpsMax, ttftMin);
+  for (const e of entries) {
+    const score = benchScore(e.duel.tps, e.duel.ttft_ms, tpsMax, ttftMin);
     if (score > bestScore) {
       bestScore = score;
-      best = r;
+      best = e;
     }
   }
   return { backend: best.backend, rep: best.rep };

--- a/prototype/ui-redesign/src/features/autoOpt/autoOptTypes.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/autoOptTypes.ts
@@ -1,0 +1,221 @@
+export type AutoOptBudget = 'quick' | 'standard' | 'thorough';
+export type AutoOptRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+export type AutoOptStageStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+export type AutoOptParallelMode = 'single' | 'parallel';
+export type AutoOptKvCacheQuant = 'none' | 'q8_0' | 'q5_1' | 'q4_0';
+export type AutoOptRamHeadroom = 'normal' | 'reduced' | 'minimal' | 'disabled';
+
+export interface AutoOptParallelAnswer {
+  mode: AutoOptParallelMode;
+  slots?: number;
+  dedicated?: boolean;
+}
+
+export interface AutoOptAnswers {
+  parallel: AutoOptParallelAnswer;
+  kv_cache_quant: AutoOptKvCacheQuant;
+  ram_headroom: AutoOptRamHeadroom;
+  allow_network: boolean;
+  backends_to_consider?: string[];
+}
+
+export interface AutoOptStartRequest {
+  model: string;
+  budget: AutoOptBudget;
+  allow_unload: boolean;
+  answers: AutoOptAnswers;
+}
+
+export interface WizardAnswers {
+  parallel: boolean;
+  slots: number;
+  dedicated_slots: boolean;
+  kv_cache_quant: AutoOptKvCacheQuant;
+  ram_headroom: AutoOptRamHeadroom;
+  allow_network: boolean;
+  backends_to_consider: string[];
+}
+
+export function wizardAnswersFrom(answers: AutoOptAnswers): WizardAnswers {
+  const parallel = answers.parallel?.mode === 'parallel';
+  return {
+    parallel,
+    slots: Math.max(1, answers.parallel?.slots ?? (parallel ? 2 : 1)),
+    dedicated_slots: answers.parallel?.dedicated ?? true,
+    kv_cache_quant: answers.kv_cache_quant || 'none',
+    ram_headroom: answers.ram_headroom || 'normal',
+    allow_network: answers.allow_network !== false,
+    backends_to_consider: answers.backends_to_consider || [],
+  };
+}
+
+export interface AutoOptProgress {
+  stage: string;
+  stage_index: number;
+  stage_count: number;
+  detail?: string;
+}
+
+export interface AutoOptStage {
+  name: string;
+  status: AutoOptStageStatus;
+  duration_ms?: number;
+  error?: string;
+  data?: Record<string, unknown>;
+}
+
+export interface HardwareGpu {
+  vendor: string;
+  name: string;
+  family: string;
+  vram_gb: number;
+}
+
+export interface HardwareSnapshot {
+  gpus: HardwareGpu[];
+  has_igpu: boolean;
+  ram_is_vram: boolean;
+  host_ram_gb: number;
+  installed_backends: string[];
+  os: string;
+}
+
+export interface ModelFacts {
+  architecture: string;
+  block_count: number;
+  expert_count: number;
+  full_attention_interval: number;
+  swa_layer_count: number;
+  n_ctx_train: number;
+  kv_bytes_per_token: number;
+  weights_mib: number;
+  is_moe: boolean;
+  is_hybrid_or_recurrent: boolean;
+  has_mtp: boolean;
+  base_model_repo: string;
+  checkpoint: string;
+  metadata_present: boolean;
+}
+
+export interface FitEstimate {
+  backend: string;
+  fits_fully: boolean;
+  fitted_ctx: number;
+  fitted_ngl: number;
+  fitted_ncmoe: number;
+  weights_mib: number;
+  kv_mib: number;
+  compute_mib: number;
+  total_mib: number;
+  available_mib: number;
+  degraded: boolean;
+  ok: boolean;
+  note?: string;
+}
+
+export interface BenchParams {
+  d?: number;
+  b?: number;
+  ub?: number;
+  spec_n?: number;
+  ladder?: boolean;
+}
+
+export interface BenchPoint {
+  backend: string;
+  label: string;
+  ctx_size: number;
+  llamacpp_args: string;
+  params: BenchParams;
+  ttft_ms: number;
+  tps: number;
+  vram_gb: number;
+  ok: boolean;
+  error?: string;
+  max_loaded_ctx?: number;
+}
+
+export interface SamplingDefaults {
+  temperature?: number;
+  top_p?: number;
+  min_p?: number;
+  top_k?: number;
+  source: string;
+}
+
+export interface AutoOptExpected {
+  ttft_ms?: number;
+  tps?: number;
+  vram_gb?: number;
+}
+
+export interface AutoOptRecommendation {
+  label: string;
+  tradeoff?: string;
+  llamacpp_backend: string;
+  ctx_size: number;
+  llamacpp_args: string;
+  rationale: string[];
+  expected?: AutoOptExpected;
+}
+
+export interface AutoOptResult {
+  primary: AutoOptRecommendation;
+  alternatives: AutoOptRecommendation[];
+  sampling_defaults?: SamplingDefaults;
+}
+
+export interface AutoOptMeasurements {
+  fit: FitEstimate[];
+  bench: BenchPoint[];
+}
+
+export interface BenchPlanEntry {
+  label: string;
+  backend: string;
+  ctx_size: number;
+  llamacpp_args: string;
+  params: BenchParams;
+  ctx_probe?: boolean;
+  ttft_key: string;
+  tps_key: string;
+  vram_key: string;
+  fallback_ctx_size?: number;
+  fallback_ttft_key?: string;
+  fallback_tps_key?: string;
+  fallback_vram_key?: string;
+}
+
+export interface SynthInputs {
+  hardware: HardwareSnapshot;
+  facts: ModelFacts;
+  fits: FitEstimate[];
+  sampling?: SamplingDefaults;
+  plan: BenchPlanEntry[];
+  step_labels: Record<string, string>;
+}
+
+export interface AutoOptRunRecord {
+  id: string;
+  model: string;
+  checkpoint: string;
+  budget: AutoOptBudget;
+  answers: AutoOptAnswers;
+  allow_unload: boolean;
+  status: AutoOptRunStatus;
+  created_at: string;
+  finished_at?: string;
+  summary?: string;
+  error?: string;
+  lemonade_version?: string;
+  progress?: AutoOptProgress;
+  stages: AutoOptStage[];
+  measurements: AutoOptMeasurements;
+  result?: AutoOptResult;
+  job_id?: string;
+  synth_inputs?: SynthInputs;
+}
+
+export function isAutoOptRunActive(run: Pick<AutoOptRunRecord, 'status'>): boolean {
+  return run.status === 'queued' || run.status === 'running';
+}

--- a/prototype/ui-redesign/src/features/autoOpt/presetFromRun.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/presetFromRun.ts
@@ -1,0 +1,126 @@
+import api, { type ModelInfo } from '../../api';
+import {
+  contextHintFromValue,
+  labelsFor,
+  loadApplied,
+  loadUserPresets,
+  modelContextSize,
+  sanitizePreset,
+  saveApplied,
+  saveOptimizedModelTuning,
+  saveUserPresets,
+  TEMPERATURE_HINT_VALUES,
+  TEMPERATURE_HINTS,
+  type Preset,
+  type RecipeOptions,
+  type SamplingParams,
+  type TemperatureHint,
+} from '../../presetStore';
+import type { AutoOptRecommendation, AutoOptRunRecord, SamplingDefaults } from './autoOptTypes';
+
+function modelShortName(model: string): string {
+  const parts = model.split('/').filter(Boolean);
+  return parts[parts.length - 1] || model;
+}
+
+function nearestTemperatureHint(value: number | undefined): TemperatureHint {
+  if (value === undefined || !Number.isFinite(value)) return 'balanced';
+  return TEMPERATURE_HINTS.reduce((best, hint) =>
+    Math.abs(TEMPERATURE_HINT_VALUES[hint] - value) < Math.abs(TEMPERATURE_HINT_VALUES[best] - value) ? hint : best,
+  'balanced' as TemperatureHint);
+}
+
+function recommendationRecipeOptions(rec: AutoOptRecommendation): RecipeOptions {
+  const options: RecipeOptions = {};
+  if (rec.ctx_size > 0) options.ctx_size = rec.ctx_size;
+  if (rec.llamacpp_backend) options.llamacpp_backend = rec.llamacpp_backend;
+  if (rec.llamacpp_args) options.llamacpp_args = rec.llamacpp_args;
+  return options;
+}
+
+function installedBackends(systemInfo: Record<string, unknown> | null | undefined): string[] {
+  const recipes = (systemInfo?.recipes || {}) as Record<string, { backends?: Record<string, { state?: unknown }> }>;
+  const backends = recipes.llamacpp?.backends || {};
+  return Object.entries(backends)
+    .filter(([, info]) => ['installed', 'update_available'].includes(String(info?.state || '')))
+    .map(([name]) => name);
+}
+
+export function assertRunApplicable(run: AutoOptRunRecord, modelInfo: ModelInfo | null | undefined): void {
+  const runCheckpoint = String(run.checkpoint || '').trim();
+  const currentCheckpoint = String((modelInfo as Record<string, unknown> | null | undefined)?.checkpoint || '').trim();
+  if (runCheckpoint && currentCheckpoint && runCheckpoint !== currentCheckpoint) {
+    throw new Error(`This run was measured on a different build of ${run.model} `
+      + `(${runCheckpoint} vs current ${currentCheckpoint}). Re-run AutoOpt to apply it.`);
+  }
+  const backend = run.result?.primary?.llamacpp_backend;
+  const installed = installedBackends(api.systemInfoData);
+  if (backend && installed.length > 0 && !installed.includes(backend)) {
+    throw new Error(`The recommended backend "${backend}" is not installed on this server. `
+      + 'Re-run AutoOpt to pick an available backend.');
+  }
+}
+
+function samplingFromDefaults(defaults: SamplingDefaults | undefined): SamplingParams {
+  if (!defaults) return {};
+  const sampling: SamplingParams = {};
+  if (defaults.temperature !== undefined) sampling.temperature = defaults.temperature;
+  if (defaults.top_p !== undefined) sampling.top_p = defaults.top_p;
+  if (defaults.top_k !== undefined) sampling.top_k = defaults.top_k;
+  if (defaults.min_p !== undefined) sampling.min_p = defaults.min_p;
+  return sampling;
+}
+
+export function createPresetFromRun(
+  run: AutoOptRunRecord,
+  rec: AutoOptRecommendation,
+  modelInfo: ModelInfo | null | undefined,
+): Preset {
+  assertRunApplicable(run, modelInfo);
+  const samplingDefaults = run.result?.sampling_defaults;
+  const preset = sanitizePreset({
+    id: `u-${Date.now()}`,
+    name: `AutoOpt · ${modelShortName(run.model)}`,
+    description: rec.rationale?.[0] || run.summary || '',
+    applies_to: modelInfo ? labelsFor(modelInfo) : ['chat'],
+    temperature_hint: nearestTemperatureHint(samplingDefaults?.temperature),
+    context_hint: rec.ctx_size > 0
+      ? contextHintFromValue(rec.ctx_size, modelContextSize(modelInfo))
+      : 'medium',
+    thinking_mode: 'normal',
+    recipe_options: {},
+    sampling: {},
+    engine_hint: 'llamacpp',
+    starter: false,
+    auto_opt_run_id: run.id,
+    auto_opt_enabled: true,
+  });
+  if (!preset) throw new Error('Could not build a preset from this run.');
+  saveUserPresets([preset, ...loadUserPresets()]);
+  saveOptimizedModelTuning(run.model, {
+    recipe_options: recommendationRecipeOptions(rec),
+    sampling: samplingFromDefaults(samplingDefaults),
+  }, preset.id, run.id);
+  saveApplied({ ...loadApplied(), [run.model]: preset.id });
+  return preset;
+}
+
+export async function applyRunNow(
+  run: AutoOptRunRecord,
+  rec: AutoOptRecommendation,
+  { save }: { save: boolean },
+): Promise<void> {
+  assertRunApplicable(run, api.allModels.find(model =>
+    String((model as Record<string, unknown>).model_name || model.name || model.id || '').trim() === run.model));
+  const loaded = api.loadedModels.some(model => model.model_name === run.model);
+  if (save) {
+
+    if (loaded) await api.reloadModel(run.model);
+    else await api.loadModel(run.model);
+    return;
+  }
+
+  const tempOptions = { ...recommendationRecipeOptions(rec), save_options: false };
+  if (loaded) await api.reloadModel(run.model, tempOptions);
+  else await api.loadModel(run.model, tempOptions);
+}

--- a/prototype/ui-redesign/src/features/autoOpt/wizardCopy.ts
+++ b/prototype/ui-redesign/src/features/autoOpt/wizardCopy.ts
@@ -1,0 +1,147 @@
+import type { AutoOptBudget, AutoOptKvCacheQuant, AutoOptParallelMode, AutoOptRamHeadroom } from './autoOptTypes';
+
+export const WIZARD_TITLE = 'Optimize this model';
+export const WIZARD_INTRO = 'AutoOpt benchmarks this model on your hardware and recommends the fastest safe configuration. The benchmark runs as a job on the server — you can close this window or reload the page and it keeps going. Answer a few questions so it optimizes for how you actually use it.';
+
+export const MODEL_STEP = {
+  legend: 'Which model should be optimized?',
+  help: 'AutoOpt tunes one model at a time. The result applies to this exact model on this machine.',
+  note: 'AutoOpt currently supports downloaded llama.cpp models; it compares llama.cpp backend variants (Vulkan/ROCm/CUDA), not other engines.',
+  empty: 'No downloaded llama.cpp chat models are available. Download a llama.cpp chat or omni model first.',
+};
+
+export const PARALLEL_STEP = {
+  legend: 'How will you use this model?',
+  options: [
+    {
+      value: 'single' as AutoOptParallelMode,
+      label: 'Just me, one conversation at a time',
+      description: 'One request at a time gets the whole context window and the fastest single-stream speed.',
+    },
+    {
+      value: 'parallel' as AutoOptParallelMode,
+      label: 'Several chats or clients at once',
+      description: 'Multiple requests are served in parallel slots. Total throughput goes up; each request gets a slice of the context.',
+    },
+  ],
+  slotsLabel: 'Parallel slots',
+  dedicatedLabel: 'This machine is a dedicated server (allow more aggressive memory use)',
+  footnote: 'With N parallel slots, a context window of C tokens gives each request about C / N tokens. Example: 32K context with 4 slots means roughly 8K tokens per conversation.',
+};
+
+export const KV_QUANT_STEP = {
+  legend: 'Context size vs. answer quality',
+  help: 'Compressing the KV cache frees memory for a larger context window at a small quality cost.',
+  options: [
+    {
+      value: 'none' as AutoOptKvCacheQuant,
+      label: 'Full quality (no compression)',
+      description: 'Keeps the KV cache at full precision. Best answer quality, largest memory use per token of context.',
+    },
+    {
+      value: 'q8_0' as AutoOptKvCacheQuant,
+      label: 'Balanced (q8_0)',
+      description: 'Halves KV cache memory with virtually no measurable quality loss. The safe default when you want more context.',
+    },
+    {
+      value: 'q5_1' as AutoOptKvCacheQuant,
+      label: 'More context (q5_1)',
+      description: 'About one third of the full-precision memory. Slight quality loss on long, detail-heavy tasks.',
+    },
+    {
+      value: 'q4_0' as AutoOptKvCacheQuant,
+      label: 'Maximum context (q4_0)',
+      description: 'Quarter of the full-precision memory for the biggest context windows. Noticeable quality loss is possible; prefer q8_0 unless you truly need the space.',
+    },
+  ],
+};
+
+export const RAM_STEP = {
+  legend: 'How much system RAM should stay free for other applications?',
+  help: "This sizes llama.cpp's prompt cache: checkpoints of already-processed conversations kept in "
+    + 'system RAM (--cache-ram, -ctxcp) so that switching back to a swapped-out conversation is instant '
+    + 'instead of re-processing its whole prompt. A bigger cache means faster conversation switching; '
+    + 'a smaller one keeps more RAM free for everything else you run.',
+  suggestionChip: (gb: number) => `Suggested for this machine (${gb} GB RAM)`,
+  options: [
+    {
+      value: 'normal' as AutoOptRamHeadroom,
+      label: 'Default cache',
+      description: "Keeps llama.cpp's default prompt-cache size. Every recent conversation resumes "
+        + 'instantly; pick this when RAM is plentiful.',
+    },
+    {
+      value: 'reduced' as AutoOptRamHeadroom,
+      label: 'Reduced cache (4 GB, 16 checkpoints)',
+      description: 'Caps the prompt cache at 4 GB of system RAM. Recent conversations still resume '
+        + 'instantly; more RAM stays free for heavier applications running next to the model.',
+    },
+    {
+      value: 'minimal' as AutoOptRamHeadroom,
+      label: 'Minimal cache (2 GB, 8 checkpoints)',
+      description: 'Caps the prompt cache at 2 GB. Keeps most system RAM free; switching back to '
+        + 'older conversations re-processes their prompt instead of resuming instantly.',
+    },
+    {
+      value: 'disabled' as AutoOptRamHeadroom,
+      label: 'No cache (0 GB)',
+      description: 'No prompt cache at all: every conversation switch re-processes the full prompt '
+        + 'from scratch. Warning: hybrid and recurrent models cannot shift their cache, so any cache '
+        + 'miss already forces a full prompt recompute — AutoOpt bumps them back to the minimal cache.',
+    },
+  ],
+};
+
+export const BUDGET_STEP = {
+  legend: 'How thorough should the optimization be?',
+  options: [
+    {
+      value: 'quick' as AutoOptBudget,
+      label: 'Fast Scan',
+      description: 'Heuristic memory fit only — no loads, no benchmarks. The recommendation is not load-validated. (~seconds)',
+    },
+    {
+      value: 'standard' as AutoOptBudget,
+      label: 'Benchmark',
+      description: 'A server job loads and times each candidate: a backend duel at depth 0 and at deep context (~30k tokens), a batch ladder on unified-memory machines, and an MTP sweep {2,3,4} where supported. A memory-heavy load that fails falls back to a smaller context. (~5–15 min)',
+    },
+    {
+      value: 'thorough' as AutoOptBudget,
+      label: 'Deep Benchmark',
+      description: 'The same measurements with full batch ladders {512…8192} and a wider MTP sweep {1…6}. (~15–45 min)',
+    },
+  ],
+  networkLabel: 'Allow fetching model metadata from Hugging Face',
+  networkHelp: "Only the base model's metadata and generation_config.json are fetched from Hugging Face. Nothing else is downloaded.",
+  consentLabel: 'AutoOpt may unload the models currently loaded on this server while it benchmarks',
+  consentHelp: 'The benchmark job needs exclusive access to the hardware: it repeatedly unloads and reloads the model to clear the prompt cache between timed runs, and normal inference queues behind it until it finishes. Loaded models are evicted during the run and are not reloaded automatically. Fast Scan runs no benchmarks and never unloads anything.',
+};
+
+export const REVIEW_STEP = {
+  legend: 'Review and start',
+  help: 'AutoOpt will run with these answers. You can cancel the run at any time.',
+};
+
+export const RUNNING_STEP = {
+  closeNote: 'You can close this window or reload the page — the benchmark keeps running on the server and this view re-attaches to it.',
+};
+
+export const KV_QUANT_LABELS: Record<AutoOptKvCacheQuant, string> = {
+  none: 'Full quality',
+  q8_0: 'Balanced (q8_0)',
+  q5_1: 'More context (q5_1)',
+  q4_0: 'Maximum context (q4_0)',
+};
+
+export const RAM_HEADROOM_LABELS: Record<AutoOptRamHeadroom, string> = {
+  normal: 'Default cache',
+  reduced: 'Reduced cache (4 GB)',
+  minimal: 'Minimal cache (2 GB)',
+  disabled: 'No cache',
+};
+
+export const BUDGET_LABELS: Record<AutoOptBudget, string> = {
+  quick: 'Fast Scan',
+  standard: 'Benchmark',
+  thorough: 'Deep Benchmark',
+};

--- a/prototype/ui-redesign/src/presetStore.ts
+++ b/prototype/ui-redesign/src/presetStore.ts
@@ -46,12 +46,14 @@ export interface RecipeOptions {
   voice?: string;
   speed?: number;
   merge_args?: boolean;
+  mmproj_enabled?: boolean;
 }
 
 export interface SamplingParams {
   temperature?: number;
   top_p?: number;
   top_k?: number;
+  min_p?: number;
   repeat_penalty?: number;
 }
 
@@ -90,8 +92,8 @@ export interface ModelTuning {
   sampling: SamplingParams;
   /** Optional runtime hint kept separate from shared Preset intent. */
   engine_hint?: PresetRecipe;
-  /** 'model' means discovered from model metadata/GGUF; 'user' means locally customized. */
-  source?: 'model' | 'user';
+  source?: 'model' | 'user' | 'optimized';
+  auto_opt_run_id?: string;
   updated_at?: string;
 }
 
@@ -654,8 +656,8 @@ export function sanitizeRecipeOptions(options: Partial<RecipeOptions> | null | u
   if (!options || typeof options !== 'object') return out;
   for (const [key, value] of Object.entries(options) as Array<[keyof RecipeOptions, unknown]>) {
     if (isBlankValue(value)) continue;
-    if (key === 'merge_args') {
-      if (typeof value === 'boolean') out.merge_args = value;
+    if (key === 'merge_args' || key === 'mmproj_enabled') {
+      if (typeof value === 'boolean') (out as Record<string, unknown>)[key] = value;
       continue;
     }
     if (RECIPE_OPTION_NUMBER_KEYS.has(key)) {
@@ -676,7 +678,7 @@ export function sanitizeRecipeOptions(options: Partial<RecipeOptions> | null | u
 export function sanitizeSamplingParams(params: Partial<SamplingParams> | null | undefined): SamplingParams {
   const out: SamplingParams = {};
   if (!params || typeof params !== 'object') return out;
-  for (const key of ['temperature', 'top_p', 'top_k', 'repeat_penalty'] as Array<keyof SamplingParams>) {
+  for (const key of ['temperature', 'top_p', 'top_k', 'min_p', 'repeat_penalty'] as Array<keyof SamplingParams>) {
     const n = optionalNumberValue(params[key]);
     if (n !== undefined) out[key] = n;
   }
@@ -714,7 +716,8 @@ export function sanitizeModelTuning(raw: Partial<ModelTuning> | null | undefined
     recipe_options,
     sampling,
     ...(engine_hint ? { engine_hint } : {}),
-    source: raw?.source === 'user' ? 'user' : (raw?.source === 'model' ? 'model' : undefined),
+    source: raw?.source === 'user' || raw?.source === 'model' || raw?.source === 'optimized' ? raw.source : undefined,
+    ...(typeof raw?.auto_opt_run_id === 'string' && raw.auto_opt_run_id ? { auto_opt_run_id: raw.auto_opt_run_id } : {}),
     updated_at: typeof raw?.updated_at === 'string' ? raw.updated_at : undefined,
   };
 }
@@ -842,6 +845,22 @@ export function saveModelTuning(modelName: string, tuning: Partial<ModelTuning>,
   if (!modelName) return;
   const resolvedPresetId = presetId || activePresetIdForModelName(modelName);
   const sanitized = migrateLegacyConcreteIntentValues({ ...tuning, source: 'user', updated_at: new Date().toISOString() }, resolvedPresetId);
+  const next = { ...loadModelTunings() };
+  const key = modelPresetTuningKey(modelName, resolvedPresetId);
+  if (hasConcreteTuning(sanitized)) next[key] = sanitized;
+  else delete next[key];
+  saveModelTunings(next);
+}
+
+export function saveOptimizedModelTuning(modelName: string, tuning: Partial<ModelTuning>, presetId: string, autoOptRunId: string): void {
+  if (!modelName) return;
+  const resolvedPresetId = presetId || activePresetIdForModelName(modelName);
+  const sanitized = migrateLegacyConcreteIntentValues({
+    ...tuning,
+    source: 'optimized',
+    auto_opt_run_id: autoOptRunId,
+    updated_at: new Date().toISOString(),
+  }, resolvedPresetId);
   const next = { ...loadModelTunings() };
   const key = modelPresetTuningKey(modelName, resolvedPresetId);
   if (hasConcreteTuning(sanitized)) next[key] = sanitized;
@@ -1141,7 +1160,7 @@ function resolveIntentTranslations(
   };
 
   apply(builtIn, 'built-in');
-  apply(user, 'custom');
+  apply(user, user?.source === 'optimized' ? 'optimized' : 'custom');
   context.small = Math.min(maxContext, Math.max(1, context.small));
   if (context.medium < context.small) {
     context.medium = context.small;
@@ -1195,7 +1214,7 @@ function resolveModelTuning(
   };
 
   applyConcrete(builtIn, 'built-in');
-  applyConcrete(user, 'custom');
+  applyConcrete(user, user?.source === 'optimized' ? 'optimized' : 'custom');
 
   if (supportsIntent) {
     const contextHint = preset.context_hint || 'medium';
@@ -1217,7 +1236,8 @@ function resolveModelTuning(
       recipe_options: sanitizeRecipeOptions(recipe_options),
       sampling: sanitizeSamplingParams(sampling),
       engine_hint: user?.engine_hint || builtIn?.engine_hint || (activeRecipeName(model) as PresetRecipe) || 'auto',
-      source: user ? 'user' : 'model',
+      source: user ? (user.source === 'optimized' ? 'optimized' : 'user') : 'model',
+      ...(user?.auto_opt_run_id ? { auto_opt_run_id: user.auto_opt_run_id } : {}),
       updated_at: user?.updated_at,
     },
     preset_id: preset.id,
@@ -1508,7 +1528,7 @@ export function recipeOptionsForCapability(options: RecipeOptions, capability: M
     case 'omni':
     case 'vision':
     case 'code':
-      return pickRecipeOptions(options, ['ctx_size', 'llamacpp_backend', 'llamacpp_device', 'llamacpp_args', 'flm_args', 'vllm_backend', 'vllm_args', 'merge_args']);
+      return pickRecipeOptions(options, ['ctx_size', 'llamacpp_backend', 'llamacpp_device', 'llamacpp_args', 'mmproj_enabled', 'flm_args', 'vllm_backend', 'vllm_args', 'merge_args']);
     case 'all':
     default:
       return { ...options };

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -3822,6 +3822,467 @@ input, textarea {
   font-size: var(--text-xs);
 }
 
+/* ---------- AutoOpt: rail cards, wizard, run detail ---------- */
+
+.auto-run-card__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-3) var(--space-2);
+}
+
+.auto-run-card__delete-action {
+  margin-left: auto;
+  color: var(--danger) !important;
+}
+
+.auto-run-card--failed {
+  border-color: color-mix(in srgb, var(--danger) 45%, var(--border-subtle));
+}
+
+.auto-run-card--cancelled .auto-run-card__text strong {
+  color: var(--text-tertiary);
+}
+
+.autoopt-status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.autoopt-status-chip--failed { color: var(--danger); }
+.autoopt-status-chip--completed { color: var(--success); }
+.autoopt-status-chip--cancelled { color: var(--text-tertiary); }
+
+.autoopt-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+  flex-shrink: 0;
+}
+
+.autoopt-status-x {
+  color: var(--danger);
+  font-weight: var(--weight-semibold);
+}
+
+.autoopt-spinner {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--accent-fg);
+  animation: autoopt-spin 0.9s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes autoopt-spin {
+  to { transform: rotate(360deg); }
+}
+
+.slideover--wide {
+  width: min(680px, 94vw);
+}
+
+.scrim--autoopt-wizard { z-index: 52; }
+.slideover--autoopt-wizard { z-index: 53; }
+.scrim--autoopt-detail { z-index: 54; }
+.slideover--autoopt-detail { z-index: 55; }
+
+.autoopt-wizard__progress {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.autoopt-wizard__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--surface-3);
+  border: 1px solid var(--border-strong);
+}
+
+.autoopt-wizard__dot.is-active {
+  background: var(--accent-fg);
+  border-color: var(--accent-fg);
+}
+
+.autoopt-wizard__dot.is-done {
+  background: color-mix(in srgb, var(--accent) 45%, var(--surface-3));
+}
+
+.autoopt-wizard__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.autoopt-wizard__fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.autoopt-wizard__options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.autoopt-option {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-1);
+  color: var(--text-secondary);
+  transition: border-color var(--duration-fast) var(--ease-out), background var(--duration-fast) var(--ease-out);
+}
+
+.autoopt-option:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}
+
+.autoopt-option[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border-strong));
+  background: var(--accent-soft);
+}
+
+.autoopt-option strong {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.autoopt-option span {
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  color: var(--text-tertiary);
+}
+
+.autoopt-wizard__subfields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.autoopt-wizard__checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.autoopt-wizard__checkbox input {
+  margin-top: 3px;
+}
+
+.autoopt-wizard__checkbox--consent {
+  color: var(--text-primary);
+}
+
+.autoopt-wizard__footnote {
+  border-top: 1px dashed var(--border-subtle);
+  padding-top: var(--space-2);
+}
+
+.autoopt-suggestion-chip {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 2px var(--space-2);
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border-subtle));
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+}
+
+.autoopt-review {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-1) var(--space-4);
+  margin: 0;
+  font-size: var(--text-sm);
+}
+
+.autoopt-review dt {
+  color: var(--text-tertiary);
+}
+
+.autoopt-review dd {
+  margin: 0;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.autoopt-wizard__running {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.autoopt-wizard__running h3 {
+  margin: 0;
+}
+
+.autoopt-stage-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.autoopt-stage {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.autoopt-stage__marker {
+  width: 16px;
+  text-align: center;
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+}
+
+.autoopt-stage--completed .autoopt-stage__marker { color: var(--success); }
+.autoopt-stage--failed .autoopt-stage__marker { color: var(--danger); }
+.autoopt-stage--running { background: var(--surface-2); }
+.autoopt-stage--skipped { color: var(--text-tertiary); }
+
+.autoopt-stage__name {
+  color: var(--text-primary);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.autoopt-stage--skipped .autoopt-stage__name { color: var(--text-tertiary); }
+
+.autoopt-stage__duration,
+.autoopt-stage__status {
+  margin-left: auto;
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.autoopt-stage__duration + .autoopt-stage__status {
+  margin-left: var(--space-2);
+}
+
+.autoopt-stage__error {
+  flex-basis: 100%;
+  color: var(--danger);
+  font-size: var(--text-xs);
+}
+
+.autoopt-stage__note {
+  flex-basis: 100%;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}
+
+.autoopt-detail__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.autoopt-detail__error {
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--border-subtle));
+  border-radius: var(--radius-lg);
+  background: var(--danger-soft);
+}
+
+.autoopt-detail__notice {
+  min-height: 1.2em;
+  margin: 0;
+  color: var(--success);
+  font-size: var(--text-sm);
+}
+
+.autoopt-detail__cta-help {
+  margin: 0;
+  padding: var(--space-2) var(--space-5) 0;
+}
+
+.autoopt-rec-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-1);
+}
+
+.autoopt-rec-card__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.autoopt-rec-card__head strong {
+  color: var(--text-primary);
+}
+
+.autoopt-rec-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.autoopt-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  white-space: nowrap;
+}
+
+.autoopt-rec-card__args {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
+.autoopt-rec-card__args code {
+  flex: 1;
+  display: block;
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  background: var(--surface-3);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.autoopt-rec-card__rationale {
+  margin: 0;
+  padding-left: var(--space-4);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.autoopt-alt-table-wrap {
+  overflow-x: auto;
+}
+
+.autoopt-alt-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-xs);
+}
+
+.autoopt-alt-table th,
+.autoopt-alt-table td {
+  padding: var(--space-1) var(--space-2);
+  text-align: left;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.autoopt-alt-table th {
+  color: var(--text-tertiary);
+  font-weight: var(--weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
+  font-size: 10px;
+}
+
+.autoopt-alt-table tr.is-selected td {
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
+.autoopt-preset-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 2px var(--space-2);
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border-subtle));
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.autoopt-preset-chip:hover {
+  border-color: var(--accent-fg);
+}
+
+.recipe-card__linked,
+.preset-linked-note {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 1px var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  align-self: flex-start;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preset-linked-note {
+  padding: 2px var(--space-2);
+}
+
+.recipe-card__linked--optimized,
+.preset-linked-note--optimized {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-subtle));
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}
+
+.recipe-card--flash {
+  animation: autoopt-card-flash 1.2s ease-out 3;
+}
+
+@keyframes autoopt-card-flash {
+  0% {
+    border-color: var(--accent-fg);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 40%, transparent);
+  }
+  100% {
+    border-color: var(--border-subtle);
+    box-shadow: none;
+  }
+}
+
 .cell--selectable {
   position: relative; /* needed for overlay select button */
   cursor: pointer;

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -805,11 +805,32 @@ test.describe('Accessibility — capability chip toggle-button semantics (#2350)
 // ─── 14. AutoOpt run selection state — issue #2352 ───────────────────────────
 
 test.describe('Accessibility — AutoOpt run selection state (#2352)', () => {
+  const mockAutoOpt = async (page: Page) => {
+    await page.route('**/api/v1/health**', route => route.fulfill({
+      json: { status: 'ok', version: 'test', all_models_loaded: [] },
+    }));
+    // AutoOpt runs are client-persisted and scoped to the server's base URL.
+    await page.addInitScript(() => {
+      const base = {
+        checkpoint: '', answers: { parallel: { mode: 'single' }, kv_cache_quant: 'none', ram_headroom: 'normal', allow_network: true },
+        allow_unload: false, stages: [], measurements: { fit: [], bench: [] },
+      };
+      localStorage.setItem('lemonade_autoopt_runs_v2::http://127.0.0.1:13305', JSON.stringify({
+        version: 2,
+        runs: [
+          { ...base, id: 'run-b', model: 'org/model-b', status: 'completed', budget: 'standard', created_at: '2026-07-02T10:00:00Z', finished_at: '2026-07-02T10:12:00Z' },
+          { ...base, id: 'run-a', model: 'org/model-a', status: 'completed', budget: 'quick', created_at: '2026-07-01T10:00:00Z', finished_at: '2026-07-01T10:01:00Z' },
+        ],
+      }));
+    });
+  };
+
   test('A44 — AutoOpt run buttons expose selected state via aria-pressed', async ({ page }) => {
+    await mockAutoOpt(page);
     await page.goto('/');
     await page.waitForSelector('.titlebar__nav');
     await navigateToView(page, 'Presets');
-    await page.waitForSelector('.auto-run-list');
+    await page.waitForSelector('.auto-run-card__main', { timeout: 10000 });
 
     const buttons = page.locator('.auto-run-card__main');
     const count = await buttons.count();
@@ -823,10 +844,11 @@ test.describe('Accessibility — AutoOpt run selection state (#2352)', () => {
   });
 
   test('A45 — clicking a different AutoOpt run updates aria-pressed to true on that button', async ({ page }) => {
+    await mockAutoOpt(page);
     await page.goto('/');
     await page.waitForSelector('.titlebar__nav');
     await navigateToView(page, 'Presets');
-    await page.waitForSelector('.auto-run-list');
+    await page.waitForSelector('.auto-run-card__main', { timeout: 10000 });
 
     const buttons = page.locator('.auto-run-card__main');
     // Click the second button (index 1) to change selection
@@ -839,6 +861,89 @@ test.describe('Accessibility — AutoOpt run selection state (#2352)', () => {
     // First button must now be false
     const firstPressed = await buttons.nth(0).getAttribute('aria-pressed');
     expect(firstPressed).toBe('false');
+  });
+
+  test('A45b — AutoOpt rail exposes a polite live region for run completion announcements', async ({ page }) => {
+    await mockAutoOpt(page);
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await navigateToView(page, 'Presets');
+
+    const liveRegion = page.locator('[data-autoopt-announcement]');
+    await expect(liveRegion).toHaveAttribute('role', 'status');
+    await expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+  });
+});
+
+// ─── 14b. AutoOpt wizard dialog — semantics, focus trap, fieldsets ─────────────
+
+test.describe('Accessibility — AutoOpt wizard dialog', () => {
+  const openWizard = async (page: Page) => {
+    await page.route('**/api/v1/health**', route => route.fulfill({
+      json: { status: 'ok', version: 'test', all_models_loaded: [] },
+    }));
+    await page.route('**/api/v1/models**', route => route.fulfill({
+      json: { data: [{ id: 'org/chat-model', name: 'org/chat-model', labels: ['llm'], recipe: 'llamacpp', downloaded: true }] },
+    }));
+    await page.route('**/api/v1/system-info**', route => route.fulfill({
+      json: { 'Physical Memory': '64.0 GB', recipes: { llamacpp: { default_backend: 'cpu', backends: { cpu: { state: 'installed' } } } } },
+    }));
+    await page.goto('/');
+    await page.waitForSelector('.titlebar__nav');
+    await navigateToView(page, 'Presets');
+    await page.locator('[data-autoopt-run-optimizer]').click();
+    await page.waitForSelector('[data-autoopt-wizard]', { timeout: 5000 });
+  };
+
+  test('A46 — wizard is a modal dialog and moves focus inside', async ({ page }) => {
+    await openWizard(page);
+
+    const wizard = page.locator('[data-autoopt-wizard]');
+    await expect(wizard).toHaveAttribute('role', 'dialog');
+    await expect(wizard).toHaveAttribute('aria-modal', 'true');
+
+    const activeIsInWizard = await page.evaluate(() => {
+      const dialog = document.querySelector('[data-autoopt-wizard]');
+      return dialog?.contains(document.activeElement) ?? false;
+    });
+    expect(activeIsInWizard).toBe(true);
+  });
+
+  test('A47 — Tab never escapes the wizard dialog', async ({ page }) => {
+    await openWizard(page);
+
+    const count = await page.locator(
+      '[data-autoopt-wizard] :is(a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]))',
+    ).evaluateAll(els => els.filter(el => !el.closest('[aria-hidden="true"]')).length);
+
+    for (let i = 0; i < count + 2; i++) {
+      await page.keyboard.press('Tab');
+    }
+
+    const activeIsInWizard = await page.evaluate(() => {
+      const dialog = document.querySelector('[data-autoopt-wizard]');
+      return dialog?.contains(document.activeElement) ?? false;
+    });
+    expect(activeIsInWizard, 'Focus should stay inside the wizard after wrapping').toBe(true);
+  });
+
+  test('A48 — every wizard step is a fieldset with a legend', async ({ page }) => {
+    await openWizard(page);
+
+    await page.locator('[data-autoopt-model-select]').selectOption('org/chat-model');
+    const stepOrder = ['model', 'parallel', 'kv', 'ram', 'budget', 'review'];
+    for (const step of stepOrder) {
+      const fieldset = page.locator(`fieldset[data-autoopt-step="${step}"]`);
+      await expect(fieldset).toBeVisible();
+      await expect(fieldset.locator('legend')).toBeVisible();
+      if (step !== 'review') await page.locator('[data-autoopt-next]').click();
+    }
+  });
+
+  test('A49 — Escape closes the wizard', async ({ page }) => {
+    await openWizard(page);
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-autoopt-wizard]')).toHaveCount(0);
   });
 });
 

--- a/prototype/ui-redesign/tests/autoopt-glue.runtime.cjs
+++ b/prototype/ui-redesign/tests/autoopt-glue.runtime.cjs
@@ -1,0 +1,182 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const webpack = require('webpack');
+
+async function bundlePresetStore() {
+  const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), 'lemonade-autoopt-glue-'));
+  const config = {
+    mode: 'development',
+    target: 'node',
+    entry: path.resolve(__dirname, '../src/presetStore.ts'),
+    output: {
+      path: outputPath,
+      filename: 'presetStore.cjs',
+      library: { type: 'commonjs2' },
+    },
+    resolve: { extensions: ['.ts', '.tsx', '.js'] },
+    module: {
+      rules: [{ test: /\.tsx?$/, use: 'ts-loader', exclude: /node_modules/ }],
+    },
+    optimization: { minimize: false },
+  };
+
+  await new Promise((resolve, reject) => {
+    webpack(config, (error, stats) => {
+      if (error) return reject(error);
+      if (stats?.hasErrors()) return reject(new Error(stats.toString({ all: false, errors: true })));
+      resolve();
+    });
+  });
+
+  return { outputPath, modulePath: path.join(outputPath, 'presetStore.cjs') };
+}
+
+function installBrowserStorageShim() {
+  const storage = new Map();
+  global.localStorage = {
+    getItem: key => storage.has(key) ? storage.get(key) : null,
+    setItem: (key, value) => storage.set(key, String(value)),
+    removeItem: key => storage.delete(key),
+    clear: () => storage.clear(),
+  };
+  global.CustomEvent = class CustomEvent {
+    constructor(type) { this.type = type; }
+  };
+  global.window = { dispatchEvent() {} };
+  return storage;
+}
+
+(async () => {
+  const { outputPath, modulePath } = await bundlePresetStore();
+  const storage = installBrowserStorageShim();
+
+  try {
+    const presets = require(modulePath);
+
+    assert.deepEqual(
+      presets.sanitizeSamplingParams({ temperature: 0.7, top_p: 0.9, min_p: 0.03, bogus: 5 }),
+      { temperature: 0.7, top_p: 0.9, min_p: 0.03 },
+      'min_p must survive sampling sanitization',
+    );
+    assert.deepEqual(
+      presets.sanitizeRecipeOptions({ mmproj_enabled: false, llamacpp_args: '-b 512' }),
+      { mmproj_enabled: false, llamacpp_args: '-b 512' },
+      'mmproj_enabled=false must survive recipe-option sanitization',
+    );
+
+    const codePreset = presets.STARTERS.find(preset => preset.id === 's-code');
+    assert.ok(codePreset);
+    const model = {
+      id: 'opt-model',
+      name: 'opt-model',
+      labels: ['llm', 'coding'],
+      recipe: 'llamacpp',
+      ctx_size: 4096,
+      max_context_window: 12288,
+    };
+
+    presets.saveOptimizedModelTuning('opt-model', {
+      recipe_options: { ctx_size: 8192, llamacpp_backend: 'vulkan', llamacpp_args: '-b 512 -ub 256', mmproj_enabled: false },
+      sampling: { temperature: 0.7, min_p: 0.05 },
+    }, codePreset.id, 'run-123');
+
+    const stored = presets.loadModelTuning('opt-model', codePreset.id);
+    assert.equal(stored.source, 'optimized');
+    assert.equal(stored.auto_opt_run_id, 'run-123');
+    assert.equal(stored.sampling.min_p, 0.05);
+    assert.equal(stored.recipe_options.mmproj_enabled, false);
+    assert.equal(stored.recipe_options.llamacpp_backend, 'vulkan');
+
+    let resolved = presets.resolvedModelTuningForPreset('opt-model', model, codePreset);
+    assert.equal(resolved.tuning.source, 'optimized');
+    assert.equal(resolved.tuning.auto_opt_run_id, 'run-123');
+    assert.equal(resolved.tuning.recipe_options.ctx_size, 8192);
+    assert.equal(resolved.tuning.recipe_options.llamacpp_args, '-b 512 -ub 256');
+    assert.equal(resolved.tuning.recipe_options.mmproj_enabled, false);
+    assert.equal(resolved.tuning.sampling.temperature, 0.7);
+    assert.equal(resolved.tuning.sampling.min_p, 0.05);
+    assert.equal(resolved.sources.recipe_options.ctx_size, 'optimized');
+    assert.equal(resolved.sources.recipe_options.llamacpp_args, 'optimized');
+    assert.equal(resolved.sources.recipe_options.mmproj_enabled, 'optimized');
+    assert.equal(resolved.sources.sampling.temperature, 'optimized');
+    assert.equal(resolved.sources.sampling.min_p, 'optimized');
+
+    presets.saveModelTuning('opt-model', {
+      recipe_options: { llamacpp_args: '-b 256' },
+      sampling: { min_p: 0.02 },
+    }, codePreset.id);
+
+    const downgraded = presets.loadModelTuning('opt-model', codePreset.id);
+    assert.equal(downgraded.source, 'user', 'manual save must downgrade optimized tuning to user');
+    assert.equal(downgraded.auto_opt_run_id, undefined);
+    assert.equal(downgraded.sampling.min_p, 0.02);
+
+    resolved = presets.resolvedModelTuningForPreset('opt-model', model, codePreset);
+    assert.equal(resolved.tuning.source, 'user');
+    assert.equal(resolved.tuning.auto_opt_run_id, undefined);
+    assert.equal(resolved.sources.recipe_options.llamacpp_args, 'custom');
+    assert.equal(resolved.sources.sampling.min_p, 'custom');
+
+    storage.clear();
+    presets.saveOptimizedModelTuning('opt-model', {
+      recipe_options: { ctx_size: 8192, llamacpp_args: '-b 512' },
+      sampling: {},
+    }, codePreset.id, 'run-456');
+    presets.saveApplied({ 'opt-model': codePreset.id });
+    const loadOptions = presets.recipeOptionsForModel('opt-model', model);
+    assert.equal(loadOptions.ctx_size, 8192, 'optimized ctx_size must flow into load options');
+    assert.equal(loadOptions.llamacpp_args, '-b 512');
+
+    // createPresetFromRun path: a recommended ctx BELOW the model maximum
+    // (e.g. clamped to 65536 on a 262144 model) maps to an editable hint and
+    // resolves the optimizer's exact ctx with source 'optimized'.
+    storage.clear();
+    const bigModel = {
+      id: 'big-model',
+      name: 'big-model',
+      labels: ['llm'],
+      recipe: 'llamacpp',
+      ctx_size: 4096,
+      max_context_window: 262144,
+      downloaded: true,
+    };
+    const hint = presets.contextHintFromValue(65536, presets.modelContextSize(bigModel));
+    assert.equal(hint, 'medium', 'a below-max optimized ctx must map to an editable hint');
+    const aoPreset = presets.sanitizePreset({
+      id: 'u-autoopt-ctx',
+      name: 'AutoOpt · big-model',
+      description: '',
+      applies_to: ['chat'],
+      temperature_hint: 'balanced',
+      context_hint: hint,
+      thinking_mode: 'normal',
+      recipe_options: {},
+      sampling: {},
+      engine_hint: 'llamacpp',
+      starter: false,
+      auto_opt_run_id: 'run-ctx',
+      auto_opt_enabled: true,
+    });
+    presets.saveUserPresets([aoPreset]);
+    presets.saveApplied({ 'big-model': aoPreset.id });
+    presets.saveOptimizedModelTuning('big-model', {
+      recipe_options: { ctx_size: 65536, llamacpp_backend: 'vulkan', llamacpp_args: '-b 2048 -ub 2048' },
+      sampling: {},
+    }, aoPreset.id, 'run-ctx');
+    const resolvedBig = presets.resolvedModelTuningForPreset('big-model', bigModel, aoPreset);
+    assert.equal(resolvedBig.tuning.recipe_options.ctx_size, 65536,
+      'the optimizer ctx must survive intent migration exactly');
+    assert.equal(resolvedBig.sources.recipe_options.ctx_size, 'optimized');
+    assert.equal(resolvedBig.tuning.source, 'optimized');
+    assert.equal(presets.recipeOptionsForModel('big-model', bigModel).ctx_size, 65536);
+
+    console.log('AutoOpt glue runtime tests passed.');
+  } finally {
+    fs.rmSync(outputPath, { recursive: true, force: true });
+  }
+})().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/prototype/ui-redesign/tests/autoopt-store-scope.runtime.cjs
+++ b/prototype/ui-redesign/tests/autoopt-store-scope.runtime.cjs
@@ -1,0 +1,158 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const webpack = require('webpack');
+
+const KEY_A = 'lemonade_autoopt_runs_v2::http://server-a:1111';
+const KEY_B = 'lemonade_autoopt_runs_v2::http://server-b:2222';
+
+function installLocalStorage() {
+  const store = new Map();
+  global.localStorage = {
+    getItem: k => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => { store.set(k, String(v)); },
+    removeItem: k => { store.delete(k); },
+    _dump: () => store,
+  };
+  return store;
+}
+
+function baseRun(id, extra) {
+  return {
+    id,
+    model: 'org/chat-model',
+    checkpoint: 'org/chat-model-GGUF:Q4_K_M',
+    budget: 'standard',
+    answers: { parallel: { mode: 'single' }, kv_cache_quant: 'none', ram_headroom: 'normal', allow_network: true },
+    allow_unload: true,
+    status: 'completed',
+    created_at: '2026-07-15T10:00:00Z',
+    finished_at: '2026-07-15T10:10:00Z',
+    summary: 'vulkan · ctx 32768',
+    stages: [],
+    measurements: { fit: [], bench: [] },
+    ...extra,
+  };
+}
+
+const SYNTH_INPUTS = {
+  hardware: { gpus: [], has_igpu: true, ram_is_vram: true, host_ram_gb: 64, installed_backends: ['vulkan'], os: 'linux' },
+  facts: { architecture: 'qwen3', block_count: 36, expert_count: 0, full_attention_interval: 0, swa_layer_count: 0, n_ctx_train: 32768, kv_bytes_per_token: 90112, weights_mib: 4096, is_moe: false, is_hybrid_or_recurrent: false, has_mtp: false, base_model_repo: '', checkpoint: '', metadata_present: true },
+  fits: [],
+  plan: [],
+  step_labels: {},
+};
+
+async function bundleStore() {
+  const srcDir = path.resolve(__dirname, '../src');
+  const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), 'lemonade-autoopt-store-'));
+  const apiStub = path.resolve(__dirname, 'stubs/autoOptApiStub.js');
+  const ctrlStub = path.resolve(__dirname, 'stubs/autoOptControllerStub.js');
+
+  const config = {
+    mode: 'development',
+    target: 'node',
+    entry: path.resolve(srcDir, 'features/autoOpt/autoOptStore.ts'),
+    output: { path: outputPath, filename: 'autoOptStore.cjs', library: { type: 'commonjs2' } },
+    resolve: { extensions: ['.ts', '.tsx', '.js'] },
+    module: { rules: [{ test: /\.tsx?$/, use: 'ts-loader', exclude: /node_modules/ }] },
+    optimization: { minimize: false },
+    plugins: [
+      new webpack.NormalModuleReplacementPlugin(/^\.\.\/\.\.\/api$/, apiStub),
+      new webpack.NormalModuleReplacementPlugin(/^\.\/autoOptController$/, ctrlStub),
+    ],
+  };
+
+  await new Promise((resolve, reject) => {
+    webpack(config, (error, stats) => {
+      if (error) return reject(error);
+      if (stats?.hasErrors()) return reject(new Error(stats.toString({ all: false, errors: true })));
+      resolve();
+    });
+  });
+
+  return { outputPath, modulePath: path.join(outputPath, 'autoOptStore.cjs') };
+}
+
+let failures = 0;
+function check(name, ok) {
+  console.log(`[${ok ? 'PASS' : 'FAIL'}] ${name}`);
+  if (!ok) failures += 1;
+}
+
+const tick = () => new Promise(resolve => setImmediate(resolve));
+
+(async () => {
+  const lsStore = installLocalStorage();
+  globalThis.__AO_INITIAL_BASE__ = 'http://server-a:1111';
+
+  // Seed server A (one in-flight run to reattach + one completed) and server B (one completed).
+  lsStore.set(KEY_A, JSON.stringify({ version: 2, runs: [
+    baseRun('ao-a-live', { status: 'running', finished_at: undefined, summary: undefined, job_id: 'job-a-live', synth_inputs: SYNTH_INPUTS }),
+    baseRun('ao-a-done'),
+  ] }));
+  lsStore.set(KEY_B, JSON.stringify({ version: 2, runs: [baseRun('ao-b-done')] }));
+
+  const { outputPath, modulePath } = await bundleStore();
+
+  try {
+    const { autoOptStore } = require(modulePath);
+    const ctrl = globalThis.__AO_CTRL__;
+    const apiControl = globalThis.__AO_API_CONTROL__;
+    const idsOf = () => autoOptStore.snapshot().runs.map(r => r.id).sort();
+    const storedIds = (key) => JSON.parse(lsStore.get(key)).runs.map(r => r.id).sort();
+
+    // Initial scope = A: A's runs are visible and the in-flight run is reattached.
+    check('scope: server A runs loaded', JSON.stringify(idsOf()) === JSON.stringify(['ao-a-done', 'ao-a-live']));
+    const aLive = ctrl.attached.find(a => a.id === 'ao-a-live');
+    check('scope: A in-flight job reattached', !!aLive);
+    check('scope: A poller not yet aborted', aLive && aLive.signal.aborted === false);
+
+    // Defect #2: baseUrl changes to B WITHOUT a status event (loadConnectionSettings path),
+    // so the scope generation is still gen-0. A stale A poller that writes now must land in
+    // A's CAPTURED key, never B's.
+    apiControl.setBaseSilent('http://server-b:2222');
+    ctrl.fire('ao-a-live');
+    await tick();
+    check('gen0-race: B key never overwritten by A', JSON.stringify(storedIds(KEY_B)) === JSON.stringify(['ao-b-done']));
+    check('gen0-race: A write landed in A key', JSON.stringify(storedIds(KEY_A)) === JSON.stringify(['ao-a-done', 'ao-a-live']));
+    // (bring live base back to A so the explicit switch below is a real A->B transition)
+    apiControl.setBaseSilent('http://server-a:1111');
+
+    // Switch A -> B (explicit, fires a status event).
+    apiControl.setBase('http://server-b:2222');
+    await tick();
+
+    check('switch: server B runs now shown', JSON.stringify(idsOf()) === JSON.stringify(['ao-b-done']));
+    check('switch: A runs no longer in memory', !idsOf().includes('ao-a-live'));
+    check('switch: A poller aborted', aLive && aLive.signal.aborted === true);
+    check('switch: activeRunId reset', autoOptStore.snapshot().activeRunId === null);
+
+    // Defect #3: switching servers must NOT interrupt the job (it keeps running on its own server);
+    // only the local poller is aborted.
+    check('switch: job NOT interrupted', apiControl.interruptCalls.length === 0);
+
+    // No cross-write on the explicit switch either.
+    check('no-cross-write: B key holds only B runs', JSON.stringify(storedIds(KEY_B)) === JSON.stringify(['ao-b-done']));
+    check('no-cross-write: A key intact', JSON.stringify(storedIds(KEY_A)) === JSON.stringify(['ao-a-done', 'ao-a-live']));
+
+    // Switching back to A restores A's runs and reattaches its in-flight job.
+    apiControl.setBase('http://server-a:1111');
+    await tick();
+    check('switch-back: A runs restored', JSON.stringify(idsOf()) === JSON.stringify(['ao-a-done', 'ao-a-live']));
+
+    // Defect #3: explicit user cancel DOES interrupt the job.
+    autoOptStore.cancelRun('ao-a-live');
+    await tick();
+    check('cancel: job interrupted', apiControl.interruptCalls.includes('job-a-live'));
+
+    if (failures > 0) throw new Error(`${failures} store-scope checks failed`);
+    console.log('\nAutoOpt store server-scope runtime tests passed.');
+  } finally {
+    fs.rmSync(outputPath, { recursive: true, force: true });
+  }
+})().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/prototype/ui-redesign/tests/autoopt-synthesize.runtime.cjs
+++ b/prototype/ui-redesign/tests/autoopt-synthesize.runtime.cjs
@@ -523,6 +523,18 @@ function check(name, ok) {
         // Per-backend load args: rocm gets --direct-io in BOTH the bench and the recommendation.
         check('r2#2: shared builder emits rocm --direct-io',
           backendLoadArgs(igpuHw(), 'rocm-stable', partialFit, denseModel(), 'none').includes('--direct-io'));
+
+        // ── round-3 #2: the deep probe loads at the recommended ctx, not a larger one ──
+        const fitMid = fitting('vulkan', 8192, { fits_fully: true, fitted_ctx: 8192 });
+        const recipeMid = buildBenchRecipe([fitMid], ansNo, igpuHw(), denseModel(), 'org/m', 'standard', ['vulkan']);
+        const recMid = synthesize(igpuHw(), denseModel(), ansNo, [fitMid], [], undefined);
+        const deepStep = recipeMid.steps.find(s => /^load_vulkan_d\d+$/.test(s.id) && s.id !== 'load_vulkan_d0');
+        const deepPlan = recipeMid.plan.find(e => (e.params.d ?? 0) > 0 && e.backend === 'vulkan');
+        check('r3#2: a deep probe exists', !!deepStep && !!deepPlan);
+        check('r3#2: deep probe loads at the recommended ctx, not larger',
+          deepStep.params.ctx_size === recMid.primary.ctx_size);
+        check('r3#2: deep prompt depth fits inside the recommended ctx',
+          deepPlan.params.d < recMid.primary.ctx_size);
       } finally {
         fs.rmSync(recipeBundle.outputPath, { recursive: true, force: true });
       }
@@ -540,13 +552,19 @@ function check(name, ok) {
       };
       check('r2#1: cuda fitted vs NVIDIA VRAM', Math.abs(availableMibForBackend(mixed, 'cuda') - 24 * 0.92 * 1024) < 1);
       check('r2#1: rocm fitted vs AMD budget', Math.abs(availableMibForBackend(mixed, 'rocm') - 100 * 0.92 * 1024) < 1);
-      check('r2#1: vulkan follows the AMD budget when AMD present',
-        availableMibForBackend(mixed, 'vulkan') === availableMibForBackend(mixed, 'rocm'));
       check('r2#1: cuda budget differs from rocm budget on a mixed box',
         availableMibForBackend(mixed, 'cuda') !== availableMibForBackend(mixed, 'rocm'));
 
+      // round-3 #3: vulkan is budgeted conservatively (smallest pool) on a mixed-vendor box.
+      check('r3#3: vulkan uses the conservative (smaller) pool on a mixed box',
+        Math.abs(availableMibForBackend(mixed, 'vulkan') - 24 * 0.92 * 1024) < 1);
+      check('r3#3: vulkan budget is smaller than the AMD rocm budget on a mixed box',
+        availableMibForBackend(mixed, 'vulkan') < availableMibForBackend(mixed, 'rocm'));
+
       const apu = { gpus: [{ vendor: 'amd', name: 'APU', family: 'gfx1151', vram_gb: 96 }], has_igpu: true, ram_is_vram: true, host_ram_gb: 128, installed_backends: ['rocm', 'vulkan'], os: 'linux' };
       check('r2#1: unified APU rocm uses 0.9x host RAM', Math.abs(availableMibForBackend(apu, 'rocm') - 128 * 0.9 * 1024) < 1);
+      check('r3#3: single-vendor APU vulkan matches rocm (AMD unified)',
+        availableMibForBackend(apu, 'vulkan') === availableMibForBackend(apu, 'rocm'));
     }
 
     // ── round-2 #3: a backend that FAILS the deep run cannot win the duel ──
@@ -572,6 +590,43 @@ function check(name, ok) {
       const rs = synthesize(igpuHw(), denseModel(), answers(),
         [fitting('vulkan', 65536), fitting('rocm-stable', 65536)], shallow, undefined);
       check('r2#3: no deep runs → depth-0 winner stands', rs.primary.llamacpp_backend === 'vulkan');
+
+      // round-3 #2 (synthesize): a backend whose deep run SUCCEEDS is not disqualified and wins.
+      const okDeep = [
+        dp('vulkan', 0, true, 90), dp('vulkan', 6553, true, 85),
+        dp('rocm-stable', 0, true, 40), dp('rocm-stable', 6553, true, 38),
+      ];
+      const rOk = synthesize(igpuHw(), denseModel(), answers(),
+        [fitting('vulkan', 8192), fitting('rocm-stable', 8192)], okDeep, undefined);
+      check('r3#2: backend that runs the recommended-ctx deep run wins', rOk.primary.llamacpp_backend === 'vulkan');
+    }
+
+    // ── round-3 #1: MTP/ladder tuning comes from the DUEL WINNER, not candidates[0] ──
+    {
+      const mk = (backend, extra) => ({
+        backend, label: backend, ctx_size: 4096, llamacpp_args: '',
+        ttft_ms: 100, tps: 40, vram_gb: 20, ok: true, params: { d: 0 }, ...extra,
+      });
+      const bench = [
+        mk('vulkan', { tps: 40 }),
+        mk('rocm-stable', { tps: 80 }),
+        mk('vulkan', { params: { spec_n: 2 }, tps: 200 }),
+        mk('vulkan', { params: { spec_n: 3 }, tps: 40 }),
+        mk('rocm-stable', { params: { spec_n: 5 }, tps: 95 }),
+        mk('rocm-stable', { params: { spec_n: 2 }, tps: 30 }),
+        mk('vulkan', { params: { ladder: true, b: 512, ub: 512 }, ttft_ms: 100 }),
+        mk('vulkan', { params: { ladder: true, b: 2048, ub: 2048 }, ttft_ms: 70 }),
+        mk('rocm-stable', { params: { ladder: true, b: 512, ub: 512 }, ttft_ms: 100 }),
+        mk('rocm-stable', { params: { ladder: true, b: 4096, ub: 4096 }, ttft_ms: 55 }),
+      ];
+      const mtpModel = { ...denseModel(), has_mtp: true };
+      const r = synthesize(igpuHw(), mtpModel, answers(),
+        [fitting('vulkan', 65536), fitting('rocm-stable', 65536)], bench, undefined);
+      check('r3#1: duel winner is rocm-stable (not candidates[0])', r.primary.llamacpp_backend === 'rocm-stable');
+      check('r3#1: MTP draft length comes from the winner (n=5)', r.primary.llamacpp_args.includes('--spec-draft-n-max 5'));
+      check('r3#1: MTP not taken from candidates[0] (n=2)', !r.primary.llamacpp_args.includes('--spec-draft-n-max 2'));
+      check('r3#1: batch size comes from the winner (b=4096)', r.primary.llamacpp_args.includes('-b 4096 -ub 4096'));
+      check('r3#1: batch not taken from candidates[0] (b=2048)', !r.primary.llamacpp_args.includes('-b 2048'));
     }
 
     if (failures > 0) {

--- a/prototype/ui-redesign/tests/autoopt-synthesize.runtime.cjs
+++ b/prototype/ui-redesign/tests/autoopt-synthesize.runtime.cjs
@@ -175,7 +175,7 @@ function check(name, ok) {
     const engine = require(modulePath);
     const {
       synthesize, checkpointRepoId, computeFitEstimate, benchScore, roundUpCtx,
-      selectCandidates, availableMib, NO_GPU_BACKEND_ERROR,
+      selectCandidates, availableMib, availableMibForBackend, backendLoadArgs, NO_GPU_BACKEND_ERROR,
     } = engine;
 
     // ── checkpoint_repo_id ────────────────────────────────────────────
@@ -482,7 +482,7 @@ function check(name, ok) {
         const ans = answers({ kv_cache_quant: 'q8_0' });
 
         const rec = synthesize(igpuHw(), mf, ans, [fit], [], undefined);
-        const recipe = buildBenchRecipe(fit, ans, igpuHw(), mf, 'org/m', 'standard', ['vulkan']);
+        const recipe = buildBenchRecipe([fit], ans, igpuHw(), mf, 'org/m', 'standard', ['vulkan']);
         const load0 = recipe.steps.find(s => s.id === 'load_vulkan_d0');
         const benchedCtx = load0 && load0.params && load0.params.ctx_size;
 
@@ -502,9 +502,76 @@ function check(name, ok) {
         };
         const capped = synthesize(igpuHw(), mf, ans, [fit], [fellBack], undefined);
         check('#1: failed quant-scaled load falls back to the loaded ctx', capped.primary.ctx_size === 2048);
+
+        // ── round-2 #2: the bench loads the SAME placement flags that get recommended ──
+        const partialFit = fitting('vulkan', 4096, { fits_fully: false, fitted_ngl: 18, fitted_ncmoe: 0, fitted_ctx: 4096 });
+        const ansNo = answers({ kv_cache_quant: 'none' });
+        const recPartial = synthesize(igpuHw(), denseModel(), ansNo, [partialFit], [], undefined);
+        const recipePartial = buildBenchRecipe([partialFit], ansNo, igpuHw(), denseModel(), 'org/m', 'standard', ['vulkan']);
+        const load0p = recipePartial.steps.find(s => s.id === 'load_vulkan_d0');
+        check('r2#2: recommendation includes -ngl placement', recPartial.primary.llamacpp_args.includes('-ngl 18'));
+        check('r2#2: benched load carries the same -ngl placement', String(load0p.params.llamacpp_args).includes('-ngl 18'));
+
+        const moeFit = fitting('vulkan', 4096, { fits_fully: false, fitted_ngl: -1, fitted_ncmoe: 10, fitted_ctx: 4096 });
+        const moeModel = { ...denseModel(), is_moe: true, expert_count: 128 };
+        const recMoe = synthesize(igpuHw(), moeModel, ansNo, [moeFit], [], undefined);
+        const recipeMoe = buildBenchRecipe([moeFit], ansNo, igpuHw(), moeModel, 'org/m', 'standard', ['vulkan']);
+        const load0m = recipeMoe.steps.find(s => s.id === 'load_vulkan_d0');
+        check('r2#2: recommendation includes --n-cpu-moe placement', recMoe.primary.llamacpp_args.includes('--n-cpu-moe 10'));
+        check('r2#2: benched load carries the same --n-cpu-moe placement', String(load0m.params.llamacpp_args).includes('--n-cpu-moe 10'));
+
+        // Per-backend load args: rocm gets --direct-io in BOTH the bench and the recommendation.
+        check('r2#2: shared builder emits rocm --direct-io',
+          backendLoadArgs(igpuHw(), 'rocm-stable', partialFit, denseModel(), 'none').includes('--direct-io'));
       } finally {
         fs.rmSync(recipeBundle.outputPath, { recursive: true, force: true });
       }
+    }
+
+    // ── round-2 #1: memory is accounted PER backend / device group ────
+    {
+      const mixed = {
+        gpus: [
+          { vendor: 'amd', name: 'APU', family: 'gfx1151', vram_gb: 100 },
+          { vendor: 'nvidia', name: 'RTX 4090', family: 'sm_89', vram_gb: 24 },
+        ],
+        has_igpu: true, ram_is_vram: false, host_ram_gb: 110,
+        installed_backends: ['vulkan', 'rocm', 'cuda'], os: 'linux',
+      };
+      check('r2#1: cuda fitted vs NVIDIA VRAM', Math.abs(availableMibForBackend(mixed, 'cuda') - 24 * 0.92 * 1024) < 1);
+      check('r2#1: rocm fitted vs AMD budget', Math.abs(availableMibForBackend(mixed, 'rocm') - 100 * 0.92 * 1024) < 1);
+      check('r2#1: vulkan follows the AMD budget when AMD present',
+        availableMibForBackend(mixed, 'vulkan') === availableMibForBackend(mixed, 'rocm'));
+      check('r2#1: cuda budget differs from rocm budget on a mixed box',
+        availableMibForBackend(mixed, 'cuda') !== availableMibForBackend(mixed, 'rocm'));
+
+      const apu = { gpus: [{ vendor: 'amd', name: 'APU', family: 'gfx1151', vram_gb: 96 }], has_igpu: true, ram_is_vram: true, host_ram_gb: 128, installed_backends: ['rocm', 'vulkan'], os: 'linux' };
+      check('r2#1: unified APU rocm uses 0.9x host RAM', Math.abs(availableMibForBackend(apu, 'rocm') - 128 * 0.9 * 1024) < 1);
+    }
+
+    // ── round-2 #3: a backend that FAILS the deep run cannot win the duel ──
+    {
+      const dp = (backend, depth, ok, tps) => ({
+        backend, label: `${backend} d${depth}`, ctx_size: depth > 0 ? 32768 : 4096, llamacpp_args: '',
+        params: { d: depth }, ttft_ms: ok ? 100 : 0, tps: ok ? tps : 0, vram_gb: ok ? 20 : -1, ok,
+      });
+      // vulkan has a HIGHER depth-0 tps but FAILS the deep (target-context) run;
+      // rocm-stable is slower at depth 0 but succeeds at depth. rocm must win.
+      const bench = [
+        dp('vulkan', 0, true, 99),
+        dp('vulkan', 30000, false, 0),
+        dp('rocm-stable', 0, true, 40),
+        dp('rocm-stable', 30000, true, 38),
+      ];
+      const r = synthesize(igpuHw(), denseModel(), answers(),
+        [fitting('vulkan', 65536), fitting('rocm-stable', 65536)], bench, undefined);
+      check('r2#3: deep-run failure disqualifies the faster-at-d0 backend', r.primary.llamacpp_backend === 'rocm-stable');
+
+      // When neither backend has a deep run (small ctx), depth-0 comparison stands.
+      const shallow = [dp('vulkan', 0, true, 99), dp('rocm-stable', 0, true, 40)];
+      const rs = synthesize(igpuHw(), denseModel(), answers(),
+        [fitting('vulkan', 65536), fitting('rocm-stable', 65536)], shallow, undefined);
+      check('r2#3: no deep runs → depth-0 winner stands', rs.primary.llamacpp_backend === 'vulkan');
     }
 
     if (failures > 0) {

--- a/prototype/ui-redesign/tests/autoopt-synthesize.runtime.cjs
+++ b/prototype/ui-redesign/tests/autoopt-synthesize.runtime.cjs
@@ -535,6 +535,20 @@ function check(name, ok) {
           deepStep.params.ctx_size === recMid.primary.ctx_size);
         check('r3#2: deep prompt depth fits inside the recommended ctx',
           deepPlan.params.d < recMid.primary.ctx_size);
+
+        // ── blocker #1: bench loads use the SAME merge path as apply ──
+        // apply/save omit merge_args (server default true), so pre-existing model /
+        // architecture / global _args are merged into the final command line. The
+        // bench must not disable that merge, or it measures a different command line
+        // than the one that gets applied.
+        const mergeRecipe = buildBenchRecipe(
+          [partialFit], ansNo, igpuHw(), denseModel(), 'org/m', 'thorough', ['vulkan', 'rocm-stable']);
+        const mergeLoads = mergeRecipe.steps.filter(s => s.op === 'load');
+        check('blocker#1: at least one bench load exists', mergeLoads.length > 0);
+        check('blocker#1: no bench load disables merge_args (same path as apply)',
+          mergeLoads.every(s => s.params.merge_args !== false));
+        check('blocker#1: bench loads still never persist options',
+          mergeLoads.every(s => s.params.save_options === false));
       } finally {
         fs.rmSync(recipeBundle.outputPath, { recursive: true, force: true });
       }
@@ -599,6 +613,22 @@ function check(name, ok) {
       const rOk = synthesize(igpuHw(), denseModel(), answers(),
         [fitting('vulkan', 8192), fitting('rocm-stable', 8192)], okDeep, undefined);
       check('r3#2: backend that runs the recommended-ctx deep run wins', rOk.primary.llamacpp_backend === 'vulkan');
+
+      // ── blocker #2: the duel is decided on a COMMON workload (d0), not on the
+      // per-backend deep runs measured at different depths. Here vulkan's deep run
+      // (shallow ~6k depth) is faster than rocm's deep run (~30k depth), but both
+      // succeed, so deep is only an eligibility check; the common d0 workload —
+      // where rocm is faster — must decide the winner.
+      const uneven = [
+        dp('vulkan', 0, true, 50), { ...dp('vulkan', 6000, true, 90), ttft_ms: 200 },
+        dp('rocm-stable', 0, true, 80), { ...dp('rocm-stable', 30000, true, 85), ttft_ms: 800 },
+      ];
+      const rUneven = synthesize(igpuHw(), denseModel(), answers(),
+        [fitting('vulkan', 65536), fitting('rocm-stable', 65536)], uneven, undefined);
+      check('blocker#2: duel decided on the common d0 workload, not unequal deep depths',
+        rUneven.primary.llamacpp_backend === 'rocm-stable');
+      check('blocker#2: winner expected reflects its own deep run, not d0',
+        rUneven.primary.expected && rUneven.primary.expected.ttft_ms === 800);
     }
 
     // ── round-3 #1: MTP/ladder tuning comes from the DUEL WINNER, not candidates[0] ──

--- a/prototype/ui-redesign/tests/autoopt-synthesize.runtime.cjs
+++ b/prototype/ui-redesign/tests/autoopt-synthesize.runtime.cjs
@@ -1,0 +1,520 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const webpack = require('webpack');
+
+async function bundleSynthesize() {
+  const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), 'lemonade-autoopt-synth-'));
+  const config = {
+    mode: 'development',
+    target: 'node',
+    entry: path.resolve(__dirname, '../src/features/autoOpt/autoOptSynthesize.ts'),
+    output: {
+      path: outputPath,
+      filename: 'autoOptSynthesize.cjs',
+      library: { type: 'commonjs2' },
+    },
+    resolve: { extensions: ['.ts', '.tsx', '.js'] },
+    module: {
+      rules: [{ test: /\.tsx?$/, use: 'ts-loader', exclude: /node_modules/ }],
+    },
+    optimization: { minimize: false },
+  };
+
+  await new Promise((resolve, reject) => {
+    webpack(config, (error, stats) => {
+      if (error) return reject(error);
+      if (stats?.hasErrors()) return reject(new Error(stats.toString({ all: false, errors: true })));
+      resolve();
+    });
+  });
+
+  return { outputPath, modulePath: path.join(outputPath, 'autoOptSynthesize.cjs') };
+}
+
+async function bundleRecipe() {
+  const outputPath = fs.mkdtempSync(path.join(os.tmpdir(), 'lemonade-autoopt-recipe-'));
+  const config = {
+    mode: 'development',
+    target: 'node',
+    entry: path.resolve(__dirname, '../src/features/autoOpt/autoOptRecipe.ts'),
+    output: {
+      path: outputPath,
+      filename: 'autoOptRecipe.cjs',
+      library: { type: 'commonjs2' },
+    },
+    resolve: { extensions: ['.ts', '.tsx', '.js'] },
+    module: {
+      rules: [{ test: /\.tsx?$/, use: 'ts-loader', exclude: /node_modules/ }],
+    },
+    optimization: { minimize: false },
+  };
+
+  await new Promise((resolve, reject) => {
+    webpack(config, (error, stats) => {
+      if (error) return reject(error);
+      if (stats?.hasErrors()) return reject(new Error(stats.toString({ all: false, errors: true })));
+      resolve();
+    });
+  });
+
+  return { outputPath, modulePath: path.join(outputPath, 'autoOptRecipe.cjs') };
+}
+
+function igpuHw() {
+  return {
+    gpus: [{ vendor: 'amd', name: 'Radeon 8060S', family: 'gfx1151', vram_gb: 96.0 }],
+    has_igpu: true,
+    ram_is_vram: true,
+    host_ram_gb: 128,
+    installed_backends: ['vulkan', 'rocm-stable'],
+    os: 'linux',
+  };
+}
+
+function dgpuHw() {
+  return {
+    gpus: [{ vendor: 'nvidia', name: 'RTX 4090', family: 'sm_89', vram_gb: 24.0 }],
+    has_igpu: false,
+    ram_is_vram: false,
+    host_ram_gb: 64,
+    installed_backends: ['cuda'],
+    os: 'linux',
+  };
+}
+
+function denseModel() {
+  return {
+    architecture: 'qwen3',
+    block_count: 36,
+    expert_count: 0,
+    full_attention_interval: 0,
+    swa_layer_count: 0,
+    n_ctx_train: 131072,
+    kv_bytes_per_token: 90112,
+    weights_mib: 18000,
+    is_moe: false,
+    is_hybrid_or_recurrent: false,
+    has_mtp: false,
+    base_model_repo: '',
+    checkpoint: '',
+    metadata_present: true,
+  };
+}
+
+function answers(overrides = {}) {
+  return {
+    parallel: false,
+    slots: 1,
+    dedicated_slots: true,
+    kv_cache_quant: 'none',
+    ram_headroom: 'normal',
+    allow_network: true,
+    backends_to_consider: [],
+    ...overrides,
+  };
+}
+
+// A heuristic fit that fully fits, with a chosen f16 context cap.
+function fitting(backend, ctx, overrides = {}) {
+  return {
+    backend,
+    fits_fully: true,
+    fitted_ctx: ctx,
+    fitted_ngl: -1,
+    fitted_ncmoe: 0,
+    weights_mib: 18000,
+    kv_mib: 4000,
+    compute_mib: 512,
+    total_mib: 22512,
+    available_mib: 98304,
+    degraded: false,
+    ok: true,
+    ...overrides,
+  };
+}
+
+// A measured bench point in the new TTFT/TPS shape.
+function duelPoint(backend, depth, ttftMs, tps) {
+  return {
+    backend, label: `${backend} · d${depth}`, ctx_size: depth > 0 ? 32768 : 4096,
+    llamacpp_args: '', params: { d: depth }, ttft_ms: ttftMs, tps, vram_gb: 20, ok: true,
+  };
+}
+
+function ladderPoint(backend, b, ttftMs) {
+  return {
+    backend, label: `${backend} · b${b}`, ctx_size: 4096,
+    llamacpp_args: `-b ${b} -ub ${b}`, params: { ladder: true, b, ub: b, d: 0 },
+    ttft_ms: ttftMs, tps: 40, vram_gb: 20, ok: true,
+  };
+}
+
+function mtpPoint(backend, n, tps) {
+  return {
+    backend, label: `${backend} · mtp${n}`, ctx_size: 4096,
+    llamacpp_args: '', params: { spec_n: n, d: 0 }, ttft_ms: 100, tps, vram_gb: 20, ok: true,
+  };
+}
+
+function hasArg(preset, needle) {
+  return preset.llamacpp_args.includes(needle);
+}
+
+let failures = 0;
+function check(name, ok) {
+  console.log(`[${ok ? 'PASS' : 'FAIL'}] ${name}`);
+  if (!ok) failures += 1;
+}
+
+(async () => {
+  const { outputPath, modulePath } = await bundleSynthesize();
+
+  try {
+    const engine = require(modulePath);
+    const {
+      synthesize, checkpointRepoId, computeFitEstimate, benchScore, roundUpCtx,
+      selectCandidates, availableMib, NO_GPU_BACKEND_ERROR,
+    } = engine;
+
+    // ── checkpoint_repo_id ────────────────────────────────────────────
+    check('ckpt: plain repo', checkpointRepoId('Qwen/Qwen3-32B') === 'Qwen/Qwen3-32B');
+    check('ckpt: variant suffix stripped',
+      checkpointRepoId('ilintar/Agents-A1-GGUF:IQ4_XS') === 'ilintar/Agents-A1-GGUF');
+    check('ckpt: url form',
+      checkpointRepoId('https://huggingface.co/Qwen/Qwen3-32B') === 'Qwen/Qwen3-32B');
+    check('ckpt: bare name rejected', checkpointRepoId('just-a-name') === '');
+
+    // ── roundUpCtx ────────────────────────────────────────────────────
+    check('roundUp: 30000 -> 32768', roundUpCtx(30000) === 32768);
+    check('roundUp: 2048 -> 2048', roundUpCtx(2048) === 2048);
+
+    // ── benchScore: monotonic in the right directions ─────────────────
+    check('score: higher tps wins at equal ttft',
+      benchScore(50, 100, 50, 100) > benchScore(40, 100, 50, 100));
+    check('score: lower ttft wins at equal tps',
+      benchScore(50, 100, 50, 100) > benchScore(50, 200, 50, 100));
+    check('score: best on both = 1.0',
+      Math.abs(benchScore(50, 100, 50, 100) - 1.0) < 1e-9);
+    check('score: tps weighted higher than ttft',
+      // candidate A: best tps, worst ttft; candidate B: worst tps, best ttft.
+      benchScore(50, 200, 50, 100) > benchScore(25, 100, 50, 100));
+
+    // ── computeFitEstimate: heuristic memory fit ──────────────────────
+    {
+      // Fits fully with the whole trained window.
+      const full = computeFitEstimate({
+        backend: 'vulkan', availableMib: 98304, weightsMib: 18000,
+        kvBytesPerToken: 90112, blockCount: 36, isMoe: false, nCtxTrain: 32768, degraded: false,
+      });
+      check('fit: full fit, no cap', full.fits_fully && full.fitted_ctx === 0 && full.fitted_ngl === -1);
+
+      // Weights fit but KV must be capped below the trained window.
+      const capped = computeFitEstimate({
+        backend: 'vulkan', availableMib: 24000, weightsMib: 18000,
+        kvBytesPerToken: 1048576, blockCount: 36, isMoe: false, nCtxTrain: 131072, degraded: false,
+      });
+      check('fit: weights fit, ctx capped', capped.fits_fully && capped.fitted_ctx > 0 && capped.fitted_ctx < 131072);
+
+      // Dense weights don't fit → partial -ngl offload.
+      const dense = computeFitEstimate({
+        backend: 'vulkan', availableMib: 8000, weightsMib: 18000,
+        kvBytesPerToken: 90112, blockCount: 36, isMoe: false, nCtxTrain: 32768, degraded: false,
+      });
+      check('fit: dense offload sets partial ngl',
+        !dense.fits_fully && dense.fitted_ngl >= 0 && dense.fitted_ngl < 36 && dense.fitted_ncmoe === 0);
+
+      // MoE weights don't fit → -n-cpu-moe.
+      const moe = computeFitEstimate({
+        backend: 'vulkan', availableMib: 8000, weightsMib: 40000,
+        kvBytesPerToken: 90112, blockCount: 48, isMoe: true, nCtxTrain: 32768, degraded: false,
+      });
+      check('fit: moe offload sets ncmoe', !moe.fits_fully && moe.fitted_ncmoe > 0);
+
+      // Degraded (no metadata): uses a default kv/token and flags degraded.
+      const degraded = computeFitEstimate({
+        backend: 'vulkan', availableMib: 98304, weightsMib: 12000,
+        kvBytesPerToken: 0, blockCount: 0, isMoe: false, nCtxTrain: 0, degraded: true,
+      });
+      check('fit: degraded flagged, still ok', degraded.degraded && degraded.ok);
+    }
+
+    // ── synthesis: dense partial offload EMITS -ngl (review #4) ────────
+    {
+      const denseFit = fitting('vulkan', 4096, {
+        fits_fully: false, fitted_ngl: 20, fitted_ncmoe: 0, fitted_ctx: 4096,
+      });
+      const r = synthesize(igpuHw(), denseModel(), answers(), [denseFit], [], undefined);
+      check('dense offload: -ngl 20 emitted', hasArg(r.primary, '-ngl 20'));
+      check('dense offload: rationale mentions layers',
+        r.primary.rationale.some(s => s.includes('20 of 36 layers')));
+    }
+
+    // ── lever: cache ram scale + hybrid bump ──────────────────────────
+    {
+      let r = synthesize(igpuHw(), denseModel(), answers({ ram_headroom: 'reduced' }),
+        [fitting('vulkan', 65536)], [], undefined);
+      check('cache: reduced scale', hasArg(r.primary, '--cache-ram 4096 -ctxcp 16'));
+
+      r = synthesize(igpuHw(), denseModel(), answers({ ram_headroom: 'normal' }),
+        [fitting('vulkan', 65536)], [], undefined);
+      check('cache: normal omits flags', !hasArg(r.primary, '--cache-ram'));
+
+      const mf = { ...denseModel(), full_attention_interval: 4, is_hybrid_or_recurrent: true };
+      r = synthesize(igpuHw(), mf, answers({ ram_headroom: 'disabled' }),
+        [fitting('vulkan', 65536)], [], undefined);
+      check('cache: hybrid never disabled', hasArg(r.primary, '--cache-ram 2048 -ctxcp 8'));
+    }
+
+    // ── lever: kv quant + alternatives ────────────────────────────────
+    {
+      const r = synthesize(igpuHw(), denseModel(), answers({ kv_cache_quant: 'q8_0' }),
+        [fitting('vulkan', 32768)], [], undefined);
+      check('kv: ctk/ctv emitted', hasArg(r.primary, '-ctk q8_0 -ctv q8_0'));
+      check('kv: ctx doubled by q8_0', r.primary.ctx_size === 65536);
+      check('kv: max-quality alternative present',
+        r.alternatives.length > 0 && r.alternatives[0].label === 'Maximum quality'
+        && !r.alternatives[0].llamacpp_args.includes('-ctk'));
+      check('kv: max-context alternative q4_0',
+        r.alternatives.length >= 2 && r.alternatives[1].llamacpp_args.includes('-ctk q4_0'));
+    }
+
+    // ── lever: tensor split ───────────────────────────────────────────
+    {
+      const hw = dgpuHw();
+      hw.gpus.push({ vendor: 'nvidia', name: 'RTX 4090', family: 'sm_89', vram_gb: 24.0 });
+      let r = synthesize(hw, denseModel(), answers(), [fitting('cuda', 65536)], [], undefined);
+      check('split: tensor split on dual identical CUDA', hasArg(r.primary, '--split-mode tensor'));
+
+      const vk = igpuHw();
+      vk.gpus.push({ vendor: 'amd', name: 'RX 7900', family: 'gfx1100', vram_gb: 24.0 });
+      r = synthesize(vk, denseModel(), answers(), [fitting('vulkan', 65536)], [], undefined);
+      check('split: no tensor split off CUDA', !hasArg(r.primary, '--split-mode'));
+    }
+
+    // ── lever: parallel slots ─────────────────────────────────────────
+    {
+      let r = synthesize(igpuHw(), denseModel(),
+        answers({ parallel: true, slots: 4, dedicated_slots: true }),
+        [fitting('vulkan', 65536)], [], undefined);
+      check('parallel: dedicated slots', hasArg(r.primary, '-np 4 -no-kvu'));
+
+      r = synthesize(igpuHw(), denseModel(),
+        answers({ parallel: true, slots: 4, dedicated_slots: false }),
+        [fitting('vulkan', 65536)], [], undefined);
+      check('parallel: shared pool', hasArg(r.primary, '-np 4 -kvu'));
+    }
+
+    // ── lever: speculative + MTP argmax by tps ────────────────────────
+    {
+      let r = synthesize(igpuHw(), denseModel(), answers(), [fitting('vulkan', 65536)], [], undefined);
+      check('spec: spec-default always', hasArg(r.primary, '--spec-default'));
+      check('spec: no mtp flags on non-mtp', !hasArg(r.primary, 'draft-mtp'));
+
+      const mtp = { ...denseModel(), has_mtp: true };
+      const sweep = [mtpPoint('vulkan', 1, 41), mtpPoint('vulkan', 2, 55), mtpPoint('vulkan', 3, 43), mtpPoint('vulkan', 4, 44)];
+      r = synthesize(igpuHw(), mtp, answers(), [fitting('vulkan', 65536)], sweep, undefined);
+      check('spec: measured argmax n=2 (highest tps)', hasArg(r.primary, '--spec-draft-n-max 2'));
+
+      r = synthesize(igpuHw(), mtp, answers(), [fitting('vulkan', 65536)], [], undefined);
+      check('spec: default n=3 unmeasured', hasArg(r.primary, '--spec-draft-n-max 3'));
+    }
+
+    // ── lever: backend duel by TTFT/TPS ───────────────────────────────
+    {
+      // vulkan: higher tps AND lower ttft → wins.
+      const duel = [
+        duelPoint('vulkan', 0, 90, 42), duelPoint('vulkan', 30000, 300, 40),
+        duelPoint('rocm-stable', 0, 120, 37), duelPoint('rocm-stable', 30000, 380, 35),
+      ];
+      const r = synthesize(igpuHw(), denseModel(), answers(),
+        [fitting('vulkan', 65536), fitting('rocm-stable', 65536)], duel, undefined);
+      check('duel: measured winner (better tps+ttft)', r.primary.llamacpp_backend === 'vulkan');
+      check('duel: expected carries ttft/tps',
+        r.primary.expected && r.primary.expected.tps > 0 && r.primary.expected.ttft_ms > 0);
+
+      const rh = synthesize(igpuHw(), denseModel(), answers(), [fitting('vulkan', 65536)], [], undefined);
+      check('duel: heuristic fallback picks installed', rh.primary.llamacpp_backend === 'vulkan');
+    }
+
+    // ── lever: sampling passthrough ───────────────────────────────────
+    {
+      const sd = { temperature: 0.7, top_p: 0.8, top_k: 20, source: 'hf:Qwen/Qwen3-32B/generation_config.json' };
+      const r = synthesize(igpuHw(), denseModel(), answers(), [fitting('vulkan', 65536)], [], sd);
+      check('sampling: passthrough', r.sampling_defaults && r.sampling_defaults.temperature === 0.7);
+      check('sampling: not in args', !hasArg(r.primary, 'temp'));
+    }
+
+    // ── lever: batch ladder by LOWEST ttft ────────────────────────────
+    {
+      // b=2048 has the lowest TTFT (fastest prefill) and clears the 5% gate.
+      const ladder = [ladderPoint('vulkan', 512, 100), ladderPoint('vulkan', 2048, 70), ladderPoint('vulkan', 8192, 80)];
+      const r = synthesize(igpuHw(), denseModel(), answers(), [fitting('vulkan', 65536)], ladder, undefined);
+      check('ladder: lowest-ttft rung chosen', hasArg(r.primary, '-b 2048 -ub 2048'));
+
+      // Not enough improvement (all ~equal) → no ladder flag.
+      const flat = [ladderPoint('vulkan', 512, 100), ladderPoint('vulkan', 2048, 99), ladderPoint('vulkan', 8192, 98)];
+      const rf = synthesize(igpuHw(), denseModel(), answers(), [fitting('vulkan', 65536)], flat, undefined);
+      check('ladder: no flag without meaningful gain', !hasArg(rf.primary, '-b 2048'));
+
+      // iGPU heuristic without any bench data.
+      const rq = synthesize(igpuHw(), denseModel(), answers(), [fitting('vulkan', 65536)], [], undefined);
+      check('ladder: iGPU heuristic without bench', hasArg(rq.primary, '-b 2048 -ub 2048'));
+
+      const rd = synthesize(dgpuHw(), denseModel(), answers(), [fitting('cuda', 65536)], [], undefined);
+      check('ladder: no heuristic on dGPU', !hasArg(rd.primary, '-b '));
+    }
+
+    // ── lever: ROCm direct-io ─────────────────────────────────────────
+    {
+      let r = synthesize(igpuHw(), denseModel(), answers({ backends_to_consider: ['rocm-stable'] }),
+        [fitting('rocm-stable', 65536)], [], undefined);
+      check('rocm: gets --direct-io', hasArg(r.primary, '--direct-io'));
+
+      r = synthesize(igpuHw(), denseModel(), answers({ backends_to_consider: ['vulkan'] }),
+        [fitting('vulkan', 65536)], [], undefined);
+      check('rocm: vulkan does not', !hasArg(r.primary, '--direct-io'));
+    }
+
+    // ── lever: cpu-moe fit strategy + conservative alternative ────────
+    {
+      const moe = { ...denseModel(), is_moe: true, expert_count: 128 };
+      const f = fitting('vulkan', 32768, { fits_fully: false, fitted_ngl: -1, fitted_ncmoe: 12, fitted_ctx: 4096 });
+      const r = synthesize(igpuHw(), moe, answers(), [f], [], undefined);
+      check('moe: n-cpu-moe from fit', hasArg(r.primary, '--n-cpu-moe 12'));
+      check('moe: conservative alternative',
+        r.alternatives.some(a => a.llamacpp_args.includes('--cpu-moe')));
+    }
+
+    // ── lever: ctx rounded to fit / capped at trained window ──────────
+    {
+      const r = synthesize(igpuHw(), denseModel(), answers(), [fitting('vulkan', 40000)], [], undefined);
+      check('ctx: rounded down to fit', r.primary.ctx_size === 32768);
+
+      const rmax = synthesize(igpuHw(), denseModel(), answers(), [fitting('vulkan', 0)], [], undefined);
+      check('ctx: full-window fit uses trained window', rmax.primary.ctx_size === 131072);
+    }
+
+    // ── review #1: available-memory unit (GiB→MiB after the floor) ────
+    {
+      const unified = (gb) => availableMib({
+        gpus: [{ vendor: 'amd', name: '', family: '', vram_gb: gb }],
+        has_igpu: true, ram_is_vram: true, host_ram_gb: gb,
+        installed_backends: ['vulkan'], os: 'linux',
+      });
+      check('mem: 16 GB unified ≈ 0.9x in MiB', Math.abs(unified(16) - 16 * 0.9 * 1024) < 1);
+      check('mem: 64 GB unified ≈ 0.9x in MiB', Math.abs(unified(64) - 64 * 0.9 * 1024) < 1);
+      check('mem: 128 GB unified ≈ 0.9x in MiB', Math.abs(unified(128) - 128 * 0.9 * 1024) < 1);
+      // Regression: the old `max(1024, gb*0.9)*1024` treated a 64 GB box as ~1 TiB.
+      check('mem: 64 GB not treated as ~1 TiB', unified(64) < 128 * 1024);
+      check('mem: 16 GB stays under 20 GiB', unified(16) < 20 * 1024);
+
+      const cpuOnlyAvail = (gb) => availableMib({
+        gpus: [], has_igpu: false, ram_is_vram: false, host_ram_gb: gb,
+        installed_backends: ['cpu'], os: 'linux',
+      });
+      check('mem: cpu 64 GB ≈ 0.7x in MiB', Math.abs(cpuOnlyAvail(64) - 64 * 0.7 * 1024) < 1);
+      check('mem: cpu 64 GB stays under host RAM', cpuOnlyAvail(64) < 64 * 1024);
+
+      // A 16 GB unified box cannot fit an 18 GB model fully — it must offload with a finite ctx.
+      const fit16 = computeFitEstimate({
+        backend: 'vulkan', availableMib: unified(16), weightsMib: 18000,
+        kvBytesPerToken: 90112, blockCount: 36, isMoe: false, nCtxTrain: 131072, degraded: false,
+      });
+      check('fit: 16 GB box offloads an 18 GB model',
+        !fit16.fits_fully && fit16.fitted_ngl >= 0 && fit16.fitted_ngl < 36
+        && fit16.fitted_ctx > 0 && Number.isFinite(fit16.fitted_ctx));
+      // The same model on a 128 GB box fits fully.
+      const fit128 = computeFitEstimate({
+        backend: 'vulkan', availableMib: unified(128), weightsMib: 18000,
+        kvBytesPerToken: 90112, blockCount: 36, isMoe: false, nCtxTrain: 32768, degraded: false,
+      });
+      check('fit: 128 GB box fits the same model fully', fit128.fits_fully);
+    }
+
+    // ── review #3: one candidate list; CPU-only rejected ──────────────
+    {
+      check('cand: gpu backends selected',
+        selectCandidates(igpuHw(), answers()).join(',') === 'vulkan,rocm-stable');
+      check('cand: metal kept as a gpu backend',
+        selectCandidates({ ...igpuHw(), installed_backends: ['metal', 'vulkan'] }, answers()).join(',') === 'metal,vulkan');
+      const cpuOnly = {
+        gpus: [], has_igpu: false, ram_is_vram: false, host_ram_gb: 32,
+        installed_backends: ['system', 'cpu'], os: 'linux',
+      };
+      check('cand: cpu-only yields no candidates', selectCandidates(cpuOnly, answers()).length === 0);
+      let threw = '';
+      try {
+        synthesize(cpuOnly, denseModel(), answers(), [], [], undefined);
+      } catch (e) {
+        threw = String((e && e.message) || e);
+      }
+      check('cand: synthesize rejects cpu-only with the shared message', threw === NO_GPU_BACKEND_ERROR);
+    }
+
+    // ── review #2: recommendation capped to the ctx that actually loaded ─
+    {
+      const capPoint = {
+        backend: 'vulkan', label: 'vulkan · d0', ctx_size: 2048, llamacpp_args: '',
+        params: { d: 0 }, ttft_ms: 95, tps: 40, vram_gb: 20, ok: true, max_loaded_ctx: 2048,
+      };
+      const capped = synthesize(igpuHw(), denseModel(), answers(), [fitting('vulkan', 0)], [capPoint], undefined);
+      check('fallback-cap: ctx capped to the loaded 2048', capped.primary.ctx_size === 2048);
+      check('fallback-cap: rationale explains the cap',
+        capped.primary.rationale.some(s => s.includes('largest context that actually loaded')));
+
+      const okPoint = { ...capPoint, ctx_size: 131072 };
+      delete okPoint.max_loaded_ctx;
+      const uncapped = synthesize(igpuHw(), denseModel(), answers(), [fitting('vulkan', 0)], [okPoint], undefined);
+      check('fallback-cap: full window kept without a ceiling', uncapped.primary.ctx_size === 131072);
+    }
+
+    // ── review #1: the bench validates the ctx it will recommend (kv quant) ──
+    {
+      const recipeBundle = await bundleRecipe();
+      try {
+        const { buildBenchRecipe } = require(recipeBundle.modulePath);
+        // Partial ctx fit: heuristic fitted_ctx is an f16 estimate; q8_0 doubles the
+        // recommended window, so the benched load must also target the doubled ctx.
+        const fit = fitting('vulkan', 8000, { fits_fully: true, fitted_ctx: 8000 });
+        const mf = { ...denseModel(), n_ctx_train: 131072 };
+        const ans = answers({ kv_cache_quant: 'q8_0' });
+
+        const rec = synthesize(igpuHw(), mf, ans, [fit], [], undefined);
+        const recipe = buildBenchRecipe(fit, ans, igpuHw(), mf, 'org/m', 'standard', ['vulkan']);
+        const load0 = recipe.steps.find(s => s.id === 'load_vulkan_d0');
+        const benchedCtx = load0 && load0.params && load0.params.ctx_size;
+
+        check('#1: benched depth-0 ctx == recommended ctx', benchedCtx === rec.primary.ctx_size);
+        check('#1: benched ctx is quant-scaled, not raw fitted_ctx', benchedCtx > 8000);
+        check('#1: recommended ctx is the quant-scaled window', rec.primary.ctx_size === 12288);
+        check('#1: depth-0 load carries -ctk quant', String(load0.params.llamacpp_args).includes('-ctk q8_0'));
+
+        const probe = recipe.plan.find(e => e.backend === 'vulkan' && e.params && e.params.d === 0);
+        check('#1: depth-0 plan entry is the ctx probe with a fallback',
+          probe && probe.ctx_probe === true && probe.fallback_ctx_size === 2048);
+
+        // If that quant-scaled load fails and only the fallback loads, cap the recommendation.
+        const fellBack = {
+          backend: 'vulkan', label: 'vulkan · d0', ctx_size: 2048, llamacpp_args: '-ctk q8_0 -ctv q8_0',
+          params: { d: 0 }, ttft_ms: 90, tps: 40, vram_gb: 20, ok: true, max_loaded_ctx: 2048,
+        };
+        const capped = synthesize(igpuHw(), mf, ans, [fit], [fellBack], undefined);
+        check('#1: failed quant-scaled load falls back to the loaded ctx', capped.primary.ctx_size === 2048);
+      } finally {
+        fs.rmSync(recipeBundle.outputPath, { recursive: true, force: true });
+      }
+    }
+
+    if (failures > 0) {
+      throw new Error(`${failures} synthesis checks failed`);
+    }
+    console.log('\nAutoOpt synthesis runtime tests passed.');
+  } finally {
+    fs.rmSync(outputPath, { recursive: true, force: true });
+  }
+})().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/prototype/ui-redesign/tests/autoopt.spec.ts
+++ b/prototype/ui-redesign/tests/autoopt.spec.ts
@@ -41,9 +41,9 @@ const SYSTEM_INFO = {
 };
 
 function metricsForKey(measKey: string): { ttft: number; tps: number; vram: number } {
-  let m = /^ladder_b(\d+)$/.exec(measKey);
+  let m = /^ladder_.+_b(\d+)$/.exec(measKey);
   if (m) { const b = Number(m[1]); return { ttft: b === 2048 ? 70 : (b === 8192 ? 80 : 100), tps: 40, vram: 20 }; }
-  m = /^mtp_n(\d+)$/.exec(measKey);
+  m = /^mtp_.+_n(\d+)$/.exec(measKey);
   if (m) { const n = Number(m[1]); return { ttft: 100, tps: n === 2 ? 55 : 40, vram: 20 }; }
   m = /^(.+)_d(\d+)$/.exec(measKey);
   if (m) {
@@ -353,7 +353,11 @@ test.describe('AutoOpt wizard + server-side bench job', () => {
     expect(extractKeys.some(k => k.endsWith('_ttft'))).toBe(true);
     expect(extractKeys.some(k => k.endsWith('_tps'))).toBe(true);
 
-    expect(extractKeys).toEqual(expect.arrayContaining(['vulkan_d0_tps', 'vulkan_d30000_tps', 'ladder_b512_ttft', 'ladder_b2048_ttft', 'ladder_b8192_ttft']));
+    expect(extractKeys).toEqual(expect.arrayContaining([
+      'vulkan_d0_tps', 'vulkan_d30000_tps',
+      'ladder_vulkan_b512_ttft', 'ladder_vulkan_b2048_ttft', 'ladder_vulkan_b8192_ttft',
+      'ladder_rocm_b512_ttft',
+    ]));
 
     const fallbackLoad = steps.find(s => s.op === 'load' && typeof s.on_fail === 'string' && String(s.on_fail).startsWith('loadlo_'));
     expect(fallbackLoad).toBeTruthy();

--- a/prototype/ui-redesign/tests/autoopt.spec.ts
+++ b/prototype/ui-redesign/tests/autoopt.spec.ts
@@ -1,0 +1,813 @@
+import { test, expect, Page } from '@playwright/test';
+
+const CHAT_MODEL = 'org/chat-model';
+const NPU_MODEL = 'org/npu-model';
+const REGISTRY_MODEL = 'org/registry-only-model';
+const RUNS_KEY = 'lemonade_autoopt_runs_v2::http://127.0.0.1:13305';
+const CHAT_CHECKPOINT = 'org/chat-model-GGUF:Q4_K_M';
+
+const MODELS = [
+  {
+    id: CHAT_MODEL, name: CHAT_MODEL, labels: ['llm'], recipe: 'llamacpp', downloaded: true,
+    checkpoint: CHAT_CHECKPOINT, size: 4, max_context_window: 32768,
+    metadata: {
+      architecture: 'qwen3', block_count: 36, context_length: 32768, expert_count: 0,
+      full_attention_interval: 0, swa_layer_count: 0, kv_bytes_per_token: 90112,
+      base_model_repo: 'https://huggingface.co/org/base-model',
+    },
+  },
+  { id: NPU_MODEL, name: NPU_MODEL, labels: ['llm'], recipe: 'flm', downloaded: true, max_context_window: 32768 },
+  { id: REGISTRY_MODEL, name: REGISTRY_MODEL, labels: ['llm'], recipe: 'llamacpp', downloaded: false, max_context_window: 32768 },
+];
+
+const SYSTEM_INFO = {
+  'OS Version': 'Linux test',
+  'Physical Memory': '64.0 GB',
+  devices: {
+    amd_gpu: [{ available: true, name: 'Radeon 8060S', family: 'gfx1151', vram_gb: 2.0, virtual_mem_gb: 62.0 }],
+    nvidia_gpu: [{ available: false, name: '' }],
+  },
+  recipes: {
+    llamacpp: {
+      default_backend: 'vulkan',
+      backends: {
+        vulkan: { state: 'installed' },
+        rocm: { state: 'installed' },
+        system: { state: 'installed' },
+        cpu: { state: 'installable' },
+      },
+    },
+  },
+};
+
+function metricsForKey(measKey: string): { ttft: number; tps: number; vram: number } {
+  let m = /^ladder_b(\d+)$/.exec(measKey);
+  if (m) { const b = Number(m[1]); return { ttft: b === 2048 ? 70 : (b === 8192 ? 80 : 100), tps: 40, vram: 20 }; }
+  m = /^mtp_n(\d+)$/.exec(measKey);
+  if (m) { const n = Number(m[1]); return { ttft: 100, tps: n === 2 ? 55 : 40, vram: 20 }; }
+  m = /^(.+)_d(\d+)$/.exec(measKey);
+  if (m) {
+    const deep = Number(m[2]) > 0;
+    if (m[1] === 'vulkan') return { ttft: deep ? 300 : 90, tps: deep ? 40 : 42, vram: 20 };
+    return { ttft: deep ? 380 : 120, tps: deep ? 35 : 37, vram: 21 };
+  }
+  return { ttft: 100, tps: 30, vram: 20 };
+}
+
+function measKeysFromSteps(steps: Array<Record<string, unknown>>): string[] {
+  const keys = new Set<string>();
+  for (const step of steps) {
+    const extract = step.extract as Record<string, string> | undefined;
+    if (!extract) continue;
+    for (const k of Object.keys(extract)) keys.add(k.replace(/_(ttft|tps|vram)$/, ''));
+  }
+  return [...keys];
+}
+
+function contextForKeys(measKeys: string[]): Record<string, unknown> {
+  const ctx: Record<string, unknown> = { inputs: {} };
+  for (const mk of measKeys) {
+    const met = metricsForKey(mk);
+    ctx[`${mk}_ttft`] = met.ttft;
+    ctx[`${mk}_tps`] = met.tps;
+    ctx[`${mk}_vram`] = met.vram;
+  }
+  return ctx;
+}
+
+interface MockCounts {
+  load: Array<Record<string, unknown>>;
+  unload: Array<Record<string, unknown>>;
+  chat: Array<Record<string, unknown>>;
+  jobs: Array<Record<string, unknown>>;
+  interrupts: string[];
+  deletes: string[];
+}
+
+interface MockOptions {
+  loadedModels?: Array<Record<string, unknown>>;
+  jobRunningPolls?: number;
+  jobFails?: boolean;
+  failPrimaryLoads?: boolean;
+  loadHandler?: (body: Record<string, unknown>) => { status?: number; json?: unknown } | null;
+}
+
+async function mockServer(page: Page, options: MockOptions = {}): Promise<MockCounts> {
+  const counts: MockCounts = { load: [], unload: [], chat: [], jobs: [], interrupts: [], deletes: [] };
+  const loaded = options.loadedModels || [];
+  const runningPolls = options.jobRunningPolls ?? 0;
+
+  const jobs = new Map<string, { steps: Array<Record<string, unknown>>; polls: number }>();
+  let jobSeq = 0;
+
+  await page.route('**/api/v1/health**', route => route.fulfill({
+    json: { status: 'ok', version: 'test', all_models_loaded: loaded },
+  }));
+  await page.route('**/api/v1/models**', route => route.fulfill({ json: { data: MODELS } }));
+  await page.route('**/api/v1/models/*', route => {
+    const id = decodeURIComponent(route.request().url().split('/').pop() || '').split('?')[0];
+    const model = MODELS.find(m => m.id === id);
+    if (!model) return route.fulfill({ status: 404, json: { error: 'unknown model' } });
+    return route.fulfill({ json: model });
+  });
+  await page.route('**/api/v1/system-info**', route => route.fulfill({ json: SYSTEM_INFO }));
+  await page.route('**/api/v1/system-stats', route => route.fulfill({
+    json: { cpu_percent: 10, memory_gb: 40, gpu_percent: 80, vram_gb: 20, npu_percent: 0 },
+  }));
+  await page.route('**/api/v1/unload', route => {
+    counts.unload.push(route.request().postDataJSON() || {});
+    return route.fulfill({ json: { status: 'ok' } });
+  });
+  await page.route('**/api/v1/load', async route => {
+    const body = route.request().postDataJSON() as Record<string, unknown>;
+    counts.load.push(body);
+    const override = options.loadHandler ? options.loadHandler(body) : null;
+    if (override) return route.fulfill({ status: override.status ?? 200, json: override.json ?? { status: 'ok' } });
+    return route.fulfill({ json: { status: 'ok' } });
+  });
+  await page.route('**/api/v1/chat/completions', route => {
+    counts.chat.push(route.request().postDataJSON() || {});
+    return route.fulfill({ json: { choices: [{ message: { role: 'assistant', content: 'ok' } }] } });
+  });
+
+  await page.route('**/api/v1/jobs', async route => {
+    if (route.request().method() !== 'POST') return route.fulfill({ json: { jobs: [] } });
+    const body = route.request().postDataJSON() as Record<string, unknown>;
+    counts.jobs.push(body);
+    const steps = ((body.definition as Record<string, unknown>)?.steps || []) as Array<Record<string, unknown>>;
+    const id = `job-test-${++jobSeq}`;
+    jobs.set(id, { steps, polls: 0 });
+    return route.fulfill({ status: 202, json: { id } });
+  });
+  await page.route('**/api/v1/jobs/*/interrupt', route => {
+    counts.interrupts.push(decodeURIComponent(route.request().url().split('/').slice(-2)[0]));
+    return route.fulfill({ json: { status: 'ok' } });
+  });
+  await page.route('**/api/v1/jobs/*/pause', route => route.fulfill({ json: { status: 'ok' } }));
+  await page.route('**/api/v1/jobs/*/resume', route => route.fulfill({ json: { status: 'ok' } }));
+  await page.route('**/api/v1/jobs/*', async route => {
+    const id = decodeURIComponent(route.request().url().split('/').pop() || '').split('?')[0];
+    if (route.request().method() === 'DELETE') {
+      counts.deletes.push(id);
+      return route.fulfill({ json: { status: 'ok' } });
+    }
+    const entry = jobs.get(id) || { steps: [], polls: 0 };
+    if (!jobs.has(id)) jobs.set(id, entry);
+    entry.polls += 1;
+
+    const measKeys = entry.steps.length ? measKeysFromSteps(entry.steps) : ['vulkan_d0', 'rocm_d0'];
+    const stepIds: string[] = entry.steps.length
+      ? entry.steps.map(s => String(s.id))
+      : ['load_vulkan_d0', 'chat_vulkan_d0'];
+
+    const running = entry.polls <= runningPolls;
+    if (running) {
+      return route.fulfill({
+        json: {
+          id, name: 'autoopt', status: 'running', context: { inputs: {} },
+          cursor: stepIds[0],
+          steps: stepIds.map((sid, i) => ({ id: sid, op: 'load', status: i === 0 ? 'running' : 'pending' })),
+        },
+      });
+    }
+    if (options.jobFails) {
+      return route.fulfill({
+        json: {
+          id, name: 'autoopt', status: 'failed', context: { inputs: {} },
+          steps: stepIds.map(sid => ({ id: sid, op: 'load', status: 'failed', error: 'CUDA out of memory' })),
+        },
+      });
+    }
+    const context = contextForKeys(measKeys);
+    if (options.failPrimaryLoads) {
+      for (const mk of measKeys) {
+        if (/_d\d+$/.test(mk) && !mk.endsWith('_lo')) {
+          delete context[`${mk}_ttft`];
+          delete context[`${mk}_tps`];
+          delete context[`${mk}_vram`];
+        }
+      }
+    }
+    return route.fulfill({
+      json: {
+        id, name: 'autoopt', status: 'completed', context,
+        steps: stepIds.map(sid => ({ id: sid, op: 'load', status: 'completed', duration_ms: 100 })),
+      },
+    });
+  });
+
+  await page.route('https://huggingface.co/org/base-model/resolve/main/generation_config.json',
+    route => route.fulfill({ json: { temperature: 0.7, top_p: 0.8, top_k: 20 } }));
+  await page.route('https://huggingface.co/org/base-model/resolve/main/config.json',
+    route => route.fulfill({ status: 404, body: 'Not Found' }));
+  await page.route('https://huggingface.co/api/models/**', route => route.fulfill({
+    json: { cardData: { base_model: 'org/base-model' } },
+  }));
+
+  return counts;
+}
+
+const COMPLETED_RUN = {
+  id: 'ao-20260712-101500-cafe',
+  model: CHAT_MODEL,
+  checkpoint: CHAT_CHECKPOINT,
+  budget: 'standard',
+  answers: { parallel: { mode: 'single' }, kv_cache_quant: 'q8_0', ram_headroom: 'normal', allow_network: true },
+  allow_unload: true,
+  status: 'completed',
+  created_at: '2026-07-12T10:00:00Z',
+  finished_at: '2026-07-12T10:15:00Z',
+  summary: 'vulkan · ctx 32768 · -ctk q8_0 -ctv q8_0 --spec-default -b 2048 -ub 2048',
+  lemonade_version: 'test',
+  job_id: 'job-test-old',
+  stages: [
+    { name: 'snapshot', status: 'completed', duration_ms: 12 },
+    { name: 'model_facts', status: 'completed', duration_ms: 8 },
+    { name: 'hf_metadata', status: 'completed', duration_ms: 420 },
+    { name: 'fit_estimate', status: 'completed', duration_ms: 3 },
+    { name: 'bench_job', status: 'completed', duration_ms: 431000 },
+    { name: 'synthesize', status: 'completed', duration_ms: 2 },
+  ],
+  measurements: {
+    fit: [
+      { backend: 'vulkan', fits_fully: true, fitted_ctx: 0, fitted_ngl: -1, fitted_ncmoe: 0, weights_mib: 4096, kv_mib: 2816, compute_mib: 512, total_mib: 7424, available_mib: 58982, degraded: false, ok: true },
+    ],
+    bench: [
+      { backend: 'vulkan', label: 'vulkan · d0', ctx_size: 2048, llamacpp_args: '-ctk q8_0 -ctv q8_0', params: { d: 0 }, ttft_ms: 90, tps: 42, vram_gb: 20, ok: true },
+      { backend: 'rocm', label: 'rocm · d0', ctx_size: 2048, llamacpp_args: '-ctk q8_0 -ctv q8_0', params: { d: 0 }, ttft_ms: 120, tps: 37, vram_gb: 21, ok: true },
+      { backend: 'vulkan', label: 'vulkan · b512', ctx_size: 2048, llamacpp_args: '-b 512 -ub 512', params: { ladder: true, b: 512, ub: 512, d: 0 }, ttft_ms: 100, tps: 40, vram_gb: 20, ok: true },
+      { backend: 'vulkan', label: 'vulkan · b2048', ctx_size: 2048, llamacpp_args: '-b 2048 -ub 2048', params: { ladder: true, b: 2048, ub: 2048, d: 0 }, ttft_ms: 70, tps: 40, vram_gb: 20, ok: true },
+    ],
+  },
+  result: {
+    primary: {
+      label: 'Recommended',
+      llamacpp_backend: 'vulkan',
+      ctx_size: 32768,
+      llamacpp_args: '-ctk q8_0 -ctv q8_0 --spec-default -b 2048 -ub 2048',
+      rationale: ['vulkan chosen over rocm: best measured throughput/latency balance'],
+      expected: { ttft_ms: 90, tps: 42, vram_gb: 20 },
+    },
+    alternatives: [
+      {
+        label: 'Maximum quality',
+        llamacpp_backend: 'vulkan',
+        ctx_size: 16384,
+        llamacpp_args: '--spec-default -b 2048 -ub 2048',
+        rationale: ['Unquantized f16 KV cache'],
+        tradeoff: 'smaller context window',
+      },
+    ],
+    sampling_defaults: { temperature: 0.7, top_p: 0.9, top_k: 40, min_p: 0.05, source: 'hf:org/base-model/generation_config.json' },
+  },
+};
+
+const SYNTH_INPUTS = {
+  hardware: { gpus: [{ vendor: 'amd', name: 'x', family: 'gfx1151', vram_gb: 62 }], has_igpu: true, ram_is_vram: true, host_ram_gb: 64, installed_backends: ['vulkan', 'rocm'], os: 'linux' },
+  facts: { architecture: 'qwen3', block_count: 36, expert_count: 0, full_attention_interval: 0, swa_layer_count: 0, n_ctx_train: 32768, kv_bytes_per_token: 90112, weights_mib: 4096, is_moe: false, is_hybrid_or_recurrent: false, has_mtp: false, base_model_repo: '', checkpoint: CHAT_CHECKPOINT, metadata_present: true },
+  fits: [{ backend: 'vulkan', fits_fully: true, fitted_ctx: 0, fitted_ngl: -1, fitted_ncmoe: 0, weights_mib: 4096, kv_mib: 2816, compute_mib: 512, total_mib: 7424, available_mib: 58982, degraded: false, ok: true }],
+  plan: [
+    { label: 'Benchmarking vulkan at depth 0', backend: 'vulkan', ctx_size: 32768, llamacpp_args: '', params: { d: 0 }, ttft_key: 'vulkan_d0_ttft', tps_key: 'vulkan_d0_tps', vram_key: 'vulkan_d0_vram' },
+    { label: 'Benchmarking rocm at depth 0', backend: 'rocm', ctx_size: 2048, llamacpp_args: '', params: { d: 0 }, ttft_key: 'rocm_d0_ttft', tps_key: 'rocm_d0_tps', vram_key: 'rocm_d0_vram' },
+  ],
+  step_labels: { load_vulkan_d0: 'Benchmarking vulkan at depth 0', chat_vulkan_d0: 'Benchmarking vulkan at depth 0' },
+};
+
+async function seedRuns(page: Page, runs: Array<Record<string, unknown>>, key = RUNS_KEY) {
+  await page.addInitScript(([k, payload]) => {
+    localStorage.setItem(k as string, JSON.stringify({ version: 2, runs: payload }));
+  }, [key, runs] as const);
+}
+
+async function openPresets(page: Page) {
+  await page.goto('/');
+  await page.waitForSelector('.titlebar__nav');
+  await page.locator('.titlebar__nav').getByText('Presets').click();
+  await page.waitForSelector('.recipes');
+}
+
+async function openWizard(page: Page) {
+  await openPresets(page);
+  await page.locator('[data-autoopt-run-optimizer]').click();
+  await page.waitForSelector('[data-autoopt-wizard]');
+}
+
+async function walkToBudget(page: Page, model = CHAT_MODEL) {
+  await page.locator('[data-autoopt-model-select]').selectOption(model);
+  await page.locator('[data-autoopt-next]').click();
+  await page.locator('[data-autoopt-next]').click();
+  await page.locator('[data-autoopt-next]').click();
+  await page.locator('[data-autoopt-next]').click();
+  await expect(page.locator('[data-autoopt-step="budget"]')).toBeVisible();
+}
+
+test.describe('AutoOpt wizard + server-side bench job', () => {
+
+  test('full Benchmark flow — posts a recipe, polls the job, synthesizes the result', async ({ page }) => {
+    const counts = await mockServer(page, {
+      loadedModels: [{ model_name: CHAT_MODEL, type: 'llm', recipe: 'llamacpp', device: 'gpu', checkpoint: '', backend_url: '', pid: 1, last_use: Date.now() }],
+    });
+
+    await openWizard(page);
+    await expect(page.locator('[data-autoopt-model-select]')).toHaveValue(CHAT_MODEL, { timeout: 10000 });
+    await page.locator('[data-autoopt-next]').click();
+    await page.locator('[data-autoopt-next]').click();
+    await expect(page.locator('[data-autoopt-option="kv:q8_0"]')).toHaveAttribute('aria-pressed', 'true');
+    await page.locator('[data-autoopt-next]').click();
+    await page.locator('[data-autoopt-option="ram:minimal"]').click();
+    await page.locator('[data-autoopt-next]').click();
+
+    await expect(page.locator('[data-autoopt-step="budget"]')).toBeVisible();
+    await expect(page.locator('[data-autoopt-step="vision"]')).toHaveCount(0);
+    await page.locator('[data-autoopt-option="budget:standard"]').click();
+
+    await page.locator('[data-autoopt-next]').click();
+    await expect(page.locator('[data-autoopt-start]')).toBeDisabled();
+    await page.locator('[data-autoopt-back]').click();
+    await page.locator('[data-autoopt-consent]').check();
+    await page.locator('[data-autoopt-next]').click();
+    await page.locator('[data-autoopt-start]').click();
+
+    await expect(page.locator('[data-autoopt-step="running"]')).toBeVisible();
+    await expect(page.locator('[data-autoopt-close-note]')).toContainText('keeps running on the server');
+    await expect(page.locator('[data-autoopt-stage-list] .autoopt-stage--completed')).toHaveCount(6, { timeout: 20000 });
+    await page.locator('[data-autoopt-wizard] .slideover__close').click();
+
+    const run = page.locator('[data-autoopt-run]');
+    await expect(run.locator('.autoopt-status-chip--completed')).toBeVisible();
+    await expect(page.locator('[data-autoopt-announcement]')).toContainText(`AutoOpt run for ${CHAT_MODEL} completed.`);
+
+    expect(counts.jobs).toHaveLength(1);
+    const recipe = counts.jobs[0] as { inputs: Record<string, unknown>; definition: { steps: Array<Record<string, unknown>> } };
+    const steps = recipe.definition.steps;
+    const ops = new Set(steps.map(s => s.op));
+    expect(ops.has('load')).toBe(true);
+    expect(ops.has('chat')).toBe(true);
+    expect(ops.has('unload')).toBe(true);
+
+    const loadBackends = new Set(steps.filter(s => s.op === 'load').map(s => (s.params as any)?.llamacpp_backend));
+    expect(loadBackends.has('vulkan')).toBe(true);
+    expect(loadBackends.has('rocm')).toBe(true);
+
+    const extractKeys = steps.flatMap(s => Object.keys((s.extract as Record<string, string>) || {}));
+    expect(extractKeys.some(k => k.endsWith('_ttft'))).toBe(true);
+    expect(extractKeys.some(k => k.endsWith('_tps'))).toBe(true);
+
+    expect(extractKeys).toEqual(expect.arrayContaining(['vulkan_d0_tps', 'vulkan_d30000_tps', 'ladder_b512_ttft', 'ladder_b2048_ttft', 'ladder_b8192_ttft']));
+
+    const fallbackLoad = steps.find(s => s.op === 'load' && typeof s.on_fail === 'string' && String(s.on_fail).startsWith('loadlo_'));
+    expect(fallbackLoad).toBeTruthy();
+    expect(steps.some(s => String(s.id).startsWith('loadlo_'))).toBe(true);
+
+    expect(counts.load).toHaveLength(0);
+    expect(counts.chat).toHaveLength(0);
+
+    await page.locator('[data-autoopt-inspect]').click();
+    await page.waitForSelector('[data-autoopt-detail]');
+    const args = page.locator('[data-autoopt-rec-args]');
+    await expect(args).toContainText('-ctk q8_0 -ctv q8_0');
+    await expect(args).toContainText('--cache-ram 2048 -ctxcp 8');
+    await expect(args).toContainText('-b 2048 -ub 2048');
+    await expect(page.locator('.autoopt-rec-card__chips')).toContainText('vulkan');
+    await expect(page.locator('[data-autoopt-bench-duel] thead')).toContainText('TTFT ms');
+    await expect(page.locator('[data-autoopt-bench-ladder] thead')).toContainText('TTFT ms');
+  });
+
+  test('reload re-attaches to an in-flight server job and finishes it (review #6a)', async ({ page }) => {
+    await mockServer(page, { jobRunningPolls: 1 });
+    await seedRuns(page, [{
+      ...COMPLETED_RUN,
+      id: 'ao-reattach',
+      status: 'running',
+      finished_at: undefined,
+      summary: undefined,
+      result: undefined,
+      job_id: 'job-reattach-1',
+      synth_inputs: { ...SYNTH_INPUTS, facts: { ...SYNTH_INPUTS.facts }, plan: SYNTH_INPUTS.plan },
+      answers: { parallel: { mode: 'single' }, kv_cache_quant: 'none', ram_headroom: 'normal', allow_network: true },
+      stages: [
+        { name: 'snapshot', status: 'completed' },
+        { name: 'model_facts', status: 'completed' },
+        { name: 'hf_metadata', status: 'completed' },
+        { name: 'fit_estimate', status: 'completed' },
+        { name: 'bench_job', status: 'running' },
+        { name: 'synthesize', status: 'pending' },
+      ],
+      measurements: { fit: SYNTH_INPUTS.fits, bench: [] },
+    }]);
+
+    await openPresets(page);
+
+    const run = page.locator('[data-autoopt-run="ao-reattach"]');
+    await expect(run.locator('.autoopt-status-chip--running')).toBeVisible();
+
+    await expect(run.locator('.autoopt-status-chip--completed')).toBeVisible({ timeout: 15000 });
+    await page.locator('[data-autoopt-inspect="ao-reattach"]').click();
+    await page.waitForSelector('[data-autoopt-detail]');
+    await expect(page.locator('.autoopt-rec-card__chips')).toContainText('vulkan');
+    await expect(page.locator('[data-autoopt-rec-args]')).toContainText('--spec-default');
+  });
+
+  test('Fast Scan skips the bench job and never touches the model slot', async ({ page }) => {
+    const counts = await mockServer(page, {
+      loadedModels: [{ model_name: CHAT_MODEL, type: 'llm', recipe: 'llamacpp', device: 'gpu', checkpoint: '', backend_url: '', pid: 1, last_use: Date.now() }],
+    });
+
+    await openWizard(page);
+    await expect(page.locator('[data-autoopt-model-select]')).toHaveValue(CHAT_MODEL, { timeout: 10000 });
+    await walkToBudget(page);
+    await page.locator('[data-autoopt-option="budget:quick"]').click();
+    await expect(page.locator('[data-autoopt-consent]')).toHaveCount(0);
+    await page.locator('[data-autoopt-next]').click();
+    await expect(page.locator('[data-autoopt-step="review"]')).toContainText('Not needed for Fast Scan');
+    await page.locator('[data-autoopt-start]').click();
+
+    await expect(page.locator('[data-autoopt-step="running"]')).toBeVisible();
+    await expect(page.locator('[data-autoopt-stage-list] .autoopt-stage--completed')).toHaveCount(5, { timeout: 15000 });
+    await expect(page.locator('[data-autoopt-stage-list] .autoopt-stage--skipped')).toHaveCount(1);
+
+    expect(counts.jobs).toHaveLength(0);
+    expect(counts.load).toHaveLength(0);
+    expect(counts.unload).toHaveLength(0);
+  });
+
+  test('a late system-info reply must not clobber an explicit RAM-headroom choice', async ({ page }) => {
+    await mockServer(page);
+    await page.unroute('**/api/v1/system-info**');
+    await page.route('**/api/v1/system-info**', async route => {
+      await new Promise(resolve => setTimeout(resolve, 2500));
+      await route.fulfill({ json: SYSTEM_INFO });
+    });
+
+    await openWizard(page);
+    await page.locator('[data-autoopt-model-select]').selectOption(CHAT_MODEL);
+    await page.locator('[data-autoopt-next]').click();
+    await page.locator('[data-autoopt-next]').click();
+    await page.locator('[data-autoopt-next]').click();
+    await expect(page.locator('[data-autoopt-step="ram"]')).toBeVisible();
+    await page.locator('[data-autoopt-option="ram:minimal"]').click();
+    await page.waitForTimeout(3000);
+    await expect(page.locator('[data-autoopt-option="ram:minimal"]')).toHaveAttribute('aria-pressed', 'true');
+
+    await page.locator('[data-autoopt-next]').click();
+    await page.locator('[data-autoopt-option="budget:quick"]').click();
+    await page.locator('[data-autoopt-next]').click();
+    await expect(page.locator('[data-autoopt-step="review"]')).toContainText('Minimal');
+    await page.locator('[data-autoopt-start]').click();
+    await expect(page.locator('[data-autoopt-stage-list] .autoopt-stage--completed')).toHaveCount(5, { timeout: 15000 });
+
+    await page.locator('[data-autoopt-wizard] .slideover__close').click();
+    await page.locator('[data-autoopt-inspect]').click();
+    await page.waitForSelector('[data-autoopt-detail]');
+    await expect(page.locator('[data-autoopt-rec-args]')).toContainText('--cache-ram 2048 -ctxcp 8');
+  });
+
+  async function runFastScan(page: Page) {
+    await openWizard(page);
+    await walkToBudget(page);
+    await page.locator('[data-autoopt-option="budget:quick"]').click();
+    await page.locator('[data-autoopt-next]').click();
+    await page.locator('[data-autoopt-start]').click();
+    await expect(page.locator('[data-autoopt-stage-list] .autoopt-stage--skipped')).toHaveCount(1, { timeout: 15000 });
+  }
+
+  test('a model without published sampling defaults completes hf_metadata with a neutral note', async ({ page }) => {
+    await mockServer(page);
+    await page.unroute('https://huggingface.co/org/base-model/resolve/main/generation_config.json');
+    await page.route('https://huggingface.co/org/base-model/resolve/main/generation_config.json',
+      route => route.fulfill({ status: 404, body: 'Not Found' }));
+
+    await runFastScan(page);
+    await expect(page.locator('[data-autoopt-stage-list] .autoopt-stage--failed')).toHaveCount(0);
+    await page.locator('[data-autoopt-wizard] .slideover__close').click();
+    await page.locator('[data-autoopt-inspect]').click();
+    await page.waitForSelector('[data-autoopt-detail]');
+    await expect(page.locator('.autoopt-stage__note')).toContainText('no sampling defaults published');
+  });
+
+  test('hf_metadata falls back to generation defaults inside config.json', async ({ page }) => {
+    await mockServer(page);
+    await page.unroute('https://huggingface.co/org/base-model/resolve/main/generation_config.json');
+    await page.route('https://huggingface.co/org/base-model/resolve/main/generation_config.json',
+      route => route.fulfill({ status: 404, body: 'Not Found' }));
+    await page.unroute('https://huggingface.co/org/base-model/resolve/main/config.json');
+    await page.route('https://huggingface.co/org/base-model/resolve/main/config.json',
+      route => route.fulfill({ json: { architectures: ['Qwen3ForCausalLM'], generation_config: { temperature: 0.6, top_k: 20 } } }));
+
+    await runFastScan(page);
+    await page.locator('[data-autoopt-wizard] .slideover__close').click();
+    await page.locator('[data-autoopt-inspect]').click();
+    await page.waitForSelector('[data-autoopt-detail]');
+    await expect(page.locator('.autoopt-rec-card__chips')).toContainText('temp 0.6');
+  });
+
+  test('model picker only offers downloaded llama.cpp models and explains the scope', async ({ page }) => {
+    await mockServer(page);
+    await openWizard(page);
+
+    await expect(page.locator('[data-autoopt-model-note]')).toContainText('AutoOpt currently supports downloaded llama.cpp models');
+    const select = page.locator('[data-autoopt-model-select]');
+    await expect(select.locator(`option[value="${CHAT_MODEL}"]`)).toHaveCount(1);
+    await expect(select.locator(`option[value="${NPU_MODEL}"]`)).toHaveCount(0);
+    await expect(select.locator(`option[value="${REGISTRY_MODEL}"]`)).toHaveCount(0);
+  });
+
+  test('cancel interrupts the server job and marks the run cancelled', async ({ page }) => {
+    const counts = await mockServer(page, { jobRunningPolls: 1000 });
+
+    await openWizard(page);
+    await walkToBudget(page);
+    await page.locator('[data-autoopt-option="budget:standard"]').click();
+    await page.locator('[data-autoopt-next]').click();
+    await page.locator('[data-autoopt-start]').click();
+
+    await expect(page.locator('[data-autoopt-step="running"]')).toBeVisible();
+    await expect.poll(() => counts.jobs.length, { timeout: 15000 }).toBe(1);
+    await page.locator('[data-autoopt-cancel-run]').click();
+
+    await expect.poll(() => counts.interrupts.length, { timeout: 15000 }).toBeGreaterThan(0);
+    await page.locator('[data-autoopt-wizard] .slideover__close').click();
+    await expect(page.locator('[data-autoopt-run] .autoopt-status-chip--cancelled')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('when the primary ctx fails to load, the recommendation reflects the fallback ctx (review #2)', async ({ page }) => {
+    await mockServer(page, { failPrimaryLoads: true });
+
+    await openWizard(page);
+    await walkToBudget(page);
+    await page.locator('[data-autoopt-option="budget:standard"]').click();
+    await page.locator('[data-autoopt-next]').click();
+    await page.locator('[data-autoopt-start]').click();
+
+    await expect(page.locator('[data-autoopt-stage-list] .autoopt-stage--completed')).toHaveCount(6, { timeout: 20000 });
+    await page.locator('[data-autoopt-wizard] .slideover__close').click();
+    await page.locator('[data-autoopt-inspect]').click();
+    await page.waitForSelector('[data-autoopt-detail]');
+
+    await expect(page.locator('.autoopt-rec-card__chips')).toContainText('ctx 2,048');
+    await expect(page.locator('.autoopt-rec-card__chips')).not.toContainText('ctx 32,768');
+    await expect(page.locator('.autoopt-rec-card__rationale')).toContainText('largest context that actually loaded');
+  });
+
+  test('a server job that fails surfaces the error in rail and detail', async ({ page }) => {
+    await mockServer(page, { jobFails: true });
+
+    await openWizard(page);
+    await walkToBudget(page);
+    await page.locator('[data-autoopt-option="budget:standard"]').click();
+    await page.locator('[data-autoopt-next]').click();
+    await page.locator('[data-autoopt-start]').click();
+
+    await expect(page.locator('[data-autoopt-step="running"] .preset-error')).toContainText('CUDA out of memory', { timeout: 20000 });
+    await page.locator('[data-autoopt-wizard] .slideover__close').click();
+    const run = page.locator('[data-autoopt-run]');
+    await expect(run.locator('.autoopt-status-chip--failed')).toContainText('CUDA out of memory');
+  });
+
+  test('the rail fires no server calls before a run is started', async ({ page }) => {
+    const counts = await mockServer(page);
+    await openPresets(page);
+    await expect(page.locator('[data-autoopt-run-optimizer]')).toBeEnabled();
+    await page.waitForTimeout(500);
+    expect(counts.jobs).toHaveLength(0);
+    expect(counts.load).toHaveLength(0);
+  });
+});
+
+test.describe('AutoOpt rail persistence + server scoping', () => {
+
+  test('a client-only run interrupted by reload is failed as interrupted', async ({ page }) => {
+    await mockServer(page);
+    await seedRuns(page, [{ ...COMPLETED_RUN, id: 'ao-dead', status: 'running', job_id: undefined, synth_inputs: undefined, finished_at: undefined, result: undefined, summary: undefined }]);
+
+    await openPresets(page);
+    const run = page.locator('[data-autoopt-run="ao-dead"]');
+    await expect(run).toBeVisible();
+    await expect(run.locator('.autoopt-status-chip--failed')).toContainText('interrupted');
+  });
+
+  test('completed runs survive a reload with their result intact', async ({ page }) => {
+    await mockServer(page);
+    await seedRuns(page, [COMPLETED_RUN]);
+
+    await openPresets(page);
+    await expect(page.locator(`[data-autoopt-run="${COMPLETED_RUN.id}"] .autoopt-status-chip--completed`)).toBeVisible();
+    await page.locator(`[data-autoopt-inspect="${COMPLETED_RUN.id}"]`).click();
+    await page.waitForSelector('[data-autoopt-detail]');
+    await expect(page.locator('[data-autoopt-rec-args]')).toContainText('-b 2048 -ub 2048');
+    await expect(page.locator('[data-autoopt-bench-duel] tbody tr')).toHaveCount(2);
+    await expect(page.locator('[data-autoopt-bench-ladder] tbody tr')).toHaveCount(2);
+  });
+
+  test('runs measured on a different server do not appear here', async ({ page }) => {
+    await mockServer(page);
+    await seedRuns(page, [{ ...COMPLETED_RUN, id: 'ao-other-server' }], 'lemonade_autoopt_runs_v2::http://other-server:9999');
+
+    await openPresets(page);
+    await expect(page.locator('[data-autoopt-empty]')).toBeVisible();
+    await expect(page.locator('[data-autoopt-run="ao-other-server"]')).toHaveCount(0);
+  });
+
+  test('delete removes a run permanently; a failed persist rolls the row and selection back', async ({ page }) => {
+    const otherRun = { ...COMPLETED_RUN, id: 'ao-20260713-110000-beef', created_at: '2026-07-13T11:00:00Z' };
+    await mockServer(page);
+    await seedRuns(page, [otherRun, COMPLETED_RUN]);
+
+    await openPresets(page);
+    const run = page.locator(`[data-autoopt-run="${COMPLETED_RUN.id}"]`);
+    await expect(run).toBeVisible();
+    await run.locator('.auto-run-card__main').click();
+    await expect(run.locator('.auto-run-card__main')).toHaveAttribute('aria-pressed', 'true');
+    await page.evaluate((key) => {
+      const original = localStorage.setItem.bind(localStorage);
+      let armed = true;
+      localStorage.setItem = (k: string, v: string) => {
+        if (k === key && armed) { armed = false; throw new Error('storage quota exceeded'); }
+        return original(k, v);
+      };
+    }, RUNS_KEY);
+
+    await page.locator(`[data-autoopt-delete="${COMPLETED_RUN.id}"]`).click();
+    await expect(run).toBeVisible();
+    await expect(page.locator('[data-autoopt-rail-error]')).toContainText('storage quota exceeded');
+    await expect(run.locator('.auto-run-card__main')).toHaveAttribute('aria-pressed', 'true');
+
+    await page.locator(`[data-autoopt-delete="${COMPLETED_RUN.id}"]`).click();
+    await expect(run).toHaveCount(0);
+    const persisted = await page.evaluate((key) => {
+      const parsed = JSON.parse(localStorage.getItem(key) || '{}');
+      return Array.isArray(parsed.runs) ? parsed.runs.map((r: any) => r.id) : [];
+    }, RUNS_KEY);
+    expect(persisted).toEqual([otherRun.id]);
+  });
+});
+
+test.describe('AutoOpt run detail actions', () => {
+
+  async function openCompletedRunDetail(page: Page, options: MockOptions = {}): Promise<MockCounts> {
+    const counts = await mockServer(page, options);
+    await seedRuns(page, [COMPLETED_RUN]);
+    await openPresets(page);
+    await expect(page.locator(`[data-autoopt-run="${COMPLETED_RUN.id}"]`)).toBeVisible();
+    await page.locator(`[data-autoopt-inspect="${COMPLETED_RUN.id}"]`).click();
+    await page.waitForSelector('[data-autoopt-detail]');
+    await expect(page.locator('[data-autoopt-recommendation]')).toBeVisible();
+    return counts;
+  }
+
+  test('"Create preset" writes an optimized preset and model tuning without loading', async ({ page }) => {
+    const counts = await openCompletedRunDetail(page);
+    await page.locator('[data-autoopt-create-preset]').click();
+    await expect(page.locator('[data-autoopt-detail-notice]')).toContainText('selected it for future loads');
+    expect(counts.load).toHaveLength(0);
+
+    const stored = await page.evaluate((model) => {
+      let preset: any = null;
+      let tuning: any = null;
+      for (const key of Object.keys(localStorage)) {
+        if (key.includes('user_presets')) {
+          const presets = JSON.parse(localStorage.getItem(key) || '[]');
+          preset = presets.find((p: any) => p.auto_opt_run_id) || preset;
+        }
+        if (key.includes('model_tunings')) {
+          const tunings = JSON.parse(localStorage.getItem(key) || '{}');
+          for (const [tuningKey, value] of Object.entries(tunings)) {
+            if (tuningKey.startsWith(`${model}@@`) && (value as any).source === 'optimized') tuning = value;
+          }
+        }
+      }
+      return { preset, tuning };
+    }, CHAT_MODEL);
+
+    expect(stored.preset?.auto_opt_run_id).toBe(COMPLETED_RUN.id);
+    expect(stored.preset.name).toContain('AutoOpt');
+    expect(stored.tuning?.source).toBe('optimized');
+    expect(stored.tuning.recipe_options.llamacpp_args).toBe('-ctk q8_0 -ctv q8_0 --spec-default -b 2048 -ub 2048');
+    expect(stored.tuning.sampling.min_p).toBe(0.05);
+  });
+
+  test('"Create preset & apply now" also loads the model', async ({ page }) => {
+    const counts = await openCompletedRunDetail(page);
+    await page.locator('[data-autoopt-create-apply]').click();
+    await expect(page.locator('[data-autoopt-detail-notice]')).toContainText('applied it to');
+    expect(counts.load).toHaveLength(1);
+    expect(counts.load[0].model_name).toBe(CHAT_MODEL);
+  });
+
+  test('"Create preset & apply now" keeps the created preset when the load fails', async ({ page }) => {
+    await openCompletedRunDetail(page);
+    await page.unroute('**/api/v1/load');
+    await page.route('**/api/v1/load', route => route.fulfill({ status: 500, json: { error: { message: 'llama-server failed to start' } } }));
+
+    await page.locator('[data-autoopt-create-apply]').click();
+    const error = page.locator('[data-autoopt-detail] .preset-error');
+    await expect(error).toContainText('was created and selected, but loading');
+    await expect(error).toContainText('llama-server failed to start');
+
+    const stored = await page.evaluate(() => {
+      for (const key of Object.keys(localStorage)) {
+        if (!key.includes('user_presets')) continue;
+        const presets = JSON.parse(localStorage.getItem(key) || '[]');
+        const preset = presets.find((p: any) => p.auto_opt_run_id);
+        if (preset) return preset;
+      }
+      return null;
+    });
+    expect(stored?.name).toContain('AutoOpt');
+  });
+
+  test('"Try now without saving" loads a not-loaded model with the exact recommended options', async ({ page }) => {
+    const counts = await openCompletedRunDetail(page);
+    await page.locator('[data-autoopt-try-now]').click();
+    await expect(page.locator('[data-autoopt-detail-notice]')).toContainText('nothing saved');
+
+    expect(counts.load).toHaveLength(1);
+    const body = counts.load[0];
+    expect(body.model_name).toBe(CHAT_MODEL);
+    expect(body.ctx_size).toBe(32768);
+    expect(body.llamacpp_args).toBe('-ctk q8_0 -ctv q8_0 --spec-default -b 2048 -ub 2048');
+    expect(body.llamacpp_backend).toBe('vulkan');
+    expect(body.save_options).toBe(false);
+    const saved = await page.evaluate(() => {
+      for (const key of Object.keys(localStorage)) {
+        if (key.includes('user_presets')) {
+          const presets = JSON.parse(localStorage.getItem(key) || '[]');
+          if (presets.some((p: any) => p.auto_opt_run_id)) return 'preset-created';
+        }
+      }
+      return 'nothing-saved';
+    });
+    expect(saved).toBe('nothing-saved');
+  });
+
+  test('"Try now without saving" RELOADS a model that is already loaded (review #2)', async ({ page }) => {
+    const counts = await openCompletedRunDetail(page, {
+      loadedModels: [{ model_name: CHAT_MODEL, type: 'llm', recipe: 'llamacpp', device: 'gpu', checkpoint: '', backend_url: '', pid: 1, last_use: Date.now() }],
+    });
+    await page.locator('[data-autoopt-try-now]').click();
+    await expect(page.locator('[data-autoopt-detail-notice]')).toContainText('nothing saved');
+
+    expect(counts.unload.some(b => b.model_name === CHAT_MODEL)).toBe(true);
+    expect(counts.load).toHaveLength(1);
+    expect(counts.load[0].save_options).toBe(false);
+    expect(counts.load[0].llamacpp_args).toBe('-ctk q8_0 -ctv q8_0 --spec-default -b 2048 -ub 2048');
+  });
+
+  test('"Use this instead" swaps the CTA target to the alternative', async ({ page }) => {
+    const counts = await openCompletedRunDetail(page);
+    await page.locator('[data-autoopt-use-alternative="Maximum quality"]').click();
+    await expect(page.locator('[data-autoopt-rec-args]')).toContainText('--spec-default -b 2048 -ub 2048');
+    await page.locator('[data-autoopt-try-now]').click();
+    await expect(page.locator('[data-autoopt-detail-notice]')).toContainText('nothing saved');
+    expect(counts.load[0].ctx_size).toBe(16384);
+  });
+
+  test('a run whose checkpoint no longer matches the model is refused on apply (review #5)', async ({ page }) => {
+    await mockServer(page);
+    await seedRuns(page, [{ ...COMPLETED_RUN, checkpoint: 'org/chat-model-GGUF:OLD_QUANT' }]);
+    await openPresets(page);
+    await page.locator(`[data-autoopt-inspect="${COMPLETED_RUN.id}"]`).click();
+    await page.waitForSelector('[data-autoopt-detail]');
+
+    await page.locator('[data-autoopt-create-preset]').click();
+    await expect(page.locator('[data-autoopt-detail] .preset-error')).toContainText('different build');
+    const saved = await page.evaluate(() => {
+      for (const key of Object.keys(localStorage)) {
+        if (key.includes('user_presets')) {
+          const presets = JSON.parse(localStorage.getItem(key) || '[]');
+          if (presets.some((p: any) => p.auto_opt_run_id)) return true;
+        }
+      }
+      return false;
+    });
+    expect(saved).toBe(false);
+  });
+
+  test('a created preset is discoverable: sorted first, flashed, and named after its model', async ({ page }) => {
+    await openCompletedRunDetail(page);
+    await page.locator('[data-autoopt-create-preset]').click();
+    await expect(page.locator('[data-autoopt-detail-notice]')).toContainText('Created preset');
+    await page.locator('[data-autoopt-detail] .slideover__close').click();
+
+    const zoneTitles = await page.locator('.recipes__body .zone__title').allTextContents();
+    expect(zoneTitles.indexOf('Your presets')).toBeLessThan(zoneTitles.indexOf('Bundled starters'));
+
+    const card = page.locator('[data-recipe-grid="yours"] .recipe-card').first();
+    await expect(card).toHaveClass(/recipe-card--flash/);
+    await expect(card.locator('[data-preset-linked-models]')).toContainText(`Optimized for ${CHAT_MODEL}`);
+  });
+
+  test('preset editor links back to the producing run via the AutoOpt chip', async ({ page }) => {
+    await openCompletedRunDetail(page);
+    await page.locator('[data-autoopt-create-preset]').click();
+    await expect(page.locator('[data-autoopt-detail-notice]')).toContainText('Created preset');
+    await page.locator('[data-autoopt-detail] .slideover__close').click();
+
+    const yourCards = page.locator('[data-recipe-grid="yours"] .recipe-card');
+    await yourCards.first().locator('.recipe-card__overlay-btn').click();
+    await page.waitForSelector('.slideover.is-open');
+    await expect(page.locator('[data-preset-editor-linked]')).toContainText(`Optimized for ${CHAT_MODEL}`);
+    await page.locator('[data-preset-autoopt-chip]').click();
+    await expect(page.locator('[data-autoopt-detail]')).toBeVisible();
+  });
+});

--- a/prototype/ui-redesign/tests/features.spec.ts
+++ b/prototype/ui-redesign/tests/features.spec.ts
@@ -440,9 +440,10 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await expect(lede).toContainText('describe how you want to use a model');
     await expect(lede).toContainText('Model Tuning');
 
-    // Zone: Bundled starters (scope to recipes view to avoid hitting Models zones)
+    // Zone: Bundled starters (scope to recipes view to avoid hitting Models zones).
+    // User-created content sorts above the starters, so match by title.
     const recipesView = page.locator('.recipes').last();
-    const starterZone = recipesView.locator('.zone').first();
+    const starterZone = recipesView.locator('.zone').filter({ hasText: 'Bundled starters' });
     await expect(starterZone.locator('.zone__title')).toContainText('Bundled starters');
 
     // Should have 8 starter cards

--- a/prototype/ui-redesign/tests/stubs/autoOptApiStub.js
+++ b/prototype/ui-redesign/tests/stubs/autoOptApiStub.js
@@ -1,0 +1,33 @@
+const statusListeners = [];
+const state = { base: globalThis.__AO_INITIAL_BASE__ || 'http://server-a:1111' };
+const interruptCalls = [];
+const deleteCalls = [];
+
+const api = {
+  get baseUrl() { return state.base; },
+  get healthData() { return { version: 'test' }; },
+  get allModels() { return []; },
+  onStatusChange(fn) {
+    statusListeners.push(fn);
+    return () => {
+      const i = statusListeners.indexOf(fn);
+      if (i >= 0) statusListeners.splice(i, 1);
+    };
+  },
+  interruptJob(id) { interruptCalls.push(id); return Promise.resolve(); },
+  deleteJob(id) { deleteCalls.push(id); return Promise.resolve(); },
+};
+
+globalThis.__AO_API_CONTROL__ = {
+  interruptCalls,
+  deleteCalls,
+  setBase(b) {
+    state.base = b;
+    statusListeners.slice().forEach(fn => { try { fn('connected'); } catch {} });
+  },
+  setBaseSilent(b) {
+    state.base = b;
+  },
+};
+
+module.exports = { __esModule: true, default: api };

--- a/prototype/ui-redesign/tests/stubs/autoOptControllerStub.js
+++ b/prototype/ui-redesign/tests/stubs/autoOptControllerStub.js
@@ -1,0 +1,35 @@
+const AUTOOPT_STAGES = ['snapshot', 'model_facts', 'hf_metadata', 'fit_estimate', 'bench_job', 'synthesize'];
+
+const attached = [];
+
+function track(id, cb, signal) {
+  const entry = { id, cb, signal };
+  attached.push(entry);
+  return new Promise((_resolve, reject) => {
+    signal.addEventListener('abort', () => {
+      reject(Object.assign(new Error('cancelled by user'), { name: 'AbortError' }));
+    }, { once: true });
+  });
+}
+
+function resumeAutoOptRun(run, cb, signal) {
+  return track(run.id, cb, signal);
+}
+
+function executeAutoOptRun(_request, signal, cb) {
+  return track('(new)', cb, signal);
+}
+
+globalThis.__AO_CTRL__ = {
+  attached,
+  fire(id) {
+    const entry = attached.find(a => a.id === id);
+    if (!entry || !entry.cb) return;
+    entry.cb.bench([{
+      backend: 'vulkan', label: 'probe', ctx_size: 2048, llamacpp_args: '',
+      params: { d: 0 }, ttft_ms: 10, tps: 10, vram_gb: 5, ok: true,
+    }]);
+  },
+};
+
+module.exports = { __esModule: true, AUTOOPT_STAGES, resumeAutoOptRun, executeAutoOptRun };


### PR DESCRIPTION
This is meant to be added on top of #2695 as the frontend part for the autoopt wizard. Utilizes the backend queries to `llama-bench` and `llama-fit` to perform a full optimization pass for llama.cpp parameters.