### PR TITLE
Add JSON schema checking to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,11 @@ repos:
     hooks:
       - id: black
         language_version: python3
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.4
+    hooks:
+      - id: check-jsonschema
+        files: .*\.json$
+        args: ["--schemafile", "schemas/foo.json"]
+      - id: check-github-actions
+      - id: check-github-workflows


### PR DESCRIPTION
Helps save some CI time for dumb mistakes.

For example now catches this mistake that I made on a PR.

```
Validate files with jsonschema...........................................Failed
- hook id: check-jsonschema
- exit code: 1

Several files failed to parse.
  Failed to parse src/cpp/resources/backend_versions.json
    JSONDecodeError: Expecting property name enclosed in double quotes: line 14 column 9 (char 1361)
```