### PR TITLE
Fix arm64 PPA packages missing bundled web UI

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -8,11 +8,13 @@ Build-Depends:
  dh-cmake,
  dh-cmake-compat (= 1),
  dh-sequence-cmake,
+ fonts-katex,
  jq,
  libdrm-dev,
  libcli11-dev,
  libcpp-httplib-dev (>> 0.26),
  libcurl4-openssl-dev,
+ libjs-katex,
  libmbedtls-dev,
  libssl-dev,
  libsystemd-dev,
@@ -20,11 +22,6 @@ Build-Depends:
  libzstd-dev,
  ninja-build,
  nlohmann-json3-dev,
- pkgconf,
- quilt,
-Build-Depends-Indep:
- fonts-katex,
- libjs-katex,
  node-buffer,
  node-css-loader,
  node-highlight.js,
@@ -40,6 +37,8 @@ Build-Depends-Indep:
  node-webpack,
  node-webpack-cli,
  nodejs,
+ pkgconf,
+ quilt,
 Testsuite: autopkgtest-pkg-python
 Standards-Version: 4.7.3
 Homepage: https://lemonade-server.ai/


### PR DESCRIPTION
## Summary
- The nodejs/webpack build-deps in `contrib/debian/control` were listed under `Build-Depends-Indep`, but the web app they produce ships inside the arch-specific `lemonade-server` package (`Architecture: linux-any`), not the arch-indep `lemonade-desktop` package.
- Debian arch-only builds (`dpkg-buildpackage -B`) never install `Build-Depends-Indep`. Launchpad runs exactly this kind of build for every architecture except its nominated arch-indep architecture (amd64), so on arm64 webpack was never installed, `CAN_BUILD_WEB_APP` silently stayed false, and the web app was skipped with no build failure — reproducing the bug in #2737.
- Moved those deps into the unconditional `Build-Depends` list so they're installed for arch-only builds too.

Fixes #2737

## Test plan
- [ ] CI `launchpad-ppa.yml` arm64 job (`package-arm64`, `arch-only: true`) builds a `.deb` that includes `share/lemonade-server/resources/web-app`
- [ ] Install the resulting arm64 `.deb` and confirm the web UI (not the fallback status page) is served at the root