### PR TITLE
Add MiniCPM GGUF models to catalog

### DIFF
--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -186,7 +186,7 @@ the generator instead. Prose outside the markers is preserved. -->
 |-------|-----------|--------|
 | `kokoro-v1` | 0.354 | tts |
 
-#### `llamacpp` — Llama.cpp GPU (77 models)
+#### `llamacpp` — Llama.cpp GPU (87 models)
 
 | Model | Size (GB) | Labels |
 |-------|-----------|--------|
@@ -217,6 +217,16 @@ the generator instead. Prose outside the markers is preserved. -->
 | `Llama-3.2-1B-Instruct-GGUF` | 0.834 | — |
 | `Llama-3.2-3B-Instruct-GGUF` | 2.06 | — |
 | `Llama-4-Scout-17B-16E-Instruct-GGUF` | 63.2 | vision |
+| `MiniCPM-V-4-GGUF` | 3.15 | vision |
+| `MiniCPM-V-4.5-GGUF` | 6.12 | vision |
+| `MiniCPM-V-4.6-GGUF` | 1.64 | hot, vision |
+| `MiniCPM-V-4.6-Thinking-GGUF` | 1.64 | reasoning, vision |
+| `MiniCPM-o-2.6-Vision-GGUF` | 5.73 | vision |
+| `MiniCPM-o-4.5-Vision-GGUF` | 6.12 | vision |
+| `MiniCPM3-4B-GGUF` | 2.47 | — |
+| `MiniCPM4-8B-GGUF` | 4.97 | — |
+| `MiniCPM4.1-8B-GGUF` | 4.97 | reasoning |
+| `MiniCPM5-1B-GGUF` | 0.69 | hot, reasoning |
 | `Ministral-3-3B-Instruct-2512-GGUF` | 2.99 | vision |
 | `Nemotron-3-Nano-30B-A3B-GGUF` | 22.8 | — |
 | `Phi-4-mini-instruct-GGUF` | 2.49 | — |

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -536,6 +536,109 @@
         "suggested": true,
         "size": 13.4
     },
+    "MiniCPM5-1B-GGUF": {
+        "source": "modelscope",
+        "checkpoint": "OpenBMB/MiniCPM5-1B-GGUF:MiniCPM5-1B-Q4_K_M.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "hot",
+            "reasoning"
+        ],
+        "size": 0.69
+    },
+    "MiniCPM4.1-8B-GGUF": {
+        "source": "modelscope",
+        "checkpoint": "OpenBMB/MiniCPM4.1-8B-GGUF:MiniCPM4.1-8B-Q4_K_M.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "reasoning"
+        ],
+        "size": 4.97
+    },
+    "MiniCPM4-8B-GGUF": {
+        "source": "modelscope",
+        "checkpoint": "OpenBMB/MiniCPM4-8B-GGUF:MiniCPM4-8B-Q4_K_M.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "size": 4.97
+    },
+    "MiniCPM3-4B-GGUF": {
+        "source": "modelscope",
+        "checkpoint": "OpenBMB/MiniCPM3-4B-GGUF:minicpm3-4b-q4_k_m.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "size": 2.47
+    },
+    "MiniCPM-V-4.6-GGUF": {
+        "source": "modelscope",
+        "checkpoint": "OpenBMB/MiniCPM-V-4.6-gguf:MiniCPM-V-4_6-Q4_K_M.gguf",
+        "mmproj": "mmproj-model-f16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "hot",
+            "vision"
+        ],
+        "size": 1.64
+    },
+    "MiniCPM-V-4.6-Thinking-GGUF": {
+        "source": "modelscope",
+        "checkpoint": "OpenBMB/MiniCPM-V-4.6-Thinking-gguf:MiniCPM-V-4_6-Thinking-Q4_K_M.gguf",
+        "mmproj": "mmproj-model-f16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "reasoning",
+            "vision"
+        ],
+        "size": 1.64
+    },
+    "MiniCPM-V-4.5-GGUF": {
+        "source": "modelscope",
+        "checkpoint": "OpenBMB/MiniCPM-V-4_5-gguf:MiniCPM-V-4_5-Q4_K_M.gguf",
+        "mmproj": "mmproj-model-f16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "vision"
+        ],
+        "size": 6.12
+    },
+    "MiniCPM-V-4-GGUF": {
+        "source": "modelscope",
+        "checkpoint": "OpenBMB/MiniCPM-V-4-gguf:ggml-model-Q4_K_M.gguf",
+        "mmproj": "mmproj-model-f16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "vision"
+        ],
+        "size": 3.15
+    },
+    "MiniCPM-o-4.5-Vision-GGUF": {
+        "source": "modelscope",
+        "checkpoint": "OpenBMB/MiniCPM-o-4_5-gguf:MiniCPM-o-4_5-Q4_K_M.gguf",
+        "mmproj": "vision/MiniCPM-o-4_5-vision-F16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "vision"
+        ],
+        "size": 6.12
+    },
+    "MiniCPM-o-2.6-Vision-GGUF": {
+        "source": "modelscope",
+        "checkpoint": "OpenBMB/MiniCPM-o-2_6-gguf:Model-7.6B-Q4_K_M.gguf",
+        "mmproj": "mmproj-model-f16.gguf",
+        "recipe": "llamacpp",
+        "suggested": true,
+        "labels": [
+            "vision"
+        ],
+        "size": 5.73
+    },
     "Qwen3-0.6B-GGUF": {
         "checkpoint": "unsloth/Qwen3-0.6B-GGUF:Q4_0",
         "recipe": "llamacpp",


### PR DESCRIPTION
## Summary

Add 10 MiniCPM GGUF models from ModelScope to Lemonade's built-in llama.cpp catalog.

The entries cover:

- Text: MiniCPM3, MiniCPM4, MiniCPM4.1, and MiniCPM5
- Vision: MiniCPM-V 4, 4.5, 4.6, 4.6 Thinking, MiniCPM-o 2.6, and MiniCPM-o 4.5

All entries reuse the existing `llamacpp` recipe and ModelScope registry support. This change only updates the model catalog and generated backend reference; no backend or core registry code is changed.

MiniCPM-o entries intentionally expose the vision path only. Audio and full-duplex support are out of scope for this catalog change.

## Validation

- Verified all ModelScope repository and GGUF/mmproj paths.
- Confirmed all 10 entries use `source: modelscope`.
- Confirmed the generated llama.cpp catalog count changes from 77 to 87.
- Validated JSON parsing and registry field constraints.
- Ran `git diff --check`.