### PR TITLE
fix(security): apply HTTP trust policies to POST request paths

### DIFF
--- a/src/cpp/include/lemon/backends/cloud/cloud_server.h
+++ b/src/cpp/include/lemon/backends/cloud/cloud_server.h
@@ -99,6 +99,8 @@ private:
         std::string api_key;
         std::string base_url;
         bool insecure_http_blocked = false;
+        utils::HttpSecurityPolicy policy =
+            utils::HttpSecurityPolicy::ExternalHttpsOnly;
     };
 
     // Looks up creds from the registry. Returns empty fields when the

--- a/src/cpp/include/lemon/utils/http_client.h
+++ b/src/cpp/include/lemon/utils/http_client.h
@@ -52,9 +52,9 @@ struct DownloadResult {
 using ProgressCallback = std::function<bool(size_t downloaded, size_t total)>;
 using StreamCallback = std::function<bool(const char* data, size_t length)>;
 
-// Trust boundary for HTTP requests that may follow redirects. Selects which URL
-// schemes are allowed for the initial request and for redirect targets, and
-// whether redirects are followed at all.
+// Trust boundary for outgoing HTTP requests. Selects which URL schemes are
+// allowed for the initial request and, for request types that follow redirects,
+// which schemes are allowed for redirect targets.
 enum class HttpSecurityPolicy {
     // External hosts (Hugging Face, GitHub, release CDNs). Require https for the
     // initial request and every redirect hop; bound the redirect chain. This is
@@ -65,7 +65,8 @@ enum class HttpSecurityPolicy {
     // http and never follow redirects.
     TrustedLoopback,
     // User-configured plaintext endpoints that explicitly opted in via
-    // allow_insecure_http. Permit http and https; bound the redirect chain.
+    // allow_insecure_http. Permit http and https; when redirects are enabled,
+    // bound the redirect chain.
     AllowInsecureHttp,
 };
 
@@ -107,26 +108,33 @@ public:
                            long timeout_seconds = 0,
                            HttpSecurityPolicy policy = HttpSecurityPolicy::ExternalHttpsOnly);
 
-    // Simple POST request
-    static HttpResponse post(const std::string& url,
-                            const std::string& body,
-                            const std::map<std::string, std::string>& headers = {},
-                            long timeout_seconds = 300);
+    // Simple POST request. Redirects are never followed.
+    static HttpResponse post(
+        const std::string& url,
+        const std::string& body,
+        const std::map<std::string, std::string>& headers = {},
+        long timeout_seconds = 300,
+        HttpSecurityPolicy policy = HttpSecurityPolicy::ExternalHttpsOnly);
 
-    // Multipart form data POST request
-    static HttpResponse post_multipart(const std::string& url,
-                                       const std::vector<MultipartField>& fields,
-                                       long timeout_seconds = 300);
+    // Multipart form data POST request. Redirects are never followed.
+    static HttpResponse post_multipart(
+        const std::string& url,
+        const std::vector<MultipartField>& fields,
+        long timeout_seconds = 300,
+        HttpSecurityPolicy policy = HttpSecurityPolicy::ExternalHttpsOnly);
 
     // Streaming POST request (calls callback for each chunk as it arrives).
     // on_status fires once, before the first chunk is delivered, so callers can
-    // divert an error body instead of forwarding it as payload bytes.
-    static HttpResponse post_stream(const std::string& url,
-                                   const std::string& body,
-                                   StreamCallback stream_callback,
-                                   const std::map<std::string, std::string>& headers = {},
-                                   long timeout_seconds = 300,
-                                   std::function<void(int status_code)> on_status = nullptr);
+    // divert an error body instead of forwarding it as payload bytes. Redirects
+    // are never followed.
+    static HttpResponse post_stream(
+        const std::string& url,
+        const std::string& body,
+        StreamCallback stream_callback,
+        const std::map<std::string, std::string>& headers = {},
+        long timeout_seconds = 300,
+        std::function<void(int status_code)> on_status = nullptr,
+        HttpSecurityPolicy policy = HttpSecurityPolicy::ExternalHttpsOnly);
 
     // Download file to disk with automatic retry and resume support
     static DownloadResult download_file(const std::string& url,
@@ -136,8 +144,11 @@ public:
                                         const DownloadOptions& options = DownloadOptions(),
                                         HttpSecurityPolicy policy = HttpSecurityPolicy::ExternalHttpsOnly);
 
-    // Check if URL is reachable
-    static bool is_reachable(const std::string& url, int timeout_seconds = 5);
+    // Check if URL is reachable. Redirects are never followed.
+    static bool is_reachable(
+        const std::string& url,
+        int timeout_seconds = 5,
+        HttpSecurityPolicy policy = HttpSecurityPolicy::ExternalHttpsOnly);
 
 private:
     static std::atomic<long> default_timeout_seconds_;

--- a/src/cpp/server/backends/acestep/acestep_server.cpp
+++ b/src/cpp/server/backends/acestep/acestep_server.cpp
@@ -187,8 +187,12 @@ bool AceStepServer::run_job(const std::string& path, const std::string& body,
                             std::string& result, std::string& error) {
     const std::string stage = path.substr(1);
     const std::string base = get_base_url();
-    auto submit = utils::HttpClient::post(base + path, body,
-                                          {{"Content-Type", "application/json"}}, 60);
+    auto submit = utils::HttpClient::post(
+        base + path,
+        body,
+        {{"Content-Type", "application/json"}},
+        60,
+        utils::HttpSecurityPolicy::TrustedLoopback);
     if (submit.status_code != 200) {
         LOG(ERROR, "acestep-server") << stage << " submit failed (HTTP " << submit.status_code
                                      << "): " << submit.body << std::endl;

--- a/src/cpp/server/backends/cloud/cloud_server.cpp
+++ b/src/cpp/server/backends/cloud/cloud_server.cpp
@@ -335,16 +335,21 @@ CloudServer::ResolvedCreds CloudServer::resolve_creds() const {
     }
     creds.api_key = registry_->resolve_key(provider_);
     creds.base_url = registry_->base_url_for(provider_);
-    if (!creds.api_key.empty() &&
-        CloudProviderRegistry::is_http_base_url(creds.base_url) &&
-        !registry_->allow_insecure_http_for(provider_)) {
-        creds.insecure_http_blocked = true;
-    }
+
     // The registry already normalizes base_url on install, but a defensive
     // strip here keeps the contract local — anyone tracing post_with_auth
     // can see the joined URL can't double-slash.
     while (!creds.base_url.empty() && creds.base_url.back() == '/') {
         creds.base_url.pop_back();
+    }
+
+    const bool allow_insecure_http =
+        registry_->allow_insecure_http_for(provider_);
+    creds.policy = discovery_policy(creds.base_url, allow_insecure_http);
+    if (!creds.api_key.empty() &&
+        CloudProviderRegistry::is_http_base_url(creds.base_url) &&
+        !allow_insecure_http) {
+        creds.insecure_http_blocked = true;
     }
     return creds;
 }
@@ -435,7 +440,12 @@ json CloudServer::post_with_auth(const std::string& path, const json& request,
     };
 
     try {
-        auto response = utils::HttpClient::post(url, request.dump(), headers, timeout_seconds);
+        auto response = utils::HttpClient::post(
+            url,
+            request.dump(),
+            headers,
+            timeout_seconds,
+            creds.policy);
         if (response.status_code == 200) {
             // Return the body unchanged so the server.cpp handler picks up the
             // `usage` telemetry like every other backend.
@@ -632,7 +642,9 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
                     return true;
                 },
                 headers,
-                timeout_seconds
+                timeout_seconds,
+                nullptr,
+                creds.policy
             );
 
             if (result.curl_code != CURLE_OK) {
@@ -695,7 +707,9 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
                     return sink.write(data, length);
                 },
                 headers,
-                timeout_seconds
+                timeout_seconds,
+                nullptr,
+                creds.policy
             );
             if (result.curl_code != CURLE_OK) {
                 if (result.curl_code == CURLE_WRITE_ERROR) {

--- a/src/cpp/server/backends/fastflowlm/fastflowlm_server.cpp
+++ b/src/cpp/server/backends/fastflowlm/fastflowlm_server.cpp
@@ -268,7 +268,8 @@ bool FastFlowLMServer::wait_for_ready() {
             return false;
         }
 
-        if (utils::HttpClient::is_reachable(tags_url, 1)) {
+        if (utils::HttpClient::is_reachable(
+                tags_url, 1, utils::HttpSecurityPolicy::TrustedLoopback)) {
             LOG(INFO, "FastFlowLM") << server_name_ + " is ready!" << std::endl;
             start_backend_watchdog("/api/tags");
             return true;

--- a/src/cpp/server/backends/moonshine/moonshine_server.cpp
+++ b/src/cpp/server/backends/moonshine/moonshine_server.cpp
@@ -288,7 +288,11 @@ json MoonshineServer::forward_multipart_audio_data(const std::string& audio_data
     const std::string url = "http://127.0.0.1:" + std::to_string(get_backend_port()) + "/inference";
     LOG(DEBUG, "MoonshineServer") << "Sending multipart request to " << url << " (direct data)" << std::endl;
 
-    auto res = utils::HttpClient::post_multipart(url, fields, 0);
+    auto res = utils::HttpClient::post_multipart(
+        url,
+        fields,
+        0,
+        utils::HttpSecurityPolicy::TrustedLoopback);
 
     LOG(DEBUG, "MoonshineServer") << "Response status: " << res.status_code << std::endl;
 

--- a/src/cpp/server/backends/trellis/trellis_server.cpp
+++ b/src/cpp/server/backends/trellis/trellis_server.cpp
@@ -190,7 +190,11 @@ void TrellisServer::model_3d_generations(const json& request, httplib::DataSink&
         sink.write(payload.data(), payload.size());
     };
     try {
-        auto resp = utils::HttpClient::post_multipart(get_base_url() + "/generate", fields, 1800);
+        auto resp = utils::HttpClient::post_multipart(
+            get_base_url() + "/generate",
+            fields,
+            1800,
+            utils::HttpSecurityPolicy::TrustedLoopback);
         if (resp.curl_code != 0) {
             LOG(ERROR, "trellis-server") << "generation transport error: " << resp.curl_error << std::endl;
             fail("generation transport error: " + resp.curl_error);

--- a/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
+++ b/src/cpp/server/backends/whispercpp/whispercpp_server.cpp
@@ -554,7 +554,11 @@ json WhisperServer::forward_multipart_audio_request(const std::string& file_path
     // sync with `global_timeout` in config.json (see server.cpp). Hard-coding 300
     // caused long-form audio (~35+ min on slower backends) to fail regardless of
     // the user's configuration.
-    auto res = utils::HttpClient::post_multipart(url, fields, 0);
+    auto res = utils::HttpClient::post_multipart(
+        url,
+        fields,
+        0,
+        utils::HttpSecurityPolicy::TrustedLoopback);
 
     LOG(DEBUG, "WhisperServer") << "Response status: " << res.status_code << std::endl;
     LOG(DEBUG, "WhisperServer") << "Response body: " << res.body << std::endl;
@@ -641,7 +645,11 @@ json WhisperServer::forward_multipart_audio_data(const std::string& audio_data,
 
     // See the note on the file-path variant above: 0 inherits the configured
     // global timeout so long transcriptions aren't artificially capped at 300s.
-    auto res = utils::HttpClient::post_multipart(url, fields, 0);
+    auto res = utils::HttpClient::post_multipart(
+        url,
+        fields,
+        0,
+        utils::HttpSecurityPolicy::TrustedLoopback);
 
     LOG(DEBUG, "WhisperServer") << "Response status: " << res.status_code << std::endl;
 

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -131,7 +131,9 @@ void StreamingProxy::forward_sse_stream(
             return true;
         },
         {},
-        timeout_seconds
+        timeout_seconds,
+        nullptr,
+        utils::HttpSecurityPolicy::TrustedLoopback
     );
 
     const bool transport_interrupted =
@@ -249,7 +251,8 @@ void StreamingProxy::forward_byte_stream(
         },
         {},
         timeout_seconds,
-        [&backend_status](int status) { backend_status = status; }
+        [&backend_status](int status) { backend_status = status; },
+        utils::HttpSecurityPolicy::TrustedLoopback
     );
 
     const bool transport_interrupted =

--- a/src/cpp/server/telemetry.cpp
+++ b/src/cpp/server/telemetry.cpp
@@ -617,7 +617,15 @@ private:
                 bool retryable = true;
                 std::string error_detail;
                 try {
-                    auto response = utils::HttpClient::post(batch_endpoint, payload, batch_headers, 3);
+                    const auto policy = batch_endpoint.rfind("http://", 0) == 0
+                        ? utils::HttpSecurityPolicy::AllowInsecureHttp
+                        : utils::HttpSecurityPolicy::ExternalHttpsOnly;
+                    auto response = utils::HttpClient::post(
+                        batch_endpoint,
+                        payload,
+                        batch_headers,
+                        3,
+                        policy);
                     if (response.status_code >= 200 && response.status_code < 300) {
                         success = true;
                         LOG(DEBUG, "Telemetry") << "Successfully sent telemetry batch." << std::endl;

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -359,28 +359,42 @@ static int progress_callback(void* clientp, curl_off_t dltotal, curl_off_t dlnow
 }
 
 namespace {
-// Applies the scheme and redirect restrictions for a trust boundary. Returns
-// false if any security-relevant option fails to apply so callers can fail
-// closed instead of issuing an unrestricted request.
-bool apply_http_security_policy(CURL* curl, HttpSecurityPolicy policy) {
-    auto set = [curl](CURLoption opt, auto value) {
-        return curl_easy_setopt(curl, opt, value) == CURLE_OK;
+// Applies scheme and redirect restrictions for a trust boundary. Redirect
+// behavior is supplied separately so extending policy enforcement to POST
+// paths does not silently change their existing no-redirect semantics.
+// Returns false if any security-relevant option fails to apply, allowing each
+// caller to fail closed instead of issuing an unrestricted request.
+bool apply_http_security_policy(
+    CURL* curl,
+    HttpSecurityPolicy policy,
+    bool follow_redirects) {
+    auto set = [curl](CURLoption option, auto value) {
+        return curl_easy_setopt(curl, option, value) == CURLE_OK;
     };
+
+    const auto apply_protocols = [&](const char* protocols,
+                                     const char* redirect_protocols) {
+        if (!set(CURLOPT_FOLLOWLOCATION, follow_redirects ? 1L : 0L) ||
+            !set(CURLOPT_PROTOCOLS_STR, protocols)) {
+            return false;
+        }
+        if (!follow_redirects) {
+            return true;
+        }
+        return set(CURLOPT_MAXREDIRS, 5L) &&
+               set(CURLOPT_REDIR_PROTOCOLS_STR, redirect_protocols);
+    };
+
     switch (policy) {
         case HttpSecurityPolicy::TrustedLoopback:
+            // Managed loopback backends are plain HTTP and must never redirect.
             return set(CURLOPT_FOLLOWLOCATION, 0L) &&
                    set(CURLOPT_PROTOCOLS_STR, "http");
         case HttpSecurityPolicy::AllowInsecureHttp:
-            return set(CURLOPT_FOLLOWLOCATION, 1L) &&
-                   set(CURLOPT_MAXREDIRS, 5L) &&
-                   set(CURLOPT_PROTOCOLS_STR, "http,https") &&
-                   set(CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+            return apply_protocols("http,https", "http,https");
         case HttpSecurityPolicy::ExternalHttpsOnly:
         default:
-            return set(CURLOPT_FOLLOWLOCATION, 1L) &&
-                   set(CURLOPT_MAXREDIRS, 5L) &&
-                   set(CURLOPT_PROTOCOLS_STR, "https") &&
-                   set(CURLOPT_REDIR_PROTOCOLS_STR, "https");
+            return apply_protocols("https", "https");
     }
 }
 } // namespace
@@ -400,7 +414,7 @@ HttpResponse HttpClient::get(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
-    if (!apply_http_security_policy(curl, policy)) {
+    if (!apply_http_security_policy(curl, policy, true)) {
         curl_easy_cleanup(curl);
         throw std::runtime_error("Failed to apply HTTP security policy");
     }
@@ -441,7 +455,8 @@ HttpResponse HttpClient::get(const std::string& url,
 HttpResponse HttpClient::post(const std::string& url,
                               const std::string& body,
                               const std::map<std::string, std::string>& headers,
-                              long timeout_seconds) {
+                              long timeout_seconds,
+                              HttpSecurityPolicy policy) {
     CURL* curl = curl_easy_init();
     if (!curl) {
         throw std::runtime_error("Failed to initialize CURL");
@@ -455,10 +470,14 @@ HttpResponse HttpClient::post(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.size()));
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
+    if (!apply_http_security_policy(curl, policy, false)) {
+        curl_easy_cleanup(curl);
+        throw std::runtime_error("Failed to apply HTTP security policy");
+    }
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
-     // Add custom headers
+    // Add custom headers
     bool has_content_type = false;
     for (const auto& header : headers) {
         std::string key = header.first;
@@ -501,7 +520,8 @@ HttpResponse HttpClient::post(const std::string& url,
 
 HttpResponse HttpClient::post_multipart(const std::string& url,
                                          const std::vector<MultipartField>& fields,
-                                         long timeout_seconds) {
+                                         long timeout_seconds,
+                                         HttpSecurityPolicy policy) {
     CURL* curl = curl_easy_init();
     if (!curl) {
         throw std::runtime_error("Failed to initialize CURL");
@@ -528,6 +548,11 @@ HttpResponse HttpClient::post_multipart(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
+    if (!apply_http_security_policy(curl, policy, false)) {
+        curl_mime_free(mime);
+        curl_easy_cleanup(curl);
+        throw std::runtime_error("Failed to apply HTTP security policy");
+    }
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
@@ -597,7 +622,8 @@ HttpResponse HttpClient::post_stream(const std::string& url,
                                      StreamCallback stream_callback,
                                      const std::map<std::string, std::string>& headers,
                                      long timeout_seconds,
-                                     std::function<void(int)> on_status) {
+                                     std::function<void(int)> on_status,
+                                     HttpSecurityPolicy policy) {
     CURL* curl = curl_easy_init();
     if (!curl) {
         throw std::runtime_error("Failed to initialize CURL");
@@ -617,6 +643,10 @@ HttpResponse HttpClient::post_stream(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(body.size()));
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, stream_write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &callback_data);
+    if (!apply_http_security_policy(curl, policy, false)) {
+        curl_easy_cleanup(curl);
+        throw std::runtime_error("Failed to apply HTTP security policy");
+    }
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
 
@@ -709,7 +739,7 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_file_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
-    if (!apply_http_security_policy(curl, policy)) {
+    if (!apply_http_security_policy(curl, policy, true)) {
         result.error_message = "Failed to apply HTTP security policy";
         fclose(fp);
         curl_easy_cleanup(curl);
@@ -879,7 +909,7 @@ DownloadResult HttpClient::download_attempt(const std::string& url,
             if (head_curl) {
                 curl_easy_setopt(head_curl, CURLOPT_URL, url.c_str());
                 curl_easy_setopt(head_curl, CURLOPT_NOBODY, 1L);  // HEAD request
-                if (!apply_http_security_policy(head_curl, policy)) {
+                if (!apply_http_security_policy(head_curl, policy, true)) {
                     curl_easy_cleanup(head_curl);
                     result.error_message = "Resume failed (HTTP 416) - could not apply security policy";
                     result.can_resume = false;
@@ -1184,7 +1214,9 @@ DownloadResult HttpClient::download_file(const std::string& url,
     return final_result;
 }
 
-bool HttpClient::is_reachable(const std::string& url, int timeout_seconds) {
+bool HttpClient::is_reachable(const std::string& url,
+                              int timeout_seconds,
+                              HttpSecurityPolicy policy) {
     CURL* curl = curl_easy_init();
     if (!curl) {
         return false;
@@ -1197,6 +1229,10 @@ bool HttpClient::is_reachable(const std::string& url, int timeout_seconds) {
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
+    if (!apply_http_security_policy(curl, policy, false)) {
+        curl_easy_cleanup(curl);
+        return false;
+    }
 
     CURLcode res = curl_easy_perform(curl);
 

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -477,7 +477,10 @@ void WrappedServer::backend_watchdog_loop() {
             break;
         }
 
-        const bool reachable = utils::HttpClient::is_reachable(health_url, probe_timeout_seconds);
+        const bool reachable = utils::HttpClient::is_reachable(
+            health_url,
+            probe_timeout_seconds,
+            utils::HttpSecurityPolicy::TrustedLoopback);
         if (reachable) {
             consecutive_failures = 0;
             note_backend_activity();
@@ -548,7 +551,8 @@ bool WrappedServer::wait_for_ready(const std::string& endpoint, long timeout_sec
         }
 
         // Try health endpoint
-        if (utils::HttpClient::is_reachable(health_url, 1)) {
+        if (utils::HttpClient::is_reachable(
+                health_url, 1, utils::HttpSecurityPolicy::TrustedLoopback)) {
             LOG(INFO, "WrappedServer") << server_name_ + " is ready!" << std::endl;
             start_backend_watchdog(normalized_endpoint);
             return true;
@@ -635,8 +639,12 @@ json WrappedServer::forward_request(const std::string& endpoint, const json& req
     std::map<std::string, std::string> headers = {{"Content-Type", "application/json"}};
 
     try {
-        auto response = utils::HttpClient::post(url, request.dump(), headers,
-                                               timeout_seconds);
+        auto response = utils::HttpClient::post(
+            url,
+            request.dump(),
+            headers,
+            timeout_seconds,
+            utils::HttpSecurityPolicy::TrustedLoopback);
         note_backend_activity();
 
         if (response.status_code == 200) {
@@ -688,8 +696,11 @@ json WrappedServer::forward_multipart_request(const std::string& endpoint,
     std::string url = get_base_url() + endpoint;
 
     try {
-        auto response = utils::HttpClient::post_multipart(url, fields,
-                                                         timeout_seconds);
+        auto response = utils::HttpClient::post_multipart(
+            url,
+            fields,
+            timeout_seconds,
+            utils::HttpSecurityPolicy::TrustedLoopback);
         note_backend_activity();
 
         if (response.status_code == 200) {

--- a/test/cpp/test_http_client_security.cpp
+++ b/test/cpp/test_http_client_security.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include <httplib.h>
 #include <curl/curl.h>
@@ -18,6 +19,7 @@
 
 using lemon::utils::HttpClient;
 using lemon::utils::HttpSecurityPolicy;
+using lemon::utils::MultipartField;
 
 struct TestResult {
     int passed = 0;
@@ -59,6 +61,12 @@ int main() {
     });
     svr.Get("/to-file", [](const httplib::Request&, httplib::Response& res) {
         res.set_redirect("file:///etc/passwd");
+    });
+    svr.Post("/post-ok", [](const httplib::Request&, httplib::Response& res) {
+        res.set_content("post-ok", "text/plain");
+    });
+    svr.Post("/post-redirect", [](const httplib::Request&, httplib::Response& res) {
+        res.set_redirect("/post-ok");
     });
 
     std::thread server_thread([&svr]() { svr.listen_after_bind(); });
@@ -134,6 +142,129 @@ int main() {
         }
         r.check(rejected, "insecure: redirect to file:// is rejected");
     }
+
+    // Trusted loopback: JSON POST succeeds over plain HTTP.
+    try {
+        auto resp = HttpClient::post(
+            base + "/post-ok",
+            "{}",
+            {},
+            5,
+            HttpSecurityPolicy::TrustedLoopback);
+        r.check(resp.status_code == 200 && resp.body == "post-ok",
+                "loopback: http POST returns 200");
+    } catch (const std::exception& e) {
+        r.check(false, std::string("loopback: http POST returns 200 (threw: ") +
+                           e.what() + ")");
+    }
+
+    // The default policy is external HTTPS-only, so an initial plain HTTP URL
+    // is rejected without requiring callers to opt into the secure behavior.
+    {
+        bool rejected = false;
+        try {
+            HttpClient::post(base + "/post-ok", "{}", {}, 5);
+        } catch (const std::exception&) {
+            rejected = true;
+        }
+        r.check(rejected, "default: initial http:// POST is rejected");
+    }
+
+    // Explicit insecure POST remains supported, but POST redirects remain
+    // disabled exactly as they were before policy enforcement was added.
+    try {
+        auto resp = HttpClient::post(
+            base + "/post-redirect",
+            "{}",
+            {},
+            5,
+            HttpSecurityPolicy::AllowInsecureHttp);
+        r.check(resp.status_code == 302 && resp.body != "post-ok",
+                "insecure: POST redirect is not followed");
+    } catch (const std::exception& e) {
+        r.check(false, std::string("insecure: POST redirect is not followed (threw: ") +
+                           e.what() + ")");
+    }
+
+    // Trusted loopback: multipart POST succeeds over plain HTTP.
+    const std::vector<MultipartField> fields = {
+        {"file", "test", "test.txt", "text/plain"},
+    };
+    try {
+        auto resp = HttpClient::post_multipart(
+            base + "/post-ok",
+            fields,
+            5,
+            HttpSecurityPolicy::TrustedLoopback);
+        r.check(resp.status_code == 200 && resp.body == "post-ok",
+                "loopback: multipart POST returns 200");
+    } catch (const std::exception& e) {
+        r.check(false, std::string("loopback: multipart POST returns 200 (threw: ") +
+                           e.what() + ")");
+    }
+
+    // External policy: multipart POST rejects an initial plain HTTP URL.
+    {
+        bool rejected = false;
+        try {
+            HttpClient::post_multipart(
+                base + "/post-ok",
+                fields,
+                5,
+                HttpSecurityPolicy::ExternalHttpsOnly);
+        } catch (const std::exception&) {
+            rejected = true;
+        }
+        r.check(rejected, "external: initial http:// multipart POST is rejected");
+    }
+
+    // Trusted loopback: streaming POST succeeds over plain HTTP.
+    try {
+        std::string streamed_body;
+        auto resp = HttpClient::post_stream(
+            base + "/post-ok",
+            "{}",
+            [&streamed_body](const char* data, size_t length) {
+                streamed_body.append(data, length);
+                return true;
+            },
+            {},
+            5,
+            nullptr,
+            HttpSecurityPolicy::TrustedLoopback);
+        r.check(resp.status_code == 200 && streamed_body == "post-ok",
+                "loopback: streaming POST returns 200");
+    } catch (const std::exception& e) {
+        r.check(false, std::string("loopback: streaming POST returns 200 (threw: ") +
+                           e.what() + ")");
+    }
+
+    // External policy: streaming POST rejects an initial plain HTTP URL.
+    {
+        bool rejected = false;
+        try {
+            HttpClient::post_stream(
+                base + "/post-ok",
+                "{}",
+                [](const char*, size_t) { return true; },
+                {},
+                5,
+                nullptr,
+                HttpSecurityPolicy::ExternalHttpsOnly);
+        } catch (const std::exception&) {
+            rejected = true;
+        }
+        r.check(rejected, "external: initial http:// streaming POST is rejected");
+    }
+
+    r.check(
+        HttpClient::is_reachable(
+            base + "/ok", 5, HttpSecurityPolicy::TrustedLoopback),
+        "loopback: reachability probe succeeds");
+    r.check(
+        !HttpClient::is_reachable(
+            base + "/ok", 5, HttpSecurityPolicy::ExternalHttpsOnly),
+        "external: http:// reachability probe is rejected");
 
     // Note: An HTTPS→HTTP protocol-downgrade test (client connects to https://
     // and is redirected to http://) is not exercised here. Running a curl


### PR DESCRIPTION
## Summary

Follow-up to #2634 that applies the existing HTTP trust-boundary model consistently across all `HttpClient` request paths.

## Why this is needed

#2634 hardened GET and download requests, but `post()`, `post_multipart()`, `post_stream()`, and `is_reachable()` still bypassed `HttpSecurityPolicy`.

This left security behavior dependent on the HTTP method:

* external POST requests were not restricted to HTTPS,
* local backend requests relied on implicit plaintext HTTP behavior,
* multipart and streaming paths had no explicit trust boundary,
* future secure defaults could break loopback backends such as Whisper, Moonshine, Trellis, and AceStep.

This follow-up closes that gap by making every request path explicitly declare whether it targets a trusted local backend or an external service.

## Changes

* Add `HttpSecurityPolicy` support to POST, multipart, streaming, and reachability requests.
* Default external requests to `ExternalHttpsOnly`.
* Mark internal `127.0.0.1` backend communication as `TrustedLoopback`.
* Preserve the existing cloud-provider HTTP opt-in.
* Keep HTTPS providers HTTPS-only, even when an insecure-HTTP setting is present.
* Preserve existing POST behavior by keeping redirects disabled.
* Add regression coverage for JSON POST, multipart, streaming, reachability, default policy enforcement, and redirect behavior.
