### PR TITLE
Apply a canonical backend preference order to all descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows</td>
     </tr>
     <tr>
-      <td><code>rocm</code></td>
-      <td>Supported AMD ROCm iGPU/dGPU families*</td>
-      <td>Windows, Linux</td>
+      <td><code>metal</code></td>
+      <td>Apple Silicon GPU</td>
+      <td>macOS</td>
     </tr>
     <tr>
       <td><code>vulkan</code></td>
@@ -203,14 +203,14 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows, Linux</td>
     </tr>
     <tr>
-      <td><code>cpu</code></td>
-      <td><code>x86_64</code> CPU</td>
+      <td><code>rocm</code></td>
+      <td>Supported AMD ROCm iGPU/dGPU families*</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>
-      <td><code>metal</code></td>
-      <td>Apple Silicon GPU</td>
-      <td>macOS</td>
+      <td><code>cpu</code></td>
+      <td><code>x86_64</code> CPU</td>
+      <td>Windows, Linux</td>
     </tr>
     <tr>
       <td rowspan="1"><code>moonshine</code></td>
@@ -221,39 +221,34 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td rowspan="5"><strong>Text-to-speech</strong></td>
       <td rowspan="2"><code>kokoro</code></td>
-      <td><code>cpu</code></td>
-      <td><code>x86_64</code> CPU</td>
-      <td>Windows, Linux</td>
-    </tr>
-    <tr>
       <td><code>metal</code></td>
       <td>Apple Silicon GPU</td>
       <td>macOS</td>
     </tr>
     <tr>
+      <td><code>cpu</code></td>
+      <td><code>x86_64</code> CPU</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
       <td rowspan="3"><code>openmoss</code> (experimental)</td>
+      <td><code>cuda</code></td>
+      <td>NVIDIA GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>vulkan</code></td>
+      <td>Vulkan-capable GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
       <td><code>rocm</code></td>
       <td>AMD GPUs (ROCm via TheRock)</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>
-      <td><code>cuda</code></td>
-      <td>NVIDIA GPUs</td>
-      <td>Windows, Linux</td>
-    </tr>
-    <tr>
-      <td><code>vulkan</code></td>
-      <td>Vulkan-capable GPUs</td>
-      <td>Windows, Linux</td>
-    </tr>
-    <tr>
       <td rowspan="6"><strong>Audio generation</strong></td>
       <td rowspan="3"><code>thinksound</code> (experimental)</td>
-      <td><code>rocm</code></td>
-      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
-      <td>Windows, Linux</td>
-    </tr>
-    <tr>
       <td><code>cuda</code></td>
       <td>NVIDIA GPUs</td>
       <td>Windows, Linux</td>
@@ -261,15 +256,15 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td><code>vulkan</code></td>
       <td>Vulkan-capable GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>rocm</code></td>
+      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>
       <td rowspan="3"><code>acestep</code> (experimental)</td>
-      <td><code>rocm</code></td>
-      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
-      <td>Windows, Linux</td>
-    </tr>
-    <tr>
       <td><code>cuda</code></td>
       <td>NVIDIA GPUs</td>
       <td>Windows, Linux</td>
@@ -277,14 +272,19 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td><code>vulkan</code></td>
       <td>Vulkan-capable GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>rocm</code></td>
+      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>
       <td rowspan="5"><strong>Image generation</strong></td>
       <td rowspan="5"><code>sd-cpp</code></td>
-      <td><code>rocm</code></td>
-      <td>Supported AMD ROCm iGPU/dGPU families*</td>
-      <td>Windows, Linux</td>
+      <td><code>metal</code></td>
+      <td>Apple Silicon GPU</td>
+      <td>macOS</td>
     </tr>
     <tr>
       <td><code>cuda</code></td>
@@ -297,23 +297,18 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows, Linux</td>
     </tr>
     <tr>
