### PR TITLE
add support for kvcache reuse

### DIFF
--- a/src/app/src/renderer/components/panels/LLMChatPanel.tsx
+++ b/src/app/src/renderer/components/panels/LLMChatPanel.tsx
@@ -497,6 +497,29 @@ const LLMChatPanel: React.FC<LLMChatPanelProps> = ({
     ...buildChatRequestOverrides(appSettings),
   });
 
+  const handleStartNewChat = async () => {
+    const body: Record<string, string> = { conversation_id: 'default' };
+    if (chatModelName) {
+      body.model = chatModelName;
+    }
+
+    try {
+      const response = await serverFetch('/chat/sessions/reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        const detail = await response.text();
+        console.warn('Chat session reset failed:', response.status, detail);
+      }
+    } catch (error) {
+      console.warn('Chat session reset failed:', error);
+    }
+
+    onNewChat?.();
+  };
+
   /** Build an error message enriched with backend action help text when available. */
   const buildErrorMessage = (error: any): string => {
     const errorMessage = error.message || 'Failed to get response from the model.';
@@ -1263,7 +1286,7 @@ const LLMChatPanel: React.FC<LLMChatPanelProps> = ({
           )}
           <button
             className="new-chat-button"
-            onClick={onNewChat}
+            onClick={handleStartNewChat}
             disabled={isBusy}
             title="Start a new chat"
           >

--- a/src/cpp/include/lemon/backends/amdgpuserver.h
+++ b/src/cpp/include/lemon/backends/amdgpuserver.h
@@ -50,6 +50,7 @@ public:
     json chat_completion(const json& request) override;
     json completion(const json& request) override;
     json responses(const json& request) override;
+    json reset_chat_session(const json& request) override;
 
 private:
     std::string model_name_;

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -107,6 +107,7 @@ public:
     json slots_action(int slot_id, const std::string& action, const json& request_body);
     json tokenize(const json& request);
     json responses(const json& request);
+    json reset_chat_session(const json& request);
 
     json audio_transcriptions(const json& request);
     void audio_speech(const json& request, httplib::DataSink& sink);

--- a/src/cpp/include/lemon/server.h
+++ b/src/cpp/include/lemon/server.h
@@ -103,6 +103,7 @@ private:
     void handle_slots_by_id(const httplib::Request& req, httplib::Response& res);
     void handle_tokenize(const httplib::Request& req, httplib::Response& res);
     void handle_responses(const httplib::Request& req, httplib::Response& res);
+    void handle_chat_session_reset(const httplib::Request& req, httplib::Response& res);
     void handle_pull(const httplib::Request& req, httplib::Response& res);
     void handle_pull_variants(const httplib::Request& req, httplib::Response& res);
     void handle_load(const httplib::Request& req, httplib::Response& res);

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -312,6 +312,9 @@ public:
     virtual json completion(const json& request) override = 0;
     virtual json responses(const json& request) = 0;
 
+    // Reset multi-turn KV cache on backends that support session reuse (e.g. OGA).
+    virtual json reset_chat_session(const json& request);
+
     // Forward streaming requests to the wrapped server (public for Router access)
     // Virtual so backends can transform request (e.g., FLM needs checkpoint in model field)
     using TelemetryCallback = std::function<void(int input_tokens,

--- a/src/cpp/server/backends/amdgpuserver.cpp
+++ b/src/cpp/server/backends/amdgpuserver.cpp
@@ -165,4 +165,11 @@ json AMDGPUServer::responses(const json& request) {
     return forward_request("/v1/responses", request);
 }
 
+json AMDGPUServer::reset_chat_session(const json& request) {
+    if (!is_loaded_) {
+        throw ModelNotLoadedException("AMDGPU-Server");
+    }
+    return forward_request("/v1/sessions/reset", request);
+}
+
 } // namespace lemon

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -1185,6 +1185,50 @@ json Router::responses(const json& request) {
     });
 }
 
