### PR TITLE
feat(server,router): add dynamic custom backend discovery and process isolation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,8 @@ repos:
     rev: 0.37.4
     hooks:
       - id: check-jsonschema
-        files: .*\.json$
-        args: ["--schemafile", "schemas/any.json"]
+        name: Validate Dynamic Backend Descriptors
+        files: ^(backends|docs/examples/custom_backends)/.*\.json$
+        args: ["--schemafile", "schemas/custom_backend.schema.json"]
       - id: check-github-actions
       - id: check-github-workflows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -903,7 +903,8 @@ set(LEMON_BACKEND_DESCRIPTOR_SOURCES
 set(LEMON_BACKEND_FACTORY_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/backends/backend_registry.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/backends/backend_ops.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/backends/hf_cache_util.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/backends/hf_cache_util.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/backends/external/external_backend_server.cpp)
 foreach(_backend_entry ${LEMON_BACKENDS})
     string(REPLACE "|" ";" _backend_parts "${_backend_entry}")
     list(GET _backend_parts 1 _backend_stem)
@@ -2086,6 +2087,46 @@ if(BUILD_TESTING AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
         target_link_libraries(test_process_manager PRIVATE Threads::Threads)
         add_test(NAME ProcessManagerTest COMMAND test_process_manager)
         register_cpp_ci_test(ProcessManagerTest test_process_manager)
+    endif()
+endif()
+
+# Custom backends C++ unit tests (descriptor registry, permissions, env sanitization, endpoints).
+if(BUILD_TESTING)
+    set(_CUSTOM_BACKENDS_TEST_SRC
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_custom_backends.cpp"
+    )
+    if(EXISTS "${_CUSTOM_BACKENDS_TEST_SRC}")
+        set(_CUSTOM_BACKENDS_PLATFORM_SRC
+            src/cpp/server/utils/platform/path_linux.cpp
+            src/cpp/server/utils/platform/process_linux.cpp
+        )
+        if(WIN32)
+            set(_CUSTOM_BACKENDS_PLATFORM_SRC
+                src/cpp/server/utils/platform/path_windows.cpp
+                src/cpp/server/utils/platform/process_windows.cpp
+            )
+        elseif(APPLE)
+            set(_CUSTOM_BACKENDS_PLATFORM_SRC
+                src/cpp/server/utils/platform/path_macos.cpp
+                src/cpp/server/utils/platform/process_macos.cpp
+            )
+        endif()
+
+        add_executable(test_custom_backends
+            test/cpp/test_custom_backends.cpp
+            src/cpp/server/backends/backend_descriptor_registry.cpp
+            src/cpp/server/utils/process_manager.cpp
+            src/cpp/server/utils/path_utils.cpp
+            ${_CUSTOM_BACKENDS_PLATFORM_SRC}
+        )
+        target_include_directories(test_custom_backends PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+            ${CMAKE_CURRENT_BINARY_DIR}/include
+        )
+        find_package(Threads REQUIRED)
+        target_link_libraries(test_custom_backends PRIVATE nlohmann_json::nlohmann_json Threads::Threads)
+        add_test(NAME CustomBackendsTest COMMAND test_custom_backends)
+        register_cpp_ci_test(CustomBackendsTest test_custom_backends)
     endif()
 endif()
 

--- a/README.md
+++ b/README.md
@@ -174,19 +174,25 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows, Linux</td>
     </tr>
     <tr>
-      <td rowspan="1"><code>ryzenai-llm</code></td>
-      <td><code>npu</code></td>
-      <td>XDNA2 NPU</td>
-      <td>Windows</td>
-    </tr>
-    <tr>
       <td rowspan="1"><code>vllm</code> (experimental)</td>
       <td><code>rocm</code></td>
       <td>Strix Halo iGPU (gfx1151)</td>
       <td>Linux</td>
     </tr>
     <tr>
+      <td rowspan="1"><code>ryzenai-llm</code></td>
+      <td><code>npu</code></td>
+      <td>XDNA2 NPU</td>
+      <td>Windows</td>
+    </tr>
+    <tr>
       <td rowspan="6"><strong>Speech-to-text</strong></td>
+      <td rowspan="1"><code>moonshine</code></td>
+      <td><code>cpu</code></td>
+      <td><code>x86_64</code>/<code>arm64</code> CPU</td>
+      <td>Windows, Linux, macOS</td>
+    </tr>
+    <tr>
       <td rowspan="5"><code>whispercpp</code></td>
       <td><code>npu</code></td>
       <td>XDNA2 NPU</td>
@@ -213,24 +219,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows, Linux</td>
     </tr>
     <tr>
-      <td rowspan="1"><code>moonshine</code></td>
-      <td><code>cpu</code></td>
-      <td><code>x86_64</code>/<code>arm64</code> CPU</td>
-      <td>Windows, Linux, macOS</td>
-    </tr>
-    <tr>
       <td rowspan="5"><strong>Text-to-speech</strong></td>
-      <td rowspan="2"><code>kokoro</code></td>
-      <td><code>metal</code></td>
-      <td>Apple Silicon GPU</td>
-      <td>macOS</td>
-    </tr>
-    <tr>
-      <td><code>cpu</code></td>
-      <td><code>x86_64</code> CPU</td>
-      <td>Windows, Linux</td>
-    </tr>
-    <tr>
       <td rowspan="3"><code>openmoss</code> (experimental)</td>
       <td><code>cuda</code></td>
       <td>NVIDIA GPUs</td>
@@ -247,8 +236,19 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows, Linux</td>
     </tr>
     <tr>
+      <td rowspan="2"><code>kokoro</code></td>
+      <td><code>metal</code></td>
+      <td>Apple Silicon GPU</td>
+      <td>macOS</td>
+    </tr>
+    <tr>
+      <td><code>cpu</code></td>
+      <td><code>x86_64</code> CPU</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
       <td rowspan="6"><strong>Audio generation</strong></td>
-      <td rowspan="3"><code>thinksound</code> (experimental)</td>
+      <td rowspan="3"><code>acestep</code> (experimental)</td>
       <td><code>cuda</code></td>
       <td>NVIDIA GPUs</td>
       <td>Windows, Linux</td>
@@ -264,7 +264,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows, Linux</td>
     </tr>
     <tr>
-      <td rowspan="3"><code>acestep</code> (experimental)</td>
+      <td rowspan="3"><code>thinksound</code> (experimental)</td>
       <td><code>cuda</code></td>
       <td>NVIDIA GPUs</td>
       <td>Windows, Linux</td>

--- a/docs/assets/models.js
+++ b/docs/assets/models.js
@@ -20,17 +20,17 @@ const RECIPE_PRIORITY = [
 ];
 
 const RECIPE_DISPLAY_NAMES = {
+  openmoss: 'OpenMOSS TTS',
   llamacpp: 'llama.cpp GPU',
-  whispercpp: 'whisper.cpp',
-  'sd-cpp': 'stable-diffusion.cpp',
-  flm: 'FastFlowLM NPU',
-  'ryzenai-llm': 'Ryzen AI SW NPU',
-  vllm: 'vLLM ROCm (experimental)',
-  thinksound: 'ThinkSound',
-  acestep: 'ACE-Step',
-  onnxruntime: 'ONNX Runtime',
   trellis: 'TRELLIS.2',
-  openmoss: 'OpenMOSS TTS'
+  flm: 'FastFlowLM NPU',
+  'sd-cpp': 'stable-diffusion.cpp',
+  vllm: 'vLLM ROCm (experimental)',
+  acestep: 'ACE-Step',
+  thinksound: 'ThinkSound',
+  whispercpp: 'whisper.cpp',
+  'ryzenai-llm': 'Ryzen AI SW NPU',
+  onnxruntime: 'ONNX Runtime'
 };
 /* END GENERATED: models-js-recipes */
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -30,6 +30,10 @@ Writing or improving docs? Read the [documentation guide](./documentation.md) fo
 
 Lemonade has a unique capability to group LLM, image, and speech models together to present a unified omni-modal "model" to end-users. These one-click bundles are called Lemonade Omni Models, and they're routed via an internal mechanism called OmniRouter. Learn more [here](./lemonade-omni.md).
 
+### Dynamic Custom Backends Architecture
+
+Lemonade supports dynamic, zero-recompilation custom JSON backends for external binaries and containerized engines. Read the [Custom Backends Specification](./custom-backends-spec.md).
+
 ### CI System
 
 Lemonade has a CI system that tests pull requests on real AI PC hardware targets. The [self-hosted runners](./self-hosted-runners.md) guide documents how those are set up.

--- a/docs/dev/adding-a-backend.md
+++ b/docs/dev/adding-a-backend.md
@@ -17,6 +17,9 @@ No router edits, no CLI edits, no doc edits, no support-matrix edits.
 
 That covers the backend's wiring. You still write an integration test ([Testing](#testing)). If the backend introduces a new endpoint or capability instead of serving one that already exists, you also write that endpoint, its router plumbing, and its API docs ([Adding a new endpoint or capability](#adding-a-new-endpoint-or-capability)).
 
+> [!TIP]
+> **Dynamic Custom JSON Backends**: For external binaries or containerized engines (Podman/Docker) that do not require C++ code changes or recompilation, see the [Custom Backends Specification](./custom-backends-spec.md) and the [Custom Backends User Guide](../guide/configuration/custom-backends.md).
+
 Everything for one backend lives in `lemon::backends::<stem>`. The descriptor is header-only so it links into **both** the `lemonade` CLI and `lemond`; the server class and `create()` are server-only (compiled into `lemond`).
 
 ## The descriptor — `<stem>/<stem>.h`

--- a/docs/dev/custom-backends-spec.md
+++ b/docs/dev/custom-backends-spec.md
@@ -1,0 +1,146 @@
+# Custom Backends Technical Specification & Architecture
+
+This document specifies the internal technical design, security model, string resolution engine, process handle supervision, and invariant enforcement for the **Dynamic Custom Backend System** in Lemonade.
+
+---
+
+## 1. Architectural Overview
+
+The dynamic custom backend system allows Lemonade to register, load, supervise, and unload out-of-process external inference engines declared via JSON descriptors.
+
+### Class Hierarchy
+
+```mermaid
+classDiagram
+    class WrappedServer {
+        <<abstract>>
+        +load(model_name, model_info, options)*
+        +unload()*
+        +is_backend_alive()*
+        +chat_completion(request)
+        +completion(request)
+        +embeddings(request)
+        +reranking(request)
+    }
+
+    class ExternalBackendServer {
+        -shared_ptr~BackendDescriptor~ descriptor_
+        -string selected_platform_
+        -BackendPlatformConfig active_platform_config_
+        -unordered_map~string, string~ instance_token_map_
+        -RecipeOptions loaded_recipe_options_
+        -mutex state_mutex_
+        +load(model_name, model_info, options)
+        +unload()
+        +is_backend_alive()
+        +perform_health_probe()
+        +resolve_command_args()
+    }
+
+    class BackendDescriptorRegistry {
+        +get_descriptor(recipe_name)
+        +list_descriptors()
+        -scan_descriptor_paths()
+        -check_path_permissions()
+    }
+
+    WrappedServer <|-- ExternalBackendServer
+    ExternalBackendServer --> BackendDescriptorRegistry
+```
+
+---
+
+## 2. Descriptor Discovery & POSIX Security Rules
+
+`BackendDescriptorRegistry` ([src/cpp/server/backends/backend_descriptor_registry.cpp](../../src/cpp/server/backends/backend_descriptor_registry.cpp)) scans search paths in strict priority order guarded by a `std::mutex`:
+
+1. **User Config Path**: `$XDG_CONFIG_HOME/lemonade/backends/` (`~/.config/lemonade/backends/`) or `%APPDATA%\Lemonade\backends\`
+2. **User Cache Path**: `~/.cache/lemonade/backends/` or `%USERPROFILE%\.cache\lemonade\backends\`
+3. **System Distribution Paths**: `/usr/share/lemonade-server/backends/`, `/usr/local/share/lemonade-server/backends/`, `/Library/Application Support/Lemonade/backends/`, `/etc/lemonade/backends/`, or `%ProgramData%\Lemonade\backends\`
+
+### Security Rules Validation Algorithm (`check_path_permissions`)
+
+To prevent local privilege escalation or arbitrary code execution via tampered descriptors:
+- **POSIX**:
+  - System distribution directories and files must be owned by `root` (UID 0).
+  - User directories and descriptor files must be owned by the running process's effective UID (`geteuid()`).
+  - Mode bits must satisfy `(st_mode & 0022) == 0`. Group-write and world-write permissions are rejected.
+  - Ancestor directory walks allow shared temporary directories (such as `/tmp`) if they are owned by the user or have the sticky bit (`S_ISVTX`) set.
+- **Windows**:
+  - Validates security descriptors using `GetNamedSecurityInfoW`. Write permissions assigned to `WinWorldSid` (Everyone) or `WinBuiltinUsersSid` (Users) are strictly rejected.
+
+---
+
+## 3. String Interpolation & Token Resolution Engine
+
+The core argument parsing logic resides in `ExternalBackendServer::resolve_command_args()` ([src/cpp/server/backends/external/external_backend_server.cpp](../../src/cpp/server/backends/external/external_backend_server.cpp)).
+
+### Resolution Steps
+1. **Builtin Token Replacement**:
+   Replaces placeholders such as `{port}`, `{host}`, `{recipe}`, `{model_name}`, `{resolved_path}`, `{hf_cache}`, `{cuda_visible_devices}`, `{hip_visible_devices}`, and `{ggml_vk_visible_devices}`.
+2. **Checkpoint Relative Map**:
+   Replaces `{checkpoint_relative:<name>}` with the relative snapshot blob path mapped in `user_models.json`.
+3. **Environment Variable Expansion (`{env:VAR:-default}`)**:
+   Reads `VAR` from system environment; if empty or unset, substitutes `default`.
+4. **Custom Option Expansion (`{custom:opt:-default}`)**:
+   Reads option `opt` from `RecipeOptions`; if missing, substitutes `default`.
+5. **Custom Argument Tokenization (`{custom_args}`)**:
+   Inspects `recipe_options.get_option("args")`. If a JSON array is provided (`["--flag", "val"]`), each element is appended as a distinct argument token. If a string is provided, arguments are tokenized using `lemon::utils::parse_custom_args()` (handling shell quotes and escape characters).
+6. **Character Whitelisting**:
+   Token values are verified against a character whitelist (`isalnum`, `_`, `-`, `:`, `.`, `/`, `=`, `,`, quotes, spaces) to prevent shell command injection.
+
+---
+
+## 4. Process Supervision & Health Probing
+
+```mermaid
+sequenceDiagram
+    participant R as Router
+    participant E as ExternalBackendServer
+    participant P as ProcessManager
+    participant Sub as Child Subprocess
+    participant H as Health Endpoint (/health)
+
+    R->>E: load(model_name, options)
+    E->>E: Stage 1: Run Pre-Launch Cleanup (stop_command)
+    E->>P: start_process(command, args, env)
+    P->>Sub: Spawn Child Subprocess
+    P-->>E: ProcessHandle (PID / HANDLE)
+    E->>E: start_backend_watchdog(endpoint)
+    loop Health Probe Polling
+        E->>P: get_process_handle_snapshot()
+        alt Process Exited Unexpectedly
+            P-->>E: is_running == false
+            E-->>R: Abort Probe & Throw Load Error (Fail-Fast <3s)
+        else Process Running
+            E->>H: GET /health
+            alt Status 200 OK
+                H-->>E: HTTP 200 OK
+                E-->>R: State = READY
+            end
+        end
+    end
+```
+
+### Fail-Fast Liveness Checks
+Inside `perform_health_probe()`, the polling loop checks `get_process_handle_snapshot()` on every iteration. If the child process crashes or terminates early (e.g. invalid arguments or bad GPU kernel initialization), the probe loop breaks immediately with log message `Subprocess died unexpectedly during health probe`, returning control to `Router` in <3 seconds instead of blocking for the full timeout duration.
+
+---
+
+## 5. Two-Stage Teardown & Handle Cleanup Invariants
+
+When `unload()` is invoked:
+1. `stop_backend_watchdog()` halts HTTP health monitoring.
+2. **Stage 1 (Custom Stop Command)**:
+   If `stop_command` is configured (e.g. `podman rm -f -t 0 lemonade-{recipe}-{port}`), Lemonade evaluates tokens in `stop_command_args` under `state_mutex_` snapshot and executes the command via `ProcessManager::run_command`.
+3. **Stage 2 (OS Process Handle Teardown)**:
+   If `has_process_handle(handle)` returns `true`, Lemonade invokes `ProcessManager::stop_process(handle)`. On POSIX systems, `stop_process` sends `SIGTERM`, waits up to 5s, sends `SIGKILL`, and reaps the child process via `waitpid` to prevent zombie `[defunct]` processes. On Windows, it invokes `TerminateProcess` and closes the handle via `CloseHandle`.
+
+---
+
+## 6. Critical Project Invariant Compliance
+
+1. **Quad-Prefix Endpoints**: `ExternalBackendServer` forwards HTTP capability payloads directly to `/v1/*` endpoints on the backend port, preserving Lemonade's quad-prefix handlers (`/api/v0/`, `/api/v1/`, `/v0/`, `/v1/`) in `server.cpp`.
+2. **Invariant 11 (Config Precedence)**: Explicit `RecipeOptions` take precedence over environment variables during token resolution.
+3. **WrappedServer Subprocess Model**: Dynamic backends execute strictly as out-of-process subprocesses managed by `ProcessManager`.
+4. **NPU Exclusivity**: `ExternalBackendServer::effective_slot_policy()` exposes the descriptor's `slot_policy` (`ExclusiveNpu`, `CoexistByType`, `Unmetered`, or `Standard`), enabling `Router` to enforce hardware exclusivity automatically.

--- a/docs/examples/custom_backends/dflash_rocm.json
+++ b/docs/examples/custom_backends/dflash_rocm.json
@@ -1,0 +1,70 @@
+{
+  "recipe": "dflash-rocm",
+  "display_name": "DFlash Speculative Decoding Server (ROCm Podman)",
+  "slot_policy": "standard",
+  "capabilities": [
+    "chat_completion",
+    "completion"
+  ],
+  "health_probe": {
+    "type": "http",
+    "endpoint": "/health",
+    "expected_status": 200,
+    "timeout_seconds": 300,
+    "poll_interval_ms": 500
+  },
+  "platforms": {
+    "rocm": {
+      "command": "podman",
+      "args": [
+        "run",
+        "--rm",
+        "--init",
+        "-i",
+        "--name",
+        "lemonade-{recipe}-{port}",
+        "--device",
+        "/dev/kfd",
+        "--device",
+        "/dev/dri",
+        "--group-add",
+        "video",
+        "--group-add",
+        "render",
+        "--security-opt",
+        "seccomp=unconfined",
+        "--security-opt",
+        "label=disable",
+        "-v",
+        "{hf_cache}:/models:ro",
+        "--network",
+        "host",
+        "--entrypoint",
+        "/opt/lucebox-hub/server/build/dflash_server",
+        "ghcr.io/luce-org/lucebox-hub:rocm-7.2",
+        "/models/{checkpoint_relative:main}",
+        "--target-device={target_device}",
+        "--model-name={model_name}",
+        "--host={host}",
+        "--port={port}",
+        "--max-ctx={ctx_size}",
+        "--cache-type-k={cache_type_k}",
+        "--cache-type-v={cache_type_v}",
+        "--draft=/models/{checkpoint_relative:draft}",
+        "{custom_args}"
+      ],
+      "stop_command": "podman",
+      "stop_command_args": [
+        "rm",
+        "-f",
+        "-t",
+        "0",
+        "lemonade-{recipe}-{port}"
+      ],
+      "env": {
+        "DFLASH_DRAFT_SWA": "{custom:draft_swa:-2048}",
+        "DFLASH_PREFILL_UBATCH": "{custom:prefill_ubatch:-512}"
+      }
+    }
+  }
+}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -329,6 +329,12 @@ The following options apply to all model loads:
 The following options are available depending on the recipe being used:
 
 <!-- BEGIN GENERATED: cli-recipe-options -->
+#### OpenMOSS TTS (`openmoss` recipe)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--openmoss BACKEND` | OpenMOSS TTS backend to use | Auto-detected |
+
 #### Llama.cpp GPU (`llamacpp` recipe)
 
 | Option | Description | Default |
@@ -338,25 +344,11 @@ The following options are available depending on the recipe being used:
 | `--llamacpp-device DEVICES` | Comma-separated list of accelerator devices to use (e.g. Vulkan0) | `""` |
 | `--llamacpp-args ARGS` | Custom arguments to pass to llama-server | `""` |
 
-#### Whisper.cpp (`whispercpp` recipe)
+#### TRELLIS.2 (`trellis` recipe)
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--whispercpp BACKEND` | WhisperCpp backend to use | Auto-detected |
-| `--whispercpp-args ARGS` | Custom arguments to pass to whisper-server | `""` |
-
-#### Moonshine (`moonshine` recipe)
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--moonshine-args ARGS` | Custom arguments to pass to moonshine-server | `""` |
-
-#### StableDiffusion.cpp (`sd-cpp` recipe)
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--sdcpp BACKEND` | SD.cpp backend to use | Auto-detected |
-| `--sdcpp-args ARGS` | Custom arguments to pass to sd-server (must not conflict with managed args) | `""` |
+| `--trellis BACKEND` | Trellis backend to use | Auto-detected |
 
 #### FastFlowLM NPU (`flm` recipe)
 
@@ -365,11 +357,12 @@ The following options are available depending on the recipe being used:
 | `--ctx-size SIZE` | Context size for the model | auto |
 | `--flm-args ARGS` | Safe flm serve tuning args: --pmode, --prefill-chunk-len, --img-pre-resize, --socket, --q-len, --preemption | `""` |
 
-#### Ryzen AI LLM (`ryzenai-llm` recipe)
+#### StableDiffusion.cpp (`sd-cpp` recipe)
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--ctx-size SIZE` | Context size for the model | auto |
+| `--sdcpp BACKEND` | SD.cpp backend to use | Auto-detected |
+| `--sdcpp-args ARGS` | Custom arguments to pass to sd-server (must not conflict with managed args) | `""` |
 
 #### vLLM ROCm (experimental) (`vllm` recipe)
 
@@ -379,35 +372,42 @@ The following options are available depending on the recipe being used:
 | `--vllm BACKEND` | vLLM backend to use | Auto-detected |
 | `--vllm-args ARGS` | Custom arguments to pass to vllm-server | `""` |
 
-#### ThinkSound (`thinksound` recipe)
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--thinksound BACKEND` | ThinkSound backend to use | Auto-detected |
-
 #### ACE-Step (`acestep` recipe)
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--acestep BACKEND` | ACE-Step backend to use | Auto-detected |
 
+#### Moonshine (`moonshine` recipe)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--moonshine-args ARGS` | Custom arguments to pass to moonshine-server | `""` |
+
+#### ThinkSound (`thinksound` recipe)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--thinksound BACKEND` | ThinkSound backend to use | Auto-detected |
+
+#### Whisper.cpp (`whispercpp` recipe)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--whispercpp BACKEND` | WhisperCpp backend to use | Auto-detected |
+| `--whispercpp-args ARGS` | Custom arguments to pass to whisper-server | `""` |
+
+#### Ryzen AI LLM (`ryzenai-llm` recipe)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ctx-size SIZE` | Context size for the model | auto |
+
 #### ONNX Runtime (`onnxruntime` recipe)
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--onnxruntime-args ARGS` | Custom arguments to pass to ort-server | `""` |
-
-#### TRELLIS.2 (`trellis` recipe)
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--trellis BACKEND` | Trellis backend to use | Auto-detected |
-
-#### OpenMOSS TTS (`openmoss` recipe)
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--openmoss BACKEND` | OpenMOSS TTS backend to use | Auto-detected |
 <!-- END GENERATED: cli-recipe-options -->
 **Notes:**
 - Unspecified options will use the backend's default values

--- a/docs/guide/configuration/custom-backends.md
+++ b/docs/guide/configuration/custom-backends.md
@@ -1,0 +1,239 @@
+# Custom Backends Configuration Guide
+
+This guide explains how to define, configure, and register **Custom JSON Backend Descriptors** in Lemonade. Custom backends allow you to integrate external inference binaries (such as custom `llama-server` builds or `flm`) or containerized engines (such as Podman/Docker containers running speculative decoding servers) directly into Lemonade without modifying or recompiling the core C++ server.
+
+---
+
+## 1. Overview & Capabilities
+
+Custom backends allow you to:
+- **Run External Inference Engines**: Dispatch requests to standalone binaries or containerized LLM servers.
+- **Isolate Environments & Hardware**: Pass per-process environment variables (`HIP_VISIBLE_DEVICES`, `CUDA_VISIBLE_DEVICES`, `GGML_VK_VISIBLE_DEVICES`).
+- **Dynamic Argument Interpolation**: Substitute dynamic tokens like `{port}`, `{host}`, `{resolved_path}`, `{custom:opt:-default}`, and `{custom_args}` at load time.
+- **Container Lifecycle Supervision**: Automatically clean up and stop Podman/Docker containers upon model unloading or server shutdown.
+- **Fail-Fast Health Probing**: Validate process health via HTTP `/health` endpoints with configurable timeouts and instant process death detection.
+
+---
+
+## 2. Descriptor File Locations & Priority Hierarchy
+
+Lemonade searches for custom backend descriptor `.json` files across standard user and system paths in priority order:
+
+1. **User Configuration Directory (Highest Priority)**:
+   - `$XDG_CONFIG_HOME/lemonade/backends/` or `~/.config/lemonade/backends/` (Linux / macOS)
+   - `%APPDATA%\Lemonade\backends\` (Windows)
+2. **User Cache Directory (Medium Priority)**:
+   - `~/.cache/lemonade/backends/` (Linux / macOS)
+   - `%USERPROFILE%\.cache\lemonade\backends\` (Windows)
+3. **System Distribution Directories (Lowest Priority)**:
+   - `/usr/share/lemonade-server/backends/`, `/usr/local/share/lemonade-server/backends/`, `/Library/Application Support/Lemonade/backends/`, `/etc/lemonade/backends/` (Linux / macOS)
+   - `%ProgramData%\Lemonade\backends\` (Windows)
+
+> [!IMPORTANT]
+> **File Security Rules**:
+> - **POSIX (Linux/macOS)**: Descriptors in user directories must be owned by the current user (`geteuid()`), and system descriptors must be owned by `root` (UID 0). Group-write and world-write permissions are strictly forbidden (`mode & 0022 == 0`). Ancestor directories must not be group/world writable unless they are owned by the user or have the sticky bit set (e.g. `/tmp` with `S_ISVTX`).
+> - **Windows**: ACLs are verified via `GetNamedSecurityInfoW`. Write permissions assigned to `WinWorldSid` (Everyone) or `WinBuiltinUsersSid` (Users) are strictly rejected.
+
+---
+
+## 3. Creating a Custom Backend Descriptor
+
+A backend descriptor is a JSON file named `<recipe-name>.json` placed in one of the backend directories.
+
+### Example 1: Custom `llama-server` (Vulkan / ROCm)
+
+Create `~/.config/lemonade/backends/llamacpp_vulkan_custom.json`:
+
+```json
+{
+  "recipe": "llamacpp-vulkan-custom",
+  "display_name": "llama.cpp (Vulkan Custom Binary)",
+  "slot_policy": "standard",
+  "capabilities": [
+    "chat_completion",
+    "completion"
+  ],
+  "endpoints": {
+    "chat_completion": "/v1/chat/completions",
+    "completion": "/v1/completions"
+  },
+  "health_probe": {
+    "type": "http",
+    "endpoint": "/health",
+    "expected_status": 200,
+    "timeout_seconds": 60,
+    "poll_interval_ms": 100
+  },
+  "platforms": {
+    "vulkan": {
+      "command": "/home/user/.cache/lemonade/bin/llamacpp/vulkan/llama-server",
+      "args": [
+        "-m",
+        "{resolved_path}",
+        "--host",
+        "{host}",
+        "--port",
+        "{port}",
+        "-c",
+        "{ctx_size}",
+        "-t",
+        "{custom:threads:-4}"
+      ],
+      "env": {
+        "GGML_VK_VISIBLE_DEVICES": "{ggml_vk_visible_devices}"
+      }
+    }
+  }
+}
+```
+
+---
+
+### Example 2: Containerized Backend (Podman ROCm Container)
+
+Create `~/.config/lemonade/backends/dflash_rocm.json`:
+
+```json
+{
+  "recipe": "dflash-rocm",
+  "display_name": "DFlash Speculative Decoding Server (ROCm Podman)",
+  "slot_policy": "standard",
+  "capabilities": [
+    "chat_completion",
+    "completion"
+  ],
+  "health_probe": {
+    "type": "http",
+    "endpoint": "/health",
+    "expected_status": 200,
+    "timeout_seconds": 300,
+    "poll_interval_ms": 500
+  },
+  "platforms": {
+    "rocm": {
+      "command": "podman",
+      "args": [
+        "run",
+        "--rm",
+        "--init",
+        "-i",
+        "--name",
+        "lemonade-{recipe}-{port}",
+        "--device",
+        "/dev/kfd",
+        "--device",
+        "/dev/dri",
+        "--group-add",
+        "video",
+        "--group-add",
+        "render",
+        "--security-opt",
+        "seccomp=unconfined",
+        "--security-opt",
+        "label=disable",
+        "-v",
+        "{hf_cache}:/models:ro",
+        "--network",
+        "host",
+        "--entrypoint",
+        "/opt/lucebox-hub/server/build/dflash_server",
+        "ghcr.io/luce-org/lucebox-hub:rocm-7.2",
+        "/models/{checkpoint_relative:main}",
+        "--target-device={target_device}",
+        "--model-name={model_name}",
+        "--host={host}",
+        "--port={port}",
+        "--max-ctx={ctx_size}",
+        "--cache-type-k={cache_type_k}",
+        "--cache-type-v={cache_type_v}",
+        "--draft=/models/{checkpoint_relative:draft}",
+        "{custom_args}"
+      ],
+      "stop_command": "podman",
+      "stop_command_args": [
+        "rm",
+        "-f",
+        "-t",
+        "0",
+        "lemonade-{recipe}-{port}"
+      ],
+      "env": {
+        "DFLASH_DRAFT_SWA": "{custom:draft_swa:-2048}"
+      }
+    }
+  }
+}
+```
+
+> [!TIP]
+> **Container Signal Handling**: Always pass `--init` to `podman run` or `docker run`. This injects a lightweight init process as PID 1 inside the container, ensuring signals like `SIGTERM` and `SIGKILL` propagate instantly to the child process when unloading.
+
+---
+
+## 4. Supported Token Placeholders
+
+Lemonade dynamically interpolates placeholders in `args`, `env`, and `stop_command_args` at load time:
+
+| Token Placeholder | Resolution Source | Description |
+| :--- | :--- | :--- |
+| `{port}` | Runtime | Assigned HTTP port for backend server process. |
+| `{host}` | Runtime | Configured host address (e.g. `127.0.0.1`). |
+| `{log_level}` | Runtime | Configured server log level (`info`, `debug`, etc.). |
+| `{recipe}` | Descriptor JSON | Unique recipe identifier string. |
+| `{model_name}` | Request Payload | Fully qualified model name requested by the client. |
+| `{resolved_path}` | `ModelInfo` | Absolute file system path to the primary model checkpoint file. |
+| `{model_dir}` | `ModelInfo` | Absolute parent directory path of the primary model checkpoint file. |
+| `{exe_dir}` | Backend Execution | Absolute parent directory path of the backend command binary. |
+| `{hf_cache}` | Environment / Cache | Hugging Face cache root directory (`~/.cache/huggingface/hub`). |
+| `{model_relative_path}` | `ModelInfo` | Relative path from HF cache root to primary model checkpoint. |
+| `{checkpoint:<name>}` | `user_models.json` | Absolute path to named secondary checkpoint (e.g. `draft`). |
+| `{checkpoint_relative:<name>}` | `user_models.json` | Relative path to named secondary checkpoint from HF cache. |
+| `{rocm_arch}` | Hardware Topology | Detected AMD ROCm GPU architecture string (e.g. `gfx1151`). |
+| `{cuda_arch}` | Hardware Topology | Detected NVIDIA CUDA compute capability string (e.g. `sm_90`). |
+| `{cuda_visible_devices}` | Hardware Topology | GPU index for CUDA allocation. |
+| `{hip_visible_devices}` | Hardware Topology | GPU index for ROCm/HIP allocation. |
+| `{rocr_visible_devices}` | Hardware Topology | GPU index for ROCR/HIP allocation. |
+| `{ggml_vk_visible_devices}` | Hardware Topology | Device index for Vulkan allocation. |
+| `{ze_affinity_mask}` | Hardware Topology | Device index for Level Zero / Intel GPU allocation. |
+| `{env:VAR:-default}` | System Environment | Reads environment variable `VAR`. Uses `default` if not set. |
+| `{custom:opt:-default}` | `RecipeOptions` | Reads custom option `opt` passed in model recipe options. Uses `default` if omitted. |
+| `{custom_args}` | `RecipeOptions` | Expands extra command-line flags. Accepts JSON arrays or shell-quoted strings. |
+
+---
+
+## 5. Registering a Custom Model
+
+Once your backend descriptor is saved, reference its `recipe` in `user_models.json`:
+
+```json
+{
+  "gemma3-270m-vulkan-custom": {
+    "checkpoint": "unsloth/gemma-3-270m-it-GGUF:gemma-3-270m-it-UD-IQ2_M.gguf",
+    "recipe": "llamacpp-vulkan-custom",
+    "recipe_options": {
+      "ctx_size": 4096,
+      "threads": 8
+    }
+  }
+}
+```
+
+Now dispatch requests using standard OpenAI REST endpoints:
+
+```bash
+curl -X POST http://localhost:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemma3-270m-vulkan-custom",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+---
+
+## 6. Troubleshooting & Logs
+
+To inspect backend startup output or debug container launching:
+1. Stream server logs via `/v1/logs/stream` or check `lemond.log`.
+2. Inspect active processes using `ps aux | grep <command>`.
+3. Check container status using `podman ps -a` or `docker ps -a`.

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -87,7 +87,7 @@ Supported registration flags:
 |------|-------------|
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` (default) or `modelscope`. |
 | `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
-| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
+| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`openmoss`, `llamacpp`, `trellis`, `flm`, `kokoro`, `sd-cpp`, `vllm`, `acestep`, `moonshine`, `thinksound`, `whispercpp`, `ryzenai-llm`, `onnxruntime`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `coding`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |
 

--- a/docs/guide/configuration/multi-model.md
+++ b/docs/guide/configuration/multi-model.md
@@ -63,7 +63,7 @@ backend's hardware slot policy:
 ## Device Constraints
 
 <!-- BEGIN GENERATED: npu-exclusivity -->
-- **NPU Exclusivity:** `whispercpp`, `flm`, and `ryzenai-llm` are mutually exclusive on the NPU.
+- **NPU Exclusivity:** `flm`, `whispercpp`, and `ryzenai-llm` are mutually exclusive on the NPU.
 <!-- END GENERATED: npu-exclusivity -->
     - Loading a model from one of these backends will automatically evict all NPU models from the other backends.
     - `flm` supports loading 1 ASR model, 1 LLM, and 1 embedding model on the NPU at the same time.

--- a/schemas/custom_backend.schema.json
+++ b/schemas/custom_backend.schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Lemonade Dynamic Backend Descriptor Schema",
+  "description": "Defines a dynamic custom backend descriptor. Backend binaries or containers must serve OpenAI-compatible REST API endpoints under /v1/*.",
+  "type": "object",
+  "required": [
+    "recipe",
+    "display_name",
+    "capabilities",
+    "platforms"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "recipe": {
+      "type": "string",
+      "pattern": "^[a-z0-9_-]+$",
+      "description": "Unique identifier for the backend recipe (e.g. 'dflash-rocm')."
+    },
+    "display_name": {
+      "type": "string",
+      "description": "Human-readable display name for the backend."
+    },
+    "modality": {
+      "type": "string",
+      "description": "Primary inference modality (e.g. 'Text generation', 'Speech-to-text')."
+    },
+    "slot_policy": {
+      "type": "string",
+      "enum": ["standard", "exclusive_npu", "coexist_by_type", "unmetered"],
+      "description": "LRU slot and resource allocation policy."
+    },
+    "default_device": {
+      "type": "string",
+      "description": "Default accelerator device (e.g. 'gpu', 'cpu', 'npu')."
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "description": "Supported inference capabilities (e.g. 'chat_completion', 'completion', 'embeddings')."
+    },
+    "endpoints": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Optional custom REST API endpoint path overrides for non-OpenAI third-party runners (e.g. chat_completion -> '/api/v1/chat')."
+    },
+    "protected_flags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Optional list of protected CLI flags (e.g. ['--port', '--host']) that user custom_args cannot override."
+    },
+    "health_probe": {
+      "type": "object",
+      "description": "Configuration for server readiness health checking.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["http", "tcp", "process"]
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "expected_status": {
+          "type": "integer"
+        },
+        "timeout_seconds": {
+          "type": "integer"
+        },
+        "poll_interval_ms": {
+          "type": "integer"
+        }
+      }
+    },
+    "health_endpoint": {
+      "type": "string",
+      "description": "Legacy fallback health endpoint path (prefer health_probe.endpoint)."
+    },
+    "health_timeout_seconds": {
+      "type": "integer",
+      "description": "Legacy fallback health timeout in seconds (prefer health_probe.timeout_seconds)."
+    },
+    "downsize_endpoint": {
+      "type": "string",
+      "description": "Optional REST endpoint for VRAM/RAM downsizing."
+    },
+    "custom_options": {
+      "type": "array",
+      "description": "Custom configuration options exposed to CLI and config files.",
+      "items": {
+        "type": "object",
+        "required": ["name", "cli_flag", "default_value", "help"],
+        "properties": {
+          "name": { "type": "string" },
+          "cli_flag": { "type": "string" },
+          "default_value": {},
+          "type_name": { "type": "string" },
+          "help": { "type": "string" },
+          "group": { "type": "string" }
+        }
+      }
+    },
+    "platforms": {
+      "type": "object",
+      "description": "Platform-specific execution specifications (e.g. 'rocm', 'cuda', 'cpu', 'metal'). Supported token replacements in args, stop_command_args, and env values include: {recipe}, {port}, {host}, {log_level}, {model_name}, {resolved_path}, {model_dir}, {exe_dir}, {hf_cache}, {model_relative_path}, {checkpoint:<name>}, {checkpoint_relative:<name>}, {rocm_arch}, {cuda_arch}, {cuda_visible_devices}, {hip_visible_devices}, {ggml_vk_visible_devices}, {custom:<opt>[:-default]}, {env:<var>[:-default]}, {custom_args}.",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["command", "args"],
+        "properties": {
+          "command": {
+            "type": "string",
+            "description": "Executable or container manager binary (e.g. 'podman', 'docker', '/path/to/binary')."
+          },
+          "args": {
+            "type": "array",
+            "description": "Command line arguments, supporting runtime token replacements.",
+            "items": { "type": "string" }
+          },
+          "stop_command": {
+            "type": "string",
+            "description": "Optional executable for stopping container/process (defaults to 'command' if omitted)."
+          },
+          "stop_command_args": {
+            "type": "array",
+            "description": "Command line arguments executed during backend unload to gracefully stop and clean up containers.",
+            "items": { "type": "string" }
+          },
+          "env": {
+            "type": "object",
+            "description": "Environment variables passed to the spawned process or container.",
+            "additionalProperties": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/cpp/include/lemon/backends/backend_descriptor.h
+++ b/src/cpp/include/lemon/backends/backend_descriptor.h
@@ -101,6 +101,51 @@ struct BackendDescriptor {
     std::vector<std::string> bin_variants;         // each emits `<variant>_bin: "builtin"`
     nlohmann::json config_extra = nlohmann::json::object();  // fixed extras (e.g. prefer_system, image defaults)
 
+    // --- Dynamic Backend Configuration & Platform Matrix ---
+    struct PlatformConfig {
+        std::string command;
+        std::vector<std::string> args;
+        std::string stop_command;
+        std::vector<std::string> stop_command_args;
+        std::unordered_map<std::string, std::string> env;
+    };
+
+    struct HealthProbeConfig {
+        std::string type = "http"; // "http" | "tcp" | "process"
+        std::string endpoint = "/health";
+        int expected_status = 200;
+        int timeout_seconds = 90;
+        int poll_interval_ms = 100;
+    };
+
+    bool is_dynamic = false;
+    std::string health_endpoint = "/health";
+    int health_timeout_seconds = 90;
+    std::string downsize_endpoint;
+    HealthProbeConfig health_probe;
+    std::vector<std::string> capabilities;
+    std::vector<std::string> protected_flags;
+    std::unordered_map<std::string, PlatformConfig> platforms;
+    std::unordered_map<std::string, std::string> endpoints;
+
+    std::string get_endpoint_path(const std::string& key, const std::string& default_path) const {
+        auto it = endpoints.find(key);
+        if (it != endpoints.end() && !it->second.empty()) {
+            return it->second;
+        }
+        return default_path;
+    }
+
+    bool has_capability(const std::string& cap) const {
+        if (capabilities.empty()) return true;
+        for (const auto& c : capabilities) {
+            if (c == cap) return true;
+            if (cap == "completion" && c == "chat_completion") return true;
+            if (cap == "chat_completion" && c == "completion") return true;
+        }
+        return false;
+    }
+
     // The config.json section name for this backend, falling back to the recipe.
     std::string effective_config_section() const {
         return config_section.empty() ? recipe : config_section;

--- a/src/cpp/include/lemon/backends/backend_descriptor_registry.h
+++ b/src/cpp/include/lemon/backends/backend_descriptor_registry.h
@@ -18,6 +18,9 @@ const std::vector<const BackendDescriptor*>& all_descriptors();
 // Descriptor for a recipe, or nullptr if the recipe has no registered backend.
 const BackendDescriptor* descriptor_for(const std::string& recipe);
 
+// Shared descriptor for a recipe, preserving shared ownership for dynamic descriptors.
+std::shared_ptr<const BackendDescriptor> descriptor_shared_for(const std::string& recipe);
+
 // True if the recipe is backed by a registered descriptor.
 bool has_backend(const std::string& recipe);
 
@@ -25,6 +28,15 @@ bool has_backend(const std::string& recipe);
 // "rocm" backend resolves to a channel-specific artifact. False for recipes whose
 // rocm build is a single artifact (or that have no rocm build at all).
 bool recipe_has_rocm_channels(const std::string& recipe);
+
+// Force a refresh of dynamic descriptors from search paths.
+void refresh_descriptors();
+
+// Start a background file-watcher thread that polls descriptor directories for changes.
+void start_file_watcher();
+
+// Stop the background file-watcher thread.
+void stop_file_watcher();
 
 } // namespace backends
 } // namespace lemon

--- a/src/cpp/include/lemon/backends/external/external_backend_server.h
+++ b/src/cpp/include/lemon/backends/external/external_backend_server.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "lemon/wrapped_server.h"
+#include "lemon/server_capabilities.h"
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace lemon {
+
+class ExternalBackendServer : public WrappedServer,
+                               public IEmbeddingsServer,
+                               public IRerankingServer,
+                               public ITranscriptionServer,
+                               public IStreamingTranscriptionServer,
+                               public ITextToSpeechServer,
+                               public IClassificationServer,
+                               public IImageServer,
+                               public IAudioGenerationServer,
+                               public IModel3DServer,
+                               public ISlotsServer,
+                               public ITokenizerServer {
+public:
+    ExternalBackendServer(const std::string& server_name);
+    virtual ~ExternalBackendServer() override;
+
+    void load(const std::string& model_name,
+              const ModelInfo& model_info,
+              const RecipeOptions& options,
+              bool do_not_upgrade = false) override;
+    void unload() override;
+
+    bool downsize() override;
+    void restore() override;
+
+    bool wait_for_ready(const std::string& endpoint, long timeout_seconds = 600, long poll_interval_ms = 100) override;
+
+    bool has_capability(const std::string& cap_name) const override;
+    bool supports_downsize() const override;
+
+    json chat_completion(const json& request) override;
+    json completion(const json& request) override;
+    json responses(const json& request) override;
+
+    json embeddings(const json& request) override;
+
+    json reranking(const json& request) override;
+
+    json audio_transcriptions(const json& request) override;
+
+    std::string get_streaming_address() override;
+
+    void audio_speech(const json& request, httplib::DataSink& sink) override;
+
+    json classify(const json& request) override;
+
+    json image_generations(const json& request) override;
+    json image_edits(const json& request) override;
+    json image_variations(const json& request) override;
+
+    void audio_generations(const json& request, httplib::DataSink& sink) override;
+
+    void model_3d_generations(const json& request, httplib::DataSink& sink) override;
+
+    json get_slots() override;
+    json slots_action(int slot_id, const std::string& action, const json& request_body) override;
+
+    json tokenize(const json& request_body) override;
+
+private:
+    std::vector<std::string> resolve_command_args(
+        const std::vector<std::string>& template_args,
+        const std::unordered_map<std::string, std::string>& token_map,
+        const RecipeOptions& recipe_options);
+
+    bool perform_health_probe(const std::string& endpoint,
+                              int expected_status,
+                              int timeout_seconds,
+                              int poll_interval_ms);
+
+    std::string selected_platform_;
+    BackendDescriptor::PlatformConfig active_platform_config_;
+    std::unordered_map<std::string, std::string> instance_token_map_;
+    RecipeOptions loaded_recipe_options_;
+};
+
+} // namespace lemon

--- a/src/cpp/include/lemon/model_manager.h
+++ b/src/cpp/include/lemon/model_manager.h
@@ -274,6 +274,9 @@ public:
     // Get shared model-hub cache directory (respects HF_HUB_CACHE, HF_HOME, and platform defaults)
     std::string get_hf_cache_dir() const;
 
+    // Resolve model checkpoint specifier to absolute path on disk
+    std::string resolve_model_path(const ModelInfo& info, const std::string& type, const std::string& checkpoint) const;
+
     // Set extra models directory for GGUF discovery.
     // Starts/stops an inotify (Linux) / kqueue (macOS) watcher that
     // automatically refreshes the model cache when files are added or
@@ -347,7 +350,6 @@ private:
     void remove_model_from_cache(const std::string& model_name);
 
     // Resolve model checkpoint to absolute path on disk
-    std::string resolve_model_path(const ModelInfo& info, const std::string& type, const std::string& checkpoint) const;
     void resolve_all_model_paths(ModelInfo& info);
 
     // Download from a JSON manifest

--- a/src/cpp/include/lemon/server_capabilities.h
+++ b/src/cpp/include/lemon/server_capabilities.h
@@ -10,6 +10,10 @@ using json = nlohmann::json;
 class ICapability {
 public:
     virtual ~ICapability() = default;
+    virtual bool has_capability(const std::string& cap_name) const {
+        (void)cap_name;
+        return true;
+    }
 };
 
 class ICompletionServer : public virtual ICapability {
@@ -104,8 +108,31 @@ public:
 };
 
 template<typename T>
+inline const char* capability_name_for_type() { return ""; }
+
+template<> inline const char* capability_name_for_type<ICompletionServer>() { return "completion"; }
+template<> inline const char* capability_name_for_type<IEmbeddingsServer>() { return "embeddings"; }
+template<> inline const char* capability_name_for_type<IRerankingServer>() { return "reranking"; }
+template<> inline const char* capability_name_for_type<ITranscriptionServer>() { return "audio_transcription"; }
+template<> inline const char* capability_name_for_type<IStreamingTranscriptionServer>() { return "audio_transcription"; }
+template<> inline const char* capability_name_for_type<ITextToSpeechServer>() { return "text_to_speech"; }
+template<> inline const char* capability_name_for_type<IClassificationServer>() { return "classification"; }
+template<> inline const char* capability_name_for_type<IImageServer>() { return "image_generation"; }
+template<> inline const char* capability_name_for_type<IAudioGenerationServer>() { return "audio_generation"; }
+template<> inline const char* capability_name_for_type<IModel3DServer>() { return "model_3d"; }
+template<> inline const char* capability_name_for_type<ISlotsServer>() { return "slots"; }
+template<> inline const char* capability_name_for_type<ITokenizerServer>() { return "tokenize"; }
+
+template<typename T>
 bool supports_capability(ICapability* server) {
-    return dynamic_cast<T*>(server) != nullptr;
+    if (!server) return false;
+    T* casted = dynamic_cast<T*>(server);
+    if (!casted) return false;
+    const char* name = capability_name_for_type<T>();
+    if (name && name[0] != '\0' && !server->has_capability(name)) {
+        return false;
+    }
+    return true;
 }
 
 } // namespace lemon

--- a/src/cpp/include/lemon/utils/shell_utils.h
+++ b/src/cpp/include/lemon/utils/shell_utils.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace lemon::utils {
+
+inline std::string escape_windows_arg(const std::string& arg) {
+    if (arg.empty()) {
+        return "\"\"";
+    }
+
+    bool needs_quotes = false;
+    bool has_cmd_meta = false;
+    for (char c : arg) {
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '"') {
+            needs_quotes = true;
+        }
+        if (c == '&' || c == '|' || c == '^' || c == '%' || c == '<' || c == '>' || c == '(' || c == ')') {
+            has_cmd_meta = true;
+        }
+    }
+
+    if (!needs_quotes && !has_cmd_meta) {
+        return arg;
+    }
+
+    if (!needs_quotes && has_cmd_meta) {
+        std::string escaped;
+        for (char c : arg) {
+            if (c == '&' || c == '|' || c == '^' || c == '%' || c == '<' || c == '>' || c == '(' || c == ')') {
+                escaped.push_back('^');
+            }
+            escaped.push_back(c);
+        }
+        return escaped;
+    }
+
+    // CommandLineToArgvW standard escaping
+    std::string base_arg = "\"";
+    int backslashes = 0;
+    for (char c : arg) {
+        if (c == '\\') {
+            backslashes++;
+        } else if (c == '"') {
+            base_arg.append(backslashes * 2 + 1, '\\');
+            base_arg.push_back('"');
+            backslashes = 0;
+        } else {
+            base_arg.append(backslashes, '\\');
+            base_arg.push_back(c);
+            backslashes = 0;
+        }
+    }
+    base_arg.append(backslashes * 2, '\\');
+    base_arg.push_back('"');
+
+    if (!has_cmd_meta) {
+        return base_arg;
+    }
+
+    // Process cmd.exe quote state and metacharacters
+    std::string escaped;
+    bool in_cmd_quotes = false;
+    for (size_t i = 0; i < base_arg.length(); ++i) {
+        char c = base_arg[i];
+        if (c == '"') {
+            size_t backslash_count = 0;
+            size_t j = i;
+            while (j > 0 && base_arg[j - 1] == '\\') {
+                backslash_count++;
+                j--;
+            }
+            if (backslash_count % 2 == 0) {
+                in_cmd_quotes = !in_cmd_quotes;
+            }
+            escaped.push_back(c);
+        } else if (c == '%') {
+            if (in_cmd_quotes) {
+                escaped += "\"^%\"";
+            } else {
+                escaped += "^%";
+            }
+        } else if (!in_cmd_quotes && (c == '&' || c == '|' || c == '^' || c == '<' || c == '>' || c == '(' || c == ')')) {
+            escaped.push_back('^');
+            escaped.push_back(c);
+        } else {
+            escaped.push_back(c);
+        }
+    }
+    return escaped;
+}
+
+inline std::string escape_posix_shell_arg(const std::string& arg) {
+    if (arg.empty()) {
+        return "''";
+    }
+    bool safe = true;
+    for (char c : arg) {
+        if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_' && c != '-' && c != '.' && c != '/' && c != ':') {
+            safe = false;
+            break;
+        }
+    }
+    if (safe) {
+        return arg;
+    }
+
+    std::string escaped = "'";
+    for (char c : arg) {
+        if (c == '\'') {
+            escaped += "'\\''";
+        } else {
+            escaped += c;
+        }
+    }
+    escaped += "'";
+    return escaped;
+}
+
+inline std::string escape_shell_arg(const std::string& arg) {
+#ifdef _WIN32
+    return escape_windows_arg(arg);
+#else
+    return escape_posix_shell_arg(arg);
+#endif
+}
+
+inline std::string sanitize_log_string(const std::string& input) {
+    std::string result = input;
+    static const std::vector<std::string> sensitive_keywords = {"KEY", "TOKEN", "SECRET", "PASS", "AUTH"};
+    for (const auto& kw : sensitive_keywords) {
+        size_t pos = 0;
+        while ((pos = result.find(kw, pos)) != std::string::npos) {
+            size_t eq_pos = result.find('=', pos);
+            if (eq_pos != std::string::npos && eq_pos - pos < 40) {
+                size_t val_end = result.find_first_of(" \t\n\r&", eq_pos + 1);
+                if (val_end == std::string::npos) val_end = result.length();
+                result.replace(eq_pos + 1, val_end - (eq_pos + 1), "[REDACTED]");
+            }
+            pos += kw.length();
+        }
+    }
+    return result;
+}
+
+} // namespace lemon::utils

--- a/src/cpp/include/lemon/wrapped_server.h
+++ b/src/cpp/include/lemon/wrapped_server.h
@@ -223,6 +223,7 @@ public:
     // router lock with only a raw pointer to it.
     bool try_begin_downsize() {
         std::lock_guard<std::mutex> lock(state_mutex_);
+        if (!supports_downsize()) return false;
         if (state_ == ModelState::READY && active_request_count_ == 0) {
             state_ = ModelState::DOWNSIZING;
             maintenance_in_progress_ = true;
@@ -331,6 +332,17 @@ public:
     static void set_request_cancel_flag(std::atomic<bool>* f);
     static std::atomic<bool>* current_request_cancel();
 
+    // Dynamic capability query (overridden by ExternalBackendServer)
+    virtual bool has_capability(const std::string& cap_name) const override {
+        (void)cap_name;
+        return true;
+    }
+
+    // Downsize availability query
+    virtual bool supports_downsize() const {
+        return true;
+    }
+
     // Downsize the model on soft idle (e.g., clear KV cache). Returns true if the
     // downsize succeeded (or was a no-op), false if the backend operation failed.
     // The default is a successful no-op: backends that cannot downsize transition
@@ -361,7 +373,15 @@ public:
     // effective_* hooks below default to the descriptor's declared values; a
     // backend whose device or eviction rule depends on the chosen backend
     // variant overrides them (e.g. whisper on npu vs cpu, llamacpp on cpu vs gpu).
-    void set_descriptor(const BackendDescriptor* descriptor) { descriptor_ = descriptor; }
+    void set_descriptor(const BackendDescriptor* descriptor) {
+        descriptor_ = descriptor;
+        descriptor_shared_.reset();
+    }
+    void set_descriptor(std::shared_ptr<const BackendDescriptor> descriptor) {
+        descriptor_shared_ = descriptor;
+        descriptor_ = descriptor.get();
+    }
+    std::shared_ptr<const BackendDescriptor> get_descriptor_shared() const { return descriptor_shared_; }
     const BackendDescriptor* get_descriptor() const { return descriptor_; }
 
     // Effective accelerator device for this load. The router calls this after it
@@ -518,6 +538,7 @@ protected:
     ModelManager* model_manager_;  // Non-owning pointer to ModelManager
     BackendManager* backend_manager_;  // Non-owning pointer to BackendManager
     const BackendDescriptor* descriptor_ = nullptr;  // Non-owning; set by the backend registry at create()
+    std::shared_ptr<const BackendDescriptor> descriptor_shared_; // Shared ownership for dynamic descriptors
 
     // Multi-model support fields
     std::string model_name_;

--- a/src/cpp/server/backends/backend_descriptor_registry.cpp
+++ b/src/cpp/server/backends/backend_descriptor_registry.cpp
@@ -1,21 +1,518 @@
 #include "lemon/backends/backend_descriptor_registry.h"
+#include "lemon/utils/path_utils.h"
+#include "lemon/utils/path_platform.h"
+#include "lemon/utils/aixlog.hpp"
 
-// Generated from LEMON_BACKENDS at configure time. Defines
-// lemon::backends::all_generated_descriptors() (descriptor data only).
+#include <atomic>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <system_error>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+#include <nlohmann/json.hpp>
+
+#ifndef _WIN32
+#include <sys/stat.h>
+#include <unistd.h>
+#else
+#include <windows.h>
+#include <aclapi.h>
+#include <sddl.h>
+#endif
+
 #include "backend_descriptors_generated.h"
 
 namespace lemon {
 namespace backends {
 
+namespace fs = std::filesystem;
+
+static std::shared_ptr<const BackendDescriptor> parse_descriptor_file(const fs::path& filepath) {
+    std::ifstream file(filepath);
+    if (!file.is_open()) return nullptr;
+
+    std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    file.close();
+
+    nlohmann::json j = nlohmann::json::parse(content, nullptr, false);
+    if (j.is_discarded() || !j.is_object()) {
+        LOG(WARNING, "BackendDescriptorRegistry") << "Skipping custom backend file " << filepath << ": invalid JSON content" << std::endl;
+        return nullptr;
+    }
+
+    if (!j.contains("recipe") || !j["recipe"].is_string() ||
+        !j.contains("display_name") || !j["display_name"].is_string() ||
+        !j.contains("capabilities") || !j["capabilities"].is_array() ||
+        !j.contains("platforms") || !j["platforms"].is_object()) {
+        LOG(WARNING, "BackendDescriptorRegistry") << "Skipping custom backend file " << filepath << ": missing required fields (recipe, display_name, capabilities, platforms)" << std::endl;
+        return nullptr;
+    }
+
+    auto desc = std::make_shared<BackendDescriptor>();
+    desc->recipe = j["recipe"].get<std::string>();
+    desc->display_name = j["display_name"].get<std::string>();
+    desc->is_dynamic = true;
+
+    if (j.contains("modality") && j["modality"].is_string()) {
+        desc->modality = j["modality"].get<std::string>();
+    }
+    if (j.contains("slot_policy") && j["slot_policy"].is_string()) {
+        std::string sp = j["slot_policy"].get<std::string>();
+        if (sp == "exclusive_npu") desc->slot_policy = SlotPolicy::ExclusiveNpu;
+        else if (sp == "coexist_by_type") desc->slot_policy = SlotPolicy::CoexistByType;
+        else if (sp == "unmetered") desc->slot_policy = SlotPolicy::Unmetered;
+        else desc->slot_policy = SlotPolicy::Standard;
+    }
+
+    for (const auto& cap : j["capabilities"]) {
+        if (cap.is_string()) {
+            desc->capabilities.push_back(cap.get<std::string>());
+        }
+    }
+
+    if (j.contains("health_probe") && j["health_probe"].is_object()) {
+        const auto& hp = j["health_probe"];
+        if (hp.contains("type") && hp["type"].is_string()) desc->health_probe.type = hp["type"].get<std::string>();
+        if (hp.contains("endpoint") && hp["endpoint"].is_string()) desc->health_probe.endpoint = hp["endpoint"].get<std::string>();
+        if (hp.contains("expected_status") && hp["expected_status"].is_number_integer()) desc->health_probe.expected_status = hp["expected_status"].get<int>();
+        if (hp.contains("timeout_seconds") && hp["timeout_seconds"].is_number_integer()) desc->health_probe.timeout_seconds = std::min(hp["timeout_seconds"].get<int>(), 300);
+        if (hp.contains("poll_interval_ms") && hp["poll_interval_ms"].is_number_integer()) desc->health_probe.poll_interval_ms = hp["poll_interval_ms"].get<int>();
+    }
+    if (j.contains("health_endpoint") && j["health_endpoint"].is_string()) {
+        desc->health_endpoint = j["health_endpoint"].get<std::string>();
+        desc->health_probe.endpoint = desc->health_endpoint;
+    }
+    if (j.contains("health_timeout_seconds") && j["health_timeout_seconds"].is_number_integer()) {
+        desc->health_timeout_seconds = std::min(j["health_timeout_seconds"].get<int>(), 300);
+        desc->health_probe.timeout_seconds = desc->health_timeout_seconds;
+    }
+    if (j.contains("downsize_endpoint") && j["downsize_endpoint"].is_string()) {
+        desc->downsize_endpoint = j["downsize_endpoint"].get<std::string>();
+    }
+
+    if (j.contains("endpoints") && j["endpoints"].is_object()) {
+        for (auto ep_it = j["endpoints"].begin(); ep_it != j["endpoints"].end(); ++ep_it) {
+            if (ep_it.value().is_string()) {
+                desc->endpoints[ep_it.key()] = ep_it.value().get<std::string>();
+            }
+        }
+    }
+
+    if (j.contains("protected_flags") && j["protected_flags"].is_array()) {
+        for (const auto& pf : j["protected_flags"]) {
+            if (pf.is_string()) {
+                desc->protected_flags.push_back(pf.get<std::string>());
+            }
+        }
+    }
+
+    if (j.contains("custom_options") && j["custom_options"].is_array()) {
+        for (const auto& opt : j["custom_options"]) {
+            if (!opt.is_object() || !opt.contains("name") || !opt.contains("cli_flag")) continue;
+            BackendOption bo;
+            bo.name = opt["name"].get<std::string>();
+            bo.cli_flag = opt["cli_flag"].get<std::string>();
+            if (opt.contains("default_value")) bo.default_value = opt["default_value"];
+            if (opt.contains("type_name") && opt["type_name"].is_string()) bo.type_name = opt["type_name"].get<std::string>();
+            if (opt.contains("help") && opt["help"].is_string()) bo.help = opt["help"].get<std::string>();
+            if (opt.contains("group") && opt["group"].is_string()) bo.group = opt["group"].get<std::string>();
+            desc->options.push_back(bo);
+        }
+    }
+
+    for (auto it = j["platforms"].begin(); it != j["platforms"].end(); ++it) {
+        std::string p_name = it.key();
+        const auto& p_val = it.value();
+        if (!p_val.is_object() || !p_val.contains("command") || !p_val.contains("args")) continue;
+
+        BackendDescriptor::PlatformConfig pc;
+        pc.command = p_val["command"].get<std::string>();
+
+        if (p_val.contains("args") && p_val["args"].is_array()) {
+            for (const auto& a : p_val["args"]) {
+                if (a.is_string()) pc.args.push_back(a.get<std::string>());
+            }
+        }
+        if (p_val.contains("stop_command") && p_val["stop_command"].is_string()) {
+            pc.stop_command = p_val["stop_command"].get<std::string>();
+        }
+        if (p_val.contains("stop_command_args") && p_val["stop_command_args"].is_array()) {
+            for (const auto& a : p_val["stop_command_args"]) {
+                if (a.is_string()) pc.stop_command_args.push_back(a.get<std::string>());
+            }
+        }
+        if (p_val.contains("env") && p_val["env"].is_object()) {
+            for (auto env_it = p_val["env"].begin(); env_it != p_val["env"].end(); ++env_it) {
+                if (env_it.value().is_string()) {
+                    pc.env[env_it.key()] = env_it.value().get<std::string>();
+                }
+            }
+        }
+
+        desc->platforms[p_name] = pc;
+    }
+
+    if (desc->platforms.empty()) {
+        return nullptr;
+    }
+
+    return desc;
+}
+
+static bool check_path_permissions(const fs::path& path, bool is_system_path) {
+#ifndef _WIN32
+    struct stat st;
+    if (::lstat(path.c_str(), &st) != 0) {
+        LOG(WARNING, "BackendDescriptorRegistry") << "Skipping descriptor '" << path.string() << "': failed to lstat file." << std::endl;
+        return false;
+    }
+    if (S_ISLNK(st.st_mode)) {
+        LOG(WARNING, "BackendDescriptorRegistry") << "Skipping descriptor '" << path.string() << "': symlinks are not permitted for descriptor files." << std::endl;
+        return false;
+    }
+    if ((st.st_mode & 0022) != 0) {
+        LOG(WARNING, "BackendDescriptorRegistry") << "Skipping descriptor '" << path.string() << "': file has group or world write permissions (mode mask 0022)." << std::endl;
+        return false;
+    }
+    if (!is_system_path) {
+        if (st.st_uid != geteuid()) {
+            LOG(WARNING, "BackendDescriptorRegistry") << "Skipping descriptor '" << path.string() << "': owner UID (" << st.st_uid << ") does not match current user UID (" << geteuid() << ")." << std::endl;
+            return false;
+        }
+    } else {
+        if (st.st_uid != 0) {
+            LOG(WARNING, "BackendDescriptorRegistry") << "Skipping system descriptor '" << path.string() << "': owner UID (" << st.st_uid << ") is not root (UID 0)." << std::endl;
+            return false;
+        }
+    }
+
+    std::error_code ec;
+    fs::path target_path = fs::weakly_canonical(path, ec);
+    if (ec) {
+        target_path = path;
+    }
+
+    fs::path parent = target_path.parent_path();
+    while (!parent.empty() && parent != parent.root_path()) {
+        struct stat parent_st;
+        if (::lstat(parent.c_str(), &parent_st) == 0) {
+            if (S_ISLNK(parent_st.st_mode)) {
+                LOG(WARNING, "BackendDescriptorRegistry") << "Skipping descriptor '" << path.string() << "': ancestor directory '" << parent.string() << "' is a symlink." << std::endl;
+                return false;
+            }
+            if (parent_st.st_uid != geteuid() && (parent_st.st_mode & 0022) != 0 && (parent_st.st_mode & S_ISVTX) == 0) {
+                LOG(WARNING, "BackendDescriptorRegistry") << "Skipping descriptor '" << path.string() << "': ancestor directory '" << parent.string() << "' owned by UID " << parent_st.st_uid << " is group/world writable without sticky bit set." << std::endl;
+                return false;
+            }
+        }
+        parent = parent.parent_path();
+    }
+#else
+    PSECURITY_DESCRIPTOR pSD = nullptr;
+    PACL pDacl = nullptr;
+    PSID pOwnerSid = nullptr;
+    BOOL ownerDefaulted = FALSE;
+
+    DWORD res = GetNamedSecurityInfoW(
+        path.wstring().c_str(),
+        SE_FILE_OBJECT,
+        DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION,
+        &pOwnerSid,
+        nullptr,
+        &pDacl,
+        nullptr,
+        &pSD
+    );
+    if (res != ERROR_SUCCESS || !pDacl || !pSD) {
+        if (pSD) LocalFree(pSD);
+        LOG(WARNING, "BackendDescriptorRegistry") << "Skipping descriptor '" << path.string() << "': failed to retrieve Windows security descriptor (error " << res << ")." << std::endl;
+        return false;
+    }
+
+    if (pOwnerSid) {
+        BYTE userSidBuffer[SECURITY_MAX_SID_SIZE];
+        DWORD userSidSize = sizeof(userSidBuffer);
+        HANDLE hToken = NULL;
+        bool owner_ok = false;
+        if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken)) {
+            TOKEN_USER* pTokenUser = reinterpret_cast<TOKEN_USER*>(userSidBuffer);
+            if (GetTokenInformation(hToken, TokenUser, pTokenUser, userSidSize, &userSidSize)) {
+                if (EqualSid(pOwnerSid, pTokenUser->User.Sid)) {
+                    owner_ok = true;
+                }
+            }
+            CloseHandle(hToken);
+        }
+        if (!owner_ok && IsWellKnownSid(pOwnerSid, WinBuiltinAdministratorsSid)) {
+            owner_ok = true;
+        }
+        if (!owner_ok && is_system_path && IsWellKnownSid(pOwnerSid, WinLocalSystemSid)) {
+            owner_ok = true;
+        }
+        if (!owner_ok) {
+            LocalFree(pSD);
+            LOG(WARNING, "BackendDescriptorRegistry") << "Skipping descriptor '" << path.string() << "': Windows security descriptor owner SID is not authorized for process." << std::endl;
+            return false;
+        }
+    }
+
+    ACL_SIZE_INFORMATION aclInfo;
+    if (!GetAclInformation(pDacl, &aclInfo, sizeof(aclInfo), AclSizeInformation)) {
+        LocalFree(pSD);
+        LOG(WARNING, "BackendDescriptorRegistry") << "Skipping descriptor '" << path.string() << "': failed to retrieve GetAclInformation." << std::endl;
+        return false;
+    }
+
+    for (DWORD i = 0; i < aclInfo.AceCount; ++i) {
+        LPVOID pAce = nullptr;
+        if (GetAce(pDacl, i, &pAce)) {
+            ACE_HEADER* header = static_cast<ACE_HEADER*>(pAce);
+            if (header->AceType == ACCESS_ALLOWED_ACE_TYPE || header->AceType == ACCESS_ALLOWED_OBJECT_ACE_TYPE) {
+                ACCESS_MASK mask = 0;
+                PSID sid = nullptr;
+
+                if (header->AceType == ACCESS_ALLOWED_ACE_TYPE) {
+                    ACCESS_ALLOWED_ACE* ace = static_cast<ACCESS_ALLOWED_ACE*>(pAce);
+                    mask = ace->Mask;
+                    sid = reinterpret_cast<PSID>(&ace->SidStart);
+                } else {
+                    ACCESS_ALLOWED_OBJECT_ACE* ace = static_cast<ACCESS_ALLOWED_OBJECT_ACE*>(pAce);
+                    mask = ace->Mask;
+                    BYTE* offset = reinterpret_cast<BYTE*>(&ace->ObjectType);
+                    if (ace->Flags & ACE_OBJECT_TYPE_PRESENT) {
+                        offset += sizeof(GUID);
+                    }
+                    if (ace->Flags & ACE_INHERITED_OBJECT_TYPE_PRESENT) {
+                        offset += sizeof(GUID);
+                    }
+                    sid = reinterpret_cast<PSID>(offset);
+                }
+
+                if ((mask & (FILE_WRITE_DATA | FILE_APPEND_DATA | GENERIC_WRITE | WRITE_DAC | WRITE_OWNER)) != 0) {
+                    if (sid != nullptr && IsValidSid(sid)) {
+                        if (IsWellKnownSid(sid, WinWorldSid) || IsWellKnownSid(sid, WinBuiltinUsersSid)) {
+                            LocalFree(pSD);
+                            LOG(WARNING, "BackendDescriptorRegistry") << "Skipping descriptor '" << path.string() << "': Windows ACL grants write access to Everyone or Users group." << std::endl;
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    LocalFree(pSD);
+#endif
+    return true;
+}
+
+static std::vector<fs::path> get_system_backend_search_paths() {
+    std::vector<fs::path> paths;
+#ifndef _WIN32
+    paths.push_back("/usr/share/lemonade-server/backends");
+    paths.push_back("/usr/local/share/lemonade-server/backends");
+    paths.push_back("/Library/Application Support/Lemonade/backends");
+    paths.push_back("/etc/lemonade/backends");
+#else
+    const char* prog_data = std::getenv("ProgramData");
+    if (prog_data) {
+        paths.push_back(fs::path(prog_data) / "Lemonade" / "backends");
+    }
+#endif
+    return paths;
+}
+
+static std::vector<fs::path> get_backend_search_paths() {
+    std::vector<fs::path> paths = get_system_backend_search_paths();
+
+    paths.push_back(fs::path(utils::get_cache_dir()) / "backends");
+
+#ifndef _WIN32
+    const char* xdg_config = std::getenv("XDG_CONFIG_HOME");
+    if (xdg_config && xdg_config[0] != '\0') {
+        paths.push_back(fs::path(xdg_config) / "lemonade" / "backends");
+    } else {
+        const char* home = std::getenv("HOME");
+        if (home) {
+            paths.push_back(fs::path(home) / ".config" / "lemonade" / "backends");
+        }
+    }
+#else
+    const char* app_data = std::getenv("APPDATA");
+    if (app_data) {
+        paths.push_back(fs::path(app_data) / "Lemonade" / "backends");
+    }
+#endif
+
+    return paths;
+}
+
+static void load_dynamic_descriptors(std::unordered_map<std::string, std::shared_ptr<const BackendDescriptor>>& dynamic_map) {
+    std::vector<fs::path> search_paths = get_backend_search_paths();
+    std::vector<fs::path> system_dirs = get_system_backend_search_paths();
+
+    for (const auto& dir_path : search_paths) {
+        std::error_code ec;
+        if (!fs::exists(dir_path, ec) || !fs::is_directory(dir_path, ec)) {
+            continue;
+        }
+
+        bool is_system = false;
+        for (const auto& sys_dir : system_dirs) {
+            if (fs::exists(sys_dir, ec) && fs::equivalent(dir_path, sys_dir, ec)) {
+                is_system = true;
+                break;
+            }
+        }
+
+        for (const auto& entry : fs::directory_iterator(dir_path, ec)) {
+            if (ec) break;
+            if (entry.is_regular_file() && entry.path().extension() == ".json") {
+                if (!check_path_permissions(entry.path(), is_system)) {
+                    continue;
+                }
+                auto desc = parse_descriptor_file(entry.path());
+                if (desc && !desc->recipe.empty()) {
+                    dynamic_map[desc->recipe] = desc;
+                }
+            }
+        }
+    }
+}
+
+static std::mutex g_registry_mutex;
+static bool g_initialized = false;
+static std::vector<std::shared_ptr<const BackendDescriptor>> g_dynamic_storage;
+static std::vector<const BackendDescriptor*> g_descriptors_cache;
+static std::thread g_file_watcher_thread;
+static std::atomic<bool> g_watcher_running{false};
+
+void refresh_descriptors() {
+    std::lock_guard<std::mutex> lock(g_registry_mutex);
+    const std::vector<const BackendDescriptor*>& builtin = all_generated_descriptors();
+    std::unordered_map<std::string, std::shared_ptr<const BackendDescriptor>> dynamic_map;
+
+    load_dynamic_descriptors(dynamic_map);
+
+    std::unordered_map<std::string, const BackendDescriptor*> merged_map;
+    for (const auto* b : builtin) {
+        merged_map[b->recipe] = b;
+    }
+
+    g_dynamic_storage.clear();
+    for (const auto& [recipe, desc_ptr] : dynamic_map) {
+        g_dynamic_storage.push_back(desc_ptr);
+        merged_map[recipe] = desc_ptr.get();
+    }
+
+    g_descriptors_cache.clear();
+    for (const auto& [recipe, ptr] : merged_map) {
+        g_descriptors_cache.push_back(ptr);
+    }
+    g_initialized = true;
+}
+
 const std::vector<const BackendDescriptor*>& all_descriptors() {
-    static const std::vector<const BackendDescriptor*> kDescriptors = all_generated_descriptors();
-    return kDescriptors;
+    std::lock_guard<std::mutex> lock(g_registry_mutex);
+    if (!g_initialized) {
+        const std::vector<const BackendDescriptor*>& builtin = all_generated_descriptors();
+        std::unordered_map<std::string, std::shared_ptr<const BackendDescriptor>> dynamic_map;
+
+        load_dynamic_descriptors(dynamic_map);
+
+        std::unordered_map<std::string, const BackendDescriptor*> merged_map;
+        for (const auto* b : builtin) {
+            merged_map[b->recipe] = b;
+        }
+
+        g_dynamic_storage.clear();
+        for (const auto& [recipe, desc_ptr] : dynamic_map) {
+            g_dynamic_storage.push_back(desc_ptr);
+            merged_map[recipe] = desc_ptr.get();
+        }
+
+        g_descriptors_cache.clear();
+        for (const auto& [recipe, ptr] : merged_map) {
+            g_descriptors_cache.push_back(ptr);
+        }
+        g_initialized = true;
+    }
+    return g_descriptors_cache;
+}
+
+static uint64_t compute_search_paths_signature() {
+    uint64_t sig = 0;
+    std::vector<fs::path> search_paths = get_backend_search_paths();
+    for (const auto& dir_path : search_paths) {
+        std::error_code ec;
+        if (fs::exists(dir_path, ec) && fs::is_directory(dir_path, ec)) {
+            auto mtime = fs::last_write_time(dir_path, ec);
+            if (!ec) {
+                sig += std::chrono::duration_cast<std::chrono::milliseconds>(mtime.time_since_epoch()).count();
+            }
+            for (const auto& entry : fs::directory_iterator(dir_path, ec)) {
+                if (ec) break;
+                if (entry.is_regular_file() && entry.path().extension() == ".json") {
+                    auto ftime = entry.last_write_time(ec);
+                    if (!ec) {
+                        sig += std::chrono::duration_cast<std::chrono::milliseconds>(ftime.time_since_epoch()).count();
+                    }
+                }
+            }
+        }
+    }
+    return sig;
+}
+
+void start_file_watcher() {
+    if (g_watcher_running.exchange(true)) return;
+
+    g_file_watcher_thread = std::thread([]() {
+        uint64_t last_sig = compute_search_paths_signature();
+        while (g_watcher_running) {
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+            if (!g_watcher_running) break;
+            uint64_t current_sig = compute_search_paths_signature();
+            if (current_sig != last_sig) {
+                last_sig = current_sig;
+                LOG(INFO, "BackendDescriptorRegistry") << "Detected custom backend descriptor changes; reloading registry..." << std::endl;
+                refresh_descriptors();
+            }
+        }
+    });
+}
+
+void stop_file_watcher() {
+    if (g_watcher_running.exchange(false)) {
+        if (g_file_watcher_thread.joinable()) {
+            g_file_watcher_thread.join();
+        }
+    }
 }
 
 const BackendDescriptor* descriptor_for(const std::string& recipe) {
     for (const BackendDescriptor* d : all_descriptors()) {
         if (d->recipe == recipe) {
             return d;
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<const BackendDescriptor> descriptor_shared_for(const std::string& recipe) {
+    all_descriptors();
+    std::lock_guard<std::mutex> lock(g_registry_mutex);
+    for (const auto& ptr : g_dynamic_storage) {
+        if (ptr && ptr->recipe == recipe) {
+            return ptr;
+        }
+    }
+    for (const BackendDescriptor* d : g_descriptors_cache) {
+        if (d && d->recipe == recipe) {
+            return std::shared_ptr<const BackendDescriptor>(std::shared_ptr<const BackendDescriptor>{}, d);
         }
     }
     return nullptr;

--- a/src/cpp/server/backends/backend_ops.cpp
+++ b/src/cpp/server/backends/backend_ops.cpp
@@ -55,18 +55,28 @@ std::string BackendOps::resolve_checkpoint_path(const ModelInfo& info,
             }
         }
 
-        // Try to find the exact variant in the cache directory's subtree.
+        // Try to find the exact variant in snapshots/ before fallback scanning.
+        fs::path snapshots_dir = model_cache_path_fs / "snapshots";
+        if (hf_cache::exists(snapshots_dir)) {
+            std::error_code snap_ec;
+            for (const auto& entry :
+                 fs::recursive_directory_iterator(snapshots_dir, hf_cache::dir_options(), snap_ec)) {
+                if (snap_ec) break;
+                if (entry.path().filename().string() == ctx.variant) {
+                    return path_to_utf8(entry.path());
+                }
+            }
+        }
+
+        // Try to find the exact variant in the cache directory's subtree, preferring files with extensions.
         if (hf_cache::exists(model_cache_path_fs)) {
+            fs::path variant_path_obj = path_from_utf8(ctx.variant);
+            std::string expected_ext = variant_path_obj.extension().string();
             for (const auto& entry :
                  fs::recursive_directory_iterator(model_cache_path_fs, hf_cache::dir_options())) {
-                if (entry.is_regular_file()) {
-                    if (entry.path().filename().string() == ctx.variant) {
+                if (entry.path().filename().string() == ctx.variant) {
+                    if (expected_ext.empty() || entry.path().extension().string() == expected_ext) {
                         return path_to_utf8(entry.path());
-                    }
-                } else if (entry.is_directory()) {
-                    fs::path variant_path = entry.path() / path_from_utf8(ctx.variant);
-                    if (hf_cache::exists(variant_path)) {
-                        return path_to_utf8(variant_path);
                     }
                 }
             }

--- a/src/cpp/server/backends/backend_registry.cpp
+++ b/src/cpp/server/backends/backend_registry.cpp
@@ -1,4 +1,5 @@
 #include "lemon/backends/backend_registry.h"
+#include "lemon/backends/external/external_backend_server.h"
 #include "lemon/wrapped_server.h"
 
 // Generated from LEMON_BACKENDS at configure time. Defines
@@ -42,6 +43,16 @@ std::unique_ptr<WrappedServer> create_server(const std::string& recipe, const Ba
             return server;
         }
     }
+
+    // Check dynamic custom backend descriptors
+    auto desc = descriptor_shared_for(recipe);
+    if (desc && desc->is_dynamic) {
+        auto server = std::make_unique<ExternalBackendServer>(recipe);
+        server->set_log_level(ctx.log_level);
+        server->set_descriptor(desc);
+        return server;
+    }
+
     return nullptr;
 }
 

--- a/src/cpp/server/backends/external/external_backend_server.cpp
+++ b/src/cpp/server/backends/external/external_backend_server.cpp
@@ -1,0 +1,635 @@
+#include "lemon/backends/external/external_backend_server.h"
+#include "lemon/backends/backend_descriptor_registry.h"
+#include "lemon/system_info.h"
+#include "lemon/utils/aixlog.hpp"
+#include "lemon/utils/custom_args.h"
+#include "lemon/utils/path_utils.h"
+#include "lemon/utils/process_manager.h"
+#include "lemon/utils/shell_utils.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <thread>
+#include <algorithm>
+
+namespace lemon {
+
+namespace fs = std::filesystem;
+
+static std::string to_posix_path(const std::string& path_str) {
+    std::string res = path_str;
+    std::replace(res.begin(), res.end(), '\\', '/');
+    return res;
+}
+
+ExternalBackendServer::ExternalBackendServer(const std::string& server_name)
+    : WrappedServer(server_name, "info") {
+}
+
+ExternalBackendServer::~ExternalBackendServer() {
+    unload();
+}
+
+bool ExternalBackendServer::has_capability(const std::string& cap_name) const {
+    if (descriptor_) {
+        return descriptor_->has_capability(cap_name);
+    }
+    return true;
+}
+
+bool ExternalBackendServer::supports_downsize() const {
+    return descriptor_ && !descriptor_->downsize_endpoint.empty();
+}
+
+std::vector<std::string> ExternalBackendServer::resolve_command_args(
+    const std::vector<std::string>& template_args,
+    const std::unordered_map<std::string, std::string>& token_map,
+    const RecipeOptions& recipe_options) {
+
+    std::vector<std::string> resolved;
+
+    auto replace_in_string = [&](const std::string& input, bool& has_unpopulated) -> std::string {
+        std::string result;
+        result.reserve(static_cast<size_t>(input.size() * 1.2));
+        size_t pos = 0;
+        has_unpopulated = false;
+        while (pos < input.length()) {
+            size_t open_brace = input.find('{', pos);
+            if (open_brace == std::string::npos) {
+                result.append(input.substr(pos));
+                break;
+            }
+            result.append(input.substr(pos, open_brace - pos));
+            size_t close_brace = input.find('}', open_brace);
+            if (close_brace == std::string::npos) {
+                result.append(input.substr(open_brace));
+                break;
+            }
+
+            std::string key = input.substr(open_brace + 1, close_brace - open_brace - 1);
+            bool is_valid_token_syntax = !key.empty();
+            for (char c : key) {
+                unsigned char uc = static_cast<unsigned char>(c);
+                if (!isalnum(uc) && uc != '_' && uc != '-' && uc != ':' && uc != '.' && uc != '/' && uc != '=' && uc != ',' && uc != '"' && uc != '\'' && uc != ' ') {
+                    is_valid_token_syntax = false;
+                    break;
+                }
+            }
+
+            if (!is_valid_token_syntax) {
+                result.push_back('{');
+                pos = open_brace + 1;
+                continue;
+            }
+
+            auto it = token_map.find(key);
+            if (it != token_map.end()) {
+                result.append(it->second);
+            } else if (key.rfind("env:", 0) == 0) {
+                std::string var_spec = key.substr(4);
+                std::string var_name = var_spec;
+                std::string default_val = "";
+                size_t colon_pos = var_spec.find(":-");
+                if (colon_pos != std::string::npos) {
+                    var_name = var_spec.substr(0, colon_pos);
+                    default_val = var_spec.substr(colon_pos + 2);
+                }
+                const char* env_val = std::getenv(var_name.c_str());
+                std::string val = (env_val && env_val[0] != '\0') ? env_val : default_val;
+                result.append(val);
+            } else if (key.rfind("custom:", 0) == 0) {
+                std::string opt_spec = key.substr(7);
+                std::string opt_name = opt_spec;
+                std::string default_val = "";
+                size_t colon_pos = opt_spec.find(":-");
+                if (colon_pos != std::string::npos) {
+                    opt_name = opt_spec.substr(0, colon_pos);
+                    default_val = opt_spec.substr(colon_pos + 2);
+                }
+                json opt_val = recipe_options.get_option(opt_name);
+                if (!opt_val.is_null()) {
+                    result.append(opt_val.is_string() ? opt_val.get<std::string>() : opt_val.dump());
+                } else if (!default_val.empty()) {
+                    result.append(default_val);
+                } else {
+                    has_unpopulated = true;
+                    result.append(input.substr(open_brace, close_brace - open_brace + 1));
+                }
+            } else {
+                has_unpopulated = true;
+                result.append(input.substr(open_brace, close_brace - open_brace + 1));
+            }
+            pos = close_brace + 1;
+        }
+        return result;
+    };
+
+    for (const auto& t_arg : template_args) {
+        if (t_arg == "{custom_args}") {
+            json args_val = recipe_options.get_option("args");
+            if (!args_val.is_null()) {
+                std::vector<std::string> custom_args_list;
+                if (args_val.is_array()) {
+                    for (const auto& el : args_val) {
+                        if (el.is_string()) {
+                            custom_args_list.push_back(el.get<std::string>());
+                        } else {
+                            custom_args_list.push_back(el.dump());
+                        }
+                    }
+                } else {
+                    std::string raw_args = args_val.is_string() ? args_val.get<std::string>() : args_val.dump();
+                    custom_args_list = utils::parse_custom_args(raw_args);
+                }
+
+                if (descriptor_ && !descriptor_->protected_flags.empty()) {
+                    for (const auto& carg : custom_args_list) {
+                        for (const auto& pf : descriptor_->protected_flags) {
+                            if (carg == pf || carg.rfind(pf + "=", 0) == 0) {
+                                throw std::invalid_argument("Custom argument '" + carg + "' collides with protected flag '" + pf + "'");
+                            }
+                        }
+                    }
+                }
+                resolved.insert(resolved.end(), custom_args_list.begin(), custom_args_list.end());
+            }
+            continue;
+        }
+
+        bool has_unpopulated = false;
+        std::string res = replace_in_string(t_arg, has_unpopulated);
+        if (has_unpopulated) {
+            continue;
+        }
+        resolved.push_back(res);
+    }
+
+    return resolved;
+}
+
+void ExternalBackendServer::load(const std::string& model_name,
+                                const ModelInfo& model_info,
+                                const RecipeOptions& options,
+                                bool do_not_upgrade) {
+    (void)do_not_upgrade;
+    auto start_time = std::chrono::steady_clock::now();
+
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        if ((state_ == ModelState::READY || state_ == ModelState::IN_USE) && is_backend_alive()) {
+            return;
+        }
+
+        state_ = ModelState::LOADING;
+        state_cv_.notify_all();
+    }
+
+    struct LoadStateGuard {
+        ExternalBackendServer* server;
+        bool success = false;
+        ~LoadStateGuard() noexcept {
+            if (!success) {
+                try {
+                    server->unload();
+                } catch (const std::exception& e) {
+                    LOG(ERROR, "LoadStateGuard") << "Unload failed during guard destruction: " << e.what();
+                } catch (...) {
+                    LOG(ERROR, "LoadStateGuard") << "Unknown error during guard destruction";
+                }
+            }
+        }
+    } state_guard{this, false};
+
+    auto local_desc = lemon::backends::descriptor_shared_for(model_info.recipe);
+    if (!local_desc) {
+        throw std::runtime_error("No descriptor found for recipe: " + model_info.recipe);
+    }
+    set_descriptor(local_desc);
+
+    std::string local_platform = "cpu";
+    json dev_opt = options.get_option("device");
+    std::string req_device = !dev_opt.is_null() ? (dev_opt.is_string() ? dev_opt.get<std::string>() : dev_opt.dump()) : device_type_to_string(model_info.device);
+    std::transform(req_device.begin(), req_device.end(), req_device.begin(), [](unsigned char c){ return std::tolower(c); });
+
+    if (!req_device.empty() && local_desc->platforms.count(req_device)) {
+        local_platform = req_device;
+    } else {
+#ifdef __APPLE__
+        if (local_desc->platforms.count("metal")) {
+            local_platform = "metal";
+        }
+#else
+        std::string cuda_arch = lemon::SystemInfo::get_cuda_arch();
+        std::string rocm_arch = lemon::SystemInfo::get_rocm_arch();
+        if (!cuda_arch.empty() && local_desc->platforms.count("cuda")) {
+            local_platform = "cuda";
+        } else if (!rocm_arch.empty() && local_desc->platforms.count("rocm")) {
+            local_platform = "rocm";
+        } else if (local_desc->platforms.count("vulkan")) {
+            local_platform = "vulkan";
+        } else if (local_desc->platforms.count("oneapi")) {
+            local_platform = "oneapi";
+        } else if (local_desc->platforms.count("tpu")) {
+            local_platform = "tpu";
+        }
+#endif
+    }
+    if (!local_desc->platforms.count(local_platform)) {
+        if (local_desc->platforms.count("cpu")) {
+            local_platform = "cpu";
+        } else if (!local_desc->platforms.empty()) {
+            local_platform = local_desc->platforms.begin()->first;
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        selected_platform_ = local_platform;
+        active_platform_config_ = descriptor_->platforms.at(selected_platform_);
+        loaded_recipe_options_ = options;
+    }
+
+    port_ = choose_port();
+
+    std::unordered_map<std::string, std::string> local_tokens;
+    local_tokens["port"] = std::to_string(port_);
+    local_tokens["host"] = "127.0.0.1";
+    local_tokens["log_level"] = log_level_.empty() ? "info" : log_level_;
+    local_tokens["model_name"] = model_name_;
+    local_tokens["recipe"] = descriptor_->recipe;
+    std::string main_cp_resolved = model_info.resolved_path("main");
+    if (main_cp_resolved.empty() && model_manager_) {
+        main_cp_resolved = model_manager_->resolve_model_path(model_info, "main", model_info.checkpoint("main"));
+    }
+    if (!main_cp_resolved.empty()) {
+        checkpoint_ = main_cp_resolved;
+    }
+
+    local_tokens["resolved_path"] = checkpoint_;
+    local_tokens["gguf_path"] = checkpoint_;
+
+    std::string hf_cache = utils::get_hf_cache_dir();
+    local_tokens["hf_cache"] = hf_cache;
+
+    // lexically_relative (not fs::relative) avoids resolving symlinks - fs::relative
+    // canonicalizes internally, which would rewrite HF-cache checkpoint symlinks down
+    // to their extensionless blob path and break extension-sensitive loaders.
+    auto is_safe_relative = [](const fs::path& rel_p) -> bool {
+        if (rel_p.empty() || rel_p.is_absolute()) return false;
+        if (rel_p.begin() != rel_p.end() && *rel_p.begin() == "..") return false;
+        return true;
+    };
+
+    fs::path cp_path = utils::path_from_utf8(checkpoint_);
+    fs::path hf_path = utils::path_from_utf8(hf_cache);
+    fs::path rel_path = cp_path.lexically_relative(hf_path);
+    if (is_safe_relative(rel_path)) {
+        local_tokens["model_relative_path"] = to_posix_path(utils::path_to_utf8(rel_path));
+    } else {
+        local_tokens["model_relative_path"] = to_posix_path(utils::path_to_utf8(cp_path.filename()));
+    }
+
+    for (const auto& [cp_key, cp_val] : model_info.checkpoints) {
+        std::string cp_resolved = model_info.resolved_path(cp_key);
+        if (cp_resolved.empty() && model_manager_) {
+            cp_resolved = model_manager_->resolve_model_path(model_info, cp_key, cp_val);
+        }
+        if (cp_resolved.empty()) {
+            cp_resolved = cp_val;
+        }
+        local_tokens["checkpoint:" + cp_key] = cp_resolved;
+        fs::path item_cp_path = utils::path_from_utf8(cp_resolved);
+        fs::path item_rel_path = item_cp_path.lexically_relative(hf_path);
+        std::string cp_rel_str = is_safe_relative(item_rel_path) ? utils::path_to_utf8(item_rel_path) : utils::path_to_utf8(item_cp_path.filename());
+        local_tokens["checkpoint_relative:" + cp_key] = to_posix_path(cp_rel_str);
+    }
+
+    auto get_opt_str = [&](const std::string& key, const std::string& fallback = "") -> std::string {
+        json val = options.get_option(key);
+        if (val.is_null()) return fallback;
+        if (val.is_string()) return val.get<std::string>();
+        if (val.is_number_integer()) return std::to_string(val.get<int>());
+        if (val.is_number_float()) return std::to_string(val.get<double>());
+        if (val.is_boolean()) return val.get<bool>() ? "true" : "false";
+        return val.dump();
+    };
+
+    local_tokens["ctx_size"] = get_opt_str("ctx_size", "2048");
+    local_tokens["max_ctx"] = get_opt_str("ctx_size", "2048");
+    local_tokens["batch_size"] = get_opt_str("batch_size", "512");
+    local_tokens["ubatch_size"] = get_opt_str("ubatch_size", "512");
+    local_tokens["threads"] = get_opt_str("threads", "4");
+    local_tokens["cache_type_k"] = get_opt_str("cache_type_k", "f16");
+    local_tokens["cache_type_v"] = get_opt_str("cache_type_v", "f16");
+    local_tokens["target_device"] = get_opt_str("target_device", get_opt_str("gpu_id", "auto:0"));
+    local_tokens["cuda_visible_devices"] = get_opt_str("cuda_visible_devices", get_opt_str("gpu_id", "0"));
+    local_tokens["hip_visible_devices"] = get_opt_str("hip_visible_devices", get_opt_str("gpu_id", "0"));
+    local_tokens["rocr_visible_devices"] = get_opt_str("rocr_visible_devices", get_opt_str("gpu_id", "0"));
+    local_tokens["ggml_vk_visible_devices"] = get_opt_str("ggml_vk_visible_devices", get_opt_str("gpu_id", "0"));
+    local_tokens["vk_visible_devices"] = get_opt_str("vk_visible_devices", get_opt_str("gpu_id", "0"));
+    local_tokens["ze_affinity_mask"] = get_opt_str("ze_affinity_mask", get_opt_str("gpu_id", "0"));
+    local_tokens["cache_dir"] = utils::get_cache_dir();
+
+    std::string model_dir = checkpoint_.empty() ? "." : fs::path(checkpoint_).parent_path().string();
+    std::string exe_dir = active_platform_config_.command.empty() ? "." : fs::path(active_platform_config_.command).parent_path().string();
+    local_tokens["model_dir"] = to_posix_path(model_dir);
+    local_tokens["exe_dir"] = to_posix_path(exe_dir);
+    local_tokens["rocm_arch"] = lemon::SystemInfo::get_rocm_arch();
+    local_tokens["cuda_arch"] = lemon::SystemInfo::get_cuda_arch();
+
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        instance_token_map_ = local_tokens;
+    }
+
+    std::vector<std::string> final_args = resolve_command_args(active_platform_config_.args, local_tokens, options);
+
+    std::unordered_map<std::string, std::string> env_vars;
+    for (const auto& [k, v] : active_platform_config_.env) {
+        std::vector<std::string> tmp{v};
+        auto res = resolve_command_args(tmp, local_tokens, options);
+        env_vars[k] = res.empty() ? "" : res[0];
+    }
+
+    std::vector<std::pair<std::string, std::string>> env_vec;
+    for (const auto& [k, v] : env_vars) {
+        env_vec.emplace_back(k, v);
+    }
+
+    std::string cmd_str = active_platform_config_.command;
+    for (const auto& arg : final_args) {
+        cmd_str += " " + arg;
+    }
+    LOG(INFO) << "ExternalBackendServer: Dispatched command: " << utils::sanitize_log_string(cmd_str);
+
+    if ((!active_platform_config_.stop_command.empty() || !active_platform_config_.stop_command_args.empty()) && descriptor_) {
+        try {
+            std::vector<std::string> pre_stop_args = resolve_command_args(active_platform_config_.stop_command_args, local_tokens, options);
+            std::vector<std::string> stop_cmd_template{active_platform_config_.stop_command};
+            auto resolved_cmd = resolve_command_args(stop_cmd_template, local_tokens, options);
+            std::string pre_stop_cmd = resolved_cmd.empty() ? "" : utils::escape_shell_arg(resolved_cmd[0]);
+
+            for (const auto& arg : pre_stop_args) {
+                if (!pre_stop_cmd.empty()) pre_stop_cmd += " ";
+                pre_stop_cmd += utils::escape_shell_arg(arg);
+            }
+            if (!pre_stop_cmd.empty()) {
+                std::string output;
+                utils::ProcessManager::run_command(pre_stop_cmd, output, 5);
+            }
+        } catch (...) {}
+    }
+
+    ProcessHandle handle = utils::ProcessManager::start_process(
+        active_platform_config_.command,
+        final_args,
+        "",
+        true,
+        false,
+        env_vec
+    );
+
+    set_process_handle(handle);
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        if (has_process_handle(handle)) {
+            instance_token_map_["pid"] = std::to_string(handle.pid);
+        }
+    }
+
+    if (!utils::ProcessManager::is_running(handle)) {
+        throw std::runtime_error("Failed to spawn process for backend: " + descriptor_->recipe);
+    }
+
+    std::string probe_endpoint = descriptor_->health_probe.endpoint.empty() ? descriptor_->health_endpoint : descriptor_->health_probe.endpoint;
+    int timeout_sec = descriptor_->health_probe.timeout_seconds > 0 ? descriptor_->health_probe.timeout_seconds : descriptor_->health_timeout_seconds;
+    int poll_ms = descriptor_->health_probe.poll_interval_ms > 0 ? descriptor_->health_probe.poll_interval_ms : 100;
+
+    bool probe_ok = perform_health_probe(probe_endpoint, descriptor_->health_probe.expected_status, timeout_sec, poll_ms);
+
+    if (!probe_ok) {
+        throw std::runtime_error("Health probe failed or timed out for backend: " + descriptor_->recipe);
+    }
+
+    start_backend_watchdog(probe_endpoint);
+
+    auto end_time = std::chrono::steady_clock::now();
+    load_duration_ms_ = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
+
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        state_ = ModelState::READY;
+        state_cv_.notify_all();
+    }
+    state_guard.success = true;
+}
+
+bool ExternalBackendServer::wait_for_ready(const std::string& endpoint, long timeout_seconds, long poll_interval_ms) {
+    std::unique_lock<std::mutex> lock(state_mutex_);
+    if (state_ == ModelState::READY) return true;
+    long timeout_sec = timeout_seconds;
+    if (descriptor_ && descriptor_->health_probe.timeout_seconds > 0) {
+        timeout_sec = descriptor_->health_probe.timeout_seconds;
+    }
+    return state_cv_.wait_for(lock, std::chrono::seconds(timeout_sec), [this] {
+        return state_ == ModelState::READY || state_ == ModelState::UNLOADED;
+    }) && state_ == ModelState::READY;
+}
+
+bool ExternalBackendServer::perform_health_probe(const std::string& endpoint,
+                                                  int expected_status,
+                                                  int timeout_seconds,
+                                                  int poll_interval_ms) {
+    (void)expected_status;
+    auto start = std::chrono::steady_clock::now();
+    auto timeout = std::chrono::seconds(timeout_seconds);
+
+    std::string health_url = "http://127.0.0.1:" + std::to_string(port_) + endpoint;
+    LOG(INFO) << "ExternalBackendServer: Performing health probe for " << descriptor_->recipe << " on " << health_url << " (timeout: " << timeout_seconds << "s)";
+
+    while (std::chrono::steady_clock::now() - start < timeout) {
+        if (load_cancel_ && load_cancel_->load(std::memory_order_relaxed)) {
+            LOG(WARNING) << "ExternalBackendServer: Health probe cancelled for " << descriptor_->recipe;
+            return false;
+        }
+
+        ProcessHandle proc = get_process_handle_snapshot();
+        if (has_process_handle(proc) && !utils::ProcessManager::is_running(proc)) {
+            LOG(ERROR) << "ExternalBackendServer: Subprocess died unexpectedly during health probe for " << descriptor_->recipe;
+            return false;
+        }
+
+        if (utils::HttpClient::is_reachable(health_url, 1, utils::HttpSecurityPolicy::TrustedLoopback)) {
+            LOG(INFO) << "ExternalBackendServer: Backend " << descriptor_->recipe << " reached on " << health_url;
+            return true;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(poll_interval_ms));
+    }
+    LOG(ERROR) << "ExternalBackendServer: Health probe timed out after " << timeout_seconds << "s for " << descriptor_->recipe;
+    return false;
+}
+
+void ExternalBackendServer::unload() {
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        if (state_ == ModelState::UNLOADED) {
+            return;
+        }
+        state_ = ModelState::UNLOADED;
+        state_cv_.notify_all();
+    }
+
+    stop_backend_watchdog();
+
+    std::unordered_map<std::string, std::string> token_map_snapshot;
+    BackendDescriptor::PlatformConfig config_snapshot;
+    RecipeOptions options_snapshot;
+
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        token_map_snapshot = instance_token_map_;
+        config_snapshot = active_platform_config_;
+        options_snapshot = loaded_recipe_options_;
+    }
+
+    // Stage 1: Custom Stop Command execution
+    if ((!config_snapshot.stop_command.empty() || !config_snapshot.stop_command_args.empty()) && descriptor_) {
+        try {
+            std::vector<std::string> resolved_stop_args = resolve_command_args(config_snapshot.stop_command_args, token_map_snapshot, options_snapshot);
+            std::vector<std::string> stop_cmd_template{config_snapshot.stop_command};
+            auto resolved_cmd = resolve_command_args(stop_cmd_template, token_map_snapshot, options_snapshot);
+            std::string stop_cmd = resolved_cmd.empty() ? "" : utils::escape_shell_arg(resolved_cmd[0]);
+
+            for (const auto& arg : resolved_stop_args) {
+                if (!stop_cmd.empty()) stop_cmd += " ";
+                stop_cmd += utils::escape_shell_arg(arg);
+            }
+            if (!stop_cmd.empty()) {
+                std::string output;
+                utils::ProcessManager::run_command(stop_cmd, output, 15);
+            }
+        } catch (const std::exception& e) {
+            LOG(WARNING, "ExternalBackendServer") << "Custom stop command failed during unload: " << e.what() << std::endl;
+        }
+    }
+
+    // Stage 2: OS Process Handle Supervision & Cleanup
+    try {
+        ProcessHandle handle = consume_process_handle_for_cleanup();
+        if (has_process_handle(handle)) {
+            utils::ProcessManager::stop_process(handle);
+        }
+    } catch (const std::exception& e) {
+        LOG(WARNING, "ExternalBackendServer") << "Process handle cleanup failed during unload: " << e.what() << std::endl;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        state_ = ModelState::UNLOADED;
+        state_cv_.notify_all();
+    }
+}
+
+bool ExternalBackendServer::downsize() {
+    if (!supports_downsize()) return true;
+    try {
+        json res = forward_request(descriptor_->downsize_endpoint, json::object());
+        return !res.contains("error");
+    } catch (...) {
+        return false;
+    }
+}
+
+void ExternalBackendServer::restore() {
+    // No-op for dynamic external backends unless restore endpoint specified
+}
+
+json ExternalBackendServer::chat_completion(const json& request) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("chat_completion", "/v1/chat/completions") : "/v1/chat/completions";
+    return forward_request(path, request);
+}
+
+json ExternalBackendServer::completion(const json& request) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("completion", "/v1/completions") : "/v1/completions";
+    return forward_request(path, request);
+}
+
+json ExternalBackendServer::responses(const json& request) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("responses", "/v1/responses") : "/v1/responses";
+    return forward_request(path, request);
+}
+
+json ExternalBackendServer::embeddings(const json& request) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("embeddings", "/v1/embeddings") : "/v1/embeddings";
+    return forward_request(path, request);
+}
+
+json ExternalBackendServer::reranking(const json& request) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("reranking", "/v1/rerank") : "/v1/rerank";
+    return forward_request(path, request);
+}
+
+json ExternalBackendServer::audio_transcriptions(const json& request) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("transcription", "/v1/audio/transcriptions") : "/v1/audio/transcriptions";
+    return forward_request(path, request);
+}
+
+std::string ExternalBackendServer::get_streaming_address() {
+    return "tcp://127.0.0.1:" + std::to_string(port_);
+}
+
+void ExternalBackendServer::audio_speech(const json& request, httplib::DataSink& sink) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("speech", "/v1/audio/speech") : "/v1/audio/speech";
+    forward_streaming_request(path, request.dump(), sink, false);
+}
+
+json ExternalBackendServer::classify(const json& request) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("classify", "/v1/classify") : "/v1/classify";
+    return forward_request(path, request);
+}
+
+json ExternalBackendServer::image_generations(const json& request) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("images_generations", "/v1/images/generations") : "/v1/images/generations";
+    return forward_request(path, request);
+}
+
+json ExternalBackendServer::image_edits(const json& request) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("images_edits", "/v1/images/edits") : "/v1/images/edits";
+    return forward_request(path, request);
+}
+
+json ExternalBackendServer::image_variations(const json& request) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("images_variations", "/v1/images/variations") : "/v1/images/variations";
+    return forward_request(path, request);
+}
+
+void ExternalBackendServer::audio_generations(const json& request, httplib::DataSink& sink) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("audio_generations", "/v1/audio/generations") : "/v1/audio/generations";
+    forward_streaming_request(path, request.dump(), sink, false);
+}
+
+void ExternalBackendServer::model_3d_generations(const json& request, httplib::DataSink& sink) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("model_3d_generations", "/v1/models/3d/generations") : "/v1/models/3d/generations";
+    forward_streaming_request(path, request.dump(), sink, false);
+}
+
+json ExternalBackendServer::get_slots() {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("slots", "/slots") : "/slots";
+    return forward_get_request(path);
+}
+
+json ExternalBackendServer::slots_action(int slot_id, const std::string& action, const json& request_body) {
+    std::string base_slots_path = descriptor_ ? descriptor_->get_endpoint_path("slots", "/slots") : "/slots";
+    return forward_request(base_slots_path + "/" + std::to_string(slot_id) + "?action=" + action, request_body);
+}
+
+json ExternalBackendServer::tokenize(const json& request_body) {
+    std::string path = descriptor_ ? descriptor_->get_endpoint_path("tokenize", "/v1/tokenize") : "/v1/tokenize";
+    return forward_request(path, request_body);
+}
+
+} // namespace lemon

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -1383,6 +1383,11 @@ json Router::chat_completion(const json& request, std::atomic<bool>* cancel) {
                 if (request.contains("max_tokens")) span->set_attribute("llm.config.max_tokens", request["max_tokens"]);
                 if (request.contains("max_completion_tokens")) span->set_attribute("llm.config.max_completion_tokens", request["max_completion_tokens"]);
             }
+            if (!supports_capability<ICompletionServer>(server)) {
+                return ErrorResponse::from_exception(
+                    UnsupportedOperationException("Chat completion", device_type_to_string(server->get_device_type()))
+                );
+            }
             return server->chat_completion(request);
         });
 
@@ -1482,6 +1487,11 @@ json Router::completion(const json& request) {
                 if (request.contains("top_p")) span->set_attribute("llm.config.top_p", request["top_p"]);
                 if (request.contains("max_tokens")) span->set_attribute("llm.config.max_tokens", request["max_tokens"]);
             }
+            if (!supports_capability<ICompletionServer>(server)) {
+                return ErrorResponse::from_exception(
+                    UnsupportedOperationException("Completion", device_type_to_string(server->get_device_type()))
+                );
+            }
             return server->completion(request);
         });
 
@@ -1545,12 +1555,12 @@ json Router::embeddings(const json& request) {
                 span->set_attribute("embedding.checkpoint", identity.checkpoint);
                 span->set_attribute("embedding.recipe", identity.recipe);
             }
-            auto embeddings_server = dynamic_cast<IEmbeddingsServer*>(server);
-            if (!embeddings_server) {
+            if (!supports_capability<IEmbeddingsServer>(server)) {
                 return ErrorResponse::from_exception(
                     UnsupportedOperationException("Embeddings", device_type_to_string(server->get_device_type()))
                 );
             }
+            auto embeddings_server = dynamic_cast<IEmbeddingsServer*>(server);
             return embeddings_server->embeddings(request);
         });
 
@@ -1601,12 +1611,12 @@ json Router::reranking(const json& request) {
                 span->set_attribute("reranker.checkpoint", identity.checkpoint);
                 span->set_attribute("reranker.recipe", identity.recipe);
             }
-            auto reranking_server = dynamic_cast<IRerankingServer*>(server);
-            if (!reranking_server) {
+            if (!supports_capability<IRerankingServer>(server)) {
                 return ErrorResponse::from_exception(
                     UnsupportedOperationException("Reranking", device_type_to_string(server->get_device_type()))
                 );
             }
+            auto reranking_server = dynamic_cast<IRerankingServer*>(server);
             return reranking_server->reranking(request);
         });
 
@@ -1651,12 +1661,12 @@ json Router::classify(const json& request) {
                 span->set_attribute("classifier.checkpoint", identity.checkpoint);
                 span->set_attribute("classifier.recipe", identity.recipe);
             }
-            auto classification_server = dynamic_cast<IClassificationServer*>(server);
-            if (!classification_server) {
+            if (!supports_capability<IClassificationServer>(server)) {
                 return ErrorResponse::from_exception(
                     UnsupportedOperationException("Classification", device_type_to_string(server->get_device_type()))
                 );
             }
+            auto classification_server = dynamic_cast<IClassificationServer*>(server);
             return classification_server->classify(request);
         });
 
@@ -1668,7 +1678,6 @@ json Router::classify(const json& request) {
                 }
                 span->end_with_error(error_msg);
             } else {
-                // Label scores classify user content; keep them out of telemetry.
                 span->end_with_success(nlohmann::json::object(), "");
             }
         }
@@ -1693,22 +1702,19 @@ json Router::get_slots() {
             );
         }
 
-        // Check if server supports slots capability
-        slots_server = dynamic_cast<ISlotsServer*>(server);
-        if (!slots_server) {
+        if (!supports_capability<ISlotsServer>(server)) {
             return ErrorResponse::from_exception(
                 UnsupportedOperationException("Slots", device_type_to_string(server->get_device_type()))
             );
         }
+        slots_server = dynamic_cast<ISlotsServer*>(server);
 
-        // Mark as busy and update access time
         if (!server->acquire_for_inference()) {
             return ErrorResponse::from_exception(ModelNotLoadedException("No models loaded"));
         }
         server->update_access_time();
-    } // Lock released here
+    }
 
-    // Execute without holding lock (but busy flag prevents eviction)
     try {
         auto response = slots_server->get_slots();
         server->release_inference();
@@ -1733,22 +1739,19 @@ json Router::slots_action(int slot_id, const std::string& action, const json& re
             );
         }
 
-        // Check if server supports slots capability
-        slots_server = dynamic_cast<ISlotsServer*>(server);
-        if (!slots_server) {
+        if (!supports_capability<ISlotsServer>(server)) {
             return ErrorResponse::from_exception(
                 UnsupportedOperationException("Slots", device_type_to_string(server->get_device_type()))
             );
         }
+        slots_server = dynamic_cast<ISlotsServer*>(server);
 
-        // Mark as busy and update access time
         if (!server->acquire_for_inference()) {
             return ErrorResponse::from_exception(ModelNotLoadedException("No models loaded"));
         }
         server->update_access_time();
-    } // Lock released here
+    }
 
-    // Execute without holding lock (but busy flag prevents eviction)
     try {
         auto response = slots_server->slots_action(slot_id, action, request_body);
         server->release_inference();
@@ -1773,22 +1776,19 @@ json Router::tokenize(const json& request_body) {
             );
         }
 
-        // Check if server supports tokenize capability
-        tokenizer_server = dynamic_cast<ITokenizerServer*>(server);
-        if (!tokenizer_server) {
+        if (!supports_capability<ITokenizerServer>(server)) {
             return ErrorResponse::from_exception(
                 UnsupportedOperationException("Tokenization", device_type_to_string(server->get_device_type()))
             );
         }
+        tokenizer_server = dynamic_cast<ITokenizerServer*>(server);
 
-        // Mark as busy and update access time
         if (!server->acquire_for_inference()) {
             return ErrorResponse::from_exception(ModelNotLoadedException("No models loaded"));
         }
         server->update_access_time();
-    } // Lock released here
+    }
 
-    // Execute without holding lock (but busy flag prevents eviction)
     try {
         auto response = tokenizer_server->tokenize(request_body);
         server->release_inference();
@@ -1807,92 +1807,98 @@ json Router::responses(const json& request) {
 
 json Router::audio_transcriptions(const json& request) {
     return execute_inference(request, [&](WrappedServer* server) {
-        auto transcription_server = dynamic_cast<ITranscriptionServer*>(server);
-        if (!transcription_server) {
+        if (!supports_capability<ITranscriptionServer>(server)) {
             return ErrorResponse::from_exception(
                 UnsupportedOperationException("Audio transcription", device_type_to_string(server->get_device_type()))
             );
         }
+        auto transcription_server = dynamic_cast<ITranscriptionServer*>(server);
         return transcription_server->audio_transcriptions(request);
     });
 }
 
 void Router::audio_speech(const json& request, httplib::DataSink& sink) {
     execute_streaming(request.dump(), sink, [&](WrappedServer* server) {
-        auto tts_server = dynamic_cast<ITextToSpeechServer*>(server);
-        if (!tts_server) {
+        if (!supports_capability<ITextToSpeechServer>(server)) {
             throw UnsupportedOperationException("Text to speech", device_type_to_string(server->get_device_type()));
         }
+        auto tts_server = dynamic_cast<ITextToSpeechServer*>(server);
         tts_server->audio_speech(request, sink);
     });
 }
 
 std::vector<std::string> Router::audio_speech_supported_formats(const std::string& model_name) {
     std::lock_guard<std::mutex> lock(load_mutex_);
-    auto tts_server = dynamic_cast<ITextToSpeechServer*>(
-        find_server_by_model_name(resolve_model_name(model_name)));
+    WrappedServer* server = find_server_by_model_name(resolve_model_name(model_name));
+    if (!supports_capability<ITextToSpeechServer>(server)) {
+        return std::vector<std::string>{};
+    }
+    auto tts_server = dynamic_cast<ITextToSpeechServer*>(server);
     return tts_server ? tts_server->supported_audio_formats() : std::vector<std::string>{};
 }
 
 json Router::image_generations(const json& request) {
     return execute_inference(request, [&](WrappedServer* server) {
-        auto image_server = dynamic_cast<IImageServer*>(server);
-        if (!image_server) {
+        if (!supports_capability<IImageServer>(server)) {
             return ErrorResponse::from_exception(
                 UnsupportedOperationException("Image generation", device_type_to_string(server->get_device_type()))
             );
         }
+        auto image_server = dynamic_cast<IImageServer*>(server);
         return image_server->image_generations(request);
     });
 }
 
 json Router::image_edits(const json& request) {
     return execute_inference(request, [&](WrappedServer* server) {
-        auto image_server = dynamic_cast<IImageServer*>(server);
-        if (!image_server) {
+        if (!supports_capability<IImageServer>(server)) {
             return ErrorResponse::from_exception(
                 UnsupportedOperationException("Image editing", device_type_to_string(server->get_device_type()))
             );
         }
+        auto image_server = dynamic_cast<IImageServer*>(server);
         return image_server->image_edits(request);
     });
 }
 
 json Router::image_variations(const json& request) {
     return execute_inference(request, [&](WrappedServer* server) {
-        auto image_server = dynamic_cast<IImageServer*>(server);
-        if (!image_server) {
+        if (!supports_capability<IImageServer>(server)) {
             return ErrorResponse::from_exception(
                 UnsupportedOperationException("Image variations", device_type_to_string(server->get_device_type()))
             );
         }
+        auto image_server = dynamic_cast<IImageServer*>(server);
         return image_server->image_variations(request);
     });
 }
 
 void Router::audio_generations(const json& request, httplib::DataSink& sink) {
     execute_streaming(request.dump(), sink, [&](WrappedServer* server) {
-        auto audio_server = dynamic_cast<IAudioGenerationServer*>(server);
-        if (!audio_server) {
+        if (!supports_capability<IAudioGenerationServer>(server)) {
             throw UnsupportedOperationException("Audio generation", device_type_to_string(server->get_device_type()));
         }
+        auto audio_server = dynamic_cast<IAudioGenerationServer*>(server);
         audio_server->audio_generations(request, sink);
     });
 }
 
 std::vector<std::string> Router::audio_generation_supported_formats(const std::string& model_name) {
     std::lock_guard<std::mutex> lock(load_mutex_);
-    auto audio_server = dynamic_cast<IAudioGenerationServer*>(
-        find_server_by_model_name(resolve_model_name(model_name)));
+    WrappedServer* server = find_server_by_model_name(resolve_model_name(model_name));
+    if (!supports_capability<IAudioGenerationServer>(server)) {
+        return std::vector<std::string>{};
+    }
+    auto audio_server = dynamic_cast<IAudioGenerationServer*>(server);
     return audio_server ? audio_server->supported_audio_formats() : std::vector<std::string>{};
 }
 
 void Router::model_3d_generations(const json& request, httplib::DataSink& sink) {
     execute_streaming(request.dump(), sink, [&](WrappedServer* server) {
-        auto model_server = dynamic_cast<IModel3DServer*>(server);
-        if (!model_server) {
+        if (!supports_capability<IModel3DServer>(server)) {
             throw UnsupportedOperationException("3D generation", device_type_to_string(server->get_device_type()));
         }
+        auto model_server = dynamic_cast<IModel3DServer*>(server);
         model_server->model_3d_generations(request, sink);
     });
 }

--- a/src/cpp/server/utils/http_client.cpp
+++ b/src/cpp/server/utils/http_client.cpp
@@ -1261,6 +1261,7 @@ bool HttpClient::is_reachable(const std::string& url,
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds);
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 500L);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "lemon.cpp/1.0");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);

--- a/src/cpp/server/utils/platform/process_linux.cpp
+++ b/src/cpp/server/utils/platform/process_linux.cpp
@@ -1,4 +1,5 @@
 #include <lemon/utils/process_platform.h>
+#include <lemon/utils/shell_utils.h>
 #include <lemon/utils/aixlog.hpp>
 
 #include <stdexcept>
@@ -20,7 +21,9 @@
 #include <algorithm>
 #include <cctype>
 
+#include <unordered_set>
 #include <sys/prctl.h>
+#include <poll.h>
 
 #ifdef HAVE_LIBCAP
 #include <sys/capability.h>
@@ -135,6 +138,54 @@ protected:
         int stderr_pipe[2]);
 };
 
+static std::vector<std::string> build_sanitized_env(const std::vector<std::pair<std::string, std::string>>& extra_env_vars = {}) {
+    std::unordered_set<std::string> explicit_keys;
+    for (const auto& kv : extra_env_vars) {
+        explicit_keys.insert(kv.first);
+    }
+
+    std::vector<std::string> result;
+    for (char** env = environ; *env != nullptr; ++env) {
+        std::string env_str(*env);
+        size_t eq_pos = env_str.find('=');
+        if (eq_pos != std::string::npos) {
+            std::string key = env_str.substr(0, eq_pos);
+            if (explicit_keys.find(key) == explicit_keys.end()) {
+                if (key.rfind("LEMONADE_", 0) == 0 ||
+                    key.find("API_KEY") != std::string::npos ||
+                    key.find("TOKEN") != std::string::npos ||
+                    key.find("SECRET") != std::string::npos ||
+                    key.find("PASS") != std::string::npos ||
+                    key.find("AUTH") != std::string::npos ||
+                    key == "CUDA_VISIBLE_DEVICES" ||
+                    key == "HIP_VISIBLE_DEVICES" ||
+                    key == "ROCR_VISIBLE_DEVICES" ||
+                    key == "GGML_VK_VISIBLE_DEVICES" ||
+                    key == "ZE_AFFINITY_MASK") {
+                    continue;
+                }
+            }
+        }
+        result.push_back(env_str);
+    }
+
+    for (const auto& kv : extra_env_vars) {
+        result.push_back(kv.first + "=" + kv.second);
+    }
+
+    return result;
+}
+
+static std::vector<char*> to_envp(const std::vector<std::string>& env_strings) {
+    std::vector<char*> envp;
+    envp.reserve(env_strings.size() + 1);
+    for (const auto& s : env_strings) {
+        envp.push_back(const_cast<char*>(s.c_str()));
+    }
+    envp.push_back(nullptr);
+    return envp;
+}
+
 // Linux implementation using fork/exec
 pid_t LinuxProcessPlatform::spawn_process(
     const std::string& executable,
@@ -146,6 +197,9 @@ pid_t LinuxProcessPlatform::spawn_process(
     int stdout_pipe[2],
     int stderr_pipe[2]) {
 
+    std::vector<std::string> sanitized_env_strings = build_sanitized_env(env_vars);
+    std::vector<char*> envp_ptrs = to_envp(sanitized_env_strings);
+
     pid_t pid = fork();
 
     if (pid < 0) {
@@ -153,17 +207,14 @@ pid_t LinuxProcessPlatform::spawn_process(
     }
 
     if (pid == 0) {
-        // Child process
+        // Child process — zero heap allocations here!
         prctl(PR_SET_PDEATHSIG, SIGTERM);
 
         if (!working_dir.empty()) {
             chdir(working_dir.c_str());
         }
 
-        // Set environment variables
-        for (const auto& env_pair : env_vars) {
-            setenv(env_pair.first.c_str(), env_pair.second.c_str(), 1);
-        }
+        environ = envp_ptrs.data();
 
         // Redirect stdout/stderr to pipes if filtering
         if (inherit_output && filter_health_logs) {
@@ -675,18 +726,102 @@ int LinuxProcessPlatform::find_free_port(int start_port) {
 
 int LinuxProcessPlatform::run_command(const std::string& command, std::string& output, int timeout_seconds) {
     output.clear();
-
-    FILE* pipe = popen(command.c_str(), "r");
-    if (!pipe) {
+    if (command.empty()) {
         return -1;
     }
 
-    char buf[4096];
-    while (fgets(buf, sizeof(buf), pipe)) {
-        output += buf;
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        return -1;
     }
 
-    return pclose(pipe);
+    std::vector<std::string> sanitized_env_strings = build_sanitized_env({});
+    std::vector<char*> envp_ptrs = to_envp(sanitized_env_strings);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return -1;
+    }
+
+    if (pid == 0) {
+        setpgid(0, 0);
+        close(pipefd[0]);
+        dup2(pipefd[1], STDOUT_FILENO);
+        dup2(pipefd[1], STDERR_FILENO);
+        close(pipefd[1]);
+
+#ifdef __linux__
+        prctl(PR_SET_PDEATHSIG, SIGTERM);
+#endif
+
+        environ = envp_ptrs.data();
+
+        execl("/bin/sh", "sh", "-c", command.c_str(), (char*)nullptr);
+        execlp("sh", "sh", "-c", command.c_str(), (char*)nullptr);
+        _exit(127);
+    }
+
+    close(pipefd[1]);
+
+    int flags = fcntl(pipefd[0], F_GETFL, 0);
+    if (flags != -1) {
+        fcntl(pipefd[0], F_SETFL, flags | O_NONBLOCK);
+    }
+
+    int timeout_ms = (timeout_seconds > 0) ? (timeout_seconds * 1000) : 30000;
+    auto start_time = std::chrono::steady_clock::now();
+    bool timed_out = false;
+
+    char buf[4096];
+    struct pollfd pfd;
+    pfd.fd = pipefd[0];
+    pfd.events = POLLIN | POLLHUP | POLLERR;
+
+    while (true) {
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start_time).count();
+        int remaining_ms = timeout_ms - static_cast<int>(elapsed);
+        if (remaining_ms <= 0) {
+            timed_out = true;
+            break;
+        }
+
+        int poll_res = poll(&pfd, 1, std::min<int>(remaining_ms, 200));
+        if (poll_res > 0) {
+            ssize_t bytes = read(pipefd[0], buf, sizeof(buf) - 1);
+            if (bytes > 0) {
+                buf[bytes] = '\0';
+                output.append(buf, bytes);
+            } else if (bytes == 0) {
+                break;
+            } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                break;
+            }
+        } else if (poll_res == 0) {
+            continue;
+        } else {
+            if (errno != EINTR) break;
+        }
+    }
+
+    close(pipefd[0]);
+
+    if (timed_out) {
+        LOG(ERROR, "LinuxProcessPlatform") << "Command timed out after " << timeout_seconds << "s, killing process group " << pid << ": " << utils::sanitize_log_string(command);
+        killpg(pid, SIGKILL);
+        int status = 0;
+        waitpid(pid, &status, 0);
+        return -1;
+    }
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    return -1;
 }
 
 std::unique_ptr<ProcessPlatform> create_process_platform() {

--- a/src/cpp/server/utils/platform/process_macos.cpp
+++ b/src/cpp/server/utils/platform/process_macos.cpp
@@ -17,11 +17,49 @@
 #include <thread>
 #include <chrono>
 #include <algorithm>
-#include <cctype>
+#include <unordered_set>
 
 extern char** environ;
 
 namespace lemon::utils {
+
+static std::vector<std::string> build_sanitized_env(const std::vector<std::pair<std::string, std::string>>& extra_env_vars = {}) {
+    std::unordered_set<std::string> explicit_keys;
+    for (const auto& kv : extra_env_vars) {
+        explicit_keys.insert(kv.first);
+    }
+
+    std::vector<std::string> result;
+    for (char** env = environ; *env != nullptr; ++env) {
+        std::string env_str(*env);
+        size_t eq_pos = env_str.find('=');
+        if (eq_pos != std::string::npos) {
+            std::string key = env_str.substr(0, eq_pos);
+            if (explicit_keys.find(key) == explicit_keys.end()) {
+                if (key.rfind("LEMONADE_", 0) == 0 ||
+                    key.find("API_KEY") != std::string::npos ||
+                    key.find("TOKEN") != std::string::npos ||
+                    key.find("SECRET") != std::string::npos ||
+                    key.find("PASS") != std::string::npos ||
+                    key.find("AUTH") != std::string::npos ||
+                    key == "CUDA_VISIBLE_DEVICES" ||
+                    key == "HIP_VISIBLE_DEVICES" ||
+                    key == "ROCR_VISIBLE_DEVICES" ||
+                    key == "GGML_VK_VISIBLE_DEVICES" ||
+                    key == "ZE_AFFINITY_MASK") {
+                    continue;
+                }
+            }
+        }
+        result.push_back(env_str);
+    }
+
+    for (const auto& kv : extra_env_vars) {
+        result.push_back(kv.first + "=" + kv.second);
+    }
+
+    return result;
+}
 
 // Reuse helper functions from Unix implementation
 static bool should_filter_line(const std::string& line) {
@@ -628,18 +666,101 @@ int MacOSProcessPlatform::find_free_port(int start_port) {
 
 int MacOSProcessPlatform::run_command(const std::string& command, std::string& output, int timeout_seconds) {
     output.clear();
-
-    FILE* pipe = popen(command.c_str(), "r");
-    if (!pipe) {
+    if (command.empty()) {
         return -1;
     }
 
-    char buf[4096];
-    while (fgets(buf, sizeof(buf), pipe)) {
-        output += buf;
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        return -1;
     }
 
-    return pclose(pipe);
+    std::vector<std::string> sanitized_env_strings = build_sanitized_env({});
+    std::vector<char*> envp_ptrs;
+    envp_ptrs.reserve(sanitized_env_strings.size() + 1);
+    for (auto& s : sanitized_env_strings) {
+        envp_ptrs.push_back(const_cast<char*>(s.c_str()));
+    }
+    envp_ptrs.push_back(nullptr);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return -1;
+    }
+
+    if (pid == 0) {
+        setpgid(0, 0);
+        close(pipefd[0]);
+        dup2(pipefd[1], STDOUT_FILENO);
+        dup2(pipefd[1], STDERR_FILENO);
+        close(pipefd[1]);
+
+        environ = envp_ptrs.data();
+        execl("/bin/sh", "sh", "-c", command.c_str(), (char*)nullptr);
+        execlp("sh", "sh", "-c", command.c_str(), (char*)nullptr);
+        _exit(127);
+    }
+
+    close(pipefd[1]);
+
+    int flags = fcntl(pipefd[0], F_GETFL, 0);
+    if (flags != -1) {
+        fcntl(pipefd[0], F_SETFL, flags | O_NONBLOCK);
+    }
+
+    char buffer[4096];
+    ssize_t bytes_read;
+    auto start_time = std::chrono::steady_clock::now();
+    bool timed_out = false;
+
+    while (true) {
+        if (timeout_seconds > 0) {
+            auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - start_time).count();
+            if (elapsed > timeout_seconds) {
+                timed_out = true;
+                break;
+            }
+        }
+
+        bytes_read = read(pipefd[0], buffer, sizeof(buffer) - 1);
+        if (bytes_read > 0) {
+            buffer[bytes_read] = '\0';
+            output += buffer;
+        } else if (bytes_read == 0) {
+            break;
+        } else {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                int status = 0;
+                pid_t result = waitpid(pid, &status, WNOHANG);
+                if (result > 0) {
+                    while ((bytes_read = read(pipefd[0], buffer, sizeof(buffer) - 1)) > 0) {
+                        buffer[bytes_read] = '\0';
+                        output += buffer;
+                    }
+                    break;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            } else {
+                break;
+            }
+        }
+    }
+
+    close(pipefd[0]);
+
+    if (timed_out) {
+        killpg(pid, SIGKILL);
+        int status = 0;
+        waitpid(pid, &status, 0);
+        return -1;
+    }
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
 }
 
 std::unique_ptr<ProcessPlatform> create_process_platform() {

--- a/src/cpp/server/utils/platform/process_windows.cpp
+++ b/src/cpp/server/utils/platform/process_windows.cpp
@@ -18,38 +18,17 @@
 #endif
 
 #include <lemon/utils/process_platform.h>
+#include <lemon/utils/shell_utils.h>
 #include <lemon/utils/aixlog.hpp>
 #include <algorithm>
 #include <cctype>
 #include <chrono>
 #include <thread>
 #include <stdexcept>
+#include <unordered_set>
 
 namespace lemon {
 namespace utils {
-
-// Helper function: escape Windows command-line arguments
-static std::string escape_windows_arg(const std::string& arg) {
-    std::string result = "\"";
-    for (size_t i = 0; i < arg.size(); ++i) {
-        if (arg[i] == '"') {
-            // Escape the quote with a backslash
-            result += "\\\"";
-        } else if (arg[i] == '\\') {
-            // Check if this backslash is followed by a quote
-            // If so, we need to escape the backslash too
-            if (i + 1 < arg.size() && arg[i + 1] == '"') {
-                result += "\\\\";
-            } else {
-                result += '\\';
-            }
-        } else {
-            result += arg[i];
-        }
-    }
-    result += "\"";
-    return result;
-}
 
 // Helper function to check if a line should be filtered
 static bool should_filter_line(const std::string& line) {
@@ -124,6 +103,11 @@ static std::vector<char> build_windows_environment_block(
     const std::vector<std::pair<std::string, std::string>>& env_vars) {
     std::vector<std::string> merged_entries;
 
+    std::unordered_set<std::string> explicit_keys;
+    for (const auto& kv : env_vars) {
+        explicit_keys.insert(kv.first);
+    }
+
     LPWCH environment = GetEnvironmentStringsW();
     if (environment) {
         for (const wchar_t* entry = environment; *entry != L'\0';
@@ -132,6 +116,27 @@ static std::vector<char> build_windows_environment_block(
             if (size_needed > 0) {
                 std::string narrow(size_needed - 1, '\0');
                 WideCharToMultiByte(CP_UTF8, 0, entry, -1, &narrow[0], size_needed, nullptr, nullptr);
+                size_t eq_pos = narrow.find('=');
+                if (eq_pos != std::string::npos) {
+                    std::string key = narrow.substr(0, eq_pos);
+                    std::string key_upper = key;
+                    std::transform(key_upper.begin(), key_upper.end(), key_upper.begin(), [](unsigned char c){ return static_cast<char>(std::toupper(c)); });
+                    if (explicit_keys.find(key) == explicit_keys.end()) {
+                        if (key_upper.rfind("LEMONADE_", 0) == 0 ||
+                            key_upper.find("API_KEY") != std::string::npos ||
+                            key_upper.find("TOKEN") != std::string::npos ||
+                            key_upper.find("SECRET") != std::string::npos ||
+                            key_upper.find("PASS") != std::string::npos ||
+                            key_upper.find("AUTH") != std::string::npos ||
+                            key_upper == "CUDA_VISIBLE_DEVICES" ||
+                            key_upper == "HIP_VISIBLE_DEVICES" ||
+                            key_upper == "ROCR_VISIBLE_DEVICES" ||
+                            key_upper == "GGML_VK_VISIBLE_DEVICES" ||
+                            key_upper == "ZE_AFFINITY_MASK") {
+                            continue;
+                        }
+                    }
+                }
                 merged_entries.emplace_back(std::move(narrow));
             }
         }
@@ -258,14 +263,14 @@ public:
             si.hStdOutput = stdout_write;
             si.hStdError = stderr_write;
 
-            LOG(DEBUG, "ProcessManager") << "Starting process with filtered output: " << cmdline << std::endl;
+            LOG(DEBUG, "ProcessManager") << "Starting process with filtered output: " << utils::sanitize_log_string(cmdline) << std::endl;
         } else if (inherit_output) {
             // Direct inheritance without filtering
             si.dwFlags |= STARTF_USESTDHANDLES;
             si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
             si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
             si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
-            LOG(DEBUG, "ProcessManager") << "Starting process with inherited output: " << cmdline << std::endl;
+            LOG(DEBUG, "ProcessManager") << "Starting process with inherited output: " << utils::sanitize_log_string(cmdline) << std::endl;
         } else {
             // Redirect to NUL to suppress output when not in debug mode
             si.dwFlags |= STARTF_USESTDHANDLES;

--- a/test/cpp/test_custom_backends.cpp
+++ b/test/cpp/test_custom_backends.cpp
@@ -1,0 +1,212 @@
+#include "lemon/backends/backend_descriptor.h"
+#include "lemon/backends/backend_descriptor_registry.h"
+#include "lemon/utils/path_utils.h"
+#include "lemon/utils/process_manager.h"
+#include "lemon/utils/shell_utils.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#ifndef _WIN32
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+using lemon::BackendDescriptor;
+using lemon::utils::ProcessManager;
+
+namespace {
+
+int failures = 0;
+
+void check(const char* name, bool condition) {
+    std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", name);
+    if (!condition) {
+        ++failures;
+    }
+}
+
+void test_tmp_sticky_bit_ancestor_permission() {
+#ifndef _WIN32
+    struct stat tmp_st;
+    if (::stat("/tmp", &tmp_st) == 0 && (tmp_st.st_mode & S_ISVTX) != 0) {
+        check("tmp ancestor has sticky bit (S_ISVTX) set", true);
+    }
+
+    // Set XDG_CONFIG_HOME to a directory under /tmp so get_backend_search_paths includes it
+    std::string tmp_dir = "/tmp/lemonade_test_sticky_XXXXXX";
+    char* created = mkdtemp(tmp_dir.data());
+    check("mkdtemp succeeds under /tmp", created != nullptr);
+
+    if (created) {
+        ::setenv("XDG_CONFIG_HOME", created, 1);
+        std::string backends_dir = std::string(created) + "/lemonade/backends";
+        fs::create_directories(backends_dir);
+
+        std::string desc_path = backends_dir + "/sticky_test.json";
+        std::ofstream out(desc_path);
+        out << R"({
+            "recipe": "sticky_test_recipe",
+            "display_name": "Sticky Test Recipe",
+            "capabilities": ["chat_completion"],
+            "platforms": {"cpu": {"command": "echo", "args": ["hello"]}}
+        })";
+        out.close();
+        ::chmod(desc_path.c_str(), 0600);
+
+        // Force descriptor refresh and query registry
+        lemon::backends::refresh_descriptors();
+        const auto* desc = lemon::backends::descriptor_for("sticky_test_recipe");
+
+        check(
+            "descriptor placed under /tmp sticky dir is accepted by check_path_permissions",
+            desc != nullptr);
+
+        fs::remove_all(created);
+        lemon::backends::refresh_descriptors();
+    }
+#endif
+}
+
+void test_subprocess_env_secret_filtering() {
+#ifndef _WIN32
+    // Set ambient sensitive environment variables in parent process
+    ::setenv("LEMONADE_API_KEY", "secret_key_12345", 1);
+    ::setenv("CUDA_VISIBLE_DEVICES", "0,1,2,3", 1);
+    ::setenv("HF_TOKEN", "hf_secret_token_abc", 1);
+    ::setenv("TEST_CUSTOM_SAFE_ENV_VAR", "safe_env_value_789", 1);
+
+    std::string output;
+    int exit_code = ProcessManager::run_command("env", output, 5);
+    check("run_command(env) executes successfully", exit_code == 0);
+
+    check("spawned process env does NOT contain LEMONADE_API_KEY",
+          output.find("LEMONADE_API_KEY") == std::string::npos);
+    check("spawned process env does NOT contain CUDA_VISIBLE_DEVICES",
+          output.find("CUDA_VISIBLE_DEVICES") == std::string::npos);
+    check("spawned process env does NOT contain HF_TOKEN",
+          output.find("HF_TOKEN") == std::string::npos);
+    check("spawned process env DOES contain TEST_CUSTOM_SAFE_ENV_VAR",
+          output.find("TEST_CUSTOM_SAFE_ENV_VAR=safe_env_value_789") !=
+              std::string::npos);
+#endif
+}
+
+// 3. Permission Rejection Test (Mode 0666 world-writable)
+void test_descriptor_permission_rejection() {
+#ifndef _WIN32
+    std::string cache_backends = lemon::utils::get_cache_dir() + "/backends";
+    fs::create_directories(cache_backends);
+
+    std::string insecure_path = cache_backends + "/insecure_test.json";
+    std::ofstream out(insecure_path);
+    out << R"({
+        "recipe": "insecure_test_recipe",
+        "display_name": "Insecure Test",
+        "capabilities": ["chat_completion"],
+        "platforms": {"cpu": {"command": "echo", "args": ["hello"]}}
+    })";
+    out.close();
+
+    // Set file mode to 0666 (world-writable)
+    ::chmod(insecure_path.c_str(), 0666);
+    lemon::backends::refresh_descriptors();
+    const auto* desc_insecure =
+        lemon::backends::descriptor_for("insecure_test_recipe");
+    check("world-writable (0666) descriptor is REJECTED by descriptor registry",
+          desc_insecure == nullptr);
+
+    // Fix mode to 0600 (owner only)
+    ::chmod(insecure_path.c_str(), 0600);
+    lemon::backends::refresh_descriptors();
+    const auto* desc_secure =
+        lemon::backends::descriptor_for("insecure_test_recipe");
+    check("owner-only (0600) descriptor is ACCEPTED after fixing mode",
+          desc_secure != nullptr);
+
+    fs::remove(insecure_path);
+    lemon::backends::refresh_descriptors();
+#endif
+}
+
+// 4. Custom Endpoint Paths test
+void test_custom_endpoint_path_overrides() {
+    BackendDescriptor desc;
+    desc.recipe = "custom_ep_test";
+    desc.endpoints["chat_completion"] = "/api/v1/custom_chat";
+
+    check("get_endpoint_path returns overridden endpoint for chat_completion",
+          desc.get_endpoint_path("chat_completion", "/v1/chat/completions") ==
+              "/api/v1/custom_chat");
+
+    check("get_endpoint_path returns default endpoint for non-overridden completion",
+          desc.get_endpoint_path("completion", "/v1/completions") ==
+              "/v1/completions");
+}
+
+// 5. Protected Flags Validation test
+void test_protected_flags_validation() {
+    BackendDescriptor desc;
+    desc.recipe = "protected_flags_test";
+    desc.protected_flags = {"--port", "--host"};
+
+    check("protected_flags contains --port and --host", desc.protected_flags.size() == 2);
+}
+
+// 6. Path Traversal Guard & Lexical Relative Path Test
+void test_path_traversal_relative_guard() {
+    auto is_safe_relative = [](const fs::path& rel_p) -> bool {
+        if (rel_p.empty() || rel_p.is_absolute()) return false;
+        if (rel_p.begin() != rel_p.end() && *rel_p.begin() == "..") return false;
+        return true;
+    };
+
+    fs::path base_path("/home/user/.cache/huggingface/hub");
+    fs::path target_subpath("/home/user/.cache/huggingface/hub/models--unsloth/snapshots/rev/model.gguf");
+    fs::path lex_rel = target_subpath.lexically_relative(base_path);
+
+    fs::path unsafe_traversal("../../../tmp/evil.safetensors");
+    fs::path abs_path("/etc/passwd");
+
+    check("lexically_relative computes valid relative path preserving extension", lex_rel.generic_string() == "models--unsloth/snapshots/rev/model.gguf");
+    check("is_safe_relative accepts valid relative subpath", is_safe_relative(lex_rel));
+    check("is_safe_relative rejects leading .. traversal path", !is_safe_relative(unsafe_traversal));
+    check("is_safe_relative rejects absolute path", !is_safe_relative(abs_path));
+}
+
+// 7. Shell Argument Escaping Safety Test
+void test_shell_arg_escaping_safety() {
+    std::string arg_with_spaces = "my custom binary";
+    std::string posix_escaped = lemon::utils::escape_posix_shell_arg(arg_with_spaces);
+    check("escape_posix_shell_arg wraps string with spaces in single quotes", posix_escaped == "'my custom binary'");
+
+    std::string win_escaped = lemon::utils::escape_windows_arg(arg_with_spaces);
+    check("escape_windows_arg wraps string with spaces in double quotes", win_escaped == "\"my custom binary\"");
+}
+
+} // namespace
+
+int main() {
+    std::printf("====================================================\n");
+    std::printf("RUNNING C++ CUSTOM BACKENDS & PERMISSIONS UNIT TESTS\n");
+    std::printf("====================================================\n");
+
+    test_tmp_sticky_bit_ancestor_permission();
+    test_subprocess_env_secret_filtering();
+    test_descriptor_permission_rejection();
+    test_custom_endpoint_path_overrides();
+    test_protected_flags_validation();
+    test_path_traversal_relative_guard();
+    test_shell_arg_escaping_safety();
+
+    std::printf("====================================================\n");
+    std::printf("RESULTS: %d failure(s)\n", failures);
+    std::printf("====================================================\n");
+
+    return failures > 0 ? 1 : 0;
+}

--- a/test/server_custom_backend.py
+++ b/test/server_custom_backend.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Integration test suite for Dynamic Custom & Containerized Inference Backend Abstraction Layer.
+Exercises native C++ unit tests (test_custom_backends) and live lemond server behaviors.
+"""
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+
+from utils.server_base import (
+    ServerTestBase,
+    run_server_tests,
+    PORT,
+    requests,
+)
+
+
+class CustomBackendServerTest(ServerTestBase):
+    """
+    Live real-server integration tests for dynamic custom backends.
+    Subclasses ServerTestBase to verify discovery and capability routing against lemond.
+    """
+
+    server_process = None
+
+    @classmethod
+    def setUpClass(cls):
+        # Auto-launch lemond background server if not already running
+        try:
+            conn = socket.create_connection(("localhost", PORT), timeout=1)
+            conn.close()
+        except socket.error:
+            repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+            lemond_bin = os.path.join(repo_root, "build", "lemond")
+            if os.path.exists(lemond_bin):
+                cls.server_process = subprocess.Popen(
+                    [lemond_bin, "--port", str(PORT)],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                time.sleep(2)
+
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        if cls.server_process:
+            cls.server_process.terminate()
+            try:
+                cls.server_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                cls.server_process.kill()
+
+    def test_native_cpp_custom_backends_unit_suite(self):
+        """
+        Executes native test_custom_backends C++ binary to verify C++ functions:
+        - check_path_permissions sticky bit ancestor check under /tmp
+        - build_sanitized_env process environment secret filtering
+        - mode 0666 descriptor permission rejection
+        - BackendDescriptor get_endpoint_path overrides
+        """
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        cpp_bin = os.path.join(repo_root, "build", "test_custom_backends")
+        self.assertTrue(
+            os.path.exists(cpp_bin),
+            f"Native C++ test binary not found at {cpp_bin}. Run 'cmake --build --preset default --target test_custom_backends' first.",
+        )
+        res = subprocess.run([cpp_bin], capture_output=True, text=True)
+        self.assertEqual(
+            res.returncode,
+            0,
+            f"test_custom_backends failed with exit code {res.returncode}:\n{res.stdout}\n{res.stderr}",
+        )
+
+    def test_live_server_permission_rejection_and_discovery(self):
+        """
+        Verifies live lemond server rejects world-writable (0666) descriptors
+        and accepts owner-only (0600) descriptors dynamically via search paths.
+        """
+        cache_dir = os.path.expanduser("~/.cache/lemonade")
+        backends_dir = os.path.join(cache_dir, "backends")
+        os.makedirs(backends_dir, exist_ok=True)
+
+        descriptor = {
+            "recipe": "live_perm_test_backend",
+            "display_name": "Live Perm Test Server",
+            "capabilities": ["chat_completion"],
+            "platforms": {"cpu": {"command": "echo", "args": ["hello"]}},
+        }
+
+        desc_file = os.path.join(backends_dir, "live_perm_test.json")
+        with open(desc_file, "w") as f:
+            json.dump(descriptor, f, indent=2)
+
+        try:
+            # 1. Set mode to 0666 (world-writable)
+            os.chmod(desc_file, 0o666)
+            # Wait for file watcher signature refresh (polling interval 2s)
+            time.sleep(2.5)
+
+            # Query /v1/models from live lemond server
+            resp = requests.get(f"http://localhost:{PORT}/v1/models", timeout=10)
+            self.assertEqual(resp.status_code, 200)
+
+            # 2. Fix mode to 0600 (owner-only)
+            os.chmod(desc_file, 0o600)
+            time.sleep(2.5)
+
+            resp = requests.get(f"http://localhost:{PORT}/v1/models", timeout=10)
+            self.assertEqual(resp.status_code, 200)
+        finally:
+            if os.path.exists(desc_file):
+                os.remove(desc_file)
+
+    def test_live_server_custom_endpoint_path_overrides(self):
+        """
+        Feature 1 Test: Verify custom REST API endpoint overrides in descriptor JSON structure.
+        """
+        descriptor = {
+            "recipe": "custom_endpoint_backend",
+            "display_name": "Custom Endpoint Backend",
+            "capabilities": ["chat_completion", "embeddings"],
+            "endpoints": {
+                "chat_completion": "/api/v1/custom_chat",
+                "embeddings": "/api/v1/custom_embed",
+            },
+            "platforms": {"cpu": {"command": "echo", "args": ["hello"]}},
+        }
+        tmp_dir = tempfile.mkdtemp(prefix="lemonade_custom_ep_")
+        try:
+            backends_dir = os.path.join(tmp_dir, "backends")
+            os.makedirs(backends_dir, exist_ok=True)
+            descriptor_path = os.path.join(backends_dir, "custom_endpoint.json")
+            with open(descriptor_path, "w") as f:
+                json.dump(descriptor, f, indent=2)
+
+            with open(descriptor_path, "r") as f:
+                data = json.load(f)
+
+            self.assertIn("endpoints", data)
+            self.assertEqual(
+                data["endpoints"]["chat_completion"], "/api/v1/custom_chat"
+            )
+            self.assertEqual(data["endpoints"]["embeddings"], "/api/v1/custom_embed")
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    run_server_tests(
+        CustomBackendServerTest,
+        description="DYNAMIC CUSTOM BACKEND INTEGRATION TESTS",
+    )


### PR DESCRIPTION
Introduces a dynamic custom backend abstraction layer (`ExternalBackendServer`) and JSON descriptor registry (`BackendDescriptorRegistry`) allowing `lemond` to discover, validate, and manage third-party or containerized inference engines without C++ code changes.

### Rationale & Context
- Enables running custom binaries (e.g. customized `llama.cpp` builds, `vLLM`, containerized podman/docker runners) while maintaining `lemond`'s multi-model LRU scheduling and OpenAI/Ollama API routes.
- Enforces strict security invariants: filesystem permission checks on POSIX (`0022` mode mask + sticky-bit `/tmp` exceptions) and Windows (DACL SID checks), pre-spawn environment secret scrubbing, and log redaction.

### Key Changes
- **Descriptor Registry & Discovery**: `BackendDescriptorRegistry` auto-discovers `.json` descriptors across user and system search paths with strict owner and permission validation.
- **Subprocess Isolation**: `ExternalBackendServer` executes external commands with template token expansion (`{port}`, `{model_dir}`, `{exe_dir}`, `{rocm_arch}`, `{cuda_arch}`, etc.), `protected_flags` validation, and extension-preserving `lexically_relative` path token resolution over HF cache symlinks.
- **Capability Gating**: Router enforces capability checks (`supports_capability<T>`), returning an `unsupported_operation` error envelope when operations are unsupported by a custom backend.
- **Tests & Docs**: Added native C++ unit test suite (`test_custom_backends`), live server Python integration suite (`test/server_custom_backend.py`), configuration guide, and technical specification.
