### PR TITLE
fix(server): release large request memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3167,6 +3167,40 @@ if(BUILD_TESTING AND EXISTS "${_RECIPE_OPTIONS_PRECEDENCE_TEST_SRC}")
     add_cpp_ci_test(RecipeOptionsPrecedence CI ON COMMAND test_recipe_options_precedence)
 endif()
 
+set(_GLIBC_MALLOPT_PROBE_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/glibc_mallopt_probe.cpp"
+)
+set(_GLIBC_ALLOCATOR_POLICY_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/test_glibc_allocator_policy.py"
+)
+if(BUILD_TESTING AND
+   CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+   EXISTS "${_GLIBC_MALLOPT_PROBE_SRC}" AND
+   EXISTS "${_GLIBC_ALLOCATOR_POLICY_TEST_SRC}")
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if(Python3_Interpreter_FOUND)
+        add_library(test_glibc_mallopt_probe SHARED
+            ${_GLIBC_MALLOPT_PROBE_SRC}
+        )
+        add_cpp_ci_test(
+            GlibcAllocatorPolicyTest
+            CI ON
+            COMMAND
+                ${Python3_EXECUTABLE}
+                ${_GLIBC_ALLOCATOR_POLICY_TEST_SRC}
+                --lemond $<TARGET_FILE:${EXECUTABLE_NAME}>
+                --probe $<TARGET_FILE:test_glibc_mallopt_probe>
+            DEPENDS
+                ${EXECUTABLE_NAME}
+                test_glibc_mallopt_probe
+        )
+        set_tests_properties(
+            GlibcAllocatorPolicyTest
+            PROPERTIES SKIP_RETURN_CODE 77
+        )
+    endif()
+endif()
+
 if(BUILD_TESTING)
     add_cpp_ci_test(HttplibDetection_config_only CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_config_only -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=config_only -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
     add_cpp_ci_test(HttplibDetection_old_header CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_old_header -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=old_header -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -37,3 +37,9 @@ Lemonade has a unique capability to group LLM, image, and speech models together
 ### CI System
 
 Lemonade has a CI system that tests changes on real AI PC hardware targets — in the merge queue by default, or on a labeled PR (the [testing guide](./testing.md#what-defers-to-the-merge-queue) maps each `ci:*` label to the jobs it opts in). The [self-hosted runners](./self-hosted-runners.md) guide documents how those are set up.
+
+### Performance Diagnostics
+
+The [large-request memory benchmark](./large-request-memory-benchmark.md)
+documents the manual Linux reproducer for allocator high-water retention and
+its real-backend validation mode.

--- a/docs/dev/large-request-memory-benchmark.md
+++ b/docs/dev/large-request-memory-benchmark.md
@@ -53,6 +53,11 @@ the JSON body, it isolates allocator behaviour: baseline and
 serialization-only should match, as should allocator-only and combined. Use a
 mock or real inference route to measure serialization and end-to-end effects.
 
+Both modes authenticate requests with `LEMONADE_ADMIN_API_KEY` when it is set,
+falling back to `LEMONADE_API_KEY`. Stress-mode subprocesses inherit the same
+environment, and the selected credential is also used for their internal
+shutdown request. Credential values are never written to the result JSON.
+
 ## Backend-free RSS run
 
 Run three fresh-process repetitions per variant:

--- a/docs/dev/large-request-memory-benchmark.md
+++ b/docs/dev/large-request-memory-benchmark.md
@@ -7,12 +7,13 @@ kernel, host load, and allocator history.
 
 ## What the allocator setting changes
 
-At process startup, glibc's `M_MMAP_THRESHOLD` is fixed at 1 MiB. This is a
-process-wide allocator policy, not an HTTP-only setting. Eligible allocations
-throughout `lemond` may become mmap-backed, including large registry, cache,
-telemetry, and JSON allocations. The threshold does not guarantee that every
-allocation above 1 MiB uses mmap; glibc can reuse suitable free blocks and is
-also subject to its mmap limits.
+Unless an operator override is present, `lemond` attempts to fix glibc's
+`M_MMAP_THRESHOLD` at 1 MiB during startup. This is a process-wide allocator
+policy, not an HTTP-only setting. Eligible allocations throughout `lemond` may
+become mmap-backed, including large registry, cache, telemetry, and JSON
+allocations. The threshold does not guarantee that every allocation above
+1 MiB uses mmap; glibc can reuse suitable free blocks and is also subject to its
+mmap limits.
 
 The call must happen before `Server` construction because `JobManager` starts a
 worker thread in its constructor and glibc documents `mallopt()` as MT-Unsafe.
@@ -22,6 +23,13 @@ built-in 1 MiB threshold without rebuilding by setting either
 `MALLOC_MMAP_THRESHOLD_` or `glibc.malloc.mmap_threshold` in `GLIBC_TUNABLES`;
 `lemond` does not overwrite either value. Non-glibc builds do not compile or
 call this code.
+
+This targets glibc's dynamically increasing mmap threshold directly.
+`MALLOC_ARENA_MAX` limits arena proliferation but does not prevent that
+threshold from increasing, while `malloc_trim(0)` only releases releasable
+arena pages and would add process-wide work after selected requests. A static
+threshold gives deterministic release behaviour for the affected allocations,
+while the environment overrides retain an operator-controlled escape hatch.
 
 The second change avoids creating a serialized copy of parsed JSON in
 non-streaming chat, completions, and responses handlers. Streaming handlers

--- a/docs/dev/large-request-memory-benchmark.md
+++ b/docs/dev/large-request-memory-benchmark.md
@@ -1,0 +1,138 @@
+# Large-request memory benchmark
+
+This manual Linux benchmark reproduces `lemond` RSS retention after repeated
+multi-megabyte HTTP requests and separates the two changes in the associated
+fix. It is intentionally not a normal CI gate: process RSS varies by libc,
+kernel, host load, and allocator history.
+
+## What the allocator setting changes
+
+At process startup, glibc's `M_MMAP_THRESHOLD` is fixed at 1 MiB. This is a
+process-wide allocator policy, not an HTTP-only setting. Eligible allocations
+throughout `lemond` may become mmap-backed, including large registry, cache,
+telemetry, and JSON allocations. The threshold does not guarantee that every
+allocation above 1 MiB uses mmap; glibc can reuse suitable free blocks and is
+also subject to its mmap limits.
+
+The call must happen before `Server` construction because `JobManager` starts a
+worker thread in its constructor and glibc documents `mallopt()` as MT-Unsafe.
+The setting is a tuning, not a correctness requirement: if `mallopt()` reports
+failure, `lemond` logs a warning and continues. Operators can replace the
+built-in 1 MiB threshold without rebuilding by setting either
+`MALLOC_MMAP_THRESHOLD_` or `glibc.malloc.mmap_threshold` in `GLIBC_TUNABLES`;
+`lemond` does not overwrite either value. Non-glibc builds do not compile or
+call this code.
+
+The second change avoids creating a serialized copy of parsed JSON in
+non-streaming chat, completions, and responses handlers. Streaming handlers
+still create the string immediately before installing their SSE provider,
+which retains it by value.
+
+## Four attribution variants
+
+Build all variants from the same baseline commit and with the same Release
+toolchain:
+
+1. `baseline`: neither change;
+2. `serialization-only`: lazy non-streaming serialization only;
+3. `allocator-only`: startup allocator configuration only;
+4. `combined`: both changes, matching the proposed patch.
+
+The checked-in runner records every binary path, SHA-256 digest and reported
+version so the result can be tied back to exact artifacts. Its default
+backend-free route is `/api/v1/test`. Because that route deliberately ignores
+the JSON body, it isolates allocator behaviour: baseline and
+serialization-only should match, as should allocator-only and combined. Use a
+mock or real inference route to measure serialization and end-to-end effects.
+
+## Backend-free RSS run
+
+Run three fresh-process repetitions per variant:
+
+```bash
+python3 tools/benchmark_large_request_memory.py stress \
+  --variant baseline=/path/to/baseline/lemond \
+  --variant serialization-only=/path/to/serialization-only/lemond \
+  --variant allocator-only=/path/to/allocator-only/lemond \
+  --variant combined=/path/to/combined/lemond \
+  --source-commit baseline=<full-baseline-sha> \
+  --source-commit serialization-only=<full-serialization-only-sha> \
+  --source-commit allocator-only=<full-allocator-only-sha> \
+  --source-commit combined=<full-combined-sha> \
+  --requests 170 \
+  --body-mib 3 \
+  --concurrency 1 \
+  --repetitions 3 \
+  --settle-seconds 1 \
+  --output large-request-memory-sequential.json
+```
+
+There is no large-request warm-up by default. Each repetition starts a new
+`lemond` with an empty cache, waits for `/live`, records `VmRSS` and `VmData`
+from `/proc/PID/status`, sends the measured batch with one fresh TCP connection
+per request, waits one second, and samples memory again. The JSON contains all
+raw repetitions plus the median and range for memory, elapsed time, and request
+rate.
+
+For a deliberately allocator-heavy concurrent throughput boundary, increase
+the batch and concurrency while keeping fresh processes and repeated runs:
+
+```bash
+python3 tools/benchmark_large_request_memory.py stress \
+  --variant baseline=/path/to/baseline/lemond \
+  --variant serialization-only=/path/to/serialization-only/lemond \
+  --variant allocator-only=/path/to/allocator-only/lemond \
+  --variant combined=/path/to/combined/lemond \
+  --source-commit baseline=<full-baseline-sha> \
+  --source-commit serialization-only=<full-serialization-only-sha> \
+  --source-commit allocator-only=<full-allocator-only-sha> \
+  --source-commit combined=<full-combined-sha> \
+  --requests 8192 \
+  --body-mib 3 \
+  --concurrency 32 \
+  --repetitions 3 \
+  --output large-request-memory-concurrent.json
+```
+
+This no-op route is a worst-case allocator benchmark, not inference
+throughput. Report its cost rather than extrapolating it directly to model
+latency.
+
+## Real-backend validation
+
+`real-backend` mode measures already-running Lemonade targets. Each target must
+have the named model loaded with the same context, backend, model artifact, and
+runtime options. The PID is the corresponding `lemond`, not its backend child.
+
+```bash
+python3 tools/benchmark_large_request_memory.py real-backend \
+  --target baseline=http://127.0.0.1:19001,12345 \
+  --target combined=http://127.0.0.1:19002,12346 \
+  --source-commit baseline=<full-baseline-sha> \
+  --source-commit combined=<full-combined-sha> \
+  --model Qwen3.5-122B-A10B-GGUF \
+  --prompt-file /path/to/fixed-long-context-prompt.txt \
+  --max-tokens 128 \
+  --repetitions 3 \
+  --output large-request-memory-real-backend.json
+```
+
+The runner records request-body bytes, wall time, prompt and generation token
+rates reported by the backend, and `lemond` RSS/VmData change. Leave
+`--cache-prompt` disabled for independent full-prefill repetitions; enable it
+only when the test is explicitly intended to measure maximum-depth cached
+generation. By default, one unmeasured one-token request warms each target
+before the repeated long-context samples; set `--warmup-requests 0` to include
+cold-start effects instead. With multiple targets, odd repetitions use the
+listed order and even repetitions reverse it to reduce fixed-order bias.
+For release validation, include a longer generation and a non-ROCm backend when
+the target hardware supports one.
+
+For every published result, preserve the JSON and report:
+
+- baseline and patched source commits;
+- OS, kernel, glibc, compiler and hardware;
+- endpoint and exact payload construction;
+- request count, concurrency, warm-up, settle delay and repetition count;
+- median and full range rather than excessive single-run precision;
+- model artifact, context, backend/runtime and cache policy for real inference.

--- a/docs/dev/large-request-memory-benchmark.md
+++ b/docs/dev/large-request-memory-benchmark.md
@@ -15,11 +15,11 @@ allocations. The threshold does not guarantee that every allocation above
 1 MiB uses mmap; glibc can reuse suitable free blocks and is also subject to its
 mmap limits.
 
-The call must happen before `Server` construction because `JobManager` starts a
-worker thread in its constructor and glibc documents `mallopt()` as MT-Unsafe.
-The setting is a tuning, not a correctness requirement: if `mallopt()` reports
-failure, `lemond` logs a warning and continues. Operators can replace the
-built-in 1 MiB threshold without rebuilding by setting either
+The call happens before telemetry initialization and `Server` construction,
+both of which start worker threads, because glibc documents `mallopt()` as
+MT-Unsafe. The setting is a tuning, not a correctness requirement: if
+`mallopt()` reports failure, `lemond` logs a warning and continues. Operators
+can replace the built-in 1 MiB threshold without rebuilding by setting either
 `MALLOC_MMAP_THRESHOLD_` or `glibc.malloc.mmap_threshold` in `GLIBC_TUNABLES`;
 `lemond` does not overwrite either value. Non-glibc builds do not compile or
 call this code.

--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -14,11 +14,63 @@
 #include <lemon/utils/path_utils.h>
 #include <lemon/version.h>
 
+#if defined(__GLIBC__)
+#include <cstdlib>
+#include <malloc.h>
+#include <string_view>
+#endif
+
 #ifndef _WIN32
 #include <unistd.h>
 #endif
 
 using namespace lemon;
+
+namespace {
+
+#if defined(__GLIBC__)
+constexpr int GLIBC_MMAP_THRESHOLD_BYTES = 1024 * 1024;
+constexpr std::string_view GLIBC_MMAP_THRESHOLD_TUNABLE =
+    "glibc.malloc.mmap_threshold";
+
+bool glibc_tunable_is_set(std::string_view tunables,
+                          std::string_view name) noexcept {
+    while (!tunables.empty()) {
+        const size_t separator = tunables.find(':');
+        const std::string_view entry = tunables.substr(0, separator);
+        const size_t assignment = entry.find('=');
+        if (assignment != std::string_view::npos &&
+            entry.substr(0, assignment) == name) {
+            return true;
+        }
+        if (separator == std::string_view::npos) {
+            break;
+        }
+        tunables.remove_prefix(separator + 1);
+    }
+    return false;
+}
+
+bool glibc_mmap_threshold_is_overridden() noexcept {
+    if (std::getenv("MALLOC_MMAP_THRESHOLD_") != nullptr) {
+        return true;
+    }
+    const char* tunables = std::getenv("GLIBC_TUNABLES");
+    return tunables != nullptr &&
+           glibc_tunable_is_set(tunables, GLIBC_MMAP_THRESHOLD_TUNABLE);
+}
+
+bool configure_glibc_mmap_threshold() noexcept {
+    if (glibc_mmap_threshold_is_overridden()) {
+        return true;
+    }
+    // Fixing the threshold prevents glibc from retaining large temporary
+    // allocations after its dynamic threshold has increased.
+    return mallopt(M_MMAP_THRESHOLD, GLIBC_MMAP_THRESHOLD_BYTES) != 0;
+}
+#endif
+
+} // namespace
 
 // Global flags for signal handling
 static std::atomic<bool> g_reload_requested(false);
@@ -64,6 +116,16 @@ void signal_handler(int signal) {
 }
 
 int main(int argc, char** argv) {
+#if defined(__GLIBC__)
+    // mallopt() is process-wide and MT-Unsafe. Apply it before constructing
+    // Server, whose JobManager starts a worker thread in its constructor.
+    if (!configure_glibc_mmap_threshold()) {
+        std::cerr << "Warning: failed to set glibc M_MMAP_THRESHOLD; "
+                  << "memory from large requests may not be released promptly"
+                  << std::endl;
+    }
+#endif
+
     try {
         CLIParser parser;
         parser.parse(argc, argv);

--- a/src/cpp/server/main.cpp
+++ b/src/cpp/server/main.cpp
@@ -13,6 +13,7 @@
 #include <lemon/utils/json_utils.h>
 #include <lemon/utils/path_utils.h>
 #include <lemon/version.h>
+#include "telemetry.h"
 
 #if defined(__GLIBC__)
 #include <cstdlib>
@@ -117,14 +118,16 @@ void signal_handler(int signal) {
 
 int main(int argc, char** argv) {
 #if defined(__GLIBC__)
-    // mallopt() is process-wide and MT-Unsafe. Apply it before constructing
-    // Server, whose JobManager starts a worker thread in its constructor.
+    // mallopt() is process-wide and MT-Unsafe. Apply it before initializing
+    // telemetry or constructing Server, both of which start worker threads.
     if (!configure_glibc_mmap_threshold()) {
         std::cerr << "Warning: failed to set glibc M_MMAP_THRESHOLD; "
                   << "memory from large requests may not be released promptly"
                   << std::endl;
     }
 #endif
+
+    telemetry::initialize();
 
     try {
         CLIParser parser;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3920,7 +3920,6 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
             LOG(DEBUG, "Server") << "No tools in request" << std::endl;
         }
 
-        bool request_modified = false;
         std::optional<RouterDispatchResult> route_dispatch;
 
         // Omni "collection" models run a server-side tool-calling loop instead of a
@@ -4015,22 +4014,13 @@ void Server::handle_chat_completions(const httplib::Request& req, httplib::Respo
         // Check if streaming is requested
         bool is_streaming = request_json.contains("stream") && request_json["stream"].get<bool>();
 
-        // Use original request body - each backend (FLM, llamacpp, etc.) handles
-        // model name transformation internally via their forward methods.
-        // Note: request_json was already normalized at the top of this function
-        std::string request_body = req.body;
-
         // OpenCode and other OpenAI-compatible clients may send thinking=false
         // instead of Lemonade's enable_thinking=false.
-        request_modified = normalize_thinking_controls(request_json) || request_modified;
-
-        // If we modified the request (or normalized the model name earlier), serialize to string
-        // The early normalize_client_model_name() call modifies request_json but doesn't set a flag,
-        // so we always use request_json for the body to ensure model name normalization is applied
-        request_body = request_json.dump();
+        normalize_thinking_controls(request_json);
 
         if (is_streaming) {
             try {
+                std::string request_body = request_json.dump();
                 // Log the HTTP request
                 LOG(INFO, "Server") << "POST /api/v1/chat/completions - Streaming" << std::endl;
 
@@ -4160,11 +4150,9 @@ void Server::handle_completions(const httplib::Request& req, httplib::Response& 
         // Check if streaming is requested
         bool is_streaming = request_json.contains("stream") && request_json["stream"].get<bool>();
 
-        // Use normalized request - model name was already normalized at the top
-        std::string request_body = request_json.dump();
-
         if (is_streaming) {
             try {
+                std::string request_body = request_json.dump();
                 // Log the HTTP request
                 LOG(INFO, "Server") << "POST /api/v1/completions - Streaming" << std::endl;
 
@@ -5734,12 +5722,10 @@ void Server::handle_responses(const httplib::Request& req, httplib::Response& re
         // Check if streaming is requested
         bool is_streaming = request_json.contains("stream") && request_json["stream"].get<bool>();
 
-        // Re-serialize so any collection.router model rewrite reaches the backend
-        // (streaming forwards this body verbatim).
-        std::string request_body = request_json.dump();
-
         if (is_streaming) {
             try {
+                // Re-serialize so any collection.router model rewrite reaches the backend.
+                std::string request_body = request_json.dump();
                 LOG(INFO, "Server") << "POST /api/v1/responses - Streaming" << std::endl;
 
                 set_route_decision_sse_content_provider(

--- a/src/cpp/server/telemetry.cpp
+++ b/src/cpp/server/telemetry.cpp
@@ -449,7 +449,10 @@ private:
     }
 };
 
-static MetricsWorker g_metrics_worker;
+static MetricsWorker& get_metrics_worker() {
+    static MetricsWorker worker;
+    return worker;
+}
 
 class TelemetryQueue {
 private:
@@ -792,13 +795,17 @@ static TelemetryQueue& get_queue() {
     return queue;
 }
 
+void initialize() {
+    (void)get_metrics_worker();
+}
+
 void shutdown() {
-    g_metrics_worker.stop();
+    get_metrics_worker().stop();
     get_queue().shutdown();
 }
 
 void flush() {
-    g_metrics_worker.drain();
+    get_metrics_worker().drain();
     get_queue().flush();
 }
 
@@ -1399,7 +1406,7 @@ void end_llm_span_async(
         return;
     }
 
-    if (!g_metrics_worker.enqueue(span, metrics_url, parser, usage_payload, text_output, tool_calls)) {
+    if (!get_metrics_worker().enqueue(span, metrics_url, parser, usage_payload, text_output, tool_calls)) {
         LOG(WARNING, "Telemetry") << "MetricsWorker queue full. Dropping optional metrics and completing span immediately." << std::endl;
         span->end_with_success(usage_payload, text_output, tool_calls);
     }

--- a/src/cpp/server/telemetry.h
+++ b/src/cpp/server/telemetry.h
@@ -15,6 +15,9 @@ struct ToolCall {
     std::string function_arguments;
 };
 
+// Start the metrics worker explicitly after process-wide startup configuration.
+void initialize();
+
 class InferenceSpan {
 public:
     InferenceSpan(const std::string& span_kind, const std::string& name, const std::string& model_name, const nlohmann::json& request_json);

--- a/test/cpp/glibc_mallopt_probe.cpp
+++ b/test/cpp/glibc_mallopt_probe.cpp
@@ -5,27 +5,75 @@
 #include <malloc.h>
 #include <unistd.h>
 
-extern "C" int mallopt(int param, int value) noexcept {
-    if (param == M_MMAP_THRESHOLD) {
-        const char* path = std::getenv("LEMONADE_MALLOPT_PROBE_PATH");
-        if (path != nullptr) {
-            const int fd = open(path, O_CREAT | O_WRONLY | O_APPEND, 0600);
-            if (fd >= 0) {
-                constexpr char expected[] = "1048576\n";
-                constexpr char unexpected[] = "unexpected\n";
-                if (value == 1024 * 1024) {
-                    const ssize_t written =
-                        write(fd, expected, sizeof(expected) - 1);
-                    (void)written;
-                } else {
-                    const ssize_t written =
-                        write(fd, unexpected, sizeof(unexpected) - 1);
-                    (void)written;
-                }
-                close(fd);
-            }
-        }
+namespace {
+
+bool process_has_exactly_one_thread() noexcept {
+  const int fd = open("/proc/self/status", O_RDONLY | O_CLOEXEC);
+  if (fd < 0) {
+    return false;
+  }
+
+  char status[4096];
+  const ssize_t length = read(fd, status, sizeof(status));
+  close(fd);
+  if (length <= 0) {
+    return false;
+  }
+
+  constexpr char field[] = "Threads:";
+  for (ssize_t offset = 0;
+       offset + static_cast<ssize_t>(sizeof(field) - 1) < length; ++offset) {
+    if (offset != 0 && status[offset - 1] != '\n') {
+      continue;
     }
-    return 1;
+
+    bool matches = true;
+    for (size_t index = 0; index < sizeof(field) - 1; ++index) {
+      if (status[offset + static_cast<ssize_t>(index)] != field[index]) {
+        matches = false;
+        break;
+      }
+    }
+    if (!matches) {
+      continue;
+    }
+
+    ssize_t value = offset + static_cast<ssize_t>(sizeof(field) - 1);
+    while (value < length && (status[value] == ' ' || status[value] == '\t')) {
+      ++value;
+    }
+    return value < length && status[value] == '1' && value + 1 < length &&
+           status[value + 1] == '\n';
+  }
+  return false;
+}
+
+} // namespace
+
+extern "C" int mallopt(int param, int value) noexcept {
+  if (param == M_MMAP_THRESHOLD) {
+    const char *path = std::getenv("LEMONADE_MALLOPT_PROBE_PATH");
+    if (path != nullptr) {
+      const int fd = open(path, O_CREAT | O_WRONLY | O_APPEND, 0600);
+      if (fd >= 0) {
+        constexpr char expected[] = "1048576 threads=1\n";
+        constexpr char threaded[] = "1048576 threads!=1\n";
+        constexpr char unexpected[] = "unexpected\n";
+        if (value == 1024 * 1024) {
+          const bool single_threaded = process_has_exactly_one_thread();
+          const char *message = single_threaded ? expected : threaded;
+          const size_t message_size =
+              single_threaded ? sizeof(expected) - 1 : sizeof(threaded) - 1;
+          const ssize_t written = write(fd, message, message_size);
+          (void)written;
+        } else {
+          const ssize_t written = write(fd, unexpected, sizeof(unexpected) - 1);
+          (void)written;
+        }
+        close(fd);
+      }
+    }
+  }
+  return 1;
 }
 #endif

--- a/test/cpp/glibc_mallopt_probe.cpp
+++ b/test/cpp/glibc_mallopt_probe.cpp
@@ -1,0 +1,31 @@
+#include <cstdlib>
+
+#if defined(__GLIBC__)
+#include <fcntl.h>
+#include <malloc.h>
+#include <unistd.h>
+
+extern "C" int mallopt(int param, int value) noexcept {
+    if (param == M_MMAP_THRESHOLD) {
+        const char* path = std::getenv("LEMONADE_MALLOPT_PROBE_PATH");
+        if (path != nullptr) {
+            const int fd = open(path, O_CREAT | O_WRONLY | O_APPEND, 0600);
+            if (fd >= 0) {
+                constexpr char expected[] = "1048576\n";
+                constexpr char unexpected[] = "unexpected\n";
+                if (value == 1024 * 1024) {
+                    const ssize_t written =
+                        write(fd, expected, sizeof(expected) - 1);
+                    (void)written;
+                } else {
+                    const ssize_t written =
+                        write(fd, unexpected, sizeof(unexpected) - 1);
+                    (void)written;
+                }
+                close(fd);
+            }
+        }
+    }
+    return 1;
+}
+#endif

--- a/test/test_benchmark_large_request_memory.py
+++ b/test/test_benchmark_large_request_memory.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unit tests for the large-request memory benchmark client."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "benchmark_large_request_memory.py"
+)
+MODULE_SPEC = importlib.util.spec_from_file_location(
+    "benchmark_large_request_memory", MODULE_PATH
+)
+if MODULE_SPEC is None or MODULE_SPEC.loader is None:
+    raise RuntimeError(f"could not load benchmark module from {MODULE_PATH}")
+benchmark = importlib.util.module_from_spec(MODULE_SPEC)
+sys.modules[MODULE_SPEC.name] = benchmark
+MODULE_SPEC.loader.exec_module(benchmark)
+
+
+class FakeResponse:
+    def read(self) -> bytes:
+        return b"{}"
+
+
+class RecordingConnection:
+    requests: list[tuple[str, str, bytes | None, dict[str, str]]] = []
+
+    def __init__(self, host: str, port: int, timeout: float):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None,
+        headers: dict[str, str],
+    ) -> None:
+        self.requests.append((method, path, body, headers.copy()))
+
+    def getresponse(self) -> FakeResponse:
+        response = FakeResponse()
+        response.status = 200
+        return response
+
+    def close(self) -> None:
+        pass
+
+
+class BenchmarkAuthenticationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        RecordingConnection.requests.clear()
+
+    def request_headers(self, body: bytes | None = None) -> dict[str, str]:
+        with mock.patch.object(
+            benchmark.http.client, "HTTPConnection", RecordingConnection
+        ):
+            benchmark.request_json(
+                "http://127.0.0.1:8000", "POST", "/api/v1/test", body=body
+            )
+        return RecordingConnection.requests[-1][3]
+
+    def test_request_without_credentials_has_no_authorization_header(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            headers = self.request_headers(body=b"{}")
+
+        self.assertEqual(headers, {"Content-Type": "application/json"})
+
+    def test_regular_api_key_is_forwarded(self) -> None:
+        with mock.patch.dict(
+            os.environ, {"LEMONADE_API_KEY": "regular-secret"}, clear=True
+        ):
+            headers = self.request_headers()
+
+        self.assertEqual(headers["Authorization"], "Bearer regular-secret")
+
+    def test_admin_api_key_takes_precedence(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {
+                "LEMONADE_API_KEY": "regular-secret",
+                "LEMONADE_ADMIN_API_KEY": "admin-secret",
+            },
+            clear=True,
+        ):
+            headers = self.request_headers(body=b"{}")
+
+        self.assertEqual(headers["Authorization"], "Bearer admin-secret")
+        self.assertEqual(headers["Content-Type"], "application/json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_glibc_allocator_policy.py
+++ b/test/test_glibc_allocator_policy.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Exercise lemond's glibc allocator override policy through mallopt interposition."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import platform
+import subprocess
+import tempfile
+
+
+def run_case(
+    lemond: Path,
+    probe: Path,
+    name: str,
+    overrides: dict[str, str],
+    expect_mallopt: bool,
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="lemond-mallopt-test-") as directory:
+        log_path = Path(directory) / "mallopt.log"
+        environment = os.environ.copy()
+        environment.pop("MALLOC_MMAP_THRESHOLD_", None)
+        environment.pop("GLIBC_TUNABLES", None)
+        environment.update(overrides)
+        environment["LEMONADE_MALLOPT_PROBE_PATH"] = str(log_path)
+        existing_preload = environment.get("LD_PRELOAD")
+        environment["LD_PRELOAD"] = (
+            f"{probe}{os.pathsep}{existing_preload}" if existing_preload else str(probe)
+        )
+
+        result = subprocess.run(
+            [str(lemond), "--version"],
+            check=False,
+            capture_output=True,
+            env=environment,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"{name}: lemond --version returned {result.returncode}\n"
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            )
+
+        calls = (
+            log_path.read_text(encoding="utf-8").splitlines()
+            if log_path.exists()
+            else []
+        )
+        observed = "1048576" in calls
+        if observed != expect_mallopt:
+            expectation = (
+                "a 1 MiB mallopt call" if expect_mallopt else "no mallopt call"
+            )
+            raise RuntimeError(f"{name}: expected {expectation}, observed {calls}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lemond", type=Path, required=True)
+    parser.add_argument("--probe", type=Path, required=True)
+    args = parser.parse_args()
+
+    if platform.libc_ver()[0] != "glibc":
+        print("SKIP: glibc allocator policy is not compiled on this platform")
+        return 77
+
+    cases = (
+        ("default", {}, True),
+        ("legacy override", {"MALLOC_MMAP_THRESHOLD_": "2097152"}, False),
+        ("empty legacy override", {"MALLOC_MMAP_THRESHOLD_": ""}, False),
+        (
+            "exact tunable",
+            {"GLIBC_TUNABLES": "glibc.malloc.mmap_threshold=2097152"},
+            False,
+        ),
+        (
+            "tunable among entries",
+            {
+                "GLIBC_TUNABLES": (
+                    "glibc.malloc.trim_threshold=131072:"
+                    "glibc.malloc.mmap_threshold=2097152:glibc.malloc.arena_max=4"
+                )
+            },
+            False,
+        ),
+        (
+            "empty tunable value",
+            {"GLIBC_TUNABLES": "glibc.malloc.mmap_threshold="},
+            False,
+        ),
+        (
+            "unrelated tunable",
+            {"GLIBC_TUNABLES": "glibc.malloc.trim_threshold=131072"},
+            True,
+        ),
+        (
+            "prefixed name",
+            {"GLIBC_TUNABLES": "xglibc.malloc.mmap_threshold=2097152"},
+            True,
+        ),
+        (
+            "suffixed name",
+            {"GLIBC_TUNABLES": "glibc.malloc.mmap_threshold_extra=2097152"},
+            True,
+        ),
+        (
+            "missing assignment",
+            {"GLIBC_TUNABLES": "glibc.malloc.mmap_threshold"},
+            True,
+        ),
+    )
+
+    for name, overrides, expect_mallopt in cases:
+        run_case(args.lemond, args.probe, name, overrides, expect_mallopt)
+        print(f"PASS: {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_glibc_allocator_policy.py
+++ b/test/test_glibc_allocator_policy.py
@@ -49,10 +49,13 @@ def run_case(
             if log_path.exists()
             else []
         )
-        observed = "1048576" in calls
-        if observed != expect_mallopt:
+        expected_call = "1048576 threads=1"
+        expected_calls = [expected_call] if expect_mallopt else []
+        if calls != expected_calls:
             expectation = (
-                "a 1 MiB mallopt call" if expect_mallopt else "no mallopt call"
+                "a single-threaded 1 MiB mallopt call"
+                if expect_mallopt
+                else "no mallopt call"
             )
             raise RuntimeError(f"{name}: expected {expectation}, observed {calls}")
 

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -464,26 +464,6 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
     )
     def test_006a_thinking_false_maps_to_no_think_for_non_streaming_chat(self):
         """Verify non-streaming chat preserves thinking-control normalization."""
-        self._write_llama_server(MOCK_LLAMA_SERVER_PYTHON)
-        self._add_dummy_llama_server_to_path()
-
-        capture_path = os.path.join(
-            self.temp_bin_dir, "captured_chat_request_non_streaming.json"
-        )
-        os.environ["MOCK_LLAMA_REQUEST_PATH"] = capture_path
-        self.addCleanup(os.environ.pop, "MOCK_LLAMA_REQUEST_PATH", None)
-
-        _stop_server()
-        _start_server(wrapped_server="llamacpp", backend="system")
-        self._ensure_model_pulled()
-
-        load_response = requests.post(
-            f"http://localhost:{PORT}/api/v1/load",
-            json={"model_name": ENDPOINT_TEST_MODEL, "llamacpp_backend": "system"},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        self.assertEqual(load_response.status_code, 200)
-
         response = requests.post(
             f"http://localhost:{PORT}/api/v1/chat/completions",
             json={
@@ -497,7 +477,7 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-        with open(capture_path, "r", encoding="utf-8") as handle:
+        with open(self.capture_path, "r", encoding="utf-8") as handle:
             forwarded_request = json.load(handle)
 
         self.assertEqual(

--- a/test/test_llamacpp_system_backend.py
+++ b/test/test_llamacpp_system_backend.py
@@ -462,6 +462,54 @@ class LlamaCppSystemBackendTests(unittest.TestCase):
     @unittest.skipUnless(
         sys.platform.startswith("linux"), "System backend only supported on Linux"
     )
+    def test_006a_thinking_false_maps_to_no_think_for_non_streaming_chat(self):
+        """Verify non-streaming chat preserves thinking-control normalization."""
+        self._write_llama_server(MOCK_LLAMA_SERVER_PYTHON)
+        self._add_dummy_llama_server_to_path()
+
+        capture_path = os.path.join(
+            self.temp_bin_dir, "captured_chat_request_non_streaming.json"
+        )
+        os.environ["MOCK_LLAMA_REQUEST_PATH"] = capture_path
+        self.addCleanup(os.environ.pop, "MOCK_LLAMA_REQUEST_PATH", None)
+
+        _stop_server()
+        _start_server(wrapped_server="llamacpp", backend="system")
+        self._ensure_model_pulled()
+
+        load_response = requests.post(
+            f"http://localhost:{PORT}/api/v1/load",
+            json={"model_name": ENDPOINT_TEST_MODEL, "llamacpp_backend": "system"},
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(load_response.status_code, 200)
+
+        response = requests.post(
+            f"http://localhost:{PORT}/api/v1/chat/completions",
+            json={
+                "model": ENDPOINT_TEST_MODEL,
+                "messages": [{"role": "user", "content": "Say hello."}],
+                "stream": False,
+                "thinking": False,
+                "max_tokens": 8,
+            },
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        with open(capture_path, "r", encoding="utf-8") as handle:
+            forwarded_request = json.load(handle)
+
+        self.assertEqual(
+            forwarded_request["messages"][-1]["content"],
+            "/no_think\nSay hello.",
+        )
+        self.assertNotIn("thinking", forwarded_request)
+        self.assertNotIn("enable_thinking", forwarded_request)
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"), "System backend only supported on Linux"
+    )
     def test_007_enable_thinking_takes_precedence_over_thinking_false(self):
         """Verify enable_thinking:true takes precedence over thinking:false."""
         response = requests.post(

--- a/tools/benchmark_large_request_memory.py
+++ b/tools/benchmark_large_request_memory.py
@@ -20,7 +20,6 @@ import time
 from typing import Any
 from urllib.parse import urlparse
 
-
 EXPECTED_VARIANTS = {
     "baseline",
     "serialization-only",
@@ -156,6 +155,13 @@ def free_port() -> int:
         return int(sock.getsockname()[1])
 
 
+def lemonade_api_key() -> str | None:
+    """Return the credential accepted by both regular and internal routes."""
+    return os.environ.get("LEMONADE_ADMIN_API_KEY") or os.environ.get(
+        "LEMONADE_API_KEY"
+    )
+
+
 def request_json(
     base_url: str,
     method: str,
@@ -172,6 +178,9 @@ def request_json(
     connection = connection_class(parsed.hostname, parsed.port, timeout=timeout)
     try:
         headers = {"Content-Type": "application/json"} if body is not None else {}
+        api_key = lemonade_api_key()
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         connection.request(method, f"{parsed.path.rstrip('/')}{path}", body, headers)
         response = connection.getresponse()
         payload = response.read()

--- a/tools/benchmark_large_request_memory.py
+++ b/tools/benchmark_large_request_memory.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+"""Reproduce and attribute lemond large-request memory retention on Linux."""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+import hashlib
+import http.client
+import json
+import os
+from pathlib import Path
+import platform
+import socket
+import statistics
+import subprocess
+import tempfile
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+
+EXPECTED_VARIANTS = {
+    "baseline",
+    "serialization-only",
+    "allocator-only",
+    "combined",
+}
+
+
+@dataclass(frozen=True)
+class Variant:
+    name: str
+    binary: Path
+
+
+@dataclass(frozen=True)
+class Target:
+    name: str
+    base_url: str
+    pid: int
+
+
+def parse_assignment(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise argparse.ArgumentTypeError("expected NAME=VALUE")
+    name, assigned = value.split("=", 1)
+    if not name or not assigned:
+        raise argparse.ArgumentTypeError("expected non-empty NAME=VALUE")
+    return name, assigned
+
+
+def parse_source_commit(value: str) -> tuple[str, str]:
+    name, commit = parse_assignment(value)
+    if len(commit) != 40 or any(
+        character not in "0123456789abcdefABCDEF" for character in commit
+    ):
+        raise argparse.ArgumentTypeError(
+            "source commit must be a full 40-character SHA"
+        )
+    return name, commit.lower()
+
+
+def source_commits_by_name(
+    assignments: list[tuple[str, str]], expected_names: set[str]
+) -> dict[str, str]:
+    names = [name for name, _commit in assignments]
+    if len(set(names)) != len(names):
+        raise RuntimeError("source commit names must be unique")
+    actual_names = set(names)
+    if actual_names != expected_names:
+        missing = sorted(expected_names - actual_names)
+        extra = sorted(actual_names - expected_names)
+        raise RuntimeError(
+            f"source commits must match measured names; missing={missing}, extra={extra}"
+        )
+    return dict(assignments)
+
+
+def parse_variant(value: str) -> Variant:
+    name, binary = parse_assignment(value)
+    path = Path(binary).expanduser().resolve()
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise argparse.ArgumentTypeError(f"not an executable file: {path}")
+    return Variant(name, path)
+
+
+def parse_target(value: str) -> Target:
+    name, target = parse_assignment(value)
+    if "," not in target:
+        raise argparse.ArgumentTypeError("expected NAME=URL,PID")
+    url, pid_text = target.rsplit(",", 1)
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise argparse.ArgumentTypeError(f"invalid target URL: {url}")
+    try:
+        pid = int(pid_text)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(f"invalid PID: {pid_text}") from error
+    if pid <= 0:
+        raise argparse.ArgumentTypeError("PID must be positive")
+    return Target(name, url.rstrip("/"), pid)
+
+
+def command_first_line(command: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return "unavailable"
+    output = result.stdout.strip() or result.stderr.strip()
+    return output.splitlines()[0] if output else "unavailable"
+
+
+def environment_manifest() -> dict[str, Any]:
+    return {
+        "timestamp_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "hostname": platform.node(),
+        "platform": platform.platform(),
+        "kernel": platform.release(),
+        "machine": platform.machine(),
+        "libc": " ".join(part for part in platform.libc_ver() if part),
+        "python": platform.python_version(),
+        "compiler": command_first_line(["c++", "--version"]),
+    }
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def process_memory_kib(pid: int) -> dict[str, int]:
+    values: dict[str, int] = {}
+    for line in Path(f"/proc/{pid}/status").read_text().splitlines():
+        if line.startswith(("VmRSS:", "VmData:")):
+            key, value, _unit = line.split()
+            values[key.rstrip(":")] = int(value)
+    if set(values) != {"VmRSS", "VmData"}:
+        raise RuntimeError(f"could not read memory status for PID {pid}")
+    return {"rss_kib": values["VmRSS"], "data_kib": values["VmData"]}
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def request_json(
+    base_url: str,
+    method: str,
+    path: str,
+    body: bytes | None = None,
+    timeout: float = 30,
+) -> tuple[int, bytes]:
+    parsed = urlparse(base_url)
+    connection_class = (
+        http.client.HTTPSConnection
+        if parsed.scheme == "https"
+        else http.client.HTTPConnection
+    )
+    connection = connection_class(parsed.hostname, parsed.port, timeout=timeout)
+    try:
+        headers = {"Content-Type": "application/json"} if body is not None else {}
+        connection.request(method, f"{parsed.path.rstrip('/')}{path}", body, headers)
+        response = connection.getresponse()
+        payload = response.read()
+        return response.status, payload
+    finally:
+        connection.close()
+
+
+def wait_until_live(
+    base_url: str, process: subprocess.Popen[Any], timeout: int
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"lemond exited with status {process.returncode}")
+        try:
+            status, _body = request_json(base_url, "GET", "/live", timeout=2)
+            if status == 200:
+                return
+        except OSError:
+            pass
+        time.sleep(0.2)
+    raise RuntimeError(f"lemond did not become live within {timeout} seconds")
+
+
+def send_many(
+    base_url: str,
+    endpoint: str,
+    body: bytes,
+    count: int,
+    concurrency: int,
+    timeout: float,
+) -> float:
+    def send_one(_request_number: int) -> None:
+        status, response = request_json(
+            base_url, "POST", endpoint, body=body, timeout=timeout
+        )
+        if status != 200:
+            excerpt = response[:500].decode("utf-8", errors="replace")
+            raise RuntimeError(f"{endpoint} returned HTTP {status}: {excerpt}")
+
+    start = time.monotonic()
+    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+        list(executor.map(send_one, range(count)))
+    return time.monotonic() - start
+
+
+def summarize_numbers(rows: list[dict[str, Any]], field: str) -> dict[str, float]:
+    values = [float(row[field]) for row in rows]
+    return {
+        "median": statistics.median(values),
+        "min": min(values),
+        "max": max(values),
+    }
+
+
+def stop_server(process: subprocess.Popen[Any], base_url: str) -> None:
+    try:
+        request_json(base_url, "POST", "/internal/shutdown", body=b"{}", timeout=5)
+    except OSError:
+        pass
+    try:
+        process.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+
+
+def run_stress(args: argparse.Namespace) -> dict[str, Any]:
+    if platform.system() != "Linux":
+        raise RuntimeError("stress mode requires Linux /proc process metrics")
+
+    variants = args.variant
+    names = {variant.name for variant in variants}
+    if len(names) != len(variants):
+        raise RuntimeError("variant names must be unique")
+    if names != EXPECTED_VARIANTS:
+        missing = sorted(EXPECTED_VARIANTS - names)
+        extra = sorted(names - EXPECTED_VARIANTS)
+        raise RuntimeError(
+            f"expected the four attribution variants; missing={missing}, extra={extra}"
+        )
+    source_commits = source_commits_by_name(args.source_commit, names)
+
+    prompt = "x" * (args.body_mib * 1024 * 1024)
+    body = json.dumps(
+        {"model": "mock", "prompt": prompt, "stream": False},
+        separators=(",", ":"),
+    ).encode()
+    runs: list[dict[str, Any]] = []
+    binaries = {
+        variant.name: {
+            "path": str(variant.binary),
+            "sha256": sha256(variant.binary),
+            "version": command_first_line([str(variant.binary), "--version"]),
+        }
+        for variant in variants
+    }
+
+    for repetition in range(1, args.repetitions + 1):
+        for variant in variants:
+            port = free_port()
+            base_url = f"http://127.0.0.1:{port}"
+            with tempfile.TemporaryDirectory(
+                prefix=f"lemond-memory-{variant.name}-"
+            ) as cache_dir:
+                log_path = Path(cache_dir) / "lemond.log"
+                with log_path.open("w", encoding="utf-8") as log:
+                    process = subprocess.Popen(
+                        [
+                            str(variant.binary),
+                            cache_dir,
+                            "--host",
+                            "127.0.0.1",
+                            "--port",
+                            str(port),
+                        ],
+                        stdout=log,
+                        stderr=subprocess.STDOUT,
+                    )
+                try:
+                    try:
+                        wait_until_live(base_url, process, args.startup_timeout)
+                    except Exception as error:
+                        log_text = log_path.read_text(
+                            encoding="utf-8", errors="replace"
+                        )
+                        raise RuntimeError(
+                            f"{error}\nlemond log:\n{log_text[-4000:]}"
+                        ) from error
+
+                    if args.warmup_requests:
+                        send_many(
+                            base_url,
+                            args.endpoint,
+                            body,
+                            args.warmup_requests,
+                            args.concurrency,
+                            args.request_timeout,
+                        )
+                    before = process_memory_kib(process.pid)
+                    elapsed = send_many(
+                        base_url,
+                        args.endpoint,
+                        body,
+                        args.requests,
+                        args.concurrency,
+                        args.request_timeout,
+                    )
+                    time.sleep(args.settle_seconds)
+                    after = process_memory_kib(process.pid)
+                    runs.append(
+                        {
+                            "variant": variant.name,
+                            "repetition": repetition,
+                            "pid": process.pid,
+                            "elapsed_s": elapsed,
+                            "requests_per_s": args.requests / elapsed,
+                            "rss_before_kib": before["rss_kib"],
+                            "rss_after_kib": after["rss_kib"],
+                            "rss_delta_kib": after["rss_kib"] - before["rss_kib"],
+                            "data_before_kib": before["data_kib"],
+                            "data_after_kib": after["data_kib"],
+                            "data_delta_kib": after["data_kib"] - before["data_kib"],
+                        }
+                    )
+                finally:
+                    stop_server(process, base_url)
+
+    summary: dict[str, Any] = {}
+    for variant in variants:
+        selected = [row for row in runs if row["variant"] == variant.name]
+        summary[variant.name] = {
+            field: summarize_numbers(selected, field)
+            for field in (
+                "rss_delta_kib",
+                "data_delta_kib",
+                "elapsed_s",
+                "requests_per_s",
+            )
+        }
+
+    return {
+        "mode": "stress",
+        "environment": environment_manifest(),
+        "configuration": {
+            "endpoint": args.endpoint,
+            "body_mib": args.body_mib,
+            "body_bytes": len(body),
+            "requests": args.requests,
+            "concurrency": args.concurrency,
+            "warmup_requests": args.warmup_requests,
+            "repetitions": args.repetitions,
+            "settle_seconds": args.settle_seconds,
+            "connection_policy": "one fresh TCP connection per request",
+            "sampling": "VmRSS and VmData from /proc/PID/status before the measured batch and after the settle delay",
+        },
+        "source_commits": source_commits,
+        "binaries": binaries,
+        "runs": runs,
+        "summary": summary,
+    }
+
+
+def get_timing(response: dict[str, Any], field: str) -> float | None:
+    timings = response.get("timings")
+    if isinstance(timings, dict) and isinstance(timings.get(field), (int, float)):
+        return float(timings[field])
+    return None
+
+
+def run_real_backend(args: argparse.Namespace) -> dict[str, Any]:
+    if platform.system() != "Linux":
+        raise RuntimeError("real-backend mode requires Linux /proc process metrics")
+
+    target_names = [target.name for target in args.target]
+    if len(set(target_names)) != len(target_names):
+        raise RuntimeError("target names must be unique")
+    source_commits = source_commits_by_name(args.source_commit, set(target_names))
+    binaries: dict[str, dict[str, str]] = {}
+    for target in args.target:
+        binary = Path(f"/proc/{target.pid}/exe").resolve(strict=True)
+        binaries[target.name] = {
+            "path": str(binary),
+            "sha256": sha256(binary),
+            "version": command_first_line([str(binary), "--version"]),
+        }
+
+    prompt = args.prompt_file.read_text(encoding="utf-8")
+    request = {
+        "model": args.model,
+        "prompt": prompt,
+        "max_tokens": args.max_tokens,
+        "temperature": 0,
+        "stream": False,
+        "cache_prompt": args.cache_prompt,
+    }
+    body = json.dumps(request, separators=(",", ":")).encode()
+    warmup_body = json.dumps(
+        {
+            "model": args.model,
+            "prompt": "warmup",
+            "max_tokens": 1,
+            "temperature": 0,
+            "stream": False,
+            "cache_prompt": False,
+        },
+        separators=(",", ":"),
+    ).encode()
+    runs: list[dict[str, Any]] = []
+    warmed_targets: set[str] = set()
+
+    for repetition in range(1, args.repetitions + 1):
+        targets = args.target if repetition % 2 else list(reversed(args.target))
+        for target in targets:
+            health_status, health_body = request_json(
+                target.base_url, "GET", "/api/v1/health", timeout=10
+            )
+            if health_status != 200:
+                raise RuntimeError(
+                    f"{target.name} health returned HTTP {health_status}: "
+                    f"{health_body[:500].decode('utf-8', errors='replace')}"
+                )
+            if target.name not in warmed_targets:
+                for _warmup in range(args.warmup_requests):
+                    warmup_status, warmup_response = request_json(
+                        target.base_url,
+                        "POST",
+                        args.endpoint,
+                        body=warmup_body,
+                        timeout=args.request_timeout,
+                    )
+                    if warmup_status != 200:
+                        excerpt = warmup_response[:1000].decode(
+                            "utf-8", errors="replace"
+                        )
+                        raise RuntimeError(
+                            f"{target.name} warm-up returned HTTP "
+                            f"{warmup_status}: {excerpt}"
+                        )
+                warmed_targets.add(target.name)
+            before = process_memory_kib(target.pid)
+            start = time.monotonic()
+            status, response_body = request_json(
+                target.base_url,
+                "POST",
+                args.endpoint,
+                body=body,
+                timeout=args.request_timeout,
+            )
+            elapsed = time.monotonic() - start
+            if status != 200:
+                excerpt = response_body[:1000].decode("utf-8", errors="replace")
+                raise RuntimeError(f"{target.name} returned HTTP {status}: {excerpt}")
+            response = json.loads(response_body)
+            time.sleep(args.settle_seconds)
+            after = process_memory_kib(target.pid)
+            timings = response.get("timings", {})
+            runs.append(
+                {
+                    "target": target.name,
+                    "repetition": repetition,
+                    "wall_s": elapsed,
+                    "rss_delta_kib": after["rss_kib"] - before["rss_kib"],
+                    "data_delta_kib": after["data_kib"] - before["data_kib"],
+                    "prompt_tokens": timings.get("prompt_n"),
+                    "generated_tokens": timings.get("predicted_n"),
+                    "prompt_tokens_per_s": get_timing(response, "prompt_per_second"),
+                    "generation_tokens_per_s": get_timing(
+                        response, "predicted_per_second"
+                    ),
+                }
+            )
+
+    summary: dict[str, Any] = {}
+    numeric_fields = (
+        "wall_s",
+        "rss_delta_kib",
+        "data_delta_kib",
+        "prompt_tokens_per_s",
+        "generation_tokens_per_s",
+    )
+    for target in args.target:
+        selected = [row for row in runs if row["target"] == target.name]
+        summary[target.name] = {
+            field: summarize_numbers(
+                [row for row in selected if row[field] is not None], field
+            )
+            for field in numeric_fields
+            if any(row[field] is not None for row in selected)
+        }
+
+    return {
+        "mode": "real-backend",
+        "environment": environment_manifest(),
+        "configuration": {
+            "targets": [asdict(target) for target in args.target],
+            "target_order": "listed order on odd repetitions, reversed on even repetitions",
+            "endpoint": args.endpoint,
+            "model": args.model,
+            "prompt_file": str(args.prompt_file),
+            "prompt_characters": len(prompt),
+            "body_bytes": len(body),
+            "max_tokens": args.max_tokens,
+            "cache_prompt": args.cache_prompt,
+            "warmup_requests": args.warmup_requests,
+            "warmup_prompt": "warmup",
+            "warmup_max_tokens": 1,
+            "repetitions": args.repetitions,
+            "settle_seconds": args.settle_seconds,
+        },
+        "source_commits": source_commits,
+        "binaries": binaries,
+        "runs": runs,
+        "summary": summary,
+    }
+
+
+def add_common_output(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--output", type=Path, help="write the complete JSON result")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+
+    stress = subparsers.add_parser(
+        "stress", help="run four fresh-binary allocator attribution variants"
+    )
+    stress.add_argument(
+        "--variant",
+        action="append",
+        type=parse_variant,
+        required=True,
+        metavar="NAME=BINARY",
+        help="repeat for baseline, serialization-only, allocator-only, and combined",
+    )
+    stress.add_argument(
+        "--source-commit",
+        action="append",
+        type=parse_source_commit,
+        required=True,
+        metavar="NAME=FULL_SHA",
+        help="repeat for each measured variant",
+    )
+    stress.add_argument("--endpoint", default="/api/v1/test")
+    stress.add_argument("--body-mib", type=int, default=3)
+    stress.add_argument("--requests", type=int, default=170)
+    stress.add_argument("--concurrency", type=int, default=1)
+    stress.add_argument("--warmup-requests", type=int, default=0)
+    stress.add_argument("--repetitions", type=int, default=3)
+    stress.add_argument("--settle-seconds", type=float, default=1.0)
+    stress.add_argument("--startup-timeout", type=int, default=30)
+    stress.add_argument("--request-timeout", type=float, default=30)
+    add_common_output(stress)
+
+    real = subparsers.add_parser(
+        "real-backend", help="measure one or more already-running inference targets"
+    )
+    real.add_argument(
+        "--target",
+        action="append",
+        type=parse_target,
+        required=True,
+        metavar="NAME=URL,PID",
+    )
+    real.add_argument(
+        "--source-commit",
+        action="append",
+        type=parse_source_commit,
+        required=True,
+        metavar="NAME=FULL_SHA",
+        help="repeat for each measured target",
+    )
+    real.add_argument("--model", required=True)
+    real.add_argument("--prompt-file", type=Path, required=True)
+    real.add_argument("--endpoint", default="/api/v1/completions")
+    real.add_argument("--max-tokens", type=int, default=128)
+    real.add_argument("--cache-prompt", action="store_true")
+    real.add_argument("--warmup-requests", type=int, default=1)
+    real.add_argument("--repetitions", type=int, default=3)
+    real.add_argument("--settle-seconds", type=float, default=1.0)
+    real.add_argument("--request-timeout", type=float, default=7200)
+    add_common_output(real)
+    return parser
+
+
+def validate_positive(args: argparse.Namespace) -> None:
+    for name in ("repetitions", "settle_seconds", "request_timeout"):
+        if getattr(args, name) <= 0:
+            raise RuntimeError(f"--{name.replace('_', '-')} must be positive")
+    if args.mode == "stress":
+        for name in ("body_mib", "requests", "concurrency", "startup_timeout"):
+            if getattr(args, name) <= 0:
+                raise RuntimeError(f"--{name.replace('_', '-')} must be positive")
+        if args.warmup_requests < 0:
+            raise RuntimeError("--warmup-requests cannot be negative")
+    else:
+        if args.max_tokens <= 0:
+            raise RuntimeError("--max-tokens must be positive")
+        if args.warmup_requests < 0:
+            raise RuntimeError("--warmup-requests cannot be negative")
+        if not args.prompt_file.is_file():
+            raise RuntimeError(f"prompt file not found: {args.prompt_file}")
+
+
+def print_summary(result: dict[str, Any]) -> None:
+    print(json.dumps(result["summary"], indent=2, sort_keys=True))
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        validate_positive(args)
+        result = run_stress(args) if args.mode == "stress" else run_real_backend(args)
+    except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    print_summary(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes `lemond` high-water RSS after repeated multi-megabyte requests by avoiding an eager JSON copy on non-streaming inference paths and applying a 1 MiB glibc mmap threshold before worker-thread creation. The allocator tuning is best-effort, preserves both legacy and `GLIBC_TUNABLES` operator overrides, and is excluded from non-glibc builds.

On the current 11.7.0 `main`, the combined implementation reduced median retained RSS by **97.57%** in the sequential reproducer. Long-prompt generation throughput was **+0.26% on ROCm** (4,096 generated tokens) and **-0.54% on Vulkan** (1,024 generated tokens); retained server RSS fell by about 79% on both real backends.

- [Methodology and trade-offs](https://github.com/soothill/lemonade/blob/agent/release-large-request-memory/docs/dev/large-request-memory-benchmark.md)
- [Refreshed benchmark evidence and validation](https://github.com/lemonade-sdk/lemonade/pull/2873#issuecomment-5160890780)
- [Complete reviewer-safe result JSON](https://gist.github.com/soothill/4d398c25ee3e16c8b538d39011a51fc2)
- [Exact allocator-only benchmark source](https://github.com/soothill/lemonade/commit/308cc2f1bb382d7445393555d2b2cfb5cd64befa)
