### PR TITLE
Unify HF search UX and add detail panel for HF models (#2564)

### DIFF
--- a/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelDetailPanel.tsx
@@ -7,7 +7,7 @@
 import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import MarkdownIt from 'markdown-it';
 import DOMPurify from 'dompurify';
-import type { ModelInfo, LoadedModel, ModelFileInfo } from '../api';
+import type { ModelInfo, LoadedModel, ModelFileInfo, HFModelResult, PullVariantsResult } from '../api';
 import api from '../api';
 import { capabilityFromModelInfo, capabilityLabel } from '../modelCapabilities';
 import {
@@ -36,6 +36,12 @@ function fmtSize(gb: number): string {
   if (gb >= 1) return `${gb.toFixed(1)} GB`;
   if (gb >= 0.01) return `${(gb * 1000).toFixed(0)} MB`;
   return '< 1 MB';
+}
+
+function fmtDownloads(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
 }
 
 function recipeDisplayLabel(recipe: string): string {
@@ -532,7 +538,311 @@ const ModelReadmeTab: React.FC<{ model: ModelInfo | null | undefined; isActive: 
   );
 };
 
-/* ── Presets tab ─────────────────────────────────────────────── */
+/* ── HF README tab ────────────────────────────────────────────── */
+
+const HfReadmeTab: React.FC<{ hfId: string; isActive: boolean }> = ({ hfId, isActive }) => {
+  const readmeUrl = `https://huggingface.co/${hfId}/raw/main/README.md`;
+  const [readme, setReadme] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const cached = readmeCache.get(readmeUrl);
+    if (cached !== undefined) { setReadme(cached); return; }
+    let cancelled = false;
+    setLoading(true);
+    fetch(readmeUrl)
+      .then(r => r.ok ? r.text() : null)
+      .then(text => {
+        if (cancelled) return;
+        const content = text || '';
+        readmeCache.set(readmeUrl, content);
+        setReadme(content);
+      })
+      .catch(() => {
+        if (!cancelled) { readmeCache.set(readmeUrl, ''); setReadme(''); }
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [readmeUrl, isActive]);
+
+  if (loading) {
+    return (
+      <div className="detail-tab-content detail-readme detail-readme--loading" aria-live="polite" aria-busy="true">
+        <span>Loading README…</span>
+      </div>
+    );
+  }
+  if (!readme) {
+    return (
+      <div className="detail-tab-content detail-readme detail-readme--empty">
+        <Icon name="book-open" size={32} aria-hidden="true" />
+        <p>README unavailable for this model.</p>
+      </div>
+    );
+  }
+  const html = DOMPurify.sanitize(readmeMd.render(stripFrontmatter(readme)), README_PURIFY_CONFIG);
+  return (
+    <div className="detail-tab-content detail-readme" dangerouslySetInnerHTML={{ __html: html }} />
+  );
+};
+
+/* ── HF overview tab ──────────────────────────────────────────── */
+
+const HfOverviewTab: React.FC<{
+  hfModel: HFModelResult;
+  hfVariants?: PullVariantsResult;
+  onHfPull?: (hfId: string, variantName: string, recipe: string) => void;
+  isPulling: boolean;
+  isActive: boolean;
+}> = ({ hfModel, hfVariants, onHfPull, isPulling, isActive }) => {
+  if (!isActive) return null;
+  return (
+    <div className="detail-tab-content hf-detail__overview">
+      {hfVariants ? (
+        <>
+          {hfVariants.suggested_labels.length > 0 && (
+            <div className="hf-detail__overview-section">
+              <span className="hf-detail__overview-label">Capabilities</span>
+              <div className="hf-detail__overview-value">{hfVariants.suggested_labels.join(', ')}</div>
+            </div>
+          )}
+          {hfVariants.variants.length > 0 ? (
+            <div className="hf-detail__overview-section">
+              <span className="hf-detail__overview-label">Variants — pick one to download</span>
+              <div className="hf-detail__gguf-list">
+                {hfVariants.variants.map(v => (
+                  <button
+                    key={v.name}
+                    className="hf-detail__gguf-btn"
+                    aria-label={`Download ${v.name} from ${hfModel.id}`}
+                    disabled={isPulling}
+                    onClick={() => onHfPull?.(hfModel.id, v.name, hfVariants.recipe)}
+                  >
+                    <span className="hf-detail__gguf-name">
+                      {v.name}{v.sharded ? ' (sharded)' : ''}
+                    </span>
+                    <span className="hf-detail__gguf-size">{fmtBytes(v.size_bytes)}</span>
+                    <span className="hf-detail__gguf-action">Download</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="hf-detail__overview-section">
+              <span className="hf-detail__overview-value hf-detail__overview-value--muted">No downloadable variants found for this repository.</span>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="hf-detail__overview-section">
+          <span className="hf-detail__overview-value hf-detail__overview-value--muted">Loading variant information…</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+/* ── HF detail view ───────────────────────────────────────────── */
+
+type HfDetailTab = 'overview' | 'readme';
+
+const HF_DETAIL_TABS: Array<{ id: HfDetailTab; label: string }> = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'readme', label: 'README' },
+];
+
+const HfDetailView: React.FC<{
+  hfModel: HFModelResult;
+  hfVariants?: PullVariantsResult;
+  onFetchHfVariants?: (hfId: string) => void;
+  onHfPull?: (hfId: string, variantName: string, recipe: string) => void;
+  pullingHf?: Record<string, number>;
+  onCancelHfPull?: (hfId: string) => void;
+  onBack?: () => void;
+  onClose?: () => void;
+}> = ({ hfModel, hfVariants, onFetchHfVariants, onHfPull, pullingHf, onCancelHfPull, onBack, onClose }) => {
+  const [activeTab, setActiveTab] = useState<HfDetailTab>('overview');
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const panelHeadingRef = useRef<HTMLHeadingElement>(null);
+
+  const repoName = hfModel.id;
+  const pipelineTag = hfModel.pipeline_tag || '';
+  const displayTags = (hfModel.tags || [])
+    .filter(t => t !== 'gguf' && t !== 'transformers' && t !== 'pytorch' && t !== 'safetensors')
+    .slice(0, 8);
+  const isPulling = (pullingHf?.[hfModel.id]) !== undefined;
+  const pullPct = pullingHf?.[hfModel.id] ?? 0;
+
+  useEffect(() => {
+    setActiveTab('overview');
+    panelHeadingRef.current?.focus();
+  }, [repoName]);
+
+  useEffect(() => {
+    if (!hfVariants && onFetchHfVariants) {
+      onFetchHfVariants(hfModel.id);
+    }
+  }, [hfModel.id, hfVariants, onFetchHfVariants]);
+
+  const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    const count = HF_DETAIL_TABS.length;
+    let next = -1;
+    if (e.key === 'ArrowRight') { e.preventDefault(); next = (index + 1) % count; }
+    else if (e.key === 'ArrowLeft') { e.preventDefault(); next = (index - 1 + count) % count; }
+    else if (e.key === 'Home') { e.preventDefault(); next = 0; }
+    else if (e.key === 'End') { e.preventDefault(); next = count - 1; }
+    if (next >= 0) {
+      setActiveTab(HF_DETAIL_TABS[next].id);
+      tabRefs.current[next]?.focus();
+    }
+  };
+
+  return (
+    <div className="model-detail-panel model-detail-panel--hf" role="region" aria-label={`HuggingFace model: ${repoName}`}>
+      {onClose && (
+        <button
+          type="button"
+          className="model-detail-panel__close-btn"
+          onClick={onClose}
+          aria-label="Close detail panel"
+        >
+          ×
+        </button>
+      )}
+      {onBack && (
+        <button
+          type="button"
+          className="model-detail-panel__back-btn"
+          onClick={onBack}
+          aria-label="Back to models list"
+        >
+          ← Back to models
+        </button>
+      )}
+
+      <div className="model-detail-panel__head model-detail-panel__head--hf">
+        <div className="hf-detail__source-label">
+          <Icon name="download" size={11} aria-hidden="true" /> HuggingFace
+        </div>
+        <h2
+          className="model-detail-panel__name"
+          ref={panelHeadingRef}
+          tabIndex={-1}
+          id="detail-panel-heading"
+        >
+          {repoName}
+        </h2>
+
+        <div className="model-detail-panel__meta">
+          {pipelineTag && (
+            <span className="model-detail-panel__badge model-detail-panel__badge--pipeline">{pipelineTag}</span>
+          )}
+          {hfVariants?.recipe && (
+            <span className="model-detail-panel__badge model-detail-panel__badge--recipe">
+              {recipeDisplayLabel(hfVariants.recipe)}
+            </span>
+          )}
+          <span className="model-detail-panel__badge">{fmtDownloads(hfModel.downloads)} downloads</span>
+          <span className="model-detail-panel__badge">{fmtDownloads(hfModel.likes)} likes</span>
+          {hfModel.createdAt && (
+            <span className="model-detail-panel__badge">{new Date(hfModel.createdAt).toLocaleDateString()}</span>
+          )}
+        </div>
+
+        {displayTags.length > 0 && (
+          <div className="hf-detail__tag-row">
+            {displayTags.map(t => (
+              <span key={t} className="row__label row__label--hf">{t}</span>
+            ))}
+          </div>
+        )}
+
+        <div className="model-detail-panel__actions" aria-label={`Actions for ${repoName}`}>
+          {isPulling ? (
+            <>
+              <div className="row__progress">
+                <div className="row__progress-bar">
+                  <div className="row__progress-fill" style={{ width: `${pullPct}%` }} />
+                </div>
+                <span className="row__progress-text">{pullPct.toFixed(0)}%</span>
+              </div>
+              {onCancelHfPull && (
+                <button
+                  type="button"
+                  className="btn btn--ghost btn--sm"
+                  onClick={() => onCancelHfPull(hfModel.id)}
+                  aria-label={`Cancel download of ${repoName}`}
+                >
+                  Cancel
+                </button>
+              )}
+            </>
+          ) : null}
+          <a
+            className="model-detail-panel__hf-link"
+            href={`https://huggingface.co/${repoName}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`View ${repoName} on Hugging Face (opens in new tab)`}
+          >
+            <Icon name="globe" size={12} /> Hugging Face
+          </a>
+        </div>
+      </div>
+
+      <div
+        className="detail-tabs__tablist"
+        role="tablist"
+        aria-label="Model details sections"
+        aria-labelledby="detail-panel-heading"
+      >
+        {HF_DETAIL_TABS.map((tab, i) => (
+          <button
+            key={tab.id}
+            ref={el => { tabRefs.current[i] = el; }}
+            role="tab"
+            id={`detail-tab-${tab.id}`}
+            aria-selected={activeTab === tab.id}
+            aria-controls={`detail-panel-${tab.id}`}
+            tabIndex={activeTab === tab.id ? 0 : -1}
+            className={`detail-tabs__tab${activeTab === tab.id ? ' detail-tabs__tab--active' : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+            onKeyDown={e => handleTabKeyDown(e, i)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {HF_DETAIL_TABS.map(tab => (
+        <div
+          key={tab.id}
+          id={`detail-panel-${tab.id}`}
+          role="tabpanel"
+          aria-labelledby={`detail-tab-${tab.id}`}
+          className={`detail-tabs__panel${activeTab === tab.id ? ' detail-tabs__panel--active' : ''}`}
+          hidden={activeTab !== tab.id}
+        >
+          {tab.id === 'overview' && (
+            <HfOverviewTab
+              hfModel={hfModel}
+              hfVariants={hfVariants}
+              onHfPull={onHfPull}
+              isPulling={isPulling}
+              isActive={activeTab === 'overview'}
+            />
+          )}
+          {tab.id === 'readme' && (
+            <HfReadmeTab hfId={hfModel.id} isActive={activeTab === 'readme'} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+
 
 const ModelPresetsTab: React.FC<{
   model: ModelInfo;
@@ -1743,9 +2053,23 @@ export interface ModelDetailPanelProps {
   onEditCustomCollection?: (model: ModelInfo) => void;
   /** Called when the "Back to models" button is clicked (narrow viewports). */
   onBack?: () => void;
+  /** Called when the close button is clicked to dismiss the detail panel. */
+  onClose?: () => void;
   /** True when the registry has no models at all (empty state guidance differs
       from the normal "nothing selected yet" copy). */
   noModelsAvailable?: boolean;
+  /** HuggingFace model to show in the detail panel (alternative to a local model). */
+  hfModel?: HFModelResult | null;
+  /** Pre-fetched variant data for the selected HF model. */
+  hfVariants?: PullVariantsResult;
+  /** Trigger fetching variants for an HF model id. */
+  onFetchHfVariants?: (hfId: string) => void;
+  /** Initiate a pull of a specific HF variant. */
+  onHfPull?: (hfId: string, variantName: string, recipe: string) => void;
+  /** Current pull progress per HF model id (0-100). */
+  pullingHf?: Record<string, number>;
+  /** Cancel an in-progress HF download. */
+  onCancelHfPull?: (hfId: string) => void;
 }
 
 type DetailTab = 'settings' | 'readme' | 'presets' | 'tuning' | 'files';
@@ -1780,7 +2104,14 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   onToggleFavorite,
   onEditCustomCollection,
   onBack,
+  onClose,
   noModelsAvailable = false,
+  hfModel,
+  hfVariants,
+  onFetchHfVariants,
+  onHfPull,
+  pullingHf,
+  onCancelHfPull,
 }) => {
   const [activeTab, setActiveTab] = useState<DetailTab>('readme');
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -1929,6 +2260,21 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
     }
   };
 
+  if (!model && hfModel) {
+    return (
+      <HfDetailView
+        hfModel={hfModel}
+        hfVariants={hfVariants}
+        onFetchHfVariants={onFetchHfVariants}
+        onHfPull={onHfPull}
+        pullingHf={pullingHf}
+        onCancelHfPull={onCancelHfPull}
+        onBack={onBack}
+        onClose={onClose}
+      />
+    );
+  }
+
   if (!model) {
     return (
       <div className="model-detail-panel model-detail-panel--empty" aria-label="Model detail">
@@ -1983,6 +2329,18 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
 
   return (
     <div className="model-detail-panel" role="region" aria-label={`Model details: ${name}`}>
+
+      {/* Close button */}
+      {onClose && (
+        <button
+          type="button"
+          className="model-detail-panel__close-btn"
+          onClick={onClose}
+          aria-label="Close detail panel"
+        >
+          ×
+        </button>
+      )}
 
       {/* Back button for narrow viewports */}
       {onBack && (

--- a/prototype/ui-redesign/src/components/ModelListPanel.tsx
+++ b/prototype/ui-redesign/src/components/ModelListPanel.tsx
@@ -219,7 +219,7 @@ export function modelMatchesFilter(m: ModelInfo, filter: FilterTab): boolean {
    the model list the prototype already loads — no lemond calls. */
 
 /** Primary nav buckets in the left rail. */
-export type PrimaryFilter = 'all' | 'downloaded' | 'my-models' | 'favorites' | 'huggingface';
+export type PrimaryFilter = 'all' | 'downloaded' | 'my-models' | 'favorites';
 
 /** A model counts as "downloaded" if it is locally present or running. */
 export function modelIsDownloaded(m: ModelInfo, loadedNames: Set<string>): boolean {
@@ -242,8 +242,6 @@ export function modelMatchesPrimary(
     case 'downloaded': return modelIsDownloaded(m, loadedNames);
     case 'my-models': return modelIsCustom(m);
     case 'favorites': return favoriteNames?.has(listModelName(m).toLowerCase()) ?? false;
-    // Hugging Face results are supplied as their own list, so every entry matches.
-    case 'huggingface': return true;
     case 'all':
     default: return true;
   }
@@ -315,6 +313,12 @@ export interface ModelListPanelProps {
   onTogglePin?: (name: string) => void;
   /** Lowercased set of favorited model names (distinct from pinned). Client-local. */
   favoriteNames?: Set<string>;
+  /** Optional content rendered below the model list in the shared scroll area (e.g. HF results). */
+  hfZone?: React.ReactNode;
+  /** Elevated HF zone rendered above the list when no local results match the query. */
+  hfZoneTop?: React.ReactNode;
+  /** Number of HF results for the anchor bar count (used when hfZone is at the bottom). */
+  hfResultCount?: number;
 }
 
 /* ── ModelListPanel ──────────────────────────────────────────── */
@@ -340,6 +344,9 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   pinnedNames,
   onTogglePin,
   favoriteNames,
+  hfZone,
+  hfZoneTop,
+  hfResultCount = 0,
 }) => {
   const [filterOpen, setFilterOpen] = useState(false);
   const [filterPopoverStyle, setFilterPopoverStyle] = useState<FilterPopoverStyle | null>(null);
@@ -798,6 +805,10 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
         {filterTab !== 'all' && ` (${FILTER_TABS.find(t => t.key === filterTab)?.label})`}
       </div>
 
+      {/* Scrollable area: model list + optional inline HF results zone */}
+      <div className="model-list-panel__scroll-area">
+      {/* Elevated HF zone: shown above list when no local results match */}
+      {hfZoneTop}
       {/* Model list */}
       <ul
         ref={listRef}
@@ -888,13 +899,27 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
             selected" / empty-registry placeholder now lives in the RIGHT detail
             pane (ModelDetailPanel) per fl0rianr #2424 — it must NOT leak into the
             top of the model list. */}
-        {flatList.length === 0 && searchQuery && (
+        {flatList.length === 0 && searchQuery && !hfZoneTop && (
           <li className="model-list-panel__empty manager__empty" aria-live="polite">
             <Icon name="search" size={18} aria-hidden="true" />
             <span>No models match your search.</span>
           </li>
         )}
       </ul>
+      {hfZone && hfResultCount > 0 && flatList.length > 0 && (
+        <button
+          type="button"
+          className="hf-zone-anchor"
+          onClick={() => {
+            document.querySelector(".zone--hf")?.scrollIntoView({ behavior: "smooth", block: "start" });
+          }}
+          aria-label={`Scroll to ${hfResultCount} HuggingFace result${hfResultCount !== 1 ? "s" : ""}`}
+        >
+          ↓ {hfResultCount} result{hfResultCount !== 1 ? "s" : ""} on HuggingFace
+        </button>
+      )}
+      {hfZone}
+      </div>
     </div>
   );
 };

--- a/prototype/ui-redesign/src/components/ModelManager.tsx
+++ b/prototype/ui-redesign/src/components/ModelManager.tsx
@@ -1205,6 +1205,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   const [hfLoading, setHfLoading] = useState(false);
   const [hfError, setHfError] = useState<string | null>(null);
   const [expandedHfModel, setExpandedHfModel] = useState<string | null>(null);
+  const [selectedHfModel, setSelectedHfModel] = useState<HFModelResult | null>(null);
   const [pullingHf, setPullingHf] = useState<Record<string, number>>({}); // hf id → percent
   const pullHfAbortRef = useRef<Record<string, AbortController>>({});
   const [hfVariants, setHfVariants] = useState<Record<string, PullVariantsResult>>({}); // hf id → variants data
@@ -1576,7 +1577,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     model: LoadedModel,
     recipeOptions?: Record<string, unknown>,
   ) => {
-    const info = listModels.find(m => modelName(m) === model.model_name) ?? null;
+    const info = allModels.find(m => modelName(m) === model.model_name) ?? null;
     await api.reloadModel(model.model_name, recipeOptions, info);
     await refresh();
   };
@@ -2188,32 +2189,20 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
     return hfResults.filter(r => !localIds.has(r.id.toLowerCase()));
   }, [hfResults, allModels, filterTab]);
 
-  // The "Hugging Face" rail entry is live only while a search yields HF matches.
-  const hfSearchActive = filteredHfResults.length > 0;
-
-  // Map HF search results into ModelInfo rows so the SAME middle list can render
-  // them when the Hugging Face nav entry is selected (#2424 item 5).
-  const hfModelInfos = useMemo<ModelInfo[]>(() => filteredHfResults.map(r => ({
-    id: r.id,
-    name: r.id,
-    display_name: r.modelId || r.id,
-    labels: [...(Array.isArray(r.tags) ? r.tags : []), ...(r.pipeline_tag ? [r.pipeline_tag] : [])],
-    downloads: r.downloads,
-    recipe: 'huggingface',
-    huggingface: true,
-  } as ModelInfo)), [filteredHfResults]);
-
-  // When the HF search clears, drop out of the HF view back to All Models.
-  useEffect(() => {
-    if (!hfSearchActive && primaryFilter === 'huggingface') {
-      setPrimaryFilter('all');
-    }
-  }, [hfSearchActive, primaryFilter]);
-
-  // The middle list shows HF results when the HF nav entry is active, otherwise
-  // the normal local registry.
-  const hfMode = primaryFilter === 'huggingface' && hfSearchActive;
-  const listModels = hfMode ? hfModelInfos : allModels;
+  // Rough check: does any local model match the current search query?
+  // Used to decide whether to elevate the HF zone (top, prominent) or
+  // keep it inline at the bottom with an anchor bar.
+  const hasLocalMatches = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (q.length < 2) return true;
+    return allModels.some(m => {
+      const mName = modelName(m).toLowerCase();
+      const disp = String(m.display_name || '').toLowerCase();
+      const recipe = String((m as any).recipe || '').toLowerCase();
+      const labels = (m.labels || []).join(' ').toLowerCase();
+      return `${mName} ${disp} ${recipe} ${labels}`.includes(q);
+    });
+  }, [allModels, searchQuery]);
   const selectedDetailModel = selectedDetailModelId
     ? (allModels.find(m => modelName(m) === selectedDetailModelId) ?? null)
     : null;
@@ -2636,6 +2625,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
       const next = isExpanded ? null : r.id;
       setExpandedHfModel(next);
       if (next) fetchHfVariants(r.id);
+      setSelectedHfModel(r);
+      setSelectedDetailModelId(null);
+      setMobileDetailOpen(true);
     };
 
     return (
@@ -2859,18 +2851,17 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
   };
 
 
-  const shouldPinHuggingFaceZone = showHuggingFaceZone && searchQuery.trim().length >= 2;
-  const renderHuggingFaceZone = () => !showHuggingFaceZone ? null : (
-    <section className="zone zone--hf zone--hf-compact">
+  const renderHuggingFaceZone = () => !hasHuggingFaceActivity ? null : (
+    <section className="zone zone--hf" aria-label="HuggingFace search results">
       <div className="zone__head">
-        <span className="zone__dot zone__dot--hf" />
+        <span className="zone__dot zone__dot--hf" aria-hidden="true" />
         <span className="zone__title">HuggingFace</span>
         {!hfLoading && hfResults.length > 0 && <span className="zone__count">{filteredHfResults.length}</span>}
         <span className="zone__rule" />
       </div>
       {hfLoading ? (
-        <div className="hf-zone__loading">
-          <span className="hf-zone__spinner" />
+        <div className="hf-zone__loading" role="status" aria-live="polite">
+          <span className="hf-zone__spinner" aria-hidden="true" />
           <span>Searching HuggingFace…</span>
         </div>
       ) : hfError ? (
@@ -2878,13 +2869,8 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
           <Icon name="alert" size={16} />
           <span>HuggingFace search is unavailable: {hfError}</span>
         </div>
-      ) : searchQuery.trim().length >= 2 && filteredHfResults.length > 0 ? (
-        filteredHfResults.map(r => renderHfRow(r))
       ) : (
-        <div className="hf-zone__empty">
-          <Icon name="download" size={16} />
-          <span>{searchQuery.trim().length < 2 ? 'Type at least 2 characters to search HuggingFace' : 'No HuggingFace results for this query'}</span>
-        </div>
+        filteredHfResults.map(r => renderHfRow(r))
       )}
     </section>
   );
@@ -2920,35 +2906,38 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
         tagFilter={tagFilter}
         onTagFilterChange={(t) => { setTagFilter(t); setNavRailOpen(false); }}
         storageInfo={storageInfo}
-        hfCount={filteredHfResults.length}
       />
 
       {/* Middle panel: searchable/filterable model list */}
       <ModelListPanel
-        allModels={listModels}
+        allModels={allModels}
         loadedNames={loadedNames}
         pulling={pulling}
         downloadItems={downloadItems}
         selectedModelId={selectedDetailModelId}
         onSelectModel={(id) => {
           setSelectedDetailModelId(id);
+          setSelectedHfModel(null);
           setMobileDetailOpen(true);
           if (showCustomForm) closeCustomForm();
         }}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
-        filterTab={hfMode ? 'all' : filterTab}
+        filterTab={filterTab}
         onFilterChange={setFilterTab}
         capabilityFilter={capabilityFilter}
         onCapabilityFilterChange={setCapabilityFilter}
         primaryFilter={primaryFilter}
-        backendFilter={hfMode ? 'all' : backendFilter}
-        tagFilter={hfMode ? null : tagFilter}
+        backendFilter={backendFilter}
+        tagFilter={tagFilter}
         searchInputRef={searchRef}
         onOpenCustomModels={() => openCustomForm('model')}
         pinnedNames={pinnedNameSet}
         onTogglePin={togglePinnedModel}
         favoriteNames={favoriteNameSet}
+        hfZoneTop={hasHuggingFaceActivity && !hasLocalMatches ? renderHuggingFaceZone() : undefined}
+        hfZone={hasHuggingFaceActivity && hasLocalMatches ? renderHuggingFaceZone() : undefined}
+        hfResultCount={filteredHfResults.length}
       />
 
       <div
@@ -3244,9 +3233,14 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
           onToggleFavorite={toggleFavoriteModel}
           onEditCustomCollection={openCustomCollectionEditor}
           noModelsAvailable={allModels.length === 0}
+          hfModel={selectedHfModel}
+          hfVariants={selectedHfModel ? hfVariants[selectedHfModel.id] : undefined}
+          onFetchHfVariants={fetchHfVariants}
+          onHfPull={handleHfPull}
+          pullingHf={pullingHf}
+          onCancelHfPull={handleCancelHfPull}
           onBack={() => {
             setMobileDetailOpen(false);
-            // Return focus to the selected list item
             if (selectedDetailModelId) {
               requestAnimationFrame(() => {
                 const sel = document.querySelector<HTMLElement>(`[data-model-id="${CSS.escape(selectedDetailModelId)}"]`);
@@ -3254,6 +3248,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, selectedMode
               });
             }
           }}
+          onClose={() => { setSelectedDetailModelId(null); setSelectedHfModel(null); }}
         />
       )}
     </div>

--- a/prototype/ui-redesign/src/components/ModelNavRail.tsx
+++ b/prototype/ui-redesign/src/components/ModelNavRail.tsx
@@ -91,9 +91,6 @@ export interface ModelNavRailProps {
   /** Real disk usage of the model-storage drive, when available (else null →
       derived fallback). Sourced from api.getStorageInfo(). */
   storageInfo?: StorageInfo | null;
-  /** Count of HuggingFace search matches. When > 0, a "Hugging Face" nav entry
-      appears below the primary list; clicking it filters to HF results. */
-  hfCount?: number;
   /** id used by the responsive nav toggle's aria-controls. */
   id?: string;
 }
@@ -114,7 +111,6 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
   tagFilter,
   onTagFilterChange,
   storageInfo,
-  hfCount = 0,
   id = 'model-nav-rail',
 }) => {
   const [categoriesOpen, setCategoriesOpen] = useState(true);
@@ -122,7 +118,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
 
   // ── Client-side derived counts ──────────────────────────────
   const primaryCounts = useMemo<Record<PrimaryFilter, number>>(() => {
-    const counts: Record<PrimaryFilter, number> = { all: 0, downloaded: 0, 'my-models': 0, favorites: 0, huggingface: 0 };
+    const counts: Record<PrimaryFilter, number> = { all: 0, downloaded: 0, 'my-models': 0, favorites: 0 };
     for (const m of allModels) {
       if (!listModelName(m)) continue;
       counts.all += 1;
@@ -215,24 +211,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
             </li>
           );
         })}
-        {/* HuggingFace search results — only present while a search is active.
-            Positioned BELOW My Models and Favorites (#2424). Count reflects the
-            current HF search matches; clicking filters the middle list to them. */}
-        {hfCount > 0 && (
-          <li>
-            <button
-              type="button"
-              className={`model-nav-rail__nav-item${primaryFilter === 'huggingface' ? ' model-nav-rail__nav-item--active' : ''}`}
-              aria-current={primaryFilter === 'huggingface' ? 'true' : undefined}
-              onClick={() => onPrimaryFilterChange('huggingface')}
-            >
-              <Icon name="hugging-face" size={15} aria-hidden="true" className="model-nav-rail__nav-icon" />
-              <span className="model-nav-rail__nav-label">Hugging Face</span>
-              <span className="model-nav-rail__nav-count" aria-hidden="true">{hfCount}</span>
-              <span className="sr-only">{`, ${hfCount} HuggingFace search results`}</span>
-            </button>
-          </li>
-        )}
+
       </ul>
       <section className="model-nav-rail__section">
         <h2 className="model-nav-rail__section-head">

--- a/prototype/ui-redesign/src/styles/styles.css
+++ b/prototype/ui-redesign/src/styles/styles.css
@@ -6726,11 +6726,6 @@ input, textarea {
   margin-bottom: var(--space-3);
 }
 
-.zone--hf-compact .hf-card,
-.zone--hf-compact .model-row {
-  padding-top: var(--space-3);
-  padding-bottom: var(--space-3);
-}
 
 .manager__body {
   gap: var(--space-3);
@@ -8889,13 +8884,63 @@ input, textarea {
 }
 
 /* Scrollable list */
+.model-list-panel__scroll-area {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.model-list-panel__scroll-area .zone--hf {
+  border-top: 1px solid var(--border-subtle);
+  margin: var(--space-2) 0 0;
+  padding: var(--space-2) 0;
+}
+.hf-zone-anchor {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  width: 100%;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  background: none;
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.hf-zone-anchor:hover,
+.hf-zone-anchor:focus-visible {
+  color: var(--accent-fg);
+  outline: 2px solid var(--accent-focus);
+  outline-offset: -2px;
+}
+.model-list-panel__scroll-area .row--hf .row__icon {
+  width: 28px;
+  height: 28px;
+}
+
+.model-list-panel__scroll-area .row--hf .row__summary {
+  grid-template-columns: 1fr;
+  gap: var(--space-2);
+}
+
+.model-list-panel__scroll-area .row--hf .row__content {
+  width: 100%;
+}
+
+.model-list-panel__scroll-area .row--hf .row__right {
+  justify-content: flex-start;
+  padding: 0 var(--space-4) var(--space-2);
+}
+
 .model-list-panel__list {
   list-style: none;
   margin: 0;
   padding: var(--space-1) var(--space-2);
-  overflow-y: auto;
-  flex: 1;
-  min-height: 0;
 }
 
 /* Model list items */
@@ -9017,6 +9062,7 @@ input, textarea {
 /* ── Model detail panel (right) ───────────────────────────────── */
 
 .model-detail-panel {
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -9221,6 +9267,71 @@ input, textarea {
 
 .model-detail-panel__hf-link:hover { color: var(--accent-fg); }
 .model-detail-panel__hf-link:focus-visible { outline: 2px solid var(--accent-focus); border-radius: 2px; }
+
+/* ── HF detail panel variant ────────────────────────────────── */
+
+.model-detail-panel--hf .model-detail-panel__head--hf {
+  padding-top: var(--space-5);
+}
+
+.hf-detail__source-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: #FF9D00;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-1);
+}
+
+.model-detail-panel__badge--pipeline {
+  background: color-mix(in srgb, #FF9D00 12%, transparent);
+  border-color: color-mix(in srgb, #FF9D00 30%, transparent);
+  color: #FF9D00;
+}
+
+.hf-detail__tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+
+.hf-detail__overview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  overflow-y: auto;
+}
+
+.hf-detail__overview-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.hf-detail__overview-label {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.hf-detail__overview-value {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.hf-detail__overview-value--muted {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+
 
 /* ── Tab list ─────────────────────────────────────────────────── */
 
@@ -9653,6 +9764,34 @@ input, textarea {
 
 .model-detail-panel__back-btn:hover { background: var(--surface-2); }
 .model-detail-panel__back-btn:focus-visible { outline: 2px solid var(--accent-focus); outline-offset: -2px; }
+
+.model-detail-panel__close-btn {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  font-size: 18px;
+  line-height: 1;
+  color: var(--text-tertiary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  z-index: 1;
+  transition: color 0.12s, background 0.12s;
+}
+.model-detail-panel__close-btn:hover {
+  color: var(--text-primary);
+  background: var(--surface-2);
+}
+.model-detail-panel__close-btn:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: -2px;
+}
 
 /* ── Favorite (star) toggle in the detail header ───────────────── */
 .model-detail-panel__fav-btn {

--- a/prototype/ui-redesign/tests/a11y.spec.ts
+++ b/prototype/ui-redesign/tests/a11y.spec.ts
@@ -3498,7 +3498,7 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     expect(ariaValueText).toContain('estimat');
   });
 
-  // ── 8. HuggingFace search nav entry in the left rail (#2424) ──────────────
+  // ── 8. HuggingFace inline zone in the model list panel (#2564) ──────────────
 
   async function goToModelsRefinedWithHf(page: Page): Promise<void> {
     await page.route('**huggingface.co/api/models**', async route =>
@@ -3513,37 +3513,37 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     await goToModelsRefined(page);
   }
 
-  test('A152 — a HuggingFace nav entry appears below the primary list on search, shows the count, is keyboard operable, and clears', async ({ page }) => {
+  test('A152 — HuggingFace results appear inline in the model list panel on search and clear when search is cleared', async ({ page }) => {
     await goToModelsRefinedWithHf(page);
     const search = page.locator('#model-list-search');
     await search.fill('mistral');
     // Allow the debounced HF search (400ms) + render to settle.
     await page.waitForTimeout(900);
 
-    const hf = page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Hugging Face' });
-    await expect(hf).toBeVisible();
-    await expect(hf).toContainText('2');
+    // No nav rail HF entry — results are inline in the list panel.
+    await expect(page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Hugging Face' })).toHaveCount(0);
 
-    // Keyboard operable: focus + Enter selects it and filters the middle list.
-    await hf.focus();
-    await page.keyboard.press('Enter');
-    await page.waitForTimeout(150);
-    expect(await hf.getAttribute('aria-current')).toBe('true');
-    const rows = page.locator('.model-list-item');
-    await expect(rows.first()).toContainText(/Mistral-7B|Phi-3/);
+    // HF zone is visible (elevated at top since no local models match "mistral").
+    const hfZone = page.locator('.zone--hf');
+    await expect(hfZone).toBeVisible();
+    await expect(hfZone).toContainText('HuggingFace');
 
-    // Clearing the search removes the HF entry entirely.
+    // HF result cards are present in the zone.
+    const hfRows = page.locator('.zone--hf .row--hf');
+    await expect(hfRows).toHaveCount(2);
+
+    // Clearing the search removes the HF zone entirely.
     await search.fill('');
     await page.waitForTimeout(300);
-    await expect(page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Hugging Face' })).toHaveCount(0);
+    await expect(page.locator('.zone--hf')).toHaveCount(0);
   });
 
   test('A153 — the model view with an active HuggingFace search passes WCAG 2.1 AA axe-core scan', async ({ page }) => {
     await goToModelsRefinedWithHf(page);
     await page.locator('#model-list-search').fill('mistral');
     await page.waitForTimeout(900);
-    await page.locator('.model-nav-rail__nav-item').filter({ hasText: 'Hugging Face' }).click();
-    await page.waitForTimeout(150);
+    // HF zone is now inline in the list panel; no nav rail click needed.
+    await expect(page.locator('.zone--hf')).toBeVisible();
     const results = await new AxeBuilder({ page })
       .withTags([...WCAG_TAGS])
       .analyze();


### PR DESCRIPTION
Unifies the HuggingFace search experience on the Models page and adds detail panel support for HF results.

**Changes:**
- Removed dead compact HF rendering path that showed degraded rows with non-functional clicks (double rendering bug)
- HF search results now use rich zone cards as the single rendering path
- Clicking an HF result opens the right-pane ModelDetailPanel with an HF-specific view: repo metadata, downloads/likes, tags, variant picker with download buttons, and a README tab fetched from HuggingFace
- Added close button (x) to ModelDetailPanel top-right corner (works for both local and HF models, touch-friendly)
- Removed HuggingFace entry from nav rail (was a dead-end filter)
- HF zone auto-elevates to top of list when no local models match the search query

Addresses #2564

Tests: 201 passed / 9 skipped — zero regressions