### PR TITLE
feat: add jobs for all operations besides chat completion to the job engine

### DIFF
--- a/docs/how-to-add-new-job-ops.md
+++ b/docs/how-to-add-new-job-ops.md
@@ -1,0 +1,137 @@
+# How to add a new op to the jobs endpoint
+
+## Summary
+
+The jobs engine uses a **pluggable op registry**. Adding a new op is additive: you
+declare a handler function, wire it to existing server/backend code via a provider
+lambda, and register it. No changes to the job graph, expression language, HTTP
+routes, or persistence layer are needed.
+
+## Files involved
+
+| File | Role |
+|------|------|
+| `src/cpp/include/lemon/jobs/job_ops.h` | Declares `OpProviders` (function-pointer contract) and `OpRegistry` |
+| `src/cpp/server/jobs/job_ops.cpp` | Implements `build_op_registry()` — the place where ops are **registered** |
+| `src/cpp/server/server.cpp` | Constructs `OpProviders` and passes lambdas that call into Router/backends |
+| `src/cpp/include/lemon/jobs/job_graph.h` | Validates op names at job-creation time against the registry's known set |
+| `src/cpp/include/lemon/jobs/job_types.h` | Defines `StepRecord`, `Job`, `JobError`, status enums |
+| `test/server_jobs.py` | Integration tests for the jobs HTTP API |
+
+## Step-by-step
+
+### 1. Decide if the op needs a provider
+
+If the op only uses data already available in the job `context` or is a pure
+computation (like the built-in `sleep`), you can implement it inline inside
+`build_op_registry()` without adding anything to `OpProviders`.
+
+If the op needs to call into the server's Router, backends, model manager, etc.,
+add a function pointer to `OpProviders` in `job_ops.h`:
+
+```cpp
+// job_ops.h
+struct OpProviders {
+    // ... existing providers ...
+    std::function<json(const json& params, CancelFlag& cancel)> my_new_op;
+};
+```
+
+### 2. Implement the provider lambda in `server.cpp`
+
+Inside `Server::Server()`, locate the `lemon::jobs::OpProviders providers;` block
+(~line 413). Add a lambda that captures `this` (and any other state you need) and
+forwards to the relevant Router/backend path:
+
+```cpp
+providers.my_new_op = [this](const lemon::jobs::json& params,
+                             lemon::jobs::CancelFlag& cancel) -> lemon::jobs::json {
+    // 1. Validate params, throw JobError(status, message) on bad input
+    // 2. Call router_ / backend / model_manager_ etc.
+    // 3. Return arbitrary JSON
+};
+```
+
+**Rules:**
+- Throw `lemon::jobs::JobError(int status, std::string message)` for client-facing
+  failures (e.g. `400` for bad params, `404` for unknown model, `424` for backend
+  failure, `499` for interrupt).
+- Respect the `cancel` flag. Check `cancel.load()` at sensible cancellation points
+  and throw `JobError(499, "interrupted")` if you detect it.
+- The return value is arbitrary JSON; it will be stored under
+  `context[<step id>]` and is available to later steps via `${step_id.field}`.
+
+### 3. Register the op in `build_op_registry()`
+
+In `src/cpp/server/jobs/job_ops.cpp`, add a `reg.register_op(...)` call inside
+`build_op_registry()`:
+
+```cpp
+reg.register_op("my_new_op", {[providers](const json& params, const json& context, CancelFlag& cancel) -> json {
+    if (!providers.my_new_op) throw JobError(501, "my_new_op not available");
+    return providers.my_new_op(params, cancel);
+}, /* exclusive = */ false});
+```
+
+**Exclusive flag:** Set to `true` only if the op touches the model slot (loads,
+unloads, or runs inference on a loaded model). Exclusive ops queue behind the
+Router's exclusive gate; non-exclusive ops run concurrently with normal traffic.
+
+### 4. (Optional) Add tests
+
+In `test/server_jobs.py`, add a test method to `JobEngineTests` that posts a job
+using the new op and asserts on the resulting `context` and step status.
+
+Example pattern:
+
+```python
+def test_my_new_op(self):
+    steps = [
+        {"id": "a", "op": "my_new_op", "params": {"...": "..."}},
+    ]
+    job = self.create_job("my-new-op", steps)
+    done = self.poll_status(job["id"], "completed")
+    self.assertEqual(self.step_by_id(done, "a")["status"], "completed")
+    self.assertIn("expected_key", done["context"]["a"])
+```
+
+## Op handler signature
+
+```cpp
+std::function<json(const json& params, const json& context, CancelFlag& cancel)> run;
+```
+
+- `params` — the step's `params` object with `${refs}` already resolved against
+  the job context.
+- `context` — a snapshot of the full job context *before* this step ran (so the
+  op can read earlier step outputs without consuming them).
+- `cancel` — atomic bool; set to `true` on interrupt/delete. The op should poll
+  it and throw `JobError(499, "interrupted")` when detected.
+
+## Data flow between steps
+
+1. Step `a` runs and returns `{"tps": 42.0, "model": "x"}`.
+2. The engine stores it at `context["a"]`.
+3. If `extract: {"tps": "timings.predicted_per_second"}` is set, it also copies
+   `output.timings.predicted_second` to `context["tps"]`.
+4. Step `b` can reference `${a.tps}`, `${a.model}`, or `${tps}` in its params.
+
+## Existing ops for reference
+
+| Op | Exclusive | Provider location | Notes |
+|----|-----------|-------------------|-------|
+| `system_info` | no | inline in `job_ops.cpp` | Calls `SystemInfoCache` |
+| `system_stats` | no | inline in `job_ops.cpp` | Calls CPU/GPU/VRAM metrics |
+| `models` | no | inline in `job_ops.cpp` | Lists models or returns one by `params.id` |
+| `sleep` | no | inline in `job_ops.cpp` | Cancellable `params.ms` sleep |
+| `load` | yes | lambda in `server.cpp` | Calls `router_->load_model(...)` |
+| `unload` | yes | lambda in `server.cpp` | Calls `router_->unload_model(...)` |
+| `chat` | yes | lambda in `server.cpp` | Calls `router_->chat_completion(...)` |
+
+## Constraints from project notes
+
+- **Purely additive**: do not remove or change the signature of existing ops.
+- **Static linkage**: new server helpers must use static linkage to avoid symbol
+  conflicts.
+- **Omni collections**: if your op touches model loading/unloading, ensure omni
+  collections are skipped so the orchestrator retains its existing logic.

