### PR TITLE
feat: add Modelscope search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ All core endpoints are registered under **4 path prefixes**:
 - `/v0/` — Legacy short
 - `/v1/` — OpenAI SDK / LiteLLM compatibility
 
-**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `load`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`
+**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `pull/variants`, `registry/search`, `load`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`
 
 **Ollama-compatible endpoints** (under `/api/` without version prefix): `chat`, `generate`, `tags`, `show`, `delete`, `pull`, `embed`, `embeddings`, `ps`, `version`
 

--- a/src/app/src/renderer/ModelManager.tsx
+++ b/src/app/src/renderer/ModelManager.tsx
@@ -202,6 +202,26 @@ interface HFModelInfo {
   pipeline_tag?: string;
 }
 
+interface RegistrySearchResult {
+  repository_id?: string;
+  display_name?: string;
+  source?: string;
+  description?: string;
+  tags?: string[];
+  task?: string;
+  downloads?: number;
+  likes?: number;
+  has_gguf?: boolean;
+}
+
+interface RegistrySearchResponse {
+  results?: RegistrySearchResult[];
+  error?: string | {
+    message?: string;
+    path?: string;
+  };
+}
+
 interface HFSibling {
   rfilename: string;
 }
@@ -226,6 +246,22 @@ interface DetectedBackend {
   mmprojFiles?: string[];
   suggestedLabels?: string[];
 }
+
+interface ModelScopeVariantCacheEntry {
+  backend: DetectedBackend;
+  selectedQuantization: string;
+  size?: number;
+}
+
+interface ValidatedModelScopeResult extends ModelScopeVariantCacheEntry {
+  model: HFModelInfo;
+  order: number;
+}
+
+const MODELSCOPE_SEARCH_LIMIT = 14;
+const MODELSCOPE_MAX_RESULTS = 10;
+const MODELSCOPE_VALIDATION_CONCURRENCY = 4;
+const MODELSCOPE_SEARCH_DEBOUNCE_MS = 400;
 
 // Strip the canonical prefix (if any) to get the bare model name. Used for
 // family-regex matching and family grouping.
@@ -376,6 +412,20 @@ const [searchQuery, setSearchQuery] = useState('');
   const [hfModelSizes, setHfModelSizes] = useState<Record<string, number | undefined>>({});
   const [detectingBackendFor, setDetectingBackendFor] = useState<string | null>(null);
   const hfSearchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // ModelScope mirrors the proven Hugging Face UX, but uses lemond for search
+  // and variant discovery so endpoint/token configuration stays server-side.
+  const [modelScopeSearchResults, setModelScopeSearchResults] = useState<HFModelInfo[]>([]);
+  const [isSearchingModelScope, setIsSearchingModelScope] = useState(false);
+  const [modelScopeRateLimited, setModelScopeRateLimited] = useState(false);
+  const [modelScopeSearchError, setModelScopeSearchError] = useState<string | null>(null);
+  const [modelScopeModelBackends, setModelScopeModelBackends] = useState<Record<string, DetectedBackend | null>>({});
+  const [modelScopeSelectedQuantizations, setModelScopeSelectedQuantizations] = useState<Record<string, string>>({});
+  const [modelScopeModelSizes, setModelScopeModelSizes] = useState<Record<string, number | undefined>>({});
+  const modelScopeSearchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const modelScopeSearchRequestRef = useRef(0);
+  const modelScopeVariantCacheRef = useRef(new Map<string, ModelScopeVariantCacheEntry>());
+
   const updateCheckDoneRef = useRef(false);
 
 
@@ -863,6 +913,215 @@ const [searchQuery, setSearchQuery] = useState('');
     }
   }, []);
 
+  const searchModelScope = useCallback(async (
+    query: string,
+    requestId: number,
+    signal: AbortSignal,
+  ) => {
+    const normalizedQuery = query.trim();
+    if (normalizedQuery.length < 3) return;
+
+    setIsSearchingModelScope(true);
+    setModelScopeRateLimited(false);
+    setModelScopeSearchError(null);
+    setModelScopeSearchResults([]);
+    setModelScopeModelBackends({});
+    setModelScopeSelectedQuantizations({});
+    setModelScopeModelSizes({});
+
+    try {
+      const response = await serverFetch(
+        `/registry/search?source=modelscope&query=${encodeURIComponent(normalizedQuery)}&limit=${MODELSCOPE_SEARCH_LIMIT}&format=gguf`,
+        { signal },
+      );
+
+      let payload: RegistrySearchResponse = {};
+      try {
+        payload = await response.json();
+      } catch {
+        // Use the HTTP status below when the response body is not JSON.
+      }
+
+      if (!response.ok) {
+        const errorPayload = payload.error;
+        const baseMessage = typeof errorPayload === 'string'
+          ? errorPayload
+          : errorPayload?.message || `ModelScope search failed (${response.status})`;
+        const path = typeof errorPayload === 'object' ? errorPayload?.path : undefined;
+        const error = new Error(path ? `${baseMessage} [${path}]` : baseMessage) as Error & { status?: number };
+        error.status = response.status;
+        throw error;
+      }
+
+      if (requestId !== modelScopeSearchRequestRef.current) return;
+
+      const deduplicated = new Map<string, HFModelInfo>();
+      for (const result of Array.isArray(payload.results) ? payload.results : []) {
+        const id = typeof result.repository_id === 'string' ? result.repository_id.trim() : '';
+        const source = typeof result.source === 'string' ? result.source.toLowerCase() : 'modelscope';
+        if (!id || (source !== 'modelscope' && source !== 'ms')) continue;
+        if (!deduplicated.has(id)) {
+          deduplicated.set(id, {
+            id,
+            author: id.split('/')[0] ?? '',
+            downloads: typeof result.downloads === 'number' ? result.downloads : 0,
+            likes: typeof result.likes === 'number' ? result.likes : 0,
+            tags: Array.isArray(result.tags) ? result.tags : [],
+            pipeline_tag: typeof result.task === 'string' ? result.task : undefined,
+          });
+        }
+      }
+
+      // The server performs provider-aware relevance ranking. Preserve that
+      // order while the file-level compatibility checks finish asynchronously.
+      const candidates = [...deduplicated.values()]
+        .slice(0, MODELSCOPE_SEARCH_LIMIT)
+        .map((model, order) => ({ model, order }));
+
+      const validated: ValidatedModelScopeResult[] = [];
+      const maxResults = MODELSCOPE_MAX_RESULTS;
+      let nextCandidate = 0;
+
+      const publishValidated = (): void => {
+        if (requestId !== modelScopeSearchRequestRef.current) return;
+        const ordered = [...validated]
+          .sort((a, b) => a.order - b.order)
+          .slice(0, maxResults);
+
+        const backends: Record<string, DetectedBackend | null> = {};
+        const selectedQuantizations: Record<string, string> = {};
+        const sizes: Record<string, number | undefined> = {};
+        for (const result of ordered) {
+          backends[result.model.id] = result.backend;
+          selectedQuantizations[result.model.id] = result.selectedQuantization;
+          sizes[result.model.id] = result.size;
+        }
+
+        setModelScopeModelBackends(backends);
+        setModelScopeSelectedQuantizations(selectedQuantizations);
+        setModelScopeModelSizes(sizes);
+        setModelScopeSearchResults(ordered.map(result => result.model));
+        // Stop presenting the search as blocked once the first usable result is
+        // available; remaining probes continue to fill the list incrementally.
+        if (ordered.length > 0) setIsSearchingModelScope(false);
+      };
+
+      const validateCandidate = async (
+        model: HFModelInfo,
+        order: number,
+      ): Promise<ValidatedModelScopeResult | null> => {
+        const cached = modelScopeVariantCacheRef.current.get(model.id);
+        if (cached) return { model, order, ...cached };
+
+        const variantsRes = await serverFetch(
+          `/pull/variants?source=modelscope&checkpoint=${encodeURIComponent(model.id)}`,
+          { signal },
+        );
+        if (!variantsRes.ok) return null;
+
+        const variantsPayload: {
+          variants?: Array<{
+            name: string;
+            primary_file: string;
+            files: string[];
+            sharded: boolean;
+            size_bytes: number;
+          }>;
+          mmproj_files?: string[];
+          recipe?: string;
+          suggested_name?: string;
+          suggested_labels?: string[];
+        } = await variantsRes.json();
+
+        const variants = Array.isArray(variantsPayload.variants)
+          ? variantsPayload.variants
+          : [];
+        if (variants.length === 0) return null;
+
+        const quantizations: GGUFQuantization[] = variants.map(variant => ({
+          filename: variant.name,
+          quantization: variant.name,
+          size: variant.size_bytes || undefined,
+        }));
+        const suggestedLabels = Array.isArray(variantsPayload.suggested_labels)
+          ? variantsPayload.suggested_labels.filter(
+              (label): label is string => typeof label === 'string'
+            )
+          : [];
+        const firstVariant = quantizations[0];
+
+        const cacheEntry: ModelScopeVariantCacheEntry = {
+          selectedQuantization: firstVariant.filename,
+          size: firstVariant.size,
+          backend: {
+            recipe: variantsPayload.recipe || 'llamacpp',
+            label: 'GGUF',
+            suggestedName: variantsPayload.suggested_name,
+            quantizations,
+            mmprojFiles: variantsPayload.mmproj_files?.length
+              ? variantsPayload.mmproj_files
+              : undefined,
+            suggestedLabels,
+          },
+        };
+        modelScopeVariantCacheRef.current.set(model.id, cacheEntry);
+        return { model, order, ...cacheEntry };
+      };
+
+      const worker = async (): Promise<void> => {
+        while (
+          requestId === modelScopeSearchRequestRef.current &&
+          !signal.aborted &&
+          validated.length < maxResults &&
+          nextCandidate < candidates.length
+        ) {
+          const candidate = candidates[nextCandidate++];
+          try {
+            const result = await validateCandidate(candidate.model, candidate.order);
+            if (
+              result &&
+              requestId === modelScopeSearchRequestRef.current &&
+              validated.length < maxResults &&
+              !validated.some(item => item.model.id === result.model.id)
+            ) {
+              validated.push(result);
+              // Publish immediately instead of waiting for every file-tree probe.
+              // This is the main latency improvement for ModelScope search.
+              publishValidated();
+            }
+          } catch {
+            // Search metadata is only a candidate hint. Invalid or inaccessible
+            // repositories are silently omitted from marketplace results.
+          }
+        }
+      };
+
+      await Promise.all(
+        Array.from({
+          length: Math.min(MODELSCOPE_VALIDATION_CONCURRENCY, candidates.length),
+        }, () => worker())
+      );
+    } catch (error) {
+      if (requestId !== modelScopeSearchRequestRef.current || signal.aborted) return;
+      setModelScopeSearchResults([]);
+      setModelScopeModelBackends({});
+      setModelScopeSelectedQuantizations({});
+      setModelScopeModelSizes({});
+      const status = (error as Error & { status?: number }).status;
+      if (status === 429) {
+        setModelScopeRateLimited(true);
+      } else {
+        setModelScopeSearchError(
+          error instanceof Error ? error.message : 'ModelScope search failed'
+        );
+      }
+    } finally {
+      if (requestId === modelScopeSearchRequestRef.current && !signal.aborted) {
+        setIsSearchingModelScope(false);
+      }
+    }
+  }, []);
+
   const detectBackend = useCallback(async (modelId: string) => {
     if (hfModelBackends[modelId] !== undefined) return;
     setDetectingBackendFor(modelId);
@@ -980,7 +1239,6 @@ const [searchQuery, setSearchQuery] = useState('');
       setDetectingBackendFor(null);
     }
   }, [hfModelBackends, hfSelectedQuantizations]);
