### PR TITLE
Wire collection.router classifiers to Router::classify + validate model capability at parse time

### DIFF
--- a/src/cpp/include/lemon/backends/kokoro/kokoro.h
+++ b/src/cpp/include/lemon/backends/kokoro/kokoro.h
@@ -27,7 +27,9 @@ inline const BackendDescriptor descriptor = {
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
         {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
     },
-    /*default_labels*/  {},  // kokoro models carry "tts" explicitly in server_models.json
+    /*default_labels*/  {"tts"},  // kokoro only does TTS; declare it so a label-less
+                                   // user model is typed TTS, not LLM (catalog models
+                                   // also carry "tts" explicitly in server_models.json)
     /*required_checkpoints*/ {"main"},
     /*modality*/        "Text-to-speech",
     /*experimental*/    false,

--- a/src/cpp/include/lemon/routing_classifier_services.h
+++ b/src/cpp/include/lemon/routing_classifier_services.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "lemon/model_types.h"
 #include "lemon/routing_policy.h"
 
 #include <functional>
@@ -13,17 +14,26 @@ class Router;
 
 using EnsureClassifierModelLoaded = std::function<void(const std::string& model)>;
 using RouterJsonCall = std::function<json(const json& request)>;
+using RouterModelTypeCall = std::function<ModelType(const std::string& model)>;
 
 ClassifierServices make_router_classifier_services(
     Router& router,
     EnsureClassifierModelLoaded ensure_loaded = {});
 
 // Testable adapter seam: production binds these calls to Router::embeddings and
-// Router::chat_completion; unit tests bind them to fake Router-like functions.
+// Router::chat_completion (plus Router::classify/get_model_type for models
+// tagged ModelType::CLASSIFICATION); unit tests bind them to fake Router-like
+// functions. `classify`/`get_model_type` default to empty so existing
+// embeddings+chat_completion-only call sites keep compiling unchanged — a
+// `run_classifier` call against a model with no `get_model_type` configured,
+// or one that isn't ModelType::CLASSIFICATION, falls back to the original
+// chat-completion-based classification.
 ClassifierServices make_classifier_services_from_router_calls(
     RouterJsonCall embeddings,
     RouterJsonCall chat_completion,
-    EnsureClassifierModelLoaded ensure_loaded = {});
+    EnsureClassifierModelLoaded ensure_loaded = {},
+    RouterJsonCall classify = {},
+    RouterModelTypeCall get_model_type = {});
 
 std::vector<float> parse_embedding_vector(const json& response);
 std::map<std::string, double> parse_classifier_scores(const json& response);

--- a/src/cpp/include/lemon/routing_policy_parser.h
+++ b/src/cpp/include/lemon/routing_policy_parser.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "lemon/model_types.h"
 #include "lemon/routing_policy.h"
 
 #include <functional>
@@ -16,8 +17,15 @@ namespace lemon {
 using RoutingComponentResolver =
     std::function<std::optional<std::string>(const std::string& component)>;
 
+// Looks up a resolved component's deployment ModelType. Server integration
+// binds this to the model registry (ModelInfo::type); pure parser tests leave
+// it unset, which skips the capability check entirely (matching prior
+// behavior — this option is additive and opt-in).
+using RoutingModelTypeResolver = std::function<ModelType(const std::string& resolved_model)>;
+
 struct RoutingPolicyParseOptions {
     RoutingComponentResolver resolve_component;
+    RoutingModelTypeResolver get_model_type;
     bool require_declared_components = true;
 };
 

--- a/src/cpp/include/lemon/routing_policy_parser.h
+++ b/src/cpp/include/lemon/routing_policy_parser.h
@@ -21,7 +21,14 @@ using RoutingComponentResolver =
 // binds this to the model registry (ModelInfo::type); pure parser tests leave
 // it unset, which skips the capability check entirely (matching prior
 // behavior — this option is additive and opt-in).
-using RoutingModelTypeResolver = std::function<ModelType(const std::string& resolved_model)>;
+//
+// Returns nullopt when the type genuinely cannot be established (e.g. an
+// inline collection component with no matching `models[]` definition to fall
+// back on) — the parser treats that as a hard error rather than guessing a
+// type, since guessing wrong is worse than not checking at all: it can both
+// reject valid configs and silently accept invalid ones.
+using RoutingModelTypeResolver =
+    std::function<std::optional<ModelType>(const std::string& resolved_model)>;
 
 struct RoutingPolicyParseOptions {
     RoutingComponentResolver resolve_component;

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -2550,6 +2550,26 @@ size_t ModelManager::count_cloud_models(const std::string& provider) const {
                          });
 }
 
+// The label set a user or inline model definition normalizes to. Kept in one
+// place so model registration (register_user_model) and collection.router
+// capability validation (validate_collection_request) derive the same type for
+// the same definition: explicit labels + legacy capability flags + the backend
+// descriptor's default labels (e.g. sd-cpp -> "image", whispercpp -> "transcription").
+static std::set<std::string> normalized_definition_labels(const json& model_data) {
+    std::set<std::string> labels = {"custom"};
+    std::vector<std::string> extra = model_data.value("labels", std::vector<std::string>{});
+    labels.insert(extra.begin(), extra.end());
+    if (model_data.value("reasoning", false)) labels.insert("reasoning");
+    if (model_data.value("vision", false)) labels.insert("vision");
+    if (model_data.value("embedding", false)) labels.insert("embeddings");
+    if (model_data.value("reranking", false)) labels.insert("reranking");
+    if (const auto* desc =
+            lemon::backends::descriptor_for(model_data.value("recipe", std::string()))) {
+        for (const auto& label : desc->default_labels) labels.insert(label);
+    }
+    return labels;
+}
+
 void ModelManager::register_user_model(const std::string& model_name,
                                       const json& model_data,
                                       const std::string& source) {
@@ -2566,35 +2586,11 @@ void ModelManager::register_user_model(const std::string& model_name,
             model_entry[prop] = model_data[prop];
         }
     }
