### PR TITLE
[bench] Refactor & add hardware info

### DIFF
--- a/src/cpp/cli/CMakeLists.txt
+++ b/src/cpp/cli/CMakeLists.txt
@@ -22,6 +22,9 @@ set(COMMON_SOURCES
     recipe_import.cpp
     hf_pull.cpp
     bench.cpp
+    bench_output.cpp
+    bench_comparison.cpp
+    bench_sysinfo.cpp
     chat_repl.cpp
     ../server/recipe_options.cpp
     ../server/utils/process_manager.cpp

--- a/src/cpp/cli/bench.cpp
+++ b/src/cpp/cli/bench.cpp
@@ -1,19 +1,21 @@
 #include "lemon_cli/bench.h"
+#include "lemon_cli/bench_comparison.h"
+#include "lemon_cli/bench_output.h"
+#include "lemon_cli/bench_sysinfo.h"
 #include "lemon_cli/lemonade_client.h"
 #include "lemon/backends/backend_descriptor_registry.h"
+#include "lemon/model_types.h"
 #include <CLI/CLI.hpp>
 #include <lemon/utils/path_utils.h>
 #include <algorithm>
 #include <chrono>
-#include <cmath>
 #include <ctime>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <map>
-#include <sstream>
-#include <unordered_map>
+#include <numeric>
 #include <unordered_set>
 
 namespace lemon_cli {
@@ -35,107 +37,51 @@ std::string get_timestamp_iso() {
     return std::string(buf);
 }
 
-static double percentile(std::vector<double> values, double p) {
-    if (values.empty()) return 0.0;
-    std::sort(values.begin(), values.end());
-    if (values.size() == 1) return values[0];
-    double index = (p / 100.0) * (static_cast<double>(values.size()) - 1.0);
-    size_t lower = static_cast<size_t>(std::floor(index));
-    size_t upper = static_cast<size_t>(std::ceil(index));
-    if (lower == upper) return values[lower];
-    double frac = index - static_cast<double>(lower);
-    return values[lower] * (1.0 - frac) + values[upper] * frac;
+template<typename T>
+static std::vector<T> collect_field(const BenchScenarioResult& self, T (BenchRunResult::*field)) {
+    std::vector<T> vals;
+    vals.reserve(self.runs.size());
+    for (const auto& r : self.runs) vals.push_back(r.*field);
+    return vals;
 }
 
-double BenchScenarioResult::ttft_mean_ms() const {
-    if (runs.empty()) return 0.0;
-    double sum = 0.0;
-    for (const auto& r : runs) sum += r.ttft_ms;
-    return sum / runs.size();
+template<typename T>
+static T reduce_mean(std::vector<T> vals) {
+    if (vals.empty()) return T{};
+    return std::accumulate(vals.begin(), vals.end(), T{}) / static_cast<double>(vals.size());
 }
 
-double BenchScenarioResult::ttft_min_ms() const {
-    if (runs.empty()) return 0.0;
-    double min_val = runs[0].ttft_ms;
-    for (const auto& r : runs) if (r.ttft_ms < min_val) min_val = r.ttft_ms;
-    return min_val;
+template<typename T>
+static T reduce_min(std::vector<T> vals) {
+    if (vals.empty()) return T{};
+    return *std::min_element(vals.begin(), vals.end());
 }
 
-double BenchScenarioResult::ttft_max_ms() const {
-    if (runs.empty()) return 0.0;
-    double max_val = runs[0].ttft_ms;
-    for (const auto& r : runs) if (r.ttft_ms > max_val) max_val = r.ttft_ms;
-    return max_val;
+template<typename T>
+static T reduce_max(std::vector<T> vals) {
+    if (vals.empty()) return T{};
+    return *std::max_element(vals.begin(), vals.end());
 }
 
-double BenchScenarioResult::ttft_p50_ms() const {
-    std::vector<double> vals;
-    for (const auto& r : runs) vals.push_back(r.ttft_ms);
-    return percentile(vals, 50.0);
+template<typename T>
+static T reduce_peak(std::vector<T> vals, T initial = T{-1}) {
+    return reduce_max(vals.empty() ? std::vector<T>{initial} : vals);
 }
 
-double BenchScenarioResult::ttft_p95_ms() const {
-    std::vector<double> vals;
-    for (const auto& r : runs) vals.push_back(r.ttft_ms);
-    return percentile(vals, 95.0);
-}
-
-double BenchScenarioResult::tps_mean() const {
-    if (runs.empty()) return 0.0;
-    double sum = 0.0;
-    for (const auto& r : runs) sum += r.tps;
-    return sum / runs.size();
-}
-
-double BenchScenarioResult::tps_min() const {
-    if (runs.empty()) return 0.0;
-    double min_val = runs[0].tps;
-    for (const auto& r : runs) if (r.tps < min_val) min_val = r.tps;
-    return min_val;
-}
-
-double BenchScenarioResult::tps_max() const {
-    if (runs.empty()) return 0.0;
-    double max_val = runs[0].tps;
-    for (const auto& r : runs) if (r.tps > max_val) max_val = r.tps;
-    return max_val;
-}
-
-double BenchScenarioResult::tps_p50() const {
-    std::vector<double> vals;
-    for (const auto& r : runs) vals.push_back(r.tps);
-    return percentile(vals, 50.0);
-}
-
-double BenchScenarioResult::tps_p95() const {
-    std::vector<double> vals;
-    for (const auto& r : runs) vals.push_back(r.tps);
-    return percentile(vals, 95.0);
-}
-
-double BenchScenarioResult::vram_peak_gb() const {
-    double peak = -1.0;
-    for (const auto& r : runs) {
-        if (r.vram_gb > peak) peak = r.vram_gb;
-    }
-    return peak;
-}
-
-double BenchScenarioResult::memory_peak_gb() const {
-    double peak = -1.0;
-    for (const auto& r : runs) {
-        if (r.memory_gb > peak) peak = r.memory_gb;
-    }
-    return peak;
-}
-
-int BenchScenarioResult::input_tokens() const {
-    return runs.empty() ? 0 : runs[0].input_tokens;
-}
-
-int BenchScenarioResult::output_tokens() const {
-    return runs.empty() ? 0 : runs[0].output_tokens;
-}
+double BenchScenarioResult::ttft_mean_ms() const { return reduce_mean(collect_field(*this, &BenchRunResult::ttft_ms)); }
+double BenchScenarioResult::ttft_min_ms() const { return reduce_min(collect_field(*this, &BenchRunResult::ttft_ms)); }
+double BenchScenarioResult::ttft_max_ms() const { return reduce_max(collect_field(*this, &BenchRunResult::ttft_ms)); }
+double BenchScenarioResult::ttft_p50_ms() const { return percentile(collect_field(*this, &BenchRunResult::ttft_ms), 50.0); }
+double BenchScenarioResult::ttft_p95_ms() const { return percentile(collect_field(*this, &BenchRunResult::ttft_ms), 95.0); }
+double BenchScenarioResult::tps_mean() const { return reduce_mean(collect_field(*this, &BenchRunResult::tps)); }
+double BenchScenarioResult::tps_min() const { return reduce_min(collect_field(*this, &BenchRunResult::tps)); }
+double BenchScenarioResult::tps_max() const { return reduce_max(collect_field(*this, &BenchRunResult::tps)); }
+double BenchScenarioResult::tps_p50() const { return percentile(collect_field(*this, &BenchRunResult::tps), 50.0); }
+double BenchScenarioResult::tps_p95() const { return percentile(collect_field(*this, &BenchRunResult::tps), 95.0); }
+double BenchScenarioResult::vram_peak_gb() const { return reduce_peak(collect_field(*this, &BenchRunResult::vram_gb)); }
+double BenchScenarioResult::memory_peak_gb() const { return reduce_peak(collect_field(*this, &BenchRunResult::memory_gb)); }
+int BenchScenarioResult::input_tokens() const { return runs.empty() ? 0 : runs[0].input_tokens; }
+int BenchScenarioResult::output_tokens() const { return runs.empty() ? 0 : runs[0].output_tokens; }
 
 std::string BenchBackendResult::label() const {
     std::string s = recipe + "/" + backend;
@@ -145,121 +91,37 @@ std::string BenchBackendResult::label() const {
     return s;
 }
 
-
 static std::string extract_user_content(const std::vector<json>& messages) {
     for (const auto& msg : messages) {
         if (msg.contains("role") && msg["role"] == "user" && msg.contains("content")) {
-            if (msg["content"].is_string()) {
-                return msg["content"].get<std::string>();
-            }
+            if (msg["content"].is_string()) return msg["content"].get<std::string>();
         }
     }
     return "Answer the question.";
-}
-
-// Check if a backend supports a specific capability based on its descriptor
-// Uses the BackendDescriptor's modality field and model_type
-static bool backend_supports_capability(const std::string& recipe,
-                                        const std::string& backend_name,
-                                        const lemon::ModelType required_type) {
-    const auto* desc = lemon::backends::descriptor_for(recipe);
-    if (!desc) return false;
-
-    // Get the model type from the descriptor's modality field
-    // This is a simplified mapping - in practice we might need more sophisticated logic
-    std::string modality = desc->modality;
-
-    // Map modality to ModelType
-    if (modality == "Text generation" || modality == "Completion") {
-        return required_type == lemon::ModelType::LLM;
-    }
-    if (modality == "Embeddings" || modality == "Embedding") {
-        return required_type == lemon::ModelType::EMBEDDING;
-    }
-    if (modality == "Image generation") {
-        return required_type == lemon::ModelType::IMAGE;
-    }
-    if (modality == "Speech-to-text" || modality == "Transcription") {
-        return required_type == lemon::ModelType::TRANSCRIPTION;
-    }
-    if (modality == "Text-to-speech") {
-        return required_type == lemon::ModelType::TTS;
-    }
-    if (modality == "Generative audio" || modality == "Audio generation") {
-        return required_type == lemon::ModelType::AUDIO_GENERATION;
-    }
-
-    // Default to LLM for unknown modalities
-    return required_type == lemon::ModelType::LLM;
-}
-
-// Get the required ModelType for a scenario category
-static lemon::ModelType get_required_model_type_for_scenario(const std::string& category) {
-    if (category == "embed") {
-        return lemon::ModelType::EMBEDDING;
-    }
-    if (category == "imagegen") {
-        return lemon::ModelType::IMAGE;
-    }
-    if (category == "transcription") {
-        return lemon::ModelType::TRANSCRIPTION;
-    }
-    if (category == "tts") {
-        return lemon::ModelType::TTS;
-    }
-    if (category == "audio-generation") {
-        return lemon::ModelType::AUDIO_GENERATION;
-    }
-    // Default: text generation
-    return lemon::ModelType::LLM;
-}
-
-// Check if a model has the embeddings label (for llamacpp recipe filtering)
-static bool model_has_embeddings_label(const json& model_info) {
-    if (!model_info.contains("labels") || !model_info["labels"].is_array()) {
-        return false;
-    }
-    const auto& labels = model_info["labels"];
-    for (const auto& label : labels) {
-        if (label.is_string()) {
-            std::string label_str = label.get<std::string>();
-            if (label_str == "embed" || label_str == "embedding" || label_str == "embeddings") {
-                return true;
-            }
-        }
-    }
-    return false;
 }
 
 std::string expand_context(const json& context_block, const std::vector<json>& messages) {
     std::string filler = context_block.value("filler", "");
     int target_tokens = context_block.value("target_tokens", 2000);
     std::string position = context_block.value("position", "end");
-
     if (filler.empty()) return "";
 
-    // Estimate ~4 chars per token for English
     size_t target_chars = static_cast<size_t>(target_tokens) * 4;
     size_t filler_len = filler.size();
     if (filler_len == 0) return "";
 
     std::string expanded;
     expanded.reserve(target_chars);
-    size_t reps = (target_chars + filler_len - 1) / filler_len;
-    for (size_t i = 0; i < reps; ++i) {
+    for (size_t i = 0, reps = (target_chars + filler_len - 1) / filler_len; i < reps; ++i)
         expanded += filler;
-    }
 
     std::string question = extract_user_content(messages);
-
-    if (position == "start") {
-        return question + "\n\n" + expanded;
-    } else if (position == "middle") {
+    if (position == "start") return question + "\n\n" + expanded;
+    if (position == "middle") {
         size_t mid = expanded.size() / 2;
         return expanded.substr(0, mid) + "\n\n" + question + "\n\n" + expanded.substr(mid);
-    } else {
-        return expanded + "\n\n" + question;
     }
+    return expanded + "\n\n" + question;
 }
 
 static std::vector<BenchScenario> parse_scenario_file(const std::string& path) {
@@ -268,58 +130,46 @@ static std::vector<BenchScenario> parse_scenario_file(const std::string& path) {
         std::cerr << "Warning: Could not open scenario file: " << path << std::endl;
         return {};
     }
-
     json data;
-    try {
-        data = json::parse(file);
-    } catch (const json::exception& e) {
+    try { data = json::parse(file); }
+    catch (const json::exception& e) {
         std::cerr << "Warning: Failed to parse scenario file " << path << ": " << e.what() << std::endl;
         return {};
     }
-
-    std::vector<BenchScenario> scenarios;
-
     if (!data.contains("scenarios") || !data["scenarios"].is_array()) {
         std::cerr << "Warning: No 'scenarios' array in " << path << std::endl;
         return {};
     }
 
+    std::vector<BenchScenario> scenarios;
     for (const auto& item : data["scenarios"]) {
         BenchScenario scenario;
-
         if (!item.contains("name") || !item["name"].is_string()) continue;
         scenario.name = item["name"].get<std::string>();
         scenario.category = item.value("category", "general");
         scenario.measurement_runs = item.value("measurement_runs", 3);
 
-        if (scenario.category == "embed"){
-            if (scenario.category == "embed" && item.contains("input"))
-                scenario.input = item["input"].get<json>();
-        } else if (scenario.category == "imagegen"){
+        if (scenario.category == "embed") {
+            if (item.contains("input")) scenario.input = item["input"].get<json>();
+        } else if (scenario.category == "imagegen") {
             scenario.warmup_runs = 0;
-            if (scenario.category == "imagegen" && item.contains("prompt"))
-                scenario.imgconfig = item.get<json>();
+            if (item.contains("prompt")) scenario.imgconfig = item.get<json>();
         } else {
-            if (item.contains("messages") && item["messages"].is_array()) {
+            if (item.contains("messages") && item["messages"].is_array())
                 scenario.messages = item["messages"].get<std::vector<json>>();
-            }
-
             scenario.max_tokens = item.value("max_tokens", 128);
             scenario.warmup_runs = item.value("warmup_runs", 0);
-
             if (item.contains("context") && item["context"].is_object()) {
                 std::string expanded = expand_context(item["context"], scenario.messages);
                 for (auto& msg : scenario.messages) {
-                    if (msg.contains("role") && msg["role"] == "user") {
-                        if (msg.contains("content") && msg["content"].is_string()) {
-                            msg["content"] = expanded;
-                        }
+                    if (msg.contains("role") && msg["role"] == "user" &&
+                        msg.contains("content") && msg["content"].is_string()) {
+                        msg["content"] = expanded;
                         break;
                     }
                 }
             }
         }
-
         scenarios.push_back(scenario);
     }
     return scenarios;
@@ -333,26 +183,21 @@ std::vector<BenchScenario> load_scenarios_from_dir(const std::string& path) {
     std::vector<BenchScenario> all;
     std::unordered_set<std::string> seen_names;
 
-    // Use std::filesystem to iterate directory
     std::vector<std::string> entries;
     try {
         for (const auto& entry : std::filesystem::directory_iterator(path)) {
-            if (entry.is_regular_file()) {
+            if (entry.is_regular_file())
                 entries.push_back(entry.path().filename().string());
-            }
         }
     } catch (const std::exception& e) {
         std::cerr << "Warning: Could not read scenario directory " << path << ": " << e.what() << std::endl;
         return {};
     }
-
-    // Sort entries alphabetically for deterministic ordering
     std::sort(entries.begin(), entries.end());
 
     for (const auto& entry : entries) {
         if (entry.size() < 5 || entry.substr(entry.size() - 5) != ".json") continue;
-        std::string full_path = path + "/" + entry;
-        auto scenarios = parse_scenario_file(full_path);
+        auto scenarios = parse_scenario_file(path + "/" + entry);
         for (auto& s : scenarios) {
             if (seen_names.count(s.name)) {
                 std::cerr << "Warning: Duplicate scenario name '" << s.name
@@ -363,30 +208,20 @@ std::vector<BenchScenario> load_scenarios_from_dir(const std::string& path) {
             all.push_back(std::move(s));
         }
     }
-
     return all;
 }
 
 std::string resolve_default_scenario_file() {
-    // Try resources path relative to executable
     std::string path = lemon::utils::get_resource_path("resources/bench_scenarios.json");
     std::ifstream test(path);
-    if (test.good()) {
-        return path;
-    }
-
-    // Fallback: relative to current directory
+    if (test.good()) return path;
     return "bench_scenarios.json";
 }
 
-// Check if a scenario matches a filter token.
-// A token matches if it equals the scenario name, equals the scenario category,
-// or equals "all" (matches every scenario).
 static bool scenario_matches_filter(const BenchScenario& s, const std::string& token) {
     if (token == "all") return true;
     if (s.name == token) return true;
-    if (s.category == token) return true;
-    return false;
+    return s.category == token;
 }
 
 std::vector<BenchScenario> filter_scenarios(const std::vector<BenchScenario>& all,
@@ -397,75 +232,93 @@ std::vector<BenchScenario> filter_scenarios(const std::vector<BenchScenario>& al
         for (const auto& token : tokens) {
             if (scenario_matches_filter(s, token)) {
                 filtered.push_back(s);
-                break;  // avoid duplicates if multiple tokens match
+                break;
             }
         }
     }
     return filtered;
 }
 
-// Return scenarios excluding the given category (e.g. "long-context").
 static std::vector<BenchScenario> exclude_category(const std::vector<BenchScenario>& all,
                                                     const std::string& category) {
     std::vector<BenchScenario> filtered;
-    for (const auto& s : all) {
-        if (s.category != category) {
-            filtered.push_back(s);
-        }
-    }
+    for (const auto& s : all)
+        if (s.category != category) filtered.push_back(s);
     return filtered;
 }
 
+static bool backend_supports_capability(const std::string& recipe,
+                                        const std::string& /*backend_name*/,
+                                        const lemon::ModelType required_type) {
+    const auto* desc = lemon::backends::descriptor_for(recipe);
+    if (!desc) return false;
+    std::string modality = desc->modality;
+    if (modality == "Text generation" || modality == "Completion")
+        return required_type == lemon::ModelType::LLM;
+    if (modality == "Embeddings" || modality == "Embedding")
+        return required_type == lemon::ModelType::EMBEDDING;
+    if (modality == "Image generation")
+        return required_type == lemon::ModelType::IMAGE;
+    if (modality == "Speech-to-text" || modality == "Transcription")
+        return required_type == lemon::ModelType::TRANSCRIPTION;
+    if (modality == "Text-to-speech")
+        return required_type == lemon::ModelType::TTS;
+    if (modality == "Generative audio" || modality == "Audio generation")
+        return required_type == lemon::ModelType::AUDIO_GENERATION;
+    return required_type == lemon::ModelType::LLM;
+}
+
+static lemon::ModelType get_required_model_type_for_scenario(const std::string& category) {
+    if (category == "embed") return lemon::ModelType::EMBEDDING;
+    if (category == "imagegen") return lemon::ModelType::IMAGE;
+    if (category == "transcription") return lemon::ModelType::TRANSCRIPTION;
+    if (category == "tts") return lemon::ModelType::TTS;
+    if (category == "audio-generation") return lemon::ModelType::AUDIO_GENERATION;
+    return lemon::ModelType::LLM;
+}
+
+static bool model_has_embeddings_label(const json& model_info) {
+    if (!model_info.contains("labels") || !model_info["labels"].is_array()) return false;
+    for (const auto& label : model_info["labels"]) {
+        if (label.is_string()) {
+            std::string s = label.get<std::string>();
+            if (s == "embed" || s == "embedding" || s == "embeddings") return true;
+        }
+    }
+    return false;
+}
 
 std::vector<BackendDiscovery> discover_backends(const json& sys_info,
-                                                const std::string& model,
                                                 const std::vector<std::string>& requested,
                                                 const json& model_info) {
     std::vector<BackendDiscovery> result;
-
     if (!sys_info.contains("recipes") || !sys_info["recipes"].is_object()) {
         std::cerr << "Warning: No recipes found in system-info" << std::endl;
         return result;
     }
 
-    // Determine model recipe from pre-fetched model info
     std::string model_recipe;
-    if (model_info.contains("recipe") && model_info["recipe"].is_string()) {
+    if (model_info.contains("recipe") && model_info["recipe"].is_string())
         model_recipe = model_info["recipe"].get<std::string>();
-    }
 
     for (const auto& [recipe_name, recipe_data] : sys_info["recipes"].items()) {
-            // If model has a specific recipe, only consider that recipe
-            if (!model_recipe.empty() && recipe_name != model_recipe) {
-                continue;
+        if (!model_recipe.empty() && recipe_name != model_recipe) continue;
+        if (!recipe_data.contains("backends") || !recipe_data["backends"].is_object()) continue;
+        for (const auto& [backend_name, backend_data] : recipe_data["backends"].items()) {
+            std::string state = backend_data.value("state", "unknown");
+            if (state != "installed" && state != "update_required" && state != "update_available") continue;
+            if (!requested.empty()) {
+                bool found = false;
+                for (const auto& req : requested)
+                    if (req == backend_name) { found = true; break; }
+                if (!found) continue;
             }
-
-            if (!recipe_data.contains("backends") || !recipe_data["backends"].is_object()) {
-                continue;
-            }
-
-            for (const auto& [backend_name, backend_data] : recipe_data["backends"].items()) {
-                std::string state = backend_data.value("state", "unknown");
-                if (state != "installed" && state != "update_required" && state != "update_available") continue;
-
-                // If specific backends requested, filter
-                if (!requested.empty()) {
-                    bool found = false;
-                    for (const auto& req : requested) {
-                        if (req == backend_name) { found = true; break; }
-                    }
-                    if (!found) continue;
-                }
-
-                result.push_back({recipe_name, backend_name});
-            }
+            result.push_back({recipe_name, backend_name});
         }
-
+    }
     return result;
 }
 
-
-// Map recipe name to the recipe_options key for custom args
 static const std::map<std::string, std::string> RECIPE_ARGS_KEY = {
     {"llamacpp", "llamacpp_args"},
     {"vllm", "vllm_args"},
@@ -483,23 +336,15 @@ bool load_model_for_backend(lemonade::LemonadeClient& client,
         json request_body;
         request_body["model_name"] = model;
         request_body["save_options"] = false;
-
-        // For recipes that expose a selectable backend, pass the override.
         if (const auto* desc = lemon::backends::descriptor_for(recipe);
             desc && desc->selectable_backend) {
             request_body[desc->effective_config_section() + "_backend"] = backend;
         }
-
-        if (ctx_size > 0) {
-            request_body["ctx_size"] = ctx_size;
-        }
-
-        // Pass backend-specific custom args if provided
+        if (ctx_size > 0) request_body["ctx_size"] = ctx_size;
         if (!backend_args.empty()) {
             auto it = RECIPE_ARGS_KEY.find(recipe);
             if (it != RECIPE_ARGS_KEY.end()) {
                 request_body[it->second] = backend_args;
-                // Disable merge so explicit benchmark args fully override defaults
                 request_body["merge_args"] = false;
             }
         }
@@ -510,11 +355,8 @@ bool load_model_for_backend(lemonade::LemonadeClient& client,
         tmp.ctx_size = ctx_size;
         tmp.backend_args = backend_args;
         std::cout << "  Loading model with " << tmp.label() << "..." << std::flush;
-
-        // Long timeout for model loading
         client.make_request("/api/v1/load", "POST", request_body.dump(), "application/json",
                             86400000, 86400000);
-
         std::cout << " done" << std::endl;
         return true;
     } catch (const lemonade::HttpError& e) {
@@ -537,202 +379,204 @@ bool unload_all_models(lemonade::LemonadeClient& client) {
     }
 }
 
-
-static void query_system_stats(lemonade::LemonadeClient& client, double& vram_gb, double& memory_gb) {
-    vram_gb = -1.0;
-    memory_gb = -1.0;
-    try {
-        std::string response = client.make_request("/api/v1/system-stats", "GET", "", "", 5000, 5000);
-        auto stats = json::parse(response);
-        if (stats.contains("vram_gb") && stats["vram_gb"].is_number()) {
-            vram_gb = stats["vram_gb"].get<double>();
-        }
-        if (stats.contains("memory_gb") && stats["memory_gb"].is_number()) {
-            memory_gb = stats["memory_gb"].get<double>();
-        }
-    } catch (...) {
-        // Best-effort: memory tracking is optional
-    }
-}
-
-// Helper: parse "XX.XX GB" or "XX GB" into a double (GB)
-static double parse_gb_string(const std::string& s) {
-    // Strip trailing " GB" and parse the number
-    std::string num_str = s;
-    size_t space_pos = num_str.find(' ');
-    if (space_pos != std::string::npos) {
-        num_str = num_str.substr(0, space_pos);
-    }
-    try {
-        return std::stod(num_str);
-    } catch (...) {
-        return -1.0;
-    }
-}
-
-// Build a hardware profile JSON from system-info + system-stats.
-// Captures OS, CPU, GPU array, RAM, and backend versions for shareable benchmarks.
-static json build_hardware_profile(lemonade::LemonadeClient& client,
-                                   const json& sys_info,
-                                   const std::vector<std::string>& recipes,
-                                   const std::vector<std::string>& backends) {
-    json profile;
-
-    try {
-
-        std::string os_version = sys_info.value("OS Version", "unknown");
-        std::string os;
-        if (os_version.find("Windows") != std::string::npos) os = "windows";
-        else if (os_version.find("macOS") != std::string::npos || os_version.find("Darwin") != std::string::npos) os = "macos";
-        else if (os_version.find("Linux") != std::string::npos) os = "linux";
-        else os = os_version;
-        profile["os"] = os;
-
-        if (sys_info.contains("devices") && sys_info["devices"].contains("cpu")) {
-            profile["cpu"] = sys_info["devices"]["cpu"].value("name", "unknown");
-        } else {
-            profile["cpu"] = sys_info.value("Processor", "unknown");
-        }
-
-        if (sys_info.contains("Physical Memory") && sys_info["Physical Memory"].is_string()) {
-            double ram_gb = parse_gb_string(sys_info["Physical Memory"].get<std::string>());
-            if (ram_gb > 0) {
-                profile["ram_gb"] = ram_gb;
-            }
-        }
-
-        json gpu_array = json::array();
-        if (sys_info.contains("devices")) {
-            const auto& devices = sys_info["devices"];
-
-            if (devices.contains("amd_gpu") && devices["amd_gpu"].is_array()) {
-                for (const auto& gpu : devices["amd_gpu"]) {
-                    if (gpu.value("available", false)) {
-                        json gpu_entry;
-                        gpu_entry["name"] = gpu.value("name", "unknown");
-                        gpu_entry["type"] = "amd";
-                        gpu_entry["integrated"] = gpu.value("integrated", false);
-                        if (gpu.contains("vram_gb") && gpu["vram_gb"].is_number()) {
-                            gpu_entry["vram_gb"] = gpu["vram_gb"].get<double>();
-                        }
-                        gpu_array.push_back(gpu_entry);
-                    }
-                }
-            }
-
-            if (devices.contains("nvidia_gpu") && devices["nvidia_gpu"].is_array()) {
-                for (const auto& gpu : devices["nvidia_gpu"]) {
-                    if (gpu.value("available", false)) {
-                        json gpu_entry;
-                        gpu_entry["name"] = gpu.value("name", "unknown");
-                        gpu_entry["type"] = "nvidia";
-                        if (gpu.contains("vram_gb") && gpu["vram_gb"].is_number()) {
-                            gpu_entry["vram_gb"] = gpu["vram_gb"].get<double>();
-                        }
-                        gpu_array.push_back(gpu_entry);
-                    }
-                }
-            }
-
-            if (devices.contains("metal") && devices["metal"].is_object()) {
-                const auto& metal = devices["metal"];
-                if (metal.value("available", false)) {
-                    json gpu_entry;
-                    gpu_entry["name"] = metal.value("name", "unknown");
-                    gpu_entry["type"] = "metal";
-                    if (metal.contains("vram_gb") && metal["vram_gb"].is_number()) {
-                        gpu_entry["vram_gb"] = metal["vram_gb"].get<double>();
-                    }
-                    gpu_array.push_back(gpu_entry);
-                }
-            }
-        }
-        profile["gpu"] = gpu_array;
-
-        json backend_versions = json::object();
-        if (sys_info.contains("recipes") && sys_info["recipes"].is_object()) {
-            for (const auto& [recipe_name, recipe_data] : sys_info["recipes"].items()) {
-                if (!recipes.empty()) {
-                    bool found = std::find(recipes.begin(), recipes.end(), recipe_name) != recipes.end();
-                    if (!found) continue;
-                }
-
-                if (!recipe_data.contains("backends") || !recipe_data["backends"].is_object()) {
-                    continue;
-                }
-
-                for (const auto& [backend_name, backend_data] : recipe_data["backends"].items()) {
-                    if (!backends.empty()) {
-                        bool found = std::find(backends.begin(), backends.end(), backend_name) != backends.end();
-                        if (!found) continue;
-                    }
-
-                    std::string state = backend_data.value("state", "unknown");
-                    if (state != "installed" && state != "update_required" && state != "update_available") {
-                        continue;
-                    }
-
-                    std::string version = backend_data.value("version", "");
-                    if (!version.empty()) {
-                        backend_versions[recipe_name + "/" + backend_name] = version;
-                    }
-                }
-            }
-        }
-        if (!backend_versions.empty()) {
-            profile["backends"] = backend_versions;
-        }
-
-    } catch (const std::exception& e) {
-        std::cerr << "Warning: Failed to build hardware profile: " << e.what() << std::endl;
-    }
-
-    return profile;
-}
-
 static void extract_usage_into_result(const json& usage, BenchRunResult& result) {
-    if (usage.contains("prompt_tokens")) {
-        result.input_tokens = usage["prompt_tokens"].get<int>();
-    }
-    if (usage.contains("completion_tokens")) {
-        result.output_tokens = usage["completion_tokens"].get<int>();
-    }
-    if (usage.contains("prefill_duration_ttft")) {
-        result.ttft_ms = usage["prefill_duration_ttft"].get<double>() * 1000.0;
-    }
-    if (usage.contains("decoding_speed_tps")) {
-        result.tps = usage["decoding_speed_tps"].get<double>();
-    }
+    if (usage.contains("prompt_tokens")) result.input_tokens = usage["prompt_tokens"].get<int>();
+    if (usage.contains("completion_tokens")) result.output_tokens = usage["completion_tokens"].get<int>();
+    if (usage.contains("prefill_duration_ttft")) result.ttft_ms = usage["prefill_duration_ttft"].get<double>() * 1000.0;
+    if (usage.contains("decoding_speed_tps")) result.tps = usage["decoding_speed_tps"].get<double>();
 }
 
 static void extract_timings_into_result(const json& timings, BenchRunResult& result) {
-    if (timings.contains("prompt_ms")) {
-        result.ttft_ms = timings["prompt_ms"].get<double>();
-    }
-    if (timings.contains("predicted_per_second")) {
-        result.tps = timings["predicted_per_second"].get<double>();
-    }
-    if (timings.contains("prompt_n")) {
-        result.input_tokens = timings["prompt_n"].get<int>();
-    }
-    if (timings.contains("predicted_n")) {
-        result.output_tokens = timings["predicted_n"].get<int>();
-    }
+    if (timings.contains("prompt_ms")) result.ttft_ms = timings["prompt_ms"].get<double>();
+    if (timings.contains("predicted_per_second")) result.tps = timings["predicted_per_second"].get<double>();
+    if (timings.contains("prompt_n")) result.input_tokens = timings["prompt_n"].get<int>();
+    if (timings.contains("predicted_n")) result.output_tokens = timings["predicted_n"].get<int>();
 }
 
 static void extract_mem_use_into_result(lemonade::LemonadeClient& client, BenchRunResult& result) {
-        double vram_after = -1.0, mem_after = -1.0;
-        query_system_stats(client, vram_after, mem_after);
-        result.vram_gb = vram_after;
-        result.memory_gb = mem_after;
+    double vram = -1.0, mem = -1.0;
+    try {
+        std::string resp = client.make_request("/api/v1/system-stats", "GET", "", "", 5000, 5000);
+        auto stats = json::parse(resp);
+        if (stats.contains("vram_gb") && stats["vram_gb"].is_number()) vram = stats["vram_gb"].get<double>();
+        if (stats.contains("memory_gb") && stats["memory_gb"].is_number()) mem = stats["memory_gb"].get<double>();
+    } catch (...) {}
+    result.vram_gb = vram;
+    result.memory_gb = mem;
 }
 
 static void compute_tps_from_tokens_and_time(BenchRunResult& result) {
-    if (result.tps <= 0 && result.output_tokens > 0 && result.total_time_ms > 0) {
+    if (result.tps <= 0 && result.output_tokens > 0 && result.total_time_ms > 0)
         result.tps = (result.output_tokens * 1000.0) / result.total_time_ms;
-    }
 }
 
+struct BenchStrategy {
+    std::string endpoint;
+    std::function<json()> build_request;
+    std::function<void(const json&, BenchRunResult&, bool)> parse_response;
+};
+
+static BenchRunResult run_single_bench(lemonade::LemonadeClient& client,
+                                                bool memory_tracking,
+                                                bool capture_response,
+                                                int timeout,
+                                                const BenchStrategy& strategy) {
+    BenchRunResult result;
+    result.success = false;
+
+    if (memory_tracking) {
+        // Warmup memory stats query (discard)
+        try {
+            client.make_request("/api/v1/system-stats", "GET", "", "", 5000, 5000);
+        } catch (...) {}
+    }
+
+    json request_body = strategy.build_request();
+    auto start = steady_clock::now();
+
+    try {
+        std::string response = client.make_request(strategy.endpoint, "POST",
+                                                    request_body.dump(), "application/json",
+                                                    timeout, timeout);
+        auto resp_json = json::parse(response);
+        strategy.parse_response(resp_json, result, capture_response);
+    } catch (const std::exception& e) {
+        std::cerr << "    Benchmark run failed: " << e.what() << std::endl;
+        return result;
+    }
+
+    auto end = steady_clock::now();
+    result.total_time_ms = duration<double, std::milli>(end - start).count();
+    compute_tps_from_tokens_and_time(result);
+
+    if (memory_tracking)
+        extract_mem_use_into_result(client, result);
+
+    if (!result.valid) {
+        std::cerr << "    Benchmark run failed (no meaningful data extracted)" << std::endl;
+        return result;
+    }
+
+    result.success = true;
+    return result;
+}
+
+static BenchStrategy make_textgen_strategy(const std::string& model, const BenchScenario& scenario) {
+    return BenchStrategy{
+        "/api/v1/chat/completions",
+        [&model, &scenario]() -> json {
+            json body;
+            body["model"] = model;
+            body["messages"] = scenario.messages;
+            body["max_completion_tokens"] = scenario.max_tokens;
+            body["temperature"] = 0;
+            return body;
+        },
+        [](const json& resp, BenchRunResult& result, bool capture_response) {
+            if (capture_response) {
+                if (resp.contains("output")) {
+                    result.response_text = resp["output"].dump();
+                } else if (resp.contains("choices") && resp["choices"].is_array() &&
+                           !resp["choices"].empty()) {
+                    const auto& choice = resp["choices"][0];
+                    if (choice.contains("message") && choice["message"].contains("content")) {
+                        const auto& content = choice["message"]["content"];
+                        result.response_text = content.is_string() ? content.get<std::string>() : content.dump();
+                    } else {
+                        result.response_text = choice.dump();
+                    }
+                } else {
+                    result.response_text = "null";
+                }
+            }
+            if (resp.contains("timings") && resp["timings"].is_object()) {
+                extract_timings_into_result(resp["timings"], result);
+            }
+            if (resp.contains("usage") && resp["usage"].is_object()) {
+                extract_usage_into_result(resp["usage"], result);
+            }
+
+            result.valid = !(result.ttft_ms <= 0 && result.tps <= 0 && result.input_tokens <= 0 && result.output_tokens <= 0);
+        }
+    };
+}
+
+static BenchStrategy make_embed_strategy(const std::string& model, const BenchScenario& scenario) {
+    return BenchStrategy{
+        "/api/v1/embeddings",
+        [&model, &scenario]() -> json {
+            json body;
+            body["model"] = model;
+            body["input"] = scenario.input;
+            return body;
+        },
+        [](const json& resp, BenchRunResult& result, bool capture_response) {
+            if (capture_response) {
+                if (resp.contains("data") && !resp["data"].empty())
+                    result.response_text = resp["data"].dump();
+                else
+                    result.response_text = "null";
+            }
+            if (resp.contains("timings") && resp["timings"].is_object()) {
+                extract_timings_into_result(resp["timings"], result);
+            }
+            if (resp.contains("usage") && resp["usage"].is_object()) {
+                result.input_tokens = resp["usage"]["prompt_tokens"].get<int>();
+                result.output_tokens = resp["usage"]["total_tokens"].get<int>();
+            }
+
+            result.valid = !(result.ttft_ms <= 0 && result.tps <= 0 && result.input_tokens <= 0 && result.output_tokens <= 0);
+        }
+    };
+}
+
+static BenchStrategy make_imagegen_strategy(const std::string& model, const BenchScenario& scenario,
+                                             bool capture_response) {
+    return BenchStrategy{
+        "/api/v1/images/generations",
+        [&scenario, capture_response, model]() -> json {
+            json body;
+            body["model"] = model;
+            if (!scenario.imgconfig.contains("prompt") || !scenario.imgconfig["prompt"].is_string()) {
+                // Will fail with a clear error message
+                body["prompt"] = "";
+            } else {
+                body["prompt"] = scenario.imgconfig.value("prompt", "");
+            }
+            if (capture_response) body["response_format"] = "b64_json";
+            if (scenario.imgconfig.contains("size") && scenario.imgconfig["size"].is_string())
+                body["size"] = scenario.imgconfig.value("size", "256x256");
+            if (scenario.imgconfig.contains("steps") && scenario.imgconfig["steps"].is_number_integer())
+                body["steps"] = scenario.imgconfig.value("steps", 1);
+            if (scenario.imgconfig.contains("cfg_scale") && scenario.imgconfig["cfg_scale"].is_number())
+                body["cfg_scale"] = scenario.imgconfig.value("cfg_scale", 1.0);
+            if (scenario.imgconfig.contains("seed") && scenario.imgconfig["seed"].is_number_integer())
+                body["seed"] = scenario.imgconfig.value("seed", 42);
+            else
+                body["seed"] = 42;
+            return body;
+        },
+        [](const json& resp, BenchRunResult& result, bool capture_response) {
+            result.response_text = "null";
+            if (capture_response && resp.contains("data") && !resp["data"].empty()) {
+                const auto& data = resp["data"];
+                if (data.is_array() && !data.empty()) {
+                    const auto& first = data[0];
+                    if (first.contains("b64_json"))
+                        result.response_text = first["b64_json"].get<std::string>();
+                }
+            }
+            if (resp.contains("timings") && resp["timings"].is_object()) {
+                extract_timings_into_result(resp["timings"], result);
+            }
+            if (resp.contains("data") && resp["data"].is_array() && !resp["data"].empty()) {
+                result.valid = true;
+            }
+        }
+    };
+}
+
+// Public dispatchers (kept for API compatibility with header declarations)
 BenchRunResult run_single_bench(lemonade::LemonadeClient& client,
                                 const std::string& model,
                                 const BenchScenario& scenario,
@@ -743,250 +587,57 @@ BenchRunResult run_single_bench(lemonade::LemonadeClient& client,
         return run_single_bench_embed(client, model, scenario, memory_tracking, capture_response, timeout);
     if (scenario.category == "imagegen")
         return run_single_bench_imagegen(client, model, scenario, memory_tracking, capture_response, timeout);
-    // default mode is text generation
     return run_single_bench_textgen(client, model, scenario, memory_tracking, capture_response, timeout);
 }
 
 BenchRunResult run_single_bench_textgen(lemonade::LemonadeClient& client,
-                                const std::string& model,
-                                const BenchScenario& scenario,
-                                bool memory_tracking,
-                                bool capture_response,
-                                int timeout) {
-    BenchRunResult result;
-    result.success = false;  // assume failure until proven otherwise
-
-    // Warmup memory stats query (discard — we take post-run snapshot)
-    if (memory_tracking) {
-        double _vram, _mem;
-        query_system_stats(client, _vram, _mem);
-    }
-
-    json request_body;
-    request_body["model"] = model;
-    request_body["messages"] = scenario.messages;
-    request_body["max_completion_tokens"] = scenario.max_tokens;
-    request_body["temperature"] = 0;
-
-    std::string body = request_body.dump();
-    auto start = steady_clock::now();
-
-    try {
-        std::string response = client.make_request("/api/v1/chat/completions", "POST", body, "application/json",
-                                                   timeout, timeout);
-        auto resp_json = json::parse(response);
-
-        if (capture_response) {
-            if (resp_json.contains("output")) {
-                // Preserve structured Responses API payloads for downstream analysis.
-                result.response_text = resp_json["output"].dump();
-            } else if (resp_json.contains("choices") && resp_json["choices"].is_array() &&
-                       !resp_json["choices"].empty()) {
-                const auto& choice = resp_json["choices"][0];
-                if (choice.contains("message") && choice["message"].contains("content")) {
-                    const auto& content = choice["message"]["content"];
-                    if (content.is_string()) {
-                        result.response_text = content.get<std::string>();
-                    } else {
-                        result.response_text = content.dump();
-                    }
-                } else {
-                    result.response_text = choice.dump();
-                }
-            } else {
-                result.response_text = "null";
-            }
-        }
-
-        if (resp_json.contains("timings") && resp_json["timings"].is_object()) {
-            extract_timings_into_result(resp_json["timings"], result);
-        }
-        if (resp_json.contains("usage") && resp_json["usage"].is_object()) {
-            extract_usage_into_result(resp_json["usage"], result);
-        }
-    } catch (const std::exception& e) {
-        std::cerr << "    Benchmark run failed: " << e.what() << std::endl;
-        return result;
-    }
-
-    auto end = steady_clock::now();
-    result.total_time_ms = duration<double, std::milli>(end - start).count();
-
-    // Last resort: derive TPS from total time
-    compute_tps_from_tokens_and_time(result);
-
-    // Query memory after
-    if (memory_tracking)
-        extract_mem_use_into_result(client, result);
-
-    // Validate: if all key metrics are zero the run failed server-side
-    // (e.g. context size mismatch, model error). VRAM is excluded — it's
-    // always reported correctly even for failed runs.
-    if (result.ttft_ms <= 0 && result.tps <= 0 &&
-        result.input_tokens <= 0 && result.output_tokens <= 0) {
-        std::cerr << "    Benchmark run failed (all metrics zero)" << std::endl;
-        return result;  // success stays false
-    }
-
-    result.success = true;
-    return result;
+                                        const std::string& model,
+                                        const BenchScenario& scenario,
+                                        bool memory_tracking,
+                                        bool capture_response,
+                                        int timeout) {
+    return run_single_bench(client, memory_tracking, capture_response, timeout, make_textgen_strategy(model, scenario));
 }
 
 BenchRunResult run_single_bench_embed(lemonade::LemonadeClient& client,
-                                const std::string& model,
-                                const BenchScenario& scenario,
-                                bool memory_tracking,
-                                bool capture_response,
-                                int timeout) {
-    BenchRunResult result;
-    result.success = false;
-
-    if (memory_tracking) {
-        double _vram, _mem;
-        query_system_stats(client, _vram, _mem);
+                                      const std::string& model,
+                                      const BenchScenario& scenario,
+                                      bool memory_tracking,
+                                      bool capture_response,
+                                      int timeout) {
+    auto strategy = make_embed_strategy(model, scenario);
+    auto result = run_single_bench(client, memory_tracking, capture_response, timeout, strategy);
+    if (result.success) {
+        // Embedding benchmarks: ttft_ms is the total wall-clock time
+        result.ttft_ms = result.total_time_ms;
     }
-
-    json request_body;
-    request_body["model"] = model;
-    request_body["input"] = scenario.input;  // may be string or array
-
-    std::string body = request_body.dump();
-
-    // Timing setup
-    auto start = steady_clock::now();
-
-    try {
-        std::string response = client.make_request(
-            "/api/v1/embeddings", "POST", body, "application/json",
-            timeout, timeout);
-
-        auto resp_json = json::parse(response);
-
-        if (capture_response) {
-            if (resp_json.contains("data") && !resp_json["data"].empty()) {
-                result.response_text = resp_json["data"].dump();
-            } else {
-                result.response_text = "null";
-            }
-        }
-
-        if (resp_json.contains("timings") && resp_json["timings"].is_object()) {
-            extract_timings_into_result(resp_json["timings"], result);
-        }
-
-        // Extract usage statistics
-        if (resp_json.contains("usage") && resp_json["usage"].is_object()) {
-            // prompt_tokens = input tokens, total_tokens = output tokens
-            result.input_tokens = resp_json["usage"]["prompt_tokens"].get<int>();
-            result.output_tokens = resp_json["usage"]["total_tokens"].get<int>();
-        }
-
-        // Populate timing fields
-        auto end = steady_clock::now();
-        result.ttft_ms = duration<double, std::milli>(end - start).count();
-
-        compute_tps_from_tokens_and_time(result);
-
-    } catch (const std::exception& e) {
-        std::cerr << "    Embedding benchmark run failed: " << e.what() << std::endl;
-        return result;  // success stays false
-    }
-
-    // Query memory after
-    if (memory_tracking)
-        extract_mem_use_into_result(client, result);
-
-
-    // Success flag is already true by default if we reach here
-    result.success = true;
     return result;
 }
 
 BenchRunResult run_single_bench_imagegen(lemonade::LemonadeClient& client,
-                                const std::string& model,
-                                const BenchScenario& scenario,
-                                bool memory_tracking,
-                                bool capture_response,
-                                int timeout) {
-    BenchRunResult result;
-    result.success = false;
-
-    if (memory_tracking) {
-        double _vram, _mem;
-        query_system_stats(client, _vram, _mem);
-    }
-
-    json request_body;
-    request_body["model"] = model;
-    if (!(scenario.imgconfig.contains("prompt") && scenario.imgconfig["prompt"].is_string())) {
+                                         const std::string& model,
+                                         const BenchScenario& scenario,
+                                         bool memory_tracking,
+                                         bool capture_response,
+                                         int timeout) {
+    if (!scenario.imgconfig.contains("prompt") || !scenario.imgconfig["prompt"].is_string()) {
         std::cerr << "    Image generation scenario missing 'prompt' field." << std::endl;
+        BenchRunResult result;
+        result.success = false;
         return result;
     }
-    request_body["prompt"] = scenario.imgconfig.value("prompt", "");
-    // Request base64-encoded JSON response if we want to capture the image data. This makes
-    // the response log file easily readable.
-    if (capture_response)
-        request_body["response_format"] = "b64_json";
-    // Optional fields, if unspecified let the model use its defaults.
-    // default values won't actaully be used, they're just here to satisfy the type system
-    if (scenario.imgconfig.contains("size") && scenario.imgconfig["size"].is_string()) {
-        request_body["size"] = scenario.imgconfig.value("size", "256x256");
+    auto strategy = make_imagegen_strategy(model, scenario, capture_response);
+    // Fix the model in the request body (strategy uses a placeholder)
+    auto orig_build = strategy.build_request;
+    strategy.build_request = [orig_build, model]() -> json {
+        json body = orig_build();
+        body["model"] = model;
+        return body;
+    };
+    auto result = run_single_bench(client, memory_tracking, capture_response, timeout, strategy);
+    if (result.success) {
+        result.ttft_ms = result.total_time_ms;
     }
-    if (scenario.imgconfig.contains("steps") && scenario.imgconfig["steps"].is_number_integer()) {
-        request_body["steps"] = scenario.imgconfig.value("steps", 1);
-    }
-    if (scenario.imgconfig.contains("cfg_scale") && scenario.imgconfig["cfg_scale"].is_number()) {
-        request_body["cfg_scale"] = scenario.imgconfig.value("cfg_scale", 1.0);
-    }
-    if (scenario.imgconfig.contains("seed") && scenario.imgconfig["seed"].is_number_integer()) {
-        request_body["seed"] = scenario.imgconfig.value("seed", 42);
-    } else
-        request_body["seed"] = 42;  // default seed for reproducibility
-
-    std::string body = request_body.dump();
-
-    // Timing setup
-    auto start = steady_clock::now();
-
-    try {
-        std::string response = client.make_request(
-            "/api/v1/images/generations", "POST", body, "application/json",
-            timeout, timeout);
-
-        auto resp_json = json::parse(response);
-
-        result.response_text = "null";
-        if (capture_response) {
-            if (resp_json.contains("data") && !resp_json["data"].empty()) {
-                const auto& data = resp_json["data"];
-                if (data.is_array() && !data.empty()) {
-                    const auto& first_item = data[0];
-                    if (first_item.contains("b64_json"))
-                        result.response_text = first_item["b64_json"].get<std::string>();
-                }
-            }
-        }
-
-        if (resp_json.contains("timings") && resp_json["timings"].is_object()) {
-            extract_timings_into_result(resp_json["timings"], result);
-        }
-
-        // Populate timing fields
-        auto end = steady_clock::now();
-        result.ttft_ms = duration<double, std::milli>(end - start).count();
-        result.total_time_ms += result.ttft_ms;
-
-    } catch (const std::exception& e) {
-        std::cerr << "    Image generation benchmark run failed: " << e.what() << std::endl;
-        return result;  // success stays false
-    }
-
-    // Query memory after
-    if (memory_tracking)
-        extract_mem_use_into_result(client, result);
-
-
-    result.success = true;
     return result;
 }
 
@@ -1008,7 +659,6 @@ BenchScenarioResult run_scenario(lemonade::LemonadeClient& client,
     result.scenario_name = scenario.name;
     result.category = scenario.category;
 
-    // Load model (once if not reloading, or before each run if reloading)
     bool loaded = false;
     if (!reload) {
         unload_all_models(client);
@@ -1045,7 +695,8 @@ BenchScenarioResult run_scenario(lemonade::LemonadeClient& client,
         }
 
         std::cout << "    Run " << (i + 1) << "/" << runs << "..." << std::flush;
-        auto run_result = run_single_bench(client, model, scenario, memory_tracking, !response_log_path.empty(), timeout);
+        auto run_result = run_single_bench(client, model, scenario, memory_tracking,
+                                            !response_log_path.empty(), timeout);
         if (!run_result.success) {
             result.failed_runs++;
             std::cout << " FAILED (excluded from stats)" << std::endl;
@@ -1053,10 +704,8 @@ BenchScenarioResult run_scenario(lemonade::LemonadeClient& client,
         }
 
         if (!response_log_path.empty()) {
-            std::ofstream response_log(response_log_path, std::ios::app);
-            if (!response_log.is_open()) {
-                std::cerr << "\nWarning: Could not open response log: " << response_log_path << std::endl;
-            } else {
+            std::ofstream log(response_log_path, std::ios::app);
+            if (log.is_open()) {
                 json entry;
                 entry["timestamp"] = response_timestamp;
                 entry["model"] = model;
@@ -1072,10 +721,10 @@ BenchScenarioResult run_scenario(lemonade::LemonadeClient& client,
                 entry["ttft_ms"] = run_result.ttft_ms;
                 entry["tps"] = run_result.tps;
                 entry["response"] = run_result.response_text;
-                response_log << entry.dump() << "\n";
+                log << entry.dump() << "\n";
+            } else {
+                std::cerr << "\nWarning: Could not open response log: " << response_log_path << std::endl;
             }
-
-            // Avoid retaining large response bodies in memory after logging.
             run_result.response_text.clear();
             run_result.response_text.shrink_to_fit();
         }
@@ -1088,522 +737,88 @@ BenchScenarioResult run_scenario(lemonade::LemonadeClient& client,
     return result;
 }
 
+static std::map<std::string, json> preflight_models(lemonade::LemonadeClient& client,
+                                                     const std::vector<std::string>& models,
+                                                     bool auto_pull) {
+    std::map<std::string, json> info_by_name;
+    for (const auto& model : models) {
+        json model_info = client.get_model_info(model);
 
-// Write JSON to file. Returns true on success, false on error (with stderr message).
-// If error_fatal is true, the error message says "Error"; otherwise "Warning".
-static bool write_json_file(const std::string& path, const std::string& json_str, bool error_fatal) {
-    std::ofstream out(path);
-    if (!out.is_open()) {
-        std::cerr << (error_fatal ? "Error" : "Warning")
-                  << ": Could not write to " << path << std::endl;
-        return false;
-    }
-    out << json_str;
-    out.close();
-    return true;
-}
-
-static std::string fmt_double(double val, int precision = 1) {
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(precision) << val;
-    return oss.str();
-}
-
-static std::string fmt_vram(double val) {
-    if (val < 0) return "-";
-    return fmt_double(val, 1);
-}
-
-static std::string fmt_pct_change(double pct) {
-    std::ostringstream oss;
-    oss << (pct >= 0 ? "+" : "") << std::fixed << std::setprecision(1) << pct << "%";
-    return oss.str();
-}
-
-static std::string fmt_vram_change(std::optional<double> val) {
-    if (!val.has_value()) return "-";
-    if (*val >= 0) return "+" + fmt_double(*val) + " GB";
-    return fmt_double(*val) + " GB";
-}
-
-static size_t calculate_number_width(double value, int precision = 1) {
-    if (value < 0) {
-        value = -value;
-    }
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(precision) << value;
-    return oss.str().length();
-}
-
-static size_t calculate_vram_width(double value) {
-    if (value < 0) return 1;
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(1) << value;
-    return oss.str().length();
-}
-
-FieldWidths calculate_field_widths(const std::vector<BenchBackendResult>& results) {
-    FieldWidths widths;
-
-    for (const auto& backend_result : results) {
-        for (const auto& scenario : backend_result.scenarios) {
-            size_t scenario_len = scenario.scenario_name.length();
-            if (scenario_len > 0) {
-                if (scenario.failed_runs > 0) {
-                    scenario_len += 2 + std::to_string(scenario.failed_runs).length() + 1;
-                }
-                if (scenario_len > widths.scenario_name) {
-                    widths.scenario_name = std::min<size_t>(scenario_len, 36)+3;
-                }
+        if (model_info.empty()) {
+            if (!auto_pull) {
+                std::cerr << "Error: Model '" << model << "' not found." << std::endl;
+                std::cerr << "Use --auto-pull to download missing models before benchmarking." << std::endl;
+                return {};
+            }
+            std::cout << "Preflight: model '" << model << "' not found. Auto-pulling..." << std::endl;
+            json pull_req;
+            pull_req["model_name"] = model;
+            if (client.pull_model(pull_req) != 0) {
+                std::cerr << "Error: Failed to pull model '" << model << "'." << std::endl;
+                return {};
+            }
+            model_info = client.get_model_info(model);
+            if (model_info.empty()) {
+                std::cerr << "Error: Model '" << model << "' still unavailable after auto-pull." << std::endl;
+                return {};
             }
         }
-    }
 
-    for (const auto& backend_result : results) {
-        for (const auto& scenario : backend_result.scenarios) {
-            if (scenario.runs.empty()) {
-                widths.ttft = std::max(widths.ttft, size_t{8});
-                widths.tps  = std::max(widths.tps,  size_t{8});
-            } else {
-                double max_ttft = scenario.ttft_max_ms();
-                widths.ttft = std::max(widths.ttft, calculate_number_width(max_ttft, 1));
-
-                double max_tps = scenario.tps_max();
-                widths.tps = std::max(widths.tps, calculate_number_width(max_tps, 1));
+        if (model_info.contains("downloaded") && !model_info["downloaded"].get<bool>()) {
+            if (!auto_pull) {
+                std::cerr << "Error: Model '" << model << "' is not downloaded." << std::endl;
+                std::cerr << "Run 'lemonade pull " << model << "' first, or use --auto-pull." << std::endl;
+                return {};
             }
-
-            double vram_peak = scenario.vram_peak_gb();
-            if (vram_peak >= 0) {
-                widths.vram = std::max(widths.vram, calculate_vram_width(vram_peak));
+            std::cout << "Preflight: model '" << model << "' is not downloaded. Auto-pulling..." << std::endl;
+            json pull_req;
+            pull_req["model_name"] = model;
+            if (client.pull_model(pull_req) != 0) {
+                std::cerr << "Error: Failed to pull model '" << model << "'." << std::endl;
+                return {};
             }
-        }
-    }
-
-    return widths;
-}
-
-static void print_scenario_row(const BenchScenarioResult& scenario, bool use_percentiles, const FieldWidths& widths) {
-    double ttft_1 = use_percentiles ? scenario.ttft_p50_ms() : scenario.ttft_min_ms();
-    double ttft_2 = use_percentiles ? scenario.ttft_p95_ms() : scenario.ttft_max_ms();
-    double tps_1 = use_percentiles ? scenario.tps_p50() : scenario.tps_min();
-    double tps_2 = use_percentiles ? scenario.tps_p95() : scenario.tps_max();
-    std::string name = scenario.scenario_name;
-    if (scenario.failed_runs > 0) {
-        name += " *" + std::to_string(scenario.failed_runs) + "f ";
-    }
-    if (scenario.runs.empty()) {
-        // All runs failed — show dashes
-        std::cout << std::left << std::setw(widths.scenario_name) << name
-                  << std::setw(widths.ttft) << "-"
-                  << std::setw(widths.ttft) << "-"
-                  << std::setw(widths.ttft) << "-"
-                  << std::setw(widths.tps) << "-"
-                  << std::setw(widths.tps) << "-"
-                  << std::setw(widths.tps) << "-"
-                  << std::setw(widths.vram) << "-"
-                  << std::endl;
-    } else {
-        std::cout << std::left << std::setw(widths.scenario_name) << name
-                  << std::setw(widths.ttft) << fmt_double(scenario.ttft_mean_ms())
-                  << " " << std::setw(widths.ttft) << fmt_double(ttft_1)
-                  << " " << std::setw(widths.ttft) << fmt_double(ttft_2)
-                  << " " << std::setw(widths.tps) << fmt_double(scenario.tps_mean())
-                  << " " << std::setw(widths.tps) << fmt_double(tps_1)
-                  << " " << std::setw(widths.tps) << fmt_double(tps_2)
-                  << " " << std::setw(widths.vram) << fmt_vram(scenario.vram_peak_gb())
-                  << std::endl;
-    }
-}
-
-void print_table(const std::vector<BenchBackendResult>& results, const std::string& model,
-                 bool use_percentiles) {
-    FieldWidths widths = calculate_field_widths(results);
-    std::cout << std::endl;
-    std::cout << "Benchmark: " << model << std::endl;
-    std::cout << std::string(100, '=') << std::endl;
-
-    for (const auto& backend_result : results) {
-        std::cout << std::endl;
-        std::cout << "Backend: " << backend_result.label() << std::endl;
-        std::cout << std::string(100, '-') << std::endl;
-
-        // Header — show min/max by default, switch to p50/p95 when runs >= 10
-        std::cout << std::left << std::setw(widths.scenario_name) << "Scenario"
-                  << std::setw(widths.ttft) << "TTFT"
-                  << " " << std::setw(widths.ttft) << (use_percentiles ? "p50" : "min")
-                  << " " << std::setw(widths.ttft) << (use_percentiles ? "p95" : "max")
-                  << " " << std::setw(widths.tps) << "TPS"
-                  << " " << std::setw(widths.tps) << (use_percentiles ? "p50" : "min")
-                  << " " << std::setw(widths.tps) << (use_percentiles ? "p95" : "max")
-                  << " " << std::setw(widths.vram) << "VRAM (GB)" << std::endl;
-        std::cout << std::string(100, '-') << std::endl;
-
-        for (const auto& scenario : backend_result.scenarios) {
-            print_scenario_row(scenario, use_percentiles, widths);
-        }
-    }
-
-    std::cout << std::endl;
-    std::cout << "(*Nf = N failed runs excluded from stats)" << std::endl;
-    std::cout << std::endl;
-}
-
-json to_json(const std::vector<BenchBackendResult>& results,
-             const std::string& model,
-             const std::string& timestamp,
-             const BenchConfig& config) {
-    json output;
-    output["model"] = model;
-    output["timestamp"] = timestamp;
-
-    json config_json;
-    config_json["warmup_runs"] = config.warmup_runs;
-    config_json["measurement_runs"] = config.measurement_runs;
-    config_json["memory_tracking"] = config.memory_tracking;
-    output["config"] = config_json;
-
-    json results_json = json::array();
-    for (const auto& backend_result : results) {
-        json backend_json;
-        backend_json["recipe"] = backend_result.recipe;
-        backend_json["backend"] = backend_result.backend;
-        backend_json["ctx_size"] = backend_result.ctx_size;
-        backend_json["backend_args"] = backend_result.backend_args;
-
-        json scenarios_json = json::array();
-        for (const auto& scenario : backend_result.scenarios) {
-            json s_json;
-            s_json["name"] = scenario.scenario_name;
-            s_json["category"] = scenario.category;
-            s_json["input_tokens"] = scenario.input_tokens();
-            s_json["output_tokens"] = scenario.output_tokens();
-
-            if (scenario.runs.empty()) {
-                // All runs failed — omit metric blocks so the result is clearly
-                // distinguishable from a valid 0ms/0tps measurement.
-                s_json["all_runs_failed"] = true;
-            } else {
-                json ttft_stats;
-                ttft_stats["mean"] = scenario.ttft_mean_ms();
-                ttft_stats["min"] = scenario.ttft_min_ms();
-                ttft_stats["max"] = scenario.ttft_max_ms();
-                ttft_stats["p50"] = scenario.ttft_p50_ms();
-                ttft_stats["p95"] = scenario.ttft_p95_ms();
-                s_json["ttft_ms"] = ttft_stats;
-
-                std::vector<double> duration_vals;
-                duration_vals.reserve(scenario.runs.size());
-                double duration_sum = 0.0;
-                double duration_min = scenario.runs[0].total_time_ms;
-                double duration_max = scenario.runs[0].total_time_ms;
-                for (const auto& run : scenario.runs) {
-                    duration_vals.push_back(run.total_time_ms);
-                    duration_sum += run.total_time_ms;
-                    if (run.total_time_ms < duration_min) duration_min = run.total_time_ms;
-                    if (run.total_time_ms > duration_max) duration_max = run.total_time_ms;
-                }
-                json duration_stats;
-                duration_stats["mean"] = duration_sum / static_cast<double>(scenario.runs.size());
-                duration_stats["min"] = duration_min;
-                duration_stats["max"] = duration_max;
-                duration_stats["p50"] = percentile(duration_vals, 50.0);
-                duration_stats["p95"] = percentile(duration_vals, 95.0);
-                s_json["duration_ms"] = duration_stats;
-
-                json tps_stats;
-                tps_stats["mean"] = scenario.tps_mean();
-                tps_stats["min"] = scenario.tps_min();
-                tps_stats["max"] = scenario.tps_max();
-                tps_stats["p50"] = scenario.tps_p50();
-                tps_stats["p95"] = scenario.tps_p95();
-                s_json["tps"] = tps_stats;
-
-                double vram_peak = scenario.vram_peak_gb();
-                if (vram_peak >= 0) s_json["vram_peak_gb"] = vram_peak;
-                double mem_peak = scenario.memory_peak_gb();
-                if (mem_peak >= 0) s_json["memory_peak_gb"] = mem_peak;
-            }
-            s_json["failed_runs"] = scenario.failed_runs;
-
-            scenarios_json.push_back(s_json);
-        }
-        backend_json["scenarios"] = scenarios_json;
-        results_json.push_back(backend_json);
-    }
-    output["results"] = results_json;
-
-    return output;
-}
-
-
-json load_previous_results(const std::string& file_path) {
-    std::ifstream file(file_path);
-    if (!file.is_open()) {
-        std::cerr << "Error: Could not open comparison file: " << file_path << std::endl;
-        return json::object();
-    }
-
-    try {
-        return json::parse(file);
-    } catch (const json::exception& e) {
-        std::cerr << "Error: Failed to parse comparison file: " << e.what() << std::endl;
-        return json::object();
-    }
-}
-
-// Normalize benchmark JSON into a model->result-object map.
-// Supports both legacy single-model files and multi-model files.
-static std::map<std::string, json> extract_models_from_results(const json& root) {
-    std::map<std::string, json> by_model;
-
-    if (root.contains("models") && root["models"].is_array()) {
-        for (const auto& model_entry : root["models"]) {
-            if (model_entry.contains("model") && model_entry["model"].is_string()) {
-                by_model[model_entry["model"].get<std::string>()] = model_entry;
+            model_info = client.get_model_info(model);
+            if (model_info.empty() || (model_info.contains("downloaded") && !model_info["downloaded"].get<bool>())) {
+                std::cerr << "Error: Model '" << model << "' is not downloaded after auto-pull." << std::endl;
+                return {};
             }
         }
-        return by_model;
-    }
 
-    if (root.contains("model") && root["model"].is_string()) {
-        by_model[root["model"].get<std::string>()] = root;
+        info_by_name[model] = std::move(model_info);
     }
-
-    return by_model;
+    return info_by_name;
 }
 
-static std::string extract_results_timestamp(const json& root) {
-    if (root.contains("timestamp") && root["timestamp"].is_string()) {
-        return root["timestamp"].get<std::string>();
+struct ModelSetSummary {
+    std::vector<std::string> current_models;
+    std::vector<std::string> previous_models;
+    std::vector<std::string> matched_models;
+    std::vector<std::string> new_models;
+    std::vector<std::string> removed_models;
+};
+
+static ModelSetSummary compute_model_set_summary(
+        const std::vector<std::string>& current_models,
+        const std::map<std::string, json>& previous_by_model) {
+    ModelSetSummary summary;
+    summary.current_models = current_models;
+
+    summary.previous_models.reserve(previous_by_model.size());
+    for (const auto& [name, _] : previous_by_model)
+        summary.previous_models.push_back(name);
+
+    for (const auto& name : current_models) {
+        if (previous_by_model.find(name) != previous_by_model.end())
+            summary.matched_models.push_back(name);
+        else
+            summary.new_models.push_back(name);
     }
-    return "";
+    for (const auto& name : summary.previous_models) {
+        if (std::find(current_models.begin(), current_models.end(), name) == current_models.end())
+            summary.removed_models.push_back(name);
+    }
+    return summary;
 }
-
-static bool vector_contains(const std::vector<std::string>& items, const std::string& needle) {
-    return std::find(items.begin(), items.end(), needle) != items.end();
-}
-
-static std::string join_list(const std::vector<std::string>& values) {
-    if (values.empty()) return "-";
-    std::ostringstream oss;
-    for (size_t i = 0; i < values.size(); ++i) {
-        if (i > 0) oss << ", ";
-        oss << values[i];
-    }
-    return oss.str();
-}
-
-std::vector<BenchComparisonDelta> compute_deltas(const std::vector<BenchBackendResult>& current,
-                                                  const json& previous_results) {
-    std::vector<BenchComparisonDelta> deltas;
-
-    // Build lookup map from previous results
-    struct PrevKey {
-        std::string backend;
-        int ctx_size = 0;
-        std::string backend_args;
-        std::string scenario;
-        bool operator==(const PrevKey& o) const {
-            return backend == o.backend && ctx_size == o.ctx_size && backend_args == o.backend_args && scenario == o.scenario;
-        }
-    };
-    struct PrevKeyHash {
-        size_t operator()(const PrevKey& k) const {
-            return std::hash<std::string>()(k.backend)
-                 ^ (std::hash<int>()(k.ctx_size) << 1)
-                 ^ (std::hash<std::string>()(k.backend_args) << 2)
-                 ^ (std::hash<std::string>()(k.scenario) << 3);
-        }
-    };
-    std::unordered_map<PrevKey, json, PrevKeyHash> prev_map;
-    std::unordered_set<PrevKey, PrevKeyHash> prev_keys;
-
-    if (previous_results.contains("results") && previous_results["results"].is_array()) {
-        for (const auto& prev_backend : previous_results["results"]) {
-            std::string recipe = prev_backend.value("recipe", "");
-            std::string backend = prev_backend.value("backend", "");
-            std::string backend_label = recipe + "/" + backend;
-            int prev_ctx_size = prev_backend.value("ctx_size", 0);
-            std::string prev_backend_args = prev_backend.value("backend_args", "");
-
-            if (prev_backend.contains("scenarios") && prev_backend["scenarios"].is_array()) {
-                for (const auto& prev_scenario : prev_backend["scenarios"]) {
-                    std::string name = prev_scenario.value("name", "");
-                    PrevKey key{backend_label, prev_ctx_size, prev_backend_args, name};
-                    prev_map[key] = prev_scenario;
-                    prev_keys.insert(key);
-                }
-            }
-        }
-    }
-
-    // Track which previous keys we've matched
-    std::unordered_set<PrevKey, PrevKeyHash> matched_prev;
-
-    // Iterate current results
-    for (const auto& backend_result : current) {
-        std::string backend_label = backend_result.recipe + "/" + backend_result.backend;
-
-        for (const auto& scenario : backend_result.scenarios) {
-            PrevKey key{backend_label, backend_result.ctx_size, backend_result.backend_args, scenario.scenario_name};
-            auto it = prev_map.find(key);
-
-            BenchComparisonDelta delta;
-            delta.backend = backend_label;
-            delta.ctx_size = backend_result.ctx_size;
-            delta.backend_args = backend_result.backend_args;
-            delta.scenario = scenario.scenario_name;
-
-            if (scenario.runs.empty()) {
-                // All runs failed — no meaningful delta to compute
-                delta.status = "failed";
-                delta.ttft_pct_change = 0.0;
-                delta.tps_pct_change = 0.0;
-                delta.vram_gb_change = std::nullopt;
-            } else if (it != prev_map.end()) {
-                matched_prev.insert(key);
-
-                if (it->second.value("all_runs_failed", false)) {
-                    // Previous run failed — current succeeded but no baseline to compare
-                    delta.status = "prev_failed";
-                    delta.ttft_pct_change = 0.0;
-                    delta.tps_pct_change = 0.0;
-                    delta.vram_gb_change = std::nullopt;
-                } else {
-                    delta.status = "matched";
-
-                    double curr_ttft = scenario.ttft_mean_ms();
-                    double curr_tps = scenario.tps_mean();
-                    double curr_vram = scenario.vram_peak_gb();
-
-                    double prev_ttft = it->second.value("ttft_ms", json::object()).value("mean", 0.0);
-                    double prev_tps = it->second.value("tps", json::object()).value("mean", 0.0);
-                    double prev_vram = it->second.value("vram_peak_gb", -1.0);
-
-                    delta.ttft_pct_change = (prev_ttft > 0) ? ((curr_ttft - prev_ttft) / prev_ttft * 100.0) : 0.0;
-                    delta.tps_pct_change = (prev_tps > 0) ? ((curr_tps - prev_tps) / prev_tps * 100.0) : 0.0;
-                    delta.vram_gb_change = (prev_vram >= 0 && curr_vram >= 0) ? std::optional<double>(curr_vram - prev_vram) : std::nullopt;
-                }
-            } else {
-                delta.status = "new";
-                delta.ttft_pct_change = 0.0;
-                delta.tps_pct_change = 0.0;
-                delta.vram_gb_change = std::nullopt;
-            }
-
-            deltas.push_back(delta);
-        }
-    }
-
-    // Mark unmatched previous results as "removed"
-    for (const auto& prev_key : prev_keys) {
-        if (matched_prev.find(prev_key) == matched_prev.end()) {
-            BenchComparisonDelta delta;
-            delta.backend = prev_key.backend;
-            delta.ctx_size = prev_key.ctx_size;
-            delta.backend_args = prev_key.backend_args;
-            delta.scenario = prev_key.scenario;
-            delta.status = "removed";
-            delta.ttft_pct_change = 0.0;
-            delta.tps_pct_change = 0.0;
-            delta.vram_gb_change = std::nullopt;
-            deltas.push_back(delta);
-        }
-    }
-
-    return deltas;
-}
-
-void print_comparison(const std::vector<BenchComparisonDelta>& deltas,
-                      const std::string& model,
-                      const std::string& previous_file,
-                      const std::string& previous_timestamp) {
-    std::cout << std::endl;
-    std::cout << "Comparison: " << model << std::endl;
-    std::cout << "Previous: " << previous_file
-              << (previous_timestamp.empty() ? "" : " (" + previous_timestamp + ")") << std::endl;
-    std::cout << "Current:  " << get_timestamp_iso() << std::endl;
-    std::cout << std::string(100, '=') << std::endl;
-
-    // Group by backend + ctx_size + backend_args
-    std::map<std::string, std::vector<const BenchComparisonDelta*>> by_backend;
-    for (const auto& d : deltas) {
-        std::string label = d.backend;
-        if (d.ctx_size > 0) label += " (ctx=" + std::to_string(d.ctx_size) + ")";
-        if (!d.backend_args.empty()) label += " args=[" + d.backend_args + "]";
-        by_backend[label].push_back(&d);
-    }
-
-    for (const auto& [label, backend_deltas] : by_backend) {
-        std::cout << std::endl;
-        std::cout << "Backend: " << label << std::endl;
-        std::cout << std::string(80, '-') << std::endl;
-        std::cout << std::left << std::setw(22) << "Scenario"
-                  << std::setw(14) << "TTFT change"
-                  << std::setw(14) << "TPS change"
-                  << std::setw(16) << "VRAM change"
-                  << "Status" << std::endl;
-        std::cout << std::string(80, '-') << std::endl;
-
-        for (const auto* d : backend_deltas) {
-            std::string ttft_str = "-", tps_str = "-", vram_str = "-";
-            if (d->status == "matched") {
-                ttft_str = fmt_pct_change(d->ttft_pct_change);
-                tps_str = fmt_pct_change(d->tps_pct_change);
-                vram_str = fmt_vram_change(d->vram_gb_change);
-            }
-            // "failed" and "new" statuses keep the default "-" values
-
-            std::cout << std::left << std::setw(22) << d->scenario
-                      << std::setw(14) << ttft_str
-                      << std::setw(14) << tps_str
-                      << std::setw(16) << vram_str
-                      << "(" << d->status << ")" << std::endl;
-        }
-    }
-
-    std::cout << std::endl;
-    std::cout << "Legend: TTFT change > 0 means slower (worse). TPS change > 0 means faster (better)." << std::endl;
-    std::cout << "Status: matched = compared against previous, new = no previous data, removed = not in current run, failed = all runs errored, prev_failed = previous run errored" << std::endl;
-    std::cout << std::endl;
-}
-
-json build_comparison_json(const std::vector<BenchBackendResult>& results,
-                           const std::string& model,
-                           const std::string& timestamp,
-                           const BenchConfig& config,
-                           const json& previous_results,
-                           const std::vector<BenchComparisonDelta>& deltas) {
-    json output = to_json(results, model, timestamp, config);
-
-    output["compare_file"] = config.compare_file;
-    if (previous_results.contains("timestamp")) {
-        output["previous_timestamp"] = previous_results["timestamp"];
-    }
-    output["previous_results"] =
-        (previous_results.contains("results") && previous_results["results"].is_array())
-            ? previous_results["results"]
-            : json::array();
-
-    json comparison_json = json::array();
-    for (const auto& d : deltas) {
-        json d_json;
-        d_json["backend"] = d.backend;
-        d_json["ctx_size"] = d.ctx_size;
-        d_json["backend_args"] = d.backend_args;
-        d_json["scenario"] = d.scenario;
-        d_json["ttft_pct_change"] = d.ttft_pct_change;
-        d_json["tps_pct_change"] = d.tps_pct_change;
-        if (d.vram_gb_change.has_value()) d_json["vram_gb_change"] = *d.vram_gb_change;
-        else d_json["vram_gb_change"] = nullptr;
-        d_json["status"] = d.status;
-        comparison_json.push_back(d_json);
-    }
-    output["comparison"] = comparison_json;
-
-    return output;
-}
-
 
 int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& config) {
     if (config.models.empty()) {
@@ -1611,7 +826,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         return 1;
     }
 
-    // Deduplicate models while preserving order (first occurrence wins).
+    // Deduplicate models while preserving order
     std::vector<std::string> unique_models;
     std::unordered_set<std::string> seen_models;
     for (const auto& model : config.models) {
@@ -1620,7 +835,6 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             seen_models.insert(model);
         }
     }
-
     if (unique_models.size() < config.models.size()) {
         std::cout << "Note: Removed " << (config.models.size() - unique_models.size())
                   << " duplicate model(s). Testing " << unique_models.size()
@@ -1631,90 +845,33 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
 
     if (!config.response_log.empty()) {
         try {
-            std::filesystem::path response_log_path(config.response_log);
-            std::filesystem::path parent = response_log_path.parent_path();
-            if (!parent.empty()) {
-                std::filesystem::create_directories(parent);
-            }
+            std::filesystem::path log_path(config.response_log);
+            if (!log_path.parent_path().empty())
+                std::filesystem::create_directories(log_path.parent_path());
         } catch (const std::exception& e) {
             std::cerr << "Warning: Could not prepare response log path: " << e.what() << std::endl;
         }
     }
 
-    // Preflight: ensure all requested models are available before any benchmark starts.
-    // If --auto-pull is enabled, pull missing/not-downloaded models during this phase.
-    std::map<std::string, json> model_info_by_name;
-    for (const auto& model : unique_models) {
-        json model_info = client.get_model_info(model);
+    // Preflight: ensure all models are available
+    auto model_info_by_name = preflight_models(client, unique_models, config.auto_pull);
+    if (model_info_by_name.empty()) return 1;
 
-        if (model_info.empty()) {
-            if (!config.auto_pull) {
-                std::cerr << "Error: Model '" << model << "' not found." << std::endl;
-                std::cerr << "Use --auto-pull to download missing models before benchmarking." << std::endl;
-                return 1;
-            }
-
-            std::cout << "Preflight: model '" << model << "' not found. Auto-pulling..." << std::endl;
-            json pull_req;
-            pull_req["model_name"] = model;
-            if (client.pull_model(pull_req) != 0) {
-                std::cerr << "Error: Failed to pull model '" << model << "'." << std::endl;
-                return 1;
-            }
-
-            model_info = client.get_model_info(model);
-            if (model_info.empty()) {
-                std::cerr << "Error: Model '" << model << "' is still unavailable after auto-pull." << std::endl;
-                return 1;
-            }
-        }
-
-        if (model_info.contains("downloaded") && !model_info["downloaded"].get<bool>()) {
-            if (!config.auto_pull) {
-                std::cerr << "Error: Model '" << model << "' is not downloaded." << std::endl;
-                std::cerr << "Run 'lemonade pull " << model << "' first, or use --auto-pull." << std::endl;
-                return 1;
-            }
-
-            std::cout << "Preflight: model '" << model << "' is not downloaded. Auto-pulling..." << std::endl;
-            json pull_req;
-            pull_req["model_name"] = model;
-            if (client.pull_model(pull_req) != 0) {
-                std::cerr << "Error: Failed to pull model '" << model << "'." << std::endl;
-                return 1;
-            }
-
-            model_info = client.get_model_info(model);
-            if (model_info.empty() || (model_info.contains("downloaded") && !model_info["downloaded"].get<bool>())) {
-                std::cerr << "Error: Model '" << model << "' is not downloaded after auto-pull." << std::endl;
-                return 1;
-            }
-        }
-
-        model_info_by_name[model] = std::move(model_info);
-    }
-
-    // 1. Load scenarios (shared across models)
+    // Load scenarios (shared across models)
     std::vector<BenchScenario> scenarios;
     if (!config.scenario_file.empty()) {
         scenarios = load_scenarios_from_file(config.scenario_file);
     } else if (!config.scenario_dir.empty()) {
         scenarios = load_scenarios_from_dir(config.scenario_dir);
     } else {
-        std::string default_path = resolve_default_scenario_file();
-        scenarios = load_scenarios_from_file(default_path);
+        scenarios = load_scenarios_from_file(resolve_default_scenario_file());
     }
-
     if (scenarios.empty()) {
         std::cerr << "Error: No scenarios loaded." << std::endl;
         return 1;
     }
 
     // Filter scenarios
-    // When no --scenarios filter is given, exclude long-context by default
-    // (they run very long and fail on many systems). Also exclude embeddings
-    // since they're not the usual text generation use case.
-    // When --scenarios is provided, match by name, category, or "all".
     if (config.scenario_names.empty()) {
         scenarios = exclude_category(scenarios, "long-context");
         scenarios = exclude_category(scenarios, "embed");
@@ -1726,18 +883,11 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         return 1;
     }
 
-    struct ModelBenchResult {
-        std::string model;
-        std::string timestamp;
-        std::vector<BenchBackendResult> results;
-    };
-
-    std::vector<ModelBenchResult> by_model;
-
+    // Fetch system-info and discover backends
     json sys_info;
     try {
-        std::string response = client.make_request("/api/v1/system-info", "GET", "", "", 10000, 10000);
-        sys_info = json::parse(response);
+        std::string resp = client.make_request("/api/v1/system-info", "GET", "", "", 10000, 10000);
+        sys_info = json::parse(resp);
     } catch (const std::exception& e) {
         std::cerr << "Error: Failed to fetch system-info: " << e.what() << std::endl;
         return 1;
@@ -1746,9 +896,9 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
     std::unordered_set<std::string> test_recipes, test_backends;
     std::map<std::string, std::vector<BackendDiscovery>> backends_by_model;
     for (const auto& model : unique_models) {
-        const auto model_it = model_info_by_name.find(model);
-        const json& model_info = (model_it != model_info_by_name.end()) ? model_it->second : json::object();
-        auto backends = discover_backends(sys_info, model, config.backends, model_info);
+        const auto it = model_info_by_name.find(model);
+        const json& model_info = (it != model_info_by_name.end()) ? it->second : json::object();
+        auto backends = discover_backends(sys_info, config.backends, model_info);
         backends_by_model[model] = backends;
         for (const auto& [recipe, backend] : backends) {
             test_recipes.insert(recipe);
@@ -1756,18 +906,25 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         }
     }
     json hardware_profile = build_hardware_profile(
-        client, sys_info,
-        std::vector<std::string>(test_recipes.begin(), test_recipes.end()),
-        std::vector<std::string>(test_backends.begin(), test_backends.end()));
+        sys_info,
+        {test_recipes.begin(), test_recipes.end()},
+        {test_backends.begin(), test_backends.end()});
 
-    // 2. Execute benchmark workflow for each model
+    // Execute benchmarks for each model
+    struct ModelBenchResult {
+        std::string model;
+        std::string timestamp;
+        std::vector<BenchBackendResult> results;
+    };
+    std::vector<ModelBenchResult> by_model;
+
     for (const auto& model : unique_models) {
-        const auto model_it = model_info_by_name.find(model);
-        if (model_it == model_info_by_name.end()) {
+        const auto it = model_info_by_name.find(model);
+        if (it == model_info_by_name.end()) {
             std::cerr << "Error: Missing preflight model info for '" << model << "'." << std::endl;
             return 1;
         }
-        const json& model_info = model_it->second;
+        const json& model_info = it->second;
         const std::string model_timestamp = get_timestamp_iso();
 
         auto backends = backends_by_model[model];
@@ -1776,16 +933,14 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             return 1;
         }
 
-        // Determine context sizes for this model
+        // Determine context sizes
         std::vector<int> ctx_sizes = config.ctx_sizes;
         if (ctx_sizes.empty()) {
-            // Use model's default context size from info, or a reasonable default
             int default_ctx = 4096;
             if (model_info.contains("recipe_options") && model_info["recipe_options"].is_object()) {
                 auto& opts = model_info["recipe_options"];
-                if (opts.contains("ctx_size") && opts["ctx_size"].is_number()) {
+                if (opts.contains("ctx_size") && opts["ctx_size"].is_number())
                     default_ctx = opts["ctx_size"].get<int>();
-                }
             }
             ctx_sizes = {default_ctx};
         }
@@ -1793,17 +948,13 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         std::vector<BenchBackendResult> all_results;
 
         for (const auto& [recipe, backend] : backends) {
-            // Look up backend-specific args for this recipe
-            // If none specified, use a single empty-string entry so we still iterate once
             std::vector<std::string> recipe_args_list;
             auto args_it = config.backend_args.find(recipe);
-            if (args_it != config.backend_args.end() && !args_it->second.empty()) {
+            if (args_it != config.backend_args.end() && !args_it->second.empty())
                 recipe_args_list = args_it->second;
-            } else {
-                recipe_args_list = {""};  // default: no extra args
-            }
+            else
+                recipe_args_list = {""};
 
-            // Iterate all combinations of ctx_size × backend_args
             for (int ctx_size : ctx_sizes) {
                 for (const auto& recipe_args : recipe_args_list) {
                     BenchBackendResult tmp;
@@ -1822,20 +973,17 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
                     for (const auto& scenario : scenarios) {
                         std::cout << "  Scenario: " << scenario.name << " (" << scenario.category << ")" << std::endl;
 
-                        // Filter backends based on scenario category and backend capabilities
+                        // Filter backends based on scenario category
                         bool backend_suitable = false;
                         const auto required_type = get_required_model_type_for_scenario(scenario.category);
-
                         if (scenario.category == "embed") {
                             backend_suitable = model_has_embeddings_label(model_info);
                         } else if (scenario.category == "imagegen") {
                             backend_suitable = backend_supports_capability(recipe, backend, lemon::ModelType::IMAGE);
                         } else {
                             backend_suitable = backend_supports_capability(recipe, backend, required_type);
-                            if (model_has_embeddings_label(model_info)) {
-                                // don't send text-gen scenarios to embedding-only models, even if the backend supports it
+                            if (model_has_embeddings_label(model_info))
                                 backend_suitable = false;
-                            }
                         }
 
                         if (!backend_suitable) {
@@ -1845,23 +993,18 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
 
                         int warmup = scenario.warmup_runs;
                         int runs = scenario.measurement_runs;
-
-                        // Allow config overrides
                         if (config.warmup_runs > 0) warmup = config.warmup_runs;
                         if (config.measurement_runs > 0) runs = config.measurement_runs;
 
                         auto scenario_result = run_scenario(client, model, scenario, warmup, runs,
                                                             config.memory_tracking, config.reload,
                                                             recipe, backend, ctx_size, config.timeout, recipe_args,
-                                                            config.response_log,
-                                                            command_timestamp);
+                                                            config.response_log, command_timestamp);
                         backend_result.scenarios.push_back(scenario_result);
                     }
 
-                    // Only add results if at least one scenario ran
-                    if (!backend_result.scenarios.empty()) {
+                    if (!backend_result.scenarios.empty())
                         all_results.push_back(backend_result);
-                    }
                 }
             }
         }
@@ -1874,44 +1017,46 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         by_model.push_back({model, model_timestamp, std::move(all_results)});
     }
 
-    // 3. Output results
+    // Output results
     if (config.compare_file.empty()) {
-        // Normal output (single- or multi-model)
+        // Normal output
         if (config.json_output) {
             json output;
             output["timestamp"] = command_timestamp;
             output["hardware"] = hardware_profile;
             output["models"] = json::array();
-            for (const auto& model_result : by_model) {
-                output["models"].push_back(
-                    to_json(model_result.results, model_result.model,
-                            model_result.timestamp, config));
-            }
+            for (const auto& mr : by_model)
+                output["models"].push_back(to_json(mr.results, mr.model, mr.timestamp, config));
 
             std::string json_str = output.dump(2);
             if (!config.output_file.empty()) {
-                if (!write_json_file(config.output_file, json_str, true)) return 1;
+                std::ofstream out(config.output_file);
+                if (!out.is_open()) {
+                    std::cerr << "Error: Could not write to " << config.output_file << std::endl;
+                    return 1;
+                }
+                out << json_str;
                 std::cout << "Results written to " << config.output_file << std::endl;
             } else {
                 std::cout << json_str << std::endl;
             }
         } else {
-            for (const auto& model_result : by_model) {
-                print_table(model_result.results, model_result.model, config.measurement_runs >= 10);
-            }
+            for (const auto& mr : by_model)
+                print_table(mr.results, mr.model, config.measurement_runs >= 10);
 
             if (!config.output_file.empty()) {
                 json output;
                 output["timestamp"] = command_timestamp;
                 output["hardware"] = hardware_profile;
                 output["models"] = json::array();
-                for (const auto& model_result : by_model) {
-                    output["models"].push_back(
-                        to_json(model_result.results, model_result.model,
-                                model_result.timestamp, config));
-                }
-                if (write_json_file(config.output_file, output.dump(2), false)) {
+                for (const auto& mr : by_model)
+                    output["models"].push_back(to_json(mr.results, mr.model, mr.timestamp, config));
+                std::ofstream out(config.output_file);
+                if (out.is_open()) {
+                    out << output.dump(2);
                     std::cout << "JSON results also written to " << config.output_file << std::endl;
+                } else {
+                    std::cerr << "Warning: Could not write to " << config.output_file << std::endl;
                 }
             }
         }
@@ -1923,37 +1068,14 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             return 1;
         }
 
-        const std::map<std::string, json> previous_by_model = extract_models_from_results(previous_results);
-        const std::string previous_timestamp = extract_results_timestamp(previous_results);
+        auto previous_by_model = extract_models_from_results(previous_results);
+        std::string previous_timestamp = extract_results_timestamp(previous_results);
 
         std::vector<std::string> current_models;
         current_models.reserve(by_model.size());
-        for (const auto& model_result : by_model) {
-            current_models.push_back(model_result.model);
-        }
+        for (const auto& mr : by_model) current_models.push_back(mr.model);
 
-        std::vector<std::string> previous_models;
-        previous_models.reserve(previous_by_model.size());
-        for (const auto& [model_name, _] : previous_by_model) {
-            previous_models.push_back(model_name);
-        }
-
-        std::vector<std::string> matched_models;
-        std::vector<std::string> new_models;
-        std::vector<std::string> removed_models;
-
-        for (const auto& model_name : current_models) {
-            if (previous_by_model.find(model_name) != previous_by_model.end()) {
-                matched_models.push_back(model_name);
-            } else {
-                new_models.push_back(model_name);
-            }
-        }
-        for (const auto& model_name : previous_models) {
-            if (!vector_contains(current_models, model_name)) {
-                removed_models.push_back(model_name);
-            }
-        }
+        auto summary = compute_model_set_summary(current_models, previous_by_model);
 
         struct ModelComparisonResult {
             std::string model;
@@ -1962,52 +1084,45 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             std::vector<BenchComparisonDelta> deltas;
             const std::vector<BenchBackendResult>* results = nullptr;
         };
-
         std::vector<ModelComparisonResult> comparison_results;
         comparison_results.reserve(by_model.size());
 
-        for (const auto& model_result : by_model) {
+        for (const auto& mr : by_model) {
             json prev_for_model = json::object();
-            auto it = previous_by_model.find(model_result.model);
-            if (it != previous_by_model.end()) {
-                prev_for_model = it->second;
-            }
-
+            auto it = previous_by_model.find(mr.model);
+            if (it != previous_by_model.end()) prev_for_model = it->second;
             comparison_results.emplace_back(ModelComparisonResult{
-                model_result.model,
-                model_result.timestamp,
-                prev_for_model,
-                compute_deltas(model_result.results, prev_for_model),
-                &model_result.results
+                mr.model, mr.timestamp, prev_for_model,
+                compute_deltas(mr.results, prev_for_model), &mr.results
             });
         }
 
         if (config.json_output) {
             json output;
-
             output["timestamp"] = command_timestamp;
             output["hardware"] = hardware_profile;
             output["compare_file"] = config.compare_file;
-            if (!previous_timestamp.empty()) {
-                output["previous_timestamp"] = previous_timestamp;
-            }
+            if (!previous_timestamp.empty()) output["previous_timestamp"] = previous_timestamp;
             output["model_summary"] = {
-                {"current_models", current_models},
-                {"previous_models", previous_models},
-                {"matched_models", matched_models},
-                {"new_models", new_models},
-                {"removed_models", removed_models}
+                {"current_models", summary.current_models},
+                {"previous_models", summary.previous_models},
+                {"matched_models", summary.matched_models},
+                {"new_models", summary.new_models},
+                {"removed_models", summary.removed_models}
             };
             output["models"] = json::array();
-            for (const auto& c : comparison_results) {
-                output["models"].push_back(
-                    build_comparison_json(*c.results, c.model, c.timestamp, config,
-                                          c.previous_for_model, c.deltas));
-            }
+            for (const auto& c : comparison_results)
+                output["models"].push_back(build_comparison_json(*c.results, c.model, c.timestamp,
+                                                                  config, c.previous_for_model, c.deltas));
 
             std::string json_str = output.dump(2);
             if (!config.output_file.empty()) {
-                if (!write_json_file(config.output_file, json_str, true)) return 1;
+                std::ofstream out(config.output_file);
+                if (!out.is_open()) {
+                    std::cerr << "Error: Could not write to " << config.output_file << std::endl;
+                    return 1;
+                }
+                out << json_str;
                 std::cout << "Results written to " << config.output_file << std::endl;
             } else {
                 std::cout << json_str << std::endl;
@@ -2015,52 +1130,43 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         } else {
             std::cout << "\nModel set comparison" << std::endl;
             std::cout << std::string(100, '=') << std::endl;
-            std::cout << "Current models (" << current_models.size() << "):  "
-                      << join_list(current_models) << std::endl;
-            std::cout << "Previous models (" << previous_models.size() << "): "
-                      << join_list(previous_models) << std::endl;
-            std::cout << "Matched: " << join_list(matched_models) << std::endl;
-            std::cout << "New:     " << join_list(new_models) << std::endl;
-            std::cout << "Removed: " << join_list(removed_models) << std::endl;
+            std::cout << "Current models (" << summary.current_models.size() << "):  "
+                      << join_list(summary.current_models) << std::endl;
+            std::cout << "Previous models (" << summary.previous_models.size() << "): "
+                      << join_list(summary.previous_models) << std::endl;
+            std::cout << "Matched: " << join_list(summary.matched_models) << std::endl;
+            std::cout << "New:     " << join_list(summary.new_models) << std::endl;
+            std::cout << "Removed: " << join_list(summary.removed_models) << std::endl;
 
             for (const auto& c : comparison_results) {
-                // Print normal table first, then comparison
                 print_table(*c.results, c.model, config.measurement_runs >= 10);
-                print_comparison(c.deltas, c.model, config.compare_file,
-                                 previous_timestamp);
+                print_comparison(c.deltas, c.model, config.compare_file, previous_timestamp);
             }
         }
     }
 
-    // Unload models on exit
     unload_all_models(client);
-
     return 0;
 }
-
 
 CLI::App* register_bench_command(CLI::App& parent,
                                  std::string& output_file,
                                  BenchCliOptions& opts) {
-    CLI::App* cmd = parent.add_subcommand("bench", "Benchmark model performance for different model types")->group("Model management");
+    CLI::App* cmd = parent.add_subcommand("bench", "Benchmark model performance for different model types")
+        ->group("Model management");
     cmd->add_option("models", opts.models, "One or more model names to benchmark")
-        ->required()
-        ->type_name("MODEL")
-        ->expected(1, -1);
+        ->required()->type_name("MODEL")->expected(1, -1);
     cmd->add_option("--backend", opts.backends, "Backend to test (e.g., vulkan, metal, cpu). Repeat for multiple.")
-        ->type_name("BACKEND")
-        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
+        ->type_name("BACKEND")->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     cmd->add_option("--ctx-size", opts.ctx_sizes, "Context size to test. Repeat for multiple sizes.")
-        ->type_name("SIZE")
-        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
+        ->type_name("SIZE")->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     cmd->add_option("--runs", opts.runs, "Number of measurement runs per scenario (default: 3)")->type_name("N");
     cmd->add_option("--warmup", opts.warmup, "Number of warmup runs per scenario (default: 0)")->type_name("N");
     cmd->add_option("--scenarios", opts.scenario_names,
         "Scenario name(s) or category to run (e.g. chat, coding, long-context). "
         "Use 'all' to include every scenario including long-context. "
         "Default: all scenarios except long-context.")
-        ->type_name("NAME|CATEGORY")
-        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
+        ->type_name("NAME|CATEGORY")->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     cmd->add_option("--scenario-file", opts.scenario_file, "Load scenarios from a single JSON file")->type_name("FILE");
     cmd->add_option("--scenario-dir", opts.scenario_dir, "Load all .json scenario files from a directory")->type_name("DIR");
     cmd->add_flag("--json", opts.json_output, "Output results as JSON");
@@ -2071,20 +1177,15 @@ CLI::App* register_bench_command(CLI::App& parent,
     cmd->add_flag("--no-reload", opts.no_reload, "Skip model reload between scenarios (faster but prompt cache may skew results)");
     cmd->add_option("--response-log", opts.response_log, "Write captured responses to a JSONL logfile")->type_name("FILE");
     cmd->add_option("--llamacpp-args", opts.llamacpp_args, "Custom args for llama-server (e.g. \"-b 2048 -ub 1024\"). Repeat for multiple.")
-        ->type_name("ARGS")
-        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
+        ->type_name("ARGS")->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     cmd->add_option("--flm-args", opts.flm_args, "Safe custom args for flm serve. Repeat for multiple.")
-        ->type_name("ARGS")
-        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
+        ->type_name("ARGS")->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     cmd->add_option("--vllm-args", opts.vllm_args, "Custom args for vllm-server. Repeat for multiple.")
-        ->type_name("ARGS")
-        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
+        ->type_name("ARGS")->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     cmd->add_option("--sdcpp-args", opts.sdcpp_args, "Custom args for sd-server. Repeat for multiple.")
-        ->type_name("ARGS")
-        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
+        ->type_name("ARGS")->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     cmd->add_option("--whispercpp-args", opts.whispercpp_args, "Custom args for whisper-server. Repeat for multiple.")
-        ->type_name("ARGS")
-        ->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
+        ->type_name("ARGS")->multi_option_policy(CLI::MultiOptionPolicy::TakeAll);
     cmd->add_option("--timeout", opts.timeout, "Timeout in seconds for individual requests (default: 300)")
         ->type_name("SECONDS");
     return cmd;
@@ -2108,7 +1209,6 @@ BenchConfig build_bench_config(const std::string& output_file,
     config.compare_file = cli.compare_file;
     config.scenario_names = cli.scenario_names;
     config.response_log = cli.response_log;
-    // Populate backend-specific args map (only non-empty values)
     if (!cli.llamacpp_args.empty()) config.backend_args["llamacpp"] = cli.llamacpp_args;
     if (!cli.flm_args.empty()) config.backend_args["flm"] = cli.flm_args;
     if (!cli.vllm_args.empty()) config.backend_args["vllm"] = cli.vllm_args;

--- a/src/cpp/cli/bench.cpp
+++ b/src/cpp/cli/bench.cpp
@@ -416,7 +416,7 @@ struct BenchStrategy {
     std::function<void(const json&, BenchRunResult&, bool)> parse_response;
 };
 
-static BenchRunResult run_single_bench(lemonade::LemonadeClient& client,
+static BenchRunResult run_bench_with_strategy(lemonade::LemonadeClient& client,
                                                 bool memory_tracking,
                                                 bool capture_response,
                                                 int timeout,
@@ -525,7 +525,7 @@ static BenchStrategy make_embed_strategy(const std::string& model, const BenchSc
                 result.output_tokens = resp["usage"]["total_tokens"].get<int>();
             }
 
-            result.valid = !(result.ttft_ms <= 0 && result.tps <= 0 && result.input_tokens <= 0 && result.output_tokens <= 0);
+            result.valid = true;
         }
     };
 }
@@ -596,7 +596,7 @@ BenchRunResult run_single_bench_textgen(lemonade::LemonadeClient& client,
                                         bool memory_tracking,
                                         bool capture_response,
                                         int timeout) {
-    return run_single_bench(client, memory_tracking, capture_response, timeout, make_textgen_strategy(model, scenario));
+    return run_bench_with_strategy(client, memory_tracking, capture_response, timeout, make_textgen_strategy(model, scenario));
 }
 
 BenchRunResult run_single_bench_embed(lemonade::LemonadeClient& client,
@@ -606,7 +606,7 @@ BenchRunResult run_single_bench_embed(lemonade::LemonadeClient& client,
                                       bool capture_response,
                                       int timeout) {
     auto strategy = make_embed_strategy(model, scenario);
-    auto result = run_single_bench(client, memory_tracking, capture_response, timeout, strategy);
+    auto result = run_bench_with_strategy(client, memory_tracking, capture_response, timeout, strategy);
     if (result.success) {
         // Embedding benchmarks: ttft_ms is the total wall-clock time
         result.ttft_ms = result.total_time_ms;
@@ -627,14 +627,7 @@ BenchRunResult run_single_bench_imagegen(lemonade::LemonadeClient& client,
         return result;
     }
     auto strategy = make_imagegen_strategy(model, scenario, capture_response);
-    // Fix the model in the request body (strategy uses a placeholder)
-    auto orig_build = strategy.build_request;
-    strategy.build_request = [orig_build, model]() -> json {
-        json body = orig_build();
-        body["model"] = model;
-        return body;
-    };
-    auto result = run_single_bench(client, memory_tracking, capture_response, timeout, strategy);
+    auto result = run_bench_with_strategy(client, memory_tracking, capture_response, timeout, strategy);
     if (result.success) {
         result.ttft_ms = result.total_time_ms;
     }

--- a/src/cpp/cli/bench.cpp
+++ b/src/cpp/cli/bench.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <map>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -416,28 +417,24 @@ static std::vector<BenchScenario> exclude_category(const std::vector<BenchScenar
 }
 
 
-std::vector<BackendDiscovery> discover_backends(lemonade::LemonadeClient& client,
+std::vector<BackendDiscovery> discover_backends(const json& sys_info,
                                                 const std::string& model,
-                                                const std::vector<std::string>& requested) {
+                                                const std::vector<std::string>& requested,
+                                                const json& model_info) {
     std::vector<BackendDiscovery> result;
 
-    try {
-        std::string response = client.make_request("/api/v1/system-info", "GET", "", "", 10000, 10000);
-        auto sys_info = json::parse(response);
+    if (!sys_info.contains("recipes") || !sys_info["recipes"].is_object()) {
+        std::cerr << "Warning: No recipes found in system-info" << std::endl;
+        return result;
+    }
 
-        if (!sys_info.contains("recipes") || !sys_info["recipes"].is_object()) {
-            std::cerr << "Warning: No recipes found in system-info" << std::endl;
-            return result;
-        }
+    // Determine model recipe from pre-fetched model info
+    std::string model_recipe;
+    if (model_info.contains("recipe") && model_info["recipe"].is_string()) {
+        model_recipe = model_info["recipe"].get<std::string>();
+    }
 
-        // Also get model info to find its recipe
-        json model_info = client.get_model_info(model);
-        std::string model_recipe;
-        if (model_info.contains("recipe") && model_info["recipe"].is_string()) {
-            model_recipe = model_info["recipe"].get<std::string>();
-        }
-
-        for (const auto& [recipe_name, recipe_data] : sys_info["recipes"].items()) {
+    for (const auto& [recipe_name, recipe_data] : sys_info["recipes"].items()) {
             // If model has a specific recipe, only consider that recipe
             if (!model_recipe.empty() && recipe_name != model_recipe) {
                 continue;
@@ -463,9 +460,6 @@ std::vector<BackendDiscovery> discover_backends(lemonade::LemonadeClient& client
                 result.push_back({recipe_name, backend_name});
             }
         }
-    } catch (const std::exception& e) {
-        std::cerr << "Warning: Failed to discover backends: " << e.what() << std::endl;
-    }
 
     return result;
 }
@@ -559,6 +553,141 @@ static void query_system_stats(lemonade::LemonadeClient& client, double& vram_gb
     } catch (...) {
         // Best-effort: memory tracking is optional
     }
+}
+
+// Helper: parse "XX.XX GB" or "XX GB" into a double (GB)
+static double parse_gb_string(const std::string& s) {
+    // Strip trailing " GB" and parse the number
+    std::string num_str = s;
+    size_t space_pos = num_str.find(' ');
+    if (space_pos != std::string::npos) {
+        num_str = num_str.substr(0, space_pos);
+    }
+    try {
+        return std::stod(num_str);
+    } catch (...) {
+        return -1.0;
+    }
+}
+
+// Build a hardware profile JSON from system-info + system-stats.
+// Captures OS, CPU, GPU array, RAM, and backend versions for shareable benchmarks.
+static json build_hardware_profile(lemonade::LemonadeClient& client,
+                                   const json& sys_info,
+                                   const std::vector<std::string>& recipes,
+                                   const std::vector<std::string>& backends) {
+    json profile;
+
+    try {
+
+        std::string os_version = sys_info.value("OS Version", "unknown");
+        std::string os;
+        if (os_version.find("Windows") != std::string::npos) os = "windows";
+        else if (os_version.find("macOS") != std::string::npos || os_version.find("Darwin") != std::string::npos) os = "macos";
+        else if (os_version.find("Linux") != std::string::npos) os = "linux";
+        else os = os_version;
+        profile["os"] = os;
+
+        if (sys_info.contains("devices") && sys_info["devices"].contains("cpu")) {
+            profile["cpu"] = sys_info["devices"]["cpu"].value("name", "unknown");
+        } else {
+            profile["cpu"] = sys_info.value("Processor", "unknown");
+        }
+
+        if (sys_info.contains("Physical Memory") && sys_info["Physical Memory"].is_string()) {
+            double ram_gb = parse_gb_string(sys_info["Physical Memory"].get<std::string>());
+            if (ram_gb > 0) {
+                profile["ram_gb"] = ram_gb;
+            }
+        }
+
+        json gpu_array = json::array();
+        if (sys_info.contains("devices")) {
+            const auto& devices = sys_info["devices"];
+
+            if (devices.contains("amd_gpu") && devices["amd_gpu"].is_array()) {
+                for (const auto& gpu : devices["amd_gpu"]) {
+                    if (gpu.value("available", false)) {
+                        json gpu_entry;
+                        gpu_entry["name"] = gpu.value("name", "unknown");
+                        gpu_entry["type"] = "amd";
+                        gpu_entry["integrated"] = gpu.value("integrated", false);
+                        if (gpu.contains("vram_gb") && gpu["vram_gb"].is_number()) {
+                            gpu_entry["vram_gb"] = gpu["vram_gb"].get<double>();
+                        }
+                        gpu_array.push_back(gpu_entry);
+                    }
+                }
+            }
+
+            if (devices.contains("nvidia_gpu") && devices["nvidia_gpu"].is_array()) {
+                for (const auto& gpu : devices["nvidia_gpu"]) {
+                    if (gpu.value("available", false)) {
+                        json gpu_entry;
+                        gpu_entry["name"] = gpu.value("name", "unknown");
+                        gpu_entry["type"] = "nvidia";
+                        if (gpu.contains("vram_gb") && gpu["vram_gb"].is_number()) {
+                            gpu_entry["vram_gb"] = gpu["vram_gb"].get<double>();
+                        }
+                        gpu_array.push_back(gpu_entry);
+                    }
+                }
+            }
+
+            if (devices.contains("metal") && devices["metal"].is_object()) {
+                const auto& metal = devices["metal"];
+                if (metal.value("available", false)) {
+                    json gpu_entry;
+                    gpu_entry["name"] = metal.value("name", "unknown");
+                    gpu_entry["type"] = "metal";
+                    if (metal.contains("vram_gb") && metal["vram_gb"].is_number()) {
+                        gpu_entry["vram_gb"] = metal["vram_gb"].get<double>();
+                    }
+                    gpu_array.push_back(gpu_entry);
+                }
+            }
+        }
+        profile["gpu"] = gpu_array;
+
+        json backend_versions = json::object();
+        if (sys_info.contains("recipes") && sys_info["recipes"].is_object()) {
+            for (const auto& [recipe_name, recipe_data] : sys_info["recipes"].items()) {
+                if (!recipes.empty()) {
+                    bool found = std::find(recipes.begin(), recipes.end(), recipe_name) != recipes.end();
+                    if (!found) continue;
+                }
+
+                if (!recipe_data.contains("backends") || !recipe_data["backends"].is_object()) {
+                    continue;
+                }
+
+                for (const auto& [backend_name, backend_data] : recipe_data["backends"].items()) {
+                    if (!backends.empty()) {
+                        bool found = std::find(backends.begin(), backends.end(), backend_name) != backends.end();
+                        if (!found) continue;
+                    }
+
+                    std::string state = backend_data.value("state", "unknown");
+                    if (state != "installed" && state != "update_required" && state != "update_available") {
+                        continue;
+                    }
+
+                    std::string version = backend_data.value("version", "");
+                    if (!version.empty()) {
+                        backend_versions[recipe_name + "/" + backend_name] = version;
+                    }
+                }
+            }
+        }
+        if (!backend_versions.empty()) {
+            profile["backends"] = backend_versions;
+        }
+
+    } catch (const std::exception& e) {
+        std::cerr << "Warning: Failed to build hardware profile: " << e.what() << std::endl;
+    }
+
+    return profile;
 }
 
 static void extract_usage_into_result(const json& usage, BenchRunResult& result) {
@@ -1605,6 +1734,32 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
 
     std::vector<ModelBenchResult> by_model;
 
+    json sys_info;
+    try {
+        std::string response = client.make_request("/api/v1/system-info", "GET", "", "", 10000, 10000);
+        sys_info = json::parse(response);
+    } catch (const std::exception& e) {
+        std::cerr << "Error: Failed to fetch system-info: " << e.what() << std::endl;
+        return 1;
+    }
+
+    std::unordered_set<std::string> test_recipes, test_backends;
+    std::map<std::string, std::vector<BackendDiscovery>> backends_by_model;
+    for (const auto& model : unique_models) {
+        const auto model_it = model_info_by_name.find(model);
+        const json& model_info = (model_it != model_info_by_name.end()) ? model_it->second : json::object();
+        auto backends = discover_backends(sys_info, model, config.backends, model_info);
+        backends_by_model[model] = backends;
+        for (const auto& [recipe, backend] : backends) {
+            test_recipes.insert(recipe);
+            test_backends.insert(backend);
+        }
+    }
+    json hardware_profile = build_hardware_profile(
+        client, sys_info,
+        std::vector<std::string>(test_recipes.begin(), test_recipes.end()),
+        std::vector<std::string>(test_backends.begin(), test_backends.end()));
+
     // 2. Execute benchmark workflow for each model
     for (const auto& model : unique_models) {
         const auto model_it = model_info_by_name.find(model);
@@ -1615,8 +1770,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         const json& model_info = model_it->second;
         const std::string model_timestamp = get_timestamp_iso();
 
-        // Discover backends for this model
-        auto backends = discover_backends(client, model, config.backends);
+        auto backends = backends_by_model[model];
         if (backends.empty()) {
             std::cerr << "Error: No suitable backends found for model '" << model << "'." << std::endl;
             return 1;
@@ -1726,6 +1880,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
         if (config.json_output) {
             json output;
             output["timestamp"] = command_timestamp;
+            output["hardware"] = hardware_profile;
             output["models"] = json::array();
             for (const auto& model_result : by_model) {
                 output["models"].push_back(
@@ -1748,6 +1903,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             if (!config.output_file.empty()) {
                 json output;
                 output["timestamp"] = command_timestamp;
+                output["hardware"] = hardware_profile;
                 output["models"] = json::array();
                 for (const auto& model_result : by_model) {
                     output["models"].push_back(
@@ -1830,6 +1986,7 @@ int handle_bench_command(lemonade::LemonadeClient& client, const BenchConfig& co
             json output;
 
             output["timestamp"] = command_timestamp;
+            output["hardware"] = hardware_profile;
             output["compare_file"] = config.compare_file;
             if (!previous_timestamp.empty()) {
                 output["previous_timestamp"] = previous_timestamp;

--- a/src/cpp/cli/bench_comparison.cpp
+++ b/src/cpp/cli/bench_comparison.cpp
@@ -1,0 +1,273 @@
+#include "lemon_cli/bench_comparison.h"
+#include "lemon_cli/bench_output.h"
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace lemon_cli {
+
+using json = nlohmann::json;
+
+std::map<std::string, json> extract_models_from_results(const json& root) {
+    std::map<std::string, json> by_model;
+
+    if (root.contains("models") && root["models"].is_array()) {
+        for (const auto& model_entry : root["models"]) {
+            if (model_entry.contains("model") && model_entry["model"].is_string()) {
+                by_model[model_entry["model"].get<std::string>()] = model_entry;
+            }
+        }
+        return by_model;
+    }
+
+    if (root.contains("model") && root["model"].is_string()) {
+        by_model[root["model"].get<std::string>()] = root;
+    }
+
+    return by_model;
+}
+
+std::string extract_results_timestamp(const json& root) {
+    if (root.contains("timestamp") && root["timestamp"].is_string()) {
+        return root["timestamp"].get<std::string>();
+    }
+    return "";
+}
+
+std::string join_list(const std::vector<std::string>& values) {
+    if (values.empty()) return "-";
+    std::ostringstream oss;
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (i > 0) oss << ", ";
+        oss << values[i];
+    }
+    return oss.str();
+}
+
+json load_previous_results(const std::string& file_path) {
+    std::ifstream file(file_path);
+    if (!file.is_open()) {
+        std::cerr << "Error: Could not open comparison file: " << file_path << std::endl;
+        return json::object();
+    }
+
+    try {
+        return json::parse(file);
+    } catch (const json::exception& e) {
+        std::cerr << "Error: Failed to parse comparison file: " << e.what() << std::endl;
+        return json::object();
+    }
+}
+
+std::vector<BenchComparisonDelta> compute_deltas(const std::vector<BenchBackendResult>& current,
+                                                  const json& previous_results) {
+    // Build lookup map from previous results
+    struct PrevKey {
+        std::string backend;
+        int ctx_size = 0;
+        std::string backend_args;
+        std::string scenario;
+        bool operator==(const PrevKey& o) const {
+            return backend == o.backend && ctx_size == o.ctx_size && backend_args == o.backend_args && scenario == o.scenario;
+        }
+    };
+    struct PrevKeyHash {
+        size_t operator()(const PrevKey& k) const {
+            return std::hash<std::string>()(k.backend)
+                 ^ (std::hash<int>()(k.ctx_size) << 1)
+                 ^ (std::hash<std::string>()(k.backend_args) << 2)
+                 ^ (std::hash<std::string>()(k.scenario) << 3);
+        }
+    };
+    std::unordered_map<PrevKey, json, PrevKeyHash> prev_map;
+    std::unordered_set<PrevKey, PrevKeyHash> prev_keys;
+
+    if (previous_results.contains("results") && previous_results["results"].is_array()) {
+        for (const auto& prev_backend : previous_results["results"]) {
+            std::string recipe = prev_backend.value("recipe", "");
+            std::string backend = prev_backend.value("backend", "");
+            std::string backend_label = recipe + "/" + backend;
+            int prev_ctx_size = prev_backend.value("ctx_size", 0);
+            std::string prev_backend_args = prev_backend.value("backend_args", "");
+
+            if (prev_backend.contains("scenarios") && prev_backend["scenarios"].is_array()) {
+                for (const auto& prev_scenario : prev_backend["scenarios"]) {
+                    std::string name = prev_scenario.value("name", "");
+                    PrevKey key{backend_label, prev_ctx_size, prev_backend_args, name};
+                    prev_map[key] = prev_scenario;
+                    prev_keys.insert(key);
+                }
+            }
+        }
+    }
+
+    std::unordered_set<PrevKey, PrevKeyHash> matched_prev;
+    std::vector<BenchComparisonDelta> deltas;
+
+    for (const auto& backend_result : current) {
+        std::string backend_label = backend_result.recipe + "/" + backend_result.backend;
+
+        for (const auto& scenario : backend_result.scenarios) {
+            PrevKey key{backend_label, backend_result.ctx_size, backend_result.backend_args, scenario.scenario_name};
+            auto it = prev_map.find(key);
+
+            BenchComparisonDelta delta;
+            delta.backend = backend_label;
+            delta.ctx_size = backend_result.ctx_size;
+            delta.backend_args = backend_result.backend_args;
+            delta.scenario = scenario.scenario_name;
+
+            if (scenario.runs.empty()) {
+                delta.status = "failed";
+                delta.ttft_pct_change = 0.0;
+                delta.tps_pct_change = 0.0;
+                delta.vram_gb_change = std::nullopt;
+            } else if (it != prev_map.end()) {
+                matched_prev.insert(key);
+
+                if (it->second.value("all_runs_failed", false)) {
+                    delta.status = "prev_failed";
+                    delta.ttft_pct_change = 0.0;
+                    delta.tps_pct_change = 0.0;
+                    delta.vram_gb_change = std::nullopt;
+                } else {
+                    delta.status = "matched";
+
+                    double curr_ttft = scenario.ttft_mean_ms();
+                    double curr_tps = scenario.tps_mean();
+                    double curr_vram = scenario.vram_peak_gb();
+
+                    double prev_ttft = it->second.value("ttft_ms", json::object()).value("mean", 0.0);
+                    double prev_tps = it->second.value("tps", json::object()).value("mean", 0.0);
+                    double prev_vram = it->second.value("vram_peak_gb", -1.0);
+
+                    delta.ttft_pct_change = (prev_ttft > 0) ? ((curr_ttft - prev_ttft) / prev_ttft * 100.0) : 0.0;
+                    delta.tps_pct_change = (prev_tps > 0) ? ((curr_tps - prev_tps) / prev_tps * 100.0) : 0.0;
+                    delta.vram_gb_change = (prev_vram >= 0 && curr_vram >= 0)
+                        ? std::optional<double>(curr_vram - prev_vram)
+                        : std::nullopt;
+                }
+            } else {
+                delta.status = "new";
+                delta.ttft_pct_change = 0.0;
+                delta.tps_pct_change = 0.0;
+                delta.vram_gb_change = std::nullopt;
+            }
+
+            deltas.push_back(delta);
+        }
+    }
+
+    // Mark unmatched previous results as "removed"
+    for (const auto& prev_key : prev_keys) {
+        if (matched_prev.find(prev_key) == matched_prev.end()) {
+            BenchComparisonDelta delta;
+            delta.backend = prev_key.backend;
+            delta.ctx_size = prev_key.ctx_size;
+            delta.backend_args = prev_key.backend_args;
+            delta.scenario = prev_key.scenario;
+            delta.status = "removed";
+            delta.ttft_pct_change = 0.0;
+            delta.tps_pct_change = 0.0;
+            delta.vram_gb_change = std::nullopt;
+            deltas.push_back(delta);
+        }
+    }
+
+    return deltas;
+}
+
+void print_comparison(const std::vector<BenchComparisonDelta>& deltas,
+                      const std::string& model,
+                      const std::string& previous_file,
+                      const std::string& previous_timestamp) {
+    std::cout << std::endl;
+    std::cout << "Comparison: " << model << std::endl;
+    std::cout << "Previous: " << previous_file
+              << (previous_timestamp.empty() ? "" : " (" + previous_timestamp + ")") << std::endl;
+    std::cout << "Current:  " << get_timestamp_iso() << std::endl;
+    std::cout << std::string(100, '=') << std::endl;
+
+    // Group by backend + ctx_size + backend_args
+    std::map<std::string, std::vector<const BenchComparisonDelta*>> by_backend;
+    for (const auto& d : deltas) {
+        std::string label = d.backend;
+        if (d.ctx_size > 0) label += " (ctx=" + std::to_string(d.ctx_size) + ")";
+        if (!d.backend_args.empty()) label += " args=[" + d.backend_args + "]";
+        by_backend[label].push_back(&d);
+    }
+
+    for (const auto& [label, backend_deltas] : by_backend) {
+        std::cout << std::endl;
+        std::cout << "Backend: " << label << std::endl;
+        std::cout << std::string(80, '-') << std::endl;
+        std::cout << std::left << std::setw(22) << "Scenario"
+                  << std::setw(14) << "TTFT change"
+                  << std::setw(14) << "TPS change"
+                  << std::setw(16) << "VRAM change"
+                  << "Status" << std::endl;
+        std::cout << std::string(80, '-') << std::endl;
+
+        for (const auto* d : backend_deltas) {
+            std::string ttft_str = "-", tps_str = "-", vram_str = "-";
+            if (d->status == "matched") {
+                ttft_str = fmt_pct_change(d->ttft_pct_change);
+                tps_str = fmt_pct_change(d->tps_pct_change);
+                vram_str = fmt_vram_change(d->vram_gb_change);
+            }
+
+            std::cout << std::left << std::setw(22) << d->scenario
+                      << std::setw(14) << ttft_str
+                      << std::setw(14) << tps_str
+                      << std::setw(16) << vram_str
+                      << "(" << d->status << ")" << std::endl;
+        }
+    }
+
+    std::cout << std::endl;
+    std::cout << "Legend: TTFT change > 0 means slower (worse). TPS change > 0 means faster (better)." << std::endl;
+    std::cout << "Status: matched = compared against previous, new = no previous data, removed = not in current run, failed = all runs errored, prev_failed = previous run errored" << std::endl;
+    std::cout << std::endl;
+}
+
+json build_comparison_json(const std::vector<BenchBackendResult>& results,
+                           const std::string& model,
+                           const std::string& timestamp,
+                           const BenchConfig& config,
+                           const json& previous_results,
+                           const std::vector<BenchComparisonDelta>& deltas) {
+    json output = to_json(results, model, timestamp, config);
+
+    output["compare_file"] = config.compare_file;
+    if (previous_results.contains("timestamp")) {
+        output["previous_timestamp"] = previous_results["timestamp"];
+    }
+    output["previous_results"] =
+        (previous_results.contains("results") && previous_results["results"].is_array())
+            ? previous_results["results"]
+            : json::array();
+
+    json comparison_json = json::array();
+    for (const auto& d : deltas) {
+        json d_json;
+        d_json["backend"] = d.backend;
+        d_json["ctx_size"] = d.ctx_size;
+        d_json["backend_args"] = d.backend_args;
+        d_json["scenario"] = d.scenario;
+        d_json["ttft_pct_change"] = d.ttft_pct_change;
+        d_json["tps_pct_change"] = d.tps_pct_change;
+        if (d.vram_gb_change.has_value()) d_json["vram_gb_change"] = *d.vram_gb_change;
+        else d_json["vram_gb_change"] = nullptr;
+        d_json["status"] = d.status;
+        comparison_json.push_back(d_json);
+    }
+    output["comparison"] = comparison_json;
+
+    return output;
+}
+
+} // namespace lemon_cli

--- a/src/cpp/cli/bench_output.cpp
+++ b/src/cpp/cli/bench_output.cpp
@@ -1,0 +1,252 @@
+#include "lemon_cli/bench_output.h"
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+namespace lemon_cli {
+
+using json = nlohmann::json;
+
+double percentile(std::vector<double> values, double p) {
+    if (values.empty()) return 0.0;
+    std::sort(values.begin(), values.end());
+    if (values.size() == 1) return values[0];
+    double index = (p / 100.0) * (static_cast<double>(values.size()) - 1.0);
+    size_t lower = static_cast<size_t>(std::floor(index));
+    size_t upper = static_cast<size_t>(std::ceil(index));
+    if (lower == upper) return values[lower];
+    double frac = index - static_cast<double>(lower);
+    return values[lower] * (1.0 - frac) + values[upper] * frac;
+}
+
+std::string fmt_double(double val, int precision) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(precision) << val;
+    return oss.str();
+}
+
+std::string fmt_vram(double val) {
+    if (val < 0) return "-";
+    return fmt_double(val, 1);
+}
+
+std::string fmt_pct_change(double pct) {
+    std::ostringstream oss;
+    oss << (pct >= 0 ? "+" : "") << std::fixed << std::setprecision(1) << pct << "%";
+    return oss.str();
+}
+
+std::string fmt_vram_change(std::optional<double> val) {
+    if (!val.has_value()) return "-";
+    if (*val >= 0) return "+" + fmt_double(*val) + " GB";
+    return fmt_double(*val) + " GB";
+}
+
+static size_t calculate_number_width(double value, int precision) {
+    if (value < 0) {
+        value = -value;
+    }
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(precision) << value;
+    return oss.str().length();
+}
+
+static size_t calculate_vram_width(double value) {
+    if (value < 0) return 1;
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(1) << value;
+    return oss.str().length();
+}
+
+FieldWidths calculate_field_widths(const std::vector<BenchBackendResult>& results) {
+    FieldWidths widths;
+
+    for (const auto& backend_result : results) {
+        for (const auto& scenario : backend_result.scenarios) {
+            size_t scenario_len = scenario.scenario_name.length();
+            if (scenario_len > 0) {
+                if (scenario.failed_runs > 0) {
+                    scenario_len += 2 + std::to_string(scenario.failed_runs).length() + 1;
+                }
+                if (scenario_len > widths.scenario_name) {
+                    widths.scenario_name = std::min<size_t>(scenario_len, 36)+3;
+                }
+            }
+        }
+    }
+
+    for (const auto& backend_result : results) {
+        for (const auto& scenario : backend_result.scenarios) {
+            if (scenario.runs.empty()) {
+                widths.ttft = std::max(widths.ttft, size_t{8});
+                widths.tps  = std::max(widths.tps,  size_t{8});
+            } else {
+                double max_ttft = scenario.ttft_max_ms();
+                widths.ttft = std::max(widths.ttft, calculate_number_width(max_ttft, 1));
+
+                double max_tps = scenario.tps_max();
+                widths.tps = std::max(widths.tps, calculate_number_width(max_tps, 1));
+            }
+
+            double vram_peak = scenario.vram_peak_gb();
+            if (vram_peak >= 0) {
+                widths.vram = std::max(widths.vram, calculate_vram_width(vram_peak));
+            }
+        }
+    }
+
+    return widths;
+}
+
+static void print_scenario_row(const BenchScenarioResult& scenario, bool use_percentiles, const FieldWidths& widths) {
+    double ttft_1 = use_percentiles ? scenario.ttft_p50_ms() : scenario.ttft_min_ms();
+    double ttft_2 = use_percentiles ? scenario.ttft_p95_ms() : scenario.ttft_max_ms();
+    double tps_1 = use_percentiles ? scenario.tps_p50() : scenario.tps_min();
+    double tps_2 = use_percentiles ? scenario.tps_p95() : scenario.tps_max();
+    std::string name = scenario.scenario_name;
+    if (scenario.failed_runs > 0) {
+        name += " *" + std::to_string(scenario.failed_runs) + "f ";
+    }
+    if (scenario.runs.empty()) {
+        std::cout << std::left << std::setw(widths.scenario_name) << name
+                  << std::setw(widths.ttft) << "-"
+                  << std::setw(widths.ttft) << "-"
+                  << std::setw(widths.ttft) << "-"
+                  << std::setw(widths.tps) << "-"
+                  << std::setw(widths.tps) << "-"
+                  << std::setw(widths.tps) << "-"
+                  << std::setw(widths.vram) << "-"
+                  << std::endl;
+    } else {
+        std::cout << std::left << std::setw(widths.scenario_name) << name
+                  << std::setw(widths.ttft) << fmt_double(scenario.ttft_mean_ms())
+                  << " " << std::setw(widths.ttft) << fmt_double(ttft_1)
+                  << " " << std::setw(widths.ttft) << fmt_double(ttft_2)
+                  << " " << std::setw(widths.tps) << fmt_double(scenario.tps_mean())
+                  << " " << std::setw(widths.tps) << fmt_double(tps_1)
+                  << " " << std::setw(widths.tps) << fmt_double(tps_2)
+                  << " " << std::setw(widths.vram) << fmt_vram(scenario.vram_peak_gb())
+                  << std::endl;
+    }
+}
+
+void print_table(const std::vector<BenchBackendResult>& results, const std::string& model,
+                 bool use_percentiles) {
+    FieldWidths widths = calculate_field_widths(results);
+    std::cout << std::endl;
+    std::cout << "Benchmark: " << model << std::endl;
+    std::cout << std::string(100, '=') << std::endl;
+
+    for (const auto& backend_result : results) {
+        std::cout << std::endl;
+        std::cout << "Backend: " << backend_result.label() << std::endl;
+        std::cout << std::string(100, '-') << std::endl;
+
+        std::cout << std::left << std::setw(widths.scenario_name) << "Scenario"
+                  << std::setw(widths.ttft) << "TTFT"
+                  << " " << std::setw(widths.ttft) << (use_percentiles ? "p50" : "min")
+                  << " " << std::setw(widths.ttft) << (use_percentiles ? "p95" : "max")
+                  << " " << std::setw(widths.tps) << "TPS"
+                  << " " << std::setw(widths.tps) << (use_percentiles ? "p50" : "min")
+                  << " " << std::setw(widths.tps) << (use_percentiles ? "p95" : "max")
+                  << " " << std::setw(widths.vram) << "VRAM (GB)" << std::endl;
+        std::cout << std::string(100, '-') << std::endl;
+
+        for (const auto& scenario : backend_result.scenarios) {
+            print_scenario_row(scenario, use_percentiles, widths);
+        }
+    }
+
+    std::cout << std::endl;
+    std::cout << "(*Nf = N failed runs excluded from stats)" << std::endl;
+    std::cout << std::endl;
+}
+
+json to_json(const std::vector<BenchBackendResult>& results,
+             const std::string& model,
+             const std::string& timestamp,
+             const BenchConfig& config) {
+    json output;
+    output["model"] = model;
+    output["timestamp"] = timestamp;
+
+    json config_json;
+    config_json["warmup_runs"] = config.warmup_runs;
+    config_json["measurement_runs"] = config.measurement_runs;
+    config_json["memory_tracking"] = config.memory_tracking;
+    output["config"] = config_json;
+
+    json results_json = json::array();
+    for (const auto& backend_result : results) {
+        json backend_json;
+        backend_json["recipe"] = backend_result.recipe;
+        backend_json["backend"] = backend_result.backend;
+        backend_json["ctx_size"] = backend_result.ctx_size;
+        backend_json["backend_args"] = backend_result.backend_args;
+
+        json scenarios_json = json::array();
+        for (const auto& scenario : backend_result.scenarios) {
+            json s_json;
+            s_json["name"] = scenario.scenario_name;
+            s_json["category"] = scenario.category;
+            s_json["input_tokens"] = scenario.input_tokens();
+            s_json["output_tokens"] = scenario.output_tokens();
+
+            if (scenario.runs.empty()) {
+                s_json["all_runs_failed"] = true;
+            } else {
+                json ttft_stats;
+                ttft_stats["mean"] = scenario.ttft_mean_ms();
+                ttft_stats["min"] = scenario.ttft_min_ms();
+                ttft_stats["max"] = scenario.ttft_max_ms();
+                ttft_stats["p50"] = scenario.ttft_p50_ms();
+                ttft_stats["p95"] = scenario.ttft_p95_ms();
+                s_json["ttft_ms"] = ttft_stats;
+
+                std::vector<double> duration_vals;
+                duration_vals.reserve(scenario.runs.size());
+                double duration_sum = 0.0;
+                double duration_min = scenario.runs[0].total_time_ms;
+                double duration_max = scenario.runs[0].total_time_ms;
+                for (const auto& run : scenario.runs) {
+                    duration_vals.push_back(run.total_time_ms);
+                    duration_sum += run.total_time_ms;
+                    if (run.total_time_ms < duration_min) duration_min = run.total_time_ms;
+                    if (run.total_time_ms > duration_max) duration_max = run.total_time_ms;
+                }
+                json duration_stats;
+                duration_stats["mean"] = duration_sum / static_cast<double>(scenario.runs.size());
+                duration_stats["min"] = duration_min;
+                duration_stats["max"] = duration_max;
+                duration_stats["p50"] = percentile(duration_vals, 50.0);
+                duration_stats["p95"] = percentile(duration_vals, 95.0);
+                s_json["duration_ms"] = duration_stats;
+
+                json tps_stats;
+                tps_stats["mean"] = scenario.tps_mean();
+                tps_stats["min"] = scenario.tps_min();
+                tps_stats["max"] = scenario.tps_max();
+                tps_stats["p50"] = scenario.tps_p50();
+                tps_stats["p95"] = scenario.tps_p95();
+                s_json["tps"] = tps_stats;
+
+                double vram_peak = scenario.vram_peak_gb();
+                if (vram_peak >= 0) s_json["vram_peak_gb"] = vram_peak;
+                double mem_peak = scenario.memory_peak_gb();
+                if (mem_peak >= 0) s_json["memory_peak_gb"] = mem_peak;
+            }
+            s_json["failed_runs"] = scenario.failed_runs;
+
+            scenarios_json.push_back(s_json);
+        }
+        backend_json["scenarios"] = scenarios_json;
+        results_json.push_back(backend_json);
+    }
+    output["results"] = results_json;
+
+    return output;
+}
+
+} // namespace lemon_cli

--- a/src/cpp/cli/bench_sysinfo.cpp
+++ b/src/cpp/cli/bench_sysinfo.cpp
@@ -1,0 +1,143 @@
+#include "lemon_cli/bench_sysinfo.h"
+#include <algorithm>
+#include <iostream>
+#include <string>
+
+namespace lemon_cli {
+
+using json = nlohmann::json;
+
+static double parse_gb_string(const std::string& s) {
+    std::string num_str = s;
+    size_t space_pos = num_str.find(' ');
+    if (space_pos != std::string::npos) {
+        num_str = num_str.substr(0, space_pos);
+    }
+    try {
+        return std::stod(num_str);
+    } catch (...) {
+        return -1.0;
+    }
+}
+
+// ============================================================
+// Public API
+// ============================================================
+
+json build_hardware_profile(const json& sys_info,
+                            const std::vector<std::string>& recipes,
+                            const std::vector<std::string>& backends) {
+    json profile;
+
+    try {
+        std::string os_version = sys_info.value("OS Version", "unknown");
+        std::string os;
+        if (os_version.find("Windows") != std::string::npos) os = "windows";
+        else if (os_version.find("macOS") != std::string::npos || os_version.find("Darwin") != std::string::npos) os = "macos";
+        else if (os_version.find("Linux") != std::string::npos) os = "linux";
+        else os = os_version;
+        profile["os"] = os;
+
+        if (sys_info.contains("devices") && sys_info["devices"].contains("cpu")) {
+            profile["cpu"] = sys_info["devices"]["cpu"].value("name", "unknown");
+        } else {
+            profile["cpu"] = sys_info.value("Processor", "unknown");
+        }
+
+        if (sys_info.contains("Physical Memory") && sys_info["Physical Memory"].is_string()) {
+            double ram_gb = parse_gb_string(sys_info["Physical Memory"].get<std::string>());
+            if (ram_gb > 0) {
+                profile["ram_gb"] = ram_gb;
+            }
+        }
+
+        json gpu_array = json::array();
+        if (sys_info.contains("devices")) {
+            const auto& devices = sys_info["devices"];
+
+            if (devices.contains("amd_gpu") && devices["amd_gpu"].is_array()) {
+                for (const auto& gpu : devices["amd_gpu"]) {
+                    if (gpu.value("available", false)) {
+                        json gpu_entry;
+                        gpu_entry["name"] = gpu.value("name", "unknown");
+                        gpu_entry["type"] = "amd";
+                        gpu_entry["integrated"] = gpu.value("integrated", false);
+                        if (gpu.contains("vram_gb") && gpu["vram_gb"].is_number()) {
+                            gpu_entry["vram_gb"] = gpu["vram_gb"].get<double>();
+                        }
+                        gpu_array.push_back(gpu_entry);
+                    }
+                }
+            }
+
+            if (devices.contains("nvidia_gpu") && devices["nvidia_gpu"].is_array()) {
+                for (const auto& gpu : devices["nvidia_gpu"]) {
+                    if (gpu.value("available", false)) {
+                        json gpu_entry;
+                        gpu_entry["name"] = gpu.value("name", "unknown");
+                        gpu_entry["type"] = "nvidia";
+                        if (gpu.contains("vram_gb") && gpu["vram_gb"].is_number()) {
+                            gpu_entry["vram_gb"] = gpu["vram_gb"].get<double>();
+                        }
+                        gpu_array.push_back(gpu_entry);
+                    }
+                }
+            }
+
+            if (devices.contains("metal") && devices["metal"].is_object()) {
+                const auto& metal = devices["metal"];
+                if (metal.value("available", false)) {
+                    json gpu_entry;
+                    gpu_entry["name"] = metal.value("name", "unknown");
+                    gpu_entry["type"] = "metal";
+                    if (metal.contains("vram_gb") && metal["vram_gb"].is_number()) {
+                        gpu_entry["vram_gb"] = metal["vram_gb"].get<double>();
+                    }
+                    gpu_array.push_back(gpu_entry);
+                }
+            }
+        }
+        profile["gpu"] = gpu_array;
+
+        json backend_versions = json::object();
+        if (sys_info.contains("recipes") && sys_info["recipes"].is_object()) {
+            for (const auto& [recipe_name, recipe_data] : sys_info["recipes"].items()) {
+                if (!recipes.empty()) {
+                    bool found = std::find(recipes.begin(), recipes.end(), recipe_name) != recipes.end();
+                    if (!found) continue;
+                }
+
+                if (!recipe_data.contains("backends") || !recipe_data["backends"].is_object()) {
+                    continue;
+                }
+
+                for (const auto& [backend_name, backend_data] : recipe_data["backends"].items()) {
+                    if (!backends.empty()) {
+                        bool found = std::find(backends.begin(), backends.end(), backend_name) != backends.end();
+                        if (!found) continue;
+                    }
+
+                    std::string state = backend_data.value("state", "unknown");
+                    if (state != "installed" && state != "update_required" && state != "update_available") {
+                        continue;
+                    }
+
+                    std::string version = backend_data.value("version", "");
+                    if (!version.empty()) {
+                        backend_versions[recipe_name + "/" + backend_name] = version;
+                    }
+                }
+            }
+        }
+        if (!backend_versions.empty()) {
+            profile["backends"] = backend_versions;
+        }
+
+    } catch (const std::exception& e) {
+        std::cerr << "Warning: Failed to build hardware profile: " << e.what() << std::endl;
+    }
+
+    return profile;
+}
+
+} // namespace lemon_cli

--- a/src/cpp/include/lemon_cli/bench.h
+++ b/src/cpp/include/lemon_cli/bench.h
@@ -107,10 +107,11 @@ struct BackendDiscovery {
     std::string backend;
 };
 
-// Discover available backends for a model
-std::vector<BackendDiscovery> discover_backends(lemonade::LemonadeClient& client,
+// Discover available backends for a model (uses pre-fetched system-info and model-info)
+std::vector<BackendDiscovery> discover_backends(const json& sys_info,
                                                 const std::string& model,
-                                                const std::vector<std::string>& requested);
+                                                const std::vector<std::string>& requested,
+                                                const json& model_info);
 
 // ============================================================
 // Model Load/Unload

--- a/src/cpp/include/lemon_cli/bench.h
+++ b/src/cpp/include/lemon_cli/bench.h
@@ -2,7 +2,6 @@
 #define LEMON_CLI_BENCH_H
 
 #include <map>
-#include <optional>
 #include <string>
 #include <vector>
 #include <nlohmann/json.hpp>
@@ -41,6 +40,7 @@ struct BenchRunResult {
     double vram_gb = -1.0;      // -1 means not available
     double memory_gb = -1.0;    // -1 means not available
     bool success = true;        // false if the run failed (exception, HTTP error, etc.)
+    bool valid = false;         // set by parse_response when meaningful data was extracted
     std::string response_text;  // LLM response text (only populated if capture enabled)
 };
 
@@ -109,7 +109,6 @@ struct BackendDiscovery {
 
 // Discover available backends for a model (uses pre-fetched system-info and model-info)
 std::vector<BackendDiscovery> discover_backends(const json& sys_info,
-                                                const std::string& model,
                                                 const std::vector<std::string>& requested,
                                                 const json& model_info);
 
@@ -249,69 +248,6 @@ BenchConfig build_bench_config(
 CLI::App* register_bench_command(CLI::App& parent,
                                  std::string& output_file,
                                  BenchCliOptions& opts);
-
-// ============================================================
-// Output Formatting
-// ============================================================
-struct FieldWidths {
-    size_t scenario_name = 20;
-    size_t ttft = 8;
-    size_t tps = 8;
-    size_t vram = 8;
-};
-
-FieldWidths calculate_field_widths(const std::vector<BenchBackendResult>& results);
-
-// Print results as a comparison table to stdout
-// use_percentiles: show p50/p95 columns (true when runs >= 10); otherwise show min/max
-void print_table(const std::vector<BenchBackendResult>& results, const std::string& model,
-                 bool use_percentiles);
-
-// Convert results to JSON for programmatic consumption
-json to_json(const std::vector<BenchBackendResult>& results,
-             const std::string& model,
-             const std::string& timestamp,
-             const BenchConfig& config);
-
-// ============================================================
-// Comparison
-// ============================================================
-
-struct BenchComparisonDelta {
-    std::string backend;
-    int ctx_size = 0;
-    std::string backend_args;
-    std::string scenario;
-    double ttft_pct_change;    // Positive = slower, negative = faster
-    double tps_pct_change;     // Positive = faster, negative = slower
-    std::optional<double> vram_gb_change; // Positive = more VRAM used, nullopt = no data
-    std::string status;        // "matched", "new", "removed"
-};
-
-// Load previous results from a JSON file
-json load_previous_results(const std::string& file_path);
-
-// Compute deltas between current and previous results
-std::vector<BenchComparisonDelta> compute_deltas(const std::vector<BenchBackendResult>& current,
-                                                  const json& previous_results);
-
-// Print comparison table to stdout
-void print_comparison(const std::vector<BenchComparisonDelta>& deltas,
-                      const std::string& model,
-                      const std::string& previous_file,
-                      const std::string& previous_timestamp);
-
-// Build comparison JSON (for --json --compare)
-json build_comparison_json(const std::vector<BenchBackendResult>& results,
-                           const std::string& model,
-                           const std::string& timestamp,
-                           const BenchConfig& config,
-                           const json& previous_results,
-                           const std::vector<BenchComparisonDelta>& deltas);
-
-// ============================================================
-// Utility
-// ============================================================
 
 // Get ISO 8601 timestamp string
 std::string get_timestamp_iso();

--- a/src/cpp/include/lemon_cli/bench.h
+++ b/src/cpp/include/lemon_cli/bench.h
@@ -1,5 +1,4 @@
-#ifndef LEMON_CLI_BENCH_H
-#define LEMON_CLI_BENCH_H
+#pragma once
 
 #include <map>
 #include <string>
@@ -253,5 +252,3 @@ CLI::App* register_bench_command(CLI::App& parent,
 std::string get_timestamp_iso();
 
 } // namespace lemon_cli
-
-#endif // LEMON_CLI_BENCH_H

--- a/src/cpp/include/lemon_cli/bench_comparison.h
+++ b/src/cpp/include/lemon_cli/bench_comparison.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "lemon_cli/bench.h"
+#include "lemon_cli/bench_output.h"
+#include <map>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace lemon_cli {
+
+using json = nlohmann::json;
+
+struct BenchComparisonDelta {
+    std::string backend;
+    int ctx_size = 0;
+    std::string backend_args;
+    std::string scenario;
+    double ttft_pct_change;    // Positive = slower, negative = faster
+    double tps_pct_change;     // Positive = faster, negative = slower
+    std::optional<double> vram_gb_change; // Positive = more VRAM used, nullopt = no data
+    std::string status;        // "matched", "new", "removed", "failed", "prev_failed"
+};
+
+// Load previous results from a JSON file. Returns empty object on error.
+json load_previous_results(const std::string& file_path);
+
+// Normalize benchmark JSON into a model->result-object map.
+// Supports both legacy single-model files and multi-model files.
+std::map<std::string, json> extract_models_from_results(const json& root);
+
+// Extract the top-level timestamp from benchmark JSON.
+std::string extract_results_timestamp(const json& root);
+
+// Join a vector of strings with ", ". Returns "-" for empty input.
+std::string join_list(const std::vector<std::string>& values);
+
+// Compute deltas between current and previous benchmark results.
+std::vector<BenchComparisonDelta> compute_deltas(const std::vector<BenchBackendResult>& current,
+                                                  const json& previous_results);
+
+// Print comparison table to stdout.
+void print_comparison(const std::vector<BenchComparisonDelta>& deltas,
+                      const std::string& model,
+                      const std::string& previous_file,
+                      const std::string& previous_timestamp);
+
+// Build comparison JSON (for --json --compare).
+json build_comparison_json(const std::vector<BenchBackendResult>& results,
+                           const std::string& model,
+                           const std::string& timestamp,
+                           const BenchConfig& config,
+                           const json& previous_results,
+                           const std::vector<BenchComparisonDelta>& deltas);
+
+} // namespace lemon_cli

--- a/src/cpp/include/lemon_cli/bench_output.h
+++ b/src/cpp/include/lemon_cli/bench_output.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "lemon_cli/bench.h"
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace lemon_cli {
+
+using json = nlohmann::json;
+
+struct FieldWidths {
+    size_t scenario_name = 20;
+    size_t ttft = 8;
+    size_t tps = 8;
+    size_t vram = 8;
+};
+
+// Compute percentiles for a sorted/unordered vector of doubles.
+// Returns 0.0 for empty input.
+double percentile(std::vector<double> values, double p);
+
+// Formatting helpers (used internally and by comparison module)
+std::string fmt_double(double val, int precision = 1);
+std::string fmt_vram(double val);
+std::string fmt_pct_change(double pct);
+std::string fmt_vram_change(std::optional<double> val);
+
+// Compute column widths for table output
+FieldWidths calculate_field_widths(const std::vector<BenchBackendResult>& results);
+
+// Print results as a formatted table to stdout.
+// use_percentiles: show p50/p95 columns (true when runs >= 10); otherwise show min/max.
+void print_table(const std::vector<BenchBackendResult>& results, const std::string& model,
+                 bool use_percentiles);
+
+// Convert benchmark results to JSON for programmatic consumption / file output.
+json to_json(const std::vector<BenchBackendResult>& results,
+             const std::string& model,
+             const std::string& timestamp,
+             const BenchConfig& config);
+
+} // namespace lemon_cli

--- a/src/cpp/include/lemon_cli/bench_sysinfo.h
+++ b/src/cpp/include/lemon_cli/bench_sysinfo.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace lemonade {
+class LemonadeClient;
+}
+
+namespace lemon_cli {
+
+using json = nlohmann::json;
+
+// Build a hardware profile JSON from system-info + system-stats.
+// Captures OS, CPU, GPU array, RAM, and backend versions for shareable benchmarks.
+// `recipes` and `backends` filter which backend versions to include (empty = all).
+json build_hardware_profile(const json& sys_info,
+                            const std::vector<std::string>& recipes,
+                            const std::vector<std::string>& backends);
+
+} // namespace lemon_cli


### PR DESCRIPTION
This refactors the bench tool to remove some duplication, reduce the number of server calls and split the code across multiple files. It also adds a `hardware` section to the output, so that the results are more useful when shared and compared.

example of the hardware section:

```
  "hardware": {
    "backends": {
      "llamacpp/rocm": "b9752",
      "llamacpp/vulkan": "b9747"
    },
    "cpu": "AMD Ryzen AI 9 HX 370 w/ Radeon 890M",
    "gpu": [
      {
        "integrated": true,
        "name": "110500",
        "type": "amd",
        "vram_gb": 0.5
      }
    ],
    "os": "linux",
    "ram_gb": 61.91
  },
```