### PR TITLE
ci: improve persistent Windows runner hygiene and process lock recovery

### DIFF
--- a/.github/actions/cleanup-processes-windows/action.yml
+++ b/.github/actions/cleanup-processes-windows/action.yml
@@ -1,5 +1,5 @@
 name: 'Cleanup Processes (Windows)'
-description: 'Kill all lemonade, Python, llama-server, and FLM processes on Windows'
+description: 'Kill all lemonade, llama-server, and FLM processes on Windows'
 runs:
   using: "composite"
   steps:
@@ -108,9 +108,6 @@ runs:
             # Kill lemonade processes (lemond, lemonade, lemonade-tray, etc.)
             Stop-ProcessByPattern -Pattern "lemonade" -Description "lemonade"
             Stop-ProcessByPattern -Pattern "lemond" -Description "lemond"
-
-            # Kill Python processes
-            Stop-ProcessByPattern -Pattern "python" -Description "Python"
 
             # Kill wscript processes (VBScript launcher used by lemonade)
             Stop-ProcessByPattern -Pattern "wscript" -Description "wscript"

--- a/.github/actions/setup-windows-ci-env/action.yml
+++ b/.github/actions/setup-windows-ci-env/action.yml
@@ -1,0 +1,63 @@
+name: 'Setup Windows CI Environment'
+description: 'Set cache/install paths, cleanup legacy workspace paths, prune transient directories, and terminate stale processes.'
+inputs:
+  matrix-name:
+    description: 'Name of the current matrix leg or job to isolate caches/temp folders.'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set Windows CI cache and install paths
+      shell: PowerShell
+      run: |
+        $ErrorActionPreference = "Stop"
+        $normalizedMatrix = "${{ inputs.matrix-name }}" -replace '[^A-Za-z0-9_.-]', '-'
+        $runKey = "${{ github.run_id }}-${{ github.run_attempt }}-$normalizedMatrix"
+
+        $ciRoot = "C:\lemonade-ci"
+        $cacheRoot = Join-Path $ciRoot "cache"
+        $installRoot = Join-Path $ciRoot "install"
+        $tmpRoot = Join-Path $ciRoot "tmp"
+
+        $hfHome = Join-Path $ciRoot "hf"
+        $cacheDir = Join-Path $cacheRoot $normalizedMatrix
+        $installPath = Join-Path $installRoot $runKey
+        $tmpDir = Join-Path $tmpRoot $runKey
+
+        foreach ($path in @($ciRoot, $hfHome, $cacheDir, $installPath, $tmpDir)) {
+          New-Item -ItemType Directory -Force -Path $path | Out-Null
+        }
+
+        # Set environment variables for the current job context
+        echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
+        echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
+        echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
+        echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
+        echo "TMP=$tmpDir" >> $Env:GITHUB_ENV
+
+        Write-Host "HF_HOME=$hfHome" -ForegroundColor Gray
+        Write-Host "LEMONADE_CACHE_DIR=$cacheDir" -ForegroundColor Gray
+        Write-Host "LEMONADE_INSTALL_PATH=$installPath" -ForegroundColor Gray
+        Write-Host "TEMP/TMP=$tmpDir" -ForegroundColor Gray
+
+    - name: Cleanup legacy workspace cache dirs
+      uses: ./.github/actions/cleanup-ci-paths-windows
+      with:
+        paths: |
+          ${{ github.workspace }}\ci-cache
+          ${{ github.workspace }}\hf-cache
+          ${{ github.workspace }}\lemonade_server_install
+        expected-root: ${{ github.workspace }}
+
+    - name: Prune old transient Windows CI directories
+      uses: ./.github/actions/cleanup-ci-paths-windows
+      with:
+        paths: |
+          C:\lemonade-ci\install
+          C:\lemonade-ci\tmp
+        expected-root: C:\lemonade-ci
+        prune-children-older-than-days: '2'
+
+    - name: Cleanup processes
+      uses: ./.github/actions/cleanup-processes-windows

