### PR TITLE
Fix llama.cpp model field echoing local .gguf path

### DIFF
--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp_server.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp_server.h
@@ -47,6 +47,12 @@ public:
 
     // ITokenizerServer implementation
     json tokenize(const json& request) override;
+
+private:
+    // llama-server echoes the local .gguf path it was launched with (`-m <path>`)
+    // in the OpenAI `model` field. Rewrite it to the client-facing model id so
+    // responses don't leak absolute filesystem paths (and usernames).
+    json normalize_response_model(json response, const json& request) const;
 };
 
 namespace llamacpp {

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -608,14 +608,25 @@ bool LlamaCppServer::downsize() {
     }
 }
 
+json LlamaCppServer::normalize_response_model(json response, const json& request) const {
+    if (response.is_object() && response.contains("model")) {
+        response["model"] = request.value("model", get_model_name());
+    }
+    return response;
+}
+
 json LlamaCppServer::chat_completion(const json& request) {
-    return forward_request("/v1/chat/completions",
-                           JsonUtils::with_legacy_max_tokens_alias(request));
+    return normalize_response_model(
+        forward_request("/v1/chat/completions",
+                        JsonUtils::with_legacy_max_tokens_alias(request)),
+        request);
 }
 
 json LlamaCppServer::completion(const json& request) {
-    return forward_request("/v1/completions",
-                           JsonUtils::with_legacy_max_tokens_alias(request));
+    return normalize_response_model(
+        forward_request("/v1/completions",
+                        JsonUtils::with_legacy_max_tokens_alias(request)),
+        request);
 }
 
 json LlamaCppServer::embeddings(const json& request) {
@@ -639,7 +650,7 @@ json LlamaCppServer::tokenize(const json& request_body) {
 }
 
 json LlamaCppServer::responses(const json& request) {
-    return forward_request("/v1/responses", request);
+    return normalize_response_model(forward_request("/v1/responses", request), request);
 }
 
 } // namespace backends


### PR DESCRIPTION
### Summary
llama-server is launched with `-m <path>` and echoes that absolute path in the OpenAI `model` field, so lemond forwarded it verbatim. This normalizes `response["model"]` back to the client-facing model id at the llama.cpp response layer, mirroring what the omni orchestrator already does.

### Changes
- Added `LlamaCppServer::normalize_response_model()` which rewrites `response["model"]` to the requested model id (falling back to the registered model name).
- Applied it in `chat_completion`, `completion`, and `responses`, covering both the direct and router-forwarded non-streaming paths.
- Only rewrites responses that carry a `model` field, so error responses pass through untouched.

### Notes
- Fixes the leak of absolute filesystem paths + usernames in the `model` field (e.g. `C:\Users\<name>\...\Qwen3-0.6B-Q4_0.gguf` → `Qwen3-0.6B-GGUF`), and restores agreement with the `decision.schema.json` contract that `route_to` is also carried by `model`.
- Streaming responses are left out of scope for this change, since fixing that is more invasive.

Partially addresses #2730