-    std::set<std::string> labels = {"custom"};
-    std::vector<std::string> extra_labels = model_data.value("labels", std::vector<std::string>{});
-    labels.insert(extra_labels.begin(), extra_labels.end());
-
-    // legacy label format
-    if (model_data.value("reasoning", false)) {
-        labels.insert("reasoning");
-    }
-    if (model_data.value("vision", false)) {
-        labels.insert("vision");
-    }
-    if (model_data.value("embedding", false)) {
-        labels.insert("embeddings");
-    }
-    if (model_data.value("reranking", false)) {
-        labels.insert("reranking");
-    }
+    std::set<std::string> labels = normalized_definition_labels(model_data);
 
     // `recipe` already copied into `model_entry` by the USER_DEFINED_MODEL_PROPS
-    // loop above; this local is just for the label inference below.
+    // loop above; this local is just for the collection handling below.
     std::string recipe = model_data.value("recipe", "");
-
-    // Inject the backend's default labels for models that omit them (e.g. sd-cpp
-    // -> image, whispercpp/moonshine -> transcription).
-    if (const auto* desc = lemon::backends::descriptor_for(recipe)) {
-        for (const auto& label : desc->default_labels) {
-            labels.insert(label);
-        }
-    }
 
     model_entry["labels"] = labels;
     model_entry["suggested"] = true; // Always set suggested=true for user models
@@ -4566,13 +4562,14 @@ std::optional<std::string> ModelManager::validate_collection_request(
                 if (!def) {
                     return std::nullopt;
                 }
-                std::vector<std::string> labels;
-                if (def->contains("labels") && (*def)["labels"].is_array()) {
-                    for (const auto& label : (*def)["labels"]) {
-                        if (label.is_string()) labels.push_back(label.get<std::string>());
-                    }
-                }
-                return get_model_type_from_labels(labels);
+                // Derive the type exactly as register_user_model() would once
+                // this inline definition is registered — explicit labels, legacy
+                // capability flags, and the backend's default labels — so
+                // validation and registration cannot disagree (e.g. a label-less
+                // sd-cpp model is IMAGE, not LLM).
+                std::set<std::string> label_set = normalized_definition_labels(*def);
+                return get_model_type_from_labels(
+                    std::vector<std::string>(label_set.begin(), label_set.end()));
             }
         };
         try {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1932,6 +1932,13 @@ void ModelManager::build_cache() {
         auto it = public_model_aliases_.find(name);
         return it != public_model_aliases_.end() ? it->second : name;
     };
+    // Direct lookup into the map already being built, same rationale as
+    // resolve_component above: models_cache_ is populated and the lock is
+    // still held, so this avoids re-entering get_model_info()'s own locking.
+    policy_options.get_model_type = [this](const std::string& name) -> ModelType {
+        auto it = models_cache_.find(name);
+        return it != models_cache_.end() ? it->second.type : ModelType::LLM;
+    };
     for (auto& [name, info] : models_cache_) {
         if (!is_router_collection_recipe(info.recipe)) {
             continue;
@@ -4544,6 +4551,15 @@ std::optional<std::string> ModelManager::validate_collection_request(
                 // names stable so parser component-role validation can still
                 // compare them against the authored components array.
                 return name;
+            }
+        };
+        options.get_model_type = [this](const std::string& name) -> ModelType {
+            try {
+                return get_model_info(name).type;
+            } catch (...) {
+                // Unregistered inline-collection component: no type to check
+                // yet, so don't block registration on it here.
+                return ModelType::LLM;
             }
         };
         try {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -135,7 +135,25 @@ static ModelType get_deployment_model_type(const std::string& recipe,
             }
         }
     }
-    return get_model_type_from_labels(labels);
+    ModelType type = get_model_type_from_labels(labels);
+
+    // Reaching here means the backend declares no definitive non-LLM deployment,
+    // i.e. it is a chat/general backend (llamacpp/flm/ryzenai/vllm/cloud) — none
+    // of which implement IClassificationServer (only onnxruntime does, and it
+    // returned CLASSIFICATION above via its default label). So a `classification`
+    // label here is spurious: typing it CLASSIFICATION would send run_classifier
+    // to Router::classify() and hit an unsupported-capability error. Drop the
+    // claim so the model stays an LLM, usable as an LLM-as-classifier via chat.
+    if (type == ModelType::CLASSIFICATION) {
+        std::vector<std::string> non_classification;
+        for (const auto& label : labels) {
+            if (label != "classification" && label != "classifier") {
+                non_classification.push_back(label);
+            }
+        }
+        return get_model_type_from_labels(non_classification);
+    }
+    return type;
 }
 
 // Built-ins are keyed bare in models_cache_; user.* and extra.* keys already

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -117,6 +117,27 @@ static constexpr const char USER_MODEL_PREFIX[] = "user.";
 static constexpr size_t USER_MODEL_PREFIX_LEN = sizeof(USER_MODEL_PREFIX) - 1;
 static constexpr const char EXTRA_MODEL_PREFIX[] = "extra.";
 
+// The deployment ModelType a model actually serves, honoring backend capability.
+// get_model_type_from_labels() gives chat-indicator labels (reasoning / vision /
+// tools / chat-transcription) priority — correct for LLM backends, but wrong for
+// a backend that cannot chat: its descriptor declares a definitive non-LLM
+// deployment (onnxruntime -> classification, sd-cpp -> image, whispercpp ->
+// transcription), and a stray chat-indicator label must not promote it to LLM
+// and slip past classifier-capability validation or send run_classifier down the
+// unsupported chat_completion path at runtime.
+static ModelType get_deployment_model_type(const std::string& recipe,
+                                           const std::vector<std::string>& labels) {
+    if (const auto* desc = lemon::backends::descriptor_for(recipe)) {
+        for (const auto& label : desc->default_labels) {
+            ModelType backend_type = get_model_type_from_labels({label});
+            if (backend_type != ModelType::LLM) {
+                return backend_type;
+            }
+        }
+    }
+    return get_model_type_from_labels(labels);
+}
+
 // Built-ins are keyed bare in models_cache_; user.* and extra.* keys already
 // include their canonical prefix. This helper returns the canonical ID for any
 // cache key, which is the form used by recipe_options.json on disk.
@@ -1134,7 +1155,7 @@ std::map<std::string, ModelInfo> ModelManager::discover_extra_models() const {
             info.labels.push_back("vision");
         }
 
