### PR TITLE
feat(tray): support HTTPS server configurations

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -750,6 +750,9 @@ jobs:
           echo "Running WebSocket auth tests..."
           .venv/bin/python test/server_websocket_auth.py
           echo "WebSocket auth tests PASSED!"
+          echo "Running HTTPS tray smoke test..."
+          .venv/bin/python test/test_tray_https.py
+          echo "HTTPS tray smoke test PASSED!"
           echo "Running job engine tests..."
           .venv/bin/python test/server_jobs.py --lemond-binary ./build/lemond
           echo "Job engine tests PASSED!"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -652,6 +652,7 @@ set(SOURCES_CORE
     src/cpp/server/utils/json_utils.cpp
     src/cpp/server/utils/process_manager.cpp
     src/cpp/server/utils/path_utils.cpp
+    src/cpp/server/utils/url_utils.cpp
     src/cpp/server/utils/version_utils.cpp
     src/cpp/server/utils/wmi_helper.cpp
     src/cpp/server/utils/network_beacon.cpp
@@ -1327,11 +1328,11 @@ if(APPLE)
     endif()
 endif()
 
-# Add tray application subdirectory
-add_subdirectory(src/cpp/tray)
-
 # Add CLI application subdirectory
 add_subdirectory(src/cpp/cli)
+
+# Add tray application subdirectory
+add_subdirectory(src/cpp/tray)
 
 # Wire WiX installer targets to the binaries and frontend artifacts they package.
 # Doing this after the subdirectories are added ensures MSBuild gets real project refs.
@@ -2442,6 +2443,13 @@ if(EXISTS "${_NETWORK_UTILS_TEST_SRC}")
     add_executable(test_network_utils test/cpp/test_network_utils.cpp)
     target_link_libraries(test_network_utils PRIVATE lemonade-server-core)
     add_test(NAME NetworkUtilsTest COMMAND test_network_utils)
+endif()
+
+set(_URL_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_url_utils.cpp")
+if(EXISTS "${_URL_UTILS_TEST_SRC}")
+    add_executable(test_url_utils test/cpp/test_url_utils.cpp)
+    target_link_libraries(test_url_utils PRIVATE lemonade-server-core)
+    add_test(NAME UrlUtilsTest COMMAND test_url_utils)
 endif()
 
 # vLLM CDNA gating: the vllm descriptor support row + asset-family resolution for

--- a/src/cpp/cli/CMakeLists.txt
+++ b/src/cpp/cli/CMakeLists.txt
@@ -196,10 +196,10 @@ elseif(HTTPLIB_VERSION AND NOT HTTPLIB_VERSION VERSION_LESS "0.31.0")
 endif()
 
 if(HTTPLIB_SUPPORTS_MBEDTLS)
-    target_compile_definitions(lemonade PRIVATE LEMONADE_CLI CPPHTTPLIB_MBEDTLS_SUPPORT)
-else()
-    target_compile_definitions(lemonade PRIVATE LEMONADE_CLI)
+    target_compile_definitions(lemonade-digest-crypto INTERFACE CPPHTTPLIB_MBEDTLS_SUPPORT)
 endif()
+
+target_compile_definitions(lemonade PRIVATE LEMONADE_CLI)
 
 # Platform-specific settings
 if(WIN32)

--- a/src/cpp/cli/CMakeLists.txt
+++ b/src/cpp/cli/CMakeLists.txt
@@ -93,6 +93,7 @@ set(COMMON_SOURCES
     ../server/recipe_options.cpp
     ../server/utils/process_manager.cpp
     ../server/utils/path_utils.cpp
+    ../server/utils/url_utils.cpp
     ../server/utils/json_utils.cpp
     ../server/utils/http_client.cpp
     # recipe_import.cpp persists and validates remote registry provenance.
@@ -187,11 +188,11 @@ if(WIN32)
     )
 endif()
 
-set(HTTPLIB_SUPPORTS_MBEDTLS FALSE)
+set(HTTPLIB_SUPPORTS_MBEDTLS FALSE CACHE INTERNAL "mbedtls support in httplib")
 if(NOT USE_SYSTEM_HTTPLIB)
-    set(HTTPLIB_SUPPORTS_MBEDTLS TRUE)
+    set(HTTPLIB_SUPPORTS_MBEDTLS TRUE CACHE INTERNAL "mbedtls support in httplib")
 elseif(HTTPLIB_VERSION AND NOT HTTPLIB_VERSION VERSION_LESS "0.31.0")
-    set(HTTPLIB_SUPPORTS_MBEDTLS TRUE)
+    set(HTTPLIB_SUPPORTS_MBEDTLS TRUE CACHE INTERNAL "mbedtls support in httplib")
 endif()
 
 if(HTTPLIB_SUPPORTS_MBEDTLS)

--- a/src/cpp/cli/lemonade_client.cpp
+++ b/src/cpp/cli/lemonade_client.cpp
@@ -1,4 +1,5 @@
 #include "lemon_cli/lemonade_client.h"
+#include "lemon/utils/url_utils.h"
 #include <httplib.h>
 #include <iostream>
 #include <algorithm>
@@ -84,50 +85,7 @@ const std::string& HttpError::response_body() const {
 }
 
 void LemonadeClient::parse_target_url(const std::string& input_host, std::string& out_clean_host, int& out_port, bool& out_is_ssl) {
-    std::string remaining = input_host;
-    bool has_scheme = false;
-
-    if (remaining.rfind("https://", 0) == 0) {
-        out_is_ssl = true;
-        remaining = remaining.substr(8);
-        has_scheme = true;
-    } else if (remaining.rfind("http://", 0) == 0) {
-        out_is_ssl = false;
-        remaining = remaining.substr(7);
-        has_scheme = true;
-    }
-
-    // Strip path if present (anything starting with '/')
-    size_t path_pos = remaining.find('/');
-    if (path_pos != std::string::npos) {
-        remaining = remaining.substr(0, path_pos);
-    }
-
-    // Parse port
-    size_t close_bracket = remaining.find(']');
-    size_t colon_pos = std::string::npos;
-    if (remaining.rfind("[", 0) == 0 && close_bracket != std::string::npos) {
-        size_t post_bracket_colon = remaining.find(':', close_bracket);
-        if (post_bracket_colon != std::string::npos) {
-            colon_pos = post_bracket_colon;
-        }
-    } else {
-        colon_pos = remaining.rfind(':');
-    }
-
-    if (colon_pos != std::string::npos) {
-        out_clean_host = remaining.substr(0, colon_pos);
-        std::string port_str = remaining.substr(colon_pos + 1);
-        try {
-            out_port = std::stoi(port_str);
-        } catch (...) {
-        }
-    } else {
-        out_clean_host = remaining;
-        if (has_scheme) {
-            out_port = out_is_ssl ? 443 : 80;
-        }
-    }
+    lemon::utils::parse_target_url(input_host, out_clean_host, out_port, out_is_ssl);
 }
 
 LemonadeClient::LemonadeClient(const std::string& host, int port, const std::string& api_key, bool is_ssl)

--- a/src/cpp/include/lemon/utils/url_utils.h
+++ b/src/cpp/include/lemon/utils/url_utils.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace lemon::utils {
+
+/**
+ * @brief Parses a target URL or host string into its constituent parts.
+ *
+ * @param input_host The raw input string containing the host, URL, or IP address.
+ * @param out_clean_host Output parameter for the parsed host (without scheme/port/path/query/fragment).
+ * @param out_port Output parameter for the parsed port. Set to -1 if invalid; retains incoming value if not present.
+ * @param out_is_ssl Output parameter indicating if scheme is HTTPS. Retains incoming value if no scheme is matched.
+ * @param override_default_port If true and scheme is present, overrides the port with 80/443 if no explicit port is found.
+ */
+void parse_target_url(std::string_view input_host, std::string& out_clean_host, int& out_port, bool& out_is_ssl, bool override_default_port = true);
+
+/**
+ * @brief Encloses raw IPv6 address strings in brackets ([::1]) for use in URLs.
+ *
+ * @param host The hostname or IP address to check.
+ * @return A bracketed version if it contains colons and is not already bracketed, otherwise the original string.
+ */
+std::string bracket_host_if_ipv6(std::string_view host);
+
+} // namespace lemon::utils

--- a/src/cpp/include/lemon_tray/tray_ui.h
+++ b/src/cpp/include/lemon_tray/tray_ui.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <lemon/utils/url_utils.h>
 #include "lemon_tray/platform/tray_interface.h"
 #include <httplib.h>
 #include <nlohmann/json.hpp>
@@ -40,9 +41,16 @@ struct LoadedModelInfo {
     }
 };
 
+struct TrayUIOptions {
+    int port = 13305;
+    std::string host = "127.0.0.1";
+    bool is_ssl = false;
+    bool silent = false;
+};
+
 class TrayUI {
 public:
-    TrayUI(int port, const std::string& host, bool silent = false);
+    explicit TrayUI(const TrayUIOptions& options);
     ~TrayUI();
 
     bool initialize();
@@ -53,6 +61,8 @@ private:
     // HTTP helpers (inline, using httplib::Client)
     std::string http_get(const std::string& endpoint);
     std::string http_post(const std::string& endpoint, const std::string& body = "");
+    httplib::Client make_client(const std::string& host, int port, bool is_ssl) const;
+    httplib::Client make_client() const;
 
     // Data fetchers
     std::pair<bool, std::vector<LoadedModelInfo>> fetch_server_state();
@@ -96,6 +106,7 @@ private:
     // State
     int port_;
     std::string host_;
+    bool is_ssl_ = false;
     int max_loaded_models_ = 1;  // Mirrors server config; default 1 per configuration.md
     bool silent_;  // Suppress startup notification
     std::unique_ptr<TrayInterface> tray_;

--- a/src/cpp/server/utils/url_utils.cpp
+++ b/src/cpp/server/utils/url_utils.cpp
@@ -1,0 +1,85 @@
+#include <lemon/utils/url_utils.h>
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+
+namespace lemon::utils {
+
+void parse_target_url(std::string_view input_host, std::string& out_clean_host, int& out_port, bool& out_is_ssl, bool override_default_port) {
+    std::string_view remaining = input_host;
+    bool has_scheme = false;
+
+    // Helper for case-insensitive scheme matching
+    auto starts_with_case_insensitive = [](std::string_view str, std::string_view prefix) {
+        if (str.size() < prefix.size()) return false;
+        for (size_t i = 0; i < prefix.size(); ++i) {
+            if (std::tolower(static_cast<unsigned char>(str[i])) != std::tolower(static_cast<unsigned char>(prefix[i]))) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    if (starts_with_case_insensitive(remaining, "https://")) {
+        out_is_ssl = true;
+        remaining.remove_prefix(8);
+        has_scheme = true;
+    } else if (starts_with_case_insensitive(remaining, "http://")) {
+        out_is_ssl = false;
+        remaining.remove_prefix(7);
+        has_scheme = true;
+    }
+
+    // Strip path, query parameters, or fragments
+    size_t limit_pos = remaining.find_first_of("/?#");
+    if (limit_pos != std::string_view::npos) {
+        remaining = remaining.substr(0, limit_pos);
+    }
+
+    // Parse port and host
+    size_t close_bracket = remaining.find(']');
+    size_t colon_pos = std::string_view::npos;
+    if (remaining.rfind('[', 0) == 0 && close_bracket != std::string_view::npos) {
+        size_t post_bracket_colon = remaining.find(':', close_bracket);
+        if (post_bracket_colon != std::string_view::npos) {
+            colon_pos = post_bracket_colon;
+        }
+    } else {
+        // Only treat the last colon as a port separator if there is at most one colon.
+        // Multiple colons without brackets indicate a raw IPv6 address.
+        size_t colon_count = 0;
+        for (char c : remaining) {
+            if (c == ':') colon_count++;
+        }
+        if (colon_count <= 1) {
+            colon_pos = remaining.rfind(':');
+        }
+    }
+
+    if (colon_pos != std::string_view::npos) {
+        out_clean_host = std::string(remaining.substr(0, colon_pos));
+        std::string_view port_str = remaining.substr(colon_pos + 1);
+        int parsed_port = 0;
+        auto [ptr, ec] = std::from_chars(port_str.data(), port_str.data() + port_str.size(), parsed_port);
+        if (ec == std::errc{} && ptr == port_str.data() + port_str.size() && parsed_port >= 1 && parsed_port <= 65535) {
+            out_port = parsed_port;
+        } else {
+            out_port = -1; // Flag invalid port
+        }
+    } else {
+        out_clean_host = std::string(remaining);
+        if (has_scheme && override_default_port) {
+            out_port = out_is_ssl ? 443 : 80;
+        }
+    }
+}
+
+std::string bracket_host_if_ipv6(std::string_view host) {
+    if (host.find(':') != std::string_view::npos && host.front() != '[') {
+        return "[" + std::string(host) + "]";
+    }
+    return std::string(host);
+}
+
+} // namespace lemon::utils

--- a/src/cpp/tray/CMakeLists.txt
+++ b/src/cpp/tray/CMakeLists.txt
@@ -170,7 +170,6 @@ function(apply_tray_deps target_name)
     endif()
 
     if(HTTPLIB_SUPPORTS_MBEDTLS)
-        target_compile_definitions(${target_name} PRIVATE CPPHTTPLIB_MBEDTLS_SUPPORT)
         target_link_libraries(${target_name} PRIVATE lemonade-digest-crypto)
         if(APPLE)
             find_library(SECURITY_FRAMEWORK Security REQUIRED)

--- a/src/cpp/tray/CMakeLists.txt
+++ b/src/cpp/tray/CMakeLists.txt
@@ -134,6 +134,7 @@ set(TRAY_UI_SOURCES
 if(NOT WIN32)
     list(APPEND TRAY_UI_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/../server/utils/path_utils.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../server/utils/url_utils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../server/utils/json_utils.cpp
     )
     # Add platform-specific path implementation
@@ -166,6 +167,15 @@ function(apply_tray_deps target_name)
         target_include_directories(${target_name} PRIVATE ${CLI11_INCLUDE_DIRS})
     else()
         target_link_libraries(${target_name} PRIVATE CLI11::CLI11)
+    endif()
+
+    if(HTTPLIB_SUPPORTS_MBEDTLS)
+        target_compile_definitions(${target_name} PRIVATE CPPHTTPLIB_MBEDTLS_SUPPORT)
+        target_link_libraries(${target_name} PRIVATE lemonade-digest-crypto)
+        if(APPLE)
+            find_library(SECURITY_FRAMEWORK Security REQUIRED)
+            target_link_libraries(${target_name} PRIVATE ${SECURITY_FRAMEWORK})
+        endif()
     endif()
 endfunction()
 

--- a/src/cpp/tray/main.cpp
+++ b/src/cpp/tray/main.cpp
@@ -11,6 +11,7 @@
 #include "lemon_tray/tray_ui.h"
 #include <lemon/single_instance.h>
 #include <lemon/utils/aixlog.hpp>
+#include <lemon/utils/url_utils.h>
 #include <lemon/version.h>
 
 #include <atomic>
@@ -66,9 +67,15 @@ static void create_child_process_job() {
 // Helpers
 // ---------------------------------------------------------------------------
 
-static bool wait_for_server(const std::string& host, int port, int timeout_seconds) {
-    std::string connect_host = (host.empty() || host == "0.0.0.0" || host == "localhost")
-        ? "127.0.0.1" : host;
+static bool wait_for_server(const std::string& clean_host, int clean_port, bool is_ssl, int timeout_seconds) {
+    std::string connect_host;
+    if (is_ssl) {
+        connect_host = (clean_host.empty() || clean_host == "0.0.0.0")
+            ? "127.0.0.1" : clean_host;
+    } else {
+        connect_host = (clean_host.empty() || clean_host == "0.0.0.0" || clean_host == "localhost")
+            ? "127.0.0.1" : clean_host;
+    }
 
     // Pass API key if set - prefer admin key over regular API key
     const char* admin_api_key = std::getenv("LEMONADE_ADMIN_API_KEY");
@@ -80,7 +87,22 @@ static bool wait_for_server(const std::string& host, int port, int timeout_secon
 
     for (int i = 0; i < timeout_seconds * 2; ++i) {
         try {
-            httplib::Client cli(connect_host, port);
+#ifndef CPPHTTPLIB_MBEDTLS_SUPPORT
+            if (is_ssl) {
+                std::cerr << "HTTPS support is not compiled in this client." << std::endl;
+                return false;
+            }
+#endif
+            std::string format_host = lemon::utils::bracket_host_if_ipv6(connect_host);
+            std::string scheme = is_ssl ? "https" : "http";
+            std::string url = scheme + "://" + format_host + ":" + std::to_string(clean_port);
+            httplib::Client cli(url);
+#ifdef CPPHTTPLIB_MBEDTLS_SUPPORT
+            const char* skip_verify = std::getenv("LEMONADE_SKIP_VERIFY");
+            if (skip_verify && std::string(skip_verify) == "1") {
+                cli.enable_server_certificate_verification(false);
+            }
+#endif
             cli.set_connection_timeout(1);
             cli.set_read_timeout(5);
             // Use /api/v1/health instead of /live — /live responds before the model
@@ -191,7 +213,7 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int) {
     server_thread.detach();
 
     // Wait for server to be ready
-    if (!wait_for_server(runtime_config->host(), runtime_config->port(), 15)) {
+    if (!wait_for_server(runtime_config->host(), runtime_config->port(), false, 15)) {
         MessageBoxA(NULL,
             "Lemonade Server failed to start within 15 seconds.",
             "Lemonade Server Error", MB_OK | MB_ICONERROR);
@@ -205,7 +227,12 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int) {
     // thread; we just need to block until shutdown.
     bool headless = false;
     try {
-        lemon_tray::TrayUI tray(runtime_config->port(), runtime_config->host(), silent);
+        lemon_tray::TrayUIOptions options;
+        options.port = runtime_config->port();
+        options.host = runtime_config->host();
+        options.is_ssl = false;
+        options.silent = silent;
+        lemon_tray::TrayUI tray(options);
         if (tray.initialize()) {
             tray.run();  // Blocks until quit
         } else {
@@ -284,14 +311,20 @@ int main(int argc, char* argv[]) {
         return app.exit(e);
     }
 
+    std::string clean_host;
+    int clean_port = port;
+    bool is_ssl = false;
+    bool explicit_port = app.count("--port") > 0 || app.count("-p") > 0;
+    lemon::utils::parse_target_url(host, clean_host, clean_port, is_ssl, !explicit_port);
+
     // Install signal handlers
     signal(SIGINT, tray_signal_handler);
     signal(SIGTERM, tray_signal_handler);
 
     // Wait for router to be reachable (retry with backoff up to 30s)
-    std::cout << "Connecting to lemond at " << host << ":" << port << "..." << std::endl;
-    if (!wait_for_server(host, port, 30)) {
-        std::cerr << "Error: Could not connect to lemond at " << host << ":" << port << std::endl;
+    std::cout << "Connecting to lemond at " << clean_host << ":" << clean_port << (is_ssl ? " (SSL)" : "") << "..." << std::endl;
+    if (!wait_for_server(clean_host, clean_port, is_ssl, 30)) {
+        std::cerr << "Error: Could not connect to lemond at " << clean_host << ":" << clean_port << std::endl;
         std::cerr << "Make sure lemond is running." << std::endl;
         return 1;
     }
@@ -299,7 +332,12 @@ int main(int argc, char* argv[]) {
     std::cout << "Connected to lemond v" << LEMON_VERSION_STRING << std::endl;
 
     // Create and run tray UI
-    lemon_tray::TrayUI tray(port, host);
+    lemon_tray::TrayUIOptions options;
+    options.port = clean_port;
+    options.host = clean_host;
+    options.is_ssl = is_ssl;
+    options.silent = false;
+    lemon_tray::TrayUI tray(options);
     if (!tray.initialize()) {
         return 1;
     }

--- a/src/cpp/tray/tray_ui.cpp
+++ b/src/cpp/tray/tray_ui.cpp
@@ -37,6 +37,12 @@ int TrayUI::signal_pipe_[2] = {-1, -1};
 // ---------------------------------------------------------------------------
 
 std::string TrayUI::get_connect_host() const {
+    if (is_ssl_) {
+        if (host_.empty() || host_ == "0.0.0.0") {
+            return "127.0.0.1";
+        }
+        return host_;
+    }
     if (host_.empty() || host_ == "0.0.0.0" || host_ == "localhost") {
         return "127.0.0.1";
     }
@@ -47,12 +53,21 @@ std::string TrayUI::get_connect_host() const {
 // Construction / destruction
 // ---------------------------------------------------------------------------
 
-TrayUI::TrayUI(int port, const std::string& host, bool silent)
-    : port_(port)
-    , host_(host)
-    , silent_(silent)
+TrayUI::TrayUI(const TrayUIOptions& options)
+    : port_(options.port)
+    , host_(options.host)
+    , is_ssl_(options.is_ssl)
+    , silent_(options.silent)
     , recipe_options_(nlohmann::json::object())
 {
+    std::string clean_host;
+    int clean_port = port_;
+    bool clean_is_ssl = is_ssl_;
+    lemon::utils::parse_target_url(host_, clean_host, clean_port, clean_is_ssl, false);
+    host_ = clean_host;
+    port_ = clean_port;
+    is_ssl_ = clean_is_ssl;
+
 #ifndef _WIN32
     if (pipe(signal_pipe_) == -1) {
         std::cerr << "Failed to create signal pipe" << std::endl;
@@ -161,43 +176,70 @@ void TrayUI::stop() {
 // HTTP helpers
 // ---------------------------------------------------------------------------
 
+httplib::Client TrayUI::make_client(const std::string& host, int port, bool is_ssl) const {
+#ifndef CPPHTTPLIB_MBEDTLS_SUPPORT
+    if (is_ssl) {
+        throw std::runtime_error("HTTPS support is not compiled in this client.");
+    }
+#endif
+    std::string format_host = lemon::utils::bracket_host_if_ipv6(host);
+    std::string scheme = is_ssl ? "https" : "http";
+    std::string url = scheme + "://" + format_host + ":" + std::to_string(port);
+    auto client = httplib::Client(url);
+#ifdef CPPHTTPLIB_MBEDTLS_SUPPORT
+    const char* skip_verify = std::getenv("LEMONADE_SKIP_VERIFY");
+    if (skip_verify && std::string(skip_verify) == "1") {
+        client.enable_server_certificate_verification(false);
+    }
+#endif
+    return client;
+}
+
+httplib::Client TrayUI::make_client() const {
+    return make_client(get_connect_host(), port_, is_ssl_);
+}
+
 std::string TrayUI::http_get(const std::string& endpoint) {
-    httplib::Client cli(get_connect_host(), port_);
-    cli.set_connection_timeout(2);
-    cli.set_read_timeout(5);
+    try {
+        auto cli = make_client();
+        cli.set_connection_timeout(2);
+        cli.set_read_timeout(5);
 
-    // Pass API key if set - prefer admin key over regular API key
-    const char* admin_api_key = std::getenv("LEMONADE_ADMIN_API_KEY");
-    const char* api_key = admin_api_key ? admin_api_key : std::getenv("LEMONADE_API_KEY");
-    httplib::Headers headers;
-    if (api_key && api_key[0]) {
-        headers.emplace("Authorization", std::string("Bearer ") + api_key);
-    }
+        // Pass API key if set - prefer admin key over regular API key
+        const char* admin_api_key = std::getenv("LEMONADE_ADMIN_API_KEY");
+        const char* api_key = admin_api_key ? admin_api_key : std::getenv("LEMONADE_API_KEY");
+        httplib::Headers headers;
+        if (api_key && api_key[0]) {
+            headers.emplace("Authorization", std::string("Bearer ") + api_key);
+        }
 
-    auto res = cli.Get(endpoint, headers);
-    if (res && res->status == 200) {
-        return res->body;
-    }
+        auto res = cli.Get(endpoint, headers);
+        if (res && res->status == 200) {
+            return res->body;
+        }
+    } catch (...) {}
     return "";
 }
 
 std::string TrayUI::http_post(const std::string& endpoint, const std::string& body) {
-    httplib::Client cli(get_connect_host(), port_);
-    cli.set_connection_timeout(2);
-    cli.set_read_timeout(30);
+    try {
+        auto cli = make_client();
+        cli.set_connection_timeout(2);
+        cli.set_read_timeout(30);
 
-    // Pass API key if set - prefer admin key over regular API key
-    const char* admin_api_key = std::getenv("LEMONADE_ADMIN_API_KEY");
-    const char* api_key = admin_api_key ? admin_api_key : std::getenv("LEMONADE_API_KEY");
-    httplib::Headers headers;
-    if (api_key && api_key[0]) {
-        headers.emplace("Authorization", std::string("Bearer ") + api_key);
-    }
+        // Pass API key if set - prefer admin key over regular API key
+        const char* admin_api_key = std::getenv("LEMONADE_ADMIN_API_KEY");
+        const char* api_key = admin_api_key ? admin_api_key : std::getenv("LEMONADE_API_KEY");
+        httplib::Headers headers;
+        if (api_key && api_key[0]) {
+            headers.emplace("Authorization", std::string("Bearer ") + api_key);
+        }
 
-    auto res = cli.Post(endpoint, headers, body, "application/json");
-    if (res && (res->status == 200 || res->status == 204)) {
-        return res->body;
-    }
+        auto res = cli.Post(endpoint, headers, body, "application/json");
+        if (res && (res->status == 200 || res->status == 204)) {
+            return res->body;
+        }
+    } catch (...) {}
     return "";
 }
 
@@ -626,7 +668,9 @@ void TrayUI::open_desktop_app(const std::string& route) {
 }
 
 void TrayUI::open_web_app(const std::string& route) {
-    std::string url = "http://" + get_connect_host() + ":" + std::to_string(port_) + "/";
+    std::string scheme = is_ssl_ ? "https" : "http";
+    std::string formatted_host = lemon::utils::bracket_host_if_ipv6(get_connect_host());
+    std::string url = scheme + "://" + formatted_host + ":" + std::to_string(port_) + "/";
     if (!route.empty()) {
         url += "?" + route;
     }

--- a/test/cpp/test_url_utils.cpp
+++ b/test/cpp/test_url_utils.cpp
@@ -1,0 +1,221 @@
+#include <lemon/utils/url_utils.h>
+
+#include <cassert>
+#include <cstdio>
+#include <string>
+
+struct TestResult {
+    int passed = 0;
+    int failed = 0;
+
+    void ok(const std::string& name) {
+        printf("[PASS] %s\n", name.c_str());
+        ++passed;
+    }
+
+    void fail(const std::string& name) {
+        printf("[FAIL] %s\n", name.c_str());
+        ++failed;
+    }
+};
+
+int main() {
+    TestResult result;
+
+    // Test case 1: simple HTTP URL
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("http://localhost:8080", clean_host, port, is_ssl, true);
+        if (clean_host == "localhost" && port == 8080 && !is_ssl) {
+            result.ok("simple HTTP URL");
+        } else {
+            result.fail("simple HTTP URL");
+        }
+    }
+
+    // Test case 2: simple HTTPS URL
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("https://my-server.com", clean_host, port, is_ssl, true);
+        if (clean_host == "my-server.com" && port == 443 && is_ssl) {
+            result.ok("simple HTTPS URL");
+        } else {
+            result.fail("simple HTTPS URL");
+        }
+    }
+
+    // Test case 3: HTTPS URL with explicit port
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("https://my-server.com:12345", clean_host, port, is_ssl, true);
+        if (clean_host == "my-server.com" && port == 12345 && is_ssl) {
+            result.ok("HTTPS URL with explicit port");
+        } else {
+            result.fail("HTTPS URL with explicit port");
+        }
+    }
+
+    // Test case 4: no scheme, with port
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("localhost:9000", clean_host, port, is_ssl, true);
+        if (clean_host == "localhost" && port == 9000 && !is_ssl) {
+            result.ok("no scheme, with port");
+        } else {
+            result.fail("no scheme, with port");
+        }
+    }
+
+    // Test case 5: no scheme, no port
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("localhost", clean_host, port, is_ssl, true);
+        if (clean_host == "localhost" && port == 13305 && !is_ssl) {
+            result.ok("no scheme, no port");
+        } else {
+            result.fail("no scheme, no port");
+        }
+    }
+
+    // Test case 6: HTTPS URL, no port, override_default_port = false
+    {
+        std::string clean_host;
+        int port = 12345;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("https://my-server.com", clean_host, port, is_ssl, false);
+        if (clean_host == "my-server.com" && port == 12345 && is_ssl) {
+            result.ok("HTTPS URL, no port, override_default_port = false");
+        } else {
+            result.fail("HTTPS URL, no port, override_default_port = false");
+        }
+    }
+
+    // Test case 7: URL with query parameters and fragments
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("http://localhost:8080?foo=bar#frag", clean_host, port, is_ssl, true);
+        if (clean_host == "localhost" && port == 8080 && !is_ssl) {
+            result.ok("URL with query parameters and fragments");
+        } else {
+            result.fail("URL with query parameters and fragments");
+        }
+    }
+
+    // Test case 8: Case-insensitive schemes
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("HTTPS://my-server.com", clean_host, port, is_ssl, true);
+        if (clean_host == "my-server.com" && port == 443 && is_ssl) {
+            result.ok("Case-insensitive schemes");
+        } else {
+            result.fail("Case-insensitive schemes");
+        }
+    }
+
+    // Test case 9: Bracketed IPv6 with port
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("[::1]:8080", clean_host, port, is_ssl, true);
+        if (clean_host == "[::1]" && port == 8080) {
+            result.ok("Bracketed IPv6 with port");
+        } else {
+            result.fail("Bracketed IPv6 with port");
+        }
+    }
+
+    // Test case 10: Bracketless IPv6 (no port)
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("::1", clean_host, port, is_ssl, true);
+        if (clean_host == "::1" && port == 13305) {
+            result.ok("Bracketless IPv6");
+        } else {
+            result.fail("Bracketless IPv6");
+        }
+    }
+
+    // Test case 11: Invalid port format
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("localhost:abc", clean_host, port, is_ssl, true);
+        if (port == -1) {
+            result.ok("Invalid port format handled");
+        } else {
+            result.fail("Invalid port format handled");
+        }
+    }
+
+    // Test case 12: Port 0
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("localhost:0", clean_host, port, is_ssl, true);
+        if (port == -1) {
+            result.ok("Port 0 handled as invalid");
+        } else {
+            result.fail("Port 0 handled as invalid");
+        }
+    }
+
+    // Test case 13: Empty port string
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("localhost:", clean_host, port, is_ssl, true);
+        if (port == -1) {
+            result.ok("Empty port string handled as invalid");
+        } else {
+            result.fail("Empty port string handled as invalid");
+        }
+    }
+
+    // Test case 14: Trailing garbage in port
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("example.com:443junk", clean_host, port, is_ssl, true);
+        if (port == -1) {
+            result.ok("Trailing garbage in port handled as invalid");
+        } else {
+            result.fail("Trailing garbage in port handled as invalid");
+        }
+    }
+
+    // Test case 15: Port out of range (> 65535)
+    {
+        std::string clean_host;
+        int port = 13305;
+        bool is_ssl = false;
+        lemon::utils::parse_target_url("localhost:65536", clean_host, port, is_ssl, true);
+        if (port == -1) {
+            result.ok("Out-of-range port handled as invalid");
+        } else {
+            result.fail("Out-of-range port handled as invalid");
+        }
+    }
+
+    return result.failed > 0 ? 1 : 0;
+}

--- a/test/test_tray_https.py
+++ b/test/test_tray_https.py
@@ -1,0 +1,135 @@
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import http.server
+import ssl
+import threading
+
+
+class MockHTTPSHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/api/v1/health":
+            self.server.health_checked = True
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        pass  # Suppress output
+
+
+def run_test():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key_path = os.path.join(tmpdir, "key.pem")
+        cert_path = os.path.join(tmpdir, "cert.pem")
+
+        # Generate self-signed certificate
+        try:
+            subprocess.run(
+                [
+                    "openssl",
+                    "req",
+                    "-new",
+                    "-newkey",
+                    "rsa:2048",
+                    "-days",
+                    "1",
+                    "-nodes",
+                    "-x509",
+                    "-subj",
+                    "/CN=localhost",
+                    "-keyout",
+                    key_path,
+                    "-out",
+                    cert_path,
+                ],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception as e:
+            print(f"Error generating self-signed cert: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        # Start Mock HTTPS Server on ephemeral port
+        server = http.server.HTTPServer(("127.0.0.1", 0), MockHTTPSHandler)
+        server.health_checked = False
+        port = server.server_port
+
+        # Wrap socket with SSL
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(certfile=cert_path, keyfile=key_path)
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+
+        server_thread = threading.Thread(target=server.serve_forever)
+        server_thread.daemon = True
+        server_thread.start()
+
+        # Determine paths
+        # Search build directory for lemonade-tray binary
+        binary_path = "./build/lemonade-tray"
+        if not os.path.exists(binary_path):
+            print(f"lemonade-tray binary not found at {binary_path}", file=sys.stderr)
+            sys.exit(1)
+
+        # Launch lemonade-tray pointing to mock HTTPS server
+        env = os.environ.copy()
+        env["LEMONADE_SKIP_VERIFY"] = "1"
+        env["XDG_RUNTIME_DIR"] = os.path.abspath("./build")
+        env["RUNTIME_DIRECTORY"] = os.path.abspath("./build")
+
+        proc = subprocess.Popen(
+            [binary_path, "--host", f"https://localhost:{port}", "--port", str(port)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+
+        # Poll until mock HTTPS server receives a health check request
+        start_time = time.time()
+        success = False
+        while time.time() - start_time < 5:
+            if getattr(server, "health_checked", False):
+                success = True
+                break
+
+            if proc.poll() is not None:
+                # Process exited early
+                break
+
+            time.sleep(0.1)
+
+        proc.terminate()
+        stdout_data = ""
+        stderr_data = ""
+        try:
+            stdout_data, stderr_data = proc.communicate(timeout=1)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            try:
+                stdout_data, stderr_data = proc.communicate(timeout=1)
+            except Exception:
+                pass
+
+        server.shutdown()
+        server.server_close()
+
+        if success:
+            print("[PASS] HTTPS Tray E2E Smoke Test passed successfully.")
+            sys.exit(0)
+        else:
+            print("[FAIL] HTTPS Tray E2E Smoke Test failed.", file=sys.stderr)
+            print(f"Stdout: {stdout_data}", file=sys.stderr)
+            print(f"Stderr: {stderr_data}", file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_test()


### PR DESCRIPTION
Extracts target URL parsing logic to a shared utility and enables HTTPS compilation definitions and mbedtls linking for standalone macOS/Linux system tray clients. This allows the tray client to connect to HTTPS-secured remote server instances.

Windows `LemonadeServer.exe` runs its embedded server locally and continues to connect over HTTP, but utilizes the new unified constructor config options.

### Key Changes:
* **Shared URL parsing utility:** Moves target URL parsing logic to a shared `url_utils` module (`std::string_view` input, `std::from_chars` port parsing with strict validation of range `[1, 65535]` and trailing characters).
* **CMake target dependency ordering:** Swaps target directories in CMake so that the tray targets link against `lemonade-digest-crypto` (packaging mbedTLS). Links `Security.framework` on macOS if SSL is enabled.
* **Tray Client HTTPS Refactoring:** Integrates a `TrayUIOptions` configuration struct to initialize `TrayUI`, formats URL connection hosts (bracketing IPv6 addresses like `[::1]`), and restricts the `localhost` to `127.0.0.1` rewrite logic to plain HTTP to preserve TLS SNI/hostname verification.
* **Testing:** Adds C++ unit test coverage for various host, scheme, and port edge cases, alongside a Python end-to-end integration smoke test running `lemonade-tray` against a mock HTTPS server.