### PR TITLE
fix(docker): include build-essential in runtime stage for vLLM Triton…

### DIFF
--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -85,6 +85,20 @@ jobs:
             "lemonade-server:test-${{ matrix.arch }}" \
             lemonade --help
 
+      - name: Verify runtime C toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker run --rm \
+            "lemonade-server:test-${{ matrix.arch }}" \
+            bash -c 'set -euo pipefail
+              tmp="$(mktemp -d)"
+              printf "%s\n" "#include <stdlib.h>" "void launcher(void) {}" > "${tmp}/launcher.c"
+              gcc -O3 -shared -fPIC -o "${tmp}/launcher.so" "${tmp}/launcher.c"
+              test -f "${tmp}/launcher.so"
+              '
+
       - name: Start server
         run: |
           docker run --detach \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,7 @@ RUN echo "=== Build directory contents ===" && \
 # # ============================================================
 FROM ubuntu:24.04
 
-# Install runtime dependencies. build-essential is required at runtime (not just
-# image build time) so bundled vLLM can JIT-compile Triton launcher modules on
-# first model load. Without gcc/ld and libc headers, vllm-server fails with
-# errors such as "stdlib.h: No such file or directory" or "cannot find crti.o".
+# vLLM/Triton JIT-compiles native launcher modules at runtime.
 RUN apt-get update && apt-get install -y \
     build-essential \
     libcurl4 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,12 @@ RUN echo "=== Build directory contents ===" && \
 # # ============================================================
 FROM ubuntu:24.04
 
-# Install runtime dependencies only
+# Install runtime dependencies. build-essential is required at runtime (not just
+# image build time) so bundled vLLM can JIT-compile Triton launcher modules on
+# first model load. Without gcc/ld and libc headers, vllm-server fails with
+# errors such as "stdlib.h: No such file or directory" or "cannot find crti.o".
 RUN apt-get update && apt-get install -y \
+    build-essential \
     libcurl4 \
     curl \
     libssl3 \

--- a/docs/guide/configuration/vllm.md
+++ b/docs/guide/configuration/vllm.md
@@ -145,11 +145,9 @@ The flat form (`vllm_args=...`) is also accepted and maps to the same setting.
 
 ## Known gotchas
 
-- **Docker runtime needs a C toolchain.** The published `ghcr.io/lemonade-sdk/lemonade-server`
-  image includes `build-essential` in its runtime stage so Triton can compile launcher
-  modules on first load. Custom images that copy only the multi-stage runtime packages
-  (without `build-essential`) will fail vLLM loads with clang/linker errors such as
-  `stdlib.h: No such file or directory` or `cannot find crti.o`.
+- **Docker runtime needs `build-essential`.** vLLM/Triton JIT-compiles native launcher
+  modules on first load. The published image includes it in the runtime stage; keep it
+  if you build your own image.
 - **Cold first-load JIT.** Loading a new model size triggers a Triton kernel compile. Expect 20 s – several minutes the first time you hit a given model+shape; subsequent loads of the same shape are faster as kernels cache to disk.
 - **FP8 first-load is slow on gfx1151.** Cold-loading `Qwen/Qwen3-4B-FP8` took ~12 minutes in our test, exceeding Lemonade's default `wait_for_ready` timeout. The engine selects `TritonFp8BlockScaledMMKernel` and emits *"Using default W8A8 Block FP8 kernel config. Performance might be sub-optimal."* warnings — i.e. no AMD-tuned kernel configs are shipped for this GPU's exact shapes, so vLLM autotunes from defaults. FP16 is the most polished path today; FP8 should improve once AMD ships tuned configs.
 - **`huggingface-hub` shadowing.** Lemonade launches `vllm-server` with `PYTHONNOUSERSITE=1` so the bundled `huggingface_hub` is used. If a module-not-found error still appears, ensure `~/.local/lib/python3.12/site-packages/huggingface_hub` isn't being injected via `PYTHONPATH`.

--- a/docs/guide/configuration/vllm.md
+++ b/docs/guide/configuration/vllm.md
@@ -145,6 +145,11 @@ The flat form (`vllm_args=...`) is also accepted and maps to the same setting.
 
 ## Known gotchas
 