--- a/.github/actions/setup-windows-ci-env/action.yml
+++ b/.github/actions/setup-windows-ci-env/action.yml
@@ -41,6 +41,9 @@ runs:
         Write-Host "LEMONADE_INSTALL_PATH=$installPath" -ForegroundColor Gray
         Write-Host "TEMP/TMP=$tmpDir" -ForegroundColor Gray
 
+    - name: Cleanup processes
+      uses: ./.github/actions/cleanup-processes-windows
+
     - name: Cleanup legacy workspace cache dirs
       uses: ./.github/actions/cleanup-ci-paths-windows
       with:
@@ -58,6 +61,3 @@ runs:
           C:\lemonade-ci\tmp
         expected-root: C:\lemonade-ci
         prune-children-older-than-days: '2'
-
-    - name: Cleanup processes
-      uses: ./.github/actions/cleanup-processes-windows

--- a/.github/actions/teardown-windows-ci-env/action.yml
+++ b/.github/actions/teardown-windows-ci-env/action.yml
@@ -4,9 +4,11 @@ runs:
   using: 'composite'
   steps:
     - name: Cleanup processes (Windows)
+      if: always()
       uses: ./.github/actions/cleanup-processes-windows
 
     - name: Cleanup current Windows CI directories
+      if: always()
       uses: ./.github/actions/cleanup-ci-paths-windows
       with:
         paths: |
@@ -15,6 +17,7 @@ runs:
         expected-root: C:\lemonade-ci
 
     - name: Cleanup legacy workspace cache dirs
+      if: always()
       uses: ./.github/actions/cleanup-ci-paths-windows
       with:
         paths: |
@@ -24,6 +27,7 @@ runs:
         expected-root: ${{ github.workspace }}
 
     - name: Prune old transient Windows CI directories
+      if: always()
       uses: ./.github/actions/cleanup-ci-paths-windows
       with:
         paths: |

--- a/.github/actions/teardown-windows-ci-env/action.yml
+++ b/.github/actions/teardown-windows-ci-env/action.yml
@@ -1,0 +1,33 @@
+name: 'Teardown Windows CI Environment'
+description: 'Terminate processes, cleanup current run directories, and prune old transient directories.'
+runs:
+  using: 'composite'
+  steps:
+    - name: Cleanup processes (Windows)
+      uses: ./.github/actions/cleanup-processes-windows
+
+    - name: Cleanup current Windows CI directories
+      uses: ./.github/actions/cleanup-ci-paths-windows
+      with:
+        paths: |
+          ${{ env.LEMONADE_INSTALL_PATH }}
+          ${{ env.TEMP }}
+        expected-root: C:\lemonade-ci
+
+    - name: Cleanup legacy workspace cache dirs
+      uses: ./.github/actions/cleanup-ci-paths-windows
+      with:
+        paths: |
+          ${{ github.workspace }}\ci-cache
+          ${{ github.workspace }}\hf-cache
+          ${{ github.workspace }}\lemonade_server_install
+        expected-root: ${{ github.workspace }}
+
+    - name: Prune old transient Windows CI directories
+      uses: ./.github/actions/cleanup-ci-paths-windows
+      with:
+        paths: |
+          C:\lemonade-ci\install
+          C:\lemonade-ci\tmp
+        expected-root: C:\lemonade-ci
+        prune-children-older-than-days: '2'

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1244,6 +1244,14 @@ jobs:
         run: |
           $ErrorActionPreference = "Continue"
 
+          # 1. Kill any running/orphaned processes to release file locks
+          $patterns = @("lemonade", "lemond", "llama-server", "llama", "flm", "ort-server", "moonshine-server", "wscript", "LemonadeServer")
+          foreach ($p in $patterns) {
+              Get-Process | Where-Object { $_.ProcessName -like "*$p*" } | Stop-Process -Force -ErrorAction SilentlyContinue
+          }
+
+          # 2. Force-delete stale in-tree legacy paths that could lock git checkout
+
           # Local composite actions are unavailable before actions/checkout,
           # so this minimal long-path-safe cleanup stays inline. It removes
           # stale workspace cache/install dirs that can otherwise make
