### PR TITLE
fix(ui): parse telemetry thinking blocks, collapse reasoning cards, and constrain panel heights

### DIFF
--- a/src/app/src/components/inspect/MessagesTab.tsx
+++ b/src/app/src/components/inspect/MessagesTab.tsx
@@ -9,14 +9,133 @@ interface MessagesTabProps {
   handleCopyFull: (text: string, label: string) => void;
 }
 
+interface MessageCardProps {
+  m: Trace['messages'][number];
+  idx: number;
+  formatTokens: (num: number) => string;
+  handleCopyFull: (text: string, label: string) => void;
+}
+
+function stripLeadingThinking(content: string): string {
+  const match = /^\s*<think>[\s\S]*?<\/think>([\s\S]*)/.exec(content);
+  return match ? match[1].trim() : content;
+}
+
+function MessageCard({ m, idx, formatTokens, handleCopyFull }: MessageCardProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [cardRenderMode, setCardRenderMode] = useState<'rendered' | 'raw'>('raw');
+  const [thinkingCollapsed, setThinkingCollapsed] = useState(true);
+
+  return (
+    <div className={`message-card ${isCollapsed ? 'collapsed' : ''}`}>
+      <div className="message-card__header">
+        <button
+          type="button"
+          className="message-card__header-toggle"
+          aria-expanded={!isCollapsed}
+          onClick={() => setIsCollapsed(!isCollapsed)}
+        >
+          <span className={`message-card__caret ${isCollapsed ? 'collapsed' : ''}`} aria-hidden="true">
+            <Icon name="chevron-down" size={12} />
+          </span>
+          <span className={`message-card__role ${m.role}`}>
+            {m.role.toUpperCase()}
+          </span>
+          {m.redacted && <span className="redacted-pill">REDACTED</span>}
+          {m.tokens && <span className="tokens-badge">{formatTokens(m.tokens)}</span>}
+        </button>
+
+        {!isCollapsed && (
+          <div className="message-card__toggle-segmented toolbar-segmented">
+            <button
+              type="button"
+              className={cardRenderMode === 'rendered' ? 'active' : ''}
+              onClick={() => setCardRenderMode('rendered')}
+            >
+              Rendered
+            </button>
+            <button
+              type="button"
+              className={cardRenderMode === 'raw' ? 'active' : ''}
+              onClick={() => setCardRenderMode('raw')}
+            >
+              Raw
+            </button>
+          </div>
+        )}
+
+        <button
+          type="button"
+          className="message-card__copy-btn"
+          onClick={() => {
+            handleCopyFull(m.content, 'Message text');
+          }}
+          title="Copy message text"
+          aria-label={`Copy message ${idx + 1} (${m.role}) content`}
+        >
+          <Icon name="copy" size={13} />
+        </button>
+      </div>
+
+      {!isCollapsed && (
+        <div className="message-card__body">
+          {cardRenderMode === 'rendered' ? (
+            <div className="fade-in">
+              <MarkdownMessage content={m.thinking ? stripLeadingThinking(m.content) : m.content} />
+            </div>
+          ) : (
+            <pre className="raw-text-body fade-in">{m.content}</pre>
+          )}
+
+          {m.thinking && (
+            <div className="reasoning-block">
+              <button
+                type="button"
+                className="reasoning-block__header"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--space-1)',
+                  background: 'none',
+                  border: 'none',
+                  padding: 0,
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  textAlign: 'left',
+                  width: '100%',
+                  outline: 'none'
+                }}
+                onClick={() => setThinkingCollapsed(!thinkingCollapsed)}
+                aria-expanded={!thinkingCollapsed}
+              >
+                <span style={{
+                  display: 'inline-flex',
+                  transform: thinkingCollapsed ? 'rotate(-90deg)' : 'none',
+                  transition: 'transform 0.15s ease'
+                }}>
+                  <Icon name="chevron-down" size={10} />
+                </span>
+                <span>Reasoning Output</span>
+              </button>
+              {!thinkingCollapsed && (
+                <div className="reasoning-block__body fade-in" style={{ marginTop: 'var(--space-2)' }}>
+                  {m.thinking}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function MessagesTab({
   selectedTrace,
   formatTokens,
   handleCopyFull
 }: MessagesTabProps) {
-  // Default to Raw (renderMarkdown = false) for secure-by-default posture on telemetry
-  const [renderMarkdown, setRenderMarkdown] = useState(false);
-  const [collapsedMessages, setCollapsedMessages] = useState<Record<number, boolean>>({});
+  const [viewMode, setViewMode] = useState<'rendered' | 'raw'>('rendered');
   const [copyDropdownOpen, setCopyDropdownOpen] = useState(false);
   const [copyFormat, setCopyFormat] = useState<'messages' | 'openinference'>('messages');
 
@@ -25,11 +144,21 @@ export default function MessagesTab({
     setCopyDropdownOpen(false);
 
     if (format === 'messages') {
-      const payload = selectedTrace.messages.map((m) => ({ role: m.role, content: m.content }));
+      const payload = selectedTrace.messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+        ...(m.thinking ? { thinking: m.thinking } : {})
+      }));
       handleCopyFull(JSON.stringify(payload, null, 2), 'Messages JSON');
     } else {
       const payload = {
-        input: { value: selectedTrace.messages.map((m) => ({ role: m.role, content: m.content })) },
+        input: {
+          value: selectedTrace.messages.map((m) => ({
+            role: m.role,
+            content: m.content,
+            ...(m.thinking ? { thinking: m.thinking } : {})
+          }))
+        },
         llm: {
           model_name: selectedTrace.model,
           usage: {
@@ -45,24 +174,24 @@ export default function MessagesTab({
   };
 
   return (
-    <div id="panel-messages" role="tabpanel" aria-labelledby="tab-messages" className="tab-pane fade-in flex-col gap-12">
+    <div id="panel-messages" role="tabpanel" aria-labelledby="tab-messages" className="tab-pane fade-in flex-col gap-12" style={{ height: '100%' }}>
       <div className="messages-toolbar">
         <div className="messages-toolbar__left">
           <span className="messages-toolbar__title">CONVERSATION</span>
           <div className="toolbar-segmented">
             <button
               type="button"
-              aria-pressed={renderMarkdown}
-              className={renderMarkdown ? 'active' : ''}
-              onClick={() => setRenderMarkdown(true)}
+              aria-pressed={viewMode === 'rendered'}
+              className={viewMode === 'rendered' ? 'active' : ''}
+              onClick={() => setViewMode('rendered')}
             >
               Rendered
             </button>
             <button
               type="button"
-              aria-pressed={!renderMarkdown}
-              className={!renderMarkdown ? 'active' : ''}
-              onClick={() => setRenderMarkdown(false)}
+              aria-pressed={viewMode === 'raw'}
+              className={viewMode === 'raw' ? 'active' : ''}
+              onClick={() => setViewMode('raw')}
             >
               Raw
             </button>
@@ -109,67 +238,49 @@ export default function MessagesTab({
         </div>
       </div>
 
-      <div className="messages-list">
-        {selectedTrace.messages.map((m, idx) => {
-          const isCollapsed = !!collapsedMessages[idx];
-          return (
-            <div key={idx} className={`message-card ${isCollapsed ? 'collapsed' : ''}`}>
-              <div className="message-card__header">
-                <button
-                  type="button"
-                  className="message-card__header-toggle"
-                  aria-expanded={!isCollapsed}
-                  onClick={() => {
-                    setCollapsedMessages((prev) => ({
-                      ...prev,
-                      [idx]: !prev[idx],
-                    }));
-                  }}
-                >
-                  <span className={`message-card__caret ${isCollapsed ? 'collapsed' : ''}`} aria-hidden="true">
-                    <Icon name="chevron-down" size={12} />
-                  </span>
-                  <span className={`message-card__role ${m.role}`}>
-                    {m.role.toUpperCase()}
-                  </span>
-                  {m.redacted && <span className="redacted-pill">REDACTED</span>}
-                  {m.tokens && <span className="tokens-badge">{formatTokens(m.tokens)}</span>}
-                </button>
-                <button
-                  type="button"
-                  className="message-card__copy-btn"
-                  onClick={() => {
-                    handleCopyFull(m.content, 'Message text');
-                  }}
-                  title="Copy message text"
-                  aria-label={`Copy message ${idx + 1} (${m.role}) content`}
-                >
-                  <Icon name="copy" size={13} />
-                </button>
-              </div>
-
-              {!isCollapsed && (
-                <div className="message-card__body">
-                  {renderMarkdown ? (
-                    <div className="fade-in">
-                      <MarkdownMessage content={m.content} />
-                    </div>
-                  ) : (
-                    <pre className="raw-text-body fade-in">{m.content}</pre>
-                  )}
-
-                  {m.thinking && (
-                    <div className="reasoning-block">
-                      <div className="reasoning-block__header">Reasoning Output</div>
-                      <div className="reasoning-block__body">{m.thinking}</div>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
+      {viewMode === 'rendered' ? (
+        <div className="messages-list">
+          {selectedTrace.messages.map((m, idx) => (
+            <MessageCard
+              key={`${selectedTrace.id}:${idx}`}
+              m={m}
+              idx={idx}
+              formatTokens={formatTokens}
+              handleCopyFull={handleCopyFull}
+            />
+          ))}
+        </div>
+      ) : (
+        <pre
+          className="raw-text-body fade-in"
+          style={{
+            padding: 'var(--space-4)',
+            background: 'var(--surface-1)',
+            border: '1px solid var(--border-subtle)',
+            borderRadius: 'var(--radius-lg)',
+            overflow: 'auto',
+            fontFamily: 'monospace',
+            fontSize: 'var(--text-sm)',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+            margin: 0,
+            flexGrow: 1
+          }}
+        >
+          <code>
+            {JSON.stringify(
+              selectedTrace.messages.map(m => ({
+                role: m.role,
+                content: m.content,
+                ...(m.thinking ? { thinking: m.thinking } : {}),
+                ...(m.tokens ? { tokens: m.tokens } : {})
+              })),
+              null,
+              2
+            )}
+          </code>
+        </pre>
+      )}
     </div>
   );
 }

--- a/src/app/src/inspectStore.ts
+++ b/src/app/src/inspectStore.ts
@@ -517,6 +517,12 @@ export function useInspectStore() {
   return state;
 }
 
+// Helper to extract thinking blocks (leading <think>...</think> only)
+function extractThinking(rawContent: string): string | undefined {
+  const thinkMatch = /^\s*<think>([\s\S]*?)<\/think>/.exec(rawContent);
+  return thinkMatch ? thinkMatch[1].trim() : undefined;
+}
+
 // OTEL attribute parser helper
 function parseOtelSpan(span: OtelSpan): Trace | null {
   if (!span || !span.traceId) return null;
@@ -553,13 +559,22 @@ function parseOtelSpan(span: OtelSpan): Trace | null {
   // Search for message array in attributes (support OpenInference & OTel GenAI)
   let i = 0;
   while (true) {
-    const role = attrs[`llm.input_messages.${i}.message.role`] || attrs[`gen_ai.input.messages.${i}.role`] || attrs[`llm.input_messages.${i}.role`];
-    const content = attrs[`llm.input_messages.${i}.message.content`] || attrs[`gen_ai.input.messages.${i}.content`] || attrs[`llm.input_messages.${i}.content`];
+    const roleRaw = attrs[`llm.input_messages.${i}.message.role`] || attrs[`gen_ai.input.messages.${i}.role`] || attrs[`llm.input_messages.${i}.role`];
+    const contentRaw = attrs[`llm.input_messages.${i}.message.content`] || attrs[`gen_ai.input.messages.${i}.content`] || attrs[`llm.input_messages.${i}.content`];
 
-    if (role === undefined && content === undefined) {
+    if (roleRaw === undefined && contentRaw === undefined) {
       break;
     }
-    messages.push({ role: (role === 'system' || role === 'assistant' ? role : 'user'), content: String(content || '') });
+
+    const role = (roleRaw === 'system' || roleRaw === 'assistant') ? roleRaw : 'user';
+    const content = String(contentRaw || '');
+    let thinking: string | undefined;
+
+    if (role === 'assistant') {
+      thinking = extractThinking(content);
+    }
+
+    messages.push({ role, content, thinking });
     i++;
   }
 
@@ -631,15 +646,8 @@ function parseOtelSpan(span: OtelSpan): Trace | null {
 
   // Extract thinking/reasoning if present (like <think> blocks)
   if (kind === 'LLM' && output && typeof output === 'string') {
-    const thinkMatch = /<think>([\s\S]*?)<\/think>([\s\S]*)/.exec(output);
-    if (thinkMatch) {
-      // Create assistant message with thinking
-      const thinking = thinkMatch[1].trim();
-      const content = thinkMatch[2].trim();
-      messages.push({ role: 'assistant', content, thinking });
-    } else {
-      messages.push({ role: 'assistant', content: output });
-    }
+    const thinking = extractThinking(output);
+    messages.push({ role: 'assistant', content: output, thinking });
   } else if (kind === 'LLM' && output) {
     messages.push({ role: 'assistant', content: String(output) });
   }

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -11226,6 +11226,7 @@ button.detail-presets__explanation-step {
 .inspect-layout {
   display: grid;
   grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+  grid-template-rows: 100%;
   height: 100%;
   width: 100%;
   background: var(--surface-0);
@@ -14922,3 +14923,19 @@ button.detail-presets__explanation-step {
   .global-settings-card__head > span { text-align: left; }
   .global-model-settings__footer > div { display: grid; grid-template-columns: 1fr 1fr; }
 }
+
+/* message-card toggler cleanroom styles */
+.message-card__toggle-segmented {
+  display: inline-flex !important;
+  padding: 1px !important;
+  background: var(--surface-3) !important;
+  border: 1px solid var(--border-subtle) !important;
+  margin-right: 8px !important;
+}
+
+.message-card__toggle-segmented button {
+  font-size: 10px !important;
+  padding: 2px 6px !important;
+  font-weight: var(--weight-semibold) !important;
+}
+

--- a/src/app/tests/inspect-interactions.spec.ts
+++ b/src/app/tests/inspect-interactions.spec.ts
@@ -370,4 +370,212 @@ test.describe('Session Inspector - Recent Improvements', () => {
     // Confirm no errors were thrown
     expect(errors).toHaveLength(0);
   });
+
+  test('Telemetry Thinking Parser, Collapse, Copy, and Scroll Constraints', async ({ page, context }) => {
+    // Grant clipboard permissions for copy assertion
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    // Setup WebSocket Mock in this test
+    await page.addInitScript(() => {
+      const instances: any[] = [];
+      class MockWebSocket {
+        static CONNECTING = 0;
+        static OPEN = 1;
+        static CLOSING = 2;
+        static CLOSED = 3;
+
+        url: string;
+        readyState: number;
+        onopen: any = null;
+        onclose: any = null;
+        onmessage: any = null;
+        onerror: any = null;
+
+        constructor(url: string) {
+          this.url = url;
+          this.readyState = MockWebSocket.CONNECTING;
+          instances.push(this);
+
+          setTimeout(() => {
+            if (this.readyState === MockWebSocket.CONNECTING) {
+              this.readyState = MockWebSocket.OPEN;
+              if (this.onopen) this.onopen();
+            }
+          }, 10);
+        }
+
+        send(data: string) {}
+        close() {
+          if (this.readyState !== MockWebSocket.CLOSED) {
+            this.readyState = MockWebSocket.CLOSED;
+            if (this.onclose) this.onclose();
+          }
+        }
+      }
+      (window as any).wsInstances = instances;
+      (window as any).WebSocket = MockWebSocket as any;
+    });
+
+    // 1. Navigate to the inspect view
+    await page.goto('/#/inspect');
+    await expect(page.locator('.inspect-rail')).toBeVisible();
+
+    // Make sure capturing is set to true on store
+    await page.evaluate(() => {
+      (window as any).inspectStore.setState({ capturing: true });
+    });
+    await page.waitForTimeout(200);
+
+    // 2. Push raw OTel span containing leading <think> tags and nested <think> blocks
+    await page.evaluate(() => {
+      const rawContent = `<think>
+This is the leading thinking block.
+</think>
+Here is how you do it:
+\`\`\`xml
+<think>
+literal inside code
+</think>
+\`\`\`
+Followed by some normal text.`;
+
+      const instances = (window as any).wsInstances;
+      const ws = instances[instances.length - 1];
+      if (ws && ws.onmessage) {
+        ws.onmessage({
+          data: JSON.stringify({
+            traceId: 'trace-thinking-spec-123',
+            spanId: 'span-thinking-spec-123',
+            startTimeUnixNano: '1720311234000000000',
+            endTimeUnixNano: '1720311235000000000',
+            attributes: [
+              { key: 'openinference.span.kind', value: { stringValue: 'LLM' } },
+              { key: 'llm.model_name', value: { stringValue: 'mock-model-thinking-spec' } },
+              { key: 'llm.input_messages.0.message.role', value: { stringValue: 'system' } },
+              { key: 'llm.input_messages.0.message.content', value: { stringValue: 'You are a helpful assistant.' } },
+              { key: 'llm.input_messages.1.message.role', value: { stringValue: 'user' } },
+              { key: 'llm.input_messages.1.message.content', value: { stringValue: 'How do you represent literal <think> in XML?' } },
+              { key: 'output.value', value: { stringValue: rawContent } }
+            ]
+          })
+        });
+      }
+    });
+
+    await page.waitForTimeout(500);
+
+    // Push Trace B (second trace to verify render state is not shared/reused)
+    await page.evaluate(() => {
+      const instances = (window as any).wsInstances;
+      const ws = instances[instances.length - 1];
+      if (ws && ws.onmessage) {
+        ws.onmessage({
+          data: JSON.stringify({
+            traceId: 'trace-thinking-spec-abc',
+            spanId: 'span-thinking-spec-abc',
+            startTimeUnixNano: '1720311244000000000',
+            endTimeUnixNano: '1720311245000000000',
+            attributes: [
+              { key: 'openinference.span.kind', value: { stringValue: 'LLM' } },
+              { key: 'llm.model_name', value: { stringValue: 'mock-model-thinking-spec' } },
+              { key: 'input.value', value: { stringValue: 'Second Trace Prompt' } },
+              { key: 'output.value', value: { stringValue: 'Second Trace Output content.' } }
+            ]
+          })
+        });
+      }
+    });
+
+    await page.waitForTimeout(500);
+
+    // Select the first trace
+    await page.locator('.trace-row').last().click(); // newest is first, so trace 1 is last
+    await page.waitForTimeout(200);
+
+    // Click on the Messages tab
+    const messagesTabButton = page.locator('button[role="tab"]:has-text("Messages")');
+    await expect(messagesTabButton).toBeVisible();
+    await messagesTabButton.click();
+    await page.waitForTimeout(200);
+
+    // A. Verify Secure-by-Default card posture: Card defaults to Raw, while global is Rendered
+    const globalRenderedBtn = page.locator('.messages-toolbar__left button:has-text("Rendered")');
+    await expect(globalRenderedBtn).toHaveAttribute('aria-pressed', 'true');
+
+    const assistantCard = page.locator('.message-card').last();
+    const cardToggleSegmented = assistantCard.locator('.message-card__toggle-segmented');
+    await expect(cardToggleSegmented.locator('button:has-text("Raw")')).toHaveClass(/active/);
+    await expect(assistantCard.locator('pre.raw-text-body')).toBeVisible();
+
+    // B. Verify strict parsing doesn't strip literal <think> inside code blocks
+    const rawContentText = await assistantCard.locator('pre.raw-text-body').innerText();
+    expect(rawContentText).toContain('<think>\nThis is the leading thinking block.\n</think>');
+    expect(rawContentText).toContain('<think>\nliteral inside code\n</think>');
+
+    // C. Click "Rendered" on the card to check collapsible reasoning blocks
+    await cardToggleSegmented.locator('button:has-text("Rendered")').click();
+    await page.waitForTimeout(200);
+
+    // Verification of collapsible reasoning header (aria-expanded = false by default)
+    const reasoningHeader = assistantCard.locator('.reasoning-block__header');
+    await expect(reasoningHeader).toBeVisible();
+    await expect(reasoningHeader).toHaveAttribute('aria-expanded', 'false');
+
+    const reasoningBody = assistantCard.locator('.reasoning-block__body');
+    await expect(reasoningBody).not.toBeVisible();
+
+    // Toggle reasoning open
+    await reasoningHeader.click();
+    await page.waitForTimeout(100);
+    await expect(reasoningHeader).toHaveAttribute('aria-expanded', 'true');
+    await expect(reasoningBody).toBeVisible();
+    await expect(reasoningBody).toHaveText('This is the leading thinking block.');
+
+    // Body text in Rendered view mode should NOT show the leading thinking block, but MUST retain the literal code block think tag
+    const renderedBody = assistantCard.locator('.message-card__body .fade-in').first();
+    await expect(renderedBody).toBeVisible();
+    const renderedText = await renderedBody.innerText();
+    expect(renderedText).not.toContain('This is the leading thinking block.');
+    expect(renderedText).toContain('<think>\nliteral inside code\n</think>');
+
+    // E. Verify copy/export functionality includes raw unstripped content & explicit thinking
+    const copyButton = page.locator('.split-button__action');
+    await expect(copyButton).toBeVisible();
+    await copyButton.click();
+    await page.waitForTimeout(100);
+
+    // Read clipboard content in browser context
+    const clipboardText = await page.evaluate(async () => navigator.clipboard.readText());
+    const parsedClipboard = JSON.parse(clipboardText);
+    expect(parsedClipboard).toHaveLength(3);
+    expect(parsedClipboard[2].role).toBe('assistant');
+    // Ensure raw unstripped content is exported
+    expect(parsedClipboard[2].content).toContain('<think>\nThis is the leading thinking block.\n</think>');
+    // Ensure thinking property is explicitly exported
+    expect(parsedClipboard[2].thinking).toBe('This is the leading thinking block.');
+
+    // F. REGRESSION TEST: Select the second trace and verify that the card rendering state resets to default 'raw'
+    await page.locator('.trace-row').first().click(); // Trace B is the first row
+    await page.waitForTimeout(200);
+
+    // Click on the Messages tab again (as changing selectedTraceId resets activeTab to 'overview')
+    await page.locator('button[role="tab"]:has-text("Messages")').click();
+    await page.waitForTimeout(200);
+
+    // Card in Trace B should default back to Raw
+    const assistantCardB = page.locator('.message-card').last();
+    const cardToggleSegmentedB = assistantCardB.locator('.message-card__toggle-segmented');
+    await expect(cardToggleSegmentedB.locator('button:has-text("Raw")')).toHaveClass(/active/);
+    await expect(assistantCardB.locator('pre.raw-text-body')).toBeVisible();
+
+    // D. Verify height constraints on the layout
+    const vcHeight = await page.locator('.view-container').evaluate(el => el.getBoundingClientRect().height);
+    const layoutHeight = await page.locator('.inspect-layout').evaluate(el => el.getBoundingClientRect().height);
+    const railHeight = await page.locator('.inspect-rail').evaluate(el => el.getBoundingClientRect().height);
+    const detailHeight = await page.locator('.inspect-detail').evaluate(el => el.getBoundingClientRect().height);
+
+    expect(layoutHeight).toBeLessThanOrEqual(vcHeight + 2);
+    expect(railHeight).toBeLessThanOrEqual(vcHeight + 2);
+    expect(detailHeight).toBeLessThanOrEqual(vcHeight + 2);
+  });
 });


### PR DESCRIPTION
This PR resolves telemetry visualization and layout scrolling issues in the `GUI3_merging` beta branch:
- **Collapsible Reasoning Blocks**: Extracts `<think>...</think>` blocks from assistant messages and renders them inside custom collapsible `Reasoning Output` elements. They default to collapsed to optimize display space and can be toggled via header buttons.
- **Card-level Toggles & React Performance**: Moves the Rendered/Raw toggles to run locally on a per-card basis inside a `<MessageCard>` sub-component. This localizes state and prevents list-wide layout updates in React 19. The top-level "Raw" tab now renders the complete conversation history as a single unrendered JSON block.
- **Scrolling Height Constraint**: Locks `.inspect-layout` column heights on desktop to 100% of the viewport container, forcing the main detail cards inside `.inspect-detail__body` to trigger scrollbars internally instead of stretching the parent container and pushing the search rail's footer buttons off-screen.

<img width="2880" height="1604" alt="image" src="https://github.com/user-attachments/assets/2e83741b-7dc4-40ae-82c7-378a5e9dc82f" />
<img width="2880" height="1604" alt="image" src="https://github.com/user-attachments/assets/d5abb6b7-2ec5-4a0d-b647-1d0cf1d43730" />
<img width="2880" height="1604" alt="image" src="https://github.com/user-attachments/assets/ca06bd9b-5936-485a-89cf-79db2f9851be" />
