### PR TITLE
feat(release): separate stable and prerelease distribution channels

### DIFF
--- a/.github/actions/classify-release-tag/action.yml
+++ b/.github/actions/classify-release-tag/action.yml
@@ -1,0 +1,97 @@
+name: Classify Release Tag
+description: Validate a Lemonade release tag and derive channel/package metadata.
+
+inputs:
+  tag:
+    description: Complete tag such as v12.0.0 or v12.0.0-beta.1. Empty for snapshots.
+    required: false
+    default: ""
+  require_tag:
+    description: Fail when tag is empty.
+    required: false
+    default: "false"
+  require_prerelease:
+    description: Fail unless the supplied tag is a prerelease.
+    required: false
+    default: "false"
+  require_stable:
+    description: Fail unless the supplied tag is a stable release.
+    required: false
+    default: "false"
+  build_serial:
+    description: Monotonic serial for published snapshots/prereleases, normally github.run_number.
+    required: false
+    default: ""
+  build_attempt:
+    description: Attempt number for the workflow run, normally github.run_attempt.
+    required: false
+    default: "1"
+  commit_sha:
+    description: Commit SHA used in snapshot labels. Defaults to the checked-out HEAD.
+    required: false
+    default: ""
+
+outputs:
+  tag_name:
+    value: ${{ steps.classify.outputs.tag_name }}
+    description: Validated complete tag.
+  base_version:
+    value: ${{ steps.classify.outputs.base_version }}
+    description: Numeric MAJOR.MINOR.PATCH version.
+  prerelease_suffix:
+    value: ${{ steps.classify.outputs.prerelease_suffix }}
+    description: Prerelease suffix without the leading dash.
+  is_release_tag:
+    value: ${{ steps.classify.outputs.is_release_tag }}
+    description: Whether a release tag was supplied.
+  is_stable:
+    value: ${{ steps.classify.outputs.is_stable }}
+    description: Whether the tag is a stable release.
+  is_prerelease:
+    value: ${{ steps.classify.outputs.is_prerelease }}
+    description: Whether the tag is a prerelease.
+  build_label:
+    value: ${{ steps.classify.outputs.build_label }}
+    description: Filesystem-safe release or snapshot label.
+  deb_version:
+    value: ${{ steps.classify.outputs.deb_version }}
+    description: Debian version ordered monotonically within the publishing workflow.
+
+runs:
+  using: composite
+  steps:
+    - name: Validate and classify release tag
+      id: classify
+      shell: bash
+      env:
+        TAG_NAME: ${{ inputs.tag }}
+        REQUIRE_TAG: ${{ inputs.require_tag }}
+        REQUIRE_PRERELEASE: ${{ inputs.require_prerelease }}
+        REQUIRE_STABLE: ${{ inputs.require_stable }}
+        BUILD_SERIAL: ${{ inputs.build_serial }}
+        BUILD_ATTEMPT: ${{ inputs.build_attempt }}
+        COMMIT_SHA: ${{ inputs.commit_sha }}
+      run: |
+        set -euo pipefail
+
+        args=(
+          classify
+          --repository "$GITHUB_WORKSPACE"
+          --output "$GITHUB_OUTPUT"
+          --require-tag "$REQUIRE_TAG"
+          --require-prerelease "$REQUIRE_PRERELEASE"
+          --require-stable "$REQUIRE_STABLE"
+          --build-attempt "$BUILD_ATTEMPT"
+        )
+
+        if [[ -n "$TAG_NAME" ]]; then
+          args+=(--tag "$TAG_NAME")
+        fi
+        if [[ -n "$BUILD_SERIAL" ]]; then
+          args+=(--build-serial "$BUILD_SERIAL")
+        fi
+        if [[ -n "$COMMIT_SHA" ]]; then
+          args+=(--commit-sha "$COMMIT_SHA")
+        fi
+
+        python3 "${GITHUB_ACTION_PATH}/../../scripts/release_channels.py" "${args[@]}"

--- a/.github/actions/prepare-debian-build/action.yml
+++ b/.github/actions/prepare-debian-build/action.yml
@@ -8,6 +8,10 @@ inputs:
   codename:
     description: Debian codename (e.g., noble, questing, resolute)
     required: true
+  version:
+    description: Optional normalized Debian package version override.
+    required: false
+    default: ""
 
 outputs:
   version:
@@ -17,14 +21,26 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Get version from git describe
+    - name: Get package version
       id: get_version
       shell: bash
+      env:
+        REQUESTED_VERSION: ${{ inputs.version }}
       run: |
