### PR TITLE
Fix Whisper realtime test isolation and stale session work

### DIFF
--- a/src/cpp/include/lemon/realtime_session.h
+++ b/src/cpp/include/lemon/realtime_session.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <future>
 #include <atomic>
+#include <cstdint>
 #include <nlohmann/json.hpp>
 #include "streaming_audio_buffer.h"
 #include "vad.h"
@@ -50,6 +51,10 @@ struct RealtimeSession {
     // Interim transcription state
     int64_t last_interim_transcription_ms = 0;  // When we last fired an interim transcription
     std::atomic<bool> interim_in_flight{false};  // Guard against overlapping interim requests
+    std::atomic<std::uint64_t> interim_generation{0}; // Invalidates stale queued interim requests
+    // Serializes all Whisper calls for this session. A final transcription
+    // invalidates queued interim work before it can reach the backend.
+    std::mutex transcription_mutex;
 
     // Streaming backend connection (used when backend supports IStreamingTranscriptionServer).
     // streaming_mutex guards streaming_client against concurrent forward/disconnect.
@@ -157,7 +162,8 @@ private:
     // When is_interim is true the result is sent as a delta event.
     void transcribe_wav(std::shared_ptr<RealtimeSession> session,
                         std::vector<uint8_t> wav_data, std::string model,
-                        bool is_interim = false);
+                        bool is_interim = false,
+                        std::uint64_t interim_generation = 0);
 
     // Process VAD for a session
     void process_vad(std::shared_ptr<RealtimeSession> session);

--- a/src/cpp/server/realtime_session.cpp
+++ b/src/cpp/server/realtime_session.cpp
@@ -1,5 +1,6 @@
 #include "lemon/realtime_session.h"
 #include "lemon/router.h"
+#include <algorithm>
 #include <random>
 #include <chrono>
 #include <iostream>
@@ -59,6 +60,7 @@ void RealtimeSessionManager::apply_turn_detection_config(
         session->vad.reset();
         session->vad_speech_window_open = false;
         session->last_interim_transcription_ms = 0;
+        session->interim_generation.fetch_add(1, std::memory_order_relaxed);
         return;
     }
 
