### PR TITLE
Router end-to-end demo, integration test, and docs (#2388)

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -2115,6 +2115,13 @@ jobs:
           .venv/bin/python test/server_websocket_auth.py
           echo "WebSocket auth tests PASSED!"
 
+      - name: Test router
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        shell: bash
+        run: |
+          .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu router"
+          .venv/bin/python test/server_router.py --cli-binary lemonade
+
       # The full smoke test can be added to a different GPU equipped pipeline
       # as well if needed, but it would significantly add to the pipeline runtime.
       - name: Test mcp
@@ -2389,6 +2396,13 @@ jobs:
           echo "Running WebSocket idle test..."
           $VENV_PYTHON test/test_websocket_idle.py
           echo "WebSocket idle test PASSED!"
+
+      - name: Test router
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' && !(runner.os == 'macOS' && needs.build-lemonade-macos-dmg.outputs.has_signing != 'true') }}
+        shell: bash
+        run: |
+          $VENV_PYTHON -m test.utils.reset_server_state --best-effort --label "${{ matrix.os }} router"
+          $VENV_PYTHON test/server_router.py --cli-binary "$CLI_BINARY"
 
       - name: Test web-app path traversal
         if: ${{ !cancelled() && steps.setup.outcome == 'success' && !(runner.os == 'macOS' && needs.build-lemonade-macos-dmg.outputs.has_signing != 'true') }}

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1183,6 +1183,11 @@ jobs:
             extra_args: "--wrapped-server onnxruntime"
             backends: "cpu"
             runner: [self-hosted, Windows, lemon-prod]
+          - name: router-onnxruntime
+            script: server_router.py
+            extra_args: "--wrapped-server onnxruntime"
+            backends: "cpu"
+            runner: [self-hosted, Windows, lemon-prod]
           - name: stable-diffusion
             script: server_sd.py
             extra_args: ""

--- a/docs/api/lemonade.md
+++ b/docs/api/lemonade.md
@@ -85,6 +85,25 @@ Label names come from the model's `id2label` — from `config.json`, or from `ma
 
 Malformed requests (invalid JSON, missing `input`/`text`, non-string fields, non-positive `top_k`) return `400` with an `error` object before any model is loaded.
 
+## Routing (`collection.router`)
+<sub>![Status](https://img.shields.io/badge/status-experimental-orange)</sub>
+
+Naming a registered `collection.router` model in the `model` field of a
+`chat/completions` or `completions` request triggers the routing engine: the
+server picks a candidate by the policy's first-matching rule (fail-open to
+`default_model`) and forwards the request to it. No dedicated endpoint or `"auto"`
+model is involved.
+
+The decision is reported on the response:
+
+- Header **`x-lemonade-route`** — the matched rule id, or `default`.
+- Request field **`route_trace: true`** adds an **`x_lemonade_route`** object to the
+  response body: `{ route_to, matched_rule, default_used, outputs, trace[] }`
+  (`route_to` is the candidate that answered). For streaming responses it is
+  attached to the first SSE event.
+
+See [Router Policies](../dev/router-policy.md) for authoring the policy.
+
 ## `POST /v1/models/check-updates`
 <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
 

--- a/docs/dev/router-policy.md
+++ b/docs/dev/router-policy.md
@@ -79,13 +79,14 @@ A `match` is a match-expression. Combine with the logical operators `any` (OR),
 |------|---------|
 | `semantic_similarity` | Cosine similarity of the input against labelled `reference_phrases`, via an embedding model. |
 | `classifier` | A `{label: score}` classifier — an encoder model via the `onnxruntime` backend (`/v1/classify`), or any model as an LLM-as-classifier via chat. |
+| `llm` | An LLM picks exactly one of the declared `labels` for the request (with a rationale); the chosen label scores `1.0`, the rest `0`. You supply the `model` and a `prompt` describing when to choose each label. |
 
 A classifier condition is a band test: `{ "classifier": "<id>", "label": "<name>",
 "min_score": 0.5, "max_score": 1.0 }` (omitting both bounds defaults to
 `min_score: 0.5`).
 
-Both model-backed conditions reference an entry defined in `routing.classifiers`,
-and each entry's `model` must be one of `components`:
+Each model-backed condition references an entry defined in `routing.classifiers`,
+and every entry's `model` must be one of `components`:
 
 ```json
 "routing": {
@@ -104,11 +105,20 @@ and each entry's `model` must be one of `components`:
       "model": "Phishing-Email-Detection-ONNX",
       "labels": ["LABEL_0", "LABEL_1", "LABEL_2", "LABEL_3"],
       "default_label": "LABEL_1"
+    },
+    {
+      "id": "intent",
+      "type": "llm",
+      "model": "Qwen3-1.7B-GGUF",
+      "prompt": "Choose 'urgent' for time-sensitive or account-security requests, otherwise 'normal'.",
+      "labels": ["urgent", "normal"],
+      "default_label": "normal"
     }
   ],
   "rules": [
     { "id": "coding-to-big",  "match": { "classifier": "topic",    "label": "coding",  "min_score": 0.6 }, "route_to": "Big-GGUF" },
-    { "id": "phishing-local", "match": { "classifier": "phishing", "label": "LABEL_1", "min_score": 0.5 }, "route_to": "Small-GGUF" }
+    { "id": "phishing-local", "match": { "classifier": "phishing", "label": "LABEL_1", "min_score": 0.5 }, "route_to": "Small-GGUF" },
+    { "id": "urgent-to-big",  "match": { "classifier": "intent",   "label": "urgent",  "min_score": 0.5 }, "route_to": "Big-GGUF" }
   ]
 }
 ```
@@ -118,6 +128,15 @@ and each entry's `model` must be one of `components`:
 - `classifier` uses the model's `{label: score}` output; declare its `labels`
   (an onnxruntime encoder serves `/v1/classify`, else it runs as an
   LLM-as-classifier via chat).
+- `llm` shows the request to an LLM and asks it to choose one of `labels`; the
+  chosen label scores `1.0`. The engine wraps your `prompt` with the request
+  context and the label set, so the prompt just needs to say when to pick each
+  label. A malformed reply fails open to `default_model`.
+
+> The [`routing.router`](#llm-as-router-routingrouter) block is shorthand for a
+> single `llm` classifier whose labels are the candidate models — use it to route
+> purely by LLM; use a `type: "llm"` classifier here when the LLM's choice is one
+> signal among other rules.
 
 ## Registering and invoking
 

--- a/docs/dev/router-policy.md
+++ b/docs/dev/router-policy.md
@@ -78,7 +78,7 @@ A `match` is a match-expression. Combine with the logical operators `any` (OR),
 | Type | Meaning |
 |------|---------|
 | `semantic_similarity` | Cosine similarity of the input against labelled `reference_phrases`, via an embedding model. |
-| `classifier` | A `{label: score}` classifier. See status note below. |
+| `classifier` | A `{label: score}` classifier — an encoder model via the `onnxruntime` backend (`/v1/classify`), or any model as an LLM-as-classifier via chat. |
 
 A classifier condition is a band test: `{ "classifier": "<id>", "label": "<name>",
 "min_score": 0.5, "max_score": 1.0 }` (omitting both bounds defaults to
@@ -145,11 +145,13 @@ routes to the cloud one — the split is entirely policy-driven.
 See `examples/router/` for runnable local and local+cloud demos, and
 `test/server_router.py` for the end-to-end tests.
 
+The `classifier` condition runs a real encoder classifier: a model of type
+`ModelType::CLASSIFICATION` (the `onnxruntime` backend, `/v1/classify`) is called
+directly; any other model backing a `classifier` is used as an LLM-as-classifier
+via chat. The classifier's model must be able to serve one of those paths, and
+that capability is checked when the collection is registered.
+
 ## Not yet implemented
 
 - The `routing.router` sugar and the `type: "llm"` classifier (LLM-as-router) are
   reserved but not implemented; the parser rejects them.
-- The `classifier` condition type resolves and validates, but the engine's
-  `run_classifier` currently answers via a chat LLM rather than a dedicated
-  classification backend. The `onnxruntime` classification backend exists
-  (`/v1/classify`); wiring the router to call it is tracked separately.

--- a/docs/dev/router-policy.md
+++ b/docs/dev/router-policy.md
@@ -51,8 +51,8 @@ on top via each rule's `outputs` pass-through bag and the request `metadata`.
 | `components` | yes | Registered model names this policy may use. Each must already be pulled/registered (or a cloud model that has been discovered — see below). |
 | `routing.candidates` | yes | The models the router may pick. Each is a `components` member. |
 | `routing.default_model` | yes | Fallback when no rule matches. Must be one of `candidates`. |
-| `routing.rules` | yes* | Ordered; first match wins. (*`routing.rules` **or** the reserved `routing.router` block is required.) |
-| `routing.classifiers` | no | Model-backed classifiers referenced by `classifier` conditions. |
+| `routing.rules` | yes* | Ordered; first match wins. (*a policy provides **either** `routing.rules` **or** a `routing.router` block — see [LLM-as-router](#llm-as-router-routingrouter).) |
+| `routing.classifiers` | no | Model-backed classifier definitions referenced by `classifier` / `semantic_similarity` conditions. |
 
 A **rule** is `{ id, match, route_to, outputs? }`. `route_to` must be one of
 `candidates`. `outputs` is an arbitrary object copied verbatim into the decision
@@ -83,6 +83,41 @@ A `match` is a match-expression. Combine with the logical operators `any` (OR),
 A classifier condition is a band test: `{ "classifier": "<id>", "label": "<name>",
 "min_score": 0.5, "max_score": 1.0 }` (omitting both bounds defaults to
 `min_score: 0.5`).
+
+Both model-backed conditions reference an entry defined in `routing.classifiers`,
+and each entry's `model` must be one of `components`:
+
+```json
+"routing": {
+  "classifiers": [
+    {
+      "id": "topic",
+      "type": "semantic_similarity",
+      "model": "nomic-embed-text-v1-GGUF",
+      "reference_phrases": {
+        "coding": ["write a function", "fix this bug", "refactor this code"]
+      }
+    },
+    {
+      "id": "phishing",
+      "type": "classifier",
+      "model": "Phishing-Email-Detection-ONNX",
+      "labels": ["LABEL_0", "LABEL_1", "LABEL_2", "LABEL_3"],
+      "default_label": "LABEL_1"
+    }
+  ],
+  "rules": [
+    { "id": "coding-to-big",  "match": { "classifier": "topic",    "label": "coding",  "min_score": 0.6 }, "route_to": "Big-GGUF" },
+    { "id": "phishing-local", "match": { "classifier": "phishing", "label": "LABEL_1", "min_score": 0.5 }, "route_to": "Small-GGUF" }
+  ]
+}
+```
+
+- `semantic_similarity` scores each concept as the max cosine similarity of the
+  input against that concept's `reference_phrases` (needs an embedding model).
+- `classifier` uses the model's `{label: score}` output; declare its `labels`
+  (an onnxruntime encoder serves `/v1/classify`, else it runs as an
+  LLM-as-classifier via chat).
 
 ## Registering and invoking
 
@@ -151,7 +186,24 @@ directly; any other model backing a `classifier` is used as an LLM-as-classifier
 via chat. The classifier's model must be able to serve one of those paths, and
 that capability is checked when the collection is registered.
 
-## Not yet implemented
+## LLM-as-router (`routing.router`)
 
-- The `routing.router` sugar and the `type: "llm"` classifier (LLM-as-router) are
-  reserved but not implemented; the parser rejects them.
+Instead of authoring rules, you can hand the decision to a small LLM. Provide a
+`routing.router` block **in place of** `routing.rules` / `routing.classifiers`:
+
+```json
+"routing": {
+  "candidates": ["Qwen3-8B-GGUF", "Qwen3.5-35B-A3B-GGUF"],
+  "default_model": "Qwen3-8B-GGUF",
+  "router": {
+    "type": "llm",
+    "model": "Qwen3-1.7B-GGUF",
+    "prompt": "Route the request. Use Qwen3-8B-GGUF for everyday questions; use Qwen3.5-35B-A3B-GGUF for hard reasoning, coding, or long context."
+  }
+}
+```
+
+The router `model` must be one of `components`. At request time the engine asks it
+to pick a candidate, and that desugars into the same first-match engine and
+`Decision`/trace as the rule form. `routing.router.type` must be `"llm"`, and the
+block is **mutually exclusive** with `routing.rules` and `routing.classifiers`.

--- a/docs/dev/router-policy.md
+++ b/docs/dev/router-policy.md
@@ -1,0 +1,155 @@
+# Router Policies (`collection.router`)
+
+The Lemonade **Router** selects a model per request from a policy you author. The
+policy is a `collection.router` collection (a sibling of `collection.omni`).
+Pointing the OpenAI `model` field at the collection's name triggers the routing
+engine — there is no `/v1/route` endpoint and no `"auto"` model. Rules are
+evaluated top-to-bottom, **first match wins**, and any request that matches
+nothing **falls open** to `default_model`.
+
+The engine does pure model selection and emits a decision trace. It contains no
+policy-domain logic (no "PII", no "block"); anything domain-specific is expressed
+on top via each rule's `outputs` pass-through bag and the request `metadata`.
+
+## Policy shape
+
+```json
+{
+  "version": "1",
+  "model_name": "user.My-Router",
+  "recipe": "collection.router",
+  "components": ["Small-GGUF", "Big-GGUF"],
+  "routing": {
+    "candidates": ["Small-GGUF", "Big-GGUF"],
+    "default_model": "Small-GGUF",
+    "rules": [
+      {
+        "id": "sensitive-stays-local",
+        "match": { "metadata": { "key": "consent", "equals": "denied" } },
+        "route_to": "Small-GGUF",
+        "outputs": { "reason": "privacy" }
+      },
+      {
+        "id": "coding-or-long-to-big",
+        "match": {
+          "any": [
+            { "keywords_any": ["def ", "function", "stack trace"] },
+            { "min_chars": 4000 }
+          ]
+        },
+        "route_to": "Big-GGUF"
+      }
+    ]
+  }
+}
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `version` | yes | Must be `"1"`. |
+| `recipe` | yes | Must be `"collection.router"`. |
+| `components` | yes | Registered model names this policy may use. Each must already be pulled/registered (or a cloud model that has been discovered — see below). |
+| `routing.candidates` | yes | The models the router may pick. Each is a `components` member. |
+| `routing.default_model` | yes | Fallback when no rule matches. Must be one of `candidates`. |
+| `routing.rules` | yes* | Ordered; first match wins. (*`routing.rules` **or** the reserved `routing.router` block is required.) |
+| `routing.classifiers` | no | Model-backed classifiers referenced by `classifier` conditions. |
+
+A **rule** is `{ id, match, route_to, outputs? }`. `route_to` must be one of
+`candidates`. `outputs` is an arbitrary object copied verbatim into the decision
+(the engine never interprets it).
+
+## Conditions
+
+A `match` is a match-expression. Combine with the logical operators `any` (OR),
+`all` (AND), and `not`; a leaf object with several keys is an implicit `all`.
+
+**Deterministic (no model needed):**
+
+| Condition | Meaning |
+|-----------|---------|
+| `keywords_any` / `keywords_all` | Case-insensitive substring match over the input. |
+| `regex` | ECMAScript regex over the input. |
+| `min_chars` / `max_chars` | Input length in UTF-8 bytes. |
+| `has_tools` / `has_images` | Boolean — request carries tools / images. |
+| `metadata` | `{ key, equals \| any \| exists }` over the request's OpenAI `metadata`. |
+
+**Model-backed:**
+
+| Type | Meaning |
+|------|---------|
+| `semantic_similarity` | Cosine similarity of the input against labelled `reference_phrases`, via an embedding model. |
+| `classifier` | A `{label: score}` classifier. See status note below. |
+
+A classifier condition is a band test: `{ "classifier": "<id>", "label": "<name>",
+"min_score": 0.5, "max_score": 1.0 }` (omitting both bounds defaults to
+`min_score: 0.5`).
+
+## Registering and invoking
+
+Register the policy like any collection — `POST /v1/pull` with the policy JSON:
+
+```bash
+curl -X POST http://localhost:13305/api/v1/pull \
+     -H "Content-Type: application/json" \
+     --data-binary @my-router.json
+```
+
+Then call it by name with a normal client:
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://localhost:13305/api/v1", api_key="lemonade")
+client.chat.completions.create(model="user.My-Router", messages=[...])
+```
+
+## The decision on the response
+
+Every routed response carries the header **`x-lemonade-route`** — the matched rule
+id, or `default`. Add `"route_trace": true` to the request body and the response
+also carries an **`x_lemonade_route`** object:
+
+```json
+{
+  "route_to": "Big-GGUF",
+  "matched_rule": "coding-or-long-to-big",
+  "default_used": false,
+  "outputs": {},
+  "trace": [
+    { "condition": "metadata", "result": false },
+    { "condition": "keywords_any", "result": true }
+  ]
+}
+```
+
+`route_to` is the candidate that actually answered. For streaming responses the
+same object is attached to the first SSE event as `x_lemonade_route`.
+
+## Cloud candidates
+
+A candidate may be a cloud model — the router derives the route category from the
+candidate's recipe, so a `recipe: "cloud"` component is dispatched to its
+provider. Because cloud models are only discovered after a provider is installed
+and authenticated, **install/auth the provider before registering the
+collection**, or the component won't resolve:
+
+```bash
+export LEMONADE_FIREWORKS_API_KEY=fw-XXXX
+lemonade cloud install fireworks --base-url https://api.fireworks.ai/inference/v1
+lemonade list | grep fireworks     # e.g. fireworks.kimi-k2p5
+```
+
+Then list `fireworks.<id>` in `components`/`candidates` next to a local model. A
+`consent: denied` request can be kept on the local candidate while heavy work
+routes to the cloud one — the split is entirely policy-driven.
+
+See `examples/router/` for runnable local and local+cloud demos, and
+`test/server_router.py` for the end-to-end tests.
+
+## Not yet implemented
+
+- The `routing.router` sugar and the `type: "llm"` classifier (LLM-as-router) are
+  reserved but not implemented; the parser rejects them.
+- The `classifier` condition type resolves and validates, but the engine's
+  `run_classifier` currently answers via a chat LLM rather than a dedicated
+  classification backend. The `onnxruntime` classification backend exists
+  (`/v1/classify`); wiring the router to call it is tracked separately.

--- a/docs/dev/router-policy.md
+++ b/docs/dev/router-policy.md
@@ -107,18 +107,29 @@ and every entry's `model` must be one of `components`:
       "default_label": "LABEL_1"
     },
     {
-      "id": "intent",
+      "id": "risk",
       "type": "llm",
       "model": "Qwen3-1.7B-GGUF",
-      "prompt": "Choose 'urgent' for time-sensitive or account-security requests, otherwise 'normal'.",
-      "labels": ["urgent", "normal"],
-      "default_label": "normal"
+      "prompt": "Classify the request's risk for tool execution. Reply with exactly one label: SAFE or RISKY.",
+      "labels": ["SAFE", "RISKY"],
+      "default_label": "SAFE",
+      "on_error": "match_false"
     }
   ],
   "rules": [
     { "id": "coding-to-big",  "match": { "classifier": "topic",    "label": "coding",  "min_score": 0.6 }, "route_to": "Big-GGUF" },
     { "id": "phishing-local", "match": { "classifier": "phishing", "label": "LABEL_1", "min_score": 0.5 }, "route_to": "Small-GGUF" },
-    { "id": "urgent-to-big",  "match": { "classifier": "intent",   "label": "urgent",  "min_score": 0.5 }, "route_to": "Big-GGUF" }
+    {
+      "id": "risky-tool-calls-stay-local",
+      "match": {
+        "all": [
+          { "classifier": "risk", "label": "RISKY", "min_score": 0.5 },
+          { "has_tools": true }
+        ]
+      },
+      "route_to": "Small-GGUF",
+      "outputs": { "reason": "llm-judged-risky" }
+    }
   ]
 }
 ```
@@ -128,15 +139,18 @@ and every entry's `model` must be one of `components`:
 - `classifier` uses the model's `{label: score}` output; declare its `labels`
   (an onnxruntime encoder serves `/v1/classify`, else it runs as an
   LLM-as-classifier via chat).
-- `llm` shows the request to an LLM and asks it to choose one of `labels`; the
-  chosen label scores `1.0`. The engine wraps your `prompt` with the request
-  context and the label set, so the prompt just needs to say when to pick each
-  label. A malformed reply fails open to `default_model`.
+- `llm` shows the request to an LLM and asks it to choose one of `labels` (the
+  chosen label scores `1.0`). Because it produces a plain label, it's a
+  **composable signal** — combine it with any other condition, as in
+  `risky-tool-calls-stay-local` above. The engine wraps your `prompt` with the
+  request context and the label set, so the prompt just needs to say when to pick
+  each label; a malformed reply fails open to `default_model`.
 
-> The [`routing.router`](#llm-as-router-routingrouter) block is shorthand for a
-> single `llm` classifier whose labels are the candidate models — use it to route
-> purely by LLM; use a `type: "llm"` classifier here when the LLM's choice is one
-> signal among other rules.
+> A `type: "llm"` classifier and the [`routing.router`](#llm-as-router-routingrouter)
+> block are the two LLM forms. `routing.router` picks the final candidate itself
+> and replaces rules entirely (it's shorthand for a single `llm` classifier whose
+> labels are the candidate models); a `type: "llm"` classifier only produces a
+> label that rules combine with any other condition.
 
 ## Registering and invoking
 

--- a/examples/router/README.md
+++ b/examples/router/README.md
@@ -1,0 +1,69 @@
+# Lemonade Router demo
+
+Route one client request to different candidate models by policy, and see *why*
+each request went where it did. The policy is a `collection.router` collection;
+naming it in the OpenAI `model` field triggers the routing engine (no `/v1/route`,
+no `"auto"`). Rules are evaluated top-to-bottom, first match wins, and anything
+that matches nothing falls open to `default_model`.
+
+## Demo A — both candidates local
+
+Two local llama.cpp models: `Qwen3-0.6B-GGUF` (default / general) and
+`Qwen3-4B-GGUF` (capable / coding + long-context). Model choice is arbitrary —
+the point is the routing, not answer quality.
+
+```bash
+# 1. start lemond (or use your running server)
+# 2. download the two candidate models
+lemonade pull Qwen3-0.6B-GGUF
+lemonade pull Qwen3-4B-GGUF
+
+# 3. register the router collection
+curl -X POST http://localhost:13305/api/v1/pull \
+     -H "Content-Type: application/json" \
+     --data-binary @examples/router/policy_local.json
+
+# 4. run the demo
+python examples/router/demo.py --model user.Demo-Router-Local
+```
+
+Four prompts exercise the policy:
+
+| prompt | matches | routes to |
+|--------|---------|-----------|
+| casual question | nothing → default | `Qwen3-0.6B-GGUF` |
+| "write a Python **function** …" | `keywords_any` | `Qwen3-4B-GGUF` |
+| ~4500-char prompt | `min_chars >= 4000` | `Qwen3-4B-GGUF` |
+| coding prompt **+ `metadata.consent = denied`** | privacy rule (first match) | `Qwen3-0.6B-GGUF` |
+
+The last one is the interesting case: the coding rule *would* send it to the big
+model, but the earlier `sensitive-stays-local` rule wins first-match, so the
+request never leaves the small local model.
+
+## Demo B — one local, one on fireworks.ai
+
+Same policy shape, but the capable candidate is a cloud model. Install the
+provider **before** registering the collection (cloud models only appear in the
+catalog after install + auth, so the collection won't resolve otherwise):
+
+```bash
+export LEMONADE_FIREWORKS_API_KEY=fw-XXXX
+lemonade cloud install fireworks --base-url https://api.fireworks.ai/inference/v1
+lemonade list | grep fireworks          # pick a model id, e.g. fireworks.kimi-k2p5
+# edit policy_cloud.json so the capable candidate is that fireworks.<id>
+curl -X POST http://localhost:13305/api/v1/pull \
+     -H "Content-Type: application/json" \
+     --data-binary @examples/router/policy_cloud.json
+python examples/router/demo.py --model user.Demo-Router-Cloud
+```
+
+Now coding / long prompts are answered by Fireworks (route category `cloud`)
+while casual and `consent:denied` prompts stay local — the local/cloud split is
+entirely policy-driven.
+
+## How the decision is reported
+
+- Response header `x-lemonade-route` → the matched rule id (or `default`).
+- With `route_trace: true` in the request, the response body carries
+  `x_lemonade_route`: `{ route_to, matched_rule, default_used, outputs, trace[] }`.
+  `route_to` is the candidate that actually answered.

--- a/examples/router/demo.py
+++ b/examples/router/demo.py
@@ -19,7 +19,9 @@ import argparse
 
 from openai import OpenAI
 
-LONG_PROMPT = "Summarize the following log. " + ("error timeout retry " * 260)  # > 4000 chars
+LONG_PROMPT = "Summarize the following log. " + (
+    "error timeout retry " * 260
+)  # > 4000 chars
 
 CASES = [
     {

--- a/examples/router/demo.py
+++ b/examples/router/demo.py
@@ -1,0 +1,103 @@
+"""Lemonade Router demo — one policy, four prompts, watch where each is routed.
+
+Drives a `collection.router` collection with a vanilla OpenAI client. The server
+picks a candidate per the policy's first-matching rule (fail-open to
+`default_model`) and reports its decision two ways:
+
+  * response header `x-lemonade-route`  -> the matched rule id (or "default")
+  * response body `x_lemonade_route`    -> { route_to, matched_rule, default_used,
+                                             outputs, trace[] }  (with route_trace=true)
+
+`route_to` is the candidate that actually answered.
+
+Usage:
+    python examples/router/demo.py --model user.Demo-Router-Local
+    python examples/router/demo.py --model user.Demo-Router-Cloud --base-url http://localhost:13305/api/v1
+"""
+
+import argparse
+
+from openai import OpenAI
+
+LONG_PROMPT = "Summarize the following log. " + ("error timeout retry " * 260)  # > 4000 chars
+
+CASES = [
+    {
+        "name": "casual",
+        "prompt": "Give me a fun fact about otters.",
+        "metadata": None,
+        "expect_route_to": "small/default",
+    },
+    {
+        "name": "coding",
+        "prompt": "Write a Python function to reverse a singly linked list.",
+        "metadata": None,
+        "expect_route_to": "capable (keyword 'function'/'def ')",
+    },
+    {
+        "name": "long-context",
+        "prompt": LONG_PROMPT,
+        "metadata": None,
+        "expect_route_to": "capable (min_chars >= 4000)",
+    },
+    {
+        "name": "coding-but-consent-denied",
+        "prompt": "Write a Python function to reverse a singly linked list.",
+        "metadata": {"consent": "denied"},
+        "expect_route_to": "small/default (privacy rule wins first-match)",
+    },
+]
+
+
+def run_case(client, model, case):
+    extra_body = {"route_trace": True}
+    if case["metadata"] is not None:
+        extra_body["metadata"] = case["metadata"]
+
+    raw = client.chat.completions.with_raw_response.create(
+        model=model,
+        messages=[{"role": "user", "content": case["prompt"]}],
+        max_tokens=64,
+        temperature=0.0,
+        extra_body=extra_body,
+    )
+    header_route = raw.headers.get("x-lemonade-route", "<missing>")
+    body = raw.http_response.json()
+    decision = body.get("x_lemonade_route", {})
+    answered_by = body.get("model", "<unknown>")
+
+    print(f"\n=== case: {case['name']} ===")
+    print(f"  chars in prompt        : {len(case['prompt'])}")
+    if case["metadata"]:
+        print(f"  metadata               : {case['metadata']}")
+    print(f"  expected               : {case['expect_route_to']}")
+    print(f"  x-lemonade-route (hdr) : {header_route}")
+    print(f"  route_to (body)        : {decision.get('route_to', '<missing>')}")
+    print(f"  matched_rule           : {decision.get('matched_rule', '<missing>')}")
+    print(f"  default_used           : {decision.get('default_used', '<missing>')}")
+    print(f"  outputs                : {decision.get('outputs', {})}")
+    print(f"  response 'model' field : {answered_by}")
+    trace = decision.get("trace", [])
+    if trace:
+        print("  trace:")
+        for t in trace:
+            score = f" score={t['score']:.3f}" if "score" in t else ""
+            print(f"    - {t['condition']}: {t['result']}{score}")
+    return decision
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True, help="collection.router model name")
+    ap.add_argument("--base-url", default="http://localhost:13305/api/v1")
+    ap.add_argument("--api-key", default="lemonade")
+    args = ap.parse_args()
+
+    client = OpenAI(base_url=args.base_url, api_key=args.api_key)
+    print(f"Router demo -> model={args.model!r}  base_url={args.base_url}")
+    for case in CASES:
+        run_case(client, args.model, case)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/router/policy_cloud.json
+++ b/examples/router/policy_cloud.json
@@ -1,0 +1,29 @@
+{
+  "version": "1",
+  "model_name": "user.Demo-Router-Cloud",
+  "recipe": "collection.router",
+  "components": ["Qwen3-0.6B-GGUF", "fireworks.REPLACE-WITH-A-MODEL-FROM-lemonade-list"],
+  "routing": {
+    "candidates": ["Qwen3-0.6B-GGUF", "fireworks.REPLACE-WITH-A-MODEL-FROM-lemonade-list"],
+    "default_model": "Qwen3-0.6B-GGUF",
+    "rules": [
+      {
+        "id": "sensitive-stays-local",
+        "match": { "metadata": { "key": "consent", "equals": "denied" } },
+        "route_to": "Qwen3-0.6B-GGUF",
+        "outputs": { "reason": "privacy" }
+      },
+      {
+        "id": "coding-or-long-to-cloud",
+        "match": {
+          "any": [
+            { "keywords_any": ["def ", "function", "stack trace", "compile", "```"] },
+            { "min_chars": 4000 }
+          ]
+        },
+        "route_to": "fireworks.REPLACE-WITH-A-MODEL-FROM-lemonade-list",
+        "outputs": { "reason": "complex-or-long", "route_category": "cloud" }
+      }
+    ]
+  }
+}

