### PR TITLE
test(ci): wait for server after host rebind

### DIFF
--- a/test/server_cli2.py
+++ b/test/server_cli2.py
@@ -638,7 +638,8 @@ sys.exit(0)
                     timeout=10,
                 )
                 if response.status_code < 400:
-                    print("[OK] Restored host to localhost")
+                    wait_for_server(port=PORT, timeout=30)
+                    print("[OK] Restored host to localhost and server is reachable")
                 else:
                     print(
                         "Warning: Failed to restore host to localhost: "


### PR DESCRIPTION
## Problem

test_043_listen_all_via_runtime_config restores the server host from 0.0.0.0 to localhost in its cleanup, then returns immediately after /internal/set accepts the change.

Changing the host stops and recreates the HTTP listeners asynchronously. The next ordered CLI test can therefore start during the short rebind window and fail with `Could not establish connection`.

This occurred in the Ubuntu CLI/endpoints CI job. The endpoint suite itself subsequently completed successfully.

## Fix

Wait for the restored `localhost` listener to become reachable before completing `test_043_listen_all_via_runtime_config`.

The existing `wait_for_server` helper is used, so the wait is bounded and does not add a fixed sleep or retry behavior to production code.

## Scope

Test-only change. No server, CLI, or endpoint behavior is modified.