--- a/src/cpp/include/lemon/jobs/job_ops.h
+++ b/src/cpp/include/lemon/jobs/job_ops.h
@@ -45,6 +45,13 @@ struct OpProviders {
     std::function<json(const json& params, CancelFlag& cancel)> unload_op;
     std::function<json(const json& params, CancelFlag& cancel)> chat_op;
 
+    std::function<json(const json& params, CancelFlag& cancel)> image_generations_op;
+    std::function<json(const json& params, CancelFlag& cancel)> image_edits_op;
+    std::function<json(const json& params, CancelFlag& cancel)> image_variations_op;
+    std::function<json(const json& params, CancelFlag& cancel)> audio_speech_op;
+    std::function<json(const json& params, CancelFlag& cancel)> audio_generations_op;
+    std::function<json(const json& params, CancelFlag& cancel)> model_3d_generations_op;
+
     std::function<bool(const std::string& job_id, CancelFlag*)> begin_exclusive;
     std::function<void()> end_exclusive;
     std::function<void(const std::string& job_id)> reconcile_unload;

--- a/src/cpp/server/jobs/job_ops.cpp
+++ b/src/cpp/server/jobs/job_ops.cpp
@@ -75,6 +75,36 @@ OpRegistry build_op_registry(OpProviders providers) {
         return providers.chat_op(params, cancel);
     }, true});
 
