### PR TITLE
fix(llamacpp): sanitize oversized tool schema limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -826,6 +826,16 @@ if(BUILD_TESTING AND EXISTS "${VLLM_ARG_RESOLVER_TEST_SOURCE}")
     add_test(NAME vllm_arg_resolver COMMAND test_vllm_arg_resolver)
 endif()
 
+set(LLAMACPP_REQUEST_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_llamacpp_request.cpp")
+if(BUILD_TESTING AND EXISTS "${LLAMACPP_REQUEST_TEST_SOURCE}")
+    add_executable(test_llamacpp_request
+        ${LLAMACPP_REQUEST_TEST_SOURCE}
+        src/cpp/server/backends/llamacpp/llamacpp_request.cpp
+    )
+    target_link_libraries(test_llamacpp_request PRIVATE nlohmann_json::nlohmann_json)
+    add_test(NAME llamacpp_request COMMAND test_llamacpp_request)
+endif()
+
 set(MCP_CLIENT_CONFIG_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_mcp_client_config.cpp")
 if(BUILD_TESTING AND EXISTS "${MCP_CLIENT_CONFIG_TEST_SOURCE}")
     find_package(Python3 COMPONENTS Interpreter QUIET)

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp_request.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp_request.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+namespace lemon {
+namespace backends {
+namespace llamacpp {
+
+nlohmann::json sanitize_tool_schema_limits(nlohmann::json request);
+
+}  // namespace llamacpp
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/include/lemon/backends/llamacpp/llamacpp_server.h
+++ b/src/cpp/include/lemon/backends/llamacpp/llamacpp_server.h
@@ -35,6 +35,13 @@ public:
     json completion(const json& request) override;
     json responses(const json& request) override;
 
+    void forward_streaming_request(const std::string& endpoint,
+                                   const std::string& request_body,
+                                   httplib::DataSink& sink,
+                                   bool sse = true,
+                                   long timeout_seconds = 0,
+                                   TelemetryCallback telemetry_callback = nullptr) override;
+
     // IEmbeddingsServer implementation
     json embeddings(const json& request) override;
 

--- a/src/cpp/server/backends/llamacpp/llamacpp_request.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_request.cpp
@@ -10,12 +10,12 @@ namespace {
 
 constexpr std::uint64_t GRAMMAR_REPETITION_LIMIT = 2000;
 
-bool exceeds_grammar_repetition_limit(const nlohmann::json& value) {
+bool has_integer_value_at_least(const nlohmann::json& value, std::uint64_t threshold) {
     if (value.is_number_unsigned()) {
-        return value.get<std::uint64_t>() >= GRAMMAR_REPETITION_LIMIT;
+        return value.get<std::uint64_t>() >= threshold;
     }
     if (value.is_number_integer()) {
-        return value.get<std::int64_t>() >= static_cast<std::int64_t>(GRAMMAR_REPETITION_LIMIT);
+        return value.get<std::int64_t>() >= static_cast<std::int64_t>(threshold);
     }
     return false;
 }
@@ -32,9 +32,18 @@ void sanitize_schema(nlohmann::json& schema) {
     // llama.cpp rejects grammar repetitions at this threshold. Remove oversized
     // bounds instead of clamping them, which would reject valid tool arguments.
     // Remove this workaround once ggml-org/llama.cpp#17473 is fixed in pinned builds.
-    for (const std::string key : {"minLength", "maxLength", "minItems", "maxItems"}) {
+    for (const std::string key : {"minLength", "maxLength"}) {
         auto limit = schema.find(key);
-        if (limit != schema.end() && exceeds_grammar_repetition_limit(*limit)) {
+        if (limit != schema.end() && has_integer_value_at_least(*limit, GRAMMAR_REPETITION_LIMIT)) {
+            schema.erase(limit);
+        }
+    }
+
+    // Array grammars emit the first item separately, so an item bound of N
+    // produces a repetition bound of N - 1.
+    for (const std::string key : {"minItems", "maxItems"}) {
+        auto limit = schema.find(key);
+        if (limit != schema.end() && has_integer_value_at_least(*limit, GRAMMAR_REPETITION_LIMIT + 1)) {
             schema.erase(limit);
         }
     }

--- a/src/cpp/server/backends/llamacpp/llamacpp_request.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_request.cpp
@@ -30,17 +30,52 @@ void sanitize_schema(nlohmann::json& schema) {
     if (!schema.is_object()) return;
 
     // llama.cpp rejects grammar repetitions at this threshold. Remove oversized
-    // upper bounds instead of clamping them, which would reject valid tool arguments.
+    // bounds instead of clamping them, which would reject valid tool arguments.
     // Remove this workaround once ggml-org/llama.cpp#17473 is fixed in pinned builds.
-    for (const std::string key : {"maxLength", "maxItems"}) {
+    for (const std::string key : {"minLength", "maxLength", "minItems", "maxItems"}) {
         auto limit = schema.find(key);
         if (limit != schema.end() && exceeds_grammar_repetition_limit(*limit)) {
             schema.erase(limit);
         }
     }
 
-    for (auto& item : schema.items()) {
-        sanitize_schema(item.value());
+    for (const std::string key : {
+             "additionalItems",
+             "additionalProperties",
+             "allOf",
+             "anyOf",
+             "contains",
+             "contentSchema",
+             "else",
+             "if",
+             "items",
+             "not",
+             "oneOf",
+             "prefixItems",
+             "propertyNames",
+             "then",
+             "unevaluatedItems",
+             "unevaluatedProperties",
+         }) {
+        auto subschema = schema.find(key);
+        if (subschema != schema.end()) {
+            sanitize_schema(*subschema);
+        }
+    }
+
+    for (const std::string key : {
+             "$defs",
+             "definitions",
+             "dependencies",
+             "dependentSchemas",
+             "patternProperties",
+             "properties",
+         }) {
+        auto subschemas = schema.find(key);
+        if (subschemas == schema.end() || !subschemas->is_object()) continue;
+        for (auto& item : subschemas->items()) {
+            sanitize_schema(item.value());
+        }
     }
 }
 

--- a/src/cpp/server/backends/llamacpp/llamacpp_request.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_request.cpp
@@ -1,5 +1,6 @@
 #include "lemon/backends/llamacpp/llamacpp_request.h"
 
+#include <cmath>
 #include <cstdint>
 #include <string>
 
@@ -17,7 +18,11 @@ bool has_integer_value_at_least(const nlohmann::json& value, std::uint64_t thres
     if (value.is_number_integer()) {
         return value.get<std::int64_t>() >= static_cast<std::int64_t>(threshold);
     }
-    return false;
+    if (!value.is_number_float()) return false;
+
+    const double number = value.get<double>();
+    return std::isfinite(number) && number >= 0.0 && std::floor(number) == number &&
+           number >= static_cast<double>(threshold);
 }
 
 void sanitize_schema(nlohmann::json& schema) {

--- a/src/cpp/server/backends/llamacpp/llamacpp_request.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_request.cpp
@@ -1,0 +1,75 @@
+#include "lemon/backends/llamacpp/llamacpp_request.h"
+
+#include <cstdint>
+#include <string>
+
+namespace lemon {
+namespace backends {
+namespace llamacpp {
+namespace {
+
+constexpr std::uint64_t GRAMMAR_REPETITION_LIMIT = 2000;
+
+bool exceeds_grammar_repetition_limit(const nlohmann::json& value) {
+    if (value.is_number_unsigned()) {
+        return value.get<std::uint64_t>() >= GRAMMAR_REPETITION_LIMIT;
+    }
+    if (value.is_number_integer()) {
+        return value.get<std::int64_t>() >= static_cast<std::int64_t>(GRAMMAR_REPETITION_LIMIT);
+    }
+    return false;
+}
+
+void sanitize_schema(nlohmann::json& schema) {
+    if (schema.is_array()) {
+        for (auto& value : schema) {
+            sanitize_schema(value);
+        }
+        return;
+    }
+    if (!schema.is_object()) return;
+
+    // llama.cpp rejects grammar repetitions at this threshold. Remove oversized
+    // upper bounds instead of clamping them, which would reject valid tool arguments.
+    // Remove this workaround once ggml-org/llama.cpp#17473 is fixed in pinned builds.
+    for (const std::string key : {"maxLength", "maxItems"}) {
+        auto limit = schema.find(key);
+        if (limit != schema.end() && exceeds_grammar_repetition_limit(*limit)) {
+            schema.erase(limit);
+        }
+    }
+
+    for (auto& item : schema.items()) {
+        sanitize_schema(item.value());
+    }
+}
+
+}  // namespace
+
+nlohmann::json sanitize_tool_schema_limits(nlohmann::json request) {
+    auto tools = request.find("tools");
+    if (tools == request.end() || !tools->is_array()) return request;
+
+    for (auto& tool : *tools) {
+        if (!tool.is_object()) continue;
+
+        auto parameters = tool.find("parameters");
+        if (parameters != tool.end()) {
+            sanitize_schema(*parameters);
+        }
+
+        auto function = tool.find("function");
+        if (function == tool.end() || !function->is_object()) continue;
+
+        parameters = function->find("parameters");
+        if (parameters != function->end()) {
+            sanitize_schema(*parameters);
+        }
+    }
+
+    return request;
+}
+
+}  // namespace llamacpp
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -620,8 +620,8 @@ json LlamaCppServer::normalize_response_model(json response, const json& request
 json LlamaCppServer::chat_completion(const json& request) {
     return normalize_response_model(
         forward_request("/v1/chat/completions",
-                        JsonUtils::with_legacy_max_tokens_alias(
-                            llamacpp::sanitize_tool_schema_limits(request))),
+                        llamacpp::sanitize_tool_schema_limits(
+                            JsonUtils::with_legacy_max_tokens_alias(request))),
         request);
 }
 
@@ -669,6 +669,9 @@ void LlamaCppServer::forward_streaming_request(const std::string& endpoint,
     if (endpoint == "/v1/chat/completions" || endpoint == "/v1/responses") {
         json request = json::parse(request_body, nullptr, false);
         if (!request.is_discarded()) {
+            if (endpoint == "/v1/chat/completions") {
+                JsonUtils::add_legacy_max_tokens_alias(request);
+            }
             body = llamacpp::sanitize_tool_schema_limits(std::move(request)).dump();
         }
     }

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -1,6 +1,7 @@
 #include "lemon/backends/llamacpp/llamacpp_server.h"
 #include "lemon/backends/llamacpp/llamacpp.h"
 #include "lemon/backends/llamacpp/llamacpp_gguf.h"
+#include "lemon/backends/llamacpp/llamacpp_request.h"
 #include "lemon/backends/backend_registry.h"
 #include "lemon/backends/backend_ops.h"
 #include "lemon/backends/backend_utils.h"
@@ -11,6 +12,7 @@
 #include <filesystem>
 #include <regex>
 #include <system_error>
+#include <utility>
 #include "lemon/auto_tune.h"
 #include "lemon/backend_manager.h"
 #include "lemon/runtime_config.h"
@@ -618,7 +620,8 @@ json LlamaCppServer::normalize_response_model(json response, const json& request
 json LlamaCppServer::chat_completion(const json& request) {
     return normalize_response_model(
         forward_request("/v1/chat/completions",
-                        JsonUtils::with_legacy_max_tokens_alias(request)),
+                        JsonUtils::with_legacy_max_tokens_alias(
+                            llamacpp::sanitize_tool_schema_limits(request))),
         request);
 }
 
@@ -650,7 +653,28 @@ json LlamaCppServer::tokenize(const json& request_body) {
 }
 
 json LlamaCppServer::responses(const json& request) {
-    return normalize_response_model(forward_request("/v1/responses", request), request);
+    return normalize_response_model(
+        forward_request("/v1/responses",
+                        llamacpp::sanitize_tool_schema_limits(request)),
+        request);
+}
+
+void LlamaCppServer::forward_streaming_request(const std::string& endpoint,
+                                               const std::string& request_body,
+                                               httplib::DataSink& sink,
+                                               bool sse,
+                                               long timeout_seconds,
+                                               TelemetryCallback telemetry_callback) {
+    std::string body = request_body;
+    if (endpoint == "/v1/chat/completions" || endpoint == "/v1/responses") {
+        json request = json::parse(request_body, nullptr, false);
+        if (!request.is_discarded()) {
+            body = llamacpp::sanitize_tool_schema_limits(std::move(request)).dump();
+        }
+    }
+
+    WrappedServer::forward_streaming_request(
+        endpoint, body, sink, sse, timeout_seconds, telemetry_callback);
 }
 
 } // namespace backends

--- a/test/cpp/test_llamacpp_request.cpp
+++ b/test/cpp/test_llamacpp_request.cpp
@@ -39,12 +39,39 @@ int main() {
                         {"name", {
                             {"type", "string"},
                             {"maxLength", 1999},
+                            {"minLength", 1999},
+                        }},
+                        {"description", {
+                            {"type", "string"},
+                            {"minLength", 2000},
                         }},
                         {"steps", {
                             {"type", "array"},
                             {"maxItems", 2000},
+                            {"minItems", 1999},
                             {"items", {
                                 {"$ref", "#/$defs/step"},
+                            }},
+                        }},
+                        {"queue", {
+                            {"type", "array"},
+                            {"maxItems", 1999},
+                            {"minItems", 2000},
+                        }},
+                        {"config", {
+                            {"const", {
+                                {"maxLength", 524288},
+                                {"minItems", 2000},
+                            }},
+                        }},
+                        {"mode", {
+                            {"enum", {
+                                {
+                                    {"maxItems", 2000},
+                                },
+                                {
+                                    {"minLength", 4096},
+                                },
                             }},
                         }},
                     }},
@@ -70,10 +97,24 @@ int main() {
            "removes oversized Chat Completions maxLength");
     expect(parameters["properties"]["name"]["maxLength"] == 1999,
            "preserves maxLength below the llama.cpp limit");
+    expect(parameters["properties"]["name"]["minLength"] == 1999,
+           "preserves minLength below the llama.cpp limit");
+    expect(!parameters["properties"]["description"].contains("minLength"),
+           "removes minLength at the llama.cpp limit");
     expect(!parameters["properties"]["steps"].contains("maxItems"),
-           "removes oversized maxItems");
+           "removes maxItems at the llama.cpp limit");
+    expect(parameters["properties"]["steps"]["minItems"] == 1999,
+           "preserves minItems below the llama.cpp limit");
+    expect(parameters["properties"]["queue"]["maxItems"] == 1999,
+           "preserves maxItems below the llama.cpp limit");
+    expect(!parameters["properties"]["queue"].contains("minItems"),
+           "removes minItems at the llama.cpp limit");
     expect(!parameters["$defs"]["step"]["properties"]["output"].contains("maxLength"),
            "recurses through $defs");
+    expect(parameters["properties"]["config"]["const"] == chat_request["tools"][0]["function"]["parameters"]["properties"]["config"]["const"],
+           "preserves object values inside const");
+    expect(parameters["properties"]["mode"]["enum"] == chat_request["tools"][0]["function"]["parameters"]["properties"]["mode"]["enum"],
+           "preserves object values inside enum");
     expect(chat_request["tools"][0]["function"]["parameters"]["properties"]["script"]["maxLength"] == 524288,
            "does not mutate the caller's request");
 

--- a/test/cpp/test_llamacpp_request.cpp
+++ b/test/cpp/test_llamacpp_request.cpp
@@ -45,6 +45,18 @@ int main() {
                             {"type", "string"},
                             {"minLength", 2000},
                         }},
+                        {"floatDescription", {
+                            {"type", "string"},
+                            {"maxLength", 2000.0},
+                        }},
+                        {"fractionalDescription", {
+                            {"type", "string"},
+                            {"maxLength", 2000.5},
+                        }},
+                        {"negativeDescription", {
+                            {"type", "string"},
+                            {"maxLength", -2000.0},
+                        }},
                         {"steps", {
                             {"type", "array"},
                             {"maxItems", 2000},
@@ -60,6 +72,10 @@ int main() {
                         {"backlog", {
                             {"type", "array"},
                             {"minItems", 2001},
+                        }},
+                        {"floatBacklog", {
+                            {"type", "array"},
+                            {"minItems", 2001.0},
                         }},
                         {"results", {
                             {"type", "array"},
@@ -108,6 +124,12 @@ int main() {
            "preserves minLength below the llama.cpp limit");
     expect(!parameters["properties"]["description"].contains("minLength"),
            "removes minLength at the llama.cpp limit");
+    expect(!parameters["properties"]["floatDescription"].contains("maxLength"),
+           "removes integral floating-point maxLength at the llama.cpp limit");
+    expect(parameters["properties"]["fractionalDescription"]["maxLength"] == 2000.5,
+           "preserves non-integral floating-point bounds");
+    expect(parameters["properties"]["negativeDescription"]["maxLength"] == -2000.0,
+           "preserves negative floating-point bounds");
     expect(parameters["properties"]["steps"]["maxItems"] == 2000,
            "preserves maxItems whose generated repetition stays below the limit");
     expect(parameters["properties"]["steps"]["minItems"] == 1999,
@@ -116,6 +138,8 @@ int main() {
            "preserves minItems whose generated repetition stays below the limit");
     expect(!parameters["properties"]["backlog"].contains("minItems"),
            "removes minItems whose generated repetition reaches the limit");
+    expect(!parameters["properties"]["floatBacklog"].contains("minItems"),
+           "removes integral floating-point minItems whose repetition reaches the limit");
     expect(!parameters["properties"]["results"].contains("maxItems"),
            "removes maxItems whose generated repetition reaches the limit");
     expect(!parameters["$defs"]["step"]["properties"]["output"].contains("maxLength"),

--- a/test/cpp/test_llamacpp_request.cpp
+++ b/test/cpp/test_llamacpp_request.cpp
@@ -1,0 +1,112 @@
+#include "lemon/backends/llamacpp/llamacpp_request.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+using lemon::backends::llamacpp::sanitize_tool_schema_limits;
+using nlohmann::json;
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const std::string& message) {
+    if (condition) {
+        std::cout << "ok: " << message << std::endl;
+        return;
+    }
+    std::cerr << "FAIL: " << message << std::endl;
+    ++failures;
+}
+
+}  // namespace
+
+int main() {
+    const json chat_request = {
+        {"model", "test"},
+        {"tools", {{
+            {"type", "function"},
+            {"function", {
+                {"name", "Workflow"},
+                {"parameters", {
+                    {"type", "object"},
+                    {"properties", {
+                        {"script", {
+                            {"type", "string"},
+                            {"maxLength", 524288},
+                        }},
+                        {"name", {
+                            {"type", "string"},
+                            {"maxLength", 1999},
+                        }},
+                        {"steps", {
+                            {"type", "array"},
+                            {"maxItems", 2000},
+                            {"items", {
+                                {"$ref", "#/$defs/step"},
+                            }},
+                        }},
+                    }},
+                    {"$defs", {
+                        {"step", {
+                            {"type", "object"},
+                            {"properties", {
+                                {"output", {
+                                    {"type", "string"},
+                                    {"maxLength", 4096},
+                                }},
+                            }},
+                        }},
+                    }},
+                }},
+            }},
+        }}},
+    };
+
+    const json sanitized_chat = sanitize_tool_schema_limits(chat_request);
+    const json& parameters = sanitized_chat["tools"][0]["function"]["parameters"];
+    expect(!parameters["properties"]["script"].contains("maxLength"),
+           "removes oversized Chat Completions maxLength");
+    expect(parameters["properties"]["name"]["maxLength"] == 1999,
+           "preserves maxLength below the llama.cpp limit");
+    expect(!parameters["properties"]["steps"].contains("maxItems"),
+           "removes oversized maxItems");
+    expect(!parameters["$defs"]["step"]["properties"]["output"].contains("maxLength"),
+           "recurses through $defs");
+    expect(chat_request["tools"][0]["function"]["parameters"]["properties"]["script"]["maxLength"] == 524288,
+           "does not mutate the caller's request");
+
+    const json responses_request = {
+        {"tools", {{
+            {"type", "function"},
+            {"name", "Workflow"},
+            {"parameters", {
+                {"type", "object"},
+                {"properties", {
+                    {"script", {
+                        {"type", "string"},
+                        {"maxLength", 524288},
+                    }},
+                }},
+            }},
+        }}},
+    };
+
+    const json sanitized_responses = sanitize_tool_schema_limits(responses_request);
+    expect(!sanitized_responses["tools"][0]["parameters"]["properties"]["script"].contains("maxLength"),
+           "removes oversized Responses API maxLength");
+
+    const json unrelated = {
+        {"metadata", {
+            {"maxLength", 524288},
+        }},
+    };
+    expect(sanitize_tool_schema_limits(unrelated) == unrelated,
+           "does not rewrite values outside tool schemas");
+
+    if (failures == 0) {
+        std::cout << "All llama.cpp request assertions passed" << std::endl;
+    }
+    return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/cpp/test_llamacpp_request.cpp
+++ b/test/cpp/test_llamacpp_request.cpp
@@ -55,8 +55,15 @@ int main() {
                         }},
                         {"queue", {
                             {"type", "array"},
-                            {"maxItems", 1999},
                             {"minItems", 2000},
+                        }},
+                        {"backlog", {
+                            {"type", "array"},
+                            {"minItems", 2001},
+                        }},
+                        {"results", {
+                            {"type", "array"},
+                            {"maxItems", 2001},
                         }},
                         {"config", {
                             {"const", {
@@ -101,14 +108,16 @@ int main() {
            "preserves minLength below the llama.cpp limit");
     expect(!parameters["properties"]["description"].contains("minLength"),
            "removes minLength at the llama.cpp limit");
-    expect(!parameters["properties"]["steps"].contains("maxItems"),
-           "removes maxItems at the llama.cpp limit");
+    expect(parameters["properties"]["steps"]["maxItems"] == 2000,
+           "preserves maxItems whose generated repetition stays below the limit");
     expect(parameters["properties"]["steps"]["minItems"] == 1999,
            "preserves minItems below the llama.cpp limit");
-    expect(parameters["properties"]["queue"]["maxItems"] == 1999,
-           "preserves maxItems below the llama.cpp limit");
-    expect(!parameters["properties"]["queue"].contains("minItems"),
-           "removes minItems at the llama.cpp limit");
+    expect(parameters["properties"]["queue"]["minItems"] == 2000,
+           "preserves minItems whose generated repetition stays below the limit");
+    expect(!parameters["properties"]["backlog"].contains("minItems"),
+           "removes minItems whose generated repetition reaches the limit");
+    expect(!parameters["properties"]["results"].contains("maxItems"),
+           "removes maxItems whose generated repetition reaches the limit");
     expect(!parameters["$defs"]["step"]["properties"]["output"].contains("maxLength"),
            "recurses through $defs");
     expect(parameters["properties"]["config"]["const"] == chat_request["tools"][0]["function"]["parameters"]["properties"]["config"]["const"],


### PR DESCRIPTION
## Summary

- Sanitize oversized `maxLength` and `maxItems` constraints in llama.cpp tool parameter schemas before forwarding requests.
- Apply the transform recursively to Chat Completions and Responses API schemas, including streaming requests.
- Remove unsafe bounds rather than clamping them, preserving the ability to generate legitimately long tool arguments.
- Keep the workaround scoped to the llama.cpp backend.

Fixes #2691.

## Validation

- `cmake --build --preset default --target test_llamacpp_request`
- `ctest --test-dir build -R '^llamacpp_request$' --output-on-failure` — 1/1 passed
- `cmake --build --preset default --target lemond`
- `git diff --check origin/main...HEAD`
- Live test with llama.cpp b9747 and a checksum-verified Qwen3 tool-calling GGUF:
  - Raw llama.cpp, `maxLength: 524288` — HTTP 400, grammar initialization failure
  - Patched Lemonade, non-streaming — HTTP 200
  - Patched Lemonade, streaming — HTTP 200 with a terminating `[DONE]` event

### Before

![Raw llama.cpp rejects the oversized tool schema](https://raw.githubusercontent.com/sujikathir/lemonade/pr-assets/pr-assets/tool-schema-limits-before.png)

### After

![Patched Lemonade accepts non-streaming and streaming requests](https://raw.githubusercontent.com/sujikathir/lemonade/pr-assets/pr-assets/tool-schema-limits-after.png)
