### PR TITLE
fix(ci): always run macOS C++ unit tests regardless of signing

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -586,7 +586,6 @@ jobs:
         shell: bash
         run: |
           cmake --build --preset default --target test_directory_watcher
-          cmake --build --preset default --target test_process_manager
           cmake --build --preset default --target test_latest_version_fallback
           cmake --build --preset default --target test_routing_policy_contract
           cmake --build --preset default --target test_routing_policy_evaluator
@@ -600,7 +599,7 @@ jobs:
           cmake --build --preset default --target test_routing_classifier_services
           cmake --build --preset default --target test_network_utils
           cd build
-          ctest --output-on-failure -R "ProcessManagerTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -583,7 +583,6 @@ jobs:
           skip-packaging: ${{ steps.check_signing.outputs.has_signing != 'true' }}
 
       - name: Run C++ unit tests
-        if: steps.check_signing.outputs.has_signing != 'true'
         shell: bash
         run: |
           cmake --build --preset default --target test_directory_watcher


### PR DESCRIPTION
The macOS "Run C++ unit tests" step only executed when `has_signing != 'true'`, so any run with signing secrets available (all internal/maintainer PRs and every merge-queue run against main) skipped ctest entirely. The only path that ever exercised these tests was external fork PRs, which don't receive repo secrets and lack things like HF_TOKEN — leaving no reliable macOS unit-test signal for code that actually lands on main, and spurious CI failures on unrelated fork PRs (e.g. docs-only changes) whenever that starved path breaks.

Run ctest unconditionally on this job; it only depends on the build, not on packaging/signing.