### PR TITLE
fix(installer): handle slow tarball listings

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -309,8 +309,9 @@ jobs:
           cmake --build --preset default --target test_origin_utils
           cmake --build --preset default --target test_model_residency
           cmake --build --preset default --target test_custom_args
+          cmake --build --preset default --target test_archive_platform
           cd build
-          ctest --output-on-failure -R "ProcessManagerTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|RoutingConformanceCorpusTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest|ModelResidencyTest|CustomArgsTest"
+          ctest --output-on-failure -R "ProcessManagerTest|ArchivePlatformTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|RoutingConformanceCorpusTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest|ModelResidencyTest|CustomArgsTest"
 
       - name: Upload .deb package
         uses: actions/upload-artifact@v7
@@ -627,8 +628,9 @@ jobs:
           cmake --build --preset default --target test_origin_utils
           cmake --build --preset default --target test_model_residency
           cmake --build --preset default --target test_custom_args
+          cmake --build --preset default --target test_archive_platform
           cd build
-          ctest --output-on-failure -R "DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|RoutingConformanceCorpusTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest|ModelResidencyTest|CustomArgsTest"
+          ctest --output-on-failure -R "ArchivePlatformTest|DirectoryWatcher|LatestVersionFallback|RoutingPolicy(Contract|Evaluator|Registry|Semantic|LlmRouter|Deterministic|Engine|Parser|Store)Test|ModelManagerCollectionValidationTest|RoutingClassifierServicesTest|RoutingConformanceCorpusTest|NetworkUtilsTest|mcp_client_config|JobExprTest|JobGraphTest|OriginUtilsTest|ModelResidencyTest|CustomArgsTest"
 
       - name: Upload .pkg package
         if: steps.check_signing.outputs.has_signing == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1858,6 +1858,19 @@ message(STATUS "  Archive: ${EMBEDDABLE_ARCHIVE_NAME}")
 # C++ Unit Tests
 # ============================================================
 
+set(_ARCHIVE_PLATFORM_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_archive_platform.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_ARCHIVE_PLATFORM_TEST_SRC}")
+    add_executable(test_archive_platform
+        test/cpp/test_archive_platform.cpp
+    )
+    target_include_directories(test_archive_platform PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+    )
+    add_test(NAME ArchivePlatformTest COMMAND test_archive_platform)
+endif()
+
 # ProcessManager zombie detection and non-mutating reap contract.
 if(BUILD_TESTING AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(_PROCESS_MANAGER_TEST_SRC

--- a/src/cpp/include/lemon/utils/archive_platform.h
+++ b/src/cpp/include/lemon/utils/archive_platform.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
-#include <memory>
 
 namespace lemon::utils {
+
+inline constexpr int tarball_listing_timeout_seconds = 300;
 
 // Decide the tar --strip-components value from a newline-separated `tar -tf`
 // listing. Strips one level only when every entry lives under a single shared
@@ -50,6 +53,15 @@ inline int compute_tarball_strip_components(const std::string& entries) {
     }
 
     return (all_same_dir && !first_dir.empty() && has_nested) ? 1 : 0;
+}
+
+inline std::optional<int> resolve_tarball_strip_components(
+    int list_result,
+    const std::string& entries) {
+    if (list_result != 0) {
+        return std::nullopt;
+    }
+    return compute_tarball_strip_components(entries);
 }
 
 // Abstract interface for platform-specific archive extraction

--- a/src/cpp/server/utils/platform/archive_unix.cpp
+++ b/src/cpp/server/utils/platform/archive_unix.cpp
@@ -54,23 +54,23 @@ public:
                 return true;
             },
             "",
-            30,
+            tarball_listing_timeout_seconds,
             false
         );
 
