### PR TITLE
fix(http): add libcurl protocol fallback for macOS libcurl compatibility

### DIFF
--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -13,6 +13,7 @@
 #include <cctype>
 #include <fstream>
 #include <memory>
+#include <string_view>
 #include <vector>
 #include <mbedtls/md.h>
 
@@ -378,29 +379,46 @@ bool apply_http_security_policy(
         return curl_easy_setopt(curl, option, value) == CURLE_OK;
     };
 
+    const auto set_proto = [&](CURLoption opt_str, CURLoption opt_bit, const char* str_val, long bit_val) {
+        if (set(opt_str, str_val)) {
+            return true;
+        }
+        return set(opt_bit, bit_val);
+    };
+
     const auto apply_protocols = [&](const char* protocols,
                                      const char* redirect_protocols) {
+        std::string_view p(protocols);
+        std::string_view r(redirect_protocols);
+        bool p_has_https = (p.find("HTTPS") != std::string_view::npos || p.find("https") != std::string_view::npos);
+        bool p_has_http = (p.find("HTTP") != std::string_view::npos || p.find("http") != std::string_view::npos);
+        bool r_has_https = (r.find("HTTPS") != std::string_view::npos || r.find("https") != std::string_view::npos);
+        bool r_has_http = (r.find("HTTP") != std::string_view::npos || r.find("http") != std::string_view::npos);
+
+        long proto_mask = (p_has_https ? 2L : 0L) | (p_has_http ? 1L : 0L);
+        long redir_mask = (r_has_https ? 2L : 0L) | (r_has_http ? 1L : 0L);
+
         if (!set(CURLOPT_FOLLOWLOCATION, follow_redirects ? 1L : 0L) ||
-            !set(CURLOPT_PROTOCOLS_STR, protocols)) {
+            !set_proto(CURLOPT_PROTOCOLS_STR, CURLOPT_PROTOCOLS, protocols, proto_mask)) {
             return false;
         }
         if (!follow_redirects) {
             return true;
         }
         return set(CURLOPT_MAXREDIRS, 5L) &&
-               set(CURLOPT_REDIR_PROTOCOLS_STR, redirect_protocols);
+               set_proto(CURLOPT_REDIR_PROTOCOLS_STR, CURLOPT_REDIR_PROTOCOLS, redirect_protocols, redir_mask);
     };
 
     switch (policy) {
         case HttpSecurityPolicy::TrustedLoopback:
             // Managed loopback backends are plain HTTP and must never redirect.
             return set(CURLOPT_FOLLOWLOCATION, 0L) &&
-                   set(CURLOPT_PROTOCOLS_STR, "http");
+                   set_proto(CURLOPT_PROTOCOLS_STR, CURLOPT_PROTOCOLS, "HTTP", 1L /* CURLPROTO_HTTP */);
         case HttpSecurityPolicy::AllowInsecureHttp:
-            return apply_protocols("http,https", "http,https");
+            return apply_protocols("HTTP,HTTPS", "HTTP,HTTPS");
         case HttpSecurityPolicy::ExternalHttpsOnly:
         default:
-            return apply_protocols("https", "https");
+            return apply_protocols("HTTPS", "HTTPS");
     }
 }
 } // namespace

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -390,10 +390,14 @@ bool apply_http_security_policy(
                                      const char* redirect_protocols) {
         std::string_view p(protocols);
         std::string_view r(redirect_protocols);
-        bool p_has_https = (p.find("HTTPS") != std::string_view::npos || p.find("https") != std::string_view::npos);
-        bool p_has_http = (p.find("HTTP") != std::string_view::npos || p.find("http") != std::string_view::npos);
-        bool r_has_https = (r.find("HTTPS") != std::string_view::npos || r.find("https") != std::string_view::npos);
-        bool r_has_http = (r.find("HTTP") != std::string_view::npos || r.find("http") != std::string_view::npos);
+        bool p_has_https = (p.find("https") != std::string_view::npos || p.find("HTTPS") != std::string_view::npos);
+        bool p_has_http = (p.find("http,") != std::string_view::npos || p.find("HTTP,") != std::string_view::npos ||
+                           p.find(",http") != std::string_view::npos || p.find(",HTTP") != std::string_view::npos ||
+                           p == "http" || p == "HTTP");
+        bool r_has_https = (r.find("https") != std::string_view::npos || r.find("HTTPS") != std::string_view::npos);
+        bool r_has_http = (r.find("http,") != std::string_view::npos || r.find("HTTP,") != std::string_view::npos ||
+                           r.find(",http") != std::string_view::npos || r.find(",HTTP") != std::string_view::npos ||
+                           r == "http" || r == "HTTP");
 
         long proto_mask = (p_has_https ? 2L : 0L) | (p_has_http ? 1L : 0L);
         long redir_mask = (r_has_https ? 2L : 0L) | (r_has_http ? 1L : 0L);
@@ -413,12 +417,12 @@ bool apply_http_security_policy(
         case HttpSecurityPolicy::TrustedLoopback:
             // Managed loopback backends are plain HTTP and must never redirect.
             return set(CURLOPT_FOLLOWLOCATION, 0L) &&
-                   set_proto(CURLOPT_PROTOCOLS_STR, CURLOPT_PROTOCOLS, "HTTP", 1L /* CURLPROTO_HTTP */);
+                   set_proto(CURLOPT_PROTOCOLS_STR, CURLOPT_PROTOCOLS, "http", 1L /* CURLPROTO_HTTP */);
         case HttpSecurityPolicy::AllowInsecureHttp:
-            return apply_protocols("HTTP,HTTPS", "HTTP,HTTPS");
+            return apply_protocols("http,https", "http,https");
         case HttpSecurityPolicy::ExternalHttpsOnly:
         default:
-            return apply_protocols("HTTPS", "HTTPS");
+            return apply_protocols("https", "https");
     }
 }
 } // namespace


### PR DESCRIPTION
Adds legacy `CURLOPT_PROTOCOLS` / `CURLOPT_REDIR_PROTOCOLS` bitmask fallback to `HttpClient::apply_http_security_policy` when string-based protocol restriction options (`CURLOPT_PROTOCOLS_STR`) are unsupported by the underlying libcurl runtime build (e.g. macOS system libcurl).

## Changes
- **HTTP Client**: In `src/cpp/server/utils/http_client.cpp`, `apply_http_security_policy` now attempts `CURLOPT_PROTOCOLS_STR` first and falls back to bitmask-based `CURLOPT_PROTOCOLS` if `curl_easy_setopt` fails.
- **Strict Bitmask Scoping**: Explicitly passes exact bitmasks (`1L` for `CURLPROTO_HTTP` in `TrustedLoopback`, `2L` for `CURLPROTO_HTTPS` in `ExternalHttpsOnly`, `3L` for `CURLPROTO_HTTP | CURLPROTO_HTTPS` in `AllowInsecureHttp`), resolving `CURLE_UNSUPPORTED_PROTOCOL` errors on macOS CI builds while maintaining strict security boundaries.