### PR TITLE
web: community links in navbar hamburger + homepage hero

### DIFF
--- a/docs/assets/navbar.js
+++ b/docs/assets/navbar.js
@@ -13,6 +13,18 @@ function createNavbar(basePath = '') {
         <a href="${basePath}models.html">Models</a>
         <a href="${basePath}marketplace.html">Apps</a>
         <a href="${basePath}news/">News</a>
+        <a class="navbar-links-social" href="https://github.com/lemonade-sdk/lemonade" target="_blank" rel="noopener" aria-label="Lemonade on GitHub">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .5a12 12 0 0 0-3.79 23.38c.6.11.82-.26.82-.58v-2.17c-3.34.73-4.04-1.42-4.04-1.42-.55-1.4-1.34-1.77-1.34-1.77-1.1-.75.08-.73.08-.73 1.21.08 1.85 1.24 1.85 1.24 1.08 1.85 2.83 1.32 3.52 1 .11-.78.42-1.32.76-1.62-2.66-.3-5.46-1.33-5.46-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6.02 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.8 5.63-5.47 5.93.43.37.81 1.1.81 2.22v3.3c0 .32.22.7.83.58A12 12 0 0 0 12 .5Z"></path></svg>GitHub
+        </a>
+        <a class="navbar-links-social" href="https://discord.gg/5xXzkMu8Zk" target="_blank" rel="noopener" aria-label="Lemonade Discord">
+          <svg viewBox="1 1.8 20 20" aria-hidden="true"><path d="M19.54 5.33A16.9 16.9 0 0 0 15.33 4l-.2.38c1.46.36 2.14.88 2.14.88a14.5 14.5 0 0 0-6.77-.26 12.3 12.3 0 0 0-3.77.26s.7-.55 2.25-.9L8.84 4a17 17 0 0 0-4.22 1.33C1.95 9.3 1.22 13.17 1.58 17c1.78 1.3 3.5 2.1 5.2 2.62l.63-.85a6.8 6.8 0 0 1-1.64-.78l.4-.3c3.16 1.48 6.6 1.48 9.72 0l.4.3c-.52.32-1.06.58-1.64.78l.63.85c1.7-.52 3.43-1.31 5.2-2.62.43-4.43-.72-8.26-2.94-11.67ZM8.52 14.64c-.95 0-1.73-.88-1.73-1.96s.76-1.96 1.73-1.96c.96 0 1.75.88 1.73 1.96 0 1.08-.77 1.96-1.73 1.96Zm6.96 0c-.95 0-1.73-.88-1.73-1.96s.76-1.96 1.73-1.96c.96 0 1.74.88 1.73 1.96 0 1.08-.77 1.96-1.73 1.96Z"></path></svg>Discord
+        </a>
+        <a class="navbar-links-social" href="https://x.com/lemonade_server" target="_blank" rel="noopener" aria-label="Lemonade on X">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.9 2.25h3.38l-7.38 8.43 8.68 11.07h-6.8l-5.32-6.72-6.1 6.72H1.98l7.9-8.7L1.55 2.25h6.97l4.82 6.17 5.56-6.17Zm-1.18 17.55h1.87L7.48 4.1H5.47l12.25 15.7Z"></path></svg>Follow
+        </a>
+        <a class="navbar-links-social" href="https://www.youtube.com/@LemonadeAI" target="_blank" rel="noopener" aria-label="Lemonade on YouTube">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23.5 6.2a3 3 0 0 0-2.1-2.13C19.56 3.58 12 3.58 12 3.58s-7.56 0-9.4.49A3 3 0 0 0 .5 6.2 31.4 31.4 0 0 0 0 12a31.4 31.4 0 0 0 .5 5.8 3 3 0 0 0 2.1 2.13c1.84.49 9.4.49 9.4.49s7.56 0 9.4-.49a3 3 0 0 0 2.1-2.13A31.4 31.4 0 0 0 24 12a31.4 31.4 0 0 0-.5-5.8ZM9.55 15.45v-6.9L15.82 12l-6.27 3.45Z"></path></svg>YouTube
+        </a>
       </div>
       <div class="navbar-actions">
         <div class="navbar-socials" aria-label="Community links">
@@ -21,7 +33,7 @@ function createNavbar(basePath = '') {
             <span id="githubStarsCount" data-community-stat="github">Stars</span>
           </a>
           <a class="navbar-social-link navbar-social-link-count" href="https://discord.gg/5xXzkMu8Zk" target="_blank" rel="noopener" aria-label="Lemonade Discord">
-            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M19.54 5.33A16.9 16.9 0 0 0 15.33 4l-.2.38c1.46.36 2.14.88 2.14.88a14.5 14.5 0 0 0-6.77-.26 12.3 12.3 0 0 0-3.77.26s.7-.55 2.25-.9L8.84 4a17 17 0 0 0-4.22 1.33C1.95 9.3 1.22 13.17 1.58 17c1.78 1.3 3.5 2.1 5.2 2.62l.63-.85a6.8 6.8 0 0 1-1.64-.78l.4-.3c3.16 1.48 6.6 1.48 9.72 0l.4.3c-.52.32-1.06.58-1.64.78l.63.85c1.7-.52 3.43-1.31 5.2-2.62.43-4.43-.72-8.26-2.94-11.67ZM8.52 14.64c-.95 0-1.73-.88-1.73-1.96s.76-1.96 1.73-1.96c.96 0 1.75.88 1.73 1.96 0 1.08-.77 1.96-1.73 1.96Zm6.96 0c-.95 0-1.73-.88-1.73-1.96s.76-1.96 1.73-1.96c.96 0 1.74.88 1.73 1.96 0 1.08-.77 1.96-1.73 1.96Z"></path></svg>
+            <svg viewBox="1 1.8 20 20" aria-hidden="true"><path d="M19.54 5.33A16.9 16.9 0 0 0 15.33 4l-.2.38c1.46.36 2.14.88 2.14.88a14.5 14.5 0 0 0-6.77-.26 12.3 12.3 0 0 0-3.77.26s.7-.55 2.25-.9L8.84 4a17 17 0 0 0-4.22 1.33C1.95 9.3 1.22 13.17 1.58 17c1.78 1.3 3.5 2.1 5.2 2.62l.63-.85a6.8 6.8 0 0 1-1.64-.78l.4-.3c3.16 1.48 6.6 1.48 9.72 0l.4.3c-.52.32-1.06.58-1.64.78l.63.85c1.7-.52 3.43-1.31 5.2-2.62.43-4.43-.72-8.26-2.94-11.67ZM8.52 14.64c-.95 0-1.73-.88-1.73-1.96s.76-1.96 1.73-1.96c.96 0 1.75.88 1.73 1.96 0 1.08-.77 1.96-1.73 1.96Zm6.96 0c-.95 0-1.73-.88-1.73-1.96s.76-1.96 1.73-1.96c.96 0 1.74.88 1.73 1.96 0 1.08-.77 1.96-1.73 1.96Z"></path></svg>
             <span data-community-stat="discord">Members</span>
           </a>
           <a class="navbar-social-link" href="https://x.com/lemonade_server" target="_blank" rel="noopener" aria-label="Lemonade on X">
@@ -68,7 +80,7 @@ function initializeNavbar(basePath = '') {
     setOpen(!links.classList.contains('is-open'));
   });
   links.addEventListener('click', function(e) {
-    if (e.target.tagName === 'A') setOpen(false);
+    if (e.target.closest('a')) setOpen(false);
   });
 }
 
