### PR TITLE
fix(router): isolate routing helpers from standard model LRU slots

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -306,8 +306,9 @@ jobs:
           cmake --build --preset default --target test_job_expr
           cmake --build --preset default --target test_job_graph
           cmake --build --preset default --target test_origin_utils
+          cmake --build --preset default --target test_model_residency
           cd build
-          ctest --output-on-failure -R "ProcessManagerTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest"
+          ctest --output-on-failure -R "ProcessManagerTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest|ModelResidencyTest"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -621,8 +622,9 @@ jobs:
           cmake --build --preset default --target test_job_expr
           cmake --build --preset default --target test_job_graph
           cmake --build --preset default --target test_origin_utils
+          cmake --build --preset default --target test_model_residency
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest|ModelResidencyTest"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1943,6 +1943,23 @@ if(EXISTS "${_GGUF_CAPS_TEST_SRC}")
     add_test(NAME GgufCapabilitiesTest COMMAND test_gguf_capabilities)
 endif()
 
+# Model residency role/pool contract for router dependencies
+set(_MODEL_RESIDENCY_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_model_residency.cpp"
+)
+if(EXISTS "${_MODEL_RESIDENCY_TEST_SRC}")
+    add_executable(test_model_residency
+        test/cpp/test_model_residency.cpp
+    )
+    target_include_directories(test_model_residency PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+
+    include(CTest)
+    add_test(NAME ModelResidencyTest COMMAND test_model_residency)
+endif()
+
 # Pure version-resolution policy test (lemon::resolve_latest_pin). Header-only
 # logic, so the test links nothing beyond the standard library — regression
 # coverage for #2265 (fall back to the installed binary when the GitHub

--- a/docs/guide/configuration/multi-model.md
+++ b/docs/guide/configuration/multi-model.md
@@ -20,6 +20,32 @@ Models are categorized into these types:
 
 Each type has its own independent LRU cache, all sharing the same slot limit set by `max_loaded_models`.
 
+## Router and Classifier Dependencies
+
+Models loaded internally to choose a candidate use a separate **routing-helper**
+residency pool. This is intentionally independent from both `ModelType` and the
+backend's hardware slot policy:
+
+- A router LLM remains an **LLM**; it is not reclassified as a classification model.
+- Each model type has one routing-helper slot in addition to its normal
+  `max_loaded_models` slots. With the default `max_loaded_models=1`, one router
+  LLM and one selected LLM candidate can therefore stay warm together.
+- If an already-loaded standard model is later used as a routing dependency, its
+  live process is promoted in place without a reload or duplicate process.
+- Pinning is pool-local for count-based LRU: a pinned normal candidate does not
+  block the routing-helper slot, and a pinned helper does not block normal slots.
+- Cloud (`Unmetered`) models consume neither pool and report `slot_pool: unmetered`.
+- Implicit model selection prefers a normal `standard` model, so a warm internal
+  helper never makes an otherwise unique candidate ambiguous.
+- Explicit idle/VRAM-pressure eviction remains independent; an unpinned routing
+  helper can still be evicted when dynamic eviction is enabled.
+- Backend/device constraints remain authoritative. If a routing helper and
+  candidate cannot physically coexist (for example, exclusive NPU ownership),
+  the load fails with HTTP `409` and code `router_residency_conflict` instead of
+  repeatedly evicting one another.
+
+`GET /api/v1/health` exposes `residency_class` and `slot_pool` for every live model.
+
 ## Device Constraints
 
 <!-- BEGIN GENERATED: npu-exclusivity -->
@@ -98,7 +124,7 @@ To prevent frequently used models from being auto-evicted by the LRU policy, you
   ```
   Or via a POST request to `/internal/pin`.
 - **Pre-emptive Warnings:** The CLI checks `/api/v1/health` before loading a new model. If all slots for that model type are occupied by pinned models, the CLI will output a pre-emptive warning alerting you that loading will fail.
-- **Capacity Failures:** If all loaded models of a type are pinned and a request to load another model of that type is received, the load request fails with a `409 Conflict` HTTP status containing a `slots_pinned_error` code. You must unpin or unload at least one model of that type to free up a slot.
+- **Capacity Failures:** If every model in the target `(residency class, model type)` pool is pinned and another model needs that pool, the load request fails with a `409 Conflict` HTTP status containing a `slots_pinned_error` code. You must unpin or unload a model from that pool to free its slot.
 
 ## Per-Model Settings
 

--- a/docs/guide/configuration/multi-model.md
+++ b/docs/guide/configuration/multi-model.md
@@ -27,11 +27,21 @@ residency pool. This is intentionally independent from both `ModelType` and the
 backend's hardware slot policy:
 
 - A router LLM remains an **LLM**; it is not reclassified as a classification model.
-- Each model type has one routing-helper slot in addition to its normal
-  `max_loaded_models` slots. With the default `max_loaded_models=1`, one router
-  LLM and one selected LLM candidate can therefore stay warm together.
-- If an already-loaded standard model is later used as a routing dependency, its
-  live process is promoted in place without a reload or duplicate process.
+- Standard pools continue to use `max_loaded_models` per `ModelType`.
+- Routing-helper capacity is keyed by the distinct helper model rather than by
+  `ModelType`. Multiple classifier or router models of the same type required by
+  one or more policies can therefore remain warm together without consuming or
+  evicting standard user-facing slots. A second process for the same helper model
+  is never created.
+- With the default `max_loaded_models=1`, a router LLM and one selected standard
+  LLM candidate can stay warm together; additional distinct helper models can
+  also remain resident until explicit or pressure-based eviction removes them.
+- Residency follows the current use of the live process. A standard model used
+  as a routing dependency is promoted in place; a routing helper called directly
+  by the user is demoted into the counted standard pool in place. Destination-pool
+  admission and pinning rules apply before either transition. The
+  `router.model == candidate` case therefore promotes for routing and demotes for
+  candidate inference within the same request without creating a second process.
 - Pinning is pool-local for count-based LRU: a pinned normal candidate does not
   block the routing-helper slot, and a pinned helper does not block normal slots.
 - Cloud (`Unmetered`) models consume neither pool and report `slot_pool: unmetered`.
@@ -39,12 +49,16 @@ backend's hardware slot policy:
   helper never makes an otherwise unique candidate ambiguous.
 - Explicit idle/VRAM-pressure eviction remains independent; an unpinned routing
   helper can still be evicted when dynamic eviction is enabled.
-- Backend/device constraints remain authoritative. If a routing helper and
-  candidate cannot physically coexist (for example, exclusive NPU ownership),
-  the load fails with HTTP `409` and code `router_residency_conflict` instead of
-  repeatedly evicting one another.
+- Backend/device constraints remain authoritative. Internal routing work never
+  evicts an already-resident model to acquire an exclusive hardware slot; that
+  attempt fails with HTTP `409` and code `router_residency_conflict`. This also
+  prevents two incompatible NPU/FLM helpers from repeatedly evicting one another.
+  A direct user request has precedence and may evict a resident routing helper
+  through the backend's normal exclusivity policy.
 
 `GET /api/v1/health` exposes `residency_class` and `slot_pool` for every live model.
+`pinned_models` remains the standard-pool summary used with `max_models`, while
+`pinned_helper_models` separately reports pinned routing helpers by `ModelType`.
 
 ## Device Constraints
 

--- a/src/cpp/include/lemon/error_types.h
+++ b/src/cpp/include/lemon/error_types.h
@@ -21,6 +21,7 @@ namespace ErrorType {
     constexpr const char* FILE_ERROR = "file_error";
     constexpr const char* INTERNAL_ERROR = "internal_error";
     constexpr const char* SLOTS_PINNED = "slots_pinned_error";
+    constexpr const char* ROUTER_RESIDENCY_CONFLICT = "router_residency_conflict";
 }
 
 // Base exception class for all Lemon errors
@@ -62,6 +63,18 @@ public:
     SlotsPinnedException(const std::string& model_type, const std::string& details = "")
         : LemonException("All loaded models of type " + model_type + " are pinned. Unload a model first." + (details.empty() ? "" : " " + details),
                         ErrorType::SLOTS_PINNED) {}
+};
+
+class RouterResidencyConflictException : public LemonException {
+public:
+    RouterResidencyConflictException(const std::string& incoming_model,
+                                     const std::string& resident_model,
+                                     const std::string& constraint)
+        : LemonException(
+              "Routing residency conflict: model '" + incoming_model +
+                  "' cannot coexist with resident model '" + resident_model +
+                  "' because " + constraint + ".",
+              ErrorType::ROUTER_RESIDENCY_CONFLICT) {}
 };
 
 class BackendException : public LemonException {

--- a/src/cpp/include/lemon/model_residency.h
+++ b/src/cpp/include/lemon/model_residency.h
@@ -43,18 +43,41 @@ inline std::string residency_class_to_string(ResidencyClass residency_class) {
     return "standard";
 }
 
-// Router/classifier dependencies get one warm process per ModelType. Keeping
-// this independent from max_loaded_models prevents a normal LLM candidate from
-// evicting an LLM router when the user keeps the default standard limit of 1.
+// Standard pools honor max_loaded_models. A RoutingHelper pool is scoped to
+// one distinct helper model, so the per-pool limit stays one while multiple
+// helper models required by a policy can remain resident together.
 inline int residency_limit(ResidencyClass residency_class, int standard_limit) {
     return residency_class == ResidencyClass::RoutingHelper ? 1 : standard_limit;
 }
 
+// Standard capacity remains shared by ModelType. Routing-helper capacity is
+// keyed by the distinct helper model, so a policy can keep multiple same-type
+// helpers warm without making them compete for one type-wide slot.
 inline bool same_residency_pool(ModelType lhs_type,
                                 ResidencyClass lhs_class,
+                                const std::string& lhs_model,
                                 ModelType rhs_type,
-                                ResidencyClass rhs_class) {
-    return lhs_type == rhs_type && lhs_class == rhs_class;
+                                ResidencyClass rhs_class,
+                                const std::string& rhs_model) {
+    if (lhs_class != rhs_class) {
+        return false;
+    }
+    if (lhs_class == ResidencyClass::RoutingHelper) {
+        return lhs_type == rhs_type && lhs_model == rhs_model;
+    }
+    return lhs_type == rhs_type;
+}
+
+// Internal routing work must not evict an already-resident process to acquire
+// an exclusive hardware slot. Reject helper -> standard and helper -> helper
+// displacement deterministically instead of creating cross-request NPU/FLM
+// thrashing. A direct user request has precedence and may evict a helper via
+// the backend's normal exclusivity policy.
+inline bool should_reject_residency_displacement(
+    ResidencyClass incoming,
+    ResidencyClass resident) {
+    (void)resident;
+    return incoming == ResidencyClass::RoutingHelper;
 }
 
 inline std::string residency_pool_to_string(ModelType type,

--- a/src/cpp/include/lemon/model_residency.h
+++ b/src/cpp/include/lemon/model_residency.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <string>
+
+#include "model_types.h"
+
+namespace lemon {
+
+// Why a model is being loaded. This is request-scoped intent, not a model
+// capability and not a backend property.
+enum class LoadPurpose {
+    UserInference,
+    RoutingDependency,
+};
+
+// Capacity/LRU class assigned to a live backend process. ModelType remains the
+// deployment/API bucket (LLM, embedding, ...); ResidencyClass decides which
+// count-based slot pool the process consumes.
+enum class ResidencyClass {
+    Standard,
+    RoutingHelper,
+};
+
+inline ResidencyClass residency_class_for_load_purpose(LoadPurpose purpose) {
+    return purpose == LoadPurpose::RoutingDependency
+        ? ResidencyClass::RoutingHelper
+        : ResidencyClass::Standard;
+}
+
+inline LoadPurpose load_purpose_for_residency_class(ResidencyClass residency_class) {
+    return residency_class == ResidencyClass::RoutingHelper
+        ? LoadPurpose::RoutingDependency
+        : LoadPurpose::UserInference;
+}
+
+inline std::string residency_class_to_string(ResidencyClass residency_class) {
+    switch (residency_class) {
+        case ResidencyClass::Standard:
+            return "standard";
+        case ResidencyClass::RoutingHelper:
+            return "routing_helper";
+    }
+    return "standard";
+}
+
+// Router/classifier dependencies get one warm process per ModelType. Keeping
+// this independent from max_loaded_models prevents a normal LLM candidate from
+// evicting an LLM router when the user keeps the default standard limit of 1.
+inline int residency_limit(ResidencyClass residency_class, int standard_limit) {
+    return residency_class == ResidencyClass::RoutingHelper ? 1 : standard_limit;
+}
+
+inline bool same_residency_pool(ModelType lhs_type,
+                                ResidencyClass lhs_class,
+                                ModelType rhs_type,
+                                ResidencyClass rhs_class) {
+    return lhs_type == rhs_type && lhs_class == rhs_class;
+}
+
+inline std::string residency_pool_to_string(ModelType type,
+                                            ResidencyClass residency_class) {
+    return residency_class_to_string(residency_class) + "/" + model_type_to_string(type);
+}
+
+} // namespace lemon

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -81,6 +81,12 @@ public:
         LoadPurpose load_purpose = LoadPurpose::UserInference,
         std::atomic<bool>* cancel_flag = nullptr);
 
+    // Apply request intent to an already-live process without reloading it.
+    // Returns false when the requested model is not currently live.
+    bool ensure_loaded_model_residency(
+        const std::string& model_name,
+        LoadPurpose load_purpose);
+
     void unload_model(const std::string& model_name = "");  // Empty = unload all
 
     std::string get_loaded_model() const;
@@ -97,6 +103,9 @@ public:
 
     // Get pinned model counts per type
     json get_pinned_model_counts() const;
+    // Pinned routing helpers, separated from the standard counts used by
+    // the CLI's max_models preflight.
+    json get_pinned_helper_counts() const;
 
     // Pin or unpin a model
     void set_model_pinned(const std::string& model_name, bool pinned);
@@ -199,10 +208,17 @@ private:
     void prune_unavailable_servers_locked();
     bool reload_model_after_watchdog_reset(const std::string& requested_model, const RecipeOptions& options);
     bool is_watchdog_reset_response(const json& response) const;
-    int count_servers_in_pool(ModelType type, ResidencyClass residency_class) const;
-    int count_pinned_servers_by_type(ModelType type) const;
-    WrappedServer* find_lru_server_in_pool(ModelType type, ResidencyClass residency_class) const;
-    void ensure_residency_capacity(ModelType type, ResidencyClass residency_class);
+    int count_servers_in_pool(ModelType type, ResidencyClass residency_class,
+                              const std::string& model_name) const;
+    int count_pinned_servers_in_pool(ModelType type,
+                                      ResidencyClass residency_class) const;
+    WrappedServer* find_lru_server_in_pool(ModelType type, ResidencyClass residency_class,
+                                                  const std::string& model_name) const;
+    void ensure_residency_capacity(ModelType type, ResidencyClass residency_class,
+                                   const std::string& model_name);
+    void transition_server_residency_locked(
+        WrappedServer* server,
+        ResidencyClass requested_residency_class);
     bool has_npu_server() const;
     WrappedServer* find_npu_server() const;
     WrappedServer* find_npu_server_by_recipe(const std::string& recipe) const;

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -13,6 +13,7 @@
 #include <nlohmann/json.hpp>
 #include <httplib.h>
 #include "wrapped_server.h"
+#include "model_residency.h"
 #include "model_manager.h"
 #include "backend_manager.h"
 #include "runtime_config.h"
@@ -70,13 +71,15 @@ public:
     // allow_reload_on_option_change: intended for explicit /load callers only.
     // Auto-load callers (inference-triggered) should leave this false so they
     // don't overturn options set by a prior explicit /load.
-    void load_model(const std::string& model_name,
-                    const ModelInfo& model_info,
-                    RecipeOptions options,
-                    bool do_not_upgrade = true,
-                    bool allow_reload_on_option_change = false,
-                    std::optional<bool> pinned = std::nullopt,
-                    std::atomic<bool>* cancel_flag = nullptr);
+    void load_model(
+        const std::string& model_name,
+        const ModelInfo& model_info,
+        RecipeOptions options,
+        bool do_not_upgrade = true,
+        bool allow_reload_on_option_change = false,
+        std::optional<bool> pinned = std::nullopt,
+        LoadPurpose load_purpose = LoadPurpose::UserInference,
+        std::atomic<bool>* cancel_flag = nullptr);
 
     void unload_model(const std::string& model_name = "");  // Empty = unload all
 
@@ -196,9 +199,10 @@ private:
     void prune_unavailable_servers_locked();
     bool reload_model_after_watchdog_reset(const std::string& requested_model, const RecipeOptions& options);
     bool is_watchdog_reset_response(const json& response) const;
-    int count_servers_by_type(ModelType type) const;
+    int count_servers_in_pool(ModelType type, ResidencyClass residency_class) const;
     int count_pinned_servers_by_type(ModelType type) const;
-    WrappedServer* find_lru_server_by_type(ModelType type) const;
+    WrappedServer* find_lru_server_in_pool(ModelType type, ResidencyClass residency_class) const;
+    void ensure_residency_capacity(ModelType type, ResidencyClass residency_class);
     bool has_npu_server() const;
     WrappedServer* find_npu_server() const;
     WrappedServer* find_npu_server_by_recipe(const std::string& recipe) const;

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -268,8 +268,10 @@ private:
     // if the model is already loaded they are ignored so explicit /v1/load settings win.
     // Callers must pass only load-level options from extract_auto_load_options() — never
     // the raw request body — to keep request-scoped fields out of persistent recipe options.
-    void auto_load_model_if_needed(const std::string& model_name,
-                                   const json& request_options = json::object());
+    void auto_load_model_if_needed(
+        const std::string& model_name,
+        const json& request_options = json::object(),
+        LoadPurpose load_purpose = LoadPurpose::UserInference);
 
     // Helper: persist the registry's installed-providers list into config.json
     // by overlaying onto the current runtime-config snapshot. Called after

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -15,6 +15,7 @@
 #include "utils/http_client.h"
 #include "server_capabilities.h"
 #include "model_manager.h"
+#include "model_residency.h"
 #include "backend_manager.h"
 #include "recipe_options.h"
 #include "backends/backend_descriptor.h"
@@ -283,6 +284,8 @@ public:
     std::string get_model_name() const { return model_name_; }
     std::string get_checkpoint() const { return checkpoint_; }
     ModelType get_model_type() const { return model_type_; }
+    ResidencyClass get_residency_class() const { return residency_class_; }
+    void set_residency_class(ResidencyClass residency_class) { residency_class_ = residency_class; }
     DeviceType get_device_type() const { return device_type_; }
     RecipeOptions get_recipe_options() const {
         std::lock_guard<std::mutex> lock(state_mutex_);
@@ -508,6 +511,7 @@ protected:
     std::string model_name_;
     std::string checkpoint_;
     ModelType model_type_ = ModelType::LLM;
+    ResidencyClass residency_class_ = ResidencyClass::Standard;
     DeviceType device_type_ = DEVICE_NONE;
     std::chrono::steady_clock::time_point last_access_time_;
     RecipeOptions recipe_options_;

--- a/src/cpp/server/anthropic_api.cpp
+++ b/src/cpp/server/anthropic_api.cpp
@@ -1,4 +1,5 @@
 #include "lemon/ollama_api.h"
+#include "lemon/error_types.h"
 #include <iostream>
 #include <sstream>
 #include <chrono>
@@ -145,6 +146,20 @@ static json parse_openai_tool_arguments(const json& tool_call, std::vector<std::
 
     add_warning(warnings, "Tool arguments had unsupported type; using empty object");
     return json::object();
+}
+
+static void set_anthropic_residency_conflict_response(
+    const RouterResidencyConflictException& error,
+    httplib::Response& res) {
+    res.status = 409;
+    json body = {
+        {"type", "error"},
+        {"error", {
+            {"type", ErrorType::ROUTER_RESIDENCY_CONFLICT},
+            {"message", error.what()},
+        }},
+    };
+    res.set_content(body.dump(), "application/json");
 }
 
 }  // namespace
@@ -890,6 +905,9 @@ void OllamaApi::handle_anthropic_messages(const httplib::Request& req, httplib::
 
         try {
             auto_load_model(model, extract_auto_load_options(request_json));
+        } catch (const RouterResidencyConflictException& e) {
+            set_anthropic_residency_conflict_response(e, res);
+            return;
         } catch (const std::exception&) {
             res.status = 404;
             json error = {

--- a/src/cpp/server/ollama_api.cpp
+++ b/src/cpp/server/ollama_api.cpp
@@ -1,4 +1,5 @@
 #include "lemon/ollama_api.h"
+#include "lemon/error_types.h"
 #include "lemon/model_types.h"
 #include "lemon/runtime_config.h"
 #include <iostream>
@@ -104,6 +105,18 @@ static bool send_backend_error(const json& response, httplib::Response& res) {
 // Ollama → OpenAI option name mapping (ollama_key → openai_key)
 // Options where both names are the same use identical strings.
 // ============================================================================
+static void set_ollama_residency_conflict_response(
+    const RouterResidencyConflictException& error,
+    httplib::Response& res) {
+    res.status = 409;
+    json body = {
+        {"error", error.what()},
+        {"type", ErrorType::ROUTER_RESIDENCY_CONFLICT},
+        {"code", ErrorType::ROUTER_RESIDENCY_CONFLICT},
+    };
+    res.set_content(body.dump(), "application/json");
+}
+
 struct OptionMapping { const char* ollama_key; const char* openai_key; };
 
 static const OptionMapping OPTION_MAPPINGS[] = {
@@ -227,7 +240,8 @@ std::string OllamaApi::normalize_model_name(const std::string& name) {
 void OllamaApi::auto_load_model(const std::string& model, const json& request_options) {
     std::string name = normalize_model_name(model);
 
-    if (router_->is_model_loaded(name)) {
+    if (router_->ensure_loaded_model_residency(
+            name, LoadPurpose::UserInference)) {
         if (request_options.contains("ctx_size")) {
             auto loaded_ctx = router_->get_model_recipe_options(name).get_option("ctx_size");
             LOG(DEBUG, "OllamaApi")
@@ -731,6 +745,9 @@ void OllamaApi::handle_chat(const httplib::Request& req, httplib::Response& res)
         // Auto-load the model
         try {
             auto_load_model(model, extract_auto_load_options(request_json));
+        } catch (const RouterResidencyConflictException& e) {
+            set_ollama_residency_conflict_response(e, res);
+            return;
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found, try pulling it first"}};
@@ -863,6 +880,9 @@ void OllamaApi::handle_generate(const httplib::Request& req, httplib::Response& 
 
         try {
             auto_load_model(model, extract_auto_load_options(request_json));
+        } catch (const RouterResidencyConflictException& e) {
+            set_ollama_residency_conflict_response(e, res);
+            return;
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found, try pulling it first"}};
@@ -1300,6 +1320,9 @@ void OllamaApi::handle_embed(const httplib::Request& req, httplib::Response& res
 
         try {
             auto_load_model(model, extract_auto_load_options(request_json));
+        } catch (const RouterResidencyConflictException& e) {
+            set_ollama_residency_conflict_response(e, res);
+            return;
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found"}};
@@ -1367,6 +1390,9 @@ void OllamaApi::handle_embeddings(const httplib::Request& req, httplib::Response
 
         try {
             auto_load_model(model, extract_auto_load_options(request_json));
+        } catch (const RouterResidencyConflictException& e) {
+            set_ollama_residency_conflict_response(e, res);
+            return;
         } catch (const std::exception& e) {
             res.status = 404;
             json error = {{"error", "model '" + model + "' not found"}};

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -108,16 +108,27 @@ std::string Router::resolve_model_name(const std::string& model_name) const {
 }
 
 WrappedServer* Router::get_most_recent_server() const {
-    WrappedServer* most_recent = nullptr;
-    for (const auto& server : loaded_servers_) {
-        if (!server->is_backend_alive()) {
-            continue;
+    auto most_recent_in_class = [this](ResidencyClass residency_class) {
+        WrappedServer* most_recent = nullptr;
+        for (const auto& server : loaded_servers_) {
+            if (!server->is_backend_alive() ||
+                server->get_residency_class() != residency_class) {
+                continue;
+            }
+            if (!most_recent ||
+                server->get_last_access_time() > most_recent->get_last_access_time()) {
+                most_recent = server.get();
+            }
         }
-        if (!most_recent || server->get_last_access_time() > most_recent->get_last_access_time()) {
-            most_recent = server.get();
-        }
+        return most_recent;
+    };
+
+    // Internal routing dependencies must not become the implicit user-facing
+    // model merely because the classifier ran immediately before dispatch.
+    if (auto* standard = most_recent_in_class(ResidencyClass::Standard)) {
+        return standard;
     }
-    return most_recent;
+    return most_recent_in_class(ResidencyClass::RoutingHelper);
 }
 
 void Router::prune_unavailable_servers_locked() {
@@ -160,14 +171,17 @@ bool Router::reload_model_after_watchdog_reset(const std::string& requested_mode
                                 << requested_model << std::endl;
         auto info = model_manager_->get_model_info(requested_model);
         bool was_pinned = false;
+        ResidencyClass was_residency_class = ResidencyClass::Standard;
         {
             std::lock_guard<std::mutex> lock(load_mutex_);
             auto* existing = find_server_by_model_name(requested_model);
             if (existing) {
                 was_pinned = existing->is_pinned();
+                was_residency_class = existing->get_residency_class();
             }
         }
-        load_model(requested_model, info, options, true, false, was_pinned);
+        load_model(requested_model, info, options, true, false, was_pinned,
+                   load_purpose_for_residency_class(was_residency_class));
         return true;
     } catch (const std::exception& e) {
         LOG(ERROR, "Router") << "Automatic reload after watchdog reset failed for "
@@ -189,32 +203,42 @@ static bool is_unmetered_recipe(const std::string& recipe) {
     return slot_policy_for_recipe(recipe) == SlotPolicy::Unmetered;
 }
 
-int Router::count_servers_by_type(ModelType type) const {
+int Router::count_servers_in_pool(ModelType type,
+                                         ResidencyClass residency_class) const {
     int count = 0;
     for (const auto& server : loaded_servers_) {
-        // Unmetered backends (cloud) consume no local memory and stay loaded for
-        // free, so they are excluded from the slot accounting that drives LRU eviction.
+        // Unmetered backends (cloud) consume no local memory and therefore do
+        // not consume either a standard or routing-helper capacity slot.
         if (is_unmetered_recipe(server->get_recipe_options().get_recipe())) {
             continue;
         }
-        if (server->is_backend_alive() && server->get_model_type() == type) {
+        if (server->is_backend_alive() &&
+            same_residency_pool(server->get_model_type(),
+                                server->get_residency_class(),
+                                type,
+                                residency_class)) {
             count++;
         }
     }
     return count;
 }
 
-WrappedServer* Router::find_lru_server_by_type(ModelType type) const {
+WrappedServer* Router::find_lru_server_in_pool(
+    ModelType type,
+    ResidencyClass residency_class) const {
     WrappedServer* lru = nullptr;
 
     for (const auto& server : loaded_servers_) {
         // Unmetered backends (cloud) are not eviction candidates; they have no
-        // memory cost and reloading them is essentially free, but evicting them
-        // throws away the cached api key/upstream-id binding for no benefit.
+        // local memory cost and retain provider/upstream bindings while warm.
         if (is_unmetered_recipe(server->get_recipe_options().get_recipe())) {
             continue;
         }
-        if (server->is_backend_alive() && server->get_model_type() == type) {
+        if (server->is_backend_alive() &&
+            same_residency_pool(server->get_model_type(),
+                                server->get_residency_class(),
+                                type,
+                                residency_class)) {
             if (server->is_pinned()) {
                 continue;
             }
@@ -225,6 +249,24 @@ WrappedServer* Router::find_lru_server_by_type(ModelType type) const {
     }
 
     return lru;
+}
+
+void Router::ensure_residency_capacity(ModelType type,
+                                       ResidencyClass residency_class) {
+    const int limit = residency_limit(residency_class, config_->max_loaded_models());
+    if (limit == -1 || count_servers_in_pool(type, residency_class) < limit) {
+        return;
+    }
+
+    WrappedServer* lru = find_lru_server_in_pool(type, residency_class);
+    if (!lru) {
+        throw SlotsPinnedException(residency_pool_to_string(type, residency_class));
+    }
+
+    LOG(INFO, "Router") << "Slot limit reached for pool "
+                         << residency_pool_to_string(type, residency_class)
+                         << ", evicting LRU: " << lru->get_model_name() << std::endl;
+    evict_server(lru);
 }
 
 bool Router::has_npu_server() const {
@@ -468,13 +510,16 @@ std::string Router::canonical_model_name(const std::string& model_name) const {
 }
 
 void Router::load_model(const std::string& model_name,
-                       const ModelInfo& model_info,
-                       RecipeOptions options,
-                       bool do_not_upgrade,
-                       bool allow_reload_on_option_change,
-                       std::optional<bool> pinned,
-                       std::atomic<bool>* cancel_flag) {
+                        const ModelInfo& model_info,
+                        RecipeOptions options,
+                        bool do_not_upgrade,
+                        bool allow_reload_on_option_change,
+                        std::optional<bool> pinned,
+                        LoadPurpose load_purpose,
+                        std::atomic<bool>* cancel_flag) {
     const std::string canonical_model_name = resolve_model_name(model_name);
+    const ResidencyClass requested_residency_class =
+        residency_class_for_load_purpose(load_purpose);
     const std::string backend_option = model_info.recipe + "_backend";
 
     RecipeOptions tentative = options.inherit(model_info.recipe_options.inherit(
@@ -503,7 +548,9 @@ void Router::load_model(const std::string& model_name,
             << " (checkpoint: " << model_info.checkpoint()
             << ", recipe: " << model_info.recipe
             << ", type: " << model_type_to_string(model_info.type)
-            << ", device: " << device_type_to_string(model_info.device) << ")" << std::endl;
+            << ", device: " << device_type_to_string(model_info.device)
+            << ", residency: "
+            << residency_class_to_string(requested_residency_class) << ")" << std::endl;
 
     try {
         WrappedServer* existing_pre = find_server_by_model_name(canonical_model_name);
@@ -539,6 +586,21 @@ void Router::load_model(const std::string& model_name,
                 evict_server(existing);
                 // Fall through to create and load with new options
             } else {
+                // A model first loaded directly can later become a router/classifier
+                // dependency. Promote the live process in place instead of loading a
+                // duplicate. We intentionally do not auto-demote routing helpers on a
+                // normal inference request; explicit unload resets the role.
+                if (requested_residency_class == ResidencyClass::RoutingHelper &&
+                    existing->get_residency_class() != ResidencyClass::RoutingHelper) {
+                    if (!is_unmetered_recipe(existing->get_recipe_options().get_recipe())) {
+                        ensure_residency_capacity(existing->get_model_type(),
+                                                  ResidencyClass::RoutingHelper);
+                    }
+                    existing->set_residency_class(ResidencyClass::RoutingHelper);
+                    LOG(INFO, "Router") << "Promoted loaded model "
+                                         << canonical_model_name
+                                         << " to routing_helper residency" << std::endl;
+                }
                 LOG(DEBUG, "Router") << "Model already loaded, updating access time and pinned status" << std::endl;
                 existing->set_pinned(final_pinned);
                 existing->update_access_time();
@@ -552,9 +614,6 @@ void Router::load_model(const std::string& model_name,
         ModelType model_type = model_info.type;
         DeviceType device_type = model_info.device;
 
-        // Get max models for this type (same limit for all types)
-        int max_models = config_->max_loaded_models();
-
         // NPU EXCLUSIVITY CHECK — driven by the backend's slot policy (descriptor).
         //   ExclusiveNpu (ryzenai-llm, whisper-on-npu): lock the entire NPU,
         //                evicting ALL NPU servers first.
@@ -563,6 +622,19 @@ void Router::load_model(const std::string& model_name,
         // Standard/Unmetered backends share no device exclusivity.
         switch (slot_policy_for_recipe(model_info.recipe)) {
             case SlotPolicy::ExclusiveNpu: {
+                // Hardware exclusivity is stronger than count-based pools. Never
+                // alternate a router helper and its candidate across the same NPU:
+                // reject the cross-residency combination deterministically instead.
+                for (const auto& server : loaded_servers_) {
+                    if (server->is_backend_alive() &&
+                        (server->get_device_type() & DEVICE_NPU) &&
+                        server->get_residency_class() != requested_residency_class) {
+                        throw RouterResidencyConflictException(
+                            canonical_model_name,
+                            server->get_model_name(),
+                            model_info.recipe + " requires exclusive NPU access");
+                    }
+                }
                 if (has_npu_server()) {
                     LOG(INFO, "Router") << model_info.recipe
                               << " requires exclusive NPU access, evicting all NPU servers..." << std::endl;
@@ -579,6 +651,12 @@ void Router::load_model(const std::string& model_name,
                     if (server->is_backend_alive() && (server->get_device_type() & DEVICE_NPU) &&
                         slot_policy_for_recipe(server->get_recipe_options().get_recipe()) !=
                             SlotPolicy::CoexistByType) {
+                        if (server->get_residency_class() != requested_residency_class) {
+                            throw RouterResidencyConflictException(
+                                canonical_model_name,
+                                server->get_model_name(),
+                                "FLM cannot coexist with the resident exclusive-NPU backend");
+                        }
                         exclusive_peers.push_back(server.get());
                     }
                 }
@@ -591,6 +669,12 @@ void Router::load_model(const std::string& model_name,
                 // 2. Evict FLM of the SAME model type (max 1 per type: 1 LLM, 1 transcription, 1 embed)
                 WrappedServer* same_type_flm = find_coexisting_server_by_type(model_type);
                 if (same_type_flm) {
+                    if (same_type_flm->get_residency_class() != requested_residency_class) {
+                        throw RouterResidencyConflictException(
+                            canonical_model_name,
+                            same_type_flm->get_model_name(),
+                            "FLM supports only one resident model per ModelType");
+                    }
                     LOG(INFO, "Router") << "FLM " << model_type_to_string(model_type)
                               << " slot occupied by: " << same_type_flm->get_model_name()
                               << ", evicting..." << std::endl;
@@ -603,24 +687,12 @@ void Router::load_model(const std::string& model_name,
                 break;
         }
 
-        // LRU EVICTION CHECK (from spec: Least Recently Used Cache)
-        // Skip eviction if unlimited (-1). Unmetered (cloud) loads also skip the
-        // check entirely: they consume no local resources, so they have no
-        // business kicking a warm local model out of memory.
-        bool is_unmetered_load = is_unmetered_recipe(model_info.recipe);
-        int current_count = count_servers_by_type(model_type);
-        if (!is_unmetered_load && max_models != -1 && current_count >= max_models) {
-            WrappedServer* lru = find_lru_server_by_type(model_type);
-            if (lru) {
-                LOG(INFO, "Router") << "Slot limit reached for type "
-                          << model_type_to_string(model_type)
-                          << ", evicting LRU: " << lru->get_model_name() << std::endl;
-                evict_server(lru);
-            } else {
-                is_loading_ = false;
-                load_cv_.notify_all();
-                throw SlotsPinnedException(model_type_to_string(model_type));
-            }
+        // Count-based LRU is scoped to (ModelType, ResidencyClass). A local
+        // routing helper therefore does not consume or evict a normal candidate
+        // slot of the same ModelType. Cloud remains unmetered and outside both pools.
+        const bool is_unmetered_load = is_unmetered_recipe(model_info.recipe);
+        if (!is_unmetered_load) {
+            ensure_residency_capacity(model_type, requested_residency_class);
         }
 
         // Auto-tune: resolve ctx_size = -1 → computed from memory + arch metadata
@@ -638,6 +710,7 @@ void Router::load_model(const std::string& model_name,
 
         // Set model metadata
         new_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
+        new_server->set_residency_class(requested_residency_class);
         new_server->set_pinned(final_pinned);
         new_server->update_access_time();
 
@@ -716,6 +789,7 @@ void Router::load_model(const std::string& model_name,
             // Create new server for retry
             std::unique_ptr<WrappedServer> retry_server = create_backend_server(model_info);
             retry_server->set_model_metadata(canonical_model_name, model_info.checkpoint(), model_type, device_type, effective_options);
+            retry_server->set_residency_class(requested_residency_class);
             retry_server->set_pinned(final_pinned);
             retry_server->update_access_time();
             retry_server->set_load_cancel_flag(cancel_flag);
@@ -832,14 +906,28 @@ std::string Router::get_loaded_recipe() const {
 std::string Router::get_sole_loaded_model_of_type(ModelType type) const {
     std::lock_guard<std::mutex> lock(load_mutex_);
 
-    WrappedServer* match = nullptr;
+    WrappedServer* standard_match = nullptr;
+    WrappedServer* helper_match = nullptr;
+    bool helper_ambiguous = false;
     for (const auto& server : loaded_servers_) {
         if (!server->is_backend_alive() || server->get_model_type() != type) {
             continue;
         }
-        if (match) return "";  // ambiguous: caller must name the model
-        match = server.get();
+        if (server->get_residency_class() == ResidencyClass::Standard) {
+            if (standard_match) return "";  // multiple user-facing models
+            standard_match = server.get();
+        } else if (helper_match) {
+            helper_ambiguous = true;
+        } else {
+            helper_match = server.get();
+        }
     }
+
+    // A single standard model remains an unambiguous default even while an
+    // internal router/classifier model of the same ModelType is resident.
+    WrappedServer* match = standard_match
+        ? standard_match
+        : (helper_ambiguous ? nullptr : helper_match);
     return match ? model_manager_->get_public_model_name(match->get_model_name()) : "";
 }
 
@@ -858,6 +946,12 @@ json Router::get_all_loaded_models() const {
         model_info["model_name"] = model_manager_->get_public_model_name(server->get_model_name());
         model_info["checkpoint"] = server->get_checkpoint();
         model_info["type"] = model_type_to_string(server->get_model_type());
+        model_info["residency_class"] = residency_class_to_string(server->get_residency_class());
+        model_info["slot_pool"] = is_unmetered_recipe(
+            server->get_recipe_options().get_recipe())
+            ? "unmetered"
+            : residency_pool_to_string(
+                  server->get_model_type(), server->get_residency_class());
         model_info["device"] = device_type_to_string(server->get_device_type());
         model_info["backend_url"] = server->get_address();  // For debugging port issues
         model_info["pid"] = server->get_process_id();
@@ -2289,7 +2383,14 @@ int Router::count_pinned_servers_by_type(ModelType type) const {
         if (is_unmetered_recipe(server->get_recipe_options().get_recipe())) {
             continue;
         }
-        if (server->is_backend_alive() && server->get_model_type() == type && server->is_pinned()) {
+        // /health.pinned_models is compared with max_models by the CLI, and
+        // max_models describes only the standard user-facing pool. A pinned
+        // routing helper must therefore not produce a false "all slots pinned"
+        // warning for a standard model load.
+        if (server->is_backend_alive() &&
+            server->get_model_type() == type &&
+            server->get_residency_class() == ResidencyClass::Standard &&
+            server->is_pinned()) {
             count++;
         }
     }

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -204,7 +204,8 @@ static bool is_unmetered_recipe(const std::string& recipe) {
 }
 
 int Router::count_servers_in_pool(ModelType type,
-                                         ResidencyClass residency_class) const {
+                                  ResidencyClass residency_class,
+                                  const std::string& model_name) const {
     int count = 0;
     for (const auto& server : loaded_servers_) {
         // Unmetered backends (cloud) consume no local memory and therefore do
@@ -215,8 +216,10 @@ int Router::count_servers_in_pool(ModelType type,
         if (server->is_backend_alive() &&
             same_residency_pool(server->get_model_type(),
                                 server->get_residency_class(),
+                                server->get_model_name(),
                                 type,
-                                residency_class)) {
+                                residency_class,
+                                model_name)) {
             count++;
         }
     }
@@ -225,7 +228,8 @@ int Router::count_servers_in_pool(ModelType type,
 
 WrappedServer* Router::find_lru_server_in_pool(
     ModelType type,
-    ResidencyClass residency_class) const {
+    ResidencyClass residency_class,
+    const std::string& model_name) const {
     WrappedServer* lru = nullptr;
 
     for (const auto& server : loaded_servers_) {
@@ -237,8 +241,10 @@ WrappedServer* Router::find_lru_server_in_pool(
         if (server->is_backend_alive() &&
             same_residency_pool(server->get_model_type(),
                                 server->get_residency_class(),
+                                server->get_model_name(),
                                 type,
-                                residency_class)) {
+                                residency_class,
+                                model_name)) {
             if (server->is_pinned()) {
                 continue;
             }
@@ -251,14 +257,16 @@ WrappedServer* Router::find_lru_server_in_pool(
     return lru;
 }
 
-void Router::ensure_residency_capacity(ModelType type,
-                                       ResidencyClass residency_class) {
+void Router::ensure_residency_capacity(
+    ModelType type,
+    ResidencyClass residency_class,
+    const std::string& model_name) {
     const int limit = residency_limit(residency_class, config_->max_loaded_models());
-    if (limit == -1 || count_servers_in_pool(type, residency_class) < limit) {
+    if (limit == -1 || count_servers_in_pool(type, residency_class, model_name) < limit) {
         return;
     }
 
-    WrappedServer* lru = find_lru_server_in_pool(type, residency_class);
+    WrappedServer* lru = find_lru_server_in_pool(type, residency_class, model_name);
     if (!lru) {
         throw SlotsPinnedException(residency_pool_to_string(type, residency_class));
     }
@@ -267,6 +275,60 @@ void Router::ensure_residency_capacity(ModelType type,
                          << residency_pool_to_string(type, residency_class)
                          << ", evicting LRU: " << lru->get_model_name() << std::endl;
     evict_server(lru);
+}
+
+void Router::transition_server_residency_locked(
+    WrappedServer* server,
+    ResidencyClass requested_residency_class) {
+    if (!server || server->get_residency_class() == requested_residency_class) {
+        return;
+    }
+
+    if (!is_unmetered_recipe(server->get_recipe_options().get_recipe())) {
+        // Admit into the destination pool before changing the live role. Standard
+        // admission remains type-wide; helper admission is keyed by model name.
+        ensure_residency_capacity(
+            server->get_model_type(), requested_residency_class,
+            server->get_model_name());
+    }
+
+    const ResidencyClass previous = server->get_residency_class();
+    server->set_residency_class(requested_residency_class);
+
+    LOG(INFO, "Router") << "Changed loaded model " << server->get_model_name()
+                         << " residency from "
+                         << residency_class_to_string(previous)
+                         << " to "
+                         << residency_class_to_string(requested_residency_class)
+                         << std::endl;
+}
+
+bool Router::ensure_loaded_model_residency(
+    const std::string& model_name,
+    LoadPurpose load_purpose) {
+    const std::string canonical_model_name = resolve_model_name(model_name);
+    const ResidencyClass requested_residency_class =
+        residency_class_for_load_purpose(load_purpose);
+
+    std::unique_lock<std::mutex> lock(load_mutex_);
+    load_cv_.wait(lock, [&] {
+        return !is_loading_ &&
+               (!exclusive_active_ ||
+                exclusive_owner_ == std::this_thread::get_id());
+    });
+
+    prune_unavailable_servers_locked();
+
+    WrappedServer* existing =
+        find_server_by_model_name(canonical_model_name);
+    if (!existing || !existing->is_backend_alive()) {
+        return false;
+    }
+
+    transition_server_residency_locked(
+        existing, requested_residency_class);
+    existing->update_access_time();
+    return true;
 }
 
 bool Router::has_npu_server() const {
@@ -586,21 +648,11 @@ void Router::load_model(const std::string& model_name,
                 evict_server(existing);
                 // Fall through to create and load with new options
             } else {
-                // A model first loaded directly can later become a router/classifier
-                // dependency. Promote the live process in place instead of loading a
-                // duplicate. We intentionally do not auto-demote routing helpers on a
-                // normal inference request; explicit unload resets the role.
-                if (requested_residency_class == ResidencyClass::RoutingHelper &&
-                    existing->get_residency_class() != ResidencyClass::RoutingHelper) {
-                    if (!is_unmetered_recipe(existing->get_recipe_options().get_recipe())) {
-                        ensure_residency_capacity(existing->get_model_type(),
-                                                  ResidencyClass::RoutingHelper);
-                    }
-                    existing->set_residency_class(ResidencyClass::RoutingHelper);
-                    LOG(INFO, "Router") << "Promoted loaded model "
-                                         << canonical_model_name
-                                         << " to routing_helper residency" << std::endl;
-                }
+                // Residency follows the current use of the live process. Promotion
+                // and demotion both reuse the process and obey destination-pool
+                // admission and pinning rules.
+                transition_server_residency_locked(
+                    existing, requested_residency_class);
                 LOG(DEBUG, "Router") << "Model already loaded, updating access time and pinned status" << std::endl;
                 existing->set_pinned(final_pinned);
                 existing->update_access_time();
@@ -628,7 +680,9 @@ void Router::load_model(const std::string& model_name,
                 for (const auto& server : loaded_servers_) {
                     if (server->is_backend_alive() &&
                         (server->get_device_type() & DEVICE_NPU) &&
-                        server->get_residency_class() != requested_residency_class) {
+                        should_reject_residency_displacement(
+                            requested_residency_class,
+                            server->get_residency_class())) {
                         throw RouterResidencyConflictException(
                             canonical_model_name,
                             server->get_model_name(),
@@ -651,7 +705,9 @@ void Router::load_model(const std::string& model_name,
                     if (server->is_backend_alive() && (server->get_device_type() & DEVICE_NPU) &&
                         slot_policy_for_recipe(server->get_recipe_options().get_recipe()) !=
                             SlotPolicy::CoexistByType) {
-                        if (server->get_residency_class() != requested_residency_class) {
+                        if (should_reject_residency_displacement(
+                                requested_residency_class,
+                                server->get_residency_class())) {
                             throw RouterResidencyConflictException(
                                 canonical_model_name,
                                 server->get_model_name(),
@@ -669,7 +725,9 @@ void Router::load_model(const std::string& model_name,
                 // 2. Evict FLM of the SAME model type (max 1 per type: 1 LLM, 1 transcription, 1 embed)
                 WrappedServer* same_type_flm = find_coexisting_server_by_type(model_type);
                 if (same_type_flm) {
-                    if (same_type_flm->get_residency_class() != requested_residency_class) {
+                    if (should_reject_residency_displacement(
+                            requested_residency_class,
+                            same_type_flm->get_residency_class())) {
                         throw RouterResidencyConflictException(
                             canonical_model_name,
                             same_type_flm->get_model_name(),
@@ -692,7 +750,8 @@ void Router::load_model(const std::string& model_name,
         // slot of the same ModelType. Cloud remains unmetered and outside both pools.
         const bool is_unmetered_load = is_unmetered_recipe(model_info.recipe);
         if (!is_unmetered_load) {
-            ensure_residency_capacity(model_type, requested_residency_class);
+            ensure_residency_capacity(model_type, requested_residency_class,
+                                      canonical_model_name);
         }
 
         // Auto-tune: resolve ctx_size = -1 → computed from memory + arch metadata
@@ -2376,20 +2435,17 @@ void Router::responses_stream(const std::string& request_body, httplib::DataSink
     }
 }
 
-int Router::count_pinned_servers_by_type(ModelType type) const {
+int Router::count_pinned_servers_in_pool(
+    ModelType type,
+    ResidencyClass residency_class) const {
     int count = 0;
     for (const auto& server : loaded_servers_) {
-        // Unmetered servers (cloud) never occupy a slot, so they don't count.
         if (is_unmetered_recipe(server->get_recipe_options().get_recipe())) {
             continue;
         }
-        // /health.pinned_models is compared with max_models by the CLI, and
-        // max_models describes only the standard user-facing pool. A pinned
-        // routing helper must therefore not produce a false "all slots pinned"
-        // warning for a standard model load.
         if (server->is_backend_alive() &&
             server->get_model_type() == type &&
-            server->get_residency_class() == ResidencyClass::Standard &&
+            server->get_residency_class() == residency_class &&
             server->is_pinned()) {
             count++;
         }
@@ -2400,13 +2456,26 @@ int Router::count_pinned_servers_by_type(ModelType type) const {
 json Router::get_pinned_model_counts() const {
     std::lock_guard<std::mutex> lock(load_mutex_);
     return {
-        {"llm", count_pinned_servers_by_type(ModelType::LLM)},
-        {"embedding", count_pinned_servers_by_type(ModelType::EMBEDDING)},
-        {"reranking", count_pinned_servers_by_type(ModelType::RERANKING)},
-        {"transcription", count_pinned_servers_by_type(ModelType::TRANSCRIPTION)},
-        {"image", count_pinned_servers_by_type(ModelType::IMAGE)},
-        {"tts", count_pinned_servers_by_type(ModelType::TTS)},
-        {"classification", count_pinned_servers_by_type(ModelType::CLASSIFICATION)}
+        {"llm", count_pinned_servers_in_pool(ModelType::LLM, ResidencyClass::Standard)},
+        {"embedding", count_pinned_servers_in_pool(ModelType::EMBEDDING, ResidencyClass::Standard)},
+        {"reranking", count_pinned_servers_in_pool(ModelType::RERANKING, ResidencyClass::Standard)},
+        {"transcription", count_pinned_servers_in_pool(ModelType::TRANSCRIPTION, ResidencyClass::Standard)},
+        {"image", count_pinned_servers_in_pool(ModelType::IMAGE, ResidencyClass::Standard)},
+        {"tts", count_pinned_servers_in_pool(ModelType::TTS, ResidencyClass::Standard)},
+        {"classification", count_pinned_servers_in_pool(ModelType::CLASSIFICATION, ResidencyClass::Standard)}
+    };
+}
+
+json Router::get_pinned_helper_counts() const {
+    std::lock_guard<std::mutex> lock(load_mutex_);
+    return {
+        {"llm", count_pinned_servers_in_pool(ModelType::LLM, ResidencyClass::RoutingHelper)},
+        {"embedding", count_pinned_servers_in_pool(ModelType::EMBEDDING, ResidencyClass::RoutingHelper)},
+        {"reranking", count_pinned_servers_in_pool(ModelType::RERANKING, ResidencyClass::RoutingHelper)},
+        {"transcription", count_pinned_servers_in_pool(ModelType::TRANSCRIPTION, ResidencyClass::RoutingHelper)},
+        {"image", count_pinned_servers_in_pool(ModelType::IMAGE, ResidencyClass::RoutingHelper)},
+        {"tts", count_pinned_servers_in_pool(ModelType::TTS, ResidencyClass::RoutingHelper)},
+        {"classification", count_pinned_servers_in_pool(ModelType::CLASSIFICATION, ResidencyClass::RoutingHelper)}
     };
 }
 

--- a/src/cpp/server/routing_policy.cpp
+++ b/src/cpp/server/routing_policy.cpp
@@ -1,4 +1,5 @@
 #include "lemon/routing_policy.h"
+#include "lemon/error_types.h"
 
 #include <algorithm>
 #include <cmath>
@@ -295,6 +296,10 @@ public:
         try {
             reply = ctx.services.chat(model_, effective_prompt(),
                                       build_context_payload(ctx.request));
+        } catch (const RouterResidencyConflictException&) {
+            // A hardware coexistence conflict is not a classifier-quality
+            // failure and must reach the HTTP layer as a deterministic 409.
+            throw;
         } catch (...) {
             return failed_score();
         }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1,4 +1,5 @@
 #include "lemon/server.h"
+#include "lemon/error_types.h"
 #include <optional>
 #include "lemon/collection_orchestrator.h"
 #include "lemon/hf_variants.h"
@@ -139,6 +140,21 @@ void set_error_response(const json& response, httplib::Response& res,
     res.set_content(response.dump(), "application/json");
 }
 
+void set_router_residency_conflict_response(
+    const RouterResidencyConflictException& error,
+    httplib::Response& res) {
+    res.status = 409;
+    const json response = {
+        {"error", {
+            {"message", error.what()},
+            {"type", ErrorType::ROUTER_RESIDENCY_CONFLICT},
+            {"param", "model"},
+            {"code", ErrorType::ROUTER_RESIDENCY_CONFLICT},
+        }},
+    };
+    res.set_content(response.dump(), "application/json");
+}
+
 void attach_route_decision(json& response, httplib::Response& res,
                            const std::optional<RouterDispatchResult>& dispatch) {
     if (!dispatch.has_value()) {
@@ -184,7 +200,8 @@ void set_route_decision_sse_content_provider(
 }
 
 int get_http_status_from_error(const std::string& error_code) {
-    if (error_code == "slots_pinned_error") {
+    if (error_code == "slots_pinned_error" ||
+        error_code == "router_residency_conflict") {
         return 409;
     } else if (error_code == "model_load_error") {
         return 500;
@@ -413,7 +430,8 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
             if (params.contains("pinned") && params["pinned"].is_boolean())
                 pinned = params["pinned"].get<bool>();
             try {
-                router_->load_model(model, info, options, true, true, pinned, &cancel);
+                router_->load_model(model, info, options, true, true, pinned,
+                                    LoadPurpose::UserInference, &cancel);
             } catch (const std::exception& e) {
                 throw lemon::jobs::JobError(500, e.what());
             }
@@ -555,7 +573,8 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
                     std::optional<bool> pinned = std::nullopt;
                     if (kv.second.contains("pinned") && kv.second["pinned"].is_boolean())
                         pinned = kv.second["pinned"].get<bool>();
-                    router_->load_model(kv.first, info, options, true, true, pinned, cancel);
+                    router_->load_model(kv.first, info, options, true, true, pinned,
+                                        LoadPurpose::UserInference, cancel);
                     const int pid = router_->loaded_model_pid(kv.first);
                     std::lock_guard<std::mutex> lk(*state_mutex);
                     auto it = job_states->find(job_id);
@@ -2094,7 +2113,18 @@ nlohmann::json Server::create_model_error(const std::string& requested_model, co
         return error_response;
     }
 
-    // Case 3: Model exists and is available, but failed to load (engine error or pinned slots constraint)
+    // Case 3: Model exists and is available, but failed to load.
+    if (exception_msg.rfind("Routing residency conflict:", 0) == 0) {
+        error_response["error"] = {
+            {"message", exception_msg},
+            {"type", "router_residency_conflict"},
+            {"param", "model"},
+            {"code", "router_residency_conflict"},
+            {"requested_model", requested_model}
+        };
+        return error_response;
+    }
+
     if (exception_msg.find("are pinned") != std::string::npos) {
         error_response["error"] = {
             {"message", exception_msg},
@@ -2154,9 +2184,13 @@ nlohmann::json Server::extract_auto_load_options(const json& request) {
 
 void Server::auto_load_model_if_needed(
     const std::string& requested_model,
-    const json& request_options) {
-    // Check if this specific model is already loaded (multi-model aware)
-    if (router_->is_model_loaded(requested_model)) {
+    const json& request_options,
+    LoadPurpose load_purpose) {
+    // Standard requests keep the fast no-op path. Routing dependencies still
+    // enter Router::load_model when already live so a standard process can be
+    // promoted to routing_helper residency without a reload.
+    if (load_purpose == LoadPurpose::UserInference &&
+        router_->is_model_loaded(requested_model)) {
         LOG(DEBUG, "Server") << "Model already loaded: " << requested_model << std::endl;
         if (request_options.contains("ctx_size")) {
             auto loaded_ctx = router_->get_model_recipe_options(requested_model)
@@ -2209,7 +2243,11 @@ void Server::auto_load_model_if_needed(
     // Load model with do_not_upgrade=true, applying per-request options on first load.
     // For FLM models: FastFlowLMServer will handle download internally if needed
     // For non-FLM models: Model should already be cached at this point
-    router_->load_model(requested_model, info, RecipeOptions(info.recipe, request_options), true);
+    router_->load_model(requested_model, info,
+                        RecipeOptions(info.recipe, request_options), true,
+                        /*allow_reload_on_option_change=*/false,
+                        /*pinned=*/std::nullopt,
+                        load_purpose);
     LOG(INFO, "Server") << "Model loaded successfully: " << requested_model << std::endl;
 }
 
@@ -2620,7 +2658,10 @@ std::optional<RouterDispatchResult> Server::route_collection_request(
     // immutable policy into it.
     RoutePolicy policy = *collection_info.route_policy;
     ClassifierServices services = make_router_classifier_services(
-        *router_, [this](const std::string& m) { auto_load_model_if_needed(m); });
+        *router_, [this](const std::string& m) {
+            auto_load_model_if_needed(m, json::object(),
+                                      LoadPurpose::RoutingDependency);
+        });
     RoutingPolicyEngine engine(std::move(policy), std::move(services));
 
     RouteContext ctx = build_route_context(request_json, collection_info.model_name);
@@ -2657,6 +2698,11 @@ std::optional<RouterDispatchResult> Server::apply_router_collection_dispatch(
         request_json["model"] = dispatch->selected_model;
         request_json.erase("route_trace");
         return dispatch;
+    } catch (const RouterResidencyConflictException&) {
+        // This is a deterministic hardware-policy conflict, not a routing miss.
+        // Let the endpoint serialize it as HTTP 409 instead of silently falling
+        // back to trying to load the collection recipe itself.
+        throw;
     } catch (const std::exception& e) {
         LOG(WARNING, "Server") << "Router collection dispatch failed for '"
                                << requested_model << "': " << e.what() << std::endl;
@@ -2711,6 +2757,11 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
                         }
                     }
                 }
+            } catch (const RouterResidencyConflictException& e) {
+                LOG(WARNING, "Server") << "Router residency conflict for '"
+                                       << requested_model << "': " << e.what() << std::endl;
+                set_router_residency_conflict_response(e, res);
+                return;
             } catch (const std::exception& e) {
                 LOG(DEBUG, "Server") << "Collection check failed for '" << requested_model
                                      << "': " << e.what() << std::endl;
@@ -3145,6 +3196,10 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
             }
         }
 
+    } catch (const RouterResidencyConflictException& e) {
+        LOG(WARNING, "Server") << "Router residency conflict in completions: "
+                               << e.what() << std::endl;
+        set_router_residency_conflict_response(e, res);
     } catch (const std::exception& e) {
         LOG(ERROR, "Server") << "ERROR in handle_completions: " << e.what() << std::endl;
         res.status = 500;
@@ -4607,6 +4662,10 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
             res.set_content(response.dump(), "application/json");
         }
 
+    } catch (const RouterResidencyConflictException& e) {
+        LOG(WARNING, "Server") << "Router residency conflict in responses: "
+                               << e.what() << std::endl;
+        set_router_residency_conflict_response(e, res);
     } catch (const std::exception& e) {
         LOG(ERROR, "Server") << "ERROR in handle_responses: " << e.what() << std::endl;
         res.status = 500;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2186,12 +2186,17 @@ void Server::auto_load_model_if_needed(
     const std::string& requested_model,
     const json& request_options,
     LoadPurpose load_purpose) {
-    // Standard requests keep the fast no-op path. Routing dependencies still
-    // enter Router::load_model when already live so a standard process can be
-    // promoted to routing_helper residency without a reload.
-    if (load_purpose == LoadPurpose::UserInference &&
-        router_->is_model_loaded(requested_model)) {
-        LOG(DEBUG, "Server") << "Model already loaded: " << requested_model << std::endl;
+    // A live process follows its current use without a reload: routing work
+    // promotes it to RoutingHelper, while direct inference demotes it into the
+    // counted Standard pool. Destination-pool admission remains authoritative.
+    if (router_->ensure_loaded_model_residency(
+            requested_model, load_purpose)) {
+        LOG(DEBUG, "Server")
+            << "Model already loaded: " << requested_model
+            << " (residency="
+            << residency_class_to_string(
+                   residency_class_for_load_purpose(load_purpose))
+            << ")" << std::endl;
         if (request_options.contains("ctx_size")) {
             auto loaded_ctx = router_->get_model_recipe_options(requested_model)
                                   .get_option("ctx_size");
@@ -2324,6 +2329,7 @@ void Server::handle_health(const httplib::Request& req, httplib::Response& res) 
 
     // Add pinned model counts
     response["pinned_models"] = router_->get_pinned_model_counts();
+    response["pinned_helper_models"] = router_->get_pinned_helper_counts();
 
     // Add WebSocket server port for realtime API and log streaming
     if (websocket_server_ && websocket_server_->is_running()) {

--- a/test/cpp/test_model_residency.cpp
+++ b/test/cpp/test_model_residency.cpp
@@ -1,0 +1,69 @@
+// Standalone contract test for model residency roles and slot-pool limits.
+// Compile manually with:
+//   g++ -std=c++17 -I src/cpp/include test/cpp/test_model_residency.cpp -o test_model_residency
+
+#include "lemon/model_residency.h"
+
+#include <cstdio>
+
+using lemon::LoadPurpose;
+using lemon::ModelType;
+using lemon::ResidencyClass;
+using lemon::load_purpose_for_residency_class;
+using lemon::residency_class_for_load_purpose;
+using lemon::residency_class_to_string;
+using lemon::residency_limit;
+using lemon::residency_pool_to_string;
+using lemon::same_residency_pool;
+
+static int failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++failures;
+}
+
+int main() {
+    check("user inference maps to standard",
+          residency_class_for_load_purpose(LoadPurpose::UserInference) ==
+              ResidencyClass::Standard);
+    check("routing dependency maps to routing helper",
+          residency_class_for_load_purpose(LoadPurpose::RoutingDependency) ==
+              ResidencyClass::RoutingHelper);
+    check("routing helper round-trips to routing dependency",
+          load_purpose_for_residency_class(ResidencyClass::RoutingHelper) ==
+              LoadPurpose::RoutingDependency);
+
+    check("standard pool honors configured limit",
+          residency_limit(ResidencyClass::Standard, 3) == 3);
+    check("standard pool preserves unlimited",
+          residency_limit(ResidencyClass::Standard, -1) == -1);
+    check("routing helper has one slot independent of standard limit",
+          residency_limit(ResidencyClass::RoutingHelper, -1) == 1 &&
+              residency_limit(ResidencyClass::RoutingHelper, 8) == 1);
+
+    check("same type and role share a pool",
+          same_residency_pool(ModelType::LLM, ResidencyClass::Standard,
+                              ModelType::LLM, ResidencyClass::Standard));
+    check("same type but different role do not share a pool",
+          !same_residency_pool(ModelType::LLM, ResidencyClass::Standard,
+                               ModelType::LLM, ResidencyClass::RoutingHelper));
+    check("different types do not share a helper pool",
+          !same_residency_pool(ModelType::LLM, ResidencyClass::RoutingHelper,
+                               ModelType::EMBEDDING, ResidencyClass::RoutingHelper));
+
+    check("health class string is stable",
+          residency_class_to_string(ResidencyClass::RoutingHelper) ==
+              "routing_helper");
+    check("pool string contains role and type",
+          residency_pool_to_string(ModelType::LLM,
+                                   ResidencyClass::RoutingHelper) ==
+              "routing_helper/llm");
+
+    if (failures == 0) {
+        std::printf("\nAll model_residency tests passed\n");
+        return 0;
+    }
+    std::printf("\n%d model_residency test(s) FAILED\n", failures);
+    return 1;
+}

--- a/test/cpp/test_model_residency.cpp
+++ b/test/cpp/test_model_residency.cpp
@@ -15,6 +15,7 @@ using lemon::residency_class_to_string;
 using lemon::residency_limit;
 using lemon::residency_pool_to_string;
 using lemon::same_residency_pool;
+using lemon::should_reject_residency_displacement;
 
 static int failures = 0;
 
@@ -38,19 +39,42 @@ int main() {
           residency_limit(ResidencyClass::Standard, 3) == 3);
     check("standard pool preserves unlimited",
           residency_limit(ResidencyClass::Standard, -1) == -1);
-    check("routing helper has one slot independent of standard limit",
+    check("each distinct helper model has one capacity identity",
           residency_limit(ResidencyClass::RoutingHelper, -1) == 1 &&
               residency_limit(ResidencyClass::RoutingHelper, 8) == 1);
 
-    check("same type and role share a pool",
-          same_residency_pool(ModelType::LLM, ResidencyClass::Standard,
-                              ModelType::LLM, ResidencyClass::Standard));
-    check("same type but different role do not share a pool",
-          !same_residency_pool(ModelType::LLM, ResidencyClass::Standard,
-                               ModelType::LLM, ResidencyClass::RoutingHelper));
-    check("different types do not share a helper pool",
-          !same_residency_pool(ModelType::LLM, ResidencyClass::RoutingHelper,
-                               ModelType::EMBEDDING, ResidencyClass::RoutingHelper));
+    check("standard same type and different models share capacity",
+          same_residency_pool(ModelType::LLM, ResidencyClass::Standard, "model-a",
+                              ModelType::LLM, ResidencyClass::Standard, "model-b"));
+    check("same helper model shares its helper capacity identity",
+          same_residency_pool(ModelType::LLM, ResidencyClass::RoutingHelper, "helper-a",
+                              ModelType::LLM, ResidencyClass::RoutingHelper, "helper-a"));
+    check("distinct same-type helper models do not compete",
+          !same_residency_pool(ModelType::LLM, ResidencyClass::RoutingHelper, "helper-a",
+                               ModelType::LLM, ResidencyClass::RoutingHelper, "helper-b"));
+    check("different residency classes never share capacity",
+          !same_residency_pool(ModelType::LLM, ResidencyClass::Standard, "model-a",
+                               ModelType::LLM, ResidencyClass::RoutingHelper, "model-a"));
+    check("different standard model types do not share capacity",
+          !same_residency_pool(ModelType::LLM, ResidencyClass::Standard, "model-a",
+                               ModelType::EMBEDDING, ResidencyClass::Standard, "model-b"));
+
+    check("routing helper cannot displace standard residency",
+          should_reject_residency_displacement(
+              ResidencyClass::RoutingHelper,
+              ResidencyClass::Standard));
+    check("routing helper cannot displace another routing helper",
+          should_reject_residency_displacement(
+              ResidencyClass::RoutingHelper,
+              ResidencyClass::RoutingHelper));
+    check("standard request may displace routing helper",
+          !should_reject_residency_displacement(
+              ResidencyClass::Standard,
+              ResidencyClass::RoutingHelper));
+    check("standard request may replace standard residency",
+          !should_reject_residency_displacement(
+              ResidencyClass::Standard,
+              ResidencyClass::Standard));
 
     check("health class string is stable",
           residency_class_to_string(ResidencyClass::RoutingHelper) ==

--- a/test/cpp/test_routing_policy_llm_router.cpp
+++ b/test/cpp/test_routing_policy_llm_router.cpp
@@ -16,6 +16,7 @@
 
 #include "fake_classifier_services.h"
 #include "lemon/routing_policy.h"
+#include "lemon/error_types.h"
 #include "lemon/routing_policy_parser.h"
 
 #include <cstdio>
@@ -255,6 +256,22 @@ static void test_classifier_backend_failure() {
     check("llm: backend failure yields Score::ok=false", !s.ok);
 }
 
+static void test_classifier_residency_conflict_propagates() {
+    ClassifierServices svc;
+    svc.chat = [](const std::string&, const std::string&, const std::string&) -> std::string {
+        throw lemon::RouterResidencyConflictException(
+            "router-model", "candidate-model", "exclusive NPU access");
+    };
+    auto llm = make_llm({"Qwen3-8B-GGUF", "Qwen3.5-35B-A3B-GGUF"});
+    bool propagated = false;
+    try {
+        (void)llm->evaluate(ClassifierContext{make_route("hi"), svc});
+    } catch (const lemon::RouterResidencyConflictException&) {
+        propagated = true;
+    }
+    check("llm: residency conflict propagates for HTTP 409", propagated);
+}
+
 // ---------------------------------------------------------------------------
 // Parser desugaring
 // ---------------------------------------------------------------------------
@@ -344,6 +361,7 @@ int main() {
     test_classifier_fenced_json_is_tolerated();
     test_classifier_rejects_non_exact_replies();
     test_classifier_backend_failure();
+    test_classifier_residency_conflict_propagates();
     test_desugar_shape();
     test_desugar_rejects_router_plus_rules();
     test_e2e_routes_to_chosen();

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -919,7 +919,7 @@ class EndpointTests(ServerTestBase):
         /v1/chat/completions. When `sse_chunks` is provided, the chat
         endpoint emits each chunk as an SSE `data:` line (the caller is
         responsible for shaping each chunk as OpenAI-compat JSON) and
-        terminates with `data: [DONE]\\n\\n`. Otherwise it falls back to
+        terminates with `data: [DONE]\n\n`. Otherwise it falls back to
         the non-streaming chat_handler(body) -> dict shape. Returns
         (base_url, stop_fn). The base URL ends with /v1.
         """
@@ -3436,9 +3436,9 @@ class EndpointTests(ServerTestBase):
         and demotion reuse live processes, pool-local pinning remains valid, and
         a later third standard model must not leave two user-facing LLMs resident.
         """
-        router_model = SECOND_TEST_MODEL_EVICTION
+        router_model = MULTI_MODEL_TERTIARY
         candidate_model = ENDPOINT_TEST_MODEL
-        third_model = MULTI_MODEL_TERTIARY
+        third_model = SECOND_TEST_MODEL_EVICTION
         for model in (router_model, candidate_model, third_model):
             pull_model_with_retry(model)
 
@@ -3457,7 +3457,8 @@ class EndpointTests(ServerTestBase):
                 json={
                     "model": router_model,
                     "messages": [{"role": "user", "content": "Reply briefly."}],
-                    "max_tokens": 4,
+                    "max_tokens": 1,
+                    "enable_thinking": False,
                 },
                 timeout=TIMEOUT_MODEL_OPERATION,
             )
@@ -3499,7 +3500,7 @@ class EndpointTests(ServerTestBase):
                     json={
                         "model": public_name,
                         "messages": [{"role": "user", "content": message}],
-                        "max_tokens": 16,
+                        "max_tokens": 1,
                         "route_trace": True,
                     },
                     timeout=TIMEOUT_MODEL_OPERATION,
@@ -3619,7 +3620,8 @@ class EndpointTests(ServerTestBase):
                     "messages": [
                         {"role": "user", "content": "Reply directly and briefly."}
                     ],
-                    "max_tokens": 4,
+                    "max_tokens": 1,
+                    "enable_thinking": False,
                 },
                 timeout=TIMEOUT_MODEL_OPERATION,
             )
@@ -3646,7 +3648,7 @@ class EndpointTests(ServerTestBase):
                 json={
                     "model": third_model,
                     "messages": [{"role": "user", "content": "Say hello."}],
-                    "max_tokens": 4,
+                    "max_tokens": 1,
                 },
                 timeout=TIMEOUT_MODEL_OPERATION,
             )

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -43,6 +43,7 @@ from utils.server_base import (
 from utils.test_models import (
     PORT,
     ENDPOINT_TEST_MODEL,
+    SECOND_TEST_MODEL_EVICTION,
     get_default_lemond_binary,
     SHARED_REPO_MODEL_A_NAME,
     SHARED_REPO_MODEL_A_CHECKPOINT,
@@ -3426,6 +3427,313 @@ class EndpointTests(ServerTestBase):
             except Exception:
                 pass
             stop_provider()
+
+    def test_021zk_router_llm_residency_live(self):
+        """Regression coverage for #2725.
+
+        With max_loaded_models=1, the router LLM must occupy routing_helper/llm
+        while the selected candidate occupies standard/llm. Repeated requests must
+        keep both backend processes warm, and a pinned standard candidate must not
+        block reloading the routing helper.
+
+        Structured router-output correctness is intentionally not asserted here.
+        That contract is covered deterministically by test_021zj using a mock cloud
+        router. A real local router may fail open to default_model without affecting
+        the residency behavior covered by this test.
+        """
+
+        router_model = SECOND_TEST_MODEL_EVICTION
+        candidate_model = ENDPOINT_TEST_MODEL
+
+        pull_model_with_retry(router_model)
+        pull_model_with_retry(candidate_model)
+
+        suffix = uuid.uuid4().hex[:8]
+        canonical_name = f"user.RouterL0a-{suffix}"
+        public_name = canonical_name[5:]
+
+        try:
+            unload_all = requests.post(
+                f"{self.base_url}/unload",
+                json={},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(unload_all.status_code, 200, unload_all.text)
+
+            routing = {
+                "candidates": [candidate_model],
+                "default_model": candidate_model,
+                "router": {
+                    "type": "llm",
+                    "model": router_model,
+                    "prompt": (
+                        "You are a model router. Always choose "
+                        f"{candidate_model} for every request."
+                    ),
+                },
+            }
+
+            pull_response = self._pull_router_collection(
+                canonical_name,
+                routing=routing,
+                overrides={"components": [router_model, candidate_model]},
+            )
+            self.assertEqual(pull_response.status_code, 200, pull_response.text)
+            self.assertEqual(pull_response.json()["status"], "success")
+
+            # First routed request loads the router into routing_helper/llm and the
+            # selected/default candidate into standard/llm.
+            first_response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": public_name,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Explain gradient descent.",
+                        }
+                    ],
+                    "max_tokens": 16,
+                    "route_trace": True,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(
+                first_response.status_code,
+                200,
+                first_response.text,
+            )
+
+            first_body = first_response.json()
+            self.assertNotIn("error", first_body, first_body)
+
+            first_route = first_body.get("x_lemonade_route")
+            self.assertIsInstance(first_route, dict)
+            self.assertEqual(
+                first_route.get("route_to"),
+                candidate_model,
+                "the router must select or fail open to the configured candidate",
+            )
+
+            health = requests.get(
+                f"{self.base_url}/health",
+                timeout=TIMEOUT_DEFAULT,
+            ).json()
+
+            self.assertEqual(
+                health.get("max_models", {}).get("llm"),
+                1,
+                "the test must exercise the default standard LLM limit",
+            )
+
+            loaded = {
+                item.get("model_name"): item
+                for item in health.get("all_models_loaded", [])
+            }
+
+            self.assertIn(router_model, loaded, loaded)
+            self.assertIn(candidate_model, loaded, loaded)
+
+            self.assertEqual(
+                loaded[router_model].get("residency_class"),
+                "routing_helper",
+            )
+            self.assertEqual(
+                loaded[router_model].get("slot_pool"),
+                "routing_helper/llm",
+            )
+            self.assertEqual(
+                loaded[candidate_model].get("residency_class"),
+                "standard",
+            )
+            self.assertEqual(
+                loaded[candidate_model].get("slot_pool"),
+                "standard/llm",
+            )
+
+            first_pids = {
+                router_model: int(loaded[router_model]["pid"]),
+                candidate_model: int(loaded[candidate_model]["pid"]),
+            }
+
+            # A second request must reuse both live processes.
+            second_response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": public_name,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Explain gradient descent again.",
+                        }
+                    ],
+                    "max_tokens": 16,
+                    "route_trace": True,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(
+                second_response.status_code,
+                200,
+                second_response.text,
+            )
+
+            second_body = second_response.json()
+            self.assertNotIn("error", second_body, second_body)
+            self.assertEqual(
+                second_body.get("x_lemonade_route", {}).get("route_to"),
+                candidate_model,
+            )
+
+            health_after = requests.get(
+                f"{self.base_url}/health",
+                timeout=TIMEOUT_DEFAULT,
+            ).json()
+
+            loaded_after = {
+                item.get("model_name"): item
+                for item in health_after.get("all_models_loaded", [])
+            }
+
+            self.assertIn(router_model, loaded_after, loaded_after)
+            self.assertIn(candidate_model, loaded_after, loaded_after)
+
+            self.assertEqual(
+                int(loaded_after[router_model]["pid"]),
+                first_pids[router_model],
+                "router backend must stay warm across routed requests",
+            )
+            self.assertEqual(
+                int(loaded_after[candidate_model]["pid"]),
+                first_pids[candidate_model],
+                "candidate backend must stay warm across routed requests",
+            )
+
+            # Pinning is local to the standard pool. Remove only the helper and
+            # verify that it can be loaded again without evicting or being blocked
+            # by the pinned standard candidate.
+            pin_response = requests.post(
+                f"{self.base_url.replace('/api/v1', '')}/internal/pin",
+                json={
+                    "model_name": candidate_model,
+                    "pinned": True,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                pin_response.status_code,
+                200,
+                pin_response.text,
+            )
+
+            unload_router = requests.post(
+                f"{self.base_url}/unload",
+                json={"model_name": router_model},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                unload_router.status_code,
+                200,
+                unload_router.text,
+            )
+
+            pinned_response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": public_name,
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Explain gradient descent briefly.",
+                        }
+                    ],
+                    "max_tokens": 16,
+                    "route_trace": True,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(
+                pinned_response.status_code,
+                200,
+                pinned_response.text,
+            )
+
+            pinned_body = pinned_response.json()
+            self.assertNotIn("error", pinned_body, pinned_body)
+            self.assertEqual(
+                pinned_body.get("x_lemonade_route", {}).get("route_to"),
+                candidate_model,
+            )
+
+            pinned_health = requests.get(
+                f"{self.base_url}/health",
+                timeout=TIMEOUT_DEFAULT,
+            ).json()
+
+            pinned_loaded = {
+                item.get("model_name"): item
+                for item in pinned_health.get("all_models_loaded", [])
+            }
+
+            self.assertIn(router_model, pinned_loaded, pinned_loaded)
+            self.assertIn(candidate_model, pinned_loaded, pinned_loaded)
+
+            self.assertTrue(
+                pinned_loaded[candidate_model].get("pinned"),
+                "the standard candidate must remain pinned",
+            )
+            self.assertEqual(
+                pinned_health.get("pinned_models", {}).get("llm"),
+                1,
+                "only pinned standard models count against max_models; "
+                "routing helpers use their own pool",
+            )
+            self.assertEqual(
+                int(pinned_loaded[candidate_model]["pid"]),
+                first_pids[candidate_model],
+                "reloading the helper must not evict the pinned candidate",
+            )
+            self.assertEqual(
+                pinned_loaded[candidate_model].get("slot_pool"),
+                "standard/llm",
+            )
+            self.assertEqual(
+                pinned_loaded[router_model].get("residency_class"),
+                "routing_helper",
+            )
+            self.assertEqual(
+                pinned_loaded[router_model].get("slot_pool"),
+                "routing_helper/llm",
+            )
+
+            print(
+                "[OK] L0a residency: stable router/candidate PIDs and "
+                "pool-local pinning at max_loaded_models=1"
+            )
+
+        finally:
+            # Explicit unload is permitted even when the candidate is pinned.
+            for body in (
+                {"model_name": router_model},
+                {"model_name": candidate_model},
+            ):
+                try:
+                    requests.post(
+                        f"{self.base_url}/unload",
+                        json=body,
+                        timeout=TIMEOUT_DEFAULT,
+                    )
+                except Exception:
+                    pass
+
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": canonical_name},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
 
     def _pull_router_collection(self, canonical_name, routing=None, overrides=None):
         """Register a collection.router whose single candidate is

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -44,6 +44,7 @@ from utils.test_models import (
     PORT,
     ENDPOINT_TEST_MODEL,
     SECOND_TEST_MODEL_EVICTION,
+    MULTI_MODEL_TERTIARY,
     get_default_lemond_binary,
     SHARED_REPO_MODEL_A_NAME,
     SHARED_REPO_MODEL_A_CHECKPOINT,
@@ -3429,24 +3430,17 @@ class EndpointTests(ServerTestBase):
             stop_provider()
 
     def test_021zk_router_llm_residency_live(self):
-        """Regression coverage for #2725.
+        """Regression coverage for #2725 and direct-use demotion.
 
-        With max_loaded_models=1, the router LLM must occupy routing_helper/llm
-        while the selected candidate occupies standard/llm. Repeated requests must
-        keep both backend processes warm, and a pinned standard candidate must not
-        block reloading the routing helper.
-
-        Structured router-output correctness is intentionally not asserted here.
-        That contract is covered deterministically by test_021zj using a mock cloud
-        router. A real local router may fail open to default_model without affecting
-        the residency behavior covered by this test.
+        The router and candidate must coexist at max_loaded_models=1. Promotion
+        and demotion reuse live processes, pool-local pinning remains valid, and
+        a later third standard model must not leave two user-facing LLMs resident.
         """
-
         router_model = SECOND_TEST_MODEL_EVICTION
         candidate_model = ENDPOINT_TEST_MODEL
-
-        pull_model_with_retry(router_model)
-        pull_model_with_retry(candidate_model)
+        third_model = MULTI_MODEL_TERTIARY
+        for model in (router_model, candidate_model, third_model):
+            pull_model_with_retry(model)
 
         suffix = uuid.uuid4().hex[:8]
         canonical_name = f"user.RouterL0a-{suffix}"
@@ -3454,11 +3448,31 @@ class EndpointTests(ServerTestBase):
 
         try:
             unload_all = requests.post(
-                f"{self.base_url}/unload",
-                json={},
-                timeout=TIMEOUT_DEFAULT,
+                f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT
             )
             self.assertEqual(unload_all.status_code, 200, unload_all.text)
+
+            warm_router = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": router_model,
+                    "messages": [{"role": "user", "content": "Reply briefly."}],
+                    "max_tokens": 4,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(warm_router.status_code, 200, warm_router.text)
+            warm_health = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            ).json()
+            warm_loaded = {
+                item.get("model_name"): item
+                for item in warm_health.get("all_models_loaded", [])
+            }
+            self.assertEqual(
+                warm_loaded[router_model].get("slot_pool"), "standard/llm"
+            )
+            warm_router_pid = int(warm_loaded[router_model]["pid"])
 
             routing = {
                 "candidates": [candidate_model],
@@ -3472,260 +3486,206 @@ class EndpointTests(ServerTestBase):
                     ),
                 },
             }
-
             pull_response = self._pull_router_collection(
                 canonical_name,
                 routing=routing,
                 overrides={"components": [router_model, candidate_model]},
             )
             self.assertEqual(pull_response.status_code, 200, pull_response.text)
-            self.assertEqual(pull_response.json()["status"], "success")
 
-            # First routed request loads the router into routing_helper/llm and the
-            # selected/default candidate into standard/llm.
-            first_response = requests.post(
-                f"{self.base_url}/chat/completions",
-                json={
-                    "model": public_name,
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": "Explain gradient descent.",
-                        }
-                    ],
-                    "max_tokens": 16,
-                    "route_trace": True,
-                },
-                timeout=TIMEOUT_MODEL_OPERATION,
-            )
-            self.assertEqual(
-                first_response.status_code,
-                200,
-                first_response.text,
-            )
+            def routed_request(message):
+                response = requests.post(
+                    f"{self.base_url}/chat/completions",
+                    json={
+                        "model": public_name,
+                        "messages": [{"role": "user", "content": message}],
+                        "max_tokens": 16,
+                        "route_trace": True,
+                    },
+                    timeout=TIMEOUT_MODEL_OPERATION,
+                )
+                self.assertEqual(response.status_code, 200, response.text)
+                body = response.json()
+                self.assertNotIn("error", body, body)
+                self.assertEqual(
+                    body.get("x_lemonade_route", {}).get("route_to"),
+                    candidate_model,
+                )
+                return body
 
-            first_body = first_response.json()
-            self.assertNotIn("error", first_body, first_body)
-
-            first_route = first_body.get("x_lemonade_route")
-            self.assertIsInstance(first_route, dict)
-            self.assertEqual(
-                first_route.get("route_to"),
-                candidate_model,
-                "the router must select or fail open to the configured candidate",
-            )
-
+            routed_request("Explain gradient descent.")
             health = requests.get(
-                f"{self.base_url}/health",
-                timeout=TIMEOUT_DEFAULT,
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
             ).json()
-
-            self.assertEqual(
-                health.get("max_models", {}).get("llm"),
-                1,
-                "the test must exercise the default standard LLM limit",
-            )
-
+            self.assertEqual(health.get("max_models", {}).get("llm"), 1)
             loaded = {
                 item.get("model_name"): item
                 for item in health.get("all_models_loaded", [])
             }
-
-            self.assertIn(router_model, loaded, loaded)
-            self.assertIn(candidate_model, loaded, loaded)
-
             self.assertEqual(
-                loaded[router_model].get("residency_class"),
-                "routing_helper",
+                loaded[router_model].get("slot_pool"), "routing_helper/llm"
             )
             self.assertEqual(
-                loaded[router_model].get("slot_pool"),
-                "routing_helper/llm",
+                loaded[candidate_model].get("slot_pool"), "standard/llm"
             )
-            self.assertEqual(
-                loaded[candidate_model].get("residency_class"),
-                "standard",
-            )
-            self.assertEqual(
-                loaded[candidate_model].get("slot_pool"),
-                "standard/llm",
-            )
-
             first_pids = {
                 router_model: int(loaded[router_model]["pid"]),
                 candidate_model: int(loaded[candidate_model]["pid"]),
             }
-
-            # A second request must reuse both live processes.
-            second_response = requests.post(
-                f"{self.base_url}/chat/completions",
-                json={
-                    "model": public_name,
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": "Explain gradient descent again.",
-                        }
-                    ],
-                    "max_tokens": 16,
-                    "route_trace": True,
-                },
-                timeout=TIMEOUT_MODEL_OPERATION,
-            )
             self.assertEqual(
-                second_response.status_code,
-                200,
-                second_response.text,
+                first_pids[router_model],
+                warm_router_pid,
+                "promotion must reuse the existing router process",
             )
 
-            second_body = second_response.json()
-            self.assertNotIn("error", second_body, second_body)
-            self.assertEqual(
-                second_body.get("x_lemonade_route", {}).get("route_to"),
-                candidate_model,
-            )
-
+            routed_request("Explain gradient descent again.")
             health_after = requests.get(
-                f"{self.base_url}/health",
-                timeout=TIMEOUT_DEFAULT,
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
             ).json()
-
             loaded_after = {
                 item.get("model_name"): item
                 for item in health_after.get("all_models_loaded", [])
             }
-
-            self.assertIn(router_model, loaded_after, loaded_after)
-            self.assertIn(candidate_model, loaded_after, loaded_after)
-
             self.assertEqual(
-                int(loaded_after[router_model]["pid"]),
-                first_pids[router_model],
-                "router backend must stay warm across routed requests",
+                int(loaded_after[router_model]["pid"]), first_pids[router_model]
             )
             self.assertEqual(
                 int(loaded_after[candidate_model]["pid"]),
                 first_pids[candidate_model],
-                "candidate backend must stay warm across routed requests",
             )
 
-            # Pinning is local to the standard pool. Remove only the helper and
-            # verify that it can be loaded again without evicting or being blocked
-            # by the pinned standard candidate.
-            pin_response = requests.post(
+            pin_candidate = requests.post(
                 f"{self.base_url.replace('/api/v1', '')}/internal/pin",
-                json={
-                    "model_name": candidate_model,
-                    "pinned": True,
-                },
+                json={"model_name": candidate_model, "pinned": True},
                 timeout=TIMEOUT_DEFAULT,
             )
-            self.assertEqual(
-                pin_response.status_code,
-                200,
-                pin_response.text,
-            )
-
+            self.assertEqual(pin_candidate.status_code, 200, pin_candidate.text)
             unload_router = requests.post(
                 f"{self.base_url}/unload",
                 json={"model_name": router_model},
                 timeout=TIMEOUT_DEFAULT,
             )
-            self.assertEqual(
-                unload_router.status_code,
-                200,
-                unload_router.text,
-            )
+            self.assertEqual(unload_router.status_code, 200, unload_router.text)
 
-            pinned_response = requests.post(
-                f"{self.base_url}/chat/completions",
-                json={
-                    "model": public_name,
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": "Explain gradient descent briefly.",
-                        }
-                    ],
-                    "max_tokens": 16,
-                    "route_trace": True,
-                },
-                timeout=TIMEOUT_MODEL_OPERATION,
-            )
-            self.assertEqual(
-                pinned_response.status_code,
-                200,
-                pinned_response.text,
-            )
-
-            pinned_body = pinned_response.json()
-            self.assertNotIn("error", pinned_body, pinned_body)
-            self.assertEqual(
-                pinned_body.get("x_lemonade_route", {}).get("route_to"),
-                candidate_model,
-            )
-
+            routed_request("Explain gradient descent briefly.")
             pinned_health = requests.get(
-                f"{self.base_url}/health",
-                timeout=TIMEOUT_DEFAULT,
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
             ).json()
-
             pinned_loaded = {
                 item.get("model_name"): item
                 for item in pinned_health.get("all_models_loaded", [])
             }
-
-            self.assertIn(router_model, pinned_loaded, pinned_loaded)
-            self.assertIn(candidate_model, pinned_loaded, pinned_loaded)
-
-            self.assertTrue(
-                pinned_loaded[candidate_model].get("pinned"),
-                "the standard candidate must remain pinned",
-            )
+            self.assertTrue(pinned_loaded[candidate_model].get("pinned"))
             self.assertEqual(
-                pinned_health.get("pinned_models", {}).get("llm"),
-                1,
-                "only pinned standard models count against max_models; "
-                "routing helpers use their own pool",
+                pinned_health.get("pinned_models", {}).get("llm"), 1
             )
             self.assertEqual(
                 int(pinned_loaded[candidate_model]["pid"]),
                 first_pids[candidate_model],
-                "reloading the helper must not evict the pinned candidate",
+            )
+            helper_pid_before_demotion = int(pinned_loaded[router_model]["pid"])
+
+            pin_helper = requests.post(
+                f"{self.base_url.replace('/api/v1', '')}/internal/pin",
+                json={"model_name": router_model, "pinned": True},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(pin_helper.status_code, 200, pin_helper.text)
+            helper_pin_health = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            ).json()
+            self.assertEqual(
+                helper_pin_health.get("pinned_helper_models", {}).get("llm"), 1
+            )
+            unpin_helper = requests.post(
+                f"{self.base_url.replace('/api/v1', '')}/internal/pin",
+                json={"model_name": router_model, "pinned": False},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(unpin_helper.status_code, 200, unpin_helper.text)
+            unpin_candidate = requests.post(
+                f"{self.base_url.replace('/api/v1', '')}/internal/pin",
+                json={"model_name": candidate_model, "pinned": False},
+                timeout=TIMEOUT_DEFAULT,
             )
             self.assertEqual(
-                pinned_loaded[candidate_model].get("slot_pool"),
-                "standard/llm",
+                unpin_candidate.status_code, 200, unpin_candidate.text
+            )
+
+            direct_router = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": router_model,
+                    "messages": [
+                        {"role": "user", "content": "Reply directly and briefly."}
+                    ],
+                    "max_tokens": 4,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(direct_router.status_code, 200, direct_router.text)
+            demoted_health = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            ).json()
+            demoted_loaded = {
+                item.get("model_name"): item
+                for item in demoted_health.get("all_models_loaded", [])
+            }
+            self.assertNotIn(candidate_model, demoted_loaded)
+            self.assertEqual(
+                demoted_loaded[router_model].get("slot_pool"), "standard/llm"
             )
             self.assertEqual(
-                pinned_loaded[router_model].get("residency_class"),
-                "routing_helper",
+                int(demoted_loaded[router_model]["pid"]),
+                helper_pid_before_demotion,
+                "demotion must reuse the live process",
             )
+
+            third_response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": third_model,
+                    "messages": [{"role": "user", "content": "Say hello."}],
+                    "max_tokens": 4,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(third_response.status_code, 200, third_response.text)
+            final_health = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            ).json()
+            final_loaded = {
+                item.get("model_name"): item
+                for item in final_health.get("all_models_loaded", [])
+            }
+            self.assertIn(third_model, final_loaded, final_loaded)
+            self.assertNotIn(router_model, final_loaded, final_loaded)
+            self.assertNotIn(candidate_model, final_loaded, final_loaded)
+            standard_llms = [
+                item
+                for item in final_loaded.values()
+                if item.get("slot_pool") == "standard/llm"
+            ]
             self.assertEqual(
-                pinned_loaded[router_model].get("slot_pool"),
-                "routing_helper/llm",
+                len(standard_llms),
+                1,
+                "three-model sequence must preserve max_loaded_models=1",
             )
 
             print(
-                "[OK] L0a residency: stable router/candidate PIDs and "
-                "pool-local pinning at max_loaded_models=1"
+                "[OK] residency promotion/demotion, pool-local pinning, and "
+                "three-model standard capacity"
             )
-
         finally:
-            # Explicit unload is permitted even when the candidate is pinned.
-            for body in (
-                {"model_name": router_model},
-                {"model_name": candidate_model},
-            ):
+            for model in (router_model, candidate_model, third_model):
                 try:
                     requests.post(
                         f"{self.base_url}/unload",
-                        json=body,
+                        json={"model_name": model},
                         timeout=TIMEOUT_DEFAULT,
                     )
                 except Exception:
                     pass
-
             try:
                 requests.post(
                     f"{self.base_url}/delete",
@@ -3735,6 +3695,256 @@ class EndpointTests(ServerTestBase):
             except Exception:
                 pass
 
+    def test_021zl_router_multiple_same_type_helpers_stay_warm(self):
+        """Two distinct local LLM helpers must not share one helper slot."""
+        helper_a = ENDPOINT_TEST_MODEL
+        helper_b = MULTI_MODEL_TERTIARY
+        for model in (helper_a, helper_b):
+            pull_model_with_retry(model)
+
+        provider = "helperpoolcloud"
+        upstream_id = "mock/helper-candidate"
+        candidate_model = f"{provider}.{upstream_id}"
+
+        def chat_response(req):
+            return {
+                "id": "cmpl-helper-pool",
+                "object": "chat.completion",
+                "created": 1,
+                "model": req.get("model", upstream_id),
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }
+
+        base_url, stop_provider = self._start_mock_cloud_provider(
+            [upstream_id], chat_handler=chat_response
+        )
+        suffix = uuid.uuid4().hex[:8]
+        canonical_name = f"user.RouterHelpers-{suffix}"
+        public_name = canonical_name[5:]
+        try:
+            install = requests.post(
+                f"{self.base_url}/install",
+                json={
+                    "backend": "cloud",
+                    "provider": provider,
+                    "base_url": base_url,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(install.status_code, 200, install.text)
+            auth = requests.post(
+                f"{self.base_url}/cloud/auth",
+                json={
+                    "provider": provider,
+                    "api_key": "dummy-key",
+                    "allow_insecure_http": True,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(auth.status_code, 200, auth.text)
+            requests.post(
+                f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT
+            )
+
+            routing = {
+                "candidates": [candidate_model],
+                "default_model": candidate_model,
+                "classifiers": [
+                    {
+                        "id": "helper-a",
+                        "type": "llm",
+                        "model": helper_a,
+                        "prompt": "Choose the configured candidate.",
+                        "labels": [candidate_model],
+                        "on_error": "match_false",
+                    },
+                    {
+                        "id": "helper-b",
+                        "type": "llm",
+                        "model": helper_b,
+                        "prompt": "Choose the configured candidate.",
+                        "labels": [candidate_model],
+                        "on_error": "match_false",
+                    },
+                ],
+                "rules": [
+                    {
+                        "id": "probe-helper-a",
+                        "match": {
+                            "classifier": "helper-a",
+                            "label": candidate_model,
+                            "min_score": 0.5,
+                            "max_score": 0.5,
+                        },
+                        "route_to": candidate_model,
+                    },
+                    {
+                        "id": "probe-helper-b",
+                        "match": {
+                            "classifier": "helper-b",
+                            "label": candidate_model,
+                            "min_score": 0.5,
+                            "max_score": 0.5,
+                        },
+                        "route_to": candidate_model,
+                    },
+                ],
+            }
+            pull = self._pull_router_collection(
+                canonical_name,
+                routing=routing,
+                overrides={
+                    "components": [helper_a, helper_b, candidate_model]
+                },
+            )
+            self.assertEqual(pull.status_code, 200, pull.text)
+
+            def request_once(text):
+                response = requests.post(
+                    f"{self.base_url}/chat/completions",
+                    json={
+                        "model": public_name,
+                        "messages": [{"role": "user", "content": text}],
+                        "max_tokens": 4,
+                    },
+                    timeout=TIMEOUT_MODEL_OPERATION,
+                )
+                self.assertEqual(response.status_code, 200, response.text)
+
+            request_once("First helper-pool request")
+            first_health = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            ).json()
+            first_loaded = {
+                item.get("model_name"): item
+                for item in first_health.get("all_models_loaded", [])
+            }
+            for helper in (helper_a, helper_b):
+                self.assertIn(helper, first_loaded, first_loaded)
+                self.assertEqual(
+                    first_loaded[helper].get("slot_pool"), "routing_helper/llm"
+                )
+            first_pids = {
+                helper_a: int(first_loaded[helper_a]["pid"]),
+                helper_b: int(first_loaded[helper_b]["pid"]),
+            }
+
+            request_once("Second helper-pool request")
+            second_health = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            ).json()
+            second_loaded = {
+                item.get("model_name"): item
+                for item in second_health.get("all_models_loaded", [])
+            }
+            for helper in (helper_a, helper_b):
+                self.assertEqual(
+                    int(second_loaded[helper]["pid"]),
+                    first_pids[helper],
+                    f"{helper} must stay warm across policy evaluations",
+                )
+            print("[OK] two same-type routing helpers retained stable PIDs")
+        finally:
+            for model in (helper_a, helper_b):
+                try:
+                    requests.post(
+                        f"{self.base_url}/unload",
+                        json={"model_name": model},
+                        timeout=TIMEOUT_DEFAULT,
+                    )
+                except Exception:
+                    pass
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": canonical_name},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+            try:
+                requests.post(
+                    f"{self.base_url}/uninstall",
+                    json={"backend": "cloud", "provider": provider},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+            stop_provider()
+
+    def test_021zm_router_same_model_candidate_demotes_in_request(self):
+        """router.model == candidate must end as one Standard process."""
+        model = ENDPOINT_TEST_MODEL
+        pull_model_with_retry(model)
+        suffix = uuid.uuid4().hex[:8]
+        canonical_name = f"user.RouterSameModel-{suffix}"
+        public_name = canonical_name[5:]
+        try:
+            requests.post(
+                f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT
+            )
+            routing = {
+                "candidates": [model],
+                "default_model": model,
+                "router": {
+                    "type": "llm",
+                    "model": model,
+                    "prompt": f"Always choose {model}.",
+                },
+            }
+            pull = self._pull_router_collection(
+                canonical_name,
+                routing=routing,
+                overrides={"components": [model]},
+            )
+            self.assertEqual(pull.status_code, 200, pull.text)
+            response = requests.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": public_name,
+                    "messages": [{"role": "user", "content": "Say hello."}],
+                    "max_tokens": 4,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(response.status_code, 200, response.text)
+            health = requests.get(
+                f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT
+            ).json()
+            loaded = [
+                item
+                for item in health.get("all_models_loaded", [])
+                if item.get("model_name") == model
+            ]
+            self.assertEqual(len(loaded), 1, loaded)
+            self.assertEqual(loaded[0].get("slot_pool"), "standard/llm")
+            print("[OK] router.model == candidate demoted in the same request")
+        finally:
+            try:
+                requests.post(
+                    f"{self.base_url}/unload",
+                    json={"model_name": model},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": canonical_name},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
     def _pull_router_collection(self, canonical_name, routing=None, overrides=None):
         """Register a collection.router whose single candidate is
         ENDPOINT_TEST_MODEL. `overrides` is merged into the top-level pull


### PR DESCRIPTION
## Summary

Fixes #2725 by giving router/classifier dependencies an explicit residency role instead of making them compete with user-facing models in the same count-based LRU pool.

With the default `max_loaded_models=1`, an LLM router and its selected LLM candidate can now remain loaded together:

- router: `routing_helper/llm`
- candidate: `standard/llm`

This is intentionally a narrow residency fix, not the full resource-policy redesign discussed in #1705.

> **Stacking note:** this PR is based on #2698 because that PR introduces the live LLM-router path and its L0a integration test. Rebase onto `main` after #2698 merges.

## Why not raise `max_loaded_models`?

Automatically changing `max_loaded_models` would alter user memory behavior globally, still mix two different responsibilities in one LRU pool, and remain ambiguous for pinning and device-exclusive backends. A warning would describe the cold-start loop without fixing the default behavior.

## Implementation

### Request intent and live residency

Adds two independent concepts:

```cpp
enum class LoadPurpose {
    UserInference,
    RoutingDependency,
};

enum class ResidencyClass {
    Standard,
    RoutingHelper,
};
```

`LoadPurpose` is request-scoped intent. `ResidencyClass` is stored on the live `WrappedServer` and controls count-based admission and LRU eviction.

`ModelType` remains unchanged: an LLM router is still an LLM. Backend `SlotPolicy` also remains recipe-static and continues to describe hardware constraints.

### Capacity and eviction

- Standard pools continue to use `max_loaded_models` independently per `ModelType`.
- Routing helpers get one slot per `ModelType`.
- LRU lookup and pinned-slot failure are scoped to `(ResidencyClass, ModelType)`.
- Cloud/`Unmetered` models consume neither local pool and report `slot_pool: unmetered`.
- An already-loaded standard model is promoted to `RoutingHelper` in place when it is first used as a routing dependency; no second process or reload is created.
- A normal inference request does not auto-demote an existing helper. Explicit unload/reload resets the role.
- Implicit model selection prefers `standard` residency, so a warm helper does not make one normal candidate ambiguous or hijack legacy most-recent-model operations.

### Pinning

Pinning remains eviction protection, not a residency role:

- a pinned standard candidate does not block the helper pool;
- a pinned helper does not block the standard pool;
- a full target pool containing only pinned models still returns `slots_pinned_error`.

### NPU/backend exclusivity

Hardware constraints remain authoritative and orthogonal to count-based pools. When an incoming model would require a cross-residency eviction because of exclusive NPU ownership or FLM's one-per-type rule, the load fails deterministically with:

- HTTP `409 Conflict`
- error code `router_residency_conflict`

This avoids replacing the slot-thrashing loop with an NPU-specific thrashing loop.

### Observability

`GET /api/v1/health` now reports for every live model:

- `residency_class`
- `slot_pool`

## Tests

- Adds a header-only `ModelResidencyTest` covering purpose mapping, capacity rules, pool identity, and stable health strings.
- Extends the live L0a LLM-router test from #2698 to verify:
  - the default standard LLM limit is `1`;
  - router and candidate are simultaneously resident in separate pools;
  - two consecutive routed requests retain both backend PIDs;
  - unloading/reloading only the helper succeeds while the standard candidate is pinned;
  - the pinned candidate PID remains unchanged.

## Non-goals

This PR deliberately does not add:

- global or per-device memory budgets;
- generalized utility-model policy;
- role-weighted pressure-eviction scoring;
- configurable helper-pool counts;
- automatic `max_loaded_models` mutation;
- implicit router pinning.

Those belong to the broader policy work in #1705.