+- **Docker runtime needs a C toolchain.** The published `ghcr.io/lemonade-sdk/lemonade-server`
+  image includes `build-essential` in its runtime stage so Triton can compile launcher
+  modules on first load. Custom images that copy only the multi-stage runtime packages
+  (without `build-essential`) will fail vLLM loads with clang/linker errors such as
+  `stdlib.h: No such file or directory` or `cannot find crti.o`.
 - **Cold first-load JIT.** Loading a new model size triggers a Triton kernel compile. Expect 20 s – several minutes the first time you hit a given model+shape; subsequent loads of the same shape are faster as kernels cache to disk.
 - **FP8 first-load is slow on gfx1151.** Cold-loading `Qwen/Qwen3-4B-FP8` took ~12 minutes in our test, exceeding Lemonade's default `wait_for_ready` timeout. The engine selects `TritonFp8BlockScaledMMKernel` and emits *"Using default W8A8 Block FP8 kernel config. Performance might be sub-optimal."* warnings — i.e. no AMD-tuned kernel configs are shipped for this GPU's exact shapes, so vLLM autotunes from defaults. FP16 is the most polished path today; FP8 should improve once AMD ships tuned configs.
 - **`huggingface-hub` shadowing.** Lemonade launches `vllm-server` with `PYTHONNOUSERSITE=1` so the bundled `huggingface_hub` is used. If a module-not-found error still appears, ensure `~/.local/lib/python3.12/site-packages/huggingface_hub` isn't being injected via `PYTHONPATH`.

--- a/docs/guide/install/docker.md
+++ b/docs/guide/install/docker.md
@@ -108,6 +108,11 @@ docker run -d \
 
 > This will run the server using the ROCm backend as the default for llama.cpp.
 >
+> **vLLM note:** loading a `vllm` recipe also requires a C toolchain inside the
+> container for first-run Triton JIT. The published image includes
+> `build-essential` in the runtime stage for this reason. If you build your own
+> image, do not omit it from the final stage.
+
 ### Docker Run with AMD GPU Passthrough using ROCm on WSL
 
 Make sure you follow install steps described in [ROCm for WSL](https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/wsl/howto_wsl.html)
@@ -297,8 +302,10 @@ RUN echo "=== Build directory contents ===" && \
 # # ============================================================
 FROM ubuntu:24.04
 
-# Install runtime dependencies only
+# Install runtime dependencies. build-essential is required at runtime so bundled
+# vLLM can JIT-compile Triton launcher modules on first model load.
 RUN apt-get update && apt-get install -y \
+    build-essential \
     libcurl4 \
     curl \
     libssl3 \
@@ -508,3 +515,7 @@ docker run -d \
 
 - Model download fails: Ensure /opt/lemonade/.cache/huggingface volume is writable
 - Vulkan errors on CPU-only machine: The server will fallback to CPU backend automatically
+- vLLM load fails with Triton/clang errors (`stdlib.h: No such file or directory`,
+  `cannot find crti.o`, or `posix_spawn failed`): the runtime image is missing a
+  C toolchain. Install `build-essential` in the final Docker stage (see the
+  Dockerfile in the repository root) and rebuild the image.

--- a/docs/guide/install/docker.md
+++ b/docs/guide/install/docker.md
@@ -107,11 +107,6 @@ docker run -d \
 ```
 
 > This will run the server using the ROCm backend as the default for llama.cpp.
->
-> **vLLM note:** loading a `vllm` recipe also requires a C toolchain inside the
-> container for first-run Triton JIT. The published image includes
-> `build-essential` in the runtime stage for this reason. If you build your own
-> image, do not omit it from the final stage.
 
 ### Docker Run with AMD GPU Passthrough using ROCm on WSL
 
@@ -302,8 +297,7 @@ RUN echo "=== Build directory contents ===" && \
 # # ============================================================
 FROM ubuntu:24.04
 
-# Install runtime dependencies. build-essential is required at runtime so bundled
-# vLLM can JIT-compile Triton launcher modules on first model load.
+# vLLM/Triton JIT-compiles native launcher modules at runtime.
 RUN apt-get update && apt-get install -y \
     build-essential \
     libcurl4 \
@@ -515,7 +509,3 @@ docker run -d \
 
 - Model download fails: Ensure /opt/lemonade/.cache/huggingface volume is writable
 - Vulkan errors on CPU-only machine: The server will fallback to CPU backend automatically
-- vLLM load fails with Triton/clang errors (`stdlib.h: No such file or directory`,
-  `cannot find crti.o`, or `posix_spawn failed`): the runtime image is missing a
-  C toolchain. Install `build-essential` in the final Docker stage (see the
-  Dockerfile in the repository root) and rebuild the image.


### PR DESCRIPTION
fix(docker): include build-essential in runtime stage for vLLM Triton JIT

The multi-stage Dockerfile installed build-essential only in the builder stage, but vLLM needs gcc, binutils, and libc headers at runtime to compile Triton launcher modules on first model load. Without them, vllm-server fails with clang errors such as missing stdlib.h or crti.o.

Document the requirement in the Docker and vLLM configuration guides.