### PR TITLE
New helper combining add_test() and register_cpp_ci_test()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,33 @@ python test/server_sd.py
 
 Test utilities in `test/utils/` with `server_base.py` as the base class. Test dependencies include `requests`, `httpx`, `openai`, `huggingface_hub`, `psutil`, `numpy`, `websockets`, and `ollama`.
 
+### C++ unit tests
+
+C++ unit tests live in `test/cpp/` and are wired up in the root `CMakeLists.txt`. The packaging workflow builds the `cpp-ci-tests` aggregate target and runs `ctest -L cpp-ci`, so a test only runs in CI if it is both labeled `cpp-ci` **and** a dependency of that aggregate target.
+
+**Direct `add_test()` is disabled** (the built-in is overridden to fail with a fatal error just before the test section). Every test MUST be declared with the `add_cpp_ci_test()` helper, which forces an explicit `CI <ON|OFF>` decision at the call site so a test is never silently omitted from — or accidentally added to — CI:
+
+```cmake
+add_executable(test_my_feature test/cpp/test_my_feature.cpp ...)
+# ...target_include_directories / target_link_libraries...
+
+include(CTest)
+add_cpp_ci_test(MyFeatureTest CI ON COMMAND test_my_feature)
+```
+
+```cmake
+add_cpp_ci_test(<TestName>
+                CI <ON|OFF>                 # required — run under `ctest -L cpp-ci`?
+                COMMAND <command> [args...] # required — what CTest runs
+                [DEPENDS <target>...])      # CI build deps; defaults to the
+                                            # first COMMAND token (the test target)
+```
+
+- `CI ON` labels the test `cpp-ci` and makes its build target(s) a dependency of `cpp-ci-tests`.
+- `CI OFF` still creates the CTest test (for local/other runs) but keeps it out of packaging CI. Use this only for tests that are intentionally excluded (e.g. tests that need a backend, are platform-gated, or are slow CMake-configuration tests).
+
+Pass `DEPENDS` only when the CI build needs targets beyond the `COMMAND` executable. `add_cpp_ci_test` calls `register_cpp_ci_test()` internally; do not call `add_test()` or `register_cpp_ci_test()` directly.
+
 ## Code Style
 
 ### Comments & Documentation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,9 @@ if(NOT TARGET cpp-ci-tests)
     add_custom_target(cpp-ci-tests)
 endif()
 
-# Register a CTest test for the packaging CI and make the aggregate build
-# target depend on every executable/helper target needed by that test.
+# Label a CTest test for the packaging CI and make the aggregate build target
+# depend on every executable/helper target needed by that test. Internal helper
+# used by add_cpp_ci_test(); call add_cpp_ci_test() instead of this directly.
 #
 # Usage:
 #   register_cpp_ci_test(TestName test_target [additional_target...])
@@ -32,6 +33,48 @@ function(register_cpp_ci_test test_name)
             cpp-ci-tests
             ${ARGN}
         )
+    endif()
+endfunction()
+
+# Declare a CTest test with an explicit CI decision. This is the ONLY supported
+# way to add a test: direct add_test() is disabled (see the override installed
+# before the test section) so that every test states, at its call site, whether
+# it runs in the packaging CI (`ctest -L cpp-ci`).
+#
+#   * CI ON  -> the test is labeled cpp-ci and its build target(s) become a
+#               dependency of the cpp-ci-tests aggregate target.
+#   * CI OFF -> the test is created for local/other runs but excluded from CI.
+#
+# Usage:
+#   add_cpp_ci_test(<TestName>
+#                   CI <ON|OFF>                 # required, explicit CI decision
+#                   COMMAND <command> [args...] # required, what CTest runs
+#                   [DEPENDS <target>...])      # CI build deps; defaults to the
+#                                               # first COMMAND token (the test
+#                                               # executable target)
+function(add_cpp_ci_test test_name)
+    cmake_parse_arguments(ACT "" "CI" "COMMAND;DEPENDS" ${ARGN})
+
+    if(NOT DEFINED ACT_CI)
+        message(FATAL_ERROR
+            "add_cpp_ci_test(${test_name}): required 'CI <ON|OFF>' argument is missing")
+    endif()
+    if(NOT ACT_COMMAND)
+        message(FATAL_ERROR
+            "add_cpp_ci_test(${test_name}): required 'COMMAND <command>' argument is missing")
+    endif()
+
+    # _add_test is the built-in add_test preserved by the override below, so this
+    # helper stays exempt from the direct-add_test() ban it enforces.
+    _add_test(NAME ${test_name} COMMAND ${ACT_COMMAND})
+
+    if(ACT_CI)
+        if(ACT_DEPENDS)
+            register_cpp_ci_test(${test_name} ${ACT_DEPENDS})
+        else()
+            list(GET ACT_COMMAND 0 _act_ci_target)
+            register_cpp_ci_test(${test_name} ${_act_ci_target})
+        endif()
     endif()
 endfunction()
 