-
 
   const handleDownloadModel = useCallback(async (modelName: string, registrationData?: ModelRegistrationData, upgrade?: boolean) => {
     let downloadId: string | null = null;
@@ -1157,6 +1415,80 @@ const [searchQuery, setSearchQuery] = useState('');
     });
   }, [hfModelBackends, resolveGgufCheckpoint, resolveHfModelName, handleDownloadModel]);
 
+  const resolveModelScopeGgufCheckpoint = useCallback((modelId: string, backend: DetectedBackend): string => {
+    const selectedFilename = modelScopeSelectedQuantizations[modelId];
+    if (!selectedFilename) return modelId;
+    const quantObj = backend.quantizations?.find(q => q.filename === selectedFilename);
+    return `${modelId}:${quantObj?.quantization ?? selectedFilename}`;
+  }, [modelScopeSelectedQuantizations]);
+
+  const resolveModelScopeModelName = useCallback((modelId: string, backend: DetectedBackend, checkpoint?: string): string => {
+    const lookupModelInfo = (modelName: string): ModelInfo | undefined =>
+      modelsData[`user.${modelName}`] ?? modelsData[modelName];
+
+    const matchesModelScopeCheckpoint = (info: ModelInfo | undefined): boolean => {
+      if (!info || !checkpoint) return false;
+      const registrySource = info.registry_source
+        ?? (info.source === 'modelscope' || info.source === 'huggingface' ? info.source : 'huggingface');
+      return registrySource === 'modelscope'
+        && (info.checkpoint === checkpoint || info.checkpoints?.main === checkpoint);
+    };
+
+    const suggestedName = backend.suggestedName || modelId.split('/').pop() || modelId;
+    const selectedFilename = modelScopeSelectedQuantizations[modelId];
+    const quantObj = backend.quantizations?.find(q => q.filename === selectedFilename);
+    const defaultName = backend.recipe === 'llamacpp' && selectedFilename
+      ? `${suggestedName}-${quantObj?.quantization ?? selectedFilename}`
+      : suggestedName;
+
+    const existingDefault = lookupModelInfo(defaultName);
+    if (!existingDefault || matchesModelScopeCheckpoint(existingDefault)) return defaultName;
+
+    // A mirrored HF repository may already own the default name. Keep the
+    // ModelScope entry distinct while preserving the source+repository identity.
+    const owner = modelId.split('/')[0]?.trim();
+    const safeOwner = owner?.replace(/[^A-Za-z0-9_.-]+/g, '-').replace(/^-+|-+$/g, '');
+    const fallbackBase = safeOwner ? `${defaultName}-${safeOwner}` : `${defaultName}-modelscope`;
+    let candidate = fallbackBase;
+    let suffix = 2;
+    let existingCandidate = lookupModelInfo(candidate);
+    while (existingCandidate && !matchesModelScopeCheckpoint(existingCandidate)) {
+      candidate = `${fallbackBase}-${suffix}`;
+      suffix += 1;
+      existingCandidate = lookupModelInfo(candidate);
+    }
+    return candidate;
+  }, [modelScopeSelectedQuantizations, modelsData]);
+
+  const handleInstallModelScopeModel = useCallback((model: HFModelInfo) => {
+    const backend = modelScopeModelBackends[model.id];
+    if (!backend) return;
+
+    const checkpoint = backend.recipe === 'llamacpp'
+      ? resolveModelScopeGgufCheckpoint(model.id, backend)
+      : model.id;
+    const modelName = `user.${resolveModelScopeModelName(model.id, backend, checkpoint)}`;
+    const labels = new Set(backend.suggestedLabels ?? []);
+    const mmproj = backend.mmprojFiles?.[0];
+    if (mmproj) labels.add('vision');
+
+    handleDownloadModel(modelName, {
+      checkpoint,
+      recipe: backend.recipe,
+      source: 'modelscope',
+      mmproj,
+      labels: Array.from(labels),
+      vision: labels.has('vision'),
+      embedding: labels.has('embeddings'),
+      reranking: labels.has('reranking'),
+    });
+  }, [
+    modelScopeModelBackends,
+    resolveModelScopeGgufCheckpoint,
+    resolveModelScopeModelName,
+    handleDownloadModel,
+  ]);
+
   // Debounced HF search effect - to avoid HF API rate limit error
   useEffect(() => {
     if (currentView !== 'models') return;
@@ -1176,6 +1508,69 @@ const [searchQuery, setSearchQuery] = useState('');
       if (hfModelBackends[model.id] === undefined) detectBackend(model.id);
     });
   }, [hfSearchResults, hfModelBackends, detectBackend]);
