### PR TITLE
[Router] Fix DirectoryWatcher missing policy delete+rewrite on Windows

### DIFF
--- a/src/cpp/server/directory_watcher.cpp
+++ b/src/cpp/server/directory_watcher.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <cstring>
 #include <set>
+#include <tuple>
 #include <filesystem>
 
 namespace fs = std::filesystem;
@@ -423,14 +424,24 @@ public:
     void set_callback(std::function<void()> cb) { callback_ = std::move(cb); }
 
 private:
-    // Take a snapshot of directory contents (set of "name+mtime" pairs).
-    static std::set<std::pair<std::string, long long>> take_snapshot(const std::string& dir) {
-        std::set<std::pair<std::string, long long>> snap;
+    // Take a snapshot of directory contents (set of "name+size+mtime" tuples).
+    // Size and a high-resolution mtime are both included so that a delete +
+    // rewrite of the same file within one wall-clock second is still detected:
+    // ::stat's st_mtime has only 1-second resolution, which on Windows makes
+    // such rewrites invisible to a name-and-second-only diff.
+    static std::set<std::tuple<std::string, long long, long long>> take_snapshot(const std::string& dir) {
+        std::set<std::tuple<std::string, long long, long long>> snap;
         for (const auto& entry : fs::recursive_directory_iterator(dir,
                      fs::directory_options::skip_permission_denied | fs::directory_options::follow_directory_symlink)) {
-            struct stat st;
-            if (::stat(entry.path().string().c_str(), &st) != 0) continue;
-            snap.emplace(entry.path().filename().string(), st.st_mtime);
+            std::error_code ec;
+            auto mtime = fs::last_write_time(entry.path(), ec).time_since_epoch().count();
+            if (ec) continue;
+            long long size = 0;
+            if (entry.is_regular_file(ec)) {
+                size = static_cast<long long>(entry.file_size(ec));
+                if (ec) size = 0;
+            }
+            snap.emplace(entry.path().filename().string(), size, static_cast<long long>(mtime));
         }
         return snap;
     }
@@ -448,7 +459,7 @@ private:
             if (!dir_exists) return;
         }
 
-        std::set<std::pair<std::string, long long>> prev = take_snapshot(dir_path_);
+        std::set<std::tuple<std::string, long long, long long>> prev = take_snapshot(dir_path_);
 
         while (!stop_flag_.load()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(200));

--- a/test/cpp/test_routing_policy_store.cpp
+++ b/test/cpp/test_routing_policy_store.cpp
@@ -105,6 +105,7 @@ static void test_directory_watcher_reload() {
     // Delete first to trigger a directory entry change. macOS's kqueue-based
     // DirectoryWatcher monitors the directory fd and does not detect inline writes.
     fs::remove(policy_path);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     write_json(policy_path, doc);
 
     std::shared_ptr<const lemon::RoutingPolicyEngine> next_engine;


### PR DESCRIPTION
### Summary
The Windows polling `DirectoryWatcher` keyed its change-detection snapshot on `(filename, st_mtime)` where `st_mtime` has 1-second resolution, so a delete-then-rewrite of the same policy file within one wall-clock second produced an identical snapshot and the hot-reload callback never fired. This fixes the missed event and de-flakes `RoutingPolicyStoreTest` on Windows.

Closes #2787

### Changes
- Snapshot key now includes file **size** and a **high-resolution mtime** (`fs::last_write_time` 100 ns ticks instead of `time_t` seconds), so a same-second same-name rewrite is still detected.
- Test now inserts a short wait between the `remove` and the recreate so the two are distinct filesystem events.

### Testing
- `test_routing_policy_store.exe`: 15/15 passing (previously failed ~2 of 3).
- `test_directory_watcher.exe`: 10/10 passing (no regression).

Note: only the Windows polling backend was affected; the Linux (inotify) and macOS (kqueue) backends receive real delete/create events and were already correct.