### PR TITLE
Add libgomp runtime dependency to deb/rpm packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1529,10 +1529,6 @@ if(UNIX AND NOT APPLE)
     set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Lemonade Local LLM Server")
     set(CPACK_PACKAGE_DESCRIPTION "A lightweight, high-performance local LLM server with support for multiple backends including llama.cpp, FastFlowLM, and RyzenAI.")
 
-    # Backends such as llama-server are OpenMP-linked and require libgomp1 at
-    # runtime. It's not always present on minimal Debian/Ubuntu installs.
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libgomp1")
-
     # Only install our executables (not curl/development files)
     install(TARGETS ${EXECUTABLE_NAME}
         RUNTIME DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1529,6 +1529,10 @@ if(UNIX AND NOT APPLE)
     set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Lemonade Local LLM Server")
     set(CPACK_PACKAGE_DESCRIPTION "A lightweight, high-performance local LLM server with support for multiple backends including llama.cpp, FastFlowLM, and RyzenAI.")
 
+    # Backends such as llama-server are OpenMP-linked and require libgomp1 at
+    # runtime. It's not always present on minimal Debian/Ubuntu installs.
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "libgomp1")
+
     # Only install our executables (not curl/development files)
     install(TARGETS ${EXECUTABLE_NAME}
         RUNTIME DESTINATION bin

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -48,7 +48,7 @@ Vcs-Git: https://salsa.debian.org/debian/lemonade.git
 Package: lemonade-server
 Architecture: linux-any
 Multi-Arch: foreign
-Depends: ${shlibs:Depends}, ${misc:Depends}, fonts-katex, unzip, libatomic1
+Depends: ${shlibs:Depends}, ${misc:Depends}, fonts-katex, unzip, libatomic1, libgomp1
 Description: Local LLM serving with GPU and NPU acceleration server
  Lemonade helps users run local LLMs with the highest performance by
  configuring state-of-the-art inference engines for their NPUs and GPUs.

--- a/src/cpp/CPackRPM.cmake
+++ b/src/cpp/CPackRPM.cmake
@@ -9,7 +9,8 @@ set(CPACK_RPM_PACKAGE_URL "https://github.com/lemonade-sdk/lemonade")
 
 # RPM runtime requirements (package names on Fedora/RHEL)
 # Adjust for target distro if needed.
-set(CPACK_RPM_PACKAGE_REQUIRES "libcurl, openssl, zlib")
+# libgomp is required at runtime by OpenMP-linked backends (e.g. llama-server).
+set(CPACK_RPM_PACKAGE_REQUIRES "libcurl, openssl, zlib, libgomp")
 
 # Architecture and file name
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")


### PR DESCRIPTION
## Summary
`llama-server` (and other OpenMP-linked backends) requires `libgomp.so.1` at runtime, but the `.deb`/`.rpm` packages never declared it as a dependency. On minimal installs (e.g. fresh Ubuntu 26.04) this causes model loading to fail with a 500 error.

## Fix
- Add `CPACK_DEBIAN_PACKAGE_DEPENDS "libgomp1"` for Debian/Ubuntu packages.
- Add `libgomp` to `CPACK_RPM_PACKAGE_REQUIRES` for Fedora/RHEL packages.

Fixes #2793