### PR TITLE
fix(ci): prevent MSI verify flake from stale ARP entries on shared runners

### DIFF
--- a/.github/actions/cleanup-processes-windows/action.yml
+++ b/.github/actions/cleanup-processes-windows/action.yml
@@ -212,32 +212,38 @@ runs:
             "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
         )
 
-        $productCode = $null
-        $foundProduct = $null
+        # A single stale ARP entry (uninstallable, exit code 1605) must not shadow
+        # a real registration of the same DisplayName, so collect every GUID-keyed
+        # match across all hives instead of stopping at the first one.
+        $foundProducts = @()
 
         foreach ($path in $uninstallPaths) {
             $subkeys = Get-ItemProperty $path -ErrorAction SilentlyContinue
             foreach ($key in $subkeys) {
-                if ($key.DisplayName -eq $productName) {
-                    $foundProduct = $key
-                    $productCode = $key.PSChildName
-                    break
+                if ($key.DisplayName -eq $productName -and $key.PSChildName -like "{*}") {
+                    $foundProducts += $key
                 }
             }
-            if ($productCode) { break }
         }
 
-        if ($productCode) {
-            Write-Host "Found installed product: $($foundProduct.DisplayName) (Version: $($foundProduct.DisplayVersion))" -ForegroundColor Green
-            Write-Host "Product Code: $productCode" -ForegroundColor Gray
+        if ($foundProducts.Count -gt 0) {
+            foreach ($foundProduct in $foundProducts) {
+                $productCode = $foundProduct.PSChildName
+                Write-Host "Found installed product: $($foundProduct.DisplayName) (Version: $($foundProduct.DisplayVersion))" -ForegroundColor Green
+                Write-Host "Product Code: $productCode" -ForegroundColor Gray
 
-            Write-Host "Uninstalling..." -ForegroundColor Yellow
-            $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x $productCode /qn" -Wait -PassThru
+                Write-Host "Uninstalling..." -ForegroundColor Yellow
+                $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x $productCode /qn" -Wait -PassThru
 
-            if ($proc.ExitCode -eq 0) {
-                Write-Host "Uninstall successful!" -ForegroundColor Green
-            } else {
-                Write-Host "Uninstall failed with exit code $($proc.ExitCode)" -ForegroundColor Red
+                if ($proc.ExitCode -eq 0) {
+                    Write-Host "Uninstall successful!" -ForegroundColor Green
+                } elseif ($proc.ExitCode -eq 1605) {
+                    Write-Host "Windows Installer reports product not installed (1605). Removing stale ARP registry key..." -ForegroundColor Yellow
+                    Remove-Item -Path $foundProduct.PSPath -Recurse -Force -ErrorAction SilentlyContinue
+                    Write-Host "Stale ARP registry key removed: $productCode" -ForegroundColor Green
+                } else {
+                    Write-Host "Uninstall failed with exit code $($proc.ExitCode)" -ForegroundColor Red
+                }
             }
         } else {
             Write-Host "Product '$productName' not found installed via MSI in registry." -ForegroundColor Gray

--- a/.github/actions/cleanup-processes-windows/action.yml
+++ b/.github/actions/cleanup-processes-windows/action.yml
@@ -233,14 +233,25 @@ runs:
                 Write-Host "Product Code: $productCode" -ForegroundColor Gray
 
                 Write-Host "Uninstalling..." -ForegroundColor Yellow
-                $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x $productCode /qn" -Wait -PassThru
+                $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x $productCode /qn /norestart" -Wait -PassThru
 
                 if ($proc.ExitCode -eq 0) {
                     Write-Host "Uninstall successful!" -ForegroundColor Green
+                } elseif ($proc.ExitCode -eq 3010) {
+                    Write-Host "Uninstall successful (3010: reboot pending, not performed on CI runners)." -ForegroundColor Yellow
                 } elseif ($proc.ExitCode -eq 1605) {
                     Write-Host "Windows Installer reports product not installed (1605). Removing stale ARP registry key..." -ForegroundColor Yellow
-                    Remove-Item -Path $foundProduct.PSPath -Recurse -Force -ErrorAction SilentlyContinue
-                    Write-Host "Stale ARP registry key removed: $productCode" -ForegroundColor Green
+                    try {
+                        Remove-Item -Path $foundProduct.PSPath -Recurse -Force -ErrorAction Stop
+                    } catch {
+                        Write-Host "  Remove-Item failed: $_" -ForegroundColor Red
+                    }
+
+                    if (Test-Path $foundProduct.PSPath) {
+                        Write-Host "WARNING: stale ARP registry key still present: $productCode" -ForegroundColor Red
+                    } else {
+                        Write-Host "Stale ARP registry key removed: $productCode" -ForegroundColor Green
+                    }
                 } else {
                     Write-Host "Uninstall failed with exit code $($proc.ExitCode)" -ForegroundColor Red
                 }
@@ -251,10 +262,12 @@ runs:
             # Fallback: Check if we can uninstall via the MSI file if it exists in current directory
             if (Test-Path "lemonade-server-minimal.msi") {
                 Write-Host "Found lemonade-server-minimal.msi in current directory. Attempting uninstall via file..." -ForegroundColor Yellow
-                $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x lemonade-server-minimal.msi /qn" -Wait -PassThru
+                $proc = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x lemonade-server-minimal.msi /qn /norestart" -Wait -PassThru
 
                 if ($proc.ExitCode -eq 0) {
                     Write-Host "Uninstall via MSI file successful!" -ForegroundColor Green
+                } elseif ($proc.ExitCode -eq 3010) {
+                    Write-Host "Uninstall via MSI file successful (3010: reboot pending, not performed on CI runners)." -ForegroundColor Yellow
                 } else {
                     Write-Host "Uninstall via MSI file failed with exit code $($proc.ExitCode)" -ForegroundColor Red
                 }

--- a/.github/actions/install-lemonade-server-msi/action.yml
+++ b/.github/actions/install-lemonade-server-msi/action.yml
@@ -32,6 +32,18 @@ runs:
             exit 1
         }
 
+        # If this MSI's ProductCode is already registered (leftover from a prior
+        # job on a shared runner), msiexec runs in maintenance mode and ignores
+        # INSTALLDIR, leaving nothing at the requested path. Uninstall by file
+        # first so the install below is always a fresh one. 1605 = not installed.
+        Write-Host "Removing any pre-existing registration of this MSI..." -ForegroundColor Gray
+        $u = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x lemonade-server-minimal.msi /qn" -Wait -PassThru
+        if ($u.ExitCode -eq 0) {
+            Write-Host "Removed a pre-existing installation of this MSI." -ForegroundColor Yellow
+        } elseif ($u.ExitCode -ne 1605) {
+            Write-Host "WARNING: Pre-install uninstall attempt exited with code $($u.ExitCode). Continuing." -ForegroundColor Yellow
+        }
+
         # Run installer silently with verbose logging
         $args = "/i lemonade-server-minimal.msi /qn INSTALLDIR=`"$installPath`" /L*V `"$logPath`""
         $p = Start-Process -FilePath "msiexec.exe" -ArgumentList $args -Wait -PassThru

--- a/.github/actions/install-lemonade-server-msi/action.yml
+++ b/.github/actions/install-lemonade-server-msi/action.yml
@@ -35,20 +35,51 @@ runs:
         # If this MSI's ProductCode is already registered (leftover from a prior
         # job on a shared runner), msiexec runs in maintenance mode and ignores
         # INSTALLDIR, leaving nothing at the requested path. Uninstall by file
-        # first so the install below is always a fresh one. 1605 = not installed.
+        # first so the install below is always a fresh one. Anything other than
+        # 0 (removed), 1605 (not installed) or 3010 (removed, reboot pending)
+        # can leave the registration active, so retry and then fail loudly
+        # rather than installing into maintenance mode.
+        $uninstallLogPath = "$((Get-Location).Path)\lemonade-msi-preuninstall.log"
         Write-Host "Removing any pre-existing registration of this MSI..." -ForegroundColor Gray
-        $u = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x lemonade-server-minimal.msi /qn" -Wait -PassThru
-        if ($u.ExitCode -eq 0) {
-            Write-Host "Removed a pre-existing installation of this MSI." -ForegroundColor Yellow
-        } elseif ($u.ExitCode -ne 1605) {
-            Write-Host "WARNING: Pre-install uninstall attempt exited with code $($u.ExitCode). Continuing." -ForegroundColor Yellow
+
+        $uninstallCleared = $false
+        for ($attempt = 1; $attempt -le 3; $attempt++) {
+            $u = Start-Process -FilePath "msiexec.exe" -ArgumentList "/x lemonade-server-minimal.msi /qn /norestart /L*V `"$uninstallLogPath`"" -Wait -PassThru
+
+            if ($u.ExitCode -eq 0) {
+                Write-Host "Removed a pre-existing installation of this MSI." -ForegroundColor Yellow
+                $uninstallCleared = $true
+            } elseif ($u.ExitCode -eq 1605) {
+                Write-Host "No pre-existing registration of this MSI (1605)." -ForegroundColor Gray
+                $uninstallCleared = $true
+            } elseif ($u.ExitCode -eq 3010) {
+                Write-Host "Removed a pre-existing installation of this MSI (3010: reboot pending)." -ForegroundColor Yellow
+                $uninstallCleared = $true
+            } else {
+                Write-Host "Pre-install uninstall attempt $attempt exited with code $($u.ExitCode)" -ForegroundColor Yellow
+                if ($attempt -lt 3) { Start-Sleep -Seconds 10 }
+            }
+
+            if ($uninstallCleared) { break }
+        }
+
+        if (-not $uninstallCleared) {
+            Write-Host "ERROR: Could not clear a pre-existing registration of this MSI. Installing now would run in maintenance mode and ignore INSTALLDIR." -ForegroundColor Red
+            if (Test-Path $uninstallLogPath) {
+                Write-Host "=== MSI Uninstall Log ($uninstallLogPath) ===" -ForegroundColor Yellow
+                Get-Content $uninstallLogPath
+                Write-Host "=== End MSI Uninstall Log ===" -ForegroundColor Yellow
+            }
+            exit 1
         }
 
         # Run installer silently with verbose logging
-        $args = "/i lemonade-server-minimal.msi /qn INSTALLDIR=`"$installPath`" /L*V `"$logPath`""
+        $args = "/i lemonade-server-minimal.msi /qn /norestart INSTALLDIR=`"$installPath`" /L*V `"$logPath`""
         $p = Start-Process -FilePath "msiexec.exe" -ArgumentList $args -Wait -PassThru
 
-        if ($p.ExitCode -ne 0) {
+        if ($p.ExitCode -eq 3010) {
+            Write-Host "Installation complete (3010: reboot pending, not performed on CI runners)." -ForegroundColor Yellow
+        } elseif ($p.ExitCode -ne 0) {
              Write-Host "ERROR: Installation failed with exit code $($p.ExitCode)" -ForegroundColor Red
 
              if (Test-Path $logPath) {
@@ -60,9 +91,9 @@ runs:
              }
 
              exit $p.ExitCode
+        } else {
+             Write-Host "Installation complete." -ForegroundColor Green
         }
-
-        Write-Host "Installation complete." -ForegroundColor Green
 
     - name: Verify Installation
       shell: PowerShell


### PR DESCRIPTION
## Root cause

The flaky "Verify Installation" failures (e.g. [omni](https://github.com/lemonade-sdk/lemonade/actions/runs/30916113014/job/92021491020), [audio-gen-thinksound](https://github.com/lemonade-sdk/lemonade/actions/runs/30916113014/job/92021491306)) are machine-state dependent, not random:

1. Runner `sjlab-stx-halo-06` has a stale ARP registry entry ("Lemonade Server 9.0.3") that Windows Installer no longer recognizes — `msiexec /x` on it returns 1605.
2. The cleanup action's uninstall step stops at the **first** DisplayName match, which is always that stale entry, so the actually-installed product is never uninstalled (visible as `Uninstall failed with exit code 1605` in every job on that runner).
3. The next job installs the same MSI (same ProductCode) → MSI log shows `Product registered: entering maintenance mode` → `INSTALLDIR` is ignored in maintenance mode → no files land in the new per-job install path → verify fails with `Missing: bin\LemonadeServer.exe`.

In run 30916113014, `stable-diffusion` installed fine on that runner (nothing registered yet), its teardown hit the stale entry and left the product registered, then `omni` and `audio-gen-thinksound` both failed in maintenance mode.

## Fix

- **cleanup-processes-windows**: uninstall every GUID-keyed registry match instead of only the first, and delete stale ARP keys when msiexec returns 1605 so they stop shadowing real registrations.
- **install-lemonade-server-msi**: uninstall by MSI file (ignoring 1605) before installing, so a leftover registration of the same ProductCode can never push the install into maintenance mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)