### PR TITLE
feat: job engine

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -302,8 +302,10 @@ jobs:
           cmake --build --preset default --target test_routing_classifier_services
           cmake --build --preset default --target test_network_utils
           cmake --build --preset default --target test_mcp_client_config
+          cmake --build --preset default --target test_job_expr
+          cmake --build --preset default --target test_job_graph
           cd build
-          ctest --output-on-failure -R "ProcessManagerTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config"
+          ctest --output-on-failure -R "ProcessManagerTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -613,8 +615,10 @@ jobs:
           cmake --build --preset default --target test_routing_classifier_services
           cmake --build --preset default --target test_network_utils
           cmake --build --preset default --target test_mcp_client_config
+          cmake --build --preset default --target test_job_expr
+          cmake --build --preset default --target test_job_graph
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'
@@ -734,6 +738,9 @@ jobs:
           echo "Running WebSocket auth tests..."
           .venv/bin/python test/server_websocket_auth.py
           echo "WebSocket auth tests PASSED!"
+          echo "Running job engine tests..."
+          .venv/bin/python test/server_jobs.py --lemond-binary ./build/lemond
+          echo "Job engine tests PASSED!"
 
       - name: Run web-app path traversal tests (unsigned path)
         if: steps.check_signing.outputs.has_signing != 'true'

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -2147,6 +2147,13 @@ jobs:
           .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu streaming-errors"
           .venv/bin/python test/server_streaming_errors.py --cli-binary lemonade
 
+      - name: Test jobs
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        shell: bash
+        run: |
+          .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu jobs"
+          .venv/bin/python test/server_jobs.py --lemond-binary lemond
+
       # Must run last: its tearDown stops lemond via /internal/shutdown to
       # launch its own instance, and nothing after it can rely on the server.
       - name: Test llamacpp-system

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,9 @@ All core endpoints are registered under **4 path prefixes**:
 - `/v0/` — Legacy short
 - `/v1/` — OpenAI SDK / LiteLLM compatibility
 
-**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `pull/variants`, `registry/search`, `load`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`
+**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `pull/variants`, `registry/search`, `load`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`, `jobs`, `jobs/{id}`, `jobs/{id}/pause`, `jobs/{id}/interrupt`, `jobs/{id}/resume`
+
+**Job engine** (`POST jobs`, `GET jobs`, `GET/DELETE jobs/{id}`, `POST jobs/{id}/{pause,interrupt,resume}`): server-side sequences of ops (`system_info`, `system_stats`, `models`, `sleep`, `load`, `unload`, `chat`) with data passing, forward-only branching, and a pause/interrupt/resume lifecycle persisted across restart. Exclusive ops hold a Router slot so normal traffic queues. See `docs/dev/job-system.md` and `docs/dev/job-expression-language.md`.
 
 **Ollama-compatible endpoints** (under `/api/` without version prefix): `chat`, `generate`, `tags`, `show`, `delete`, `pull`, `embed`, `embeddings`, `ps`, `version`
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1960,6 +1960,33 @@ if(EXISTS "${_LATEST_FALLBACK_TEST_SRC}")
     add_test(NAME LatestVersionFallbackTest COMMAND test_latest_version_fallback)
 endif()
 