@@ -1835,6 +1843,13 @@ jobs:
           Pop-Location
           Write-Host "Embeddable Windows smoke test PASSED!" -ForegroundColor Green
 
+      - name: Cleanup processes (Windows)
+        if: always()
+        shell: PowerShell
+        run: |
+          Stop-Process -Name lemond -Force -ErrorAction SilentlyContinue
+          Stop-Process -Name lemonade -Force -ErrorAction SilentlyContinue
+
   test-dmg-inference:
     name: Test .dmg - macOS inference
     runs-on: macos-latest
@@ -2229,6 +2244,21 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       LEMONADE_VERSION: ${{ needs.build-lemonade-macos-dmg.outputs.version }}
     steps:
+      # Pre-checkout cleanup is run here as a safeguard to release file locks on Windows
+      # in case this job is mapped to persistent self-hosted runners labeled as 'windows-latest'.
+      - name: Prepare Windows runner for long paths and stale workspace caches
+        if: runner.os == 'Windows'
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          # 1. Kill any running/orphaned processes to release file locks
+          $patterns = @("lemonade", "lemond", "llama-server", "llama", "flm", "ort-server", "moonshine-server", "wscript", "LemonadeServer")
+          foreach ($p in $patterns) {
+              Get-Process | Where-Object { $_.ProcessName -like "*$p*" } | Stop-Process -Force -ErrorAction SilentlyContinue
+          }
+
+
       - uses: actions/checkout@v5
 
       # ---- Windows Setup ----
@@ -2466,6 +2496,20 @@ jobs:
       PYTHONIOENCODING: utf-8
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
+      # Pre-checkout cleanup is run here as a safeguard to release file locks on Windows
+      # in case this job is mapped to persistent self-hosted runners labeled as 'windows-latest'.
+      - name: Prepare Windows runner for long paths and stale workspace caches
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          # 1. Kill any running/orphaned processes to release file locks
+          $patterns = @("lemonade", "lemond", "llama-server", "llama", "flm", "ort-server", "moonshine-server", "wscript", "LemonadeServer")
+          foreach ($p in $patterns) {
+              Get-Process | Where-Object { $_.ProcessName -like "*$p*" } | Stop-Process -Force -ErrorAction SilentlyContinue
+          }
+
+
       - uses: actions/checkout@v5
 
       - name: Setup & sanitize Windows CI environment

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1297,65 +1297,10 @@ jobs:
           clean: true
           fetch-depth: 0
 
-      - name: Set Windows CI cache and install paths
-        shell: PowerShell
-        run: |
-          $ErrorActionPreference = "Stop"
-          $matrixName = "${{ matrix.name }}" -replace '[^A-Za-z0-9_.-]', '-'
-          $runKey = "${{ github.run_id }}-${{ github.run_attempt }}-$matrixName"
-
-          # Keep all heavyweight runtime state outside $GITHUB_WORKSPACE. This
-          # prevents actions/checkout from trying to clean TheRock/backend caches
-          # and keeps paths short enough for Windows self-hosted runners.
-          $ciRoot = "C:\lemonade-ci"
-          $cacheRoot = Join-Path $ciRoot "cache"
-          $installRoot = Join-Path $ciRoot "install"
-          $tmpRoot = Join-Path $ciRoot "tmp"
-
-          $hfHome = Join-Path $ciRoot "hf"
-          $cacheDir = Join-Path $cacheRoot $matrixName
-          $installPath = Join-Path $installRoot $runKey
-          $tmpDir = Join-Path $tmpRoot $runKey
-
-          foreach ($path in @($ciRoot, $hfHome, $cacheDir, $installPath, $tmpDir)) {
-            New-Item -ItemType Directory -Force -Path $path | Out-Null
-          }
-          # Persistent HF cache outside the workspace so models survive across
-          # jobs; the Lemonade backend/TheRock cache lives under LEMONADE_CACHE_DIR
-          # (bin\therock), so it also stays outside the workspace.
-          echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
-          echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
-          echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
-          # Set both Windows temp aliases: different tools read either TEMP or TMP.
-          echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
-          echo "TMP=$tmpDir" >> $Env:GITHUB_ENV
-
-          Write-Host "HF_HOME=$hfHome" -ForegroundColor Gray
-          Write-Host "LEMONADE_CACHE_DIR=$cacheDir" -ForegroundColor Gray
-          Write-Host "LEMONADE_INSTALL_PATH=$installPath" -ForegroundColor Gray
-          Write-Host "TEMP/TMP=$tmpDir" -ForegroundColor Gray
-
-
-      - name: Cleanup legacy workspace cache dirs
-        uses: ./.github/actions/cleanup-ci-paths-windows
+      - name: Setup & sanitize Windows CI environment
+        uses: ./.github/actions/setup-windows-ci-env
         with:
