### PR TITLE
feat: effective options in model loading bar with optional power-user override

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ All core endpoints are registered under **4 path prefixes**:
 - `/v0/` — Legacy short
 - `/v1/` — OpenAI SDK / LiteLLM compatibility
 
-**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `pull/variants`, `registry/search`, `load`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`, `jobs`, `jobs/{id}`, `jobs/{id}/pause`, `jobs/{id}/interrupt`, `jobs/{id}/resume`
+**Core endpoints:** `chat/completions`, `completions`, `embeddings`, `reranking`, `models`, `models/{id}`, `health`, `pull`, `pull/variants`, `registry/search`, `load`, `load/command`, `unload`, `delete`, `params`, `install`, `uninstall`, `audio/transcriptions`, `audio/speech`, `images/generations`, `images/edits`, `images/variations`, `responses`, `stats`, `system-info`, `system-stats`, `log-level`, `logs/stream`, `jobs`, `jobs/{id}`, `jobs/{id}/pause`, `jobs/{id}/interrupt`, `jobs/{id}/resume`
 
 **Job engine** (`POST jobs`, `GET jobs`, `GET/DELETE jobs/{id}`, `POST jobs/{id}/{pause,interrupt,resume}`): server-side sequences of ops (`system_info`, `system_stats`, `models`, `sleep`, `load`, `unload`, `chat`) with data passing, forward-only branching, and a pause/interrupt/resume lifecycle persisted across restart. Exclusive ops hold a Router slot so normal traffic queues. See `docs/dev/job-system.md` and `docs/dev/job-expression-language.md`.
 

--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -232,6 +232,7 @@ export interface EffectiveLoadCommand {
   backend: string;
   options: Record<string, unknown>;
   args: string[];
+  ctx_size_auto_resolved?: boolean;
 }
 
 export interface ModelInfo {

--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -226,6 +226,14 @@ export interface LoadedModel {
   recipe_options?: Record<string, unknown>;
 }
 
+export interface EffectiveLoadCommand {
+  model_name: string;
+  recipe: string;
+  backend: string;
+  options: Record<string, unknown>;
+  args: string[];
+}
+
 export interface ModelInfo {
   id: string;
   name?: string;
@@ -1295,6 +1303,14 @@ class LemonadeAPI {
     const result = await this._json('/api/v1/load', { method: 'POST', body });
     this._notifyModelsChanged();
     return result;
+  }
+
+  async effectiveLoadCommand(modelName: string, recipeOptions?: Record<string, unknown>, modelInfo?: ModelInfo | null): Promise<EffectiveLoadCommand> {
+    const target = modelName.trim().toLowerCase();
+    const cachedModelInfo = modelInfo || this.allModels.find(model => modelInfoKey(model).toLowerCase() === target) || null;
+    const stagedOptions = recipeOptionsForModel(modelName, cachedModelInfo, recipeOptions as RecipeOptions | undefined, this._systemInfoData);
+    const body: Record<string, unknown> = { model_name: modelName, ...(stagedOptions || {}), ...recipeOptions };
+    return this._json<EffectiveLoadCommand>('/api/v1/load/command', { method: 'POST', body });
   }
 
   async unloadModel(modelName?: string): Promise<unknown> {

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -6,6 +6,7 @@ import LogViewer from './LogViewer';
 import { Icon, CapabilityIcon, PresetIcon } from './Icon';
 
 const Model3DResult = lazy(() => import('./Model3DResult'));
+import EffectiveSettingsModal from './EffectiveSettingsModal';
 import { useChatStreaming, ToolCallEntry, ChatToolRuntime, ToolArtifact } from '../hooks/useChatStreaming';
 import { useAudioCapture } from '../hooks/useAudioCapture';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -731,6 +732,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel, loadedModels, onModel
   const [presetPickerQuery, setPresetPickerQuery] = useState('');
   const [presetPickerApplying, setPresetPickerApplying] = useState<string | null>(null);
   const [presetPickerError, setPresetPickerError] = useState<string | null>(null);
+  const [effectiveSettingsOpen, setEffectiveSettingsOpen] = useState(false);
   const threadRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -2997,6 +2999,17 @@ ${finalText}`
               )}
             </div>
           )}
