### PR TITLE
fix: make MCP server setup instructions clearer

### DIFF
--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -148,7 +148,7 @@ function normalizeHealth(data: unknown): HealthData {
     websocket_port: Number(obj.websocket_port || 0),
     all_models_loaded: loaded,
     max_models: isObject(obj.max_models) ? obj.max_models as Record<string, number> : {},
-    high_security: obj.high_security === true,
+    high_security: typeof obj.high_security === 'boolean' ? obj.high_security : undefined,
   };
 }
 
@@ -209,7 +209,7 @@ export interface HealthData {
   websocket_port: number;
   all_models_loaded: LoadedModel[];
   max_models: Record<string, number>;
-  high_security: boolean;
+  high_security?: boolean;
 }
 
 export interface LoadedModel {
@@ -911,7 +911,7 @@ class LemonadeAPI {
   get lastConnectionError(): string | null { return this._lastConnectionError; }
   get isConnected(): boolean { return this._status === 'connected'; }
   get healthData(): HealthData | null { return this._healthData; }
-  get highSecurity(): boolean { return this._healthData?.high_security === true; }
+  get highSecurity(): boolean | undefined { return this._healthData?.high_security; }
   get modelsData(): ModelsData | null { return this._modelsData; }
   get systemInfoData(): Record<string, unknown> | null { return this._systemInfoData; }
 

--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -148,6 +148,7 @@ function normalizeHealth(data: unknown): HealthData {
     websocket_port: Number(obj.websocket_port || 0),
     all_models_loaded: loaded,
     max_models: isObject(obj.max_models) ? obj.max_models as Record<string, number> : {},
+    high_security: obj.high_security === true,
   };
 }
 
@@ -208,6 +209,7 @@ export interface HealthData {
   websocket_port: number;
   all_models_loaded: LoadedModel[];
   max_models: Record<string, number>;
+  high_security: boolean;
 }
 
 export interface LoadedModel {
@@ -909,6 +911,7 @@ class LemonadeAPI {
   get lastConnectionError(): string | null { return this._lastConnectionError; }
   get isConnected(): boolean { return this._status === 'connected'; }
   get healthData(): HealthData | null { return this._healthData; }
+  get highSecurity(): boolean { return this._healthData?.high_security === true; }
   get modelsData(): ModelsData | null { return this._modelsData; }
   get systemInfoData(): Record<string, unknown> | null { return this._systemInfoData; }
 
@@ -1439,6 +1442,18 @@ class LemonadeAPI {
       { auth: 'admin' },
     );
     return Array.isArray(data.servers) ? data.servers : [];
+  }
+
+  async probeMcpAccess(): Promise<{ ok: true; servers: McpServerState[] } | { ok: false; status: number }> {
+    try {
+      const data = await this._json<{ servers?: McpServerState[] }>(
+        '/internal/mcp/servers',
+        { auth: 'admin' },
+      );
+      return { ok: true, servers: Array.isArray(data.servers) ? data.servers : [] };
+    } catch (error) {
+      return { ok: false, status: (error as LemonadeRequestError).status ?? 0 };
+    }
   }
 
   async saveMcpServer(server: Omit<McpServerConfig, 'transport' | 'id'> & { id?: string; transport?: 'stdio' }): Promise<McpServerConfig> {

--- a/src/app/src/components/McpPanel.tsx
+++ b/src/app/src/components/McpPanel.tsx
@@ -152,27 +152,31 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
     }
   }, [mcpUrl]);
 
