### PR TITLE
fix(installer): remember custom install location

### DIFF
--- a/src/cpp/installer/Product.wxs.in
+++ b/src/cpp/installer/Product.wxs.in
@@ -93,7 +93,7 @@
     <SetProperty Id="INSTALLDIR"
                  Value="[EXISTINGINSTALLDIR]"
                  Before="CostFinalize"
-                 Sequence="both"
+                 Sequence="first"
                  Condition="EXISTINGINSTALLDIR AND (ALLUSERS &lt;&gt; 1)" />
 
     <!-- ============================================ -->

--- a/src/cpp/installer/Product.wxs.in
+++ b/src/cpp/installer/Product.wxs.in
@@ -90,6 +90,11 @@
                       Name="InstallLocation"
                       Type="raw" />
     </Property>
+    <SetProperty Id="INSTALLDIR"
+                 Value="[EXISTINGINSTALLDIR]"
+                 Before="CostFinalize"
+                 Sequence="both"
+                 Condition="EXISTINGINSTALLDIR AND (ALLUSERS &lt;&gt; 1)" />
 
     <!-- ============================================ -->
     <!-- Conflict Detection: Block dual per-user/all-users installs -->


### PR DESCRIPTION
## Summary

- Restore the saved per-user `InstallLocation` to `INSTALLDIR` before installer costing.
- Preserve the existing all-users install-directory behavior.

Fixes #1119

## Testing

- Configured-template XML validation with `xmllint --noout`
- Restore-action regression check: upstream `0`, patched `1`
- `git diff --check`

An interactive Windows upgrade was not available locally; the Windows installer CI build provides WiX/MSI compilation and packaging validation.

## Screenshots

Not applicable; this changes Windows installer authoring rather than application UI.