+
+  // ModelScope follows the same query and placement as Hugging Face, but has
+  // its own debounce and request generation so neither provider can cancel or
+  // overwrite the other provider's state.
+  useEffect(() => {
+    if (modelScopeSearchTimeoutRef.current) {
+      clearTimeout(modelScopeSearchTimeoutRef.current);
+      modelScopeSearchTimeoutRef.current = null;
+    }
+
+    const requestId = ++modelScopeSearchRequestRef.current;
+
+    if (currentView !== 'models') {
+      setIsSearchingModelScope(false);
+      setModelScopeSearchResults([]);
+      setModelScopeModelBackends({});
+      setModelScopeSelectedQuantizations({});
+      setModelScopeModelSizes({});
+      setModelScopeRateLimited(false);
+      setModelScopeSearchError(null);
+      return;
+    }
+
+    const query = searchQuery.trim();
+    if (query.length >= 3) {
+      setModelScopeSearchResults([]);
+      setModelScopeModelBackends({});
+      setModelScopeSelectedQuantizations({});
+      setModelScopeModelSizes({});
+      setModelScopeRateLimited(false);
+      setModelScopeSearchError(null);
+      // ModelScope is server-proxied and does not share Hugging Face's browser
+      // rate limit, so a shorter debounce keeps the secondary provider responsive.
+      setIsSearchingModelScope(true);
+      const controller = new AbortController();
+      modelScopeSearchTimeoutRef.current = setTimeout(() => {
+        void searchModelScope(query, requestId, controller.signal);
+      }, MODELSCOPE_SEARCH_DEBOUNCE_MS);
+
+      return () => {
+        controller.abort();
+        if (modelScopeSearchTimeoutRef.current) {
+          clearTimeout(modelScopeSearchTimeoutRef.current);
+          modelScopeSearchTimeoutRef.current = null;
+        }
+      };
+    } else {
+      setIsSearchingModelScope(false);
+      setModelScopeSearchResults([]);
+      setModelScopeModelBackends({});
+      setModelScopeSelectedQuantizations({});
+      setModelScopeModelSizes({});
+      setModelScopeRateLimited(false);
+      setModelScopeSearchError(null);
+    }
+
+    return () => {
+      if (modelScopeSearchTimeoutRef.current) {
+        clearTimeout(modelScopeSearchTimeoutRef.current);
+        modelScopeSearchTimeoutRef.current = null;
+      }
+    };
+  }, [searchQuery, currentView, searchModelScope]);
 
   // Separate useEffect for download resume/retry to avoid stale closure issues
   useEffect(() => {
@@ -1805,6 +2200,16 @@ const [searchQuery, setSearchQuery] = useState('');
     );
   };
 
