### PR TITLE
fix(build): fix system cpp-httplib detection and HTTPS compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,13 +125,14 @@ find_package(nlohmann_json ${MIN_NLOHMANN_JSON_VERSION} QUIET)
 if(PkgConfig_FOUND)
     pkg_check_modules(CURL QUIET libcurl>=${MIN_CURL_VERSION})
     pkg_check_modules(ZSTD QUIET libzstd>=${MIN_ZSTD_VERSION})
-    # Debian ships the package as `cpp-httplib`, Nixpkgs as `httplib` — search
-    # both. No IMPORTED_TARGET: we build our own interface target below so we
-    # can skip the .pc Cflags (see there for why).
-    pkg_search_module(HTTPLIB QUIET
-        cpp-httplib>=${MIN_HTTPLIB_VERSION}
-        httplib>=${MIN_HTTPLIB_VERSION})
     pkg_check_modules(LWS QUIET libwebsockets>=${MIN_LWS_VERSION})
+endif()
+
+include(${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+if(NOT APPLE)
+    detect_system_httplib(${MIN_HTTPLIB_VERSION})
+else()
+    set(HTTPLIB_FOUND FALSE)
 endif()
 find_path(CLI11_INCLUDE_DIRS "CLI/CLI.hpp")
 # Verify CLI11 version if found
@@ -359,21 +360,183 @@ if(NOT USE_SYSTEM_HTTPLIB)
             ${zstd_SOURCE_DIR}/lib/common
         )
     endif()
+endif()
+
+# ============================================================
+# Download digest verification dependency (mbedTLS)
+# ============================================================
+if(NOT TARGET lemonade-digest-crypto)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(MBEDTLS QUIET mbedtls mbedx509 mbedcrypto)
+    endif()
+
+    add_library(lemonade-digest-crypto INTERFACE)
+
+    if(MBEDTLS_FOUND)
+        message(STATUS "Using system mbedtls for CLI HTTPS and digest verification")
+        if(MBEDTLS_INCLUDE_DIRS)
+            target_include_directories(lemonade-digest-crypto INTERFACE ${MBEDTLS_INCLUDE_DIRS})
+        endif()
+        if(MBEDTLS_LIBRARY_DIRS)
+            target_link_directories(lemonade-digest-crypto INTERFACE ${MBEDTLS_LIBRARY_DIRS})
+        endif()
+        target_link_libraries(lemonade-digest-crypto INTERFACE ${MBEDTLS_LIBRARIES})
+        if(MBEDTLS_CFLAGS_OTHER)
+            target_compile_options(lemonade-digest-crypto INTERFACE ${MBEDTLS_CFLAGS_OTHER})
+        endif()
+    else()
+        find_path(MBEDTLS_INCLUDE_DIR NAMES mbedtls/ssl.h)
+        find_library(MBEDTLS_LIBRARY NAMES mbedtls)
+        find_library(MBEDX509_LIBRARY NAMES mbedx509)
+        find_library(MBEDCRYPTO_LIBRARY NAMES mbedcrypto)
+
+        if(MBEDTLS_INCLUDE_DIR AND MBEDTLS_LIBRARY AND MBEDX509_LIBRARY AND MBEDCRYPTO_LIBRARY)
+            message(STATUS "Using system mbedtls libraries for CLI HTTPS and digest verification")
+            target_include_directories(lemonade-digest-crypto INTERFACE ${MBEDTLS_INCLUDE_DIR})
+            target_link_libraries(lemonade-digest-crypto INTERFACE ${MBEDTLS_LIBRARY} ${MBEDX509_LIBRARY} ${MBEDCRYPTO_LIBRARY})
+        else()
+            if(FETCHCONTENT_FULLY_DISCONNECTED AND NOT FETCHCONTENT_SOURCE_DIR_MBEDTLS)
+                message(FATAL_ERROR
+                    "System mbedtls was not found and FetchContent is fully disconnected. "
+                    "Install the distro development package (for Debian/Ubuntu: libmbedtls-dev) "
+                    "or provide FETCHCONTENT_SOURCE_DIR_MBEDTLS.")
+            endif()
+
+            message(STATUS "System mbedtls not found; fetching mbedTLS for CLI HTTPS and digest verification")
+            include(FetchContent)
+            FetchContent_Declare(mbedtls
+                GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls.git
+                GIT_TAG 107ea89daaefb9867ea9121002fbbdf926780e98
+                EXCLUDE_FROM_ALL
+            )
+            set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
+            set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+            set(MBEDTLS_FATAL_WARNINGS OFF CACHE BOOL "" FORCE)
+            set(USE_SHARED_MBEDTLS_LIBRARY OFF CACHE BOOL "" FORCE)
+            set(USE_STATIC_MBEDTLS_LIBRARY ON CACHE BOOL "" FORCE)
+            FetchContent_MakeAvailable(mbedtls)
+
+            target_include_directories(lemonade-digest-crypto INTERFACE ${mbedtls_SOURCE_DIR}/include)
+            if(TARGET MbedTLS::mbedtls AND TARGET MbedTLS::mbedx509 AND TARGET MbedTLS::mbedcrypto)
+                target_link_libraries(lemonade-digest-crypto INTERFACE MbedTLS::mbedtls MbedTLS::mbedx509 MbedTLS::mbedcrypto)
+            elseif(TARGET mbedtls AND TARGET mbedx509 AND TARGET mbedcrypto)
+                target_link_libraries(lemonade-digest-crypto INTERFACE mbedtls mbedx509 mbedcrypto)
+            else()
+                message(FATAL_ERROR "mbedTLS FetchContent did not create expected targets")
+            endif()
+        endif()
+    endif()
+endif()
+
+if(UNIX AND NOT APPLE)
+    find_package(Threads REQUIRED)
+endif()
+
+# ============================================================
+# lemonade-httplib target (Single Source of Truth for HTTPS)
+# ============================================================
+add_library(lemonade-httplib INTERFACE)
+
+if(NOT USE_SYSTEM_HTTPLIB)
+    # Bundled cpp-httplib path: wraps httplib::httplib and attaches MbedTLS support
+    target_link_libraries(lemonade-httplib INTERFACE httplib::httplib lemonade-digest-crypto)
+    target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_MBEDTLS_SUPPORT)
+    if(APPLE)
+        find_library(SECURITY_FRAMEWORK Security REQUIRED)
+        target_link_libraries(lemonade-httplib INTERFACE ${SECURITY_FRAMEWORK})
+    endif()
 else()