--- a/examples/router/policy_local.json
+++ b/examples/router/policy_local.json
@@ -1,0 +1,29 @@
+{
+  "version": "1",
+  "model_name": "user.Demo-Router-Local",
+  "recipe": "collection.router",
+  "components": ["Qwen3-0.6B-GGUF", "Qwen3-4B-GGUF"],
+  "routing": {
+    "candidates": ["Qwen3-0.6B-GGUF", "Qwen3-4B-GGUF"],
+    "default_model": "Qwen3-0.6B-GGUF",
+    "rules": [
+      {
+        "id": "sensitive-stays-local",
+        "match": { "metadata": { "key": "consent", "equals": "denied" } },
+        "route_to": "Qwen3-0.6B-GGUF",
+        "outputs": { "reason": "privacy" }
+      },
+      {
+        "id": "coding-or-long-to-capable",
+        "match": {
+          "any": [
+            { "keywords_any": ["def ", "function", "stack trace", "compile", "```"] },
+            { "min_chars": 4000 }
+          ]
+        },
+        "route_to": "Qwen3-4B-GGUF",
+        "outputs": { "reason": "complex-or-long" }
+      }
+    ]
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
     - Desktop App: dev/app.md
     - Web UI: dev/web-ui.md
     - Lemonade Omni Models: dev/lemonade-omni.md
+    - Router Policies: dev/router-policy.md
     - Infrastructure: dev/self-hosted-runners.md
     - Release Process: dev/release.md
   - App Integrations:

--- a/test/server_router.py
+++ b/test/server_router.py
@@ -165,6 +165,18 @@ class RouterTests(ServerTestBase):
         ), f"register failed: {resp.status_code} {resp.text}"
         cls._setup_done = True
 
+    @classmethod
+    def tearDownClass(cls):
+        # Remove the shared collection so no router is left registered on
+        # persistent (self-hosted) runners after the suite.
+        if cls._setup_done:
+            requests.post(
+                f"http://localhost:{PORT}/api/v1/delete",
+                json={"model_name": COLLECTION_NAME},
+                timeout=TIMEOUT_DEFAULT,
+            )
+        super().tearDownClass()
+
     def setUp(self):
         super().setUp()
         self._ensure_setup()
@@ -189,6 +201,22 @@ class RouterTests(ServerTestBase):
         header = resp.headers.get("x-lemonade-route", "<missing>")
         decision = resp.json().get("x_lemonade_route", {})
         return header, decision, resp.json()
+
+    def _delete_collection(self, collection):
+        """Remove a registered router collection. `/delete` is a POST endpoint
+        keyed on `model_name`; assert it actually deleted so a stale router
+        isn't left behind on persistent runners (esp. before a cloud provider
+        it references is uninstalled)."""
+        resp = requests.post(
+            f"{self.base_url}/delete",
+            json={"model_name": collection},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            resp.status_code,
+            200,
+            f"cleanup delete failed: {resp.status_code} {resp.text}",
+        )
 
     def _trace_map(self, decision):
         return {t["condition"]: t["result"] for t in decision.get("trace", [])}
@@ -373,11 +401,7 @@ class RouterTests(ServerTestBase):
             self.assertTrue(decision.get("default_used"))
             print(f"[OK] casual -> {DEFAULT_MODEL} (local default)")
         finally:
-            requests.delete(
-                f"{self.base_url}/delete",
-                json={"model": collection},
-                timeout=TIMEOUT_DEFAULT,
-            )
+            self._delete_collection(collection)
             requests.delete(
                 f"{self.base_url}/cloud/auth/{provider}", timeout=TIMEOUT_DEFAULT
             )
@@ -473,11 +497,7 @@ class RouterTests(ServerTestBase):
             self.assertLess(other_score, 0.6)
             print(f"[OK] semantic non-coding ({other_score:.3f}) -> {DEFAULT_MODEL}")
         finally:
-            requests.post(
-                f"{self.base_url}/delete",
-                json={"model": collection},
-                timeout=TIMEOUT_DEFAULT,
-            )
+            self._delete_collection(collection)
 
     def test_621_semantic_similarity_cloud_candidate(self):
         """A `semantic_similarity` match routes to a *cloud* candidate.
@@ -595,11 +615,7 @@ class RouterTests(ServerTestBase):
             self.assertTrue(decision.get("default_used"))
             print(f"[OK] semantic non-coding -> {DEFAULT_MODEL} (local default)")
         finally:
-            requests.post(
-                f"{self.base_url}/delete",
-                json={"model": collection},
-                timeout=TIMEOUT_DEFAULT,
-            )
+            self._delete_collection(collection)
             requests.delete(
                 f"{self.base_url}/cloud/auth/{provider}", timeout=TIMEOUT_DEFAULT
             )
@@ -696,11 +712,7 @@ class RouterTests(ServerTestBase):
             self.assertLess(lo, 0.5)
             print(f"[OK] classifier benign ({lo:.3f}) -> {DEFAULT_MODEL}")
         finally:
-            requests.post(
-                f"{self.base_url}/delete",
-                json={"model": collection},
-                timeout=TIMEOUT_DEFAULT,
-            )
+            self._delete_collection(collection)
 
 
 if __name__ == "__main__":

--- a/test/server_router.py
+++ b/test/server_router.py
@@ -203,18 +203,22 @@ class RouterTests(ServerTestBase):
         return header, decision, resp.json()
 
     def _delete_collection(self, collection):
-        """Remove a registered router collection. `/delete` is a POST endpoint
-        keyed on `model_name`; assert it actually deleted so a stale router
-        isn't left behind on persistent runners (esp. before a cloud provider
-        it references is uninstalled)."""
+        """Remove a registered router collection so a stale router isn't left on
+        persistent runners (esp. before a cloud provider it references is
+        uninstalled). `/delete` is a POST endpoint keyed on `model_name`.
+
+        Runs in `finally`, which also fires when a test fails *before*
+        registration; a 404 then just means "nothing to clean up", so accept it —
+        asserting only 200 would let the cleanup mask the real failure. Any other
+        status is a genuine cleanup problem worth surfacing."""
         resp = requests.post(
             f"{self.base_url}/delete",
             json={"model_name": collection},
             timeout=TIMEOUT_DEFAULT,
         )
-        self.assertEqual(
+        self.assertIn(
             resp.status_code,
-            200,
+            (200, 404),
             f"cleanup delete failed: {resp.status_code} {resp.text}",
         )
 

--- a/test/server_router.py
+++ b/test/server_router.py
@@ -476,6 +476,137 @@ class RouterTests(ServerTestBase):
                 timeout=TIMEOUT_DEFAULT,
             )
 
+    def test_621_semantic_similarity_cloud_candidate(self):
+        """A `semantic_similarity` match routes to a *cloud* candidate.
+
+        The intersection of the two model-backed / cloud paths: an embedding
+        classifier decides, and the winning candidate is a `recipe:"cloud"`
+        model served by an in-process mock provider (no real key). A coding
+        query goes to the cloud model; an unrelated query stays local.
+        """
+        pull_model_with_retry(EMBED_MODEL)
+        provider = "testsemcloud"
+        upstream_id = "vendor/sem-cloud-model"
+        marker = "answered-by-cloud-provider"
+        collection = "user.Test-Router-Semantic-Cloud"
+
+        base_url, stop_provider = start_mock_cloud_provider([upstream_id], marker)
+        try:
+            resp = requests.post(
+                f"{self.base_url}/install",
+                json={
+                    "backend": "cloud",
+                    "provider": provider,
+                    "base_url": base_url,
+                    "allow_insecure_http": True,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 200, f"install failed: {resp.text}")
+            resp = requests.post(
+                f"{self.base_url}/cloud/auth",
+                json={
+                    "provider": provider,
+                    "api_key": "dummy-key",
+                    "allow_insecure_http": True,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 200, f"auth failed: {resp.text}")
+            models = requests.get(
+                f"{self.base_url}/models", timeout=TIMEOUT_DEFAULT
+            ).json()
+            cloud_ids = [
+                m["id"]
+                for m in models.get("data", [])
+                if m["id"].startswith(f"{provider}.")
+            ]
+            self.assertEqual(
+                len(cloud_ids), 1, f"expected one cloud model: {cloud_ids}"
+            )
+            cloud_model = cloud_ids[0]
+
+            policy = {
+                "version": "1",
+                "model_name": collection,
+                "recipe": "collection.router",
+                "components": [DEFAULT_MODEL, cloud_model, EMBED_MODEL],
+                "routing": {
+                    "candidates": [DEFAULT_MODEL, cloud_model],
+                    "default_model": DEFAULT_MODEL,
+                    "classifiers": [
+                        {
+                            "id": "topic",
+                            "type": "semantic_similarity",
+                            "model": EMBED_MODEL,
+                            "reference_phrases": {
+                                "coding": [
+                                    "write a function",
+                                    "fix this bug",
+                                    "refactor this code",
+                                    "debug a stack trace",
+                                    "time complexity of an algorithm",
+                                ]
+                            },
+                        }
+                    ],
+                    "rules": [
+                        {
+                            "id": "coding-to-cloud",
+                            "match": {
+                                "classifier": "topic",
+                                "label": "coding",
+                                "min_score": 0.6,
+                            },
+                            "route_to": cloud_model,
+                            "outputs": {"route_category": "cloud"},
+                        }
+                    ],
+                },
+            }
+            resp = requests.post(
+                f"http://localhost:{PORT}/api/v1/pull", json=policy, timeout=60
+            )
+            self.assertEqual(resp.status_code, 200, f"register failed: {resp.text}")
+
+            # Semantically coding -> cloud candidate, answered by the mock provider.
+            _, decision, data = self._route(
+                "How do I refactor this recursive function to lower its time complexity?",
+                collection=collection,
+            )
+            self.assertEqual(decision.get("route_to"), cloud_model)
+            self.assertEqual(decision.get("matched_rule"), "coding-to-cloud")
+            self.assertEqual(
+                data["choices"][0]["message"]["content"],
+                marker,
+                "coding prompt should be answered by the cloud provider",
+            )
+            print(f"[OK] semantic coding -> {cloud_model} (cloud), answered by mock")
+
+            # Unrelated -> stays local (default).
+            _, decision, _ = self._route(
+                "What are some good recipes for a summer picnic by the lake?",
+                collection=collection,
+            )
+            self.assertEqual(decision.get("route_to"), DEFAULT_MODEL)
+            self.assertTrue(decision.get("default_used"))
+            print(f"[OK] semantic non-coding -> {DEFAULT_MODEL} (local default)")
+        finally:
+            requests.post(
+                f"{self.base_url}/delete",
+                json={"model": collection},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            requests.delete(
+                f"{self.base_url}/cloud/auth/{provider}", timeout=TIMEOUT_DEFAULT
+            )
+            requests.post(
+                f"{self.base_url}/uninstall",
+                json={"backend": "cloud", "provider": provider},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            stop_provider()
+
 
 if __name__ == "__main__":
     run_server_tests(RouterTests, description="ROUTER TESTS")

--- a/test/server_router.py
+++ b/test/server_router.py
@@ -4,8 +4,9 @@ Router end-to-end tests for Lemonade Server (issue #2388).
 Registers a `collection.router` collection and drives it with a vanilla OpenAI
 client, asserting that requests are dispatched to the right candidate by the
 policy's rules. Covers deterministic conditions (keywords / min_chars /
-metadata), first-match ordering, fail-open to `default_model`, and the decision
-surfaced on the response (`x-lemonade-route` header + `x_lemonade_route` body).
+metadata), a model-backed `semantic_similarity` classifier, a cloud candidate,
+first-match ordering, fail-open to `default_model`, and the decision surfaced on
+the response (`x-lemonade-route` header + `x_lemonade_route` body).
 
 The routing decision is computed server-side before the request is forwarded to
 the chosen candidate, so these are true end-to-end runs: a real completion comes
@@ -104,6 +105,8 @@ def start_mock_cloud_provider(upstream_ids, marker_content):
 # test — only which one answers matters.
 DEFAULT_MODEL = "Tiny-Test-Model-GGUF"
 CAPABLE_MODEL = "Qwen3-0.6B-GGUF"
+# Small embedding model that backs the semantic_similarity classifier.
+EMBED_MODEL = "nomic-embed-text-v1-GGUF"
 
 COLLECTION_NAME = "user.Test-Router-Local"
 
@@ -163,10 +166,10 @@ class RouterTests(ServerTestBase):
         super().setUp()
         self._ensure_setup()
 
-    def _route(self, prompt, metadata=None):
+    def _route(self, prompt, metadata=None, collection=COLLECTION_NAME):
         """Send a chat request through the router; return (header, decision, body)."""
         body = {
-            "model": COLLECTION_NAME,
+            "model": collection,
             "messages": [{"role": "user", "content": prompt}],
             "max_tokens": 8,
             "temperature": 0.0,
@@ -381,6 +384,97 @@ class RouterTests(ServerTestBase):
                 timeout=TIMEOUT_DEFAULT,
             )
             stop_provider()
+
+    def test_620_semantic_similarity_routing(self):
+        """A `semantic_similarity` classifier routes by embedding similarity.
+
+        This is the first *model-backed* condition in the suite: it embeds the
+        input (via `Router::embeddings`) and scores it against labelled
+        reference phrases. Scores are deterministic for a fixed model, so the
+        0.6 threshold reliably separates a coding query (~0.74) from an
+        unrelated one (~0.47).
+        """
+        pull_model_with_retry(EMBED_MODEL)
+        collection = "user.Test-Router-Semantic"
+        policy = {
+            "version": "1",
+            "model_name": collection,
+            "recipe": "collection.router",
+            "components": [DEFAULT_MODEL, CAPABLE_MODEL, EMBED_MODEL],
+            "routing": {
+                "candidates": [DEFAULT_MODEL, CAPABLE_MODEL],
+                "default_model": DEFAULT_MODEL,
+                "classifiers": [
+                    {
+                        "id": "topic",
+                        "type": "semantic_similarity",
+                        "model": EMBED_MODEL,
+                        "reference_phrases": {
+                            "coding": [
+                                "write a function",
+                                "fix this bug",
+                                "refactor this code",
+                                "debug a stack trace",
+                                "time complexity of an algorithm",
+                            ]
+                        },
+                    }
+                ],
+                "rules": [
+                    {
+                        "id": "coding-to-capable",
+                        "match": {
+                            "classifier": "topic",
+                            "label": "coding",
+                            "min_score": 0.6,
+                        },
+                        "route_to": CAPABLE_MODEL,
+                    }
+                ],
+            },
+        }
+        resp = requests.post(
+            f"http://localhost:{PORT}/api/v1/pull", json=policy, timeout=60
+        )
+        self.assertEqual(resp.status_code, 200, f"register failed: {resp.text}")
+
+        try:
+
+            def classify_score(decision):
+                for t in decision.get("trace", []):
+                    if t["condition"] == "classifier:topic":
+                        return t.get("score")
+                return None
+
+            # A semantically coding prompt (no literal rule keyword) -> capable.
+            _, decision, _ = self._route(
+                "How do I refactor this recursive function to lower its time complexity?",
+                collection=collection,
+            )
+            self.assertEqual(decision.get("route_to"), CAPABLE_MODEL)
+            self.assertEqual(decision.get("matched_rule"), "coding-to-capable")
+            coding_score = classify_score(decision)
+            self.assertIsNotNone(coding_score)
+            self.assertGreaterEqual(coding_score, 0.6)
+            print(f"[OK] semantic coding ({coding_score:.3f}) -> {CAPABLE_MODEL}")
+
+            # An unrelated prompt scores below threshold -> default.
+            _, decision, _ = self._route(
+                "What are some good recipes for a summer picnic by the lake?",
+                collection=collection,
+            )
+            self.assertEqual(decision.get("route_to"), DEFAULT_MODEL)
+            self.assertTrue(decision.get("default_used"))
+            other_score = classify_score(decision)
+            self.assertIsNotNone(other_score)
+            self.assertLess(other_score, 0.6)
+            print(f"[OK] semantic non-coding ({other_score:.3f}) -> {DEFAULT_MODEL}")
+        finally:
+            requests.post(
+                f"{self.base_url}/delete",
+                json={"model": collection},
+                timeout=TIMEOUT_DEFAULT,
+            )
 
 
 if __name__ == "__main__":

--- a/test/server_router.py
+++ b/test/server_router.py
@@ -1,0 +1,387 @@
+"""
+Router end-to-end tests for Lemonade Server (issue #2388).
+
+Registers a `collection.router` collection and drives it with a vanilla OpenAI
+client, asserting that requests are dispatched to the right candidate by the
+policy's rules. Covers deterministic conditions (keywords / min_chars /
+metadata), first-match ordering, fail-open to `default_model`, and the decision
+surfaced on the response (`x-lemonade-route` header + `x_lemonade_route` body).
+
+The routing decision is computed server-side before the request is forwarded to
+the chosen candidate, so these are true end-to-end runs: a real completion comes
+back from the routed model.
+
+Usage:
+    python server_router.py
+"""
+
+import json as _json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import requests
+
+from utils.server_base import (
+    ServerTestBase,
+    run_server_tests,
+    pull_model_with_retry,
+)
+from utils.test_models import PORT, TIMEOUT_DEFAULT
+
+
+def start_mock_cloud_provider(upstream_ids, marker_content):
+    """In-process OpenAI-compatible provider: GET /v1/models + POST
+    /v1/chat/completions. The chat reply content is `marker_content` so a test
+    can prove a request actually reached this (cloud) provider. Returns
+    (base_url ending in /v1, stop_fn)."""
+
+    class _FakeProvider(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            if self.path.rstrip("/").endswith("/models"):
+                data = [{"id": uid, "object": "model"} for uid in upstream_ids]
+                payload = _json.dumps({"object": "list", "data": data}).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def do_POST(self):  # noqa: N802
+            if "/chat/completions" not in self.path:
+                self.send_response(404)
+                self.end_headers()
+                return
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length) if length else b""
+            try:
+                parsed = _json.loads(body or b"{}")
+            except _json.JSONDecodeError:
+                parsed = {}
+            resp = {
+                "id": "cmpl-mock",
+                "object": "chat.completion",
+                "created": 1,
+                "model": parsed.get("model", upstream_ids[0]),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": marker_content},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }
+            payload = _json.dumps(resp).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):
+            pass
+
+    httpd = HTTPServer(("127.0.0.1", 0), _FakeProvider)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+
+    def stop():
+        httpd.shutdown()
+        httpd.server_close()
+
+    return f"http://127.0.0.1:{port}/v1", stop
+
+
+# Two small, distinct local candidates. Model choice is arbitrary for a routing
+# test — only which one answers matters.
+DEFAULT_MODEL = "Tiny-Test-Model-GGUF"
+CAPABLE_MODEL = "Qwen3-0.6B-GGUF"
+
+COLLECTION_NAME = "user.Test-Router-Local"
+
+POLICY = {
+    "version": "1",
+    "model_name": COLLECTION_NAME,
+    "recipe": "collection.router",
+    "components": [DEFAULT_MODEL, CAPABLE_MODEL],
+    "routing": {
+        "candidates": [DEFAULT_MODEL, CAPABLE_MODEL],
+        "default_model": DEFAULT_MODEL,
+        "rules": [
+            {
+                "id": "sensitive-stays-local",
+                "match": {"metadata": {"key": "consent", "equals": "denied"}},
+                "route_to": DEFAULT_MODEL,
+                "outputs": {"reason": "privacy"},
+            },
+            {
+                "id": "coding-or-long-to-capable",
+                "match": {
+                    "any": [
+                        {"keywords_any": ["def ", "function", "stack trace"]},
+                        {"min_chars": 4000},
+                    ]
+                },
+                "route_to": CAPABLE_MODEL,
+                "outputs": {"reason": "complex-or-long"},
+            },
+        ],
+    },
+}
+
+
+class RouterTests(ServerTestBase):
+    """End-to-end routing through a collection.router collection."""
+
+    _setup_done = False
+
+    @classmethod
+    def _ensure_setup(cls):
+        if cls._setup_done:
+            return
+        for model in (DEFAULT_MODEL, CAPABLE_MODEL):
+            print(f"\n[SETUP] Ensuring {model} is pulled...")
+            pull_model_with_retry(model)
+        print(f"[SETUP] Registering {COLLECTION_NAME}...")
+        resp = requests.post(
+            f"http://localhost:{PORT}/api/v1/pull", json=POLICY, timeout=60
+        )
+        assert (
+            resp.status_code == 200
+        ), f"register failed: {resp.status_code} {resp.text}"
+        cls._setup_done = True
+
+    def setUp(self):
+        super().setUp()
+        self._ensure_setup()
+
+    def _route(self, prompt, metadata=None):
+        """Send a chat request through the router; return (header, decision, body)."""
+        body = {
+            "model": COLLECTION_NAME,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 8,
+            "temperature": 0.0,
+            "route_trace": True,
+        }
+        if metadata is not None:
+            body["metadata"] = metadata
+        resp = requests.post(
+            f"{self.base_url}/chat/completions", json=body, timeout=600
+        )
+        self.assertEqual(
+            resp.status_code, 200, f"status {resp.status_code}: {resp.text}"
+        )
+        header = resp.headers.get("x-lemonade-route", "<missing>")
+        decision = resp.json().get("x_lemonade_route", {})
+        return header, decision, resp.json()
+
+    def _trace_map(self, decision):
+        return {t["condition"]: t["result"] for t in decision.get("trace", [])}
+
+    def test_600_default_fallthrough(self):
+        """A prompt matching no rule falls open to default_model."""
+        header, decision, _ = self._route("Give me a fun fact about otters.")
+        self.assertEqual(decision.get("route_to"), DEFAULT_MODEL)
+        self.assertTrue(decision.get("default_used"))
+        self.assertEqual(decision.get("matched_rule"), "")
+        self.assertEqual(header, "default")
+        print(f"[OK] no-match -> {DEFAULT_MODEL} (default)")
+
+    def test_601_keyword_routes_to_capable(self):
+        """A coding keyword routes to the capable candidate."""
+        header, decision, _ = self._route(
+            "Write a Python function to reverse a linked list."
+        )
+        self.assertEqual(decision.get("route_to"), CAPABLE_MODEL)
+        self.assertEqual(decision.get("matched_rule"), "coding-or-long-to-capable")
+        self.assertFalse(decision.get("default_used"))
+        self.assertEqual(header, "coding-or-long-to-capable")
+        self.assertTrue(self._trace_map(decision).get("keywords_any"))
+        print(f"[OK] keyword -> {CAPABLE_MODEL}")
+
+    def test_602_min_chars_routes_to_capable(self):
+        """A long prompt (no keyword) routes via min_chars."""
+        long_prompt = "Summarize this. " + ("data point " * 400)  # > 4000 chars
+        self.assertGreater(len(long_prompt), 4000)
+        _, decision, _ = self._route(long_prompt)
+        self.assertEqual(decision.get("route_to"), CAPABLE_MODEL)
+        self.assertEqual(decision.get("matched_rule"), "coding-or-long-to-capable")
+        tmap = self._trace_map(decision)
+        self.assertFalse(tmap.get("keywords_any"))
+        self.assertTrue(tmap.get("min_chars"))
+        print(f"[OK] min_chars -> {CAPABLE_MODEL}")
+
+    def test_603_metadata_first_match_wins(self):
+        """A coding prompt with consent=denied hits the earlier privacy rule."""
+        header, decision, _ = self._route(
+            "Write a Python function to reverse a linked list.",
+            metadata={"consent": "denied"},
+        )
+        self.assertEqual(decision.get("route_to"), DEFAULT_MODEL)
+        self.assertEqual(decision.get("matched_rule"), "sensitive-stays-local")
+        self.assertEqual(decision.get("outputs", {}).get("reason"), "privacy")
+        self.assertEqual(header, "sensitive-stays-local")
+        print(f"[OK] consent=denied coding prompt -> {DEFAULT_MODEL} (first-match)")
+
+    def test_604_no_trace_when_not_requested(self):
+        """Without route_trace the decision omits the per-condition trace."""
+        body = {
+            "model": COLLECTION_NAME,
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 8,
+            "temperature": 0.0,
+        }
+        resp = requests.post(
+            f"{self.base_url}/chat/completions", json=body, timeout=600
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        # Header is always present; the body trace is opt-in.
+        self.assertIn("x-lemonade-route", resp.headers)
+        decision = resp.json().get("x_lemonade_route", {})
+        self.assertEqual(decision.get("trace", []), [])
+        print("[OK] route_trace omitted -> no trace array")
+
+    def test_610_cloud_candidate_routing(self):
+        """A candidate whose recipe is `cloud` routes to a cloud provider.
+
+        Uses an in-process mock provider (no real key), so this exercises the
+        local-vs-cloud split end-to-end: the coding prompt is answered by the
+        cloud provider, a casual prompt stays on the local default.
+        """
+        provider = "testroutercloud"
+        upstream_id = "vendor/router-cloud-model"
+        marker = "answered-by-cloud-provider"
+        collection = "user.Test-Router-Cloud"
+
+        base_url, stop_provider = start_mock_cloud_provider([upstream_id], marker)
+        cloud_model = None
+        try:
+            # Install + auth the provider so its model is discovered. This MUST
+            # happen before registering the collection (a cloud candidate only
+            # exists in the catalog after discovery).
+            resp = requests.post(
+                f"{self.base_url}/install",
+                json={
+                    "backend": "cloud",
+                    "provider": provider,
+                    "base_url": base_url,
+                    "allow_insecure_http": True,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 200, f"install failed: {resp.text}")
+            resp = requests.post(
+                f"{self.base_url}/cloud/auth",
+                json={
+                    "provider": provider,
+                    "api_key": "dummy-key",
+                    "allow_insecure_http": True,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 200, f"auth failed: {resp.text}")
+
+            # Find the discovered cloud model id (testroutercloud.<cleaned>).
+            models = requests.get(
+                f"{self.base_url}/models", timeout=TIMEOUT_DEFAULT
+            ).json()
+            cloud_ids = [
+                m["id"]
+                for m in models.get("data", [])
+                if m["id"].startswith(f"{provider}.")
+            ]
+            self.assertEqual(
+                len(cloud_ids), 1, f"expected one cloud model, got {cloud_ids}"
+            )
+            cloud_model = cloud_ids[0]
+
+            policy = {
+                "version": "1",
+                "model_name": collection,
+                "recipe": "collection.router",
+                "components": [DEFAULT_MODEL, cloud_model],
+                "routing": {
+                    "candidates": [DEFAULT_MODEL, cloud_model],
+                    "default_model": DEFAULT_MODEL,
+                    "rules": [
+                        {
+                            "id": "coding-to-cloud",
+                            "match": {"keywords_any": ["def ", "function"]},
+                            "route_to": cloud_model,
+                            "outputs": {"route_category": "cloud"},
+                        },
+                    ],
+                },
+            }
+            resp = requests.post(
+                f"http://localhost:{PORT}/api/v1/pull", json=policy, timeout=60
+            )
+            self.assertEqual(resp.status_code, 200, f"register failed: {resp.text}")
+
+            # Coding prompt -> cloud candidate, answered by the mock provider.
+            body = {
+                "model": collection,
+                "route_trace": True,
+                "max_tokens": 8,
+                "messages": [
+                    {"role": "user", "content": "Write a function to sort a list."}
+                ],
+            }
+            resp = requests.post(
+                f"{self.base_url}/chat/completions", json=body, timeout=600
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            data = resp.json()
+            decision = data.get("x_lemonade_route", {})
+            self.assertEqual(decision.get("route_to"), cloud_model)
+            self.assertEqual(decision.get("matched_rule"), "coding-to-cloud")
+            self.assertEqual(
+                data["choices"][0]["message"]["content"],
+                marker,
+                "coding prompt should be answered by the cloud provider",
+            )
+            print(f"[OK] coding -> {cloud_model} (cloud), answered by mock provider")
+
+            # Casual prompt -> stays local (default).
+            body = {
+                "model": collection,
+                "route_trace": True,
+                "max_tokens": 8,
+                "messages": [{"role": "user", "content": "Tell me a fun fact."}],
+            }
+            resp = requests.post(
+                f"{self.base_url}/chat/completions", json=body, timeout=600
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            decision = resp.json().get("x_lemonade_route", {})
+            self.assertEqual(decision.get("route_to"), DEFAULT_MODEL)
+            self.assertTrue(decision.get("default_used"))
+            print(f"[OK] casual -> {DEFAULT_MODEL} (local default)")
+        finally:
+            requests.delete(
+                f"{self.base_url}/delete",
+                json={"model": collection},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            requests.delete(
+                f"{self.base_url}/cloud/auth/{provider}", timeout=TIMEOUT_DEFAULT
+            )
+            requests.post(
+                f"{self.base_url}/uninstall",
+                json={"backend": "cloud", "provider": provider},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            stop_provider()
+
+
+if __name__ == "__main__":
+    run_server_tests(RouterTests, description="ROUTER TESTS")

--- a/test/server_router.py
+++ b/test/server_router.py
@@ -26,6 +26,7 @@ from utils.server_base import (
     ServerTestBase,
     run_server_tests,
     pull_model_with_retry,
+    get_config,
 )
 from utils.test_models import PORT, TIMEOUT_DEFAULT
 
@@ -107,6 +108,8 @@ DEFAULT_MODEL = "Tiny-Test-Model-GGUF"
 CAPABLE_MODEL = "Qwen3-0.6B-GGUF"
 # Small embedding model that backs the semantic_similarity classifier.
 EMBED_MODEL = "nomic-embed-text-v1-GGUF"
+# Real encoder classifier (onnxruntime backend) for the `classifier` condition.
+CLASSIFIER_MODEL = "Phishing-Email-Detection-ONNX"
 
 COLLECTION_NAME = "user.Test-Router-Local"
 
@@ -606,6 +609,98 @@ class RouterTests(ServerTestBase):
                 timeout=TIMEOUT_DEFAULT,
             )
             stop_provider()
+
+    def test_630_classifier_condition_routing(self):
+        """A `classifier` condition routes via a real onnxruntime classifier.
+
+        This exercises the model-backed classifier path end-to-end: the engine
+        calls `Router::classify` on an encoder model served by the onnxruntime
+        backend (`/v1/classify`), not a chat LLM. Requires that backend, so it
+        runs under `--wrapped-server onnxruntime` and is skipped otherwise.
+
+        Scores are deterministic; the two probes separate cleanly on LABEL_1
+        (~0.9999 vs ~0.25), so the 0.5 threshold is stable.
+        """
+        if get_config().get("wrapped_server") != "onnxruntime":
+            self.skipTest(
+                "classifier-condition e2e needs the onnxruntime backend; "
+                "run with --wrapped-server onnxruntime"
+            )
+        pull_model_with_retry(CLASSIFIER_MODEL)
+        collection = "user.Test-Router-Classifier"
+        policy = {
+            "version": "1",
+            "model_name": collection,
+            "recipe": "collection.router",
+            "components": [DEFAULT_MODEL, CAPABLE_MODEL, CLASSIFIER_MODEL],
+            "routing": {
+                "candidates": [DEFAULT_MODEL, CAPABLE_MODEL],
+                "default_model": DEFAULT_MODEL,
+                "classifiers": [
+                    {
+                        "id": "phishing",
+                        "type": "classifier",
+                        "model": CLASSIFIER_MODEL,
+                        "labels": ["LABEL_0", "LABEL_1", "LABEL_2", "LABEL_3"],
+                        "default_label": "LABEL_1",
+                        "on_error": "match_false",
+                    }
+                ],
+                "rules": [
+                    {
+                        "id": "phishing-to-restricted",
+                        "match": {
+                            "classifier": "phishing",
+                            "label": "LABEL_1",
+                            "min_score": 0.5,
+                        },
+                        "route_to": CAPABLE_MODEL,
+                    }
+                ],
+            },
+        }
+        resp = requests.post(
+            f"http://localhost:{PORT}/api/v1/pull", json=policy, timeout=120
+        )
+        self.assertEqual(resp.status_code, 200, f"register failed: {resp.text}")
+
+        try:
+
+            def clf_score(decision):
+                for t in decision.get("trace", []):
+                    if t["condition"] == "classifier:phishing":
+                        return t.get("score")
+                return None
+
+            # High-confidence phishing text -> classifier fires -> restricted.
+            _, decision, _ = self._route(
+                "Please verify your account at http://secure-login.example now.",
+                collection=collection,
+            )
+            self.assertEqual(decision.get("route_to"), CAPABLE_MODEL)
+            self.assertEqual(decision.get("matched_rule"), "phishing-to-restricted")
+            hi = clf_score(decision)
+            self.assertIsNotNone(hi)
+            self.assertGreaterEqual(hi, 0.5)
+            print(f"[OK] classifier phishing ({hi:.3f}) -> {CAPABLE_MODEL}")
+
+            # Benign text scores below threshold on LABEL_1 -> default.
+            _, decision, _ = self._route(
+                "Account notice: sign in to review recent activity.",
+                collection=collection,
+            )
+            self.assertEqual(decision.get("route_to"), DEFAULT_MODEL)
+            self.assertTrue(decision.get("default_used"))
+            lo = clf_score(decision)
+            self.assertIsNotNone(lo)
+            self.assertLess(lo, 0.5)
+            print(f"[OK] classifier benign ({lo:.3f}) -> {DEFAULT_MODEL}")
+        finally:
+            requests.post(
+                f"{self.base_url}/delete",
+                json={"model": collection},
+                timeout=TIMEOUT_DEFAULT,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2388.

End-to-end demo, integration test, and docs for the Lemonade Router — the demonstrable exit criterion for the milestone. Naming a `collection.router` model in the OpenAI `model` field routes the request to a candidate by the policy's first-matching rule (fail-open to `default_model`), and the decision is reported on the response.

## What's here

**Runnable demo — `examples/router/`**
- `policy_local.json` + `demo.py` + `README.md`: a two-candidate router driven by a vanilla `openai` client. Deterministic conditions (`keywords_any`, `min_chars`, `metadata`), first-match ordering, fail-open, and the decision/trace on the response.
- `policy_cloud.json`: same shape with a cloud candidate (fireworks.ai).

**Integration test — `test/server_router.py`** (wired into both `Test CLI/Endpoints` jobs)
- `test_600`–`604`: default fallthrough, keyword → capable, `min_chars` → capable, `metadata` first-match wins, and trace opt-in.
- `test_610`: a `recipe:"cloud"` candidate via an in-process mock provider (install → auth → discover → register → route) — covers the local-vs-cloud split with no real key, so it runs in CI.

**Docs**
- `docs/dev/router-policy.md`: authoring guide (policy shape, condition vocabulary, first-match + fail-open, decision/trace contract, cloud candidates).
- Routing section in `docs/api/lemonade.md`; added to mkdocs nav.

## Verification

- **Local demo**: all four cases route correctly on a real `lemond` (Qwen3-0.6B default + Qwen3-4B capable).
- **Cloud demo (live)**: verified against **fireworks.ai** — coding/long prompts routed to a Fireworks model and returned real completions; casual and `consent:denied` prompts stayed local. The CI test reproduces the code path with a mock provider.
- `test/server_router.py`: **6/6 green locally.**

## Scope notes

- All routing condition types are covered end-to-end: deterministic (keywords / min_chars / metadata), `semantic_similarity` (embeddings, local + cloud candidate), and a real `classifier` condition backed by an `onnxruntime` encoder model (`test_630`, added after #2727 wired `run_classifier` -> `Router::classify`; runs on the self-hosted onnxruntime CI runner, skips on GitHub-hosted).
- Finding while building this: llama.cpp responses echo the local `.gguf` path in the OpenAI `model` field (pre-existing, not router-specific). Filed separately as #2730 — does not affect routing (the decision is reported cleanly via `x_lemonade_route.route_to`).

Draft while CI settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


