### PR TITLE
fix(websocket): allow Windows Tauri WebView2 origin for upgrades

### DIFF
--- a/src/cpp/server/websocket_server.cpp
+++ b/src/cpp/server/websocket_server.cpp
@@ -116,7 +116,10 @@ int WebSocketServer::ws_callback(struct lws* wsi,
                     request_host = request_host.substr(0, r_path_pos);
                 }
 
-                bool is_allowed = (origin_host == "localhost" || origin_host == "127.0.0.1" || origin_host == "[::1]" || origin_host == "::1");
+                // tauri.localhost is the Windows WebView2 origin for the desktop app.
+                bool is_allowed = (origin_host == "localhost" || origin_host == "127.0.0.1" ||
+                                   origin_host == "[::1]" || origin_host == "::1" ||
+                                   origin_host == "tauri.localhost");
                 if (!is_allowed && !request_host.empty() && origin_host == request_host) {
                     is_allowed = true;
                 }

--- a/test/server_websocket_auth.py
+++ b/test/server_websocket_auth.py
@@ -239,6 +239,44 @@ class WebSocketAuthTests(unittest.TestCase):
 
         asyncio.run(run())
 
+    # --- origin -------------------------------------------------------------
+
+    def test_009_tauri_windows_origin_accepted(self):
+        """The Windows Tauri WebView2 origin (http://tauri.localhost) upgrades."""
+
+        async def run():
+            uri = f"ws://localhost:{self.port}/logs/stream"
+            async with websockets.connect(
+                uri,
+                subprotocols=auth_subprotocols(API_KEY),
+                origin="http://tauri.localhost",
+            ) as ws:
+                await ws.send(json.dumps({"type": "logs.subscribe", "after_seq": None}))
+                msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=3.0))
+                self.assertEqual(msg.get("type"), "logs.snapshot")
+
+        asyncio.run(run())
+
+    def test_010_foreign_origin_rejected(self):
+        """A cross-site browser origin is rejected even with valid credentials."""
+
+        async def run():
+            uri = f"ws://localhost:{self.port}/logs/stream"
+            with self.assertRaises(
+                (
+                    websockets.exceptions.InvalidStatus,
+                    websockets.exceptions.InvalidHandshake,
+                )
+            ):
+                async with websockets.connect(
+                    uri,
+                    subprotocols=auth_subprotocols(API_KEY),
+                    origin="http://evil.example.com",
+                ):
+                    pass
+
+        asyncio.run(run())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #2719.

On Windows the Tauri desktop app's WebView2 serves the UI from `http://tauri.localhost`, so every WebSocket upgrade sent that as its `Origin`. The origin allowlist (added in #2574) only accepted `localhost`/`127.0.0.1`/`::1`, so it rejected the app — breaking log streaming (and realtime) on Windows only. macOS/Linux use `tauri://localhost` (host `localhost`) and were unaffected; chat kept working because HTTP uses `Access-Control-Allow-Origin: *` and isn't subject to this check.

- Add `tauri.localhost` to the WebSocket origin allowlist. Safe against CSWSH: browsers set `Origin` themselves and only the actual Tauri WebView2 can present that value.
- Add regression tests: `tauri.localhost` is accepted; a foreign browser origin is still rejected with valid credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)