-  const probeAccess = useCallback(async (): Promise<'ok' | 'needs-admin' | 'unavailable'> => {
+  const probeAccess = useCallback(async (): Promise<
+    "ok" | "needs-admin" | "unavailable"
+  > => {
     setHostLoading(true);
-    setHostError('');
+    setHostError("");
     const result = await api.probeMcpAccess();
     setHostLoading(false);
     if (result.ok) {
       setServers(result.servers);
-      setAdminAccess('ok');
-      return 'ok';
+      setAdminAccess("ok");
+      return "ok";
     }
     setServers([]);
     if (result.status === 401) {
-      setAdminAccess('needs-admin');
-    } else if (result.status === 403) {
-      setAdminAccess('security-required');
+      setAdminAccess("needs-admin");
+      return "needs-admin";
     }
-    setAdminAccess('unavailable');
-    setHostError(result.status
-      ? `Could not reach MCP administration (HTTP ${result.status}).`
-      : 'Could not reach MCP administration. Check that the server is running and reachable.');
-    return 'unavailable';
+
+    setAdminAccess("unavailable");
+    setHostError(
+      result.status
+        ? `Could not reach MCP administration (HTTP ${result.status}).`
+        : "Could not reach MCP administration. Check that the server is running and reachable.",
+    );
+    return "unavailable";
   }, []);
 
   useEffect(() => {

--- a/src/app/src/components/McpPanel.tsx
+++ b/src/app/src/components/McpPanel.tsx
@@ -163,9 +163,10 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
       return 'ok';
     }
     setServers([]);
-    if (result.status === 401 || result.status === 403) {
+    if (result.status === 401) {
       setAdminAccess('needs-admin');
-      return 'needs-admin';
+    } else if (result.status === 403) {
+      setAdminAccess('security-required');
     }
     setAdminAccess('unavailable');
     setHostError(result.status

--- a/src/app/src/components/McpPanel.tsx
+++ b/src/app/src/components/McpPanel.tsx
@@ -88,7 +88,7 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
   const [hostError, setHostError] = useState('');
   const [hostLoading, setHostLoading] = useState(false);
   const [secure, setSecure] = useState<boolean | null>(null);
-  const [adminAccess, setAdminAccess] = useState<'checking' | 'ok' | 'needs-admin'>('checking');
+  const [adminAccess, setAdminAccess] = useState<'checking' | 'ok' | 'needs-admin' | 'unavailable'>('checking');
   const [adminKeyDraft, setAdminKeyDraft] = useState(() => api.explicitAdminApiKey);
   const [adminKeyNotice, setAdminKeyNotice] = useState('');
   const [busyId, setBusyId] = useState('');
@@ -152,23 +152,26 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
     }
   }, [mcpUrl]);
 
-  const probeAccess = useCallback(async () => {
+  const probeAccess = useCallback(async (): Promise<'ok' | 'needs-admin' | 'unavailable'> => {
     setHostLoading(true);
     setHostError('');
     const result = await api.probeMcpAccess();
+    setHostLoading(false);
     if (result.ok) {
       setServers(result.servers);
       setAdminAccess('ok');
-    } else {
-      setServers([]);
-      setAdminAccess('needs-admin');
-      if (result.status !== 401 && result.status !== 403) {
-        setHostError(result.status
-          ? `Could not reach MCP administration (HTTP ${result.status}).`
-          : 'Could not reach MCP administration.');
-      }
+      return 'ok';
     }
-    setHostLoading(false);
+    setServers([]);
+    if (result.status === 401 || result.status === 403) {
+      setAdminAccess('needs-admin');
+      return 'needs-admin';
+    }
+    setAdminAccess('unavailable');
+    setHostError(result.status
+      ? `Could not reach MCP administration (HTTP ${result.status}).`
+      : 'Could not reach MCP administration. Check that the server is running and reachable.');
+    return 'unavailable';
   }, []);
 
   useEffect(() => {
@@ -181,9 +184,10 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
       setAdminAccess('checking');
       return;
     }
-    setSecure(api.highSecurity);
+    const flag = api.highSecurity;
+    setSecure(flag === false ? false : true);
     void loadGatewayTools();
-    if (api.highSecurity) {
+    if (flag !== false) {
       setAdminAccess('checking');
       void probeAccess();
     }
@@ -198,9 +202,14 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
 
   const applyAdminKey = async () => {
     api.setSessionAdminApiKey(adminKeyDraft);
-    setAdminKeyNotice(adminKeyDraft.trim() ? 'Admin key applied for this app session.' : '');
+    setAdminKeyNotice('');
     setAdminAccess('checking');
-    await probeAccess();
+    const outcome = await probeAccess();
+    if (outcome === 'ok') {
+      setAdminKeyNotice('Admin key applied for this app session.');
+    } else if (outcome === 'needs-admin') {
+      setHostError('Admin API key was rejected.');
+    }
   };
 
   const runServerAction = async (id: string, action: 'connect' | 'disconnect' | 'refresh' | 'remove') => {
@@ -317,6 +326,13 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
                 Please set the respective environment variable in your Lemonade Server launch script, then restart the
                 server to use this feature.
               </p>
+            </div>
+          ) : adminAccess === 'unavailable' ? (
+            <div className="connect__notice mcp-panel__host-unavailable" role="alert" data-mcp-host-unavailable>
+              <p>{hostError || 'MCP administration is currently unavailable.'}</p>
+              <button type="button" className="btn btn--ghost" onClick={() => void probeAccess()} disabled={connectionStatus !== 'connected' || hostLoading}>
+                {hostLoading ? 'Retrying…' : 'Retry'}
+              </button>
             </div>
           ) : adminAccess === 'needs-admin' ? (
             <div className="mcp-panel__admin-auth" data-mcp-admin-auth>

--- a/src/app/src/components/McpPanel.tsx
+++ b/src/app/src/components/McpPanel.tsx
@@ -87,6 +87,8 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
   const [servers, setServers] = useState<McpServerState[]>([]);
   const [hostError, setHostError] = useState('');
   const [hostLoading, setHostLoading] = useState(false);
+  const [secure, setSecure] = useState<boolean | null>(null);
+  const [adminAccess, setAdminAccess] = useState<'checking' | 'ok' | 'needs-admin'>('checking');
   const [adminKeyDraft, setAdminKeyDraft] = useState(() => api.explicitAdminApiKey);
   const [adminKeyNotice, setAdminKeyNotice] = useState('');
   const [busyId, setBusyId] = useState('');
@@ -150,21 +152,23 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
     }
   }, [mcpUrl]);
 
-  const loadServers = useCallback(async () => {
+  const probeAccess = useCallback(async () => {
     setHostLoading(true);
     setHostError('');
-    try {
-      if (!api.adminApiKey) {
-        setServers([]);
-        setHostError('External MCP server administration requires LEMONADE_ADMIN_API_KEY or LEMONADE_API_KEY. Enter the matching key below to manage external servers.');
-        return;
+    const result = await api.probeMcpAccess();
+    if (result.ok) {
+      setServers(result.servers);
+      setAdminAccess('ok');
+    } else {
+      setServers([]);
+      setAdminAccess('needs-admin');
+      if (result.status !== 401 && result.status !== 403) {
+        setHostError(result.status
+          ? `Could not reach MCP administration (HTTP ${result.status}).`
+          : 'Could not reach MCP administration.');
       }
-      setServers(await api.listMcpServers());
-    } catch (error) {
-      setHostError(friendlyErrorMessage(error));
-    } finally {
-      setHostLoading(false);
     }
+    setHostLoading(false);
   }, []);
 
   useEffect(() => {
@@ -173,11 +177,18 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
       setGatewayStatus('idle');
       setGatewayTools([]);
       setServers([]);
+      setSecure(null);
+      setAdminAccess('checking');
       return;
     }
-    void loadGatewayTools().then(loadServers);
+    setSecure(api.highSecurity);
+    void loadGatewayTools();
+    if (api.highSecurity) {
+      setAdminAccess('checking');
+      void probeAccess();
+    }
     return () => abortRef.current?.abort();
-  }, [connectionStatus, isActive, loadGatewayTools, loadServers]);
+  }, [connectionStatus, isActive, loadGatewayTools, probeAccess]);
 
   const gatewayLabel = gatewayStatus === 'connected' ? 'Connected'
     : gatewayStatus === 'checking' ? 'Checking…'
@@ -185,14 +196,11 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
 
   const connectedExternal = useMemo(() => servers.filter(server => server.connected).length, [servers]);
 
-  const applyAdminKey = async (useApiKey = false) => {
-    const next = useApiKey ? '' : adminKeyDraft;
-    api.setSessionAdminApiKey(next);
-    if (useApiKey) setAdminKeyDraft('');
-    setAdminKeyNotice(next.trim()
-      ? 'Admin key applied for this app session.'
-      : 'Using the regular API key for MCP administration.');
-    await loadServers();
+  const applyAdminKey = async () => {
+    api.setSessionAdminApiKey(adminKeyDraft);
+    setAdminKeyNotice(adminKeyDraft.trim() ? 'Admin key applied for this app session.' : '');
+    setAdminAccess('checking');
+    await probeAccess();
   };
 
   const runServerAction = async (id: string, action: 'connect' | 'disconnect' | 'refresh' | 'remove') => {
@@ -203,7 +211,7 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
       else if (action === 'disconnect') await api.disconnectMcpServer(id);
       else if (action === 'refresh') await api.refreshMcpServerTools(id);
       else await api.removeMcpServer(id);
-      await loadServers();
+      await probeAccess();
     } catch (error) {
       setHostError(friendlyErrorMessage(error));
     } finally {
@@ -231,7 +239,7 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
         enabled: true,
       });
       await api.connectMcpServer(saved.id);
-      await loadServers();
+      await probeAccess();
       setDraft(EMPTY_DRAFT);
       setShowForm(false);
     } catch (error) {
@@ -286,42 +294,53 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
               <h3 id="external-mcp-title">External MCP servers</h3>
               <p>{connectedExternal}/{servers.length} connected · stdio transport · select up to four per preset.</p>
             </div>
-            <button
-              type="button"
-              className="btn btn--primary"
-              onClick={() => { setDraft(EMPTY_DRAFT); setFormError(''); setShowForm(value => !value); }}
-              disabled={connectionStatus !== 'connected' || !api.adminApiKey}
-              title={!api.adminApiKey ? 'Apply an admin-capable API key before adding an external MCP server' : undefined}
-            >
-              {showForm ? 'Cancel' : 'Add server'}
-            </button>
+            {secure === true && adminAccess === 'ok' && (
+              <button
+                type="button"
+                className="btn btn--primary"
+                onClick={() => { setDraft(EMPTY_DRAFT); setFormError(''); setShowForm(value => !value); }}
+                disabled={connectionStatus !== 'connected'}
+              >
+                {showForm ? 'Cancel' : 'Add server'}
+              </button>
+            )}
           </div>
 
-          <div className="mcp-panel__admin-auth" data-mcp-admin-auth>
-            <div>
-              <label htmlFor="mcp-admin-key">Admin API key</label>
-              <p>Required for <code>/internal/mcp/*</code>. Empty means “use the regular API key”. This client field does not configure the lemond process.</p>
+          {secure === null || (secure === true && adminAccess === 'checking') ? (
+            <p className="connect__empty">Checking MCP administration access…</p>
+          ) : secure === false ? (
+            <div className="connect__notice mcp-panel__security-warning" role="note" data-mcp-security-warning>
+              <p><strong>External MCP servers are unavailable on this server.</strong></p>
+              <p>
+                Due to security constraints, using external MCP servers requires your server to be set up with either a
+                general API key (<code>LEMONADE_API_KEY</code>) or a dedicated admin API key (<code>LEMONADE_ADMIN_API_KEY</code>).
+                Please set the respective environment variable in your Lemonade Server launch script, then restart the
+                server to use this feature.
+              </p>
             </div>
-            <div className="mcp-panel__admin-auth-controls">
-              <input
-                id="mcp-admin-key"
-                type="password"
-                autoComplete="off"
-                value={adminKeyDraft}
-                onChange={event => setAdminKeyDraft(event.target.value)}
-                onKeyDown={event => { if (event.key === 'Enter') { event.preventDefault(); void applyAdminKey(false); } }}
-                placeholder="Uses API key when empty"
-                aria-describedby="mcp-admin-key-help"
-              />
-              <button type="button" className="btn btn--primary" onClick={() => void applyAdminKey(false)} disabled={connectionStatus !== 'connected' || hostLoading}>Apply</button>
-              <button type="button" className="btn btn--ghost" onClick={() => void applyAdminKey(true)} disabled={connectionStatus !== 'connected' || hostLoading}>Use API key</button>
+          ) : adminAccess === 'needs-admin' ? (
+            <div className="mcp-panel__admin-auth" data-mcp-admin-auth>
+              <div>
+                <label htmlFor="mcp-admin-key">Admin API key</label>
+                <p>Server requires admin API key to access external MCP feature setup.</p>
+              </div>
+              <div className="mcp-panel__admin-auth-controls">
+                <input
+                  id="mcp-admin-key"
+                  type="password"
+                  autoComplete="off"
+                  value={adminKeyDraft}
+                  onChange={event => setAdminKeyDraft(event.target.value)}
+                  onKeyDown={event => { if (event.key === 'Enter') { event.preventDefault(); void applyAdminKey(); } }}
+                  placeholder="Admin API key"
+                />
+                <button type="button" className="btn btn--primary" onClick={() => void applyAdminKey()} disabled={connectionStatus !== 'connected' || hostLoading || !adminKeyDraft.trim()}>Apply</button>
+              </div>
+              {adminKeyNotice && <div className="connect__notice" role="status">{adminKeyNotice}</div>}
+              {hostError && <div className="connect__error" role="alert">{hostError}</div>}
             </div>
-            <p id="mcp-admin-key-help" className="mcp-server-form__note">
-              Server side: set <code>LEMONADE_ADMIN_API_KEY</code> (or <code>LEMONADE_API_KEY</code>) before starting lemond, then restart it.
-            </p>
-            {adminKeyNotice && <div className="connect__notice" role="status">{adminKeyNotice}</div>}
-          </div>
-
+          ) : (
+            <>
           {showForm && (
             <form className="mcp-server-form" onSubmit={saveServer}>
               <label><span>Name</span><input value={draft.name} onChange={event => setDraft(current => ({ ...current, name: event.target.value }))} placeholder="Filesystem" /></label>
@@ -338,7 +357,7 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
 
           {hostError && <div className="connect__error" role="alert">{hostError}</div>}
           {hostLoading ? <p className="connect__empty">Loading MCP servers…</p> : servers.length === 0 ? (
-            <p className="connect__empty">{hostError ? 'External MCP server list is unavailable. Fix or change the admin key above; preset MCP controls remain editable.' : 'No external MCP server configured. Lemon-Tools MCP remains available in presets.'}</p>
+            <p className="connect__empty">No external MCP server configured. Lemon-Tools MCP remains available in presets.</p>
           ) : (
             <div className="mcp-server-list">
               {servers.map(server => (
@@ -362,6 +381,8 @@ const McpPanel: React.FC<McpPanelProps> = ({ connectionStatus, isActive }) => {
                 </article>
               ))}
             </div>
+          )}
+            </>
           )}
         </section>
       </div>

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -14452,7 +14452,9 @@ button.detail-presets__explanation-step {
 .mcp-panel__admin-auth > div:first-child { display: grid; gap: 3px; }
 .mcp-panel__admin-auth label { color: var(--text-primary); font-weight: 600; }
 .mcp-panel__admin-auth p { margin: 0; color: var(--text-secondary); font-size: var(--text-sm); line-height: 1.45; }
-.mcp-panel__admin-auth-controls { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; gap: var(--space-2); align-items: center; }
+.mcp-panel__admin-auth-controls { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: var(--space-2); align-items: center; }
+.mcp-panel__host-unavailable { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: var(--space-2); }
+.mcp-panel__host-unavailable p { margin: 0; }
 .mcp-panel__admin-auth-controls input { width: 100%; min-width: 0; box-sizing: border-box; padding: 8px 10px; border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); background: var(--surface-1); color: var(--text-primary); font: inherit; }
 .mcp-panel__status-dot.is-connected { background: var(--color-success, #3fb950); }
 .mcp-server-list { display: grid; gap: var(--space-2); }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -2296,6 +2296,8 @@ void Server::handle_health(const httplib::Request& req, httplib::Response& res) 
         response["telemetry"] = telemetry_info;
     }
 
+    response["high_security"] = !admin_api_key_.empty();
+
     // Add model loaded information like Python implementation
     std::string loaded_model = router_->get_loaded_model();
 


### PR DESCRIPTION
This change adds two things:

* auto detects when the server isn't configured with secure access (neither LEMONADE_API_KEY nor  LEMONADE_ADMIN_API_KEY set) and disables the configuration of MCP servers alltogether with a message explaining the proper configuration
* only displays the needed "Admin API key" window when the Admin API key is actually required