-    # System cpp-httplib: a local interface target carrying the include dirs
-    # and link lib (empty for a header-only install like Nixpkgs, the compiled
-    # .so on Debian). We deliberately skip HTTPLIB_CFLAGS_OTHER: the .pc Cflags
-    # carry cpp-httplib's feature macros (-DCPPHTTPLIB_OPENSSL_SUPPORT, etc.),
-    # which would flip on header features needing link deps (libcrypto) we
-    # don't provide. Created at top level, so it is visible to the cli/tray
-    # subdirs added later.
-    add_library(lemonade-httplib INTERFACE)
-    target_include_directories(lemonade-httplib INTERFACE ${HTTPLIB_INCLUDE_DIRS})
-    if(HTTPLIB_LINK_LIBRARIES)
+    # System cpp-httplib path
+    if(HTTPLIB_INCLUDE_DIRS)
+        target_include_directories(lemonade-httplib INTERFACE ${HTTPLIB_INCLUDE_DIRS})
+    endif()
+
+    if(TARGET httplib::httplib)
+        target_link_libraries(lemonade-httplib INTERFACE httplib::httplib)
+    elseif(HTTPLIB_LINK_LIBRARIES)
         target_link_libraries(lemonade-httplib INTERFACE ${HTTPLIB_LINK_LIBRARIES})
     else()
         target_link_libraries(lemonade-httplib INTERFACE ${HTTPLIB_LIBRARIES})
         target_link_directories(lemonade-httplib INTERFACE ${HTTPLIB_LIBRARY_DIRS})
+    endif()
+
+    if(UNIX AND NOT APPLE AND TARGET Threads::Threads)
+        target_link_libraries(lemonade-httplib INTERFACE Threads::Threads)
+    endif()
+
+    # Propagate compiler options from pkg-config (e.g. -DCPPHTTPLIB_OPENSSL_SUPPORT)
+    if(HTTPLIB_CFLAGS_OTHER)
+        target_compile_options(lemonade-httplib INTERFACE ${HTTPLIB_CFLAGS_OTHER})
+    endif()
+
+    # Determine and propagate the TLS backend configured on system httplib
+    set(SYSTEM_HTTPLIB_HAS_TLS FALSE)
+    set(SYSTEM_HTTPLIB_USES_OPENSSL FALSE)
+    set(SYSTEM_HTTPLIB_USES_MBEDTLS FALSE)
+    set(SYSTEM_HTTPLIB_USES_WOLFSSL FALSE)
+    set(SYSTEM_HTTPLIB_USES_SCHANNEL FALSE)
+
+    # 1. Use exported configuration variables from find_package(httplib)
+    if(HTTPLIB_IS_USING_OPENSSL)
+        set(SYSTEM_HTTPLIB_HAS_TLS TRUE)
+        set(SYSTEM_HTTPLIB_USES_OPENSSL TRUE)
+    elseif(HTTPLIB_IS_USING_MBEDTLS)
+        set(SYSTEM_HTTPLIB_HAS_TLS TRUE)
+        set(SYSTEM_HTTPLIB_USES_MBEDTLS TRUE)
+    elseif(HTTPLIB_IS_USING_WOLFSSL)
+        set(SYSTEM_HTTPLIB_HAS_TLS TRUE)
+        set(SYSTEM_HTTPLIB_USES_WOLFSSL TRUE)
+    endif()
+
+    # 2. Fall back to checking pkg-config flags
+    if(NOT SYSTEM_HTTPLIB_HAS_TLS AND HTTPLIB_CFLAGS_OTHER)
+        if(HTTPLIB_CFLAGS_OTHER MATCHES "CPPHTTPLIB_OPENSSL_SUPPORT")
+            set(SYSTEM_HTTPLIB_HAS_TLS TRUE)
+            set(SYSTEM_HTTPLIB_USES_OPENSSL TRUE)
+        elseif(HTTPLIB_CFLAGS_OTHER MATCHES "CPPHTTPLIB_MBEDTLS_SUPPORT")
+            set(SYSTEM_HTTPLIB_HAS_TLS TRUE)
+            set(SYSTEM_HTTPLIB_USES_MBEDTLS TRUE)
+        elseif(HTTPLIB_CFLAGS_OTHER MATCHES "CPPHTTPLIB_WOLFSSL_SUPPORT")
+            set(SYSTEM_HTTPLIB_HAS_TLS TRUE)
+            set(SYSTEM_HTTPLIB_USES_WOLFSSL TRUE)
+        elseif(HTTPLIB_CFLAGS_OTHER MATCHES "CPPHTTPLIB_SCHANNEL_SUPPORT")
+            set(SYSTEM_HTTPLIB_HAS_TLS TRUE)
+            set(SYSTEM_HTTPLIB_USES_SCHANNEL TRUE)
+        endif()
+    endif()
+
+    # 3. Propagate definitions and link requirements
+    if(SYSTEM_HTTPLIB_USES_OPENSSL)
+        target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_OPENSSL_SUPPORT)
+        find_package(OpenSSL REQUIRED)
+        target_link_libraries(lemonade-httplib INTERFACE OpenSSL::SSL OpenSSL::Crypto)
+    elseif(SYSTEM_HTTPLIB_USES_MBEDTLS)
+        target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_MBEDTLS_SUPPORT)
+        target_link_libraries(lemonade-httplib INTERFACE lemonade-digest-crypto)
+        if(APPLE)
+            find_library(SECURITY_FRAMEWORK Security REQUIRED)
+            target_link_libraries(lemonade-httplib INTERFACE ${SECURITY_FRAMEWORK})
+        endif()
+    elseif(SYSTEM_HTTPLIB_USES_WOLFSSL)
+        target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_WOLFSSL_SUPPORT)
+    elseif(SYSTEM_HTTPLIB_USES_SCHANNEL)
+        target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_SCHANNEL_SUPPORT)
+        if(WIN32)
+            target_link_libraries(lemonade-httplib INTERFACE crypt32 secur32)
+        endif()
+    endif()
+
+    # 4. If neither target nor pkg-config explicitly defined a TLS backend, configure MbedTLS fallback for header-only
+    if(NOT SYSTEM_HTTPLIB_HAS_TLS AND NOT HTTPLIB_IS_COMPILED)
+        if(HTTPLIB_VERSION AND NOT HTTPLIB_VERSION VERSION_LESS "0.31.0")
+            target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_MBEDTLS_SUPPORT)
+            target_link_libraries(lemonade-httplib INTERFACE lemonade-digest-crypto)
+            if(APPLE)
+                find_library(SECURITY_FRAMEWORK Security REQUIRED)
+                target_link_libraries(lemonade-httplib INTERFACE ${SECURITY_FRAMEWORK})
+            endif()
+        endif()
     endif()
 endif()
 
@@ -788,13 +951,10 @@ endif()
 # Server core dependencies (PUBLIC — inherited by consumers)
 # ============================================================
 
-target_link_libraries(lemonade-server-core PUBLIC nlohmann_json::nlohmann_json)
-
-if(USE_SYSTEM_HTTPLIB)
-    target_link_libraries(lemonade-server-core PUBLIC lemonade-httplib)
-else()
-    target_link_libraries(lemonade-server-core PUBLIC httplib::httplib)
-endif()
+target_link_libraries(lemonade-server-core PUBLIC
+    nlohmann_json::nlohmann_json
+    lemonade-httplib
+)
 
 if(USE_SYSTEM_CLI11)
     target_include_directories(lemonade-server-core PUBLIC ${CLI11_INCLUDE_DIRS})
@@ -846,12 +1006,7 @@ if(BUILD_TESTING AND EXISTS "${MCP_CLIENT_CONFIG_TEST_SOURCE}")
         ${MCP_CLIENT_CONFIG_TEST_SOURCE}
         src/cpp/server/mcp_client.cpp
     )