+      <td><code>rocm</code></td>
+      <td>Supported AMD ROCm iGPU/dGPU families*</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
       <td><code>cpu</code></td>
       <td><code>x86_64</code> CPU</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>
-      <td><code>metal</code></td>
-      <td>Apple Silicon GPU</td>
-      <td>macOS</td>
-    </tr>
-    <tr>
       <td rowspan="3"><strong>3D generation</strong></td>
       <td rowspan="3"><code>trellis</code> (experimental)</td>
-      <td><code>rocm</code></td>
-      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
-      <td>Windows, Linux</td>
-    </tr>
-    <tr>
       <td><code>cuda</code></td>
       <td>NVIDIA GPUs</td>
       <td>Windows, Linux</td>
@@ -321,6 +316,11 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td><code>vulkan</code></td>
       <td>Vulkan-capable GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>rocm</code></td>
+      <td>Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -29,12 +29,12 @@ the generator instead. Prose outside the markers is preserved. -->
 <!-- BEGIN GENERATED: backends-matrix -->
 | Recipe | Backend | OS | Device families |
 |--------|---------|----|-----------------|
-| `acestep` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `acestep` | cuda | linux, windows | nvidia_gpu |
 | `acestep` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
+| `acestep` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `flm` | npu | linux, windows | amd_npu (XDNA2) |
-| `kokoro` | cpu | linux, windows | cpu (x86_64) |
 | `kokoro` | metal | macos | metal |
+| `kokoro` | cpu | linux, windows | cpu (x86_64) |
 | `llamacpp` | system | linux | cpu (arm64, x86_64) |
 | `llamacpp` | metal | macos | metal |
 | `llamacpp` | cuda | linux, windows | nvidia_gpu (sm_100, sm_120, sm_121, sm_75, sm_80, sm_86, sm_89, sm_90) |
@@ -47,27 +47,27 @@ the generator instead. Prose outside the markers is preserved. -->
 | `onnxruntime` | cpu | windows | cpu (x86_64) |
 | `onnxruntime` | cpu | linux | cpu (arm64, x86_64) |
 | `onnxruntime` | cpu | macos | cpu (arm64) |
-| `openmoss` | rocm | linux, windows | amd_gpu |
 | `openmoss` | cuda | linux, windows | nvidia_gpu |
 | `openmoss` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
+| `openmoss` | rocm | linux, windows | amd_gpu |
 | `ryzenai-llm` | npu | windows | amd_npu (XDNA2) |
-| `sd-cpp` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
+| `sd-cpp` | metal | macos | metal |
 | `sd-cpp` | cuda | linux, windows | nvidia_gpu (sm_100, sm_120, sm_121, sm_75, sm_80, sm_86, sm_89, sm_90) |
 | `sd-cpp` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
+| `sd-cpp` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `sd-cpp` | cpu | linux, windows | cpu (x86_64) |
-| `sd-cpp` | metal | macos | metal |
-| `thinksound` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `thinksound` | cuda | linux, windows | nvidia_gpu |
 | `thinksound` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
-| `trellis` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
+| `thinksound` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `trellis` | cuda | linux, windows | nvidia_gpu |
 | `trellis` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
+| `trellis` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `vllm` | rocm | linux | amd_gpu (gfx110X, gfx1150, gfx1151, gfx120X) |
 | `whispercpp` | npu | windows | amd_npu (XDNA2) |
-| `whispercpp` | rocm | linux, windows | amd_gpu (gfx110X, gfx1150, gfx1151, gfx120X) |
-| `whispercpp` | vulkan | linux, windows | amd_gpu; cpu (x86_64) |
-| `whispercpp` | cpu | linux, windows | cpu (x86_64) |
 | `whispercpp` | metal | macos | metal |