@@ -1004,6 +1047,17 @@ if(USE_SYSTEM_ZSTD)
     target_compile_options(lemonade-server-core PUBLIC ${ZSTD_CFLAGS_OTHER})
 endif()
 
+# Disable direct add_test() from here on: every test below must be declared with
+# add_cpp_ci_test(... CI <ON|OFF> ...) so its CI status is explicit. Overriding
+# the built-in command preserves the original as _add_test (used by the helper
+# above). Installed after all third-party dependencies are configured so their
+# vendored test suites keep working.
+function(add_test)
+    message(FATAL_ERROR
+        "Direct add_test() is disabled in this project. Declare the test with "
+        "add_cpp_ci_test(<Name> CI <ON|OFF> COMMAND <...>) so its CI status is explicit.")
+endfunction()
+
 set(VLLM_ARG_RESOLVER_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_vllm_arg_resolver.cpp")
 if(BUILD_TESTING AND EXISTS "${VLLM_ARG_RESOLVER_TEST_SOURCE}")
     add_executable(test_vllm_arg_resolver
@@ -1011,7 +1065,7 @@ if(BUILD_TESTING AND EXISTS "${VLLM_ARG_RESOLVER_TEST_SOURCE}")
         src/cpp/server/backends/vllm/vllm_arg_resolver.cpp
     )
     target_link_libraries(test_vllm_arg_resolver PRIVATE nlohmann_json::nlohmann_json)
-    add_test(NAME vllm_arg_resolver COMMAND test_vllm_arg_resolver)
+    add_cpp_ci_test(vllm_arg_resolver CI OFF COMMAND test_vllm_arg_resolver)
 endif()
 
 set(LLAMACPP_REQUEST_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_llamacpp_request.cpp")
@@ -1021,7 +1075,7 @@ if(BUILD_TESTING AND EXISTS "${LLAMACPP_REQUEST_TEST_SOURCE}")
         src/cpp/server/backends/llamacpp/llamacpp_request.cpp
     )
     target_link_libraries(test_llamacpp_request PRIVATE nlohmann_json::nlohmann_json)
-    add_test(NAME llamacpp_request COMMAND test_llamacpp_request)
+    add_cpp_ci_test(llamacpp_request CI OFF COMMAND test_llamacpp_request)
 endif()
 
 set(MCP_CLIENT_CONFIG_TEST_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_mcp_client_config.cpp")
@@ -1043,8 +1097,7 @@ if(BUILD_TESTING AND EXISTS "${MCP_CLIENT_CONFIG_TEST_SOURCE}")
             "LEMONADE_TEST_MCP_STDIO_SERVER=\"${LEMONADE_TEST_MCP_STDIO_SERVER_PATH}\"")
     endif()
 
-    add_test(NAME mcp_client_config COMMAND test_mcp_client_config)
-    register_cpp_ci_test(mcp_client_config test_mcp_client_config)
+    add_cpp_ci_test(mcp_client_config CI ON COMMAND test_mcp_client_config)
 endif()
 
 # libwebsockets for the realtime and log-stream WebSocket server
@@ -2062,9 +2115,7 @@ if(BUILD_TESTING AND EXISTS "${_ARCHIVE_PLATFORM_TEST_SRC}")
     target_include_directories(test_archive_platform PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
     )
-    add_test(NAME ArchivePlatformTest COMMAND test_archive_platform)
-
-    register_cpp_ci_test(ArchivePlatformTest test_archive_platform)
+    add_cpp_ci_test(ArchivePlatformTest CI ON COMMAND test_archive_platform)
 endif()
 
 # ProcessManager zombie detection and non-mutating reap contract.
@@ -2084,8 +2135,7 @@ if(BUILD_TESTING AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
         )
         find_package(Threads REQUIRED)
         target_link_libraries(test_process_manager PRIVATE Threads::Threads)
-        add_test(NAME ProcessManagerTest COMMAND test_process_manager)
-        register_cpp_ci_test(ProcessManagerTest test_process_manager)
+        add_cpp_ci_test(ProcessManagerTest CI ON COMMAND test_process_manager)
     endif()
 endif()
 
@@ -2106,7 +2156,7 @@ if(EXISTS "${_FLM_ARG_RESOLVER_TEST_SRC}" AND EXISTS "${_FLM_ARG_RESOLVER_SRC}")
         ${CMAKE_CURRENT_BINARY_DIR}/include
     )
 
-    add_test(NAME FlmArgResolverTest COMMAND test_flm_arg_resolver)
+    add_cpp_ci_test(FlmArgResolverTest CI OFF COMMAND test_flm_arg_resolver)
 endif()
 
 # Custom arg parsing helpers (header-only utility shared by all arg resolvers).
