### PR TITLE
fix(custom_args): treat negative numbers as values, not flags

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -307,8 +307,9 @@ jobs:
           cmake --build --preset default --target test_job_graph
           cmake --build --preset default --target test_origin_utils
           cmake --build --preset default --target test_model_residency
+          cmake --build --preset default --target test_custom_args
           cd build
-          ctest --output-on-failure -R "ProcessManagerTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest|ModelResidencyTest"
+          ctest --output-on-failure -R "ProcessManagerTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest|ModelResidencyTest|CustomArgsTest"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -623,8 +624,9 @@ jobs:
           cmake --build --preset default --target test_job_graph
           cmake --build --preset default --target test_origin_utils
           cmake --build --preset default --target test_model_residency
+          cmake --build --preset default --target test_custom_args
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest|ModelResidencyTest"
+          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest|ModelResidencyTest|CustomArgsTest"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1899,6 +1899,18 @@ if(EXISTS "${_FLM_ARG_RESOLVER_TEST_SRC}" AND EXISTS "${_FLM_ARG_RESOLVER_SRC}")
     add_test(NAME FlmArgResolverTest COMMAND test_flm_arg_resolver)
 endif()
 
+# Custom arg parsing helpers (header-only utility shared by all arg resolvers).
+set(_CUSTOM_ARGS_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_custom_args.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_CUSTOM_ARGS_TEST_SRC}")
+    add_executable(test_custom_args ${_CUSTOM_ARGS_TEST_SRC})
+    target_include_directories(test_custom_args PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+    )
+    add_test(NAME CustomArgsTest COMMAND test_custom_args)
+endif()
+
 set(_DIR_WATCHER_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_directory_watcher.cpp"
 )