+| `whispercpp` | vulkan | linux, windows | amd_gpu; cpu (x86_64) |
+| `whispercpp` | rocm | linux, windows | amd_gpu (gfx110X, gfx1150, gfx1151, gfx120X) |
+| `whispercpp` | cpu | linux, windows | cpu (x86_64) |
 <!-- END GENERATED: backends-matrix -->
 
 > **Note:** The `llamacpp` `rocm` row lists `linux, windows` for the family as a

--- a/src/cpp/include/lemon/backends/acestep/acestep.h
+++ b/src/cpp/include/lemon/backends/acestep/acestep.h
@@ -23,9 +23,9 @@ inline const BackendDescriptor descriptor = {
          "ACE-Step backend to use", "Audio Generation Options"},
     },
     /*support*/ {
-        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
         {"cuda", {"linux", "windows"}, {{"nvidia_gpu", {}}}, "NVIDIA GPUs"},
         {"vulkan", {"linux", "windows"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
+        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
     },
     /*default_labels*/  {"audio-generation"},
     /*required_checkpoints*/ {"main"},

--- a/src/cpp/include/lemon/backends/kokoro/kokoro.h
+++ b/src/cpp/include/lemon/backends/kokoro/kokoro.h
@@ -24,8 +24,8 @@ inline const BackendDescriptor descriptor = {
     /*dynamic_models*/  false,
     /*options*/ {},
     /*support*/ {
-        {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
         {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
+        {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
     },
     /*default_labels*/  {"tts"},  // kokoro only does TTS; declare it so a label-less
                                    // user model is typed TTS, not LLM (catalog models

--- a/src/cpp/include/lemon/backends/openmoss/openmoss.h
+++ b/src/cpp/include/lemon/backends/openmoss/openmoss.h
@@ -21,9 +21,9 @@ inline const BackendDescriptor descriptor = {
          "OpenMOSS TTS backend to use", "Text-to-Speech Options"},
     },
     /*support*/ {
-        {"rocm", {"linux", "windows"}, {{"amd_gpu", {}}}, "AMD GPUs (ROCm via TheRock)"},
         {"cuda", {"linux", "windows"}, {{"nvidia_gpu", {}}}, "NVIDIA GPUs"},
         {"vulkan", {"linux", "windows"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
+        {"rocm", {"linux", "windows"}, {{"amd_gpu", {}}}, "AMD GPUs (ROCm via TheRock)"},
     },
     /*default_labels*/  {"tts"},
     /*required_checkpoints*/ {"main"},

--- a/src/cpp/include/lemon/backends/sdcpp/sdcpp.h
+++ b/src/cpp/include/lemon/backends/sdcpp/sdcpp.h
@@ -36,13 +36,13 @@ inline const BackendDescriptor descriptor = {
         {"flow_shift", "", 0.0, "SIZE", "Flow shift", "Stable Diffusion Options"},
     },
     /*support*/ {
-        {"rocm", {"windows", "linux"},
-         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families*"},
+        {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
         {"cuda", {"windows", "linux"},
          {{"nvidia_gpu", {"sm_75", "sm_80", "sm_86", "sm_89", "sm_90", "sm_100", "sm_120", "sm_121"}}}, "NVIDIA GPUs (Turing or newer)**"},
         {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
+        {"rocm", {"windows", "linux"},
+         {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families*"},
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
-        {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
     },
     /*default_labels*/  {"image"},
     /*required_checkpoints*/ {"main"},  // flux text_encoder+vae validated together in load()

--- a/src/cpp/include/lemon/backends/thinksound/thinksound.h
+++ b/src/cpp/include/lemon/backends/thinksound/thinksound.h
@@ -23,9 +23,9 @@ inline const BackendDescriptor descriptor = {
          "ThinkSound backend to use", "Audio Generation Options"},
     },
     /*support*/ {
-        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
         {"cuda", {"linux", "windows"}, {{"nvidia_gpu", {}}}, "NVIDIA GPUs"},
         {"vulkan", {"linux", "windows"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
+        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
     },
     /*default_labels*/  {"audio-generation"},
     /*required_checkpoints*/ {"main"},

--- a/src/cpp/include/lemon/backends/trellis/trellis.h
+++ b/src/cpp/include/lemon/backends/trellis/trellis.h
@@ -21,9 +21,9 @@ inline const BackendDescriptor descriptor = {
          "Trellis backend to use", "3D Generation Options"},
     },
     /*support*/ {
-        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
         {"cuda", {"linux", "windows"}, {{"nvidia_gpu", {}}}, "NVIDIA GPUs"},
         {"vulkan", {"linux", "windows"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
+        {"rocm", {"linux", "windows"}, {{"amd_gpu", {"gfx1150", "gfx1151", "gfx1152", "gfx103X", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families (ROCm via TheRock)"},
     },
     /*default_labels*/  {"3d"},
     /*required_checkpoints*/ {"main"},

--- a/src/cpp/include/lemon/backends/whispercpp/whispercpp.h
+++ b/src/cpp/include/lemon/backends/whispercpp/whispercpp.h
@@ -30,11 +30,11 @@ inline const BackendDescriptor descriptor = {
     },
     /*support*/ {
         {"npu", {"windows"}, {{"amd_npu", {"XDNA2"}}}, "XDNA2 NPU"},
+        {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
+        {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}}, "x86_64 CPU"},
         {"rocm", {"windows", "linux"},
          {{"amd_gpu", {"gfx1150", "gfx1151", "gfx110X", "gfx120X"}}}, "Supported AMD ROCm iGPU/dGPU families*"},
-        {"vulkan", {"windows", "linux"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}}, "x86_64 CPU"},
         {"cpu", {"windows", "linux"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
-        {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
     },
     /*default_labels*/  {"transcription", "realtime-transcription"},
     /*required_checkpoints*/ {"main"},  // npu_cache validated in load() (npu variant only)


### PR DESCRIPTION
Orders every backend descriptor's `support` rows consistently, since the order of those rows *is* the `auto` preference order (see `recipe_backend_def.h`):

```
system > metal > cuda > vulkan > rocm > cpu
```

### Justification

We don't have the CI resources to test ROCm across the range of AMD GPUs, which has led to an uneven user experience across our releases. ROCm binaries are also much larger than Vulkan right now. This change reflects that Vulkan offers the right new user experience for most people, who can then opt-in to ROCm.

### Making ROCm the default

We can make ROCm the default across the board under 3 conditions:
1. Performance regression testing shows that ROCm is the right choice for performance across hot models.
2. ROCm binary size is comparable to Vulkan binary size (under 500 MB)
3. Sufficient ROCm runners are available in Lemonade CI to ensure functional correctness across supported AMD GPUs  

### Details

(skipping backends a recipe doesn't offer). `llamacpp` already followed this order; the other descriptors did not. This is a pure reordering — no support row's content changed.

**Behavior changes:** vulkan is now preferred over rocm everywhere it's available, and metal over cpu on macOS for `kokoro` and `sd-cpp`.

**Notes:** `npu` is not part of the order and keeps its existing leading position in `whispercpp`. `vllm` (rocm-only), `flm`/`ryzenai-llm` (npu-only), `moonshine` and `onnxruntime` (cpu-only) are unchanged.

| Recipe | Order |
|---|---|
| `llamacpp` | system → metal → cuda → vulkan → rocm → cpu *(already canonical)* |
| `sd-cpp` | metal → cuda → vulkan → rocm → cpu |
| `whispercpp` | npu → metal → vulkan → rocm → cpu |
| `openmoss`, `acestep`, `thinksound`, `trellis` | cuda → vulkan → rocm |
| `kokoro` | metal → cpu |

`README.md` and `docs/dev/backends-reference.md` regenerated via `docs/tools/gen_backend_boilerplate.py`; `--check` passes. Verified against a locally built `lemond` that `/system-info` reports the expected `default_backend` per recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
