### PR TITLE
fix(docker): Add libreadline8 to Dockerfile dependencies 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update && apt-get install -y \
     xz-utils \
     libgomp1 \
     libatomic1 \
+    libreadline8 \
     && rm -rf /var/lib/apt/lists/*
 
 # Run as an unprivileged user; lemond never needs root at runtime.


### PR DESCRIPTION
After installing the FastFlowLM npu backend, the server fails to load the respective catalog models with the following error.

```
(ModelManager) FLM model discovery failed: Failed to parse JSON string: [json.exception.parse_error.101] parse error at line 1, column 1: attempting to parse an empty input; check that your input string or stream contains the expected JSON
```

Trying to download however a model using the FastFlowLM recipe reveals the actual cause of the above error.

```
/opt/lemonade/.cache/lemonade/bin/flm/npu/flm-real: error while loading shared libraries: libreadline.so.8: cannot open shared object file: No such file or directory
```

Adding libreadline8 as a runtime dependency, resolves the issue and FLM model discover after the installation of backend works as expected