-        VERSION=$(git describe --tags --always)
-        # Strip leading 'v' for Debian version compatibility
-        DEB_VERSION=$(echo "${VERSION}" | sed 's/^v//')
-        echo "version=${DEB_VERSION}" >> $GITHUB_OUTPUT
+        set -euo pipefail
+
+        if [[ -n "$REQUESTED_VERSION" ]]; then
+          DEB_VERSION="$REQUESTED_VERSION"
+        else
+          # Preserve the historical fallback for non-PPA callers. Published PPA
+          # builds always pass an explicit, normalized version from the release
+          # classifier and never depend on git describe for channel ordering.
+          VERSION=$(git describe --tags --always)
+          DEB_VERSION="${VERSION#v}"
+        fi
+
+        echo "Debian version: $DEB_VERSION"
+        echo "version=${DEB_VERSION}" >> "$GITHUB_OUTPUT"
 
     - name: Create Debian packaging metadata
       shell: bash

--- a/.github/scripts/release_channels.py
+++ b/.github/scripts/release_channels.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Shared release-tag parser and monotonic Debian version generator."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Mapping, Optional
+
+
+class ReleaseChannelError(RuntimeError):
+    pass
+
+
+CMAKE_VERSION_RE = re.compile(
+    r"^[ \t]*project\(lemon_cpp[ \t]+VERSION[ \t]+"
+    r"(?P<version>[0-9]+\.[0-9]+\.[0-9]+)",
+    re.MULTILINE,
+)
+TAG_RE = re.compile(
+    r"^v(?P<base>(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*))"
+    r"(?:-(?P<phase>alpha|beta|rc)\."
+    r"(?P<number>0|[1-9][0-9]*))?$"
+)
+POSITIVE_INTEGER_RE = re.compile(r"^[1-9][0-9]*$")
+SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+
+
+@dataclass(frozen=True)
+class ParsedTag:
+    name: str
+    base_version: str
+    phase: Optional[str]
+    phase_number: Optional[int]
+
+    @property
+    def prerelease_suffix(self) -> str:
+        if self.phase is None:
+            return ""
+        return f"{self.phase}.{self.phase_number}"
+
+    @property
+    def is_stable(self) -> bool:
+        return self.phase is None
+
+
+@dataclass(frozen=True)
+class Classification:
+    tag_name: str
+    base_version: str
+    prerelease_suffix: str
+    is_release_tag: bool
+    is_stable: bool
+    is_prerelease: bool
+    build_label: str
+    deb_version: str
+
+    def outputs(self) -> Mapping[str, str]:
+        return {
+            "tag_name": self.tag_name,
+            "base_version": self.base_version,
+            "prerelease_suffix": self.prerelease_suffix,
+            "is_release_tag": str(self.is_release_tag).lower(),
+            "is_stable": str(self.is_stable).lower(),
+            "is_prerelease": str(self.is_prerelease).lower(),
+            "build_label": self.build_label,
+            "deb_version": self.deb_version,
+        }
+
+
+def run_git(repository: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise ReleaseChannelError(
+            f"git {' '.join(args)} failed: {completed.stderr.strip()}"
+        )
+    return completed.stdout.strip()
+
+
+def project_version(repository: Path) -> str:
+    cmake_path = repository / "CMakeLists.txt"
+    try:
+        content = cmake_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ReleaseChannelError(f"Cannot read {cmake_path}: {exc}") from exc
+    match = CMAKE_VERSION_RE.search(content)
+    if not match:
+        raise ReleaseChannelError(
+            "Could not extract project version from CMakeLists.txt."
+        )
+    version = match.group("version")
+    # The tag parser also enforces the no-leading-zero rule for the project version.
+    if not TAG_RE.fullmatch(f"v{version}"):
+        raise ReleaseChannelError(
+            f"CMake project version '{version}' is not canonical MAJOR.MINOR.PATCH."
+        )
+    return version
+
+
+def parse_tag(tag_name: str, expected_base: str) -> ParsedTag:
+    match = TAG_RE.fullmatch(tag_name)
+    if not match:
+        raise ReleaseChannelError(
+            f"Invalid tag '{tag_name}'. Expected vMAJOR.MINOR.PATCH or "
+            "vMAJOR.MINOR.PATCH-(alpha|beta|rc).N without leading zeroes."
+        )
+    base = match.group("base")
+    if base != expected_base:
+        raise ReleaseChannelError(
+            f"Tag base version '{base}' does not match CMake version "
+            f"'{expected_base}'."
+        )
+    number_text = match.group("number")
+    return ParsedTag(
+        name=tag_name,
+        base_version=base,
+        phase=match.group("phase"),
+        phase_number=int(number_text) if number_text is not None else None,
+    )
+
+
+def parse_bool(value: str, name: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    raise ReleaseChannelError(f"{name} must be 'true' or 'false', got '{value}'.")
+
+
+def positive_integer(value: str, name: str) -> str:
+    if not POSITIVE_INTEGER_RE.fullmatch(value):
+        raise ReleaseChannelError(f"{name} must be a positive integer, got '{value}'.")
+    return value
+
+
+def normalized_sha(value: str) -> str:
+    if not SHA_RE.fullmatch(value):
+        raise ReleaseChannelError(
+            f"commit_sha must contain 7-64 hexadecimal characters, got '{value}'."
+        )
+    return value.lower()[:7]
+
+
+def verify_tag_at_head(repository: Path, tag_name: str) -> None:
+    tag_commit = run_git(repository, "rev-parse", "--verify", f"refs/tags/{tag_name}^{{commit}}")
+    head_commit = run_git(repository, "rev-parse", "HEAD")
+    if tag_commit != head_commit:
+        raise ReleaseChannelError(
+            f"Tag '{tag_name}' points to {tag_commit}, but the checkout is {head_commit}."
+        )
+
+
+def derive_debian_version(
+    base_version: str,
+    parsed_tag: Optional[ParsedTag],
+    build_serial: str,
+    build_attempt: str,
+    commit_sha: str,
+) -> tuple[str, str]:
+    """Return (deb_version, build_label).
+
+    Stable releases intentionally omit the workflow serial so that the final
+    version sorts above every '~0.*' snapshot/prerelease. All packages uploaded
+    to bleeding-edge use the serial first, making publication order independent
+    from tag reachability, tag type, and release-branch topology.
+    """
+    if parsed_tag is not None and parsed_tag.is_stable:
+        return base_version, base_version
+
+    if not build_serial:
+        if parsed_tag is None:
+            return "", ""
+        suffix = parsed_tag.prerelease_suffix
+        return f"{base_version}~0.{suffix}", f"{base_version}-{suffix}"
+
+    serial = positive_integer(build_serial, "build_serial")
+    attempt = positive_integer(build_attempt, "build_attempt")
+
+    if parsed_tag is not None:
+        suffix = parsed_tag.prerelease_suffix
+        return (
+            f"{base_version}~0.{serial}.{attempt}.{suffix}",
+            f"{base_version}-{suffix}-build.{serial}.{attempt}",
+        )
+
+    short_sha = normalized_sha(commit_sha)
+    return (
+        f"{base_version}~0.{serial}.{attempt}.dev+g{short_sha}",
+        f"{base_version}-dev.{serial}.{attempt}-g{short_sha}",
+    )
+
+
+def classify(
+    repository: Path,
+    tag_name: str,
+    require_tag: bool,
+    require_prerelease: bool,
+    require_stable: bool,
+    build_serial: str,
+    build_attempt: str,
+    commit_sha: str,
+) -> Classification:
+    if require_stable and require_prerelease:
+        raise ReleaseChannelError(
+            "require_stable and require_prerelease are mutually exclusive."
+        )
+
+    base_version = project_version(repository)
+    parsed: Optional[ParsedTag] = None
+    if tag_name:
+        parsed = parse_tag(tag_name, base_version)
+        verify_tag_at_head(repository, tag_name)
+    elif require_tag or require_stable or require_prerelease:
+        raise ReleaseChannelError(
+            "A release tag is required for the requested classification."
+        )
+
+    if parsed is not None and require_stable and not parsed.is_stable:
+        raise ReleaseChannelError(
+            f"This operation requires a stable tag, got '{tag_name}'."
+        )
+    if parsed is not None and require_prerelease and parsed.is_stable:
+        raise ReleaseChannelError(
+            f"This operation requires a prerelease tag, got '{tag_name}'."
+        )
+
+    if not commit_sha:
+        commit_sha = run_git(repository, "rev-parse", "HEAD")
+
+    deb_version, build_label = derive_debian_version(
+        base_version=base_version,
+        parsed_tag=parsed,
+        build_serial=build_serial,
+        build_attempt=build_attempt,
+        commit_sha=commit_sha,
+    )
+
+    return Classification(
+        tag_name=tag_name,
+        base_version=base_version,
+        prerelease_suffix=parsed.prerelease_suffix if parsed else "",
+        is_release_tag=parsed is not None,
+        is_stable=bool(parsed and parsed.is_stable),
+        is_prerelease=bool(parsed and not parsed.is_stable),
+        build_label=build_label,
+        deb_version=deb_version,
+    )
+
+
+def write_outputs(path: Path, values: Mapping[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            if "\n" in value or "\r" in value:
+                raise ReleaseChannelError(f"Output '{key}' contains a newline.")
+            handle.write(f"{key}={value}\n")
+
+
+def command_classify(args: argparse.Namespace) -> int:
+    repository = Path(args.repository).resolve()
+    result = classify(
+        repository=repository,
+        tag_name=args.tag or "",
+        require_tag=parse_bool(args.require_tag, "require_tag"),
+        require_prerelease=parse_bool(
+            args.require_prerelease, "require_prerelease"
+        ),
+        require_stable=parse_bool(args.require_stable, "require_stable"),
+        build_serial=args.build_serial or "",
+        build_attempt=args.build_attempt,
+        commit_sha=args.commit_sha or "",
+    )
+    if args.output:
+        write_outputs(Path(args.output), result.outputs())
+    for key, value in result.outputs().items():
+        print(f"{key}={value}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    classify_parser = subparsers.add_parser("classify")
+    classify_parser.add_argument("--repository", required=True)
+    classify_parser.add_argument("--tag", default="")
+    classify_parser.add_argument("--require-tag", default="false")
+    classify_parser.add_argument("--require-prerelease", default="false")
+    classify_parser.add_argument("--require-stable", default="false")
+    classify_parser.add_argument("--build-serial", default="")
+    classify_parser.add_argument("--build-attempt", default="1")
+    classify_parser.add_argument("--commit-sha", default="")
+    classify_parser.add_argument("--output", default="")
+    classify_parser.set_defaults(handler=command_classify)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.handler(args)
+    except ReleaseChannelError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_release_channels.py
+++ b/.github/scripts/test_release_channels.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Unit tests for .github/scripts/release_channels.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("release_channels.py")
+SPEC = importlib.util.spec_from_file_location("release_channels", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+release_channels = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = release_channels
+SPEC.loader.exec_module(release_channels)
+
+
+class ReleaseChannelTests(unittest.TestCase):
+    def test_supported_tags(self) -> None:
+        base = "12.0.0"
+        stable = release_channels.parse_tag("v12.0.0", base)
+        beta = release_channels.parse_tag("v12.0.0-beta.2", base)
+        self.assertTrue(stable.is_stable)
+        self.assertEqual(beta.prerelease_suffix, "beta.2")
+
+    def test_invalid_tags(self) -> None:
+        invalid = [
+            "v012.0.0",
+            "v12.0.0-beta.01",
+            "v12.0.0-beta.2oops",
+            "v12.0.0-preview.1",
+            "v12.0.0+build1",
+        ]
+        for tag in invalid:
+            with self.subTest(tag=tag):
+                with self.assertRaises(release_channels.ReleaseChannelError):
+                    release_channels.parse_tag(tag, "12.0.0")
+
+    def test_monotonic_serial_is_independent_of_tag_selection(self) -> None:
+        base = "12.0.0"
+        alpha = release_channels.parse_tag("v12.0.0-alpha.1", base)
+        beta = release_channels.parse_tag("v12.0.0-beta.2", base)
+        rc = release_channels.parse_tag("v12.0.0-rc.1", base)
+        versions = [
+            release_channels.derive_debian_version(
+                base, None, "100", "1", "aaaaaaa"
+            )[0],
+            release_channels.derive_debian_version(
+                base, alpha, "101", "1", "bbbbbbb"
+            )[0],
+            release_channels.derive_debian_version(
+                base, beta, "102", "1", "ccccccc"
+            )[0],
+            release_channels.derive_debian_version(
+                base, None, "103", "1", "ddddddd"
+            )[0],
+            release_channels.derive_debian_version(
+                base, rc, "104", "1", "eeeeeee"
+            )[0],
+            release_channels.derive_debian_version(
+                base, None, "104", "2", "fffffff"
+            )[0],
+            base,
+        ]
+        for left, right in zip(versions, versions[1:]):
+            completed = subprocess.run(
+                ["dpkg", "--compare-versions", left, "lt", right],
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 0, f"{left} !< {right}")
+
+    def test_same_commit_tag_type_and_invalid_extra_tag_do_not_matter(self) -> None:
+        # Version derivation consumes the explicitly validated event tag and the
+        # workflow serial. It never searches repository tags, so annotated vs.
+        # lightweight tags and unrelated invalid tags cannot change the result.
+        base = "12.0.0"
+        rc = release_channels.parse_tag("v12.0.0-rc.1", base)
+        version, _ = release_channels.derive_debian_version(
+            base, rc, "42", "1", "abcdef0"
+        )
+        self.assertEqual(version, "12.0.0~0.42.1.rc.1")
+
+    def test_stable_always_supersedes_bleeding_edge(self) -> None:
+        prerelease = release_channels.parse_tag("v12.0.0-rc.99", "12.0.0")
+        bleeding, _ = release_channels.derive_debian_version(
+            "12.0.0", prerelease, "999999", "9", "abcdef0"
+        )
+        self.assertEqual(
+            subprocess.run(
+                ["dpkg", "--compare-versions", bleeding, "lt", "12.0.0"],
+                check=False,
+            ).returncode,
+            0,
+        )
+
+    def test_require_flags_are_mutually_exclusive(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            (repo / "CMakeLists.txt").write_text(
+                "project(lemon_cpp VERSION 12.0.0)\n", encoding="utf-8"
+            )
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "test@example.invalid"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Test"], cwd=repo, check=True
+            )
+            subprocess.run(["git", "add", "CMakeLists.txt"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "init"], cwd=repo, check=True)
+            subprocess.run(["git", "tag", "v12.0.0"], cwd=repo, check=True)
+            with self.assertRaises(release_channels.ReleaseChannelError):
+                release_channels.classify(
+                    repository=repo,
+                    tag_name="v12.0.0",
+                    require_tag=True,
+                    require_prerelease=True,
+                    require_stable=True,
+                    build_serial="1",
+                    build_attempt="1",
+                    commit_sha="abcdef0",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/build-and-push-container.yml
+++ b/.github/workflows/build-and-push-container.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - main
     tags:
-      - "v*"
+      # Only stable tags publish automatically and move the latest tag.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       tag:
@@ -32,26 +33,69 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0 # needed to fetch tags
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Checkout current release tooling
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: .release-tools
+          sparse-checkout: |
+            .github/actions/classify-release-tag
+            .github/scripts/release_channels.py
+          sparse-checkout-cone-mode: false
+
+      - name: Validate automatic stable tag
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        uses: ./.github/actions/classify-release-tag
+        with:
+          tag: ${{ github.ref_name }}
+          require_tag: "true"
+          require_stable: "true"
+
+      - name: Validate manually selected tag
+        id: manual-tag
+        if: github.event_name == 'workflow_dispatch'
+        uses: ./.release-tools/.github/actions/classify-release-tag
+        with:
+          tag: ${{ inputs.tag }}
+          require_tag: "true"
+
+      - name: Remove release tooling from build context
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: rm -rf .release-tools
 
       - name: Determine tag
         id: tag
+        shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ "$GITHUB_REF" == refs/tags/* ]]; then
               # Tagged release: publish the version tag and move latest.
-              echo "tag=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
-              echo "push_latest=true" >> $GITHUB_OUTPUT
+              echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+              echo "push_latest=true" >> "$GITHUB_OUTPUT"
             else
               # Push to main: publish a rolling edge tag plus an immutable sha tag.
-              echo "tag=edge" >> $GITHUB_OUTPUT
-              echo "sha_tag=sha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-              echo "push_latest=false" >> $GITHUB_OUTPUT
+              echo "tag=edge" >> "$GITHUB_OUTPUT"
+              echo "sha_tag=sha-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+              echo "push_latest=false" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
-            echo "push_latest=${{ inputs.add_latest }}" >> $GITHUB_OUTPUT
-            git checkout "refs/tags/${{ inputs.tag }}"
+            # Manual prerelease images may be published under their exact version
+            # tag, but only a validated stable tag may move :latest.
+            if [[ "${{ inputs.add_latest }}" == "true" &&
+                  "${{ steps.manual-tag.outputs.is_stable }}" != "true" ]]; then
+              echo "::error::Moving the container latest tag requires a stable release tag."
+              exit 1
+            fi
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "push_latest=${{ inputs.add_latest }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Log in to GHCR

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: ["main", "release-v*"]
     tags:
-      - v*
+      # Match stable MAJOR.MINOR.PATCH tags only. The classifier performs strict validation.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
   merge_group:
   workflow_dispatch:
@@ -27,6 +28,27 @@ env:
   LEMONADE_DISABLE_SYSTEMD_JOURNAL: "1"
 
 jobs:
+  validate-release-tag:
+    name: Validate stable release tag
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    outputs:
+      is_stable: ${{ steps.release-tag.outputs.is_stable }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          clean: true
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Validate stable release tag
+        id: release-tag
+        uses: ./.github/actions/classify-release-tag
+        with:
+          tag: ${{ github.ref_name }}
+          require_tag: "true"
+          require_stable: "true"
+
   # ========================================================================
   # BUILD JOBS - Run on rai-160-sdk workers
   # ========================================================================
@@ -2562,6 +2584,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs:
+      - validate-release-tag
       - sign-msi-installers
       - build-lemonade-rpm
       - build-lemonade-debian13
@@ -2574,7 +2597,7 @@ jobs:
       - test-rpm-package
       - test-embeddable-posix
       - test-embeddable-windows
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: ${{ github.ref_type == 'tag' && needs.validate-release-tag.result == 'success' && needs.validate-release-tag.outputs.is_stable == 'true' }}
     env:
       LEMONADE_VERSION: ${{ needs.build-lemonade-rpm.outputs.version }}
     steps:

--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - 'v*'
   pull_request:
     branches:
       - main
@@ -19,6 +19,29 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  classify-release:
+    name: Classify release channel
+    runs-on: ubuntu-latest
+    outputs:
+      is_stable: ${{ steps.release-tag.outputs.is_stable }}
+      is_prerelease: ${{ steps.release-tag.outputs.is_prerelease }}
+      deb_version: ${{ steps.release-tag.outputs.deb_version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          clean: true
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Classify release and derive Debian version
+        id: release-tag
+        uses: ./.github/actions/classify-release-tag
+        with:
+          tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+          build_serial: ${{ github.run_number }}
+          build_attempt: ${{ github.run_attempt }}
+          commit_sha: ${{ github.sha }}
+
   prepare-matrix:
     name: Prepare matrix
     runs-on: ubuntu-latest
@@ -59,7 +82,7 @@ jobs:
 
   package:
     name: Build
-    needs: prepare-matrix
+    needs: [prepare-matrix, classify-release]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -87,6 +110,7 @@ jobs:
         with:
           release: ${{ matrix.release }}
           codename: ${{ matrix.codename }}
+          version: ${{ needs.classify-release.outputs.deb_version }}
 
       - name: Get short SHA
         id: short_sha
@@ -203,10 +227,10 @@ jobs:
     name: Upload (Stable)
     strategy:
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.package_matrix) }}
-    needs: [prepare-matrix, package]
+    needs: [prepare-matrix, package, classify-release]
     permissions:
       contents: read
-    if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && needs.classify-release.outputs.is_stable == 'true' }}
     uses: ./.github/workflows/upload.yml
     with:
       target: ppa:lemonade-team/stable
@@ -217,10 +241,10 @@ jobs:
     name: Upload (Bleeding Edge)
     strategy:
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.package_matrix) }}
-    needs: [prepare-matrix, package]
+    needs: [prepare-matrix, package, classify-release]
     permissions:
       contents: read
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || needs.classify-release.outputs.is_prerelease == 'true') }}
     uses: ./.github/workflows/upload.yml
     with:
       target: ppa:lemonade-team/bleeding-edge

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -3,7 +3,8 @@ name: Publish Website
 on:
   push:
     tags:
-      - v*
+      # Production website updates are stable-only.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
   repository_dispatch:
     types: [marketplace-updated]
@@ -16,6 +17,15 @@ jobs:
         - uses: actions/checkout@v5
           with:
             fetch-depth: 0
+            fetch-tags: true
+
+        - name: Validate stable tag before publishing production website
+          if: github.ref_type == 'tag'
+          uses: ./.github/actions/classify-release-tag
+          with:
+            tag: ${{ github.ref_name }}
+            require_tag: "true"
+            require_stable: "true"
         - name: Set up Python
           uses: actions/setup-python@v6
           with:

--- a/.github/workflows/test_release_channels.yml
+++ b/.github/workflows/test_release_channels.yml
@@ -1,0 +1,190 @@
+name: Test Release Channels
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions/classify-release-tag/**"
+      - ".github/actions/prepare-debian-build/**"
+      - ".github/scripts/release_channels.py"
+      - ".github/scripts/test_release_channels.py"
+      - ".github/workflows/build-and-push-container.yml"
+      - ".github/workflows/cpp_server_build_test_release.yml"
+      - ".github/workflows/launchpad-ppa.yml"
+      - ".github/workflows/publish-website.yml"
+      - ".github/workflows/test_release_channels.yml"
+      - "docs/dev/release.md"
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: Release channel unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Run parser and Debian-ordering tests
+        run: python3 .github/scripts/test_release_channels.py
+
+  action-integration:
+    name: Composite action integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Create tag fixtures
+        id: fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(sed -nE \
+            's/^[[:space:]]*project\(lemon_cpp[[:space:]]+VERSION[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' \
+            CMakeLists.txt | head -n1)
+          SHA=$(git rev-parse --short=7 HEAD)
+          git tag -d "v${VERSION}" "v${VERSION}-rc.1" "v${VERSION}-beta.2oops" >/dev/null 2>&1 || true
+          git tag "v${VERSION}" HEAD
+          git tag "v${VERSION}-rc.1" HEAD
+          git tag "v${VERSION}-beta.2oops" HEAD
+          {
+            echo "version=$VERSION"
+            echo "sha=$SHA"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Classify snapshot
+        id: snapshot
+        uses: ./.github/actions/classify-release-tag
+        with:
+          build_serial: "100"
+          build_attempt: "1"
+          commit_sha: ${{ steps.fixture.outputs.sha }}
+
+      - name: Classify prerelease
+        id: prerelease
+        uses: ./.github/actions/classify-release-tag
+        with:
+          tag: v${{ steps.fixture.outputs.version }}-rc.1
+          require_tag: "true"
+          require_prerelease: "true"
+          build_serial: "101"
+          build_attempt: "1"
+
+      - name: Classify stable release
+        id: stable
+        uses: ./.github/actions/classify-release-tag
+        with:
+          tag: v${{ steps.fixture.outputs.version }}
+          require_tag: "true"
+          require_stable: "true"
+          build_serial: "102"
+          build_attempt: "1"
+
+      - name: Reject invalid tag
+        id: invalid
+        continue-on-error: true
+        uses: ./.github/actions/classify-release-tag
+        with:
+          tag: v${{ steps.fixture.outputs.version }}-beta.2oops
+          require_tag: "true"
+          build_serial: "103"
+
+      - name: Reject conflicting requirements
+        id: conflicting
+        continue-on-error: true
+        uses: ./.github/actions/classify-release-tag
+        with:
+          tag: v${{ steps.fixture.outputs.version }}
+          require_tag: "true"
+          require_stable: "true"
+          require_prerelease: "true"
+
+      - name: Verify generated outputs
+        shell: bash
+        env:
+          VERSION: ${{ steps.fixture.outputs.version }}
+          SHA: ${{ steps.fixture.outputs.sha }}
+          SNAPSHOT: ${{ steps.snapshot.outputs.deb_version }}
+          PRERELEASE: ${{ steps.prerelease.outputs.deb_version }}
+          STABLE: ${{ steps.stable.outputs.deb_version }}
+          INVALID_OUTCOME: ${{ steps.invalid.outcome }}
+          CONFLICTING_OUTCOME: ${{ steps.conflicting.outcome }}
+        run: |
+          set -euo pipefail
+          [[ "$SNAPSHOT" == "${VERSION}~0.100.1.dev+g${SHA}" ]]
+          [[ "$PRERELEASE" == "${VERSION}~0.101.1.rc.1" ]]
+          [[ "$STABLE" == "$VERSION" ]]
+          [[ "$INVALID_OUTCOME" == "failure" ]]
+          [[ "$CONFLICTING_OUTCOME" == "failure" ]]
+          dpkg --compare-versions "$SNAPSHOT" lt "$PRERELEASE"
+          dpkg --compare-versions "$PRERELEASE" lt "$STABLE"
+
+  version-override:
+    name: Debian version override integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Define override
+        id: fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=$(sed -nE \
+            's/^[[:space:]]*project\(lemon_cpp[[:space:]]+VERSION[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' \
+            CMakeLists.txt | head -n1)
+          echo "version=${VERSION}~0.500.1.beta.1" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare Debian metadata with explicit version
+        id: prepare
+        uses: ./.github/actions/prepare-debian-build
+        with:
+          release: "24.04"
+          codename: noble
+          version: ${{ steps.fixture.outputs.version }}
+
+      - name: Verify override
+        shell: bash
+        env:
+          EXPECTED: ${{ steps.fixture.outputs.version }}
+          ACTUAL: ${{ steps.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          [[ "$ACTUAL" == "$EXPECTED" ]]
+          grep -F "(${EXPECTED}~24.04)" debian/changelog
+
+  downstream-publisher-guards:
+    name: Stable downstream publisher guards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify stable-only automatic publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          STABLE_PATTERN="- 'v[0-9]+.[0-9]+.[0-9]+'"
+          CONTAINER=.github/workflows/build-and-push-container.yml
+          WEBSITE=.github/workflows/publish-website.yml
+
+          grep -F -- "$STABLE_PATTERN" "$CONTAINER"
+          grep -F -- "$STABLE_PATTERN" "$WEBSITE"
+
+          if grep -F -- '- "v*"' "$CONTAINER"; then
+            echo "Container workflow still accepts every v* tag."
+            exit 1
+          fi
+          if grep -F -- '- v*' "$WEBSITE"; then
+            echo "Website workflow still accepts every v* tag."
+            exit 1
+          fi
+
+          grep -F 'require_stable: "true"' "$CONTAINER"
+          grep -F 'Moving the container latest tag requires a stable release tag.' "$CONTAINER"
+          grep -F 'Validate stable tag before publishing production website' "$WEBSITE"
+          grep -F 'require_stable: "true"' "$WEBSITE"

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -84,7 +84,7 @@ Confirm with the team before pushing directly to `main`.
 
 Before tagging, check the **`Release vX.Y.Z final checklist`** issue. All P1 items should be resolved and the verdict should read `Ready`.
 
-Lemonade releases are automatically created by the [cpp_server_build_test_release.yml workflow](https://github.com/lemonade-sdk/lemonade/blob/main/.github/workflows/cpp_server_build_test_release.yml) final step, which is triggered by pushing a tag that matches the `v*` pattern. The tag must match the pattern `v<major>.<minor>.<patch>`, i.e., the value from CMakeLists.txt with a leading `v`.
+Stable Lemonade releases are automatically created by the [cpp_server_build_test_release.yml workflow](https://github.com/lemonade-sdk/lemonade/blob/main/.github/workflows/cpp_server_build_test_release.yml) final step. Only a stable tag matching `v<major>.<minor>.<patch>` triggers that full release path; prerelease tags use the bleeding-edge flow described below.
 
 Let's say you're releasing v10.8.0, this will trigger the release action:
 
@@ -99,6 +99,34 @@ git push origin v10.8.0
 ```
 
 Example action from v10.7.0: https://github.com/lemonade-sdk/lemonade/actions/runs/27283434473/job/80590025966
+
+### Prerelease Tags and Bleeding-Edge Ordering
+
+Prereleases are created from the same `release-vX.Y.Z` branch as the final release. The supported tag forms are:
+
+```text
+vX.Y.Z-alpha.N
+vX.Y.Z-beta.N
+vX.Y.Z-rc.N
+```
+
+Pushing one of these tags publishes Debian packages to `ppa:lemonade-team/bleeding-edge`. It does **not** run the full stable release workflow or create the normal GitHub release. The final `vX.Y.Z` tag remains the only trigger for the full signed, cross-platform release.
+
+Prerelease tags also do **not** move the production container `:latest` tag or publish the production website. Automatic container and website publication is stable-only. Maintainers may manually publish a prerelease container under its exact version tag, but the container workflow rejects moving `:latest` unless the selected tag is a validated stable release.
+
+`main` snapshots and prerelease tags share the bleeding-edge PPA even though their commits may live on divergent branches. Their Debian versions therefore do not use `git describe` or tag reachability for ordering. The Launchpad workflow assigns every run a monotonically increasing `github.run_number` plus `github.run_attempt`, for example:
+
+```text
+X.Y.Z~0.120.1.dev+gabcdef0
+X.Y.Z~0.121.1.beta.1
+X.Y.Z~0.122.1.dev+g1234567
+X.Y.Z~0.123.1.rc.1
+X.Y.Z
+```
+
+This guarantees that each later bleeding-edge publication supersedes the previous one, independent of annotated versus lightweight tags or release-branch ancestry. The final stable version has no `~0` suffix and therefore supersedes every snapshot and prerelease for the same base version.
+
+The Step 6 reconciliation is still required for the final stable tag because other repository tooling uses tag ancestry. Prerelease reconciliation is not required for PPA ordering.
 
 ## Step 4: Windows Signing
 
@@ -134,7 +162,7 @@ git push origin vX.Y.Z --force
 
 ## Step 6: Reconcile the Tag into `main`
 
-The tag lives on `release-vX.Y.Z`, so it isn't reachable from `main`, and `git describe --tags` on `main` reports the *previous* release — feeding a stale version into the Debian/PPA build (`prepare-debian-build`) and `test_release_notes.yml`. Link it in with an `ours` merge (records the ancestry only, changes no files).
+The stable tag lives on `release-vX.Y.Z`, so it isn't reachable from `main`. Some repository tooling still uses tag ancestry and would report the previous stable release. Link the final stable tag in with an `ours` merge (records the ancestry only, changes no files). PPA package ordering does not depend on this reconciliation.
 
 First confirm **every release-branch fix is forward-ported to `main`** — `-s ours` silently drops anything that isn't (see Step 2's forward-port guidance).
 


### PR DESCRIPTION
## Summary

This PR separates stable releases, prereleases, and development snapshots into explicit release channels.

Stable tags such as `v12.0.0` continue through the full signed release pipeline and stable PPA. Supported prerelease tags such as `v12.0.0-beta.1` publish to the bleeding-edge PPA without entering the full stable release workflow.

## Why

Previously, every `v*` tag could enter stable release paths, while Debian package versions were derived from Git tag ancestry. That is unsafe for prereleases because release tags live on dedicated release branches and are not necessarily reachable from `main`.

Git history is also not a reliable release-channel ordering mechanism: tag selection can vary with commit distance, annotated versus lightweight tags, and unrelated invalid tags.

## Changes

* accept only `alpha.N`, `beta.N`, and `rc.N` prerelease tags
* validate tag syntax, CMake version, and tagged commit
* restrict the full release workflow to stable tags
* route prereleases to the bleeding-edge PPA
* keep stable releases in the stable PPA
* assign all bleeding-edge publications a monotonic workflow serial
* keep every bleeding-edge package below the final stable version
* add parser, ordering, action-integration, override, and merge-queue tests
* document the prerelease process and Debian version policy

Example ordering:

```text
12.0.0~0.120.1.dev+gabcdef0
<
12.0.0~0.121.1.beta.1
<
12.0.0~0.122.1.dev+g1234567
<
12.0.0~0.123.1.rc.1
<
12.0.0
```

## Design

The bleeding-edge order is based on the Launchpad workflow's monotonically increasing run number and rerun attempt, not on `git describe` or tag reachability.

This keeps package upgrades monotonic even when prerelease tags are created on release branches that diverge from `main`.

## Result

Stable users remain on a conservative release path, while prerelease and development builds share a predictable opt-in channel without risking package-version regressions.
