### PR TITLE
[docs] Correct UID/GID for migration instructions in docs/guide/install/docker.md

### DIFF
--- a/docs/guide/install/docker.md
+++ b/docs/guide/install/docker.md
@@ -30,9 +30,9 @@ docker run -d \
 > If you're upgrading from an image that ran as root (versions prior to v10.10.1), your existing named volumes may still be owned by root. The new image runs as UID 10001 and will fail to write to root-owned volumes. Fix ownership with helper containers:
 >
 > ```bash
-> docker run --rm -v lemonade-cache:/v ubuntu:24.04 chown -R 10001:10001 /v
-> docker run --rm -v lemonade-llama:/v ubuntu:24.04 chown -R 10001:10001 /v
-> docker run --rm -v lemonade-recipe:/v ubuntu:24.04 chown -R 10001:10001 /v
+> docker run --rm -v lemonade-cache:/v ubuntu:24.04 chown -R 10001:999 /v
+> docker run --rm -v lemonade-llama:/v ubuntu:24.04 chown -R 10001:999 /v
+> docker run --rm -v lemonade-recipe:/v ubuntu:24.04 chown -R 10001:999 /v
 > ```
 >
 > Alternatively, remove the old volumes and let the new container recreate them:


### PR DESCRIPTION
Continuing from: github.com/lemonade-sdk/lemonade/pull/2617
The actual group ID (GID) inside container is 999:
```
lemonade@d62ed54ac02c:~$ id lemonade
uid=10001(lemonade) gid=999(lemonade) groups=999(lemonade)
```
This small PR fixes docker guide on migration from prior v10.10.,1