### PR TITLE
fix(llamacpp): validate device-backend compatibility during model load

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2593,6 +2593,13 @@ if(EXISTS "${_ROCM_ROOT_TEST_SRC}")
     add_test(NAME RocmRootResolutionTest COMMAND test_rocm_root_resolution)
 endif()
 
+set(_GPU_ENV_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_backend_utils_gpu_env.cpp")
+if(EXISTS "${_GPU_ENV_TEST_SRC}")
+    add_executable(test_backend_utils_gpu_env test/cpp/test_backend_utils_gpu_env.cpp)
+    target_link_libraries(test_backend_utils_gpu_env PRIVATE lemonade-server-core)
+    add_test(NAME BackendUtilsGpuEnvTest COMMAND test_backend_utils_gpu_env)
+endif()
+
 set(_NETWORK_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_network_utils.cpp")
 if(EXISTS "${_NETWORK_UTILS_TEST_SRC}")
     add_executable(test_network_utils test/cpp/test_network_utils.cpp)

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -201,5 +201,14 @@ namespace lemon::backends {
             std::vector<std::pair<std::string, std::string>>& env_vars,
             const std::string& log_tag,
             bool skip_visible_devices = false);
+
+        /**
+         * Validates that the device selection string prefix matches the selected backend.
+         * Throws std::invalid_argument if a device prefix contradicts the backend choice
+         * (e.g. passing target_device "ROCm2" to a "vulkan" or "cuda" backend).
+         */
+        static void validate_device_backend_match(
+            const std::string& backend,
+            const std::string& target_device);
     };
 } // namespace lemon::backends

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -1228,8 +1228,8 @@ namespace lemon::backends {
             const std::string& log_tag,
             bool skip_visible_devices) {
         if (!skip_visible_devices) {
-            const char* existing_visible_devices = std::getenv("CUDA_VISIBLE_DEVICES");
-            const bool has_visible_override = existing_visible_devices && existing_visible_devices[0] != '\0';
+            std::string existing_visible_devices = utils::get_environment_variable_utf8("CUDA_VISIBLE_DEVICES");
+            const bool has_visible_override = !existing_visible_devices.empty();
 
             if (has_visible_override) {
                 LOG(INFO, log_tag) << "Respecting existing CUDA_VISIBLE_DEVICES="
@@ -1256,5 +1256,48 @@ namespace lemon::backends {
                                << std::endl;
         }
 #endif
+    }
+
+    void BackendUtils::validate_device_backend_match(
+            const std::string& backend,
+            const std::string& target_device) {
+        if (backend.empty() || backend == "auto" || backend == "system" || target_device.empty()) {
+            return;
+        }
+
+        std::string lower_device = target_device;
+        for (char& c : lower_device) {
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        }
+
+        std::string lower_backend = backend;
+        for (char& c : lower_backend) {
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        }
+
+        const bool is_rocm_device = (lower_device.rfind("rocm", 0) == 0);
+        const bool is_cuda_device = (lower_device.rfind("cuda", 0) == 0);
+        const bool is_vulkan_device = (lower_device.rfind("vulkan", 0) == 0);
+
+        const bool is_rocm_backend = (lower_backend.rfind("rocm", 0) == 0);
+        const bool is_cuda_backend = (lower_backend.rfind("cuda", 0) == 0);
+        const bool is_vulkan_backend = (lower_backend.rfind("vulkan", 0) == 0);
+
+        if (is_rocm_device && !is_rocm_backend) {
+            throw std::invalid_argument(
+                "Device selection '" + target_device + "' contradicts backend choice '" + backend +
+                "'. Expected a " + backend + " device identifier (e.g. " +
+                (is_vulkan_backend ? "Vulkan0" : is_cuda_backend ? "CUDA0" : "a matching device") + ").");
+        }
+        if (is_cuda_device && !is_cuda_backend) {
+            throw std::invalid_argument(
+                "Device selection '" + target_device + "' contradicts backend choice '" + backend +
+                "'. Expected a " + backend + " device identifier.");
+        }
+        if (is_vulkan_device && !is_vulkan_backend) {
+            throw std::invalid_argument(
+                "Device selection '" + target_device + "' contradicts backend choice '" + backend +
+                "'. Expected a " + backend + " device identifier.");
+        }
     }
 } // namespace lemon::backends

--- a/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_server.cpp
@@ -340,7 +340,8 @@ void LlamaCppServer::load(const std::string& model_name,
     }
     push_arg(args, reserved_flags, "--ctx-size", std::to_string(ctx_size), std::vector<std::string>{"-c"});
 
-    if (llamacpp_device != "") {
+    if (!llamacpp_device.empty()) {
+        BackendUtils::validate_device_backend_match(llamacpp_backend, llamacpp_device);
         push_arg(args, reserved_flags, "--device", llamacpp_device);
     }
     push_reserved(reserved_flags, "--device", std::vector<std::string>{"-dev"});
@@ -503,8 +504,8 @@ void LlamaCppServer::load(const std::string& model_name,
 #endif
 
     if (is_llamacpp_cuda_backend(llamacpp_backend)) {
-        const char* existing_llama_device = std::getenv("LLAMA_ARG_DEVICE");
-        const bool has_llama_device_override = existing_llama_device && existing_llama_device[0] != '\0';
+        std::string existing_llama_device = utils::get_environment_variable_utf8("LLAMA_ARG_DEVICE");
+        const bool has_llama_device_override = !existing_llama_device.empty();
 
         bool skip_visible_devices = false;
         if (!llamacpp_device.empty()) {

--- a/test/cpp/test_backend_utils_gpu_env.cpp
+++ b/test/cpp/test_backend_utils_gpu_env.cpp
@@ -1,0 +1,123 @@
+// Unit tests for lemon::backends::BackendUtils::validate_device_backend_match()
+// and lemon::backends::BackendUtils::apply_cuda_env_vars().
+//
+// These tests exercise environment variable override precedence and device
+// selection validation deterministically without requiring physical GPU hardware.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <lemon/backends/backend_utils.h>
+
+#ifdef _WIN32
+#include <process.h>
+#else
+#include <unistd.h>
+#endif
+
+using lemon::backends::BackendUtils;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, const char* msg) {
+    if (cond) {
+        std::cout << "[ok] " << msg << std::endl;
+    } else {
+        std::cerr << "[FAIL] " << msg << std::endl;
+        ++g_failures;
+    }
+}
+
+void set_env_var(const std::string& name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name.c_str(), value.c_str());
+#else
+    setenv(name.c_str(), value.c_str(), /*overwrite=*/1);
+#endif
+}
+
+void clear_env_var(const std::string& name) {
+#ifdef _WIN32
+    _putenv((name + "=").c_str());
+#else
+    unsetenv(name.c_str());
+#endif
+}
+
+bool has_key(const std::vector<std::pair<std::string, std::string>>& env_vars,
+             const std::string& key) {
+    for (const auto& pair : env_vars) {
+        if (pair.first == key) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+int main() {
+    // Ensure clean host environment state before running tests
+    clear_env_var("HIP_VISIBLE_DEVICES");
+    clear_env_var("ROCR_VISIBLE_DEVICES");
+    clear_env_var("CUDA_VISIBLE_DEVICES");
+
+    // Test 1: apply_cuda_env_vars respects pre-existing CUDA_VISIBLE_DEVICES in host environment
+    {
+        set_env_var("CUDA_VISIBLE_DEVICES", "3");
+        std::vector<std::pair<std::string, std::string>> env_vars;
+        BackendUtils::apply_cuda_env_vars(env_vars, "TestCuda", /*skip_visible_devices=*/false);
+        check(!has_key(env_vars, "CUDA_VISIBLE_DEVICES"),
+              "apply_cuda_env_vars respects pre-existing CUDA_VISIBLE_DEVICES host override");
+        clear_env_var("CUDA_VISIBLE_DEVICES");
+    }
+
+    // Test 2: validate_device_backend_match throws invalid_argument on device/backend mismatch
+    {
+        bool threw_rocm_vulkan = false;
+        try {
+            BackendUtils::validate_device_backend_match("vulkan", "ROCm2");
+        } catch (const std::invalid_argument& e) {
+            threw_rocm_vulkan = true;
+        }
+        check(threw_rocm_vulkan,
+              "validate_device_backend_match throws invalid_argument for ROCm device on vulkan backend");
+
+        bool threw_cuda_rocm = false;
+        try {
+            BackendUtils::validate_device_backend_match("rocm-stable", "CUDA0");
+        } catch (const std::invalid_argument& e) {
+            threw_cuda_rocm = true;
+        }
+        check(threw_cuda_rocm,
+              "validate_device_backend_match throws invalid_argument for CUDA device on rocm backend");
+
+        bool no_throw_matching = true;
+        try {
+            BackendUtils::validate_device_backend_match("vulkan", "Vulkan0");
+            BackendUtils::validate_device_backend_match("rocm-stable", "ROCm1");
+            BackendUtils::validate_device_backend_match("cuda", "CUDA2");
+            BackendUtils::validate_device_backend_match("system", "ROCm2");
+            BackendUtils::validate_device_backend_match("auto", "ROCm2");
+            BackendUtils::validate_device_backend_match("", "ROCm1");
+            BackendUtils::validate_device_backend_match("vulkan", "");
+        } catch (...) {
+            no_throw_matching = false;
+        }
+        check(no_throw_matching,
+              "validate_device_backend_match accepts matching pairs and system/auto backends gracefully");
+    }
+
+    if (g_failures > 0) {
+        std::cerr << "Total failures: " << g_failures << std::endl;
+        return 1;
+    }
+
+    std::cout << "All GPU environment unit tests passed!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
Validates that explicit `llamacpp_device` targets match the resolved `llamacpp_backend` before starting `llama-server`.

### Why
When a request or recipe specifies a device identifier that contradicts the resolved backend (for example, passing `llamacpp_device = ROCm2` when `llamacpp_backend` resolved to `vulkan` via auto-selection), `llama-server` fails during CLI argument parsing with `invalid device: ROCm2`. Because this failure occurs asynchronously inside the child process, it surfaces to clients as an uninformative error (`llama-server failed to start`) without explaining the backend/device mismatch.

### Changes
- Adds `BackendUtils::validate_device_backend_match` in `LlamaCppServer::load()`. Throws `std::invalid_argument` before process launch if a device prefix (`rocm`, `cuda`, `vulkan`) contradicts the resolved backend, providing an explicit error message (`Device selection 'ROCm2' contradicts backend choice 'vulkan'`).
- Bypasses prefix validation when `backend` is `"system"` or `"auto"` (or empty) so system binaries and PATH-resolved backends pass through cleanly.
- Standardizes `LLAMA_ARG_DEVICE` and `CUDA_VISIBLE_DEVICES` lookups using cross-platform UTF-8 environment accessors (`utils::get_environment_variable_utf8`).
- Adds C++ unit test suite `test_backend_utils_gpu_env.cpp` verifying CUDA host override handling, system/auto backend passthrough, and mismatch validation exception throwing without physical GPU hardware dependencies.