### PR TITLE
ci: add and scope concurrency policies across workflows

### DIFF
--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/container-build-test.yml
+++ b/.github/workflows/container-build-test.yml
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-smoke-test:
     name: Build and smoke test (${{ matrix.arch }})

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -19,6 +19,10 @@ permissions:
   contents: write
   actions: read  # Required for SignPath to read workflow/job details
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   LEMONADE_DISABLE_SYSTEMD_JOURNAL: "1"
 

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -20,7 +20,7 @@ permissions:
   actions: read  # Required for SignPath to read workflow/job details
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/docker-build-smoke-test.yml
+++ b/.github/workflows/docker-build-smoke-test.yml
@@ -17,8 +17,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   docker-smoke-test:

--- a/.github/workflows/docs_and_style.yml
+++ b/.github/workflows/docs_and_style.yml
@@ -13,8 +13,8 @@ jobs:
   app-regression-tests:
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-app-regression-${{ github.ref }}
-      cancel-in-progress: true
+      group: ${{ github.workflow }}-app-regression-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node.js
@@ -38,8 +38,8 @@ jobs:
     # if the committed doc is stale — the same guarantee a lint provides.
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-backend-docs-${{ github.ref }}
-      cancel-in-progress: true
+      group: ${{ github.workflow }}-backend-docs-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     env:
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -66,8 +66,8 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node.js

--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -14,6 +14,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   prepare-matrix:
     name: Prepare matrix

--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/linux_distro_builds.yml
+++ b/.github/workflows/linux_distro_builds.yml
@@ -24,8 +24,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-linux:

--- a/.github/workflows/mcp-smoke-test.yml
+++ b/.github/workflows/mcp-smoke-test.yml
@@ -31,8 +31,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ========================================================================

--- a/.github/workflows/routing_schema_tests.yml
+++ b/.github/workflows/routing_schema_tests.yml
@@ -13,8 +13,8 @@ jobs:
     name: Routing schema + fixtures
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v5
       - name: Setup Python

--- a/.github/workflows/server_download_registry.yml
+++ b/.github/workflows/server_download_registry.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   LEMONADE_DISABLE_SYSTEMD_JOURNAL: "1"

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -16,6 +16,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   LEMONADE_CI_MODE: "True"
   PYTHONIOENCODING: utf-8

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -50,8 +50,8 @@ env:
   LEMONADE_VALIDATE_SD_TIMEOUT: "7200"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   discover-release:

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -16,6 +16,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   LEMONADE_CI_MODE: "True"
   PYTHONIOENCODING: utf-8

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:


### PR DESCRIPTION
Gives the five `pull_request`-triggered workflows that lacked a concurrency policy one, so a new commit supersedes the in-flight run instead of stacking a full duplicate. Three of them (`cpp_server_build_test_release`, `validate_llamacpp`, `validate_vllm`) contend for the self-hosted `lemon-prod` runners, so the stacking costs real hardware time.

The group is scoped so that **only successive PR revisions supersede one another**:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

`github.ref` is `refs/heads/main` for push, `schedule`, and `workflow_dispatch` alike, so a plain ref-keyed group collapses all three into one — and GitHub evicts any *pending* run when a newer one joins a group, regardless of `cancel-in-progress`. Suffixing with `github.run_id` for non-PR events puts each in its own singleton group, so a dispatched signing run can't be silently dropped while queued behind a long `main` build, and a scheduled validation can't lose its `create-pr` job.

- Adds the policy to `cpp_server_build_test_release`, `validate_llamacpp`, `validate_vllm`, `container-build-test`, and `launchpad-ppa`.
- Applies the same scoping to the seven files that already had a policy — they carried the same exposure in a stronger form, since bare `cancel-in-progress: true` also cancels *in-progress* runs.
- Bot workflows (`repo-manager`, `auto-label`, `claude-review`) are deliberately untouched; their groups are keyed to issue/PR number by design.
- `upload.yml` needs no change — it is `workflow_call`-only and inherits its group from its sole caller, `launchpad-ppa.yml`.

Note this means superseded `main`-branch runs now complete instead of being cancelled, a small increase in main-branch CI load traded for never silently dropping a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
