### PR TITLE
docs(telemetry): improve telemetry and arize phoenix setup guide

### DIFF
--- a/docs/guide/telemetry.md
+++ b/docs/guide/telemetry.md
@@ -20,112 +20,15 @@ graph TD
 Lemonade supports two co-existing trace formats:
 
 1. **OpenInference (`openinference.*`)**:
-   - A mature convention designed specifically for LLM and agentic application tracing.
+   - A convention designed specifically for LLM and agentic application tracing.
    - Deeply integrated into AI evaluation suites (e.g., **Arize Phoenix**, **Langfuse**).
-   - Captures rich LLM attributes (such as `llm.token_count.prompt`, `llm.token_count.completion`, and raw inputs/outputs/thinking).
+   - Captures rich LLM attributes (such as token counts, prompt inputs, completion outputs, and raw thinking blocks).
 2. **OpenTelemetry GenAI (`gen_ai.*`)**:
    - The official, vendor-neutral standard defined by the OpenTelemetry community.
    - Supported by mainstream APM backends (e.g., **Honeycomb**, **Datadog**, **Grafana**).
-   - Captures standardized attributes (such as `gen_ai.system`, `gen_ai.request.model`, and `gen_ai.usage.input_tokens`).
+   - Captures standardized attributes (such as system type, request model, and input/output token usage).
 
