### PR TITLE
fix(server): keep interrupted variantless model downloads resumable

### DIFF
--- a/src/cpp/server/backends/backend_ops.cpp
+++ b/src/cpp/server/backends/backend_ops.cpp
@@ -97,7 +97,17 @@ std::string BackendOps::resolve_checkpoint_path(const ModelInfo& info,
         return "";
     }
 
-    // No variant: return the cache directory.
+    fs::path active_snapshot = hf_cache::active_snapshot_path(model_cache_path_fs);
+    if (!active_snapshot.empty()) {
+        return path_to_utf8(active_snapshot);
+    }
+
+    // A snapshots directory without a usable refs/main is an interrupted or
+    // otherwise uncommitted pull. Do not expose the cache root as a downloaded
+    // model; a later pull can resume the preserved .partial files.
+    if (hf_cache::exists(model_cache_path_fs / "snapshots")) {
+        return "";
+    }
     return ctx.model_cache_path;
 }
 

--- a/src/cpp/server/backends/llamacpp/llamacpp_gguf.cpp
+++ b/src/cpp/server/backends/llamacpp/llamacpp_gguf.cpp
@@ -33,8 +33,29 @@ std::string resolve_gguf_path(const std::string& model_cache_path, const std::st
         return model_cache_path;
     }
 
+    const fs::path snapshots_path = model_cache_path_fs / "snapshots";
+    const fs::path active_snapshot = hf_cache::active_snapshot_path(model_cache_path_fs);
+
+    if (active_snapshot.empty() && hf_cache::exists(snapshots_path)) {
+        return "";
+    }
+
+    auto is_uncommitted_snapshot_file = [&](const fs::path& candidate) {
+        fs::path relative = candidate.lexically_relative(snapshots_path);
+        if (relative.empty()) {
+            return false;
+        }
+
+        auto first = relative.begin();
+        if (first == relative.end() || *first == "." || *first == "..") {
+            return false;
+        }
+
+        return hf_cache::exists(snapshots_path / *first / ".download_manifest.json");
+    };
+
     // Collect the (sorted, mmproj-excluded) GGUF files under a search root.
