### PR TITLE
Fix rocm-stable loader paths and prefer vulkan for trellis on AMD GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,11 +309,6 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td rowspan="3"><strong>3D generation</strong></td>
       <td rowspan="3"><code>trellis</code> (experimental)</td>
-      <td><code>rocm</code></td>
-      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
-      <td>Windows, Linux</td>
-    </tr>
-    <tr>
       <td><code>cuda</code></td>
       <td>NVIDIA GPUs</td>
       <td>Windows, Linux</td>
@@ -321,6 +316,11 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td><code>vulkan</code></td>
       <td>Vulkan-capable GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>rocm</code></td>
+      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -59,9 +59,9 @@ the generator instead. Prose outside the markers is preserved. -->
 | `thinksound` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `thinksound` | cuda | linux, windows | nvidia_gpu |
 | `thinksound` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
-| `trellis` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `trellis` | cuda | linux, windows | nvidia_gpu |
 | `trellis` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
+| `trellis` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `vllm` | rocm | linux | amd_gpu (gfx110X, gfx1150, gfx1151, gfx120X) |
 | `whispercpp` | npu | windows | amd_npu (XDNA2) |
 | `whispercpp` | rocm | linux, windows | amd_gpu (gfx110X, gfx1150, gfx1151, gfx120X) |

--- a/src/cpp/include/lemon/backends/trellis/trellis.h
+++ b/src/cpp/include/lemon/backends/trellis/trellis.h
@@ -21,9 +21,13 @@ inline const BackendDescriptor descriptor = {
          "Trellis backend to use", "3D Generation Options"},
     },
     /*support*/ {
-        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
+        // vulkan is listed before rocm so it wins default-backend selection on
+        // AMD GPUs: trellis-server's ROCm build dies silently at the first HIP
+        // compute on Windows/gfx1151 (reproduced on both v0.1.5 and v0.4.3),
+        // while vulkan generates correctly on the same hardware.
         {"cuda", {"linux", "windows"}, {{"nvidia_gpu", {}}}, "NVIDIA GPUs"},
         {"vulkan", {"linux", "windows"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
+        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
     },
     /*default_labels*/  {"3d"},
     /*required_checkpoints*/ {"main"},

--- a/src/cpp/server/backends/acestep/acestep_server.cpp
+++ b/src/cpp/server/backends/acestep/acestep_server.cpp
@@ -140,7 +140,7 @@ void AceStepServer::load(const std::string& model_name,
         env_vars.push_back({"LD_LIBRARY_PATH", ld});
 #endif
     };
-    if (backend == "rocm") {
+    if (backend.rfind("rocm", 0) == 0) {
         const std::string arch = SystemInfo::get_rocm_arch();
         const std::string therock_lib = arch.empty() ? "" : BackendUtils::get_therock_lib_path(arch);
         std::string dirs;

--- a/src/cpp/server/backends/openmoss/openmoss_server.cpp
+++ b/src/cpp/server/backends/openmoss/openmoss_server.cpp
@@ -101,7 +101,7 @@ void OpenMossServer::load(const std::string& model_name,
         env_vars.push_back({"LD_LIBRARY_PATH", ld});
 #endif
     };
-    if (backend == "rocm") {
+    if (backend.rfind("rocm", 0) == 0) {
         const std::string arch = SystemInfo::get_rocm_arch();
         const std::string therock_lib = arch.empty() ? "" : BackendUtils::get_therock_lib_path(arch);
         std::string dirs;

--- a/src/cpp/server/backends/trellis/trellis_server.cpp
+++ b/src/cpp/server/backends/trellis/trellis_server.cpp
@@ -105,7 +105,7 @@ void TrellisServer::load(const std::string& model_name,
         env_vars.push_back({"LD_LIBRARY_PATH", ld});
 #endif
     };
-    if (backend == "rocm") {
+    if (backend.rfind("rocm", 0) == 0) {
         const std::string arch = SystemInfo::get_rocm_arch();
         const std::string therock_lib = arch.empty() ? "" : BackendUtils::get_therock_lib_path(arch);
         std::string dirs;


### PR DESCRIPTION
Two related fixes found while release-testing v11.5.0 (checklist #2774); targeting the next release, not the v11.5.0 branch.

**1. `rocm-stable` never got the TheRock loader paths.** `trellis_server.cpp`, `openmoss_server.cpp`, and `acestep_server.cpp` gate the TheRock `PATH`/`LD_LIBRARY_PATH` setup on `backend == "rocm"`, but the stable channel's backend name is `rocm-stable` — the same files already normalize with `rfind("rocm", 0) == 0` in `get_install_params`, so this aligns the env-var branch with that. On Windows this was masked because the AMD driver ships `amdhip64_7.dll` in System32; on Linux without a system ROCm install the subprocess would start with no ROCm runtime on the loader path.

**2. Trellis on AMD GPUs now defaults to vulkan.** `trellis-server`'s ROCm build dies **silently** at the first HIP compute on Windows/gfx1151 (Strix Halo) — reproduced identically with the v0.1.5 and v0.4.3 assets, with the GPU correctly detected (`using ROCm0`) and gfx1151 code objects present in `ggml-hip.dll`, and regardless of whether TheRock or the driver HIP runtime is used. Vulkan generates correctly on the same hardware (~7 min for a 125k-tri textured GLB at res 512). Listing `vulkan` ahead of `rocm` in the support matrix makes default-backend selection pick the working path; users can still opt into ROCm via `trellis_backend`. Generated docs regions regenerated via `gen_backend_boilerplate.py`.

@pwilkin — the silent ROCm crash itself looks like a trellis.cpp issue (nothing on stderr, no WER entry; process exits right after `ggml_cuda_init` succeeds when the first kernel launches, both v0.1.5 and v0.4.3, Windows + gfx1151 + driver HIP 7.x). Happy to file it upstream with full repro details if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)