-        int strip = 0;
-        if (list_result == 0) {
-            strip = compute_tarball_strip_components(entries);
-            LOG(DEBUG, backend_name) << "Tarball strip-components: " << strip << std::endl;
-        } else {
-            LOG(DEBUG, backend_name) << "Could not list tarball contents, using strip=0" << std::endl;
+        const auto strip = resolve_tarball_strip_components(list_result, entries);
+        if (!strip.has_value()) {
+            LOG(ERROR, backend_name) << "Could not list tarball contents, code: "
+                                     << list_result << std::endl;
+            return false;
         }
+        LOG(DEBUG, backend_name) << "Tarball strip-components: " << *strip << std::endl;
 
         std::string output;
         int result = ProcessManager::run_process_with_output(
             "tar",
             {"-xf", tarball_path, "-C", dest_dir,
-             "--strip-components=" + std::to_string(strip), "--no-same-owner"},
+             "--strip-components=" + std::to_string(*strip), "--no-same-owner"},
             [&output](const std::string& line) {
                 output += line + "\n";
                 return true;

--- a/src/cpp/server/utils/platform/archive_windows.cpp
+++ b/src/cpp/server/utils/platform/archive_windows.cpp
@@ -117,23 +117,23 @@ public:
                 return true;
             },
             "",
-            30,
+            tarball_listing_timeout_seconds,
             false
         );
 
-        int strip = 0;
-        if (list_result == 0) {
-            strip = compute_tarball_strip_components(entries);
-            LOG(DEBUG, backend_name) << "Tarball strip-components: " << strip << std::endl;
-        } else {
-            LOG(DEBUG, backend_name) << "Could not list tarball contents, using strip=0" << std::endl;
+        const auto strip = resolve_tarball_strip_components(list_result, entries);
+        if (!strip.has_value()) {
+            LOG(ERROR, backend_name) << "Could not list tarball contents, code: "
+                                     << list_result << std::endl;
+            return false;
         }
+        LOG(DEBUG, backend_name) << "Tarball strip-components: " << *strip << std::endl;
 
         std::string output;
         int result = ProcessManager::run_process_with_output(
             get_native_tar_path(),
             {"-xf", tarball_path, "-C", dest_dir,
-             "--strip-components=" + std::to_string(strip), "--no-same-owner"},
+             "--strip-components=" + std::to_string(*strip), "--no-same-owner"},
             [&output](const std::string& line) {
                 output += line + "\n";
                 return true;

--- a/test/cpp/test_archive_platform.cpp
+++ b/test/cpp/test_archive_platform.cpp
@@ -1,0 +1,53 @@
+#include "lemon/utils/archive_platform.h"
+
+#include <cstdio>
+#include <optional>
+#include <string>
+
+using lemon::utils::resolve_tarball_strip_components;
+using lemon::utils::tarball_listing_timeout_seconds;
+
+namespace {
+
+int failures = 0;
+
+void check(const char* name, bool condition) {
+    std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", name);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+} // namespace
+
+int main() {
+    check(
+        "tarball listing allows large archives to finish",
+        tarball_listing_timeout_seconds == 300);
+
+    check(
+        "wrapped archive strips one directory",
+        resolve_tarball_strip_components(
+            0,
+            "therock-dist/\n"
+            "therock-dist/bin/rocminfo.exe\n"
+            "therock-dist/lib/amdhip64.lib\n") == std::optional<int>{1});
+
+    check(
+        "root-level archive keeps its layout",
+        resolve_tarball_strip_components(
+            0,
+            "bin/rocminfo\n"
+            "lib/libamdhip64.so\n"
+            "version.txt\n") == std::optional<int>{0});
+
+    check(
+        "failed listing has no safe strip value",
+        !resolve_tarball_strip_components(
+            -1,
+            "therock-dist/\n"
+            "therock-dist/bin/rocminfo.exe\n").has_value());
+
+    std::printf("\n%d failures\n", failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Allow tarball listings up to five minutes for large backend archives.
- Abort extraction when archive listing fails instead of guessing `strip-components`.
- Add regression coverage for wrapped, root-level, and failed archive listings.

Fixes #2823

## Testing

- `cmake --build build --target test_archive_platform -j 6`
- `ctest --test-dir build -R "^ArchivePlatformTest$" --output-on-failure` (1/1 passed)
- `cmake --build build --target lemond -j 6`

Windows TheRock end-to-end validation was not available locally; CI and maintainer Windows validation are requested.

## Screenshots

Not applicable; this is a non-UI installer change.