-        info.type = get_model_type_from_labels(info.labels);
+        info.type = get_deployment_model_type(info.recipe, info.labels);
 
         discovered[model_name] = info;
     }
@@ -1746,7 +1767,7 @@ void ModelManager::build_cache() {
         }
 
         // Populate type and device fields (multi-model support)
-        info.type = get_model_type_from_labels(info.labels);
+        info.type = get_deployment_model_type(info.recipe, info.labels);
         info.device = device_type_for_recipe(info.recipe);
 
         try {
@@ -1806,7 +1827,7 @@ void ModelManager::build_cache() {
         }
 
         // Populate type and device fields (multi-model support)
-        info.type = get_model_type_from_labels(info.labels);
+        info.type = get_deployment_model_type(info.recipe, info.labels);
         info.device = device_type_for_recipe(info.recipe);
 
         try {
@@ -2021,7 +2042,7 @@ void ModelManager::add_model_to_cache(const std::string& model_name) {
     }
 
     // Populate type and device fields (multi-model support)
-    info.type = get_model_type_from_labels(info.labels);
+    info.type = get_deployment_model_type(info.recipe, info.labels);
     info.device = device_type_for_recipe(info.recipe);
 
     resolve_all_model_paths(info);
@@ -4562,13 +4583,16 @@ std::optional<std::string> ModelManager::validate_collection_request(
                 if (!def) {
                     return std::nullopt;
                 }
-                // Derive the type exactly as register_user_model() would once
-                // this inline definition is registered — explicit labels, legacy
-                // capability flags, and the backend's default labels — so
-                // validation and registration cannot disagree (e.g. a label-less
-                // sd-cpp model is IMAGE, not LLM).
+                // Derive the type exactly as register_user_model() +
+                // get_deployment_model_type() would once this inline definition
+                // is registered — explicit labels, legacy capability flags, and
+                // the backend's default labels, with the backend's deployment
+                // capability winning over chat-indicator labels — so validation
+                // and runtime cannot disagree (e.g. a label-less sd-cpp model is
+                // IMAGE, and onnxruntime + reasoning:true is CLASSIFICATION, not LLM).
                 std::set<std::string> label_set = normalized_definition_labels(*def);
-                return get_model_type_from_labels(
+                return get_deployment_model_type(
+                    def->value("recipe", std::string()),
                     std::vector<std::string>(label_set.begin(), label_set.end()));
             }
         };

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -4559,16 +4559,20 @@ std::optional<std::string> ModelManager::validate_collection_request(
             } catch (...) {
                 // Not registered yet - the name may match an inline `models[]`
                 // definition in this same request; derive its type from that
-                // definition's declared labels instead of guessing one.
+                // definition's declared labels (absent labels default to LLM,
+                // same as everywhere else). Only nullopt if no definition
+                // exists at all - that's the "truly unknown" case.
                 const json* def = find_inline_def(bare_component_name(name));
-                if (def && def->contains("labels") && (*def)["labels"].is_array()) {
-                    std::vector<std::string> labels;
+                if (!def) {
+                    return std::nullopt;
+                }
+                std::vector<std::string> labels;
+                if (def->contains("labels") && (*def)["labels"].is_array()) {
                     for (const auto& label : (*def)["labels"]) {
                         if (label.is_string()) labels.push_back(label.get<std::string>());
                     }
-                    return get_model_type_from_labels(labels);
                 }
-                return std::nullopt;
+                return get_model_type_from_labels(labels);
             }
         };
         try {

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -1935,9 +1935,9 @@ void ModelManager::build_cache() {
     // Direct lookup into the map already being built, same rationale as
     // resolve_component above: models_cache_ is populated and the lock is
     // still held, so this avoids re-entering get_model_info()'s own locking.
-    policy_options.get_model_type = [this](const std::string& name) -> ModelType {
+    policy_options.get_model_type = [this](const std::string& name) -> std::optional<ModelType> {
         auto it = models_cache_.find(name);
-        return it != models_cache_.end() ? it->second.type : ModelType::LLM;
+        return it != models_cache_.end() ? std::optional<ModelType>(it->second.type) : std::nullopt;
     };
     for (auto& [name, info] : models_cache_) {
         if (!is_router_collection_recipe(info.recipe)) {
@@ -4553,13 +4553,22 @@ std::optional<std::string> ModelManager::validate_collection_request(
                 return name;
             }
         };
-        options.get_model_type = [this](const std::string& name) -> ModelType {
+        options.get_model_type = [this, &find_inline_def](const std::string& name) -> std::optional<ModelType> {
             try {
                 return get_model_info(name).type;
             } catch (...) {
-                // Unregistered inline-collection component: no type to check
-                // yet, so don't block registration on it here.
-                return ModelType::LLM;
+                // Not registered yet - the name may match an inline `models[]`
+                // definition in this same request; derive its type from that
+                // definition's declared labels instead of guessing one.
+                const json* def = find_inline_def(bare_component_name(name));
+                if (def && def->contains("labels") && (*def)["labels"].is_array()) {
+                    std::vector<std::string> labels;
+                    for (const auto& label : (*def)["labels"]) {
+                        if (label.is_string()) labels.push_back(label.get<std::string>());
+                    }
+                    return get_model_type_from_labels(labels);
+                }
+                return std::nullopt;
             }
         };
         try {

--- a/src/cpp/server/routing_classifier_services.cpp
+++ b/src/cpp/server/routing_classifier_services.cpp
@@ -237,11 +237,14 @@ std::map<std::string, double> parse_classifier_scores(const json& response) {
 ClassifierServices make_classifier_services_from_router_calls(
     RouterJsonCall embeddings,
     RouterJsonCall chat_completion,
-    EnsureClassifierModelLoaded ensure_loaded) {
+    EnsureClassifierModelLoaded ensure_loaded,
+    RouterJsonCall classify,
+    RouterModelTypeCall get_model_type) {
     ClassifierServices services;
     auto embeddings_call = std::make_shared<RouterJsonCall>(std::move(embeddings));
     auto chat_completion_call =
         std::make_shared<RouterJsonCall>(std::move(chat_completion));
+    auto classify_call = std::make_shared<RouterJsonCall>(std::move(classify));
 
     services.embed = [embeddings_call,
                       ensure_loaded](const std::string& model,
@@ -257,14 +260,30 @@ ClassifierServices make_classifier_services_from_router_calls(
         return parse_embedding_vector((*embeddings_call)(request));
     };
 
-    services.run_classifier = [chat_completion_call,
+    services.run_classifier = [chat_completion_call, classify_call, get_model_type,
                                ensure_loaded](const std::string& model,
                                               const std::string& input)
         -> std::map<std::string, double> {
+        ensure_model(ensure_loaded, model);
+
+        // Models registered under ModelType::CLASSIFICATION (the onnxruntime
+        // backend) speak /v1/classify natively — a real encoder classification
+        // head, not an LLM asked to emit JSON. Route to it directly instead of
+        // going through chat_completion, which such a model can't serve at all
+        // (WrappedServer's default chat_completion() is an unsupported-capability
+        // error for any backend that doesn't implement it).
+        if (classify_call && *classify_call && get_model_type &&
+            get_model_type(model) == ModelType::CLASSIFICATION) {
+            json request = {
+                {"model", model},
+                {"input", input},
+            };
+            return parse_classifier_scores((*classify_call)(request));
+        }
+
         if (!*chat_completion_call) {
             throw std::runtime_error("Router chat_completion call is not configured");
         }
-        ensure_model(ensure_loaded, model);
         json request = {
             {"model", model},
             {"stream", false},

--- a/src/cpp/server/routing_classifier_services.cpp
+++ b/src/cpp/server/routing_classifier_services.cpp
@@ -264,6 +264,15 @@ ClassifierServices make_classifier_services_from_router_calls(
                                ensure_loaded](const std::string& model,
                                               const std::string& input)
         -> std::map<std::string, double> {
+        // Load the model BEFORE resolving its runtime type. The production
+        // resolver (Router::get_model_type) reports ModelType::LLM until the
+        // backend is loaded and alive, so resolving first would make a cold-start
+        // request — the first after startup, eviction, or a backend restart —
+        // pick the chat path for a model that only speaks /v1/classify,
+        // recreating the unsupported-capability failure this routing exists to
+        // avoid.
+        ensure_model(ensure_loaded, model);
+
         // Models registered under ModelType::CLASSIFICATION (the onnxruntime
         // backend) speak /v1/classify natively — a real encoder classification
         // head, not an LLM asked to emit JSON. Route to it directly instead of
@@ -274,18 +283,16 @@ ClassifierServices make_classifier_services_from_router_calls(
             classify_call && *classify_call && get_model_type &&
             get_model_type(model) == ModelType::CLASSIFICATION;
 
-        if (!use_classify_endpoint && !*chat_completion_call) {
-            throw std::runtime_error("Router chat_completion call is not configured");
-        }
-
-        ensure_model(ensure_loaded, model);
-
         if (use_classify_endpoint) {
             json request = {
                 {"model", model},
                 {"input", input},
             };
             return parse_classifier_scores((*classify_call)(request));
+        }
+
+        if (!*chat_completion_call) {
+            throw std::runtime_error("Router chat_completion call is not configured");
         }
 
         json request = {

--- a/src/cpp/server/routing_classifier_services.cpp
+++ b/src/cpp/server/routing_classifier_services.cpp
@@ -264,16 +264,23 @@ ClassifierServices make_classifier_services_from_router_calls(
                                ensure_loaded](const std::string& model,
                                               const std::string& input)
         -> std::map<std::string, double> {
-        ensure_model(ensure_loaded, model);
-
         // Models registered under ModelType::CLASSIFICATION (the onnxruntime
         // backend) speak /v1/classify natively — a real encoder classification
         // head, not an LLM asked to emit JSON. Route to it directly instead of
         // going through chat_completion, which such a model can't serve at all
         // (WrappedServer's default chat_completion() is an unsupported-capability
         // error for any backend that doesn't implement it).
-        if (classify_call && *classify_call && get_model_type &&
-            get_model_type(model) == ModelType::CLASSIFICATION) {
+        const bool use_classify_endpoint =
+            classify_call && *classify_call && get_model_type &&
+            get_model_type(model) == ModelType::CLASSIFICATION;
+
+        if (!use_classify_endpoint && !*chat_completion_call) {
+            throw std::runtime_error("Router chat_completion call is not configured");
+        }
+
+        ensure_model(ensure_loaded, model);
+
+        if (use_classify_endpoint) {
             json request = {
                 {"model", model},
                 {"input", input},
@@ -281,9 +288,6 @@ ClassifierServices make_classifier_services_from_router_calls(
             return parse_classifier_scores((*classify_call)(request));
         }
 
-        if (!*chat_completion_call) {
-            throw std::runtime_error("Router chat_completion call is not configured");
-        }
         json request = {
             {"model", model},
             {"stream", false},

--- a/src/cpp/server/routing_classifier_services_router.cpp
+++ b/src/cpp/server/routing_classifier_services_router.cpp
@@ -12,7 +12,9 @@ ClassifierServices make_router_classifier_services(
     return make_classifier_services_from_router_calls(
         [&router](const json& request) { return router.embeddings(request); },
         [&router](const json& request) { return router.chat_completion(request); },
-        std::move(ensure_loaded));
+        std::move(ensure_loaded),
+        [&router](const json& request) { return router.classify(request); },
+        [&router](const std::string& model) { return router.get_model_type(model); });
 }
 
 } // namespace lemon

--- a/src/cpp/server/routing_policy_parser.cpp
+++ b/src/cpp/server/routing_policy_parser.cpp
@@ -413,6 +413,32 @@ json parse_classifier_configs(const json& routing,
             const std::string original = optional_string(classifier, "model", path);
             std::string resolved_model = resolve_component(original, options, path + ".model");
             require_declared(resolved_model, original, declared, options, path + ".model");
+
+            // Fail at parse time, not at first request: a "classifier" model
+            // must be able to answer /v1/classify (ModelType::CLASSIFICATION)
+            // or serve as an LLM-as-classifier via chat_completion
+            // (ModelType::LLM); a "semantic_similarity" model must be able to
+            // embed (ModelType::EMBEDDING). Skipped when get_model_type isn't
+            // configured (pure parser tests, and callers that don't have a
+            // model registry to check against).
+            if (options.get_model_type) {
+                const ModelType model_type = options.get_model_type(resolved_model);
+                if (type == "classifier" &&
+                    model_type != ModelType::LLM && model_type != ModelType::CLASSIFICATION) {
+                    throw std::invalid_argument(
+                        path + ".model '" + original + "' has type '" +
+                        model_type_to_string(model_type) +
+                        "', which cannot serve as a classifier (needs an LLM or "
+                        "classification model)");
+                }
+                if (type == "semantic_similarity" && model_type != ModelType::EMBEDDING) {
+                    throw std::invalid_argument(
+                        path + ".model '" + original + "' has type '" +
+                        model_type_to_string(model_type) +
+                        "', which cannot serve semantic_similarity (needs an embedding model)");
+                }
+            }
+
             item["model"] = std::move(resolved_model);
         }
 

--- a/src/cpp/server/routing_policy_parser.cpp
+++ b/src/cpp/server/routing_policy_parser.cpp
@@ -422,7 +422,13 @@ json parse_classifier_configs(const json& routing,
             // configured (pure parser tests, and callers that don't have a
             // model registry to check against).
             if (options.get_model_type) {
-                const ModelType model_type = options.get_model_type(resolved_model);
+                const std::optional<ModelType> resolved_type = options.get_model_type(resolved_model);
+                if (!resolved_type) {
+                    throw std::invalid_argument(
+                        path + ".model '" + original + "' has an unresolvable type; "
+                        "cannot validate it as a '" + type + "'");
+                }
+                const ModelType model_type = *resolved_type;
                 if (type == "classifier" &&
                     model_type != ModelType::LLM && model_type != ModelType::CLASSIFICATION) {
                     throw std::invalid_argument(

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -206,6 +206,15 @@ static void test_backend_capability_over_chat_indicator(ModelManager& manager) {
     check("sd-cpp + vision:true rejected as classifier (still IMAGE)",
           error_contains(manager.validate_collection_request("user.RouterKit", sd_vision),
                          "cannot serve as a classifier"));
+
+    // kokoro only does TTS but has no explicit labels; its default label must
+    // still keep a label-less kokoro model out of the classifier path.
+    json kokoro_clf = router_with_classifier(
+        "classifier",
+        json{{"model_name", "voice"}, {"recipe", "kokoro"}, {"checkpoint", "example/voice"}});
+    check("label-less kokoro rejected as classifier (default label 'tts')",
+          error_contains(manager.validate_collection_request("user.RouterKit", kokoro_clf),
+                         "cannot serve as a classifier"));
 }
 
 static void test_register_preserves_routing(ModelManager& manager) {

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -106,6 +106,69 @@ static void test_rejects_bad_routing(ModelManager& manager) {
           error_contains(err, "catastrophic backtracking"));
 }
 
+// Build a minimal router whose single classifier of `type` is backed by the
+// given inline model definition. `local` is the only candidate.
+static json router_with_classifier(const std::string& type,
+                                   const json& classifier_model_def) {
+    const std::string cmodel = classifier_model_def.value("model_name", "clf");
+    json classifier = {{"id", "clf"}, {"type", type}, {"model", cmodel}};
+    json match;
+    if (type == "semantic_similarity") {
+        classifier["reference_phrases"] = {{"coding", {"write code"}}};
+        match = {{"classifier", "clf"}, {"label", "coding"}, {"min_score", 0.5}};
+    } else {
+        classifier["labels"] = {"A", "B"};
+        classifier["default_label"] = "A";
+        match = {{"classifier", "clf"}, {"min_score", 0.5}};
+    }
+    return json{
+        {"model_name", "user.RouterKit"},
+        {"version", "1"},
+        {"recipe", "collection.router"},
+        {"components", {"local", cmodel}},
+        {"models", {component_def("local"), classifier_model_def}},
+        {"routing", {
+            {"candidates", {"local"}},
+            {"default_model", "local"},
+            {"classifiers", {classifier}},
+            {"rules", {{
+                {"id", "r"},
+                {"match", match},
+                {"route_to", "local"},
+            }}},
+        }},
+    };
+}
+
+// The inline type resolver must mirror registration's normalization, not just
+// read explicit labels: a label-less definition still picks up legacy flags and
+// the backend's default labels.
+static void test_inline_capability_matches_registration(ModelManager& manager) {
+    // Label-less sd-cpp -> IMAGE at registration, so it cannot be a classifier.
+    json sd_clf = router_with_classifier(
+        "classifier",
+        json{{"model_name", "img"}, {"recipe", "sd-cpp"}, {"checkpoint", "example/img"}});
+    auto err = manager.validate_collection_request("user.RouterKit", sd_clf);
+    check("label-less sd-cpp rejected as classifier (backend default label 'image')",
+          error_contains(err, "cannot serve as a classifier"));
+
+    // Legacy `embedding: true` -> EMBEDDING, valid for semantic_similarity.
+    json emb_sem = router_with_classifier(
+        "semantic_similarity",
+        json{{"model_name", "emb"}, {"recipe", "llamacpp"},
+             {"checkpoint", "example/emb:Q4_K_M"}, {"embedding", true}});
+    err = manager.validate_collection_request("user.RouterKit", emb_sem);
+    check("legacy embedding:true accepted for semantic_similarity", !err.has_value());
+
+    // Label-less regular llamacpp still defaults to LLM, valid as a classifier.
+    json llm_clf = router_with_classifier(
+        "classifier",
+        json{{"model_name", "reg"}, {"recipe", "llamacpp"},
+             {"checkpoint", "example/reg:Q4_K_M"}});
+    err = manager.validate_collection_request("user.RouterKit", llm_clf);
+    check("label-less llamacpp still defaults to LLM (valid classifier)", !err.has_value());
+}
+
 static void test_register_preserves_routing(ModelManager& manager) {
     json doc = valid_router_collection();
     manager.register_user_model("user.RouterKit", doc);
@@ -122,6 +185,7 @@ int main() {
     ModelManager manager;
     test_accepts_valid_router_policy(manager);
     test_rejects_bad_routing(manager);
+    test_inline_capability_matches_registration(manager);
     test_register_preserves_routing(manager);
 
     fs::remove_all(temp);

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -169,6 +169,45 @@ static void test_inline_capability_matches_registration(ModelManager& manager) {
     check("label-less llamacpp still defaults to LLM (valid classifier)", !err.has_value());
 }
 
+// A chat-indicator label (reasoning/vision/…) must not promote a non-chat
+// backend to LLM. The backend's deployment capability wins, at both the model
+// type (which drives runtime routing) and collection.router validation.
+static void test_backend_capability_over_chat_indicator(ModelManager& manager) {
+    // onnxruntime is a classification backend: reasoning:true stays CLASSIFICATION,
+    // so run_classifier routes to /classify, not the (unsupported) chat path.
+    manager.register_user_model(
+        "user.GuardX",
+        json{{"model_name", "user.GuardX"}, {"recipe", "onnxruntime"},
+             {"checkpoint", "example/guard"}, {"reasoning", true}});
+    check("onnxruntime + reasoning:true is CLASSIFICATION, not LLM",
+          manager.get_model_info("user.GuardX").type == lemon::ModelType::CLASSIFICATION);
+
+    // sd-cpp is an image backend: vision:true stays IMAGE, not LLM.
+    manager.register_user_model(
+        "user.ImgX",
+        json{{"model_name", "user.ImgX"}, {"recipe", "sd-cpp"},
+             {"checkpoint", "example/img"}, {"vision", true}});
+    check("sd-cpp + vision:true is IMAGE, not LLM",
+          manager.get_model_info("user.ImgX").type == lemon::ModelType::IMAGE);
+
+    // …and the same models used as router classifiers resolve accordingly:
+    // onnxruntime is accepted (CLASSIFICATION), sd-cpp is rejected (IMAGE).
+    json onnx_reason = router_with_classifier(
+        "classifier",
+        json{{"model_name", "guard"}, {"recipe", "onnxruntime"},
+             {"checkpoint", "example/guard"}, {"reasoning", true}});
+    check("onnxruntime + reasoning:true accepted as classifier (CLASSIFICATION)",
+          !manager.validate_collection_request("user.RouterKit", onnx_reason).has_value());
+
+    json sd_vision = router_with_classifier(
+        "classifier",
+        json{{"model_name", "img"}, {"recipe", "sd-cpp"},
+             {"checkpoint", "example/img"}, {"vision", true}});
+    check("sd-cpp + vision:true rejected as classifier (still IMAGE)",
+          error_contains(manager.validate_collection_request("user.RouterKit", sd_vision),
+                         "cannot serve as a classifier"));
+}
+
 static void test_register_preserves_routing(ModelManager& manager) {
     json doc = valid_router_collection();
     manager.register_user_model("user.RouterKit", doc);
@@ -186,6 +225,7 @@ int main() {
     test_accepts_valid_router_policy(manager);
     test_rejects_bad_routing(manager);
     test_inline_capability_matches_registration(manager);
+    test_backend_capability_over_chat_indicator(manager);
     test_register_preserves_routing(manager);
 
     fs::remove_all(temp);

--- a/test/cpp/test_model_manager_collection_validation.cpp
+++ b/test/cpp/test_model_manager_collection_validation.cpp
@@ -215,6 +215,24 @@ static void test_backend_capability_over_chat_indicator(ModelManager& manager) {
     check("label-less kokoro rejected as classifier (default label 'tts')",
           error_contains(manager.validate_collection_request("user.RouterKit", kokoro_clf),
                          "cannot serve as a classifier"));
+
+    // The inverse: /v1/classify is served only by onnxruntime. A `classification`
+    // label on llamacpp (which cannot classify) must NOT type it CLASSIFICATION,
+    // or run_classifier would call Router::classify() and fail. It stays LLM and
+    // is accepted as an LLM-as-classifier via the chat path.
+    manager.register_user_model(
+        "user.LlamaClf",
+        json{{"model_name", "user.LlamaClf"}, {"recipe", "llamacpp"},
+             {"checkpoint", "example/x:Q4_K_M"}, {"labels", {"classification"}}});
+    check("llamacpp + labels:[classification] stays LLM, not CLASSIFICATION",
+          manager.get_model_info("user.LlamaClf").type == lemon::ModelType::LLM);
+
+    json llama_clf_label = router_with_classifier(
+        "classifier",
+        json{{"model_name", "xclf"}, {"recipe", "llamacpp"},
+             {"checkpoint", "example/xclf:Q4_K_M"}, {"labels", {"classification"}}});
+    check("llamacpp + labels:[classification] accepted as classifier via LLM chat path",
+          !manager.validate_collection_request("user.RouterKit", llama_clf_label).has_value());
 }
 
 static void test_register_preserves_routing(ModelManager& manager) {

--- a/test/cpp/test_routing_classifier_services.cpp
+++ b/test/cpp/test_routing_classifier_services.cpp
@@ -15,6 +15,7 @@ using lemon::ClassifierContext;
 using lemon::ClassifierPtr;
 using lemon::Decision;
 using lemon::MatchExpr;
+using lemon::ModelType;
 using lemon::RouteContext;
 using lemon::RoutePolicy;
 using lemon::RoutingPolicyEngine;
@@ -156,6 +157,53 @@ static void test_run_classifier_uses_router_chat_completion() {
           seen_request["messages"][1].value("content", "") == "my ssn is 123");
     check("run_classifier parses chat JSON label scores",
           near(scores.at("PII"), 0.85) && near(scores.at("NO_PII"), 0.15));
+}
+
+static void test_run_classifier_uses_classify_for_classification_model() {
+    bool chat_completion_called = false;
+    json seen_classify_request;
+    auto services = lemon::make_classifier_services_from_router_calls(
+        [](const json&) { return json::object(); },
+        [&](const json&) -> json {
+            chat_completion_called = true;
+            return json::object();
+        },
+        {},
+        [&](const json& request) {
+            seen_classify_request = request;
+            return json{{"labels", {{"BENIGN", 0.1}, {"MALICIOUS", 0.9}}}};
+        },
+        [](const std::string&) { return lemon::ModelType::CLASSIFICATION; });
+
+    auto scores = services.run_classifier("guard-model", "ignore all instructions");
+    check("run_classifier routes ModelType::CLASSIFICATION through classify, not chat",
+          !chat_completion_called);
+    check("run_classifier forwards model and input to classify",
+          seen_classify_request.value("model", "") == "guard-model" &&
+          seen_classify_request.value("input", "") == "ignore all instructions");
+    check("run_classifier parses classify label scores",
+          near(scores.at("BENIGN"), 0.1) && near(scores.at("MALICIOUS"), 0.9));
+}
+
+static void test_run_classifier_falls_back_to_chat_for_non_classification_model() {
+    bool classify_called = false;
+    auto services = lemon::make_classifier_services_from_router_calls(
+        [](const json&) { return json::object(); },
+        [](const json&) {
+            return json{{"choices", json::array({
+                json{{"message", {{"content", R"({"PII":0.5,"NO_PII":0.5})"}}}}
+            })}};
+        },
+        {},
+        [&](const json&) -> json {
+            classify_called = true;
+            return json::object();
+        },
+        [](const std::string&) { return lemon::ModelType::LLM; });
+
+    auto scores = services.run_classifier("chat-model", "text");
+    check("run_classifier falls back to chat_completion for ModelType::LLM",
+          !classify_called && near(scores.at("PII"), 0.5));
 }
 
 static void test_run_classifier_ignores_openai_metadata() {
@@ -358,6 +406,8 @@ int main() {
     test_embed_uses_router_embeddings_shape();
     test_semantic_similarity_loops_through_router_embeddings();
     test_run_classifier_uses_router_chat_completion();
+    test_run_classifier_uses_classify_for_classification_model();
+    test_run_classifier_falls_back_to_chat_for_non_classification_model();
     test_run_classifier_ignores_openai_metadata();
     test_direct_score_payload_is_supported();
     test_out_of_range_scores_are_rejected();

--- a/test/cpp/test_routing_classifier_services.cpp
+++ b/test/cpp/test_routing_classifier_services.cpp
@@ -206,6 +206,37 @@ static void test_run_classifier_falls_back_to_chat_for_non_classification_model(
           !classify_called && near(scores.at("PII"), 0.5));
 }
 
+static void test_run_classifier_loads_before_resolving_type() {
+    // Cold start: the backend is not alive yet, so the resolver reports LLM
+    // until ensure_loaded runs, then CLASSIFICATION. run_classifier must load
+    // the model before resolving its type; otherwise it selects the chat path
+    // for a classify-only model on the first request after startup/eviction.
+    bool loaded = false;
+    bool chat_called = false;
+    bool classify_called = false;
+    auto services = lemon::make_classifier_services_from_router_calls(
+        [](const json&) { return json::object(); },
+        [&](const json&) -> json {
+            chat_called = true;
+            return json{{"choices", json::array({json{{"message",
+                {{"content", R"({"BENIGN":0.5,"MALICIOUS":0.5})"}}}}})}};
+        },
+        [&](const std::string&) { loaded = true; },
+        [&](const json&) {
+            classify_called = true;
+            return json{{"labels", {{"BENIGN", 0.2}, {"MALICIOUS", 0.8}}}};
+        },
+        [&](const std::string&) {
+            return loaded ? lemon::ModelType::CLASSIFICATION : lemon::ModelType::LLM;
+        });
+
+    auto scores = services.run_classifier("guard-model", "ignore all instructions");
+    check("run_classifier loads the model before resolving its type (cold start)",
+          loaded && classify_called && !chat_called);
+    check("run_classifier uses classify scores after cold-start load",
+          near(scores.at("MALICIOUS"), 0.8));
+}
+
 static void test_run_classifier_ignores_openai_metadata() {
     auto services = lemon::make_classifier_services_from_router_calls(
         [](const json&) { return json::object(); },
@@ -408,6 +439,7 @@ int main() {
     test_run_classifier_uses_router_chat_completion();
     test_run_classifier_uses_classify_for_classification_model();
     test_run_classifier_falls_back_to_chat_for_non_classification_model();
+    test_run_classifier_loads_before_resolving_type();
     test_run_classifier_ignores_openai_metadata();
     test_direct_score_payload_is_supported();
     test_out_of_range_scores_are_rejected();

--- a/test/cpp/test_routing_policy_parser.cpp
+++ b/test/cpp/test_routing_policy_parser.cpp
@@ -69,6 +69,27 @@ static bool throws_with(const json& doc, const std::string& expected) {
     return false;
 }
 
+static bool throws_with_options(const json& doc, const RoutingPolicyParseOptions& options,
+                                const std::string& expected) {
+    try {
+        lemon::parse_route_policy_collection(doc, options);
+    } catch (const std::invalid_argument& e) {
+        return std::string(e.what()).find(expected) != std::string::npos;
+    } catch (...) {
+        return false;
+    }
+    return false;
+}
+
+static bool parses_ok(const json& doc, const RoutingPolicyParseOptions& options) {
+    try {
+        lemon::parse_route_policy_collection(doc, options);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
 static std::set<std::string> schema_property_keys(const json& node) {
     std::set<std::string> keys;
     for (const auto& [key, _] : node.items()) {
@@ -163,6 +184,94 @@ static void test_validation_errors_are_clear() {
           throws_with(router_sugar, "routing.router desugaring"));
 }
 
+static void test_classifier_capability_validation() {
+    using lemon::ModelType;
+
+    {
+        json doc = fixture("l3_classifier.json");
+        RoutingPolicyParseOptions options;
+        options.get_model_type = [](const std::string& name) -> std::optional<ModelType> {
+            if (name == "pii-detector-small") return ModelType::CLASSIFICATION;
+            return ModelType::LLM;
+        };
+        check("classifier accepts CLASSIFICATION and LLM model types", parses_ok(doc, options));
+    }
+    {
+        json doc = fixture("l3_classifier.json");
+        RoutingPolicyParseOptions options;
+        options.get_model_type = [](const std::string& name) -> std::optional<ModelType> {
+            if (name == "pii-detector-small") return ModelType::EMBEDDING;
+            return ModelType::LLM;
+        };
+        check("classifier rejects a model typed EMBEDDING",
+              throws_with_options(doc, options, "cannot serve as a classifier"));
+    }
+    {
+        json doc = fixture("l2_semantic.json");
+        RoutingPolicyParseOptions options;
+        options.get_model_type = [](const std::string&) -> std::optional<ModelType> {
+            return ModelType::EMBEDDING;
+        };
+        check("semantic_similarity accepts an EMBEDDING model type", parses_ok(doc, options));
+    }
+    {
+        json doc = fixture("l2_semantic.json");
+        RoutingPolicyParseOptions options;
+        options.get_model_type = [](const std::string&) -> std::optional<ModelType> {
+            return ModelType::LLM;
+        };
+        check("semantic_similarity rejects a model typed LLM",
+              throws_with_options(doc, options, "cannot serve semantic_similarity"));
+    }
+    {
+        json doc = fixture("l3_classifier.json");
+        RoutingPolicyParseOptions options;
+        options.get_model_type = [](const std::string&) -> std::optional<ModelType> {
+            return std::nullopt;
+        };
+        check("unresolvable model type is rejected, not silently accepted",
+              throws_with_options(doc, options, "unresolvable type"));
+    }
+}
+
+// Regression pair from PR review (fl0rianr): an inline collection component
+// that isn't registered yet must have its type derived from its own inline
+// definition (e.g. declared `labels`), not defaulted to a fixed type — a
+// fixed-default fallback both rejects valid configs and accepts invalid ones,
+// depending on which type it defaults to. This exercises the parser's side of
+// that contract: as long as the resolver reports the inline definition's real
+// type instead of guessing, both directions behave correctly.
+static void test_inline_component_type_regression_pair() {
+    using lemon::ModelType;
+
+    json semantic_doc = fixture("l2_semantic.json");
+    semantic_doc["components"] = json::array({"Qwen3-8B-GGUF", "vllm.qwen3-32b", "inline-embedder"});
+    semantic_doc["routing"]["classifiers"][0]["model"] = "inline-embedder";
+    {
+        RoutingPolicyParseOptions options;
+        options.get_model_type = [](const std::string& name) -> std::optional<ModelType> {
+            if (name == "inline-embedder") return ModelType::EMBEDDING;
+            return ModelType::LLM;
+        };
+        check("inline semantic_similarity + inline embedding definition passes",
+              parses_ok(semantic_doc, options));
+    }
+
+    json classifier_doc = fixture("l3_classifier.json");
+    classifier_doc["components"] = json::array(
+        {"Qwen3-8B-GGUF", "vllm.qwen3-32b", "inline-embedder", "jailbreak-detector-small"});
+    classifier_doc["routing"]["classifiers"][0]["model"] = "inline-embedder";
+    {
+        RoutingPolicyParseOptions options;
+        options.get_model_type = [](const std::string& name) -> std::optional<ModelType> {
+            if (name == "inline-embedder") return ModelType::EMBEDDING;
+            return ModelType::LLM;
+        };
+        check("inline classifier + that same inline embedding definition fails",
+              throws_with_options(classifier_doc, options, "cannot serve as a classifier"));
+    }
+}
+
 static void test_schema_parser_key_parity() {
     json schema = load_json_file(ROUTING_SCHEMA_FILE);
     check_keys("root keys match schema",
@@ -192,6 +301,8 @@ int main() {
     test_parse_keywords_fixture_and_route();
     test_component_resolver_canonicalizes_policy();
     test_validation_errors_are_clear();
+    test_classifier_capability_validation();
+    test_inline_component_type_regression_pair();
     test_schema_parser_key_parity();
 
     if (g_failures == 0) {


### PR DESCRIPTION
### Summary
Two related bugs in the `collection.router` + `onnxruntime` classifier feature (#2626):

1. **A `type: "classifier"` condition can never actually reach an `onnxruntime`-backed model.** `run_classifier` in `routing_classifier_services.cpp` only calls `Router::chat_completion`, which `WrappedServer`'s default implementation turns into an "unsupported capability" error for any backend that doesn't implement it (`OnnxRuntimeServer` doesn't — it only implements `classify()`). The failure is swallowed by the engine's fail-open design, so a policy with `on_error: match_true` (the natural choice for a security-relevant classifier) silently matches on *every* request regardless of input — worse than an outright error, since it looks like it's working.

2. **No capability check on `routing.classifiers[].model` at parse time.** `resolve_component`/`require_declared` only check that the referenced model exists, never that it can actually serve as a classifier (or, for `semantic_similarity`, as an embedder). A misconfigured policy registers successfully and only fails at request time via bug #1's failure mode.

### Fix
- Add optional `classify`/`get_model_type` callbacks to `ClassifierServices` (`routing_classifier_services.h/.cpp`, `routing_classifier_services_router.cpp`). `run_classifier` now calls `Router::classify()` when the target model is `ModelType::CLASSIFICATION`, falling back to the original chat-completion-based path otherwise — fully backward compatible, existing call sites and tests are unaffected by the new (defaulted) parameters.
- Add an optional `get_model_type` resolver to `RoutingPolicyParseOptions` (`routing_policy_parser.h/.cpp`), wired at both places a policy actually gets parsed in production (`ModelManager::build_cache()` and `validate_collection_request`). `type: "classifier"` now requires `ModelType::LLM` or `ModelType::CLASSIFICATION`; `type: "semantic_similarity"` requires `ModelType::EMBEDDING`.

### Verification
- All existing `test_routing_policy_parser` and `test_routing_classifier_services` unit tests pass unchanged.
- Live, end-to-end, against a build of current `main`:
  - A `collection.router` policy using `Bert-Phishing-ONNX` as classifier: phishing input → real score (`0.9999`), routes to the restricted candidate; benign input → real score (`0.00003`), falls through to default. (Before the fix: both inputs routed identically regardless of content.)
  - Same result reproduced with `meta-llama/Llama-Prompt-Guard-2-86M` (ONNX export) as the classifier — real prompt-injection/jailbreak detection, correct routing divergence between malicious and benign input.
  - Registering a policy whose classifier `model` is an embedding model is now rejected immediately with a clear error instead of silently succeeding.

### Context
This was requested as a follow-up PR by @SlawomirNowaczyk on #2626's review thread rather than being bundled into that PR.