### PR TITLE
fix(build): patch libwebsockets GENHDR OUTPUT to silence MSB8065

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,6 +607,15 @@ if(NOT USE_SYSTEM_LWS)
     # remove directory from OUTPUT list (MSBuild interprets it as file path — MSB8065)
     string(REPLACE "\t\t\t\${PROJECT_BINARY_DIR}/include/libwebsockets\n" ""
            LWS_CMAKE_MAIN "${LWS_CMAKE_MAIN}")
+    # copy_directory only adds/overwrites — wipe the destination first so stale
+    # headers removed upstream don't survive a GENHDR rerun across a dep update.
+    # Works on every generator (ADDITIONAL_CLEAN_FILES below is Make/Ninja only).
+    if(NOT LWS_CMAKE_MAIN MATCHES "rm -rf.*include/libwebsockets")
+        string(REPLACE
+            "COMMAND \${CMAKE_COMMAND} -E copy_directory \${CMAKE_CURRENT_SOURCE_DIR}/include/libwebsockets/"
+            "COMMAND \${CMAKE_COMMAND} -E rm -rf \${CMAKE_CURRENT_BINARY_DIR}/include/libwebsockets\n\t\tCOMMAND \${CMAKE_COMMAND} -E copy_directory \${CMAKE_CURRENT_SOURCE_DIR}/include/libwebsockets/"
+            LWS_CMAKE_MAIN "${LWS_CMAKE_MAIN}")
+    endif()
     file(WRITE "${libwebsockets_SOURCE_DIR}/CMakeLists.txt" "${LWS_CMAKE_MAIN}")
     file(READ "${libwebsockets_SOURCE_DIR}/lib/CMakeLists.txt" LWS_CMAKE_LIB)
     string(REPLACE "\r" "" LWS_CMAKE_LIB "${LWS_CMAKE_LIB}")
@@ -614,6 +623,18 @@ if(NOT USE_SYSTEM_LWS)
     file(WRITE "${libwebsockets_SOURCE_DIR}/lib/CMakeLists.txt" "${LWS_CMAKE_LIB}")
     # Now add the subdirectory
     add_subdirectory(${libwebsockets_SOURCE_DIR} ${libwebsockets_BINARY_DIR})
+    # Removing the directory from OUTPUT above also drops it from the GENHDR clean
+    # rules. Re-attach it as an additional clean file so stale LWS headers don't
+    # survive a `clean` target across a dependency update (copy_directory only
+    # adds/overwrites, never deletes).
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.15")
+        set_property(
+            TARGET GENHDR
+            APPEND
+            PROPERTY ADDITIONAL_CLEAN_FILES
+            "${libwebsockets_BINARY_DIR}/include/libwebsockets"
+        )
+    endif()
     message(STATUS "libwebsockets will be fetched (v${MIN_LWS_VERSION})")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,9 +601,15 @@ if(NOT USE_SYSTEM_LWS)
     FetchContent_Populate(libwebsockets)
     # Patch the CMakeLists.txt files to remove -Werror
     file(READ "${libwebsockets_SOURCE_DIR}/CMakeLists.txt" LWS_CMAKE_MAIN)
+    # CRLF-safe: normalize CR before any line-based patching (autocrlf leaves \r\n on Windows)
+    string(REPLACE "\r" "" LWS_CMAKE_MAIN "${LWS_CMAKE_MAIN}")
     string(REPLACE "-Werror" "" LWS_CMAKE_MAIN "${LWS_CMAKE_MAIN}")
+    # remove directory from OUTPUT list (MSBuild interprets it as file path — MSB8065)
+    string(REPLACE "\t\t\t\${PROJECT_BINARY_DIR}/include/libwebsockets\n" ""
+           LWS_CMAKE_MAIN "${LWS_CMAKE_MAIN}")
     file(WRITE "${libwebsockets_SOURCE_DIR}/CMakeLists.txt" "${LWS_CMAKE_MAIN}")
     file(READ "${libwebsockets_SOURCE_DIR}/lib/CMakeLists.txt" LWS_CMAKE_LIB)
+    string(REPLACE "\r" "" LWS_CMAKE_LIB "${LWS_CMAKE_LIB}")
     string(REPLACE "-Werror" "" LWS_CMAKE_LIB "${LWS_CMAKE_LIB}")
     file(WRITE "${libwebsockets_SOURCE_DIR}/lib/CMakeLists.txt" "${LWS_CMAKE_LIB}")
     # Now add the subdirectory


### PR DESCRIPTION
## Summary

The `add_custom_command(OUTPUT ...)` for libwebsockets' `GENHDR` target lists a bare directory (`${PROJECT_BINARY_DIR}/include/libwebsockets`) alongside actual files. MSBuild, under the Visual Studio generator, interprets that directory as a file path and emits **warning MSB8065** on every build, which disables incremental builds for the LWS subproject.

This removes the directory from the `OUTPUT` list. The directory is still created by the adjacent `copy_directory` COMMAND, so the build is unaffected either way.

Additionally, the upstream `CMakeLists.txt` is checked out with CRLF on Windows (`core.autocrlf = true`, no `.gitattributes` upstream), which made the original `string(REPLACE "... \n" ...)` a silent no-op. A `\r`-strip is now applied to both patched files before any line-based substitution, making the patches reproducible across line-ending configurations.

## Verification

- `cmake -S . -B build` (VS 18 2026 generator) — configures cleanly.
- `cmake --build build --target GENHDR` after deleting `include/lws_config.h` and `include/libwebsockets.h` → no MSB8065, both declared outputs (`lws_config.h`, `libwebsockets.h`) created and the `include/libwebsockets/` directory populated as a side effect.
- `-Werror` strip confirmed (0 occurrences in both `CMakeLists.txt` and `lib/CMakeLists.txt` after patch).

## Upstream

Tracked upstream — no fix released as of v4.3.3:
https://github.com/warmcat/libwebsockets/issues/3060