### PR TITLE
Fix: re-pulling a `collection.router` model fails with "unknown key 'source'"

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -3146,7 +3146,10 @@ void ModelManager::download_model(const std::string& model_name,
         bool is_collection_overwrite = is_model_collection_recipe(actual_recipe) &&
                                         model_data.contains("components");
         if (is_collection_overwrite) {
-            if (auto err = validate_collection_request(model_name, registration_data)) {
+            // Validate the original user-authored request, not registration_data:
+            // the latter is enriched with the persisted registry source, which is
+            // not part of the public routing-policy document the parser accepts.
+            if (auto err = validate_collection_request(model_name, model_data)) {
                 throw std::runtime_error(*err);
             }
             model_registered = false;

--- a/src/cpp/server/routing_policy_parser.cpp
+++ b/src/cpp/server/routing_policy_parser.cpp
@@ -496,8 +496,7 @@ std::vector<Rule> parse_rules(const json& routing,
 
 const std::set<std::string>& routing_policy_root_keys() {
     static const std::set<std::string> keys = {
-        "version", "model_name", "recipe", "components", "models", "routing",
-        "source", "registry_source"};
+        "version", "model_name", "recipe", "components", "models", "routing"};
     return keys;
 }
 

--- a/src/cpp/server/routing_policy_parser.cpp
+++ b/src/cpp/server/routing_policy_parser.cpp
@@ -496,7 +496,8 @@ std::vector<Rule> parse_rules(const json& routing,
 
 const std::set<std::string>& routing_policy_root_keys() {
     static const std::set<std::string> keys = {
-        "version", "model_name", "recipe", "components", "models", "routing"};
+        "version", "model_name", "recipe", "components", "models", "routing",
+        "source", "registry_source"};
     return keys;
 }
 

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -3067,6 +3067,63 @@ class EndpointTests(ServerTestBase):
             except Exception:
                 pass
 
+    def test_021zh_router_collection_repull_overwrite(self):
+        """Re-pulling an already-registered collection.router under the same
+        name must succeed (#2703). On overwrite the registration data is
+        enriched with the persisted registry source; that internal field must
+        not reach the strict routing-policy parser, which would otherwise reject
+        it as an unknown root key."""
+        suffix = uuid.uuid4().hex[:8]
+        canonical_name = f"user.RouterRepull-{suffix}"
+        collection_body = {
+            "model_name": canonical_name,
+            "version": "1",
+            "recipe": "collection.router",
+            "components": [ENDPOINT_TEST_MODEL],
+            "routing": {
+                "candidates": [ENDPOINT_TEST_MODEL],
+                "default_model": ENDPOINT_TEST_MODEL,
+                "rules": [
+                    {
+                        "id": "always-test-model",
+                        "match": {"keywords_any": ["code"]},
+                        "route_to": ENDPOINT_TEST_MODEL,
+                    }
+                ],
+            },
+        }
+        try:
+            # Initial registration.
+            first = requests.post(
+                f"{self.base_url}/pull",
+                json=collection_body,
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(first.status_code, 200, first.text)
+            self.assertEqual(first.json()["status"], "success")
+
+            # Re-pull the identical body (no explicit source/registry_source).
+            # The overwrite path injects the persisted registry source into the
+            # registration data; validating that enriched object used to 500
+            # with "collection contains unknown key 'source'".
+            second = requests.post(
+                f"{self.base_url}/pull",
+                json=collection_body,
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(second.status_code, 200, second.text)
+            self.assertEqual(second.json()["status"], "success")
+            print(f"[OK] collection.router re-pull overwrite: {canonical_name}")
+        finally:
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": canonical_name},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+
     def test_021zi_router_collection_trace_and_outputs(self):
         """route_trace=true returns the full Decision trace and copies rule
         outputs verbatim without interpreting them (#2386)."""


### PR DESCRIPTION
## Summary

Re-pulling (overwriting) an already-registered `collection.router` model returned HTTP 500 with
`Invalid collection.router routing policy: collection contains unknown key 'source'`. The overwrite
path validated the internally-enriched model entry (which carries an injected `source`/`registry_source`)
against the strict routing-policy parser, which rejects unknown root keys.

## Details

- For an already-registered model, `register_model` enriches `registration_data` with the persisted
  registry `source` before validation (`model_manager.cpp`).
- In the collection-overwrite path, validation was handed that enriched `registration_data` rather than
  the original user-authored `model_data`, so the injected `source` reached
  `validate_collection_request` → `parse_route_policy_collection` and tripped the strict unknown-key check.
- `source`/`registry_source` are persisted model-entry properties, not part of the routing-policy
  document, so they must not be introduced into the parser's grammar.

## Fix

Validate the original user-authored `model_data` in the collection-overwrite path instead of the
enriched `registration_data`. `registration_data` (with the injected registry source) is still used
afterwards for `register_user_model()`, so the existing registry source remains preserved — without
making `source`/`registry_source` part of the public routing-policy document. This keeps the
schema/parser parity intact (`route_policy.schema.json` does not define these root properties).

## Testing

- Added regression test `test_021zh_router_collection_repull_overwrite`: registers a
  `collection.router`, then overwrites/re-pulls the same collection without explicitly providing a
  registry source; both pulls must return 200.
- `RoutingPolicyParserTest` (schema/parser parity) passes.