### PR TITLE
feat(logging): add log rotation and transition default server posture to stdout/stderr

### DIFF
--- a/.github/actions/capture-server-logs/action.yml
+++ b/.github/actions/capture-server-logs/action.yml
@@ -13,21 +13,18 @@ runs:
       run: |
         New-Item -ItemType Directory -Path server-logs -Force | Out-Null
 
-        # Check common log locations
-        $candidates = @(
-          "$env:TEMP\lemonade-server.log",
-          "$env:TEMP\lemond.log",
-          "$env:LOCALAPPDATA\lemonade_server\lemonade-server.log"
-        )
-
+        # Check common log locations (including rotated log files .1, .2, etc.)
+        $logFiles = Get-ChildItem -Path "$env:TEMP", "$env:LOCALAPPDATA\lemonade_server" -Filter "lemonade-server.log*" -ErrorAction SilentlyContinue
         $found = $false
-        foreach ($logFile in $candidates) {
-          if (Test-Path $logFile) {
-            Write-Host "=== Last 200 lines of $logFile ==="
-            Get-Content $logFile -Tail 200
-            Copy-Item $logFile server-logs/ -ErrorAction SilentlyContinue
-            $found = $true
-          }
+        foreach ($file in $logFiles) {
+          Write-Host "=== Last 200 lines of $($file.FullName) ==="
+          Get-Content $file.FullName -Tail 200
+          Copy-Item $file.FullName server-logs/ -ErrorAction SilentlyContinue
+          $found = $true
+        }
+        if (Test-Path "$env:TEMP\lemond.log") {
+          Copy-Item "$env:TEMP\lemond.log" server-logs/ -ErrorAction SilentlyContinue
+          $found = $true
         }
 
         if (-not $found) {
@@ -53,20 +50,22 @@ runs:
           done
         fi
 
-        # --- Linux: check file-based logs ---
+        # --- Linux: check file-based logs (including rotated backups) ---
         if [ "$RUNNER_OS" = "Linux" ]; then
           # XDG runtime dir (e.g. /run/user/1001/lemonade/)
           LEMON_RUNTIME_DIR="${XDG_RUNTIME_DIR:+${XDG_RUNTIME_DIR}/lemonade}"
-          for candidate in \
-            "${LEMON_RUNTIME_DIR}/lemonade-server.log" \
-            "$RUNNER_TEMP/lemonade-server.log" \
-            "$RUNNER_TEMP/lemond.log"; do
-            if [ -f "$candidate" ]; then
-              echo "=== Last 200 lines of $candidate ==="
-              tail -200 "$candidate"
-              cp "$candidate" server-logs/ 2>/dev/null || true
-              found=true
-            fi
+          for log_pattern in \
+            "${LEMON_RUNTIME_DIR}"/lemonade-server.log* \
+            "$RUNNER_TEMP"/lemonade-server.log* \
+            "$RUNNER_TEMP"/lemond.log*; do
+            for candidate in $log_pattern; do
+              if [ -f "$candidate" ]; then
+                echo "=== Last 200 lines of $candidate ==="
+                tail -200 "$candidate"
+                cp "$candidate" server-logs/ 2>/dev/null || true
+                found=true
+              fi
+            done
           done
 
           # Systemd journal (works when server runs as lemond.service)

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1986,6 +1986,13 @@ jobs:
           .venv/bin/python test/server_websocket_auth.py
           echo "WebSocket auth tests PASSED!"
 
+      - name: Test log rotation
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        shell: bash
+        run: |
+          .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu log-rotation"
+          .venv/bin/python test/server_log_rotation.py
+
       - name: Test router
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         shell: bash

--- a/.github/workflows/linux_distro_builds.yml
+++ b/.github/workflows/linux_distro_builds.yml
@@ -243,6 +243,21 @@ jobs:
 
           echo "Endpoint tests PASSED!"
 
+      - name: Run log rotation tests
+        env:
+          LEMONADE_CI_MODE: "True"
+          PYTHONIOENCODING: utf-8
+        run: |
+          set -e
+
+          . .venv/bin/activate
+          CLI_BINARY="$(pwd)/build/lemonade"
+
+          echo "Running log rotation tests..."
+          python test/server_log_rotation.py
+
+          echo "Log rotation tests PASSED!"
+
       - name: Capture and upload server logs
         if: always()
         uses: ./.github/actions/capture-server-logs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3049,6 +3049,13 @@ if(BUILD_TESTING AND EXISTS "${_CLI_RUNTIME_OVERRIDE_TEST_SRC}")
     add_cpp_ci_test(CliRuntimeOverrideTest CI ON COMMAND test_cli_runtime_override)
 endif()
 
+set(_LOG_ROTATION_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_log_rotation.cpp")
+if(BUILD_TESTING AND EXISTS "${_LOG_ROTATION_TEST_SRC}")
+    add_executable(test_log_rotation test/cpp/test_log_rotation.cpp)
+    target_link_libraries(test_log_rotation PRIVATE lemonade-server-core)
+    add_cpp_ci_test(LogRotationTest CI ON COMMAND test_log_rotation)
+endif()
+
 # ROCm root resolution (ROCM_PATH / rocm-sdk / /opt/rocm priority): covers the
 # external-ROCm detection that lets Lemonade skip the bundled TheRock download.
 set(_ROCM_ROOT_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_rocm_root_resolution.cpp")

--- a/docs/dev/getting-started.md
+++ b/docs/dev/getting-started.md
@@ -827,7 +827,7 @@ The tray application provides a system tray icon for desktop users:
 ### Logging and Console Output
 
 When running `LemonadeServer.exe` or `lemond`:
-- **Log File:** Direct runs write logs to a persistent log file (default: `%TEMP%\lemonade-server.log` on Windows). When `lemond` runs as the systemd service, logs go to the journal instead.
+- **Log File:** Direct CLI server runs (`lemond`) default to standard console output (`stdout`/`stderr`) with file logging disabled (`"auto"` mode), allowing systemd, launchd, container runtimes, and CI runners to capture and rotate logs natively. When running via `LemonadeServer.exe` (embedded tray app) or when file logging is explicitly enabled (`--log-file enabled` or a custom file path), logs are written to `lemonade-server.log` (under `%TEMP%` on Windows, `$XDG_RUNTIME_DIR/lemonade/` on Linux) with automatic log rotation (10 MB file cap, 5 rotated backups `.1` through `.5`, bounding steady-state log disk usage to ~60 MB under normal record sizes). Pre-existing legacy logs at startup are rotated into `.1` to preserve diagnostic history and pruned across subsequent rotation cycles.
 - **Logs UI:** Click "Show Logs" in the tray or use `lemonade logs` to open the desktop app's logs view
   - Connects to the server's WebSocket log stream
   - Shows retained recent log history plus live entries

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -80,7 +80,10 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
     "vulkan_args": "",
     "vulkan_bin": "builtin"
   },
+  "log_file": "auto",
   "log_level": "info",
+  "log_max_file_size_mb": 10,
+  "log_max_files": 5,
   "max_loaded_models": 1,
   "models_dir": "auto",
   "moonshine": {
@@ -193,6 +196,9 @@ When `lemond` starts, effective configuration is resolved by deep-merging settin
 | `port` | int | 13305 | Port number for the HTTP server |
 | `host` | string | "localhost" | Address to bind for connections |
 | `log_level` | string | "info" | Logging level (trace, debug, info, warning, error, fatal, none) |
+| `log_file` | string | "auto" | File logging mode: "auto" (console-only for direct server runs, lemonade-server.log for embedded tray app), "disabled", "enabled", or custom target file path |
+| `log_max_file_size_mb` | int | 10 | Max active log file size in MB before triggering rotation (steady-state footprint bounded to ~`log_max_file_size_mb * (log_max_files + 1)`) |
+| `log_max_files` | int | 5 | Max number of rotated log backup files to retain (.1 through .N); legacy oversized files are rotated into .1 and pruned over cycles |
 | `global_timeout` | int | 600 | Timeout in seconds for HTTP, inference, and readiness checks |
 | `max_loaded_models` | int | 1 | Max models per type slot. Use -1 for unlimited |
 | `broadcast` | bool | true | Enable or disable UDP broadcasting for server discovery |

--- a/src/cpp/include/lemon/cli_parser.h
+++ b/src/cpp/include/lemon/cli_parser.h
@@ -12,6 +12,9 @@ struct ServerConfig {
     int port = -1;             // -1 = not specified on CLI, use config.json value
     std::string host;          // Empty = not specified on CLI, use config.json value
     std::optional<bool> broadcast;        // std::nullopt = not specified on CLI, use config.json value
+    std::string log_file;                 // Empty = not specified on CLI, use config.json value
+    int log_max_file_size_mb = -1;        // -1 = not specified on CLI, use config.json value
+    int log_max_files = -1;               // -1 = not specified on CLI, use config.json value
 };
 
 class CLIParser {

--- a/src/cpp/include/lemon/logging_config.h
+++ b/src/cpp/include/lemon/logging_config.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "lemon/utils/aixlog.hpp"
+
+#include <fstream>
+#include <mutex>
 #include <optional>
 #include <string>
 
@@ -10,15 +14,47 @@ enum class LoggingMode {
     embedded_tray_server,
 };
 
+struct LogRotationConfig {
+    std::string file_mode = "auto";
+    size_t max_file_size_mb = 10;
+    size_t max_files = 5;
+};
+
 struct LoggingTargets {
     bool console = false;
     bool stream_hub = true;
     bool file = false;
     std::optional<std::string> file_path;
+    LogRotationConfig rotation;
 };
 
-LoggingTargets resolve_logging_targets(LoggingMode mode);
-void configure_application_logging(const std::string& log_level, LoggingMode mode);
-void reconfigure_application_logging(const std::string& log_level);
+class RotatingFileSink : public AixLog::SinkFormat {
+public:
+    RotatingFileSink(const AixLog::Filter& filter,
+                     const std::string& filename,
+                     const std::string& format,
+                     size_t max_file_size_mb,
+                     size_t max_files);
+    ~RotatingFileSink() override;
+
+    void log(const AixLog::Metadata& metadata, const std::string& message) override;
+
+    size_t current_size() const;
+
+private:
+    void rotate_if_needed_nolock();
+    void prune_excess_backups_nolock();
+
+    std::string filename_;
+    size_t max_file_size_bytes_;
+    size_t max_files_;
+    size_t current_size_{0};
+    std::ofstream file_;
+    mutable std::mutex mutex_;
+};
+
+LoggingTargets resolve_logging_targets(LoggingMode mode, const LogRotationConfig& rotation = {});
+void configure_application_logging(const std::string& log_level, LoggingMode mode, const LogRotationConfig& rotation = {});
+void reconfigure_application_logging(const std::string& log_level, const LogRotationConfig& rotation = {});
 
 } // namespace lemon

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -32,6 +32,12 @@ public:
     void set_host_override(std::optional<std::string> override_val);
     int websocket_port() const;
     std::string log_level() const;
+    std::string log_file() const;
+    void set_log_file_override(std::optional<std::string> override_val);
+    int log_max_file_size_mb() const;
+    void set_log_max_file_size_mb_override(std::optional<int> override_val);
+    int log_max_files() const;
+    void set_log_max_files_override(std::optional<int> override_val);
     std::string extra_models_dir() const;
     bool broadcast() const;
     void set_broadcast_override(std::optional<bool> override_val);
@@ -161,6 +167,9 @@ private:
     std::optional<int> port_override_;
     std::optional<std::string> host_override_;
     std::optional<bool> broadcast_override_;
+    std::optional<std::string> log_file_override_;
+    std::optional<int> log_max_file_size_mb_override_;
+    std::optional<int> log_max_files_override_;
 
     // Valid log levels
     static const std::vector<std::string> valid_log_levels_;

--- a/src/cpp/include/lemon/utils/aixlog.hpp
+++ b/src/cpp/include/lemon/utils/aixlog.hpp
@@ -51,6 +51,12 @@
 #endif
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <Windows.h>
 // ERROR macro is defined in Windows header
 // To avoid conflict between these macro and declaration of ERROR / DEBUG in SEVERITY enum

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -42,7 +42,10 @@
     "vulkan_args": "",
     "vulkan_bin": "builtin"
   },
+  "log_file": "auto",
   "log_level": "info",
+  "log_max_file_size_mb": 10,
+  "log_max_files": 5,
   "max_loaded_models": 1,
   "models_dir": "auto",
   "moonshine": {

--- a/src/cpp/server/cli_parser.cpp
+++ b/src/cpp/server/cli_parser.cpp
@@ -31,6 +31,17 @@ CLIParser::CLIParser()
         ->type_name("HOST");
 
     app_.add_flag("--broadcast,!--no-broadcast", config_.broadcast, "Enable or disable UDP broadcasting for server discovery");
+
+    app_.add_option("--log-file", config_.log_file, "File logging mode: auto (default), disabled, enabled, or custom file path (overrides config.json)")
+        ->type_name("MODE");
+
+    app_.add_option("--log-max-size-mb", config_.log_max_file_size_mb, "Max active log file size in MB before rotation (1..2048, overrides config.json)")
+        ->type_name("MB")
+        ->check(CLI::Range(1, 2048));
+
+    app_.add_option("--log-max-files", config_.log_max_files, "Max number of rotated log backup files to retain (0..100, overrides config.json)")
+        ->type_name("N")
+        ->check(CLI::Range(0, 100));
 }
 
 int CLIParser::parse(int argc, char** argv) {

--- a/src/cpp/server/logging_config.cpp
+++ b/src/cpp/server/logging_config.cpp
@@ -5,6 +5,8 @@
 #include "lemon/system_info.h"
 #include "lemon/utils/path_utils.h"
 
+#include <algorithm>
+#include <filesystem>
 #include <fstream>
 #include <mutex>
 #include <sstream>
@@ -12,6 +14,8 @@
 #include <vector>
 
 namespace lemon {
+
+namespace fs = std::filesystem;
 
 namespace {
 
@@ -34,31 +38,171 @@ public:
     }
 };
 
-class FileLogSink : public AixLog::SinkFormat {
-public:
-    FileLogSink(const AixLog::Filter& filter,
-                const std::string& filename,
-                const std::string& format)
-        : AixLog::SinkFormat(filter, format),
-          file_(filename.c_str(), std::ofstream::out | std::ofstream::app) {
+} // namespace
+
+RotatingFileSink::RotatingFileSink(const AixLog::Filter& filter,
+                                   const std::string& filename,
+                                   const std::string& format,
+                                   size_t max_file_size_mb,
+                                   size_t max_files)
+    : AixLog::SinkFormat(filter, format),
+      filename_(filename),
+      max_file_size_bytes_(max_file_size_mb * 1024 * 1024),
+      max_files_(max_files) {
+    if (max_file_size_mb < 1 || max_file_size_mb > 2048) {
+        throw std::invalid_argument("'log_max_file_size_mb' must be between 1 and 2048");
+    }
+    if (max_files > 100) {
+        throw std::invalid_argument("'log_max_files' must be between 0 and 100");
     }
 
-    void log(const AixLog::Metadata& metadata, const std::string& message) override {
-        std::ostringstream stream;
-        do_log(stream, metadata, message);
+    std::error_code ec;
+    fs::path p = utils::path_from_utf8(filename_);
+    if (p.has_parent_path()) {
+        fs::create_directories(p.parent_path(), ec);
+    }
+    if (fs::exists(p, ec)) {
+        if (fs::is_directory(p, ec)) {
+            throw std::invalid_argument("Log file path cannot be a directory: " + filename_);
+        }
+        current_size_ = static_cast<size_t>(fs::file_size(p, ec));
+    }
 
-        std::string formatted = stream.str();
-        if (!formatted.empty() && formatted.back() == '\n') {
-            formatted.pop_back();
+    prune_excess_backups_nolock();
+
+    if (max_file_size_bytes_ > 0 && current_size_ >= max_file_size_bytes_) {
+        rotate_if_needed_nolock();
+    } else {
+        file_.open(p, std::ofstream::out | std::ofstream::app | std::ofstream::binary);
+    }
+}
+
+RotatingFileSink::~RotatingFileSink() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (file_.is_open()) {
+        file_.flush();
+        file_.close();
+    }
+}
+
+void RotatingFileSink::log(const AixLog::Metadata& metadata, const std::string& message) {
+    std::ostringstream stream;
+    do_log(stream, metadata, message);
+
+    std::string formatted = stream.str();
+    if (!formatted.empty() && formatted.back() == '\n') {
+        formatted.pop_back();
+    }
+
+    size_t line_len = formatted.size() + 1; // +1 for newline
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!file_.is_open()) {
+        return;
+    }
+
+    if (max_file_size_bytes_ > 0 && current_size_ > 0 && (current_size_ + line_len) >= max_file_size_bytes_) {
+        rotate_if_needed_nolock();
+    }
+
+    file_ << formatted << '\n';
+    file_.flush();
+    current_size_ += line_len;
+}
+
+size_t RotatingFileSink::current_size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return current_size_;
+}
+
+void RotatingFileSink::prune_excess_backups_nolock() {
+    std::error_code ec;
+    size_t start_idx = (max_files_ == 0) ? 1 : (max_files_ + 1);
+    for (size_t i = start_idx; i <= 100; ++i) {
+        fs::path backup = utils::path_from_utf8(filename_ + "." + std::to_string(i));
+        if (fs::exists(backup, ec) && fs::is_regular_file(backup, ec)) {
+            fs::remove(backup, ec);
+        }
+    }
+}
+
+void RotatingFileSink::rotate_if_needed_nolock() {
+    if (file_.is_open()) {
+        file_.flush();
+        file_.close();
+    }
+
+    std::error_code ec;
+    fs::path active_log = utils::path_from_utf8(filename_);
+    if (fs::exists(active_log, ec) && !fs::is_regular_file(active_log, ec)) {
+        return;
+    }
+
+    prune_excess_backups_nolock();
+
+    bool rename_succeeded = false;
+    bool all_slots_blocked = (max_files_ > 0);
+    if (max_files_ > 0) {
+        for (size_t i = 1; i <= max_files_; ++i) {
+            fs::path target_backup = utils::path_from_utf8(filename_ + "." + std::to_string(i));
+            if (!fs::exists(target_backup, ec) || fs::is_regular_file(target_backup, ec)) {
+                all_slots_blocked = false;
+                break;
+            }
         }
 
-        file_ << formatted << std::endl;
-        file_.flush();
+        for (size_t i = max_files_; i > 1; --i) {
+            fs::path dst = utils::path_from_utf8(filename_ + "." + std::to_string(i));
+            fs::path src = utils::path_from_utf8(filename_ + "." + std::to_string(i - 1));
+            if (fs::exists(src, ec) && fs::is_regular_file(src, ec)) {
+                if (fs::exists(dst, ec)) {
+                    if (fs::is_regular_file(dst, ec)) {
+                        fs::remove(dst, ec);
+                    } else {
+                        continue;
+                    }
+                }
+                fs::rename(src, dst, ec);
+            }
+        }
+
+        if (fs::exists(active_log, ec) && fs::is_regular_file(active_log, ec)) {
+            for (size_t i = 1; i <= max_files_; ++i) {
+                fs::path target_backup = utils::path_from_utf8(filename_ + "." + std::to_string(i));
+                if (fs::exists(target_backup, ec)) {
+                    if (fs::is_regular_file(target_backup, ec)) {
+                        fs::remove(target_backup, ec);
+                    } else {
+                        continue;
+                    }
+                }
+                if (!fs::exists(target_backup, ec)) {
+                    ec.clear();
+                    fs::rename(active_log, target_backup, ec);
+                    if (!ec) {
+                        rename_succeeded = true;
+                        break;
+                    }
+                }
+            }
+        }
     }
 
-private:
-    std::ofstream file_;
-};
+    if (rename_succeeded || max_files_ == 0 || all_slots_blocked) {
+        file_.open(active_log, std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
+    }
+    if (!file_.is_open()) {
+        file_.open(active_log, std::ofstream::out | std::ofstream::app | std::ofstream::binary);
+    }
+
+    if (fs::exists(active_log, ec) && fs::is_regular_file(active_log, ec)) {
+        current_size_ = static_cast<size_t>(fs::file_size(active_log, ec));
+    } else {
+        current_size_ = 0;
+    }
+}
+
+namespace {
 
 std::vector<std::shared_ptr<AixLog::Sink>> build_logging_sinks(
     const std::string& log_level,
@@ -70,16 +214,23 @@ std::vector<std::shared_ptr<AixLog::Sink>> build_logging_sinks(
         sinks.push_back(std::make_shared<AixLog::SinkCout>(filter, RuntimeConfig::LOG_FORMAT));
     }
     if (targets.file && targets.file_path.has_value()) {
-        sinks.push_back(std::make_shared<FileLogSink>(
+        sinks.push_back(std::make_shared<RotatingFileSink>(
             filter,
             *targets.file_path,
-            RuntimeConfig::LOG_FORMAT));
+            RuntimeConfig::LOG_FORMAT,
+            targets.rotation.max_file_size_mb,
+            targets.rotation.max_files));
     }
     if (targets.stream_hub) {
         sinks.push_back(std::make_shared<HubPublishingSink>(filter, RuntimeConfig::LOG_FORMAT));
     }
 
     return sinks;
+}
+
+LoggingMode& active_logging_mode() {
+    static LoggingMode mode = LoggingMode::direct_server;
+    return mode;
 }
 
 LoggingTargets& active_logging_targets() {
@@ -99,48 +250,59 @@ std::mutex& logging_config_mutex() {
 
 } // namespace
 
-LoggingTargets resolve_logging_targets(LoggingMode mode) {
+LoggingTargets resolve_logging_targets(LoggingMode mode, const LogRotationConfig& rotation) {
     LoggingTargets targets;
     targets.stream_hub = true;
+    targets.rotation = rotation;
 
     switch (mode) {
     case LoggingMode::direct_server:
         targets.console = true;
-        targets.file = !SystemInfo::is_running_under_systemd();
+        if (rotation.file_mode == "enabled") {
+            targets.file = true;
+        } else if (rotation.file_mode == "disabled" || rotation.file_mode == "auto" || rotation.file_mode.empty()) {
+            targets.file = false;
+        } else {
+            targets.file = true;
+        }
         break;
     case LoggingMode::embedded_tray_server:
         targets.console = false;
-        targets.file = true;
+        if (rotation.file_mode == "disabled") {
+            targets.file = false;
+        } else {
+            targets.file = true;
+        }
         break;
     }
 
     if (targets.file) {
-#ifdef _WIN32
-        targets.file_path = utils::get_runtime_dir() + "lemonade-server.log";
-#else
-        targets.file_path = utils::get_runtime_dir() + "/lemonade-server.log";
-#endif
+        if (rotation.file_mode != "enabled" && rotation.file_mode != "disabled" && rotation.file_mode != "auto" && !rotation.file_mode.empty()) {
+            targets.file_path = rotation.file_mode;
+        } else {
+            fs::path p = utils::path_from_utf8(utils::get_runtime_dir()) / "lemonade-server.log";
+            targets.file_path = utils::path_to_utf8(p);
+        }
     }
 
     return targets;
 }
 
-void configure_application_logging(const std::string& log_level, LoggingMode mode) {
-    const LoggingTargets targets = resolve_logging_targets(mode);
-
+void configure_application_logging(const std::string& log_level, LoggingMode mode, const LogRotationConfig& rotation) {
     std::lock_guard<std::mutex> lock(logging_config_mutex());
+    active_logging_mode() = mode;
+    const LoggingTargets targets = resolve_logging_targets(mode, rotation);
     active_logging_targets() = targets;
     active_logging_targets_initialized() = true;
     AixLog::Log::init(build_logging_sinks(log_level, targets));
 }
 
-void reconfigure_application_logging(const std::string& log_level) {
+void reconfigure_application_logging(const std::string& log_level, const LogRotationConfig& rotation) {
     std::lock_guard<std::mutex> lock(logging_config_mutex());
 
-    if (!active_logging_targets_initialized()) {
-        active_logging_targets() = resolve_logging_targets(LoggingMode::direct_server);
-        active_logging_targets_initialized() = true;
-    }
+    const LoggingTargets targets = resolve_logging_targets(active_logging_mode(), rotation);
+    active_logging_targets() = targets;
+    active_logging_targets_initialized() = true;
 
     AixLog::Log::init(build_logging_sinks(log_level, active_logging_targets()));
 }

--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -1,12 +1,8 @@
-#include <iostream>
-#include <csignal>
-#include <atomic>
-#include <chrono>
-#include <thread>
+#include <lemon/server.h>
+
 #include <lemon/cli_parser.h>
 #include <lemon/config_file.h>
 #include <lemon/logging_config.h>
-#include <lemon/server.h>
 #include <lemon/system_info.h>
 #include <lemon/utils/aixlog.hpp>
 #include <lemon/utils/http_client.h>
@@ -14,6 +10,12 @@
 #include <lemon/utils/path_utils.h>
 #include <lemon/version.h>
 #include "telemetry.h"
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <iostream>
+#include <thread>
 
 #if defined(__GLIBC__)
 #include <cstdlib>
@@ -165,9 +167,22 @@ int main(int argc, char** argv) {
         if (cli_config.broadcast.has_value()) {
             config->set_broadcast_override(cli_config.broadcast);
         }
+        if (!cli_config.log_file.empty()) {
+            config->set_log_file_override(cli_config.log_file);
+        }
+        if (cli_config.log_max_file_size_mb != -1) {
+            config->set_log_max_file_size_mb_override(cli_config.log_max_file_size_mb);
+        }
+        if (cli_config.log_max_files != -1) {
+            config->set_log_max_files_override(cli_config.log_max_files);
+        }
 
-        // Initialize logging with the configured level — console + file + log hub
-        configure_application_logging(config->log_level(), LoggingMode::direct_server);
+        // Initialize logging with configured level and rotation limits
+        LogRotationConfig rot_cfg;
+        rot_cfg.file_mode = config->log_file();
+        rot_cfg.max_file_size_mb = static_cast<size_t>(config->log_max_file_size_mb());
+        rot_cfg.max_files = static_cast<size_t>(config->log_max_files());
+        configure_application_logging(config->log_level(), LoggingMode::direct_server, rot_cfg);
 
         utils::set_models_dir(config->models_dir());
 
@@ -178,6 +193,9 @@ int main(int argc, char** argv) {
         LOG(INFO) << "  Port: " << config->port() << std::endl;
         LOG(INFO) << "  Host: " << config->host() << std::endl;
         LOG(INFO) << "  Log level: " << config->log_level() << std::endl;
+        LOG(INFO) << "  Log file mode: " << config->log_file() << std::endl;
+        LOG(INFO) << "  Log max file size: " << config->log_max_file_size_mb() << " MB" << std::endl;
+        LOG(INFO) << "  Log max files: " << config->log_max_files() << std::endl;
         if (!config->extra_models_dir().empty()) {
             LOG(INFO) << "  Extra models dir: " << config->extra_models_dir() << std::endl;
         }

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -274,6 +274,20 @@ RuntimeConfig::RuntimeConfig(const json& config)
         config_.erase("no_broadcast");
     }
 
+    // Validate logging settings on startup
+    if (config_.contains("log_max_file_size_mb")) {
+        validate("log_max_file_size_mb", config_["log_max_file_size_mb"]);
+    }
+    if (config_.contains("log_max_files")) {
+        validate("log_max_files", config_["log_max_files"]);
+    }
+    if (config_.contains("log_file")) {
+        validate("log_file", config_["log_file"]);
+    }
+    if (config_.contains("log_level")) {
+        validate("log_level", config_["log_level"]);
+    }
+
     // In CI mode, override log level to debug for easier diagnostics
     const char* ci_mode = std::getenv("LEMONADE_CI_MODE");
     if (ci_mode && (std::string(ci_mode) == "1" || std::string(ci_mode) == "true" ||
@@ -320,6 +334,51 @@ int RuntimeConfig::websocket_port() const {
 std::string RuntimeConfig::log_level() const {
     std::shared_lock lock(mutex_);
     return config_["log_level"].get<std::string>();
+}
+
+std::string RuntimeConfig::log_file() const {
+    {
+        std::shared_lock lock(mutex_);
+        if (log_file_override_.has_value()) {
+            return *log_file_override_;
+        }
+    }
+    return get_string_opt(nullptr, {"log_file"}, "auto");
+}
+
+void RuntimeConfig::set_log_file_override(std::optional<std::string> override_val) {
+    std::unique_lock lock(mutex_);
+    log_file_override_ = std::move(override_val);
+}
+
+int RuntimeConfig::log_max_file_size_mb() const {
+    {
+        std::shared_lock lock(mutex_);
+        if (log_max_file_size_mb_override_.has_value()) {
+            return *log_max_file_size_mb_override_;
+        }
+    }
+    return get_int_opt(nullptr, {"log_max_file_size_mb"}, 10);
+}
+
+void RuntimeConfig::set_log_max_file_size_mb_override(std::optional<int> override_val) {
+    std::unique_lock lock(mutex_);
+    log_max_file_size_mb_override_ = override_val;
+}
+
+int RuntimeConfig::log_max_files() const {
+    {
+        std::shared_lock lock(mutex_);
+        if (log_max_files_override_.has_value()) {
+            return *log_max_files_override_;
+        }
+    }
+    return get_int_opt(nullptr, {"log_max_files"}, 5);
+}
+
+void RuntimeConfig::set_log_max_files_override(std::optional<int> override_val) {
+    std::unique_lock lock(mutex_);
+    log_max_files_override_ = override_val;
 }
 
 std::string RuntimeConfig::extra_models_dir() const {
@@ -697,7 +756,7 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
         if (!value.is_number_integer()) {
             throw std::invalid_argument("'port' must be an integer");
         }
-        int p = value.get<int>();
+        int64_t p = value.get<int64_t>();
         if (p < 1 || p > 65535) {
             throw std::invalid_argument("'port' must be between 1 and 65535");
         }
@@ -712,7 +771,7 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
                     "'websocket_port' must be \"auto\" or an integer 0-65535");
             }
         } else if (value.is_number_integer()) {
-            int p = value.get<int>();
+            int64_t p = value.get<int64_t>();
             if (p < 0 || p > 65535) {
                 throw std::invalid_argument(
                     "'websocket_port' must be between 0 and 65535");
@@ -730,6 +789,34 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
             == valid_log_levels_.end()) {
             throw std::invalid_argument(
                 "'log_level' must be one of: trace, debug, info, warning, error, fatal, none");
+        }
+    } else if (key == "log_file") {
+        if (!value.is_string()) {
+            throw std::invalid_argument("'log_file' must be a string");
+        }
+        std::string mode = value.get<std::string>();
+        if (mode != "auto" && mode != "enabled" && mode != "disabled" && !mode.empty()) {
+            std::error_code ec;
+            fs::path p = utils::path_from_utf8(mode);
+            if (fs::exists(p, ec) && fs::is_directory(p, ec)) {
+                throw std::invalid_argument("'log_file' path cannot be a directory: " + mode);
+            }
+        }
+    } else if (key == "log_max_file_size_mb") {
+        if (!value.is_number_integer()) {
+            throw std::invalid_argument("'log_max_file_size_mb' must be an integer");
+        }
+        int64_t sz = value.get<int64_t>();
+        if (sz < 1 || sz > 2048) {
+            throw std::invalid_argument("'log_max_file_size_mb' must be between 1 and 2048");
+        }
+    } else if (key == "log_max_files") {
+        if (!value.is_number_integer()) {
+            throw std::invalid_argument("'log_max_files' must be an integer");
+        }
+        int64_t n = value.get<int64_t>();
+        if (n < 0 || n > 100) {
+            throw std::invalid_argument("'log_max_files' must be between 0 and 100");
         }
     } else if (key == "extra_models_dir" || key == "models_dir") {
         if (!value.is_string()) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -7307,10 +7307,16 @@ void Server::apply_config_side_effects(const json& applied_changes) {
                     websocket_server_->start();
                 }
             }
-        } else if (key == "log_level") {
-            std::string level = config_->log_level();
-            LOG(INFO, "Server") << "Log level changed to: " << level << std::endl;
-            reconfigure_application_logging(level);
+        } else if (key == "log_level" || key == "log_file" || key == "log_max_file_size_mb" || key == "log_max_files") {
+            LogRotationConfig rot_cfg;
+            rot_cfg.file_mode = config_->log_file();
+            rot_cfg.max_file_size_mb = config_->log_max_file_size_mb();
+            rot_cfg.max_files = config_->log_max_files();
+            LOG(INFO, "Server") << "Logging configuration updated (level=" << config_->log_level()
+                                << ", file=" << rot_cfg.file_mode
+                                << ", max_size=" << rot_cfg.max_file_size_mb << "MB"
+                                << ", max_files=" << rot_cfg.max_files << ")" << std::endl;
+            reconfigure_application_logging(config_->log_level(), rot_cfg);
         } else if (key == "global_timeout") {
             long timeout = config_->global_timeout();
             LOG(INFO, "Server") << "Global timeout changed to: " << timeout << "s" << std::endl;

--- a/src/cpp/tray/main.cpp
+++ b/src/cpp/tray/main.cpp
@@ -187,12 +187,25 @@ int WINAPI wWinMain(HINSTANCE, HINSTANCE, LPWSTR, int) {
     if (!cli_config.host.empty()) {
         runtime_config->set_host_override(cli_config.host);
     }
+    if (!cli_config.log_file.empty()) {
+        runtime_config->set_log_file_override(cli_config.log_file);
+    }
+    if (cli_config.log_max_file_size_mb != -1) {
+        runtime_config->set_log_max_file_size_mb_override(cli_config.log_max_file_size_mb);
+    }
+    if (cli_config.log_max_files != -1) {
+        runtime_config->set_log_max_files_override(cli_config.log_max_files);
+    }
 
     lemon::utils::set_models_dir(runtime_config->models_dir());
 
     // Initialize logging (file + log hub; SUBSYSTEM:WINDOWS has no console)
+    lemon::LogRotationConfig rot_cfg;
+    rot_cfg.file_mode = runtime_config->log_file();
+    rot_cfg.max_file_size_mb = runtime_config->log_max_file_size_mb();
+    rot_cfg.max_files = runtime_config->log_max_files();
     lemon::configure_application_logging(
-        runtime_config->log_level(), lemon::LoggingMode::embedded_tray_server);
+        runtime_config->log_level(), lemon::LoggingMode::embedded_tray_server, rot_cfg);
 
     // Initialize Winsock (required by httplib)
     WSADATA wsa;

--- a/test/cpp/test_cli_runtime_override.cpp
+++ b/test/cpp/test_cli_runtime_override.cpp
@@ -68,23 +68,35 @@ int main() {
         if (cli_cfg.port != -1) {
             runtime_cfg.set_port_override(cli_cfg.port);
         }
-        if (!cli_cfg.host.empty()) {
+        if (cli_cfg.host != "") {
             runtime_cfg.set_host_override(cli_cfg.host);
         }
+        runtime_cfg.set_log_file_override("enabled");
+        runtime_cfg.set_log_max_file_size_mb_override(50);
+        runtime_cfg.set_log_max_files_override(10);
 
         check(runtime_cfg.port() == 8888, "RuntimeConfig::port() returns overridden port 8888");
         check(runtime_cfg.host() == "127.0.0.1", "RuntimeConfig::host() returns overridden host 127.0.0.1");
+        check(runtime_cfg.log_file() == "enabled", "RuntimeConfig::log_file() returns overridden log_file");
+        check(runtime_cfg.log_max_file_size_mb() == 50, "RuntimeConfig::log_max_file_size_mb() returns overridden max_file_size");
+        check(runtime_cfg.log_max_files() == 10, "RuntimeConfig::log_max_files() returns overridden max_files");
 
         // Verify snapshot() does NOT leak the CLI overrides into the persistent representation
         json snap = runtime_cfg.snapshot();
         check(snap["port"] == 13305, "snapshot() contains persistent port 13305, not override");
         check(snap["host"] == "localhost", "snapshot() contains persistent host localhost, not override");
+        check(!snap.contains("log_file") || snap["log_file"] == "auto", "snapshot() does not leak log_file override");
 
-        // Simulate persisting a config update without leaking runtime overrides
+        // Simulate persisting a config update (e.g. log_level change) without dropping CLI overrides
         runtime_cfg.set(json{{"log_level", "debug"}});
+        check(runtime_cfg.log_level() == "debug", "RuntimeConfig updated log_level");
+        check(runtime_cfg.log_file() == "enabled", "RuntimeConfig::log_file() preserves CLI override after reconfiguration");
+        check(runtime_cfg.log_max_file_size_mb() == 50, "RuntimeConfig::log_max_file_size_mb() preserves CLI override after reconfiguration");
+        check(runtime_cfg.log_max_files() == 10, "RuntimeConfig::log_max_files() preserves CLI override after reconfiguration");
+
         ConfigFile::save(cli_cfg.config_dir, runtime_cfg.snapshot());
 
-        // Re-read from disk to ensure config.json was updated with log_level but did NOT leak port/host overrides
+        // Re-read from disk to ensure config.json was updated with log_level but did NOT leak port/host/log overrides
         json disk_cfg = ConfigFile::load(cli_cfg.cache_dir, cli_cfg.config_dir);
         check(disk_cfg["log_level"] == "debug", "config.json on disk updated log_level to debug");
         check(disk_cfg["port"] == 13305, "config.json on disk preserved original port 13305 after config set");
@@ -93,8 +105,14 @@ int main() {
         // Verify removing overrides reverts to underlying config values
         runtime_cfg.set_port_override(std::nullopt);
         runtime_cfg.set_host_override(std::nullopt);
+        runtime_cfg.set_log_file_override(std::nullopt);
+        runtime_cfg.set_log_max_file_size_mb_override(std::nullopt);
+        runtime_cfg.set_log_max_files_override(std::nullopt);
         check(runtime_cfg.port() == 13305, "RuntimeConfig::port() reverts to persistent port after clearing override");
         check(runtime_cfg.host() == "localhost", "RuntimeConfig::host() reverts to persistent host after clearing override");
+        check(runtime_cfg.log_file() == "auto", "RuntimeConfig::log_file() reverts to default after clearing override");
+        check(runtime_cfg.log_max_file_size_mb() == 10, "RuntimeConfig::log_max_file_size_mb() reverts to default after clearing override");
+        check(runtime_cfg.log_max_files() == 5, "RuntimeConfig::log_max_files() reverts to default after clearing override");
 
         fs::remove_all(temp_dir);
     }

--- a/test/cpp/test_log_rotation.cpp
+++ b/test/cpp/test_log_rotation.cpp
@@ -1,0 +1,389 @@
+#include "lemon/logging_config.h"
+#include "lemon/runtime_config.h"
+#include "lemon/utils/path_utils.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+using lemon::RotatingFileSink;
+using lemon::RuntimeConfig;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static fs::path make_temp_dir() {
+    fs::path dir = fs::temp_directory_path();
+    dir /= "lemonade_test_log_rot_" +
+           std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+    fs::create_directories(dir);
+    return dir;
+}
+
+static AixLog::Metadata make_metadata() {
+    AixLog::Metadata md;
+    md.severity = AixLog::Severity::info;
+    return md;
+}
+
+static void test_incremental_runtime_rotation() {
+    fs::path temp_dir = make_temp_dir();
+    fs::path log_path = temp_dir / "lemonade-server.log";
+    AixLog::Filter filter(AixLog::Severity::info);
+
+    {
+        RotatingFileSink sink(filter, log_path.string(), "%m", 1, 2);
+
+        std::string chunk(100 * 1024, 'A'); // 100 KB
+        for (int i = 0; i < 11; ++i) {
+            sink.log(make_metadata(), chunk);
+        }
+    }
+
+    check("active log exists after rotation", fs::exists(log_path));
+    fs::path backup_1 = temp_dir / "lemonade-server.log.1";
+    check("backup .1 created at runtime", fs::exists(backup_1));
+    check("backup .1 size >= 1000KB", fs::file_size(backup_1) >= 1000 * 1024);
+    check("active log size < 200KB", fs::file_size(log_path) < 200 * 1024);
+
+    fs::remove_all(temp_dir);
+}
+
+static void test_preexisting_oversized_file() {
+    fs::path temp_dir = make_temp_dir();
+    fs::path log_path = temp_dir / "lemonade-server.log";
+
+    {
+        std::ofstream f(log_path, std::ios::binary);
+        std::string oversized(1200 * 1024, 'O');
+        f << oversized;
+    }
+
+    AixLog::Filter filter(AixLog::Severity::info);
+    {
+        RotatingFileSink sink(filter, log_path.string(), "%m", 1, 2);
+        sink.log(make_metadata(), "New fresh entry");
+    }
+
+    fs::path backup_1 = temp_dir / "lemonade-server.log.1";
+    check("pre-existing oversized file rotated to .1", fs::exists(backup_1));
+    check("pre-existing .1 size >= 1.1MB", fs::file_size(backup_1) >= 1100 * 1024);
+    check("active log contains new entry", fs::file_size(log_path) < 1000);
+
+    fs::remove_all(temp_dir);
+}
+
+static void test_single_large_record_boundary() {
+    fs::path temp_dir = make_temp_dir();
+    fs::path log_path = temp_dir / "lemonade-server.log";
+    AixLog::Filter filter(AixLog::Severity::info);
+
+    {
+        RotatingFileSink sink(filter, log_path.string(), "%m", 1, 2);
+
+        // Record larger than 1 MB threshold written to fresh file
+        std::string huge_record(1300 * 1024, 'H');
+        sink.log(make_metadata(), huge_record);
+
+        check("single huge record written without crash", fs::file_size(log_path) >= 1300 * 1024);
+
+        // Next log call triggers rotation
+        sink.log(make_metadata(), "Next record after huge line");
+    }
+
+    fs::path backup_1 = temp_dir / "lemonade-server.log.1";
+    check("huge record rotated to .1 on next write", fs::exists(backup_1));
+    check("backup .1 contains huge record", fs::file_size(backup_1) >= 1300 * 1024);
+    check("active log has subsequent entry", fs::file_size(log_path) < 1000);
+
+    fs::remove_all(temp_dir);
+}
+
+static void test_retention_cap_pruning() {
+    fs::path temp_dir = make_temp_dir();
+    fs::path log_path = temp_dir / "lemonade-server.log";
+    AixLog::Filter filter(AixLog::Severity::info);
+
+    // Pre-create higher-numbered backups (e.g. from a prior run with max_files=5)
+    for (int i = 1; i <= 5; ++i) {
+        std::ofstream f(temp_dir / ("lemonade-server.log." + std::to_string(i)));
+        f << "legacy backup " << i << "\n";
+    }
+    std::ofstream f10(temp_dir / "lemonade-server.log.10");
+    f10 << "legacy backup 10\n";
+    std::ofstream f_date(temp_dir / "lemonade-server.log.20260825");
+    f_date << "date-based backup 20260825\n";
+    std::ofstream f_101(temp_dir / "lemonade-server.log.101");
+    f_101 << "out of range 101\n";
+
+    {
+        RotatingFileSink sink(filter, log_path.string(), "%m", 1, 2);
+
+        std::string block(600 * 1024, 'X');
+        // Trigger rotations under max_files=2
+        for (int r = 0; r < 6; ++r) {
+            sink.log(make_metadata(), block);
+        }
+    }
+
+    fs::path backup_1 = temp_dir / "lemonade-server.log.1";
+    fs::path backup_2 = temp_dir / "lemonade-server.log.2";
+    fs::path backup_3 = temp_dir / "lemonade-server.log.3";
+    fs::path backup_4 = temp_dir / "lemonade-server.log.4";
+    fs::path backup_5 = temp_dir / "lemonade-server.log.5";
+    fs::path backup_10 = temp_dir / "lemonade-server.log.10";
+    fs::path backup_date = temp_dir / "lemonade-server.log.20260825";
+    fs::path backup_101 = temp_dir / "lemonade-server.log.101";
+
+    check("backup .1 exists", fs::exists(backup_1));
+    check("backup .2 exists", fs::exists(backup_2));
+    check("backup .3 pruned (max_files=2)", !fs::exists(backup_3));
+    check("backup .4 pruned (max_files=2)", !fs::exists(backup_4));
+    check("backup .5 pruned (max_files=2)", !fs::exists(backup_5));
+    check("backup .10 pruned (max_files=2)", !fs::exists(backup_10));
+    check("date-based backup 20260825 preserved", fs::exists(backup_date));
+    check("out of range backup 101 preserved", fs::exists(backup_101));
+
+    fs::remove_all(temp_dir);
+}
+
+static void test_max_files_zero_truncation() {
+    fs::path temp_dir = make_temp_dir();
+    fs::path log_path = temp_dir / "lemonade-server.log";
+    AixLog::Filter filter(AixLog::Severity::info);
+
+    // Pre-create legacy backups
+    std::ofstream f1(temp_dir / "lemonade-server.log.1");
+    f1 << "legacy 1\n";
+    std::ofstream f2(temp_dir / "lemonade-server.log.2");
+    f2 << "legacy 2\n";
+
+    {
+        RotatingFileSink sink(filter, log_path.string(), "%m", 1, 0);
+
+        std::string block(600 * 1024, 'Z');
+        sink.log(make_metadata(), block);
+        sink.log(make_metadata(), block); // Crosses 1MB -> truncate, writes 2nd block
+        sink.log(make_metadata(), "Post truncation line");
+    }
+
+    fs::path backup_1 = temp_dir / "lemonade-server.log.1";
+    fs::path backup_2 = temp_dir / "lemonade-server.log.2";
+    check("max_files=0 creates no .1 backup and prunes old ones", !fs::exists(backup_1));
+    check("max_files=0 prunes old .2 backup", !fs::exists(backup_2));
+    check("active log exists after truncation", fs::exists(log_path));
+    check("active log size reflects truncation", fs::file_size(log_path) < 700 * 1024);
+
+    fs::remove_all(temp_dir);
+}
+
+static void test_validation_rejection() {
+    AixLog::Filter filter(AixLog::Severity::info);
+    bool threw = false;
+    try {
+        RotatingFileSink sink(filter, "test.log", "%m", 0, 5);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("RotatingFileSink rejects max_file_size_mb = 0", threw);
+
+    threw = false;
+    try {
+        RotatingFileSink sink(filter, "test.log", "%m", 5000, 5);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("RotatingFileSink rejects max_file_size_mb > 2048", threw);
+
+    threw = false;
+    try {
+        RotatingFileSink sink(filter, "test.log", "%m", 10, 150);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("RotatingFileSink rejects max_files > 100", threw);
+
+    threw = false;
+    try {
+        nlohmann::json bad_cfg = {{"log_max_file_size_mb", 0}};
+        RuntimeConfig cfg(bad_cfg);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("RuntimeConfig rejects log_max_file_size_mb = 0", threw);
+
+    threw = false;
+    try {
+        nlohmann::json bad_cfg = {{"log_max_file_size_mb", 999999999999999999LL}};
+        RuntimeConfig cfg(bad_cfg);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("RuntimeConfig rejects 64-bit out-of-bounds log_max_file_size_mb", threw);
+
+    threw = false;
+    try {
+        nlohmann::json bad_cfg = {{"log_max_files", -1}};
+        RuntimeConfig cfg(bad_cfg);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("RuntimeConfig rejects log_max_files = -1", threw);
+
+    threw = false;
+    try {
+        nlohmann::json bad_cfg = {{"log_max_files", 999999999999999999LL}};
+        RuntimeConfig cfg(bad_cfg);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("RuntimeConfig rejects 64-bit out-of-bounds log_max_files", threw);
+
+    fs::path temp_dir = make_temp_dir();
+    threw = false;
+    try {
+        RotatingFileSink sink(filter, temp_dir.string(), "%m", 1, 2);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("RotatingFileSink rejects directory path as log file", threw);
+
+    threw = false;
+    try {
+        nlohmann::json bad_cfg = {{"log_file", temp_dir.string()}};
+        RuntimeConfig cfg(bad_cfg);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    check("RuntimeConfig rejects directory path as log_file", threw);
+
+    fs::remove_all(temp_dir);
+}
+
+static void test_directory_collision_slot_fallback() {
+    fs::path temp_dir = make_temp_dir();
+    fs::path log_path = temp_dir / "lemonade.log";
+    fs::path backup_1 = temp_dir / "lemonade.log.1";
+    fs::path backup_2 = temp_dir / "lemonade.log.2";
+
+    // Create a directory at backup_1 path
+    fs::create_directories(backup_1);
+
+    // Write initial data to log_path
+    {
+        std::ofstream f(log_path, std::ios::binary);
+        std::string chunk = "INITIAL_CANARY_RECORD\n" + std::string(500 * 1024, 'X') + "\n";
+        f << chunk;
+        f.flush();
+    }
+
+    AixLog::Filter filter(AixLog::Severity::info);
+    {
+        RotatingFileSink sink(filter, log_path.string(), "%m", 1, 2);
+
+        std::string extra_chunk = "NEW_ROTATED_RECORD\n" + std::string(600 * 1024, 'Y');
+        sink.log(make_metadata(), extra_chunk);
+    }
+
+    std::error_code ec;
+    check("backup_1 directory remains untouched", fs::is_directory(backup_1, ec));
+    check("active log rotated into slot .2 when .1 is a directory", fs::exists(backup_2, ec));
+    check("backup .2 contains initial canary data", fs::file_size(backup_2, ec) >= 500 * 1024);
+
+    std::ifstream in(log_path, std::ios::binary);
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    check("active log does not contain old canary after rotation", content.find("INITIAL_CANARY_RECORD") == std::string::npos);
+    check("active log contains new rotated record", content.find("NEW_ROTATED_RECORD") != std::string::npos);
+
+    fs::remove_all(temp_dir);
+}
+
+static void test_all_backup_slots_blocked_fallback() {
+    fs::path temp_dir = make_temp_dir();
+    fs::path log_path = temp_dir / "lemonade.log";
+    fs::path backup_1 = temp_dir / "lemonade.log.1";
+    fs::path backup_2 = temp_dir / "lemonade.log.2";
+
+    // Create directories at all backup slots
+    fs::create_directories(backup_1);
+    fs::create_directories(backup_2);
+
+    // Write initial canary record
+    {
+        std::ofstream f(log_path, std::ios::binary);
+        f << "INITIAL_CANARY_RECORD\n" + std::string(500 * 1024, 'K') + "\n";
+    }
+
+    AixLog::Filter filter(AixLog::Severity::info);
+    {
+        RotatingFileSink sink(filter, log_path.string(), "%m", 1, 2);
+        sink.log(make_metadata(), "NEW_POST_ROTATION_RECORD\n" + std::string(600 * 1024, 'L'));
+    }
+
+    std::error_code ec;
+    check("backup_1 directory remains untouched", fs::is_directory(backup_1, ec));
+    check("backup_2 directory remains untouched", fs::is_directory(backup_2, ec));
+
+    std::ifstream in(log_path, std::ios::binary);
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    check("all blocked slots truncates old canary (bounded policy)", content.find("INITIAL_CANARY_RECORD") == std::string::npos);
+    check("all blocked slots contains fresh record", content.find("NEW_POST_ROTATION_RECORD") != std::string::npos);
+    check("all blocked slots bounds active log size", fs::file_size(log_path, ec) < 700 * 1024);
+
+    fs::remove_all(temp_dir);
+}
+
+static void test_real_rename_os_error_fallback() {
+    fs::path temp_dir = make_temp_dir();
+    // Filename of 254 chars + ".1" = 256 chars (> 255 NAME_MAX), causing fs::rename to fail with ENAMETOOLONG
+    std::string long_base(254, 'l');
+    fs::path log_path = temp_dir / long_base;
+
+    // Write initial canary record
+    {
+        std::ofstream f(log_path, std::ios::binary);
+        f << "INITIAL_CANARY_RECORD\n" + std::string(500 * 1024, 'K') + "\n";
+    }
+
+    AixLog::Filter filter(AixLog::Severity::info);
+    {
+        RotatingFileSink sink(filter, log_path.string(), "%m", 1, 2);
+        sink.log(make_metadata(), "APPENDED_FALLBACK_RECORD\n" + std::string(600 * 1024, 'L'));
+    }
+
+    std::ifstream in(log_path, std::ios::binary);
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    check("real rename OS error preserves initial canary", content.find("INITIAL_CANARY_RECORD") != std::string::npos);
+    check("real rename OS error appends new record", content.find("APPENDED_FALLBACK_RECORD") != std::string::npos);
+
+    fs::remove_all(temp_dir);
+}
+
+int main() {
+    test_incremental_runtime_rotation();
+    test_preexisting_oversized_file();
+    test_single_large_record_boundary();
+    test_retention_cap_pruning();
+    test_max_files_zero_truncation();
+    test_validation_rejection();
+    test_directory_collision_slot_fallback();
+    test_all_backup_slots_blocked_fallback();
+    test_real_rename_os_error_fallback();
+
+    std::printf("\nSummary: %d failure(s)\n", g_failures);
+    return g_failures == 0 ? 0 : 1;
+}

--- a/test/server_log_rotation.py
+++ b/test/server_log_rotation.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""
+Test suite for Lemonade Server log rotation and retention management.
+
+Verifies:
+1. Active log file creation and size-triggered log rotation (.1, .2 backups).
+2. Backup pruning cap enforcement (max_files = 2 prunes .3).
+3. max_files = 0 truncation mode (no backup files created).
+4. Instant startup rotation for pre-existing over-quota log files.
+5. Rejection of invalid out-of-bounds CLI range options.
+"""
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import requests
+
+from utils.test_models import get_default_cli_binary
+
+
+def get_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def find_lemond_binary():
+    cli_bin = get_default_cli_binary()
+    if cli_bin:
+        build_dir = os.path.dirname(cli_bin)
+        exe = "lemond.exe" if sys.platform == "win32" else "lemond"
+        lemond_bin = os.path.join(build_dir, exe)
+        if os.path.exists(lemond_bin):
+            return lemond_bin
+    exe = "lemond.exe" if sys.platform == "win32" else "lemond"
+    for path in [f"build/{exe}", f"build/src/cpp/server/{exe}"]:
+        if os.path.exists(path):
+            return os.path.abspath(path)
+    return exe
+
+
+class TestLogRotation(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="lemonade_log_test_")
+        self.runtime_dir = os.path.join(self.test_dir, "runtime")
+        os.makedirs(self.runtime_dir, exist_ok=True)
+        self.lemond_bin = find_lemond_binary()
+        self.server_proc = None
+
+    def tearDown(self):
+        if self.server_proc:
+            if self.server_proc.stdout:
+                self.server_proc.stdout.close()
+            if self.server_proc.stderr:
+                self.server_proc.stderr.close()
+            try:
+                self.server_proc.terminate()
+                self.server_proc.wait(timeout=5)
+            except Exception:
+                self.server_proc.kill()
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_log_rotation_and_retention_cap(self):
+        """Verify active log rotation (.1, .2) and retention pruning of .3 when max_files=2."""
+        log_dir = os.path.join(self.runtime_dir, "lemonade")
+        os.makedirs(log_dir, exist_ok=True)
+        active_log = os.path.join(log_dir, "lemonade-server.log")
+
+        # Pre-create legacy higher-numbered backups (e.g. from previous run with max_files=5)
+        for i in [3, 4, 5]:
+            with open(os.path.join(log_dir, f"lemonade-server.log.{i}"), "w") as f:
+                f.write(f"LEGACY_BACKUP_{i}\n")
+
+        # Step 1: Pre-exist 1.2MB file and launch instance 1 -> rotates to .1
+        with open(active_log, "wb") as f:
+            f.write(b"FIRST_LOG_BLOCK\n" + b"A" * (1024 * 1024 + 200))
+
+        env = os.environ.copy()
+        env["XDG_RUNTIME_DIR"] = self.runtime_dir
+        env["LEMONADE_CACHE_DIR"] = self.test_dir
+        env["LEMONADE_DISABLE_SYSTEMD_JOURNAL"] = "1"
+
+        base_cmd = [
+            self.lemond_bin,
+            self.test_dir,
+            "--log-file",
+            "enabled",
+            "--log-max-size-mb",
+            "1",
+            "--log-max-files",
+            "2",
+        ]
+
+        self.assertTrue(
+            self.run_server_instance(base_cmd, env), "Instance 1 failed to start"
+        )
+        backup_1 = os.path.join(log_dir, "lemonade-server.log.1")
+        self.assertTrue(os.path.exists(backup_1), "Rotation 1 failed to create .1")
+        # Legacy backups .3, .4, .5 should already be pruned on startup/rotation
+        for i in [3, 4, 5]:
+            self.assertFalse(
+                os.path.exists(os.path.join(log_dir, f"lemonade-server.log.{i}")),
+                f"Legacy backup .{i} was not pruned",
+            )
+
+        # Step 2: Pre-exist 1.2MB file and launch instance 2 -> shifts .1 to .2, creates new .1
+        with open(active_log, "wb") as f:
+            f.write(b"SECOND_LOG_BLOCK\n" + b"B" * (1024 * 1024 + 200))
+        self.assertTrue(
+            self.run_server_instance(base_cmd, env), "Instance 2 failed to start"
+        )
+        backup_2 = os.path.join(log_dir, "lemonade-server.log.2")
+        self.assertTrue(os.path.exists(backup_2), "Rotation 2 failed to create .2")
+
+        # Step 3: Pre-exist 1.2MB file and launch instance 3 -> shifts .1->.2, prunes .3
+        with open(active_log, "wb") as f:
+            f.write(b"THIRD_LOG_BLOCK\n" + b"C" * (1024 * 1024 + 200))
+        self.assertTrue(
+            self.run_server_instance(base_cmd, env), "Instance 3 failed to start"
+        )
+
+        backup_3 = os.path.join(log_dir, "lemonade-server.log.3")
+        self.assertFalse(
+            os.path.exists(backup_3),
+            f"Backup {backup_3} exists but should have been pruned (max_files=2)",
+        )
+
+    def run_server_instance(self, base_cmd, env):
+        port = get_free_port()
+        cmd = base_cmd + ["--port", str(port)]
+        with subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ) as proc:
+            ready = False
+            for _ in range(30):
+                try:
+                    conn = socket.create_connection(("127.0.0.1", port))
+                    conn.close()
+                    ready = True
+                    break
+                except Exception:
+                    time.sleep(0.2)
+            try:
+                proc.terminate()
+                proc.wait(timeout=3)
+            except Exception:
+                proc.kill()
+                proc.wait(timeout=3)
+            return ready
+
+    def test_max_files_zero(self):
+        """Verify max_files=0 truncates active file upon rotation without creating backup files."""
+        log_dir = os.path.join(self.runtime_dir, "lemonade")
+        os.makedirs(log_dir, exist_ok=True)
+        active_log = os.path.join(log_dir, "lemonade-server.log")
+
+        with open(active_log, "wb") as f:
+            f.write(b"INITIAL_OVERSIZE\n" + b"Z" * (1024 * 1024 + 500))
+
+        env = os.environ.copy()
+        env["XDG_RUNTIME_DIR"] = self.runtime_dir
+        env["LEMONADE_CACHE_DIR"] = self.test_dir
+        env["LEMONADE_DISABLE_SYSTEMD_JOURNAL"] = "1"
+
+        base_cmd = [
+            self.lemond_bin,
+            self.test_dir,
+            "--log-file",
+            "enabled",
+            "--log-max-size-mb",
+            "1",
+            "--log-max-files",
+            "0",
+        ]
+
+        self.assertTrue(
+            self.run_server_instance(base_cmd, env),
+            "Server failed to start in max_files=0 mode",
+        )
+        backup_1 = os.path.join(log_dir, "lemonade-server.log.1")
+        self.assertFalse(os.path.exists(backup_1), "Backup .1 created when max_files=0")
+
+    def test_runtime_log_rotation(self):
+        """Verify active server log rotates at runtime when live traffic exceeds max_size."""
+        log_dir = os.path.join(self.runtime_dir, "lemonade")
+        os.makedirs(log_dir, exist_ok=True)
+        active_log = os.path.join(log_dir, "lemonade-server.log")
+        backup_1 = os.path.join(log_dir, "lemonade-server.log.1")
+
+        # Pre-seed active log at 1020 KB (startup writes ~3KB, so startup alone leaves ~1.5KB headroom)
+        with open(active_log, "wb") as f:
+            f.write(b"PRE_SEED_LOG_LINE\n" + b"X" * (1020 * 1024))
+
+        env = os.environ.copy()
+        env["XDG_RUNTIME_DIR"] = self.runtime_dir
+        env["LEMONADE_CACHE_DIR"] = self.test_dir
+        env["LEMONADE_DISABLE_SYSTEMD_JOURNAL"] = "1"
+
+        port = get_free_port()
+        cmd = [
+            self.lemond_bin,
+            self.test_dir,
+            "--port",
+            str(port),
+            "--log-file",
+            "enabled",
+            "--log-max-size-mb",
+            "1",
+            "--log-max-files",
+            "2",
+        ]
+
+        proc = subprocess.Popen(
+            cmd,
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        ready = False
+        try:
+            for _ in range(30):
+                try:
+                    conn = socket.create_connection(("127.0.0.1", port))
+                    conn.close()
+                    ready = True
+                    break
+                except Exception:
+                    time.sleep(0.2)
+
+            self.assertTrue(ready, "Server failed to start for runtime rotation test")
+            self.assertFalse(
+                os.path.exists(backup_1),
+                "Backup .1 must NOT exist immediately after startup (proves startup did not rotate)",
+            )
+
+            # Send HTTP requests to push total log volume past 1MB and trigger runtime rotation
+            session = requests.Session()
+            session.trust_env = False
+            for i in range(100):
+                if os.path.exists(backup_1):
+                    break
+                try:
+                    resp = session.post(
+                        f"http://127.0.0.1:{port}/api/v1/chat/completions",
+                        json={},
+                        timeout=1,
+                    )
+                except Exception:
+                    pass
+
+        finally:
+            try:
+                proc.terminate()
+                proc.wait(timeout=3)
+            except Exception:
+                proc.kill()
+                proc.wait(timeout=3)
+
+        self.assertTrue(os.path.exists(active_log), "Active log file should exist")
+        self.assertTrue(
+            os.path.exists(backup_1),
+            "Rotated backup .1 should exist after live HTTP traffic exceeded 1MB",
+        )
+        self.assertGreater(
+            os.path.getsize(backup_1),
+            1000 * 1024,
+            "Rotated backup .1 should be >= 1000KB",
+        )
+
+    def test_reject_directory_path(self):
+        """Verify passing an existing directory as log file path is rejected."""
+        env = os.environ.copy()
+        env["XDG_RUNTIME_DIR"] = self.runtime_dir
+
+        cmd = [
+            self.lemond_bin,
+            self.test_dir,
+            "--log-file",
+            self.runtime_dir,
+        ]
+
+        proc = subprocess.run(
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        self.assertNotEqual(
+            proc.returncode, 0, "lemond accepted directory path as --log-file"
+        )
+
+    def test_invalid_cli_flags(self):
+        """Verify out-of-bounds CLI flags are rejected with non-zero exit code."""
+        env = os.environ.copy()
+        env["XDG_RUNTIME_DIR"] = self.runtime_dir
+
+        for flag, val in [
+            ("--log-max-size-mb", "0"),
+            ("--log-max-size-mb", "999999999999999999"),
+            ("--log-max-files", "-1"),
+            ("--log-max-files", "999999999999999999"),
+        ]:
+            cmd = [
+                self.lemond_bin,
+                self.test_dir,
+                flag,
+                val,
+            ]
+            proc = subprocess.run(
+                cmd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            self.assertNotEqual(
+                proc.returncode,
+                0,
+                f"lemond accepted invalid flag {flag} {val}",
+            )
+
+    def test_invalid_cli_does_not_corrupt_config_json(self):
+        """Verify invalid CLI override failure does not persist corrupt values into config.json."""
+        env = os.environ.copy()
+        env["XDG_RUNTIME_DIR"] = self.runtime_dir
+
+        config_path = os.path.join(self.test_dir, "config.json")
+        initial_config = {"port": 9999}
+        with open(config_path, "w", encoding="utf-8") as f:
+            json.dump(initial_config, f)
+
+        cmd = [
+            self.lemond_bin,
+            self.test_dir,
+            "--log-file",
+            self.runtime_dir,
+        ]
+
+        proc = subprocess.run(
+            cmd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        self.assertNotEqual(proc.returncode, 0)
+
+        with open(config_path, "r", encoding="utf-8") as f:
+            persisted = json.load(f)
+
+        self.assertEqual(persisted.get("port"), 9999)
+        self.assertNotEqual(
+            persisted.get("log_file"),
+            self.runtime_dir,
+            "Invalid log_file should not be saved to config.json",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Previously, Lemonade Server (`lemond`) unconditionally appended to a single, un-rotated log file in runtime directories (e.g. `/run/user/<uid>/` mounted on RAM `tmpfs` on systemd Linux distributions). Under heavy or long-running workloads, this file grew unbounded, risking host RAM and disk space exhaustion.

To resolve this, `lemond` now defaults to standard output streams (`stdout`/`stderr`), allowing OS service managers (`systemd`, `launchd`), container runtimes (Docker/Kubernetes), and CI runners to capture and rotate logs natively. When file logging is explicitly enabled (`--log-file enabled` or custom target path), a thread-safe `RotatingFileSink` caps active file size and manages historic log backup retention.

## Summary

- **Console-Default Posture (`log_file = "auto"`)**: Out-of-the-box direct `lemond` server runs stream to `stdout`/`stderr`, creating zero silent log files on disk or RAM `tmpfs`, while embedded tray runs retain file logging (`lemonade-server.log`).
- **Thread-Safe `RotatingFileSink`**: Explicitly enabling file logging caps active log size at 10 MB and retains up to 5 historic backups (`lemonade-server.log.1` .. `.5`), bounding steady-state log disk usage to ~60 MB under normal record sizes.
- **Strict Excess Backup Pruning & Bounded Fallback**: Automatically prunes higher-numbered backups (e.g. `.3`–`.10` if `log_max_files` is lowered to 2, or all backups if `log_max_files = 0`). If slot `.1` is occupied by a directory, the sink safely falls back to subsequent available slots (`.2`..`.N`). If all backup slots are blocked by non-regular entries, the sink applies a bounded fallback policy by truncating `active_log` in-place on the rotation boundary to strictly prevent unbounded file growth.
- **Filesystem Error Resilience**: If moving the active log to backup fails due to OS filesystem permission/locking errors, the sink preserves existing data and falls back to append mode rather than truncating.
- **CLI & Configuration Levers**: Added `--log-file`, `--log-max-size-mb` (1..2048), and `--log-max-files` (0..100) options to `lemond` CLI and `config.json` with 64-bit integer range validation. CLI options act as in-memory runtime overrides whose precedence survives runtime reconfiguration (e.g. `log_level` changes) without mutating persistent `config.json` on disk.
- **CI Artifact Capture**: Updated `.github/actions/capture-server-logs/action.yml` wildcard patterns (`lemonade-server.log*`) to archive active and rotated log backups across Windows, Linux, and macOS.
- **Integration & Unit Test Suites**: Added `test/cpp/test_log_rotation.cpp` (35 C++ assertions) and `test/server_log_rotation.py` (6 integration tests) verifying runtime rotation, retention capping, legacy pruning, slot fallback, OS rename error recovery, bounded fallback, and limit/directory rejection.

## Scope

- [x] This PR addresses one clear issue or change.
- [x] I reviewed the full diff myself before submitting.
- [x] I removed unrelated local changes.
- [x] I kept refactoring separate unless it is required for this change.

## Testing

- [x] Code builds without errors locally.
- [x] I tested this change locally.
- [x] I described the testing performed below.

_Testing details:_
- Ran C++ unit tests: `./build/test_log_rotation` (35/35 passed).
- Ran CLI runtime override tests: `./build/test_cli_runtime_override` (31/31 passed).
- Ran Python integration test suite: `python3 test/server_log_rotation.py` (6/6 passed in 19.3s).
- Ran boilerplate drift check: `python3 docs/tools/gen_backend_boilerplate.py --check` (0 drift).

## Documentation

- [x] Documentation is affected and has been updated. (Updated `docs/dev/getting-started.md` and `docs/guide/configuration/README.md`).

## Breaking Changes

- [x] This PR does not introduce breaking changes.

## AI-assisted contribution

- [x] I used AI tools for this PR.
- [x] I verified that I understand the changes.
- [x] I checked for hallucinated APIs, unrelated changes, and incorrect assumptions.