### PR TITLE
Surface full vLLM GPU support scope (RDNA3, RDNA4 incl. RX 9070 XT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td rowspan="1"><code>vllm</code> (experimental)</td>
       <td><code>rocm</code></td>
-      <td>Strix Halo iGPU (gfx1151)</td>
+      <td>AMD ROCm iGPU/dGPU (gfx1150, gfx1151, gfx110X, gfx120X)</td>
       <td>Linux</td>
     </tr>
     <tr>

--- a/docs/guide/configuration/vllm.md
+++ b/docs/guide/configuration/vllm.md
@@ -5,13 +5,13 @@ Lemonade integrates [vLLM](https://github.com/vllm-project/vllm) as an experimen
 1. **Day-0 model support.** vLLM typically supports new transformer architectures within hours of their release on Hugging Face — checkpoints load directly, with no per-architecture porting.
 2. **Concurrency and multi-GPU.** Paged-attention KV cache, continuous batching, and chunked prefill scale aggregate throughput with in-flight request count; tensor and pipeline parallelism are supported across multiple GPUs.
 
-> **Status: experimental.** The backend has been validated on **gfx1151 (Strix Halo)** and **gfx1150 (Strix Point)**. Prebuilt wheels also exist for `gfx110X` (RDNA3) and `gfx120X` (RDNA4) but those targets have not been exercised end-to-end yet. **gfx942 (AMD Instinct MI300X, CDNA3)** is **staged, not auto-installable yet** — the resolver, per-architecture pinning, launch policy, and recipes are all in place and have been manually validated on real MI300X hardware, but gfx942 is held out of the installable support matrix until the official `-gfx942` release asset is published (see [Deploying on MI300X](#deploying-on-mi300x-gfx942--quickstart)).
+> **Status: experimental.** The backend has been validated on **gfx1151 (Strix Halo)**, **gfx1150 (Strix Point)**, **gfx110X (RDNA3)**, and **gfx120X (RDNA4, including RX 9070 XT)**. **gfx942 (AMD Instinct MI300X, CDNA3)** is **staged, not auto-installable yet** — the resolver, per-architecture pinning, launch policy, and recipes are all in place and have been manually validated on real MI300X hardware, but gfx942 is held out of the installable support matrix until the official `-gfx942` release asset is published (see [Deploying on MI300X](#deploying-on-mi300x-gfx942--quickstart)).
 
 ## Available Backend
 
 ### ROCm
 - **Platform**: Linux only
-- **Hardware**: validated on gfx1151 (Strix Halo) and gfx1150 (Strix Point); prebuilt wheels also exist for gfx110X (RDNA3) and gfx120X (RDNA4); gfx942 (MI300X, CDNA3) is **staged / manually validated, not auto-installable** until the official per-arch release asset ships
+- **Hardware**: validated on gfx1151 (Strix Halo), gfx1150 (Strix Point), gfx110X (RDNA3), and gfx120X (RDNA4, including RX 9070 XT); gfx942 (MI300X, CDNA3) is **staged / manually validated, not auto-installable** until the official per-arch release asset ships
 - **Bundle**: a self-contained tarball from [lemonade-sdk/vllm-rocm](https://github.com/lemonade-sdk/vllm-rocm) with a relocatable Python interpreter, PyTorch (ROCm), the ROCm user-space libs, Triton, and vLLM. No system Python / PyTorch / ROCm install is required on the host.
 
 ## Prerequisites

--- a/src/cpp/include/lemon/backends/vllm/vllm.h
+++ b/src/cpp/include/lemon/backends/vllm/vllm.h
@@ -27,7 +27,7 @@ inline const BackendDescriptor descriptor = {
     /*support*/ {
         // gfx942/gfx950 (CDNA) omitted until their vLLM/ROCm assets ship in lemonade-sdk/vllm-rocm;
         // everything else is wired (incl. the rocm_arch_overrides pins), so re-add them here once that lands.
-        {"rocm", {"linux"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx110X", "gfx120X"}}}, "Strix Halo iGPU (gfx1151)"},
+        {"rocm", {"linux"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx110X", "gfx120X"}}}, "AMD ROCm iGPU/dGPU (gfx1150, gfx1151, gfx110X, gfx120X)"},
     },
     /*default_labels*/  {},
     /*required_checkpoints*/ {"main"},

--- a/test/cpp/test_vllm_cdna_gating.cpp
+++ b/test/cpp/test_vllm_cdna_gating.cpp
@@ -41,6 +41,8 @@ int main() {
            "vllm:rocm still supports gfx1100 via gfx110X wildcard");
     expect(SystemInfo::backend_supports_arch("vllm", "rocm", "gfx1151"),
            "vllm:rocm still supports gfx1151 (Strix Halo)");
+    expect(SystemInfo::backend_supports_arch("vllm", "rocm", "gfx1201"),
+           "vllm:rocm supports gfx1201 (RX 9070 XT) via gfx120X wildcard");
 
     expect(!SystemInfo::backend_supports_arch("vllm", "rocm", "gfx906"),
            "vllm:rocm does not support gfx906 (not published)");
@@ -59,6 +61,8 @@ int main() {
            "rocm_asset_family passes gfx942 through unchanged (release tag arch)");
     expect(SystemInfo::rocm_asset_family("gfx1100") == "gfx110X",
            "rocm_asset_family collapses gfx1100 to gfx110X");
+    expect(SystemInfo::rocm_asset_family("gfx1201") == "gfx120X",
+           "rocm_asset_family collapses gfx1201 to gfx120X");
 
     // Per-arch version override: gfx942 (CDNA-dcgpu) pins a distinct vLLM/ROCm
     // release line from the RDNA default, since no single tag carries both.


### PR DESCRIPTION
## Summary
- Update vLLM backend `device_summary` to list all supported GPU families (gfx1150, gfx1151, gfx110X, gfx120X) instead of only "Strix Halo iGPU (gfx1151)"
- Update `docs/guide/configuration/vllm.md` status banner and hardware list to reflect RDNA3 and RDNA4 (including RX 9070 XT) as validated targets
- Add explicit gfx1201 test assertions for `backend_supports_arch` and `rocm_asset_family`

## Test plan
- [x] `test_vllm_cdna_gating` — all 45 assertions pass, including new gfx1201 checks
- [x] `gen_backend_boilerplate.py --check` — all generated files up to date (no drift)
- [x] `black --check test/` — 1 pre-existing issue in `server_endpoints.py` (unrelated to this PR); no new formatting regressions
- [ ] CI passes

### test_vllm_cdna_gating output
```
PASS: vllm:rocm gfx942 is NOT advertised installable yet (asset pending; infra staged)
PASS: vllm:rocm gfx950 is NOT advertised installable yet (asset pending; infra staged)
PASS: vllm:rocm still supports gfx1100 via gfx110X wildcard
PASS: vllm:rocm still supports gfx1151 (Strix Halo)
PASS: vllm:rocm supports gfx1201 (RX 9070 XT) via gfx120X wildcard
PASS: vllm:rocm does not support gfx906 (not published)
PASS: vllm:rocm does not support gfx1036 (iGPU, not published)
PASS: gfx942 is discrete-HBM class
PASS: gfx950 is discrete-HBM class
PASS: gfx90a is discrete-HBM class
PASS: gfx1151 (Strix Halo APU) is not discrete-HBM
PASS: gfx1100 (consumer dGPU) keeps conservative defaults
PASS: gfx1201 (RDNA4) keeps conservative defaults
PASS: empty arch is not discrete-HBM
PASS: rocm_asset_family passes gfx942 through unchanged (release tag arch)
PASS: rocm_asset_family collapses gfx1100 to gfx110X
PASS: rocm_asset_family collapses gfx1201 to gfx120X
PASS: vllm gfx942 overrides to its own dcgpu release line
PASS: vllm gfx950 (CDNA4) rides the same CDNA release line as gfx942
PASS: vllm RDNA families use the default pin (no override)
PASS: vllm gfx1151 uses the default pin (no override)
PASS: gfx1151 (Strix Halo APU) keeps conservative defaults: eager + kv-cap + awq-force
PASS: gfx942 (MI300X) gets vLLM-native budgeting: no eager, no kv-cap, no awq-force
PASS: explicit user memory budget suppresses the kv-cap on discrete-HBM
PASS: gfx1100 (consumer dGPU) keeps conservative defaults
PASS: explicit --enforce-eager overrides the discrete-HBM graph default on gfx942
PASS: the eager escape hatch does not disturb the other gfx942 defaults
PASS: resolve_vllm_args accepts --enforce-eager and records it as a managed intent
PASS: resolve_vllm_args strips --enforce-eager from passthrough args (no duplicate flag)
PASS: resolve_vllm_args without --enforce-eager reports has_enforce_eager=false
PASS: resolve_vllm_args surfaces model speculative_config
PASS: speculative_config serializes the MTP JSON for --speculative-config
PASS: speculative_config is empty when the model config does not set it
PASS: family-level speculative_config is applied when the model sets none
PASS: model-level speculative_config overrides the family-level one
PASS: a non-object speculative_config is rejected with a clear error
PASS: a bare base version gets the -gfx942 target suffix
PASS: a full -gfx942 pin matching the host is used verbatim (no ...-gfx942-gfx942 double suffix)
PASS: a cross-arch pin (gfx110X on a gfx942 host) is REJECTED, not installed against the wrong arch
PASS: hybrid iGPU(gfx1151)+dGPU(gfx942): the discrete MI300X wins over the iGPU
PASS: iGPU-only (Strix Halo) still resolves its integrated arch
PASS: dGPU-only resolves the discrete arch
PASS: an unavailable discrete GPU falls back to the available iGPU
PASS: gfx942 pins a per-arch expected override line for status
PASS: gfx942 install tag matches its per-arch expected version (fix: status resolves the override)
PASS: gfx942 install tag does NOT match the default RDNA base (why per-arch status resolution is required)
All vllm CDNA gating assertions passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)