@@ -2118,8 +2168,7 @@ if(BUILD_TESTING AND EXISTS "${_CUSTOM_ARGS_TEST_SRC}")
     target_include_directories(test_custom_args PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
     )
-    add_test(NAME CustomArgsTest COMMAND test_custom_args)
-    register_cpp_ci_test(CustomArgsTest test_custom_args)
+    add_cpp_ci_test(CustomArgsTest CI ON COMMAND test_custom_args)
 endif()
 
 set(_DIR_WATCHER_TEST_SRC
@@ -2144,8 +2193,7 @@ if(EXISTS "${_DIR_WATCHER_TEST_SRC}" AND EXISTS "${_DIR_WATCHER_LIB_SRC}")
 
     # Enable testing and register the test with CTest
     include(CTest)
-    add_test(NAME DirectoryWatcherTest COMMAND test_directory_watcher)
-    register_cpp_ci_test(DirectoryWatcherTest test_directory_watcher)
+    add_cpp_ci_test(DirectoryWatcherTest CI ON COMMAND test_directory_watcher)
 endif()
 
 # GGUF capability detection (MTP / vision / tool-calling label logic).
@@ -2164,7 +2212,7 @@ if(EXISTS "${_GGUF_CAPS_TEST_SRC}")
 
     # Enable testing and register the test with CTest
     include(CTest)
-    add_test(NAME GgufCapabilitiesTest COMMAND test_gguf_capabilities)
+    add_cpp_ci_test(GgufCapabilitiesTest CI OFF COMMAND test_gguf_capabilities)
 endif()
 
 # Model residency role/pool contract for router dependencies
@@ -2181,8 +2229,7 @@ if(EXISTS "${_MODEL_RESIDENCY_TEST_SRC}")
     )
 
     include(CTest)
-    add_test(NAME ModelResidencyTest COMMAND test_model_residency)
-    register_cpp_ci_test(ModelResidencyTest test_model_residency)
+    add_cpp_ci_test(ModelResidencyTest CI ON COMMAND test_model_residency)
 endif()
 
 # Pure version-resolution policy test (lemon::resolve_latest_pin). Header-only
@@ -2202,8 +2249,7 @@ if(EXISTS "${_LATEST_FALLBACK_TEST_SRC}")
     )
 
     include(CTest)
-    add_test(NAME LatestVersionFallbackTest COMMAND test_latest_version_fallback)
-    register_cpp_ci_test(LatestVersionFallbackTest test_latest_version_fallback)
+    add_cpp_ci_test(LatestVersionFallbackTest CI ON COMMAND test_latest_version_fallback)
 endif()
 
 # Job engine pure core: the `when`/`branch` expression evaluator + reference
@@ -2218,8 +2264,7 @@ if(EXISTS "${_JOB_EXPR_TEST_SRC}")
     )
     target_link_libraries(test_job_expr PRIVATE nlohmann_json::nlohmann_json)
     include(CTest)
-    add_test(NAME JobExprTest COMMAND test_job_expr)
-    register_cpp_ci_test(JobExprTest test_job_expr)
+    add_cpp_ci_test(JobExprTest CI ON COMMAND test_job_expr)
 endif()
 
 set(_JOB_GRAPH_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_job_graph.cpp")
@@ -2231,8 +2276,7 @@ if(EXISTS "${_JOB_GRAPH_TEST_SRC}")
     )
     target_link_libraries(test_job_graph PRIVATE nlohmann_json::nlohmann_json)
     include(CTest)
-    add_test(NAME JobGraphTest COMMAND test_job_graph)
-    register_cpp_ci_test(JobGraphTest test_job_graph)
+    add_cpp_ci_test(JobGraphTest CI ON COMMAND test_job_graph)
 endif()
 
 # Backend install atomicity (staging + verified atomic swap).
@@ -2251,7 +2295,7 @@ if(EXISTS "${_INSTALL_ATOMICITY_TEST_SRC}")
 
     # Enable testing and register the test with CTest
     include(CTest)
-    add_test(NAME InstallAtomicityTest COMMAND test_install_atomicity)
+    add_cpp_ci_test(InstallAtomicityTest CI OFF COMMAND test_install_atomicity)
 endif()
 
 # Routing engine contract surface (issue #2407). Header-only foundation: the
@@ -2276,8 +2320,7 @@ if(EXISTS "${_ROUTING_CONTRACT_TEST_SRC}")
     )
 
     include(CTest)
-    add_test(NAME RoutingPolicyContractTest COMMAND test_routing_policy_contract)
-    register_cpp_ci_test(RoutingPolicyContractTest test_routing_policy_contract)
+    add_cpp_ci_test(RoutingPolicyContractTest CI ON COMMAND test_routing_policy_contract)
 endif()
 
 # Routing match evaluator (issue #2378): composite Condition nodes,