+          {currentPreset && currentModel && currentCapability !== 'image' && (
+            <button
+              type="button"
+              className="composer__tools-toggle composer__effective-settings"
+              onClick={() => setEffectiveSettingsOpen(true)}
+              title="Effective settings"
+              aria-label="Effective settings"
+            >
+              <Icon name="sliders-horizontal" size={13} />
+            </button>
+          )}
           <button
             className={`composer__tools-toggle ${useMcp && modeSupportsMcp ? 'composer__tools-toggle--active' : ''}`}
             onClick={() => {
@@ -3021,6 +3034,21 @@ ${finalText}`
             <Icon name="logs" size={13} /> Logs
           </button>
         </div>
+        {currentModel && currentPreset && (
+          <EffectiveSettingsModal
+            open={effectiveSettingsOpen}
+            onClose={() => setEffectiveSettingsOpen(false)}
+            modelName={currentModel}
+            modelInfo={currentKnownModelInfo || currentCustomModelInfo || null}
+            preset={currentPreset}
+            recipe={currentRecipe}
+            isModelLoaded={!!currentLoadedModel}
+            onReload={async () => {
+              await api.reloadModel(currentModel, undefined, currentKnownModelInfo || currentCustomModelInfo || null);
+              await Promise.resolve(onRefresh());
+            }}
+          />
+        )}
         {streamingToolStatus && (
           <div className="composer__tool-status">
             <span className="composer__tool-status-dot" />

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -3047,6 +3047,10 @@ ${finalText}`
               await api.reloadModel(currentModel, undefined, currentKnownModelInfo || currentCustomModelInfo || null);
               await Promise.resolve(onRefresh());
             }}
+            onLoad={async () => {
+              await api.loadModel(currentModel, undefined, currentKnownModelInfo || currentCustomModelInfo || null);
+              await Promise.resolve(onRefresh());
+            }}
           />
         )}
         {streamingToolStatus && (

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -327,6 +327,11 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
                 <p className="effective-settings__note">
                   <Icon name="info" size={12} /> Fixed launch flags (model path, port, chat template, metrics) are added by the server at load time and are not shown here.
                 </p>
+                {(preview?.ctx_size_auto_resolved ?? effective?.ctx_size_auto_resolved) && (
+                  <p className="effective-settings__note">
+                    <Icon name="info" size={12} /> Context size is auto-resolved from available memory. This is an estimate — the final value is computed at load time after any model eviction.
+                  </p>
+                )}
               </>
             )}
           </section>

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -168,7 +168,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
     const handle = setTimeout(async () => {
       setPreviewError(null);
       try {
-        const result = await api.effectiveLoadCommand(modelName, { [argsField]: draft }, modelInfo);
+        const result = await api.effectiveLoadCommand(modelName, { [argsField]: draft, merge_args: false }, modelInfo);
         if (!cancelled) setPreview(result);
       } catch (err) {
         if (!cancelled) { setPreview(null); setPreviewError(friendlyErrorMessage(err)); }

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -106,10 +106,11 @@ interface EffectiveSettingsModalProps {
   fallbackCtxSize?: number;
   isModelLoaded: boolean;
   onReload: () => Promise<void>;
+  onLoad: () => Promise<void>;
 }
 
 const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
-  open, onClose, modelName, modelInfo, preset, recipe, fallbackCtxSize, isModelLoaded, onReload,
+  open, onClose, modelName, modelInfo, preset, recipe, fallbackCtxSize, isModelLoaded, onReload, onLoad,
 }) => {
   const argsField = backendArgsFieldForRecipe(recipe);
   const canEditArgs = backendSupportsArgs(recipe) && !!argsField;
@@ -205,7 +206,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
           await onReload();
         } catch (reloadErr) {
           restorePreviousOverride();
-          try { await onReload(); } catch { /* keep the original failure */ }
+          try { await onLoad(); } catch { /* keep the original failure */ }
           throw reloadErr;
         }
         setNotice('Applied and reloaded with the new arguments.');
@@ -219,7 +220,7 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
       await loadEffective();
       setBusy(false);
     }
-  }, [argsField, modelName, recipe, draft, isModelLoaded, onReload, loadEffective]);
+  }, [argsField, modelName, recipe, draft, isModelLoaded, onReload, onLoad, loadEffective]);
 
   const resetOverride = useCallback(async () => {
     setBusy(true);

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -85,7 +85,7 @@ function shellQuote(token: string): string {
 }
 
 function formatCommand(modelName: string, args: string[]): string {
-  const parts = ['lemonade-server', 'load', shellQuote(modelName), ...args.map(shellQuote)];
+  const parts = ['lemonade', 'load', shellQuote(modelName), ...args.map(shellQuote)];
   return parts.join(' ');
 }
 
@@ -193,19 +193,30 @@ const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
     if (!argsField) return;
     setBusy(true);
     setNotice(null);
+    const previousOverride = getSessionArgsOverride(modelName);
+    const restorePreviousOverride = () => {
+      if (previousOverride) setSessionArgsOverride(modelName, previousOverride.recipe, previousOverride.args);
+      else clearSessionArgsOverride(modelName);
+    };
     try {
       setSessionArgsOverride(modelName, recipe, draft.trim());
       if (isModelLoaded) {
-        await onReload();
+        try {
+          await onReload();
+        } catch (reloadErr) {
+          restorePreviousOverride();
+          try { await onReload(); } catch { /* keep the original failure */ }
+          throw reloadErr;
+        }
         setNotice('Applied and reloaded with the new arguments.');
       } else {
         setNotice('Saved for this session. It will take effect the next time this model loads.');
       }
-      await loadEffective();
       setUnlocked(false);
     } catch (err) {
       setNotice(friendlyErrorMessage(err));
     } finally {
+      await loadEffective();
       setBusy(false);
     }
   }, [argsField, modelName, recipe, draft, isModelLoaded, onReload, loadEffective]);