+json Router::reset_chat_session(const json& request) {
+    std::string requested_model;
+    if (request.contains("model") && request["model"].is_string()) {
+        requested_model = request["model"].get<std::string>();
+    } else if (request.contains("model_name") && request["model_name"].is_string()) {
+        requested_model = request["model_name"].get<std::string>();
+    }
+
+    WrappedServer* server = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(load_mutex_);
+        if (!requested_model.empty()) {
+            server = find_server_by_model_name(resolve_model_name(requested_model));
+        } else {
+            for (const auto& loaded : loaded_servers_) {
+                if (!loaded->is_backend_alive() || loaded->get_model_type() != ModelType::LLM) {
+                    continue;
+                }
+                if (!server || loaded->get_last_access_time() > server->get_last_access_time()) {
+                    server = loaded.get();
+                }
+            }
+        }
+
+        if (!server || !server->is_backend_alive()) {
+            return json{{"status", "success"}, {"message", "No loaded model to reset"}};
+        }
+
+        if (!server->acquire_for_inference()) {
+            return ErrorResponse::from_exception(ModelNotLoadedException("No models loaded"));
+        }
+        server->update_access_time();
+    }
+
+    try {
+        auto response = server->reset_chat_session(request);
+        server->release_inference();
+        return response;
+    } catch (...) {
+        server->release_inference();
+        throw;
+    }
+}
+
 json Router::audio_transcriptions(const json& request) {
     return execute_inference(request, [&](WrappedServer* server) {
         auto transcription_server = dynamic_cast<ITranscriptionServer*>(server);

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -530,6 +530,10 @@ void Server::setup_routes(httplib::Server &web_server) {
         handle_chat_completions(req, res);
     });
 
+    register_post("chat/sessions/reset", [this](const httplib::Request& req, httplib::Response& res) {
+        handle_chat_session_reset(req, res);
+    });
+
     // Completions
     register_post("completions", [this](const httplib::Request& req, httplib::Response& res) {
         handle_completions(req, res);
@@ -1000,9 +1004,10 @@ window.api = {
 
             // Determine content type based on extension
             std::string content_type = "application/octet-stream";
+            std::string ext;
             size_t dot_pos = file_path.rfind('.');
             if (dot_pos != std::string::npos) {
-                std::string ext = file_path.substr(dot_pos);
+                ext = file_path.substr(dot_pos);
                 if (ext == ".js") content_type = "text/javascript";
                 else if (ext == ".css") content_type = "text/css";
                 else if (ext == ".html") content_type = "text/html";
@@ -1017,6 +1022,12 @@ window.api = {
             }
 
             res.set_content(content, content_type);
+
+            if (ext == ".js" || ext == ".css" || ext == ".html") {
+                res.set_header("Cache-Control", "no-cache, no-store, must-revalidate");
+                res.set_header("Pragma", "no-cache");
+                res.set_header("Expires", "0");
+            }
         };
 
         // Serve favicon from web-app directory at root
@@ -2562,6 +2573,38 @@ void Server::handle_slots_by_id(const httplib::Request& req, httplib::Response& 
 
     } catch (const std::exception& e) {
         LOG(ERROR, "Server") << "ERROR in handle_slots_by_id: " << e.what() << std::endl;
+        res.status = 500;
+        nlohmann::json error = {{"error", e.what()}};
+        res.set_content(error.dump(), "application/json");
+    }
+}
+
+void Server::handle_chat_session_reset(const httplib::Request& req, httplib::Response& res) {
+    try {
+        LOG(INFO, "Server") << "POST /api/v1/chat/sessions/reset" << std::endl;
+
+        json request_body = json::object();
+        if (!req.body.empty()) {
+            try {
+                request_body = json::parse(req.body);
+            } catch (const std::exception& e) {
+                LOG(ERROR, "Server") << "Failed to parse request body: " << e.what() << std::endl;
+                res.status = 400;
+                res.set_content("{\"error\": \"Invalid JSON in request body\"}", "application/json");
+                return;
+            }
+        }
+
+        auto response = router_->reset_chat_session(request_body);
+        if (response.contains("error")) {
+            set_error_response(response, res);
+            return;
+        }
+
+        res.status = 200;
+        res.set_content(response.dump(), "application/json");
+    } catch (const std::exception& e) {
+        LOG(ERROR, "Server") << "ERROR in handle_chat_session_reset: " << e.what() << std::endl;
         res.status = 500;
         nlohmann::json error = {{"error", e.what()}};
         res.set_content(error.dump(), "application/json");

--- a/src/cpp/server/wrapped_server.cpp
+++ b/src/cpp/server/wrapped_server.cpp
@@ -570,6 +570,14 @@ bool WrappedServer::is_process_running() const {
     return is_backend_alive();
 }
 
+json WrappedServer::reset_chat_session(const json& request) {
+    (void)request;
+    return json{
+        {"status", "unsupported"},
+        {"message", server_name_ + " does not support chat session reset"}
+    };
+}
+
 json WrappedServer::forward_get_request(const std::string& endpoint, long timeout_seconds) {
     (void)timeout_seconds;
     if (!is_backend_alive()) {


### PR DESCRIPTION
main improvement is:
add new API to reset server's kvcache status by calling og->rewindTo(0)
new API is: POST /api/v1/chat/sessions/reset

Otherwise,  will always use multi-chat function in OGA.

Currently, if you click the "Start a new chat" button in right-up corner in web UI,
the oga will reset the kvcache status to 0.