@@ -2297,8 +2340,7 @@ if(EXISTS "${_ROUTING_EVALUATOR_TEST_SRC}")
     target_link_libraries(test_routing_policy_evaluator PRIVATE nlohmann_json::nlohmann_json)
 
     include(CTest)
-    add_test(NAME RoutingPolicyEvaluatorTest COMMAND test_routing_policy_evaluator)
-    register_cpp_ci_test(RoutingPolicyEvaluatorTest test_routing_policy_evaluator)
+    add_cpp_ci_test(RoutingPolicyEvaluatorTest CI ON COMMAND test_routing_policy_evaluator)
 endif()
 
 # Routing classifier/condition registry (issue #2379): classifier JSON
@@ -2319,8 +2361,7 @@ if(EXISTS "${_ROUTING_REGISTRY_TEST_SRC}")
     target_link_libraries(test_routing_policy_registry PRIVATE nlohmann_json::nlohmann_json)
 
     include(CTest)
-    add_test(NAME RoutingPolicyRegistryTest COMMAND test_routing_policy_registry)
-    register_cpp_ci_test(RoutingPolicyRegistryTest test_routing_policy_registry)
+    add_cpp_ci_test(RoutingPolicyRegistryTest CI ON COMMAND test_routing_policy_registry)
 endif()
 
 # Routing semantic_similarity classifier (issue #2381): max-cosine scoring over
@@ -2342,8 +2383,7 @@ if(EXISTS "${_ROUTING_SEMANTIC_TEST_SRC}")
     target_link_libraries(test_routing_policy_semantic PRIVATE nlohmann_json::nlohmann_json)
 
     include(CTest)
-    add_test(NAME RoutingPolicySemanticTest COMMAND test_routing_policy_semantic)
-    register_cpp_ci_test(RoutingPolicySemanticTest test_routing_policy_semantic)
+    add_cpp_ci_test(RoutingPolicySemanticTest CI ON COMMAND test_routing_policy_semantic)
 endif()
 
 # LLM router classifier + routing.router desugaring (issue #2405): the L0a
@@ -2365,8 +2405,7 @@ if(EXISTS "${_ROUTING_LLM_ROUTER_TEST_SRC}")
     target_link_libraries(test_routing_policy_llm_router PRIVATE nlohmann_json::nlohmann_json)
 
     include(CTest)
-    add_test(NAME RoutingPolicyLlmRouterTest COMMAND test_routing_policy_llm_router)
-    register_cpp_ci_test(RoutingPolicyLlmRouterTest test_routing_policy_llm_router)
+    add_cpp_ci_test(RoutingPolicyLlmRouterTest CI ON COMMAND test_routing_policy_llm_router)
 endif()
 
 # Routing deterministic leaf conditions (issue #2380): keywords/regex/min_chars/
@@ -2387,8 +2426,7 @@ if(EXISTS "${_ROUTING_DETERMINISTIC_TEST_SRC}")
     target_link_libraries(test_routing_policy_deterministic PRIVATE nlohmann_json::nlohmann_json)
 
     include(CTest)
-    add_test(NAME RoutingPolicyDeterministicTest COMMAND test_routing_policy_deterministic)
-    register_cpp_ci_test(RoutingPolicyDeterministicTest test_routing_policy_deterministic)
+    add_cpp_ci_test(RoutingPolicyDeterministicTest CI ON COMMAND test_routing_policy_deterministic)
 endif()
 
 # Routing engine assembly (issue #2382): RoutingPolicyEngine constructor rule
@@ -2412,8 +2450,7 @@ if(EXISTS "${_ROUTING_ENGINE_TEST_SRC}")
     target_link_libraries(test_routing_policy_engine PRIVATE Threads::Threads)
 
     include(CTest)
-    add_test(NAME RoutingPolicyEngineTest COMMAND test_routing_policy_engine)
-    register_cpp_ci_test(RoutingPolicyEngineTest test_routing_policy_engine)
+    add_cpp_ci_test(RoutingPolicyEngineTest CI ON COMMAND test_routing_policy_engine)
 endif()
 
 # Routing policy parser (issue #2383): collection.router JSON -> RoutePolicy,
@@ -2439,8 +2476,7 @@ if(EXISTS "${_ROUTING_PARSER_TEST_SRC}")
     )
 
     include(CTest)
-    add_test(NAME RoutingPolicyParserTest COMMAND test_routing_policy_parser)
-    register_cpp_ci_test(RoutingPolicyParserTest test_routing_policy_parser)
+    add_cpp_ci_test(RoutingPolicyParserTest CI ON COMMAND test_routing_policy_parser)
 endif()
 
 