-Users can specify one or both formats. When both are enabled, Lemonade packs attributes for both conventions into a **single pass** and exports them in a **single network payload** to eliminate network overhead.
-
----
-
-## Distributed Tracing (W3C Trace Context)
-
-By default, each inference request starts its own root trace. When a caller is itself an instrumented application (e.g. a multi-agent orchestrator), you can have Lemonade's spans join the caller's trace instead, so an entire multi-step workflow appears as one connected tree.
-
-Set `telemetry.trust_incoming_trace_context=true` to opt in. Lemonade then reads the standard [W3C `traceparent`](https://www.w3.org/TR/trace-context/) header on incoming requests: the request's span adopts the header's trace id and is parented to the header's span id. Requests without a valid `traceparent`, or received while the setting is `false`, keep the default root-span behavior.
-
-```bash
-lemonade config set telemetry.enabled=true \
-                    telemetry.trust_incoming_trace_context=true
-```
-
-The caller supplies the header on each request, for example:
-
-```bash
-curl http://localhost:13305/api/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -H "traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" \
-  -d '{"model": "...", "messages": [{"role": "user", "content": "Hello"}]}'
-```
-
-The setting is opt-in because it makes span parentage depend on client-supplied input; leave it disabled unless you trust the callers on your network.
-
----
-
-## Configuration
-
-Telemetry is configured under the `telemetry` block in your `config.json` or managed dynamically via the Lemonade CLI/API.
-
-### Settings Reference
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `telemetry.enabled` | boolean | `false` | Set to `true` to enable tracing. |
-| `telemetry.hide_inputs` | boolean | `false` | Redacts raw prompt inputs from trace attributes to protect privacy. |
-| `telemetry.hide_outputs` | boolean | `false` | Redacts assistant output text from trace attributes. |
-| `telemetry.hide_thinking` | boolean | `false` | Redacts internal reasoning/thinking blocks from trace attributes. |
-| `telemetry.trust_incoming_trace_context` | boolean | `false` | When `true`, honor a caller-supplied W3C `traceparent` header so inference spans join the caller's distributed trace. See [Distributed Tracing](#distributed-tracing-w3c-trace-context). |
-| `telemetry.max_queue_capacity` | int | `1000` | Target memory buffer capacity for queued spans. When exceeded, the oldest spans are evicted first (FIFO). |
-| `telemetry.otlp.endpoint` | string | `"http://localhost:4318/v1/traces"` | OTLP HTTP receiver endpoint URL. |
-| `telemetry.otlp.protocol` | string | `"http/protobuf"` | Encoding protocol: `"http/protobuf"` or `"http/json"`. |
-| `telemetry.otlp.semantics` | array | `["openinference", "otel_genai"]` | Enabled conventions. Supported: `"openinference"`, `"otel_genai"`. |
-| `telemetry.otlp.headers` | object | `{}` | Key-value pairs for HTTP request headers (e.g., authorization API keys). |
-| `telemetry.otlp.max_retries` | int | `0` | Max export retry attempts for transient server errors. Set to `0` to disable retries. |
-| `telemetry.otlp.retry_backoff_base_s` | double | `5.0` | Base exponential backoff delay in seconds. |
-| `telemetry.otlp.send_batch_size` | int | `100` | Target span batch size to dispatch in a single HTTP request. |
-| `telemetry.otlp.batch_timeout_s` | double | `1.0` | Max buffer timeout in seconds before exporting a partial batch. |
-
----
-
-## Dynamic Control via CLI & API
-
-You can toggle telemetry dynamically while the server is running without restarting.
-
-### Via Lemonade CLI
-
-```bash
-# Enable telemetry
-lemonade telemetry on
-
-# Disable telemetry
-lemonade telemetry off
-
-# View current configuration
-lemonade config
-```
-
-> [!NOTE]
-> When configuring options that require JSON arrays (such as `telemetry.otlp.semantics`) or JSON objects (such as `telemetry.otlp.headers`) via the CLI, wrap the values in single quotes (e.g. `'["openinference"]'`) so your shell does not interpret or expand the bracket `[]` or brace `{}` characters.
-
-### Via Configuration API
-
-Internal configuration is updated via the `/internal/set` endpoint:
-
-```bash
-# Enable telemetry and select only OpenTelemetry GenAI semantics
-curl -X POST http://localhost:13305/internal/set \
-  -H "Content-Type: application/json" \
-  -d '{
-    "telemetry": {
-      "enabled": true,
-      "otlp": {
-        "semantics": ["otel_genai"]
-      }
-    }
-  }'
-```
-
-### Forcing a Flush
-
-Spans are buffered in memory to optimize networking. You can force-flush the telemetry queue at any time:
-
-```bash
-curl -X POST http://localhost:13305/internal/telemetry/flush
-```
+You can enable one or both formats. When both are enabled, Lemonade packs attributes for both conventions into a **single pass** and exports them in a **single network payload** to eliminate network overhead.
 
 ---
 
@@ -133,31 +36,111 @@ curl -X POST http://localhost:13305/internal/telemetry/flush
 
 ### 1. Local LLM Observability with Arize Phoenix
 
-[Arize Phoenix](https://phoenix.arize.com/) is an open-source AI observability platform that runs locally. It consumes the `openinference` format.
+[Arize Phoenix](https://phoenix.arize.com/) is an open-source AI observability platform that runs locally. It allows you to visualize and evaluate your LLM inputs, outputs, latencies, and token counts.
 
-#### Quick Start with Podman
+Follow these step-by-step instructions to set up Arize Phoenix and connect it to Lemonade.
 
-To run Arize Phoenix in the foreground (interactive mode, automatically removed on exit):
+#### Step 1: Start Arize Phoenix
+
+You can run Arize Phoenix using either **Docker** or **Podman**. Choose one of the commands below to launch the container in the background (detached mode):
+
+**Using Docker:**
 ```bash
-podman run --rm -it --name phoenix \
-  -p 6006:6006 -p 4317:4317 -p 4318:4318 \
-  docker.io/arizeai/phoenix:latest
+docker run -d --name phoenix \
+  -p 6006:6006 -p 4317:4317 \
+  docker.io/arizephoenix/phoenix:latest
 ```
 
-Alternatively, to run it in the background (detached mode):
+**Using Podman:**
 ```bash
 podman run -d --name phoenix \
-  -p 6006:6006 -p 4317:4317 -p 4318:4318 \
-  docker.io/arizeai/phoenix:latest
+  -p 6006:6006 -p 4317:4317 \
+  docker.io/arizephoenix/phoenix:latest
 ```
 
-Once running, configure Lemonade to point to the local Phoenix OTLP endpoint:
+> [!NOTE]
+> **Understanding Port Mappings:**
+> * **Port `6006`**: Serves the Web UI and acts as the OTLP/HTTP traces ingestion endpoint (accepting HTTP protobuf payloads at `/v1/traces`).
+> * **Port `4317`**: Used for gRPC OTLP ingestion. This port expects HTTP/2 traffic and will fail with protocol errors if standard HTTP/1.1 requests are sent to it.
+> * **Port `4318`**: This is the standard OTel default port for HTTP ingest in other systems, but **Arize Phoenix does not use it**. Ensure your endpoint points to port `6006`.
+
+#### Step 2: Verify Arize Phoenix is Ready
+
+Since the container is launched in the background (detached mode), you must verify that the service is running before testing.
+
+* **Via Browser**: Open your web browser and navigate to [http://localhost:6006](http://localhost:6006). Verify that the Arize Phoenix user interface loads successfully.
+* **Via CLI**: Run the following loop in your terminal to block until the `/readyz` readiness endpoint returns success:
+  ```bash
+  until curl -fsS http://localhost:6006/readyz > /dev/null; do
+    sleep 1
+  done
+  ```
+
+#### Step 3: Configure Lemonade Telemetry
+
+With Arize Phoenix running, configure Lemonade to send traces to the local Phoenix endpoint. You can configure this using the CLI or by modifying your configuration file directly.
+
+##### Option A: Configuration via Lemonade CLI (Recommended)
+Run the following command to enable telemetry, set the endpoint, configure the OTLP protocol format, choose the `openinference` semantics, and set an optional project-routing header:
 ```bash
 lemonade config set telemetry.enabled=true \
-                    telemetry.otlp.endpoint=http://localhost:4318/v1/traces \
-                    telemetry.otlp.semantics='["openinference"]'
+                    telemetry.otlp.endpoint=http://localhost:6006/v1/traces \
+                    telemetry.otlp.protocol=http/protobuf \
+                    telemetry.otlp.semantics='["openinference"]' \
+                    telemetry.otlp.headers='{"x-project-name":"lemonade"}'
 ```
-Navigate to `http://localhost:6006` in your browser to inspect trace flows.
+
+##### Option B: Configuration via `config.json`
+Alternatively, edit the `telemetry` block in your `config.json` file inside the Lemonade cache directory.
+
+> [!IMPORTANT]
+> Manually modifying `config.json` requires a restart of the Lemonade server to apply the changes. See the [Configuration Guide](./configuration/README.md#configjson) to find the location of the `config.json` file on your operating system.
+
+```json
+{
+  "telemetry": {
+    "enabled": true,
+    "otlp": {
+      "endpoint": "http://localhost:6006/v1/traces",
+      "protocol": "http/protobuf",
+      "semantics": ["openinference"],
+      "headers": {
+        "x-project-name": "lemonade"
+      }
+    }
+  }
+}
+```
+
+#### Step 4: Send a Test Request
+
+To verify that telemetry is working correctly, send a test chat completion request to your running Lemonade server:
+
+```bash
+curl http://localhost:13305/api/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "your-model-name",
+    "messages": [
+      {"role": "user", "content": "Hello, Lemonade! This is a test request for telemetry."}
+    ]
+  }'
+```
+
+#### Step 5: Flush Traces Immediately (Optional)
+
+To optimize network performance, Lemonade buffers traces in memory and flushes them periodically. If you want to see your test request in the UI immediately without waiting, send a manual flush command:
+
+```bash
+curl -X POST http://localhost:13305/internal/telemetry/flush
+```
+
+#### Step 6: View Traces in the UI
+
+1. Open your web browser and navigate to: [http://localhost:6006](http://localhost:6006).
+2. Click on the **Projects** tab.
+3. Select the project name you configured (e.g., `lemonade`).
+4. You should see your test request listed with detailed metrics showing prompt tokens, response tokens, latency, and execution parameters.
 
 ---
 
@@ -178,17 +161,131 @@ lemonade config set telemetry.enabled=true \
 
 ---
 
-## Privacy & Redaction
+## Configuration Settings Reference
 
-By default, Lemonade captures prompts, completions, and reasoning content in span attributes to allow full evaluation and debugging.
+Telemetry settings are configured under the `telemetry` block in your `config.json` file, or managed dynamically via the Lemonade CLI/API.
 
-If you are running in a privacy-sensitive environment, redact this content from outgoing telemetry payloads:
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `telemetry.enabled` | boolean | `false` | Enables or disables telemetry tracing. |
+| `telemetry.hide_inputs` | boolean | `false` | Redacts raw prompt inputs from trace attributes to protect user privacy. |
+| `telemetry.hide_outputs` | boolean | `false` | Redacts assistant output text from trace attributes. |
+| `telemetry.hide_thinking` | boolean | `false` | Redacts internal reasoning/thinking blocks from trace attributes. |
+| `telemetry.trust_incoming_trace_context` | boolean | `false` | When `true`, honors caller-supplied W3C `traceparent` headers to link inference spans to the caller's distributed trace. |
+| `telemetry.max_queue_capacity` | int | `1000` | Target memory buffer capacity for queued spans. When full, oldest spans are evicted first (FIFO). |
+| `telemetry.max_attribute_length` | int | `4096` | Maximum allowed length in bytes for trace span attributes (e.g. prompt text, completion text). Longer attributes are truncated to this limit. |
+| `telemetry.otlp.endpoint` | string | `"http://localhost:4318/v1/traces"` | The OTLP HTTP receiver endpoint URL. |
+| `telemetry.otlp.protocol` | string | `"http/protobuf"` | The encoding protocol: `"http/protobuf"` or `"http/json"`. |
+| `telemetry.otlp.semantics` | array | `["openinference", "otel_genai"]` | Enabled trace conventions. Supported: `"openinference"`, `"otel_genai"`. |
+| `telemetry.otlp.headers` | object | `{}` | Custom HTTP headers sent with trace exports (e.g., API keys, project names). |
+| `telemetry.otlp.max_retries` | int | `0` | Maximum export retry attempts for transient server errors (0 to disable retries). |
+| `telemetry.otlp.retry_backoff_base_s` | double | `5.0` | Base exponential backoff delay in seconds for retries. |
+| `telemetry.otlp.send_batch_size` | int | `100` | Target number of spans to dispatch in a single HTTP request batch. |
+| `telemetry.otlp.batch_timeout_s` | double | `1.0` | Maximum buffer timeout in seconds before exporting a partial batch. |
+
+---
+
+## Dynamic Control via CLI & API
+
+You can toggle telemetry and modify settings dynamically while the server is running without restarting.
+
+### Via Lemonade CLI
+
+Use the Lemonade CLI configuration commands to update settings on the fly:
 
 ```bash
-# Redact inputs, outputs, and reasoning steps
+# Enable telemetry
+lemonade telemetry on
+
+# Disable telemetry
+lemonade telemetry off
+
+# View current configuration
+lemonade config
+
+# Configure telemetry options
+lemonade config set telemetry.enabled=true
+lemonade config set telemetry.otlp.semantics='["openinference"]'
+lemonade config set telemetry.otlp.headers='{"x-project-name":"lemonade"}'
+```
+
+> [!NOTE]
+> When configuring options that require JSON arrays (such as `telemetry.otlp.semantics`) or JSON objects (such as `telemetry.otlp.headers`) via the CLI, wrap the values in single quotes (e.g. `'["openinference"]'`) so your shell does not interpret or expand the bracket `[]` or brace `{}` characters.
+
+### Via Configuration API
+
+You can update the internal configuration by sending a POST request to the `/internal/set` endpoint:
+
+```bash
+# Enable telemetry and select only OpenTelemetry GenAI semantics
+curl -X POST http://localhost:13305/internal/set \
+  -H "Content-Type: application/json" \
+  -d '{
+    "telemetry": {
+      "enabled": true,
+      "otlp": {
+        "semantics": ["otel_genai"]
+      }
+    }
+  }'
+```
+
+### Forcing a Flush
+
+Because spans are buffered in memory to optimize networking, you can force-flush the telemetry queue at any time to export queued traces immediately:
+
+```bash
+curl -X POST http://localhost:13305/internal/telemetry/flush
+```
+
+---
+
+## Distributed Tracing (W3C Trace Context)
+
+By default, each inference request starts its own root trace. If your calling application is already instrumented (for example, a multi-agent orchestrator or a backend service), you can configure Lemonade to join the caller's trace. This links the entire multi-step workflow into a single trace tree.
+
+To opt in, set `telemetry.trust_incoming_trace_context` to `true`. When enabled, Lemonade looks for a standard [W3C `traceparent`](https://www.w3.org/TR/trace-context/) header on incoming HTTP requests. The inference request span will adopt the trace ID and parent span ID from that header.
+
+If the header is missing, invalid, or the setting is disabled, Lemonade defaults to creating a new root span.
+
+```bash
+# Enable distributed tracing via CLI
+lemonade config set telemetry.enabled=true \
+                    telemetry.trust_incoming_trace_context=true
+```
+
+### Example Request with Trace Parent
+
+Here is how an instrumented caller supplies the `traceparent` header to Lemonade:
+
+```bash
+curl http://localhost:13305/api/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" \
+  -d '{
+    "model": "your-model-name",
+    "messages": [
+      {"role": "user", "content": "Hello, Lemonade!"}
+    ]
+  }'
+```
+
+> [!WARNING]
+> Only enable `telemetry.trust_incoming_trace_context` if you trust the callers on your network. Enabling this setting allows client-supplied headers to modify the structure of your trace parentage.
+
+---
+
+## Privacy & Redaction
+
+By default, Lemonade captures prompts, completions, and internal reasoning/thinking steps in trace span attributes to allow full evaluation and debugging.
+
+If you are running in a privacy-sensitive or production environment, you can redact these textual payloads from outgoing telemetry data:
+
+```bash
+# Redact inputs, outputs, and thinking steps
 lemonade config set telemetry.hide_inputs=true \
                     telemetry.hide_outputs=true \
                     telemetry.hide_thinking=true
 ```
 
-When redacted, metadata (tokens, latency, model names, status codes) is still reported, but the actual text payloads are replaced with empty values.
+When redacted, metadata such as token counts, latency, model names, and HTTP status codes are still exported, but the actual text content is replaced with `[REDACTED]` values.


### PR DESCRIPTION
This PR improves the telemetry and tracing documentation, specifically updating the Arize Phoenix local observability integration guide to make it bulletproof and easy to follow for non-experts.

### Context and Rationale
- **Container Registry Update**: Corrected the Arize Phoenix container pull/run instructions to pull the official `docker.io/arizephoenix/phoenix:latest` image name (using container name `phoenix`).
- **Port Mapping Clarification**: Detailed the exact purpose of each port (`6006` for HTTP ingest and Web UI, `4317` for gRPC OTLP, and noted that standard OTel port `4318` is unused by Phoenix) to prevent protocol mismatch errors.
- **Mandatory Project Header**: Added the mandatory `x-project-name` routing header to all local Phoenix connection string examples.
- **Improved Setup Flow**: Reordered the sections so the local step-by-step integration guide starts directly after the concepts introduction, ensuring a seamless user quickstart.
- **JSON Configuration Snippet**: Added a minimal `config.json` telemetry configuration snippet as a manual file-editing alternative to the CLI commands.

> [!IMPORTANT]
> The documented CLI configuration commands (such as setting JSON arrays and objects) presuppose that the parser updates from **PR #2816** (`fix(cli): parse configuration values as JSON arrays and objects`) are merged.