+# Job engine pure core: the `when`/`branch` expression evaluator + reference
+# resolution, and step-graph validation (forward-only ⇒ no loops). Header-only,
+# so these link only nlohmann/json.
+set(_JOB_EXPR_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_job_expr.cpp")
+if(EXISTS "${_JOB_EXPR_TEST_SRC}")
+    add_executable(test_job_expr test/cpp/test_job_expr.cpp)
+    target_include_directories(test_job_expr PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_job_expr PRIVATE nlohmann_json::nlohmann_json)
+    include(CTest)
+    add_test(NAME JobExprTest COMMAND test_job_expr)
+endif()
+
+set(_JOB_GRAPH_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_job_graph.cpp")
+if(EXISTS "${_JOB_GRAPH_TEST_SRC}")
+    add_executable(test_job_graph test/cpp/test_job_graph.cpp)
+    target_include_directories(test_job_graph PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_job_graph PRIVATE nlohmann_json::nlohmann_json)
+    include(CTest)
+    add_test(NAME JobGraphTest COMMAND test_job_graph)
+endif()
+
 # Backend install atomicity (staging + verified atomic swap).
 # Header-only unit under test, so no extra source files are required.
 set(_INSTALL_ATOMICITY_TEST_SRC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,8 @@ include_directories(
 set(SOURCES_CORE
     src/cpp/server/server.cpp
     src/cpp/server/collection_orchestrator.cpp
+    src/cpp/server/jobs/job_ops.cpp
+    src/cpp/server/jobs/job_manager.cpp
     src/cpp/server/router.cpp
     src/cpp/server/global_vram_monitor.cpp
     src/cpp/server/eviction_engine.cpp

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -1667,6 +1667,24 @@ curl http://localhost:13305/live
 {"status":"ok"}
 ```
 
+## Job Engine API
+
+<sub>![Status](https://img.shields.io/badge/status-experimental-orange)</sub>
+
+Run client-posted sequences of server operations as durable, background **jobs** — steps that pass data forward, branch on results, and have a pause / interrupt / resume / delete / query lifecycle that survives client disconnect and server restart. Exclusive ops (`load`/`unload`/`chat`) hold a Router slot so normal traffic queues behind a running job.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/v1/jobs` | Create a job from `{name, definition:{steps} \| steps, inputs}`; returns `202 {"id"}`, or `400` on an invalid step graph. |
+| `GET` | `/v1/jobs` | List job summaries. |
+| `GET` | `/v1/jobs/{id}` | Full job record (status, per-step state, context). |
+| `POST` | `/v1/jobs/{id}/pause` | Stop after the current step. |
+| `POST` | `/v1/jobs/{id}/interrupt` | Cancel the current step now; resumable. |
+| `POST` | `/v1/jobs/{id}/resume` | Continue a paused/interrupted job. |
+| `DELETE` | `/v1/jobs/{id}` | Remove a job. |
+
+See [`docs/dev/job-system.md`](../dev/job-system.md) for the step schema, op set, and lifecycle, and [`docs/dev/job-expression-language.md`](../dev/job-expression-language.md) for the `when`/`branch` expression grammar.
+
 ## Internal Endpoints
 
 Internal endpoints are used for server control and configuration. By default, they are secured by `LEMONADE_ADMIN_API_KEY` (if set) to separate control privileges from standard inference operations.

--- a/docs/dev/job-expression-language.md
+++ b/docs/dev/job-expression-language.md
@@ -1,0 +1,179 @@
+# Job recipe expression language
+
+Job recipes (the step list posted to `POST /v1/jobs`) contain two kinds of
+expressions, both evaluated server-side against the job's shared **context**
+(the accumulating bag of step outputs and job `inputs`):
+
+- **References / interpolation** in a step's `params` — resolved by
+  `resolve_refs` (`lemon/jobs/job_expr.h`).
+- **Boolean conditions** in a step's `when` and in each `branch[].when` —
+  evaluated by `eval_condition`.
+
+The language is intentionally tiny: references, literals, comparisons, boolean
+logic, and basic arithmetic. It is **not** a general scripting language — there
+are no variables, assignments, function calls, or loops, and nothing outside
+the grammar below can execute.
+
+## The context
+
+The context is a JSON object. After each step runs, its raw result is stored
+under `context[<step id>]`, and any `extract` mappings copy fields to top-level
+keys. Job `inputs` are available under `context.inputs`. So a later step can
+read `${run_v.timings.prompt_ms}` (the `run_v` step's output),
+`${vulkan_tps}` (an extracted key), or `${inputs.model}`.
+
+## References — `${path}`
+
+A reference is `${` followed by a dotted **path** followed by `}`.
+
+```
+${model}
+${run_v.timings.predicted_per_second}
+${inputs.ctx}
+${list.0}
+```
+
+- Each path segment selects an **object key**, or, when the current value is an
+  array, a **numeric index** (`${list.0}` = first element).
+- A path that does not resolve is an **error** (the job fails with a clear
+  message). There is no "undefined" value.
+
+### Use in `params`: type-preserving vs. interpolating
+
+- **Whole-string reference** — when a params string is *exactly* one reference,
+  the resolved value keeps its JSON type:
+
+  ```jsonc
+  { "ctx_size": "${inputs.ctx}" }      // -> a number, not the string "32768"
+  { "messages": "${inputs.prompt}" }   // -> an array
+  ```
+
+- **Embedded reference(s)** — when a reference appears inside surrounding text
+  (or more than one reference appears), each is stringified and interpolated,
+  and the result is always a string:
+
+  ```jsonc
+  { "label": "vulkan @ ${inputs.ctx} tok" }   // -> "vulkan @ 32768 tok"
+  ```
+
+  Stringification: strings pass through; numbers/booleans use their literal
+  form; `null` becomes empty; arrays/objects use compact JSON.
+
+References inside `when`/`branch` conditions always resolve to the **typed**
+value (they are expression operands, not text).
+
+## Conditions — `when` and `branch[].when`
+
+A condition is a boolean expression. An **empty** condition is `true` (an
+omitted `when` never skips). The result is taken by **truthiness** (below).
+
+### Literals
+
+| Kind    | Examples |
+|---------|----------|
+| Number  | `42`, `3.14`, `.5` |
+| String  | `'vulkan'`, `"q8_0"` (single or double quotes; `\` escapes the next char) |
+| Boolean | `true`, `false` |
+| Null    | `null` |
+
+### Operators (highest-binding last)
+
+| Precedence | Operators | Notes |
+|------------|-----------|-------|
+| 1 (lowest) | `\|\|` | logical or |
+| 2 | `&&` | logical and |
+| 3 | `!` | logical not (unary) |
+| 4 | `==` `!=` `<` `<=` `>` `>=` | comparison; **does not chain** (`1 < 2 < 3` is an error) |
+| 5 | `+` `-` | additive (numbers only) |
+| 6 | `*` `/` | multiplicative (numbers only) |
+| 7 | `-` | unary minus (numbers only) |
+| 8 (highest)| `( … )`, literals, `${ref}` | grouping / primaries |
+
+### Truthiness
+
+A value used as a boolean (the whole condition, or an operand of `&&`/`||`/`!`)
+is truthy when it is:
+
+- boolean `true`,
+- a non-zero number,
+- a non-empty string,
+- a non-empty array or object.
+
+`false`, `0`, `""`, `null`, `[]`, and `{}` are falsy.
+
+### Comparison semantics
+
+- `==` / `!=` compare by **value and type** (deep JSON equality): `2 == 2.0`
+  is true (numeric), `1 == '1'` is false (number vs string).
+- `<` `<=` `>` `>=` compare **two numbers** numerically or **two strings**
+  lexicographically. Ordering operands of mismatched types (e.g. a string vs a
+  number) is an **error**.
+
+### Arithmetic
+
+`+ - * /` and unary `-` operate on **numbers only**; a non-numeric operand is an
+error. Division by zero is an error. Division is floating-point
+(`10 / 4 == 2.5`).
+
+## Grammar (EBNF)
+
+```
+condition  = [ or ] ;                         (* empty = true *)
+or         = and { "||" and } ;
+and        = not { "&&" not } ;
+not        = "!" not | comparison ;
+comparison = additive [ ( "==" | "!=" | "<" | "<=" | ">" | ">=" ) additive ] ;
+additive   = multiplicative { ( "+" | "-" ) multiplicative } ;
+multiplicative = unary { ( "*" | "/" ) unary } ;
+unary      = "-" unary | primary ;
+primary    = number | string | "true" | "false" | "null"
+           | reference | "(" or ")" ;
+reference  = "${" path "}" ;
+path       = segment { "." segment } ;
+```
+
+## Errors
+
+Evaluation raises a client-facing error (HTTP 400 at job creation for `when`
+syntax; job failure at run time for bad references) on:
+
+- an unknown reference path (`${no.such.key}`),
+- ordering-comparison of mismatched types,
+- arithmetic on a non-number, or division by zero,
+- an unterminated `${…}` or string literal,
+- an unknown identifier (only `true`/`false`/`null` are keywords),
+- an unexpected character or trailing tokens.
+
+At **job creation**, `when`/`branch` expressions are syntax-checked (tokenized)
+and rejected early; reference *paths* are only checked at run time, since the
+context they read is built as the job runs.
+
+## Caveat: conditions are not short-circuit
+
+`&&` and `||` evaluate **both** sides. A guard like
+`${a} != null && ${a.b} > 0` will still evaluate `${a.b}` when `a` is null and
+fail on the unknown reference. Structure recipes so a condition only references
+context that is guaranteed to exist at that point (e.g. gate on an extracted
+scalar you set earlier, not on a possibly-absent nested path).
+
+## Examples
+
+```jsonc
+// Skip a step unless the vulkan run beat the rocm run.
+{ "when": "${vulkan_tps} > ${rocm_tps}" }
+
+// Batch-ladder gate: only adopt a larger batch if it improves prefill >5%.
+{ "when": "${baseline.ttft_ms} / ${best.ttft_ms} > 1.05" }
+
+// Branch to a deeper sweep on the winning backend.
+{ "branch": [
+    { "when": "${winner} == 'vulkan'", "goto": "deep_vulkan" },
+    { "when": "${winner} == 'rocm'",   "goto": "deep_rocm" }
+] }
+
+// Interpolated params vs. type-preserving params.
+{ "params": {
+    "ctx_size": "${inputs.ctx}",                 // number
+    "summary":  "won: ${winner} @ ${best.tps} tps"  // string
+} }
+```

--- a/docs/dev/job-system.md
+++ b/docs/dev/job-system.md
@@ -1,0 +1,151 @@
+# Server-side job system
+
+The job engine runs **client-posted sequences of server operations** on lemond:
+each job is an ordered list of steps that pass data forward through a shared
+context, branch on results, and have a pause / interrupt / resume / delete /
+query lifecycle that survives client disconnect and server restart.
+
+It exists so multi-step server work — the motivating case is the AutoOpt
+benchmark methodology (repeatedly load a model with a config, time a
+completion, unload) — runs **on the server**, coordinated with model
+management, instead of being driven from a browser that a page reload would
+kill. The engine is generic and domain-agnostic: the client owns the recipe and
+any synthesis of the results; the server just executes the recipe durably.
+
+## Concepts
+
+- **Job** — a named list of steps plus an `inputs` object, an accumulating
+  `context`, a `status`, and a `cursor` (the id of the current/next step).
+- **Step** — one operation (`op`) with `params`, an optional `when` guard,
+  optional `extract` mappings, and optional forward branches. Steps have their
+  own status (`pending`/`running`/`completed`/`failed`/`skipped`).
+- **Context** — a JSON object, the data bus. After a step runs, its raw output
+  is stored under `context[<step id>]`, and any `extract` mappings copy fields
+  to top-level keys. Job `inputs` are available under `context.inputs`.
+- **Op** — a named server operation. `params` are reference-resolved against the
+  context before the op runs.
+
+## Operations
+
+| op            | exclusive | output |
+|---------------|-----------|--------|
+| `system_info` | no  | the `system-info` snapshot |
+| `system_stats`| no  | cpu/gpu/vram/npu/memory sample |
+| `models`      | no  | model list, or `{id}` metadata when `params.id` is set |
+| `sleep`       | no  | `{}` after `params.ms` (cancellable) |
+| `load`        | yes | `{loaded, model, backend, ctx_size}`; loads with `params` = `{model, llamacpp_backend, ctx_size, llamacpp_args, merge_args, save_options, pinned}` (same shape as `POST /load`) |
+| `unload`      | yes | `{}`; unloads `params.model` if set and loaded, else all |
+| `chat`        | yes | the backend chat response verbatim (`timings`/`usage` included); `params` is a chat/completions request |
+
+"Exclusive" ops require the model slot — see [Exclusivity](#exclusivity-and-queuing).
+
+## Recipe: steps
+
+```jsonc
+{
+  "id": "run_a",                 // unique within the job
+  "op": "chat",
+  "params": { "...": "${refs allowed}" },
+  "when": "boolean expression",  // optional; skip the step if false
+  "extract": { "a_tps": "timings.predicted_per_second" },  // output path -> context key
+  "branch": [ { "when": "expr", "goto": "later_step_id" } ],
+  "on_done": "later_step_id",    // where to go on success (default: next in list)
+  "on_fail": "abort"             // abort (default) | continue | <later step id>
+}
+```
+
+References (`${path}`) and the `when`/`branch` expression grammar are documented
+in [job-expression-language.md](job-expression-language.md).
+
+### Control flow (forward-only, no loops)
+
+On success the next step is: the first `branch` case whose `when` is true, else
+`on_done`, else the next step in list order (end when none). On failure `on_fail`
+decides: `abort` fails the job, `continue` proceeds to the next step, or a step
+id jumps there — **failure is a first-class branch**, which is how a `load` that
+OOMs can jump to a smaller-config `load` (test-by-failure). Every branch /
+`on_done` / `on_fail` target must reference a **later** step; the graph is
+validated at creation, so execution is acyclic and always terminates.
+
+## Lifecycle
+
+States: `queued → running → { paused | interrupted | completed | failed }`.
+A single worker runs one job at a time.
+
+- **pause** — stop *after the current step*; the job goes `paused` at the next
+  step boundary and (if exclusive) releases the slot.
+- **interrupt** — cancel the *current step now* (kills an in-flight `load`); the
+  step returns to `pending`, the job goes `interrupted`. An interrupted
+  exclusive job unloads whatever it left resident before releasing the slot.
+- **resume** — `paused` continues at the next step; `interrupted` re-runs the
+  pending step. Steps must be idempotent on re-run.
+- **delete** — removes the job (interrupting it first if running).
+- **query** — the full job record (status, per-step state, context).
+
+There is no rollback: an op commits only on completion, so an interrupted step
+never took effect and "before the step" is automatic.
+
+## Exclusivity and queuing
+
+`load` / `unload` / `chat` require the **model slot**. While a job containing any
+exclusive step runs, it holds a Router-level exclusive gate: all normal
+inference and load traffic **queues** behind it until the job finishes or is
+paused (pause is the escape hatch — it releases the slot so queued traffic
+drains, and resume re-acquires). The gate is keyed by the worker thread, so the
+job's own ops pass through while every other request waits. A job with only
+read-only ops (e.g. `system_info`, `sleep`) never takes the gate.
+
+## Persistence
+
+Jobs persist to `<cache_dir>/jobs.json` (atomic write, cap 50, oldest terminal
+evicted first). On startup a job left `running`/`queued` by a crash is marked
+`interrupted` ("server restarted while the job was active") but keeps its cursor,
+so it can be resumed from where it stopped.
+
+## API
+
+Registered under all four prefixes (`/api/v0`, `/api/v1`, `/v0`, `/v1`).
+
+| method | path | purpose |
+|--------|------|---------|
+| POST   | `jobs` | create `{name, definition:{steps} \| steps, inputs}` → `202 {id}`; `400` on an invalid graph |
+| GET    | `jobs` | `{jobs:[summaries]}` |
+| GET    | `jobs/{id}` | full record, or `404` |
+| POST   | `jobs/{id}/pause` | `200` / `404` |
+| POST   | `jobs/{id}/interrupt` | `200` / `404` |
+| POST   | `jobs/{id}/resume` | `200` / `404` |
+| DELETE | `jobs/{id}` | `200` / `404` |
+
+## Example: a bench sweep
+
+Two configs, each timed, then a branch on the measured throughput — the shape a
+benchmark/AutoOpt client posts (it reads `context` afterward and synthesizes the
+recommendation itself):
+
+```jsonc
+{ "name": "bench",
+  "inputs": { "model": "Qwen3-0.6B", "backend": "vulkan" },
+  "steps": [
+    { "id": "u0", "op": "unload" },
+    { "id": "load_a", "op": "load",
+      "params": { "model": "${inputs.model}", "llamacpp_backend": "${inputs.backend}",
+                  "ctx_size": 4096, "llamacpp_args": "" },
+      "on_fail": "load_a_lo" },
+    { "id": "run_a", "op": "chat",
+      "params": { "model": "${inputs.model}", "messages": [{"role":"user","content":"hi"}],
+                  "temperature": 0, "max_completion_tokens": 32 },
+      "extract": { "a_tps": "timings.predicted_per_second" } },
+    { "id": "u_a", "op": "unload" },
+    { "id": "load_a_lo", "op": "load",
+      "params": { "model": "${inputs.model}", "llamacpp_backend": "${inputs.backend}",
+                  "ctx_size": 2048 }, "on_fail": "abort" },
+    /* …second config, then a `decide` step branching on ${a_tps} >= ${b_tps}… */
+  ] }
+```
+
+## Source
+
+`src/cpp/include/lemon/jobs/` (`job_types.h`, `job_expr.h`, `job_graph.h`,
+`job_ops.h`, `job_manager.h`) and `src/cpp/server/jobs/`. Tests:
+`test/cpp/test_job_expr.cpp`, `test/cpp/test_job_graph.cpp`,
+`test/server_jobs.py`.

--- a/docs/dev/job-system.md
+++ b/docs/dev/job-system.md
@@ -118,8 +118,14 @@ A single worker runs one job at a time.
   external client loaded the same model while the job was interrupted, the
   restore *adopts* that residency instead of replacing it: the external
   instance is left untouched (options and pin included) and stops being
-  job-owned. If a restore fails, the job still resumes and the dependent step
-  fails with its normal `on_fail` semantics.
+  job-owned. Restore also survives a server restart: the in-memory captured
+  state is gone after a crash, so the engine reconstructs the job's model
+  state from its persisted record — the completed `load`/`unload` steps
+  (parameters resolved against the persisted context, in execution order)
+  describe exactly what should be resident, and resuming a recovered job
+  reloads that before re-running the pending step. If a restore fails, the job
+  still resumes and the dependent step fails with its normal `on_fail`
+  semantics.
 - **delete** — removes the job. Deleting an active job persists a deletion
   tombstone *before* the call returns, then interrupts it and defers the actual
   removal until the worker has finished cleanup (reconcile unload), so a deleted

--- a/docs/dev/job-system.md
+++ b/docs/dev/job-system.md
@@ -85,22 +85,41 @@ A single worker runs one job at a time.
   backend to reply); the step returns to `pending`, the job goes `interrupted`.
   Interrupting a still-`queued` job likewise dequeues and persists it as
   `interrupted` immediately. An interrupted exclusive job unloads only the
-  model(s) it introduced before releasing the slot: the reconcile snapshots the
-  router's loaded models (with their pin state) **once, the first time the job
-  acquires the exclusive slot**, and that snapshot is the job's for its whole
-  lifetime — a pause/resume cycle does not re-baseline it, so a model the job
-  loaded before pausing is still recognized as job-introduced after resume.
-  Reconcile unloads `(current set − snapshot)` — including models the job
-  pinned itself — and restores the recorded pin state of surviving pre-job
-  models. A job that ends `completed` or `failed` commits its model
-  side-effects instead (its snapshot is discarded, resident models stay).
+  model(s) it **owns**: ownership is tracked explicitly per job and is scoped
+  to the *specific residency* the job created (the backend instance its own
+  `load` op produced), not to the model name — a model the job's `unload` op
+  released, or one whose job-created instance was replaced by an external
+  client's later load of the same name, is no longer job-owned. Pre-job
+  residents are protected separately: the first slot acquisition snapshots
+  them with their pin state, and a pause/resume cycle re-baselines neither
+  ownership nor the snapshot. Models loaded by external clients — including
+  while the job is paused or interrupted and the gate is open — are never
+  touched by the job's cleanup. One caveat: an external `load` that merely
+  re-confirms the job's own still-resident instance (same model, matching
+  options — the router deduplicates instead of creating a new instance) does
+  not transfer ownership; that instance remains job-owned and is still cleaned
+  up. Clients that need a model to outlive a job should load it before the job
+  starts or after it ends. Reconcile unloads the owned instances
+  (recording their configuration for resume, see below), unpins any the job
+  pinned, and restores the recorded pin state of surviving pre-job models. A
+  job that ends `completed` or `failed` commits its model side-effects instead
+  (ownership and snapshot are discarded, resident models stay).
   **Guarantee scope:** a model that was resident before the job is preserved
   only if it is *still resident* at reconcile time. If a job `load` evicted it
   (loaded-model cap) or replaced it with different options, the reconcile does
   not reload it or restore its previous options — clients that need the exact
   prior state must reload it themselves.
 - **resume** — `paused` continues at the next step; `interrupted` re-runs the
-  pending step. Steps must be idempotent on re-run.
+  pending step. Steps must be idempotent on re-run. Before an interrupted
+  exclusive job re-runs, the engine **restores the job-owned models** that the
+  interrupt cleanup unloaded (reloading each with its recorded options and pin
+  state), so a step that depends on an earlier completed `load` — e.g. a chat
+  interrupted mid-generation — finds its model again instead of failing. If an
+  external client loaded the same model while the job was interrupted, the
+  restore *adopts* that residency instead of replacing it: the external
+  instance is left untouched (options and pin included) and stops being
+  job-owned. If a restore fails, the job still resumes and the dependent step
+  fails with its normal `on_fail` semantics.
 - **delete** — removes the job. Deleting an active job persists a deletion
   tombstone *before* the call returns, then interrupts it and defers the actual
   removal until the worker has finished cleanup (reconcile unload), so a deleted

--- a/docs/dev/job-system.md
+++ b/docs/dev/job-system.md
@@ -122,12 +122,17 @@ paused (pause is the escape hatch — it releases the slot so queued traffic
 drains, and resume re-acquires). Acquiring the gate first *drains* in-flight
 work: it waits for any active load and for every in-flight request on loaded
 backends to finish, so an external chat that started just before the job cannot
-overlap the exclusive session. Every model-touching Router path — inference,
-streaming, tokenize, slots, pinning, load/unload — checks the same gate. The
-gate is keyed by the worker thread, so the job's own ops pass through while
-every other request waits. A job with only read-only ops (e.g. `system_info`,
-`sleep`) never takes the gate. Read-only status queries (model list, health,
-telemetry) are not gated.
+overlap the exclusive session. The drain is cancellable — interrupting or
+deleting the job while it waits behind a long-running request aborts the
+acquisition and marks the job `interrupted` instead of blocking indefinitely.
+Every model-touching Router path — inference, streaming, tokenize, slots,
+pinning, load/unload — checks the same gate, and the idle-eviction/downsize
+engine suspends itself (and abandons any already-marked eviction) while an
+exclusive session is active, so background eviction cannot pull a model out
+from under a job step. The gate is keyed by the worker thread, so the job's
+own ops pass through while every other request waits. A job with only
+read-only ops (e.g. `system_info`, `sleep`) never takes the gate. Read-only
+status queries (model list, health, telemetry) are not gated.
 
 ## Persistence
 

--- a/docs/dev/job-system.md
+++ b/docs/dev/job-system.md
@@ -74,13 +74,27 @@ A single worker runs one job at a time.
 
 - **pause** — stop *after the current step*; the job goes `paused` at the next
   step boundary and (if exclusive) releases the slot.
-- **interrupt** — cancel the *current step now* (kills an in-flight `load`); the
-  step returns to `pending`, the job goes `interrupted`. An interrupted
-  exclusive job unloads whatever it left resident before releasing the slot.
+- **interrupt** — cancel the *current step now* (kills an in-flight `load`, and
+  aborts an in-flight `chat` at the HTTP layer rather than waiting for the
+  backend to reply); the step returns to `pending`, the job goes `interrupted`.
+  An interrupted exclusive job unloads only the model(s) it loaded itself before
+  releasing the slot: the reconcile snapshots the router's loaded-model set when
+  the exclusive session begins and unloads only `(current set − snapshot)`,
+  leaving models that were resident before the job started and pinned models
+  untouched.
 - **resume** — `paused` continues at the next step; `interrupted` re-runs the
   pending step. Steps must be idempotent on re-run.
-- **delete** — removes the job (interrupting it first if running).
+- **delete** — removes the job. Deleting an active job interrupts it first and
+  defers the actual removal until the worker has finished cleanup (reconcile
+  unload), so a deleted exclusive job never leaks a resident model.
 - **query** — the full job record (status, per-step state, context).
+
+Chat interrupts are genuine aborts: the chat op passes its cancel flag through
+`Router::chat_completion` to the backend `WrappedServer`, and `forward_request`
+hands it to the HTTP client, which tears down the in-flight connection (curl
+`XFERINFO` abort, fired at least once per second even when no bytes move). The
+exclusive slot is therefore released promptly instead of being held until a slow
+or stuck backend responds.
 
 There is no rollback: an op commits only on completion, so an interrupted step
 never took effect and "before the step" is automatic.

--- a/docs/dev/job-system.md
+++ b/docs/dev/job-system.md
@@ -75,20 +75,32 @@ States: `queued → running → { paused | interrupted | completed | failed }`.
 A single worker runs one job at a time.
 
 - **pause** — stop *after the current step*; the job goes `paused` at the next
-  step boundary and (if exclusive) releases the slot.
+  step boundary and (if exclusive) releases the slot. Pausing a still-`queued`
+  job takes effect immediately: it is removed from the queue and persisted as
+  `paused` before the call returns.
 - **interrupt** — cancel the *current step now* (kills an in-flight `load`, and
   aborts an in-flight `chat` at the HTTP layer rather than waiting for the
   backend to reply); the step returns to `pending`, the job goes `interrupted`.
-  An interrupted exclusive job unloads only the model(s) it loaded itself before
-  releasing the slot: the reconcile snapshots the router's loaded-model set when
-  the exclusive session begins and unloads only `(current set − snapshot)`,
-  leaving models that were resident before the job started and pinned models
-  untouched.
+  Interrupting a still-`queued` job likewise dequeues and persists it as
+  `interrupted` immediately. An interrupted exclusive job unloads only the
+  model(s) it introduced before releasing the slot: the reconcile snapshots the
+  router's loaded models (with their pin state) when the exclusive session
+  begins, unloads `(current set − snapshot)` — including models the job pinned
+  itself — and restores the recorded pin state of surviving pre-job models.
+  **Guarantee scope:** a model that was resident before the job is preserved
+  only if it is *still resident* at reconcile time. If a job `load` evicted it
+  (loaded-model cap) or replaced it with different options, the reconcile does
+  not reload it or restore its previous options — clients that need the exact
+  prior state must reload it themselves.
 - **resume** — `paused` continues at the next step; `interrupted` re-runs the
   pending step. Steps must be idempotent on re-run.
-- **delete** — removes the job. Deleting an active job interrupts it first and
-  defers the actual removal until the worker has finished cleanup (reconcile
-  unload), so a deleted exclusive job never leaks a resident model.
+- **delete** — removes the job. Deleting an active job persists a deletion
+  tombstone *before* the call returns, then interrupts it and defers the actual
+  removal until the worker has finished cleanup (reconcile unload), so a deleted
+  exclusive job never leaks a resident model. The tombstone makes the deletion
+  durable: a crash between the acknowledgement and the final removal does not
+  resurrect the job on restart, and a tombstoned job is already invisible to
+  `GET`/list.
 - **query** — the full job record (status, per-step state, context).
 
 Chat interrupts are genuine aborts: the chat op passes its cancel flag through
@@ -107,16 +119,30 @@ never took effect and "before the step" is automatic.
 exclusive step runs, it holds a Router-level exclusive gate: all normal
 inference and load traffic **queues** behind it until the job finishes or is
 paused (pause is the escape hatch — it releases the slot so queued traffic
-drains, and resume re-acquires). The gate is keyed by the worker thread, so the
-job's own ops pass through while every other request waits. A job with only
-read-only ops (e.g. `system_info`, `sleep`) never takes the gate.
+drains, and resume re-acquires). Acquiring the gate first *drains* in-flight
+work: it waits for any active load and for every in-flight request on loaded
+backends to finish, so an external chat that started just before the job cannot
+overlap the exclusive session. Every model-touching Router path — inference,
+streaming, tokenize, slots, pinning, load/unload — checks the same gate. The
+gate is keyed by the worker thread, so the job's own ops pass through while
+every other request waits. A job with only read-only ops (e.g. `system_info`,
+`sleep`) never takes the gate. Read-only status queries (model list, health,
+telemetry) are not gated.
 
 ## Persistence
 
 Jobs persist to `<cache_dir>/jobs.json` (atomic write, cap 50, oldest terminal
-evicted first). On startup a job left `running`/`queued` by a crash is marked
-`interrupted` ("server restarted while the job was active") but keeps its cursor,
-so it can be resumed from where it stopped.
+evicted first). The cap is enforced at creation: when all 50 retained jobs are
+still active or resumable (nothing `completed`/`failed` to evict), `POST jobs`
+is rejected with `429` until a job is deleted or finishes. On startup a job left
+`running`/`queued` by a crash is marked `interrupted` ("server restarted while
+the job was active") but keeps its cursor, so it can be resumed from where it
+stopped; tombstoned (deleted-while-active) jobs are dropped.
+
+A job summary's `progress.completed` counts steps that no longer need work:
+`completed`, `skipped`, and failed steps whose failure was *handled* by
+`on_fail: continue` or a recovery branch — so a recovery job that completes
+reports full progress even though one of its steps is marked `failed`.
 
 ## API
 
@@ -124,7 +150,7 @@ Registered under all four prefixes (`/api/v0`, `/api/v1`, `/v0`, `/v1`).
 
 | method | path | purpose |
 |--------|------|---------|
-| POST   | `jobs` | create `{name, definition:{steps} \| steps, inputs}` → `202 {id}`; `400` on an invalid graph |
+| POST   | `jobs` | create `{name, definition:{steps} \| steps, inputs}` → `202 {id}`; `400` on an invalid graph; `429` when the job store is full of non-evictable jobs |
 | GET    | `jobs` | `{jobs:[summaries]}` |
 | GET    | `jobs/{id}` | full record, or `404` |
 | POST   | `jobs/{id}/pause` | `200` / `404` |

--- a/docs/dev/job-system.md
+++ b/docs/dev/job-system.md
@@ -77,16 +77,23 @@ A single worker runs one job at a time.
 - **pause** — stop *after the current step*; the job goes `paused` at the next
   step boundary and (if exclusive) releases the slot. Pausing a still-`queued`
   job takes effect immediately: it is removed from the queue and persisted as
-  `paused` before the call returns.
+  `paused` before the call returns. Pause does **not** commit the job's model
+  side-effects: models the job loaded stay resident for the resume, and the
+  job keeps owning them (see below).
 - **interrupt** — cancel the *current step now* (kills an in-flight `load`, and
   aborts an in-flight `chat` at the HTTP layer rather than waiting for the
   backend to reply); the step returns to `pending`, the job goes `interrupted`.
   Interrupting a still-`queued` job likewise dequeues and persists it as
   `interrupted` immediately. An interrupted exclusive job unloads only the
   model(s) it introduced before releasing the slot: the reconcile snapshots the
-  router's loaded models (with their pin state) when the exclusive session
-  begins, unloads `(current set − snapshot)` — including models the job pinned
-  itself — and restores the recorded pin state of surviving pre-job models.
+  router's loaded models (with their pin state) **once, the first time the job
+  acquires the exclusive slot**, and that snapshot is the job's for its whole
+  lifetime — a pause/resume cycle does not re-baseline it, so a model the job
+  loaded before pausing is still recognized as job-introduced after resume.
+  Reconcile unloads `(current set − snapshot)` — including models the job
+  pinned itself — and restores the recorded pin state of surviving pre-job
+  models. A job that ends `completed` or `failed` commits its model
+  side-effects instead (its snapshot is discarded, resident models stay).
   **Guarantee scope:** a model that was resident before the job is preserved
   only if it is *still resident* at reconcile time. If a job `load` evicted it
   (loaded-model cap) or replaced it with different options, the reconcile does
@@ -97,10 +104,12 @@ A single worker runs one job at a time.
 - **delete** — removes the job. Deleting an active job persists a deletion
   tombstone *before* the call returns, then interrupts it and defers the actual
   removal until the worker has finished cleanup (reconcile unload), so a deleted
-  exclusive job never leaks a resident model. The tombstone makes the deletion
-  durable: a crash between the acknowledgement and the final removal does not
-  resurrect the job on restart, and a tombstoned job is already invisible to
-  `GET`/list.
+  exclusive job never leaks a resident model. Deleting a `paused` or
+  `interrupted` job takes the same tombstone-then-worker-cleanup path, so a
+  model introduced before a pause is still unloaded. The tombstone makes the
+  deletion durable: a crash between the acknowledgement and the final removal
+  does not resurrect the job on restart, and a tombstoned job is already
+  invisible to `GET`/list.
 - **query** — the full job record (status, per-step state, context).
 
 Chat interrupts are genuine aborts: the chat op passes its cancel flag through

--- a/docs/dev/job-system.md
+++ b/docs/dev/job-system.md
@@ -38,6 +38,8 @@ any synthesis of the results; the server just executes the recipe durably.
 | `chat`        | yes | the backend chat response verbatim (`timings`/`usage` included); `params` is a chat/completions request |
 
 "Exclusive" ops require the model slot — see [Exclusivity](#exclusivity-and-queuing).
+This is the current set, not a fixed one; ops for other modalities are additive —
+see [Extending with new ops](#extending-with-new-ops-any-modality).
 
 ## Recipe: steps
 
@@ -154,5 +156,44 @@ recommendation itself):
       "params": { "model": "${inputs.model}", "llamacpp_backend": "${inputs.backend}",
                   "ctx_size": 2048 }, "on_fail": "abort" },
     /* …second config, then a `decide` step branching on ${a_tps} >= ${b_tps}… */
+  ] }
+```
+
+## Extending with new ops (any modality)
+
+The engine is modality-agnostic — `chat` is only the first *inference* op wired
+up. Ops are a pluggable registry, not a fixed set, so image generation, TTS,
+transcription, or a 3D-mesh op are additive: no changes to the engine, graph,
+context, or expression language.
+
+An op is a handler in the op registry (`OpRegistry`):
+
+```cpp
+struct OpHandler {
+    std::function<json(const json& params, const json& context, CancelFlag& cancel)> run;
+    bool exclusive = false;   // true if it holds the model slot (see Exclusivity)
+};
+```
+
+The signature assumes nothing about text or LLMs: `params` and the return value
+are arbitrary JSON, and any op that loads a model sets `exclusive = true` (like
+`load`/`unload`/`chat`). Because every step's output lands in the shared context,
+later steps consume it via `${step_id.field}` references — that is the data-flow
+a pipeline needs.
+
+To add one, register a provider in `OpProviders` that forwards to the relevant
+already-existing Router backend (`SdServer`, `KokoroServer`, `WhisperServer`, …)
+and `register_op` it. A `text → LLM enhancer → image → 3D` pipeline is then just
+three registered ops passing data through the context:
+
+```jsonc
+{ "steps": [
+    { "id": "enhance", "op": "chat", "params": { "...": "..." },
+      "extract": { "prompt": "choices.0.message.content" } },
+    { "id": "image",   "op": "generate_image",
+      "params": { "prompt": "${enhance.prompt}" },
+      "extract": { "path": "data.0.path" } },
+    { "id": "model3d", "op": "generate_3d",
+      "params": { "image": "${image.path}" } }
   ] }
 ```

--- a/docs/dev/job-system.md
+++ b/docs/dev/job-system.md
@@ -156,10 +156,3 @@ recommendation itself):
     /* …second config, then a `decide` step branching on ${a_tps} >= ${b_tps}… */
   ] }
 ```
-
-## Source
-
-`src/cpp/include/lemon/jobs/` (`job_types.h`, `job_expr.h`, `job_graph.h`,
-`job_ops.h`, `job_manager.h`) and `src/cpp/server/jobs/`. Tests:
-`test/cpp/test_job_expr.cpp`, `test/cpp/test_job_graph.cpp`,
-`test/server_jobs.py`.

--- a/src/cpp/include/lemon/backends/whispercpp/whispercpp_server.h
+++ b/src/cpp/include/lemon/backends/whispercpp/whispercpp_server.h
@@ -7,6 +7,7 @@
 #include "lemon/backends/backend_utils.h"
 #include <string>
 #include <filesystem>
+#include <mutex>
 
 namespace lemon {
 namespace backends {
@@ -65,6 +66,7 @@ private:
 
     std::string model_path_;
     std::filesystem::path temp_dir_;  // Directory for temporary audio files
+    std::mutex inference_mutex_;
 };
 
 namespace whispercpp {

--- a/src/cpp/include/lemon/jobs/job_expr.h
+++ b/src/cpp/include/lemon/jobs/job_expr.h
@@ -133,6 +133,8 @@ public:
         return v;
     }
 
+    void set_syntax_only() { syntax_only_ = true; }
+
 private:
     const Token& peek() const { return toks_[pos_]; }
     const Token& advance() { return toks_[pos_++]; }
@@ -141,8 +143,11 @@ private:
         return false;
     }
 
-    static double num(const json& v, const char* ctx) {
-        if (!v.is_number()) throw JobError(400, std::string("expected a number for ") + ctx);
+    double num(const json& v, const char* ctx) const {
+        if (!v.is_number()) {
+            if (syntax_only_) return 0.0;
+            throw JobError(400, std::string("expected a number for ") + ctx);
+        }
         return v.get<double>();
     }
 
@@ -188,7 +193,10 @@ private:
             if (op == "*") l = num(l, "*") * num(r, "*");
             else {
                 double d = num(r, "/");
-                if (d == 0.0) throw JobError(400, "division by zero in expression");
+                if (d == 0.0) {
+                    if (syntax_only_) { l = 0.0; continue; }
+                    throw JobError(400, "division by zero in expression");
+                }
                 l = num(l, "/") / d;
             }
         }
@@ -206,7 +214,10 @@ private:
             case Tok::True: advance(); return true;
             case Tok::False: advance(); return false;
             case Tok::Null: advance(); return json(nullptr);
-            case Tok::Ref: advance(); return resolve_ref_path(t.text, ctx_);
+            case Tok::Ref:
+                advance();
+                if (syntax_only_) return json(nullptr);
+                return resolve_ref_path(t.text, ctx_);
             case Tok::Op:
                 if (t.text == "(") {
                     advance();
@@ -220,7 +231,7 @@ private:
         throw JobError(400, "unexpected token in expression");
     }
 
-    static json compare(const std::string& op, const json& l, const json& r) {
+    json compare(const std::string& op, const json& l, const json& r) const {
         if (op == "==") return l == r;
         if (op == "!=") return l != r;
         if (l.is_number() && r.is_number()) {
@@ -238,12 +249,14 @@ private:
             if (op == ">") return a > b;
             return a >= b;
         }
+        if (syntax_only_) return false;
         throw JobError(400, "cannot order-compare these operand types");
     }
 
     std::vector<Token> toks_;
     const json& ctx_;
     size_t pos_ = 0;
+    bool syntax_only_ = false;
 };
 
 }
@@ -288,6 +301,19 @@ inline json resolve_refs(const json& value, const json& ctx) {
 inline bool eval_condition(const std::string& expr, const json& ctx) {
     if (expr.empty()) return true;
     return expr_detail::truthy(expr_detail::Parser(expr_detail::tokenize(expr), ctx).parse());
+}
+
+inline std::string check_expression_syntax(const std::string& expr) {
+    if (expr.empty()) return "";
+    static const json placeholder = json(nullptr);
+    try {
+        expr_detail::Parser parser(expr_detail::tokenize(expr), placeholder);
+        parser.set_syntax_only();
+        parser.parse();
+    } catch (const JobError& e) {
+        return e.what();
+    }
+    return "";
 }
 
 }

--- a/src/cpp/include/lemon/jobs/job_expr.h
+++ b/src/cpp/include/lemon/jobs/job_expr.h
@@ -1,7 +1,3 @@
-// Reference resolution and the `when`/`branch` condition evaluator for the job
-// engine. Pure: JSON context in, values/booleans out. A recipe's expressions
-// carry only references, literals, comparisons, boolean logic, and basic
-// arithmetic — never arbitrary code.
 #pragma once
 
 #include "lemon/jobs/job_types.h"
@@ -17,8 +13,6 @@ namespace jobs {
 
 namespace expr_detail {
 
-// Descend a dotted path ("a.b.0.c") into the context; object keys and numeric
-// array indices are both honored. Missing path -> JobError.
 inline json resolve_ref_path(const std::string& path, const json& ctx) {
     const json* cur = &ctx;
     size_t start = 0;
@@ -56,16 +50,14 @@ inline bool truthy(const json& v) {
     if (v.is_number()) return v.get<double>() != 0.0;
     if (v.is_string()) return !v.get<std::string>().empty();
     if (v.is_null()) return false;
-    return !v.empty();  // array/object
+    return !v.empty();
 }
-
-// ── expression tokenizer + recursive-descent parser ──
 
 enum class Tok { Num, Str, Ref, True, False, Null, Op, End };
 
 struct Token {
     Tok kind;
-    std::string text;   // operator text, ref path, or string literal
+    std::string text;
     double num = 0;
 };
 
@@ -254,10 +246,8 @@ private:
     size_t pos_ = 0;
 };
 
-}  // namespace expr_detail
+}
 
-// Deep-resolve ${refs} in a params value. A whole-string ref preserves the
-// referenced value's type; an embedded ref interpolates as text.
 inline json resolve_refs(const json& value, const json& ctx) {
     if (value.is_object()) {
         json out = json::object();
@@ -277,10 +267,10 @@ inline json resolve_refs(const json& value, const json& ctx) {
     if (open == std::string::npos) return value;
     const size_t close = s.find('}', open + 2);
     if (close == std::string::npos) return value;
-    // Whole-string single reference -> keep the resolved value's type.
+
     if (open == 0 && close == s.size() - 1 && s.find("${", 2) == std::string::npos)
         return expr_detail::resolve_ref_path(s.substr(2, close - 2), ctx);
-    // Otherwise interpolate every ${...} into the string.
+
     std::string out;
     size_t i = 0;
     while (i < s.size()) {
@@ -295,11 +285,10 @@ inline json resolve_refs(const json& value, const json& ctx) {
     return out;
 }
 
-// Evaluate a `when`/`branch` condition to a boolean. Empty expression is true.
 inline bool eval_condition(const std::string& expr, const json& ctx) {
     if (expr.empty()) return true;
     return expr_detail::truthy(expr_detail::Parser(expr_detail::tokenize(expr), ctx).parse());
 }
 
-}  // namespace jobs
-}  // namespace lemon
+}
+}

--- a/src/cpp/include/lemon/jobs/job_expr.h
+++ b/src/cpp/include/lemon/jobs/job_expr.h
@@ -1,0 +1,305 @@
+// Reference resolution and the `when`/`branch` condition evaluator for the job
+// engine. Pure: JSON context in, values/booleans out. A recipe's expressions
+// carry only references, literals, comparisons, boolean logic, and basic
+// arithmetic — never arbitrary code.
+#pragma once
+
+#include "lemon/jobs/job_types.h"
+
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace lemon {
+namespace jobs {
+
+namespace expr_detail {
+
+// Descend a dotted path ("a.b.0.c") into the context; object keys and numeric
+// array indices are both honored. Missing path -> JobError.
+inline json resolve_ref_path(const std::string& path, const json& ctx) {
+    const json* cur = &ctx;
+    size_t start = 0;
+    while (start <= path.size()) {
+        size_t dot = path.find('.', start);
+        std::string seg = path.substr(start, dot == std::string::npos ? std::string::npos : dot - start);
+        if (cur->is_object() && cur->contains(seg)) {
+            cur = &(*cur)[seg];
+        } else if (cur->is_array()) {
+            char* end = nullptr;
+            long idx = std::strtol(seg.c_str(), &end, 10);
+            if (end == seg.c_str() || *end != '\0' || idx < 0 || (size_t)idx >= cur->size())
+                throw JobError(400, "unknown reference: ${" + path + "}");
+            cur = &(*cur)[(size_t)idx];
+        } else {
+            throw JobError(400, "unknown reference: ${" + path + "}");
+        }
+        if (dot == std::string::npos) break;
+        start = dot + 1;
+    }
+    return *cur;
+}
+
+inline std::string stringify(const json& v) {
+    if (v.is_string()) return v.get<std::string>();
+    if (v.is_number_integer()) return std::to_string(v.get<long long>());
+    if (v.is_number()) return std::to_string(v.get<double>());
+    if (v.is_boolean()) return v.get<bool>() ? "true" : "false";
+    if (v.is_null()) return "";
+    return v.dump();
+}
+
+inline bool truthy(const json& v) {
+    if (v.is_boolean()) return v.get<bool>();
+    if (v.is_number()) return v.get<double>() != 0.0;
+    if (v.is_string()) return !v.get<std::string>().empty();
+    if (v.is_null()) return false;
+    return !v.empty();  // array/object
+}
+
+// ── expression tokenizer + recursive-descent parser ──
+
+enum class Tok { Num, Str, Ref, True, False, Null, Op, End };
+
+struct Token {
+    Tok kind;
+    std::string text;   // operator text, ref path, or string literal
+    double num = 0;
+};
+
+inline std::vector<Token> tokenize(const std::string& s) {
+    std::vector<Token> out;
+    size_t i = 0;
+    auto starts = [&](const char* op) {
+        return s.compare(i, std::char_traits<char>::length(op), op) == 0;
+    };
+    while (i < s.size()) {
+        char c = s[i];
+        if (std::isspace((unsigned char)c)) { i++; continue; }
+        if (starts("${")) {
+            size_t close = s.find('}', i + 2);
+            if (close == std::string::npos) throw JobError(400, "unterminated ${ in expression");
+            out.push_back({Tok::Ref, s.substr(i + 2, close - (i + 2)), 0});
+            i = close + 1;
+            continue;
+        }
+        if (c == '"' || c == '\'') {
+            char q = c;
+            size_t j = i + 1;
+            std::string lit;
+            while (j < s.size() && s[j] != q) {
+                if (s[j] == '\\' && j + 1 < s.size()) { lit.push_back(s[j + 1]); j += 2; }
+                else lit.push_back(s[j++]);
+            }
+            if (j >= s.size()) throw JobError(400, "unterminated string in expression");
+            out.push_back({Tok::Str, lit, 0});
+            i = j + 1;
+            continue;
+        }
+        if (std::isdigit((unsigned char)c) || (c == '.' && i + 1 < s.size() && std::isdigit((unsigned char)s[i + 1]))) {
+            char* end = nullptr;
+            double v = std::strtod(s.c_str() + i, &end);
+            out.push_back({Tok::Num, "", v});
+            i = end - s.c_str();
+            continue;
+        }
+        if (std::isalpha((unsigned char)c)) {
+            size_t j = i;
+            while (j < s.size() && (std::isalnum((unsigned char)s[j]) || s[j] == '_')) j++;
+            std::string word = s.substr(i, j - i);
+            if (word == "true") out.push_back({Tok::True, word, 0});
+            else if (word == "false") out.push_back({Tok::False, word, 0});
+            else if (word == "null") out.push_back({Tok::Null, word, 0});
+            else throw JobError(400, "unexpected identifier '" + word + "' in expression");
+            i = j;
+            continue;
+        }
+        for (const char* op : {"&&", "||", "==", "!=", "<=", ">="}) {
+            if (starts(op)) { out.push_back({Tok::Op, op, 0}); i += 2; goto next; }
+        }
+        if (std::string("!<>+-*/()").find(c) != std::string::npos) {
+            out.push_back({Tok::Op, std::string(1, c), 0});
+            i++;
+            continue;
+        }
+        throw JobError(400, std::string("unexpected character '") + c + "' in expression");
+    next:;
+    }
+    out.push_back({Tok::End, "", 0});
+    return out;
+}
+
+class Parser {
+public:
+    Parser(std::vector<Token> toks, const json& ctx) : toks_(std::move(toks)), ctx_(ctx) {}
+
+    json parse() {
+        json v = parse_or();
+        if (peek().kind != Tok::End) throw JobError(400, "trailing tokens in expression");
+        return v;
+    }
+
+private:
+    const Token& peek() const { return toks_[pos_]; }
+    const Token& advance() { return toks_[pos_++]; }
+    bool accept_op(const char* op) {
+        if (peek().kind == Tok::Op && peek().text == op) { pos_++; return true; }
+        return false;
+    }
+
+    static double num(const json& v, const char* ctx) {
+        if (!v.is_number()) throw JobError(400, std::string("expected a number for ") + ctx);
+        return v.get<double>();
+    }
+
+    json parse_or() {
+        json l = parse_and();
+        while (accept_op("||")) { json r = parse_and(); l = truthy(l) || truthy(r); }
+        return l;
+    }
+    json parse_and() {
+        json l = parse_not();
+        while (accept_op("&&")) { json r = parse_not(); l = truthy(l) && truthy(r); }
+        return l;
+    }
+    json parse_not() {
+        if (accept_op("!")) return !truthy(parse_not());
+        return parse_cmp();
+    }
+    json parse_cmp() {
+        json l = parse_add();
+        for (const char* op : {"==", "!=", "<=", ">=", "<", ">"}) {
+            if (peek().kind == Tok::Op && peek().text == op) {
+                advance();
+                json r = parse_add();
+                return compare(op, l, r);
+            }
+        }
+        return l;
+    }
+    json parse_add() {
+        json l = parse_mul();
+        while (peek().kind == Tok::Op && (peek().text == "+" || peek().text == "-")) {
+            std::string op = advance().text;
+            json r = parse_mul();
+            l = op == "+" ? num(l, "+") + num(r, "+") : num(l, "-") - num(r, "-");
+        }
+        return l;
+    }
+    json parse_mul() {
+        json l = parse_unary();
+        while (peek().kind == Tok::Op && (peek().text == "*" || peek().text == "/")) {
+            std::string op = advance().text;
+            json r = parse_unary();
+            if (op == "*") l = num(l, "*") * num(r, "*");
+            else {
+                double d = num(r, "/");
+                if (d == 0.0) throw JobError(400, "division by zero in expression");
+                l = num(l, "/") / d;
+            }
+        }
+        return l;
+    }
+    json parse_unary() {
+        if (accept_op("-")) return -num(parse_unary(), "unary -");
+        return parse_primary();
+    }
+    json parse_primary() {
+        const Token& t = peek();
+        switch (t.kind) {
+            case Tok::Num: advance(); return t.num;
+            case Tok::Str: advance(); return t.text;
+            case Tok::True: advance(); return true;
+            case Tok::False: advance(); return false;
+            case Tok::Null: advance(); return json(nullptr);
+            case Tok::Ref: advance(); return resolve_ref_path(t.text, ctx_);
+            case Tok::Op:
+                if (t.text == "(") {
+                    advance();
+                    json v = parse_or();
+                    if (!accept_op(")")) throw JobError(400, "missing ) in expression");
+                    return v;
+                }
+                break;
+            default: break;
+        }
+        throw JobError(400, "unexpected token in expression");
+    }
+
+    static json compare(const std::string& op, const json& l, const json& r) {
+        if (op == "==") return l == r;
+        if (op == "!=") return l != r;
+        if (l.is_number() && r.is_number()) {
+            double a = l.get<double>(), b = r.get<double>();
+            if (op == "<") return a < b;
+            if (op == "<=") return a <= b;
+            if (op == ">") return a > b;
+            return a >= b;
+        }
+        if (l.is_string() && r.is_string()) {
+            const auto& a = l.get_ref<const std::string&>();
+            const auto& b = r.get_ref<const std::string&>();
+            if (op == "<") return a < b;
+            if (op == "<=") return a <= b;
+            if (op == ">") return a > b;
+            return a >= b;
+        }
+        throw JobError(400, "cannot order-compare these operand types");
+    }
+
+    std::vector<Token> toks_;
+    const json& ctx_;
+    size_t pos_ = 0;
+};
+
+}  // namespace expr_detail
+
+// Deep-resolve ${refs} in a params value. A whole-string ref preserves the
+// referenced value's type; an embedded ref interpolates as text.
+inline json resolve_refs(const json& value, const json& ctx) {
+    if (value.is_object()) {
+        json out = json::object();
+        for (auto it = value.begin(); it != value.end(); ++it)
+            out[it.key()] = resolve_refs(it.value(), ctx);
+        return out;
+    }
+    if (value.is_array()) {
+        json out = json::array();
+        for (const auto& e : value) out.push_back(resolve_refs(e, ctx));
+        return out;
+    }
+    if (!value.is_string()) return value;
+
+    const std::string s = value.get<std::string>();
+    const size_t open = s.find("${");
+    if (open == std::string::npos) return value;
+    const size_t close = s.find('}', open + 2);
+    if (close == std::string::npos) return value;
+    // Whole-string single reference -> keep the resolved value's type.
+    if (open == 0 && close == s.size() - 1 && s.find("${", 2) == std::string::npos)
+        return expr_detail::resolve_ref_path(s.substr(2, close - 2), ctx);
+    // Otherwise interpolate every ${...} into the string.
+    std::string out;
+    size_t i = 0;
+    while (i < s.size()) {
+        size_t o = s.find("${", i);
+        if (o == std::string::npos) { out += s.substr(i); break; }
+        out += s.substr(i, o - i);
+        size_t c = s.find('}', o + 2);
+        if (c == std::string::npos) { out += s.substr(o); break; }
+        out += expr_detail::stringify(expr_detail::resolve_ref_path(s.substr(o + 2, c - (o + 2)), ctx));
+        i = c + 1;
+    }
+    return out;
+}
+
+// Evaluate a `when`/`branch` condition to a boolean. Empty expression is true.
+inline bool eval_condition(const std::string& expr, const json& ctx) {
+    if (expr.empty()) return true;
+    return expr_detail::truthy(expr_detail::Parser(expr_detail::tokenize(expr), ctx).parse());
+}
+
+}  // namespace jobs
+}  // namespace lemon

--- a/src/cpp/include/lemon/jobs/job_graph.h
+++ b/src/cpp/include/lemon/jobs/job_graph.h
@@ -1,7 +1,3 @@
-// Step-graph validation for a client-posted job definition. Enforces the
-// invariants that keep execution well-defined and terminating: unique step ids,
-// known ops, and forward-only jump targets (every branch/on_done/on_fail target
-// references a strictly later step). Forward-only ⇒ acyclic ⇒ no loops.
 #pragma once
 
 #include "lemon/jobs/job_expr.h"
@@ -15,7 +11,6 @@
 namespace lemon {
 namespace jobs {
 
-// Returns "" if the step list is a valid graph, else a client-facing message.
 inline std::string validate_steps(const std::vector<StepRecord>& steps,
                                   const std::set<std::string>& known_ops) {
     if (steps.empty()) return "a job needs at least one step";
@@ -43,7 +38,7 @@ inline std::string validate_steps(const std::vector<StepRecord>& steps,
     auto check_expr = [](const std::string& e, const std::string& where) -> std::string {
         if (e.empty()) return "";
         try {
-            expr_detail::tokenize(e);  // syntactic pre-check; refs resolve at run time
+            expr_detail::tokenize(e);
         } catch (const JobError& err) {
             return where + ": " + err.what();
         }
@@ -77,5 +72,5 @@ inline std::string validate_steps(const std::vector<StepRecord>& steps,
     return "";
 }
 
-}  // namespace jobs
-}  // namespace lemon
+}
+}

--- a/src/cpp/include/lemon/jobs/job_graph.h
+++ b/src/cpp/include/lemon/jobs/job_graph.h
@@ -1,0 +1,81 @@
+// Step-graph validation for a client-posted job definition. Enforces the
+// invariants that keep execution well-defined and terminating: unique step ids,
+// known ops, and forward-only jump targets (every branch/on_done/on_fail target
+// references a strictly later step). Forward-only ⇒ acyclic ⇒ no loops.
+#pragma once
+
+#include "lemon/jobs/job_expr.h"
+#include "lemon/jobs/job_types.h"
+
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace lemon {
+namespace jobs {
+
+// Returns "" if the step list is a valid graph, else a client-facing message.
+inline std::string validate_steps(const std::vector<StepRecord>& steps,
+                                  const std::set<std::string>& known_ops) {
+    if (steps.empty()) return "a job needs at least one step";
+
+    std::unordered_map<std::string, int> index;
+    for (int i = 0; i < (int)steps.size(); ++i) {
+        const std::string& id = steps[i].id;
+        if (id.empty()) return "step " + std::to_string(i) + " has an empty id";
+        if (index.count(id)) return "duplicate step id '" + id + "'";
+        index[id] = i;
+    }
+
+    auto forward_target = [&](int from, const std::string& target,
+                              const char* field) -> std::string {
+        auto it = index.find(target);
+        if (it == index.end())
+            return std::string(field) + " target '" + target + "' in step '" + steps[from].id
+                   + "' is not a known step id";
+        if (it->second <= from)
+            return std::string(field) + " target '" + target + "' in step '" + steps[from].id
+                   + "' must reference a later step (no loops)";
+        return "";
+    };
+
+    auto check_expr = [](const std::string& e, const std::string& where) -> std::string {
+        if (e.empty()) return "";
+        try {
+            expr_detail::tokenize(e);  // syntactic pre-check; refs resolve at run time
+        } catch (const JobError& err) {
+            return where + ": " + err.what();
+        }
+        return "";
+    };
+
+    for (int i = 0; i < (int)steps.size(); ++i) {
+        const StepRecord& s = steps[i];
+        if (s.op.empty()) return "step '" + s.id + "' has no op";
+        if (!known_ops.count(s.op)) return "step '" + s.id + "' uses unknown op '" + s.op + "'";
+
+        std::string e = check_expr(s.when, "step '" + s.id + "' when");
+        if (!e.empty()) return e;
+
+        if (!s.on_done.empty()) {
+            std::string err = forward_target(i, s.on_done, "on_done");
+            if (!err.empty()) return err;
+        }
+        for (const Case& c : s.branch) {
+            if (c.goto_id.empty()) return "a branch case in step '" + s.id + "' has no goto";
+            std::string err = forward_target(i, c.goto_id, "branch goto");
+            if (!err.empty()) return err;
+            std::string ce = check_expr(c.when, "step '" + s.id + "' branch when");
+            if (!ce.empty()) return ce;
+        }
+        if (s.on_fail != kOnFailAbort && s.on_fail != kOnFailContinue) {
+            std::string err = forward_target(i, s.on_fail, "on_fail");
+            if (!err.empty()) return err;
+        }
+    }
+    return "";
+}
+
+}  // namespace jobs
+}  // namespace lemon

--- a/src/cpp/include/lemon/jobs/job_graph.h
+++ b/src/cpp/include/lemon/jobs/job_graph.h
@@ -19,6 +19,9 @@ inline std::string validate_steps(const std::vector<StepRecord>& steps,
     for (int i = 0; i < (int)steps.size(); ++i) {
         const std::string& id = steps[i].id;
         if (id.empty()) return "step " + std::to_string(i) + " has an empty id";
+        if (id == "inputs") return "step id 'inputs' is reserved";
+        if (id.find('.') != std::string::npos)
+            return "step id '" + id + "' must not contain '.'";
         if (index.count(id)) return "duplicate step id '" + id + "'";
         index[id] = i;
     }
@@ -37,11 +40,8 @@ inline std::string validate_steps(const std::vector<StepRecord>& steps,
 
     auto check_expr = [](const std::string& e, const std::string& where) -> std::string {
         if (e.empty()) return "";
-        try {
-            expr_detail::tokenize(e);
-        } catch (const JobError& err) {
-            return where + ": " + err.what();
-        }
+        const std::string err = check_expression_syntax(e);
+        if (!err.empty()) return where + ": " + err;
         return "";
     };
 

--- a/src/cpp/include/lemon/jobs/job_manager.h
+++ b/src/cpp/include/lemon/jobs/job_manager.h
@@ -1,0 +1,67 @@
+// The generic server-side job engine: a single persistent worker runs one
+// client-posted job at a time, passing data forward through the job context,
+// evaluating forward-only branches, and persisting every transition so a job
+// survives client disconnect and server restart.
+#pragma once
+
+#include "lemon/jobs/job_ops.h"
+#include "lemon/jobs/job_types.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace lemon {
+namespace jobs {
+
+class JobManager {
+public:
+    JobManager(std::string cache_dir, OpRegistry registry);
+    ~JobManager();
+
+    std::string create(const std::string& name, std::vector<StepRecord> steps, json inputs);
+    json list() const;
+    std::optional<json> get(const std::string& id) const;
+    bool pause(const std::string& id);
+    bool interrupt(const std::string& id);
+    bool resume(const std::string& id);
+    bool remove(const std::string& id, bool& active_out);
+
+private:
+    struct Control {
+        std::atomic<bool> pause_requested{false};
+        std::atomic<bool> interrupt_requested{false};
+        CancelFlag cancel{false};
+    };
+
+    void worker_main();
+    void execute(const std::string& id, const std::shared_ptr<Control>& ctrl);
+    void persist_locked();
+    void load_from_disk();
+    void enqueue_locked(const std::string& id);
+    std::shared_ptr<Control> control_for_locked(const std::string& id);
+
+    std::string storage_path_;
+    OpRegistry registry_;
+
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    std::map<std::string, Job> jobs_;
+    std::map<std::string, std::shared_ptr<Control>> controls_;
+    std::vector<std::string> order_;  // newest first
+    std::deque<std::string> queue_;
+    std::string active_id_;
+    uint64_t id_counter_ = 0;
+    bool stop_ = false;
+    std::thread worker_;
+};
+
+}  // namespace jobs
+}  // namespace lemon

--- a/src/cpp/include/lemon/jobs/job_manager.h
+++ b/src/cpp/include/lemon/jobs/job_manager.h
@@ -34,6 +34,7 @@ private:
     struct Control {
         std::atomic<bool> pause_requested{false};
         std::atomic<bool> interrupt_requested{false};
+        std::atomic<bool> delete_requested{false};
         CancelFlag cancel{false};
     };
 

--- a/src/cpp/include/lemon/jobs/job_manager.h
+++ b/src/cpp/include/lemon/jobs/job_manager.h
@@ -1,7 +1,3 @@
-// The generic server-side job engine: a single persistent worker runs one
-// client-posted job at a time, passing data forward through the job context,
-// evaluating forward-only branches, and persisting every transition so a job
-// survives client disconnect and server restart.
 #pragma once
 
 #include "lemon/jobs/job_ops.h"
@@ -55,7 +51,7 @@ private:
     std::condition_variable cv_;
     std::map<std::string, Job> jobs_;
     std::map<std::string, std::shared_ptr<Control>> controls_;
-    std::vector<std::string> order_;  // newest first
+    std::vector<std::string> order_;
     std::deque<std::string> queue_;
     std::string active_id_;
     uint64_t id_counter_ = 0;
@@ -63,5 +59,5 @@ private:
     std::thread worker_;
 };
 
-}  // namespace jobs
-}  // namespace lemon
+}
+}

--- a/src/cpp/include/lemon/jobs/job_ops.h
+++ b/src/cpp/include/lemon/jobs/job_ops.h
@@ -28,6 +28,7 @@ public:
     std::function<void()> end_exclusive;
 
     std::function<void(const std::string& job_id)> reconcile_unload;
+    std::function<bool(const std::string& job_id, CancelFlag*)> restore_exclusive;
     std::function<void(const std::string& job_id)> discard_exclusive;
 
 private:
@@ -47,6 +48,7 @@ struct OpProviders {
     std::function<bool(const std::string& job_id, CancelFlag*)> begin_exclusive;
     std::function<void()> end_exclusive;
     std::function<void(const std::string& job_id)> reconcile_unload;
+    std::function<bool(const std::string& job_id, CancelFlag*)> restore_exclusive;
     std::function<void(const std::string& job_id)> discard_exclusive;
 };
 

--- a/src/cpp/include/lemon/jobs/job_ops.h
+++ b/src/cpp/include/lemon/jobs/job_ops.h
@@ -24,7 +24,7 @@ public:
     const OpHandler* find(const std::string& name) const;
     std::set<std::string> names() const;
 
-    std::function<void()> begin_exclusive;
+    std::function<bool(CancelFlag*)> begin_exclusive;
     std::function<void()> end_exclusive;
 
     std::function<void()> reconcile_unload;
@@ -43,7 +43,7 @@ struct OpProviders {
     std::function<json(const json& params, CancelFlag& cancel)> unload_op;
     std::function<json(const json& params, CancelFlag& cancel)> chat_op;
 
-    std::function<void()> begin_exclusive;
+    std::function<bool(CancelFlag*)> begin_exclusive;
     std::function<void()> end_exclusive;
     std::function<void()> reconcile_unload;
 };

--- a/src/cpp/include/lemon/jobs/job_ops.h
+++ b/src/cpp/include/lemon/jobs/job_ops.h
@@ -28,7 +28,7 @@ public:
     std::function<void()> end_exclusive;
 
     std::function<void(const std::string& job_id)> reconcile_unload;
-    std::function<bool(const std::string& job_id, CancelFlag*)> restore_exclusive;
+    std::function<bool(const std::string& job_id, const json& manifest, CancelFlag*)> restore_exclusive;
     std::function<void(const std::string& job_id)> discard_exclusive;
 
 private:
@@ -48,7 +48,7 @@ struct OpProviders {
     std::function<bool(const std::string& job_id, CancelFlag*)> begin_exclusive;
     std::function<void()> end_exclusive;
     std::function<void(const std::string& job_id)> reconcile_unload;
-    std::function<bool(const std::string& job_id, CancelFlag*)> restore_exclusive;
+    std::function<bool(const std::string& job_id, const json& manifest, CancelFlag*)> restore_exclusive;
     std::function<void(const std::string& job_id)> discard_exclusive;
 };
 

--- a/src/cpp/include/lemon/jobs/job_ops.h
+++ b/src/cpp/include/lemon/jobs/job_ops.h
@@ -33,6 +33,9 @@ public:
     // the Router type. Either may be empty (no-op) in unit tests.
     std::function<void()> begin_exclusive;
     std::function<void()> end_exclusive;
+    // Unload everything a job left resident; invoked when an exclusive job is
+    // interrupted, while it still owns the slot.
+    std::function<void()> reconcile_unload;
 
 private:
     std::map<std::string, OpHandler> handlers_;
@@ -54,6 +57,7 @@ struct OpProviders {
 
     std::function<void()> begin_exclusive;
     std::function<void()> end_exclusive;
+    std::function<void()> reconcile_unload;
 };
 
 OpRegistry build_op_registry(OpProviders providers);

--- a/src/cpp/include/lemon/jobs/job_ops.h
+++ b/src/cpp/include/lemon/jobs/job_ops.h
@@ -24,10 +24,11 @@ public:
     const OpHandler* find(const std::string& name) const;
     std::set<std::string> names() const;
 
-    std::function<bool(CancelFlag*)> begin_exclusive;
+    std::function<bool(const std::string& job_id, CancelFlag*)> begin_exclusive;
     std::function<void()> end_exclusive;
 
-    std::function<void()> reconcile_unload;
+    std::function<void(const std::string& job_id)> reconcile_unload;
+    std::function<void(const std::string& job_id)> discard_exclusive;
 
 private:
     std::map<std::string, OpHandler> handlers_;
@@ -43,9 +44,10 @@ struct OpProviders {
     std::function<json(const json& params, CancelFlag& cancel)> unload_op;
     std::function<json(const json& params, CancelFlag& cancel)> chat_op;
 
-    std::function<bool(CancelFlag*)> begin_exclusive;
+    std::function<bool(const std::string& job_id, CancelFlag*)> begin_exclusive;
     std::function<void()> end_exclusive;
-    std::function<void()> reconcile_unload;
+    std::function<void(const std::string& job_id)> reconcile_unload;
+    std::function<void(const std::string& job_id)> discard_exclusive;
 };
 
 OpRegistry build_op_registry(OpProviders providers);

--- a/src/cpp/include/lemon/jobs/job_ops.h
+++ b/src/cpp/include/lemon/jobs/job_ops.h
@@ -28,6 +28,12 @@ public:
     const OpHandler* find(const std::string& name) const;
     std::set<std::string> names() const;
 
+    // Acquire/release the Router's exclusive slot; wired to the Router by
+    // build_op_registry so the engine can gate a whole job without depending on
+    // the Router type. Either may be empty (no-op) in unit tests.
+    std::function<void()> begin_exclusive;
+    std::function<void()> end_exclusive;
+
 private:
     std::map<std::string, OpHandler> handlers_;
 };
@@ -39,6 +45,15 @@ struct OpProviders {
     std::function<json()> system_stats;
     std::function<json()> models_list;
     std::function<json(const std::string& id)> model_get;
+
+    // Exclusive ops (require the model slot). Each returns the op's output json
+    // and throws JobError on bad input.
+    std::function<json(const json& params, CancelFlag& cancel)> load_op;
+    std::function<json(const json& params, CancelFlag& cancel)> unload_op;
+    std::function<json(const json& params, CancelFlag& cancel)> chat_op;
+
+    std::function<void()> begin_exclusive;
+    std::function<void()> end_exclusive;
 };
 
 OpRegistry build_op_registry(OpProviders providers);

--- a/src/cpp/include/lemon/jobs/job_ops.h
+++ b/src/cpp/include/lemon/jobs/job_ops.h
@@ -1,0 +1,47 @@
+// Operation interface and registry for the job engine. An op is a named,
+// reference-resolved unit of work the engine invokes with concrete params, the
+// job context, and a cooperative cancel flag. Ops declared here are generic and
+// know nothing about any particular recipe.
+#pragma once
+
+#include "lemon/jobs/job_types.h"
+
+#include <atomic>
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+
+namespace lemon {
+namespace jobs {
+
+using CancelFlag = std::atomic<bool>;
+
+struct OpHandler {
+    std::function<json(const json& params, const json& context, CancelFlag& cancel)> run;
+    bool exclusive = false;
+};
+
+class OpRegistry {
+public:
+    void register_op(const std::string& name, OpHandler handler);
+    const OpHandler* find(const std::string& name) const;
+    std::set<std::string> names() const;
+
+private:
+    std::map<std::string, OpHandler> handlers_;
+};
+
+// The concrete data sources the read-only ops need, injected so job_ops.cpp does
+// not depend on the whole Server. A model_get returning null signals "unknown".
+struct OpProviders {
+    std::function<json()> system_info;
+    std::function<json()> system_stats;
+    std::function<json()> models_list;
+    std::function<json(const std::string& id)> model_get;
+};
+
+OpRegistry build_op_registry(OpProviders providers);
+
+}  // namespace jobs
+}  // namespace lemon

--- a/src/cpp/include/lemon/jobs/job_ops.h
+++ b/src/cpp/include/lemon/jobs/job_ops.h
@@ -1,7 +1,3 @@
-// Operation interface and registry for the job engine. An op is a named,
-// reference-resolved unit of work the engine invokes with concrete params, the
-// job context, and a cooperative cancel flag. Ops declared here are generic and
-// know nothing about any particular recipe.
 #pragma once
 
 #include "lemon/jobs/job_types.h"
@@ -28,29 +24,21 @@ public:
     const OpHandler* find(const std::string& name) const;
     std::set<std::string> names() const;
 
-    // Acquire/release the Router's exclusive slot; wired to the Router by
-    // build_op_registry so the engine can gate a whole job without depending on
-    // the Router type. Either may be empty (no-op) in unit tests.
     std::function<void()> begin_exclusive;
     std::function<void()> end_exclusive;
-    // Unload everything a job left resident; invoked when an exclusive job is
-    // interrupted, while it still owns the slot.
+
     std::function<void()> reconcile_unload;
 
 private:
     std::map<std::string, OpHandler> handlers_;
 };
 
-// The concrete data sources the read-only ops need, injected so job_ops.cpp does
-// not depend on the whole Server. A model_get returning null signals "unknown".
 struct OpProviders {
     std::function<json()> system_info;
     std::function<json()> system_stats;
     std::function<json()> models_list;
     std::function<json(const std::string& id)> model_get;
 
-    // Exclusive ops (require the model slot). Each returns the op's output json
-    // and throws JobError on bad input.
     std::function<json(const json& params, CancelFlag& cancel)> load_op;
     std::function<json(const json& params, CancelFlag& cancel)> unload_op;
     std::function<json(const json& params, CancelFlag& cancel)> chat_op;
@@ -62,5 +50,5 @@ struct OpProviders {
 
 OpRegistry build_op_registry(OpProviders providers);
 
-}  // namespace jobs
-}  // namespace lemon
+}
+}

--- a/src/cpp/include/lemon/jobs/job_types.h
+++ b/src/cpp/include/lemon/jobs/job_types.h
@@ -89,6 +89,7 @@ struct StepRecord {
     std::string on_fail = kOnFailAbort;
 
     StepStatus status = StepStatus::Pending;
+    bool failure_handled = false;
     int64_t duration_ms = 0;
     std::string error;
     json output = json::object();
@@ -106,6 +107,7 @@ struct StepRecord {
         if (!on_done.empty()) j["on_done"] = on_done;
         if (!b.empty()) j["branch"] = b;
         if (on_fail != kOnFailAbort) j["on_fail"] = on_fail;
+        if (failure_handled) j["failure_handled"] = true;
         if (!error.empty()) j["error"] = error;
         if (!output.empty()) j["output"] = output;
         return j;
@@ -122,6 +124,7 @@ struct StepRecord {
         if (j.contains("branch") && j["branch"].is_array())
             for (const auto& c : j["branch"]) s.branch.push_back(Case::from_json(c));
         s.on_fail = j.value("on_fail", std::string(kOnFailAbort));
+        s.failure_handled = j.value("failure_handled", false);
         if (j.contains("status")) s.status = step_status_from_string(j["status"].get<std::string>());
         s.duration_ms = j.value("duration_ms", (int64_t)0);
         s.error = j.value("error", "");
@@ -134,6 +137,7 @@ struct Job {
     std::string id;
     std::string name;
     JobStatus status = JobStatus::Queued;
+    bool deleted = false;
     json inputs = json::object();
     json context = json::object();
     std::vector<StepRecord> steps;
@@ -147,7 +151,8 @@ struct Job {
     json to_summary_json() const {
         int completed = 0;
         for (const auto& s : steps)
-            if (s.status == StepStatus::Completed || s.status == StepStatus::Skipped) completed++;
+            if (s.status == StepStatus::Completed || s.status == StepStatus::Skipped
+                || (s.status == StepStatus::Failed && s.failure_handled)) completed++;
         json j = {{"id", id},
                   {"name", name},
                   {"status", to_string(status)},
@@ -172,6 +177,7 @@ struct Job {
                   {"steps", st},
                   {"cursor", cursor},
                   {"created_at", created_at}};
+        if (deleted) j["deleted"] = true;
         if (!started_at.empty()) j["started_at"] = started_at;
         if (!finished_at.empty()) j["finished_at"] = finished_at;
         if (!summary.empty()) j["summary"] = summary;
@@ -184,6 +190,7 @@ struct Job {
         job.id = j.value("id", "");
         job.name = j.value("name", "");
         if (j.contains("status")) job.status = job_status_from_string(j["status"].get<std::string>());
+        job.deleted = j.value("deleted", false);
         if (j.contains("inputs")) job.inputs = j["inputs"];
         if (j.contains("context")) job.context = j["context"];
         if (j.contains("steps") && j["steps"].is_array())

--- a/src/cpp/include/lemon/jobs/job_types.h
+++ b/src/cpp/include/lemon/jobs/job_types.h
@@ -1,0 +1,213 @@
+// Data model for the generic server-side job engine: a job is a client-posted,
+// ordered list of steps executed on the server with data passing forward
+// through a shared context, forward-only branching, and a
+// pause/interrupt/resume/delete/query lifecycle. These types are pure (JSON in,
+// JSON out) so the parser/evaluator/validator can be unit-tested with no server.
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace lemon {
+namespace jobs {
+
+using json = nlohmann::ordered_json;
+
+// Client-facing error carrying an HTTP status; thrown by parsing/validation and
+// by ops, caught at the handler boundary.
+class JobError : public std::runtime_error {
+public:
+    JobError(int status, std::string message)
+        : std::runtime_error(std::move(message)), status(status) {}
+    int status;
+};
+
+enum class JobStatus { Queued, Running, Paused, Interrupted, Completed, Failed };
+enum class StepStatus { Pending, Running, Completed, Failed, Skipped };
+
+inline std::string to_string(JobStatus s) {
+    switch (s) {
+        case JobStatus::Queued: return "queued";
+        case JobStatus::Running: return "running";
+        case JobStatus::Paused: return "paused";
+        case JobStatus::Interrupted: return "interrupted";
+        case JobStatus::Completed: return "completed";
+        default: return "failed";
+    }
+}
+
+inline JobStatus job_status_from_string(const std::string& s) {
+    if (s == "queued") return JobStatus::Queued;
+    if (s == "running") return JobStatus::Running;
+    if (s == "paused") return JobStatus::Paused;
+    if (s == "interrupted") return JobStatus::Interrupted;
+    if (s == "completed") return JobStatus::Completed;
+    return JobStatus::Failed;
+}
+
+inline std::string to_string(StepStatus s) {
+    switch (s) {
+        case StepStatus::Pending: return "pending";
+        case StepStatus::Running: return "running";
+        case StepStatus::Completed: return "completed";
+        case StepStatus::Failed: return "failed";
+        default: return "skipped";
+    }
+}
+
+inline StepStatus step_status_from_string(const std::string& s) {
+    if (s == "running") return StepStatus::Running;
+    if (s == "completed") return StepStatus::Completed;
+    if (s == "failed") return StepStatus::Failed;
+    if (s == "skipped") return StepStatus::Skipped;
+    return StepStatus::Pending;
+}
+
+// A conditional forward jump: if `when` evaluates true, control transfers to the
+// step whose id is `goto_id`.
+struct Case {
+    std::string when;
+    std::string goto_id;
+
+    json to_json() const { return {{"when", when}, {"goto", goto_id}}; }
+
+    static Case from_json(const json& j) {
+        Case c;
+        c.when = j.value("when", "");
+        c.goto_id = j.value("goto", "");
+        return c;
+    }
+};
+
+// The special non-id `on_fail` dispositions. Anything else is a step id.
+inline constexpr const char* kOnFailAbort = "abort";
+inline constexpr const char* kOnFailContinue = "continue";
+
+struct StepRecord {
+    // ── definition (client-posted) ──
+    std::string id;
+    std::string op;
+    json params = json::object();
+    std::string when;                  // optional guard; skip step if false
+    json extract = json::object();     // { context_key: "path.into.output" }
+    std::string on_done;               // optional forward jump on success
+    std::vector<Case> branch;          // first matching case wins over on_done
+    std::string on_fail = kOnFailAbort; // abort | continue | <step id>
+
+    // ── runtime ──
+    StepStatus status = StepStatus::Pending;
+    int64_t duration_ms = 0;
+    std::string error;
+    json output = json::object();
+
+    json to_json() const {
+        json b = json::array();
+        for (const auto& c : branch) b.push_back(c.to_json());
+        json j = {{"id", id},
+                  {"op", op},
+                  {"params", params},
+                  {"status", to_string(status)},
+                  {"duration_ms", duration_ms}};
+        if (!when.empty()) j["when"] = when;
+        if (!extract.empty()) j["extract"] = extract;
+        if (!on_done.empty()) j["on_done"] = on_done;
+        if (!b.empty()) j["branch"] = b;
+        if (on_fail != kOnFailAbort) j["on_fail"] = on_fail;
+        if (!error.empty()) j["error"] = error;
+        if (!output.empty()) j["output"] = output;
+        return j;
+    }
+
+    static StepRecord from_json(const json& j) {
+        StepRecord s;
+        s.id = j.value("id", "");
+        s.op = j.value("op", "");
+        if (j.contains("params") && j["params"].is_object()) s.params = j["params"];
+        s.when = j.value("when", "");
+        if (j.contains("extract") && j["extract"].is_object()) s.extract = j["extract"];
+        s.on_done = j.value("on_done", "");
+        if (j.contains("branch") && j["branch"].is_array())
+            for (const auto& c : j["branch"]) s.branch.push_back(Case::from_json(c));
+        s.on_fail = j.value("on_fail", std::string(kOnFailAbort));
+        if (j.contains("status")) s.status = step_status_from_string(j["status"].get<std::string>());
+        s.duration_ms = j.value("duration_ms", (int64_t)0);
+        s.error = j.value("error", "");
+        if (j.contains("output")) s.output = j["output"];
+        return s;
+    }
+};
+
+struct Job {
+    std::string id;
+    std::string name;
+    JobStatus status = JobStatus::Queued;
+    json inputs = json::object();
+    json context = json::object();
+    std::vector<StepRecord> steps;
+    std::string cursor;                // id of the current/next step ("" = done)
+    std::string created_at;
+    std::string started_at;
+    std::string finished_at;
+    std::string summary;
+    std::string error;
+
+    json to_summary_json() const {
+        int completed = 0;
+        for (const auto& s : steps)
+            if (s.status == StepStatus::Completed || s.status == StepStatus::Skipped) completed++;
+        json j = {{"id", id},
+                  {"name", name},
+                  {"status", to_string(status)},
+                  {"created_at", created_at},
+                  {"progress", {{"cursor", cursor},
+                                {"completed", completed},
+                                {"step_count", (int)steps.size()}}}};
+        if (!finished_at.empty()) j["finished_at"] = finished_at;
+        if (!summary.empty()) j["summary"] = summary;
+        if (!error.empty()) j["error"] = error;
+        return j;
+    }
+
+    json to_json() const {
+        json st = json::array();
+        for (const auto& s : steps) st.push_back(s.to_json());
+        json j = {{"id", id},
+                  {"name", name},
+                  {"status", to_string(status)},
+                  {"inputs", inputs},
+                  {"context", context},
+                  {"steps", st},
+                  {"cursor", cursor},
+                  {"created_at", created_at}};
+        if (!started_at.empty()) j["started_at"] = started_at;
+        if (!finished_at.empty()) j["finished_at"] = finished_at;
+        if (!summary.empty()) j["summary"] = summary;
+        if (!error.empty()) j["error"] = error;
+        return j;
+    }
+
+    static Job from_json(const json& j) {
+        Job job;
+        job.id = j.value("id", "");
+        job.name = j.value("name", "");
+        if (j.contains("status")) job.status = job_status_from_string(j["status"].get<std::string>());
+        if (j.contains("inputs")) job.inputs = j["inputs"];
+        if (j.contains("context")) job.context = j["context"];
+        if (j.contains("steps") && j["steps"].is_array())
+            for (const auto& s : j["steps"]) job.steps.push_back(StepRecord::from_json(s));
+        job.cursor = j.value("cursor", "");
+        job.created_at = j.value("created_at", "");
+        job.started_at = j.value("started_at", "");
+        job.finished_at = j.value("finished_at", "");
+        job.summary = j.value("summary", "");
+        job.error = j.value("error", "");
+        return job;
+    }
+};
+
+}  // namespace jobs
+}  // namespace lemon

--- a/src/cpp/include/lemon/jobs/job_types.h
+++ b/src/cpp/include/lemon/jobs/job_types.h
@@ -1,8 +1,3 @@
-// Data model for the generic server-side job engine: a job is a client-posted,
-// ordered list of steps executed on the server with data passing forward
-// through a shared context, forward-only branching, and a
-// pause/interrupt/resume/delete/query lifecycle. These types are pure (JSON in,
-// JSON out) so the parser/evaluator/validator can be unit-tested with no server.
 #pragma once
 
 #include <nlohmann/json.hpp>
@@ -17,8 +12,6 @@ namespace jobs {
 
 using json = nlohmann::ordered_json;
 
-// Client-facing error carrying an HTTP status; thrown by parsing/validation and
-// by ops, caught at the handler boundary.
 class JobError : public std::runtime_error {
 public:
     JobError(int status, std::string message)
@@ -67,8 +60,6 @@ inline StepStatus step_status_from_string(const std::string& s) {
     return StepStatus::Pending;
 }
 
-// A conditional forward jump: if `when` evaluates true, control transfers to the
-// step whose id is `goto_id`.
 struct Case {
     std::string when;
     std::string goto_id;
@@ -83,22 +74,20 @@ struct Case {
     }
 };
 
-// The special non-id `on_fail` dispositions. Anything else is a step id.
 inline constexpr const char* kOnFailAbort = "abort";
 inline constexpr const char* kOnFailContinue = "continue";
 
 struct StepRecord {
-    // ── definition (client-posted) ──
+
     std::string id;
     std::string op;
     json params = json::object();
-    std::string when;                  // optional guard; skip step if false
-    json extract = json::object();     // { context_key: "path.into.output" }
-    std::string on_done;               // optional forward jump on success
-    std::vector<Case> branch;          // first matching case wins over on_done
-    std::string on_fail = kOnFailAbort; // abort | continue | <step id>
+    std::string when;
+    json extract = json::object();
+    std::string on_done;
+    std::vector<Case> branch;
+    std::string on_fail = kOnFailAbort;
 
-    // ── runtime ──
     StepStatus status = StepStatus::Pending;
     int64_t duration_ms = 0;
     std::string error;
@@ -148,7 +137,7 @@ struct Job {
     json inputs = json::object();
     json context = json::object();
     std::vector<StepRecord> steps;
-    std::string cursor;                // id of the current/next step ("" = done)
+    std::string cursor;
     std::string created_at;
     std::string started_at;
     std::string finished_at;
@@ -209,5 +198,5 @@ struct Job {
     }
 };
 
-}  // namespace jobs
-}  // namespace lemon
+}
+}

--- a/src/cpp/include/lemon/recipe_options.h
+++ b/src/cpp/include/lemon/recipe_options.h
@@ -18,6 +18,7 @@ public:
     RecipeOptions inherit(const RecipeOptions& options) const;
     json get_option(const std::string& opt) const;
     void set_option(const std::string& opt, const json& value);
+    void remove_option(const std::string& opt);
     std::string get_recipe() const { return recipe_; };
 
 #ifdef LEMONADE_CLI

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -154,7 +154,10 @@ public:
     void end_exclusive();
 
     std::map<std::string, bool> snapshot_loaded_models() const;
-    void unload_models_not_in(const std::map<std::string, bool>& keep);
+    std::map<std::string, json> unload_job_models(const std::map<std::string, int>& owned_live,
+                                                  const std::map<std::string, bool>& snapshot_pins);
+    int loaded_model_pid(const std::string& model_name) const;
+    std::string canonical_model_name(const std::string& model_name) const;
 
     // Test hooks
     void simulate_vram_pressure(double pct);

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -153,8 +153,8 @@ public:
     void begin_exclusive();
     void end_exclusive();
 
-    std::set<std::string> snapshot_loaded_models() const;
-    void unload_models_not_in(const std::set<std::string>& keep);
+    std::map<std::string, bool> snapshot_loaded_models() const;
+    void unload_models_not_in(const std::map<std::string, bool>& keep);
 
     // Test hooks
     void simulate_vram_pressure(double pct);

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <memory>
 #include <map>
 #include <mutex>
 #include <condition_variable>
+#include <thread>
 #include <vector>
 #include <optional>
 #include <nlohmann/json.hpp>
@@ -72,7 +74,8 @@ public:
                     RecipeOptions options,
                     bool do_not_upgrade = true,
                     bool allow_reload_on_option_change = false,
-                    std::optional<bool> pinned = std::nullopt);
+                    std::optional<bool> pinned = std::nullopt,
+                    std::atomic<bool>* cancel_flag = nullptr);
 
     void unload_model(const std::string& model_name = "");  // Empty = unload all
 
@@ -146,6 +149,12 @@ public:
 
     void update_prompt_tokens(const std::string& model_name, int prompt_tokens);
 
+    // Exclusive slot gate: while a job engine worker holds the exclusive slot,
+    // every load/inference path on other (httplib) threads queues behind it; the
+    // owner thread passes through. begin/end run on the worker thread.
+    void begin_exclusive();
+    void end_exclusive();
+
     // Test hooks
     void simulate_vram_pressure(double pct);
 
@@ -167,6 +176,14 @@ private:
     mutable std::mutex load_mutex_;              // Protects loading state and loaded_servers_
     bool is_loading_ = false;                    // True when a load operation is in progress
     std::condition_variable load_cv_;            // Signals when load completes
+
+    // Exclusive slot gate (all guarded by load_mutex_). A running exclusive job
+    // sets exclusive_active_ with itself as owner; other threads park on
+    // exclusive_cv_ until it clears.
+    bool exclusive_active_ = false;
+    std::thread::id exclusive_owner_;
+    std::condition_variable exclusive_cv_;
+    void wait_for_slot_clearance(std::unique_lock<std::mutex>& lock);
 
     std::unique_ptr<GlobalVramMonitor> vram_monitor_;
     std::unique_ptr<EvictionEngine> eviction_engine_;

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <map>
 #include <mutex>
+#include <set>
 #include <condition_variable>
 #include <thread>
 #include <vector>
@@ -112,7 +113,7 @@ public:
     // Returns empty string if the backend does not support streaming transcription.
     std::string get_streaming_transcription_address(const std::string& model_name) const;
 
-    json chat_completion(const json& request);
+    json chat_completion(const json& request, std::atomic<bool>* cancel = nullptr);
     json completion(const json& request);
     json embeddings(const json& request);
     json reranking(const json& request);
@@ -151,6 +152,9 @@ public:
 
     void begin_exclusive();
     void end_exclusive();
+
+    std::set<std::string> snapshot_loaded_models() const;
+    void unload_models_not_in(const std::set<std::string>& keep);
 
     // Test hooks
     void simulate_vram_pressure(double pct);

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -150,7 +150,7 @@ public:
 
     void update_prompt_tokens(const std::string& model_name, int prompt_tokens);
 
-    void begin_exclusive();
+    bool begin_exclusive(std::atomic<bool>* cancel = nullptr);
     void end_exclusive();
 
     std::map<std::string, bool> snapshot_loaded_models() const;

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -149,9 +149,6 @@ public:
 
     void update_prompt_tokens(const std::string& model_name, int prompt_tokens);
 
-    // Exclusive slot gate: while a job engine worker holds the exclusive slot,
-    // every load/inference path on other (httplib) threads queues behind it; the
-    // owner thread passes through. begin/end run on the worker thread.
     void begin_exclusive();
     void end_exclusive();
 
@@ -177,9 +174,6 @@ private:
     bool is_loading_ = false;                    // True when a load operation is in progress
     std::condition_variable load_cv_;            // Signals when load completes
 
-    // Exclusive slot gate (all guarded by load_mutex_). A running exclusive job
-    // sets exclusive_active_ with itself as owner; other threads park on
-    // exclusive_cv_ until it clears.
     bool exclusive_active_ = false;
     std::thread::id exclusive_owner_;
     std::condition_variable exclusive_cv_;

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -34,6 +34,10 @@ namespace lemon {
 // Forward declaration
 class SystemMetricsPlatform;
 
+namespace jobs {
+class JobManager;
+}
+
 struct RouterDispatchResult {
     std::string requested_model;
     std::string selected_model;
@@ -157,6 +161,15 @@ private:
     void handle_log_level(const httplib::Request& req, httplib::Response& res);
     void handle_shutdown(const httplib::Request& req, httplib::Response& res);
     void handle_simulate_vram_pressure(const httplib::Request& req, httplib::Response& res);
+
+    // Generic job-engine endpoint handlers
+    void handle_jobs_create(const httplib::Request& req, httplib::Response& res);
+    void handle_jobs_list(const httplib::Request& req, httplib::Response& res);
+    void handle_jobs_get(const httplib::Request& req, httplib::Response& res);
+    void handle_jobs_pause(const httplib::Request& req, httplib::Response& res);
+    void handle_jobs_interrupt(const httplib::Request& req, httplib::Response& res);
+    void handle_jobs_resume(const httplib::Request& req, httplib::Response& res);
+    void handle_jobs_delete(const httplib::Request& req, httplib::Response& res);
 
     // Backend management endpoint handlers
     void handle_install(const httplib::Request& req, httplib::Response& res);
@@ -308,6 +321,7 @@ private:
     std::unique_ptr<BackendManager> backend_manager_;
     std::unique_ptr<CloudProviderRegistry> cloud_registry_;
     std::unique_ptr<WebSocketServer> websocket_server_;
+    std::unique_ptr<lemon::jobs::JobManager> job_manager_;
 
     std::mutex downloads_mutex_;
     std::map<std::string, std::shared_ptr<DownloadJob>> download_jobs_;

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -114,7 +114,8 @@ public:
         const std::string& body,
         const std::map<std::string, std::string>& headers = {},
         long timeout_seconds = 300,
-        HttpSecurityPolicy policy = HttpSecurityPolicy::ExternalHttpsOnly);
+        HttpSecurityPolicy policy = HttpSecurityPolicy::ExternalHttpsOnly,
+        std::atomic<bool>* cancel_flag = nullptr);
 
     // Multipart form data POST request. Redirects are never followed.
     static HttpResponse post_multipart(

--- a/src/cpp/include/lemon/utils/path_utils.h
+++ b/src/cpp/include/lemon/utils/path_utils.h
@@ -107,5 +107,9 @@ std::string get_runtime_dir();
  */
 std::string get_downloaded_bin_dir();
 
+bool atomic_replace_file(const std::filesystem::path& src,
+                         const std::filesystem::path& dest,
+                         std::error_code& ec);
+
 } // namespace utils
 } // namespace lemon

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -120,7 +120,11 @@ public:
 
     // Pinned status for eviction prevention
     bool is_pinned() const { return pinned_; }
-    void set_pinned(bool pinned) { pinned_ = pinned; }
+    void set_pinned(bool pinned) {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        pinned_ = pinned;
+        recipe_options_.set_option("pinned", pinned);
+    }
 
     // Acquire model for inference, safely recovering from DOWNSIZING/EVICTING if necessary.
     // Blocks if LOADING.
@@ -267,6 +271,7 @@ public:
     // Multi-model support: Model metadata
     void set_model_metadata(const std::string& model_name, const std::string& checkpoint,
                            ModelType type, DeviceType device, const RecipeOptions& recipe_options) {
+        std::lock_guard<std::mutex> lock(state_mutex_);
         model_name_ = model_name;
         checkpoint_ = checkpoint;
         model_type_ = type;
@@ -278,7 +283,10 @@ public:
     std::string get_checkpoint() const { return checkpoint_; }
     ModelType get_model_type() const { return model_type_; }
     DeviceType get_device_type() const { return device_type_; }
-    RecipeOptions get_recipe_options() const { return recipe_options_; }
+    RecipeOptions get_recipe_options() const {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        return recipe_options_;
+    }
     int get_process_id() const { return get_process_handle_snapshot().pid; }
     int get_backend_port() const;
 

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -294,9 +294,6 @@ public:
     // Unload the model and stop the server
     virtual void unload() = 0;
 
-    // Cooperative cancel for an in-flight load: the health-wait loop kills the
-    // spawned subprocess and returns failure when this flag flips true. Cleared
-    // by passing nullptr. Not owned.
     void set_load_cancel_flag(std::atomic<bool>* f) { load_cancel_ = f; }
 
     // Downsize the model on soft idle (e.g., clear KV cache). Returns true if the
@@ -508,7 +505,7 @@ protected:
     bool maintenance_in_progress_;
     long load_duration_ms_;
     bool pinned_ = false;
-    std::atomic<bool>* load_cancel_ = nullptr;  // Not owned; see set_load_cancel_flag
+    std::atomic<bool>* load_cancel_ = nullptr;
 
 private:
     void begin_backend_request(BackendRequestKind kind);

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -123,7 +123,8 @@ public:
     void set_pinned(bool pinned) {
         std::lock_guard<std::mutex> lock(state_mutex_);
         pinned_ = pinned;
-        recipe_options_.set_option("pinned", pinned);
+        if (pinned) recipe_options_.set_option("pinned", true);
+        else recipe_options_.remove_option("pinned");
     }
 
     // Acquire model for inference, safely recovering from DOWNSIZING/EVICTING if necessary.

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -294,6 +294,11 @@ public:
     // Unload the model and stop the server
     virtual void unload() = 0;
 
+    // Cooperative cancel for an in-flight load: the health-wait loop kills the
+    // spawned subprocess and returns failure when this flag flips true. Cleared
+    // by passing nullptr. Not owned.
+    void set_load_cancel_flag(std::atomic<bool>* f) { load_cancel_ = f; }
+
     // Downsize the model on soft idle (e.g., clear KV cache). Returns true if the
     // downsize succeeded (or was a no-op), false if the backend operation failed.
     // The default is a successful no-op: backends that cannot downsize transition
@@ -503,6 +508,7 @@ protected:
     bool maintenance_in_progress_;
     long load_duration_ms_;
     bool pinned_ = false;
+    std::atomic<bool>* load_cancel_ = nullptr;  // Not owned; see set_load_cancel_flag
 
 private:
     void begin_backend_request(BackendRequestKind kind);

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -296,7 +296,8 @@ public:
 
     void set_load_cancel_flag(std::atomic<bool>* f) { load_cancel_ = f; }
 
-    void set_request_cancel_flag(std::atomic<bool>* f) { request_cancel_ = f; }
+    static void set_request_cancel_flag(std::atomic<bool>* f);
+    static std::atomic<bool>* current_request_cancel();
 
     // Downsize the model on soft idle (e.g., clear KV cache). Returns true if the
     // downsize succeeded (or was a no-op), false if the backend operation failed.
@@ -508,7 +509,6 @@ protected:
     long load_duration_ms_;
     bool pinned_ = false;
     std::atomic<bool>* load_cancel_ = nullptr;
-    std::atomic<bool>* request_cancel_ = nullptr;
 
 private:
     void begin_backend_request(BackendRequestKind kind);

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -190,6 +190,14 @@ public:
         return false;
     }
 
+    void rescue_from_eviction() {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        if (state_ == ModelState::EVICTING) {
+            state_ = ModelState::READY;
+            state_cv_.notify_all();
+        }
+    }
+
     void release_inference() {
         std::lock_guard<std::mutex> lock(state_mutex_);
         if (--active_request_count_ == 0) {

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -296,6 +296,8 @@ public:
 
     void set_load_cancel_flag(std::atomic<bool>* f) { load_cancel_ = f; }
 
+    void set_request_cancel_flag(std::atomic<bool>* f) { request_cancel_ = f; }
+
     // Downsize the model on soft idle (e.g., clear KV cache). Returns true if the
     // downsize succeeded (or was a no-op), false if the backend operation failed.
     // The default is a successful no-op: backends that cannot downsize transition
@@ -506,6 +508,7 @@ protected:
     long load_duration_ms_;
     bool pinned_ = false;
     std::atomic<bool>* load_cancel_ = nullptr;
+    std::atomic<bool>* request_cancel_ = nullptr;
 
 private:
     void begin_backend_request(BackendRequestKind kind);

--- a/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
+++ b/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
@@ -554,11 +554,15 @@ json WhisperServer::forward_multipart_audio_request(const std::string& file_path
     // sync with `global_timeout` in config.json (see server.cpp). Hard-coding 300
     // caused long-form audio (~35+ min on slower backends) to fail regardless of
     // the user's configuration.
-    auto res = utils::HttpClient::post_multipart(
-        url,
-        fields,
-        0,
-        utils::HttpSecurityPolicy::TrustedLoopback);
+    utils::HttpResponse res;
+    {
+        std::lock_guard<std::mutex> lock(inference_mutex_);
+        res = utils::HttpClient::post_multipart(
+            url,
+            fields,
+            0,
+            utils::HttpSecurityPolicy::TrustedLoopback);
+    }
 
     LOG(DEBUG, "WhisperServer") << "Response status: " << res.status_code << std::endl;
     LOG(DEBUG, "WhisperServer") << "Response body: " << res.body << std::endl;
@@ -645,11 +649,15 @@ json WhisperServer::forward_multipart_audio_data(const std::string& audio_data,
 
     // See the note on the file-path variant above: 0 inherits the configured
     // global timeout so long transcriptions aren't artificially capped at 300s.
-    auto res = utils::HttpClient::post_multipart(
-        url,
-        fields,
-        0,
-        utils::HttpSecurityPolicy::TrustedLoopback);
+    utils::HttpResponse res;
+    {
+        std::lock_guard<std::mutex> lock(inference_mutex_);
+        res = utils::HttpClient::post_multipart(
+            url,
+            fields,
+            0,
+            utils::HttpSecurityPolicy::TrustedLoopback);
+    }
 
     LOG(DEBUG, "WhisperServer") << "Response status: " << res.status_code << std::endl;
 

--- a/src/cpp/server/eviction_engine.cpp
+++ b/src/cpp/server/eviction_engine.cpp
@@ -58,6 +58,10 @@ void EvictionEngine::evaluate_servers(double current_vram_pct) {
     {
         std::lock_guard<std::mutex> lock(router_->load_mutex_);
 
+        // An exclusive job session owns model residency; auto-eviction and
+        // downsizing would yank models out from under its next step.
+        if (router_->exclusive_active_) return;
+
         auto now = std::chrono::steady_clock::now();
         double threshold = RuntimeConfig::global()->auto_evict_threshold_pct();
         bool pressure_evict = (current_vram_pct >= threshold);
@@ -153,6 +157,7 @@ void EvictionEngine::evaluate_servers(double current_vram_pct) {
         WrappedServer* s = nullptr;
         {
             std::lock_guard<std::mutex> lk(router_->load_mutex_);
+            if (router_->exclusive_active_) break;
             s = router_->find_server_by_model_name(name);
             if (!s || !s->try_begin_downsize()) {
                 continue;  // gone, busy, or no longer idle since phase 1

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -412,6 +412,7 @@ void JobManager::worker_main() {
 
         if (cleanup_only) {
             if (registry_.reconcile_unload) registry_.reconcile_unload(id);
+            if (registry_.discard_exclusive) registry_.discard_exclusive(id);
             std::lock_guard<std::mutex> lock(mutex_);
             jobs_.erase(id);
             controls_.erase(id);
@@ -438,7 +439,10 @@ void JobManager::worker_main() {
             }
         } guard{registry_, id};
 
-        if (!exclusive || guard.begin(&ctrl->cancel)) {
+        bool ready = !exclusive || guard.begin(&ctrl->cancel);
+        if (ready && guard.held && registry_.restore_exclusive)
+            ready = registry_.restore_exclusive(id, &ctrl->cancel);
+        if (ready) {
             execute(id, ctrl);
         } else {
             std::lock_guard<std::mutex> lock(mutex_);
@@ -470,6 +474,7 @@ void JobManager::worker_main() {
         if (terminal && registry_.discard_exclusive) registry_.discard_exclusive(id);
 
         if (ctrl->delete_requested.load()) {
+            if (registry_.discard_exclusive) registry_.discard_exclusive(id);
             std::lock_guard<std::mutex> lock(mutex_);
             jobs_.erase(id);
             controls_.erase(id);

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -359,6 +359,17 @@ bool JobManager::remove(const std::string& id, bool& active_out) {
                           << " (tombstoned; erased after cleanup)" << std::endl;
         return true;
     }
+    if (it->second.status == JobStatus::Paused || it->second.status == JobStatus::Interrupted) {
+        it->second.deleted = true;
+        control_for_locked(id)->delete_requested.store(true);
+        persist_locked();
+        enqueue_locked(id);
+        cv_.notify_all();
+        LOG(INFO, "Jobs") << "delete requested for " << to_string(it->second.status)
+                          << " job " << id << " (tombstoned; erased after reconcile)"
+                          << std::endl;
+        return true;
+    }
     jobs_.erase(id);
     controls_.erase(id);
     order_.erase(std::remove(order_.begin(), order_.end(), id), order_.end());
@@ -373,6 +384,7 @@ void JobManager::worker_main() {
         std::string id;
         std::shared_ptr<Control> ctrl;
         bool exclusive = false;
+        bool cleanup_only = false;
         {
             std::unique_lock<std::mutex> lock(mutex_);
             cv_.wait(lock, [&] { return stop_ || !queue_.empty(); });
@@ -381,15 +393,33 @@ void JobManager::worker_main() {
             id = queue_.front();
             queue_.pop_front();
             auto it = jobs_.find(id);
-            if (it == jobs_.end() || it->second.status != JobStatus::Queued) continue;
+            if (it == jobs_.end()) continue;
             ctrl = control_for_locked(id);
-            it->second.status = JobStatus::Running;
-            if (it->second.started_at.empty()) it->second.started_at = iso_now();
-            active_id_ = id;
-            exclusive = job_needs_exclusive(it->second, registry_);
+            if (it->second.deleted) {
+                cleanup_only = true;
+            } else if (it->second.status != JobStatus::Queued) {
+                continue;
+            } else {
+                it->second.status = JobStatus::Running;
+                if (it->second.started_at.empty()) it->second.started_at = iso_now();
+                active_id_ = id;
+                exclusive = job_needs_exclusive(it->second, registry_);
+                persist_locked();
+                LOG(INFO, "Jobs") << "running job " << id << " from step '" << it->second.cursor
+                                  << "'" << std::endl;
+            }
+        }
+
+        if (cleanup_only) {
+            if (registry_.reconcile_unload) registry_.reconcile_unload(id);
+            std::lock_guard<std::mutex> lock(mutex_);
+            jobs_.erase(id);
+            controls_.erase(id);
+            order_.erase(std::remove(order_.begin(), order_.end(), id), order_.end());
+            queue_.erase(std::remove(queue_.begin(), queue_.end(), id), queue_.end());
             persist_locked();
-            LOG(INFO, "Jobs") << "running job " << id << " from step '" << it->second.cursor << "'"
-                              << std::endl;
+            LOG(INFO, "Jobs") << "erased deleted job " << id << " after reconcile" << std::endl;
+            continue;
         }
 
         struct ExclusiveGuard {
@@ -397,7 +427,7 @@ void JobManager::worker_main() {
             const std::string& id;
             bool held = false;
             bool begin(CancelFlag* cancel) {
-                if (reg.begin_exclusive && !reg.begin_exclusive(cancel)) return false;
+                if (reg.begin_exclusive && !reg.begin_exclusive(id, cancel)) return false;
                 held = true;
                 LOG(INFO, "Jobs") << "job " << id << " acquired exclusive slot" << std::endl;
                 return true;
@@ -421,18 +451,23 @@ void JobManager::worker_main() {
                               << " interrupted while waiting for the exclusive slot" << std::endl;
         }
         bool interrupted = false;
+        bool terminal = false;
         {
             std::lock_guard<std::mutex> lock(mutex_);
             auto it = jobs_.find(id);
-            interrupted = it != jobs_.end() && it->second.status == JobStatus::Interrupted;
+            if (it != jobs_.end()) {
+                interrupted = it->second.status == JobStatus::Interrupted;
+                terminal = is_terminal(it->second.status);
+            }
             active_id_.clear();
         }
 
-        if (guard.held && interrupted && registry_.reconcile_unload) {
-            registry_.reconcile_unload();
-            LOG(INFO, "Jobs") << "job " << id << " interrupted — unloaded resident model(s)"
+        if (interrupted && registry_.reconcile_unload) {
+            registry_.reconcile_unload(id);
+            LOG(INFO, "Jobs") << "job " << id << " interrupted — reconciled job-loaded model(s)"
                               << std::endl;
         }
+        if (terminal && registry_.discard_exclusive) registry_.discard_exclusive(id);
 
         if (ctrl->delete_requested.load()) {
             std::lock_guard<std::mutex> lock(mutex_);

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -347,9 +347,20 @@ void JobManager::worker_main() {
         if (exclusive) guard.begin();
 
         execute(id, ctrl);
+        bool interrupted = false;
         {
             std::lock_guard<std::mutex> lock(mutex_);
+            auto it = jobs_.find(id);
+            interrupted = it != jobs_.end() && it->second.status == JobStatus::Interrupted;
             active_id_.clear();
+        }
+        // An interrupted exclusive job abandons its run mid-way and may have left
+        // a model resident. Unload it while we still own the slot (this worker is
+        // the gate owner, so it passes straight through) before the guard releases.
+        if (exclusive && interrupted && registry_.reconcile_unload) {
+            registry_.reconcile_unload();
+            LOG(INFO, "Jobs") << "job " << id << " interrupted — unloaded resident model(s)"
+                              << std::endl;
         }
     }
 }

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -100,10 +100,19 @@ JobManager::~JobManager() {
 }
 
 void JobManager::load_from_disk() {
-    std::ifstream in(lemon::utils::path_from_utf8(storage_path_));
-    if (!in) return;
+    json doc;
+    {
+        std::ifstream in(lemon::utils::path_from_utf8(storage_path_));
+        if (!in) return;
+        try {
+            doc = json::parse(in);
+        } catch (const std::exception& e) {
+            LOG(WARNING, "Jobs") << "Could not load " << storage_path_ << ": " << e.what()
+                                 << std::endl;
+            return;
+        }
+    }
     try {
-        json doc = json::parse(in);
         int loaded = 0, recovered = 0, dropped = 0;
         for (const auto& jj : doc.value("jobs", json::array())) {
             Job job = Job::from_json(jj);
@@ -143,8 +152,8 @@ void JobManager::load_from_disk() {
             persist_locked();
         }
     } catch (const std::exception& e) {
-        LOG(WARNING, "Jobs") << "Could not load " << storage_path_ << ": " << e.what()
-                             << std::endl;
+        LOG(WARNING, "Jobs") << "Could not restore jobs from " << storage_path_ << ": "
+                             << e.what() << std::endl;
     }
 }
 

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -108,6 +108,10 @@ void JobManager::load_from_disk() {
         for (const auto& jj : doc.value("jobs", json::array())) {
             Job job = Job::from_json(jj);
             if (job.id.empty()) continue;
+            if (job.deleted) {
+                LOG(INFO, "Jobs") << "dropping tombstoned job " << job.id << std::endl;
+                continue;
+            }
             if (job.status == JobStatus::Running || job.status == JobStatus::Queued) {
                 job.status = JobStatus::Interrupted;
                 job.error = "server restarted while the job was active";
@@ -186,6 +190,21 @@ std::string JobManager::create(const std::string& name, std::vector<StepRecord> 
 
     std::lock_guard<std::mutex> lock(mutex_);
 
+    if (order_.size() >= kMaxJobs) {
+        bool evictable = false;
+        for (const auto& existing : order_) {
+            auto jit = jobs_.find(existing);
+            if (jit != jobs_.end() && is_terminal(jit->second.status)) {
+                evictable = true;
+                break;
+            }
+        }
+        if (!evictable)
+            throw JobError(429, "job limit (" + std::to_string(kMaxJobs)
+                                + ") reached and every existing job is still active or resumable; "
+                                  "delete a job first");
+    }
+
     Job job;
     char stamp[24];
     const std::time_t t = std::time(nullptr);
@@ -242,7 +261,7 @@ json JobManager::list() const {
     json out = json::array();
     for (const auto& id : order_) {
         auto it = jobs_.find(id);
-        if (it != jobs_.end()) out.push_back(it->second.to_summary_json());
+        if (it != jobs_.end() && !it->second.deleted) out.push_back(it->second.to_summary_json());
     }
     return out;
 }
@@ -250,16 +269,22 @@ json JobManager::list() const {
 std::optional<json> JobManager::get(const std::string& id) const {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = jobs_.find(id);
-    if (it == jobs_.end()) return std::nullopt;
+    if (it == jobs_.end() || it->second.deleted) return std::nullopt;
     return it->second.to_json();
 }
 
 bool JobManager::pause(const std::string& id) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = jobs_.find(id);
-    if (it == jobs_.end()) return false;
-    if (it->second.status != JobStatus::Running && it->second.status != JobStatus::Queued)
-        return false;
+    if (it == jobs_.end() || it->second.deleted) return false;
+    if (it->second.status == JobStatus::Queued) {
+        queue_.erase(std::remove(queue_.begin(), queue_.end(), id), queue_.end());
+        it->second.status = JobStatus::Paused;
+        persist_locked();
+        LOG(INFO, "Jobs") << "paused queued job " << id << std::endl;
+        return true;
+    }
+    if (it->second.status != JobStatus::Running) return false;
     control_for_locked(id)->pause_requested.store(true);
     LOG(INFO, "Jobs") << "pause requested for job " << id << " (takes effect at next step)"
                       << std::endl;
@@ -269,9 +294,15 @@ bool JobManager::pause(const std::string& id) {
 bool JobManager::interrupt(const std::string& id) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = jobs_.find(id);
-    if (it == jobs_.end()) return false;
-    if (it->second.status != JobStatus::Running && it->second.status != JobStatus::Queued)
-        return false;
+    if (it == jobs_.end() || it->second.deleted) return false;
+    if (it->second.status == JobStatus::Queued) {
+        queue_.erase(std::remove(queue_.begin(), queue_.end(), id), queue_.end());
+        it->second.status = JobStatus::Interrupted;
+        persist_locked();
+        LOG(INFO, "Jobs") << "interrupted queued job " << id << std::endl;
+        return true;
+    }
+    if (it->second.status != JobStatus::Running) return false;
     auto ctrl = control_for_locked(id);
     ctrl->interrupt_requested.store(true);
     ctrl->cancel.store(true);
@@ -282,7 +313,7 @@ bool JobManager::interrupt(const std::string& id) {
 bool JobManager::resume(const std::string& id) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = jobs_.find(id);
-    if (it == jobs_.end()) return false;
+    if (it == jobs_.end() || it->second.deleted) return false;
     if (it->second.status != JobStatus::Paused && it->second.status != JobStatus::Interrupted)
         return false;
     auto ctrl = control_for_locked(id);
@@ -303,15 +334,17 @@ bool JobManager::remove(const std::string& id, bool& active_out) {
     std::lock_guard<std::mutex> lock(mutex_);
     active_out = false;
     auto it = jobs_.find(id);
-    if (it == jobs_.end()) return false;
+    if (it == jobs_.end() || it->second.deleted) return false;
     if (id == active_id_) {
         active_out = true;
+        it->second.deleted = true;
+        persist_locked();
         auto ctrl = control_for_locked(id);
         ctrl->interrupt_requested.store(true);
         ctrl->cancel.store(true);
         ctrl->delete_requested.store(true);
         LOG(INFO, "Jobs") << "delete requested for active job " << id
-                          << " (erased after cleanup)" << std::endl;
+                          << " (tombstoned; erased after cleanup)" << std::endl;
         return true;
     }
     jobs_.erase(id);
@@ -560,10 +593,12 @@ void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& 
                                        << s->op << "): " << run_error << std::endl;
                     return;
                 } else if (s->on_fail == kOnFailContinue) {
+                    s->failure_handled = true;
                     job.cursor = next_in_list(job, s->id);
                     LOG(WARNING, "Jobs") << "job " << id << " step '" << step_id
                                          << "' failed (" << run_error << "), continuing" << std::endl;
                 } else {
+                    s->failure_handled = true;
                     job.cursor = s->on_fail;
                     LOG(WARNING, "Jobs") << "job " << id << " step '" << step_id << "' failed ("
                                          << run_error << "), branching to '" << s->on_fail << "'"

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -104,11 +104,12 @@ void JobManager::load_from_disk() {
     if (!in) return;
     try {
         json doc = json::parse(in);
-        int loaded = 0, recovered = 0;
+        int loaded = 0, recovered = 0, dropped = 0;
         for (const auto& jj : doc.value("jobs", json::array())) {
             Job job = Job::from_json(jj);
             if (job.id.empty()) continue;
             if (job.deleted) {
+                dropped++;
                 LOG(INFO, "Jobs") << "dropping tombstoned job " << job.id << std::endl;
                 continue;
             }
@@ -137,6 +138,10 @@ void JobManager::load_from_disk() {
         if (loaded)
             LOG(INFO, "Jobs") << "loaded " << loaded << " job(s) from " << storage_path_ << " ("
                               << recovered << " recovered as interrupted)" << std::endl;
+        if (dropped) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            persist_locked();
+        }
     } catch (const std::exception& e) {
         LOG(WARNING, "Jobs") << "Could not load " << storage_path_ << ": " << e.what()
                              << std::endl;
@@ -190,20 +195,18 @@ std::string JobManager::create(const std::string& name, std::vector<StepRecord> 
 
     std::lock_guard<std::mutex> lock(mutex_);
 
-    if (order_.size() >= kMaxJobs) {
-        bool evictable = false;
-        for (const auto& existing : order_) {
-            auto jit = jobs_.find(existing);
-            if (jit != jobs_.end() && is_terminal(jit->second.status)) {
-                evictable = true;
-                break;
-            }
-        }
-        if (!evictable)
-            throw JobError(429, "job limit (" + std::to_string(kMaxJobs)
-                                + ") reached and every existing job is still active or resumable; "
-                                  "delete a job first");
+    size_t live = 0;
+    bool evictable = false;
+    for (const auto& existing : order_) {
+        auto jit = jobs_.find(existing);
+        if (jit == jobs_.end() || jit->second.deleted) continue;
+        live++;
+        if (is_terminal(jit->second.status)) evictable = true;
     }
+    if (live >= kMaxJobs && !evictable)
+        throw JobError(429, "job limit (" + std::to_string(kMaxJobs)
+                            + ") reached and every existing job is still active or resumable; "
+                              "delete a job first");
 
     Job job;
     char stamp[24];
@@ -384,19 +387,30 @@ void JobManager::worker_main() {
             const OpRegistry& reg;
             const std::string& id;
             bool held = false;
-            void begin() {
-                if (reg.begin_exclusive) reg.begin_exclusive();
+            bool begin(CancelFlag* cancel) {
+                if (reg.begin_exclusive && !reg.begin_exclusive(cancel)) return false;
                 held = true;
                 LOG(INFO, "Jobs") << "job " << id << " acquired exclusive slot" << std::endl;
+                return true;
             }
             ~ExclusiveGuard() {
                 if (held && reg.end_exclusive) reg.end_exclusive();
                 if (held) LOG(INFO, "Jobs") << "job " << id << " released exclusive slot" << std::endl;
             }
         } guard{registry_, id};
-        if (exclusive) guard.begin();
 
-        execute(id, ctrl);
+        if (!exclusive || guard.begin(&ctrl->cancel)) {
+            execute(id, ctrl);
+        } else {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = jobs_.find(id);
+            if (it != jobs_.end()) {
+                it->second.status = JobStatus::Interrupted;
+                persist_locked();
+            }
+            LOG(INFO, "Jobs") << "job " << id
+                              << " interrupted while waiting for the exclusive slot" << std::endl;
+        }
         bool interrupted = false;
         {
             std::lock_guard<std::mutex> lock(mutex_);
@@ -405,7 +419,7 @@ void JobManager::worker_main() {
             active_id_.clear();
         }
 
-        if (exclusive && interrupted && registry_.reconcile_unload) {
+        if (guard.held && interrupted && registry_.reconcile_unload) {
             registry_.reconcile_unload();
             LOG(INFO, "Jobs") << "job " << id << " interrupted — unloaded resident model(s)"
                               << std::endl;

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -53,8 +53,6 @@ int step_index(const Job& job, const std::string& id) {
     return -1;
 }
 
-// The step to run after `from` completes: first matching branch case, else
-// on_done, else the next step in list order ("" when none remains).
 std::string next_after_success(const Job& job, const StepRecord& from) {
     for (const Case& c : from.branch)
         if (eval_condition(c.when, job.context)) return c.goto_id;
@@ -78,7 +76,7 @@ bool job_needs_exclusive(const Job& job, const OpRegistry& registry) {
     return false;
 }
 
-}  // namespace
+}
 
 JobManager::JobManager(std::string cache_dir, OpRegistry registry)
     : storage_path_((fs::path(cache_dir) / "jobs.json").string()),
@@ -327,9 +325,6 @@ void JobManager::worker_main() {
                               << std::endl;
         }
 
-        // Hold the Router's exclusive slot for the whole job so normal traffic
-        // queues behind it. begin/end run on this worker thread (the gate's
-        // owner). The guard fires end_exclusive exactly once, on every exit path.
         struct ExclusiveGuard {
             const OpRegistry& reg;
             const std::string& id;
@@ -354,9 +349,7 @@ void JobManager::worker_main() {
             interrupted = it != jobs_.end() && it->second.status == JobStatus::Interrupted;
             active_id_.clear();
         }
-        // An interrupted exclusive job abandons its run mid-way and may have left
-        // a model resident. Unload it while we still own the slot (this worker is
-        // the gate owner, so it passes straight through) before the guard releases.
+
         if (exclusive && interrupted && registry_.reconcile_unload) {
             registry_.reconcile_unload();
             LOG(INFO, "Jobs") << "job " << id << " interrupted — unloaded resident model(s)"
@@ -548,5 +541,5 @@ void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& 
     }
 }
 
-}  // namespace jobs
-}  // namespace lemon
+}
+}

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -147,9 +147,19 @@ void JobManager::persist_locked() {
     }
     json doc = {{"version", 1}, {"jobs", arr}};
     const std::string tmp = storage_path_ + ".tmp";
+    bool write_ok = false;
     {
         std::ofstream out(lemon::utils::path_from_utf8(tmp), std::ios::trunc);
         out << doc.dump(2);
+        out.flush();
+        write_ok = out.good();
+    }
+    if (!write_ok) {
+        LOG(WARNING, "Jobs") << "Could not write jobs to " << tmp
+                             << " (keeping previous state on disk)" << std::endl;
+        std::error_code rm;
+        fs::remove(lemon::utils::path_from_utf8(tmp), rm);
+        return;
     }
     std::error_code ec;
     lemon::utils::atomic_replace_file(lemon::utils::path_from_utf8(tmp),

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -152,7 +152,8 @@ void JobManager::persist_locked() {
         out << doc.dump(2);
     }
     std::error_code ec;
-    fs::rename(lemon::utils::path_from_utf8(tmp), lemon::utils::path_from_utf8(storage_path_), ec);
+    lemon::utils::atomic_replace_file(lemon::utils::path_from_utf8(tmp),
+                                      lemon::utils::path_from_utf8(storage_path_), ec);
     if (ec) LOG(WARNING, "Jobs") << "Could not persist jobs: " << ec.message() << std::endl;
 }
 

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -97,6 +97,7 @@ void JobManager::load_from_disk() {
     if (!in) return;
     try {
         json doc = json::parse(in);
+        int loaded = 0, recovered = 0;
         for (const auto& jj : doc.value("jobs", json::array())) {
             Job job = Job::from_json(jj);
             if (job.id.empty()) continue;
@@ -105,12 +106,20 @@ void JobManager::load_from_disk() {
                 job.error = "server restarted while the job was active";
                 if (StepRecord* s = find_step(job, job.cursor))
                     if (s->status == StepStatus::Running) s->status = StepStatus::Pending;
+                recovered++;
+                LOG(WARNING, "Jobs") << "recovered active job " << job.id
+                                     << " as interrupted (resumable at step '" << job.cursor
+                                     << "')" << std::endl;
             }
             const std::string id = job.id;
             controls_[id] = std::make_shared<Control>();
             order_.push_back(id);
             jobs_.emplace(id, std::move(job));
+            loaded++;
         }
+        if (loaded)
+            LOG(INFO, "Jobs") << "loaded " << loaded << " job(s) from " << storage_path_ << " ("
+                              << recovered << " recovered as interrupted)" << std::endl;
     } catch (const std::exception& e) {
         LOG(WARNING, "Jobs") << "Could not load " << storage_path_ << ": " << e.what()
                              << std::endl;
@@ -175,6 +184,7 @@ std::string JobManager::create(const std::string& name, std::vector<StepRecord> 
     job.created_at = iso_now();
 
     const std::string id = job.id;
+    const size_t n_steps = job.steps.size();
     order_.insert(order_.begin(), id);
     controls_[id] = std::make_shared<Control>();
     jobs_.emplace(id, std::move(job));
@@ -198,6 +208,8 @@ std::string JobManager::create(const std::string& name, std::vector<StepRecord> 
     enqueue_locked(id);
     persist_locked();
     cv_.notify_all();
+    LOG(INFO, "Jobs") << "created job " << id << " '" << name << "' (" << n_steps << " steps)"
+                      << std::endl;
     return id;
 }
 
@@ -225,6 +237,8 @@ bool JobManager::pause(const std::string& id) {
     if (it->second.status != JobStatus::Running && it->second.status != JobStatus::Queued)
         return false;
     control_for_locked(id)->pause_requested.store(true);
+    LOG(INFO, "Jobs") << "pause requested for job " << id << " (takes effect at next step)"
+                      << std::endl;
     return true;
 }
 
@@ -237,6 +251,7 @@ bool JobManager::interrupt(const std::string& id) {
     auto ctrl = control_for_locked(id);
     ctrl->interrupt_requested.store(true);
     ctrl->cancel.store(true);
+    LOG(INFO, "Jobs") << "interrupt requested for job " << id << std::endl;
     return true;
 }
 
@@ -255,6 +270,8 @@ bool JobManager::resume(const std::string& id) {
     enqueue_locked(id);
     persist_locked();
     cv_.notify_all();
+    LOG(INFO, "Jobs") << "resumed job " << id << " at step '" << it->second.cursor << "'"
+                      << std::endl;
     return true;
 }
 
@@ -274,6 +291,7 @@ bool JobManager::remove(const std::string& id, bool& active_out) {
     order_.erase(std::remove(order_.begin(), order_.end(), id), order_.end());
     queue_.erase(std::remove(queue_.begin(), queue_.end(), id), queue_.end());
     persist_locked();
+    LOG(INFO, "Jobs") << "deleted job " << id << (active_out ? " (was active)" : "") << std::endl;
     return true;
 }
 
@@ -295,6 +313,8 @@ void JobManager::worker_main() {
             if (it->second.started_at.empty()) it->second.started_at = iso_now();
             active_id_ = id;
             persist_locked();
+            LOG(INFO, "Jobs") << "running job " << id << " from step '" << it->second.cursor << "'"
+                              << std::endl;
         }
         execute(id, ctrl);
         {
@@ -323,17 +343,22 @@ void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& 
                 if (StepRecord* s = find_step(job, job.cursor)) s->status = StepStatus::Pending;
                 job.status = JobStatus::Interrupted;
                 persist_locked();
+                LOG(INFO, "Jobs") << "job " << id << " interrupted at step '" << job.cursor << "'"
+                                  << std::endl;
                 return;
             }
             if (ctrl->pause_requested.load()) {
                 job.status = JobStatus::Paused;
                 persist_locked();
+                LOG(INFO, "Jobs") << "job " << id << " paused before step '" << job.cursor << "'"
+                                  << std::endl;
                 return;
             }
             if (job.cursor.empty()) {
                 job.status = JobStatus::Completed;
                 if (job.finished_at.empty()) job.finished_at = iso_now();
                 persist_locked();
+                LOG(INFO, "Jobs") << "job " << id << " completed" << std::endl;
                 return;
             }
 
@@ -360,6 +385,8 @@ void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& 
             }
             if (skip) {
                 s->status = StepStatus::Skipped;
+                LOG(DEBUG, "Jobs") << "job " << id << " step '" << s->id
+                                   << "' skipped (when=false)" << std::endl;
                 job.cursor = next_in_list(job, s->id);
                 persist_locked();
                 continue;
@@ -393,6 +420,8 @@ void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& 
             context_snapshot = job.context;
             ctrl->cancel.store(false);
             persist_locked();
+            LOG(DEBUG, "Jobs") << "job " << id << " running step '" << s->id << "' (op " << s->op
+                               << ")" << std::endl;
         }
 
         json output;
@@ -422,6 +451,8 @@ void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& 
                 s->error.clear();
                 job.status = JobStatus::Interrupted;
                 persist_locked();
+                LOG(INFO, "Jobs") << "job " << id << " interrupted during step '" << step_id << "'"
+                                  << std::endl;
                 return;
             }
 
@@ -435,6 +466,9 @@ void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& 
                     const std::string next = next_after_success(job, *s);
                     s->status = StepStatus::Completed;
                     job.cursor = next;
+                    LOG(DEBUG, "Jobs") << "job " << id << " step '" << step_id << "' completed in "
+                                       << ms << "ms -> "
+                                       << (next.empty() ? "end" : "'" + next + "'") << std::endl;
                 } catch (const std::exception& e) {
                     s->status = StepStatus::Failed;
                     s->error = e.what();
@@ -442,6 +476,8 @@ void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& 
                     job.error = e.what();
                     job.finished_at = iso_now();
                     persist_locked();
+                    LOG(ERROR, "Jobs") << "job " << id << " failed at step '" << step_id
+                                       << "' (extract/branch): " << e.what() << std::endl;
                     return;
                 }
             } else {
@@ -452,11 +488,18 @@ void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& 
                     job.error = run_error;
                     job.finished_at = iso_now();
                     persist_locked();
+                    LOG(ERROR, "Jobs") << "job " << id << " failed at step '" << step_id << "' (op "
+                                       << s->op << "): " << run_error << std::endl;
                     return;
                 } else if (s->on_fail == kOnFailContinue) {
                     job.cursor = next_in_list(job, s->id);
+                    LOG(WARNING, "Jobs") << "job " << id << " step '" << step_id
+                                         << "' failed (" << run_error << "), continuing" << std::endl;
                 } else {
                     job.cursor = s->on_fail;
+                    LOG(WARNING, "Jobs") << "job " << id << " step '" << step_id << "' failed ("
+                                         << run_error << "), branching to '" << s->on_fail << "'"
+                                         << std::endl;
                 }
             }
             persist_locked();

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -70,6 +70,14 @@ std::string next_in_list(const Job& job, const std::string& id) {
     return "";
 }
 
+bool job_needs_exclusive(const Job& job, const OpRegistry& registry) {
+    for (const auto& s : job.steps) {
+        const OpHandler* h = registry.find(s.op);
+        if (h && h->exclusive) return true;
+    }
+    return false;
+}
+
 }  // namespace
 
 JobManager::JobManager(std::string cache_dir, OpRegistry registry)
@@ -299,6 +307,7 @@ void JobManager::worker_main() {
     while (true) {
         std::string id;
         std::shared_ptr<Control> ctrl;
+        bool exclusive = false;
         {
             std::unique_lock<std::mutex> lock(mutex_);
             cv_.wait(lock, [&] { return stop_ || !queue_.empty(); });
@@ -312,10 +321,31 @@ void JobManager::worker_main() {
             it->second.status = JobStatus::Running;
             if (it->second.started_at.empty()) it->second.started_at = iso_now();
             active_id_ = id;
+            exclusive = job_needs_exclusive(it->second, registry_);
             persist_locked();
             LOG(INFO, "Jobs") << "running job " << id << " from step '" << it->second.cursor << "'"
                               << std::endl;
         }
+
+        // Hold the Router's exclusive slot for the whole job so normal traffic
+        // queues behind it. begin/end run on this worker thread (the gate's
+        // owner). The guard fires end_exclusive exactly once, on every exit path.
+        struct ExclusiveGuard {
+            const OpRegistry& reg;
+            const std::string& id;
+            bool held = false;
+            void begin() {
+                if (reg.begin_exclusive) reg.begin_exclusive();
+                held = true;
+                LOG(INFO, "Jobs") << "job " << id << " acquired exclusive slot" << std::endl;
+            }
+            ~ExclusiveGuard() {
+                if (held && reg.end_exclusive) reg.end_exclusive();
+                if (held) LOG(INFO, "Jobs") << "job " << id << " released exclusive slot" << std::endl;
+            }
+        } guard{registry_, id};
+        if (exclusive) guard.begin();
+
         execute(id, ctrl);
         {
             std::lock_guard<std::mutex> lock(mutex_);

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <ctime>
 #include <filesystem>
 #include <fstream>
@@ -118,6 +119,12 @@ void JobManager::load_from_disk() {
                                      << "')" << std::endl;
             }
             const std::string id = job.id;
+            const size_t dash = id.rfind('-');
+            if (dash != std::string::npos && dash + 1 < id.size()) {
+                char* end = nullptr;
+                const unsigned long long suffix = std::strtoull(id.c_str() + dash + 1, &end, 10);
+                if (end && *end == '\0' && suffix > id_counter_) id_counter_ = suffix;
+            }
             controls_[id] = std::make_shared<Control>();
             order_.push_back(id);
             jobs_.emplace(id, std::move(job));
@@ -291,13 +298,17 @@ bool JobManager::remove(const std::string& id, bool& active_out) {
         auto ctrl = control_for_locked(id);
         ctrl->interrupt_requested.store(true);
         ctrl->cancel.store(true);
+        ctrl->delete_requested.store(true);
+        LOG(INFO, "Jobs") << "delete requested for active job " << id
+                          << " (erased after cleanup)" << std::endl;
+        return true;
     }
     jobs_.erase(id);
     controls_.erase(id);
     order_.erase(std::remove(order_.begin(), order_.end(), id), order_.end());
     queue_.erase(std::remove(queue_.begin(), queue_.end(), id), queue_.end());
     persist_locked();
-    LOG(INFO, "Jobs") << "deleted job " << id << (active_out ? " (was active)" : "") << std::endl;
+    LOG(INFO, "Jobs") << "deleted job " << id << std::endl;
     return true;
 }
 
@@ -355,6 +366,16 @@ void JobManager::worker_main() {
             LOG(INFO, "Jobs") << "job " << id << " interrupted — unloaded resident model(s)"
                               << std::endl;
         }
+
+        if (ctrl->delete_requested.load()) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            jobs_.erase(id);
+            controls_.erase(id);
+            order_.erase(std::remove(order_.begin(), order_.end(), id), order_.end());
+            queue_.erase(std::remove(queue_.begin(), queue_.end(), id), queue_.end());
+            persist_locked();
+            LOG(INFO, "Jobs") << "erased deleted job " << id << " after cleanup" << std::endl;
+        }
     }
 }
 
@@ -390,6 +411,8 @@ void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& 
             }
             if (job.cursor.empty()) {
                 job.status = JobStatus::Completed;
+                for (auto& st : job.steps)
+                    if (st.status == StepStatus::Pending) st.status = StepStatus::Skipped;
                 if (job.finished_at.empty()) job.finished_at = iso_now();
                 persist_locked();
                 LOG(INFO, "Jobs") << "job " << id << " completed" << std::endl;

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -1,0 +1,468 @@
+#include "lemon/jobs/job_manager.h"
+
+#include "lemon/jobs/job_expr.h"
+#include "lemon/jobs/job_graph.h"
+#include "lemon/utils/path_utils.h"
+
+#include <lemon/utils/aixlog.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+
+namespace fs = std::filesystem;
+
+namespace lemon {
+namespace jobs {
+
+namespace {
+
+constexpr size_t kMaxJobs = 50;
+
+std::string iso_now() {
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm_utc{};
+#ifdef _WIN32
+    gmtime_s(&tm_utc, &t);
+#else
+    gmtime_r(&t, &tm_utc);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm_utc);
+    return buf;
+}
+
+bool is_terminal(JobStatus s) {
+    return s == JobStatus::Completed || s == JobStatus::Failed;
+}
+
+StepRecord* find_step(Job& job, const std::string& id) {
+    for (auto& s : job.steps)
+        if (s.id == id) return &s;
+    return nullptr;
+}
+
+int step_index(const Job& job, const std::string& id) {
+    for (int i = 0; i < (int)job.steps.size(); ++i)
+        if (job.steps[i].id == id) return i;
+    return -1;
+}
+
+// The step to run after `from` completes: first matching branch case, else
+// on_done, else the next step in list order ("" when none remains).
+std::string next_after_success(const Job& job, const StepRecord& from) {
+    for (const Case& c : from.branch)
+        if (eval_condition(c.when, job.context)) return c.goto_id;
+    if (!from.on_done.empty()) return from.on_done;
+    const int idx = step_index(job, from.id);
+    if (idx >= 0 && idx + 1 < (int)job.steps.size()) return job.steps[idx + 1].id;
+    return "";
+}
+
+std::string next_in_list(const Job& job, const std::string& id) {
+    const int idx = step_index(job, id);
+    if (idx >= 0 && idx + 1 < (int)job.steps.size()) return job.steps[idx + 1].id;
+    return "";
+}
+
+}  // namespace
+
+JobManager::JobManager(std::string cache_dir, OpRegistry registry)
+    : storage_path_((fs::path(cache_dir) / "jobs.json").string()),
+      registry_(std::move(registry)) {
+    load_from_disk();
+    worker_ = std::thread(&JobManager::worker_main, this);
+}
+
+JobManager::~JobManager() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stop_ = true;
+        for (auto& kv : controls_) {
+            kv.second->interrupt_requested.store(true);
+            kv.second->cancel.store(true);
+        }
+    }
+    cv_.notify_all();
+    if (worker_.joinable()) worker_.join();
+}
+
+void JobManager::load_from_disk() {
+    std::ifstream in(lemon::utils::path_from_utf8(storage_path_));
+    if (!in) return;
+    try {
+        json doc = json::parse(in);
+        for (const auto& jj : doc.value("jobs", json::array())) {
+            Job job = Job::from_json(jj);
+            if (job.id.empty()) continue;
+            if (job.status == JobStatus::Running || job.status == JobStatus::Queued) {
+                job.status = JobStatus::Interrupted;
+                job.error = "server restarted while the job was active";
+                if (StepRecord* s = find_step(job, job.cursor))
+                    if (s->status == StepStatus::Running) s->status = StepStatus::Pending;
+            }
+            const std::string id = job.id;
+            controls_[id] = std::make_shared<Control>();
+            order_.push_back(id);
+            jobs_.emplace(id, std::move(job));
+        }
+    } catch (const std::exception& e) {
+        LOG(WARNING, "Jobs") << "Could not load " << storage_path_ << ": " << e.what()
+                             << std::endl;
+    }
+}
+
+void JobManager::persist_locked() {
+    json arr = json::array();
+    for (const auto& id : order_) {
+        auto it = jobs_.find(id);
+        if (it != jobs_.end()) arr.push_back(it->second.to_json());
+    }
+    json doc = {{"version", 1}, {"jobs", arr}};
+    const std::string tmp = storage_path_ + ".tmp";
+    {
+        std::ofstream out(lemon::utils::path_from_utf8(tmp), std::ios::trunc);
+        out << doc.dump(2);
+    }
+    std::error_code ec;
+    fs::rename(lemon::utils::path_from_utf8(tmp), lemon::utils::path_from_utf8(storage_path_), ec);
+    if (ec) LOG(WARNING, "Jobs") << "Could not persist jobs: " << ec.message() << std::endl;
+}
+
+void JobManager::enqueue_locked(const std::string& id) {
+    queue_.push_back(id);
+}
+
+std::shared_ptr<JobManager::Control> JobManager::control_for_locked(const std::string& id) {
+    auto it = controls_.find(id);
+    if (it != controls_.end()) return it->second;
+    auto ctrl = std::make_shared<Control>();
+    controls_[id] = ctrl;
+    return ctrl;
+}
+
+std::string JobManager::create(const std::string& name, std::vector<StepRecord> steps,
+                               json inputs) {
+    const std::string err = validate_steps(steps, registry_.names());
+    if (!err.empty()) throw JobError(400, err);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    Job job;
+    char stamp[24];
+    const std::time_t t = std::time(nullptr);
+    std::tm tm_utc{};
+#ifdef _WIN32
+    gmtime_s(&tm_utc, &t);
+#else
+    gmtime_r(&t, &tm_utc);
+#endif
+    std::strftime(stamp, sizeof(stamp), "%Y%m%d-%H%M%S", &tm_utc);
+    char suffix[16];
+    std::snprintf(suffix, sizeof(suffix), "%06llu", (unsigned long long)(++id_counter_));
+    job.id = std::string("job-") + stamp + "-" + suffix;
+    job.name = name;
+    job.status = JobStatus::Queued;
+    job.inputs = inputs.is_null() ? json::object() : inputs;
+    job.context = {{"inputs", job.inputs}};
+    job.steps = std::move(steps);
+    job.cursor = job.steps.front().id;
+    job.created_at = iso_now();
+
+    const std::string id = job.id;
+    order_.insert(order_.begin(), id);
+    controls_[id] = std::make_shared<Control>();
+    jobs_.emplace(id, std::move(job));
+
+    while (order_.size() > kMaxJobs) {
+        bool evicted = false;
+        for (auto rit = order_.rbegin(); rit != order_.rend(); ++rit) {
+            auto jit = jobs_.find(*rit);
+            if (jit != jobs_.end() && is_terminal(jit->second.status)) {
+                const std::string victim = *rit;
+                jobs_.erase(victim);
+                controls_.erase(victim);
+                order_.erase(std::next(rit).base());
+                evicted = true;
+                break;
+            }
+        }
+        if (!evicted) break;
+    }
+
+    enqueue_locked(id);
+    persist_locked();
+    cv_.notify_all();
+    return id;
+}
+
+json JobManager::list() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    json out = json::array();
+    for (const auto& id : order_) {
+        auto it = jobs_.find(id);
+        if (it != jobs_.end()) out.push_back(it->second.to_summary_json());
+    }
+    return out;
+}
+
+std::optional<json> JobManager::get(const std::string& id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = jobs_.find(id);
+    if (it == jobs_.end()) return std::nullopt;
+    return it->second.to_json();
+}
+
+bool JobManager::pause(const std::string& id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = jobs_.find(id);
+    if (it == jobs_.end()) return false;
+    if (it->second.status != JobStatus::Running && it->second.status != JobStatus::Queued)
+        return false;
+    control_for_locked(id)->pause_requested.store(true);
+    return true;
+}
+
+bool JobManager::interrupt(const std::string& id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = jobs_.find(id);
+    if (it == jobs_.end()) return false;
+    if (it->second.status != JobStatus::Running && it->second.status != JobStatus::Queued)
+        return false;
+    auto ctrl = control_for_locked(id);
+    ctrl->interrupt_requested.store(true);
+    ctrl->cancel.store(true);
+    return true;
+}
+
+bool JobManager::resume(const std::string& id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = jobs_.find(id);
+    if (it == jobs_.end()) return false;
+    if (it->second.status != JobStatus::Paused && it->second.status != JobStatus::Interrupted)
+        return false;
+    auto ctrl = control_for_locked(id);
+    ctrl->pause_requested.store(false);
+    ctrl->interrupt_requested.store(false);
+    ctrl->cancel.store(false);
+    it->second.status = JobStatus::Queued;
+    it->second.error.clear();
+    enqueue_locked(id);
+    persist_locked();
+    cv_.notify_all();
+    return true;
+}
+
+bool JobManager::remove(const std::string& id, bool& active_out) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    active_out = false;
+    auto it = jobs_.find(id);
+    if (it == jobs_.end()) return false;
+    if (id == active_id_) {
+        active_out = true;
+        auto ctrl = control_for_locked(id);
+        ctrl->interrupt_requested.store(true);
+        ctrl->cancel.store(true);
+    }
+    jobs_.erase(id);
+    controls_.erase(id);
+    order_.erase(std::remove(order_.begin(), order_.end(), id), order_.end());
+    queue_.erase(std::remove(queue_.begin(), queue_.end(), id), queue_.end());
+    persist_locked();
+    return true;
+}
+
+void JobManager::worker_main() {
+    while (true) {
+        std::string id;
+        std::shared_ptr<Control> ctrl;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait(lock, [&] { return stop_ || !queue_.empty(); });
+            if (stop_ && queue_.empty()) return;
+            if (queue_.empty()) continue;
+            id = queue_.front();
+            queue_.pop_front();
+            auto it = jobs_.find(id);
+            if (it == jobs_.end() || it->second.status != JobStatus::Queued) continue;
+            ctrl = control_for_locked(id);
+            it->second.status = JobStatus::Running;
+            if (it->second.started_at.empty()) it->second.started_at = iso_now();
+            active_id_ = id;
+            persist_locked();
+        }
+        execute(id, ctrl);
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            active_id_.clear();
+        }
+    }
+}
+
+void JobManager::execute(const std::string& id, const std::shared_ptr<Control>& ctrl) {
+    using clock = std::chrono::steady_clock;
+
+    while (true) {
+        json params;
+        json context_snapshot;
+        const OpHandler* handler = nullptr;
+        std::string step_id;
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = jobs_.find(id);
+            if (it == jobs_.end()) return;
+            Job& job = it->second;
+
+            if (ctrl->interrupt_requested.load()) {
+                if (StepRecord* s = find_step(job, job.cursor)) s->status = StepStatus::Pending;
+                job.status = JobStatus::Interrupted;
+                persist_locked();
+                return;
+            }
+            if (ctrl->pause_requested.load()) {
+                job.status = JobStatus::Paused;
+                persist_locked();
+                return;
+            }
+            if (job.cursor.empty()) {
+                job.status = JobStatus::Completed;
+                if (job.finished_at.empty()) job.finished_at = iso_now();
+                persist_locked();
+                return;
+            }
+
+            StepRecord* s = find_step(job, job.cursor);
+            if (!s) {
+                job.status = JobStatus::Failed;
+                job.error = "cursor points to unknown step '" + job.cursor + "'";
+                job.finished_at = iso_now();
+                persist_locked();
+                return;
+            }
+
+            bool skip = false;
+            try {
+                skip = !eval_condition(s->when, job.context);
+            } catch (const std::exception& e) {
+                s->status = StepStatus::Failed;
+                s->error = e.what();
+                job.status = JobStatus::Failed;
+                job.error = e.what();
+                job.finished_at = iso_now();
+                persist_locked();
+                return;
+            }
+            if (skip) {
+                s->status = StepStatus::Skipped;
+                job.cursor = next_in_list(job, s->id);
+                persist_locked();
+                continue;
+            }
+
+            handler = registry_.find(s->op);
+            if (!handler) {
+                s->status = StepStatus::Failed;
+                s->error = "unknown op '" + s->op + "'";
+                job.status = JobStatus::Failed;
+                job.error = s->error;
+                job.finished_at = iso_now();
+                persist_locked();
+                return;
+            }
+
+            try {
+                params = resolve_refs(s->params, job.context);
+            } catch (const std::exception& e) {
+                s->status = StepStatus::Failed;
+                s->error = e.what();
+                job.status = JobStatus::Failed;
+                job.error = e.what();
+                job.finished_at = iso_now();
+                persist_locked();
+                return;
+            }
+
+            s->status = StepStatus::Running;
+            step_id = s->id;
+            context_snapshot = job.context;
+            ctrl->cancel.store(false);
+            persist_locked();
+        }
+
+        json output;
+        std::string run_error;
+        bool ok = true;
+        const auto t0 = clock::now();
+        try {
+            output = handler->run(params, context_snapshot, ctrl->cancel);
+        } catch (const std::exception& e) {
+            ok = false;
+            run_error = e.what();
+        }
+        const auto ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - t0).count();
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = jobs_.find(id);
+            if (it == jobs_.end()) return;
+            Job& job = it->second;
+            StepRecord* s = find_step(job, step_id);
+            if (!s) return;
+            s->duration_ms = ms;
+
+            if (ctrl->interrupt_requested.load()) {
+                s->status = StepStatus::Pending;
+                s->error.clear();
+                job.status = JobStatus::Interrupted;
+                persist_locked();
+                return;
+            }
+
+            if (ok) {
+                s->output = output;
+                job.context[s->id] = output;
+                try {
+                    for (auto it2 = s->extract.begin(); it2 != s->extract.end(); ++it2)
+                        job.context[it2.key()] =
+                            expr_detail::resolve_ref_path(it2.value().get<std::string>(), output);
+                    const std::string next = next_after_success(job, *s);
+                    s->status = StepStatus::Completed;
+                    job.cursor = next;
+                } catch (const std::exception& e) {
+                    s->status = StepStatus::Failed;
+                    s->error = e.what();
+                    job.status = JobStatus::Failed;
+                    job.error = e.what();
+                    job.finished_at = iso_now();
+                    persist_locked();
+                    return;
+                }
+            } else {
+                s->status = StepStatus::Failed;
+                s->error = run_error;
+                if (s->on_fail == kOnFailAbort) {
+                    job.status = JobStatus::Failed;
+                    job.error = run_error;
+                    job.finished_at = iso_now();
+                    persist_locked();
+                    return;
+                } else if (s->on_fail == kOnFailContinue) {
+                    job.cursor = next_in_list(job, s->id);
+                } else {
+                    job.cursor = s->on_fail;
+                }
+            }
+            persist_locked();
+        }
+    }
+}
+
+}  // namespace jobs
+}  // namespace lemon

--- a/src/cpp/server/jobs/job_manager.cpp
+++ b/src/cpp/server/jobs/job_manager.cpp
@@ -440,8 +440,37 @@ void JobManager::worker_main() {
         } guard{registry_, id};
 
         bool ready = !exclusive || guard.begin(&ctrl->cancel);
-        if (ready && guard.held && registry_.restore_exclusive)
-            ready = registry_.restore_exclusive(id, &ctrl->cancel);
+        if (ready && guard.held && registry_.restore_exclusive) {
+            json manifest = json::object();
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                auto it = jobs_.find(id);
+                if (it != jobs_.end()) {
+                    const Job& job = it->second;
+                    for (const auto& s : job.steps) {
+                        if (s.status != StepStatus::Completed) continue;
+                        try {
+                            if (s.op == "load") {
+                                json params = resolve_refs(s.params, job.context);
+                                if (params.contains("model") && params["model"].is_string())
+                                    manifest[params["model"].get<std::string>()] = params;
+                            } else if (s.op == "unload") {
+                                json params = resolve_refs(s.params, job.context);
+                                if (params.contains("model") && params["model"].is_string())
+                                    manifest.erase(params["model"].get<std::string>());
+                                else
+                                    manifest = json::object();
+                            }
+                        } catch (const std::exception& e) {
+                            LOG(WARNING, "Jobs")
+                                << "job " << id << " restore manifest skipped step '" << s.id
+                                << "': " << e.what() << std::endl;
+                        }
+                    }
+                }
+            }
+            ready = registry_.restore_exclusive(id, manifest, &ctrl->cancel);
+        }
         if (ready) {
             execute(id, ctrl);
         } else {

--- a/src/cpp/server/jobs/job_ops.cpp
+++ b/src/cpp/server/jobs/job_ops.cpp
@@ -77,5 +77,5 @@ OpRegistry build_op_registry(OpProviders providers) {
     return reg;
 }
 
-}  // namespace jobs
-}  // namespace lemon
+}
+}

--- a/src/cpp/server/jobs/job_ops.cpp
+++ b/src/cpp/server/jobs/job_ops.cpp
@@ -44,13 +44,18 @@ OpRegistry build_op_registry(OpProviders providers) {
     }, false});
 
     reg.register_op("sleep", {[](const json& params, const json&, CancelFlag& cancel) -> json {
-        int64_t total = params.value("ms", (int64_t)0);
-        int64_t slept = 0;
-        while (slept < total) {
-            if (cancel.load()) break;
-            const int64_t chunk = std::min<int64_t>(50, total - slept);
-            std::this_thread::sleep_for(std::chrono::milliseconds(chunk));
-            slept += chunk;
+        using clock = std::chrono::steady_clock;
+
+        const int64_t total_ms =
+            std::max<int64_t>(0, params.value("ms", int64_t{0}));
+        const auto deadline = clock::now() + std::chrono::milliseconds(total_ms);
+
+        while (!cancel.load()) {
+            const auto now = clock::now();
+            if (now >= deadline) break;
+
+            const auto next_poll = now + std::chrono::milliseconds(50);
+            std::this_thread::sleep_until(next_poll < deadline ? next_poll : deadline);
         }
         return json::object();
     }, false});

--- a/src/cpp/server/jobs/job_ops.cpp
+++ b/src/cpp/server/jobs/job_ops.cpp
@@ -55,6 +55,24 @@ OpRegistry build_op_registry(OpProviders providers) {
         return json::object();
     }, false});
 
+    reg.register_op("load", {[providers](const json& params, const json&, CancelFlag& cancel) -> json {
+        if (!providers.load_op) throw JobError(501, "load op not available");
+        return providers.load_op(params, cancel);
+    }, true});
+
+    reg.register_op("unload", {[providers](const json& params, const json&, CancelFlag& cancel) -> json {
+        if (!providers.unload_op) throw JobError(501, "unload op not available");
+        return providers.unload_op(params, cancel);
+    }, true});
+
+    reg.register_op("chat", {[providers](const json& params, const json&, CancelFlag& cancel) -> json {
+        if (!providers.chat_op) throw JobError(501, "chat op not available");
+        return providers.chat_op(params, cancel);
+    }, true});
+
+    reg.begin_exclusive = providers.begin_exclusive;
+    reg.end_exclusive = providers.end_exclusive;
+
     return reg;
 }
 

--- a/src/cpp/server/jobs/job_ops.cpp
+++ b/src/cpp/server/jobs/job_ops.cpp
@@ -72,6 +72,7 @@ OpRegistry build_op_registry(OpProviders providers) {
 
     reg.begin_exclusive = providers.begin_exclusive;
     reg.end_exclusive = providers.end_exclusive;
+    reg.reconcile_unload = providers.reconcile_unload;
 
     return reg;
 }

--- a/src/cpp/server/jobs/job_ops.cpp
+++ b/src/cpp/server/jobs/job_ops.cpp
@@ -1,0 +1,62 @@
+#include "lemon/jobs/job_ops.h"
+
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
+namespace lemon {
+namespace jobs {
+
+void OpRegistry::register_op(const std::string& name, OpHandler handler) {
+    handlers_[name] = std::move(handler);
+}
+
+const OpHandler* OpRegistry::find(const std::string& name) const {
+    auto it = handlers_.find(name);
+    return it == handlers_.end() ? nullptr : &it->second;
+}
+
+std::set<std::string> OpRegistry::names() const {
+    std::set<std::string> out;
+    for (const auto& kv : handlers_) out.insert(kv.first);
+    return out;
+}
+
+OpRegistry build_op_registry(OpProviders providers) {
+    OpRegistry reg;
+
+    reg.register_op("system_info", {[providers](const json&, const json&, CancelFlag&) -> json {
+        return providers.system_info ? providers.system_info() : json::object();
+    }, false});
+
+    reg.register_op("system_stats", {[providers](const json&, const json&, CancelFlag&) -> json {
+        return providers.system_stats ? providers.system_stats() : json::object();
+    }, false});
+
+    reg.register_op("models", {[providers](const json& params, const json&, CancelFlag&) -> json {
+        if (params.contains("id")) {
+            const std::string id = params["id"].get<std::string>();
+            json model = providers.model_get ? providers.model_get(id) : json(nullptr);
+            if (model.is_null()) throw JobError(404, "unknown model '" + id + "'");
+            return model;
+        }
+        return providers.models_list ? providers.models_list() : json::object();
+    }, false});
+
+    reg.register_op("sleep", {[](const json& params, const json&, CancelFlag& cancel) -> json {
+        int64_t total = params.value("ms", (int64_t)0);
+        int64_t slept = 0;
+        while (slept < total) {
+            if (cancel.load()) break;
+            const int64_t chunk = std::min<int64_t>(50, total - slept);
+            std::this_thread::sleep_for(std::chrono::milliseconds(chunk));
+            slept += chunk;
+        }
+        return json::object();
+    }, false});
+
+    return reg;
+}
+
+}  // namespace jobs
+}  // namespace lemon

--- a/src/cpp/server/jobs/job_ops.cpp
+++ b/src/cpp/server/jobs/job_ops.cpp
@@ -73,6 +73,7 @@ OpRegistry build_op_registry(OpProviders providers) {
     reg.begin_exclusive = providers.begin_exclusive;
     reg.end_exclusive = providers.end_exclusive;
     reg.reconcile_unload = providers.reconcile_unload;
+    reg.discard_exclusive = providers.discard_exclusive;
 
     return reg;
 }

--- a/src/cpp/server/jobs/job_ops.cpp
+++ b/src/cpp/server/jobs/job_ops.cpp
@@ -73,6 +73,7 @@ OpRegistry build_op_registry(OpProviders providers) {
     reg.begin_exclusive = providers.begin_exclusive;
     reg.end_exclusive = providers.end_exclusive;
     reg.reconcile_unload = providers.reconcile_unload;
+    reg.restore_exclusive = providers.restore_exclusive;
     reg.discard_exclusive = providers.discard_exclusive;
 
     return reg;

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -237,6 +237,10 @@ void RecipeOptions::set_option(const std::string& opt, const json& value) {
     options_[opt] = value;
 }
 
+void RecipeOptions::remove_option(const std::string& opt) {
+    options_.erase(opt);
+}
+
 #ifdef LEMONADE_CLI
 // CLI_OPTIONS used only by the lemonade CLI client for add_cli_options.
 // ctx_size/merge_args are the common flags; everything else is derived from

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -413,7 +413,6 @@ void Router::load_model(const std::string& model_name,
     // LOAD SERIALIZATION STRATEGY (from spec: point #2 in Additional Considerations)
     std::unique_lock<std::mutex> lock(load_mutex_);
 
-    // Queue behind a running exclusive job (the job's worker thread passes through).
     wait_for_slot_clearance(lock);
 
     // Wait if another thread is currently loading
@@ -615,8 +614,6 @@ void Router::load_model(const std::string& model_name,
             is_loading_ = false;
             load_cv_.notify_all();
 
-            // A cancelled in-flight load (job interrupt) must not trigger the
-            // nuclear evict-all-and-retry: the subprocess was killed deliberately.
             if (cancel_flag && cancel_flag->load()) {
                 LOG(INFO, "Router") << "Load cancelled, skipping nuclear retry" << std::endl;
                 throw std::runtime_error("load cancelled");

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -406,11 +406,11 @@ void Router::unload_models_not_in(const std::set<std::string>& keep) {
     std::vector<WrappedServer*> victims;
     for (const auto& server : loaded_servers_) {
         if (!server->is_backend_alive()) continue;
-        if (server->is_pinned()) continue;
         if (keep.count(server->get_model_name())) continue;
         victims.push_back(server.get());
     }
     for (auto* victim : victims) {
+        if (victim->is_pinned()) victim->set_pinned(false);
         LOG(INFO, "Router") << "Reconcile-unload of job-loaded model: "
                             << victim->get_model_name() << std::endl;
         evict_server(victim);
@@ -454,6 +454,11 @@ void Router::load_model(const std::string& model_name,
             << ", recipe: " << model_info.recipe
             << ", type: " << model_type_to_string(model_info.type)
             << ", device: " << device_type_to_string(model_info.device) << ")" << std::endl;
+
+    struct LoadCancelGuard {
+        WrappedServer* server = nullptr;
+        ~LoadCancelGuard() { if (server) server->set_load_cancel_flag(nullptr); }
+    } load_cancel_guard;
 
     try {
         WrappedServer* existing_pre = find_server_by_model_name(canonical_model_name);
@@ -598,6 +603,7 @@ void Router::load_model(const std::string& model_name,
         auto load_start = std::chrono::steady_clock::now();
 
         new_server->set_load_cancel_flag(cancel_flag);
+        load_cancel_guard.server = new_server.get();
 
         try {
             new_server->load(canonical_model_name, model_info, effective_options, do_not_upgrade);
@@ -664,6 +670,7 @@ void Router::load_model(const std::string& model_name,
             retry_server->set_pinned(final_pinned);
             retry_server->update_access_time();
             retry_server->set_load_cancel_flag(cancel_flag);
+            load_cancel_guard.server = retry_server.get();
 
             lock.unlock();
 

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -508,8 +508,11 @@ void Router::load_model(const std::string& model_name,
             existing = nullptr;
         }
         if (existing) {
-            if (allow_reload_on_option_change &&
-                existing->get_recipe_options().to_json() != effective_options.to_json()) {
+            json existing_opts = existing->get_recipe_options().to_json();
+            json requested_opts = effective_options.to_json();
+            existing_opts.erase("pinned");
+            requested_opts.erase("pinned");
+            if (allow_reload_on_option_change && existing_opts != requested_opts) {
                 LOG(INFO, "Router") << "Options changed, reloading model: " << canonical_model_name << std::endl;
                 evict_server(existing);
                 // Fall through to create and load with new options

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -369,12 +369,22 @@ std::unique_ptr<WrappedServer> Router::create_backend_server(const ModelInfo& mo
     return std::make_unique<backends::LlamaCppServer>(log_level, model_manager_, backend_manager_);
 }
 
-void Router::begin_exclusive() {
+bool Router::begin_exclusive(std::atomic<bool>* cancel) {
     std::unique_lock<std::mutex> lock(load_mutex_);
     exclusive_active_ = true;
     exclusive_owner_ = std::this_thread::get_id();
     while (true) {
-        load_cv_.wait(lock, [&] { return !is_loading_; });
+        if (cancel && cancel->load()) {
+            exclusive_active_ = false;
+            exclusive_owner_ = std::thread::id{};
+            exclusive_cv_.notify_all();
+            load_cv_.notify_all();
+            return false;
+        }
+        if (is_loading_) {
+            load_cv_.wait_for(lock, std::chrono::milliseconds(25));
+            continue;
+        }
         bool busy = false;
         for (const auto& server : loaded_servers_) {
             if (server->is_busy()) {
@@ -389,6 +399,7 @@ void Router::begin_exclusive() {
     }
     exclusive_cv_.notify_all();
     load_cv_.notify_all();
+    return true;
 }
 
 void Router::end_exclusive() {
@@ -753,6 +764,17 @@ void Router::evict_if_committed(const std::string& model_name) {
     WrappedServer* server = find_server_by_model_name(model_name);
     if (!server) {
         return;  // Already gone
+    }
+
+    // An exclusive session may have started (and re-pinned this model via the
+    // job snapshot reconcile) since the EVICTING mark was set. Neither state
+    // was known when the eviction was decided, so abandon it.
+    if (exclusive_active_ || server->is_pinned()) {
+        server->rescue_from_eviction();
+        LOG(INFO, "Router") << "Eviction of " << model_name << " cancelled ("
+                            << (server->is_pinned() ? "pinned" : "exclusive session active")
+                            << ")" << std::endl;
+        return;
     }
 
     // Atomically confirm the model is still idle and EVICTING. If a request

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -373,6 +373,8 @@ void Router::begin_exclusive() {
     std::lock_guard<std::mutex> lock(load_mutex_);
     exclusive_active_ = true;
     exclusive_owner_ = std::this_thread::get_id();
+    exclusive_cv_.notify_all();
+    load_cv_.notify_all();
 }
 
 void Router::end_exclusive() {
@@ -380,12 +382,38 @@ void Router::end_exclusive() {
     exclusive_active_ = false;
     exclusive_owner_ = std::thread::id{};
     exclusive_cv_.notify_all();
+    load_cv_.notify_all();
 }
 
 void Router::wait_for_slot_clearance(std::unique_lock<std::mutex>& lock) {
     exclusive_cv_.wait(lock, [&] {
         return !exclusive_active_ || exclusive_owner_ == std::this_thread::get_id();
     });
+}
+
+std::set<std::string> Router::snapshot_loaded_models() const {
+    std::lock_guard<std::mutex> lock(load_mutex_);
+    std::set<std::string> names;
+    for (const auto& server : loaded_servers_)
+        if (server->is_backend_alive()) names.insert(server->get_model_name());
+    return names;
+}
+
+void Router::unload_models_not_in(const std::set<std::string>& keep) {
+    std::unique_lock<std::mutex> lock(load_mutex_);
+    wait_for_slot_clearance(lock);
+    std::vector<WrappedServer*> victims;
+    for (const auto& server : loaded_servers_) {
+        if (!server->is_backend_alive()) continue;
+        if (server->is_pinned()) continue;
+        if (keep.count(server->get_model_name())) continue;
+        victims.push_back(server.get());
+    }
+    for (auto* victim : victims) {
+        LOG(INFO, "Router") << "Reconcile-unload of job-loaded model: "
+                            << victim->get_model_name() << std::endl;
+        evict_server(victim);
+    }
 }
 
 void Router::load_model(const std::string& model_name,
@@ -413,15 +441,11 @@ void Router::load_model(const std::string& model_name,
     // LOAD SERIALIZATION STRATEGY (from spec: point #2 in Additional Considerations)
     std::unique_lock<std::mutex> lock(load_mutex_);
 
-    wait_for_slot_clearance(lock);
+    load_cv_.wait(lock, [&] {
+        return !is_loading_
+               && (!exclusive_active_ || exclusive_owner_ == std::this_thread::get_id());
+    });
 
-    // Wait if another thread is currently loading
-    while (is_loading_) {
-    LOG(INFO, "Router") << "Another load is in progress, waiting..." << std::endl;
-        load_cv_.wait(lock);
-    }
-
-    // Mark that we're now loading (prevents concurrent loads)
     is_loading_ = true;
 
     LOG(DEBUG, "Router") << "Loading model: " << canonical_model_name
@@ -638,6 +662,7 @@ void Router::load_model(const std::string& model_name,
             retry_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
             retry_server->set_pinned(final_pinned);
             retry_server->update_access_time();
+            retry_server->set_load_cancel_flag(cancel_flag);
 
             lock.unlock();
 
@@ -1104,14 +1129,25 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
     }
 }
 
-json Router::chat_completion(const json& request) {
+json Router::chat_completion(const json& request, std::atomic<bool>* cancel) {
     std::string requested_model = request.value("model", "");
     std::shared_ptr<telemetry::InferenceSpan> span = telemetry::TelemetryTracker::start_span("LLM", "chat.completions", requested_model, request);
+
+    struct RequestCancelScope {
+        WrappedServer* server = nullptr;
+        ~RequestCancelScope() {
+            if (server) server->set_request_cancel_flag(nullptr);
+        }
+    } cancel_scope;
 
     try {
         WrappedServer* active_server = nullptr;
         json response = execute_inference(request, [&](WrappedServer* server) {
             active_server = server;
+            if (cancel) {
+                server->set_request_cancel_flag(cancel);
+                cancel_scope.server = server;
+            }
             ModelTelemetryIdentity identity = get_telemetry_identity(server);
             if (span) {
                 span->set_attribute("llm.backend", identity.recipe);

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -370,9 +370,10 @@ std::unique_ptr<WrappedServer> Router::create_backend_server(const ModelInfo& mo
 }
 
 void Router::begin_exclusive() {
-    std::lock_guard<std::mutex> lock(load_mutex_);
+    std::unique_lock<std::mutex> lock(load_mutex_);
     exclusive_active_ = true;
     exclusive_owner_ = std::this_thread::get_id();
+    load_cv_.wait(lock, [&] { return !is_loading_; });
     exclusive_cv_.notify_all();
     load_cv_.notify_all();
 }

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -424,17 +424,27 @@ std::map<std::string, bool> Router::snapshot_loaded_models() const {
     return models;
 }
 
-void Router::unload_models_not_in(const std::map<std::string, bool>& keep) {
+std::map<std::string, json> Router::unload_job_models(const std::map<std::string, int>& owned_live,
+                                                      const std::map<std::string, bool>& snapshot_pins) {
     std::unique_lock<std::mutex> lock(load_mutex_);
     wait_for_slot_clearance(lock);
+    std::map<std::string, int> resolved_owned;
+    for (const auto& kv : owned_live) resolved_owned[resolve_model_name(kv.first)] = kv.second;
+    std::map<std::string, json> captured;
     std::vector<WrappedServer*> victims;
     for (const auto& server : loaded_servers_) {
         if (!server->is_backend_alive()) continue;
-        auto it = keep.find(server->get_model_name());
-        if (it != keep.end()) {
-            if (server->is_pinned() != it->second) server->set_pinned(it->second);
+        const std::string name = server->get_model_name();
+        auto pin_it = snapshot_pins.find(name);
+        if (pin_it != snapshot_pins.end()) {
+            if (server->is_pinned() != pin_it->second) server->set_pinned(pin_it->second);
             continue;
         }
+        auto own_it = resolved_owned.find(name);
+        if (own_it == resolved_owned.end()) continue;
+        if (server->get_process_id() != own_it->second) continue;
+        captured[name] = {{"options", server->get_recipe_options().to_json()},
+                          {"pinned", server->is_pinned()}};
         victims.push_back(server.get());
     }
     for (auto* victim : victims) {
@@ -443,6 +453,18 @@ void Router::unload_models_not_in(const std::map<std::string, bool>& keep) {
                             << victim->get_model_name() << std::endl;
         evict_server(victim);
     }
+    return captured;
+}
+
+int Router::loaded_model_pid(const std::string& model_name) const {
+    std::lock_guard<std::mutex> lock(load_mutex_);
+    WrappedServer* server = find_server_by_model_name(resolve_model_name(model_name));
+    return server && server->is_backend_alive() ? server->get_process_id() : -1;
+}
+
+std::string Router::canonical_model_name(const std::string& model_name) const {
+    std::lock_guard<std::mutex> lock(load_mutex_);
+    return resolve_model_name(model_name);
 }
 
 void Router::load_model(const std::string& model_name,

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -455,11 +455,6 @@ void Router::load_model(const std::string& model_name,
             << ", type: " << model_type_to_string(model_info.type)
             << ", device: " << device_type_to_string(model_info.device) << ")" << std::endl;
 
-    struct LoadCancelGuard {
-        WrappedServer* server = nullptr;
-        ~LoadCancelGuard() { if (server) server->set_load_cancel_flag(nullptr); }
-    } load_cancel_guard;
-
     try {
         WrappedServer* existing_pre = find_server_by_model_name(canonical_model_name);
         bool final_pinned = false;
@@ -603,7 +598,6 @@ void Router::load_model(const std::string& model_name,
         auto load_start = std::chrono::steady_clock::now();
 
         new_server->set_load_cancel_flag(cancel_flag);
-        load_cancel_guard.server = new_server.get();
 
         try {
             new_server->load(canonical_model_name, model_info, effective_options, do_not_upgrade);
@@ -616,6 +610,8 @@ void Router::load_model(const std::string& model_name,
             load_success = false;
             LOG(ERROR, "Router") << "Backend load failed: " << error_message << std::endl;
         }
+
+        new_server->set_load_cancel_flag(nullptr);
 
         lock.lock();
 
@@ -670,7 +666,6 @@ void Router::load_model(const std::string& model_name,
             retry_server->set_pinned(final_pinned);
             retry_server->update_access_time();
             retry_server->set_load_cancel_flag(cancel_flag);
-            load_cancel_guard.server = retry_server.get();
 
             lock.unlock();
 
@@ -685,12 +680,14 @@ void Router::load_model(const std::string& model_name,
 
                 retry_server->set_state(ModelState::READY);
                 const auto retry_duration_ms = retry_server->get_load_duration_ms();
+                retry_server->set_load_cancel_flag(nullptr);
                 loaded_servers_.push_back(std::move(retry_server));
                 is_loading_ = false;
                 load_cv_.notify_all();
 
                 LOG(DEBUG, "Router") << "Retry successful in " << retry_duration_ms << "ms!" << std::endl;
             } catch (const std::exception& retry_error) {
+                retry_server->set_load_cancel_flag(nullptr);
                 lock.lock();
                 is_loading_ = false;
                 load_cv_.notify_all();

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -369,12 +369,32 @@ std::unique_ptr<WrappedServer> Router::create_backend_server(const ModelInfo& mo
     return std::make_unique<backends::LlamaCppServer>(log_level, model_manager_, backend_manager_);
 }
 
+void Router::begin_exclusive() {
+    std::lock_guard<std::mutex> lock(load_mutex_);
+    exclusive_active_ = true;
+    exclusive_owner_ = std::this_thread::get_id();
+}
+
+void Router::end_exclusive() {
+    std::lock_guard<std::mutex> lock(load_mutex_);
+    exclusive_active_ = false;
+    exclusive_owner_ = std::thread::id{};
+    exclusive_cv_.notify_all();
+}
+
+void Router::wait_for_slot_clearance(std::unique_lock<std::mutex>& lock) {
+    exclusive_cv_.wait(lock, [&] {
+        return !exclusive_active_ || exclusive_owner_ == std::this_thread::get_id();
+    });
+}
+
 void Router::load_model(const std::string& model_name,
                        const ModelInfo& model_info,
                        RecipeOptions options,
                        bool do_not_upgrade,
                        bool allow_reload_on_option_change,
-                       std::optional<bool> pinned) {
+                       std::optional<bool> pinned,
+                       std::atomic<bool>* cancel_flag) {
     const std::string canonical_model_name = resolve_model_name(model_name);
     const std::string backend_option = model_info.recipe + "_backend";
 
@@ -392,6 +412,9 @@ void Router::load_model(const std::string& model_name,
 
     // LOAD SERIALIZATION STRATEGY (from spec: point #2 in Additional Considerations)
     std::unique_lock<std::mutex> lock(load_mutex_);
+
+    // Queue behind a running exclusive job (the job's worker thread passes through).
+    wait_for_slot_clearance(lock);
 
     // Wait if another thread is currently loading
     while (is_loading_) {
@@ -550,6 +573,8 @@ void Router::load_model(const std::string& model_name,
         std::string error_message;
         auto load_start = std::chrono::steady_clock::now();
 
+        new_server->set_load_cancel_flag(cancel_flag);
+
         try {
             new_server->load(canonical_model_name, model_info, effective_options, do_not_upgrade);
             load_success = true;
@@ -589,6 +614,13 @@ void Router::load_model(const std::string& model_name,
 
             is_loading_ = false;
             load_cv_.notify_all();
+
+            // A cancelled in-flight load (job interrupt) must not trigger the
+            // nuclear evict-all-and-retry: the subprocess was killed deliberately.
+            if (cancel_flag && cancel_flag->load()) {
+                LOG(INFO, "Router") << "Load cancelled, skipping nuclear retry" << std::endl;
+                throw std::runtime_error("load cancelled");
+            }
 
             if (is_file_not_found) {
                 LOG(ERROR, "Router") << "File not found error, NOT evicting other models" << std::endl;
@@ -652,7 +684,8 @@ void Router::load_model(const std::string& model_name,
 }
 
 void Router::unload_model(const std::string& model_name) {
-    std::lock_guard<std::mutex> lock(load_mutex_);
+    std::unique_lock<std::mutex> lock(load_mutex_);
+    wait_for_slot_clearance(lock);
 
     if (model_name.empty()) {
         // Unload all models
@@ -871,7 +904,8 @@ auto Router::execute_inference(const json& request, Func&& inference_func) -> de
         bool should_reload_before_request = false;
 
         {
-            std::lock_guard<std::mutex> lock(load_mutex_);
+            std::unique_lock<std::mutex> lock(load_mutex_);
+            wait_for_slot_clearance(lock);
             server = find_server_by_model_name(resolve_model_name(requested_model));
             if (!server) {
                 return ErrorResponse::from_exception(ModelNotLoadedException(requested_model));
@@ -970,7 +1004,8 @@ void Router::execute_streaming(const std::string& request_body, httplib::DataSin
         bool should_reload_before_request = false;
 
         {
-            std::lock_guard<std::mutex> lock(load_mutex_);
+            std::unique_lock<std::mutex> lock(load_mutex_);
+            wait_for_slot_clearance(lock);
             server = find_server_by_model_name(resolve_model_name(requested_model));
             if (!server) {
                 json error = ErrorResponse::from_exception(ModelNotLoadedException(requested_model));

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -373,7 +373,20 @@ void Router::begin_exclusive() {
     std::unique_lock<std::mutex> lock(load_mutex_);
     exclusive_active_ = true;
     exclusive_owner_ = std::this_thread::get_id();
-    load_cv_.wait(lock, [&] { return !is_loading_; });
+    while (true) {
+        load_cv_.wait(lock, [&] { return !is_loading_; });
+        bool busy = false;
+        for (const auto& server : loaded_servers_) {
+            if (server->is_busy()) {
+                busy = true;
+                break;
+            }
+        }
+        if (!busy) break;
+        lock.unlock();
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+        lock.lock();
+    }
     exclusive_cv_.notify_all();
     load_cv_.notify_all();
 }
@@ -392,21 +405,25 @@ void Router::wait_for_slot_clearance(std::unique_lock<std::mutex>& lock) {
     });
 }
 
-std::set<std::string> Router::snapshot_loaded_models() const {
+std::map<std::string, bool> Router::snapshot_loaded_models() const {
     std::lock_guard<std::mutex> lock(load_mutex_);
-    std::set<std::string> names;
+    std::map<std::string, bool> models;
     for (const auto& server : loaded_servers_)
-        if (server->is_backend_alive()) names.insert(server->get_model_name());
-    return names;
+        if (server->is_backend_alive()) models[server->get_model_name()] = server->is_pinned();
+    return models;
 }
 
-void Router::unload_models_not_in(const std::set<std::string>& keep) {
+void Router::unload_models_not_in(const std::map<std::string, bool>& keep) {
     std::unique_lock<std::mutex> lock(load_mutex_);
     wait_for_slot_clearance(lock);
     std::vector<WrappedServer*> victims;
     for (const auto& server : loaded_servers_) {
         if (!server->is_backend_alive()) continue;
-        if (keep.count(server->get_model_name())) continue;
+        auto it = keep.find(server->get_model_name());
+        if (it != keep.end()) {
+            if (server->is_pinned() != it->second) server->set_pinned(it->second);
+            continue;
+        }
         victims.push_back(server.get());
     }
     for (auto* victim : victims) {
@@ -1465,7 +1482,8 @@ json Router::get_slots() {
     ISlotsServer* slots_server = nullptr;
 
     {
-        std::lock_guard<std::mutex> lock(load_mutex_);
+        std::unique_lock<std::mutex> lock(load_mutex_);
+        wait_for_slot_clearance(lock);
         server = get_most_recent_server();
         if (!server) {
             return ErrorResponse::from_exception(
@@ -1504,7 +1522,8 @@ json Router::slots_action(int slot_id, const std::string& action, const json& re
     ISlotsServer* slots_server = nullptr;
 
     {
-        std::lock_guard<std::mutex> lock(load_mutex_);
+        std::unique_lock<std::mutex> lock(load_mutex_);
+        wait_for_slot_clearance(lock);
         server = get_most_recent_server();
         if (!server) {
             return ErrorResponse::from_exception(
@@ -1543,7 +1562,8 @@ json Router::tokenize(const json& request_body) {
     ITokenizerServer* tokenizer_server = nullptr;
 
     {
-        std::lock_guard<std::mutex> lock(load_mutex_);
+        std::unique_lock<std::mutex> lock(load_mutex_);
+        wait_for_slot_clearance(lock);
         server = get_most_recent_server();
         if (!server) {
             return ErrorResponse::from_exception(
@@ -2243,7 +2263,8 @@ json Router::get_pinned_model_counts() const {
 }
 
 void Router::set_model_pinned(const std::string& model_name, bool pinned) {
-    std::lock_guard<std::mutex> lock(load_mutex_);
+    std::unique_lock<std::mutex> lock(load_mutex_);
+    wait_for_slot_clearance(lock);
     WrappedServer* server = find_server_by_model_name(model_name);
     if (!server) {
         throw std::runtime_error("Model not loaded: " + model_name);

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -7,6 +7,7 @@
 #include "lemon/routing_classifier_services.h"
 #include "lemon/routing_policy.h"
 #include "lemon/config_file.h"
+#include "lemon/jobs/job_manager.h"
 #include "lemon/mcp_server.h"
 #include "lemon/mcp_client.h"
 #include "lemon/ollama_api.h"
@@ -406,6 +407,44 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
                                        model_manager_.get(),
                                        backend_manager_.get());
     router_->set_cloud_registry(cloud_registry_.get());
+
+    {
+        lemon::jobs::OpProviders providers;
+        providers.system_info = [] {
+            return lemon::jobs::json::parse(SystemInfoCache::get_system_info_with_cache().dump());
+        };
+        providers.system_stats = [this] {
+            lemon::jobs::json stats;
+            const double cpu_percent = get_cpu_usage();
+            stats["cpu_percent"] =
+                cpu_percent >= 0 ? lemon::jobs::json(cpu_percent) : lemon::jobs::json();
+            stats["memory_gb"] = metrics_platform_->get_memory_usage_gb();
+            const double gpu_percent = get_gpu_usage();
+            stats["gpu_percent"] =
+                gpu_percent >= 0 ? lemon::jobs::json(gpu_percent) : lemon::jobs::json();
+            const double vram_gb = get_vram_usage();
+            stats["vram_gb"] = vram_gb >= 0 ? lemon::jobs::json(vram_gb) : lemon::jobs::json();
+            const double npu_percent = get_npu_utilization();
+            stats["npu_percent"] =
+                npu_percent >= 0 ? lemon::jobs::json(npu_percent) : lemon::jobs::json();
+            return stats;
+        };
+        providers.models_list = [this] {
+            nlohmann::json data = nlohmann::json::array();
+            for (const auto& [model_id, info] : model_manager_->get_supported_models())
+                data.push_back(model_info_to_json(model_id, info));
+            nlohmann::json response = {{"object", "list"}, {"data", data}};
+            return lemon::jobs::json::parse(response.dump());
+        };
+        providers.model_get = [this](const std::string& id) -> lemon::jobs::json {
+            auto models = model_manager_->get_supported_models();
+            auto it = models.find(id);
+            if (it == models.end()) return lemon::jobs::json(nullptr);
+            return lemon::jobs::json::parse(model_info_to_json(id, it->second).dump());
+        };
+        job_manager_ = std::make_unique<lemon::jobs::JobManager>(
+            lemon::utils::get_cache_dir(), lemon::jobs::build_op_registry(std::move(providers)));
+    }
 
     LOG(DEBUG, "Server") << "Debug logging enabled - subprocess output will be visible" << std::endl;
 
@@ -860,6 +899,35 @@ void Server::setup_routes(httplib::Server &web_server) {
     register_post("downloads/control", [this](const httplib::Request& req, httplib::Response& res) {
         handle_download_control(req, res);
     });
+
+    register_post("jobs", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_jobs_create(req, res);
+    });
+    register_get("jobs", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_jobs_list(req, res);
+    });
+    for (const char* prefix : {"/api/v0", "/api/v1", "/v0", "/v1"}) {
+        web_server.Post(std::string(prefix) + R"(/jobs/([^/]+)/pause)",
+                        [this](const httplib::Request& req, httplib::Response& res) {
+                            handle_jobs_pause(req, res);
+                        });
+        web_server.Post(std::string(prefix) + R"(/jobs/([^/]+)/interrupt)",
+                        [this](const httplib::Request& req, httplib::Response& res) {
+                            handle_jobs_interrupt(req, res);
+                        });
+        web_server.Post(std::string(prefix) + R"(/jobs/([^/]+)/resume)",
+                        [this](const httplib::Request& req, httplib::Response& res) {
+                            handle_jobs_resume(req, res);
+                        });
+        web_server.Get(std::string(prefix) + R"(/jobs/([^/]+))",
+                       [this](const httplib::Request& req, httplib::Response& res) {
+                           handle_jobs_get(req, res);
+                       });
+        web_server.Delete(std::string(prefix) + R"(/jobs/([^/]+))",
+                          [this](const httplib::Request& req, httplib::Response& res) {
+                              handle_jobs_delete(req, res);
+                          });
+    }
 
 
     register_post("load", [this](const httplib::Request& req, httplib::Response& res) {
@@ -5529,6 +5597,92 @@ void Server::handle_simulate_vram_pressure(const httplib::Request& req, httplib:
         res.status = 400;
         res.set_content(json{{"error", e.what()}}.dump(), "application/json");
     }
+}
+
+namespace {
+
+std::string job_id_from_path(const httplib::Request& req) {
+    return req.matches.size() > 1 ? std::string(req.matches[1]) : std::string();
+}
+
+void job_error(httplib::Response& res, int status, const std::string& message) {
+    res.status = status;
+    res.set_content(lemon::jobs::json{{"error", message}}.dump(), "application/json");
+}
+
+}  // namespace
+
+void Server::handle_jobs_create(const httplib::Request& req, httplib::Response& res) {
+    try {
+        auto body = lemon::jobs::json::parse(req.body);
+        const std::string name = body.value("name", "");
+        lemon::jobs::json steps_json = lemon::jobs::json::array();
+        if (body.contains("definition") && body["definition"].is_object()
+            && body["definition"].contains("steps")) {
+            steps_json = body["definition"]["steps"];
+        } else if (body.contains("steps")) {
+            steps_json = body["steps"];
+        }
+        std::vector<lemon::jobs::StepRecord> steps;
+        if (steps_json.is_array())
+            for (const auto& s : steps_json)
+                steps.push_back(lemon::jobs::StepRecord::from_json(s));
+        lemon::jobs::json inputs =
+            body.contains("inputs") ? body["inputs"] : lemon::jobs::json::object();
+        const std::string id = job_manager_->create(name, std::move(steps), inputs);
+        res.status = 202;
+        res.set_content(lemon::jobs::json{{"id", id}}.dump(), "application/json");
+    } catch (const lemon::jobs::JobError& e) {
+        job_error(res, e.status, e.what());
+    } catch (const std::exception& e) {
+        job_error(res, 400, e.what());
+    }
+}
+
+void Server::handle_jobs_list(const httplib::Request&, httplib::Response& res) {
+    res.set_content(lemon::jobs::json{{"jobs", job_manager_->list()}}.dump(), "application/json");
+}
+
+void Server::handle_jobs_get(const httplib::Request& req, httplib::Response& res) {
+    const auto job = job_manager_->get(job_id_from_path(req));
+    if (!job) {
+        job_error(res, 404, "unknown job");
+        return;
+    }
+    res.set_content(job->dump(), "application/json");
+}
+
+void Server::handle_jobs_pause(const httplib::Request& req, httplib::Response& res) {
+    if (!job_manager_->pause(job_id_from_path(req))) {
+        job_error(res, 404, "job not found or not pausable");
+        return;
+    }
+    res.set_content(R"({"status":"pausing"})", "application/json");
+}
+
+void Server::handle_jobs_interrupt(const httplib::Request& req, httplib::Response& res) {
+    if (!job_manager_->interrupt(job_id_from_path(req))) {
+        job_error(res, 404, "job not found or not interruptible");
+        return;
+    }
+    res.set_content(R"({"status":"interrupting"})", "application/json");
+}
+
+void Server::handle_jobs_resume(const httplib::Request& req, httplib::Response& res) {
+    if (!job_manager_->resume(job_id_from_path(req))) {
+        job_error(res, 404, "job not found or not resumable");
+        return;
+    }
+    res.set_content(R"({"status":"resuming"})", "application/json");
+}
+
+void Server::handle_jobs_delete(const httplib::Request& req, httplib::Response& res) {
+    bool active = false;
+    if (!job_manager_->remove(job_id_from_path(req), active)) {
+        job_error(res, active ? 409 : 404, active ? "job is active" : "unknown job");
+        return;
+    }
+    res.set_content(R"({"status":"deleted"})", "application/json");
 }
 
 void Server::handle_shutdown(const httplib::Request& req, httplib::Response& res) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -442,6 +442,67 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             if (it == models.end()) return lemon::jobs::json(nullptr);
             return lemon::jobs::json::parse(model_info_to_json(id, it->second).dump());
         };
+        providers.load_op = [this](const lemon::jobs::json& params,
+                                   lemon::jobs::CancelFlag& cancel) -> lemon::jobs::json {
+            if (!params.contains("model") || !params["model"].is_string())
+                throw lemon::jobs::JobError(400, "load requires a 'model' string");
+            const std::string model = params["model"].get<std::string>();
+            if (!model_manager_->model_exists(model))
+                throw lemon::jobs::JobError(404, "unknown model '" + model + "'");
+            if (!model_manager_->is_model_downloaded(model))
+                throw lemon::jobs::JobError(404, "model '" + model + "' is not downloaded");
+            auto info = model_manager_->get_model_info(model);
+            nlohmann::json opt_json = nlohmann::json::parse(params.dump());
+            RecipeOptions options(info.recipe, opt_json);
+            std::optional<bool> pinned = std::nullopt;
+            if (params.contains("pinned") && params["pinned"].is_boolean())
+                pinned = params["pinned"].get<bool>();
+            try {
+                router_->load_model(model, info, options, true, true, pinned, &cancel);
+            } catch (const std::exception& e) {
+                throw lemon::jobs::JobError(500, e.what());
+            }
+            if (cancel.load()) {
+                router_->unload_model("");
+                throw lemon::jobs::JobError(499, "interrupted");
+            }
+            RecipeOptions effective = router_->get_model_recipe_options(model);
+            lemon::jobs::json out;
+            out["loaded"] = true;
+            out["model"] = model;
+            const nlohmann::json backend_json = effective.get_option(info.recipe + "_backend");
+            if (backend_json.is_string()) out["backend"] = backend_json.get<std::string>();
+            const nlohmann::json ctx_json = effective.get_option("ctx_size");
+            if (ctx_json.is_number()) out["ctx_size"] = ctx_json.get<int64_t>();
+            return out;
+        };
+        providers.unload_op = [this](const lemon::jobs::json& params,
+                                     lemon::jobs::CancelFlag&) -> lemon::jobs::json {
+            if (params.contains("model") && params["model"].is_string()) {
+                const std::string model = params["model"].get<std::string>();
+                if (router_->is_model_loaded(model)) router_->unload_model(model);
+            } else {
+                router_->unload_model("");
+            }
+            return lemon::jobs::json::object();
+        };
+        providers.chat_op = [this](const lemon::jobs::json& params,
+                                   lemon::jobs::CancelFlag&) -> lemon::jobs::json {
+            nlohmann::json request = nlohmann::json::parse(params.dump());
+            nlohmann::json response = router_->chat_completion(request);
+            if (response.contains("error")) {
+                std::string msg = "chat failed";
+                const auto& err = response["error"];
+                if (err.is_object() && err.contains("message") && err["message"].is_string())
+                    msg = err["message"].get<std::string>();
+                else if (err.is_string())
+                    msg = err.get<std::string>();
+                throw lemon::jobs::JobError(424, msg);
+            }
+            return lemon::jobs::json::parse(response.dump());
+        };
+        providers.begin_exclusive = [this] { router_->begin_exclusive(); };
+        providers.end_exclusive = [this] { router_->end_exclusive(); };
         job_manager_ = std::make_unique<lemon::jobs::JobManager>(
             lemon::utils::get_cache_dir(), lemon::jobs::build_op_registry(std::move(providers)));
     }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -410,6 +410,13 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
 
     {
         lemon::jobs::OpProviders providers;
+        struct JobModelState {
+            std::map<std::string, bool> snapshot;
+            std::map<std::string, nlohmann::json> owned;
+        };
+        auto job_states = std::make_shared<std::map<std::string, JobModelState>>();
+        auto current_job = std::make_shared<std::string>();
+        auto state_mutex = std::make_shared<std::mutex>();
         providers.system_info = [] {
             return lemon::jobs::json::parse(SystemInfoCache::get_system_info_with_cache().dump());
         };
@@ -442,8 +449,9 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             if (it == models.end()) return lemon::jobs::json(nullptr);
             return lemon::jobs::json::parse(model_info_to_json(id, it->second).dump());
         };
-        providers.load_op = [this](const lemon::jobs::json& params,
-                                   lemon::jobs::CancelFlag& cancel) -> lemon::jobs::json {
+        providers.load_op = [this, job_states, current_job, state_mutex](
+                                const lemon::jobs::json& params,
+                                lemon::jobs::CancelFlag& cancel) -> lemon::jobs::json {
             if (!params.contains("model") || !params["model"].is_string())
                 throw lemon::jobs::JobError(400, "load requires a 'model' string");
             const std::string model = params["model"].get<std::string>();
@@ -462,6 +470,16 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             } catch (const std::exception& e) {
                 throw lemon::jobs::JobError(500, e.what());
             }
+            {
+                const std::string canonical = router_->canonical_model_name(model);
+                const int pid = router_->loaded_model_pid(model);
+                std::lock_guard<std::mutex> lk(*state_mutex);
+                if (!current_job->empty()) {
+                    auto it = job_states->find(*current_job);
+                    if (it != job_states->end())
+                        it->second.owned[canonical] = {{"pid", pid}};
+                }
+            }
             if (cancel.load()) {
                 throw lemon::jobs::JobError(499, "interrupted");
             }
@@ -475,13 +493,26 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             if (ctx_json.is_number()) out["ctx_size"] = ctx_json.get<int64_t>();
             return out;
         };
-        providers.unload_op = [this](const lemon::jobs::json& params,
-                                     lemon::jobs::CancelFlag&) -> lemon::jobs::json {
-            if (params.contains("model") && params["model"].is_string()) {
-                const std::string model = params["model"].get<std::string>();
+        providers.unload_op = [this, job_states, current_job, state_mutex](
+                                  const lemon::jobs::json& params,
+                                  lemon::jobs::CancelFlag&) -> lemon::jobs::json {
+            std::string model;
+            if (params.contains("model") && params["model"].is_string())
+                model = params["model"].get<std::string>();
+            if (!model.empty()) {
                 if (router_->is_model_loaded(model)) router_->unload_model(model);
             } else {
                 router_->unload_model("");
+            }
+            {
+                std::lock_guard<std::mutex> lk(*state_mutex);
+                if (!current_job->empty()) {
+                    auto it = job_states->find(*current_job);
+                    if (it != job_states->end()) {
+                        if (model.empty()) it->second.owned.clear();
+                        else it->second.owned.erase(router_->canonical_model_name(model));
+                    }
+                }
             }
             return lemon::jobs::json::object();
         };
@@ -500,38 +531,89 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             }
             return lemon::jobs::json::parse(response.dump());
         };
-        auto job_snapshots =
-            std::make_shared<std::map<std::string, std::map<std::string, bool>>>();
-        auto snapshot_mutex = std::make_shared<std::mutex>();
-        providers.begin_exclusive = [this, job_snapshots, snapshot_mutex](
+        providers.begin_exclusive = [this, job_states, current_job, state_mutex](
                                         const std::string& job_id,
                                         lemon::jobs::CancelFlag* cancel) -> bool {
             if (!router_->begin_exclusive(cancel)) return false;
-            std::lock_guard<std::mutex> lk(*snapshot_mutex);
-            if (!job_snapshots->count(job_id))
-                (*job_snapshots)[job_id] = router_->snapshot_loaded_models();
+            std::lock_guard<std::mutex> lk(*state_mutex);
+            if (!job_states->count(job_id))
+                (*job_states)[job_id].snapshot = router_->snapshot_loaded_models();
+            *current_job = job_id;
             return true;
         };
-        providers.end_exclusive = [this] { router_->end_exclusive(); };
-        providers.reconcile_unload = [this, job_snapshots, snapshot_mutex](
-                                         const std::string& job_id) {
-            std::map<std::string, bool> keep;
-            bool have = false;
+        providers.end_exclusive = [this, current_job, state_mutex] {
             {
-                std::lock_guard<std::mutex> lk(*snapshot_mutex);
-                auto it = job_snapshots->find(job_id);
-                if (it != job_snapshots->end()) {
-                    keep = std::move(it->second);
-                    job_snapshots->erase(it);
-                    have = true;
+                std::lock_guard<std::mutex> lk(*state_mutex);
+                current_job->clear();
+            }
+            router_->end_exclusive();
+        };
+        providers.reconcile_unload = [this, job_states, state_mutex](
+                                         const std::string& job_id) {
+            std::map<std::string, int> owned_live;
+            std::map<std::string, bool> snapshot;
+            {
+                std::lock_guard<std::mutex> lk(*state_mutex);
+                auto it = job_states->find(job_id);
+                if (it == job_states->end()) return;
+                for (const auto& kv : it->second.owned)
+                    if (kv.second.is_object() && kv.second.contains("pid"))
+                        owned_live[kv.first] = kv.second["pid"].get<int>();
+                snapshot = it->second.snapshot;
+            }
+            if (owned_live.empty()) return;
+            auto captured = router_->unload_job_models(owned_live, snapshot);
+            std::lock_guard<std::mutex> lk(*state_mutex);
+            auto it = job_states->find(job_id);
+            if (it == job_states->end()) return;
+            for (auto& kv : captured) it->second.owned[kv.first] = std::move(kv.second);
+        };
+        providers.restore_exclusive = [this, job_states, state_mutex](
+                                          const std::string& job_id,
+                                          lemon::jobs::CancelFlag* cancel) -> bool {
+            std::map<std::string, nlohmann::json> to_restore;
+            {
+                std::lock_guard<std::mutex> lk(*state_mutex);
+                auto it = job_states->find(job_id);
+                if (it == job_states->end()) return true;
+                for (const auto& kv : it->second.owned)
+                    if (kv.second.is_object() && kv.second.contains("options"))
+                        to_restore[kv.first] = kv.second;
+            }
+            for (const auto& kv : to_restore) {
+                if (cancel && cancel->load()) return false;
+                if (router_->is_model_loaded(kv.first)) {
+                    std::lock_guard<std::mutex> lk(*state_mutex);
+                    auto it = job_states->find(job_id);
+                    if (it != job_states->end()) it->second.owned.erase(kv.first);
+                    continue;
+                }
+                try {
+                    auto info = model_manager_->get_model_info(kv.first);
+                    RecipeOptions options(info.recipe, kv.second.value("options", nlohmann::json::object()));
+                    std::optional<bool> pinned = std::nullopt;
+                    if (kv.second.contains("pinned") && kv.second["pinned"].is_boolean())
+                        pinned = kv.second["pinned"].get<bool>();
+                    router_->load_model(kv.first, info, options, true, true, pinned, cancel);
+                    const int pid = router_->loaded_model_pid(kv.first);
+                    std::lock_guard<std::mutex> lk(*state_mutex);
+                    auto it = job_states->find(job_id);
+                    if (it != job_states->end()) it->second.owned[kv.first] = {{"pid", pid}};
+                } catch (const std::exception& e) {
+                    if (cancel && cancel->load()) return false;
+                    LOG(WARNING, "Jobs") << "could not restore job model '" << kv.first
+                                         << "' on resume: " << e.what() << std::endl;
+                    std::lock_guard<std::mutex> lk(*state_mutex);
+                    auto it = job_states->find(job_id);
+                    if (it != job_states->end()) it->second.owned.erase(kv.first);
                 }
             }
-            if (have) router_->unload_models_not_in(keep);
+            return true;
         };
-        providers.discard_exclusive = [job_snapshots, snapshot_mutex](
+        providers.discard_exclusive = [job_states, state_mutex](
                                           const std::string& job_id) {
-            std::lock_guard<std::mutex> lk(*snapshot_mutex);
-            job_snapshots->erase(job_id);
+            std::lock_guard<std::mutex> lk(*state_mutex);
+            job_states->erase(job_id);
         };
         job_manager_ = std::make_unique<lemon::jobs::JobManager>(
             lemon::utils::get_cache_dir(), lemon::jobs::build_op_registry(std::move(providers)));

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5672,7 +5672,7 @@ void job_error(httplib::Response& res, int status, const std::string& message) {
     res.set_content(lemon::jobs::json{{"error", message}}.dump(), "application/json");
 }
 
-}  // namespace
+}
 
 void Server::handle_jobs_create(const httplib::Request& req, httplib::Response& res) {
     try {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -463,7 +463,6 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
                 throw lemon::jobs::JobError(500, e.what());
             }
             if (cancel.load()) {
-                router_->unload_model("");
                 throw lemon::jobs::JobError(499, "interrupted");
             }
             RecipeOptions effective = router_->get_model_recipe_options(model);
@@ -501,7 +500,7 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             }
             return lemon::jobs::json::parse(response.dump());
         };
-        auto exclusive_snapshot = std::make_shared<std::set<std::string>>();
+        auto exclusive_snapshot = std::make_shared<std::map<std::string, bool>>();
         auto snapshot_mutex = std::make_shared<std::mutex>();
         providers.begin_exclusive = [this, exclusive_snapshot, snapshot_mutex] {
             router_->begin_exclusive();
@@ -511,7 +510,7 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
         };
         providers.end_exclusive = [this] { router_->end_exclusive(); };
         providers.reconcile_unload = [this, exclusive_snapshot, snapshot_mutex] {
-            std::set<std::string> keep;
+            std::map<std::string, bool> keep;
             {
                 std::lock_guard<std::mutex> lk(*snapshot_mutex);
                 keep = *exclusive_snapshot;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -500,24 +500,38 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             }
             return lemon::jobs::json::parse(response.dump());
         };
-        auto exclusive_snapshot = std::make_shared<std::map<std::string, bool>>();
+        auto job_snapshots =
+            std::make_shared<std::map<std::string, std::map<std::string, bool>>>();
         auto snapshot_mutex = std::make_shared<std::mutex>();
-        providers.begin_exclusive = [this, exclusive_snapshot, snapshot_mutex](
+        providers.begin_exclusive = [this, job_snapshots, snapshot_mutex](
+                                        const std::string& job_id,
                                         lemon::jobs::CancelFlag* cancel) -> bool {
             if (!router_->begin_exclusive(cancel)) return false;
-            auto snap = router_->snapshot_loaded_models();
             std::lock_guard<std::mutex> lk(*snapshot_mutex);
-            *exclusive_snapshot = std::move(snap);
+            if (!job_snapshots->count(job_id))
+                (*job_snapshots)[job_id] = router_->snapshot_loaded_models();
             return true;
         };
         providers.end_exclusive = [this] { router_->end_exclusive(); };
-        providers.reconcile_unload = [this, exclusive_snapshot, snapshot_mutex] {
+        providers.reconcile_unload = [this, job_snapshots, snapshot_mutex](
+                                         const std::string& job_id) {
             std::map<std::string, bool> keep;
+            bool have = false;
             {
                 std::lock_guard<std::mutex> lk(*snapshot_mutex);
-                keep = *exclusive_snapshot;
+                auto it = job_snapshots->find(job_id);
+                if (it != job_snapshots->end()) {
+                    keep = std::move(it->second);
+                    job_snapshots->erase(it);
+                    have = true;
+                }
             }
-            router_->unload_models_not_in(keep);
+            if (have) router_->unload_models_not_in(keep);
+        };
+        providers.discard_exclusive = [job_snapshots, snapshot_mutex](
+                                          const std::string& job_id) {
+            std::lock_guard<std::mutex> lk(*snapshot_mutex);
+            job_snapshots->erase(job_id);
         };
         job_manager_ = std::make_unique<lemon::jobs::JobManager>(
             lemon::utils::get_cache_dir(), lemon::jobs::build_op_registry(std::move(providers)));

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -503,6 +503,7 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
         };
         providers.begin_exclusive = [this] { router_->begin_exclusive(); };
         providers.end_exclusive = [this] { router_->end_exclusive(); };
+        providers.reconcile_unload = [this] { router_->unload_model(""); };
         job_manager_ = std::make_unique<lemon::jobs::JobManager>(
             lemon::utils::get_cache_dir(), lemon::jobs::build_op_registry(std::move(providers)));
     }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -502,11 +502,13 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
         };
         auto exclusive_snapshot = std::make_shared<std::map<std::string, bool>>();
         auto snapshot_mutex = std::make_shared<std::mutex>();
-        providers.begin_exclusive = [this, exclusive_snapshot, snapshot_mutex] {
-            router_->begin_exclusive();
+        providers.begin_exclusive = [this, exclusive_snapshot, snapshot_mutex](
+                                        lemon::jobs::CancelFlag* cancel) -> bool {
+            if (!router_->begin_exclusive(cancel)) return false;
             auto snap = router_->snapshot_loaded_models();
             std::lock_guard<std::mutex> lk(*snapshot_mutex);
             *exclusive_snapshot = std::move(snap);
+            return true;
         };
         providers.end_exclusive = [this] { router_->end_exclusive(); };
         providers.reconcile_unload = [this, exclusive_snapshot, snapshot_mutex] {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -570,15 +570,29 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
         };
         providers.restore_exclusive = [this, job_states, state_mutex](
                                           const std::string& job_id,
+                                          const lemon::jobs::json& manifest,
                                           lemon::jobs::CancelFlag* cancel) -> bool {
             std::map<std::string, nlohmann::json> to_restore;
+            std::set<std::string> tracked;
             {
                 std::lock_guard<std::mutex> lk(*state_mutex);
                 auto it = job_states->find(job_id);
-                if (it == job_states->end()) return true;
-                for (const auto& kv : it->second.owned)
-                    if (kv.second.is_object() && kv.second.contains("options"))
-                        to_restore[kv.first] = kv.second;
+                if (it != job_states->end()) {
+                    for (const auto& kv : it->second.owned) {
+                        tracked.insert(kv.first);
+                        if (kv.second.is_object() && kv.second.contains("options"))
+                            to_restore[kv.first] = kv.second;
+                    }
+                }
+            }
+            for (auto it = manifest.begin(); it != manifest.end(); ++it) {
+                const std::string canonical = router_->canonical_model_name(it.key());
+                if (tracked.count(canonical) || to_restore.count(canonical)) continue;
+                nlohmann::json params = nlohmann::json::parse(it.value().dump());
+                nlohmann::json entry = {{"options", params}};
+                if (params.contains("pinned") && params["pinned"].is_boolean())
+                    entry["pinned"] = params["pinned"].get<bool>();
+                to_restore[canonical] = std::move(entry);
             }
             for (const auto& kv : to_restore) {
                 if (cancel && cancel->load()) return false;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -487,9 +487,9 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             return lemon::jobs::json::object();
         };
         providers.chat_op = [this](const lemon::jobs::json& params,
-                                   lemon::jobs::CancelFlag&) -> lemon::jobs::json {
+                                   lemon::jobs::CancelFlag& cancel) -> lemon::jobs::json {
             nlohmann::json request = nlohmann::json::parse(params.dump());
-            nlohmann::json response = router_->chat_completion(request);
+            nlohmann::json response = router_->chat_completion(request, &cancel);
             if (response.contains("error")) {
                 std::string msg = "chat failed";
                 const auto& err = response["error"];
@@ -501,9 +501,23 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             }
             return lemon::jobs::json::parse(response.dump());
         };
-        providers.begin_exclusive = [this] { router_->begin_exclusive(); };
+        auto exclusive_snapshot = std::make_shared<std::set<std::string>>();
+        auto snapshot_mutex = std::make_shared<std::mutex>();
+        providers.begin_exclusive = [this, exclusive_snapshot, snapshot_mutex] {
+            router_->begin_exclusive();
+            auto snap = router_->snapshot_loaded_models();
+            std::lock_guard<std::mutex> lk(*snapshot_mutex);
+            *exclusive_snapshot = std::move(snap);
+        };
         providers.end_exclusive = [this] { router_->end_exclusive(); };
-        providers.reconcile_unload = [this] { router_->unload_model(""); };
+        providers.reconcile_unload = [this, exclusive_snapshot, snapshot_mutex] {
+            std::set<std::string> keep;
+            {
+                std::lock_guard<std::mutex> lk(*snapshot_mutex);
+                keep = *exclusive_snapshot;
+            }
+            router_->unload_models_not_in(keep);
+        };
         job_manager_ = std::make_unique<lemon::jobs::JobManager>(
             lemon::utils::get_cache_dir(), lemon::jobs::build_op_registry(std::move(providers)));
     }
@@ -794,7 +808,7 @@ void Server::setup_routes(httplib::Server &web_server) {
         web_server.Post("/api/v1/" + endpoint, handler);
         web_server.Post("/v0/" + endpoint, handler);
         web_server.Post("/v1/" + endpoint, handler);
-        if (endpoint != "params") {
+        if (endpoint != "params" && endpoint != "jobs") {
             web_server.Get("/api/v0/" + endpoint, [](const httplib::Request&, httplib::Response& res) {
                 res.status = 405;
                 res.set_content("{\"error\": \"Method Not Allowed. Use POST for this endpoint\"}", "application/json");

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -253,6 +253,12 @@ static size_t write_file_callback(void* ptr, size_t size, size_t nmemb, void* st
     return written;
 }
 
+static int cancel_xferinfo_callback(void* clientp, curl_off_t, curl_off_t, curl_off_t,
+                                    curl_off_t) {
+    auto* flag = static_cast<std::atomic<bool>*>(clientp);
+    return (flag && flag->load()) ? 1 : 0;
+}
+
 struct ProgressData {
     ProgressCallback callback;
     bool cancelled = false;
@@ -456,7 +462,8 @@ HttpResponse HttpClient::post(const std::string& url,
                               const std::string& body,
                               const std::map<std::string, std::string>& headers,
                               long timeout_seconds,
-                              HttpSecurityPolicy policy) {
+                              HttpSecurityPolicy policy,
+                              std::atomic<bool>* cancel_flag) {
     CURL* curl = curl_easy_init();
     if (!curl) {
         throw std::runtime_error("Failed to initialize CURL");
@@ -476,6 +483,12 @@ HttpResponse HttpClient::post(const std::string& url,
     }
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
+
+    if (cancel_flag) {
+        curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, cancel_xferinfo_callback);
+        curl_easy_setopt(curl, CURLOPT_XFERINFODATA, cancel_flag);
+        curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+    }
 
     // Add custom headers
     bool has_content_type = false;

--- a/src/cpp/server/utils/path_utils.cpp
+++ b/src/cpp/server/utils/path_utils.cpp
@@ -242,6 +242,7 @@ bool atomic_replace_file(const fs::path& src, const fs::path& dest, std::error_c
     std::error_code copy_ec;
     fs::copy_file(src, dest, fs::copy_options::overwrite_existing, copy_ec);
     if (copy_ec) {
+        ec = copy_ec;
         std::error_code rm_ec;
         fs::remove(src, rm_ec);
         return false;

--- a/src/cpp/server/utils/path_utils.cpp
+++ b/src/cpp/server/utils/path_utils.cpp
@@ -227,5 +227,30 @@ std::string get_downloaded_bin_dir() {
     return bin_dir;
 }
 
+bool atomic_replace_file(const fs::path& src, const fs::path& dest, std::error_code& ec) {
+    ec.clear();
+#ifdef _WIN32
+    if (MoveFileExW(src.c_str(), dest.c_str(),
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        return true;
+    }
+    ec = std::error_code(static_cast<int>(GetLastError()), std::system_category());
+#else
+    fs::rename(src, dest, ec);
+    if (!ec) return true;
+#endif
+    std::error_code copy_ec;
+    fs::copy_file(src, dest, fs::copy_options::overwrite_existing, copy_ec);
+    if (copy_ec) {
+        std::error_code rm_ec;
+        fs::remove(src, rm_ec);
+        return false;
+    }
+    ec.clear();
+    std::error_code rm_ec;
+    fs::remove(src, rm_ec);
+    return true;
+}
+
 
 } // namespace utils::lemon

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -532,8 +532,6 @@ bool WrappedServer::wait_for_ready(const std::string& endpoint, long timeout_sec
     const int max_attempts = (timeout_seconds * 1000) / poll_interval_ms;
 
     for (int i = 0; i < max_attempts; i++) {
-        // A job interrupt landing mid-startup kills the spawned subprocess and
-        // aborts the wait; the caller (load_model) then throws "load cancelled".
         if (load_cancel_ && load_cancel_->load()) {
             const ProcessHandle h = consume_process_handle_for_cleanup();
             if (has_process_handle(h)) utils::ProcessManager::stop_process(h);

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -532,6 +532,15 @@ bool WrappedServer::wait_for_ready(const std::string& endpoint, long timeout_sec
     const int max_attempts = (timeout_seconds * 1000) / poll_interval_ms;
 
     for (int i = 0; i < max_attempts; i++) {
+        // A job interrupt landing mid-startup kills the spawned subprocess and
+        // aborts the wait; the caller (load_model) then throws "load cancelled".
+        if (load_cancel_ && load_cancel_->load()) {
+            const ProcessHandle h = consume_process_handle_for_cleanup();
+            if (has_process_handle(h)) utils::ProcessManager::stop_process(h);
+            LOG(WARNING, "WrappedServer") << server_name_ << " load cancelled" << std::endl;
+            return false;
+        }
+
         // Check if process is still running. If it already exited, consume and
         // reap the owned handle here so the caller cannot later signal a stale
         // PID while cleaning up a failed startup.

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -14,6 +14,12 @@
 
 namespace lemon {
 
+static thread_local std::atomic<bool>* t_request_cancel = nullptr;
+
+void WrappedServer::set_request_cancel_flag(std::atomic<bool>* f) { t_request_cancel = f; }
+
+std::atomic<bool>* WrappedServer::current_request_cancel() { return t_request_cancel; }
+
 namespace {
 
 std::string lower_copy(std::string value) {
@@ -652,7 +658,7 @@ json WrappedServer::forward_request(const std::string& endpoint, const json& req
             headers,
             timeout_seconds,
             utils::HttpSecurityPolicy::TrustedLoopback,
-            request_cancel_);
+            current_request_cancel());
         note_backend_activity();
 
         if (response.status_code == 200) {

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -651,7 +651,8 @@ json WrappedServer::forward_request(const std::string& endpoint, const json& req
             request.dump(),
             headers,
             timeout_seconds,
-            utils::HttpSecurityPolicy::TrustedLoopback);
+            utils::HttpSecurityPolicy::TrustedLoopback,
+            request_cancel_);
         note_backend_activity();
 
         if (response.status_code == 200) {

--- a/test/cpp/test_job_expr.cpp
+++ b/test/cpp/test_job_expr.cpp
@@ -1,6 +1,3 @@
-// Unit tests for the job engine's reference resolution and condition evaluator.
-// Pure — driven entirely by synthetic JSON contexts.
-
 #include "lemon/jobs/job_expr.h"
 
 #include <cstdio>
@@ -30,7 +27,6 @@ static void test_reference_resolution() {
                 {"list", {10, 20, 30}},
                 {"cfg", {{"nested", {{"deep", 5}}}}}};
 
-    // Whole-string ref preserves type.
     json m = resolve_refs("${model}", ctx);
     check("ref: whole-string keeps string", m.is_string() && m == "Agents-A1");
     json tps = resolve_refs("${run_v.tps}", ctx);
@@ -40,20 +36,17 @@ static void test_reference_resolution() {
     json deep = resolve_refs("${cfg.nested.deep}", ctx);
     check("ref: deep path", deep.get<int>() == 5);
 
-    // Embedded refs interpolate to text.
     json interp = resolve_refs("model=${model} tps=${run_v.tps}", ctx);
     check("ref: embedded interpolates",
           interp.is_string() && interp.get<std::string>().find("model=Agents-A1") == 0
               && interp.get<std::string>().find("tps=73.3") != std::string::npos);
 
-    // Nested params get resolved recursively.
     json params = {{"a", "${model}"}, {"b", {{"c", "${run_v.tps}"}}}, {"d", {1, "${list.0}"}}};
     json out = resolve_refs(params, ctx);
     check("ref: recurses objects/arrays",
           out["a"] == "Agents-A1" && out["b"]["c"].get<double>() == 73.3
               && out["d"][1].get<int>() == 10);
 
-    // Missing reference is an error.
     check("ref: missing path throws", threw("${nope.missing}", ctx));
     bool caught = false;
     try { resolve_refs("${also.missing}", ctx); } catch (const JobError&) { caught = true; }

--- a/test/cpp/test_job_expr.cpp
+++ b/test/cpp/test_job_expr.cpp
@@ -95,11 +95,24 @@ static void test_truthiness_and_edges() {
     check("edge: unterminated ref throws", threw("${a", c));
 }
 
+static void test_syntax_check() {
+    check("syntax: valid passes", check_expression_syntax("${a} > 1 && ${b} == 'x'").empty());
+    check("syntax: unresolved ref deferred", check_expression_syntax("${x.y.z} + 1").empty());
+    check("syntax: type mismatch deferred", check_expression_syntax("${backend} < 5").empty());
+    check("syntax: incomplete rejected", !check_expression_syntax("1 +").empty());
+    check("syntax: unmatched paren rejected", !check_expression_syntax("(true").empty());
+    check("syntax: chained comparison rejected", !check_expression_syntax("1 < 2 < 3").empty());
+    check("syntax: trailing tokens rejected", !check_expression_syntax("1 2").empty());
+    check("syntax: bad char rejected", !check_expression_syntax("1 @ 2").empty());
+    check("syntax: empty ok", check_expression_syntax("").empty());
+}
+
 int main() {
     test_reference_resolution();
     test_arithmetic_and_precedence();
     test_comparison_and_boolean();
     test_truthiness_and_edges();
+    test_syntax_check();
     if (g_failures) {
         std::printf("%d FAILURE(S)\n", g_failures);
         return 1;

--- a/test/cpp/test_job_expr.cpp
+++ b/test/cpp/test_job_expr.cpp
@@ -1,0 +1,116 @@
+// Unit tests for the job engine's reference resolution and condition evaluator.
+// Pure — driven entirely by synthetic JSON contexts.
+
+#include "lemon/jobs/job_expr.h"
+
+#include <cstdio>
+#include <string>
+
+using namespace lemon::jobs;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static bool threw(const std::string& expr, const json& ctx) {
+    try {
+        eval_condition(expr, ctx);
+        return false;
+    } catch (const JobError&) {
+        return true;
+    }
+}
+
+static void test_reference_resolution() {
+    json ctx = {{"model", "Agents-A1"},
+                {"run_v", {{"tps", 73.3}, {"ttft", 120.0}}},
+                {"list", {10, 20, 30}},
+                {"cfg", {{"nested", {{"deep", 5}}}}}};
+
+    // Whole-string ref preserves type.
+    json m = resolve_refs("${model}", ctx);
+    check("ref: whole-string keeps string", m.is_string() && m == "Agents-A1");
+    json tps = resolve_refs("${run_v.tps}", ctx);
+    check("ref: whole-string keeps number", tps.is_number() && tps.get<double>() == 73.3);
+    json idx = resolve_refs("${list.1}", ctx);
+    check("ref: array index", idx.is_number() && idx.get<int>() == 20);
+    json deep = resolve_refs("${cfg.nested.deep}", ctx);
+    check("ref: deep path", deep.get<int>() == 5);
+
+    // Embedded refs interpolate to text.
+    json interp = resolve_refs("model=${model} tps=${run_v.tps}", ctx);
+    check("ref: embedded interpolates",
+          interp.is_string() && interp.get<std::string>().find("model=Agents-A1") == 0
+              && interp.get<std::string>().find("tps=73.3") != std::string::npos);
+
+    // Nested params get resolved recursively.
+    json params = {{"a", "${model}"}, {"b", {{"c", "${run_v.tps}"}}}, {"d", {1, "${list.0}"}}};
+    json out = resolve_refs(params, ctx);
+    check("ref: recurses objects/arrays",
+          out["a"] == "Agents-A1" && out["b"]["c"].get<double>() == 73.3
+              && out["d"][1].get<int>() == 10);
+
+    // Missing reference is an error.
+    check("ref: missing path throws", threw("${nope.missing}", ctx));
+    bool caught = false;
+    try { resolve_refs("${also.missing}", ctx); } catch (const JobError&) { caught = true; }
+    check("ref: resolve_refs throws on missing", caught);
+}
+
+static void test_arithmetic_and_precedence() {
+    json c = json::object();
+    check("expr: add", eval_condition("2 + 3 == 5", c));
+    check("expr: mul before add", eval_condition("2 + 3 * 4 == 14", c));
+    check("expr: parens", eval_condition("(2 + 3) * 4 == 20", c));
+    check("expr: division", eval_condition("10 / 4 == 2.5", c));
+    check("expr: unary minus", eval_condition("-3 + 5 == 2", c));
+    check("expr: div by zero throws", threw("1 / 0", c));
+    check("expr: ratio gate", eval_condition("898.8 / 813.4 > 1.05", c));
+}
+
+static void test_comparison_and_boolean() {
+    json c = {{"a", 73.3}, {"b", 55.8}, {"backend", "vulkan"}, {"ok", true}, {"empty", ""}};
+    check("cmp: numeric >", eval_condition("${a} > ${b}", c));
+    check("cmp: numeric >= equal", eval_condition("5 >= 5", c));
+    check("cmp: string ==", eval_condition("${backend} == 'vulkan'", c));
+    check("cmp: string !=", eval_condition("${backend} != 'rocm'", c));
+    check("cmp: string lexicographic", eval_condition("'abc' < 'abd'", c));
+    check("bool: and", eval_condition("${a} > ${b} && ${ok}", c));
+    check("bool: or short of false", eval_condition("${a} < ${b} || ${backend} == 'vulkan'", c));
+    check("bool: not", eval_condition("!(${a} < ${b})", c));
+    check("bool: precedence and over or", eval_condition("true || false && false", c));
+    check("cmp: order-compare mismatched types throws", threw("${backend} < 5", c));
+}
+
+static void test_truthiness_and_edges() {
+    json c = {{"zero", 0}, {"nonzero", 3}, {"emptystr", ""}, {"str", "x"},
+              {"t", true}, {"f", false}, {"nul", nullptr}, {"arr", json::array()},
+              {"arr2", {1}}};
+    check("truthy: number 0 false", !eval_condition("${zero}", c));
+    check("truthy: number nonzero true", eval_condition("${nonzero}", c));
+    check("truthy: empty string false", !eval_condition("${emptystr}", c));
+    check("truthy: string true", eval_condition("${str}", c));
+    check("truthy: null false", !eval_condition("${nul}", c));
+    check("truthy: empty array false", !eval_condition("${arr}", c));
+    check("truthy: nonempty array true", eval_condition("${arr2}", c));
+    check("edge: empty expression is true", eval_condition("", c));
+    check("edge: trailing tokens throw", threw("1 2", c));
+    check("edge: unexpected char throws", threw("1 @ 2", c));
+    check("edge: unterminated ref throws", threw("${a", c));
+}
+
+int main() {
+    test_reference_resolution();
+    test_arithmetic_and_precedence();
+    test_comparison_and_boolean();
+    test_truthiness_and_edges();
+    if (g_failures) {
+        std::printf("%d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    std::printf("ALL PASS (0 failures)\n");
+    return 0;
+}

--- a/test/cpp/test_job_graph.cpp
+++ b/test/cpp/test_job_graph.cpp
@@ -68,6 +68,34 @@ static void test_invalid_graphs() {
     badexpr[0].when = "1 @ 2";
     check("invalid: malformed when rejected",
           validate_steps(badexpr, kOps).find("when") != std::string::npos);
+
+    std::vector<StepRecord> incomplete = {step("a", "load")};
+    incomplete[0].when = "1 +";
+    check("invalid: incomplete expression rejected at validation",
+          !validate_steps(incomplete, kOps).empty());
+
+    std::vector<StepRecord> unbalanced = {step("a", "load")};
+    unbalanced[0].when = "(true";
+    check("invalid: unmatched paren rejected at validation",
+          !validate_steps(unbalanced, kOps).empty());
+
+    std::vector<StepRecord> chained = {step("a", "load"), step("b", "chat")};
+    chained[0].branch.push_back({"1 < 2 < 3", "b"});
+    check("invalid: chained comparison rejected at validation",
+          !validate_steps(chained, kOps).empty());
+
+    std::vector<StepRecord> defref = {step("a", "load")};
+    defref[0].when = "${some.missing.ref} > 0";
+    check("valid: unresolved ref deferred past validation",
+          validate_steps(defref, kOps).empty());
+
+    std::vector<StepRecord> reserved = {step("inputs", "load")};
+    check("invalid: step id 'inputs' rejected",
+          validate_steps(reserved, kOps).find("reserved") != std::string::npos);
+
+    std::vector<StepRecord> dotted = {step("a.b", "load")};
+    check("invalid: step id with '.' rejected",
+          validate_steps(dotted, kOps).find("'.'") != std::string::npos);
 }
 
 static void test_json_roundtrip() {

--- a/test/cpp/test_job_graph.cpp
+++ b/test/cpp/test_job_graph.cpp
@@ -1,0 +1,122 @@
+// Unit tests for job step-graph validation: unique ids, known ops, forward-only
+// jump targets. Also exercises Job/StepRecord JSON round-tripping.
+
+#include "lemon/jobs/job_graph.h"
+#include "lemon/jobs/job_types.h"
+
+#include <cstdio>
+#include <set>
+#include <string>
+
+using namespace lemon::jobs;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static const std::set<std::string> kOps = {"system_info", "load", "unload", "chat"};
+
+static StepRecord step(const std::string& id, const std::string& op) {
+    StepRecord s;
+    s.id = id;
+    s.op = op;
+    return s;
+}
+
+static void test_valid_graphs() {
+    std::vector<StepRecord> ok = {step("a", "system_info"), step("b", "load"), step("c", "chat")};
+    check("valid: linear ok", validate_steps(ok, kOps).empty());
+
+    std::vector<StepRecord> br = {step("a", "load"), step("b", "chat"), step("c", "unload")};
+    br[0].on_fail = "c";                                  // forward jump on failure
+    br[1].branch.push_back({"${b.tps} > 0", "c"});        // forward branch
+    br[1].on_done = "c";
+    check("valid: forward on_fail/branch/on_done ok", validate_steps(br, kOps).empty());
+}
+
+static void test_invalid_graphs() {
+    std::vector<StepRecord> empty;
+    check("invalid: empty rejected", !validate_steps(empty, kOps).empty());
+
+    std::vector<StepRecord> dup = {step("a", "load"), step("a", "chat")};
+    check("invalid: duplicate id rejected",
+          validate_steps(dup, kOps).find("duplicate") != std::string::npos);
+
+    std::vector<StepRecord> unk = {step("a", "teleport")};
+    check("invalid: unknown op rejected",
+          validate_steps(unk, kOps).find("unknown op") != std::string::npos);
+
+    std::vector<StepRecord> back = {step("a", "load"), step("b", "chat")};
+    back[1].on_done = "a";  // backward jump = loop
+    check("invalid: backward on_done rejected (no loops)",
+          validate_steps(back, kOps).find("later step") != std::string::npos);
+
+    std::vector<StepRecord> self = {step("a", "load"), step("b", "chat")};
+    self[0].branch.push_back({"true", "a"});  // self/backward branch
+    check("invalid: non-forward branch rejected",
+          validate_steps(self, kOps).find("later step") != std::string::npos);
+
+    std::vector<StepRecord> ghost = {step("a", "load"), step("b", "chat")};
+    ghost[0].on_fail = "nowhere";
+    check("invalid: on_fail to unknown id rejected",
+          validate_steps(ghost, kOps).find("not a known step") != std::string::npos);
+
+    std::vector<StepRecord> emptyid = {step("", "load")};
+    check("invalid: empty id rejected", !validate_steps(emptyid, kOps).empty());
+
+    std::vector<StepRecord> badexpr = {step("a", "load")};
+    badexpr[0].when = "1 @ 2";
+    check("invalid: malformed when rejected",
+          validate_steps(badexpr, kOps).find("when") != std::string::npos);
+}
+
+static void test_json_roundtrip() {
+    Job j;
+    j.id = "job-1";
+    j.name = "bench-duel";
+    j.status = JobStatus::Running;
+    j.inputs = {{"model", "Agents-A1"}};
+    j.cursor = "run_v";
+    StepRecord s = step("load_v", "load");
+    s.params = {{"llamacpp_backend", "vulkan"}, {"ctx_size", "${inputs.ctx}"}};
+    s.on_fail = "load_v_lo";
+    s.branch.push_back({"${vulkan_tps} > 0", "unload_v"});
+    s.extract = {{"vulkan_tps", "timings.predicted_per_second"}};
+    s.status = StepStatus::Completed;
+    s.duration_ms = 4200;
+    j.steps.push_back(s);
+
+    Job back = Job::from_json(j.to_json());
+    check("json: job fields", back.id == "job-1" && back.name == "bench-duel"
+              && back.status == JobStatus::Running && back.cursor == "run_v");
+    check("json: step definition survives",
+          back.steps.size() == 1 && back.steps[0].op == "load"
+              && back.steps[0].on_fail == "load_v_lo"
+              && back.steps[0].branch.size() == 1
+              && back.steps[0].branch[0].goto_id == "unload_v"
+              && back.steps[0].extract["vulkan_tps"] == "timings.predicted_per_second");
+    check("json: step runtime survives",
+          back.steps[0].status == StepStatus::Completed && back.steps[0].duration_ms == 4200);
+
+    // The round-tripped definition still validates.
+    std::set<std::string> ops = {"load"};
+    // Give the forward targets real steps so validation passes.
+    back.steps.push_back(step("unload_v", "load"));
+    back.steps.push_back(step("load_v_lo", "load"));
+    check("json: round-tripped graph validates", validate_steps(back.steps, ops).empty());
+}
+
+int main() {
+    test_valid_graphs();
+    test_invalid_graphs();
+    test_json_roundtrip();
+    if (g_failures) {
+        std::printf("%d FAILURE(S)\n", g_failures);
+        return 1;
+    }
+    std::printf("ALL PASS (0 failures)\n");
+    return 0;
+}

--- a/test/cpp/test_job_graph.cpp
+++ b/test/cpp/test_job_graph.cpp
@@ -1,6 +1,3 @@
-// Unit tests for job step-graph validation: unique ids, known ops, forward-only
-// jump targets. Also exercises Job/StepRecord JSON round-tripping.
-
 #include "lemon/jobs/job_graph.h"
 #include "lemon/jobs/job_types.h"
 
@@ -31,8 +28,8 @@ static void test_valid_graphs() {
     check("valid: linear ok", validate_steps(ok, kOps).empty());
 
     std::vector<StepRecord> br = {step("a", "load"), step("b", "chat"), step("c", "unload")};
-    br[0].on_fail = "c";                                  // forward jump on failure
-    br[1].branch.push_back({"${b.tps} > 0", "c"});        // forward branch
+    br[0].on_fail = "c";
+    br[1].branch.push_back({"${b.tps} > 0", "c"});
     br[1].on_done = "c";
     check("valid: forward on_fail/branch/on_done ok", validate_steps(br, kOps).empty());
 }
@@ -50,12 +47,12 @@ static void test_invalid_graphs() {
           validate_steps(unk, kOps).find("unknown op") != std::string::npos);
 
     std::vector<StepRecord> back = {step("a", "load"), step("b", "chat")};
-    back[1].on_done = "a";  // backward jump = loop
+    back[1].on_done = "a";
     check("invalid: backward on_done rejected (no loops)",
           validate_steps(back, kOps).find("later step") != std::string::npos);
 
     std::vector<StepRecord> self = {step("a", "load"), step("b", "chat")};
-    self[0].branch.push_back({"true", "a"});  // self/backward branch
+    self[0].branch.push_back({"true", "a"});
     check("invalid: non-forward branch rejected",
           validate_steps(self, kOps).find("later step") != std::string::npos);
 
@@ -101,9 +98,8 @@ static void test_json_roundtrip() {
     check("json: step runtime survives",
           back.steps[0].status == StepStatus::Completed && back.steps[0].duration_ms == 4200);
 
-    // The round-tripped definition still validates.
     std::set<std::string> ops = {"load"};
-    // Give the forward targets real steps so validation passes.
+
     back.steps.push_back(step("unload_v", "load"));
     back.steps.push_back(step("load_v_lo", "load"));
     check("json: round-tripped graph validates", validate_steps(back.steps, ops).empty());

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import shutil
 import signal
@@ -312,6 +313,34 @@ class JobEngineTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, r.text)
         self.poll_status(jid, "completed", timeout=25)
 
+    def test_persistence_multiple_writes(self):
+        ids = []
+        for i in range(5):
+            job = self.create_job(f"multi-{i}", [{"id": "a", "op": "system_info"}])
+            jid = job["id"]
+            self.poll_status(jid, "completed")
+            ids.append(jid)
+
+        jobs_path = os.path.join(self.cache_dir, "jobs.json")
+        self.assertTrue(os.path.isfile(jobs_path), "jobs.json was not written")
+        with open(jobs_path, "r", encoding="utf-8") as f:
+            disk = json.load(f)
+        self.assertEqual(disk.get("version"), 1)
+        on_disk = {j["id"]: j for j in disk.get("jobs", [])}
+        for jid in ids:
+            self.assertIn(jid, on_disk, f"{jid} missing from persisted jobs.json")
+            self.assertEqual(on_disk[jid]["status"], "completed")
+            self.assertEqual(self.get_job(jid).json()["status"], on_disk[jid]["status"])
+
+        recreated = self.create_job("multi-final", [{"id": "a", "op": "system_info"}])
+        self.poll_status(recreated["id"], "completed")
+        with open(jobs_path, "r", encoding="utf-8") as f:
+            disk2 = json.load(f)
+        ids_on_disk = {j["id"] for j in disk2.get("jobs", [])}
+        self.assertIn(recreated["id"], ids_on_disk)
+        for jid in ids:
+            self.assertIn(jid, ids_on_disk, f"{jid} lost after further persists")
+
     def test_real_exclusive_job(self):
         backend = self.require_real_backend()
         steps = [
@@ -545,6 +574,109 @@ class JobEngineTests(unittest.TestCase):
             requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
             TEST_MODEL,
             "interrupt cleanup unloaded a model the job did not load",
+        )
+
+    def _pinned_load_steps(self, backend):
+        return [
+            {"id": "u0", "op": "unload"},
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                    "pinned": True,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 15000}},
+            {"id": "u", "op": "unload"},
+        ]
+
+    def _wait_model_unloaded(self, timeout=15):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if (
+                requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded")
+                is None
+            ):
+                return
+            time.sleep(0.25)
+
+    def test_delete_active_pinned_model_cleans_up(self):
+        backend = self.require_real_backend()
+        job = self.create_job("delete-active-pinned", self._pinned_load_steps(backend))
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+        self.assertEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+        )
+
+        r = requests.delete(f"{BASE}/jobs/{jid}", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+
+        self._wait_model_unloaded()
+        self.assertIsNone(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            "deleting an active job did not clean up a model it pinned",
+        )
+        self.poll_gone(jid)
+
+    def test_interrupt_pinned_model_cleans_up(self):
+        backend = self.require_real_backend()
+        job = self.create_job("interrupt-pinned", self._pinned_load_steps(backend))
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+        self.assertEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+        )
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "interrupted", timeout=20)
+
+        self._wait_model_unloaded()
+        self.assertIsNone(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            "interrupt did not clean up a model the job pinned",
+        )
+
+    def test_preexisting_pinned_model_survives_job_interrupt(self):
+        backend = self.require_real_backend()
+        r = requests.post(
+            f"{BASE}/load",
+            json={
+                "model_name": TEST_MODEL,
+                "llamacpp_backend": backend,
+                "ctx_size": 2048,
+                "pinned": True,
+            },
+            timeout=120,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+        )
+
+        steps = [
+            {"id": "hold", "op": "sleep", "params": {"ms": 15000}},
+            {"id": "u", "op": "unload"},
+        ]
+        job = self.create_job("preexisting-pinned-survives", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=30)
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "interrupted", timeout=20)
+
+        self.assertEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+            "interrupt cleanup unloaded a model pinned before the job started",
         )
 
     def test_bench_shaped_sweep(self):

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -1,17 +1,3 @@
-"""
-Endpoint tests for the generic server-side job engine.
-
-These exercise the job lifecycle with no inference backend: read-only ops
-(system_info / models) plus a `sleep` op used to make pause / interrupt /
-persistence observable. Each test runs its own isolated `lemond` on a private
-cache dir and port so the persistence-across-restart case can kill and relaunch
-the server without disturbing anything else.
-
-Usage:
-    python server_jobs.py
-    python server_jobs.py --lemond-binary /path/to/lemond
-"""
-
 import argparse
 import os
 import shutil
@@ -28,7 +14,6 @@ PORT = 13401
 HOST = "127.0.0.1"
 BASE = f"http://{HOST}:{PORT}/api/v1"
 
-# Tiny llama.cpp model shared with the endpoint suite; small enough to load fast.
 TEST_MODEL = "Tiny-Test-Model-GGUF"
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -59,8 +44,6 @@ class JobEngineTests(unittest.TestCase):
     def tearDown(self):
         self.stop_server()
         shutil.rmtree(self.cache_dir, ignore_errors=True)
-
-    # ── server lifecycle ────────────────────────────────────────────────
 
     def start_server(self):
         binary = find_lemond_binary()
@@ -99,8 +82,6 @@ class JobEngineTests(unittest.TestCase):
                 self.proc.send_signal(signal.SIGKILL)
                 self.proc.wait(timeout=10)
         self.proc = None
-
-    # ── helpers ─────────────────────────────────────────────────────────
 
     def create_job(self, name, steps, inputs=None, expect=202):
         body = {"name": name, "definition": {"steps": steps}}
@@ -150,8 +131,6 @@ class JobEngineTests(unittest.TestCase):
             time.sleep(0.1)
         self.fail(f"job {job_id} cursor did not reach '{target_cursor}'")
 
-    # ── real-backend helpers ────────────────────────────────────────────
-
     def installed_llamacpp_backend(self):
         r = requests.get(f"{BASE}/system-info", timeout=10)
         self.assertEqual(r.status_code, 200, r.text)
@@ -168,7 +147,7 @@ class JobEngineTests(unittest.TestCase):
             timeout=600,
             stream=True,
         )
-        # Drain the streamed progress so the request completes.
+
         for _ in r.iter_lines():
             pass
         self.assertEqual(r.status_code, 200, "failed to pull the test model")
@@ -179,8 +158,6 @@ class JobEngineTests(unittest.TestCase):
             self.skipTest("no installed llamacpp backend available")
         self.ensure_test_model()
         return backend
-
-    # ── tests ───────────────────────────────────────────────────────────
 
     def test_system_info_job_completes(self):
         job = self.create_job("sysinfo", [{"id": "a", "op": "system_info"}])
@@ -221,7 +198,7 @@ class JobEngineTests(unittest.TestCase):
         self.assertEqual(self.step_by_id(done, "b")["status"], "skipped")
 
     def test_branch_on_input(self):
-        # step "a" branches to "c" when inputs.pick == 'b', skipping "b".
+
         steps = [
             {
                 "id": "a",
@@ -278,7 +255,7 @@ class JobEngineTests(unittest.TestCase):
         self.poll_status(jid, "completed", timeout=20)
 
     def test_delete_terminal_and_active(self):
-        # terminal job removed cleanly
+
         job = self.create_job("del", [{"id": "a", "op": "system_info"}])
         jid = job["id"]
         self.poll_status(jid, "completed")
@@ -286,7 +263,6 @@ class JobEngineTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, r.text)
         self.assertEqual(self.get_job(jid).status_code, 404)
 
-        # active (long sleep) job deleted via interrupt-then-remove
         job2 = self.create_job(
             "del2", [{"id": "w", "op": "sleep", "params": {"ms": 8000}}]
         )
@@ -302,7 +278,6 @@ class JobEngineTests(unittest.TestCase):
         jid = job["id"]
         self.poll_status(jid, "running", timeout=10)
 
-        # Hard-kill the server while the sleep step is in flight, then restart.
         self.stop_server(hard=True)
         self.start_server()
 
@@ -313,12 +288,9 @@ class JobEngineTests(unittest.TestCase):
         self.assertIn("server restarted", body.get("error", ""))
         self.assertEqual(self.step_by_id(body, "w")["status"], "pending")
 
-        # Resume re-runs the pending step and the job runs to completion.
         r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
         self.assertEqual(r.status_code, 200, r.text)
         self.poll_status(jid, "completed", timeout=25)
-
-    # ── Phase 3: exclusive ops + slot gate ──────────────────────────────
 
     def test_real_exclusive_job(self):
         backend = self.require_real_backend()
@@ -367,7 +339,6 @@ class JobEngineTests(unittest.TestCase):
     def test_queue_behind_exclusive_job(self):
         backend = self.require_real_backend()
 
-        # Control: with no job running, a normal chat on a preloaded model is prompt.
         requests.post(
             f"{BASE}/load",
             json={
@@ -391,8 +362,6 @@ class JobEngineTests(unittest.TestCase):
         control_latency = time.time() - t0
         self.assertEqual(r.status_code, 200, r.text)
 
-        # Now hold the exclusive slot with a load + a several-second sleep (no
-        # final unload, so the queued chat finds the model still loaded).
         hold_ms = 6000
         steps = [
             {
@@ -408,7 +377,7 @@ class JobEngineTests(unittest.TestCase):
         ]
         job = self.create_job("queue", steps)
         jid = job["id"]
-        self.poll_cursor(jid, "hold", timeout=60)  # load done, provably mid-exclusive
+        self.poll_cursor(jid, "hold", timeout=60)
 
         t0 = time.time()
         r = requests.post(
@@ -424,9 +393,6 @@ class JobEngineTests(unittest.TestCase):
         queued_latency = time.time() - t0
         self.assertEqual(r.status_code, 200, r.text)
 
-        # The queued request must have been held behind the job: it returns only
-        # after the slot is released, so its latency dwarfs the control call and
-        # the job is finished by the time it comes back.
         self.assertGreater(
             queued_latency,
             max(2.0, control_latency * 5),
@@ -460,8 +426,6 @@ class JobEngineTests(unittest.TestCase):
         stopped = self.poll_status(jid, "interrupted", timeout=20)
         self.assertEqual(self.step_by_id(stopped, "hold")["status"], "pending")
 
-        # Reconcile: an interrupted exclusive job unloads the model it left
-        # resident (it had loaded TEST_MODEL before the sleep it was stopped in).
         deadline = time.time() + 10
         while time.time() < deadline:
             if (
@@ -475,8 +439,6 @@ class JobEngineTests(unittest.TestCase):
             "interrupt did not unload the resident model",
         )
 
-        # The slot was released cleanly: a normal request goes through promptly
-        # rather than deadlocking behind an abandoned exclusive hold.
         t0 = time.time()
         r = requests.post(
             f"{BASE}/chat/completions",
@@ -490,12 +452,9 @@ class JobEngineTests(unittest.TestCase):
         )
         self.assertLess(time.time() - t0, 10.0, "slot was not released on interrupt")
 
-        # Resume re-runs the pending sleep and the job finishes.
         r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
         self.assertEqual(r.status_code, 200, r.text)
         self.poll_status(jid, "completed", timeout=40)
-
-    # ── Phase 4: a bench-shaped sweep (the AutoOpt methodology end-to-end) ──
 
     def test_bench_shaped_sweep(self):
         backend = self.require_real_backend()
@@ -549,14 +508,11 @@ class JobEngineTests(unittest.TestCase):
         result = self.poll_status(job["id"], "completed", timeout=180)
         ctx = result["context"]
 
-        # Both configs were measured and their throughput extracted.
         self.assertIn("a_tps", ctx)
         self.assertIn("b_tps", ctx)
         self.assertGreater(ctx["a_tps"], 0)
         self.assertGreater(ctx["b_tps"], 0)
 
-        # The branch fired on the measured metric: exactly one winner ran, and it
-        # is consistent with the extracted tps values.
         a_ran = self.step_by_id(result, "a_wins")["status"] == "completed"
         b_ran = self.step_by_id(result, "b_wins")["status"] == "completed"
         self.assertNotEqual(a_ran, b_ran, "exactly one winner branch should run")
@@ -565,7 +521,6 @@ class JobEngineTests(unittest.TestCase):
         else:
             self.assertTrue(b_ran, "b had > tps but a_wins ran")
 
-        # No model left resident after the sweep's final unload.
         h = requests.get(f"http://{HOST}:{PORT}/api/v1/health", timeout=5).json()
         self.assertIsNone(h.get("model_loaded"))
 

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -28,6 +28,9 @@ PORT = 13401
 HOST = "127.0.0.1"
 BASE = f"http://{HOST}:{PORT}/api/v1"
 
+# Tiny llama.cpp model shared with the endpoint suite; small enough to load fast.
+TEST_MODEL = "Tiny-Test-Model-GGUF"
+
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _LEMOND_BINARY = None
 
@@ -130,6 +133,52 @@ class JobEngineTests(unittest.TestCase):
             if s["id"] == step_id:
                 return s
         self.fail(f"step {step_id} not present in job")
+
+    def poll_cursor(self, job_id, target_cursor, timeout=30):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            r = self.get_job(job_id)
+            self.assertEqual(r.status_code, 200, r.text)
+            body = r.json()
+            if body["cursor"] == target_cursor:
+                return body
+            if body["status"] in ("completed", "failed"):
+                self.fail(
+                    f"job {job_id} reached {body['status']} before cursor "
+                    f"'{target_cursor}'"
+                )
+            time.sleep(0.1)
+        self.fail(f"job {job_id} cursor did not reach '{target_cursor}'")
+
+    # ── real-backend helpers ────────────────────────────────────────────
+
+    def installed_llamacpp_backend(self):
+        r = requests.get(f"{BASE}/system-info", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        backends = r.json().get("recipes", {}).get("llamacpp", {}).get("backends", {})
+        for name, info in backends.items():
+            if info.get("state") in ("installed", "ready"):
+                return name
+        return None
+
+    def ensure_test_model(self):
+        r = requests.post(
+            f"{BASE}/pull",
+            json={"model_name": TEST_MODEL},
+            timeout=600,
+            stream=True,
+        )
+        # Drain the streamed progress so the request completes.
+        for _ in r.iter_lines():
+            pass
+        self.assertEqual(r.status_code, 200, "failed to pull the test model")
+
+    def require_real_backend(self):
+        backend = self.installed_llamacpp_backend()
+        if not backend:
+            self.skipTest("no installed llamacpp backend available")
+        self.ensure_test_model()
+        return backend
 
     # ── tests ───────────────────────────────────────────────────────────
 
@@ -268,6 +317,168 @@ class JobEngineTests(unittest.TestCase):
         r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
         self.assertEqual(r.status_code, 200, r.text)
         self.poll_status(jid, "completed", timeout=25)
+
+    # ── Phase 3: exclusive ops + slot gate ──────────────────────────────
+
+    def test_real_exclusive_job(self):
+        backend = self.require_real_backend()
+        steps = [
+            {"id": "u0", "op": "unload"},
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                    "merge_args": False,
+                    "save_options": False,
+                },
+            },
+            {
+                "id": "say",
+                "op": "chat",
+                "params": {
+                    "model": TEST_MODEL,
+                    "messages": [{"role": "user", "content": "Say hi in one word."}],
+                    "temperature": 0,
+                    "max_completion_tokens": 32,
+                },
+            },
+            {"id": "u1", "op": "unload"},
+        ]
+        job = self.create_job("real-exclusive", steps)
+        done = self.poll_status(job["id"], "completed", timeout=120)
+        self.assertEqual(self.step_by_id(done, "ld")["status"], "completed")
+        self.assertEqual(self.step_by_id(done, "say")["status"], "completed")
+        self.assertEqual(done["context"]["ld"]["loaded"], True)
+        self.assertEqual(done["context"]["ld"]["backend"], backend)
+
+        chat_out = done["context"]["say"]
+        timings = chat_out.get("timings", {})
+        usage = chat_out.get("usage", {})
+        self.assertTrue(
+            "prompt_ms" in timings
+            or "predicted_per_second" in timings
+            or "total_tokens" in usage,
+            f"chat output carried neither timings nor usage: keys={list(chat_out)}",
+        )
+
+    def test_queue_behind_exclusive_job(self):
+        backend = self.require_real_backend()
+
+        # Control: with no job running, a normal chat on a preloaded model is prompt.
+        requests.post(
+            f"{BASE}/load",
+            json={
+                "model_name": TEST_MODEL,
+                "llamacpp_backend": backend,
+                "ctx_size": 2048,
+            },
+            timeout=120,
+        )
+        t0 = time.time()
+        r = requests.post(
+            f"{BASE}/chat/completions",
+            json={
+                "model": TEST_MODEL,
+                "messages": [{"role": "user", "content": "hi"}],
+                "temperature": 0,
+                "max_completion_tokens": 8,
+            },
+            timeout=60,
+        )
+        control_latency = time.time() - t0
+        self.assertEqual(r.status_code, 200, r.text)
+
+        # Now hold the exclusive slot with a load + a several-second sleep (no
+        # final unload, so the queued chat finds the model still loaded).
+        hold_ms = 6000
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": hold_ms}},
+        ]
+        job = self.create_job("queue", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)  # load done, provably mid-exclusive
+
+        t0 = time.time()
+        r = requests.post(
+            f"{BASE}/chat/completions",
+            json={
+                "model": TEST_MODEL,
+                "messages": [{"role": "user", "content": "hi"}],
+                "temperature": 0,
+                "max_completion_tokens": 8,
+            },
+            timeout=60,
+        )
+        queued_latency = time.time() - t0
+        self.assertEqual(r.status_code, 200, r.text)
+
+        # The queued request must have been held behind the job: it returns only
+        # after the slot is released, so its latency dwarfs the control call and
+        # the job is finished by the time it comes back.
+        self.assertGreater(
+            queued_latency,
+            max(2.0, control_latency * 5),
+            f"queued chat was not held behind the job "
+            f"(queued={queued_latency:.2f}s, control={control_latency:.2f}s)",
+        )
+        self.assertEqual(self.get_job(jid).json()["status"], "completed")
+        print(f"\n[queue] control={control_latency:.3f}s queued={queued_latency:.3f}s")
+
+    def test_interrupt_mid_job_cleans_up(self):
+        backend = self.require_real_backend()
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 15000}},
+            {"id": "u", "op": "unload"},
+        ]
+        job = self.create_job("interrupt-mid", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        stopped = self.poll_status(jid, "interrupted", timeout=20)
+        self.assertEqual(self.step_by_id(stopped, "hold")["status"], "pending")
+
+        # The slot was released cleanly: a normal request goes through promptly
+        # rather than deadlocking behind an abandoned exclusive hold.
+        t0 = time.time()
+        r = requests.post(
+            f"{BASE}/chat/completions",
+            json={
+                "model": TEST_MODEL,
+                "messages": [{"role": "user", "content": "hi"}],
+                "temperature": 0,
+                "max_completion_tokens": 8,
+            },
+            timeout=30,
+        )
+        self.assertLess(time.time() - t0, 10.0, "slot was not released on interrupt")
+
+        # Resume re-runs the pending sleep and the job finishes.
+        r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "completed", timeout=40)
 
 
 def parse_args():

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -1039,6 +1039,11 @@ class JobEngineTests(unittest.TestCase):
             pid_before,
             "a pin-only load reloaded the model instead of updating the pin in place",
         )
+        self.assertFalse(
+            mid.get("recipe_options", {}).get("pinned"),
+            "the stored recipe options disagree with the pin flag after an "
+            "in-place pin update",
+        )
 
         r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
         self.assertEqual(r.status_code, 200, r.text)

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -115,6 +115,14 @@ class JobEngineTests(unittest.TestCase):
                 return s
         self.fail(f"step {step_id} not present in job")
 
+    def poll_gone(self, job_id, timeout=20):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.get_job(job_id).status_code == 404:
+                return
+            time.sleep(0.2)
+        self.fail(f"job {job_id} was not erased in time")
+
     def poll_cursor(self, job_id, target_cursor, timeout=30):
         deadline = time.time() + timeout
         while time.time() < deadline:
@@ -166,6 +174,18 @@ class JobEngineTests(unittest.TestCase):
         self.assertTrue(done["context"]["a"])
         self.assertEqual(self.step_by_id(done, "a")["status"], "completed")
 
+    def test_list_jobs_get(self):
+        self.create_job("listme", [{"id": "a", "op": "system_info"}])
+        r = requests.get(f"{BASE}/jobs", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertIn("jobs", body)
+        self.assertIsInstance(body["jobs"], list)
+        self.assertTrue(
+            any(j.get("name") == "listme" for j in body["jobs"]),
+            f"created job not present in list: {body}",
+        )
+
     def test_invalid_graph_rejected(self):
         backward = [
             {"id": "a", "op": "system_info", "on_done": "a"},
@@ -211,7 +231,7 @@ class JobEngineTests(unittest.TestCase):
         job = self.create_job("branch", steps, inputs={"pick": "b"})
         done = self.poll_status(job["id"], "completed")
         self.assertEqual(self.step_by_id(done, "a")["status"], "completed")
-        self.assertEqual(self.step_by_id(done, "b")["status"], "pending")
+        self.assertEqual(self.step_by_id(done, "b")["status"], "skipped")
         self.assertEqual(self.step_by_id(done, "c")["status"], "completed")
 
     def test_on_fail_goto_recovery(self):
@@ -270,7 +290,7 @@ class JobEngineTests(unittest.TestCase):
         self.poll_status(jid2, "running", timeout=10)
         r = requests.delete(f"{BASE}/jobs/{jid2}", timeout=10)
         self.assertEqual(r.status_code, 200, r.text)
-        self.assertEqual(self.get_job(jid2).status_code, 404)
+        self.poll_gone(jid2)
 
     def test_persistence_across_restart(self):
         steps = [{"id": "w", "op": "sleep", "params": {"ms": 8000}}]
@@ -455,6 +475,77 @@ class JobEngineTests(unittest.TestCase):
         r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
         self.assertEqual(r.status_code, 200, r.text)
         self.poll_status(jid, "completed", timeout=40)
+
+    def test_delete_active_exclusive_cleans_up(self):
+        backend = self.require_real_backend()
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 15000}},
+            {"id": "u", "op": "unload"},
+        ]
+        job = self.create_job("delete-active-exclusive", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        r = requests.delete(f"{BASE}/jobs/{jid}", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            if (
+                requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded")
+                is None
+            ):
+                break
+            time.sleep(0.25)
+        self.assertIsNone(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            "deleting an active exclusive job did not unload the resident model",
+        )
+        self.poll_gone(jid)
+
+    def test_preexisting_model_survives_job_interrupt(self):
+        backend = self.require_real_backend()
+        r = requests.post(
+            f"{BASE}/load",
+            json={
+                "model_name": TEST_MODEL,
+                "llamacpp_backend": backend,
+                "ctx_size": 2048,
+            },
+            timeout=120,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+        )
+
+        steps = [
+            {"id": "hold", "op": "sleep", "params": {"ms": 15000}},
+            {"id": "u", "op": "unload"},
+        ]
+        job = self.create_job("preexisting-survives", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=30)
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "interrupted", timeout=20)
+
+        self.assertEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+            "interrupt cleanup unloaded a model the job did not load",
+        )
 
     def test_bench_shaped_sweep(self):
         backend = self.require_real_backend()

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -6,6 +6,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unittest
 
@@ -341,6 +342,140 @@ class JobEngineTests(unittest.TestCase):
         for jid in ids:
             self.assertIn(jid, ids_on_disk, f"{jid} lost after further persists")
 
+    def test_delete_active_is_durable_across_crash(self):
+        steps = [{"id": "w", "op": "sleep", "params": {"ms": 30000}}]
+        job = self.create_job("del-crash", steps)
+        jid = job["id"]
+        self.poll_status(jid, "running", timeout=10)
+
+        r = requests.delete(f"{BASE}/jobs/{jid}", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(
+            self.get_job(jid).status_code,
+            404,
+            "a deleted active job must be invisible immediately after the ack",
+        )
+
+        self.stop_server(hard=True)
+        self.start_server()
+
+        self.assertEqual(
+            self.get_job(jid).status_code,
+            404,
+            "a crash after the DELETE ack must not resurrect the job",
+        )
+        listed = requests.get(f"{BASE}/jobs", timeout=10).json()["jobs"]
+        self.assertNotIn(jid, [j["id"] for j in listed])
+
+    def test_pause_and_interrupt_queued_jobs_take_effect_immediately(self):
+        blocker = self.create_job(
+            "blocker", [{"id": "w", "op": "sleep", "params": {"ms": 20000}}]
+        )
+        self.poll_status(blocker["id"], "running", timeout=10)
+
+        queued_a = self.create_job(
+            "queued-pause", [{"id": "w", "op": "sleep", "params": {"ms": 100}}]
+        )
+        queued_b = self.create_job(
+            "queued-interrupt", [{"id": "w", "op": "sleep", "params": {"ms": 100}}]
+        )
+        self.assertEqual(self.get_job(queued_a["id"]).json()["status"], "queued")
+        self.assertEqual(self.get_job(queued_b["id"]).json()["status"], "queued")
+
+        r = requests.post(f"{BASE}/jobs/{queued_a['id']}/pause", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(
+            self.get_job(queued_a["id"]).json()["status"],
+            "paused",
+            "pausing a queued job must take effect immediately",
+        )
+
+        r = requests.post(f"{BASE}/jobs/{queued_b['id']}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(
+            self.get_job(queued_b["id"]).json()["status"],
+            "interrupted",
+            "interrupting a queued job must take effect immediately",
+        )
+
+        r = requests.post(f"{BASE}/jobs/{queued_a['id']}/resume", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertIn(
+            self.get_job(queued_a["id"]).json()["status"], ("queued", "running")
+        )
+
+        r = requests.post(f"{BASE}/jobs/{blocker['id']}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(queued_a["id"], "completed", timeout=20)
+
+    def test_job_cap_rejected_when_nothing_evictable(self):
+        blocker = self.create_job(
+            "cap-blocker", [{"id": "w", "op": "sleep", "params": {"ms": 60000}}]
+        )
+        self.poll_status(blocker["id"], "running", timeout=10)
+        for i in range(49):
+            self.create_job(
+                f"cap-{i}", [{"id": "w", "op": "sleep", "params": {"ms": 60000}}]
+            )
+
+        rejected = self.create_job(
+            "cap-overflow",
+            [{"id": "w", "op": "sleep", "params": {"ms": 60000}}],
+            expect=429,
+        )
+        self.assertIn("job limit", rejected.get("error", ""))
+
+        listed = requests.get(f"{BASE}/jobs", timeout=10).json()["jobs"]
+        victim = next(j["id"] for j in listed if j["status"] == "queued")
+        r = requests.delete(f"{BASE}/jobs/{victim}", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+
+        self.create_job(
+            "cap-after-delete", [{"id": "w", "op": "sleep", "params": {"ms": 100}}]
+        )
+        r = requests.post(f"{BASE}/jobs/{blocker['id']}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+
+    def test_progress_counts_handled_failures(self):
+        steps = [
+            {
+                "id": "boom",
+                "op": "models",
+                "params": {"id": "definitely-not-a-real-model"},
+                "on_fail": "recover",
+            },
+            {"id": "recover", "op": "system_info"},
+        ]
+        job = self.create_job("progress-recovery", steps)
+        done = self.poll_status(job["id"], "completed")
+        self.assertEqual(self.step_by_id(done, "boom")["status"], "failed")
+
+        listed = requests.get(f"{BASE}/jobs", timeout=10).json()["jobs"]
+        summary = next(j for j in listed if j["id"] == job["id"])
+        self.assertEqual(
+            summary["progress"]["completed"],
+            summary["progress"]["step_count"],
+            "a completed recovery job must report full progress "
+            "(handled failures count as processed steps)",
+        )
+
+        steps2 = [
+            {
+                "id": "boom",
+                "op": "models",
+                "params": {"id": "definitely-not-a-real-model"},
+                "on_fail": "continue",
+            },
+            {"id": "after", "op": "system_info"},
+        ]
+        job2 = self.create_job("progress-continue", steps2)
+        self.poll_status(job2["id"], "completed")
+        listed = requests.get(f"{BASE}/jobs", timeout=10).json()["jobs"]
+        summary2 = next(j for j in listed if j["id"] == job2["id"])
+        self.assertEqual(
+            summary2["progress"]["completed"], summary2["progress"]["step_count"]
+        )
+
     def test_real_exclusive_job(self):
         backend = self.require_real_backend()
         steps = [
@@ -450,6 +585,135 @@ class JobEngineTests(unittest.TestCase):
         )
         self.assertEqual(self.get_job(jid).json()["status"], "completed")
         print(f"\n[queue] control={control_latency:.3f}s queued={queued_latency:.3f}s")
+
+    def test_tokenize_gated_behind_exclusive_job(self):
+        backend = self.require_real_backend()
+        requests.post(
+            f"{BASE}/load",
+            json={
+                "model_name": TEST_MODEL,
+                "llamacpp_backend": backend,
+                "ctx_size": 2048,
+            },
+            timeout=120,
+        )
+        t0 = time.time()
+        r = requests.post(
+            f"{BASE}/tokenize",
+            json={"model": TEST_MODEL, "content": "hello world"},
+            timeout=30,
+        )
+        control_latency = time.time() - t0
+        self.assertEqual(r.status_code, 200, r.text)
+
+        hold_ms = 5000
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": hold_ms}},
+        ]
+        job = self.create_job("gate-tokenize", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        t0 = time.time()
+        r = requests.post(
+            f"{BASE}/tokenize",
+            json={"model": TEST_MODEL, "content": "hello world"},
+            timeout=60,
+        )
+        gated_latency = time.time() - t0
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertGreater(
+            gated_latency,
+            max(2.0, control_latency * 5),
+            f"tokenize was not held behind the exclusive job "
+            f"(gated={gated_latency:.2f}s, control={control_latency:.2f}s)",
+        )
+        self.assertEqual(self.get_job(jid).json()["status"], "completed")
+
+    def test_exclusive_job_drains_inflight_chat(self):
+        backend = self.require_real_backend()
+        requests.post(
+            f"{BASE}/load",
+            json={
+                "model_name": TEST_MODEL,
+                "llamacpp_backend": backend,
+                "ctx_size": 2048,
+            },
+            timeout=120,
+        )
+
+        result = {}
+
+        def long_chat():
+            t0 = time.time()
+            r = requests.post(
+                f"{BASE}/chat/completions",
+                json={
+                    "model": TEST_MODEL,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Write a very long story about a dragon.",
+                        }
+                    ],
+                    "temperature": 0,
+                    "max_completion_tokens": 1800,
+                    "ignore_eos": True,
+                },
+                timeout=120,
+            )
+            result["status"] = r.status_code
+            result["elapsed"] = time.time() - t0
+
+        chat_thread = threading.Thread(target=long_chat)
+        chat_thread.start()
+        time.sleep(0.3)
+
+        job = self.create_job(
+            "drain",
+            [
+                {
+                    "id": "ld",
+                    "op": "load",
+                    "params": {
+                        "model": TEST_MODEL,
+                        "llamacpp_backend": backend,
+                        "ctx_size": 2048,
+                    },
+                }
+            ],
+        )
+        jid = job["id"]
+
+        overlap = False
+        while chat_thread.is_alive():
+            status = self.get_job(jid).json()["status"]
+            if status == "completed" and chat_thread.is_alive():
+                overlap = True
+                break
+            time.sleep(0.05)
+        chat_thread.join()
+
+        self.assertEqual(
+            result.get("status"), 200, "the in-flight chat must not be disturbed"
+        )
+        if result.get("elapsed", 0) < 1.0:
+            self.skipTest("chat finished too quickly to observe the drain window")
+        self.assertFalse(
+            overlap,
+            "the exclusive job completed while an in-flight chat was still running "
+            "(begin_exclusive did not drain in-flight requests)",
+        )
+        self.poll_status(jid, "completed", timeout=60)
 
     def test_interrupt_mid_job_cleans_up(self):
         backend = self.require_real_backend()

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -1494,6 +1494,55 @@ class JobEngineTests(unittest.TestCase):
             "(stale alias-keyed ownership shadowed the live instance)",
         )
 
+    def test_model_dependent_resume_after_hard_restart(self):
+        backend = self.require_real_backend()
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 30000}},
+            {
+                "id": "say",
+                "op": "chat",
+                "params": {
+                    "model": TEST_MODEL,
+                    "messages": [{"role": "user", "content": "Say hi in one word."}],
+                    "temperature": 0,
+                    "max_completion_tokens": 16,
+                },
+            },
+        ]
+        job = self.create_job("restart-restore", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        self.stop_server(hard=True)
+        self.start_server()
+
+        recovered = self.get_job(jid)
+        self.assertEqual(recovered.status_code, 200, recovered.text)
+        self.assertEqual(recovered.json()["status"], "interrupted")
+        self.assertNotEqual(
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
+            TEST_MODEL,
+        )
+
+        r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        done = self.poll_status(jid, "completed", timeout=120)
+        self.assertEqual(
+            self.step_by_id(done, "say")["status"],
+            "completed",
+            "resume after a hard restart could not run the model-dependent "
+            "step (job model state was not reconstructed)",
+        )
+
     def test_bench_shaped_sweep(self):
         backend = self.require_real_backend()
 

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -1065,6 +1065,99 @@ class JobEngineTests(unittest.TestCase):
             "the pre-job model did not actually survive the job (it was reloaded)",
         )
 
+    def test_job_ownership_survives_pause_resume_interrupt(self):
+        backend = self.require_real_backend()
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 4000}},
+            {"id": "hold2", "op": "sleep", "params": {"ms": 20000}},
+        ]
+        job = self.create_job("pause-resume-interrupt", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+        self.assertEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+        )
+
+        r = requests.post(f"{BASE}/jobs/{jid}/pause", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "paused", timeout=15)
+        self.assertEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+            "pause must keep the job's models resident for the resume",
+        )
+
+        r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_cursor(jid, "hold2", timeout=30)
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "interrupted", timeout=20)
+        self.assertNotEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+            "a pause/resume cycle re-baselined the snapshot: the interrupt "
+            "preserved a model the job itself introduced",
+        )
+
+    def test_delete_while_paused_cleans_up(self):
+        backend = self.require_real_backend()
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 4000}},
+            {"id": "hold2", "op": "sleep", "params": {"ms": 20000}},
+        ]
+        job = self.create_job("delete-while-paused", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        r = requests.post(f"{BASE}/jobs/{jid}/pause", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "paused", timeout=15)
+        self.assertEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+        )
+
+        r = requests.delete(f"{BASE}/jobs/{jid}", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(self.get_job(jid).status_code, 404)
+        self.poll_gone(jid)
+
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            loaded = (
+                requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded")
+            )
+            if loaded != TEST_MODEL:
+                break
+            time.sleep(0.2)
+        self.assertNotEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+            "deleting a paused job skipped reconciliation and leaked the "
+            "model the job introduced",
+        )
+
     def test_bench_shaped_sweep(self):
         backend = self.require_real_backend()
 

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -460,6 +460,21 @@ class JobEngineTests(unittest.TestCase):
         stopped = self.poll_status(jid, "interrupted", timeout=20)
         self.assertEqual(self.step_by_id(stopped, "hold")["status"], "pending")
 
+        # Reconcile: an interrupted exclusive job unloads the model it left
+        # resident (it had loaded TEST_MODEL before the sleep it was stopped in).
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            if (
+                requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded")
+                is None
+            ):
+                break
+            time.sleep(0.25)
+        self.assertIsNone(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            "interrupt did not unload the resident model",
+        )
+
         # The slot was released cleanly: a normal request goes through promptly
         # rather than deadlocking behind an abandoned exclusive hold.
         t0 = time.time()

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -785,13 +785,13 @@ class JobEngineTests(unittest.TestCase):
         deadline = time.time() + 10
         while time.time() < deadline:
             if (
-                requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded")
+                requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded")
                 is None
             ):
                 break
             time.sleep(0.25)
         self.assertIsNone(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             "interrupt did not unload the resident model",
         )
 
@@ -837,13 +837,13 @@ class JobEngineTests(unittest.TestCase):
         deadline = time.time() + 15
         while time.time() < deadline:
             if (
-                requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded")
+                requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded")
                 is None
             ):
                 break
             time.sleep(0.25)
         self.assertIsNone(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             "deleting an active exclusive job did not unload the resident model",
         )
         self.poll_gone(jid)
@@ -861,7 +861,7 @@ class JobEngineTests(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200, r.text)
         self.assertEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
         )
 
@@ -878,7 +878,7 @@ class JobEngineTests(unittest.TestCase):
         self.poll_status(jid, "interrupted", timeout=20)
 
         self.assertEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
             "interrupt cleanup unloaded a model the job did not load",
         )
@@ -904,7 +904,7 @@ class JobEngineTests(unittest.TestCase):
         deadline = time.time() + timeout
         while time.time() < deadline:
             if (
-                requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded")
+                requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded")
                 is None
             ):
                 return
@@ -916,7 +916,7 @@ class JobEngineTests(unittest.TestCase):
         jid = job["id"]
         self.poll_cursor(jid, "hold", timeout=60)
         self.assertEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
         )
 
@@ -925,7 +925,7 @@ class JobEngineTests(unittest.TestCase):
 
         self._wait_model_unloaded()
         self.assertIsNone(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             "deleting an active job did not clean up a model it pinned",
         )
         self.poll_gone(jid)
@@ -936,7 +936,7 @@ class JobEngineTests(unittest.TestCase):
         jid = job["id"]
         self.poll_cursor(jid, "hold", timeout=60)
         self.assertEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
         )
 
@@ -946,7 +946,7 @@ class JobEngineTests(unittest.TestCase):
 
         self._wait_model_unloaded()
         self.assertIsNone(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             "interrupt did not clean up a model the job pinned",
         )
 
@@ -964,7 +964,7 @@ class JobEngineTests(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200, r.text)
         self.assertEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
         )
 
@@ -981,13 +981,13 @@ class JobEngineTests(unittest.TestCase):
         self.poll_status(jid, "interrupted", timeout=20)
 
         self.assertEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
             "interrupt cleanup unloaded a model pinned before the job started",
         )
 
     def loaded_model_entry(self, model):
-        health = requests.get(f"{BASE}/health", timeout=5).json()
+        health = requests.get(f"{BASE}/health", timeout=15).json()
         for entry in health.get("all_models_loaded", []):
             if entry.get("model") == model or entry.get("model_name") == model:
                 return entry
@@ -1050,7 +1050,7 @@ class JobEngineTests(unittest.TestCase):
         self.poll_status(jid, "interrupted", timeout=20)
 
         self.assertEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
             "reconcile evicted a pre-job model",
         )
@@ -1084,7 +1084,7 @@ class JobEngineTests(unittest.TestCase):
         jid = job["id"]
         self.poll_cursor(jid, "hold", timeout=60)
         self.assertEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
         )
 
@@ -1092,7 +1092,7 @@ class JobEngineTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, r.text)
         self.poll_status(jid, "paused", timeout=15)
         self.assertEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
             "pause must keep the job's models resident for the resume",
         )
@@ -1105,7 +1105,7 @@ class JobEngineTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, r.text)
         self.poll_status(jid, "interrupted", timeout=20)
         self.assertNotEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
             "a pause/resume cycle re-baselined the snapshot: the interrupt "
             "preserved a model the job itself introduced",
@@ -1134,7 +1134,7 @@ class JobEngineTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, r.text)
         self.poll_status(jid, "paused", timeout=15)
         self.assertEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
         )
 
@@ -1146,16 +1146,352 @@ class JobEngineTests(unittest.TestCase):
         deadline = time.time() + 20
         while time.time() < deadline:
             loaded = (
-                requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded")
+                requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded")
             )
             if loaded != TEST_MODEL:
                 break
             time.sleep(0.2)
         self.assertNotEqual(
-            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
             TEST_MODEL,
             "deleting a paused job skipped reconciliation and leaked the "
             "model the job introduced",
+        )
+
+    def test_interrupted_job_restores_model_on_resume(self):
+        backend = self.require_real_backend()
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 8000}},
+            {
+                "id": "say",
+                "op": "chat",
+                "params": {
+                    "model": TEST_MODEL,
+                    "messages": [{"role": "user", "content": "Say hi in one word."}],
+                    "temperature": 0,
+                    "max_completion_tokens": 16,
+                },
+            },
+        ]
+        job = self.create_job("interrupt-resume-restore", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "interrupted", timeout=20)
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            loaded = (
+                requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded")
+            )
+            if loaded != TEST_MODEL:
+                break
+            time.sleep(0.2)
+        self.assertNotEqual(
+            requests.get(f"{BASE}/health", timeout=15).json().get("model_loaded"),
+            TEST_MODEL,
+            "interrupt cleanup did not unload the job-loaded model",
+        )
+
+        r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        done = self.poll_status(jid, "completed", timeout=90)
+        self.assertEqual(
+            self.step_by_id(done, "say")["status"],
+            "completed",
+            "resume after interrupt cleanup could not run the chat step "
+            "(job-owned model was not restored)",
+        )
+
+    def test_external_model_survives_job_cleanup(self):
+        backend = self.require_real_backend()
+        self.stop_server()
+        with open(
+            os.path.join(self.cache_dir, "config.json"), "w", encoding="utf-8"
+        ) as f:
+            json.dump({"max_loaded_models": 2}, f)
+        self.start_server()
+
+        info = requests.get(f"{BASE}/models/{TEST_MODEL}", timeout=10).json()
+        checkpoint = info.get("checkpoint")
+        if not checkpoint:
+            self.skipTest(f"cannot determine checkpoint of {TEST_MODEL}")
+        clone = "user.TinyClone-Jobs"
+        r = requests.post(
+            f"{BASE}/pull",
+            json={
+                "model_name": clone,
+                "checkpoint": checkpoint,
+                "recipe": "llamacpp",
+                "stream": False,
+            },
+            timeout=600,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 4000}},
+            {"id": "hold2", "op": "sleep", "params": {"ms": 30000}},
+        ]
+        job = self.create_job("external-survives", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        r = requests.post(f"{BASE}/jobs/{jid}/pause", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "paused", timeout=15)
+
+        r = requests.post(
+            f"{BASE}/load",
+            json={
+                "model_name": clone,
+                "llamacpp_backend": backend,
+                "ctx_size": 2048,
+            },
+            timeout=120,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        clone_public = clone.split("user.", 1)[1]
+        loaded = {
+            e.get("model_name")
+            for e in requests.get(f"{BASE}/health", timeout=15)
+            .json()
+            .get("all_models_loaded", [])
+        }
+        self.assertIn(TEST_MODEL, loaded)
+        self.assertTrue({clone, clone_public} & loaded, f"clone not loaded: {loaded}")
+
+        r = requests.delete(f"{BASE}/jobs/{jid}", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_gone(jid)
+
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            loaded = {
+                e.get("model_name")
+                for e in requests.get(f"{BASE}/health", timeout=15)
+                .json()
+                .get("all_models_loaded", [])
+            }
+            if TEST_MODEL not in loaded:
+                break
+            time.sleep(0.2)
+        self.assertNotIn(
+            TEST_MODEL,
+            loaded,
+            "job cleanup did not unload the model the job introduced",
+        )
+        self.assertTrue(
+            {clone, clone_public} & loaded,
+            "job cleanup unloaded a model loaded externally while the job "
+            "was paused",
+        )
+
+    def test_external_same_name_model_survives_delete_of_interrupted_job(self):
+        backend = self.require_real_backend()
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 30000}},
+        ]
+        job = self.create_job("stale-ownership", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "interrupted", timeout=20)
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            health = requests.get(f"{BASE}/health", timeout=15).json()
+            if health.get("model_loaded") != TEST_MODEL:
+                break
+            time.sleep(0.2)
+
+        r = requests.post(
+            f"{BASE}/load",
+            json={
+                "model_name": TEST_MODEL,
+                "llamacpp_backend": backend,
+                "ctx_size": 2048,
+            },
+            timeout=120,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        external_pid = self.loaded_model_entry(TEST_MODEL).get("pid")
+        self.assertTrue(external_pid)
+
+        r = requests.delete(f"{BASE}/jobs/{jid}", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_gone(jid)
+        time.sleep(1.0)
+
+        after = self.loaded_model_entry(TEST_MODEL)
+        self.assertEqual(
+            after.get("pid"),
+            external_pid,
+            "deleting an interrupted job unloaded an EXTERNAL residency of a "
+            "model name the job used to own",
+        )
+
+    def test_resume_adopts_external_same_name_model(self):
+        backend = self.require_real_backend()
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 8000}},
+            {
+                "id": "say",
+                "op": "chat",
+                "params": {
+                    "model": TEST_MODEL,
+                    "messages": [{"role": "user", "content": "Say hi in one word."}],
+                    "temperature": 0,
+                    "max_completion_tokens": 16,
+                },
+            },
+        ]
+        job = self.create_job("resume-adopts-external", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "interrupted", timeout=20)
+        deadline = time.time() + 20
+        while time.time() < deadline:
+            health = requests.get(f"{BASE}/health", timeout=15).json()
+            if health.get("model_loaded") != TEST_MODEL:
+                break
+            time.sleep(0.2)
+
+        r = requests.post(
+            f"{BASE}/load",
+            json={
+                "model_name": TEST_MODEL,
+                "llamacpp_backend": backend,
+                "ctx_size": 4096,
+            },
+            timeout=120,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        external_pid = self.loaded_model_entry(TEST_MODEL).get("pid")
+
+        r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        done = self.poll_status(jid, "completed", timeout=90)
+        self.assertEqual(self.step_by_id(done, "say")["status"], "completed")
+        self.assertEqual(
+            self.loaded_model_entry(TEST_MODEL).get("pid"),
+            external_pid,
+            "resume restore replaced an external residency of the same model "
+            "name instead of adopting it",
+        )
+
+    def test_alias_loaded_model_unloads_after_interrupt_resume_interrupt(self):
+        backend = self.require_real_backend()
+        info = requests.get(f"{BASE}/models/{TEST_MODEL}", timeout=10).json()
+        checkpoint = info.get("checkpoint")
+        if not checkpoint:
+            self.skipTest(f"cannot determine checkpoint of {TEST_MODEL}")
+        clone = "user.AliasClone-Jobs"
+        alias = "AliasClone-Jobs"
+        r = requests.post(
+            f"{BASE}/pull",
+            json={
+                "model_name": clone,
+                "checkpoint": checkpoint,
+                "recipe": "llamacpp",
+                "stream": False,
+            },
+            timeout=600,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+
+        steps = [
+            {
+                "id": "ld",
+                "op": "load",
+                "params": {
+                    "model": alias,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 8000}},
+            {"id": "hold2", "op": "sleep", "params": {"ms": 8000}},
+        ]
+        job = self.create_job("alias-ownership", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        def loaded_names():
+            return {
+                e.get("model_name")
+                for e in requests.get(f"{BASE}/health", timeout=15)
+                .json()
+                .get("all_models_loaded", [])
+            }
+
+        def poll_unloaded():
+            deadline = time.time() + 20
+            while time.time() < deadline:
+                if not ({alias, clone} & loaded_names()):
+                    return True
+                time.sleep(0.2)
+            return False
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "interrupted", timeout=20)
+        self.assertTrue(
+            poll_unloaded(), "first interrupt did not unload the alias-loaded model"
+        )
+
+        r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_cursor(jid, "hold", timeout=60)
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "interrupted", timeout=20)
+        self.assertTrue(
+            poll_unloaded(),
+            "interrupt after a resume left the alias-loaded model resident "
+            "(stale alias-keyed ownership shadowed the live instance)",
         )
 
     def test_bench_shaped_sweep(self):
@@ -1223,7 +1559,7 @@ class JobEngineTests(unittest.TestCase):
         else:
             self.assertTrue(b_ran, "b had > tps but a_wins ran")
 
-        h = requests.get(f"http://{HOST}:{PORT}/api/v1/health", timeout=5).json()
+        h = requests.get(f"http://{HOST}:{PORT}/api/v1/health", timeout=15).json()
         self.assertIsNone(h.get("model_loaded"))
 
 

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -495,6 +495,80 @@ class JobEngineTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, r.text)
         self.poll_status(jid, "completed", timeout=40)
 
+    # ── Phase 4: a bench-shaped sweep (the AutoOpt methodology end-to-end) ──
+
+    def test_bench_shaped_sweep(self):
+        backend = self.require_real_backend()
+
+        def config(tag, args):
+            return [
+                {"id": f"u_{tag}0", "op": "unload"},
+                {
+                    "id": f"ld_{tag}",
+                    "op": "load",
+                    "params": {
+                        "model": TEST_MODEL,
+                        "llamacpp_backend": backend,
+                        "ctx_size": 2048,
+                        "llamacpp_args": args,
+                        "merge_args": False,
+                        "save_options": False,
+                    },
+                },
+                {
+                    "id": f"run_{tag}",
+                    "op": "chat",
+                    "params": {
+                        "model": TEST_MODEL,
+                        "messages": [{"role": "user", "content": "Count to five."}],
+                        "temperature": 0,
+                        "max_completion_tokens": 24,
+                    },
+                    "extract": {
+                        f"{tag}_tps": "timings.predicted_per_second",
+                        f"{tag}_ttft": "timings.prompt_ms",
+                    },
+                },
+                {"id": f"u_{tag}1", "op": "unload"},
+            ]
+
+        steps = config("a", "") + config("b", "-b 256")
+        steps += [
+            {
+                "id": "decide",
+                "op": "system_info",
+                "branch": [{"when": "${a_tps} >= ${b_tps}", "goto": "a_wins"}],
+                "on_done": "b_wins",
+            },
+            {"id": "a_wins", "op": "sleep", "params": {"ms": 10}, "on_done": "done"},
+            {"id": "b_wins", "op": "sleep", "params": {"ms": 10}},
+            {"id": "done", "op": "sleep", "params": {"ms": 1}},
+        ]
+
+        job = self.create_job("bench-sweep", steps)
+        result = self.poll_status(job["id"], "completed", timeout=180)
+        ctx = result["context"]
+
+        # Both configs were measured and their throughput extracted.
+        self.assertIn("a_tps", ctx)
+        self.assertIn("b_tps", ctx)
+        self.assertGreater(ctx["a_tps"], 0)
+        self.assertGreater(ctx["b_tps"], 0)
+
+        # The branch fired on the measured metric: exactly one winner ran, and it
+        # is consistent with the extracted tps values.
+        a_ran = self.step_by_id(result, "a_wins")["status"] == "completed"
+        b_ran = self.step_by_id(result, "b_wins")["status"] == "completed"
+        self.assertNotEqual(a_ran, b_ran, "exactly one winner branch should run")
+        if ctx["a_tps"] >= ctx["b_tps"]:
+            self.assertTrue(a_ran, "a had >= tps but b_wins ran")
+        else:
+            self.assertTrue(b_ran, "b had > tps but a_wins ran")
+
+        # No model left resident after the sweep's final unload.
+        h = requests.get(f"http://{HOST}:{PORT}/api/v1/health", timeout=5).json()
+        self.assertIsNone(h.get("model_loaded"))
+
 
 def parse_args():
     global _LEMOND_BINARY

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -1,0 +1,285 @@
+"""
+Endpoint tests for the generic server-side job engine.
+
+These exercise the job lifecycle with no inference backend: read-only ops
+(system_info / models) plus a `sleep` op used to make pause / interrupt /
+persistence observable. Each test runs its own isolated `lemond` on a private
+cache dir and port so the persistence-across-restart case can kill and relaunch
+the server without disturbing anything else.
+
+Usage:
+    python server_jobs.py
+    python server_jobs.py --lemond-binary /path/to/lemond
+"""
+
+import argparse
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+import requests
+
+PORT = 13401
+HOST = "127.0.0.1"
+BASE = f"http://{HOST}:{PORT}/api/v1"
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_LEMOND_BINARY = None
+
+
+def find_lemond_binary():
+    if _LEMOND_BINARY:
+        return _LEMOND_BINARY
+    env = os.environ.get("LEMOND_BINARY")
+    if env:
+        return env
+    for candidate in ("build/lemond", "build-debug/lemond", "build-release/lemond"):
+        path = os.path.join(REPO_ROOT, candidate)
+        if os.path.isfile(path):
+            return path
+    raise FileNotFoundError(
+        "could not locate the lemond binary; build it or pass --lemond-binary"
+    )
+
+
+class JobEngineTests(unittest.TestCase):
+    def setUp(self):
+        self.cache_dir = tempfile.mkdtemp(prefix="lemonade-jobs-")
+        self.proc = None
+        self.start_server()
+
+    def tearDown(self):
+        self.stop_server()
+        shutil.rmtree(self.cache_dir, ignore_errors=True)
+
+    # ── server lifecycle ────────────────────────────────────────────────
+
+    def start_server(self):
+        binary = find_lemond_binary()
+        self.proc = subprocess.Popen(
+            [binary, self.cache_dir, "--port", str(PORT), "--host", HOST],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        deadline = time.time() + 40
+        while time.time() < deadline:
+            if self.proc.poll() is not None:
+                raise RuntimeError("lemond exited during startup")
+            try:
+                r = requests.get(f"{BASE}/health", timeout=2)
+                if r.status_code == 200:
+                    return
+            except requests.RequestException:
+                pass
+            time.sleep(0.25)
+        raise RuntimeError("lemond did not become healthy in time")
+
+    def stop_server(self, hard=False):
+        if not self.proc:
+            return
+        if self.proc.poll() is None:
+            if hard:
+                self.proc.send_signal(signal.SIGKILL)
+            else:
+                try:
+                    requests.post(f"http://{HOST}:{PORT}/internal/shutdown", timeout=5)
+                except requests.RequestException:
+                    self.proc.terminate()
+            try:
+                self.proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                self.proc.send_signal(signal.SIGKILL)
+                self.proc.wait(timeout=10)
+        self.proc = None
+
+    # ── helpers ─────────────────────────────────────────────────────────
+
+    def create_job(self, name, steps, inputs=None, expect=202):
+        body = {"name": name, "definition": {"steps": steps}}
+        if inputs is not None:
+            body["inputs"] = inputs
+        r = requests.post(f"{BASE}/jobs", json=body, timeout=10)
+        self.assertEqual(r.status_code, expect, r.text)
+        return r.json()
+
+    def get_job(self, job_id):
+        r = requests.get(f"{BASE}/jobs/{job_id}", timeout=10)
+        return r
+
+    def poll_status(self, job_id, targets, timeout=30):
+        if isinstance(targets, str):
+            targets = {targets}
+        deadline = time.time() + timeout
+        last = None
+        while time.time() < deadline:
+            r = self.get_job(job_id)
+            self.assertEqual(r.status_code, 200, r.text)
+            last = r.json()
+            if last["status"] in targets:
+                return last
+            time.sleep(0.2)
+        self.fail(f"job {job_id} did not reach {targets}; last={last}")
+
+    def step_by_id(self, job, step_id):
+        for s in job["steps"]:
+            if s["id"] == step_id:
+                return s
+        self.fail(f"step {step_id} not present in job")
+
+    # ── tests ───────────────────────────────────────────────────────────
+
+    def test_system_info_job_completes(self):
+        job = self.create_job("sysinfo", [{"id": "a", "op": "system_info"}])
+        done = self.poll_status(job["id"], "completed")
+        self.assertIn("a", done["context"])
+        self.assertTrue(done["context"]["a"])
+        self.assertEqual(self.step_by_id(done, "a")["status"], "completed")
+
+    def test_invalid_graph_rejected(self):
+        backward = [
+            {"id": "a", "op": "system_info", "on_done": "a"},
+        ]
+        r = requests.post(
+            f"{BASE}/jobs",
+            json={"name": "bad", "definition": {"steps": backward}},
+            timeout=10,
+        )
+        self.assertEqual(r.status_code, 400, r.text)
+        self.assertIn("error", r.json())
+
+        unknown = [{"id": "a", "op": "does_not_exist"}]
+        r2 = requests.post(
+            f"{BASE}/jobs",
+            json={"name": "bad2", "definition": {"steps": unknown}},
+            timeout=10,
+        )
+        self.assertEqual(r2.status_code, 400, r2.text)
+        self.assertIn("unknown op", r2.json()["error"])
+
+    def test_when_skip(self):
+        steps = [
+            {"id": "a", "op": "system_info"},
+            {"id": "b", "op": "system_info", "when": "false"},
+        ]
+        job = self.create_job("skip", steps)
+        done = self.poll_status(job["id"], "completed")
+        self.assertEqual(self.step_by_id(done, "a")["status"], "completed")
+        self.assertEqual(self.step_by_id(done, "b")["status"], "skipped")
+
+    def test_branch_on_input(self):
+        # step "a" branches to "c" when inputs.pick == 'b', skipping "b".
+        steps = [
+            {
+                "id": "a",
+                "op": "system_info",
+                "branch": [{"when": "${inputs.pick}=='b'", "goto": "c"}],
+            },
+            {"id": "b", "op": "system_info"},
+            {"id": "c", "op": "system_info"},
+        ]
+        job = self.create_job("branch", steps, inputs={"pick": "b"})
+        done = self.poll_status(job["id"], "completed")
+        self.assertEqual(self.step_by_id(done, "a")["status"], "completed")
+        self.assertEqual(self.step_by_id(done, "b")["status"], "pending")
+        self.assertEqual(self.step_by_id(done, "c")["status"], "completed")
+
+    def test_on_fail_goto_recovery(self):
+        steps = [
+            {
+                "id": "boom",
+                "op": "models",
+                "params": {"id": "definitely-not-a-real-model"},
+                "on_fail": "recover",
+            },
+            {"id": "recover", "op": "system_info"},
+        ]
+        job = self.create_job("recover", steps)
+        done = self.poll_status(job["id"], "completed")
+        self.assertEqual(self.step_by_id(done, "boom")["status"], "failed")
+        self.assertEqual(self.step_by_id(done, "recover")["status"], "completed")
+
+    def test_pause_resume(self):
+        steps = [{"id": "wait", "op": "sleep", "params": {"ms": 6000}}]
+        job = self.create_job("pause", steps)
+        jid = job["id"]
+        self.poll_status(jid, "running", timeout=10)
+        r = requests.post(f"{BASE}/jobs/{jid}/pause", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "paused", timeout=15)
+        r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "completed", timeout=20)
+
+    def test_interrupt_resume(self):
+        steps = [{"id": "wait", "op": "sleep", "params": {"ms": 8000}}]
+        job = self.create_job("interrupt", steps)
+        jid = job["id"]
+        self.poll_status(jid, "running", timeout=10)
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        stopped = self.poll_status(jid, "interrupted", timeout=15)
+        self.assertEqual(self.step_by_id(stopped, "wait")["status"], "pending")
+        r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "completed", timeout=20)
+
+    def test_delete_terminal_and_active(self):
+        # terminal job removed cleanly
+        job = self.create_job("del", [{"id": "a", "op": "system_info"}])
+        jid = job["id"]
+        self.poll_status(jid, "completed")
+        r = requests.delete(f"{BASE}/jobs/{jid}", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(self.get_job(jid).status_code, 404)
+
+        # active (long sleep) job deleted via interrupt-then-remove
+        job2 = self.create_job(
+            "del2", [{"id": "w", "op": "sleep", "params": {"ms": 8000}}]
+        )
+        jid2 = job2["id"]
+        self.poll_status(jid2, "running", timeout=10)
+        r = requests.delete(f"{BASE}/jobs/{jid2}", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(self.get_job(jid2).status_code, 404)
+
+    def test_persistence_across_restart(self):
+        steps = [{"id": "w", "op": "sleep", "params": {"ms": 8000}}]
+        job = self.create_job("persist", steps)
+        jid = job["id"]
+        self.poll_status(jid, "running", timeout=10)
+
+        # Hard-kill the server while the sleep step is in flight, then restart.
+        self.stop_server(hard=True)
+        self.start_server()
+
+        recovered = self.get_job(jid)
+        self.assertEqual(recovered.status_code, 200, recovered.text)
+        body = recovered.json()
+        self.assertEqual(body["status"], "interrupted")
+        self.assertIn("server restarted", body.get("error", ""))
+        self.assertEqual(self.step_by_id(body, "w")["status"], "pending")
+
+        # Resume re-runs the pending step and the job runs to completion.
+        r = requests.post(f"{BASE}/jobs/{jid}/resume", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "completed", timeout=25)
+
+
+def parse_args():
+    global _LEMOND_BINARY
+    parser = argparse.ArgumentParser(description="Job engine endpoint tests")
+    parser.add_argument("--lemond-binary", type=str, default=None)
+    args, remaining = parser.parse_known_args()
+    _LEMOND_BINARY = args.lemond_binary
+    return remaining
+
+
+if __name__ == "__main__":
+    remaining = parse_args()
+    sys.argv = [sys.argv[0]] + remaining
+    unittest.main(verbosity=2)

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -20,6 +20,7 @@ TEST_MODEL = "Tiny-Test-Model-GGUF"
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _LEMOND_BINARY = None
+_BACKEND_BIN_TEMPLATE = None
 
 
 def find_lemond_binary():
@@ -40,6 +41,12 @@ def find_lemond_binary():
 class JobEngineTests(unittest.TestCase):
     def setUp(self):
         self.cache_dir = tempfile.mkdtemp(prefix="lemonade-jobs-")
+        if _BACKEND_BIN_TEMPLATE and os.path.isdir(_BACKEND_BIN_TEMPLATE):
+            shutil.copytree(
+                _BACKEND_BIN_TEMPLATE,
+                os.path.join(self.cache_dir, "bin"),
+                symlinks=True,
+            )
         self.proc = None
         self.start_server()
 
@@ -163,7 +170,23 @@ class JobEngineTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, "failed to pull the test model")
 
     def require_real_backend(self):
+        global _BACKEND_BIN_TEMPLATE
         backend = self.installed_llamacpp_backend()
+        if not backend and _BACKEND_BIN_TEMPLATE is None:
+            r = requests.post(
+                f"{BASE}/install",
+                json={"recipe": "llamacpp", "backend": "cpu", "subscribe": False},
+                timeout=1800,
+            )
+            if r.status_code == 200:
+                backend = self.installed_llamacpp_backend()
+                bin_dir = os.path.join(self.cache_dir, "bin")
+                if backend and os.path.isdir(bin_dir):
+                    _BACKEND_BIN_TEMPLATE = tempfile.mkdtemp(
+                        prefix="lemonade-jobs-backend-"
+                    )
+                    shutil.rmtree(_BACKEND_BIN_TEMPLATE)
+                    shutil.copytree(bin_dir, _BACKEND_BIN_TEMPLATE, symlinks=True)
         if not backend:
             self.skipTest("no installed llamacpp backend available")
         self.ensure_test_model()
@@ -350,6 +373,16 @@ class JobEngineTests(unittest.TestCase):
 
         r = requests.delete(f"{BASE}/jobs/{jid}", timeout=10)
         self.assertEqual(r.status_code, 200, r.text)
+
+        with open(
+            os.path.join(self.cache_dir, "jobs.json"), "r", encoding="utf-8"
+        ) as f:
+            on_disk = {j["id"]: j for j in json.load(f).get("jobs", [])}
+        self.assertTrue(
+            on_disk.get(jid, {}).get("deleted", jid not in on_disk),
+            "the tombstone must be on disk before the DELETE ack "
+            f"(entry: {on_disk.get(jid)})",
+        )
         self.assertEqual(
             self.get_job(jid).status_code,
             404,
@@ -672,7 +705,8 @@ class JobEngineTests(unittest.TestCase):
                 timeout=120,
             )
             result["status"] = r.status_code
-            result["elapsed"] = time.time() - t0
+            result["end_time"] = time.time()
+            result["elapsed"] = result["end_time"] - t0
 
         chat_thread = threading.Thread(target=long_chat)
         chat_thread.start()
@@ -694,11 +728,11 @@ class JobEngineTests(unittest.TestCase):
         )
         jid = job["id"]
 
-        overlap = False
+        overlap_at = None
         while chat_thread.is_alive():
             status = self.get_job(jid).json()["status"]
             if status == "completed" and chat_thread.is_alive():
-                overlap = True
+                overlap_at = time.time()
                 break
             time.sleep(0.05)
         chat_thread.join()
@@ -708,6 +742,10 @@ class JobEngineTests(unittest.TestCase):
         )
         if result.get("elapsed", 0) < 1.0:
             self.skipTest("chat finished too quickly to observe the drain window")
+        overlap = (
+            overlap_at is not None
+            and result.get("end_time", overlap_at) - overlap_at > 0.5
+        )
         self.assertFalse(
             overlap,
             "the exclusive job completed while an in-flight chat was still running "
@@ -941,6 +979,63 @@ class JobEngineTests(unittest.TestCase):
             requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
             TEST_MODEL,
             "interrupt cleanup unloaded a model pinned before the job started",
+        )
+
+    def loaded_model_pinned_state(self, model):
+        health = requests.get(f"{BASE}/health", timeout=5).json()
+        for entry in health.get("all_models_loaded", []):
+            if entry.get("model") == model or entry.get("model_name") == model:
+                return entry.get("pinned")
+        self.fail(f"{model} not present in all_models_loaded: {health}")
+
+    def test_pin_state_of_preexisting_model_restored_after_job(self):
+        backend = self.require_real_backend()
+        r = requests.post(
+            f"{BASE}/load",
+            json={
+                "model_name": TEST_MODEL,
+                "llamacpp_backend": backend,
+                "ctx_size": 2048,
+                "pinned": True,
+            },
+            timeout=120,
+        )
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertTrue(self.loaded_model_pinned_state(TEST_MODEL))
+
+        steps = [
+            {
+                "id": "unpin",
+                "op": "load",
+                "params": {
+                    "model": TEST_MODEL,
+                    "llamacpp_backend": backend,
+                    "ctx_size": 2048,
+                    "pinned": False,
+                },
+            },
+            {"id": "hold", "op": "sleep", "params": {"ms": 15000}},
+        ]
+        job = self.create_job("unpin-then-interrupt", steps)
+        jid = job["id"]
+        self.poll_cursor(jid, "hold", timeout=60)
+        self.assertFalse(
+            self.loaded_model_pinned_state(TEST_MODEL),
+            "the job load did not change the surviving model's pin state",
+        )
+
+        r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.poll_status(jid, "interrupted", timeout=20)
+
+        self.assertEqual(
+            requests.get(f"{BASE}/health", timeout=5).json().get("model_loaded"),
+            TEST_MODEL,
+            "reconcile evicted a pre-job model",
+        )
+        self.assertTrue(
+            self.loaded_model_pinned_state(TEST_MODEL),
+            "reconcile did not restore the pre-job pin state of a surviving model",
         )
 
     def test_bench_shaped_sweep(self):

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -21,6 +21,7 @@ TEST_MODEL = "Tiny-Test-Model-GGUF"
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _LEMOND_BINARY = None
 _BACKEND_BIN_TEMPLATE = None
+_BACKEND_INSTALL_ATTEMPTED = False
 
 
 def find_lemond_binary():
@@ -170,15 +171,19 @@ class JobEngineTests(unittest.TestCase):
         self.assertEqual(r.status_code, 200, "failed to pull the test model")
 
     def require_real_backend(self):
-        global _BACKEND_BIN_TEMPLATE
+        global _BACKEND_BIN_TEMPLATE, _BACKEND_INSTALL_ATTEMPTED
         backend = self.installed_llamacpp_backend()
-        if not backend and _BACKEND_BIN_TEMPLATE is None:
-            r = requests.post(
-                f"{BASE}/install",
-                json={"recipe": "llamacpp", "backend": "cpu", "subscribe": False},
-                timeout=1800,
-            )
-            if r.status_code == 200:
+        if not backend and not _BACKEND_INSTALL_ATTEMPTED:
+            _BACKEND_INSTALL_ATTEMPTED = True
+            try:
+                r = requests.post(
+                    f"{BASE}/install",
+                    json={"recipe": "llamacpp", "backend": "cpu", "subscribe": False},
+                    timeout=900,
+                )
+            except requests.RequestException:
+                r = None
+            if r is not None and r.status_code == 200:
                 backend = self.installed_llamacpp_backend()
                 bin_dir = os.path.join(self.cache_dir, "bin")
                 if backend and os.path.isdir(bin_dir):
@@ -981,12 +986,15 @@ class JobEngineTests(unittest.TestCase):
             "interrupt cleanup unloaded a model pinned before the job started",
         )
 
-    def loaded_model_pinned_state(self, model):
+    def loaded_model_entry(self, model):
         health = requests.get(f"{BASE}/health", timeout=5).json()
         for entry in health.get("all_models_loaded", []):
             if entry.get("model") == model or entry.get("model_name") == model:
-                return entry.get("pinned")
+                return entry
         self.fail(f"{model} not present in all_models_loaded: {health}")
+
+    def loaded_model_pinned_state(self, model):
+        return self.loaded_model_entry(model).get("pinned")
 
     def test_pin_state_of_preexisting_model_restored_after_job(self):
         backend = self.require_real_backend()
@@ -1002,6 +1010,8 @@ class JobEngineTests(unittest.TestCase):
         )
         self.assertEqual(r.status_code, 200, r.text)
         self.assertTrue(self.loaded_model_pinned_state(TEST_MODEL))
+        pid_before = self.loaded_model_entry(TEST_MODEL).get("pid")
+        self.assertTrue(pid_before)
 
         steps = [
             {
@@ -1019,9 +1029,15 @@ class JobEngineTests(unittest.TestCase):
         job = self.create_job("unpin-then-interrupt", steps)
         jid = job["id"]
         self.poll_cursor(jid, "hold", timeout=60)
+        mid = self.loaded_model_entry(TEST_MODEL)
         self.assertFalse(
-            self.loaded_model_pinned_state(TEST_MODEL),
+            mid.get("pinned"),
             "the job load did not change the surviving model's pin state",
+        )
+        self.assertEqual(
+            mid.get("pid"),
+            pid_before,
+            "a pin-only load reloaded the model instead of updating the pin in place",
         )
 
         r = requests.post(f"{BASE}/jobs/{jid}/interrupt", timeout=10)
@@ -1033,9 +1049,15 @@ class JobEngineTests(unittest.TestCase):
             TEST_MODEL,
             "reconcile evicted a pre-job model",
         )
+        after = self.loaded_model_entry(TEST_MODEL)
         self.assertTrue(
-            self.loaded_model_pinned_state(TEST_MODEL),
+            after.get("pinned"),
             "reconcile did not restore the pre-job pin state of a surviving model",
+        )
+        self.assertEqual(
+            after.get("pid"),
+            pid_before,
+            "the pre-job model did not actually survive the job (it was reloaded)",
         )
 
     def test_bench_shaped_sweep(self):


### PR DESCRIPTION
This is the backend powering the #2613 llama.cpp AutoOpt (#2696 ), but not only - figured it would be useful to have an actual server-side *job module*, with more complex sequences of tasks that can be queued on the server. Currently, it's impossible to do something like this without either (a) hardcoding the sequence in the backend, which is inflexible and requires updating the backend every time we want to add a new sequence or (b) driving everything from the frontend, which is not very versatile.

For now, the engine, language governing the jobs etc. are kept pretty minimal (bare sequences with simple if/then/else branching).