@@ -2470,8 +2506,7 @@ if(EXISTS "${_ROUTING_STORE_TEST_SRC}")
     )
 
     include(CTest)
-    add_test(NAME RoutingPolicyStoreTest COMMAND test_routing_policy_store)
-    register_cpp_ci_test(RoutingPolicyStoreTest test_routing_policy_store)
+    add_cpp_ci_test(RoutingPolicyStoreTest CI ON COMMAND test_routing_policy_store)
 endif()
 
 set(_ROUTE_DECISION_RESPONSE_TEST_SRC
@@ -2494,7 +2529,7 @@ if(EXISTS "${_ROUTE_DECISION_RESPONSE_TEST_SRC}")
     endif()
 
     include(CTest)
-    add_test(NAME RouteDecisionResponseTest COMMAND test_route_decision_response)
+    add_cpp_ci_test(RouteDecisionResponseTest CI OFF COMMAND test_route_decision_response)
 endif()
 
 # Router back-compat conformance corpus (issue #2425): replays the golden
@@ -2527,8 +2562,7 @@ if(EXISTS "${_ROUTING_CONFORMANCE_CORPUS_TEST_SRC}")
     )
 
     include(CTest)
-    add_test(NAME RoutingConformanceCorpusTest COMMAND test_routing_conformance_corpus)
-    register_cpp_ci_test(RoutingConformanceCorpusTest test_routing_conformance_corpus)
+    add_cpp_ci_test(RoutingConformanceCorpusTest CI ON COMMAND test_routing_conformance_corpus)
 endif()
 
 # ModelManager collection validation for collection.router registration:
@@ -2545,8 +2579,7 @@ if(EXISTS "${_MODEL_MANAGER_COLLECTION_VALIDATION_TEST_SRC}")
     add_dependencies(test_model_manager_collection_validation copy_resources)
 
     include(CTest)
-    add_test(NAME ModelManagerCollectionValidationTest COMMAND test_model_manager_collection_validation)
-    register_cpp_ci_test(ModelManagerCollectionValidationTest test_model_manager_collection_validation)
+    add_cpp_ci_test(ModelManagerCollectionValidationTest CI ON COMMAND test_model_manager_collection_validation)
 endif()
 
 # Remote model registry source parsing, cache namespaces, snapshot fingerprints,
@@ -2560,7 +2593,7 @@ if(BUILD_TESTING AND EXISTS "${_MODEL_REGISTRY_TEST_SRC}")
     add_dependencies(test_model_registry copy_resources)
 
     include(CTest)
-    add_test(NAME ModelRegistryTest COMMAND test_model_registry)
+    add_cpp_ci_test(ModelRegistryTest CI OFF COMMAND test_model_registry)
 endif()
 
 # Router-backed ClassifierServices wiring (issue #2384): binds the pure engine's
@@ -2582,8 +2615,7 @@ if(EXISTS "${_ROUTING_CLASSIFIER_SERVICES_TEST_SRC}")
     target_link_libraries(test_routing_classifier_services PRIVATE nlohmann_json::nlohmann_json)
 
     include(CTest)
-    add_test(NAME RoutingClassifierServicesTest COMMAND test_routing_classifier_services)
-    register_cpp_ci_test(RoutingClassifierServicesTest test_routing_classifier_services)
+    add_cpp_ci_test(RoutingClassifierServicesTest CI ON COMMAND test_routing_classifier_services)
 endif()
 
 # Auto-tune: GGUF array storage, scalar derivation, weighted KV cache computation.
@@ -2602,35 +2634,35 @@ if(EXISTS "${_AUTO_TUNE_TEST_SRC}")
     )
 
     include(CTest)