@@ -87,7 +99,8 @@ function compactCount(value) {
 async function fetchCommunityStats() {
   const githubEls = Array.prototype.slice.call(document.querySelectorAll('[data-community-stat="github"]'));
   const discordEls = Array.prototype.slice.call(document.querySelectorAll('[data-community-stat="discord"]'));
-  if (!githubEls.length && !discordEls.length) return;
+  const discordOnlineEls = Array.prototype.slice.call(document.querySelectorAll('[data-community-stat="discord-online"]'));
+  if (!githubEls.length && !discordEls.length && !discordOnlineEls.length) return;
   function setAll(els, text) {
     els.forEach(function(el) { el.textContent = text; });
   }
@@ -105,6 +118,8 @@ async function fetchCommunityStats() {
       const inviteData = await inviteResponse.json();
       const members = compactCount(inviteData.approximate_member_count);
       if (members) setAll(discordEls, members);
+      const online = compactCount(inviteData.approximate_presence_count);
+      if (online) setAll(discordOnlineEls, online);
     }
   } catch (error) {}
 }

--- a/docs/assets/persona-demo.css
+++ b/docs/assets/persona-demo.css
@@ -184,7 +184,10 @@ html:not([data-persona="developers"]) [data-cta-persona="developers"] {
    padding-top above separates it from the promise, while its short margin-bottom
    ties it to the buttons it sets up. */
 .hp-cta-lead {
-  max-width: 42rem;
+  /* Cap must fit the line at the largest clamped font size below; too small and a
+     wide viewport (where the font hits its 1.075rem max) wraps while a narrower
+     one — with a smaller font — stays on one line. */
+  max-width: 48rem;
   margin: 0 auto 1.7rem;
   color: var(--text-muted);
   font-family: var(--font-body);

--- a/docs/assets/website-styles.css
+++ b/docs/assets/website-styles.css
@@ -280,6 +280,19 @@ body.install-options {
   color: var(--text-nav);
 }
 
+/* GitHub/Discord live in the socials pill on desktop; these in-menu rows only
+   appear once the navbar collapses to the hamburger (see the mobile media query). */
+.navbar-links a.navbar-links-social {
+  display: none;
+}
+
+.navbar-links a.navbar-links-social svg {
+  width: 1.15em;
+  height: 1.15em;
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
 .navbar-brand .brand-title a {
   color: var(--text-primary);
 }
@@ -2700,8 +2713,15 @@ body.install-options {
     gap: 0.4rem;
   }
 
+  /* The socials pill collapses on mobile; GitHub/Discord instead ride along as
+     their own rows inside the hamburger menu (.navbar-links-social). */
   .navbar-socials {
     display: none;
+  }
+
+  .navbar-links a.navbar-links-social {
+    display: inline-flex;
+    gap: 0.6rem;
   }
 
   .navbar-persona-option {
@@ -4255,6 +4275,48 @@ body.install-options {
   font-style: normal;
 }
 
+/* Slim community links, read as a caption line under the promise subtitle. The
+   promise is a centered flex column (gap: 2rem); the negative margin tucks this
+   row up close to the subtitle so it doesn't read as a separate stacked block. */
+.hp-community-strip {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+  margin-top: -1.25rem;
+}
+
+.hp-community-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.hp-community-chip:hover,
+.hp-community-chip:focus {
+  color: var(--text-primary);
+  transform: translateY(-1px);
+}
+
+.hp-community-chip svg {
+  width: 1.1em;
+  height: 1.1em;
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
+.hp-community-chip-stat {
+  color: inherit;
+  font-weight: 500;
+}
+
 /* Demo panel — glassmorphic light theme per DESIGN.md */
 .hp-demo-panel {
   width: 100%;
@@ -5274,10 +5336,6 @@ body.install-options {
 
 /* --- Homepage responsive --- */
 @media (max-width: 1180px) {
-  .navbar-social-link:not(.navbar-social-link-count) {
-    display: none;
-  }
-
   .navbar-links {
     gap: 0.95rem;
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,12 +27,22 @@
         <span class="hp-persona-subtitle-line">Lemonade makes local AI the new default for apps and agents:</span>
         <span class="hp-persona-subtitle-line">free to use, private by design, and built for flexibility by a welcoming community.</span>
       </p>
+      <div class="hp-community-strip" aria-label="Community links">
+        <a class="hp-community-chip" href="https://discord.gg/5xXzkMu8Zk" target="_blank" rel="noopener" title="Join the Discord" aria-label="Join the Discord">
+          <svg viewBox="1 1.8 20 20" fill="currentColor" aria-hidden="true"><path d="M19.54 5.33A16.9 16.9 0 0 0 15.33 4l-.2.38c1.46.36 2.14.88 2.14.88a14.5 14.5 0 0 0-6.77-.26 12.3 12.3 0 0 0-3.77.26s.7-.55 2.25-.9L8.84 4a17 17 0 0 0-4.22 1.33C1.95 9.3 1.22 13.17 1.58 17c1.78 1.3 3.5 2.1 5.2 2.62l.63-.85a6.8 6.8 0 0 1-1.64-.78l.4-.3c3.16 1.48 6.6 1.48 9.72 0l.4.3c-.52.32-1.06.58-1.64.78l.63.85c1.7-.52 3.43-1.31 5.2-2.62.43-4.43-.72-8.26-2.94-11.67ZM8.52 14.64c-.95 0-1.73-.88-1.73-1.96s.76-1.96 1.73-1.96c.96 0 1.75.88 1.73 1.96 0 1.08-.77 1.96-1.73 1.96Zm6.96 0c-.95 0-1.73-.88-1.73-1.96s.76-1.96 1.73-1.96c.96 0 1.74.88 1.73 1.96 0 1.08-.77 1.96-1.73 1.96Z"></path></svg>
+          <span class="hp-community-chip-stat"><span data-community-stat="discord-online">&hellip;</span> online</span>
+        </a>
+        <a class="hp-community-chip" href="https://github.com/lemonade-sdk/lemonade" target="_blank" rel="noopener" title="Star the GitHub" aria-label="Star the GitHub">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5a12 12 0 0 0-3.79 23.38c.6.11.82-.26.82-.58v-2.17c-3.34.73-4.04-1.42-4.04-1.42-.55-1.4-1.34-1.77-1.34-1.77-1.1-.75.08-.73.08-.73 1.21.08 1.85 1.24 1.85 1.24 1.08 1.85 2.83 1.32 3.52 1 .11-.78.42-1.32.76-1.62-2.66-.3-5.46-1.33-5.46-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6.02 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.8 5.63-5.47 5.93.43.37.81 1.1.81 2.22v3.3c0 .32.22.7.83.58A12 12 0 0 0 12 .5Z"></path></svg>
+          <span class="hp-community-chip-stat"><span data-community-stat="github">&hellip;</span> stars</span>
+        </a>
+      </div>
     </section>
 
     <!-- ==================== HERO PERSONA SWITCH ==================== -->
     <section class="hp-section hp-cta-section hp-reveal" id="hero-cta">
       <p class="hp-cta-lead">
-        Chat with Lemonade just like a cloud AI, connect to your favorite agent, or even build it into your own app. The choice is yours!
+        Chat with Lemonade, connect to agents, or build it into your own app. The choice is yours!
       </p>
       <div class="hp-persona-switch ice-card" role="group" aria-label="Choose a quickstart path">
         <button class="hp-persona-switch-btn" type="button" data-cta-switch="people" data-persona-choice="people">


### PR DESCRIPTION
Makes the community links first-class on the marketing site and fixes a few navbar/hero layout bugs.

- **Mobile hamburger:** GitHub and Discord were dropped entirely on mobile — the menu now lists GitHub, Discord, Follow (X), and YouTube as their own rows.
- **Navbar socials:** X and YouTube were hidden between ~826–1180px; they now stay visible down to the hamburger breakpoint.
- **Hero:** added a slim community strip (Discord online · GitHub stars) under the subtitle.
- **Discord icon:** its glyph underfilled the 24px `viewBox` and rendered ~20% small next to the other icons — normalized with a tight `viewBox`.
- **CTA lead:** no longer wraps to two lines on very wide viewports (fluid font size outgrew the fixed `max-width`).

## Before / After

### Desktop — navbar X/YouTube restored + community strip (≈1120px)
| Before | After |
|:---:|:---:|
| <img width="440" src="https://raw.githubusercontent.com/lemonade-sdk/lemonade/github-links-pr-shots/.pr-shots/before-desktop-nav.png"> | <img width="440" src="https://raw.githubusercontent.com/lemonade-sdk/lemonade/github-links-pr-shots/.pr-shots/after-desktop-nav.png"> |

### Mobile — hamburger closed (community strip in hero)
| Before | After |
|:---:|:---:|
| <img width="240" src="https://raw.githubusercontent.com/lemonade-sdk/lemonade/github-links-pr-shots/.pr-shots/before-mobile-closed.png"> | <img width="240" src="https://raw.githubusercontent.com/lemonade-sdk/lemonade/github-links-pr-shots/.pr-shots/after-mobile-closed.png"> |

### Mobile — hamburger open (GitHub / Discord / Follow / YouTube rows)
| Before | After |
|:---:|:---:|
| <img width="240" src="https://raw.githubusercontent.com/lemonade-sdk/lemonade/github-links-pr-shots/.pr-shots/before-mobile-open.png"> | <img width="240" src="https://raw.githubusercontent.com/lemonade-sdk/lemonade/github-links-pr-shots/.pr-shots/after-mobile-open.png"> |

<!-- Screenshots are hosted on the throwaway branch `github-links-pr-shots` to keep binaries out of main (per the separate lemonade-sdk/assets convention). Safe to delete that branch after this PR merges. -->
