### PR TITLE
Fix: Repeated model update reports after pull

### DIFF
--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -212,6 +212,68 @@ static std::string read_hf_ref_main(const fs::path& model_cache_path) {
     return ref;
 }
 
+static std::string registry_model_selection(const ModelInfo& info) {
+    std::ostringstream selection;
+    selection << info.recipe;
+    for (const auto& [type, checkpoint] : info.checkpoints) {
+        selection << '\n' << type << '=' << checkpoint;
+    }
+    return selection.str();
+}
+
+static std::string read_processed_registry_snapshot_id(
+    const fs::path& model_cache_path,
+    const std::string& model_name,
+    const std::string& selection) {
+    const fs::path provenance_path = model_cache_path / ".lemonade_registry.json";
+    if (!safe_exists(provenance_path)) {
+        return "";
+    }
+
+    try {
+        const json provenance = JsonUtils::load_from_file(path_to_utf8(provenance_path));
+        if (!provenance.contains("processed_models") ||
+            !provenance["processed_models"].is_object()) {
+            return "";
+        }
+
+        const auto& processed_models = provenance["processed_models"];
+        auto model_it = processed_models.find(model_name);
+        if (model_it == processed_models.end() || !model_it->is_object()) {
+            return "";
+        }
+        if (JsonUtils::get_or_default<std::string>(
+                *model_it, "selection", "") != selection) {
+            return "";
+        }
+        return JsonUtils::get_or_default<std::string>(*model_it, "snapshot_id", "");
+    } catch (const std::exception&) {
+        return "";
+    }
+}
+
+static std::string snapshot_id_from_resolved_path(
+    const ModelInfo& info,
+    const fs::path& model_cache_path) {
+    const std::string resolved_path = info.resolved_path("main");
+    if (resolved_path.empty()) {
+        return "";
+    }
+
+    const fs::path snapshots_path = model_cache_path / "snapshots";
+    const fs::path relative =
+        path_from_utf8(resolved_path).lexically_relative(snapshots_path);
+    if (relative.empty()) {
+        return "";
+    }
+
+    auto first = relative.begin();
+    if (first == relative.end() || *first == "." || *first == "..") {
+        return "";
+    }
+    return path_to_utf8(*first);
+}
+
 static fs::path active_hf_snapshot_path(const fs::path& model_cache_path) {
     std::string ref = read_hf_ref_main(model_cache_path);
     if (ref.empty()) {
@@ -1326,7 +1388,7 @@ std::vector<std::string> ModelManager::check_for_model_updates() {
 
     struct RepoEntry {
         std::vector<std::string> model_names;
-        std::string cached_snapshot;
+        std::unordered_map<std::string, std::string> cached_snapshots;
         std::string repo_id;
         std::string registry_source;
     };
@@ -1374,13 +1436,19 @@ std::vector<std::string> ModelManager::check_for_model_updates() {
             entry.registry_source = source;
             entry.model_names.push_back(name);
 
-            if (entry.cached_snapshot.empty()) {
-                const fs::path cache_path =
-                    path_from_utf8(get_hf_cache_dir()) /
-                    repo_id_to_cache_dir_name(repo_id, source);
+            const fs::path cache_path =
+                path_from_utf8(get_hf_cache_dir()) /
+                repo_id_to_cache_dir_name(repo_id, source);
 
-                entry.cached_snapshot = read_hf_ref_main(cache_path);
+            std::string cached_snapshot = read_processed_registry_snapshot_id(
+                cache_path, name, registry_model_selection(info));
+            if (cached_snapshot.empty()) {
+                cached_snapshot = snapshot_id_from_resolved_path(info, cache_path);
             }
+            if (cached_snapshot.empty()) {
+                cached_snapshot = read_hf_ref_main(cache_path);
+            }
+            entry.cached_snapshots[name] = std::move(cached_snapshot);
         }
     }
 
@@ -1389,12 +1457,6 @@ std::vector<std::string> ModelManager::check_for_model_updates() {
 
     for (auto& [key, entry] : repos) {
         (void)key;
-
-        // Without a local snapshot reference, there is nothing reliable to
-        // compare against.
-        if (entry.cached_snapshot.empty()) {
-            continue;
-        }
 
         try {
             const auto source =
@@ -1413,27 +1475,29 @@ std::vector<std::string> ModelManager::check_for_model_updates() {
                 continue;
             }
 
-            // Only a successful registry response with a usable snapshot may
-            // clear an update flag discovered by an earlier check.
-            verified_models.insert(
-                entry.model_names.begin(),
-                entry.model_names.end());
+            size_t updated_variants = 0;
+            for (const auto& model_name : entry.model_names) {
+                auto cached_it = entry.cached_snapshots.find(model_name);
+                if (cached_it == entry.cached_snapshots.end() || cached_it->second.empty()) {
+                    continue;
+                }
 
-            if (latest.snapshot_id == entry.cached_snapshot) {
-                continue;
+                // Only a successful registry response with a usable local
+                // baseline may clear an update flag discovered earlier.
+                verified_models.insert(model_name);
+                if (latest.snapshot_id != cached_it->second) {
+                    updated_models.insert(model_name);
+                    ++updated_variants;
+                }
             }
 
-            LOG(INFO, "ModelManager")
-                << "Update available for " << entry.repo_id
-                << " on " << remote_registry_display_name(source)
-                << ": cached=" << entry.cached_snapshot.substr(0, 18)
-                << ", latest=" << latest.snapshot_id.substr(0, 18)
-                << " (" << entry.model_names.size()
-                << " variant(s))" << std::endl;
-
-            updated_models.insert(
-                entry.model_names.begin(),
-                entry.model_names.end());
+            if (updated_variants > 0) {
+                LOG(INFO, "ModelManager")
+                    << "Update available for " << entry.repo_id
+                    << " on " << remote_registry_display_name(source)
+                    << ": latest=" << latest.snapshot_id.substr(0, 18)
+                    << " (" << updated_variants << " variant(s))" << std::endl;
+            }
 
         } catch (const RegistryNotFoundError& e) {
             LOG(DEBUG, "ModelManager")
@@ -2686,7 +2750,9 @@ void ModelManager::download_registered_model(const ModelInfo& info, bool do_not_
     std::shared_ptr<std::mutex> repo_lock;
     {
         std::lock_guard<std::mutex> guard(download_locks_mutex_);
-        auto& slot = download_locks_[effective_registry_source(info) + ":" + info.checkpoint()];
+        auto& slot = download_locks_[
+            effective_registry_source(info) + ":" +
+            checkpoint_to_repo_id(info.checkpoint("main"))];
         if (!slot) slot = std::make_shared<std::mutex>();
         repo_lock = slot;
     }
@@ -4093,12 +4159,38 @@ void ModelManager::download_from_registry(const ModelInfo& info,
 
     for (const auto& [repo_id, snapshot_id] : repo_snapshot_ids) {
         const fs::path& cache_path = repo_cache_paths.at(repo_id);
-        if (repos_reusing_previous_snapshot.count(repo_id)) {
-            const std::string& previous_ref = repo_previous_refs.at(repo_id);
-            write_hf_ref_main(cache_path, previous_ref);
-            remove_unused_hf_snapshot(cache_path, repo_snapshot_paths.at(repo_id), previous_ref);
-        } else {
-            write_hf_ref_main(cache_path, snapshot_id);
+        const bool reusing_previous_snapshot =
+            repos_reusing_previous_snapshot.count(repo_id) != 0;
+        const std::string active_snapshot_id = reusing_previous_snapshot
+            ? repo_previous_refs.at(repo_id)
+            : snapshot_id;
+
+        write_hf_ref_main(cache_path, active_snapshot_id);
+        if (reusing_previous_snapshot) {
+            remove_unused_hf_snapshot(
+                cache_path, repo_snapshot_paths.at(repo_id), active_snapshot_id);
+        }
+
+        const fs::path provenance_path = cache_path / ".lemonade_registry.json";
+        json processed_models = json::object();
+        if (safe_exists(provenance_path)) {
+            try {
+                const json previous_provenance =
+                    JsonUtils::load_from_file(path_to_utf8(provenance_path));
+                if (previous_provenance.contains("processed_models") &&
+                    previous_provenance["processed_models"].is_object()) {
+                    processed_models = previous_provenance["processed_models"];
+                }
+            } catch (const std::exception&) {
+                // Replace invalid provenance after a successful download.
+            }
+        }
+
+        if (repo_id == main_repo_id) {
+            processed_models[info.model_name] = {
+                {"selection", registry_model_selection(info)},
+                {"snapshot_id", snapshot_id}
+            };
         }
 
         const auto& repo = repositories.at(repo_id);
@@ -4106,11 +4198,10 @@ void ModelManager::download_from_registry(const ModelInfo& info,
             {"source", source_name},
             {"repo_id", repo_id},
             {"revision", repo.revision},
-            {"snapshot_id", repos_reusing_previous_snapshot.count(repo_id)
-                                ? repo_previous_refs.at(repo_id) : snapshot_id}
+            {"snapshot_id", active_snapshot_id},
+            {"processed_models", std::move(processed_models)}
         };
-        JsonUtils::save_to_file(provenance,
-            path_to_utf8(cache_path / ".lemonade_registry.json"));
+        JsonUtils::save_to_file(provenance, path_to_utf8(provenance_path));
     }
 
     if (progress_callback) {

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -164,6 +164,7 @@ class EndpointTests(ServerTestBase):
             "completions",
             "embeddings",
             "models",
+            "models/check-updates",
             "responses",
             "pull",
             "pull/variants",
@@ -4655,6 +4656,110 @@ class EndpointTests(ServerTestBase):
                         proc.kill()
                         proc.wait(timeout=10)
             shutil.rmtree(cache_dir, ignore_errors=True)
+
+
+    def test_037_model_update_check_lifecycle(self):
+        """A successful re-pull clears a staged per-model update marker.
+
+        The production fix stores the processed upstream snapshot per model
+        selection in .lemonade_registry.json. Staging only that value as stale
+        exercises the regression without moving refs/main or model files that
+        may be shared by sibling variants in the same repository.
+        """
+        pull_response = requests.post(
+            f"{self.base_url}/pull",
+            json={"model_name": ENDPOINT_TEST_MODEL, "stream": False},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(pull_response.status_code, 200, pull_response.text)
+
+        model_response = requests.get(
+            f"{self.base_url}/models/{ENDPOINT_TEST_MODEL}",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(model_response.status_code, 200, model_response.text)
+        model_info = model_response.json()
+        checkpoint = model_info.get("checkpoint") or model_info.get(
+            "checkpoints", {}
+        ).get("main", "")
+        self.assertTrue(checkpoint, "Test model must expose a main checkpoint")
+
+        repo_id = checkpoint.split(":", 1)[0]
+        repo_cache_dir = "models--" + repo_id.replace("/", "--")
+        cache_root = self._server_hf_cache_root(repo_cache_dir)
+        if cache_root is None:
+            self.skipTest(
+                "Cannot locate the server's Hugging Face cache from the test process"
+            )
+
+        provenance_path = os.path.join(
+            cache_root, repo_cache_dir, ".lemonade_registry.json"
+        )
+        self.assertTrue(
+            os.path.isfile(provenance_path),
+            "A successful pull must write per-model registry provenance",
+        )
+
+        with open(provenance_path, "r", encoding="utf-8") as provenance_file:
+            original_provenance = provenance_file.read()
+
+        staged_provenance = json.loads(original_provenance)
+        processed_models = staged_provenance.get("processed_models", {})
+        self.assertIn(
+            ENDPOINT_TEST_MODEL,
+            processed_models,
+            "Pulled model must have a processed snapshot entry",
+        )
+        original_snapshot = processed_models[ENDPOINT_TEST_MODEL].get(
+            "snapshot_id", ""
+        )
+        self.assertTrue(original_snapshot, "Processed snapshot must not be empty")
+
+        stale_snapshot = "0" * 40
+        if stale_snapshot == original_snapshot:
+            stale_snapshot = "1" * 40
+        processed_models[ENDPOINT_TEST_MODEL]["snapshot_id"] = stale_snapshot
+
+        try:
+            with open(provenance_path, "w", encoding="utf-8") as provenance_file:
+                json.dump(staged_provenance, provenance_file, indent=2)
+                provenance_file.write("\n")
+
+            stale_response = requests.post(
+                f"{self.base_url}/models/check-updates",
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(stale_response.status_code, 200, stale_response.text)
+            stale_result = stale_response.json()
+            self.assertEqual(stale_result.get("status"), "success")
+            self.assertIn(ENDPOINT_TEST_MODEL, stale_result.get("models", []))
+
+            repull_response = requests.post(
+                f"{self.base_url}/pull",
+                json={"model_name": ENDPOINT_TEST_MODEL, "stream": False},
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(repull_response.status_code, 200, repull_response.text)
+
+            fresh_response = requests.post(
+                f"{self.base_url}/models/check-updates",
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(fresh_response.status_code, 200, fresh_response.text)
+            fresh_result = fresh_response.json()
+            self.assertEqual(fresh_result.get("status"), "success")
+            self.assertNotIn(
+                ENDPOINT_TEST_MODEL,
+                fresh_result.get("models", []),
+                "Re-pulling the model must clear its update report",
+            )
+        finally:
+            # Keep the shared test cache exactly as it was before this test, even
+            # when an assertion or network request fails midway through.
+            with open(provenance_path, "w", encoding="utf-8") as provenance_file:
+                provenance_file.write(original_provenance)
+
+        print("[OK] /models/check-updates lifecycle clears after re-pull")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

* Track processed registry snapshots per model and checkpoint selection instead of per repository.
* Use the model’s resolved snapshot before falling back to `refs/main`.
* Serialize downloads that share the same registry repository.

This clears metadata-only updates after a successful pull without hiding real updates for sibling quantizations in the same repository.

## Testing

* Ensured normal download still works fine
* Recreated issue below
* Tested the fix based on this Recreation

Fixes #2713
