### PR TITLE
fix(custom_args): preserve repeatable flags

### DIFF
--- a/src/cpp/include/lemon/utils/custom_args.h
+++ b/src/cpp/include/lemon/utils/custom_args.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <map>
 #include <set>
 #include <string>
@@ -45,8 +46,10 @@ inline std::vector<std::string> parse_custom_args(const std::string& custom_args
     return result;
 }
 
-inline std::map<std::string, std::vector<std::string>> build_custom_args_map(const std::vector<std::string>& tokens) {
-    std::map<std::string, std::vector<std::string>> result;
+using CustomArgsMap = std::map<std::string, std::vector<std::vector<std::string>>>;
+
+inline CustomArgsMap build_custom_args_map(const std::vector<std::string>& tokens) {
+    CustomArgsMap result;
     std::string last_flag;  // Track the most recently seen flag independently of map ordering
 
     // Detect a complete negative number so it's treated as a value, not a flag.
@@ -90,11 +93,11 @@ inline std::map<std::string, std::vector<std::string>> build_custom_args_map(con
     for (const auto& token : tokens) {
         if (!token.empty() && token[0] == '-' && !is_negative_number(token)) {
             // This is a flag; start a new entry
-            result[token] = {};
+            result[token].push_back({});
             last_flag = token;
         } else if (!last_flag.empty()) {
             // Append to the most recently seen flag
-            result[last_flag].push_back(token);
+            result[last_flag].back().push_back(token);
         }
     }
 
@@ -128,15 +131,17 @@ inline std::string validate_custom_args(const std::string& custom_args_str, cons
     return "";
 }
 
-inline std::string map_to_args_string(const std::map<std::string, std::vector<std::string>>& m) {
+inline std::string map_to_args_string(const CustomArgsMap& m) {
     std::string result;
     bool first = true;
-    for (const auto& [flag, values] : m) {
-        if (!first) result += " ";
-        first = false;
-        result += flag;
-        for (const auto& v : values) {
-            result += " " + v;
+    for (const auto& [flag, occurrences] : m) {
+        for (const auto& values : occurrences) {
+            if (!first) result += " ";
+            first = false;
+            result += flag;
+            for (const auto& v : values) {
+                result += " " + v;
+            }
         }
     }
     return result;
@@ -154,15 +159,20 @@ inline std::string negate_flag(const std::string& flag) {
     return "";
 }
 
-inline std::map<std::string, std::vector<std::string>> merge_args_maps(
-    const std::map<std::string, std::vector<std::string>>& target,
-    const std::map<std::string, std::vector<std::string>>& incoming) {
-    std::map<std::string, std::vector<std::string>> merged = target;
+inline CustomArgsMap merge_args_maps(
+    const CustomArgsMap& target,
+    const CustomArgsMap& incoming) {
+    CustomArgsMap merged = target;
 
     // Remove binary-flag negations from incoming that conflict with target.
     // Only flags without arguments are considered binary flags.
-    for (const auto& [flag, values] : incoming) {
-        if (values.empty()) {
+    for (const auto& [flag, occurrences] : incoming) {
+        bool is_binary = std::all_of(
+            occurrences.begin(), occurrences.end(),
+            [](const std::vector<std::string>& values) {
+                return values.empty();
+            });
+        if (is_binary) {
             std::string neg = negate_flag(flag);
             if (!neg.empty() && merged.count(neg)) {
                 // Target has the opposite binary flag — skip this incoming flag
@@ -170,7 +180,7 @@ inline std::map<std::string, std::vector<std::string>> merge_args_maps(
             }
         }
         if (!merged.count(flag)) {
-            merged[flag] = values;
+            merged[flag] = occurrences;
         }
     }
     return merged;

--- a/test/cpp/test_custom_args.cpp
+++ b/test/cpp/test_custom_args.cpp
@@ -10,19 +10,24 @@
 #include <vector>
 
 using lemon::utils::build_custom_args_map;
+using lemon::utils::map_to_args_string;
+using lemon::utils::merge_args_maps;
 using lemon::utils::parse_custom_args;
 
-using ArgMap = std::map<std::string, std::vector<std::string>>;
+using ArgMap = lemon::utils::CustomArgsMap;
 
 static std::string dump(const ArgMap& m) {
     std::string s = "{";
-    for (const auto& [flag, vals] : m) {
-        s += " " + flag + ": [";
-        for (size_t i = 0; i < vals.size(); ++i) {
-            if (i) s += ", ";
-            s += vals[i];
+    for (const auto& [flag, occurrences] : m) {
+        s += " " + flag + ":";
+        for (const auto& vals : occurrences) {
+            s += " [";
+            for (size_t i = 0; i < vals.size(); ++i) {
+                if (i) s += ", ";
+                s += vals[i];
+            }
+            s += "]";
         }
-        s += "]";
     }
     return s + " }";
 }
@@ -39,47 +44,83 @@ static bool expect_map(const char* name, const std::string& input,
     return ok;
 }
 
+static bool expect_merge(const char* name, const std::string& target,
+                         const std::string& incoming,
+                         const std::string& expected) {
+    ArgMap target_map = build_custom_args_map(parse_custom_args(target));
+    ArgMap incoming_map = build_custom_args_map(parse_custom_args(incoming));
+    std::string actual = map_to_args_string(merge_args_maps(target_map, incoming_map));
+    bool ok = (actual == expected);
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) {
+        std::printf("  got:  %s\n  want: %s\n",
+                    actual.c_str(), expected.c_str());
+    }
+    return ok;
+}
+
 int main() {
     int failures = 0;
 
     // Negative numbers attach to their flag and never become phantom keys.
     failures += !expect_map(
-        "negative integer value", "--cache-ram -1", {{"--cache-ram", {"-1"}}});
+        "negative integer value", "--cache-ram -1", {{"--cache-ram", {{"-1"}}}});
     failures += !expect_map(
-        "negative float value", "--temp -0.5", {{"--temp", {"-0.5"}}});
+        "negative float value", "--temp -0.5", {{"--temp", {{"-0.5"}}}});
     failures += !expect_map(
-        "negative leading-dot float", "--temp -.5", {{"--temp", {"-.5"}}});
+        "negative leading-dot float", "--temp -.5", {{"--temp", {{"-.5"}}}});
 
     // Scientific notation.
     failures += !expect_map(
-        "scientific notation", "--threshold -1e5", {{"--threshold", {"-1e5"}}});
+        "scientific notation", "--threshold -1e5", {{"--threshold", {{"-1e5"}}}});
     failures += !expect_map(
         "scientific notation with negative exponent",
-        "--threshold -1.5e-3", {{"--threshold", {"-1.5e-3"}}});
+        "--threshold -1.5e-3", {{"--threshold", {{"-1.5e-3"}}}});
     failures += !expect_map(
         "scientific notation capital E",
-        "--val -1E10", {{"--val", {"-1E10"}}});
+        "--val -1E10", {{"--val", {{"-1E10"}}}});
 
     // Identical negatives under two flags must both survive (std::map keys
     // are unique; treating -1 as a flag would dedupe it, dropping values).
     failures += !expect_map(
         "duplicate negative under two flags (no phantom key)",
         "--cache-ram -1 --reasoning-budget -1",
-        {{"--cache-ram", {"-1"}}, {"--reasoning-budget", {"-1"}}});
+        {{"--cache-ram", {{"-1"}}}, {"--reasoning-budget", {{"-1"}}}});
 
     // Sanity: short and long flags still parse as flags with their values.
     failures += !expect_map(
-        "short flag with value", "-ngl 99", {{"-ngl", {"99"}}});
+        "short flag with value", "-ngl 99", {{"-ngl", {{"99"}}}});
     failures += !expect_map(
-        "long flag with value", "--threads 8", {{"--threads", {"8"}}});
+        "long flag with value", "--threads 8", {{"--threads", {{"8"}}}});
 
     // Counterexamples: incomplete numerics are flags, not values.
     failures += !expect_map(
         "-1foo is a flag, not a value",
-        "--foo -1foo", {{"--foo", {}}, {"-1foo", {}}});
+        "--foo -1foo", {{"--foo", {{}}}, {"-1foo", {{}}}});
     failures += !expect_map(
         "-.future is a flag, not a value",
-        "--foo -.future", {{"--foo", {}}, {"-.future", {}}});
+        "--foo -.future", {{"--foo", {{}}}, {"-.future", {{}}}});
+
+    failures += !expect_map(
+        "repeatable flag occurrences",
+        "--override-kv a=bool:false --override-kv b=bool:false",
+        {{"--override-kv", {{"a=bool:false"}, {"b=bool:false"}}}});
+
+    failures += !expect_merge(
+        "target repeatable flag takes precedence",
+        "--override-kv a=bool:false --override-kv b=bool:false --threads 8",
+        "--override-kv default=bool:true --threads 4 --cache-type-k q8_0",
+        "--cache-type-k q8_0 --override-kv a=bool:false --override-kv b=bool:false --threads 8");
+    failures += !expect_merge(
+        "incoming repeatable flag is preserved",
+        "--threads 8",
+        "--override-kv a=bool:false --override-kv b=bool:false",
+        "--override-kv a=bool:false --override-kv b=bool:false --threads 8");
+    failures += !expect_merge(
+        "binary negation precedence is preserved",
+        "--no-mmap",
+        "--mmap --override-kv a=bool:false --override-kv b=bool:false",
+        "--no-mmap --override-kv a=bool:false --override-kv b=bool:false");
 
     std::printf("\n%d failures\n", failures);
     return failures == 0 ? 0 : 1;


### PR DESCRIPTION
## Summary

- Preserve every occurrence of repeatable custom arguments such as `--override-kv`.
- Keep the existing higher-priority source and binary-negation merge behavior.

Fixes #2831

## Testing

- `ctest --test-dir build -R '^CustomArgsTest$' --output-on-failure`
- `cmake --build --preset default --target lemond`
- Standalone AppleClang C++17 build with `-Wall -Wextra -Werror`

## Screenshots

Not applicable; this changes native argument parsing and merge behavior.