-    auto collect_gguf_files = [](const fs::path& search_root) {
+    auto collect_gguf_files = [&](const fs::path& search_root) {
         std::vector<std::string> files;
         if (search_root.empty() || !hf_cache::exists(search_root)) {
             return files;
@@ -48,11 +69,13 @@ std::string resolve_gguf_path(const std::string& model_cache_path, const std::st
                 continue;
             }
 
-            std::string filename = entry.path().filename().string();
-            std::string filename_lower = filename;
-            std::transform(filename_lower.begin(), filename_lower.end(), filename_lower.begin(), ::tolower);
+            const std::string filename_lower = to_lower(entry.path().filename().string());
+            const std::string extension_lower = to_lower(entry.path().extension().string());
 
-            if (filename.find(".gguf") != std::string::npos && filename_lower.find("mmproj") == std::string::npos) {
+            // ".gguf.partial" is an interrupted download, not a GGUF candidate.
+            if (extension_lower == ".gguf" &&
+                filename_lower.find("mmproj") == std::string::npos &&
+                !is_uncommitted_snapshot_file(entry.path())) {
                 files.push_back(path_to_utf8(entry.path()));
             }
         }
@@ -184,10 +207,10 @@ std::string resolve_gguf_path(const std::string& model_cache_path, const std::st
 
     // Prefer the active refs/main snapshot so that when upstream only changed
     // README/metadata Lemonade keeps using the previous snapshot's artifacts.
-    std::vector<std::string> active_gguf_files =
-        collect_gguf_files(hf_cache::active_snapshot_path(model_cache_path_fs));
+    std::vector<std::string> active_gguf_files = collect_gguf_files(active_snapshot);
 
-    // Whole-repo-cache candidates spanning every snapshot, populated on demand.
+    // Whole-repo-cache candidates spanning completed snapshots, populated on
+    // demand. collect_gguf_files excludes snapshots with a live manifest.
     std::vector<std::string> all_cache_gguf_files;
     bool all_cache_computed = false;
     auto whole_cache_gguf_files = [&]() -> const std::vector<std::string>& {
@@ -199,7 +222,9 @@ std::string resolve_gguf_path(const std::string& model_cache_path, const std::st
     };
 
     if (active_gguf_files.empty() && whole_cache_gguf_files().empty()) {
-        return model_cache_path;
+        // Preserve the historical flat-cache fallback, but never expose a
+        // modern snapshots cache as a valid directory checkpoint without GGUFs.
+        return hf_cache::exists(snapshots_path) ? "" : model_cache_path;
     }
 
     std::string resolved_path = resolve_gguf_variant(active_gguf_files);
@@ -207,11 +232,11 @@ std::string resolve_gguf_path(const std::string& model_cache_path, const std::st
     // #2300: a requested variant can live in a snapshot other than the one
     // refs/main points at (refs/main advances to whichever variant was pulled
     // last, stranding the others in earlier snapshots), so the active-only
-    // search above can report it missing. Broaden to every snapshot before
-    // giving up; blobs are content-addressed so reading an older snapshot is
-    // safe, and searching the active snapshot first preserves CHECKPOINT:VARIANT.
-    // The whole-cache set is a superset of the active set, so when they're equal
-    // the broader search is identical and skipped.
+    // search above can report it missing. Broaden to every completed snapshot
+    // before giving up; blobs are content-addressed so reading an older snapshot
+    // is safe, and searching the active snapshot first preserves
+    // CHECKPOINT:VARIANT. The whole-cache set is a superset of the active set,
+    // so when they're equal the broader search is identical and skipped.
     if (resolved_path.empty()) {
         const std::vector<std::string>& all_files = whole_cache_gguf_files();
         if (all_files != active_gguf_files) {

--- a/test/test_multi_checkpoint_completeness.py
+++ b/test/test_multi_checkpoint_completeness.py
@@ -183,6 +183,77 @@ class TestMultiCheckpointCompleteness(unittest.TestCase):
         )
         self.assertIn("No", [l for l in res.stdout.splitlines() if hf_model_id in l][0])
 
+    def test_uncommitted_variantless_snapshot_is_not_downloaded(self):
+        model_id = "hf-uncommitted"
+        repo = "org/uncommitted"
+        snapshot_id = "incomplete-snapshot"
+        repo_dir = os.path.join(self.tmp_dir, "hf", "models--org--uncommitted")
+        snapshot_dir = os.path.join(repo_dir, "snapshots", snapshot_id)
+        os.makedirs(snapshot_dir, exist_ok=True)
+
+        # Simulate Lemonade exiting during a large variantless repository pull.
+        # The modern cache tree exists, but refs/main was never committed.
+        manifest = os.path.join(snapshot_dir, ".download_manifest.json")
+        partial = os.path.join(snapshot_dir, "model-00002-of-00004.safetensors.partial")
+        with open(manifest, "w") as f:
+            f.write("{}")
+        with open(partial, "wb") as f:
+            f.write(b"partial")
+
+        user_models = {
+            model_id: {
+                "checkpoint": repo,
+                "recipe": "sd-cpp",
+            }
+        }
+        with open(os.path.join(self.tmp_dir, "user_models.json"), "w") as f:
+            json.dump(user_models, f)
+
+        # The old resolver returned the repository cache directory here and the
+        # server reported Downloaded. It must remain resumable/not downloaded.
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("No", [l for l in res.stdout.splitlines() if model_id in l][0])
+
+        # Finish and commit the snapshot. The same directory checkpoint is now
+        # valid.
+        os.remove(manifest)
+        os.remove(partial)
+        with open(os.path.join(snapshot_dir, "config.json"), "w") as f:
+            f.write("{}")
+        refs_dir = os.path.join(repo_dir, "refs")
+        os.makedirs(refs_dir, exist_ok=True)
+        with open(os.path.join(refs_dir, "main"), "w") as f:
+            f.write(snapshot_id)
+
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("Yes", [l for l in res.stdout.splitlines() if model_id in l][0])
+
+        # A later interrupted update must not hide the still-committed old snapshot.
+        update_dir = os.path.join(repo_dir, "snapshots", "new-incomplete-snapshot")
+        os.makedirs(update_dir, exist_ok=True)
+        with open(os.path.join(update_dir, ".download_manifest.json"), "w") as f:
+            f.write("{}")
+        with open(os.path.join(update_dir, "model.safetensors.partial"), "wb") as f:
+            f.write(b"partial")
+
+        self.start_server()
+        res = subprocess.run(
+            [self.cli_bin, "--port", str(self.port), "list"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("Yes", [l for l in res.stdout.splitlines() if model_id in l][0])
+
     def test_collection_status_with_incomplete_component(self):
         # Status-regression coverage for the collection fan-out skip predicate.
         # If a component is missing an auxiliary checkpoint, it must not be

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -254,13 +254,15 @@ MULTI_REPO_MODEL_A_MAIN = (
     "unsloth/SmolLM2-135M-Instruct-GGUF:SmolLM2-135M-Instruct-Q2_K.gguf"
 )
 MULTI_REPO_MODEL_B_NAME = "user.MultiRepo-TestB"
-MULTI_REPO_MODEL_B_MAIN = "Comfy-Org/z_image:split_files/vae/ae.safetensors"
+MULTI_REPO_MODEL_B_MAIN = (
+    "bartowski/SmolLM2-135M-Instruct-GGUF:SmolLM2-135M-Instruct-Q2_K.gguf"
+)
 MULTI_REPO_SHARED_CHECKPOINT = (
     "mradermacher/SmolLM2-135M-Instruct-GGUF:SmolLM2-135M-Instruct.Q2_K.gguf"
 )
 # Cache directory names for on-disk verification (repo_id with / replaced by --)
 MULTI_REPO_MODEL_A_CACHE_DIR = "models--unsloth--SmolLM2-135M-Instruct-GGUF"
-MULTI_REPO_MODEL_B_CACHE_DIR = "models--Comfy-Org--z_image"
+MULTI_REPO_MODEL_B_CACHE_DIR = "models--bartowski--SmolLM2-135M-Instruct-GGUF"
 MULTI_REPO_SHARED_CACHE_DIR = "models--mradermacher--SmolLM2-135M-Instruct-GGUF"
 
 # Models that should be pre-downloaded for offline testing


### PR DESCRIPTION
### Summary

- Resolve variantless registry checkpoints only from the snapshot committed by
  `refs/main`.
- Treat a modern `snapshots/` cache without a usable active ref as incomplete
  instead of exposing the repository cache root as a downloaded model.
- Preserve the legacy flat-cache fallback and all explicit-variant behavior.
- Add regression coverage for restart after interruption, successful commit,
  and an interrupted update beside a still-valid committed snapshot.

### Root cause

The shared backend resolver returned `model_cache_path` for checkpoints without
an explicit variant. An interrupted download already creates that directory, so
a cache rebuild after restart could mark the model as downloaded even though its
snapshot still contained `.partial` files and `.download_manifest.json`.

The registry downloader writes `refs/main` only after all selected artifacts
have completed and passed validation. Using the active ref as the directory
checkpoint commit marker aligns status resolution with the existing download
transaction.

### Behavior after this change

- First interrupted pull: model remains not downloaded; the next pull resumes
  the preserved partial files.
- Completed pull: model resolves to the committed active snapshot.
- Interrupted update: the previous committed snapshot remains usable until the
  new snapshot completes.
- Legacy flat caches: unchanged.
- Explicit variants and GGUF shared-repo resolution: unchanged.

### Validation

- Added `test_uncommitted_variantless_snapshot_is_not_downloaded` to
  `test/test_multi_checkpoint_completeness.py`.