-    target_link_libraries(test_mcp_client_config PRIVATE nlohmann_json::nlohmann_json Threads::Threads)
-    if(USE_SYSTEM_HTTPLIB)
-        target_link_libraries(test_mcp_client_config PRIVATE lemonade-httplib)
-    else()
-        target_link_libraries(test_mcp_client_config PRIVATE httplib::httplib)
-    endif()
+    target_link_libraries(test_mcp_client_config PRIVATE nlohmann_json::nlohmann_json Threads::Threads lemonade-httplib)
 
     if(Python3_Interpreter_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/fixtures/mock_mcp_stdio_server.py")
         file(TO_CMAKE_PATH "${Python3_EXECUTABLE}" LEMONADE_TEST_PYTHON_PATH)
@@ -2490,4 +2645,21 @@ if(EXISTS "${_ORIGIN_UTILS_TEST_SRC}")
     add_executable(test_origin_utils test/cpp/test_origin_utils.cpp)
     target_link_libraries(test_origin_utils PRIVATE lemonade-server-core)
     add_test(NAME OriginUtilsTest COMMAND test_origin_utils)
+endif()
+
+if(BUILD_TESTING)
+    add_test(NAME HttplibDetection_config_only COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_config_only -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=config_only -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_old_header COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_old_header -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=old_header -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_modern_header COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_modern_header -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=modern_header -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_openssl_target COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_openssl_target -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=openssl_target -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_disabled_generator_expression COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_disabled_generator_expression -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=disabled_generator_expression -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_too_old_config COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_too_old_config -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=too_old_config -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_compiled_no_tls COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_compiled_no_tls -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=compiled_no_tls -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_too_old_config_multiarch COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_too_old_config_multiarch -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=too_old_config_multiarch -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_header_only_pkgconfig COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_header_only_pkgconfig -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=header_only_pkgconfig -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_cli_composition_mbedtls_isolation COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_cli_composition_mbedtls_isolation -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=cli_composition_mbedtls_isolation -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_custom_httplib_dir_precheck COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_custom_httplib_dir_precheck -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=custom_httplib_dir_precheck -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_test(NAME HttplibDetection_polluted_target_fatal COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_polluted_target_fatal -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=polluted_target_fatal -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    set_tests_properties(HttplibDetection_polluted_target_fatal PROPERTIES WILL_FAIL TRUE)
+    add_test(NAME HttplibDetection_wolfssl_target COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_wolfssl_target -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=wolfssl_target -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
 endif()

--- a/cmake/DetectSystemHttplib.cmake
+++ b/cmake/DetectSystemHttplib.cmake
@@ -1,0 +1,163 @@
+# cmake/DetectSystemHttplib.cmake
+# Detect system cpp-httplib package and resolve version and TLS capabilities.
+
+macro(detect_system_httplib min_version)
+    set(HTTPLIB_FOUND FALSE)
+    set(HTTPLIB_VERSION "")
+    set(HTTPLIB_INCLUDE_DIRS "")
+    set(HTTPLIB_LIBRARIES "")
+    set(HTTPLIB_LINK_LIBRARIES "")
+    set(HTTPLIB_LIBRARY_DIRS "")
+    set(HTTPLIB_CFLAGS_OTHER "")
+
+    set(HTTPLIB_IS_USING_OPENSSL FALSE)
+    set(HTTPLIB_IS_USING_MBEDTLS FALSE)
+    set(HTTPLIB_IS_USING_WOLFSSL FALSE)
+    set(HTTPLIB_IS_COMPILED FALSE)
+
+    # 1. Try PkgConfig first
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_search_module(HTTPLIB_PKG QUIET
+            cpp-httplib>=${min_version}
+            httplib>=${min_version})
+        if(HTTPLIB_PKG_FOUND)
+            set(HTTPLIB_FOUND TRUE)
+            set(HTTPLIB_VERSION "${HTTPLIB_PKG_VERSION}")
+            set(HTTPLIB_INCLUDE_DIRS "${HTTPLIB_PKG_INCLUDE_DIRS}")
+            set(HTTPLIB_LIBRARIES "${HTTPLIB_PKG_LIBRARIES}")
+            set(HTTPLIB_LINK_LIBRARIES "${HTTPLIB_PKG_LINK_LIBRARIES}")
+            set(HTTPLIB_LIBRARY_DIRS "${HTTPLIB_PKG_LIBRARY_DIRS}")
+            set(HTTPLIB_CFLAGS_OTHER "${HTTPLIB_PKG_CFLAGS_OTHER}")
+
+            if(HTTPLIB_PKG_CFLAGS_OTHER MATCHES "CPPHTTPLIB_OPENSSL_SUPPORT")
+                set(HTTPLIB_IS_USING_OPENSSL TRUE)
+            endif()
+            if(HTTPLIB_PKG_CFLAGS_OTHER MATCHES "CPPHTTPLIB_MBEDTLS_SUPPORT")
+                set(HTTPLIB_IS_USING_MBEDTLS TRUE)
+            endif()
+            if(HTTPLIB_PKG_CFLAGS_OTHER MATCHES "CPPHTTPLIB_WOLFSSL_SUPPORT")
+                set(HTTPLIB_IS_USING_WOLFSSL TRUE)
+            endif()
+            if(HTTPLIB_PKG_LIBRARIES OR HTTPLIB_PKG_LINK_LIBRARIES)
+                set(HTTPLIB_IS_COMPILED TRUE)
+            else()
+                set(HTTPLIB_IS_COMPILED FALSE)
+            endif()
+        endif()
+    endif()
+
+    # 2. Try CMake Config fallback
+    if(NOT HTTPLIB_FOUND)
+        # Pre-check package configuration version if possible to avoid target pollution
+        set(HTTPLIB_CONFIG_VERSION_OK TRUE)
+        find_file(HTTPLIB_CONFIG_VERSION_FILE
+            NAMES httplibConfigVersion.cmake httplib-config-version.cmake
+            HINTS "${httplib_DIR}" "${httplib_ROOT}" "$ENV{httplib_DIR}" "$ENV{httplib_ROOT}"
+            PATH_SUFFIXES
+                .
+                cmake/httplib
+                lib/cmake/httplib
+                share/cmake/httplib
+                lib/${CMAKE_LIBRARY_ARCHITECTURE}/cmake/httplib
+                lib64/cmake/httplib
+                httplib
+        )
+        if(HTTPLIB_CONFIG_VERSION_FILE)
+            file(STRINGS "${HTTPLIB_CONFIG_VERSION_FILE}" version_line REGEX "set\\(PACKAGE_VERSION \"[0-9]+\\.[0-9]+\\.[0-9]+[^\"]*\"\\)")
+            if(version_line)
+                string(REGEX REPLACE ".*set\\(PACKAGE_VERSION \"([0-9]+\\.[0-9]+\\.[0-9]+[^\"]*)\"\\).*" "\\1" detected_config_version "${version_line}")
+                if(detected_config_version AND detected_config_version VERSION_LESS ${min_version})
+                    message(STATUS "Pre-check: System httplib config version ${detected_config_version} is less than required ${min_version}")
+                    set(HTTPLIB_CONFIG_VERSION_OK FALSE)
+                endif()
+            endif()
+            unset(HTTPLIB_CONFIG_VERSION_FILE CACHE)
+        endif()
+
+        if(HTTPLIB_CONFIG_VERSION_OK)
+            find_package(httplib CONFIG QUIET)
+            if(httplib_FOUND OR HTTPLIB_FOUND)
+                set(HTTPLIB_FOUND TRUE)
+                if(httplib_VERSION)
+                    set(HTTPLIB_VERSION "${httplib_VERSION}")
+                elseif(HTTPLIB_VERSION)
+                    set(HTTPLIB_VERSION "${HTTPLIB_VERSION}")
+                endif()
+
+                if(httplib_INCLUDE_DIRS)
+                    set(HTTPLIB_INCLUDE_DIRS "${httplib_INCLUDE_DIRS}")
+                elseif(httplib_INCLUDE_DIR)
+                    set(HTTPLIB_INCLUDE_DIRS "${httplib_INCLUDE_DIR}")
+                endif()
+
+                # If it's a target but we have no include dirs, extract from target
+                if(TARGET httplib::httplib AND NOT HTTPLIB_INCLUDE_DIRS)
+                    get_target_property(target_includes httplib::httplib INTERFACE_INCLUDE_DIRECTORIES)
+                    if(target_includes)
+                        foreach(inc IN LISTS target_includes)
+                            # Skip generator expressions
+                            if(NOT inc MATCHES "\\$<")
+                                list(APPEND HTTPLIB_INCLUDE_DIRS "${inc}")
+                            endif()
+                        endforeach()
+                    endif()
+                endif()
+            endif()
+        endif()
+    endif()
+
+    # 3. Try header-only path fallback
+    if(NOT HTTPLIB_FOUND)
+        find_path(HTTPLIB_INCLUDE_DIRS_TEMP "httplib.h")
+        if(HTTPLIB_INCLUDE_DIRS_TEMP)
+            set(HTTPLIB_FOUND TRUE)
+            set(HTTPLIB_INCLUDE_DIRS "${HTTPLIB_INCLUDE_DIRS_TEMP}")
+            unset(HTTPLIB_INCLUDE_DIRS_TEMP CACHE)
+        endif()
+    endif()
+
+    # 4. Extract version from header if not already set
+    if(HTTPLIB_FOUND AND NOT HTTPLIB_VERSION)
+        if(NOT HTTPLIB_INCLUDE_DIRS)
+            find_path(HTTPLIB_INCLUDE_DIRS_TEMP "httplib.h")
+            if(HTTPLIB_INCLUDE_DIRS_TEMP)
+                set(HTTPLIB_INCLUDE_DIRS "${HTTPLIB_INCLUDE_DIRS_TEMP}")
+                unset(HTTPLIB_INCLUDE_DIRS_TEMP CACHE)
+            endif()
+        endif()
+        foreach(dir IN LISTS HTTPLIB_INCLUDE_DIRS)
+            if(EXISTS "${dir}/httplib.h")
+                file(STRINGS "${dir}/httplib.h" version_line REGEX "^#define CPPHTTPLIB_VERSION ")
+                if(version_line)
+                    string(REGEX REPLACE "^#define CPPHTTPLIB_VERSION \"([0-9]+\\.[0-9]+\\.[0-9]+[^\"]*)\"" "\\1" detected_version "${version_line}")
+                    if(detected_version)
+                        set(HTTPLIB_VERSION "${detected_version}")
+                        break()
+                    endif()
+                endif()
+            endif()
+        endforeach()
+    endif()
+
+    # 5. Reject if version is below minimum
+    if(HTTPLIB_FOUND AND HTTPLIB_VERSION)
+        if(HTTPLIB_VERSION VERSION_LESS ${min_version})
+            if(TARGET httplib::httplib)
+                message(FATAL_ERROR "System httplib target 'httplib::httplib' (version ${HTTPLIB_VERSION}) imported from configuration is below required minimum ${min_version}. Please provide a compatible package version or clear httplib_DIR to use the bundled dependency.")
+            endif()
+            message(STATUS "System httplib version ${HTTPLIB_VERSION} is less than required ${min_version}")
+            set(HTTPLIB_FOUND FALSE)
+            set(HTTPLIB_VERSION "")
+            set(HTTPLIB_INCLUDE_DIRS "")
+            set(HTTPLIB_LIBRARIES "")
+            set(HTTPLIB_LINK_LIBRARIES "")
+            set(HTTPLIB_LIBRARY_DIRS "")
+            set(HTTPLIB_CFLAGS_OTHER "")
+            set(HTTPLIB_IS_USING_OPENSSL FALSE)
+            set(HTTPLIB_IS_USING_MBEDTLS FALSE)
+            set(HTTPLIB_IS_USING_WOLFSSL FALSE)
+            set(HTTPLIB_IS_COMPILED FALSE)
+        endif()
+    endif()
+endmacro()

--- a/src/cpp/cli/CMakeLists.txt
+++ b/src/cpp/cli/CMakeLists.txt
@@ -10,73 +10,6 @@
 # CLI.  Digest verification must therefore be wired to both targets from here.
 # Prefer a distro-provided mbedcrypto package, but fall back to FetchContent so
 # local Lemonade builds do not require developers to install a new package.
-if(NOT TARGET lemonade-digest-crypto)
-    find_package(PkgConfig QUIET)
-    if(PkgConfig_FOUND)
-        pkg_check_modules(MBEDTLS QUIET mbedtls mbedx509 mbedcrypto)
-    endif()
-
-    add_library(lemonade-digest-crypto INTERFACE)
-
-    if(MBEDTLS_FOUND)
-        message(STATUS "Using system mbedtls for CLI HTTPS and digest verification")
-        if(MBEDTLS_INCLUDE_DIRS)
-            target_include_directories(lemonade-digest-crypto INTERFACE ${MBEDTLS_INCLUDE_DIRS})
-        endif()
-        if(MBEDTLS_LIBRARY_DIRS)
-            target_link_directories(lemonade-digest-crypto INTERFACE ${MBEDTLS_LIBRARY_DIRS})
-        endif()
-        target_link_libraries(lemonade-digest-crypto INTERFACE ${MBEDTLS_LIBRARIES})
-        if(MBEDTLS_CFLAGS_OTHER)
-            target_compile_options(lemonade-digest-crypto INTERFACE ${MBEDTLS_CFLAGS_OTHER})
-        endif()
-    else()
-        # Some distro packages do not ship a pkg-config file for mbedtls.
-        # Keep the system-library path working for Debian/PPA builds, where
-        # FetchContent is intentionally fully disconnected.
-        find_path(MBEDTLS_INCLUDE_DIR NAMES mbedtls/ssl.h)
-        find_library(MBEDTLS_LIBRARY NAMES mbedtls)
-        find_library(MBEDX509_LIBRARY NAMES mbedx509)
-        find_library(MBEDCRYPTO_LIBRARY NAMES mbedcrypto)
-
-        if(MBEDTLS_INCLUDE_DIR AND MBEDTLS_LIBRARY AND MBEDX509_LIBRARY AND MBEDCRYPTO_LIBRARY)
-            message(STATUS "Using system mbedtls libraries for CLI HTTPS and digest verification")
-            target_include_directories(lemonade-digest-crypto INTERFACE ${MBEDTLS_INCLUDE_DIR})
-            target_link_libraries(lemonade-digest-crypto INTERFACE ${MBEDTLS_LIBRARY} ${MBEDX509_LIBRARY} ${MBEDCRYPTO_LIBRARY})
-        else()
-            if(FETCHCONTENT_FULLY_DISCONNECTED AND NOT FETCHCONTENT_SOURCE_DIR_MBEDTLS)
-                message(FATAL_ERROR
-                    "System mbedtls was not found and FetchContent is fully disconnected. "
-                    "Install the distro development package (for Debian/Ubuntu: libmbedtls-dev) "
-                    "or provide FETCHCONTENT_SOURCE_DIR_MBEDTLS.")
-            endif()
-
-            message(STATUS "System mbedtls not found; fetching mbedTLS for CLI HTTPS and digest verification")
-            include(FetchContent)
-            FetchContent_Declare(mbedtls
-                GIT_REPOSITORY https://github.com/Mbed-TLS/mbedtls.git
-                GIT_TAG 107ea89daaefb9867ea9121002fbbdf926780e98
-                EXCLUDE_FROM_ALL
-            )
-            set(ENABLE_PROGRAMS OFF CACHE BOOL "" FORCE)
-            set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
-            set(MBEDTLS_FATAL_WARNINGS OFF CACHE BOOL "" FORCE)
-            set(USE_SHARED_MBEDTLS_LIBRARY OFF CACHE BOOL "" FORCE)
-            set(USE_STATIC_MBEDTLS_LIBRARY ON CACHE BOOL "" FORCE)
-            FetchContent_MakeAvailable(mbedtls)
-
-            target_include_directories(lemonade-digest-crypto INTERFACE ${mbedtls_SOURCE_DIR}/include)
-            if(TARGET MbedTLS::mbedtls AND TARGET MbedTLS::mbedx509 AND TARGET MbedTLS::mbedcrypto)
-                target_link_libraries(lemonade-digest-crypto INTERFACE MbedTLS::mbedtls MbedTLS::mbedx509 MbedTLS::mbedcrypto)
-            elseif(TARGET mbedtls AND TARGET mbedx509 AND TARGET mbedcrypto)
-                target_link_libraries(lemonade-digest-crypto INTERFACE mbedtls mbedx509 mbedcrypto)
-            else()
-                message(FATAL_ERROR "mbedTLS FetchContent did not create expected targets")
-            endif()
-        endif()
-    endif()
-endif()
-
 if(TARGET lemonade-server-core)
     target_link_libraries(lemonade-server-core PUBLIC lemonade-digest-crypto)
 endif()
@@ -138,14 +71,8 @@ add_executable(lemonade
 target_link_libraries(lemonade PRIVATE
     nlohmann_json::nlohmann_json
     lemonade-digest-crypto
+    lemonade-httplib
 )
-
-# Link httplib based on what's available (set by parent CMakeLists.txt)
-if(USE_SYSTEM_HTTPLIB)
-    target_link_libraries(lemonade PRIVATE lemonade-httplib)
-else()
-    target_link_libraries(lemonade PRIVATE httplib::httplib)
-endif()
 
 # Link CLI11 based on what's available
 if(USE_SYSTEM_CLI11)
@@ -186,17 +113,6 @@ if(WIN32)
         RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/Debug"
         RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/Release"
     )
-endif()
-
-set(HTTPLIB_SUPPORTS_MBEDTLS FALSE CACHE INTERNAL "mbedtls support in httplib")
-if(NOT USE_SYSTEM_HTTPLIB)
-    set(HTTPLIB_SUPPORTS_MBEDTLS TRUE CACHE INTERNAL "mbedtls support in httplib")
-elseif(HTTPLIB_VERSION AND NOT HTTPLIB_VERSION VERSION_LESS "0.31.0")
-    set(HTTPLIB_SUPPORTS_MBEDTLS TRUE CACHE INTERNAL "mbedtls support in httplib")
-endif()
-
-if(HTTPLIB_SUPPORTS_MBEDTLS)
-    target_compile_definitions(lemonade-digest-crypto INTERFACE CPPHTTPLIB_MBEDTLS_SUPPORT)
 endif()
 
 target_compile_definitions(lemonade PRIVATE LEMONADE_CLI)

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -105,13 +105,14 @@ std::string LemonadeClient::normalize_host(const std::string& host) const {
 // Helper to create and configure httplib::Client (timeouts in milliseconds)
 static httplib::Client make_client(const std::string& host, int port, const std::string& api_key, bool is_ssl,
                                     time_t connection_timeout_ms = DEFAULT_CONNECTION_TIMEOUT_MS, time_t read_timeout_ms = DEFAULT_READ_TIMEOUT_MS) {
-#ifndef CPPHTTPLIB_MBEDTLS_SUPPORT
+#ifndef LEMONADE_HTTPLIB_HAS_TLS
     if (is_ssl) {
         throw std::runtime_error("HTTPS support is not compiled in this client.");
     }
 #endif
+    std::string format_host = lemon::utils::bracket_host_if_ipv6(host);
     std::string scheme = is_ssl ? "https" : "http";
-    std::string url = scheme + "://" + host + ":" + std::to_string(port);
+    std::string url = scheme + "://" + format_host + ":" + std::to_string(port);
     httplib::Client cli(url);
     cli.set_connection_timeout(connection_timeout_ms / 1000, (connection_timeout_ms % 1000) * 1000);
     cli.set_read_timeout(read_timeout_ms / 1000, (read_timeout_ms % 1000) * 1000);

--- a/src/cpp/include/lemon/utils/url_utils.h
+++ b/src/cpp/include/lemon/utils/url_utils.h
@@ -3,6 +3,13 @@
 #include <string>
 #include <string_view>
 
+#if defined(CPPHTTPLIB_MBEDTLS_SUPPORT) || \
+    defined(CPPHTTPLIB_OPENSSL_SUPPORT) || \
+    defined(CPPHTTPLIB_WOLFSSL_SUPPORT) || \
+    defined(CPPHTTPLIB_SCHANNEL_SUPPORT)
+#  define LEMONADE_HTTPLIB_HAS_TLS 1
+#endif
+
 namespace lemon::utils {
 
 /**

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -417,12 +417,12 @@ bool apply_http_security_policy(
         case HttpSecurityPolicy::TrustedLoopback:
             // Managed loopback backends are plain HTTP and must never redirect.
             return set(CURLOPT_FOLLOWLOCATION, 0L) &&
-                   set_proto(CURLOPT_PROTOCOLS_STR, CURLOPT_PROTOCOLS, "http", 1L /* CURLPROTO_HTTP */);
+                   set_proto(CURLOPT_PROTOCOLS_STR, CURLOPT_PROTOCOLS, "HTTP", 1L /* CURLPROTO_HTTP */);
         case HttpSecurityPolicy::AllowInsecureHttp:
-            return apply_protocols("http,https", "http,https");
+            return apply_protocols("HTTP,HTTPS", "HTTP,HTTPS");
         case HttpSecurityPolicy::ExternalHttpsOnly:
         default:
-            return apply_protocols("https", "https");
+            return apply_protocols("HTTPS", "HTTPS");
     }
 }
 } // namespace

--- a/src/cpp/tray/CMakeLists.txt
+++ b/src/cpp/tray/CMakeLists.txt
@@ -155,26 +155,15 @@ function(apply_tray_deps target_name)
         ${CMAKE_CURRENT_SOURCE_DIR}/../include
     )
 
-    target_link_libraries(${target_name} PRIVATE nlohmann_json::nlohmann_json)
-
-    if(USE_SYSTEM_HTTPLIB)
-        target_link_libraries(${target_name} PRIVATE lemonade-httplib)
-    else()
-        target_link_libraries(${target_name} PRIVATE httplib::httplib)
-    endif()
+    target_link_libraries(${target_name} PRIVATE
+        nlohmann_json::nlohmann_json
+        lemonade-httplib
+    )
 
     if(USE_SYSTEM_CLI11)
         target_include_directories(${target_name} PRIVATE ${CLI11_INCLUDE_DIRS})
     else()
         target_link_libraries(${target_name} PRIVATE CLI11::CLI11)
-    endif()
-
-    if(HTTPLIB_SUPPORTS_MBEDTLS)
-        target_link_libraries(${target_name} PRIVATE lemonade-digest-crypto)
-        if(APPLE)
-            find_library(SECURITY_FRAMEWORK Security REQUIRED)
-            target_link_libraries(${target_name} PRIVATE ${SECURITY_FRAMEWORK})
-        endif()
     endif()
 endfunction()
 

--- a/src/cpp/tray/main.cpp
+++ b/src/cpp/tray/main.cpp
@@ -87,7 +87,7 @@ static bool wait_for_server(const std::string& clean_host, int clean_port, bool 
 
     for (int i = 0; i < timeout_seconds * 2; ++i) {
         try {
-#ifndef CPPHTTPLIB_MBEDTLS_SUPPORT
+#ifndef LEMONADE_HTTPLIB_HAS_TLS
             if (is_ssl) {
                 std::cerr << "HTTPS support is not compiled in this client." << std::endl;
                 return false;
@@ -97,7 +97,7 @@ static bool wait_for_server(const std::string& clean_host, int clean_port, bool 
             std::string scheme = is_ssl ? "https" : "http";
             std::string url = scheme + "://" + format_host + ":" + std::to_string(clean_port);
             httplib::Client cli(url);
-#ifdef CPPHTTPLIB_MBEDTLS_SUPPORT
+#ifdef LEMONADE_HTTPLIB_HAS_TLS
             const char* skip_verify = std::getenv("LEMONADE_SKIP_VERIFY");
             if (skip_verify && std::string(skip_verify) == "1") {
                 cli.enable_server_certificate_verification(false);

--- a/src/cpp/tray/tray_ui.cpp
+++ b/src/cpp/tray/tray_ui.cpp
@@ -177,7 +177,7 @@ void TrayUI::stop() {
 // ---------------------------------------------------------------------------
 
 httplib::Client TrayUI::make_client(const std::string& host, int port, bool is_ssl) const {
-#ifndef CPPHTTPLIB_MBEDTLS_SUPPORT
+#ifndef LEMONADE_HTTPLIB_HAS_TLS
     if (is_ssl) {
         throw std::runtime_error("HTTPS support is not compiled in this client.");
     }
@@ -186,7 +186,7 @@ httplib::Client TrayUI::make_client(const std::string& host, int port, bool is_s
     std::string scheme = is_ssl ? "https" : "http";
     std::string url = scheme + "://" + format_host + ":" + std::to_string(port);
     auto client = httplib::Client(url);
-#ifdef CPPHTTPLIB_MBEDTLS_SUPPORT
+#ifdef LEMONADE_HTTPLIB_HAS_TLS
     const char* skip_verify = std::getenv("LEMONADE_SKIP_VERIFY");
     if (skip_verify && std::string(skip_verify) == "1") {
         client.enable_server_certificate_verification(false);

--- a/test/cmake/CMakeLists.txt
+++ b/test/cmake/CMakeLists.txt
@@ -1,0 +1,343 @@
+# test/cmake/CMakeLists.txt
+cmake_minimum_required(VERSION 3.15)
+project(TestHttplibDetection LANGUAGES CXX)
+
+set(MIN_HTTPLIB_VERSION "0.31.0")
+
+# Prevent searching host system paths (like /usr, /usr/local) to ensure hermetic tests
+set(CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH FALSE)
+set(CMAKE_FIND_USE_CMAKE_SYSTEM_PATH FALSE)
+
+# Include the detection macro
+include("${DETECTION_MACRO_PATH}")
+
+# Helper for assertions
+function(assert_equal var expected_val)
+    if(NOT "${${var}}" STREQUAL "${expected_val}")
+        message(FATAL_ERROR "Assertion failed: ${var} = '${${var}}', expected '${expected_val}'")
+    endif()
+endfunction()
+
+# Setup paths
+set(MOCK_DIR "${CMAKE_CURRENT_BINARY_DIR}/test_cmake_mock")
+file(REMOVE_RECURSE "${MOCK_DIR}")
+file(MAKE_DIRECTORY "${MOCK_DIR}")
+
+if(TEST_CASE STREQUAL "config_only")
+    set(pkg_dir "${MOCK_DIR}/lib/cmake/httplib")
+    file(MAKE_DIRECTORY "${pkg_dir}")
+    file(WRITE "${pkg_dir}/httplibConfig.cmake" "
+        set(httplib_FOUND TRUE)
+        set(httplib_VERSION \"0.32.0\")
+        set(httplib_INCLUDE_DIRS \"${MOCK_DIR}/include\")
+    ")
+    file(WRITE "${pkg_dir}/httplibConfigVersion.cmake" "
+        set(PACKAGE_VERSION \"0.32.0\")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    ")
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+    set(CMAKE_PREFIX_PATH "${MOCK_DIR}")
+    set(PkgConfig_FOUND FALSE)
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND TRUE)
+    assert_equal(HTTPLIB_VERSION "0.32.0")
+    assert_equal(HTTPLIB_INCLUDE_DIRS "${MOCK_DIR}/include")
+
+elseif(TEST_CASE STREQUAL "old_header")
+    set(inc_dir "${MOCK_DIR}/include")
+    file(MAKE_DIRECTORY "${inc_dir}")
+    file(WRITE "${inc_dir}/httplib.h" "
+#define CPPHTTPLIB_VERSION \"0.30.0\"
+")
+
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+    set(CMAKE_DISABLE_FIND_PACKAGE_httplib TRUE)
+    set(CMAKE_PREFIX_PATH "${MOCK_DIR}")
+    set(PkgConfig_FOUND FALSE)
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND FALSE)
+    assert_equal(HTTPLIB_VERSION "")
+
+elseif(TEST_CASE STREQUAL "modern_header")
+    set(inc_dir "${MOCK_DIR}/include")
+    file(MAKE_DIRECTORY "${inc_dir}")
+    file(WRITE "${inc_dir}/httplib.h" "
+#define CPPHTTPLIB_VERSION \"0.33.0\"
+")
+
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+    set(CMAKE_DISABLE_FIND_PACKAGE_httplib TRUE)
+    set(CMAKE_PREFIX_PATH "${MOCK_DIR}")
+    set(PkgConfig_FOUND FALSE)
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND TRUE)
+    assert_equal(HTTPLIB_VERSION "0.33.0")
+    assert_equal(HTTPLIB_INCLUDE_DIRS "${inc_dir}")
+
+elseif(TEST_CASE STREQUAL "openssl_target")
+    set(pkg_dir "${MOCK_DIR}/lib/cmake/httplib")
+    file(MAKE_DIRECTORY "${pkg_dir}")
+    file(WRITE "${pkg_dir}/httplibConfig.cmake" "
+        set(httplib_FOUND TRUE)
+        set(httplib_VERSION \"0.32.0\")
+        set(HTTPLIB_IS_USING_OPENSSL TRUE)
+        add_library(httplib::httplib INTERFACE IMPORTED)
+        set_target_properties(httplib::httplib PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS \"CPPHTTPLIB_OPENSSL_SUPPORT\"
+            INTERFACE_INCLUDE_DIRECTORIES \"${MOCK_DIR}/include\"
+        )
+    ")
+    file(WRITE "${pkg_dir}/httplibConfigVersion.cmake" "
+        set(PACKAGE_VERSION \"0.32.0\")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    ")
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+    set(CMAKE_PREFIX_PATH "${MOCK_DIR}")
+    set(PkgConfig_FOUND FALSE)
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND TRUE)
+    assert_equal(HTTPLIB_VERSION "0.32.0")
+    assert_equal(HTTPLIB_IS_USING_OPENSSL TRUE)
+
+elseif(TEST_CASE STREQUAL "disabled_generator_expression")
+    set(pkg_dir "${MOCK_DIR}/lib/cmake/httplib")
+    file(MAKE_DIRECTORY "${pkg_dir}")
+    file(WRITE "${pkg_dir}/httplibConfig.cmake" "
+        set(httplib_FOUND TRUE)
+        set(httplib_VERSION \"0.32.0\")
+        set(HTTPLIB_IS_USING_OPENSSL FALSE)
+        add_library(httplib::httplib INTERFACE IMPORTED)
+        set_target_properties(httplib::httplib PROPERTIES
+            INTERFACE_COMPILE_DEFINITIONS \"\$<\$<BOOL:FALSE>:CPPHTTPLIB_OPENSSL_SUPPORT>\"
+            INTERFACE_INCLUDE_DIRECTORIES \"${MOCK_DIR}/include\"
+        )
+    ")
+    file(WRITE "${pkg_dir}/httplibConfigVersion.cmake" "
+        set(PACKAGE_VERSION \"0.32.0\")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    ")
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+    set(CMAKE_PREFIX_PATH "${MOCK_DIR}")
+    set(PkgConfig_FOUND FALSE)
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND TRUE)
+    assert_equal(HTTPLIB_IS_USING_OPENSSL FALSE)
+
+elseif(TEST_CASE STREQUAL "too_old_config")
+    set(pkg_dir "${MOCK_DIR}/lib/cmake/httplib")
+    file(MAKE_DIRECTORY "${pkg_dir}")
+    file(WRITE "${pkg_dir}/httplibConfig.cmake" "
+        set(httplib_FOUND TRUE)
+        set(httplib_VERSION \"0.30.0\")
+        add_library(httplib::httplib INTERFACE IMPORTED)
+    ")
+    file(WRITE "${pkg_dir}/httplibConfigVersion.cmake" "
+        set(PACKAGE_VERSION \"0.30.0\")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    ")
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+    set(CMAKE_PREFIX_PATH "${MOCK_DIR}")
+    set(PkgConfig_FOUND FALSE)
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND FALSE)
+    if(TARGET httplib::httplib)
+        message(FATAL_ERROR "Assertion failed: httplib::httplib target was created despite package being too old!")
+    endif()
+
+elseif(TEST_CASE STREQUAL "compiled_no_tls")
+    set(pkg_dir "${MOCK_DIR}/lib/cmake/httplib")
+    file(MAKE_DIRECTORY "${pkg_dir}")
+    file(WRITE "${pkg_dir}/httplibConfig.cmake" "
+        set(httplib_FOUND TRUE)
+        set(httplib_VERSION \"0.32.0\")
+        set(HTTPLIB_IS_COMPILED TRUE)
+        set(HTTPLIB_IS_USING_OPENSSL FALSE)
+        set(HTTPLIB_IS_USING_MBEDTLS FALSE)
+        set(HTTPLIB_IS_USING_WOLFSSL FALSE)
+        add_library(httplib::httplib INTERFACE IMPORTED)
+        set_target_properties(httplib::httplib PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES \"${MOCK_DIR}/include\"
+        )
+    ")
+    file(WRITE "${pkg_dir}/httplibConfigVersion.cmake" "
+        set(PACKAGE_VERSION \"0.32.0\")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    ")
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+    set(CMAKE_PREFIX_PATH "${MOCK_DIR}")
+    set(PkgConfig_FOUND FALSE)
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND TRUE)
+    assert_equal(HTTPLIB_IS_COMPILED TRUE)
+    assert_equal(HTTPLIB_IS_USING_OPENSSL FALSE)
+    assert_equal(HTTPLIB_IS_USING_MBEDTLS FALSE)
+    assert_equal(HTTPLIB_IS_USING_WOLFSSL FALSE)
+
+    # Replicate target configuration logic and assert no compile definitions are added to lemonade-httplib
+    add_library(lemonade-httplib INTERFACE)
+    target_link_libraries(lemonade-httplib INTERFACE httplib::httplib)
+
+    set(SYSTEM_HTTPLIB_HAS_TLS FALSE)
+    set(SYSTEM_HTTPLIB_USES_OPENSSL FALSE)
+    set(SYSTEM_HTTPLIB_USES_MBEDTLS FALSE)
+    set(SYSTEM_HTTPLIB_USES_WOLFSSL FALSE)
+
+    if(HTTPLIB_IS_USING_OPENSSL)
+        set(SYSTEM_HTTPLIB_HAS_TLS TRUE)
+        set(SYSTEM_HTTPLIB_USES_OPENSSL TRUE)
+    elseif(HTTPLIB_IS_USING_MBEDTLS)
+        set(SYSTEM_HTTPLIB_HAS_TLS TRUE)
+        set(SYSTEM_HTTPLIB_USES_MBEDTLS TRUE)
+    elseif(HTTPLIB_IS_USING_WOLFSSL)
+        set(SYSTEM_HTTPLIB_HAS_TLS TRUE)
+        set(SYSTEM_HTTPLIB_USES_WOLFSSL TRUE)
+    endif()
+
+    if(SYSTEM_HTTPLIB_USES_OPENSSL)
+        target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_OPENSSL_SUPPORT)
+    elseif(SYSTEM_HTTPLIB_USES_MBEDTLS)
+        target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_MBEDTLS_SUPPORT)
+    elseif(SYSTEM_HTTPLIB_USES_WOLFSSL)
+        target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_WOLFSSL_SUPPORT)
+    endif()
+
+    if(NOT SYSTEM_HTTPLIB_HAS_TLS AND NOT HTTPLIB_IS_COMPILED)
+        if(HTTPLIB_VERSION AND NOT HTTPLIB_VERSION VERSION_LESS "0.31.0")
+            target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_MBEDTLS_SUPPORT)
+        endif()
+    endif()
+
+    get_target_property(target_defs lemonade-httplib INTERFACE_COMPILE_DEFINITIONS)
+    if(target_defs)
+        message(FATAL_ERROR "Assertion failed: lemonade-httplib target has compile definitions '${target_defs}' but expected none!")
+    endif()
+
+elseif(TEST_CASE STREQUAL "too_old_config_multiarch")
+    set(CMAKE_LIBRARY_ARCHITECTURE "x86_64-linux-gnu")
+    set(pkg_dir "${MOCK_DIR}/lib/x86_64-linux-gnu/cmake/httplib")
+    file(MAKE_DIRECTORY "${pkg_dir}")
+    file(WRITE "${pkg_dir}/httplibConfig.cmake" "
+        set(httplib_FOUND TRUE)
+        set(httplib_VERSION \"0.30.0\")
+        add_library(httplib::httplib INTERFACE IMPORTED)
+    ")
+    file(WRITE "${pkg_dir}/httplibConfigVersion.cmake" "
+        set(PACKAGE_VERSION \"0.30.0\")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    ")
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+    set(CMAKE_PREFIX_PATH "${MOCK_DIR}")
+    set(PkgConfig_FOUND FALSE)
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND FALSE)
+    if(TARGET httplib::httplib)
+        message(FATAL_ERROR "Assertion failed: httplib::httplib target was created despite multiarch package being too old!")
+    endif()
+
+elseif(TEST_CASE STREQUAL "header_only_pkgconfig")
+    file(WRITE "${MOCK_DIR}/FindPkgConfig.cmake" "
+        set(PkgConfig_FOUND TRUE)
+        macro(pkg_search_module prefix)
+            set(\${prefix}_FOUND TRUE)
+            set(\${prefix}_VERSION \"0.32.0\")
+            set(\${prefix}_INCLUDE_DIRS \"\${MOCK_DIR}/include\")
+            set(\${prefix}_LIBRARIES \"\")
+            set(\${prefix}_LINK_LIBRARIES \"\")
+            set(\${prefix}_LIBRARY_DIRS \"\")
+            set(\${prefix}_CFLAGS_OTHER \"\")
+        endmacro()
+    ")
+    list(APPEND CMAKE_MODULE_PATH "${MOCK_DIR}")
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND TRUE)
+    assert_equal(HTTPLIB_VERSION "0.32.0")
+    assert_equal(HTTPLIB_IS_COMPILED FALSE)
+
+elseif(TEST_CASE STREQUAL "cli_composition_mbedtls_isolation")
+    add_library(lemonade-digest-crypto INTERFACE)
+    add_library(lemonade-httplib INTERFACE)
+    target_link_libraries(lemonade-httplib INTERFACE lemonade-digest-crypto)
+    target_compile_definitions(lemonade-httplib INTERFACE CPPHTTPLIB_MBEDTLS_SUPPORT)
+
+    get_target_property(defs lemonade-httplib INTERFACE_COMPILE_DEFINITIONS)
+    assert_equal(defs "CPPHTTPLIB_MBEDTLS_SUPPORT")
+
+elseif(TEST_CASE STREQUAL "custom_httplib_dir_precheck")
+    set(httplib_DIR "${MOCK_DIR}/custom_httplib")
+    file(MAKE_DIRECTORY "${httplib_DIR}")
+    file(WRITE "${httplib_DIR}/httplibConfig.cmake" "
+        set(httplib_FOUND TRUE)
+        set(httplib_VERSION \"0.24.0\")
+        add_library(httplib::httplib INTERFACE IMPORTED)
+    ")
+    file(WRITE "${httplib_DIR}/httplibConfigVersion.cmake" "
+        set(PACKAGE_VERSION \"0.24.0\")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    ")
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND FALSE)
+    if(TARGET httplib::httplib)
+        message(FATAL_ERROR "Assertion failed: httplib::httplib target was created despite custom httplib_DIR package being too old!")
+    endif()
+
+elseif(TEST_CASE STREQUAL "polluted_target_fatal")
+    add_library(httplib::httplib INTERFACE IMPORTED)
+    set(inc_dir "${MOCK_DIR}/include")
+    file(MAKE_DIRECTORY "${inc_dir}")
+    file(WRITE "${inc_dir}/httplib.h" "
+#define CPPHTTPLIB_VERSION \"0.24.0\"
+")
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+    set(CMAKE_DISABLE_FIND_PACKAGE_httplib TRUE)
+    set(CMAKE_PREFIX_PATH "${MOCK_DIR}")
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+elseif(TEST_CASE STREQUAL "wolfssl_target")
+    set(pkg_dir "${MOCK_DIR}/lib/cmake/httplib")
+    file(MAKE_DIRECTORY "${pkg_dir}")
+    file(WRITE "${pkg_dir}/httplibConfig.cmake" "
+        set(httplib_FOUND TRUE)
+        set(httplib_VERSION \"0.32.0\")
+        set(HTTPLIB_IS_USING_WOLFSSL TRUE)
+        add_library(httplib::httplib INTERFACE IMPORTED)
+    ")
+    file(WRITE "${pkg_dir}/httplibConfigVersion.cmake" "
+        set(PACKAGE_VERSION \"0.32.0\")
+        set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    ")
+    set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig TRUE)
+    set(CMAKE_PREFIX_PATH "${MOCK_DIR}")
+
+    detect_system_httplib("${MIN_HTTPLIB_VERSION}")
+
+    assert_equal(HTTPLIB_FOUND TRUE)
+    assert_equal(HTTPLIB_IS_USING_WOLFSSL TRUE)
+
+else()
+    message(FATAL_ERROR "Unknown TEST_CASE: ${TEST_CASE}")
+endif()
+
+file(REMOVE_RECURSE "${MOCK_DIR}")
+message(STATUS "TEST_CASE ${TEST_CASE} passed successfully")


### PR DESCRIPTION
Fixes system `cpp-httplib` package detection and CLI/tray/server HTTPS compilation when building with `-DUSE_SYSTEM_HTTPLIB=ON` or custom package paths.

### Context & Rationale

When building Lemonade on Linux distributions or custom environments shipping `cpp-httplib` via CMake config files instead of pkg-config, building with `-DUSE_SYSTEM_HTTPLIB=ON` could result in target pollution, missing TLS definitions, or linker errors.

### Changes

- **Unified `lemonade-httplib` Target Architecture**: Established `lemonade-httplib` as the single source of truth for HTTPS definitions across both system and bundled builds. All consuming targets (`lemonade` CLI, `lemonade-tray`, `lemond` server) link `lemonade-httplib` unconditionally.
- **Modular Package Detection (`cmake/DetectSystemHttplib.cmake`)**: Extracted system detection supporting CMake Config packages, pkg-config, header-only fallbacks, and OpenSSL/MbedTLS/WolfSSL backends.
- **Target Pollution Protection**: Added pre-checks for custom `httplib_DIR`/`httplib_ROOT` locations and a `FATAL_ERROR` guard if an incompatible `httplib::httplib` target (`< 0.26.0`) is imported.
- **CTest Suite Coverage**: Added 9 hermetic CTest test cases under `test/cmake` asserting config-only packages, version bounds, generator expressions, multiarch paths, custom directory pre-checks, fatal guards, and WolfSSL propagation.