-    add_test(NAME AutoTuneTest COMMAND test_auto_tune)
+    add_cpp_ci_test(AutoTuneTest CI OFF COMMAND test_auto_tune)
 endif()
 
 set(_TELEMETRY_HELPERS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_telemetry_helpers.cpp")
 if(EXISTS "${_TELEMETRY_HELPERS_TEST_SRC}")
     add_executable(test_telemetry_helpers test/cpp/test_telemetry_helpers.cpp)
     target_link_libraries(test_telemetry_helpers PRIVATE lemonade-server-core)
-    add_test(NAME TelemetryHelpersTest COMMAND test_telemetry_helpers)
+    add_cpp_ci_test(TelemetryHelpersTest CI OFF COMMAND test_telemetry_helpers)
 endif()
 
 set(_SUSPEND_INHIBITOR_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_suspend_inhibitor.cpp")
 if(EXISTS "${_SUSPEND_INHIBITOR_TEST_SRC}")
     add_executable(test_suspend_inhibitor test/cpp/test_suspend_inhibitor.cpp)
     target_link_libraries(test_suspend_inhibitor PRIVATE lemonade-server-core)
-    add_test(NAME SuspendInhibitorTest COMMAND test_suspend_inhibitor)
+    add_cpp_ci_test(SuspendInhibitorTest CI OFF COMMAND test_suspend_inhibitor)
 endif()
 
 set(_CONFIG_MIGRATION_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_migration.cpp")
 if(EXISTS "${_CONFIG_MIGRATION_TEST_SRC}")
     add_executable(test_config_migration test/cpp/test_config_migration.cpp)
     target_link_libraries(test_config_migration PRIVATE lemonade-server-core)
-    add_test(NAME ConfigMigrationTest COMMAND test_config_migration)
+    add_cpp_ci_test(ConfigMigrationTest CI OFF COMMAND test_config_migration)
 endif()
 
 set(_CONFIG_TELEMETRY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_telemetry.cpp")
 if(EXISTS "${_CONFIG_TELEMETRY_TEST_SRC}")
     add_executable(test_config_telemetry test/cpp/test_config_telemetry.cpp)
     target_link_libraries(test_config_telemetry PRIVATE lemonade-server-core)
-    add_test(NAME ConfigTelemetryTest COMMAND test_config_telemetry)
+    add_cpp_ci_test(ConfigTelemetryTest CI OFF COMMAND test_config_telemetry)
 endif()
 
 # ROCm root resolution (ROCM_PATH / rocm-sdk / /opt/rocm priority): covers the
@@ -2639,29 +2671,28 @@ set(_ROCM_ROOT_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_rocm_root_res
 if(EXISTS "${_ROCM_ROOT_TEST_SRC}")
     add_executable(test_rocm_root_resolution test/cpp/test_rocm_root_resolution.cpp)
     target_link_libraries(test_rocm_root_resolution PRIVATE lemonade-server-core)
-    add_test(NAME RocmRootResolutionTest COMMAND test_rocm_root_resolution)
+    add_cpp_ci_test(RocmRootResolutionTest CI OFF COMMAND test_rocm_root_resolution)
 endif()
 
 set(_GPU_ENV_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_backend_utils_gpu_env.cpp")
 if(EXISTS "${_GPU_ENV_TEST_SRC}")
     add_executable(test_backend_utils_gpu_env test/cpp/test_backend_utils_gpu_env.cpp)
     target_link_libraries(test_backend_utils_gpu_env PRIVATE lemonade-server-core)
-    add_test(NAME BackendUtilsGpuEnvTest COMMAND test_backend_utils_gpu_env)
+    add_cpp_ci_test(BackendUtilsGpuEnvTest CI OFF COMMAND test_backend_utils_gpu_env)
 endif()
 
 set(_NETWORK_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_network_utils.cpp")
 if(EXISTS "${_NETWORK_UTILS_TEST_SRC}")
     add_executable(test_network_utils test/cpp/test_network_utils.cpp)
     target_link_libraries(test_network_utils PRIVATE lemonade-server-core)
-    add_test(NAME NetworkUtilsTest COMMAND test_network_utils)
-    register_cpp_ci_test(NetworkUtilsTest test_network_utils)
+    add_cpp_ci_test(NetworkUtilsTest CI ON COMMAND test_network_utils)
 endif()
 
 set(_URL_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_url_utils.cpp")
 if(EXISTS "${_URL_UTILS_TEST_SRC}")
     add_executable(test_url_utils test/cpp/test_url_utils.cpp)
     target_link_libraries(test_url_utils PRIVATE lemonade-server-core)
-    add_test(NAME UrlUtilsTest COMMAND test_url_utils)
+    add_cpp_ci_test(UrlUtilsTest CI OFF COMMAND test_url_utils)
 endif()
 
 # vLLM CDNA gating: the vllm descriptor support row + asset-family resolution for
@@ -2670,7 +2701,7 @@ set(_VLLM_CDNA_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_vllm_cdna_gat
 if(EXISTS "${_VLLM_CDNA_TEST_SRC}")
     add_executable(test_vllm_cdna_gating test/cpp/test_vllm_cdna_gating.cpp)
     target_link_libraries(test_vllm_cdna_gating PRIVATE lemonade-server-core)
-    add_test(NAME VllmCdnaGatingTest COMMAND test_vllm_cdna_gating)
+    add_cpp_ci_test(VllmCdnaGatingTest CI OFF COMMAND test_vllm_cdna_gating)
 endif()
 
 # llamacpp gfx950 (MI350) install gate: only the Linux + stable-channel asset is
@@ -2680,44 +2711,43 @@ set(_LLAMACPP_GFX950_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_llamacp
 if(EXISTS "${_LLAMACPP_GFX950_TEST_SRC}")
     add_executable(test_llamacpp_gfx950_gating test/cpp/test_llamacpp_gfx950_gating.cpp)
     target_link_libraries(test_llamacpp_gfx950_gating PRIVATE lemonade-server-core)
-    add_test(NAME LlamacppGfx950GatingTest COMMAND test_llamacpp_gfx950_gating)
+    add_cpp_ci_test(LlamacppGfx950GatingTest CI OFF COMMAND test_llamacpp_gfx950_gating)
 endif()
 
 set(_HTTP_CLIENT_SECURITY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_http_client_security.cpp")
 if(EXISTS "${_HTTP_CLIENT_SECURITY_TEST_SRC}")
     add_executable(test_http_client_security test/cpp/test_http_client_security.cpp)
     target_link_libraries(test_http_client_security PRIVATE lemonade-server-core)
-    add_test(NAME HttpClientSecurityTest COMMAND test_http_client_security)
+    add_cpp_ci_test(HttpClientSecurityTest CI OFF COMMAND test_http_client_security)
 endif()
 
 set(_CLOUD_DISCOVERY_POLICY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_cloud_discovery_policy.cpp")
 if(EXISTS "${_CLOUD_DISCOVERY_POLICY_TEST_SRC}")
     add_executable(test_cloud_discovery_policy test/cpp/test_cloud_discovery_policy.cpp)
     target_link_libraries(test_cloud_discovery_policy PRIVATE lemonade-server-core)
-    add_test(NAME CloudDiscoveryPolicyTest COMMAND test_cloud_discovery_policy)
+    add_cpp_ci_test(CloudDiscoveryPolicyTest CI OFF COMMAND test_cloud_discovery_policy)
 endif()
 
 set(_ORIGIN_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_origin_utils.cpp")
 if(EXISTS "${_ORIGIN_UTILS_TEST_SRC}")
     add_executable(test_origin_utils test/cpp/test_origin_utils.cpp)
     target_link_libraries(test_origin_utils PRIVATE lemonade-server-core)
-    add_test(NAME OriginUtilsTest COMMAND test_origin_utils)
-    register_cpp_ci_test(OriginUtilsTest test_origin_utils)
+    add_cpp_ci_test(OriginUtilsTest CI ON COMMAND test_origin_utils)
 endif()
 
 if(BUILD_TESTING)
-    add_test(NAME HttplibDetection_config_only COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_config_only -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=config_only -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_old_header COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_old_header -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=old_header -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_modern_header COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_modern_header -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=modern_header -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_openssl_target COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_openssl_target -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=openssl_target -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_disabled_generator_expression COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_disabled_generator_expression -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=disabled_generator_expression -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_too_old_config COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_too_old_config -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=too_old_config -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_compiled_no_tls COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_compiled_no_tls -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=compiled_no_tls -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_too_old_config_multiarch COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_too_old_config_multiarch -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=too_old_config_multiarch -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_header_only_pkgconfig COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_header_only_pkgconfig -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=header_only_pkgconfig -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_cli_composition_mbedtls_isolation COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_cli_composition_mbedtls_isolation -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=cli_composition_mbedtls_isolation -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_custom_httplib_dir_precheck COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_custom_httplib_dir_precheck -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=custom_httplib_dir_precheck -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
-    add_test(NAME HttplibDetection_polluted_target_fatal COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_polluted_target_fatal -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=polluted_target_fatal -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_config_only CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_config_only -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=config_only -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_old_header CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_old_header -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=old_header -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_modern_header CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_modern_header -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=modern_header -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_openssl_target CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_openssl_target -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=openssl_target -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_disabled_generator_expression CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_disabled_generator_expression -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=disabled_generator_expression -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_too_old_config CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_too_old_config -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=too_old_config -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_compiled_no_tls CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_compiled_no_tls -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=compiled_no_tls -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_too_old_config_multiarch CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_too_old_config_multiarch -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=too_old_config_multiarch -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_header_only_pkgconfig CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_header_only_pkgconfig -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=header_only_pkgconfig -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_cli_composition_mbedtls_isolation CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_cli_composition_mbedtls_isolation -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=cli_composition_mbedtls_isolation -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_custom_httplib_dir_precheck CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_custom_httplib_dir_precheck -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=custom_httplib_dir_precheck -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_polluted_target_fatal CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_polluted_target_fatal -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=polluted_target_fatal -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
     set_tests_properties(HttplibDetection_polluted_target_fatal PROPERTIES WILL_FAIL TRUE)
-    add_test(NAME HttplibDetection_wolfssl_target COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_wolfssl_target -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=wolfssl_target -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+    add_cpp_ci_test(HttplibDetection_wolfssl_target CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_wolfssl_target -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=wolfssl_target -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,9 +55,19 @@ endfunction()
 function(add_cpp_ci_test test_name)
     cmake_parse_arguments(ACT "" "CI" "COMMAND;DEPENDS" ${ARGN})
 
+    if(ACT_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR
+            "add_cpp_ci_test(${test_name}): unexpected argument(s) '${ACT_UNPARSED_ARGUMENTS}' "
+            "(check for a misspelled CI/COMMAND/DEPENDS keyword)")
+    endif()
     if(NOT DEFINED ACT_CI)
         message(FATAL_ERROR
             "add_cpp_ci_test(${test_name}): required 'CI <ON|OFF>' argument is missing")
+    endif()
+    string(TOUPPER "${ACT_CI}" _act_ci)
+    if(NOT _act_ci STREQUAL "ON" AND NOT _act_ci STREQUAL "OFF")
+        message(FATAL_ERROR
+            "add_cpp_ci_test(${test_name}): CI must be exactly ON or OFF, got '${ACT_CI}'")
     endif()
     if(NOT ACT_COMMAND)
         message(FATAL_ERROR
@@ -68,7 +78,7 @@ function(add_cpp_ci_test test_name)
     # helper stays exempt from the direct-add_test() ban it enforces.
     _add_test(NAME ${test_name} COMMAND ${ACT_COMMAND})
 
-    if(ACT_CI)
+    if(_act_ci STREQUAL "ON")
         if(ACT_DEPENDS)
             register_cpp_ci_test(${test_name} ${ACT_DEPENDS})
         else()


### PR DESCRIPTION
## Summary

Make the CI decision explicit for every C++ test. `add_cpp_ci_test()` now takes a required `CI <ON|OFF>` argument and a `COMMAND` (with optional `DEPENDS`), so every test states its CI status at the call site. Direct `add_test()` is disabled (overridden to fatal-error after third-party deps are configured) to prevent tests from silently bypassing packaging CI. All existing tests were migrated to the new helper with their current CI status preserved.

## What changed

**CMakeLists.txt**
- Added `add_cpp_ci_test()` with a keyword interface with an explicit, required CI decision:
  ```cmake
  add_cpp_ci_test(<TestName> CI <ON|OFF> COMMAND <command> [args...] [DEPENDS <target>...])
  ```
  `CI ON` labels the test `cpp-ci` and wires its build target into the `cpp-ci-tests` aggregate; `CI OFF` still creates the CTest test but keeps it out of packaging CI. `DEPENDS` defaults to the first `COMMAND` token.
- **Disabled direct `add_test()`**: the built-in is overridden with a function that raises a `FATAL_ERROR`, installed right after all third-party dependencies are configured (so vendored suites like libwebsockets are unaffected). The helper calls the preserved `_add_test` so it stays exempt.
- Converted **all** existing tests (executable tests + the `HttplibDetection_*` CMake tests) from `add_test()` / `register_cpp_ci_test()` pairs to the single `add_cpp_ci_test(... CI ON/OFF ...)` interface, preserving each test's current CI status.

**AGENTS.md** — updated the "C++ unit tests" section to document the explicit `CI <ON|OFF>` interface and that direct `add_test()` is disabled.

### Tests kept excluded from CI (`CI OFF`) — status quo, complete list

Executable tests (19):
- `vllm_arg_resolver`
- `llamacpp_request`
- `FlmArgResolverTest`
- `GgufCapabilitiesTest`
- `InstallAtomicityTest`
- `RouteDecisionResponseTest`
- `ModelRegistryTest`
- `AutoTuneTest`
- `TelemetryHelpersTest`
- `SuspendInhibitorTest`
- `ConfigMigrationTest`
- `ConfigTelemetryTest`
- `RocmRootResolutionTest`
- `BackendUtilsGpuEnvTest`
- `UrlUtilsTest`
- `VllmCdnaGatingTest`
- `LlamacppGfx950GatingTest`
- `HttpClientSecurityTest`
- `CloudDiscoveryPolicyTest`

CMake httplib-detection tests (13):
- `HttplibDetection_config_only`
- `HttplibDetection_old_header`
- `HttplibDetection_modern_header`
- `HttplibDetection_openssl_target`
- `HttplibDetection_disabled_generator_expression`
- `HttplibDetection_too_old_config`
- `HttplibDetection_compiled_no_tls`
- `HttplibDetection_too_old_config_multiarch`
- `HttplibDetection_header_only_pkgconfig`
- `HttplibDetection_cli_composition_mbedtls_isolation`
- `HttplibDetection_custom_httplib_dir_precheck`
- `HttplibDetection_polluted_target_fatal` (also `WILL_FAIL`)
- `HttplibDetection_wolfssl_target`

Total: **32 tests excluded** from `ctest -L cpp-ci` (unchanged from before this PR).

Note: a few of these are additionally platform/existence-gated (e.g. the GPU/ROCm/config tests), but their CI status is `OFF` regardless of platform.