### PR TITLE
fix(api): preserve native TTS stream formats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2447,6 +2447,17 @@ if(EXISTS "${_HTTP_CLIENT_SECURITY_TEST_SRC}")
     add_test(NAME HttpClientSecurityTest COMMAND test_http_client_security)
 endif()
 
+set(_TTS_RESPONSE_FORMAT_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_tts_response_format.cpp")
+if(EXISTS "${_TTS_RESPONSE_FORMAT_TEST_SRC}")
+    add_executable(test_tts_response_format test/cpp/test_tts_response_format.cpp)
+    target_include_directories(test_tts_response_format PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_tts_response_format PRIVATE nlohmann_json::nlohmann_json)
+    add_test(NAME TtsResponseFormatTest COMMAND test_tts_response_format)
+endif()
+
 set(_CLOUD_DISCOVERY_POLICY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_cloud_discovery_policy.cpp")
 if(EXISTS "${_CLOUD_DISCOVERY_POLICY_TEST_SRC}")
     add_executable(test_cloud_discovery_policy test/cpp/test_cloud_discovery_policy.cpp)

--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -929,7 +929,7 @@ Speech Generation API. You provide a text input and receive an audio file. This 
 | `voice` | No | The voice to use. All OpenAI-defined voices can be used (`alloy`, `ash`, ...), as well as those defined by the kokoro model (`af_sky`, `am_echo`, ...). Default: `shimmer` | <sub>![Status](https://img.shields.io/badge/partial-yellow)</sub> |
 | `voice` (OpenMOSS) | No | For OpenMOSS models the field is a free-text voice/style instruction instead of a fixed voice name (e.g. `a calm, deep male narrator voice`). | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `reference_wav_b64` | No | Lemonade extension (OpenMOSS voice cloning): base64-encoded WAV sample of the voice to clone. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
-| `response_format` | No | Format of the response. `mp3`, `wav`, `opus`, and `pcm` are supported. Default: `mp3`| <sub>![Status](https://img.shields.io/badge/partial-yellow)</sub> |
+| `response_format` | No | Format of the response. `mp3`, `wav`, `opus`, and `pcm` are supported. Default: `mp3`, or the backend's native format when its output is restricted (for example, `wav` for OpenMOSS). | <sub>![Status](https://img.shields.io/badge/partial-yellow)</sub> |
 | `stream_format` | No | If set, the response will be streamed. Only `audio` is supported, which will output `pcm` audio. Default: not set| <sub>![Status](https://img.shields.io/badge/partial-yellow)</sub> |
 
 ### Example request

--- a/src/cpp/include/lemon/tts_response_format.h
+++ b/src/cpp/include/lemon/tts_response_format.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace lemon {
+
+inline std::string select_tts_response_format(
+    const nlohmann::json& request,
+    const std::vector<std::string>& supported_formats) {
+    if (request.contains("stream_format")) {
+        return "pcm";
+    }
+    if (request.contains("response_format") && request["response_format"].is_string()) {
+        return request["response_format"].get<std::string>();
+    }
+    if (!supported_formats.empty()) {
+        return supported_formats.front();
+    }
+    return "mp3";
+}
+
+}  // namespace lemon

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -27,6 +27,7 @@
 #include "lemon/runtime_config.h"
 #include "telemetry.h"
 #include "lemon/system_info.h"
+#include "lemon/tts_response_format.h"
 #include "lemon/version.h"
 #include <cctype>
 #include <cstdint>
@@ -3957,14 +3958,8 @@ void Server::handle_audio_speech(const httplib::Request& req, httplib::Response&
 
         const auto supported_formats =
             router_->audio_speech_supported_formats(request_json["model"].get<std::string>());
-        std::string response_format = "mp3";
-        if (is_streaming) {
-            response_format = "pcm";
-        } else if (request_json.contains("response_format") && request_json["response_format"].is_string()) {
-            response_format = request_json["response_format"].get<std::string>();
-        } else if (!supported_formats.empty()) {
-            response_format = supported_formats.front();
-        }
+        const std::string response_format =
+            select_tts_response_format(request_json, supported_formats);
         if (!MIME_TYPES.contains(response_format)) {
             res.status = 400;
             nlohmann::json error = {{"error", {
@@ -3993,6 +3988,7 @@ void Server::handle_audio_speech(const httplib::Request& req, httplib::Response&
             return;
         }
         std::string mime_type = MIME_TYPES[response_format];
+        request_json["response_format"] = response_format;
 
         // Log the HTTP request
         LOG(INFO, "Server") << "POST /api/v1/audio/speech" << std::endl;

--- a/test/cpp/test_tts_response_format.cpp
+++ b/test/cpp/test_tts_response_format.cpp
@@ -1,0 +1,45 @@
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "lemon/tts_response_format.h"
+
+namespace {
+
+int failures = 0;
+
+void expect(const std::string& actual, const std::string& expected, const std::string& name) {
+    if (actual == expected) {
+        std::cout << "ok: " << name << std::endl;
+        return;
+    }
+    std::cerr << "FAIL: " << name << " (expected " << expected << ", got " << actual << ")"
+              << std::endl;
+    ++failures;
+}
+
+}  // namespace
+
+int main() {
+    using lemon::select_tts_response_format;
+    using nlohmann::json;
+
+    expect(select_tts_response_format(json::object(), {}), "mp3",
+           "unrestricted backend keeps the OpenAI default");
+    expect(select_tts_response_format(json::object(), {"wav"}), "wav",
+           "restricted backend defaults to its native format");
+    expect(select_tts_response_format(json{{"response_format", "opus"}}, {"wav", "opus"}), "opus",
+           "explicit response format takes precedence");
+    expect(select_tts_response_format(json{{"stream", true}}, {"wav"}), "wav",
+           "streaming preserves a backend's native format");
+    expect(select_tts_response_format(
+               json{{"stream", true}, {"response_format", "wav"}}, {"wav"}),
+           "wav", "streaming preserves an explicit response format");
+    expect(select_tts_response_format(json{{"stream_format", "audio"}}, {"wav"}), "pcm",
+           "stream_format audio selects raw PCM");
+
+    return failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/server_tts_openmoss.py
+++ b/test/server_tts_openmoss.py
@@ -264,6 +264,23 @@ class OpenMossTTSTests(ServerTestBase):
         self._assert_wav_response(response, "Voice design")
         print(f"[OK] Voice design produced a clip ({len(response.content)} bytes)")
 
+    def test_011_streaming_speech(self):
+        """Streaming uses the backend's native WAV format instead of forcing PCM."""
+        payload = {
+            "model": get_test_model("tts"),
+            "input": "Streaming speech in the backend's native format.",
+            "stream": True,
+        }
+
+        response = requests.post(
+            f"{self.base_url}/audio/speech",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self._assert_wav_response(response, "Streaming speech synthesis")
+        print(f"[OK] Streamed WAV clip ({len(response.content)} bytes)")
+
 
 if __name__ == "__main__":
     run_server_tests(


### PR DESCRIPTION
## Summary

Fixes #2655 by separating TTS transfer mode from response-format negotiation, so `stream: true` preserves a backend's explicit or native format instead of always forcing PCM. The selected format is forwarded to the backend and used for the response MIME type, while `stream_format: "audio"` retains its documented raw-PCM behavior.

## Testing

- `ctest --test-dir build -R '^TtsResponseFormatTest$' --output-on-failure` — 1/1 passed
- `cmake --build build --target lemond -j 6` — compiled and linked on macOS ARM64
- `black --check test/server_tts_openmoss.py` — passed with Black 26.1.0
- `python3 docs/tools/gen_backend_boilerplate.py --check` — generated files are current
- Added an OpenMOSS end-to-end regression test asserting that `stream: true` returns WAV; it runs in the supported Linux/Windows GPU CI matrix

## Screenshots

Not applicable; this changes backend/API format negotiation. OpenMOSS inference is not supported on the local Apple hardware, so local validation covers the deterministic format-selection test and full server build while CI exercises the hardware-backed regression.

## AI Note

AI was used to assist with implementation, tests, verification, and PR preparation. The changes and evidence were locally reviewed.