+  const compatibleHfSearchResults = hfSearchResults.filter((model: HFModelInfo) => {
+    const backend = hfModelBackends[model.id];
+    return backend !== null && !(backend != null && ['sd-cpp', 'whispercpp', 'moonshine'].includes(backend.recipe));
+  });
+
+  const noCompatibleModelScopeResults = !isSearchingModelScope
+    && !modelScopeRateLimited
+    && !modelScopeSearchError
+    && modelScopeSearchResults.length === 0;
+
   const renderModelsView = () => (
     <>
       {categories.map(category => {
@@ -2024,62 +2429,154 @@ const [searchQuery, setSearchQuery] = useState('');
                 {renderModelsView()}
               </div>
             )}
-            {currentView === 'models' && searchQuery.trim().length >= 3 && ( // Rendering the HF models by searching
-              <div className="hf-search-section widget">
-                <div className="available-models-header">
-                  <div className="loaded-model-label">FROM HUGGING FACE</div>
-                  {isSearchingHF && <span className="hf-search-spinner" />}
-                </div>
-                {hfRateLimited && (
-                  <div className="hf-search-message">Rate limited — try again shortly.</div>
-                )}
-                {!hfRateLimited && !isSearchingHF && (
-                  hfSearchResults.length === 0 ||
-                  (hfSearchResults.length > 0 &&
-                    detectingBackendFor === null &&
-                    hfSearchResults.every((m: HFModelInfo) => {
-                      const backend = hfModelBackends[m.id];
-                      return backend === null || (backend != null && ['sd-cpp', 'whispercpp', 'moonshine'].includes(backend.recipe));
-                    }))
-                ) && (
-                  <div className="hf-search-message">No compatible models found.</div>
-                )}
-                {hfSearchResults.filter((hfModel: HFModelInfo) => {
-                  const backend = hfModelBackends[hfModel.id];
-                  return backend !== null && !(backend != null && ['sd-cpp', 'whispercpp', 'moonshine'].includes(backend.recipe));
-                }).map((hfModel: HFModelInfo) => {
-                  const backend = hfModelBackends[hfModel.id];
-                  const isDetecting = detectingBackendFor === hfModel.id;
-                  const quants = backend?.quantizations ?? [];
-                  const selectedQuant = hfSelectedQuantizations[hfModel.id];
-                  const size = hfModelSizes[hfModel.id];
-                  return (
-                    <div key={hfModel.id} className="hf-model-item">
-                      <div className="hf-model-left">
-                        <span className="hf-model-name" title={hfModel.id}>{hfModel.id}</span>
-                        {size !== undefined && <span className="hf-model-size">{formatSize(size / (1024 ** 3))}</span>}
-                        <span className="hf-model-meta">↓ {formatDownloads(hfModel.downloads)}</span>
-                        {isDetecting && <span className="hf-search-spinner" />}
-                        <div className="hf-model-actions">
-                          {!isDetecting && backend && (
-                            <>
+            {currentView === 'models' && searchQuery.trim().length >= 3 && (
+              <div className="hf-search-section widget registry-search-section">
+                <section className="registry-provider-group" aria-label="Hugging Face search results">
+                  <div className="available-models-header registry-provider-header">
+                    <div className="loaded-model-label">FROM HUGGING FACE</div>
+                    {isSearchingHF && <span className="hf-search-spinner" />}
+                  </div>
+                  {hfRateLimited && (
+                    <div className="hf-search-message">Rate limited — try again shortly.</div>
+                  )}
+                  {!hfRateLimited && !isSearchingHF && compatibleHfSearchResults.length === 0 && (
+                    <div className="hf-search-message">No compatible models found.</div>
+                  )}
+                  <div className="registry-provider-results">
+                    {compatibleHfSearchResults.map((hfModel: HFModelInfo) => {
+                    const backend = hfModelBackends[hfModel.id];
+                    const isDetecting = detectingBackendFor === hfModel.id;
+                    const quants = backend?.quantizations ?? [];
+                    const selectedQuant = hfSelectedQuantizations[hfModel.id];
+                    const size = hfModelSizes[hfModel.id];
+                    return (
+                      <div key={hfModel.id} className="hf-model-item">
+                        <div className="hf-model-left">
+                          <span className="hf-model-name" title={hfModel.id}>{hfModel.id}</span>
+                          <span className="registry-result-source-badge huggingface" title="Hugging Face">HF</span>
+                          {size !== undefined && <span className="hf-model-size">{formatSize(size / (1024 ** 3))}</span>}
+                          <span className="hf-model-meta">↓ {formatDownloads(hfModel.downloads)}</span>
+                          {isDetecting && <span className="hf-search-spinner" />}
+                          <div className="hf-model-actions">
+                            {!isDetecting && backend && (
+                              <>
+                                <button
+                                  className="model-action-btn edit-btn"
+                                  title="Edit before adding"
+                                  onClick={(e: React.MouseEvent) => {
+                                    e.stopPropagation();
+                                    const checkpoint = backend.recipe === 'llamacpp'
+                                      ? resolveGgufCheckpoint(hfModel.id, backend)
+                                      : hfModel.id;
+                                    const idLower = hfModel.id.toLowerCase();
+                                    const labels = backend.suggestedLabels ?? [];
+                                    window.dispatchEvent(new CustomEvent('openAddModel', {
+                                      detail: {
+                                        initialValues: {
+                                          name: resolveHfModelName(hfModel.id, backend, checkpoint),
+                                          checkpoint,
+                                          recipe: backend.recipe,
+                                          source: 'huggingface',
+                                          mmprojOptions: backend.mmprojFiles,
+                                          labels,
+                                          vision: labels.includes('vision') || (backend.mmprojFiles?.length ?? 0) > 0,
+                                          reranking: labels.includes('reranking') || idLower.includes('rerank'),
+                                          embedding: labels.includes('embeddings') || idLower.includes('embed'),
+                                        },
+                                      },
+                                    }));
+                                  }}
+                                >
+                                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                                  </svg>
+                                </button>
+                                <button
+                                  className="model-action-btn download-btn"
+                                  title="Download from Hugging Face"
+                                  onClick={() => handleInstallHFModel(hfModel)}
+                                >
+                                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                                    <polyline points="7 10 12 15 17 10" />
+                                    <line x1="12" y1="15" x2="12" y2="3" />
+                                  </svg>
+                                </button>
+                              </>
+                            )}
+                          </div>
+                        </div>
+                        <div className="hf-model-right">
+                          {!isDetecting && backend && quants.length > 1 && (
+                            <select
+                              className="hf-quant-select"
+                              value={selectedQuant ?? ''}
+                              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                                const q = quants.find((x: GGUFQuantization) => x.filename === e.target.value);
+                                setHfSelectedQuantizations((prev: Record<string, string>) => ({ ...prev, [hfModel.id]: e.target.value }));
+                                if (q?.size !== undefined) setHfModelSizes((prev: Record<string, number | undefined>) => ({ ...prev, [hfModel.id]: q.size }));
+                              }}
+                            >
+                              {quants.map((q: GGUFQuantization) => (
+                                <option key={q.filename} value={q.filename}>{q.quantization}</option>
+                              ))}
+                            </select>
+                          )}
+                          {!isDetecting && backend && <span className="hf-backend-badge">{backend.label}</span>}
+                        </div>
+                      </div>
+                    );
+                  })}
+                  </div>
+                </section>
+
+                <section className="registry-provider-group modelscope-provider-group" aria-label="ModelScope search results">
+                  <div className="available-models-header registry-provider-header modelscope-provider-header">
+                    <div className="loaded-model-label">FROM MODELSCOPE</div>
+                    {isSearchingModelScope && <span className="hf-search-spinner" />}
+                  </div>
+                  {modelScopeRateLimited && (
+                    <div className="hf-search-message">Rate limited — try again shortly.</div>
+                  )}
+                  {!modelScopeRateLimited && modelScopeSearchError && (
+                    <div className="hf-search-message">{modelScopeSearchError}</div>
+                  )}
+                  {noCompatibleModelScopeResults && (
+                    <div className="hf-search-message">No compatible models found.</div>
+                  )}
+                  <div className="registry-provider-results">
+                    {modelScopeSearchResults.map((model: HFModelInfo) => {
+                      const backend = modelScopeModelBackends[model.id];
+                      if (!backend) return null;
+                      const quants = backend.quantizations ?? [];
+                      const selectedQuant = modelScopeSelectedQuantizations[model.id];
+                      const size = modelScopeModelSizes[model.id];
+                      return (
+                        <div key={`modelscope:${model.id}`} className="hf-model-item">
+                          <div className="hf-model-left">
+                            <span className="hf-model-name" title={model.id}>{model.id}</span>
+                            <span className="registry-result-source-badge modelscope" title="ModelScope">MS</span>
+                            {size !== undefined && <span className="hf-model-size">{formatSize(size / (1024 ** 3))}</span>}
+                            <span className="hf-model-meta">↓ {formatDownloads(model.downloads)}</span>
+                            <div className="hf-model-actions">
                               <button
                                 className="model-action-btn edit-btn"
                                 title="Edit before adding"
                                 onClick={(e: React.MouseEvent) => {
                                   e.stopPropagation();
                                   const checkpoint = backend.recipe === 'llamacpp'
-                                    ? resolveGgufCheckpoint(hfModel.id, backend)
-                                    : hfModel.id;
-                                  const idLower = hfModel.id.toLowerCase();
+                                    ? resolveModelScopeGgufCheckpoint(model.id, backend)
+                                    : model.id;
                                   const labels = backend.suggestedLabels ?? [];
+                                  const idLower = model.id.toLowerCase();
                                   window.dispatchEvent(new CustomEvent('openAddModel', {
                                     detail: {
                                       initialValues: {
-                                        name: resolveHfModelName(hfModel.id, backend, checkpoint),
+                                        name: resolveModelScopeModelName(model.id, backend, checkpoint),
                                         checkpoint,
                                         recipe: backend.recipe,
-                                        source: 'huggingface',
+                                        source: 'modelscope',
                                         mmprojOptions: backend.mmprojFiles,
                                         labels,
                                         vision: labels.includes('vision') || (backend.mmprojFiles?.length ?? 0) > 0,
@@ -2097,8 +2594,8 @@ const [searchQuery, setSearchQuery] = useState('');
                               </button>
                               <button
                                 className="model-action-btn download-btn"
-                                title="Download from Hugging Face"
-                                onClick={() => handleInstallHFModel(hfModel)}
+                                title="Download from ModelScope"
+                                onClick={() => handleInstallModelScopeModel(model)}
                               >
                                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                                   <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
@@ -2106,31 +2603,33 @@ const [searchQuery, setSearchQuery] = useState('');
                                   <line x1="12" y1="15" x2="12" y2="3" />
                                 </svg>
                               </button>
-                            </>
-                          )}
+                            </div>
+                          </div>
+                          <div className="hf-model-right">
+                            {quants.length > 1 && (
+                              <select
+                                className="hf-quant-select"
+                                value={selectedQuant ?? ''}
+                                onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+                                  const quant = quants.find((item: GGUFQuantization) => item.filename === e.target.value);
+                                  setModelScopeSelectedQuantizations(prev => ({ ...prev, [model.id]: e.target.value }));
+                                  if (quant?.size !== undefined) {
+                                    setModelScopeModelSizes(prev => ({ ...prev, [model.id]: quant.size }));
+                                  }
+                                }}
+                              >
+                                {quants.map((quant: GGUFQuantization) => (
+                                  <option key={quant.filename} value={quant.filename}>{quant.quantization}</option>
+                                ))}
+                              </select>
+                            )}
+                            <span className="hf-backend-badge">{backend.label}</span>
+                          </div>
                         </div>
-                      </div>
-                      <div className="hf-model-right">
-                        {!isDetecting && backend && quants.length > 1 && (
-                          <select
-                            className="hf-quant-select"
-                            value={selectedQuant ?? ''}
-                            onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
-                              const q = quants.find((x: GGUFQuantization) => x.filename === e.target.value);
-                              setHfSelectedQuantizations((prev: Record<string, string>) => ({ ...prev, [hfModel.id]: e.target.value }));
-                              if (q?.size !== undefined) setHfModelSizes((prev: Record<string, number | undefined>) => ({ ...prev, [hfModel.id]: q.size }));
-                            }}
-                          >
-                            {quants.map((q: GGUFQuantization) => (
-                              <option key={q.filename} value={q.filename}>{q.quantization}</option>
-                            ))}
-                          </select>
-                        )}
-                        {!isDetecting && backend && <span className="hf-backend-badge">{backend.label}</span>}
-                      </div>
-                    </div>
-                  );
-                })}
+                      );
+                    })}
+                  </div>
+                </section>
               </div>
             )}
             {currentView === 'marketplace' && (

--- a/src/app/styles/styles.css
+++ b/src/app/styles/styles.css
@@ -1382,6 +1382,25 @@ footer {
     min-width: 0;
 }
 
+.registry-result-source-badge {
+    flex-shrink: 0;
+    min-width: 18px;
+    padding: 1px 4px;
+    border: 1px solid var(--border-alpha-08);
+    border-radius: 3px;
+    background: var(--bg-alpha-04);
+    color: var(--text-quaternary);
+    font-size: 0.5rem;
+    line-height: 1.1;
+    text-align: center;
+    letter-spacing: 0.25px;
+}
+
+.registry-result-source-badge.modelscope {
+    color: var(--text-secondary);
+    border-color: var(--border-alpha-1);
+}
+
 .hf-model-meta {
     font-size: 0.6rem;
     color: var(--color-5);
@@ -7873,4 +7892,33 @@ input::-webkit-calendar-picker-indicator {
 
 [data-theme="light"] .audio-duration-label input {
   color-scheme: light;
+}
+
+/* Registry search providers share one widget. Each provider owns a bounded
+ * result viewport so a long Hugging Face list can never push ModelScope out of
+ * sight. The rows remain fully available through the provider-local scrollbar. */
+.registry-search-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.registry-provider-group {
+    min-width: 0;
+}
+
+.registry-provider-group + .registry-provider-group {
+    padding-top: 8px;
+    border-top: 1px solid var(--border-alpha-05);
+}
+
+.registry-provider-header {
+    margin-bottom: 3px;
+}
+
+.registry-provider-results {
+    max-height: 168px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
 }

--- a/src/cpp/include/lemon/model_registry.h
+++ b/src/cpp/include/lemon/model_registry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <stdexcept>
@@ -18,6 +19,35 @@ enum class RemoteRegistrySource {
 class RegistryNotFoundError : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
+};
+
+class RegistrySearchError : public std::runtime_error {
+public:
+    RegistrySearchError(int status_code, const std::string& message)
+        : std::runtime_error(message), status_code_(status_code) {}
+
+    int status_code() const noexcept { return status_code_; }
+
+private:
+    int status_code_;
+};
+
+struct RegistrySearchResult {
+    std::string repo_id;
+    std::string display_name;
+    RemoteRegistrySource source = RemoteRegistrySource::HuggingFace;
+    std::string repository_type = "model";
+    std::string description;
+    std::vector<std::string> tags;
+    std::string task;
+    std::uint64_t downloads = 0;
+    std::uint64_t likes = 0;
+    bool has_gguf = false;
+};
+
+struct RegistrySearchResponse {
+    std::vector<RegistrySearchResult> results;
+    std::uint64_t total = 0;
 };
 
 struct RegistryFile {
@@ -42,6 +72,28 @@ RemoteRegistrySource parse_remote_registry_source(const std::string& source);
 std::string remote_registry_source_name(RemoteRegistrySource source);
 std::string remote_registry_display_name(RemoteRegistrySource source);
 bool is_remote_registry_source(const std::string& source);
+
+// Normalize one provider-specific model-list entry into Lemonade's registry contract.
+// Exposed so fixture tests and future clients share the same field mapping.
+RegistrySearchResult normalize_registry_search_result(
+    RemoteRegistrySource source,
+    const nlohmann::json& metadata);
+
+// Normalize and filter a provider response without performing network I/O.
+// This keeps provider field mapping and filtering deterministic and unit-testable.
+RegistrySearchResponse normalize_registry_search_response(
+    RemoteRegistrySource source,
+    const nlohmann::json& body,
+    std::size_t limit = 12);
+
+// Search a remote model registry. Provider-side GGUF filters are candidate
+// hints only; callers must use /pull/variants as the authoritative file-level
+// compatibility check before presenting a downloadable marketplace result.
+RegistrySearchResponse search_registry_models(
+    RemoteRegistrySource source,
+    const std::string& query,
+    std::size_t limit = 12,
+    bool gguf_only = false);
 
 // Deterministic snapshot id for providers whose download revision may remain
 // mutable. Ordering of files does not affect the result.

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -128,6 +128,7 @@ private:
     void handle_tokenize(const httplib::Request& req, httplib::Response& res);
     void handle_responses(const httplib::Request& req, httplib::Response& res);
     void handle_pull(const httplib::Request& req, httplib::Response& res);
+    void handle_registry_search(const httplib::Request& req, httplib::Response& res);
     void handle_pull_variants(const httplib::Request& req, httplib::Response& res);
     void handle_load(const httplib::Request& req, httplib::Response& res);
     void handle_unload(const httplib::Request& req, httplib::Response& res);

--- a/src/cpp/server/model_registry.cpp
+++ b/src/cpp/server/model_registry.cpp
@@ -113,6 +113,159 @@ std::string first_string(const json& entry,
     return "";
 }
 
+std::uint64_t first_uint64(const json& entry,
+                           std::initializer_list<const char*> keys,
+                           std::uint64_t fallback = 0) {
+    for (const char* key : keys) {
+        auto it = entry.find(key);
+        if (it == entry.end()) continue;
+        if (it->is_number_unsigned()) return it->get<std::uint64_t>();
+        if (it->is_number_integer()) {
+            const auto value = it->get<std::int64_t>();
+            return value > 0 ? static_cast<std::uint64_t>(value) : 0;
+        }
+        if (it->is_string()) {
+            try { return static_cast<std::uint64_t>(std::stoull(it->get<std::string>())); }
+            catch (...) { continue; }
+        }
+    }
+    return fallback;
+}
+
+std::vector<std::string> first_string_array(
+    const json& entry,
+    std::initializer_list<const char*> keys) {
+    for (const char* key : keys) {
+        auto it = entry.find(key);
+        if (it == entry.end()) continue;
+        if (it->is_string()) return {it->get<std::string>()};
+        if (!it->is_array()) continue;
+        std::vector<std::string> values;
+        for (const auto& value : *it) {
+            if (value.is_string()) values.push_back(value.get<std::string>());
+        }
+        return values;
+    }
+    return {};
+}
+
+bool contains_gguf(const std::string& value) {
+    return lower_copy(value).find("gguf") != std::string::npos;
+}
+
+std::string compact_search_text(const std::string& value) {
+    std::string compact;
+    compact.reserve(value.size());
+    for (unsigned char c : value) {
+        if (std::isalnum(c)) compact.push_back(static_cast<char>(std::tolower(c)));
+    }
+    return compact;
+}
+
+std::int64_t registry_search_rank(const std::string& query,
+                                  const RegistrySearchResult& model) {
+    const std::string query_lower = lower_copy(query);
+    const std::string query_compact = compact_search_text(query);
+    const std::string id_lower = lower_copy(model.repo_id);
+    const auto slash = id_lower.find_last_of('/');
+    const std::string name_lower = slash == std::string::npos
+        ? id_lower : id_lower.substr(slash + 1);
+    const std::string id_compact = compact_search_text(id_lower);
+    const std::string name_compact = compact_search_text(name_lower);
+
+    std::int64_t score = 0;
+    if (name_lower == query_lower || name_compact == query_compact) {
+        score += 100000;
+    } else if (name_lower.rfind(query_lower, 0) == 0 ||
+               name_compact.rfind(query_compact, 0) == 0) {
+        score += 70000;
+    } else if (name_lower.find(query_lower) != std::string::npos ||
+               name_compact.find(query_compact) != std::string::npos) {
+        score += 50000;
+    } else if (id_lower.find(query_lower) != std::string::npos ||
+               id_compact.find(query_compact) != std::string::npos) {
+        score += 35000;
+    }
+
+    if (model.has_gguf) score += 12000;
+    score += static_cast<std::int64_t>(std::min<std::uint64_t>(model.downloads, 1000));
+    return score;
+}
+
+bool has_gguf_metadata(const std::string& repo_id,
+                       const std::vector<std::string>& tags,
+                       const json& metadata) {
+    if (contains_gguf(repo_id)) return true;
+    if (std::any_of(tags.begin(), tags.end(), contains_gguf)) return true;
+    for (const char* key : {"model_type", "ModelType", "format", "Format"}) {
+        const std::string value = first_string(metadata, {key});
+        if (!value.empty() && contains_gguf(value)) return true;
+    }
+    return false;
+}
+
+bool excluded_generation_task(const std::string& task) {
+    const std::string normalized = lower_copy(task);
+    static const std::vector<std::string> excluded = {
+        "automatic-speech-recognition", "text-to-speech", "audio-text-to-text",
+        "text-to-audio", "audio-to-audio", "voice-activity-detection",
+        "text-to-image", "image-to-image", "image-to-video", "image-to-3d",
+        "image-text-to-image", "image-text-to-video", "unconditional-image-generation",
+        "image-segmentation", "object-detection", "depth-estimation", "mask-generation",
+        "zero-shot-object-detection", "text-to-video", "text-to-3d", "video-to-video",
+    };
+    return std::find(excluded.begin(), excluded.end(), normalized) != excluded.end();
+}
+
+const json* registry_search_items(const json& body) {
+    const json* payload = &body;
+    if (body.is_object()) {
+        if (auto it = body.find("data"); it != body.end()) payload = &*it;
+        else if (auto it = body.find("Data"); it != body.end()) payload = &*it;
+    }
+    if (payload->is_array()) return payload;
+    if (!payload->is_object()) return nullptr;
+    for (const char* key : {"models", "Models", "items", "Items", "results", "Results", "list", "List"}) {
+        auto it = payload->find(key);
+        if (it != payload->end() && it->is_array()) return &*it;
+    }
+    return nullptr;
+}
+
+std::uint64_t registry_search_total(const json& body, std::uint64_t fallback) {
+    if (!body.is_object()) return fallback;
+    std::uint64_t total = first_uint64(body, {"total_count", "TotalCount", "total", "Total"}, fallback);
+    if (auto it = body.find("data"); it != body.end() && it->is_object()) {
+        total = first_uint64(*it, {"total_count", "TotalCount", "total", "Total"}, total);
+    } else if (auto it = body.find("Data"); it != body.end() && it->is_object()) {
+        total = first_uint64(*it, {"total_count", "TotalCount", "total", "Total"}, total);
+    }
+    return total;
+}
+
+std::string registry_search_status_message(RemoteRegistrySource source,
+                                           int status_code,
+                                           const std::string& response_body) {
+    std::string message;
+    const json body = json::parse(response_body, nullptr, false);
+    if (body.is_object()) {
+        if (auto it = body.find("error"); it != body.end()) {
+            if (it->is_string()) message = it->get<std::string>();
+            else if (it->is_object()) {
+                message = first_string(*it, {"message", "Message", "detail", "Detail"});
+            }
+        }
+        if (message.empty()) {
+            message = first_string(body, {"message", "Message", "detail", "Detail"});
+        }
+    }
+
+    std::string result = remote_registry_display_name(source) +
+        " search returned HTTP " + std::to_string(status_code);
+    if (!message.empty()) result += ": " + message;
+    return result;
+}
+
 bool is_modelscope_not_found_or_access_error(const std::string& code_text,
                                               const std::string& message) {
     const std::string code = lower_copy(code_text);
@@ -145,20 +298,26 @@ void ensure_modelscope_success(const json& body, const std::string& repo_id) {
 
     bool failed = false;
     std::string code_text;
-    if (auto it = body.find("Code"); it != body.end()) {
-        if (it->is_number_integer()) {
-            const auto code = it->get<long long>();
+    const json* code_value = nullptr;
+    if (auto it = body.find("Code"); it != body.end()) code_value = &*it;
+    else if (auto it = body.find("code"); it != body.end()) code_value = &*it;
+    if (code_value) {
+        if (code_value->is_number_integer()) {
+            const auto code = code_value->get<long long>();
             failed = code != 0 && code != 200;
             code_text = std::to_string(code);
-        } else if (it->is_string()) {
-            code_text = it->get<std::string>();
+        } else if (code_value->is_string()) {
+            code_text = code_value->get<std::string>();
             const std::string normalized = lower_copy(code_text);
             failed = normalized != "0" && normalized != "200" &&
                      normalized != "ok" && normalized != "success";
         }
     }
-    if (auto it = body.find("Success"); it != body.end() && it->is_boolean()) {
-        failed = failed || !it->get<bool>();
+    const json* success_value = nullptr;
+    if (auto it = body.find("Success"); it != body.end()) success_value = &*it;
+    else if (auto it = body.find("success"); it != body.end()) success_value = &*it;
+    if (success_value && success_value->is_boolean()) {
+        failed = failed || !success_value->get<bool>();
     }
     if (!failed) return;
 
@@ -360,6 +519,214 @@ private:
 };
 
 }  // namespace
+
+RegistrySearchResult normalize_registry_search_result(
+    RemoteRegistrySource source,
+    const nlohmann::json& metadata) {
+    RegistrySearchResult result;
+    result.source = source;
+    if (!metadata.is_object()) return result;
+
+    result.repo_id = first_string(metadata, {
+        "id", "Id", "repo_id", "repoId", "model_id", "modelId"
+    });
+    if (result.repo_id.empty()) {
+        const std::string path = first_string(metadata, {"Path", "path"});
+        if (path.find('/') != std::string::npos) {
+            result.repo_id = path;
+        } else {
+            const std::string owner = first_string(metadata, {
+                "owner", "Owner", "namespace", "Namespace", "Path", "path"
+            });
+            const std::string name = first_string(metadata, {
+                "name", "Name", "repo_name", "repoName", "model_name", "modelName"
+            });
+            if (!owner.empty() && !name.empty()) result.repo_id = owner + "/" + name;
+        }
+    }
+
+    result.display_name = first_string(metadata, {
+        "display_name", "displayName", "ChineseName", "name", "Name"
+    });
+    if (result.display_name.empty()) {
+        const auto slash = result.repo_id.find('/');
+        result.display_name = slash == std::string::npos
+            ? result.repo_id : result.repo_id.substr(slash + 1);
+    }
+    result.description = first_string(metadata, {
+        "description", "Description", "summary", "Summary"
+    });
+    result.task = first_string(metadata, {
+        "pipeline_tag", "pipelineTag", "task", "Task"
+    });
+    if (result.task.empty()) {
+        const auto tasks = first_string_array(metadata, {"tasks", "Tasks"});
+        if (!tasks.empty()) result.task = tasks.front();
+    }
+    result.tags = first_string_array(metadata, {
+        "tags", "Tags", "custom_tags", "customTags"
+    });
+    if (result.task.empty()) {
+        for (const auto& tag : result.tags) {
+            const std::string normalized_tag = lower_copy(tag);
+            if (normalized_tag.rfind("task:", 0) == 0 && tag.size() > 5) {
+                result.task = tag.substr(5);
+                break;
+            }
+        }
+    }
+    result.downloads = first_uint64(metadata, {
+        "downloads", "Downloads", "download_count", "downloadCount", "DownloadCount"
+    });
+    result.likes = first_uint64(metadata, {
+        "likes", "Likes", "like_count", "likeCount", "LikeCount"
+    });
+    result.has_gguf = has_gguf_metadata(result.repo_id, result.tags, metadata);
+    return result;
+}
+
+RegistrySearchResponse normalize_registry_search_response(
+    RemoteRegistrySource source,
+    const nlohmann::json& body,
+    std::size_t limit) {
+    limit = std::clamp<std::size_t>(limit, 1, 50);
+    if (source == RemoteRegistrySource::ModelScope) {
+        ensure_modelscope_success(body, "model search");
+    }
+
+    const json* items = registry_search_items(body);
+    if (!items) {
+        throw std::runtime_error(
+            remote_registry_display_name(source) + " search response is missing a model list");
+    }
+
+    RegistrySearchResponse result;
+    result.total = registry_search_total(body, items->size());
+    result.results.reserve(std::min<std::size_t>(items->size(), limit));
+    for (const auto& item : *items) {
+        RegistrySearchResult normalized = normalize_registry_search_result(source, item);
+        if (normalized.repo_id.empty() || excluded_generation_task(normalized.task)) continue;
+        // Provider list metadata is only a hint here. The request-specific
+        // format filter is applied by search_registry_models below, while
+        // /pull/variants remains the authoritative file compatibility check.
+        result.results.push_back(std::move(normalized));
+        if (result.results.size() >= limit) break;
+    }
+    return result;
+}
+
+RegistrySearchResponse search_registry_models(RemoteRegistrySource source,
+                                              const std::string& query,
+                                              std::size_t limit,
+                                              bool gguf_only) {
+    if (query.empty()) throw std::invalid_argument("Search query must not be empty");
+    limit = std::clamp<std::size_t>(limit, 1, 50);
+
+    struct SearchRequest {
+        std::string url;
+        bool gguf_hint = false;
+        bool optional = false;
+    };
+
+    std::string endpoint;
+    std::vector<SearchRequest> requests;
+    if (source == RemoteRegistrySource::HuggingFace) {
+        endpoint = trim_trailing_slash(env_string("HF_ENDPOINT"));
+        if (endpoint.empty()) endpoint = "https://huggingface.co";
+        std::string url = endpoint + "/api/models?search=" + percent_encode(query) +
+                          "&sort=downloads&direction=-1&limit=" + std::to_string(limit);
+        if (gguf_only) url += "&filter=gguf";
+        requests.push_back({std::move(url), gguf_only, false});
+    } else {
+        endpoint = trim_trailing_slash(env_string("MODELSCOPE_ENDPOINT"));
+        if (endpoint.empty()) endpoint = "https://modelscope.cn";
+
+        // ModelScope tokenizes version-like names broadly (Qwen3.6 may match
+        // Qwen3-0.6B). Ask for a moderately larger candidate page and rank it
+        // locally before the renderer performs the authoritative file-tree
+        // check through /pull/variants.
+        const std::size_t candidate_page_size = std::min<std::size_t>(
+            50, std::max<std::size_t>(24, limit * 2));
+        const std::string base = endpoint +
+            "/openapi/v1/models?sort=downloads&page_number=1&page_size=" +
+            std::to_string(candidate_page_size);
+
+        if (gguf_only) {
+            // Start with the explicit GGUF query. The library facet is only a
+            // fallback when that first response does not provide enough
+            // candidates; older code always made both calls and also issued a
+            // third unfiltered request, adding avoidable latency.
+            requests.push_back({
+                base + "&search=" + percent_encode(query + " GGUF"),
+                true,
+                false,
+            });
+            requests.push_back({
+                base + "&search=" + percent_encode(query) + "&filter.library=gguf",
+                true,
+                true,
+            });
+        } else {
+            requests.push_back({base + "&search=" + percent_encode(query), false, false});
+        }
+    }
+
+    RegistrySearchResponse merged;
+    for (const auto& request : requests) {
+        if (source == RemoteRegistrySource::ModelScope && gguf_only && request.optional) {
+            const std::size_t confirmed = static_cast<std::size_t>(std::count_if(
+                merged.results.begin(), merged.results.end(),
+                [](const RegistrySearchResult& model) { return model.has_gguf; }));
+            if (confirmed >= std::min<std::size_t>(limit, 8)) break;
+        }
+
+        const auto response = HttpClient::get(
+            request.url, model_registry(source).auth_headers());
+        if (response.status_code != 200) {
+            if (request.optional && !merged.results.empty()) continue;
+            throw RegistrySearchError(
+                response.status_code,
+                registry_search_status_message(source, response.status_code, response.body));
+        }
+
+        RegistrySearchResponse page;
+        try {
+            page = normalize_registry_search_response(
+                source, JsonUtils::parse(response.body), 50);
+        } catch (...) {
+            if (request.optional && !merged.results.empty()) continue;
+            throw;
+        }
+        merged.total = std::max(merged.total, page.total);
+        for (auto& model : page.results) {
+            // An explicit GGUF query or provider library facet is a useful
+            // ranking hint but not proof; /pull/variants remains the only
+            // compatibility authority.
+            if (request.gguf_hint) model.has_gguf = true;
+
+            const bool duplicate = std::any_of(
+                merged.results.begin(), merged.results.end(),
+                [&model](const RegistrySearchResult& existing) {
+                    return existing.source == model.source &&
+                           existing.repo_id == model.repo_id;
+                });
+            if (!duplicate) merged.results.push_back(std::move(model));
+        }
+    }
+
+    std::stable_sort(
+        merged.results.begin(), merged.results.end(),
+        [&query](const RegistrySearchResult& lhs,
+                 const RegistrySearchResult& rhs) {
+            const auto lhs_rank = registry_search_rank(query, lhs);
+            const auto rhs_rank = registry_search_rank(query, rhs);
+            if (lhs_rank != rhs_rank) return lhs_rank > rhs_rank;
+            if (lhs.downloads != rhs.downloads) return lhs.downloads > rhs.downloads;
+            return lhs.repo_id < rhs.repo_id;
+        });
+    if (merged.results.size() > limit) merged.results.resize(limit);
+    return merged;
+}
 
 RemoteRegistrySource parse_remote_registry_source(const std::string& source) {
     const std::string normalized = lower_copy(source);

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -822,6 +822,10 @@ void Server::setup_routes(httplib::Server &web_server) {
         handle_pull(req, res);
     });
 
+    register_get("registry/search", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_registry_search(req, res);
+    });
+
     register_get("pull/variants", [this](const httplib::Request& req, httplib::Response& res) {
         handle_pull_variants(req, res);
     });
@@ -4416,6 +4420,111 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
         res.status = 500;
         nlohmann::json error = {{"error", e.what()}};
         res.set_content(error.dump(), "application/json");
+    }
+}
+
+void Server::handle_registry_search(const httplib::Request& req, httplib::Response& res) {
+    try {
+        std::string query = req.has_param("query")
+            ? req.get_param_value("query")
+            : (req.has_param("q") ? req.get_param_value("q") : "");
+        const auto first = query.find_first_not_of(" \t\r\n");
+        const auto last = query.find_last_not_of(" \t\r\n");
+        query = first == std::string::npos ? "" : query.substr(first, last - first + 1);
+        if (query.size() < 3) {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", {
+                {"message", "Query parameter 'query' must contain at least 3 characters"},
+                {"type", "invalid_request_error"}
+            }}}.dump(), "application/json");
+            return;
+        }
+
+        const std::string source_text = req.has_param("source")
+            ? req.get_param_value("source") : "huggingface";
+        const auto source = parse_remote_registry_source(source_text);
+
+        std::size_t limit = 12;
+        if (req.has_param("limit")) {
+            const std::string limit_text = req.get_param_value("limit");
+            std::size_t parsed = 0;
+            try {
+                std::size_t consumed = 0;
+                parsed = static_cast<std::size_t>(std::stoul(limit_text, &consumed));
+                if (consumed != limit_text.size()) throw std::invalid_argument("trailing characters");
+            } catch (...) {
+                throw std::invalid_argument("Query parameter 'limit' must be an integer from 1 to 50");
+            }
+            if (parsed < 1 || parsed > 50) {
+                throw std::invalid_argument("Query parameter 'limit' must be an integer from 1 to 50");
+            }
+            limit = parsed;
+        }
+
+        bool gguf_only = false;
+        if (req.has_param("format")) {
+            const std::string format = req.get_param_value("format");
+            if (format != "gguf") {
+                throw std::invalid_argument(
+                    "Unsupported registry search format '" + format + "' (expected 'gguf')");
+            }
+            gguf_only = true;
+        }
+
+        if (config_->offline()) {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", {
+                {"message", "Lemond is in offline mode, registry search is unavailable"},
+                {"type", "invalid_request_error"},
+                {"code", "lemond_offline"}
+            }}}.dump(), "application/json");
+            return;
+        }
+
+        const auto search = search_registry_models(source, query, limit, gguf_only);
+        nlohmann::json results = nlohmann::json::array();
+        for (const auto& model : search.results) {
+            results.push_back({
+                {"repository_id", model.repo_id},
+                {"display_name", model.display_name},
+                {"source", remote_registry_source_name(model.source)},
+                {"repository_type", model.repository_type},
+                {"description", model.description},
+                {"tags", model.tags},
+                {"task", model.task},
+                {"downloads", model.downloads},
+                {"likes", model.likes},
+                {"has_gguf", model.has_gguf}
+            });
+        }
+        nlohmann::json response = {
+            {"source", remote_registry_source_name(source)},
+            {"query", query},
+            {"total", search.total},
+            {"results", std::move(results)}
+        };
+        if (gguf_only) response["format"] = "gguf";
+        res.set_content(response.dump(), "application/json");
+    } catch (const RegistrySearchError& e) {
+        res.status = e.status_code() == 429 ? 429 : 502;
+        res.set_content(nlohmann::json{{"error", {
+            {"message", e.what()},
+            {"type", "registry_error"},
+            {"upstream_status_code", e.status_code()}
+        }}}.dump(), "application/json");
+    } catch (const std::invalid_argument& e) {
+        res.status = 400;
+        res.set_content(nlohmann::json{{"error", {
+            {"message", e.what()},
+            {"type", "invalid_request_error"}
+        }}}.dump(), "application/json");
+    } catch (const std::exception& e) {
+        LOG(ERROR, "Server") << "ERROR in handle_registry_search: " << e.what() << std::endl;
+        res.status = 502;
+        res.set_content(nlohmann::json{{"error", {
+            {"message", e.what()},
+            {"type", "registry_error"}
+        }}}.dump(), "application/json");
     }
 }
 

--- a/test/app/app-regression/registrySearch.test.cjs
+++ b/test/app/app-regression/registrySearch.test.cjs
@@ -1,0 +1,73 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const modelManager = fs.readFileSync(
+  path.join(repoRoot, 'src/app/src/renderer/ModelManager.tsx'),
+  'utf8',
+);
+const registrySource = fs.readFileSync(
+  path.join(repoRoot, 'src/cpp/server/model_registry.cpp'),
+  'utf8',
+);
+const serverSource = fs.readFileSync(
+  path.join(repoRoot, 'src/cpp/server/server.cpp'),
+  'utf8',
+);
+
+module.exports.tests = [
+  {
+    name: 'ModelScope search is rendered after Hugging Face with explicit source badges',
+    run() {
+      const hfHeader = modelManager.indexOf('FROM HUGGING FACE');
+      const msHeader = modelManager.indexOf('FROM MODELSCOPE');
+      assert.ok(hfHeader >= 0 && msHeader > hfHeader);
+      assert.match(modelManager, />HF<\/span>/);
+      assert.match(modelManager, />MS<\/span>/);
+    },
+  },
+  {
+    name: 'ModelScope uses the canonical server search route and source-aware variants',
+    run() {
+      assert.match(
+        modelManager,
+        /\/registry\/search\?source=modelscope&query=\$\{encodeURIComponent\(normalizedQuery\)\}&limit=\$\{MODELSCOPE_SEARCH_LIMIT\}&format=gguf/,
+      );
+      assert.match(modelManager, /pull\/variants\?source=modelscope&checkpoint=/);
+      assert.doesNotMatch(modelManager, /operation=registry-search/);
+      assert.match(serverSource, /register_get\("registry\/search"/);
+    },
+  },
+  {
+    name: 'ModelScope results are file-validated incrementally with bounded concurrency',
+    run() {
+      assert.match(modelManager, /const maxResults = MODELSCOPE_MAX_RESULTS/);
+      assert.match(modelManager, /\.slice\(0, MODELSCOPE_SEARCH_LIMIT\)/);
+      assert.match(modelManager, /Math\.min\(MODELSCOPE_VALIDATION_CONCURRENCY, candidates\.length\)/);
+      assert.match(modelManager, /publishValidated\(\)/);
+      assert.match(modelManager, /modelScopeVariantCacheRef/);
+      assert.match(modelManager, /\{ signal \}/);
+      assert.match(modelManager, /\}, MODELSCOPE_SEARCH_DEBOUNCE_MS\);/);
+      assert.match(modelManager, /Publish immediately instead of waiting/);
+      assert.doesNotMatch(modelManager, />Unavailable</);
+    },
+  },
+  {
+    name: 'ModelScope candidate search avoids the previous third upstream request',
+    run() {
+      const functionStart = registrySource.indexOf('RegistrySearchResponse search_registry_models');
+      const functionEnd = registrySource.indexOf('RemoteRegistrySource parse_remote_registry_source', functionStart);
+      const searchFunction = registrySource.slice(functionStart, functionEnd);
+      assert.match(searchFunction, /percent_encode\(query \+ " GGUF"\)/);
+      assert.match(searchFunction, /filter\.library=gguf/);
+      const ggufBlockStart = searchFunction.indexOf('if (gguf_only) {', searchFunction.indexOf('RemoteRegistrySource::HuggingFace'));
+      const ggufBlockEnd = searchFunction.indexOf('} else {', ggufBlockStart);
+      const ggufBlock = searchFunction.slice(ggufBlockStart, ggufBlockEnd);
+      assert.equal((ggufBlock.match(/requests\.push_back/g) || []).length, 2);
+      assert.match(searchFunction, /request\.optional/);
+      assert.match(searchFunction, /confirmed >= std::min/);
+      assert.match(searchFunction, /registry_search_rank/);
+    },
+  },
+];

--- a/test/cpp/test_model_registry.cpp
+++ b/test/cpp/test_model_registry.cpp
@@ -54,6 +54,92 @@ static void test_source_parsing_and_cache_names() {
     check("unknown registry is rejected", rejected);
 }
 
+static void test_search_result_normalization() {
+    const auto hf = lemon::normalize_registry_search_result(
+        RemoteRegistrySource::HuggingFace,
+        json{{"id", "org/model-GGUF"},
+             {"downloads", 42},
+             {"likes", 7},
+             {"tags", json::array({"gguf", "text-generation"})},
+             {"pipeline_tag", "text-generation"}});
+    check("HF search result keeps canonical repo id", hf.repo_id == "org/model-GGUF");
+    check("HF GGUF metadata is normalized", hf.has_gguf && hf.downloads == 42 && hf.likes == 7);
+    check("registry result identifies repository type", hf.repository_type == "model");
+
+    const auto ms = lemon::normalize_registry_search_result(
+        RemoteRegistrySource::ModelScope,
+        json{{"Id", "Qwen/Qwen-GGUF"},
+             {"Description", "ModelScope fixture"},
+             {"Downloads", 123},
+             {"Tags", "GGUF"}});
+    check("ModelScope PascalCase fields normalize", ms.repo_id == "Qwen/Qwen-GGUF" &&
+          ms.description == "ModelScope fixture" && ms.downloads == 123);
+    check("ModelScope source remains explicit", ms.source == RemoteRegistrySource::ModelScope);
+    check("single-string ModelScope tags normalize", ms.tags.size() == 1 && ms.tags[0] == "GGUF");
+
+    const auto ms_openapi = lemon::normalize_registry_search_result(
+        RemoteRegistrySource::ModelScope,
+        json{{"Path", "Qwen/Qwen3.6-27B-GGUF"},
+             {"display_name", "Qwen3.6 27B GGUF"},
+             {"tasks", json::array({"text-generation", "chat"})}});
+    check("ModelScope Path can carry the complete repository id",
+          ms_openapi.repo_id == "Qwen/Qwen3.6-27B-GGUF");
+    check("ModelScope tasks array normalizes to the primary task",
+          ms_openapi.task == "text-generation");
+
+    const auto ms_library = lemon::normalize_registry_search_result(
+        RemoteRegistrySource::ModelScope,
+        json{{"id", "community/Qwen-GGUF"},
+             {"tags", json::array({"library:gguf", "task:text-generation"})}});
+    check("ModelScope library facet identifies GGUF", ms_library.has_gguf);
+    check("ModelScope task tag is normalized", ms_library.task == "text-generation");
+}
+
+static void test_search_response_normalization() {
+    const json hf_body = json::array({
+        json{{"id", "org/text-GGUF"}, {"pipeline_tag", "text-generation"},
+             {"tags", json::array({"gguf"})}},
+        json{{"id", "org/image-GGUF"}, {"pipeline_tag", "text-to-image"},
+             {"tags", json::array({"gguf"})}},
+    });
+    const auto hf = lemon::normalize_registry_search_response(
+        RemoteRegistrySource::HuggingFace, hf_body, 12);
+    check("HF response filters unsupported media pipelines", hf.results.size() == 1);
+    check("HF response preserves GGUF metadata", hf.results[0].has_gguf);
+
+    const json ms_body = {
+        {"data", {
+            {"models", json::array({
+                json{{"id", "Qwen/Qwen-GGUF"}, {"task", "text-generation"}, {"downloads", 9}},
+                json{{"id", "Qwen/Qwen-Image"}, {"task", "text-to-image"}},
+            })},
+            {"total_count", 2},
+        }},
+    };
+    const auto ms = lemon::normalize_registry_search_response(
+        RemoteRegistrySource::ModelScope, ms_body, 12);
+    check("ModelScope data.models envelope normalizes", ms.results.size() == 1 &&
+          ms.results[0].repo_id == "Qwen/Qwen-GGUF");
+    check("ModelScope response preserves provider total", ms.total == 2);
+    check("ModelScope normalized result preserves source", ms.results[0].source == RemoteRegistrySource::ModelScope);
+
+    const json lowercase_ms_body = {
+        {"success", true},
+        {"data", {
+            {"models", json::array({
+                json{{"Path", "community/Qwen3.6-GGUF"},
+                     {"tasks", json::array({"text-generation"})}},
+            })},
+            {"total_count", 1},
+        }},
+    };
+    const auto lowercase_ms = lemon::normalize_registry_search_response(
+        RemoteRegistrySource::ModelScope, lowercase_ms_body, 12);
+    check("lowercase ModelScope success envelope normalizes",
+          lowercase_ms.results.size() == 1 &&
+          lowercase_ms.results[0].repo_id == "community/Qwen3.6-GGUF");
+}
+
 static void test_tree_snapshot_fingerprint() {
     std::vector<RegistryFile> files = {
         {"model.gguf", 100, "sha256", "abc", false},
@@ -104,6 +190,8 @@ static void test_registration_persists_remote_provenance() {
 
 int main() {
     test_source_parsing_and_cache_names();
+    test_search_result_normalization();
+    test_search_response_normalization();
     test_tree_snapshot_fingerprint();
     test_registration_persists_remote_provenance();
 

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -166,6 +166,7 @@ class EndpointTests(ServerTestBase):
             "models",
             "responses",
             "pull",
+            "registry/search",
             "pull/variants",
             "delete",
             "load",
@@ -338,6 +339,45 @@ class EndpointTests(ServerTestBase):
             "Catalog should have more models than downloaded",
         )
         print(f"[OK] /models: downloaded={downloaded_count}, catalog={all_count}")
+
+    def test_004a_registry_search_validation(self):
+        # Registry search validates locally without contacting a provider.
+        missing_query = requests.get(
+            f"{self.base_url}/registry/search", timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(missing_query.status_code, 400)
+
+        bad_source = requests.get(
+            f"{self.base_url}/registry/search",
+            params={"query": "qwen", "source": "unknown"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(bad_source.status_code, 400)
+        self.assertIn("Unsupported model source", bad_source.text)
+
+        bad_limit = requests.get(
+            f"{self.base_url}/registry/search",
+            params={"query": "qwen", "source": "modelscope", "limit": 0},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(bad_limit.status_code, 400)
+        self.assertIn("limit", bad_limit.text)
+
+        malformed_limit = requests.get(
+            f"{self.base_url}/registry/search",
+            params={"query": "qwen", "source": "modelscope", "limit": "12x"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(malformed_limit.status_code, 400)
+        self.assertIn("limit", malformed_limit.text)
+
+        bad_format = requests.get(
+            f"{self.base_url}/registry/search",
+            params={"query": "qwen", "source": "modelscope", "format": "safetensors"},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(bad_format.status_code, 400)
+        self.assertIn("format", bad_format.text)
 
     def test_005_models_retrieve(self):
         """Test retrieving a specific model by ID with extended fields."""


### PR DESCRIPTION
Summary

Add ModelScope marketplace search alongside Hugging Face in the Model Manager.

- Add a provider-neutral registry search endpoint.
- Show separate Hugging Face and ModelScope result sections with source badges.
- Verify ModelScope repositories contain compatible GGUF variants before displaying them.
- Preserve the selected registry source through variant discovery, download, registration, and update flows.
- Keep Hugging Face as the default source for backward compatibility.
- Support existing ModelScope authentication and custom endpoint configuration.

Testing

- Built the production renderer.
- Added frontend regression coverage for ModelScope search and source-aware downloads.
- Added server endpoint and registry normalization tests.
- Verified ModelScope search results expose downloadable GGUF variants only.
- Verified existing Hugging Face search and pull behavior remains unchanged.

Closes #2699