@@ -298,13 +300,20 @@ void RealtimeSessionManager::transcribe_interim(std::shared_ptr<RealtimeSession>
     auto wav_data = session->audio_buffer.get_wav_padded(500);
     std::string model = session->model;
     session->last_interim_transcription_ms = session->audio_buffer.duration_ms();
+    const std::uint64_t generation =
+        session->interim_generation.load(std::memory_order_relaxed);
 
     LOG(DEBUG, "RealtimeSession") << "Firing interim transcription at "
               << session->last_interim_transcription_ms << "ms" << std::endl;
 
     auto future = std::async(std::launch::async,
-        [this, session, wav_data = std::move(wav_data), model = std::move(model)]() {
-            transcribe_wav(session, wav_data, model, /*is_interim=*/true);
+        [this, session, wav_data = std::move(wav_data), model = std::move(model), generation]() {
+            transcribe_wav(
+                session,
+                wav_data,
+                model,
+                /*is_interim=*/true,
+                generation);
             session->interim_in_flight.store(false);
         });
 
@@ -342,6 +351,7 @@ void RealtimeSessionManager::commit_audio(const std::string& session_id) {
         session->audio_buffer.clear();
         session->vad.reset();
         session->last_interim_transcription_ms = 0;
+        session->interim_generation.fetch_add(1, std::memory_order_relaxed);
 
         if (session->send_message) {
             json msg = {
@@ -386,6 +396,8 @@ void RealtimeSessionManager::clear_audio(const std::string& session_id) {
     session->audio_buffer.clear();
     session->vad.reset();
     session->vad_speech_window_open = false;
+    session->last_interim_transcription_ms = 0;
+    session->interim_generation.fetch_add(1, std::memory_order_relaxed);
 
     if (session->send_message) {
         json msg = {
@@ -407,6 +419,8 @@ void RealtimeSessionManager::transcribe_and_send(std::shared_ptr<RealtimeSession
     session->vad.reset();
     session->vad_speech_window_open = false;
     session->last_interim_transcription_ms = 0;  // Reset for next utterance
+    // A final result supersedes any interim jobs that have not started yet.
+    session->interim_generation.fetch_add(1, std::memory_order_relaxed);
 
     // Dispatch transcription to worker thread so it doesn't block the WebSocket callback
     auto future = std::async(std::launch::async,
@@ -432,8 +446,25 @@ void RealtimeSessionManager::transcribe_and_send(std::shared_ptr<RealtimeSession
 void RealtimeSessionManager::transcribe_wav(
     std::shared_ptr<RealtimeSession> session,
     std::vector<uint8_t> wav_data, std::string model,
-    bool is_interim) {
+    bool is_interim,
+    std::uint64_t interim_generation) {
     try {
+        const char* tag = is_interim ? "interim" : "final";
+        std::unique_lock<std::mutex> transcription_lock(session->transcription_mutex);
+
+        if (!session->session_active.load()) {
+            LOG(DEBUG, "RealtimeSession") << "Skipping " << tag
+                      << " transcription for closed session" << std::endl;
+            return;
+        }
+
+        if (is_interim &&
+            session->interim_generation.load(std::memory_order_relaxed) != interim_generation) {
+            LOG(DEBUG, "RealtimeSession") << "Skipping stale interim transcription"
+                      << std::endl;
+            return;
+        }
+
         // Convert WAV bytes to a string for the router (expects file_data as string)
         std::string file_data(reinterpret_cast<const char*>(wav_data.data()), wav_data.size());
 
@@ -445,18 +476,44 @@ void RealtimeSessionManager::transcribe_wav(
         };
 
         // Call router for transcription
-        const char* tag = is_interim ? "interim" : "final";
         LOG(DEBUG, "RealtimeSession") << "Calling Whisper " << tag << " transcription ("
                   << wav_data.size() << " bytes)..." << std::endl;
         json response = router_->audio_transcriptions(request);
+
+        // Drop stale result (including stale errors) instead of publishing it.
+        if (is_interim &&
+            session->interim_generation.load(std::memory_order_relaxed) != interim_generation) {
+            LOG(DEBUG, "RealtimeSession") << "Discarding stale interim transcription result"
+                      << std::endl;
+            return;
+        }
+
         LOG(DEBUG, "RealtimeSession") << "Whisper " << tag << " response: " << response.dump() << std::endl;
+
+        if (response.contains("error")) {
+            const json& error = response["error"];
+            std::string message = "Whisper backend returned an error";
+            if (error.is_object()) {
+                message = error.value("message", message);
+            } else if (error.is_string()) {
+                message = error.get<std::string>();
+            }
+
+            const std::string prefix = "Transcription failed: ";
+            if (message.rfind(prefix, 0) == 0) {
+                message.erase(0, prefix.size());
+            }
+            throw std::runtime_error(message);
+        }
+
+        if (!response.contains("text") || !response["text"].is_string()) {
+            throw std::runtime_error(
+                "Whisper backend response did not contain a string 'text' field");
+        }
 
         // Send transcription result if session is still active
         if (session->send_message && session->session_active.load()) {
-            std::string transcript;
-            if (response.contains("text")) {
-                transcript = response["text"].get<std::string>();
-            }
+            std::string transcript = response["text"].get<std::string>();
 
             LOG(DEBUG, "RealtimeSession") << "Sending " << tag << " transcript to client: \""
                       << transcript << "\"" << std::endl;
@@ -628,6 +685,7 @@ void RealtimeSessionManager::close_session(const std::string& session_id) {
         if (it != sessions_.end()) {
             session = it->second;
             session->session_active = false;
+            session->interim_generation.fetch_add(1, std::memory_order_relaxed);
             sessions_.erase(it);
         }
     }

--- a/test/server_whisper.py
+++ b/test/server_whisper.py
@@ -462,7 +462,7 @@ class WhisperTests(ServerTestBase):
         asyncio.run(self._test_006_realtime_websocket_connect())
 
     async def _test_006_realtime_websocket_connect(self):
-        model = _get_whisper_model()
+        model = self._load_whisper_model_or_fail()
         ws_port = self._get_websocket_port()
         print(f"[INFO] WebSocket port from /health: {ws_port}")
 
@@ -502,7 +502,7 @@ class WhisperTests(ServerTestBase):
         asyncio.run(self._test_007_realtime_websocket_transcription())
 
     async def _test_007_realtime_websocket_transcription(self):
-        model = _get_whisper_model()
+        model = self._load_whisper_model_or_fail()
         chunks = self._get_pcm16_chunks()
 
         client = self._make_openai_client()

--- a/test/server_whisper.py
+++ b/test/server_whisper.py
@@ -512,8 +512,19 @@ class WhisperTests(ServerTestBase):
             event = await asyncio.wait_for(conn.recv(), timeout=10)
             self.assertEqual(event.type, "session.created")
 
-            # Configure model
-            await conn.session.update(session={"model": model})
+            # The shared fixture contains several phrases separated by enough silence
+            # for the default VAD to create multiple final jobs. This test exits after
+            # the first completion, so those jobs used to leak into test_008. Keep the
+            # fixture in one VAD speech window and force exactly one final via commit.
+            await conn.session.update(
+                session={
+                    "model": model,
+                    "turn_detection": {
+                        "type": "server_vad",
+                        "silence_duration_ms": 6000,
+                    },
+                }
+            )
             event = await asyncio.wait_for(conn.recv(), timeout=10)
             self.assertEqual(event.type, "session.updated")
 

--- a/test/server_whisper.py
+++ b/test/server_whisper.py
@@ -102,28 +102,33 @@ class WhisperTests(ServerTestBase):
         """Load the configured Whisper model before positive transcription tests."""
         model = _get_whisper_model()
         whispercpp_backend = _get_whispercpp_backend()
-
-        # Load model with specified backend if provided
+    
+        load_payload = {"model_name": model}
+    
         if whispercpp_backend:
             print(f"[INFO] Loading model with {whispercpp_backend} backend")
-            load_payload = {
-                "model_name": model,
-                "whispercpp_backend": whispercpp_backend,
-            }
-            load_response = requests.post(
-                f"{self.base_url}/load",
-                json=load_payload,
-                timeout=TIMEOUT_MODEL_OPERATION,
-            )
-            self.assertEqual(
-                load_response.status_code,
-                200,
-                (
-                    f"Failed to load model {model} with {whispercpp_backend} "
-                    f"backend: {load_response.text}"
-                ),
-            )
-
+            load_payload["whispercpp_backend"] = whispercpp_backend
+        else:
+            print(f"[INFO] Loading model {model}")
+    
+        load_response = requests.post(
+            f"{self.base_url}/load",
+            json=load_payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+    
+        backend_description = (
+            f" with {whispercpp_backend} backend" if whispercpp_backend else ""
+        )
+        self.assertEqual(
+            load_response.status_code,
+            200,
+            (
+                f"Failed to load model {model}{backend_description}: "
+                f"{load_response.text}"
+            ),
+        )
+    
         return model
 
     def test_001_transcription_basic(self):


### PR DESCRIPTION
## Summary

Fixes a confirmed isolation race in the Whisper realtime integration tests and
prevents stale work from a closed WebSocket session from reaching the backend.

## Observed failure sequence

In both captured macOS failures, test 007 schedules several asynchronous
interim/final Whisper requests from the shared multi-phrase fixture. It later
consumes the first buffered completion and closes the WebSocket while later work
from that session is still pending. Test 008 starts immediately afterward.

The exact reason the following request is reported by libcurl as
`Unsupported protocol` is not proven. The backend already serializes actual
multipart HTTP calls with `inference_mutex_`; this change addresses the proven
session/test isolation defect rather than claiming a libcurl root cause.

Realtime handling also treated a backend `{ "error": ... }` response as a
successful completion with an empty transcript, hiding the real failure.

## Changes

- Configure test 007 with server VAD and a longer silence interval so the shared
  fixture remains one speech window and its explicit commit produces one final
  transcription.
- Serialize interim/final Whisper work within each realtime session.
- Invalidate stale interim work when a final is committed, audio is cleared,
  turn detection is disabled, or the session closes.
- Re-check interim generations after backend execution and discard stale results.
- Skip queued work before backend invocation when its session has closed.
- Convert backend error or malformed responses into realtime `error` events.