### PR TITLE
feat(telemetry): honor incoming W3C traceparent (opt-in)

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -131,7 +131,8 @@ Values set in the user's `config.json` always take precedence over these seeded 
         "otel_genai"
       ],
       "send_batch_size": 100
-    }
+    },
+    "trust_incoming_trace_context": false
   },
   "thinksound": {
     "backend": "auto",

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -251,6 +251,7 @@ API keys for these providers are **not** stored in `config.json` — they live i
 | `hide_inputs` | bool | false | Redact prompt message content from spans. |
 | `hide_outputs` | bool | false | Redact generated assistant message content from spans. |
 | `hide_thinking` | bool | false | Redact reasoning/thought content from spans. |
+| `trust_incoming_trace_context` | bool | false | Honor a caller-supplied W3C `traceparent` header so inference spans join the caller's distributed trace instead of starting a fresh root. Opt-in because span parentage then depends on client-supplied input. |
 | `max_queue_capacity` | int | 1000 | The maximum capacity of the in-memory telemetry queue buffer. Oldest spans are dropped when full. Must be `> 0`. |
 | `otlp` | object | (nested object) | Sub-block grouping OTLP transport details (see below). |
 

--- a/docs/guide/telemetry.md
+++ b/docs/guide/telemetry.md
@@ -32,6 +32,30 @@ Users can specify one or both formats. When both are enabled, Lemonade packs att
 
 ---
 
+## Distributed Tracing (W3C Trace Context)
+
+By default, each inference request starts its own root trace. When a caller is itself an instrumented application (e.g. a multi-agent orchestrator), you can have Lemonade's spans join the caller's trace instead, so an entire multi-step workflow appears as one connected tree.
+
+Set `telemetry.trust_incoming_trace_context=true` to opt in. Lemonade then reads the standard [W3C `traceparent`](https://www.w3.org/TR/trace-context/) header on incoming requests: the request's span adopts the header's trace id and is parented to the header's span id. Requests without a valid `traceparent`, or received while the setting is `false`, keep the default root-span behavior.
+
+```bash
+lemonade config set telemetry.enabled=true \
+                    telemetry.trust_incoming_trace_context=true
+```
+
+The caller supplies the header on each request, for example:
+
+```bash
+curl http://localhost:13305/api/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" \
+  -d '{"model": "...", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+The setting is opt-in because it makes span parentage depend on client-supplied input; leave it disabled unless you trust the callers on your network.
+
+---
+
 ## Configuration
 
 Telemetry is configured under the `telemetry` block in your `config.json` or managed dynamically via the Lemonade CLI/API.
@@ -44,6 +68,7 @@ Telemetry is configured under the `telemetry` block in your `config.json` or man
 | `telemetry.hide_inputs` | boolean | `false` | Redacts raw prompt inputs from trace attributes to protect privacy. |
 | `telemetry.hide_outputs` | boolean | `false` | Redacts assistant output text from trace attributes. |
 | `telemetry.hide_thinking` | boolean | `false` | Redacts internal reasoning/thinking blocks from trace attributes. |
+| `telemetry.trust_incoming_trace_context` | boolean | `false` | When `true`, honor a caller-supplied W3C `traceparent` header so inference spans join the caller's distributed trace. See [Distributed Tracing](#distributed-tracing-w3c-trace-context). |
 | `telemetry.max_queue_capacity` | int | `1000` | Target memory buffer capacity for queued spans. When exceeded, the oldest spans are evicted first (FIFO). |
 | `telemetry.otlp.endpoint` | string | `"http://localhost:4318/v1/traces"` | OTLP HTTP receiver endpoint URL. |
 | `telemetry.otlp.protocol` | string | `"http/protobuf"` | Encoding protocol: `"http/protobuf"` or `"http/json"`. |

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -41,6 +41,7 @@ public:
     bool telemetry_hide_inputs() const;
     bool telemetry_hide_outputs() const;
     bool telemetry_hide_thinking() const;
+    bool telemetry_trust_incoming_trace_context() const;
     int telemetry_max_queue_capacity() const;
     int telemetry_max_attribute_length() const;
     std::string telemetry_otlp_endpoint() const;

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -96,7 +96,8 @@
         "otel_genai"
       ],
       "send_batch_size": 100
-    }
+    },
+    "trust_incoming_trace_context": false
   },
   "thinksound": {
     "backend": "auto",

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -332,6 +332,10 @@ bool RuntimeConfig::telemetry_hide_thinking() const {
     return get_bool_opt(nullptr, {"telemetry", "hide_thinking"}, false);
 }
 
+bool RuntimeConfig::telemetry_trust_incoming_trace_context() const {
+    return get_bool_opt(nullptr, {"telemetry", "trust_incoming_trace_context"}, false);
+}
+
 int RuntimeConfig::telemetry_max_queue_capacity() const {
     return get_int_opt(nullptr, {"telemetry", "max_queue_capacity"}, 1000);
 }
@@ -602,7 +606,8 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
             throw std::invalid_argument("'telemetry' must be an object");
         }
         static const std::unordered_set<std::string> valid_telemetry_keys = {
-            "enabled", "hide_inputs", "hide_outputs", "hide_thinking", "max_queue_capacity", "max_attribute_length", "otlp"
+            "enabled", "hide_inputs", "hide_outputs", "hide_thinking", "trust_incoming_trace_context",
+            "max_queue_capacity", "max_attribute_length", "otlp"
         };
         for (auto& [t_key, t_val] : value.items()) {
             if (valid_telemetry_keys.find(t_key) == valid_telemetry_keys.end()) {
@@ -620,6 +625,9 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
         }
         if (value.contains("hide_thinking") && !value["hide_thinking"].is_boolean()) {
             throw std::invalid_argument("'telemetry.hide_thinking' must be a boolean");
+        }
+        if (value.contains("trust_incoming_trace_context") && !value["trust_incoming_trace_context"].is_boolean()) {
+            throw std::invalid_argument("'telemetry.trust_incoming_trace_context' must be a boolean");
         }
         if (value.contains("max_queue_capacity")) {
             if (!value["max_queue_capacity"].is_number_integer()) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -559,6 +559,58 @@ Server::~Server() {
     stop();
 }
 
+namespace {
+
+// Parse a W3C Trace Context "traceparent" header per the spec grammar
+// (https://www.w3.org/TR/trace-context/): version "-" trace-id "-" parent-id
+// "-" trace-flags, where version is 2 lowercase hex chars, trace-id is 32,
+// parent-id is 16, and trace-flags is 2. The all-zero trace-id and parent-id
+// are invalid. On success, out_trace_id/out_parent_id receive the lowercase
+// hex ids and the function returns true; otherwise returns false.
+bool parse_traceparent(const std::string& header, std::string& out_trace_id, std::string& out_parent_id) {
+    auto is_hex = [](const std::string& s) {
+        return !s.empty() && std::all_of(s.begin(), s.end(), [](unsigned char c) {
+            return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+        });
+    };
+    auto is_all_zero = [](const std::string& s) {
+        return s.find_first_not_of('0') == std::string::npos;
+    };
+
+    // Lowercase a copy so uppercase hex from lenient clients still validates.
+    std::string h = header;
+    std::transform(h.begin(), h.end(), h.begin(), [](unsigned char c) { return std::tolower(c); });
+
+    std::vector<std::string> parts;
+    size_t start = 0;
+    while (true) {
+        size_t dash = h.find('-', start);
+        if (dash == std::string::npos) {
+            parts.push_back(h.substr(start));
+            break;
+        }
+        parts.push_back(h.substr(start, dash - start));
+        start = dash + 1;
+    }
+
+    if (parts.size() != 4) return false;
+    const std::string& version = parts[0];
+    const std::string& trace_id = parts[1];
+    const std::string& parent_id = parts[2];
+    const std::string& flags = parts[3];
+
+    if (version.size() != 2 || !is_hex(version) || version == "ff") return false;
+    if (trace_id.size() != 32 || !is_hex(trace_id) || is_all_zero(trace_id)) return false;
+    if (parent_id.size() != 16 || !is_hex(parent_id) || is_all_zero(parent_id)) return false;
+    if (flags.size() != 2 || !is_hex(flags)) return false;
+
+    out_trace_id = trace_id;
+    out_parent_id = parent_id;
+    return true;
+}
+
+} // namespace
+
 void Server::log_request(const httplib::Request& req) {
     if (req.path != "/api/v0/health" && req.path != "/api/v1/health" &&
         req.path != "/v0/health" && req.path != "/v1/health" &&
@@ -576,6 +628,21 @@ httplib::Server::HandlerResponse Server::authenticate_request(const httplib::Req
         telemetry::g_current_client_session_id = req.get_header_value("X-Client-Session-Id");
     } else {
         telemetry::g_current_client_session_id.clear();
+    }
+
+    // Opt-in W3C Trace Context ingestion: when enabled, adopt a valid incoming
+    // "traceparent" so inference spans join the caller's distributed trace
+    // instead of starting a fresh root. Cleared otherwise so a stale thread-local
+    // never leaks across requests on a reused worker thread.
+    telemetry::g_incoming_trace_id.clear();
+    telemetry::g_incoming_parent_span_id.clear();
+    if (config_->telemetry_trust_incoming_trace_context() && req.has_header("traceparent")) {
+        std::string trace_id;
+        std::string parent_id;
+        if (parse_traceparent(req.get_header_value("traceparent"), trace_id, parent_id)) {
+            telemetry::g_incoming_trace_id = trace_id;
+            telemetry::g_incoming_parent_span_id = parent_id;
+        }
     }
 
     // Check if path requires authentication (API routes and internal endpoints).
@@ -1369,7 +1436,7 @@ void Server::setup_cors(httplib::Server &web_server) {
     web_server.set_default_headers({
         {"Access-Control-Allow-Origin", "*"},
         {"Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS"},
-        {"Access-Control-Allow-Headers", "Content-Type, Authorization, X-Client-Session-Id, X-Account-Session-Id"}
+        {"Access-Control-Allow-Headers", "Content-Type, Authorization, X-Client-Session-Id, X-Account-Session-Id, traceparent"}
     });
 
     // Handle preflight OPTIONS requests

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1721,7 +1721,7 @@ window.api = {
 void Server::setup_cors(httplib::Server &web_server) {
     // Set CORS headers for all responses
     web_server.set_default_headers({
-        {"Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS"}
+        {"Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS"},
         {"Access-Control-Allow-Headers", "Content-Type, Authorization, X-Client-Session-Id, X-Account-Session-Id, mcp-protocol-version, traceparent"}
     });
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -795,6 +795,12 @@ namespace {
 // are invalid. On success, out_trace_id/out_parent_id receive the lowercase
 // hex ids and the function returns true; otherwise returns false.
 bool parse_traceparent(const std::string& header, std::string& out_trace_id, std::string& out_parent_id) {
+    // A version-00 traceparent is exactly 55 chars. Reject anything shorter and
+    // cap the length so a header packed with dashes can't drive an unbounded
+    // split loop; the upper bound leaves room for higher versions that may
+    // append trailing fields (handled below).
+    if (header.size() < 55 || header.size() > 128) return false;
+
     auto is_hex = [](const std::string& s) {
         return !s.empty() && std::all_of(s.begin(), s.end(), [](unsigned char c) {
             return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
@@ -820,13 +826,16 @@ bool parse_traceparent(const std::string& header, std::string& out_trace_id, std
         start = dash + 1;
     }
 
-    if (parts.size() != 4) return false;
+    if (parts.size() < 4) return false;
     const std::string& version = parts[0];
     const std::string& trace_id = parts[1];
     const std::string& parent_id = parts[2];
     const std::string& flags = parts[3];
 
     if (version.size() != 2 || !is_hex(version) || version == "ff") return false;
+    // Version 00 carries exactly four fields; per W3C forward-compatibility a
+    // higher version may append trailing fields, which we parse then ignore.
+    if (version == "00" && parts.size() != 4) return false;
     if (trace_id.size() != 32 || !is_hex(trace_id) || is_all_zero(trace_id)) return false;
     if (parent_id.size() != 16 || !is_hex(parent_id) || is_all_zero(parent_id)) return false;
     if (flags.size() != 2 || !is_hex(flags)) return false;

--- a/src/cpp/server/telemetry.cpp
+++ b/src/cpp/server/telemetry.cpp
@@ -259,6 +259,10 @@ static std::string serialize_protobuf_batch(const std::vector<nlohmann::json>& s
         std::string span_id_hex = span_details["spanId"].get<std::string>();
         span_msg.write_bytes(2, hex_to_bytes(span_id_hex));
 
+        if (span_details.contains("parentSpanId")) {
+            span_msg.write_bytes(4, hex_to_bytes(span_details["parentSpanId"].get<std::string>()));
+        }
+
         span_msg.write_string(5, span_details["name"].get<std::string>());
 
         span_msg.write_uint32(6, span_details["kind"].get<uint32_t>());
@@ -809,7 +813,16 @@ static std::string truncate_string(const std::string& str, size_t max_len) {
 
 InferenceSpan::InferenceSpan(const std::string& span_kind, const std::string& name, const std::string& model_name, const nlohmann::json& request_json)
     : span_kind_(span_kind), name_(name), model_name_(model_name), start_time_(std::chrono::steady_clock::now()) {
-    trace_id_ = generate_hex_id(16);
+    // When the caller supplies a valid W3C trace context (gated behind
+    // telemetry.trust_incoming_trace_context in server.cpp), adopt its trace id
+    // and treat its span id as this span's parent so the request joins the
+    // caller's distributed trace. Otherwise start a fresh root trace.
+    if (!g_incoming_trace_id.empty()) {
+        trace_id_ = g_incoming_trace_id;
+        parent_span_id_ = g_incoming_parent_span_id;
+    } else {
+        trace_id_ = generate_hex_id(16);
+    }
     span_id_ = generate_hex_id(8);
 
     size_t max_len = 4096;
@@ -1090,6 +1103,9 @@ void InferenceSpan::end_with_success(const nlohmann::json& usage_or_timings, con
         {"attributes", attributes},
         {"status", {{"code", 1}}}
     };
+    if (!parent_span_id_.empty()) {
+        span_json["parentSpanId"] = parent_span_id_;
+    }
 
     submit_span(span_json);
 }
@@ -1123,6 +1139,9 @@ void InferenceSpan::end_with_error(const std::string& error_message) {
         {"attributes", attributes},
         {"status", {{"code", 2}, {"message", error_message}}}
     };
+    if (!parent_span_id_.empty()) {
+        span_json["parentSpanId"] = parent_span_id_;
+    }
 
     submit_span(span_json);
 }
@@ -1340,5 +1359,7 @@ std::string hash_token(const std::string& token) {
 thread_local std::string g_current_auth_token;
 thread_local std::chrono::steady_clock::time_point g_request_start_time;
 thread_local std::string g_current_client_session_id;
+thread_local std::string g_incoming_trace_id;
+thread_local std::string g_incoming_parent_span_id;
 
 } // namespace lemon::telemetry

--- a/src/cpp/server/telemetry.h
+++ b/src/cpp/server/telemetry.h
@@ -28,6 +28,7 @@ private:
     std::string request_dump_;
     std::string trace_id_;
     std::string span_id_;
+    std::string parent_span_id_;
     std::string user_id_;
     std::string session_id_;
     std::chrono::steady_clock::time_point start_time_;
@@ -69,5 +70,7 @@ std::string hash_token(const std::string& token);
 extern thread_local std::string g_current_auth_token;
 extern thread_local std::chrono::steady_clock::time_point g_request_start_time;
 extern thread_local std::string g_current_client_session_id;
+extern thread_local std::string g_incoming_trace_id;
+extern thread_local std::string g_incoming_parent_span_id;
 
 } // namespace lemon::telemetry

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -4753,6 +4753,53 @@ class EndpointTests(ServerTestBase):
                         proc.wait(timeout=10)
             shutil.rmtree(cache_dir, ignore_errors=True)
 
+    def test_050_telemetry_trust_incoming_trace_context_config(self):
+        """The opt-in W3C trace-context flag round-trips and validates as boolean."""
+        config_url = f"http://localhost:{PORT}/internal/config"
+        set_url = f"http://localhost:{PORT}/internal/set"
+
+        prior = (
+            requests.get(config_url, timeout=TIMEOUT_DEFAULT)
+            .json()
+            .get("telemetry", {})
+            .get("trust_incoming_trace_context", False)
+        )
+        try:
+            # Enable, then confirm it reads back as True.
+            resp = requests.post(
+                set_url,
+                json={"telemetry": {"trust_incoming_trace_context": True}},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                resp.status_code, 200, f"/internal/set failed: {resp.text}"
+            )
+            read_back = (
+                requests.get(config_url, timeout=TIMEOUT_DEFAULT)
+                .json()
+                .get("telemetry", {})
+                .get("trust_incoming_trace_context")
+            )
+            self.assertTrue(read_back)
+
+            # A non-boolean value must be rejected by config validation.
+            bad = requests.post(
+                set_url,
+                json={"telemetry": {"trust_incoming_trace_context": "yes"}},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                bad.status_code,
+                400,
+                f"expected 400 for non-boolean value, got {bad.status_code}: {bad.text}",
+            )
+        finally:
+            requests.post(
+                set_url,
+                json={"telemetry": {"trust_incoming_trace_context": bool(prior)}},
+                timeout=TIMEOUT_DEFAULT,
+            )
+
 
 if __name__ == "__main__":
     run_server_tests(EndpointTests, "ENDPOINT TESTS")

--- a/test/server_telemetry.py
+++ b/test/server_telemetry.py
@@ -127,6 +127,8 @@ def parse_span(data):
             span["traceId"] = val.hex()
         elif field_num == 2:
             span["spanId"] = val.hex()
+        elif field_num == 4:
+            span["parentSpanId"] = val.hex()
         elif field_num == 5:
             span["name"] = val.decode("utf-8", errors="replace")
         elif field_num == 6:
@@ -306,12 +308,12 @@ class TelemetryTestBase(ServerTestBase):
         super().tearDownClass()
 
     @classmethod
-    def _auth_post(cls, url, json_body, timeout=TIMEOUT_DEFAULT):
-        headers = {}
+    def _auth_post(cls, url, json_body, timeout=TIMEOUT_DEFAULT, headers=None):
+        req_headers = dict(headers or {})
         api_key = os.environ.get("LEMONADE_API_KEY")
         if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-        return requests.post(url, json=json_body, headers=headers, timeout=timeout)
+            req_headers["Authorization"] = f"Bearer {api_key}"
+        return requests.post(url, json=json_body, headers=req_headers, timeout=timeout)
 
     @classmethod
     def _auth_get(cls, url, timeout=TIMEOUT_DEFAULT):
@@ -332,6 +334,9 @@ class TelemetryTestBase(ServerTestBase):
             "hide_inputs": kwargs.pop("hide_inputs", False),
             "hide_outputs": kwargs.pop("hide_outputs", False),
             "hide_thinking": kwargs.pop("hide_thinking", False),
+            "trust_incoming_trace_context": kwargs.pop(
+                "trust_incoming_trace_context", False
+            ),
             "max_queue_capacity": kwargs.pop("max_queue_capacity", 1000),
         }
         otlp_params = {
@@ -385,7 +390,7 @@ class TelemetryTestBase(ServerTestBase):
         attrs = {a["key"]: a["value"] for a in span["attributes"]}
         return span, attrs
 
-    def _chat_completion(self, content, port=PORT, **extra):
+    def _chat_completion(self, content, port=PORT, request_headers=None, **extra):
         payload = {
             "model": ENDPOINT_TEST_MODEL,
             "messages": [{"role": "user", "content": content}],
@@ -393,7 +398,9 @@ class TelemetryTestBase(ServerTestBase):
             **extra,
         }
         res = self._auth_post(
-            f"http://localhost:{port}/api/v1/chat/completions", payload
+            f"http://localhost:{port}/api/v1/chat/completions",
+            payload,
+            headers=request_headers,
         )
         self.assertEqual(res.status_code, 200, res.text)
         return res
@@ -728,6 +735,89 @@ class CoreTracingTests(TelemetryTestBase):
         self.assertEqual(
             _get_header_value(span_received["headers"], "x-json-header"), "OK"
         )
+
+
+# A fixed, valid W3C traceparent (version 00): non-zero 32-hex trace id and
+# 16-hex parent id with the sampled flag set.
+_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736"
+_PARENT_ID = "00f067aa0ba902b7"
+_TRACEPARENT = f"00-{_TRACE_ID}-{_PARENT_ID}-01"
+
+
+class TraceContextTests(TelemetryTestBase):
+    """W3C traceparent ingestion gated by telemetry.trust_incoming_trace_context."""
+
+    _pull_base_model = True
+
+    def test_017_adopts_incoming_trace_context(self):
+        """With the flag enabled, a valid traceparent sets the span's trace id and parent."""
+        self._enable_telemetry(trust_incoming_trace_context=True)
+        self._chat_completion(
+            "Say hello.", request_headers={"traceparent": _TRACEPARENT}
+        )
+
+        span_received = self._wait_for_span()
+        self.assertIsNotNone(span_received, "Telemetry span was not received.")
+        span, _ = self._extract_span(span_received)
+        self.assertEqual(span["traceId"], _TRACE_ID)
+        self.assertEqual(span.get("parentSpanId"), _PARENT_ID)
+
+    def test_018_adopts_incoming_trace_context_json(self):
+        """The http/json OTLP path also adopts the incoming trace context."""
+        self._enable_telemetry(trust_incoming_trace_context=True, protocol="http/json")
+        self._chat_completion(
+            "Say hello.", request_headers={"traceparent": _TRACEPARENT}
+        )
+
+        span_received = self._wait_for_span()
+        self.assertIsNotNone(span_received, "Telemetry span was not received.")
+        span, _ = self._extract_span(span_received)
+        self.assertEqual(span["traceId"], _TRACE_ID)
+        self.assertEqual(span.get("parentSpanId"), _PARENT_ID)
+
+    def test_019_ignores_traceparent_when_disabled(self):
+        """With the flag disabled (default), the traceparent is ignored: fresh root span."""
+        self._enable_telemetry(trust_incoming_trace_context=False)
+        self._chat_completion(
+            "Say hello.", request_headers={"traceparent": _TRACEPARENT}
+        )
+
+        span_received = self._wait_for_span()
+        self.assertIsNotNone(span_received, "Telemetry span was not received.")
+        span, _ = self._extract_span(span_received)
+        self.assertNotEqual(span["traceId"], _TRACE_ID)
+        self.assertNotIn("parentSpanId", span)
+
+    def test_020_malformed_traceparent_falls_back_to_root(self):
+        """Malformed headers are ignored safely; the span starts a fresh root trace."""
+        self._enable_telemetry(trust_incoming_trace_context=True)
+        malformed = {
+            "too_short": "not-a-valid-header",
+            "zero_trace_id": f"00-{'0' * 32}-{_PARENT_ID}-01",
+            "zero_parent_id": f"00-{_TRACE_ID}-{'0' * 16}-01",
+            "forbidden_version": f"ff-{_TRACE_ID}-{_PARENT_ID}-01",
+            "v00_extra_field": f"00-{_TRACE_ID}-{_PARENT_ID}-01-extra",
+        }
+        for label, header in malformed.items():
+            with self.subTest(case=label):
+                self._chat_completion("Hi.", request_headers={"traceparent": header})
+                span_received = self._wait_for_span()
+                self.assertIsNotNone(span_received, "Telemetry span was not received.")
+                span, _ = self._extract_span(span_received)
+                self.assertNotEqual(span["traceId"], _TRACE_ID)
+                self.assertNotIn("parentSpanId", span)
+
+    def test_021_future_version_traceparent_supported(self):
+        """A higher version with a trailing field is parsed using the first four fields."""
+        self._enable_telemetry(trust_incoming_trace_context=True)
+        future = f"01-{_TRACE_ID}-{_PARENT_ID}-01-extra"
+        self._chat_completion("Hi.", request_headers={"traceparent": future})
+
+        span_received = self._wait_for_span()
+        self.assertIsNotNone(span_received, "Telemetry span was not received.")
+        span, _ = self._extract_span(span_received)
+        self.assertEqual(span["traceId"], _TRACE_ID)
+        self.assertEqual(span.get("parentSpanId"), _PARENT_ID)
 
 
 class PrivacyTests(TelemetryTestBase):
@@ -1463,6 +1553,7 @@ if __name__ == "__main__":
         [
             ConfigTests,
             CoreTracingTests,
+            TraceContextTests,
             PrivacyTests,
             ErrorTests,
             ModelTypeTests,


### PR DESCRIPTION
## Summary

Adds an opt-in setting, `telemetry.trust_incoming_trace_context` (default `false`), that makes inference spans honor a caller-supplied W3C [`traceparent`](https://www.w3.org/TR/trace-context/) header. When enabled and a valid header is present, the span adopts the incoming trace id and is parented to the incoming span id, so requests join the caller's distributed trace instead of starting a fresh root. Emitted on both the JSON and protobuf OTLP paths.

Today every inference span is an orphaned root, so a multi-step workflow across an instrumented caller (e.g. an agent orchestrator) cannot be viewed as one connected trace. This is a generic Trace Context capability that benefits any instrumented client, not a specific integration.

Opt-in because span parentage then depends on client-supplied input; default-off preserves current behavior exactly.

Closes #2735

## Changes

- `telemetry.trust_incoming_trace_context` config key (accessor + validation + default), regenerated `defaults.json` / config docs via `gen_backend_boilerplate.py`.
- Parse + validate `traceparent` per the W3C grammar in `authenticate_request` (gated by the flag); stash into request-thread thread-locals.
- `InferenceSpan` adopts the incoming trace/parent ids at construction; `parentSpanId` written on both OTLP serializers.
- Added `traceparent` to CORS allow-headers.
- Docs: new "Distributed Tracing (W3C Trace Context)" section in `docs/guide/telemetry.md`.
- Test: `test_050_telemetry_trust_incoming_trace_context_config` (round-trip + non-boolean rejection).

## Test plan

- [x] Builds clean (Linux/GCC); `gen_backend_boilerplate.py --check` passes.
- [x] New unittest passes against a live server.
- [x] Live E2E against a local OTLP collector (**JSON** path): two requests sharing one trace id land in one trace, each parented to its own incoming span id; no-header → fresh root; flag-off → header ignored; malformed header → ignored.
- [x] Live E2E against a local OTLP collector (**protobuf** path, the default): decoded the wire payload and confirmed `parent_span_id` (field 4) is emitted correctly.
- [ ] Not tested on Windows/macOS locally (change is platform-agnostic C++; happy to get help validating).

_AI-assisted: implementation and this description were drafted with AI and reviewed by me._