### PR TITLE
feat(sync): add administrative model synchronization and auto-update configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3187,3 +3187,13 @@ if(BUILD_TESTING AND EXISTS "${_LAUNCH_COMMAND_TEST_SRC}")
     target_link_libraries(test_launch_command PRIVATE lemonade-server-core)
     add_cpp_ci_test(LaunchCommandTest CI ON COMMAND test_launch_command)
 endif()
+
+set(_MODEL_SYNC_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_model_sync_and_auto_update.cpp")
+if(BUILD_TESTING AND EXISTS "${_MODEL_SYNC_TEST_SRC}")
+    add_executable(test_model_sync_and_auto_update test/cpp/test_model_sync_and_auto_update.cpp)
+    target_link_libraries(test_model_sync_and_auto_update PRIVATE lemonade-server-core)
+    add_dependencies(test_model_sync_and_auto_update copy_resources)
+
+    include(CTest)
+    add_cpp_ci_test(ModelSyncAndAutoUpdateTest CI ON COMMAND test_model_sync_and_auto_update)
+endif()

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -591,7 +591,7 @@ A GUI application for desktop users that exposes the server via a system tray ic
 The `lemonade` client communicates with `lemond` server via HTTP:
 - **Model operations:** `/api/v1/models`, `/api/v1/pull`, `/api/v1/delete`
 - **Model control:** `/api/v1/load`, `/api/v1/unload`
-- **Server management:** `/api/v1/health`, `/internal/shutdown`, `/internal/set`, `/internal/config`, `/internal/cleanup-cache`, `/internal/pin`
+- **Server management:** `/api/v1/health`, `/internal/shutdown`, `/internal/set`, `/internal/config`, `/internal/cleanup-cache`, `/internal/pin`, `/internal/models/sync`, `/internal/models/sync/status`
 - **Inference:** `/api/v1/chat/completions`, `/api/v1/completions`, `/api/v1/audio/transcriptions`
 
 The client automatically:
@@ -628,6 +628,8 @@ Internal endpoints accept connections from any address, so first-party clients o
 | `GET`  | `/internal/config/defaults` | Returns the canonical default config (factory defaults) |
 | `POST` | `/internal/cleanup-cache` | Cleans up orphaned files in the Hugging Face cache |
 | `POST` | `/internal/pin` | Pin or unpin a loaded model |
+| `POST` | `/internal/models/sync` | Sync/update downloaded models to the latest version (async or dry-run) |
+| `GET`  | `/internal/models/sync/status` | Retrieve status/progress of background model synchronization |
 
 #### `POST /internal/set`
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -57,6 +57,7 @@ The `lemonade` CLI is the primary tool for interacting with Lemonade Server from
 | `unload [MODEL_NAME]` | Unload a model. If no model name is provided, unload all loaded models. |
 | `pin MODEL_NAME`    | Pin a loaded model to prevent auto-eviction. See options [below](#options-for-pin-and-unpin). |
 | `unpin MODEL_NAME`  | Unpin a loaded model to allow auto-eviction. See options [below](#options-for-pin-and-unpin). |
+| `update-models [MODEL_NAME ...]` | Sync/update downloaded models to the latest version. Use `--check` to preview updates without downloading. |
 | `export MODEL_NAME` | Export model information to JSON format. See command options [below](#options-for-export). |
 
 ### Benchmarking
@@ -553,6 +554,42 @@ lemonade export Qwen3-0.6B-GGUF --output my-model.json
 # Export and view the JSON output
 lemonade export Qwen3-0.6B-GGUF --output model.json && cat model.json
 ```
+
+## Options for update-models
+
+
+The `update-models` command checks and updates downloaded models against upstream repositories. By default, model synchronization runs in the background.
+
+> [!NOTE]
+> Because model synchronization operates as an administrative control routing, executing `lemonade update-models` requires appropriate credentials when server-side API authentication is enabled. The client will automatically propagate the `LEMONADE_ADMIN_API_KEY` (or the standard `LEMONADE_API_KEY` if no distinct administrative key is configured) as a bearer token.
+
+```bash
+lemonade update-models [MODEL_NAME ...] [-w|--wait] [--check] [--json]
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `MODEL_NAME ...` | Optional model name(s), recipe names (`user.*`), or HF checkpoints to update | Update all downloaded models |
+| `-w, --wait` | Wait for server model synchronization task to complete | `false` |
+| `--check` | Dry-run mode: check for available updates without downloading | `false` |
+| `--json` | Output update results in JSON format | `false` |
+
+**Examples:**
+
+```bash
+# Dispatch model update in the background (default)
+lemonade update-models
+
+# Check for available model updates without downloading (dry run)
+lemonade update-models --check
+
+# Update models and wait for completion
+lemonade update-models --wait
+
+# Wait for a specific model update to complete
+lemonade update-models Gemma-4-E4B-it -w
+```
+
 
 ## Options for backends
 

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -45,6 +45,7 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
     "vulkan_bin": "builtin"
   },
   "auto_check_model_updates": true,
+  "auto_update_models": false,
   "broadcast": true,
   "cloud_providers": [],
   "config_version": 2,
@@ -196,6 +197,7 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
 | `default_model_source` | string | "huggingface" | Remote registry used to pull checkpoints when a request does not name one (`huggingface` or `modelscope`). Explicit `--source`, a `source`/`registry_source` field, or a provider URL always overrides it. |
 | `offline` | bool | false | Skip model downloads |
 | `auto_check_model_updates` | bool | true | Check downloaded Hugging Face-backed models for updates during server startup. Set to `false` to check only with `lemonade check-updates` or `POST /v1/models/check-updates`. Manual downloads and updates remain enabled. |
+| `auto_update_models` | bool | false | Automatically download model updates when available. Can be overridden per model via `auto_update` in model options. |
 | `no_fetch_executables` | bool | false | Prevent downloading backend executable artifacts; backends must already be installed or use the system backend |
 | `disable_model_filtering` | bool | false | Show all models regardless of hardware capabilities |
 | `inhibit_suspend` | bool | true | Prevent the OS from suspending while inference is active. Linux only (uses systemd-logind); no-op on Windows/macOS/non-systemd environments. |
@@ -480,6 +482,29 @@ The `LEMONADE_ALLOWED_ORIGINS` environment variable controls which remote web or
   > [!WARNING]
   > Using `LEMONADE_ALLOWED_ORIGINS=*` permits any website running in a user's browser to make requests to your local Lemonade server. In particular, if `LEMONADE_API_KEY` is not configured, this exposes the server to unauthenticated remote access and cross-origin attacks from malicious websites. Use wildcards only for development or in secure, isolated environments.
 - **Local/Loopback & Desktop Access**: Loopback addresses (`localhost`, `127.0.0.1`, `[::1]`, `*.localhost`) and custom desktop application schemes (`file://`, `app://.`, `vscode-webview://`, `jan://`, etc.) are permitted for local client connections. Opaque `null` origins (e.g. from sandboxed browser iframes) are rejected unless explicitly listed in `LEMONADE_ALLOWED_ORIGINS` to prevent CSWSH attacks.
+
+## Model Synchronization & Auto-Updates
+
+Lemonade supports manual model synchronization via `lemonade update-models` as well as automatic background updates.
+
+
+### Configuration
+- **Global Config**: Set `auto_update_models: true` in server configuration or via `lemonade config set auto_update_models=true`.
+- **Per-Model Override**: Include `"auto_update": true` or `"auto_update": false` in custom model recipes (`user.*`) to override the global default on a per-model basis.
+- **Administrative Authorization**: Because model synchronization endpoints are administrative (`/internal/*`), manual synchronization via the CLI or direct API requests requires the appropriate admin credentials (`LEMONADE_ADMIN_API_KEY`, falling back to `LEMONADE_API_KEY` if the admin key is not explicitly configured) when server-side authentication is enabled.
+
+### Risks of Automatic Model Updates
+
+> [!WARNING]
+> Enabling automatic updates (`auto_update_models: true` or per-model `"auto_update": true`) introduces operational risks that should be carefully considered:
+>
+> 1. **Output & Behavioral Drift**: Upstream Hugging Face or ModelScope repositories can release updated weights, revised tokenizers, or altered chat templates. These changes can alter model responses, reasoning characteristics, and prompt compatibility.
+> 2. **High Bandwidth & Disk Consumption**: Model updates involve downloading multi-gigabyte file revisions (e.g. GGUF quantizations). Unattended updates can unexpectedly consume substantial network bandwidth and disk space.
+> 3. **Startup & Inference Delays**: Automatic update downloads trigger on server startup when upstream revisions are detected, delaying server readiness and inference availability.
+> 4. **Quantization & Recipe Shifts**: Remote repository changes may alter file naming or tensor layouts, requiring updated recipe configurations.
+>
+> **Recommendation**: Leave `auto_update_models` set to `false` (default) in production environments. Use manual sync (`lemonade update-models --check` followed by `lemonade update-models`) to inspect and control model updates.
+
 
 ## Remote Server Connection
 

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -134,6 +134,7 @@ static void assert_http_ok(const httplib::Result& res) {
         throw HttpError(res->status, res->body,
                         "Request failed: " + std::to_string(res->status));
     }
+
 }
 
 std::string extract_server_error_message(const HttpError& error) {
@@ -298,6 +299,14 @@ int LemonadeClient::check_model_updates() const {
             throw std::runtime_error("Server returned an invalid model update response");
         }
 
+        if (result.contains("failed_models") && result["failed_models"].is_object() && !result["failed_models"].empty()) {
+            std::cerr << "Failed to check updates for:" << std::endl;
+            for (const auto& [name, err] : result["failed_models"].items()) {
+                std::cerr << "  - " << name << ": " << err.get<std::string>() << std::endl;
+            }
+            return 1;
+        }
+
         if (models.empty()) {
             std::cout << "All downloaded models are up to date." << std::endl;
             return 0;
@@ -316,6 +325,251 @@ int LemonadeClient::check_model_updates() const {
         return 1;
     } catch (const std::exception& e) {
         std::cerr << "Error checking model updates: " << e.what() << std::endl;
+        return 1;
+    }
+}
+
+int LemonadeClient::update_models(const std::vector<std::string>& models, bool check_only, bool json_output, bool wait_for_completion) const {
+
+    try {
+        if (check_only) {
+            json body = {
+                {"models", models},
+                {"dry_run", true}
+            };
+
+            std::string response = make_request(
+                "/internal/models/sync",
+                "POST",
+                body.dump(),
+                "application/json",
+                DEFAULT_CONNECTION_TIMEOUT_MS,
+                LONG_TIMEOUT_MS);
+            auto result = json::parse(response);
+
+            if (json_output) {
+                std::cout << result.dump(2) << std::endl;
+                bool failed = (result.value("status", "") == "failed") ||
+                              (result.contains("failed_models") && result["failed_models"].is_object() && !result["failed_models"].empty()) ||
+                              (result.contains("terminal_error") && !result["terminal_error"].get<std::string>().empty());
+                return failed ? 1 : 0;
+            }
+
+            int updated_count = result.value("updated_count", 0);
+            int checked_count = result.value("checked_count", 0);
+            std::cout << "Checked " << checked_count << " model(s). " << updated_count << " update(s) available." << std::endl;
+
+            if (result.contains("models_updated") && result["models_updated"].is_array() && !result["models_updated"].empty()) {
+                std::cout << "Updates available:" << std::endl;
+                for (const auto& m : result["models_updated"]) {
+                    std::cout << "  - " << m.get<std::string>() << std::endl;
+                }
+            }
+
+            if (result.contains("models_up_to_date") && result["models_up_to_date"].is_array() && !result["models_up_to_date"].empty()) {
+                std::cout << "Up to date:" << std::endl;
+                for (const auto& m : result["models_up_to_date"]) {
+                    std::cout << "  - " << m.get<std::string>() << std::endl;
+                }
+            }
+
+            if ((result.contains("failed_models") && result["failed_models"].is_object() && !result["failed_models"].empty()) ||
+                (result.contains("terminal_error") && !result["terminal_error"].get<std::string>().empty())) {
+                if (result.contains("failed_models") && result["failed_models"].is_object() && !result["failed_models"].empty()) {
+                    std::cerr << "Failed:" << std::endl;
+                    for (const auto& [name, err] : result["failed_models"].items()) {
+                        std::cerr << "  - " << name << ": " << err.get<std::string>() << std::endl;
+                    }
+                }
+                if (result.contains("terminal_error") && !result["terminal_error"].get<std::string>().empty()) {
+                    std::cerr << "Terminal error: " << result["terminal_error"].get<std::string>() << std::endl;
+                }
+                return 1;
+            }
+            return 0;
+        }
+
+        auto post_sync = [this](const json& body) -> json {
+            try {
+                std::string resp = make_request(
+                    "/internal/models/sync",
+                    "POST",
+                    body.dump(),
+                    "application/json",
+                    DEFAULT_CONNECTION_TIMEOUT_MS,
+                    LONG_TIMEOUT_MS);
+                return json::parse(resp);
+            } catch (const HttpError& e) {
+                if (e.status_code() == 202 && !e.response_body().empty()) {
+                    return json::parse(e.response_body());
+                }
+                throw;
+            }
+        };
+
+        auto is_failed_result = [](const json& res) -> bool {
+            std::string status = res.value("status", "");
+            return (status == "failed") || (status == "not_found") ||
+                   (res.contains("failed_models") && res["failed_models"].is_object() && !res["failed_models"].empty()) ||
+                   (res.contains("terminal_error") && !res["terminal_error"].get<std::string>().empty());
+        };
+
+        if (!wait_for_completion) {
+            json body = {
+                {"models", models},
+                {"async", true}
+            };
+
+            auto result = post_sync(body);
+
+            if (json_output) {
+                std::cout << result.dump(2) << std::endl;
+                return is_failed_result(result) ? 1 : 0;
+            }
+
+            if (result.value("already_in_progress", false)) {
+                std::cout << "Model synchronization is already in progress." << std::endl;
+                return 0;
+            }
+
+            if (is_failed_result(result)) {
+                if (result.contains("failed_models") && result["failed_models"].is_object() && !result["failed_models"].empty()) {
+                    std::cerr << "Failed:" << std::endl;
+                    for (const auto& [name, err] : result["failed_models"].items()) {
+                        std::cerr << "  - " << name << ": " << err.get<std::string>() << std::endl;
+                    }
+                }
+                if (result.contains("terminal_error") && !result["terminal_error"].get<std::string>().empty()) {
+                    std::cerr << "Terminal error: " << result["terminal_error"].get<std::string>() << std::endl;
+                }
+                return 1;
+            }
+
+            std::cout << "Model synchronization dispatched in background." << std::endl;
+            std::cout << "Use 'lemonade update-models --wait' to monitor progress." << std::endl;
+
+            return 0;
+        }
+
+        json dispatch_body = {
+            {"models", models},
+            {"async", true},
+            {"attach_if_running", models.empty()}
+        };
+
+        auto dispatch_result = post_sync(dispatch_body);
+
+        if (is_failed_result(dispatch_result) && !dispatch_result.value("already_in_progress", false)) {
+            if (json_output) {
+                std::cout << dispatch_result.dump(2) << std::endl;
+            } else {
+                std::cerr << "Error starting model update: " << dispatch_result.value("terminal_error", "Operation failed") << std::endl;
+            }
+            return 1;
+        }
+        bool already_running = dispatch_result.value("already_in_progress", false);
+        uint64_t target_sync_id = dispatch_result.value("sync_id", 0);
+
+        if (!json_output) {
+            if (already_running) {
+                std::cout << "Model synchronization is currently running in background. Waiting for completion..." << std::endl;
+            } else {
+                std::cout << "Starting model synchronization on server... Waiting for completion..." << std::endl;
+            }
+        }
+
+        json final_result;
+        std::string last_reported_model;
+        while (true) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            std::string poll_url = target_sync_id > 0
+                ? ("/internal/models/sync/status?sync_id=" + std::to_string(target_sync_id))
+                : "/internal/models/sync/status";
+            std::string check_resp = make_request(
+                poll_url,
+                "GET",
+                "",
+                "",
+                DEFAULT_CONNECTION_TIMEOUT_MS,
+                LONG_TIMEOUT_MS);
+            final_result = json::parse(check_resp);
+            if (target_sync_id > 0) {
+                if (final_result.value("status", "") != "in_progress" &&
+                    (final_result.value("completed_sync_id", 0) >= target_sync_id ||
+                     final_result.value("sync_id", 0) == target_sync_id)) {
+                    break;
+                }
+            } else {
+                if (!final_result.value("already_in_progress", false) && final_result.value("status", "") != "in_progress") {
+                    break;
+                }
+            }
+
+            if (final_result.contains("progress") && final_result["progress"].is_object()) {
+                const auto& prog = final_result["progress"];
+                std::string cur_model = prog.value("current_model", "");
+                int percent = prog.value("percent", 0);
+                size_t bytes = prog.value("bytes_downloaded", (size_t)0);
+                size_t total = prog.value("bytes_total", (size_t)0);
+                if (!cur_model.empty() && !json_output) {
+                    last_reported_model = cur_model;
+                    std::cerr << "\r\033[K[sync] " << cur_model;
+                    if (total > 0) {
+                        double mb_dl = static_cast<double>(bytes) / (1024.0 * 1024.0);
+                        double mb_total = static_cast<double>(total) / (1024.0 * 1024.0);
+                        std::cerr << " (" << percent << "% - " << std::fixed << std::setprecision(1) << mb_dl << " MB / " << mb_total << " MB)";
+                    }
+                    std::cerr << std::flush;
+                }
+            }
+        }
+
+        if (!last_reported_model.empty()) {
+            std::cerr << std::endl;
+        }
+
+        if (json_output) {
+            std::cout << final_result.dump(2) << std::endl;
+            return is_failed_result(final_result) ? 1 : 0;
+        }
+
+        int checked_count = final_result.value("checked_count", 0);
+        int updated_count = final_result.value("updated_count", 0);
+        std::cout << "Model synchronization completed." << std::endl;
+        std::cout << "Checked " << checked_count << " model(s). " << updated_count << " update(s) applied." << std::endl;
+
+        if (final_result.contains("terminal_error") && !final_result["terminal_error"].get<std::string>().empty()) {
+            std::cerr << "Terminal error: " << final_result["terminal_error"].get<std::string>() << std::endl;
+        }
+
+        if (final_result.contains("models_updated") && final_result["models_updated"].is_array() && !final_result["models_updated"].empty()) {
+            std::cout << "Updated models:" << std::endl;
+            for (const auto& m : final_result["models_updated"]) {
+                std::cout << "  - " << m.get<std::string>() << std::endl;
+            }
+        }
+
+        if (is_failed_result(final_result)) {
+            if (final_result.value("status", "") == "not_found") {
+                std::cerr << "Sync job " << (target_sync_id > 0 ? std::to_string(target_sync_id) : "") << " was not found or has expired on the server." << std::endl;
+            }
+            if (final_result.contains("failed_models") && final_result["failed_models"].is_object() && !final_result["failed_models"].empty()) {
+                std::cerr << "Failed:" << std::endl;
+                for (const auto& [name, err] : final_result["failed_models"].items()) {
+                    std::cerr << "  - " << name << ": " << err.get<std::string>() << std::endl;
+                }
+            }
+            return 1;
+        }
+
+        return 0;
+    } catch (const HttpError& e) {
+
+        std::cerr << "Error syncing models: "
+                  << extract_server_error_message(e) << std::endl;
+        return 1;
+    } catch (const std::exception& e) {
+        std::cerr << "Error syncing models: " << e.what() << std::endl;
         return 1;
     }
 }

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -167,6 +167,8 @@ struct CliConfig {
     std::string output_file;
     bool downloaded = false;
     bool dry_run = false;
+    bool sync_wait = false;
+    std::vector<std::string> sync_target_models;
     std::string agent;
     std::string repo_dir;
     std::string recipe_file;
@@ -1282,6 +1284,9 @@ int main(int argc, char* argv[]) {
     CLI::App* list_cmd = app.add_subcommand("list", "List available models. Use --downloaded to show only local models.")->group("Model management");
     CLI::App* check_updates_cmd = app.add_subcommand(
         "check-updates", "Check downloaded models for upstream updates")->group("Model management");
+    CLI::App* update_models_cmd = app.add_subcommand(
+        "update-models", "Check for and download updates to downloaded models")->group("Model management");
+
     CLI::App* pull_cmd = app.add_subcommand("pull",
         "Pull/download a model by registered name or remote registry checkpoint")->group("Model management");
     CLI::App* delete_cmd = app.add_subcommand("delete", "Delete a model")->group("Model management");
@@ -1298,6 +1303,14 @@ int main(int argc, char* argv[]) {
     list_cmd->add_option("name_filter", config.list_filter,
         "Optional case-insensitive model-name filter; supports * wildcards")
         ->type_name("NAME_FILTER");
+
+    // Update-models options
+    update_models_cmd->add_option("models", config.sync_target_models, "Optional model name(s) to update. If omitted, checks all downloaded models.")->type_name("MODEL");
+    update_models_cmd->add_flag("--check,--dry-run", config.dry_run, "Check for model updates without downloading files");
+    update_models_cmd->add_flag("-w,--wait", config.sync_wait, "Wait for model update operation to complete with live progress output");
+    update_models_cmd->add_flag("-j,--json", config.json_output, "Output result as JSON");
+
+
 
     // Backend management options
     backends_install_cmd->add_option("spec", config.backend_spec, "Backend spec (recipe:backend)")->required()->type_name("SPEC");
@@ -1571,7 +1584,10 @@ int main(int argc, char* argv[]) {
         return client.list_models(!config.downloaded, config.list_filter);
     } else if (check_updates_cmd->count() > 0) {
         return client.check_model_updates();
-    } else if (pull_cmd->count() > 0) {
+    } else if (update_models_cmd->count() > 0) {
+        return client.update_models(config.sync_target_models, config.dry_run, config.json_output, config.sync_wait);
+    }
+ else if (pull_cmd->count() > 0) {
         if (config.model.empty()) {
             std::cerr << "Error: 'lemonade pull' requires a model name or remote registry checkpoint." << std::endl;
             std::cerr << "       See 'lemonade pull --help'." << std::endl;

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -1,17 +1,18 @@
 #pragma once
 
 #include <atomic>
-#include <stdexcept>
+#include <condition_variable>
 #include <cstdint>
-#include <string>
 #include <filesystem>
+#include <functional>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <set>
+#include <stdexcept>
+#include <string>
 #include <vector>
-#include <mutex>
-#include <functional>
-#include <memory>
 #include <nlohmann/json.hpp>
 #include "canonical_id.h"
 #include "directory_watcher.h"
@@ -101,6 +102,7 @@ struct ModelInfo {
     std::string registry_source = "huggingface";  // Remote registry: huggingface/modelscope
     bool downloaded = false;     // Whether model is downloaded and available
     bool update_available = false; // Whether a newer remote-registry version exists
+    std::optional<bool> auto_update = std::nullopt; // Optional per-model auto-update override
     double size = 0.0;   // Model size in GB
     int64_t max_context_window = 0;  // Static model-supported text context, when known
 
@@ -305,14 +307,77 @@ public:
     // Check if model is downloaded
     bool is_model_downloaded(const std::string& model_name);
 
-    // Check all downloaded models for updates in their configured remote registry.
+struct UpdateCheckResult {
+    std::vector<std::string> updated_models;
+    std::vector<std::string> up_to_date_models;
+    std::map<std::string, std::string> failed_models;
+};
+
+    // Check downloaded models for updates in their configured remote registry.
     // Fetches the latest commit SHA for each model's repo and compares it
-    // with the cached commit (refs/main). Sets update_available on models
-    // whose upstream repo has changed and clears stale flags for repos that
-    // were successfully verified as current. Returns public model names with
-    // updates available.
+    // with the cached commit. Sets update_available on models whose upstream
+    // repo has changed and clears stale flags for repos that were successfully
+    // verified as current. If targets is non-empty, restricts check to specified targets.
     // Safe to call from a background thread — locks are internal.
-    std::vector<std::string> check_for_model_updates();
+    UpdateCheckResult check_for_model_updates(const std::vector<std::string>& targets = {});
+
+
+    // Check if model should be automatically updated when updates are detected
+    bool should_auto_update(const ModelInfo& info) const;
+
+    // Register a callback triggered when a model's files are updated on disk (e.g. to evict loaded router backends).
+    void set_model_updated_callback(std::function<void(const std::string&)> cb) {
+        on_model_updated_cb_ = std::move(cb);
+    }
+
+    // Register a callback triggered during synchronization phases (e.g. for deterministic unit testing).
+    void set_sync_phase_callback(std::function<void(const std::string&)> cb) {
+        sync_phase_callback_ = std::move(cb);
+    }
+
+    // Set update_available in cache for deterministic unit testing.
+    void set_model_update_available_for_test(const std::string& model_name, bool available) {
+        std::string canonical = resolve_model_name(model_name);
+        std::lock_guard<std::mutex> lock(models_cache_mutex_);
+        auto it = models_cache_.find(canonical);
+        if (it != models_cache_.end()) {
+            it->second.update_available = available;
+        }
+    }
+
+    // Override update check result for deterministic unit testing.
+    void set_update_check_override_for_test(std::function<UpdateCheckResult(const std::vector<std::string>&)> override_fn) {
+        update_check_override_ = std::move(override_fn);
+    }
+
+    // Override download behavior for deterministic unit testing.
+    void set_download_model_override_for_test(std::function<void(const std::string&, const json&, bool, DownloadProgressCallback)> override_fn) {
+        download_model_override_ = std::move(override_fn);
+    }
+
+    // Cancel active model synchronization.
+    void cancel_sync();
+
+
+    struct SyncEnqueueResult {
+        bool already_running = false;
+        uint64_t sync_id = 0;
+    };
+
+    // Query model sync status (running state, active/pending targets, completed count, or specific sync_id outcome)
+    json get_sync_status(uint64_t sync_id = 0) const;
+
+    // Synchronously queue targets for sync. Returns dispatch result with sync_id and whether sync was already in progress.
+    SyncEnqueueResult enqueue_sync(const std::vector<std::string>& target_models = {}, bool attach_if_running = false);
+
+    // Execute background queue processing until empty.
+    json execute_sync();
+
+    // Trigger sync/update of specified or all outdated models.
+    // When target_models is empty, targets all downloaded outdated models.
+    // If dry_run is true, returns update status without downloading files.
+    json sync_models(const std::vector<std::string>& target_models = {}, bool dry_run = false, bool attach_if_running = false);
+
 
     // True if the model's backend pulls its own models on demand (e.g. flm) and
     // so should be skipped by the router's load-time auto-download path.
@@ -496,6 +561,39 @@ private:
     // Prevent startup and manual update checks from running concurrently.
     std::mutex update_check_mutex_;
 
+    // Server sync state and queue management
+    struct ModelSyncState {
+        mutable std::mutex mutex;
+        mutable std::condition_variable cv;
+        bool is_sync_running = false;
+        bool is_full_sync = false;
+        bool cancel_requested = false;
+        uint64_t current_generation = 0;
+        uint64_t completed_generation = 0;
+        std::map<uint64_t, json> completed_generation_results;
+        std::set<std::string> active_targets;
+        std::set<std::string> pending_targets;
+        std::vector<std::string> completed_targets;
+        std::vector<std::string> models_up_to_date;
+        std::map<std::string, std::string> failed_models;
+        int checked_count = 0;
+        std::string terminal_error;
+
+        // Progress metrics for active model download
+        std::string current_model;
+        std::string current_file;
+        int file_index = 0;
+        int total_files = 0;
+        size_t bytes_downloaded = 0;
+        size_t bytes_total = 0;
+        int percent = 0;
+    };
+    mutable ModelSyncState sync_state_;
+    std::function<void(const std::string&)> on_model_updated_cb_;
+    std::function<void(const std::string&)> sync_phase_callback_;
+    std::function<UpdateCheckResult(const std::vector<std::string>&)> update_check_override_;
+    std::function<void(const std::string&, const json&, bool, DownloadProgressCallback)> download_model_override_;
+
     mutable std::map<std::string, ModelInfo> models_cache_;
     mutable std::map<std::string, std::string> public_model_aliases_;  // public name -> canonical name
     mutable std::map<std::string, std::string> canonical_public_names_;  // canonical name -> public name
@@ -510,6 +608,7 @@ private:
     // stale hard "Model not found" failures for registered user models.
     bool refresh_user_models_from_disk_for_lookup(const std::string& model_name);
 
+    json get_sync_status_locked() const;
     void rebuild_public_model_aliases_locked();
 };
 

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <string>
 #include <functional>
 #include <map>
 #include <optional>
 #include <shared_mutex>
 #include <string>
 #include <vector>
+
 #include <nlohmann/json.hpp>
 
 namespace lemon {
@@ -63,6 +63,7 @@ public:
     // Feature flags
     bool offline() const;
     bool auto_check_model_updates() const;
+    bool auto_update_models() const;
     bool no_fetch_executables() const;
     bool disable_model_filtering() const;
     bool enable_dgpu_gtt() const;

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -126,6 +126,8 @@ private:
         bool local_import);
     void handle_model_by_id(const httplib::Request& req, httplib::Response& res);
     void handle_model_update_check(const httplib::Request& req, httplib::Response& res);
+    void handle_models_sync(const httplib::Request& req, httplib::Response& res);
+    void handle_models_sync_status(const httplib::Request& req, httplib::Response& res);
     void handle_model_files(const httplib::Request& req, httplib::Response& res);
     void handle_model_options_get(const httplib::Request& req, httplib::Response& res);
     void handle_model_options_post(const httplib::Request& req, httplib::Response& res);
@@ -365,6 +367,12 @@ private:
     std::thread http_v4_thread_;
     std::thread http_v6_thread_;
     std::thread model_cache_warmup_thread_;
+    struct SyncTaskThread {
+        std::thread thread;
+        std::shared_ptr<std::atomic<bool>> finished;
+    };
+    std::vector<SyncTaskThread> background_sync_threads_;
+    std::mutex background_sync_mutex_;
 
 
     // Routed servers (all routes/handlers; never listen) and the main-port

--- a/src/cpp/include/lemon_cli/lemonade_client.h
+++ b/src/cpp/include/lemon_cli/lemonade_client.h
@@ -82,6 +82,12 @@ public:
     // Model management commands
     int list_models(bool show_all, const std::string& name_filter = "") const;
     int check_model_updates() const;
+    int update_models(const std::vector<std::string>& models = {}, bool check_only = false, bool json_output = false, bool wait_for_completion = false) const;
+    int sync_models(const std::vector<std::string>& models = {}, bool check_only = false, bool json_output = false, bool wait_for_completion = false) const {
+        return update_models(models, check_only, json_output, wait_for_completion);
+    }
+
+
     // Pulls/registers a model. By default the pull is cache-first
     // (do_not_upgrade=true): an already-downloaded model is reused without
     // contacting Hugging Face. Only the explicit `lemonade pull` update flow

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -7,6 +7,7 @@
     "vulkan_bin": "builtin"
   },
   "auto_check_model_updates": true,
+  "auto_update_models": false,
   "broadcast": true,
   "cloud_providers": [],
   "config_version": 2,

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -114,7 +114,7 @@ static constexpr auto safe_dir_options = fs::directory_options::none;
 namespace lemon {
 
 // Properties which are defined by the user for model registration.
-static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults", "components", "recipe_options", "routing", "system_prompt", "version", "source", "registry_source"};
+static const std::vector<std::string> USER_DEFINED_MODEL_PROPS = std::vector<std::string>{"checkpoints", "checkpoint", "recipe", "mmproj", "size", "image_defaults", "components", "recipe_options", "routing", "system_prompt", "version", "source", "registry_source", "auto_update"};
 
 static std::string visible_extra_variant_name(const lemon::GgufVariant& variant) {
     std::string stem = fs::path(variant.primary_file).stem().string();
@@ -1720,13 +1720,31 @@ static bool hf_selected_artifacts_unchanged(
     const std::map<std::string, std::string>& headers,
     HfTreePageCache* tree_cache);
 
-std::vector<std::string> ModelManager::check_for_model_updates() {
+ModelManager::UpdateCheckResult ModelManager::check_for_model_updates(const std::vector<std::string>& targets) {
     std::lock_guard<std::mutex> update_check_lock(update_check_mutex_);
+
+    if (update_check_override_) {
+        UpdateCheckResult res = update_check_override_(targets);
+        if (sync_phase_callback_) {
+            for (const auto& m : res.up_to_date_models) {
+                sync_phase_callback_("registry_check:" + m);
+            }
+            for (const auto& m : res.updated_models) {
+                sync_phase_callback_("registry_check:" + m);
+            }
+            for (const auto& [m, _] : res.failed_models) {
+                sync_phase_callback_("registry_check:" + m);
+            }
+        }
+        return res;
+    }
+
+    UpdateCheckResult result;
 
     if (auto* cfg = RuntimeConfig::global(); cfg && cfg->offline()) {
         LOG(DEBUG, "ModelManager")
             << "Offline mode enabled, skipping model update check" << std::endl;
-        return {};
+        return result;
     }
 
     struct RepoEntry {
@@ -1741,15 +1759,25 @@ std::vector<std::string> ModelManager::check_for_model_updates() {
     // Fast path only — never the comparison baseline (see active_local_snapshot).
     std::unordered_map<std::string, std::string> processed_snapshots;
 
+    build_cache();
+
     {
         std::lock_guard<std::mutex> lock(models_cache_mutex_);
 
-        if (!cache_valid_) {
-            return {};
+
+
+        std::unordered_set<std::string> target_canonicals;
+        for (const auto& t : targets) {
+            auto it = public_model_aliases_.find(t);
+            target_canonicals.insert(it != public_model_aliases_.end() ? it->second : t);
         }
 
         for (const auto& [name, info] : models_cache_) {
             if (!info.downloaded) {
+                continue;
+            }
+
+            if (!target_canonicals.empty() && target_canonicals.find(name) == target_canonicals.end()) {
                 continue;
             }
 
@@ -1811,6 +1839,13 @@ std::vector<std::string> ModelManager::check_for_model_updates() {
     for (auto& [key, entry] : repos) {
         (void)key;
 
+        {
+            std::lock_guard<std::mutex> lock(sync_state_.mutex);
+            if (sync_state_.cancel_requested) {
+                break;
+            }
+        }
+
         try {
             const auto source =
                 parse_remote_registry_source(entry.registry_source);
@@ -1821,10 +1856,20 @@ std::vector<std::string> ModelManager::check_for_model_updates() {
                 << remote_registry_display_name(source)
                 << ": " << entry.repo_id << std::endl;
 
+            for (const auto& model_name : entry.model_names) {
+                if (sync_phase_callback_) {
+                    sync_phase_callback_("registry_check:" + model_name);
+                }
+            }
+
             const RegistryRepository latest =
                 registry.fetch_repository(entry.repo_id);
 
             if (latest.snapshot_id.empty()) {
+                for (const auto& model_name : entry.model_names) {
+                    std::string pub_name = get_public_model_name(model_name);
+                    result.failed_models[pub_name] = "Empty snapshot returned from registry";
+                }
                 continue;
             }
 
@@ -1985,11 +2030,12 @@ std::vector<std::string> ModelManager::check_for_model_updates() {
 
         } catch (const RegistryNotFoundError& e) {
             LOG(DEBUG, "ModelManager")
-                << e.what() << ", assuming updates for "
-                << entry.model_names.size() << " model(s)" << std::endl;
+                << e.what() << ", skipping update check" << std::endl;
+            std::lock_guard<std::mutex> lock(models_cache_mutex_);
             for (const auto& model_name : entry.model_names) {
-                updated_models.insert(model_name);
-                determination_tracker.mark_determined(model_name);
+                const auto pub_it = canonical_public_names_.find(model_name);
+                std::string pub_name = pub_it != canonical_public_names_.end() ? pub_it->second : model_name;
+                result.failed_models[pub_name] = e.what();
             }
 
         } catch (const std::exception& e) {
@@ -1997,53 +2043,556 @@ std::vector<std::string> ModelManager::check_for_model_updates() {
                 << "Failed to check updates for "
                 << entry.repo_id
                 << " on " << entry.registry_source
-                << ": " << e.what()
-                << ", assuming updates for "
-                << entry.model_names.size() << " model(s)" << std::endl;
+                << ": " << e.what() << std::endl;
+            std::lock_guard<std::mutex> lock(models_cache_mutex_);
             for (const auto& model_name : entry.model_names) {
-                updated_models.insert(model_name);
-                determination_tracker.mark_determined(model_name);
+                const auto pub_it = canonical_public_names_.find(model_name);
+                std::string pub_name = pub_it != canonical_public_names_.end() ? pub_it->second : model_name;
+                result.failed_models[pub_name] = e.what();
             }
         }
     }
-
-    std::vector<std::string> public_updated_models;
 
     {
         std::lock_guard<std::mutex> lock(models_cache_mutex_);
 
         for (auto& [name, info] : models_cache_) {
             if (determination_tracker.is_verified(name)) {
-                info.update_available =
-                    updated_models.count(name) != 0;
+                auto pub_it = canonical_public_names_.find(name);
+                const std::string pub_name =
+                    pub_it != canonical_public_names_.end()
+                        ? pub_it->second
+                        : name;
+                if (result.failed_models.find(pub_name) == result.failed_models.end()) {
+                    info.update_available =
+                        updated_models.count(name) != 0;
+                }
             }
         }
 
-        public_updated_models.reserve(updated_models.size());
-
         for (const auto& name : updated_models) {
-            const auto public_it =
-                canonical_public_names_.find(name);
+            auto pub_it = canonical_public_names_.find(name);
+            const std::string pub_name =
+                pub_it != canonical_public_names_.end()
+                    ? pub_it->second
+                    : name;
+            if (result.failed_models.find(pub_name) == result.failed_models.end()) {
+                result.updated_models.push_back(pub_name);
+            }
+        }
 
-            public_updated_models.push_back(
-                public_it != canonical_public_names_.end()
-                    ? public_it->second
-                    : name);
+        for (const auto& [name, _] : candidate_models) {
+            if (determination_tracker.is_verified(name) && updated_models.count(name) == 0) {
+                auto pub_it = canonical_public_names_.find(name);
+                const std::string pub_name =
+                    pub_it != canonical_public_names_.end()
+                        ? pub_it->second
+                        : name;
+                if (result.failed_models.find(pub_name) == result.failed_models.end()) {
+                    result.up_to_date_models.push_back(pub_name);
+                }
+            }
         }
     }
 
-    std::sort(
-        public_updated_models.begin(),
-        public_updated_models.end());
+    std::sort(result.updated_models.begin(), result.updated_models.end());
+    std::sort(result.up_to_date_models.begin(), result.up_to_date_models.end());
 
-    if (!public_updated_models.empty()) {
+    if (!result.updated_models.empty()) {
         LOG(INFO, "ModelManager")
             << "Updates available for "
-            << public_updated_models.size()
+            << result.updated_models.size()
             << " model(s)" << std::endl;
     }
 
-    return public_updated_models;
+    return result;
+}
+
+bool ModelManager::should_auto_update(const ModelInfo& info) const {
+    if (info.auto_update.has_value()) {
+        return *info.auto_update;
+    }
+    auto* cfg = RuntimeConfig::global();
+    return cfg ? cfg->auto_update_models() : false;
+}
+
+json ModelManager::get_sync_status_locked() const {
+    std::string status = "idle";
+    if (sync_state_.is_sync_running) {
+        status = "in_progress";
+    } else if (!sync_state_.terminal_error.empty() || !sync_state_.failed_models.empty()) {
+        status = "failed";
+    } else if (sync_state_.checked_count > 0) {
+        status = "success";
+    }
+
+    json j = json{
+        {"status", status},
+        {"sync_id", sync_state_.current_generation},
+        {"completed_sync_id", sync_state_.completed_generation},
+        {"already_in_progress", sync_state_.is_sync_running},
+        {"is_full_sync", sync_state_.is_full_sync},
+        {"active_targets", sync_state_.active_targets},
+        {"pending_targets", sync_state_.pending_targets},
+        {"completed_targets", sync_state_.completed_targets},
+        {"models_updated", sync_state_.completed_targets},
+        {"models_up_to_date", sync_state_.models_up_to_date},
+        {"failed_models", sync_state_.failed_models},
+        {"terminal_error", sync_state_.terminal_error},
+        {"checked_count", sync_state_.checked_count},
+        {"updated_count", sync_state_.completed_targets.size()}
+    };
+    if (sync_state_.is_sync_running) {
+        j["progress"] = json{
+            {"current_model", sync_state_.current_model},
+            {"file", sync_state_.current_file},
+            {"file_index", sync_state_.file_index},
+            {"total_files", sync_state_.total_files},
+            {"bytes_downloaded", sync_state_.bytes_downloaded},
+            {"bytes_total", sync_state_.bytes_total},
+            {"percent", sync_state_.percent}
+        };
+    }
+    return j;
+}
+
+json ModelManager::get_sync_status(uint64_t sync_id) const {
+    std::lock_guard<std::mutex> lock(sync_state_.mutex);
+    if (sync_id > 0) {
+        if (sync_state_.is_sync_running && sync_state_.current_generation == sync_id) {
+            return get_sync_status_locked();
+        }
+        auto it = sync_state_.completed_generation_results.find(sync_id);
+        if (it != sync_state_.completed_generation_results.end()) {
+            return it->second;
+        }
+        return json{
+            {"status", "not_found"},
+            {"sync_id", sync_id},
+            {"completed_sync_id", sync_state_.completed_generation},
+            {"already_in_progress", false}
+        };
+    }
+    return get_sync_status_locked();
+}
+
+void ModelManager::cancel_sync() {
+
+    std::lock_guard<std::mutex> lock(sync_state_.mutex);
+    sync_state_.cancel_requested = true;
+}
+
+ModelManager::SyncEnqueueResult ModelManager::enqueue_sync(const std::vector<std::string>& target_models, bool attach_if_running) {
+    std::lock_guard<std::mutex> lock(sync_state_.mutex);
+
+    auto is_already_known = [this](const std::string& target) -> bool {
+        std::string canonical = resolve_model_name(target);
+        std::string pub = get_public_model_name(canonical);
+        if (sync_state_.active_targets.count(target) || sync_state_.active_targets.count(pub) || sync_state_.active_targets.count(canonical)) {
+            return true;
+        }
+        if (std::find(sync_state_.completed_targets.begin(), sync_state_.completed_targets.end(), target) != sync_state_.completed_targets.end() ||
+            std::find(sync_state_.completed_targets.begin(), sync_state_.completed_targets.end(), pub) != sync_state_.completed_targets.end() ||
+            std::find(sync_state_.completed_targets.begin(), sync_state_.completed_targets.end(), canonical) != sync_state_.completed_targets.end()) {
+            return true;
+        }
+        if (std::find(sync_state_.models_up_to_date.begin(), sync_state_.models_up_to_date.end(), target) != sync_state_.models_up_to_date.end() ||
+            std::find(sync_state_.models_up_to_date.begin(), sync_state_.models_up_to_date.end(), pub) != sync_state_.models_up_to_date.end() ||
+            std::find(sync_state_.models_up_to_date.begin(), sync_state_.models_up_to_date.end(), canonical) != sync_state_.models_up_to_date.end()) {
+            return true;
+        }
+        return false;
+    };
+
+    if (sync_state_.is_sync_running) {
+        LOG(INFO, "ModelManager") << "Sync requested while a model synchronization is already in progress. Enqueueing targets." << std::endl;
+        if (!attach_if_running) {
+            if (target_models.empty()) {
+                sync_state_.is_full_sync = true;
+            } else {
+                for (const auto& t : target_models) {
+                    std::string canonical = resolve_model_name(t);
+                    std::string pub = get_public_model_name(canonical);
+                    if (!is_already_known(t)) {
+                        sync_state_.pending_targets.insert(pub);
+                    }
+                }
+            }
+        }
+        return SyncEnqueueResult{/*already_running=*/true, /*sync_id=*/sync_state_.current_generation};
+    }
+
+    sync_state_.current_generation++;
+    sync_state_.is_sync_running = true;
+    sync_state_.is_full_sync = target_models.empty();
+    sync_state_.cancel_requested = false;
+    sync_state_.active_targets.clear();
+    sync_state_.pending_targets.clear();
+    sync_state_.completed_targets.clear();
+    sync_state_.models_up_to_date.clear();
+    sync_state_.failed_models.clear();
+    sync_state_.terminal_error.clear();
+    sync_state_.checked_count = 0;
+    for (const auto& t : target_models) {
+        std::string canonical = resolve_model_name(t);
+        std::string pub = get_public_model_name(canonical);
+        sync_state_.pending_targets.insert(pub);
+    }
+    return SyncEnqueueResult{/*already_running=*/false, /*sync_id=*/sync_state_.current_generation};
+}
+
+json ModelManager::execute_sync() {
+    struct SyncStateGuard {
+        ModelSyncState& state;
+        bool active = true;
+        ~SyncStateGuard() {
+            if (active) {
+                std::lock_guard<std::mutex> lock(state.mutex);
+                state.is_sync_running = false;
+                state.active_targets.clear();
+                state.current_model.clear();
+                state.current_file.clear();
+                state.file_index = 0;
+                state.total_files = 0;
+                state.bytes_downloaded = 0;
+                state.bytes_total = 0;
+                state.percent = 0;
+                state.completed_generation = state.current_generation;
+                state.completed_generation_results[state.current_generation] = json{
+                    {"status", "failed"},
+                    {"sync_id", state.current_generation},
+                    {"completed_sync_id", state.current_generation},
+                    {"already_in_progress", false},
+                    {"terminal_error", "Sync worker terminated unexpectedly"}
+                };
+                state.cv.notify_all();
+            }
+        }
+    } guard{sync_state_};
+
+    enum class ModelCheckOutcome {
+        UpToDate,
+        UpdateAvailable,
+        Failed
+    };
+    std::unordered_map<std::string, ModelCheckOutcome> checked_canonicals_in_job;
+
+    try {
+        while (true) {
+            std::vector<std::string> current_batch;
+            bool run_full_sync = false;
+
+            {
+                std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                if (sync_state_.is_full_sync) {
+                    run_full_sync = true;
+                    sync_state_.is_full_sync = false;
+                }
+            }
+
+            if (run_full_sync) {
+                LOG(INFO, "ModelManager") << "Checking all models for sync/update..." << std::endl;
+                UpdateCheckResult full_check = check_for_model_updates();
+
+                std::vector<std::string> canonicals_to_notify;
+                {
+                    std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                    for (const auto& [m, err] : full_check.failed_models) {
+                        std::string canonical = resolve_model_name(m);
+                        if (std::find(sync_state_.completed_targets.begin(), sync_state_.completed_targets.end(), m) == sync_state_.completed_targets.end()) {
+                            checked_canonicals_in_job[canonical] = ModelCheckOutcome::Failed;
+                            canonicals_to_notify.push_back(canonical);
+                            sync_state_.failed_models[m] = err;
+                            auto up_it = std::find(sync_state_.models_up_to_date.begin(), sync_state_.models_up_to_date.end(), m);
+                            if (up_it != sync_state_.models_up_to_date.end()) {
+                                sync_state_.models_up_to_date.erase(up_it);
+                            }
+                        }
+                    }
+                    for (const auto& m : full_check.updated_models) {
+                        std::string canonical = resolve_model_name(m);
+                        if (std::find(sync_state_.completed_targets.begin(), sync_state_.completed_targets.end(), m) == sync_state_.completed_targets.end()) {
+                            checked_canonicals_in_job[canonical] = ModelCheckOutcome::UpdateAvailable;
+                            canonicals_to_notify.push_back(canonical);
+                            auto up_it = std::find(sync_state_.models_up_to_date.begin(), sync_state_.models_up_to_date.end(), m);
+                            if (up_it != sync_state_.models_up_to_date.end()) {
+                                sync_state_.models_up_to_date.erase(up_it);
+                            }
+                            sync_state_.failed_models.erase(m);
+                            if (sync_state_.active_targets.find(m) == sync_state_.active_targets.end()) {
+                                sync_state_.pending_targets.insert(m);
+                            }
+                        }
+                    }
+                    for (const auto& m : full_check.up_to_date_models) {
+                        std::string canonical = resolve_model_name(m);
+                        if (std::find(sync_state_.completed_targets.begin(), sync_state_.completed_targets.end(), m) == sync_state_.completed_targets.end()) {
+                            checked_canonicals_in_job[canonical] = ModelCheckOutcome::UpToDate;
+                            canonicals_to_notify.push_back(canonical);
+                            sync_state_.failed_models.erase(m);
+                            if (std::find(sync_state_.models_up_to_date.begin(), sync_state_.models_up_to_date.end(), m) == sync_state_.models_up_to_date.end()) {
+                                sync_state_.models_up_to_date.push_back(m);
+                            }
+                        }
+                    }
+                    sync_state_.checked_count = static_cast<int>(checked_canonicals_in_job.size());
+                }
+
+                if (sync_phase_callback_) {
+                    for (const auto& canonical : canonicals_to_notify) {
+                        sync_phase_callback_("check_model:" + canonical);
+                    }
+                    sync_phase_callback_("full_check_done");
+                }
+            }
+
+            std::vector<std::string> pending;
+            {
+                std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                if (!sync_state_.pending_targets.empty()) {
+                    pending.assign(sync_state_.pending_targets.begin(), sync_state_.pending_targets.end());
+                    sync_state_.pending_targets.clear();
+                }
+            }
+
+            for (const auto& t : pending) {
+                try {
+                    std::string canonical_name = resolve_model_name(t);
+                    std::string public_name = get_public_model_name(canonical_name);
+
+                    bool skip = false;
+                    {
+                        std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                        if (sync_state_.active_targets.count(public_name) ||
+                            std::find(sync_state_.completed_targets.begin(), sync_state_.completed_targets.end(), public_name) != sync_state_.completed_targets.end() ||
+                            std::find(sync_state_.models_up_to_date.begin(), sync_state_.models_up_to_date.end(), public_name) != sync_state_.models_up_to_date.end()) {
+                            skip = true;
+                        }
+                    }
+                    if (skip) {
+                        continue;
+                    }
+
+                    if (sync_phase_callback_) {
+                        sync_phase_callback_("check_model:" + canonical_name);
+                    }
+
+                    ModelInfo info = get_model_info(canonical_name);
+                    if (!info.downloaded) {
+                        std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                        sync_state_.failed_models[public_name] = "Model is not downloaded";
+                        checked_canonicals_in_job[canonical_name] = ModelCheckOutcome::Failed;
+                        continue;
+                    }
+
+                    auto it = checked_canonicals_in_job.find(canonical_name);
+                    if (it != checked_canonicals_in_job.end()) {
+                        if (it->second == ModelCheckOutcome::UpdateAvailable) {
+                            current_batch.push_back(public_name);
+                        }
+                        continue;
+                    }
+
+                    UpdateCheckResult target_check = check_for_model_updates({public_name});
+
+                    {
+                        std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                        if (!target_check.failed_models.empty() && target_check.failed_models.count(public_name)) {
+                            sync_state_.failed_models[public_name] = target_check.failed_models[public_name];
+                            checked_canonicals_in_job[canonical_name] = ModelCheckOutcome::Failed;
+                        } else if (!target_check.updated_models.empty()) {
+                            current_batch.push_back(public_name);
+                            checked_canonicals_in_job[canonical_name] = ModelCheckOutcome::UpdateAvailable;
+                            sync_state_.checked_count++;
+                        } else if (!target_check.up_to_date_models.empty() &&
+                                   std::find(target_check.up_to_date_models.begin(), target_check.up_to_date_models.end(), public_name) != target_check.up_to_date_models.end()) {
+                            if (std::find(sync_state_.models_up_to_date.begin(), sync_state_.models_up_to_date.end(), public_name) == sync_state_.models_up_to_date.end()) {
+                                sync_state_.models_up_to_date.push_back(public_name);
+                            }
+                            checked_canonicals_in_job[canonical_name] = ModelCheckOutcome::UpToDate;
+                            sync_state_.checked_count++;
+                        } else {
+                            sync_state_.failed_models[public_name] = "Model is not eligible for remote registry update checks";
+                            checked_canonicals_in_job[canonical_name] = ModelCheckOutcome::Failed;
+                        }
+                    }
+                    if (sync_phase_callback_) {
+                        sync_phase_callback_("target_check_done:" + canonical_name);
+                    }
+                } catch (const std::exception& e) {
+                    {
+                        std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                        sync_state_.failed_models[t] = e.what();
+                        checked_canonicals_in_job[resolve_model_name(t)] = ModelCheckOutcome::Failed;
+                    }
+                    if (sync_phase_callback_) {
+                        sync_phase_callback_("target_check_done:" + resolve_model_name(t));
+                    }
+                }
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                if (current_batch.empty()) {
+                    if (sync_state_.is_full_sync || !sync_state_.pending_targets.empty()) {
+                        continue;
+                    }
+                    sync_state_.is_sync_running = false;
+                    sync_state_.active_targets.clear();
+                    sync_state_.current_model.clear();
+                    sync_state_.current_file.clear();
+                    sync_state_.file_index = 0;
+                    sync_state_.total_files = 0;
+                    sync_state_.bytes_downloaded = 0;
+                    sync_state_.bytes_total = 0;
+                    sync_state_.percent = 0;
+                    sync_state_.completed_generation = sync_state_.current_generation;
+                    json res = get_sync_status_locked();
+                    sync_state_.completed_generation_results[sync_state_.current_generation] = res;
+                    if (sync_state_.completed_generation_results.size() > 32) {
+                        sync_state_.completed_generation_results.erase(sync_state_.completed_generation_results.begin());
+                    }
+                    guard.active = false;
+                    sync_state_.cv.notify_all();
+                    return res;
+                }
+            }
+
+            for (const auto& model_name : current_batch) {
+                {
+                    std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                    sync_state_.active_targets.insert(model_name);
+                }
+
+                LOG(INFO, "ModelManager") << "Syncing model: " << model_name << std::endl;
+                try {
+                    auto progress_cb = [this, model_name](const DownloadProgress& prog) -> bool {
+                        std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                        if (sync_state_.cancel_requested) {
+                            return false;
+                        }
+                        sync_state_.current_model = model_name;
+                        sync_state_.current_file = prog.file;
+                        sync_state_.file_index = prog.file_index;
+                        sync_state_.total_files = prog.total_files;
+                        sync_state_.bytes_downloaded = prog.bytes_downloaded;
+                        sync_state_.bytes_total = prog.bytes_total;
+                        sync_state_.percent = prog.percent;
+                        return true;
+                    };
+
+                    download_model(model_name, json::object(), /*do_not_upgrade=*/false, progress_cb);
+
+                    std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                    sync_state_.active_targets.erase(model_name);
+                    sync_state_.completed_targets.push_back(model_name);
+                } catch (const std::exception& e) {
+                    LOG(ERROR, "ModelManager") << "Failed to sync model " << model_name << ": " << e.what() << std::endl;
+                    std::lock_guard<std::mutex> lock(sync_state_.mutex);
+                    sync_state_.active_targets.erase(model_name);
+                    sync_state_.failed_models[model_name] = e.what();
+                }
+            }
+        }
+    } catch (const std::exception& e) {
+        LOG(ERROR, "ModelManager") << "Terminal error in model synchronization: " << e.what() << std::endl;
+        std::lock_guard<std::mutex> lock(sync_state_.mutex);
+        sync_state_.terminal_error = e.what();
+        sync_state_.is_sync_running = false;
+        sync_state_.active_targets.clear();
+        sync_state_.current_model.clear();
+        sync_state_.current_file.clear();
+        sync_state_.file_index = 0;
+        sync_state_.total_files = 0;
+        sync_state_.bytes_downloaded = 0;
+        sync_state_.bytes_total = 0;
+        sync_state_.percent = 0;
+        sync_state_.completed_generation = sync_state_.current_generation;
+        json res = get_sync_status_locked();
+        sync_state_.completed_generation_results[sync_state_.current_generation] = res;
+        if (sync_state_.completed_generation_results.size() > 32) {
+            sync_state_.completed_generation_results.erase(sync_state_.completed_generation_results.begin());
+        }
+        guard.active = false;
+        sync_state_.cv.notify_all();
+        return res;
+    }
+
+    return get_sync_status();
+}
+
+json ModelManager::sync_models(const std::vector<std::string>& target_models, bool dry_run, bool attach_if_running) {
+    if (dry_run) {
+        LOG(INFO, "ModelManager") << "Checking models for sync/update (dry-run)..." << std::endl;
+        UpdateCheckResult check_res = check_for_model_updates(target_models);
+
+        std::vector<std::string> models_to_update = check_res.updated_models;
+        std::vector<std::string> models_up_to_date = check_res.up_to_date_models;
+        std::map<std::string, std::string> failed_models = check_res.failed_models;
+        int checked_count = check_res.up_to_date_models.size() + check_res.updated_models.size();
+
+        if (!target_models.empty()) {
+            for (const auto& input_name : target_models) {
+                std::string canonical_name = resolve_model_name(input_name);
+                std::string pub_name = get_public_model_name(canonical_name);
+                if (failed_models.count(pub_name) || failed_models.count(input_name)) {
+                    continue;
+                }
+                ModelInfo info;
+                bool found = false;
+                {
+                    std::lock_guard<std::mutex> lock(models_cache_mutex_);
+                    auto it = models_cache_.find(canonical_name);
+                    if (it != models_cache_.end()) {
+                        info = it->second;
+                        found = true;
+                    }
+                }
+
+                if (!found) {
+                    failed_models[input_name] = "Model not found or registered";
+                    continue;
+                }
+
+                if (!info.downloaded) {
+                    failed_models[input_name] = "Model is not downloaded";
+                    continue;
+                }
+            }
+        }
+
+        json status_info = get_sync_status();
+        bool running = status_info.value("already_in_progress", false);
+        return json{
+            {"status", running ? "in_progress" : (failed_models.empty() ? "success" : "failed")},
+            {"dry_run", true},
+            {"already_in_progress", running},
+            {"sync_id", status_info.value("sync_id", 0)},
+            {"completed_sync_id", status_info.value("completed_sync_id", 0)},
+            {"checked_count", checked_count},
+            {"updated_count", models_to_update.size()},
+            {"models_updated", models_to_update},
+            {"models_up_to_date", models_up_to_date},
+            {"failed_models", failed_models}
+        };
+    }
+
+    SyncEnqueueResult enqueue_res = enqueue_sync(target_models, attach_if_running);
+    uint64_t target_gen = enqueue_res.sync_id;
+
+    if (enqueue_res.already_running) {
+        std::unique_lock<std::mutex> lock(sync_state_.mutex);
+        sync_state_.cv.wait(lock, [this, target_gen]() {
+            return sync_state_.completed_generation >= target_gen && (!sync_state_.is_sync_running || sync_state_.current_generation > target_gen);
+        });
+        auto it = sync_state_.completed_generation_results.find(target_gen);
+        if (it != sync_state_.completed_generation_results.end()) {
+            return it->second;
+        }
+        return get_sync_status_locked();
+    }
+
+    return execute_sync();
 }
 
 static void load_checkpoints(ModelInfo& info, json& model_json) {
@@ -2276,6 +2825,9 @@ void ModelManager::build_cache() {
         info.size = JsonUtils::get_or_default<double>(value, "size", 0.0);
         info.cloud_provider = JsonUtils::get_or_default<std::string>(value, "cloud_provider", "");
         info.system_prompt = JsonUtils::get_or_default<std::string>(value, "system_prompt", "");
+        if (value.contains("auto_update") && value["auto_update"].is_boolean()) {
+            info.auto_update = value["auto_update"].get<bool>();
+        }
 
         // Registry-backed collections store their components remotely — the
         // cached manifest is the single source of truth. Rebuild the component
@@ -2351,6 +2903,9 @@ void ModelManager::build_cache() {
         info.size = JsonUtils::get_or_default<double>(value, "size", 0.0);
         info.cloud_provider = JsonUtils::get_or_default<std::string>(value, "cloud_provider", "");
         info.system_prompt = JsonUtils::get_or_default<std::string>(value, "system_prompt", "");
+        if (value.contains("auto_update") && value["auto_update"].is_boolean()) {
+            info.auto_update = value["auto_update"].get<bool>();
+        }
 
         // Registry-backed user collections (created by `lemonade pull <org>/<repo>` or `--source`)
         // keep only a repo pointer in user_models.json; their components live in
@@ -2478,6 +3033,10 @@ void ModelManager::build_cache() {
     for (auto& [name, info] : all_models) {
         json jro = json_recipe_options.count(name) ? json_recipe_options[name] : json(nullptr);
         info.recipe_options = build_recipe_options(info, jro, cache_key_to_canonical_id(name), recipe_options_);
+        if (info.recipe_options.to_json().contains("auto_update") &&
+            info.recipe_options.to_json()["auto_update"].is_boolean()) {
+            info.auto_update = info.recipe_options.to_json()["auto_update"].get<bool>();
+        }
     }
 
     // Step 2: Filter by backend availability. This is the full-registry pass, so
@@ -3408,7 +3967,7 @@ void ModelManager::download_registered_model(const ModelInfo& info, bool do_not_
     if (is_user_model_name(canonical_model_name))
     {
         std::lock_guard<std::mutex> lock(models_cache_mutex_);
-        auto it = models_cache_.find(info.model_name);
+        auto it = models_cache_.find(canonical_model_name);
         if (it != models_cache_.end())
         {
             json updated_user_models = load_optional_json(get_user_models_file());
@@ -3753,6 +4312,10 @@ void ModelManager::download_model(const std::string& model_name,
                                  const json& model_data,
                                  bool do_not_upgrade,
                                  DownloadProgressCallback progress_callback) {
+    if (download_model_override_) {
+        download_model_override_(model_name, model_data, do_not_upgrade, progress_callback);
+        return;
+    }
     std::set<std::string> visited;
     download_model(model_name, model_data, do_not_upgrade, progress_callback, visited,
                    false, false, false);
@@ -4037,7 +4600,7 @@ void ModelManager::download_model(const std::string& model_name,
                 continue;
             }
             auto comp_info = get_model_info(component);
-            if (comp_info.downloaded) {
+            if (comp_info.downloaded && do_not_upgrade) {
                 LOG(INFO, "ModelManager") << "Component already downloaded: " << component << std::endl;
                 continue;
             }
@@ -4139,7 +4702,35 @@ void ModelManager::download_model(const std::string& model_name,
         return;
     }
 
+    std::map<std::string, std::filesystem::path> resolved_paths_before;
+    {
+        std::lock_guard<std::mutex> lock(models_cache_mutex_);
+        auto it = models_cache_.find(model_info.model_name);
+        if (it != models_cache_.end()) {
+            for (const auto& [k, v] : it->second.resolved_paths) {
+                resolved_paths_before[k] = path_from_utf8(v).lexically_normal();
+            }
+        }
+    }
+
     download_registered_model(model_info, do_not_upgrade, progress_callback);
+
+    std::map<std::string, std::filesystem::path> resolved_paths_after;
+    {
+        std::lock_guard<std::mutex> lock(models_cache_mutex_);
+        auto it = models_cache_.find(model_info.model_name);
+        if (it != models_cache_.end()) {
+            for (const auto& [k, v] : it->second.resolved_paths) {
+                resolved_paths_after[k] = path_from_utf8(v).lexically_normal();
+            }
+        }
+    }
+
+    if (on_model_updated_cb_ && resolved_paths_before != resolved_paths_after) {
+        on_model_updated_cb_(model_name);
+    }
+
+
 }
 
 namespace registry_files {

--- a/src/cpp/server/recipe_options.cpp
+++ b/src/cpp/server/recipe_options.cpp
@@ -3,6 +3,7 @@
 #include <lemon/utils/custom_args.h>
 #include <nlohmann/json.hpp>
 #include <map>
+#include <optional>
 #ifdef LEMONADE_CLI
 #include <CLI/CLI.hpp>
 #else
@@ -25,6 +26,7 @@ static const json& common_defaults() {
         {"downsize_idle_timeout", 60},    // Default soft idle timeout (1 min)
         {"evict_weight_factor", 1.0},     // Eviction-protection weight (higher = more protected)
         {"pinned", false},
+        {"auto_update", nullptr},
     };
     return d;
 }
@@ -83,6 +85,7 @@ static std::vector<std::string> get_keys_for_recipe(const std::string& recipe) {
     keys.push_back("downsize_idle_timeout");
     keys.push_back("evict_weight_factor");
     keys.push_back("pinned");
+    keys.push_back("auto_update");
 
     return keys;
 }

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -392,14 +392,24 @@ double RuntimeConfig::auto_evict_threshold_pct() const {
 }
 
 bool RuntimeConfig::offline() const {
-
     std::shared_lock lock(mutex_);
     return config_["offline"].get<bool>();
 }
 
 bool RuntimeConfig::auto_check_model_updates() const {
     std::shared_lock lock(mutex_);
-    return config_.value("auto_check_model_updates", true);
+    if (config_.contains("auto_check_model_updates")) {
+        return config_["auto_check_model_updates"].get<bool>();
+    }
+    return true;
+}
+
+bool RuntimeConfig::auto_update_models() const {
+    std::shared_lock lock(mutex_);
+    if (config_.contains("auto_update_models")) {
+        return config_["auto_update_models"].get<bool>();
+    }
+    return false;
 }
 
 bool RuntimeConfig::no_fetch_executables() const {
@@ -725,6 +735,7 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
         }
     } else if (key == "broadcast" || key == "no_broadcast" || key == "offline" ||
                key == "auto_check_model_updates" ||
+               key == "auto_update_models" ||
                key == "no_fetch_executables" ||
                key == "disable_model_filtering" || key == "enable_dgpu_gtt") {
         if (!value.is_boolean()) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -236,7 +236,8 @@ bool is_quiet_polling_path(const std::string& path) {
            path == "/api/v0/system-stats" || path == "/api/v1/system-stats" ||
            path == "/v0/system-stats" || path == "/v1/system-stats" ||
            path == "/api/v0/stats" || path == "/api/v1/stats" ||
-           path == "/v0/stats" || path == "/v1/stats";
+           path == "/v0/stats" || path == "/v1/stats" ||
+           path == "/internal/models/sync" || path == "/internal/models/sync/status";
 }
 
 std::string join_warnings(const std::vector<std::string>& warnings) {
@@ -414,6 +415,12 @@ Server::Server(std::shared_ptr<RuntimeConfig> config,
     const std::set<std::string> seed_needed = active_policy_helper_models();
     router_->reconcile_routing_helpers(seed_needed, seed_generation);
 
+    model_manager_->set_model_updated_callback([this](const std::string& model_name) {
+        if (router_ && router_->is_model_loaded(model_name)) {
+            LOG(INFO, "Server") << "Evicting updated model from memory: " << model_name << std::endl;
+            router_->unload_model(model_name);
+        }
+    });
     {
         lemon::jobs::OpProviders providers;
         struct JobModelState {
@@ -684,8 +691,30 @@ void Server::start_model_cache_warmup() {
         if (config_->auto_check_model_updates()) {
             try {
                 LOG(DEBUG, "Server") << "Checking downloaded models for updates..." << std::endl;
-                (void)model_manager_->check_for_model_updates();
+                auto check_res = model_manager_->check_for_model_updates();
                 LOG(DEBUG, "Server") << "Model update check complete" << std::endl;
+
+                for (const auto& [model_name, err] : check_res.failed_models) {
+                    LOG(WARNING, "Server") << "Model update check failed for " << model_name << ": " << err << std::endl;
+                }
+
+                std::vector<std::string> auto_update_targets;
+                for (const auto& public_name : check_res.updated_models) {
+
+                    try {
+                        std::string canonical_name = model_manager_->resolve_model_name(public_name);
+                        ModelInfo info = model_manager_->get_model_info(canonical_name);
+                        if (model_manager_->should_auto_update(info)) {
+                            auto_update_targets.push_back(public_name);
+                        }
+                    } catch (...) {}
+                }
+
+
+                if (!auto_update_targets.empty()) {
+                    LOG(INFO, "Server") << "Auto-updating " << auto_update_targets.size() << " model(s)..." << std::endl;
+                    (void)model_manager_->sync_models(auto_update_targets, /*dry_run=*/false);
+                }
             } catch (const std::exception& e) {
                 LOG(WARNING, "Server") << "Model update check failed: " << e.what() << std::endl;
             } catch (...) {
@@ -790,11 +819,24 @@ void Server::stop_http_listeners() {
 
 Server::~Server() {
     cancel_download_jobs();
+    if (model_manager_) {
+        model_manager_->cancel_sync();
+    }
     stop();
     if (model_cache_warmup_thread_.joinable()) {
         model_cache_warmup_thread_.join();
     }
+
+    std::lock_guard<std::mutex> lock(background_sync_mutex_);
+    for (auto& entry : background_sync_threads_) {
+        if (entry.thread.joinable()) {
+            entry.thread.join();
+        }
+    }
+    background_sync_threads_.clear();
 }
+
+
 
 namespace {
 
@@ -1428,6 +1470,12 @@ void Server::setup_routes(httplib::Server &web_server) {
     });
     web_server.Post("/internal/simulate-vram-pressure", [this](const httplib::Request& req, httplib::Response& res) {
         handle_simulate_vram_pressure(req, res);
+    });
+    web_server.Post("/internal/models/sync", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_models_sync(req, res);
+    });
+    web_server.Get("/internal/models/sync/status", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_models_sync_status(req, res);
     });
 
     web_server.Get("/internal/aliases", [this](const httplib::Request& req, httplib::Response& res) {
@@ -2258,13 +2306,11 @@ void Server::stop() {
         running_ = false;
         shutdown_requested_ = false;  // Reset for potential future use
 
-        // Stop WebSocket server
         if (websocket_server_) {
             LOG(INFO, "Server") << "Stopping WebSocket server..." << std::endl;
             websocket_server_->stop();
         }
 
-        // Explicitly clean up router (unload models, stop backend servers)
         if (router_) {
             LOG(INFO, "Server") << "Unloading models and stopping backend servers..." << std::endl;
             try {
@@ -2280,8 +2326,22 @@ void Server::stop() {
         LOG(INFO, "Server") << "Cleanup complete" << std::endl;
     }
 
+    if (model_manager_) {
+        model_manager_->cancel_sync();
+    }
+
     if (model_cache_warmup_thread_.joinable()) {
         model_cache_warmup_thread_.join();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(background_sync_mutex_);
+        for (auto& task : background_sync_threads_) {
+            if (task.thread.joinable()) {
+                task.thread.join();
+            }
+        }
+        background_sync_threads_.clear();
     }
 }
 
@@ -2628,18 +2688,203 @@ void Server::handle_model_update_check(const httplib::Request& req, httplib::Res
     }
 
     try {
-        auto updated_models = model_manager_->check_for_model_updates();
+        auto check_res = model_manager_->check_for_model_updates();
+
         nlohmann::json response = {
-            {"status", "success"},
-            {"updates_available", updated_models.size()},
-            {"models", updated_models}
+            {"status", check_res.failed_models.empty() ? "success" : "failed"},
+            {"updates_available", check_res.updated_models.size()},
+            {"models", check_res.updated_models},
+            {"failed_models", check_res.failed_models}
         };
+
         res.set_content(response.dump(), "application/json");
     } catch (const std::exception& e) {
         LOG(WARNING, "Server") << "Manual model update check failed: " << e.what() << std::endl;
         res.status = 500;
         res.set_content(
             nlohmann::json{{"error", std::string("Model update check failed: ") + e.what()}}.dump(),
+            "application/json");
+    }
+}
+
+void Server::handle_models_sync(const httplib::Request& req, httplib::Response& res) {
+    if (config_->offline()) {
+        res.status = 409;
+        res.set_content(
+            nlohmann::json{{"error", "Cannot sync model updates while offline=true"}}.dump(),
+            "application/json");
+        return;
+    }
+
+    std::vector<std::string> target_models;
+    bool dry_run = false;
+    bool async_dispatch = true;
+    bool async_specified = false;
+    bool attach_if_running = false;
+
+    if (!req.body.empty()) {
+        try {
+            auto body_json = nlohmann::json::parse(req.body);
+            if (!body_json.is_object()) {
+                res.status = 400;
+                res.set_content(
+                    nlohmann::json{{"error", "Request body must be a JSON object"}}.dump(),
+                    "application/json");
+                return;
+            }
+            if (body_json.contains("models")) {
+                if (!body_json["models"].is_array()) {
+                    res.status = 400;
+                    res.set_content(
+                        nlohmann::json{{"error", "'models' must be an array of strings"}}.dump(),
+                        "application/json");
+                    return;
+                }
+                for (const auto& item : body_json["models"]) {
+                    if (!item.is_string()) {
+                        res.status = 400;
+                        res.set_content(
+                            nlohmann::json{{"error", "Each item in 'models' must be a string"}}.dump(),
+                            "application/json");
+                        return;
+                    }
+                    target_models.push_back(item.get<std::string>());
+                }
+            }
+            if (body_json.contains("dry_run")) {
+                if (!body_json["dry_run"].is_boolean()) {
+                    res.status = 400;
+                    res.set_content(
+                        nlohmann::json{{"error", "'dry_run' must be a boolean"}}.dump(),
+                        "application/json");
+                    return;
+                }
+                dry_run = body_json["dry_run"].get<bool>();
+            }
+            if (body_json.contains("async")) {
+                if (!body_json["async"].is_boolean()) {
+                    res.status = 400;
+                    res.set_content(
+                        nlohmann::json{{"error", "'async' must be a boolean"}}.dump(),
+                        "application/json");
+                    return;
+                }
+                async_dispatch = body_json["async"].get<bool>();
+                async_specified = true;
+            }
+            if (body_json.contains("attach_if_running")) {
+                if (!body_json["attach_if_running"].is_boolean()) {
+                    res.status = 400;
+                    res.set_content(
+                        nlohmann::json{{"error", "'attach_if_running' must be a boolean"}}.dump(),
+                        "application/json");
+                    return;
+                }
+                attach_if_running = body_json["attach_if_running"].get<bool>();
+            }
+        } catch (const std::exception& e) {
+            res.status = 400;
+            res.set_content(
+                nlohmann::json{{"error", std::string("Invalid JSON body: ") + e.what()}}.dump(),
+                "application/json");
+            return;
+        }
+    }
+
+    if (dry_run) {
+        try {
+            nlohmann::json sync_result = model_manager_->sync_models(target_models, true);
+            res.set_content(sync_result.dump(), "application/json");
+            res.status = 200;
+        } catch (const std::exception& e) {
+            LOG(WARNING, "Server") << "Model sync dry-run failed: " << e.what() << std::endl;
+            res.status = 500;
+            res.set_content(
+                nlohmann::json{{"error", std::string("Model sync dry-run failed: ") + e.what()}}.dump(),
+                "application/json");
+        }
+        return;
+    }
+
+    if (!async_specified || async_dispatch) {
+        auto enqueue_res = model_manager_->enqueue_sync(target_models, attach_if_running);
+        if (enqueue_res.already_running) {
+            nlohmann::json status = model_manager_->get_sync_status(enqueue_res.sync_id);
+            res.set_content(status.dump(), "application/json");
+            res.status = 200;
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(background_sync_mutex_);
+
+        for (auto it = background_sync_threads_.begin(); it != background_sync_threads_.end(); ) {
+            if (it->finished->load() && it->thread.joinable()) {
+                it->thread.join();
+                it = background_sync_threads_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        auto finished_flag = std::make_shared<std::atomic<bool>>(false);
+        std::thread worker([this, finished_flag]() {
+            try {
+                LOG(INFO, "Server") << "Background model sync thread started" << std::endl;
+                model_manager_->execute_sync();
+                LOG(INFO, "Server") << "Background model sync thread completed successfully" << std::endl;
+            } catch (const std::exception& e) {
+                LOG(WARNING, "Server") << "Background model sync failed: " << e.what() << std::endl;
+            }
+            finished_flag->store(true);
+        });
+
+        background_sync_threads_.push_back({std::move(worker), finished_flag});
+
+        nlohmann::json dispatched_result = model_manager_->get_sync_status(enqueue_res.sync_id);
+        dispatched_result["message"] = "Model synchronization dispatched in background";
+        dispatched_result["async"] = true;
+        dispatched_result["already_in_progress"] = false;
+        res.set_content(dispatched_result.dump(), "application/json");
+        res.status = 202;
+        return;
+    }
+
+
+    try {
+        nlohmann::json sync_result = model_manager_->sync_models(target_models, false, attach_if_running);
+        res.set_content(sync_result.dump(), "application/json");
+        res.status = 200;
+    } catch (const std::exception& e) {
+        LOG(WARNING, "Server") << "Model sync failed: " << e.what() << std::endl;
+        res.status = 500;
+        res.set_content(
+            nlohmann::json{{"error", std::string("Model sync failed: ") + e.what()}}.dump(),
+            "application/json");
+    }
+}
+
+void Server::handle_models_sync_status(const httplib::Request& req, httplib::Response& res) {
+    try {
+        uint64_t sync_id = 0;
+        if (req.has_param("sync_id")) {
+            try {
+                sync_id = std::stoull(req.get_param_value("sync_id"));
+            } catch (...) {
+                res.status = 400;
+                res.set_content(
+                    nlohmann::json{{"error", "Invalid sync_id parameter"}}.dump(),
+                    "application/json");
+                return;
+            }
+        }
+        nlohmann::json status = model_manager_->get_sync_status(sync_id);
+        res.set_content(status.dump(), "application/json");
+        res.status = 200;
+    } catch (const std::exception& e) {
+        LOG(WARNING, "Server") << "Failed to get sync status: " << e.what() << std::endl;
+        res.status = 500;
+        res.set_content(
+            nlohmann::json{{"error", std::string("Failed to get sync status: ") + e.what()}}.dump(),
             "application/json");
     }
 }

--- a/test/cpp/test_model_sync_and_auto_update.cpp
+++ b/test/cpp/test_model_sync_and_auto_update.cpp
@@ -1,0 +1,616 @@
+// Contract and unit tests for Model Sync and Auto-Update features.
+// Tests:
+// - RuntimeConfig auto_update_models setting and validation.
+// - ModelInfo auto_update per-model override precedence.
+// - ModelManager::should_auto_update resolution hierarchy.
+
+#include "lemon/model_manager.h"
+#include "lemon/runtime_config.h"
+#include "lemon/utils/path_utils.h"
+
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <thread>
+
+using lemon::json;
+
+static int failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++failures;
+}
+
+static void set_env_var(const std::string& name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name.c_str(), value.c_str());
+#else
+    setenv(name.c_str(), value.c_str(), 1);
+#endif
+}
+
+int main() {
+    std::cout << "=== Model Sync & Auto-Update Unit Tests ===" << std::endl;
+
+    const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+    const std::filesystem::path temp_cache =
+        std::filesystem::temp_directory_path() / ("lemonade_sync_test_" + std::to_string(tick));
+    std::error_code ec;
+    std::filesystem::create_directories(temp_cache, ec);
+    lemon::utils::set_cache_dir(temp_cache.string());
+    lemon::utils::set_config_dir(temp_cache.string());
+
+    const auto dummy_model_dir =
+        temp_cache / "huggingface" / "hub" / "models--unsloth--gemma-3-270m-it-GGUF";
+    std::filesystem::create_directories(dummy_model_dir / "refs", ec);
+    std::filesystem::create_directories(dummy_model_dir / "snapshots" / "main", ec);
+    {
+        std::ofstream refs_file((dummy_model_dir / "refs" / "main").string());
+        refs_file << "main\n";
+    }
+    {
+        std::ofstream dummy_file((dummy_model_dir / "snapshots" / "main" / "gemma-3-270m-it-UD-IQ2_M.gguf").string(), std::ios::binary);
+        dummy_file << "GGUF_dummy_content";
+    }
+
+    set_env_var("LEMONADE_CACHE_DIR", temp_cache.string());
+    set_env_var("HF_HOME", (temp_cache / "huggingface").string());
+
+    // Test 1: RuntimeConfig default for auto_update_models is false
+    json initial_config = {
+        {"offline", false},
+        {"disable_model_filtering", true},
+        {"enable_dgpu_gtt", false},
+        {"no_fetch_executables", true},
+        {"auto_check_model_updates", true},
+        {"auto_update_models", false}
+    };
+    lemon::RuntimeConfig cfg(initial_config);
+    lemon::RuntimeConfig::set_global(&cfg);
+    check("RuntimeConfig default auto_update_models is false", cfg.auto_update_models() == false);
+
+    // Test 2: RuntimeConfig set auto_update_models boolean validation
+    try {
+        cfg.set(json{{"auto_update_models", true}});
+        check("RuntimeConfig set auto_update_models=true succeeds", cfg.auto_update_models() == true);
+    } catch (const std::exception& e) {
+        std::printf("Exception in test 2: %s\n", e.what());
+        check("RuntimeConfig set auto_update_models=true succeeds", false);
+    } catch (...) {
+        check("RuntimeConfig set auto_update_models=true succeeds", false);
+    }
+
+
+    try {
+        cfg.set(json{{"auto_update_models", "not_a_boolean"}});
+        check("RuntimeConfig set invalid type for auto_update_models throws", false);
+    } catch (const std::invalid_argument&) {
+        check("RuntimeConfig set invalid type for auto_update_models throws", true);
+    } catch (...) {
+        check("RuntimeConfig set invalid type for auto_update_models throws", false);
+    }
+
+    lemon::RuntimeConfig* gcfg = lemon::RuntimeConfig::global();
+    if (!gcfg) {
+        gcfg = &cfg;
+    }
+
+    gcfg->set(json{{"auto_update_models", false}});
+
+    lemon::ModelManager mm;
+
+    // Test 3: ModelManager::should_auto_update precedence
+    // Case A: info.auto_update is std::nullopt -> uses global RuntimeConfig (false)
+    lemon::ModelInfo info1;
+    info1.model_name = "test-model-1";
+    info1.auto_update = std::nullopt;
+
+    bool should1 = mm.should_auto_update(info1);
+    check("should_auto_update fallback to global (false)", should1 == false);
+
+    // When global auto_update_models is true
+    gcfg->set(json{{"auto_update_models", true}});
+    bool should2 = mm.should_auto_update(info1);
+    check("should_auto_update fallback to global (true)", should2 == true);
+
+    // Case B: Explicit per-model override auto_update = true overrides global false
+    gcfg->set(json{{"auto_update_models", false}});
+    lemon::ModelInfo info2;
+    info2.model_name = "test-model-2";
+    info2.auto_update = true;
+    bool should3 = mm.should_auto_update(info2);
+    check("per-model auto_update=true overrides global false", should3 == true);
+
+    // Case C: Explicit per-model override auto_update = false overrides global true
+    gcfg->set(json{{"auto_update_models", true}});
+    lemon::ModelInfo info3;
+    info3.model_name = "test-model-3";
+    info3.auto_update = false;
+    bool should4 = mm.should_auto_update(info3);
+    check("per-model auto_update=false overrides global true", should4 == false);
+
+    // Test 4: ModelManager::get_sync_status and dry-run sync query
+    mm.set_update_check_override_for_test([](const auto&) {
+        lemon::ModelManager::UpdateCheckResult r;
+        r.up_to_date_models = {"Tiny-Test-Model-GGUF"};
+        return r;
+    });
+    json status = mm.get_sync_status();
+    check("get_sync_status returns idle status", status.value("status", "") == "idle");
+    check("get_sync_status already_in_progress is false", status.value("already_in_progress", true) == false);
+
+    json dry_run_res = mm.sync_models({}, /*dry_run=*/true);
+    check("sync_models dry_run returns status", dry_run_res.contains("status") && dry_run_res.contains("checked_count"));
+
+    // Test 5: RecipeOptions auto_update preservation
+    json ro_json = {{"auto_update", true}};
+    lemon::RecipeOptions ro("llamacpp", ro_json);
+    check("RecipeOptions auto_update parsed successfully", ro.to_json().value("auto_update", false) == true);
+
+    json ro_json_null = {{"auto_update", nullptr}};
+    lemon::RecipeOptions ro_null("llamacpp", ro_json_null);
+    check("RecipeOptions auto_update nullptr parsed successfully", ro_null.to_json().contains("auto_update") == false);
+
+    // Test 6: ModelSyncState outcome structure in get_sync_status
+    json status_fields = mm.get_sync_status();
+    check("get_sync_status contains checked_count", status_fields.contains("checked_count"));
+    check("get_sync_status contains updated_count", status_fields.contains("updated_count"));
+    check("get_sync_status contains models_updated", status_fields.contains("models_updated"));
+    check("get_sync_status contains models_up_to_date", status_fields.contains("models_up_to_date"));
+    check("get_sync_status contains status field", status_fields.contains("status"));
+    check("get_sync_status contains terminal_error field", status_fields.contains("terminal_error"));
+
+    // Test 8: Single-pass sync execution
+    lemon::ModelManager mm3;
+    mm3.set_update_check_override_for_test([](const auto&) {
+        lemon::ModelManager::UpdateCheckResult r;
+        r.up_to_date_models = {"Tiny-Test-Model-GGUF"};
+        return r;
+    });
+    mm3.set_download_model_override_for_test([](const auto&, const auto&, bool, auto) {});
+    mm3.enqueue_sync({});
+    json exec_res = mm3.execute_sync();
+    std::string s_status = exec_res.value("status", "");
+    check("execute_sync single pass returns valid status", s_status == "idle" || s_status == "success" || s_status == "failed");
+
+    // Test 10: UpdateCheckResult registry failure handling
+    lemon::ModelManager mm_fail;
+    mm_fail.set_update_check_override_for_test([](const auto& t) {
+        lemon::ModelManager::UpdateCheckResult r;
+        for (const auto& m : t) {
+            r.failed_models[m] = "Repository not found";
+        }
+        return r;
+    });
+    json dry_fail = mm_fail.sync_models({"non_existent_model_test_xyz"}, /*dry_run=*/true);
+    check("registry failure populates failed_models", dry_fail.contains("failed_models") && dry_fail["failed_models"].contains("non_existent_model_test_xyz"));
+    check("registry failure sets status to failed", dry_fail.value("status", "") == "failed");
+    check("registry failure does not increment checked_count", dry_fail.value("checked_count", 0) == 0);
+
+    // Test 11: Overlapping request target deduplication
+    lemon::ModelManager mm_dedup;
+    mm_dedup.set_update_check_override_for_test([](const auto& t) {
+        lemon::ModelManager::UpdateCheckResult r;
+        for (const auto& m : t) {
+            r.failed_models[m] = "Repository not found";
+        }
+        return r;
+    });
+    mm_dedup.enqueue_sync({"non_existent_model_test_xyz"});
+    auto second_enqueue = mm_dedup.enqueue_sync({"non_existent_model_test_xyz"});
+    check("overlapping enqueue detects existing sync running", second_enqueue.already_running == true);
+
+    // Test 12: Deterministic overlapping full check and targeted enqueue deduplication
+    {
+        lemon::ModelManager mm_overlap;
+        mm_overlap.set_update_check_override_for_test([](const auto& t) {
+            lemon::ModelManager::UpdateCheckResult r;
+            r.up_to_date_models = {"Tiny-Test-Model-GGUF"};
+            return r;
+        });
+        mm_overlap.set_download_model_override_for_test([](const auto&, const auto&, bool, auto) {});
+
+        std::mutex pause_m;
+        std::condition_variable pause_cv;
+        bool full_check_done_hit = false;
+        bool allow_resume = false;
+        std::atomic<int> hook_invocations{0};
+        std::atomic<int> target_check_invocations{0};
+
+        mm_overlap.set_sync_phase_callback([&](const std::string& phase) {
+            if (phase == "full_check_done") {
+                hook_invocations++;
+                std::unique_lock<std::mutex> lock(pause_m);
+                full_check_done_hit = true;
+                pause_cv.notify_all();
+                pause_cv.wait(lock, [&]() { return allow_resume; });
+            } else if (phase == "registry_check:Tiny-Test-Model-GGUF") {
+                target_check_invocations++;
+            }
+        });
+
+        mm_overlap.enqueue_sync({});
+        std::thread worker([&]() {
+            mm_overlap.execute_sync();
+        });
+
+        {
+            std::unique_lock<std::mutex> lock(pause_m);
+            pause_cv.wait(lock, [&]() { return full_check_done_hit; });
+        }
+
+        auto enqueued_during_run = mm_overlap.enqueue_sync({"Tiny-Test-Model-GGUF"});
+        check("enqueue during active sync returns true", enqueued_during_run.already_running == true);
+
+        {
+            std::lock_guard<std::mutex> lock(pause_m);
+            allow_resume = true;
+            pause_cv.notify_all();
+        }
+
+        worker.join();
+
+        json overlap_exec = mm_overlap.get_sync_status();
+        std::string o_status = overlap_exec.value("status", "");
+        check("overlap execution status is valid", o_status == "idle" || o_status == "success" || o_status == "failed");
+        check("full check callback triggered exactly once", hook_invocations.load() == 1);
+        check("target check triggered exactly once during sync", target_check_invocations.load() == 1);
+
+        int target_count = 0;
+        if (overlap_exec.contains("models_up_to_date") && overlap_exec["models_up_to_date"].is_array()) {
+            for (const auto& item : overlap_exec["models_up_to_date"]) {
+                if (item == "Tiny-Test-Model-GGUF") target_count++;
+            }
+        }
+        if (overlap_exec.contains("models_updated") && overlap_exec["models_updated"].is_array()) {
+            for (const auto& item : overlap_exec["models_updated"]) {
+                if (item == "Tiny-Test-Model-GGUF") target_count++;
+            }
+        }
+        if (overlap_exec.contains("failed_models") && overlap_exec["failed_models"].is_object()) {
+            if (overlap_exec["failed_models"].contains("Tiny-Test-Model-GGUF")) {
+                target_count++;
+            }
+        }
+        check("overlapping target checked and processed exactly once", target_count == 1);
+    }
+
+    // Test 13: Synchronous sync_models joins active sync and waits for completion
+    {
+        lemon::ModelManager mm_sync_join;
+        mm_sync_join.set_update_check_override_for_test([](const auto& t) {
+            lemon::ModelManager::UpdateCheckResult r;
+            r.up_to_date_models = {"Tiny-Test-Model-GGUF"};
+            return r;
+        });
+        mm_sync_join.set_download_model_override_for_test([](const auto&, const auto&, bool, auto) {});
+
+        std::mutex pause_m;
+        std::condition_variable pause_c;
+        bool hook_hit = false;
+        bool proceed = false;
+
+        mm_sync_join.set_sync_phase_callback([&](const std::string& phase) {
+            if (phase == "full_check_done") {
+                std::unique_lock<std::mutex> lock(pause_m);
+                hook_hit = true;
+                pause_c.notify_all();
+                pause_c.wait(lock, [&]() { return proceed; });
+            }
+        });
+
+        mm_sync_join.enqueue_sync({});
+        std::thread worker([&]() {
+            mm_sync_join.execute_sync();
+        });
+
+        {
+            std::unique_lock<std::mutex> lock(pause_m);
+            pause_c.wait(lock, [&]() { return hook_hit; });
+        }
+
+        std::atomic<bool> join_finished{false};
+        json join_result;
+        std::thread joiner([&]() {
+            join_result = mm_sync_join.sync_models({"Tiny-Test-Model-GGUF"}, /*dry_run=*/false);
+            join_finished = true;
+        });
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        check("synchronous joiner blocks while sync is running", join_finished.load() == false);
+
+        {
+            std::lock_guard<std::mutex> lock(pause_m);
+            proceed = true;
+            pause_c.notify_all();
+        }
+
+        worker.join();
+        joiner.join();
+
+        check("synchronous joiner finishes after sync completes", join_finished.load() == true);
+        std::string j_status = join_result.value("status", "");
+        check("synchronous joiner receives completed status not in_progress", j_status != "in_progress");
+    }
+
+    // Test 14: Generation ID tracking and historical status lookup
+    {
+        lemon::ModelManager mm_gen;
+        mm_gen.set_update_check_override_for_test([](const auto& t) {
+            lemon::ModelManager::UpdateCheckResult r;
+            r.up_to_date_models = {"Tiny-Test-Model-GGUF"};
+            return r;
+        });
+        mm_gen.set_download_model_override_for_test([](const auto&, const auto&, bool, auto) {});
+
+        auto enq1 = mm_gen.enqueue_sync({});
+        check("first sync enqueue allocates sync_id > 0", enq1.sync_id > 0);
+        check("first sync enqueue already_running is false", enq1.already_running == false);
+
+        auto enq2 = mm_gen.enqueue_sync({"non_existent_model_test_xyz"});
+        check("overlapping sync enqueue returns same sync_id", enq2.sync_id == enq1.sync_id);
+        check("overlapping sync enqueue already_running is true", enq2.already_running == true);
+
+        json sync1_res = mm_gen.execute_sync();
+        uint64_t completed_gen = mm_gen.get_sync_status().value("completed_sync_id", 0);
+        check("completed_sync_id matches first sync_id", completed_gen == enq1.sync_id);
+
+        json historical_status = mm_gen.get_sync_status(enq1.sync_id);
+        check("historical status lookup returns completed generation result",
+              historical_status.value("status", "") != "in_progress" &&
+              historical_status.value("sync_id", 0) == enq1.sync_id);
+
+        // Start a second sync job
+        auto enq3 = mm_gen.enqueue_sync({});
+        check("second sync enqueue allocates new sync_id", enq3.sync_id > enq1.sync_id);
+        json hist_old = mm_gen.get_sync_status(enq1.sync_id);
+        check("historical status for previous sync_id is preserved while new job is running",
+              hist_old.value("status", "") != "in_progress" &&
+              hist_old.value("sync_id", 0) == enq1.sync_id);
+        mm_gen.execute_sync();
+    }
+
+    // Test 15: Stale update_available cache flag is ignored when fresh check fails
+    {
+        lemon::ModelManager mm_stale;
+        mm_stale.set_model_update_available_for_test("Tiny-Test-Model-GGUF", true);
+        lemon::ModelInfo cached = mm_stale.get_model_info("Tiny-Test-Model-GGUF");
+        check("cached update_available flag is true before fresh check", cached.update_available == true);
+
+        mm_stale.set_update_check_override_for_test([](const auto& t) {
+            lemon::ModelManager::UpdateCheckResult r;
+            for (const auto& m : t) {
+                r.failed_models[m] = "Remote registry check failed";
+            }
+            return r;
+        });
+
+        // Targeted sync on a model whose remote check fails
+        auto enq_stale = mm_stale.enqueue_sync({"non_existent_model_test_xyz"});
+        json stale_exec = mm_stale.execute_sync();
+        check("failed fresh check populates failed_models",
+              stale_exec.contains("failed_models") && stale_exec["failed_models"].contains("non_existent_model_test_xyz"));
+        check("failed fresh check does not schedule update",
+              stale_exec.contains("models_updated") && stale_exec["models_updated"].empty());
+    }
+
+    // Test 16: Empty full-sync request arriving during running targeted sync triggers full check
+    {
+        lemon::ModelManager mm_full_attach;
+        std::mutex pause_m;
+        std::condition_variable pause_cv;
+        bool target_check_hit = false;
+        bool allow_resume = false;
+        std::atomic<int> full_check_count{0};
+
+        mm_full_attach.set_update_check_override_for_test([](const auto& t) {
+            lemon::ModelManager::UpdateCheckResult r;
+            r.up_to_date_models = {"Tiny-Test-Model-GGUF"};
+            return r;
+        });
+        mm_full_attach.set_download_model_override_for_test([](const auto&, const auto&, bool, auto) {});
+
+        mm_full_attach.set_sync_phase_callback([&](const std::string& phase) {
+            if (phase.rfind("check_model:", 0) == 0) {
+                std::unique_lock<std::mutex> lock(pause_m);
+                target_check_hit = true;
+                pause_cv.notify_all();
+                pause_cv.wait(lock, [&]() { return allow_resume; });
+            } else if (phase == "full_check_done") {
+                full_check_count++;
+            }
+        });
+
+        // 1. Enqueue targeted sync
+        mm_full_attach.enqueue_sync({"Tiny-Test-Model-GGUF"});
+        std::thread worker([&]() {
+            mm_full_attach.execute_sync();
+        });
+
+        {
+            std::unique_lock<std::mutex> lock(pause_m);
+            pause_cv.wait(lock, [&]() { return target_check_hit; });
+        }
+
+        // 2. While targeted sync is active, enqueue an empty sync (full sync)
+        auto enq_empty = mm_full_attach.enqueue_sync({});
+        check("empty sync enqueue during active sync returns already_running", enq_empty.already_running == true);
+
+        {
+            std::lock_guard<std::mutex> lock(pause_m);
+            allow_resume = true;
+            pause_cv.notify_all();
+        }
+
+        worker.join();
+
+        // 3. Verify that full check was triggered and completed
+        check("full check was executed following empty sync enqueue", full_check_count.load() == 1);
+    }
+
+    // Test 17: Synchronous execute_sync returns correct generation snapshot directly
+    {
+        lemon::ModelManager mm_exec_snap;
+        mm_exec_snap.set_update_check_override_for_test([](const auto& t) {
+            lemon::ModelManager::UpdateCheckResult r;
+            for (const auto& m : t) {
+                r.failed_models[m] = "Remote registry error";
+            }
+            return r;
+        });
+        mm_exec_snap.set_download_model_override_for_test([](const auto&, const auto&, bool, auto) {});
+
+        auto enq = mm_exec_snap.enqueue_sync({"non_existent_model_test_xyz"});
+        json res = mm_exec_snap.execute_sync();
+        check("execute_sync returns completed snapshot not in_progress", res.value("status", "") != "in_progress");
+        check("execute_sync snapshot sync_id matches generation", res.value("sync_id", 0) == enq.sync_id);
+    }
+
+    // Test 18: attach_if_running flag preserves targeted sync and prevents unexpected full sync expansion
+    {
+        lemon::ModelManager mm_attach_only;
+        std::mutex pause_m;
+        std::condition_variable pause_cv;
+        bool target_check_hit = false;
+        bool allow_resume = false;
+        std::atomic<int> full_check_count{0};
+
+        mm_attach_only.set_update_check_override_for_test([](const auto& t) {
+            lemon::ModelManager::UpdateCheckResult r;
+            r.up_to_date_models = {"Tiny-Test-Model-GGUF"};
+            return r;
+        });
+        mm_attach_only.set_download_model_override_for_test([](const auto&, const auto&, bool, auto) {});
+
+        mm_attach_only.set_sync_phase_callback([&](const std::string& phase) {
+            if (phase.rfind("check_model:", 0) == 0) {
+                std::unique_lock<std::mutex> lock(pause_m);
+                target_check_hit = true;
+                pause_cv.notify_all();
+                pause_cv.wait(lock, [&]() { return allow_resume; });
+            } else if (phase == "full_check_done") {
+                full_check_count++;
+            }
+        });
+
+        // 1. Start targeted sync
+        mm_attach_only.enqueue_sync({"Tiny-Test-Model-GGUF"});
+        std::thread worker([&]() {
+            mm_attach_only.execute_sync();
+        });
+
+        {
+            std::unique_lock<std::mutex> lock(pause_m);
+            pause_cv.wait(lock, [&]() { return target_check_hit; });
+        }
+
+        // 2. Attach only with empty targets (e.g. update-models --wait)
+        auto enq_attach = mm_attach_only.enqueue_sync({}, /*attach_if_running=*/true);
+        check("attach_if_running returns already_running true", enq_attach.already_running == true);
+
+        {
+            std::lock_guard<std::mutex> lock(pause_m);
+            allow_resume = true;
+            pause_cv.notify_all();
+        }
+
+        worker.join();
+
+        // 3. Full check should NOT have run
+        check("attach_if_running does not expand targeted sync to full sync", full_check_count.load() == 0);
+    }
+
+    // Test 19: Unknown or evicted sync_id queries return not_found status
+    {
+        lemon::ModelManager mm_not_found;
+        json unk = mm_not_found.get_sync_status(999999);
+        check("unknown sync_id returns not_found status", unk.value("status", "") == "not_found");
+        check("unknown sync_id returns matching sync_id in response", unk.value("sync_id", 0) == 999999);
+    }
+
+    // Test 20: Attached full check authoritatively updates previously checked up-to-date model
+    {
+        lemon::ModelManager mm_fresh;
+        std::atomic<bool> trigger_update{false};
+        std::vector<std::string> downloaded_models;
+
+        mm_fresh.set_update_check_override_for_test([&](const auto& t) {
+            lemon::ModelManager::UpdateCheckResult r;
+            if (trigger_update.load()) {
+                r.updated_models = {"Tiny-Test-Model-GGUF"};
+            } else {
+                r.up_to_date_models = {"Tiny-Test-Model-GGUF"};
+            }
+            return r;
+        });
+        mm_fresh.set_download_model_override_for_test([&](const auto& m, const auto&, bool, auto) {
+            downloaded_models.push_back(m);
+        });
+
+        std::mutex pause_m;
+        std::condition_variable pause_cv;
+        bool target_check_hit = false;
+        bool allow_resume = false;
+
+        mm_fresh.set_sync_phase_callback([&](const std::string& phase) {
+            if (phase.rfind("target_check_done:", 0) == 0) {
+                std::unique_lock<std::mutex> lock(pause_m);
+                target_check_hit = true;
+                pause_cv.notify_all();
+                pause_cv.wait(lock, [&]() { return allow_resume; });
+            }
+        });
+
+        // 1. Start targeted sync where model is initially up to date
+        mm_fresh.enqueue_sync({"Tiny-Test-Model-GGUF"});
+        std::thread worker([&]() {
+            mm_fresh.execute_sync();
+        });
+
+        {
+            std::unique_lock<std::mutex> lock(pause_m);
+            pause_cv.wait(lock, [&]() { return target_check_hit; });
+        }
+
+        // Verify that initial targeted check recorded the model as up to date
+        json initial_snap = mm_fresh.get_sync_status();
+        check("initial targeted check records model up to date",
+              initial_snap.contains("models_up_to_date") &&
+              std::find(initial_snap["models_up_to_date"].begin(), initial_snap["models_up_to_date"].end(), "Tiny-Test-Model-GGUF") != initial_snap["models_up_to_date"].end());
+
+        // 2. Model receives upstream update; full sync is enqueued
+        trigger_update.store(true);
+        mm_fresh.enqueue_sync({});
+
+        {
+            std::lock_guard<std::mutex> lock(pause_m);
+            allow_resume = true;
+            pause_cv.notify_all();
+        }
+
+        worker.join();
+
+        json fresh_status = mm_fresh.get_sync_status();
+        check("fresh full check authoritatively schedules model update",
+              std::find(downloaded_models.begin(), downloaded_models.end(), "Tiny-Test-Model-GGUF") != downloaded_models.end());
+    }
+
+    lemon::utils::set_cache_dir("");
+    lemon::utils::set_config_dir("");
+    std::filesystem::remove_all(temp_cache, ec);
+
+    if (failures == 0) {
+        std::cout << "All Model Sync & Auto-Update tests passed successfully!" << std::endl;
+        return 0;
+    } else {
+        std::cout << failures << " test(s) failed." << std::endl;
+        return 1;
+    }
+}

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -2226,6 +2226,33 @@ sys.exit(0)
         )
         print("[OK] After deleting B: all repo directories cleaned up")
 
+    def test_models_sync_command(self):
+        """Test the 'update-models' CLI subcommand dry-run check and execution."""
+        # 1. Run update-models dry-run check (using --check)
+        result = self.assertCommandSucceeds(
+            ["update-models", ENDPOINT_TEST_MODEL, "--check"]
+        )
+        self.assertIn("Checked", result.stdout)
+        self.assertIn("update(s) available", result.stdout)
+
+        # 3. Run update-models with --check --json option
+        result = self.assertCommandSucceeds(
+            ["update-models", ENDPOINT_TEST_MODEL, "--check", "--json"]
+        )
+        self.assertIn("checked_count", result.stdout)
+
+        # 4. Run update-models on nonexistent model with --check --json, expecting exit code 1
+        result = run_cli_command(
+            ["update-models", "nonexistent-model-test-xyz", "--check", "--json"],
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            result.returncode,
+            1,
+            f"update-models nonexistent model with --json should fail, got returncode {result.returncode}",
+        )
+        self.assertIn("failed_models", result.stdout)
+
 
 class CLIHelpDocsConsistencyTests(unittest.TestCase):
     """Lightweight checks that compare CLI help semantics with docs text."""

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -7958,6 +7958,113 @@ class EndpointTests(ServerTestBase):
 
         print("[OK] /models/check-updates ignores stale provenance snapshots")
 
+    def test_056_models_sync_internal_security_boundary(self):
+        """Verify that model sync routes are exclusively administrative internal routes and public routes return 404."""
+        # 1. Verify GET /internal/models/sync/status returns the status JSON
+        status_url = f"http://localhost:{PORT}/internal/models/sync/status"
+        resp = requests.get(status_url, timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(
+            resp.status_code, 200, f"/internal/models/sync/status failed: {resp.text}"
+        )
+        status_json = resp.json()
+        self.assertIn("status", status_json)
+        self.assertIn("sync_id", status_json)
+        self.assertIn("completed_sync_id", status_json)
+        self.assertIn("checked_count", status_json)
+        self.assertIn("models_updated", status_json)
+        self.assertIn("terminal_error", status_json)
+
+        # 2. Verify POST /internal/models/sync dry_run returns dry_run: true
+        sync_url = f"http://localhost:{PORT}/internal/models/sync"
+        resp = requests.post(
+            sync_url,
+            json={"dry_run": True, "models": [ENDPOINT_TEST_MODEL]},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            resp.status_code, 200, f"/internal/models/sync dry run failed: {resp.text}"
+        )
+        sync_json = resp.json()
+        self.assertTrue(sync_json.get("dry_run"))
+        self.assertIn("checked_count", sync_json)
+
+        # 3. Verify POST /internal/models/sync async returns 202 Accepted
+        resp = requests.post(
+            sync_url,
+            json={"async": True, "models": [ENDPOINT_TEST_MODEL]},
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(
+            resp.status_code,
+            202,
+            f"/internal/models/sync async dispatch failed: {resp.text}",
+        )
+        async_json = resp.json()
+        self.assertTrue(async_json.get("async"))
+        self.assertIn("sync_id", async_json)
+
+        # 4. Verify querying status by sync_id
+        target_sync_id = async_json.get("sync_id")
+        if target_sync_id:
+            resp = requests.get(
+                f"{status_url}?sync_id={target_sync_id}", timeout=TIMEOUT_DEFAULT
+            )
+            self.assertEqual(
+                resp.status_code,
+                200,
+                f"/internal/models/sync/status?sync_id={target_sync_id} failed: {resp.text}",
+            )
+            sync_id_json = resp.json()
+            self.assertEqual(sync_id_json.get("sync_id"), target_sync_id)
+
+        # 5. Verify public quad-prefix route /api/v1/models/sync returns 404
+        public_url = f"{self.base_url}/models/sync"
+        resp = requests.post(
+            public_url, json={"dry_run": True}, timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(
+            resp.status_code,
+            404,
+            f"public /api/v1/models/sync should not exist, got {resp.status_code}",
+        )
+
+        # 5. Verify invalid payload types return 400 Bad Request
+        resp = requests.post(
+            sync_url, json={"models": "invalid_not_array"}, timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(
+            resp.status_code,
+            400,
+            f"Expected 400 for non-array models, got {resp.status_code}",
+        )
+
+        resp = requests.post(sync_url, json={"models": [123]}, timeout=TIMEOUT_DEFAULT)
+        self.assertEqual(
+            resp.status_code,
+            400,
+            f"Expected 400 for non-string model item, got {resp.status_code}",
+        )
+
+        resp = requests.post(
+            sync_url, json={"dry_run": "invalid_not_bool"}, timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(
+            resp.status_code,
+            400,
+            f"Expected 400 for non-bool dry_run, got {resp.status_code}",
+        )
+
+        resp = requests.post(
+            sync_url, json={"async": "invalid_not_bool"}, timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(
+            resp.status_code,
+            400,
+            f"Expected 400 for non-bool async, got {resp.status_code}",
+        )
+
+        print("[OK] /internal/models/sync security boundary is secure")
+
 
 if __name__ == "__main__":
     run_server_tests(EndpointTests, "ENDPOINT TESTS")


### PR DESCRIPTION
Adds administrative model synchronization and automatic model update configuration to `lemond` and the `lemonade` CLI.

### Features & Capabilities

* **CLI `lemonade update-models` Subcommand**:
  * `lemonade update-models [models...]`: Triggers background synchronization for specified models (or all outdated models if none specified).
  * `--check, --dry-run`: Queries available updates without downloading files.
  * `-w, --wait`: Monitors synchronization progress in real time.
  * `-j, --json`: Emits machine-readable JSON output to `stdout` (with live progress output cleanly directed to `stderr`). Returns exit code `1` on failed models or terminal errors.

* **Server API Endpoints**:
  * `POST /internal/models/sync`: Administrative endpoint to initiate model updates (supports `async: true/false` dispatch). Protected behind `LEMONADE_ADMIN_API_KEY`.
  * `GET /internal/models/sync/status`: Administrative endpoint to poll current sync status, active targets, completed targets, failed models, and download byte progress.

* **Auto-Update Configuration**:
  * Global `auto_update_models` configuration option in `config.json` and `RuntimeConfig`.
  * Per-model `auto_update` field override support in `recipe_options.json` and model recipes.