+    reg.register_op("image_generations", {[providers](const json& params, const json&, CancelFlag& cancel) -> json {
+        if (!providers.image_generations_op) throw JobError(501, "image_generations op not available");
+        return providers.image_generations_op(params, cancel);
+    }, true});
+
+    reg.register_op("image_edits", {[providers](const json& params, const json&, CancelFlag& cancel) -> json {
+        if (!providers.image_edits_op) throw JobError(501, "image_edits op not available");
+        return providers.image_edits_op(params, cancel);
+    }, true});
+
+    reg.register_op("image_variations", {[providers](const json& params, const json&, CancelFlag& cancel) -> json {
+        if (!providers.image_variations_op) throw JobError(501, "image_variations op not available");
+        return providers.image_variations_op(params, cancel);
+    }, true});
+
+    reg.register_op("audio_speech", {[providers](const json& params, const json&, CancelFlag& cancel) -> json {
+        if (!providers.audio_speech_op) throw JobError(501, "audio_speech op not available");
+        return providers.audio_speech_op(params, cancel);
+    }, true});
+
+    reg.register_op("audio_generations", {[providers](const json& params, const json&, CancelFlag& cancel) -> json {
+        if (!providers.audio_generations_op) throw JobError(501, "audio_generations op not available");
+        return providers.audio_generations_op(params, cancel);
+    }, true});
+
+    reg.register_op("model_3d_generations", {[providers](const json& params, const json&, CancelFlag& cancel) -> json {
+        if (!providers.model_3d_generations_op) throw JobError(501, "model_3d_generations op not available");
+        return providers.model_3d_generations_op(params, cancel);
+    }, true});
+
     reg.begin_exclusive = providers.begin_exclusive;
     reg.end_exclusive = providers.end_exclusive;
     reg.reconcile_unload = providers.reconcile_unload;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -324,6 +324,8 @@ static const json MIME_TYPES = {
     {"pcm",  "audio/l16;rate=24000;endianness=little-endian"}
 };
 
+static nlohmann::json extract_error_payload(const std::string& buf);
+
 Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_dir)
     : config_(config),
       cache_dir_(cache_dir),
@@ -477,6 +479,138 @@ Server::Server(std::shared_ptr<RuntimeConfig> config, const std::string& cache_d
                 throw lemon::jobs::JobError(424, msg);
             }
             return lemon::jobs::json::parse(response.dump());