-          paths: |
-            ${{ github.workspace }}\ci-cache
-            ${{ github.workspace }}\hf-cache
-            ${{ github.workspace }}\lemonade_server_install
-          expected-root: ${{ github.workspace }}
-
-      - name: Prune old transient Windows CI directories
-        uses: ./.github/actions/cleanup-ci-paths-windows
-        with:
-          paths: |
-            C:\lemonade-ci\install
-            C:\lemonade-ci\tmp
-          expected-root: C:\lemonade-ci
-          prune-children-older-than-days: '2'
-
-      - name: Cleanup processes
-        uses: ./.github/actions/cleanup-processes-windows
+          matrix-name: ${{ matrix.name }}
 
       - name: Install and Verify Lemonade Server
         uses: ./.github/actions/install-lemonade-server-msi
@@ -1452,38 +1397,9 @@ jobs:
         with:
           artifact-name: server-logs-exe-${{ matrix.name }}
 
-      - name: Cleanup processes
+      - name: Teardown Windows CI environment
         if: always()
-        uses: ./.github/actions/cleanup-processes-windows
-
-      - name: Cleanup current Windows CI directories
-        if: always()
-        uses: ./.github/actions/cleanup-ci-paths-windows
-        with:
-          paths: |
-            ${{ env.LEMONADE_INSTALL_PATH }}
-            ${{ env.TEMP }}
-          expected-root: C:\lemonade-ci
-
-      - name: Cleanup legacy workspace cache dirs
-        if: always()
-        uses: ./.github/actions/cleanup-ci-paths-windows
-        with:
-          paths: |
-            ${{ github.workspace }}\ci-cache
-            ${{ github.workspace }}\hf-cache
-            ${{ github.workspace }}\lemonade_server_install
-          expected-root: ${{ github.workspace }}
-
-      - name: Prune old transient Windows CI directories
-        if: always()
-        uses: ./.github/actions/cleanup-ci-paths-windows
-        with:
-          paths: |
-            C:\lemonade-ci\install
-            C:\lemonade-ci\tmp
-          expected-root: C:\lemonade-ci
-          prune-children-older-than-days: '2'
+        uses: ./.github/actions/teardown-windows-ci-env
 
 
   test-deb-inference:
@@ -2316,38 +2232,11 @@ jobs:
       - uses: actions/checkout@v5
 
       # ---- Windows Setup ----
-      - name: Setup short Windows CI paths
+      - name: Setup & sanitize Windows CI environment
         if: runner.os == 'Windows'
