### PR TITLE
docs: add marketplace sidebar link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
     - Release Process: dev/release.md
   - App Integrations:
     - Overview: integrations/README.md
+    - Marketplace: https://lemonade-server.ai/marketplace.html
     - AI Toolkit: integrations/ai-toolkit.md
     - AnythingLLM: integrations/anythingLLM.md
     - Claude Code: integrations/claude-code.md


### PR DESCRIPTION
## Summary

- Add the Lemonade Marketplace to the App Integrations sidebar.
- Closes #1853.

## Validation

- Ran `.venv/bin/python docs/publish_website_docs.py` successfully with Zensical `0.0.39`.
- Served the generated site locally and verified Marketplace is visible under App Integrations.
- Verified the rendered sidebar link targets `https://lemonade-server.ai/marketplace.html`.
- Verified the Marketplace URL returns HTTP 200.

## Screenshot

![Marketplace visible in the App Integrations sidebar](https://raw.githubusercontent.com/sujikathir/lemonade/pr-assets/pr-assets/lemonade-marketplace-sidebar.png)
