### PR TITLE
fix(cli): parse configuration values as JSON arrays and objects

### DIFF
--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -370,6 +370,10 @@ lemonade config set llamacpp.backend=rocm
 
 # Set multiple values at once
 lemonade config set port=9000 llamacpp.backend=rocm sdcpp.steps=30
+
+# Set complex types like JSON arrays and objects (use single quotes to prevent shell expansion)
+lemonade config set telemetry.otlp.semantics='["openinference"]'
+lemonade config set telemetry.otlp.headers='{"Authorization":"Bearer key"}'
 ```
 
 ### lemond CLI arguments (fallback)

--- a/docs/guide/telemetry.md
+++ b/docs/guide/telemetry.md
@@ -98,6 +98,9 @@ lemonade telemetry off
 lemonade config
 ```
 
+> [!NOTE]
+> When configuring options that require JSON arrays (such as `telemetry.otlp.semantics`) or JSON objects (such as `telemetry.otlp.headers`) via the CLI, wrap the values in single quotes (e.g. `'["openinference"]'`) so your shell does not interpret or expand the bracket `[]` or brace `{}` characters.
+
 ### Via Configuration API
 
 Internal configuration is updated via the `/internal/set` endpoint:

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -953,6 +953,12 @@ static bool is_strict_numeric(const std::string& s, bool allow_dot) {
 }
 
 static nlohmann::json parse_typed_value(const std::string& value) {
+    if (!value.empty() && (value.front() == '[' || value.front() == '{')) {
+        auto parsed = nlohmann::json::parse(value, nullptr, false);
+        if (!parsed.is_discarded()) {
+            return parsed;
+        }
+    }
     // Strict integer: optional minus, then digits only (no hex, no scientific)
     if (is_strict_numeric(value, false)) {
         try { return std::stoi(value); } catch (...) {}

--- a/test/cpp/test_config_telemetry.cpp
+++ b/test/cpp/test_config_telemetry.cpp
@@ -32,6 +32,12 @@ static json parse_cli_args(const std::vector<std::string>& args) {
         return s;
     };
     auto parse_typed_value = [](const std::string& val) -> json {
+        if (!val.empty() && (val.front() == '[' || val.front() == '{')) {
+            auto parsed = json::parse(val, nullptr, false);
+            if (!parsed.is_discarded()) {
+                return parsed;
+            }
+        }
         if (val == "true") return true;
         if (val == "false") return false;
         try {
@@ -173,16 +179,21 @@ int main() {
     }
     check(threw_unknown_otlp, "rejects unknown telemetry.otlp subkey");
 
-    // 4. Test CLI dotted key config path parsing logic
     std::vector<std::string> cli_args = {
         "telemetry.otlp.endpoint=http://127.0.0.1:5555/v1/traces",
         "telemetry.otlp.protocol=http/json",
+        "telemetry.otlp.semantics=[\"openinference\"]",
+        "telemetry.otlp.headers={\"Authorization\":\"Bearer test-key\"}",
         "port=9090"
     };
     json cli_updates = parse_cli_args(cli_args);
     check(cli_updates["port"] == 9090, "CLI parses top-level key");
     check(cli_updates["telemetry"]["otlp"]["endpoint"] == "http://127.0.0.1:5555/v1/traces", "CLI parses 3-level dotted path endpoint");
     check(cli_updates["telemetry"]["otlp"]["protocol"] == "http/json", "CLI parses 3-level dotted path protocol");
+    check(cli_updates["telemetry"]["otlp"]["semantics"].is_array(), "CLI parses JSON array for semantics");
+    check(cli_updates["telemetry"]["otlp"]["semantics"][0] == "openinference", "CLI parsed array value matches");
+    check(cli_updates["telemetry"]["otlp"]["headers"].is_object(), "CLI parses JSON object for headers");
+    check(cli_updates["telemetry"]["otlp"]["headers"]["Authorization"] == "Bearer test-key", "CLI parsed object field matches");
 
     std::printf("================================================\n");
     if (failures > 0) {

--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -681,6 +681,7 @@ sys.exit(0)
                 "set",
                 "telemetry.otlp.endpoint=http://127.0.0.1:4444/v1/traces",
                 "telemetry.otlp.protocol=http/json",
+                'telemetry.otlp.semantics=["openinference"]',
             ]
         )
         print(f"Config set output: {result.stdout}")
@@ -697,6 +698,7 @@ sys.exit(0)
             telemetry.get("otlp", {}).get("endpoint"), "http://127.0.0.1:4444/v1/traces"
         )
         self.assertEqual(telemetry.get("otlp", {}).get("protocol"), "http/json")
+        self.assertEqual(telemetry.get("otlp", {}).get("semantics"), ["openinference"])
 
     # =============================================================================
     # Pull Tests


### PR DESCRIPTION
This PR fixes a bug in the `lemonade config set` CLI command parser. When users attempted to set options that require JSON arrays or objects (such as `telemetry.otlp.semantics` or `telemetry.otlp.headers`), the CLI parser treated the values as raw strings (e.g. `"[\"openinference\"]"`), causing the backend configuration validator to reject them.

### Changes
- **CLI Parser (`src/cpp/cli/main.cpp`)**: Updated `parse_typed_value` to check if a value starts with `[` or `{` and attempt to parse it as valid JSON first. If parsing succeeds, it preserves the JSON structure.
- **Unit Tests (`test/cpp/test_config_telemetry.cpp`)**: Aligned the test CLI parser logic and added assertions to verify JSON array and object parsing.
- **Integration Tests (`test/server_cli2.py`)**: Added telemetry.otlp.semantics config-setting integration verification.
- **Documentation (`docs/`)**: Updated guides to explain JSON option syntax and recommended single-quoting CLI args to prevent shell character expansions.