--- a/src/cpp/include/lemon/utils/custom_args.h
+++ b/src/cpp/include/lemon/utils/custom_args.h
@@ -49,8 +49,46 @@ inline std::map<std::string, std::vector<std::string>> build_custom_args_map(con
     std::map<std::string, std::vector<std::string>> result;
     std::string last_flag;  // Track the most recently seen flag independently of map ordering
 
+    // Detect a complete negative number so it's treated as a value, not a flag.
+    auto is_negative_number = [](const std::string& token) -> bool {
+        if (token.size() < 2 || token[0] != '-') {
+            return false;
+        }
+        size_t i = 1;
+        bool has_digits = false;
+        while (i < token.size() && token[i] >= '0' && token[i] <= '9') {
+            has_digits = true;
+            ++i;
+        }
+        if (i < token.size() && token[i] == '.') {
+            ++i;
+            while (i < token.size() && token[i] >= '0' && token[i] <= '9') {
+                has_digits = true;
+                ++i;
+            }
+        }
+        if (!has_digits) {
+            return false;
+        }
+        if (i < token.size() && (token[i] == 'e' || token[i] == 'E')) {
+            ++i;
+            if (i < token.size() && (token[i] == '-' || token[i] == '+')) {
+                ++i;
+            }
+            bool has_exp_digits = false;
+            while (i < token.size() && token[i] >= '0' && token[i] <= '9') {
+                has_exp_digits = true;
+                ++i;
+            }
+            if (!has_exp_digits) {
+                return false;
+            }
+        }
+        return i == token.size();
+    };
+
     for (const auto& token : tokens) {
-        if (!token.empty() && token[0] == '-') {
+        if (!token.empty() && token[0] == '-' && !is_negative_number(token)) {
             // This is a flag; start a new entry
             result[token] = {};
             last_flag = token;

--- a/test/cpp/test_custom_args.cpp
+++ b/test/cpp/test_custom_args.cpp
@@ -1,0 +1,86 @@
+// Standalone test for lemon::utils custom arg parsing helpers.
+// Build with: cmake --build --preset default --target test_custom_args
+// Run with: ctest --test-dir build -R '^CustomArgsTest$' --output-on-failure
+
+#include "lemon/utils/custom_args.h"
+
+#include <cstdio>
+#include <map>
+#include <string>
+#include <vector>
+
+using lemon::utils::build_custom_args_map;
+using lemon::utils::parse_custom_args;
+
+using ArgMap = std::map<std::string, std::vector<std::string>>;
+
+static std::string dump(const ArgMap& m) {
+    std::string s = "{";
+    for (const auto& [flag, vals] : m) {
+        s += " " + flag + ": [";
+        for (size_t i = 0; i < vals.size(); ++i) {
+            if (i) s += ", ";
+            s += vals[i];
+        }
+        s += "]";
+    }
+    return s + " }";
+}
+
+static bool expect_map(const char* name, const std::string& input,
+                       const ArgMap& expected) {
+    ArgMap actual = build_custom_args_map(parse_custom_args(input));
+    bool ok = (actual == expected);
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) {
+        std::printf("  got:  %s\n  want: %s\n",
+                    dump(actual).c_str(), dump(expected).c_str());
+    }
+    return ok;
+}
+
+int main() {
+    int failures = 0;
+
+    // Negative numbers attach to their flag and never become phantom keys.
+    failures += !expect_map(
+        "negative integer value", "--cache-ram -1", {{"--cache-ram", {"-1"}}});
+    failures += !expect_map(
+        "negative float value", "--temp -0.5", {{"--temp", {"-0.5"}}});
+    failures += !expect_map(
+        "negative leading-dot float", "--temp -.5", {{"--temp", {"-.5"}}});
+
+    // Scientific notation.
+    failures += !expect_map(
+        "scientific notation", "--threshold -1e5", {{"--threshold", {"-1e5"}}});
+    failures += !expect_map(
+        "scientific notation with negative exponent",
+        "--threshold -1.5e-3", {{"--threshold", {"-1.5e-3"}}});
+    failures += !expect_map(
+        "scientific notation capital E",
+        "--val -1E10", {{"--val", {"-1E10"}}});
+
+    // Identical negatives under two flags must both survive (std::map keys
+    // are unique; treating -1 as a flag would dedupe it, dropping values).
+    failures += !expect_map(
+        "duplicate negative under two flags (no phantom key)",
+        "--cache-ram -1 --reasoning-budget -1",
+        {{"--cache-ram", {"-1"}}, {"--reasoning-budget", {"-1"}}});
+
+    // Sanity: short and long flags still parse as flags with their values.
+    failures += !expect_map(
+        "short flag with value", "-ngl 99", {{"-ngl", {"99"}}});
+    failures += !expect_map(
+        "long flag with value", "--threads 8", {{"--threads", {"8"}}});
+
+    // Counterexamples: incomplete numerics are flags, not values.
+    failures += !expect_map(
+        "-1foo is a flag, not a value",
+        "--foo -1foo", {{"--foo", {}}, {"-1foo", {}}});
+    failures += !expect_map(
+        "-.future is a flag, not a value",
+        "--foo -.future", {{"--foo", {}}, {"-.future", {}}});
+
+    std::printf("\n%d failures\n", failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

`build_custom_args_map` flagged any token starting with `-` as a flag, so negative numeric values (`-1`, `-0.5`, `-.5`) became phantom map keys instead of attaching to their owning flag. This corrupted recipes using args like `--cache-ram -1`:

- The value detached from its flag (e.g. `--cache-ram` lost its `-1`).
- Since `std::map` keys are unique, identical negatives across flags deduped — `--cache-ram -1 --reasoning-budget -1` dropped **both** values.
- On re-serialization the stray `-1` key sorted ahead of real flags, scrambling arg order.

## Fix

A token is treated as a value only if the complete token is a valid negative number. This covers integers, decimals, leading-dot decimals, and scientific notation such as `-1`, `-0.5`, `-.5`, and `-1e5`, while keeping tokens like `-1foo` and `-.future` as flags.

## Test

New `test/cpp/test_custom_args.cpp` (registered as `CustomArgsTest`) covers negative integers, decimals, scientific 

---
Checklist:
- [x] C++ builds cross-platform (header-only change, std-only)
- [x] No new endpoints / no recipe changes
- [x] Test added and registered in CMakeLists.txt