### PR TITLE
fix: detect Arch ggml HIP plugin paths

### DIFF
--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -747,8 +747,10 @@ bool is_ggml_hip_plugin_available() {
     std::vector<std::string> possible_paths = {
         // Debian/Ubuntu multiarch path (most common)
         "/usr/lib/x86_64-linux-gnu/ggml/backends0/libggml-hip.so",
-	// Arch AUR path
-	"/usr/lib/libggml-hip.so",
+        // Arch package paths
+        "/usr/lib/libggml-hip.so",
+        "/usr/lib/ggml/libggml-hip.so",
+        "/usr/lib64/ggml/libggml-hip.so",
         // Standard Linux paths
         "/usr/lib/ggml/backends0/libggml-hip.so",
         "/usr/lib64/ggml/backends0/libggml-hip.so"


### PR DESCRIPTION
Fixes #2747

Add the Arch `ggml` plugin paths to the Linux HIP-plugin probe. This lets the system llama.cpp backend detect the official Arch package layout without requiring `LEMONADE_GGML_HIP_PATH`.

Validation:

- `git diff --check`
- Verified both Arch paths are present in `possible_paths` with a focused Python assertion.

The full CMake build was not run locally: the default preset requires Ninja, which is not installed, and the direct compilation check cannot find the project's fetched `nlohmann/json.hpp` dependency before configuration completes.