-        shell: powershell
-        run: |
-          $ErrorActionPreference = "Stop"
-
-          $ciRoot = "C:\lemonade-ci"
-          $matrixName = "${{ matrix.os }}" -replace '[^A-Za-z0-9_.-]', '-'
-          $runKey = "${{ github.run_id }}-${{ github.run_attempt }}-$matrixName"
-
-          $hfHome = Join-Path $ciRoot "hf"
-          $cacheDir = Join-Path (Join-Path $ciRoot "cache") $matrixName
-          $installPath = Join-Path (Join-Path $ciRoot "install") $runKey
-          $tmpDir = Join-Path (Join-Path $ciRoot "tmp") $runKey
-
-          foreach ($path in @($ciRoot, $hfHome, $cacheDir, $installPath, $tmpDir)) {
-            New-Item -ItemType Directory -Force -Path $path | Out-Null
-          }
-
-          # Keep runtime/cache/install/temp paths outside $GITHUB_WORKSPACE.
-          # This mirrors the .exe inference job and avoids workspace cleanup/long-path failures.
-          echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
-          echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
-          echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
-          # Set both Windows temp aliases: different tools read either TEMP or TMP.
-          echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
-          echo "TMP=$tmpDir" >> $Env:GITHUB_ENV
-
-          Write-Host "HF_HOME=$hfHome" -ForegroundColor Gray
-          Write-Host "LEMONADE_CACHE_DIR=$cacheDir" -ForegroundColor Gray
-          Write-Host "LEMONADE_INSTALL_PATH=$installPath" -ForegroundColor Gray
-          Write-Host "TEMP/TMP=$tmpDir" -ForegroundColor Gray
+        uses: ./.github/actions/setup-windows-ci-env
+        with:
+          matrix-name: ${{ matrix.os }}
 
       - name: Install Lemonade Server (Windows)
         if: runner.os == 'Windows'
@@ -2459,6 +2348,10 @@ jobs:
         uses: ./.github/actions/capture-server-logs
         with:
           artifact-name: server-logs-${{ matrix.os }}
+
+      - name: Teardown Windows CI environment
+        if: ${{ always() && runner.os == 'Windows' }}
+        uses: ./.github/actions/teardown-windows-ci-env
 
   # ========================================================================
   # API KEY TESTS - Separate job with LEMONADE_API_KEY env var
@@ -2575,35 +2468,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Setup short Windows CI paths
-        shell: powershell
-        run: |
-          $ErrorActionPreference = "Stop"
-
-          $ciRoot = "C:\lemonade-ci"
-          $runKey = "${{ github.run_id }}-${{ github.run_attempt }}-apikey-windows-latest"
-
-          $hfHome = Join-Path $ciRoot "hf"
-          $cacheDir = Join-Path (Join-Path $ciRoot "cache") "apikey-windows-latest"
-          $installPath = Join-Path (Join-Path $ciRoot "install") $runKey
-          $tmpDir = Join-Path (Join-Path $ciRoot "tmp") $runKey
-
-          foreach ($path in @($ciRoot, $hfHome, $cacheDir, $installPath, $tmpDir)) {
-            New-Item -ItemType Directory -Force -Path $path | Out-Null
-          }
-
-          # Keep runtime/cache/install/temp paths outside $GITHUB_WORKSPACE.
-          echo "HF_HOME=$hfHome" >> $Env:GITHUB_ENV
-          echo "LEMONADE_CACHE_DIR=$cacheDir" >> $Env:GITHUB_ENV
-          echo "LEMONADE_INSTALL_PATH=$installPath" >> $Env:GITHUB_ENV
-          # Set both Windows temp aliases: different tools read either TEMP or TMP.
-          echo "TEMP=$tmpDir" >> $Env:GITHUB_ENV
-          echo "TMP=$tmpDir" >> $Env:GITHUB_ENV
-
-          Write-Host "HF_HOME=$hfHome" -ForegroundColor Gray
-          Write-Host "LEMONADE_CACHE_DIR=$cacheDir" -ForegroundColor Gray
-          Write-Host "LEMONADE_INSTALL_PATH=$installPath" -ForegroundColor Gray
-          Write-Host "TEMP/TMP=$tmpDir" -ForegroundColor Gray
+      - name: Setup & sanitize Windows CI environment
+        uses: ./.github/actions/setup-windows-ci-env
+        with:
+          matrix-name: apikey-windows-latest
 
       - name: Install Lemonade Server (Windows)
         uses: ./.github/actions/install-lemonade-server-msi
@@ -2682,6 +2550,10 @@ jobs:
         uses: ./.github/actions/capture-server-logs
         with:
           artifact-name: server-logs-apikey-windows-latest
