### PR TITLE
fix(ui): resolve GUI3 titlebar window dragging, controls, and log dropdown contrast issues

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -77,6 +77,10 @@ type HostNavigateUnsubscribe = void | (() => void);
 type LemonadeHostApi = {
   onNavigate?: (callback: (payload: HostNavigationPayload) => void) => HostNavigateUnsubscribe;
   signalReady?: () => void;
+  minimizeWindow?: () => void;
+  maximizeWindow?: () => void;
+  closeWindow?: () => void;
+  isWebApp?: boolean;
 };
 
 declare global {
@@ -175,6 +179,17 @@ const App: React.FC = () => {
   const [accountResetNonce, setAccountResetNonce] = useState(0);
   const accountSessionRef = useRef(accountSession);
   const [downloadManagerOpen, setDownloadManagerOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    import('./tauriShim').then(({ tauriReady }) => {
+      tauriReady.then(() => {
+        if (window.api && window.api.isWebApp !== true) {
+          setIsDesktop(true);
+        }
+      });
+    });
+  }, []);
   const [activeDownloadCount, setActiveDownloadCount] = useState(
     () => downloadStore.snapshot().filter(isDownloadActive).length,
   );
@@ -379,9 +394,9 @@ const App: React.FC = () => {
     <>
       <a href="#main-content" className="skip-link">Skip to main content</a>
       <div className="app">
-        <header className="titlebar">
-        <div className="titlebar__brand">
-          <svg className="titlebar__lemon" width="18" height="18" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <header className="titlebar" data-tauri-drag-region>
+        <div className="titlebar__brand" data-tauri-drag-region>
+          <svg className="titlebar__lemon" data-tauri-drag-region="false" width="18" height="18" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M7.036 2.492L2 5.01c.826 2.337 3.525 3.525 6.043 2.518l6.044-2.518C13.26 2.663 9.85 1.177 7.036 2.492Z" fill="url(#ll0)"/>
             <path d="M14.924 4.6C9.52 6.507 6.69 12.45 8.592 17.87l1.252 3.558c1.403 3.989 4.987 6.583 8.93 6.908a3.07 3.07 0 0 1 1.994.884 2.56 2.56 0 0 0 3.027.605c1.078-.384 1.809-1.314 1.983-2.372a3.9 3.9 0 0 1 .997-1.942c2.864-2.745 4.035-7.013 2.632-11.002l-1.252-3.559C26.253 5.518 20.327 2.681 14.924 4.6Z" fill="url(#ll1)"/>
             <path d="M14.924 4.6C9.52 6.507 6.69 12.45 8.592 17.87l1.252 3.558c1.403 3.989 4.987 6.583 8.93 6.908a3.07 3.07 0 0 1 1.994.884 2.56 2.56 0 0 0 3.027.605c1.078-.384 1.809-1.314 1.983-2.372a3.9 3.9 0 0 1 .997-1.942c2.864-2.745 4.035-7.013 2.632-11.002l-1.252-3.559C26.253 5.518 20.327 2.681 14.924 4.6Z" fill="url(#ll2)"/>
@@ -397,7 +412,7 @@ const App: React.FC = () => {
               </radialGradient>
             </defs>
           </svg>
-          <span>lemonade</span>
+          <span data-tauri-drag-region>lemonade</span>
           <span className={`titlebar__status-dot titlebar__status-dot--brand ${
             status === 'connected' ? 'titlebar__status-dot--connected' :
             status === 'connecting' ? 'titlebar__status-dot--connecting' : ''
@@ -408,7 +423,7 @@ const App: React.FC = () => {
           />
         </div>
 
-        <nav className="titlebar__nav" aria-label="Primary">
+        <nav className="titlebar__nav" data-tauri-drag-region="false" aria-label="Primary">
           {([
             { id: 'chat',      label: 'Chat',      icon: 'chat'               },
             { id: 'models',    label: 'Models',    icon: 'hard-drive'         },
@@ -432,17 +447,20 @@ const App: React.FC = () => {
           ))}
         </nav>
 
-        <div className="titlebar__right">
-          <AccountMenu
-            session={accountSession}
-            onSessionChange={handleAccountSessionChange}
-            onDataReset={handleAccountDataReset}
-          />
-          <button className="titlebar__theme-toggle" onClick={toggleTheme} aria-label="Toggle theme" title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
+        <div className="titlebar__right" data-tauri-drag-region>
+          <div data-tauri-drag-region="false">
+            <AccountMenu
+              session={accountSession}
+              onSessionChange={handleAccountSessionChange}
+              onDataReset={handleAccountDataReset}
+            />
+          </div>
+          <button className="titlebar__theme-toggle" data-tauri-drag-region="false" onClick={toggleTheme} aria-label="Toggle theme" title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
             <Icon name={theme === 'dark' ? 'sun' : 'moon'} size={16} />
           </button>
           <button
             className={`titlebar__download-toggle${downloadManagerOpen ? ' is-active' : ''}${activeDownloadCount > 0 ? ' has-active-downloads' : ''}`}
+            data-tauri-drag-region="false"
             onClick={() => setDownloadManagerOpen(open => !open)}
             aria-label="Open download manager"
             aria-expanded={downloadManagerOpen}
@@ -451,6 +469,37 @@ const App: React.FC = () => {
             <Icon name="download" size={16} />
             {activeDownloadCount > 0 && <span className="titlebar__download-badge">{activeDownloadCount > 9 ? '9+' : activeDownloadCount}</span>}
           </button>
+          {isDesktop && (
+            <>
+              <button
+                className="titlebar__window-btn"
+                data-tauri-drag-region="false"
+                onClick={() => window.api?.minimizeWindow?.()}
+                aria-label="Minimize"
+                title="Minimize"
+              >
+                <Icon name="minimize-2" size={14} />
+              </button>
+              <button
+                className="titlebar__window-btn"
+                data-tauri-drag-region="false"
+                onClick={() => window.api?.maximizeWindow?.()}
+                aria-label="Maximize"
+                title="Maximize"
+              >
+                <Icon name="maximize-2" size={14} />
+              </button>
+              <button
+                className="titlebar__window-btn titlebar__window-btn--close"
+                data-tauri-drag-region="false"
+                onClick={() => window.api?.closeWindow?.()}
+                aria-label="Close"
+                title="Close"
+              >
+                <Icon name="x" size={14} />
+              </button>
+            </>
+          )}
         </div>
       </header>
 

--- a/src/app/src/index.tsx
+++ b/src/app/src/index.tsx
@@ -1,3 +1,4 @@
+import './tauriShim';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -5571,14 +5571,23 @@ input, textarea {
 
 .logs-level__select {
   height: 28px;
-  padding: 0 var(--space-2);
+  padding: 0 var(--space-5) 0 var(--space-2);
   background: var(--surface-2);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
   font-size: 0.78rem;
   color: var(--text-primary);
   cursor: pointer;
-  appearance: auto;
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23807a6c'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right var(--space-2) center;
+}
+
+.logs-level__select option {
+  background: var(--surface-2);
+  color: var(--text-primary);
 }
 
 .logs-level__select:disabled {

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -190,6 +190,30 @@ input, textarea {
 [data-theme="light"] .titlebar__theme-toggle { background: var(--surface-titlebar); }
 .titlebar__theme-toggle:hover { background: var(--surface-2); }
 
+.titlebar__window-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: background var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out);
+}
+
+.titlebar__window-btn:hover {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}
+
+.titlebar__window-btn--close:hover {
+  background: #e81123 !important;
+  color: #ffffff !important;
+}
+
 .titlebar__status-dot {
   width: 8px;
   height: 8px;

--- a/src/app/src/tauriShim.ts
+++ b/src/app/src/tauriShim.ts
@@ -1,0 +1,166 @@
+// Tauri shim: installs `window.api` on the renderer so the existing React
+// renderer (originally written against Electron's contextBridge) keeps working
+// unchanged.
+//
+// When running inside Tauri, we detect `window.__TAURI_INTERNALS__` and bind
+// each `window.api.*` method to the corresponding Tauri `invoke()` / event
+// `listen()` call. In pure-web mode (served by lemond's HTTP server), this
+// module does nothing — the server-injected mock in src/cpp/server/server.cpp
+// wins. The dynamic imports below are aliased to a no-op stub by
+// src/web-app/webpack.config.js so the web-app build doesn't drag in
+// @tauri-apps/* packages.
+//
+// Event channel names mirror the constants in src/app/src-tauri/src/events.rs.
+// Keep them in sync.
+
+type NavData = { view?: string; model?: string };
+
+const EVT_SETTINGS_UPDATED = 'settings-updated';
+const EVT_CONNECTION_SETTINGS_UPDATED = 'connection-settings-updated';
+const EVT_SERVER_PORT_UPDATED = 'server-port-updated';
+const EVT_MAXIMIZE_CHANGE = 'maximize-change';
+const EVT_NAVIGATE = 'navigate';
+
+declare global {
+  interface Window {
+    __TAURI_INTERNALS__?: unknown;
+  }
+}
+
+function isTauri(): boolean {
+  return typeof window !== 'undefined' && typeof window.__TAURI_INTERNALS__ !== 'undefined';
+}
+
+async function installTauriApi(): Promise<void> {
+  const { invoke } = await import('@tauri-apps/api/core');
+  const { listen } = await import('@tauri-apps/api/event');
+  const { getCurrentWindow } = await import('@tauri-apps/api/window');
+  const { openUrl } = await import('@tauri-apps/plugin-opener');
+  const { writeText } = await import('@tauri-apps/plugin-clipboard-manager');
+
+  // Fire-and-forget invoke wrapper used by every void window-control method.
+  // The .catch logs the failure with the command name for debuggability.
+  const fire = (cmd: string, args?: Record<string, unknown>) => () => {
+    invoke(cmd, args).catch((e) => console.warn(cmd, e));
+  };
+
+  // Subscribe to a Tauri event, matching the Electron callback shape (handler
+  // receives just the payload, not the whole event envelope).
+  //
+  // The `cancelled` flag handles the unmount-before-listen-resolves race: if
+  // the caller invokes the returned cleanup before `listen()` has returned its
+  // unlisten handle, we set the flag and run the unlisten immediately when the
+  // promise eventually resolves. Without this, React effects that mount and
+  // unmount synchronously would leak the underlying subscription.
+  function on<T>(channel: string, cb: (payload: T) => void): () => void {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    listen<T>(channel, (event) => cb(event.payload)).then((fn) => {
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+    return () => {
+      cancelled = true;
+      if (unlisten) {
+        unlisten();
+        unlisten = null;
+      }
+    };
+  }
+
+  // Resolved synchronously at install time so consumers can read it as a
+  // plain string field rather than a promise.
+  let platformCache = 'unknown';
+  try {
+    platformCache = (await invoke<string>('get_platform')) || 'unknown';
+  } catch (err) {
+    console.warn('get_platform failed', err);
+  }
+
+  const api = {
+    isWebApp: false,
+    platform: platformCache,
+
+    minimizeWindow: fire('minimize_window'),
+    maximizeWindow: fire('maximize_window'),
+    closeWindow: fire('close_window'),
+    zoomIn: fire('zoom_in'),
+    zoomOut: fire('zoom_out'),
+    updateMinWidth: (width: number) => fire('update_min_width', { width })(),
+
+    onMaximizeChange: (callback: (isMaximized: boolean) => void) => {
+      // Prime with current state, then subscribe.
+      getCurrentWindow().isMaximized().then(callback).catch(() => {});
+      return on<boolean>(EVT_MAXIMIZE_CHANGE, callback);
+    },
+
+    // Frameless-window edge resize. webkit2gtk does not draw resize handles on
+    // borderless windows, so the renderer paints its own invisible regions and
+    // calls this on mousedown. `getCurrentWindow().startResizeDragging` accepts
+    // the same direction strings the renderer uses (Left, TopRight, etc.).
+    startResizeDragging: (direction: string) => {
+      getCurrentWindow()
+        // The Tauri API uses a tagged enum at the type level but accepts the
+        // bare string at runtime; cast to keep the shim free of @tauri-apps types.
+        .startResizeDragging(direction as never)
+        .catch((e: unknown) => console.warn('startResizeDragging', e));
+    },
+
+    writeClipboard: async (text: string) => {
+      await writeText(String(text));
+    },
+    openExternal: (url: string) => {
+      try {
+        const u = new URL(url);
+        if (u.protocol === 'http:' || u.protocol === 'https:') {
+          openUrl(u.href).catch((e) => console.warn('openExternal', e));
+        }
+      } catch {
+        // Ignore invalid URLs
+      }
+    },
+
+    getSettings: () => invoke('get_app_settings'),
+    saveSettings: (settings: unknown) => invoke('save_app_settings', { payload: settings }),
+    onSettingsUpdated: (callback: (settings: unknown) => void) =>
+      on<unknown>(EVT_SETTINGS_UPDATED, callback),
+
+    discoverServerPort: () => invoke<number | null>('discover_server_port'),
+    getServerPort: () => invoke<number>('get_server_port'),
+    getServerBaseUrl: () => invoke<string | null>('get_server_base_url'),
+    getServerAPIKey: () => invoke<string>('get_server_api_key'),
+    onServerPortUpdated: (callback: (port: number) => void) =>
+      on<number>(EVT_SERVER_PORT_UPDATED, callback),
+    onConnectionSettingsUpdated: (
+      callback: (baseURL: string, apiKey: string) => void,
+    ) =>
+      on<{ base_url: string; api_key: string }>(
+        EVT_CONNECTION_SETTINGS_UPDATED,
+        (payload) => callback(payload.base_url, payload.api_key),
+      ),
+
+    // Server version, system stats, and system info are NOT exposed via
+    // window.api anymore. The renderer fetches /health, /system-stats, and
+    // /system-info directly via serverConfig.fetch — see StatusBar.tsx and
+    // AboutModal.tsx. The old Rust proxy (system_info.rs) was redundant.
+    getLocalMarketplaceUrl: () => invoke<string | null>('get_local_marketplace_url'),
+    signalReady: fire('renderer_ready'),
+    onNavigate: (callback: (data: NavData) => void) => on<NavData>(EVT_NAVIGATE, callback),
+  };
+
+  (window as unknown as { api: typeof api }).api = api;
+}
+
+// Exported so other modules (ServerConfig) can await window.api being ready
+// before reading from it. In pure-web mode the promise resolves immediately
+// (window.api is injected synchronously by the C++ server's HTML template).
+export let tauriReady: Promise<void> = Promise.resolve();
+
+if (typeof window !== 'undefined' && isTauri() && !(window as unknown as { api?: unknown }).api) {
+  tauriReady = installTauriApi().catch((err) => {
+    console.error('Failed to install Tauri API shim', err);
+  }) as Promise<void>;
+}


### PR DESCRIPTION
This PR resolves UI regressions and bugs in the new GUI3 redesign:

1. **Restored Tauri Desktop API Bridge:**
   - Restored the omitted `tauriShim.ts` file to `src/app/src/tauriShim.ts` to map Tauri IPC invoke and event listening functions onto `window.api`.
   - Imported the shim at the top of `src/app/src/index.tsx` to ensure `window.api` is mapped during application bootstrap.
   - Avoided asynchronous race conditions on `window.api` startup in `src/app/src/App.tsx` by implementing a reactive `isDesktop` state using `useState` and `useEffect` that waits for the tauriShim promise to resolve before showing desktop-only elements.

2. **Window Dragging & Window Controls (Refined Layout):**
   - Added `data-tauri-drag-region` to `<header className="titlebar">`, `<div className="titlebar__brand">`, the logo label `<span>lemonade</span>`, and the `<div className="titlebar__right">` container.
   - Added Minimize, Maximize, and Close custom window controls buttons under `<div className="titlebar__right">` (using `minimize-2`, `maximize-2`, and `x` icons), mapped to the native window control API handlers. These are guarded by the reactive `isDesktop` check.
   - Opted out interactive controls by adding `data-tauri-drag-region="false"` to `<svg className="titlebar__lemon">`, `<nav className="titlebar__nav">`, `<button className="titlebar__theme-toggle">`, `<button className="titlebar__download-toggle">`, all custom window control buttons, and wrapped the `<AccountMenu>` component in a `div` element with `data-tauri-drag-region="false"`.

3. **Log Dropdowns White-on-White Text:**
   - Changed `appearance: auto;` to `appearance: none;` (with `-webkit-appearance`) on `.logs-level__select` in `src/app/src/styles/styles.css` to prevent GTK-derived native theme styling from causing background conflicts on Linux/Flatpak.
   - Restored the custom chevron arrow styling using an inline SVG via `background-image` and set right padding to prevent overlapping with text.
   - Explicitly styled the `.logs-level__select option` elements with `background: var(--surface-2)` and `color: var(--text-primary)` to ensure readability across different system themes.
