### PR TITLE
Fix FLM model discovery: tolerate the flm CLI stdout banner

### DIFF
--- a/src/cpp/server/backends/fastflowlm/fastflowlm_models.cpp
+++ b/src/cpp/server/backends/fastflowlm/fastflowlm_models.cpp
@@ -140,6 +140,16 @@ std::string find_flm_binary() {
     }
 }
 
+// flm >= 0.9.45 prints an "[FLM]  Fetching models from: ..." banner on stdout
+// before the JSON payload, even with --quiet, so parse from the first '{'.
+static json parse_flm_cli_json(const std::string& output) {
+    const size_t brace = output.find('{');
+    if (brace == std::string::npos) {
+        throw std::runtime_error("no JSON object in flm list output: " + output.substr(0, 200));
+    }
+    return lemon::utils::JsonUtils::parse(output.substr(brace));
+}
+
 std::vector<std::string> flm_installed_checkpoints() {
     std::vector<std::string> installed_models;
 
@@ -167,7 +177,7 @@ std::vector<std::string> flm_installed_checkpoints() {
 
     // Parse output: { "models": [ { "name": "modelname:tag", ... }, ... ] }
     try {
-        json j = lemon::utils::JsonUtils::parse(output);
+        json j = parse_flm_cli_json(output);
         if (j.contains("models") && j["models"].is_array()) {
             for (const auto& model : j["models"]) {
                 if (model.contains("name") && model["name"].is_string()) {
@@ -247,7 +257,7 @@ std::vector<ModelInfo> flm_discover_models() {
 
     // Parse output: { "models": [ { "name": "modelname:tag", "footprint": 1.23, ... }, ... ] }
     try {
-        json j = lemon::utils::JsonUtils::parse(output);
+        json j = parse_flm_cli_json(output);
         if (j.contains("models") && j["models"].is_array()) {
             for (const auto& m : j["models"]) {
                 if (m.contains("name") && m["name"].is_string()) {
@@ -551,7 +561,7 @@ std::string flm_version() {
 
     // Parse JSON output: { "version": "0.9.34" }
     try {
-        json j = lemon::utils::JsonUtils::parse(output);
+        json j = parse_flm_cli_json(output);
         if (j.contains("version") && j["version"].is_string()) {
             std::string version = j["version"].get<std::string>();
             // If the version doesn't start with 'v', prepend it
@@ -670,7 +680,7 @@ bool run_flm_validate(const std::string& flm_path, std::string& error_message) {
 
     try {
         if (!output.empty()) {
-            json j = lemon::utils::JsonUtils::parse(output);
+            json j = parse_flm_cli_json(output);
             if (j.is_object()) {
                 bool validation_ok = false;
                 if (j.contains("ready")) {


### PR DESCRIPTION
**Fresh installs currently register zero FLM models on both Windows and Linux.** flm v0.9.45 prints an `[FLM]  Fetching models from: ...` line on **stdout** before its JSON payload (even with `--quiet`), so every `flm list/version --json` parse in `fastflowlm_models.cpp` fails with `parse error at line 1, column 2 ... last read: '[F'` and discovery bails.

- This is the root cause of the persistently red **Test .deb - flm** CI job (fresh cache each run).
- The Windows **Test .exe - flm** job passes only because its cache dir is persistent — models registered by pre-banner flm versions mask the breakage. Reproduced the failure on Windows with a fresh cache on the release-v11.5.0 build.
- The v0.9.45 pin shipped in v11.0.0, so the released version is affected too — this is not a v11.5.0 regression, but v11.5.0 would ship it again.

Fix: parse from the first `{` in the flm CLI output, applied to all four parse sites.

Verified end-to-end on a Ryzen AI (Strix Halo) machine with a fresh cache: discovery now registers 5 FLM models (incl. `llama3.2-1b-FLM`), and pull + NPU chat completion work. Found while release-testing v11.5.0 (checklist #2774).

🤖 Generated with [Claude Code](https://claude.com/claude-code)