+        };
+        providers.image_generations_op = [this](const lemon::jobs::json& params,
+                                                lemon::jobs::CancelFlag&) -> lemon::jobs::json {
+            nlohmann::json request = nlohmann::json::parse(params.dump());
+            nlohmann::json response = router_->image_generations(request);
+            if (response.contains("error")) {
+                std::string msg = "image_generations failed";
+                const auto& err = response["error"];
+                if (err.is_object() && err.contains("message") && err["message"].is_string())
+                    msg = err["message"].get<std::string>();
+                else if (err.is_string())
+                    msg = err.get<std::string>();
+                throw lemon::jobs::JobError(424, msg);
+            }
+            return lemon::jobs::json::parse(response.dump());
+        };
+        providers.image_edits_op = [this](const lemon::jobs::json& params,
+                                          lemon::jobs::CancelFlag&) -> lemon::jobs::json {
+            nlohmann::json request = nlohmann::json::parse(params.dump());
+            nlohmann::json response = router_->image_edits(request);
+            if (response.contains("error")) {
+                std::string msg = "image_edits failed";
+                const auto& err = response["error"];
+                if (err.is_object() && err.contains("message") && err["message"].is_string())
+                    msg = err["message"].get<std::string>();
+                else if (err.is_string())
+                    msg = err.get<std::string>();
+                throw lemon::jobs::JobError(424, msg);
+            }
+            return lemon::jobs::json::parse(response.dump());
+        };
+        providers.image_variations_op = [this](const lemon::jobs::json& params,
+                                               lemon::jobs::CancelFlag&) -> lemon::jobs::json {
+            nlohmann::json request = nlohmann::json::parse(params.dump());
+            nlohmann::json response = router_->image_variations(request);
+            if (response.contains("error")) {
+                std::string msg = "image_variations failed";
+                const auto& err = response["error"];
+                if (err.is_object() && err.contains("message") && err["message"].is_string())
+                    msg = err["message"].get<std::string>();
+                else if (err.is_string())
+                    msg = err.get<std::string>();
+                throw lemon::jobs::JobError(424, msg);
+            }
+            return lemon::jobs::json::parse(response.dump());
+        };
+        providers.audio_speech_op = [this](const lemon::jobs::json& params,
+                                           lemon::jobs::CancelFlag& cancel) -> lemon::jobs::json {
+            nlohmann::json request = nlohmann::json::parse(params.dump());
+            std::string response_format = "mp3";
+            if (request.contains("response_format") && request["response_format"].is_string())
+                response_format = request["response_format"].get<std::string>();
+            std::string buf;
+            httplib::DataSink sink;
+            sink.write = [&buf](const char* data, size_t len) { buf.append(data, len); return true; };
+            sink.is_writable = []() { return true; };
+            sink.done = []() {};
+            router_->audio_speech(request, sink);
+            if (buf.empty())
+                throw lemon::jobs::JobError(502, "audio_speech produced no output");
+            if (auto error_payload = extract_error_payload(buf); !error_payload.is_null()) {
+                std::string msg = "audio_speech failed";
+                const auto& err = error_payload["error"];
+                if (err.is_object() && err.contains("message") && err["message"].is_string())
+                    msg = err["message"].get<std::string>();
+                else if (err.is_string())
+                    msg = err.get<std::string>();
+                throw lemon::jobs::JobError(424, msg);
+            }
+            lemon::jobs::json out;
+            out["data"] = lemon::utils::JsonUtils::base64_encode(buf);
+            out["mime_type"] = MIME_TYPES.value(response_format, "application/octet-stream");
+            out["size"] = buf.size();
+            out["response_format"] = response_format;
+            return out;
+        };
+        providers.audio_generations_op = [this](const lemon::jobs::json& params,
+                                                lemon::jobs::CancelFlag& cancel) -> lemon::jobs::json {
+            nlohmann::json request = nlohmann::json::parse(params.dump());
+            std::string response_format = "wav";
+            if (request.contains("response_format") && request["response_format"].is_string())
+                response_format = request["response_format"].get<std::string>();
+            std::string buf;
+            httplib::DataSink sink;
+            sink.write = [&buf](const char* data, size_t len) { buf.append(data, len); return true; };
+            sink.is_writable = []() { return true; };
+            sink.done = []() {};
+            router_->audio_generations(request, sink);
+            if (buf.empty())
+                throw lemon::jobs::JobError(502, "audio_generations produced no output");
+            if (auto error_payload = extract_error_payload(buf); !error_payload.is_null()) {
+                std::string msg = "audio_generations failed";
+                const auto& err = error_payload["error"];
+                if (err.is_object() && err.contains("message") && err["message"].is_string())
+                    msg = err["message"].get<std::string>();
+                else if (err.is_string())
+                    msg = err.get<std::string>();
+                throw lemon::jobs::JobError(424, msg);
+            }
+            lemon::jobs::json out;
+            out["data"] = lemon::utils::JsonUtils::base64_encode(buf);
+            out["mime_type"] = MIME_TYPES.value(response_format, "application/octet-stream");
+            out["size"] = buf.size();
+            out["response_format"] = response_format;
+            return out;
+        };
+        providers.model_3d_generations_op = [this](const lemon::jobs::json& params,
+                                                   lemon::jobs::CancelFlag& cancel) -> lemon::jobs::json {
+            nlohmann::json request = nlohmann::json::parse(params.dump());
+            std::string buf;
+            httplib::DataSink sink;
+            sink.write = [&buf](const char* data, size_t len) { buf.append(data, len); return true; };
+            sink.is_writable = []() { return true; };
+            sink.done = []() {};
+            router_->model_3d_generations(request, sink);
+            if (buf.empty())
+                throw lemon::jobs::JobError(502, "model_3d_generations produced no output");
+            if (auto error_payload = extract_error_payload(buf); !error_payload.is_null()) {
+                std::string msg = "model_3d_generations failed";
+                const auto& err = error_payload["error"];
+                if (err.is_object() && err.contains("message") && err["message"].is_string())
+                    msg = err["message"].get<std::string>();
+                else if (err.is_string())
+                    msg = err.get<std::string>();
+                throw lemon::jobs::JobError(424, msg);
+            }
+            lemon::jobs::json out;
+            out["data"] = lemon::utils::JsonUtils::base64_encode(buf);
+            out["mime_type"] = "model/gltf-binary";
+            out["size"] = buf.size();
+            out["response_format"] = "glb";
+            return out;
         };
         providers.begin_exclusive = [this, job_states, current_job, state_mutex](
                                         const std::string& job_id,

--- a/test/cpp/test_job_graph.cpp
+++ b/test/cpp/test_job_graph.cpp
@@ -14,7 +14,11 @@ static void check(const char* name, bool ok) {
     if (!ok) ++g_failures;
 }
 
-static const std::set<std::string> kOps = {"system_info", "load", "unload", "chat"};
+static const std::set<std::string> kOps = {
+    "system_info", "load", "unload", "chat",
+    "image_generations", "image_edits", "image_variations",
+    "audio_speech", "audio_generations", "model_3d_generations",
+};
 
 static StepRecord step(const std::string& id, const std::string& op) {
     StepRecord s;

--- a/test/server_jobs.py
+++ b/test/server_jobs.py
@@ -1611,6 +1611,60 @@ class JobEngineTests(unittest.TestCase):
         h = requests.get(f"http://{HOST}:{PORT}/api/v1/health", timeout=15).json()
         self.assertIsNone(h.get("model_loaded"))
 
+    def test_generation_op_registered(self):
+        """All new generation ops are accepted by the job registry."""
+        ops = [
+            "image_generations",
+            "image_edits",
+            "image_variations",
+            "audio_speech",
+            "audio_generations",
+            "model_3d_generations",
+        ]
+        for op in ops:
+            job = self.create_job(
+                f"gen-{op}",
+                [{"id": "s", "op": op, "on_fail": "continue"}],
+            )
+            self.assertEqual(job["id"], job["id"])  # creation succeeded
+
+    def test_generation_op_fails_without_backend(self):
+        """Generation ops fail gracefully when no backend supports them."""
+        steps = [
+            {
+                "id": "img",
+                "op": "image_generations",
+                "params": {"prompt": "test"},
+                "on_fail": "continue",
+            },
+            {
+                "id": "tts",
+                "op": "audio_speech",
+                "params": {"input": "test"},
+                "on_fail": "continue",
+            },
+            {
+                "id": "audio",
+                "op": "audio_generations",
+                "params": {"prompt": "test"},
+                "on_fail": "continue",
+            },
+            {
+                "id": "3d",
+                "op": "model_3d_generations",
+                "params": {"prompt": "test"},
+                "on_fail": "continue",
+            },
+            {"id": "done", "op": "system_info"},
+        ]
+        job = self.create_job("gen-no-backend", steps)
+        done = self.poll_status(job["id"], "completed", timeout=60)
+        self.assertEqual(self.step_by_id(done, "img")["status"], "failed")
+        self.assertEqual(self.step_by_id(done, "tts")["status"], "failed")
+        self.assertEqual(self.step_by_id(done, "audio")["status"], "failed")
+        self.assertEqual(self.step_by_id(done, "3d")["status"], "failed")
+        self.assertEqual(self.step_by_id(done, "done")["status"], "completed")
+
 
 def parse_args():
     global _LEMOND_BINARY


### PR DESCRIPTION
Per discussion in #2718, add the remaining generation operations to the job engine.

cc: @bitgamma 