--- a/src/app/src/components/EffectiveSettingsModal.tsx
+++ b/src/app/src/components/EffectiveSettingsModal.tsx
@@ -1,0 +1,385 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import api, { type ModelInfo, type EffectiveLoadCommand, friendlyErrorMessage } from '../api';
+import {
+  type Preset,
+  type RecipeOptions,
+  type SamplingParams,
+  type TuningValueSource,
+  DEFAULT_CONTEXT_SIZE,
+  THINKING_MODE_LABELS,
+  backendArgsFieldForRecipe,
+  backendSupportsArgs,
+  clearSessionArgsOverride,
+  getSessionArgsOverride,
+  presetMcpDisplayText,
+  resolvedModelTuningForPreset,
+  setSessionArgsOverride,
+  systemPromptNameForPreset,
+} from '../presetStore';
+import { Icon } from './Icon';
+
+const RECIPE_OPTION_LABELS: Partial<Record<keyof RecipeOptions, string>> = {
+  ctx_size: 'Context size',
+  llamacpp_backend: 'Backend',
+  llamacpp_device: 'Device',
+  llamacpp_args: 'Backend args',
+  vllm_backend: 'Backend',
+  vllm_args: 'Backend args',
+  flm_args: 'Backend args',
+  whispercpp_backend: 'Backend',
+  whispercpp_args: 'Backend args',
+  moonshine_backend: 'Backend',
+  moonshine_args: 'Backend args',
+  sdcpp_args: 'Backend args',
+  'sd-cpp_backend': 'Backend',
+  mmproj_enabled: 'Multimodal projector',
+  merge_args: 'Merge args',
+  steps: 'Steps',
+  cfg_scale: 'CFG scale',
+  width: 'Width',
+  height: 'Height',
+  sampling_method: 'Sampling method',
+  flow_shift: 'Flow shift',
+  voice: 'Voice',
+  speed: 'Speed',
+};
+
+const SAMPLING_LABELS: Partial<Record<keyof SamplingParams, string>> = {
+  temperature: 'Temperature',
+  top_p: 'Top-p',
+  top_k: 'Top-k',
+  min_p: 'Min-p',
+  repeat_penalty: 'Repeat penalty',
+};
+
+function sourceLabel(source: TuningValueSource | undefined): string {
+  switch (source) {
+    case 'custom': return 'Model tuning';
+    case 'built-in': return 'Built-in tuning';
+    case 'optimized': return 'AutoOpt optimized';
+    default: return 'Default';
+  }
+}
+
+function sourceClass(source: TuningValueSource | undefined): string {
+  switch (source) {
+    case 'custom': return 'effective-settings__source--custom';
+    case 'built-in': return 'effective-settings__source--builtin';
+    case 'optimized': return 'effective-settings__source--optimized';
+    default: return 'effective-settings__source--generic';
+  }
+}
+
+function displayValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '—';
+  if (typeof value === 'boolean') return value ? 'On' : 'Off';
+  if (typeof value === 'number') return String(value);
+  return String(value);
+}
+
+function shellQuote(token: string): string {
+  if (token === '') return "''";
+  if (/^[A-Za-z0-9_\-./:=@]+$/.test(token)) return token;
+  return `'${token.replace(/'/g, `'\\''`)}'`;
+}
+
+function formatCommand(modelName: string, args: string[]): string {
+  const parts = ['lemonade-server', 'load', shellQuote(modelName), ...args.map(shellQuote)];
+  return parts.join(' ');
+}
+
+interface SourceRow {
+  key: string;
+  label: string;
+  value: string;
+  source: TuningValueSource | undefined;
+}
+
+interface EffectiveSettingsModalProps {
+  open: boolean;
+  onClose: () => void;
+  modelName: string;
+  modelInfo: ModelInfo | null;
+  preset: Preset;
+  recipe: string;
+  fallbackCtxSize?: number;
+  isModelLoaded: boolean;
+  onReload: () => Promise<void>;
+}
+
+const EffectiveSettingsModal: React.FC<EffectiveSettingsModalProps> = ({
+  open, onClose, modelName, modelInfo, preset, recipe, fallbackCtxSize, isModelLoaded, onReload,
+}) => {
+  const argsField = backendArgsFieldForRecipe(recipe);
+  const canEditArgs = backendSupportsArgs(recipe) && !!argsField;
+
+  const [effective, setEffective] = useState<EffectiveLoadCommand | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [unlocked, setUnlocked] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [preview, setPreview] = useState<EffectiveLoadCommand | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const hasOverride = !!getSessionArgsOverride(modelName);
+
+  const resolved = useMemo(() => {
+    if (!modelInfo || !open) return null;
+    try {
+      return resolvedModelTuningForPreset(modelName, modelInfo, preset, fallbackCtxSize ?? DEFAULT_CONTEXT_SIZE);
+    } catch {
+      return null;
+    }
+  }, [modelName, modelInfo, preset, fallbackCtxSize, open]);
+
+  const loadEffective = useCallback(async () => {
+    if (!modelName) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await api.effectiveLoadCommand(modelName, undefined, modelInfo);
+      setEffective(result);
+      const committed = argsField ? result.options[argsField] : undefined;
+      setDraft(typeof committed === 'string' ? committed : '');
+    } catch (err) {
+      setError(friendlyErrorMessage(err));
+      setEffective(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [modelName, modelInfo, argsField]);
+
+  useEffect(() => {
+    if (!open) return;
+    setUnlocked(false);
+    setNotice(null);
+    setPreview(null);
+    setPreviewError(null);
+    loadEffective();
+  }, [open, loadEffective]);
+
+  useEffect(() => {
+    if (!open || !unlocked || !argsField) { setPreview(null); return; }
+    let cancelled = false;
+    const handle = setTimeout(async () => {
+      setPreviewError(null);
+      try {
+        const result = await api.effectiveLoadCommand(modelName, { [argsField]: draft }, modelInfo);
+        if (!cancelled) setPreview(result);
+      } catch (err) {
+        if (!cancelled) { setPreview(null); setPreviewError(friendlyErrorMessage(err)); }
+      }
+    }, 350);
+    return () => { cancelled = true; clearTimeout(handle); };
+  }, [open, unlocked, draft, argsField, modelName, modelInfo]);
+
+  const closeRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (open) closeRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  const applyOverride = useCallback(async () => {
+    if (!argsField) return;
+    setBusy(true);
+    setNotice(null);
+    try {
+      setSessionArgsOverride(modelName, recipe, draft.trim());
+      if (isModelLoaded) {
+        await onReload();
+        setNotice('Applied and reloaded with the new arguments.');
+      } else {
+        setNotice('Saved for this session. It will take effect the next time this model loads.');
+      }
+      await loadEffective();
+      setUnlocked(false);
+    } catch (err) {
+      setNotice(friendlyErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [argsField, modelName, recipe, draft, isModelLoaded, onReload, loadEffective]);
+
+  const resetOverride = useCallback(async () => {
+    setBusy(true);
+    setNotice(null);
+    try {
+      clearSessionArgsOverride(modelName);
+      if (isModelLoaded) {
+        await onReload();
+        setNotice('Cleared the session override and reloaded with resolved settings.');
+      } else {
+        setNotice('Cleared the session override.');
+      }
+      await loadEffective();
+      setUnlocked(false);
+    } catch (err) {
+      setNotice(friendlyErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [modelName, isModelLoaded, onReload, loadEffective]);
+
+  const sourceRows = useMemo<SourceRow[]>(() => {
+    if (!resolved) return [];
+    const rows: SourceRow[] = [];
+    for (const [key, value] of Object.entries(resolved.tuning.recipe_options || {})) {
+      rows.push({
+        key: `ro-${key}`,
+        label: RECIPE_OPTION_LABELS[key as keyof RecipeOptions] || key,
+        value: displayValue(value),
+        source: resolved.sources.recipe_options[key as keyof RecipeOptions],
+      });
+    }
+    for (const [key, value] of Object.entries(resolved.tuning.sampling || {})) {
+      rows.push({
+        key: `sp-${key}`,
+        label: SAMPLING_LABELS[key as keyof SamplingParams] || key,
+        value: displayValue(value),
+        source: resolved.sources.sampling[key as keyof SamplingParams],
+      });
+    }
+    return rows;
+  }, [resolved]);
+
+  if (!open) return null;
+
+  const previewArgs = preview?.args ?? effective?.args ?? [];
+  const backendLabel = effective?.backend || '—';
+
+  const body = (
+    <div className="inspect-modal-overlay effective-settings-overlay" onClick={onClose}>
+      <div
+        className="inspect-modal-content effective-settings"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Effective settings"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="inspect-modal-header">
+          <h4><Icon name="sliders-horizontal" size={15} /> Effective settings</h4>
+          <button ref={closeRef} className="close-modal-btn" onClick={onClose} aria-label="Close">
+            <Icon name="x" size={16} />
+          </button>
+        </div>
+
+        <div className="inspect-modal-body effective-settings__body">
+          <p className="effective-settings__model">
+            <strong>{modelName}</strong>
+            <span className="effective-settings__meta">Preset: {preset.name} · Backend: {backendLabel}</span>
+          </p>
+
+          <section className="effective-settings__section">
+            <h5 className="effective-settings__section-title">Settings by source</h5>
+            <div className="effective-settings__rows">
+              <div className="effective-settings__row">
+                <span className="effective-settings__row-label">Preset</span>
+                <span className="effective-settings__row-value">{preset.name}</span>
+                <span className="effective-settings__source effective-settings__source--preset">Preset</span>
+              </div>
+              <div className="effective-settings__row">
+                <span className="effective-settings__row-label">System prompt</span>
+                <span className="effective-settings__row-value">{systemPromptNameForPreset(preset)}</span>
+                <span className="effective-settings__source effective-settings__source--preset">Preset</span>
+              </div>
+              <div className="effective-settings__row">
+                <span className="effective-settings__row-label">MCP servers</span>
+                <span className="effective-settings__row-value">{presetMcpDisplayText(preset)}</span>
+                <span className="effective-settings__source effective-settings__source--preset">Preset</span>
+              </div>
+              {resolved && (
+                <div className="effective-settings__row">
+                  <span className="effective-settings__row-label">Thinking</span>
+                  <span className="effective-settings__row-value">{THINKING_MODE_LABELS[resolved.thinking_mode] || resolved.thinking_mode}</span>
+                  <span className={`effective-settings__source ${sourceClass(resolved.sources.thinking_mode)}`}>{sourceLabel(resolved.sources.thinking_mode)}</span>
+                </div>
+              )}
+              {sourceRows.map(row => (
+                <div className="effective-settings__row" key={row.key}>
+                  <span className="effective-settings__row-label">{row.label}</span>
+                  <span className="effective-settings__row-value">{row.value}</span>
+                  <span className={`effective-settings__source ${sourceClass(row.source)}`}>{sourceLabel(row.source)}</span>
+                </div>
+              ))}
+              {sourceRows.length === 0 && !resolved && (
+                <p className="effective-settings__empty">Model tuning details are unavailable for this model.</p>
+              )}
+            </div>
+          </section>
+
+          <section className="effective-settings__section">
+            <h5 className="effective-settings__section-title"><Icon name="terminal-square" size={14} /> Effective load command</h5>
+            {loading && <p className="effective-settings__empty">Resolving…</p>}
+            {error && <p className="effective-settings__error">{error}</p>}
+            {!loading && !error && (
+              <>
+                <pre className="effective-settings__command"><code>{formatCommand(modelName, previewArgs)}</code></pre>
+                <p className="effective-settings__note">
+                  <Icon name="info" size={12} /> Fixed launch flags (model path, port, chat template, metrics) are added by the server at load time and are not shown here.
+                </p>
+              </>
+            )}
+          </section>
+
+          {canEditArgs && (
+            <section className="effective-settings__section effective-settings__danger">
+              <label className="effective-settings__ack">
+                <input type="checkbox" checked={unlocked} onChange={e => setUnlocked(e.target.checked)} />
+                <span><Icon name="alert" size={13} /> I know what I am doing — let me edit the final loading arguments</span>
+              </label>
+              {unlocked && (
+                <div className="effective-settings__editor">
+                  <textarea
+                    className="effective-settings__textarea"
+                    value={draft}
+                    spellCheck={false}
+                    placeholder="--threads 8 --flash-attn on"
+                    onChange={e => setDraft(e.target.value)}
+                    rows={3}
+                  />
+                  <p className="effective-settings__hint">
+                    These raw backend arguments replace the resolved ones for the next load of this model. Session-only — nothing is written to disk, and it resets when you reload the app.
+                  </p>
+                  {previewError && <p className="effective-settings__error">{previewError}</p>}
+                  <div className="effective-settings__actions">
+                    <button className="btn btn--primary" onClick={applyOverride} disabled={busy}>
+                      {busy ? 'Applying…' : (isModelLoaded ? 'Apply & reload' : 'Apply for next load')}
+                    </button>
+                    {hasOverride && (
+                      <button className="btn" onClick={resetOverride} disabled={busy}>
+                        <Icon name="rotate-ccw" size={13} /> Reset override
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+              {!unlocked && hasOverride && (
+                <div className="effective-settings__actions">
+                  <span className="effective-settings__override-flag"><Icon name="alert" size={12} /> A session override is active.</span>
+                  <button className="btn" onClick={resetOverride} disabled={busy}>
+                    <Icon name="rotate-ccw" size={13} /> Reset override
+                  </button>
+                </div>
+              )}
+              {notice && <p className="effective-settings__notice">{notice}</p>}
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(body, document.body);
+};
+
+export default EffectiveSettingsModal;

--- a/src/app/src/presetStore.ts
+++ b/src/app/src/presetStore.ts
@@ -206,6 +206,30 @@ function emitPresetStoreEvent(): void {
   try { window.dispatchEvent(new CustomEvent(PRESET_STORE_EVENT)); } catch {}
 }
 
+export interface SessionArgsOverride {
+  recipe: string;
+  args: string;
+}
+
+const sessionArgsOverrides = new Map<string, SessionArgsOverride>();
+
+function sessionArgsKey(modelName: string): string {
+  return String(modelName || '').trim().toLowerCase();
+}
+
+export function getSessionArgsOverride(modelName: string): SessionArgsOverride | null {
+  return sessionArgsOverrides.get(sessionArgsKey(modelName)) || null;
+}
+
+export function setSessionArgsOverride(modelName: string, recipe: string, args: string): void {
+  sessionArgsOverrides.set(sessionArgsKey(modelName), { recipe, args });
+  emitPresetStoreEvent();
+}
+
+export function clearSessionArgsOverride(modelName: string): void {
+  if (sessionArgsOverrides.delete(sessionArgsKey(modelName))) emitPresetStoreEvent();
+}
+
 export const DEFAULT_PRESET: Preset = {
   id: 's-default',
   name: 'Default',
@@ -1836,6 +1860,13 @@ export function recipeOptionsForModel(
   }
 
   const merged: RecipeOptions = { ...backendOptions, ...modelTuningOptions };
+
+  const sessionOverride = getSessionArgsOverride(modelName);
+  if (sessionOverride) {
+    const field = backendArgsFieldForRecipe(sessionOverride.recipe);
+    if (field) (merged as Record<string, unknown>)[field] = sessionOverride.args;
+  }
+
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 

--- a/src/app/src/presetStore.ts
+++ b/src/app/src/presetStore.ts
@@ -1864,7 +1864,10 @@ export function recipeOptionsForModel(
   const sessionOverride = getSessionArgsOverride(modelName);
   if (sessionOverride) {
     const field = backendArgsFieldForRecipe(sessionOverride.recipe);
-    if (field) (merged as Record<string, unknown>)[field] = sessionOverride.args;
+    if (field) {
+      (merged as Record<string, unknown>)[field] = sessionOverride.args;
+      merged.merge_args = false;
+    }
   }
 
   return Object.keys(merged).length > 0 ? merged : undefined;

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -14920,3 +14920,225 @@ button.detail-presets__explanation-step {
   .global-settings-card__head > span { text-align: left; }
   .global-model-settings__footer > div { display: grid; grid-template-columns: 1fr 1fr; }
 }
+
+.composer__effective-settings {
+  padding: 4px;
+  width: 30px;
+  gap: 0;
+}
+
+/* Effective settings modal */
+.effective-settings {
+  max-width: 640px;
+}
+
+.effective-settings__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.effective-settings__model {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.effective-settings__model strong {
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  word-break: break-all;
+}
+
+.effective-settings__meta {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.effective-settings__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.effective-settings__section-title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.effective-settings__rows {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.effective-settings__row {
+  display: grid;
+  grid-template-columns: minmax(110px, 1fr) minmax(0, 1.4fr) 9rem;
+  gap: var(--space-3);
+  align-items: start;
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.effective-settings__row:first-child {
+  border-top: none;
+}
+
+.effective-settings__row-label {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.effective-settings__row-value {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  word-break: break-word;
+}
+
+.effective-settings__source {
+  justify-self: end;
+  font-size: var(--text-xs, 11px);
+  padding: 1px 8px;
+  border-radius: 999px;
+  white-space: nowrap;
+  border: 1px solid transparent;
+}
+
+.effective-settings__source--preset {
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-color: var(--accent-strong);
+}
+
+.effective-settings__source--custom,
+.effective-settings__source--optimized {
+  color: var(--success);
+  background: var(--success-soft);
+}
+
+.effective-settings__source--builtin {
+  color: var(--text-secondary);
+  background: var(--surface-3);
+}
+
+.effective-settings__source--generic {
+  color: var(--text-tertiary);
+  background: var(--surface-2);
+  border-color: var(--border-subtle);
+}
+
+.effective-settings__command {
+  margin: 0;
+  padding: var(--space-3);
+  background: var(--surface-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.effective-settings__note {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs, 11px);
+}
+
+.effective-settings__empty {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+}
+
+.effective-settings__error {
+  margin: 0;
+  color: var(--danger);
+  font-size: var(--text-sm);
+}
+
+.effective-settings__danger {
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+}
+
+.effective-settings__ack {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.effective-settings__ack span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.effective-settings__editor {
+  margin-top: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.effective-settings__textarea {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--surface-1);
+  color: var(--text-primary);
+}
+
+.effective-settings__hint {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs, 11px);
+}
+
+.effective-settings__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-top: var(--space-2);
+}
+
+.effective-settings__override-flag {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--warn, var(--accent));
+  font-size: var(--text-sm);
+}
+
+.effective-settings__notice {
+  margin: var(--space-2) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -104,6 +104,9 @@ public:
 
     RecipeOptions get_model_recipe_options(const std::string& model_name) const;
 
+    RecipeOptions resolve_effective_recipe_options(const ModelInfo& model_info,
+                                                   const RecipeOptions& options) const;
+
     ModelType get_model_type(const std::string& model_name = "") const;
 
     std::string get_backend_address() const;

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -136,6 +136,7 @@ private:
     void handle_registry_search(const httplib::Request& req, httplib::Response& res);
     void handle_pull_variants(const httplib::Request& req, httplib::Response& res);
     void handle_load(const httplib::Request& req, httplib::Response& res);
+    void handle_load_command(const httplib::Request& req, httplib::Response& res);
     void handle_unload(const httplib::Request& req, httplib::Response& res);
     void handle_pin(const httplib::Request& req, httplib::Response& res);
     void handle_delete(const httplib::Request& req, httplib::Response& res);

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -120,15 +120,17 @@ std::vector<std::string> RecipeOptions::to_cli_options(const json& raw_options) 
         if (raw_options.contains(opt_name)) {
             auto val = raw_options[opt_name];
             if (!val.is_null() && val != "") {
-                cli.push_back(cli_flag);
-                if (val.is_number_float()) {
-                    cli.push_back(std::to_string((double) val));
-                } else if (val.is_number_integer()) {
-                    cli.push_back(std::to_string((int) val));
-                } else if (val.is_boolean()) {
-                    cli.push_back(val.get<bool>() ? "true" : "false");
+                if (val.is_boolean()) {
+                    cli.push_back(val.get<bool>() ? cli_flag : lemon::utils::negate_flag(cli_flag));
                 } else {
-                    cli.push_back(val);
+                    cli.push_back(cli_flag);
+                    if (val.is_number_float()) {
+                        cli.push_back(std::to_string((double) val));
+                    } else if (val.is_number_integer()) {
+                        cli.push_back(std::to_string((int) val));
+                    } else {
+                        cli.push_back(val);
+                    }
                 }
             }
         }

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -125,6 +125,8 @@ std::vector<std::string> RecipeOptions::to_cli_options(const json& raw_options) 
                     cli.push_back(std::to_string((double) val));
                 } else if (val.is_number_integer()) {
                     cli.push_back(std::to_string((int) val));
+                } else if (val.is_boolean()) {
+                    cli.push_back(val.get<bool>() ? "true" : "false");
                 } else {
                     cli.push_back(val);
                 }

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -475,19 +475,8 @@ void Router::load_model(const std::string& model_name,
                        std::optional<bool> pinned,
                        std::atomic<bool>* cancel_flag) {
     const std::string canonical_model_name = resolve_model_name(model_name);
-    const std::string backend_option = model_info.recipe + "_backend";
 
-    RecipeOptions tentative = options.inherit(model_info.recipe_options.inherit(
-    RecipeOptions(model_info.recipe, config_->recipe_options(""))));
-    json backend_json = tentative.get_option(backend_option);
-    const std::string backend = backend_json.is_string() ? backend_json.get<std::string>() : "";
-
-    // Second pass: rebuild defaults using the resolved backend.
-    // Per-architecture defaults sit between global config and model-level recipe_options.
-    RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options(backend));
-    RecipeOptions arch_opts(model_info.recipe,
-                            model_manager_->get_architecture_defaults(model_info.gguf.architecture));
-    RecipeOptions effective_options = options.inherit(model_info.recipe_options.inherit(arch_opts.inherit(default_opt)));
+    RecipeOptions effective_options = resolve_effective_recipe_options(model_info, options);
 
     // LOAD SERIALIZATION STRATEGY (from spec: point #2 in Additional Considerations)
     std::unique_lock<std::mutex> lock(load_mutex_);
@@ -940,6 +929,23 @@ RecipeOptions Router::get_model_recipe_options(const std::string& model_name) co
     auto* server = find_server_by_model_name(resolve_model_name(model_name));
     if (server && server->is_backend_alive()) return server->get_recipe_options();
     return RecipeOptions();
+}
+
+RecipeOptions Router::resolve_effective_recipe_options(const ModelInfo& model_info,
+                                                       const RecipeOptions& options) const {
+    const std::string backend_option = model_info.recipe + "_backend";
+
+    RecipeOptions tentative = options.inherit(model_info.recipe_options.inherit(
+        RecipeOptions(model_info.recipe, config_->recipe_options(""))));
+    json backend_json = tentative.get_option(backend_option);
+    const std::string backend = backend_json.is_string() ? backend_json.get<std::string>() : "";
+
+    // Second pass: rebuild defaults using the resolved backend.
+    // Per-architecture defaults sit between global config and model-level recipe_options.
+    RecipeOptions default_opt = RecipeOptions(model_info.recipe, config_->recipe_options(backend));
+    RecipeOptions arch_opts(model_info.recipe,
+                            model_manager_->get_architecture_defaults(model_info.gguf.architecture));
+    return options.inherit(model_info.recipe_options.inherit(arch_opts.inherit(default_opt)));
 }
 
 ModelType Router::get_model_type(const std::string& model_name) const {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1,5 +1,6 @@
 #include "lemon/server.h"
 #include <optional>
+#include "lemon/auto_tune.h"
 #include "lemon/collection_orchestrator.h"
 #include "lemon/hf_variants.h"
 #include "lemon/model_registry.h"
@@ -5166,6 +5167,13 @@ void Server::handle_load_command(const httplib::Request& req, httplib::Response&
         RecipeOptions options = RecipeOptions(info.recipe, request_json);
         RecipeOptions effective = router_->resolve_effective_recipe_options(info, options);
 
+        bool ctx_size_auto_resolved = false;
+        int64_t auto_ctx = resolve_auto_ctx_size(effective, info);
+        if (auto_ctx > 0) {
+            effective.set_option("ctx_size", auto_ctx);
+            ctx_size_auto_resolved = true;
+        }
+
         json backend_json = effective.get_option(info.recipe + "_backend");
 
         nlohmann::json response = {
@@ -5173,7 +5181,8 @@ void Server::handle_load_command(const httplib::Request& req, httplib::Response&
             {"recipe", info.recipe},
             {"backend", backend_json.is_string() ? backend_json.get<std::string>() : ""},
             {"options", effective.to_json()},
-            {"args", RecipeOptions::to_cli_options(effective.to_json())}
+            {"args", RecipeOptions::to_cli_options(effective.to_json())},
+            {"ctx_size_auto_resolved", ctx_size_auto_resolved}
         };
         res.set_content(response.dump(), "application/json");
     } catch (const std::exception& e) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -1121,6 +1121,10 @@ void Server::setup_routes(httplib::Server &web_server) {
         handle_load(req, res);
     });
 
+    register_post("load/command", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_load_command(req, res);
+    });
+
     register_post("unload", [this](const httplib::Request& req, httplib::Response& res) {
         handle_unload(req, res);
     });
@@ -5136,6 +5140,49 @@ void Server::handle_load(const httplib::Request& req, httplib::Response& res) {
             }}};
             res.set_content(error.dump(), "application/json");
         }
+    }
+}
+
+void Server::handle_load_command(const httplib::Request& req, httplib::Response& res) {
+    nlohmann::json request_json;
+    if (!parse_required_json_body(req, res, request_json)) return;
+
+    std::string model_name;
+    try {
+        model_name = request_json.value("model_name", "");
+        if (model_name.empty()) {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", "model_name is required"}}.dump(), "application/json");
+            return;
+        }
+
+        if (!model_manager_->model_exists(model_name)) {
+            res.status = 404;
+            res.set_content(create_model_error(model_name, "Model not found").dump(), "application/json");
+            return;
+        }
+
+        auto info = model_manager_->get_model_info(model_name);
+        RecipeOptions options = RecipeOptions(info.recipe, request_json);
+        RecipeOptions effective = router_->resolve_effective_recipe_options(info, options);
+
+        json backend_json = effective.get_option(info.recipe + "_backend");
+
+        nlohmann::json response = {
+            {"model_name", model_name},
+            {"recipe", info.recipe},
+            {"backend", backend_json.is_string() ? backend_json.get<std::string>() : ""},
+            {"options", effective.to_json()},
+            {"args", RecipeOptions::to_cli_options(effective.to_json())}
+        };
+        res.set_content(response.dump(), "application/json");
+    } catch (const std::exception& e) {
+        LOG(ERROR, "Server") << "ERROR in handle_load_command: " << e.what() << std::endl;
+        res.status = 500;
+        auto error_response = model_name.empty()
+            ? nlohmann::json{{"error", e.what()}}
+            : create_model_error(model_name, e.what());
+        res.set_content(error_response.dump(), "application/json");
     }
 }
 


### PR DESCRIPTION
Currently, a weakness of the new GUI3 loading bar is that you cannot effectively tell what the final model parameters will be - especially with model tuning. This exposes a small settings icon that displays all the effective settings together with their respective sources and allows - for the power user - to modify the final arguments for the current session.