+
+      - name: Teardown Windows CI environment
+        if: always()
+        uses: ./.github/actions/teardown-windows-ci-env
 
   # ========================================================================
   # RELEASE JOB - Add artifacts to GitHub release

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -289,6 +289,19 @@ jobs:
     if: always() && !failure() && !cancelled()
     runs-on: windows-latest
     steps:
+      - name: Prepare Windows runner for long paths and stale workspace caches
+        if: runner.os == 'Windows'
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          # 1. Kill any running/orphaned processes to release file locks
+          $patterns = @("lemonade", "lemond", "llama-server", "llama", "flm", "ort-server", "moonshine-server", "wscript", "LemonadeServer")
+          foreach ($p in $patterns) {
+              Get-Process | Where-Object { $_.ProcessName -like "*$p*" } | Stop-Process -Force -ErrorAction SilentlyContinue
+          }
+
+
       - uses: actions/checkout@v5
         with:
           clean: true
@@ -409,6 +422,19 @@ jobs:
           # - backend: cuda
           #   runner: [self-hosted, Windows, 128gb, cuda]
     steps:
+      - name: Prepare Windows runner for long paths and stale workspace caches
+        if: runner.os == 'Windows'
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          # 1. Kill any running/orphaned processes to release file locks
+          $patterns = @("lemonade", "lemond", "llama-server", "llama", "flm", "ort-server", "moonshine-server", "wscript", "LemonadeServer")
+          foreach ($p in $patterns) {
+              Get-Process | Where-Object { $_.ProcessName -like "*$p*" } | Stop-Process -Force -ErrorAction SilentlyContinue
+          }
+
+
       - uses: actions/checkout@v5
         with:
           clean: true

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -203,6 +203,19 @@ jobs:
     if: always() && !failure() && !cancelled()
     runs-on: windows-latest
     steps:
+      - name: Prepare Windows runner for long paths and stale workspace caches
+        if: runner.os == 'Windows'
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          # 1. Kill any running/orphaned processes to release file locks
+          $patterns = @("lemonade", "lemond", "llama-server", "llama", "flm", "ort-server", "moonshine-server", "wscript", "LemonadeServer")
+          foreach ($p in $patterns) {
+              Get-Process | Where-Object { $_.ProcessName -like "*$p*" } | Stop-Process -Force -ErrorAction SilentlyContinue
+          }
+
+
       - uses: actions/checkout@v5
         with:
           clean: true
@@ -279,6 +292,19 @@ jobs:
           #   channel: ""
           #   runner: [self-hosted, Windows, 128gb, cuda]
     steps:
+      - name: Prepare Windows runner for long paths and stale workspace caches
+        if: runner.os == 'Windows'
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          # 1. Kill any running/orphaned processes to release file locks
+          $patterns = @("lemonade", "lemond", "llama-server", "llama", "flm", "ort-server", "moonshine-server", "wscript", "LemonadeServer")
+          foreach ($p in $patterns) {
+              Get-Process | Where-Object { $_.ProcessName -like "*$p*" } | Stop-Process -Force -ErrorAction SilentlyContinue
+          }
+
+
       - uses: actions/checkout@v5
         with:
           clean: true


### PR DESCRIPTION
This PR improves persistent self-hosted Windows runner hygiene by isolating transient state and ensuring robust cleanup of process locks. This prevents `MAX_PATH` errors, workspace contamination, and checkout failures from lingering background daemons.

### Key Changes:
* **Pre-Checkout process termination**: Terminate lingering server/backend processes (`lemond`, `llama-server`, etc.) before `actions/checkout` runs to release active file locks on workspace files (without terminating Python).
* **Setup path relocation**: Directs test installations, caches, and temp directories to isolated directories under `C:\lemonade-ci` outside the git workspace.
* **Teardown resiliency**: Uses composite actions (`setup-windows-ci-env` / `teardown-windows-ci-env`) with `if: always()` on individual steps to ensure that processes are killed and workspaces are cleaned up even if previous steps fail.
