### PR TITLE
fix(process): detect zombie backend processes

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -275,6 +275,7 @@ jobs:
           set -e
           cmake --preset default
           cmake --build --preset default --target test_directory_watcher
+          cmake --build --preset default --target test_process_manager
           cmake --build --preset default --target test_latest_version_fallback
           cmake --build --preset default --target test_routing_policy_contract
           cmake --build --preset default --target test_routing_policy_evaluator
@@ -288,7 +289,7 @@ jobs:
           cmake --build --preset default --target test_routing_classifier_services
           cmake --build --preset default --target test_network_utils
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest"
+          ctest --output-on-failure -R "ProcessManagerTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -586,6 +587,7 @@ jobs:
         shell: bash
         run: |
           cmake --build --preset default --target test_directory_watcher
+          cmake --build --preset default --target test_process_manager
           cmake --build --preset default --target test_latest_version_fallback
           cmake --build --preset default --target test_routing_policy_contract
           cmake --build --preset default --target test_routing_policy_evaluator
@@ -599,7 +601,7 @@ jobs:
           cmake --build --preset default --target test_routing_classifier_services
           cmake --build --preset default --target test_network_utils
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest"
+          ctest --output-on-failure -R "ProcessManagerTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1824,6 +1824,27 @@ message(STATUS "  Archive: ${EMBEDDABLE_ARCHIVE_NAME}")
 # C++ Unit Tests
 # ============================================================
 
+# ProcessManager zombie detection and non-mutating reap contract.
+if(BUILD_TESTING AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(_PROCESS_MANAGER_TEST_SRC
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_process_manager.cpp"
+    )
+    if(EXISTS "${_PROCESS_MANAGER_TEST_SRC}")
+        add_executable(test_process_manager
+            test/cpp/test_process_manager.cpp
+            src/cpp/server/utils/process_manager.cpp
+            src/cpp/server/utils/platform/process_unix.cpp
+        )
+        target_include_directories(test_process_manager PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+            ${CMAKE_CURRENT_BINARY_DIR}/include
+        )
+        find_package(Threads REQUIRED)
+        target_link_libraries(test_process_manager PRIVATE Threads::Threads)
+        add_test(NAME ProcessManagerTest COMMAND test_process_manager)
+    endif()
+endif()
+
 # FastFlowLM argument validation. Keep this test independent from the server
 set(_FLM_ARG_RESOLVER_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_flm_arg_resolver.cpp"

--- a/src/cpp/server/utils/platform/process_unix.cpp
+++ b/src/cpp/server/utils/platform/process_unix.cpp
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <iostream>
+#include <fstream>
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -81,6 +82,20 @@ static void preserve_capabilities_for_exec() {
     cap_free(caps);
 }
 #endif
+
+static bool is_zombie_by_proc(pid_t pid) {
+    std::ifstream stat_file("/proc/" + std::to_string(pid) + "/stat");
+    std::string stat_line;
+    if (!std::getline(stat_file, stat_line)) {
+        return false;
+    }
+
+    // Process state is the first field after the final ')' of comm.
+    const auto close_paren = stat_line.rfind(')');
+    return close_paren != std::string::npos &&
+           close_paren + 2 < stat_line.size() &&
+           stat_line[close_paren + 2] == 'Z';
+}
 
 class UnixProcessPlatform : public ProcessPlatform {
 public:
@@ -370,6 +385,10 @@ bool UnixProcessPlatform::is_running(ProcessHandle handle) {
         return false;
     }
 #endif
+
+    if (is_zombie_by_proc(handle.pid)) {
+        return false;
+    }
 
     errno = 0;
     return ::kill(handle.pid, 0) == 0 || errno == EPERM;

--- a/test/cpp/test_process_manager.cpp
+++ b/test/cpp/test_process_manager.cpp
@@ -1,0 +1,139 @@
+#include <lemon/utils/process_manager.h>
+
+#include <cerrno>
+#include <chrono>
+#include <csignal>
+#include <cstdio>
+#include <fstream>
+#include <limits>
+#include <string>
+#include <thread>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+using lemon::utils::ProcessHandle;
+using lemon::utils::ProcessManager;
+
+namespace {
+
+int failures = 0;
+
+void check(const char* name, bool condition) {
+    std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", name);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+ProcessHandle make_handle(pid_t pid) {
+    return {nullptr, static_cast<int>(pid)};
+}
+
+pid_t spawn_exiting_child(int exit_code) {
+    const pid_t pid = fork();
+    if (pid == 0) {
+        _exit(exit_code);
+    }
+    return pid;
+}
+
+pid_t spawn_running_child() {
+    const pid_t pid = fork();
+    if (pid == 0) {
+        for (;;) {
+            pause();
+        }
+    }
+    return pid;
+}
+
+bool is_zombie(pid_t pid) {
+    std::ifstream stat_file("/proc/" + std::to_string(pid) + "/stat");
+    std::string stat_line;
+    if (!std::getline(stat_file, stat_line)) {
+        return false;
+    }
+
+    const auto close_paren = stat_line.rfind(')');
+    return close_paren != std::string::npos &&
+           close_paren + 2 < stat_line.size() &&
+           stat_line[close_paren + 2] == 'Z';
+}
+
+bool wait_for_zombie(pid_t pid, std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    do {
+        if (is_zombie(pid)) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    } while (std::chrono::steady_clock::now() < deadline);
+
+    return is_zombie(pid);
+}
+
+void kill_and_reap(pid_t pid) {
+    if (pid <= 0) {
+        return;
+    }
+
+    ::kill(pid, SIGKILL);
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+    }
+}
+
+} // namespace
+
+int main() {
+    {
+        const pid_t child = spawn_exiting_child(42);
+        check("fork exited child", child > 0);
+
+        if (child > 0) {
+            const bool zombie = wait_for_zombie(child, std::chrono::seconds(5));
+            check("child reaches zombie state without reaping", zombie);
+
+            if (zombie) {
+                const ProcessHandle handle = make_handle(child);
+                check("is_running() returns false for zombie",
+                      !ProcessManager::is_running(handle));
+                check("reap_process() preserves exit code 42",
+                      ProcessManager::reap_process(handle) == 42);
+            } else {
+                kill_and_reap(child);
+            }
+        }
+    }
+
+    {
+        const pid_t child = spawn_running_child();
+        check("fork running child", child > 0);
+
+        if (child > 0) {
+            const ProcessHandle handle = make_handle(child);
+            check("is_running() returns true for running child",
+                  ProcessManager::is_running(handle));
+            check("reap_process() does not reap running child",
+                  ProcessManager::reap_process(handle) == -1);
+            kill_and_reap(child);
+        }
+    }
+
+    check("is_running() rejects PID 0",
+          !ProcessManager::is_running(make_handle(0)));
+    check("is_running() rejects negative PID",
+          !ProcessManager::is_running(make_handle(-1)));
+    check("is_running() rejects non-existent PID",
+          !ProcessManager::is_running(
+              make_handle(std::numeric_limits<int>::max())));
+
+    if (failures == 0) {
+        std::printf("\nAll process_manager tests passed\n");
+        return 0;
+    }
+
+    std::printf("\n%d process_manager test(s) failed\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Follow-up to #2298

Detect zombie backend processes through `/proc/<pid>/stat` before falling back to `kill(pid, 0)`. The liveness check remains non-mutating, allowing the owning cleanup path to reap the child and retain its real exit code.

* Focused changes, solid logic
* Added Linux-only regression coverage for zombie and running processes, invalid PIDs, and preserved exit status
* Added the new test to the existing Linux C++ CI job
* Passed ProcessManagerTest locally
