### PR TITLE
ci: run backend validation in the merge queue instead of every PR

### DIFF
--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -8,6 +8,24 @@ on:
         type: boolean
         default: false
   pull_request:
+    paths:
+      - ".github/workflows/validate_llamacpp.yml"
+      - ".github/actions/setup-venv/**"
+      - ".github/actions/cleanup-processes-windows/**"
+      - "test/validate_llamacpp.py"
+      - "test/utils/**"
+      - "test/requirements.txt"
+      - "src/cpp/resources/backend_versions.json"
+      - "src/cpp/resources/server_models.json"
+      - "src/cpp/server/backends/llamacpp/**"
+      - "src/cpp/server/backends/backend_*.cpp"
+      - "src/cpp/server/backend_manager.cpp"
+      - "src/cpp/server/runtime_config.cpp"
+      - "src/cpp/server/system_info.cpp"
+      - "src/cpp/include/lemon/backends/llamacpp/**"
+      - "src/cpp/include/lemon/backends/backend_*.h"
+      - "src/cpp/include/lemon/backend_manager.h"
+      - "src/cpp/include/lemon/backend_version_policy.h"
   schedule:
     # Sunday at 12:00 PM ET (17:00 UTC, 16:00 UTC during EDT)
     - cron: "0 16 * * 0"

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -776,10 +776,9 @@ jobs:
             --base main \
             --head "$BRANCH"
 
-  # Required status check standing in for the jobs above: the merge queue gates
-  # only on required checks, and the per-job names shift with the matrix, while
-  # this one is fixed. It also reports on pull_request -- where the gated work is
-  # skipped -- so PRs can still enqueue.
+  # Gate job. Reports a single status check that passes only if every job in
+  # `needs:` passed. Branch protection requires this check's name, so the merge
+  # queue blocks on all of those jobs at once.
   validation-gate:
     name: llama.cpp validation
     needs: [build, validate]
@@ -790,12 +789,8 @@ jobs:
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
-          # $NEEDS is {"job-id": {"result": "success|failure|skipped|cancelled", ...}, ...}
-          # for every job listed in `needs:` above. Two separate failures to catch:
-          #   failure/cancelled          -> a gated job ran and broke
-          #   anything but success, in a -> the job never ran at all (empty matrix, or
-          #   merge_group run               an `if:` that stopped matching). Without this
-          #                                 the gate would go green having checked nothing.
+          # $NEEDS: {"job-id": {"result": "success|failure|skipped|cancelled"}, ...}
+          # Fail if any job broke. In the merge queue, also fail if any never ran.
           echo "$NEEDS"
           broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
           if [ -n "$broke" ]; then

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -8,24 +8,7 @@ on:
         type: boolean
         default: false
   pull_request:
-    paths:
-      - ".github/workflows/validate_llamacpp.yml"
-      - ".github/actions/setup-venv/**"
-      - ".github/actions/cleanup-processes-windows/**"
-      - "test/validate_llamacpp.py"
-      - "test/utils/**"
-      - "test/requirements.txt"
-      - "src/cpp/resources/backend_versions.json"
-      - "src/cpp/resources/server_models.json"
-      - "src/cpp/server/backends/llamacpp/**"
-      - "src/cpp/server/backends/backend_*.cpp"
-      - "src/cpp/server/backend_manager.cpp"
-      - "src/cpp/server/runtime_config.cpp"
-      - "src/cpp/server/system_info.cpp"
-      - "src/cpp/include/lemon/backends/llamacpp/**"
-      - "src/cpp/include/lemon/backends/backend_*.h"
-      - "src/cpp/include/lemon/backend_manager.h"
-      - "src/cpp/include/lemon/backend_version_policy.h"
+  merge_group:
   schedule:
     # Sunday at 12:00 PM ET (17:00 UTC, 16:00 UTC during EDT)
     - cron: "0 16 * * 0"
@@ -304,7 +287,7 @@ jobs:
   build:
     name: Build
     needs: [get-latest-releases, verify-release-assets]
-    if: always() && !failure() && !cancelled()
+    if: github.event_name != 'pull_request' && always() && !failure() && !cancelled()
     runs-on: windows-latest
     steps:
       - name: Prepare Windows runner for long paths and stale workspace caches
@@ -792,3 +775,31 @@ jobs:
             --body-file pr_body.md \
             --base main \
             --head "$BRANCH"
+
+  # Required status check standing in for the jobs above: the merge queue gates
+  # only on required checks, and the per-job names shift with the matrix, while
+  # this one is fixed. It also has to report on pull_request — where the work is
+  # skipped — so PRs can still enqueue.
+  validation-gate:
+    name: llama.cpp validation
+    needs: [build, validate]
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      RESULTS: build=${{ needs.build.result }} validate=${{ needs.validate.result }}
+    steps:
+      - name: Fail if any validation job did not succeed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "$RESULTS"
+            exit 1
+          fi
+
+      - name: Require the validation to have run in the merge queue
+        if: github.event_name == 'merge_group'
+        run: |
+          if [ "${{ needs.build.result }}" != "success" ] \
+            || [ "${{ needs.validate.result }}" != "success" ]; then
+            echo "$RESULTS"
+            exit 1
+          fi

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -778,28 +778,34 @@ jobs:
 
   # Required status check standing in for the jobs above: the merge queue gates
   # only on required checks, and the per-job names shift with the matrix, while
-  # this one is fixed. It also has to report on pull_request — where the work is
-  # skipped — so PRs can still enqueue.
+  # this one is fixed. It also reports on pull_request -- where the gated work is
+  # skipped -- so PRs can still enqueue.
   validation-gate:
     name: llama.cpp validation
     needs: [build, validate]
     if: always()
     runs-on: ubuntu-latest
-    env:
-      RESULTS: build=${{ needs.build.result }} validate=${{ needs.validate.result }}
     steps:
-      - name: Fail if any validation job did not succeed
+      - name: Check gated jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
         run: |
-          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
-            echo "$RESULTS"
+          # $NEEDS is {"job-id": {"result": "success|failure|skipped|cancelled", ...}, ...}
+          # for every job listed in `needs:` above. Two separate failures to catch:
+          #   failure/cancelled          -> a gated job ran and broke
+          #   anything but success, in a -> the job never ran at all (empty matrix, or
+          #   merge_group run               an `if:` that stopped matching). Without this
+          #                                 the gate would go green having checked nothing.
+          echo "$NEEDS"
+          broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
+          if [ -n "$broke" ]; then
+            echo "FAILED: $broke"
             exit 1
           fi
-
-      - name: Require the validation to have run in the merge queue
-        if: github.event_name == 'merge_group'
-        run: |
-          if [ "${{ needs.build.result }}" != "success" ] \
-            || [ "${{ needs.validate.result }}" != "success" ]; then
-            echo "$RESULTS"
-            exit 1
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            absent=$(jq -r 'to_entries[]|select(.value.result!="success")|.key' <<<"$NEEDS")
+            if [ -n "$absent" ]; then
+              echo "DID NOT RUN IN MERGE QUEUE: $absent"
+              exit 1
+            fi
           fi

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -776,9 +776,9 @@ jobs:
             --base main \
             --head "$BRANCH"
 
-  # Gate job. Reports a single status check that passes only if every job in
-  # `needs:` passed. Branch protection requires this check's name, so the merge
-  # queue blocks on all of those jobs at once.
+  # Gate job that ensures: 1. in the merge queue, all jobs in `needs:` ran
+  # successfully (otherwise the merge is blocked), and 2. these jobs do not need
+  # to run on ordinary pull request pushes.
   validation-gate:
     name: llama.cpp validation
     needs: [build, validate]

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -12,17 +12,7 @@ on:
         required: false
         type: string
   pull_request:
-    paths:
-      - ".github/workflows/validate_sdcpp.yml"
-      - ".github/scripts/update_sdcpp_versions.py"
-      - ".github/scripts/render_sdcpp_pr_body.py"
-      - "test/validate_sdcpp.py"
-      - "src/cpp/resources/backend_versions.json"
-      - "src/cpp/resources/server_models.json"
-      - "src/cpp/server/backends/sd_server.cpp"
-      - "src/cpp/server/backend_manager.cpp"
-      - "src/cpp/server/runtime_config.cpp"
-      - "src/cpp/server/system_info.cpp"
+  merge_group:
   schedule:
     # Sunday at 17:20 UTC, staggered after the llama.cpp auto-update workflow.
     - cron: "20 17 * * 0"
@@ -56,6 +46,7 @@ concurrency:
 jobs:
   discover-release:
     name: Discover stable-diffusion.cpp releases
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       base_release: ${{ steps.release.outputs.base_release }}
@@ -200,7 +191,7 @@ jobs:
   build:
     name: Build Lemonade with sd-cpp pins
     needs: discover-release
-    if: always() && !failure() && !cancelled()
+    if: github.event_name != 'pull_request' && always() && !failure() && !cancelled()
     runs-on: windows-latest
     steps:
       - name: Prepare Windows runner for long paths and stale workspace caches
@@ -688,4 +679,34 @@ jobs:
               --body-file pr_body.md \
               --base main \
               --head "$BRANCH"
+          fi
+
+  # Required status check standing in for the jobs above: the merge queue gates
+  # only on required checks, and the per-job names shift with the matrix, while
+  # this one is fixed. It also has to report on pull_request — where the work is
+  # skipped — so PRs can still enqueue.
+  validation-gate:
+    name: stable-diffusion.cpp validation
+    needs: [discover-release, build, validate, verify-cuda-assets]
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      RESULTS: discover-release=${{ needs.discover-release.result }} build=${{ needs.build.result }} validate=${{ needs.validate.result }} verify-cuda-assets=${{ needs.verify-cuda-assets.result }}
+    steps:
+      - name: Fail if any validation job did not succeed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "$RESULTS"
+            exit 1
+          fi
+
+      - name: Require the validation to have run in the merge queue
+        if: github.event_name == 'merge_group'
+        run: |
+          if [ "${{ needs.discover-release.result }}" != "success" ] \
+            || [ "${{ needs.build.result }}" != "success" ] \
+            || [ "${{ needs.validate.result }}" != "success" ] \
+            || [ "${{ needs.verify-cuda-assets.result }}" != "success" ]; then
+            echo "$RESULTS"
+            exit 1
           fi

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -681,9 +681,9 @@ jobs:
               --head "$BRANCH"
           fi
 
-  # Gate job. Reports a single status check that passes only if every job in
-  # `needs:` passed. Branch protection requires this check's name, so the merge
-  # queue blocks on all of those jobs at once.
+  # Gate job that ensures: 1. in the merge queue, all jobs in `needs:` ran
+  # successfully (otherwise the merge is blocked), and 2. these jobs do not need
+  # to run on ordinary pull request pushes.
   validation-gate:
     name: stable-diffusion.cpp validation
     needs: [discover-release, build, validate, verify-cuda-assets]

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -683,30 +683,34 @@ jobs:
 
   # Required status check standing in for the jobs above: the merge queue gates
   # only on required checks, and the per-job names shift with the matrix, while
-  # this one is fixed. It also has to report on pull_request — where the work is
-  # skipped — so PRs can still enqueue.
+  # this one is fixed. It also reports on pull_request -- where the gated work is
+  # skipped -- so PRs can still enqueue.
   validation-gate:
     name: stable-diffusion.cpp validation
     needs: [discover-release, build, validate, verify-cuda-assets]
     if: always()
     runs-on: ubuntu-latest
-    env:
-      RESULTS: discover-release=${{ needs.discover-release.result }} build=${{ needs.build.result }} validate=${{ needs.validate.result }} verify-cuda-assets=${{ needs.verify-cuda-assets.result }}
     steps:
-      - name: Fail if any validation job did not succeed
+      - name: Check gated jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
         run: |
-          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
-            echo "$RESULTS"
+          # $NEEDS is {"job-id": {"result": "success|failure|skipped|cancelled", ...}, ...}
+          # for every job listed in `needs:` above. Two separate failures to catch:
+          #   failure/cancelled          -> a gated job ran and broke
+          #   anything but success, in a -> the job never ran at all (empty matrix, or
+          #   merge_group run               an `if:` that stopped matching). Without this
+          #                                 the gate would go green having checked nothing.
+          echo "$NEEDS"
+          broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
+          if [ -n "$broke" ]; then
+            echo "FAILED: $broke"
             exit 1
           fi
-
-      - name: Require the validation to have run in the merge queue
-        if: github.event_name == 'merge_group'
-        run: |
-          if [ "${{ needs.discover-release.result }}" != "success" ] \
-            || [ "${{ needs.build.result }}" != "success" ] \
-            || [ "${{ needs.validate.result }}" != "success" ] \
-            || [ "${{ needs.verify-cuda-assets.result }}" != "success" ]; then
-            echo "$RESULTS"
-            exit 1
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            absent=$(jq -r 'to_entries[]|select(.value.result!="success")|.key' <<<"$NEEDS")
+            if [ -n "$absent" ]; then
+              echo "DID NOT RUN IN MERGE QUEUE: $absent"
+              exit 1
+            fi
           fi

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -681,10 +681,9 @@ jobs:
               --head "$BRANCH"
           fi
 
-  # Required status check standing in for the jobs above: the merge queue gates
-  # only on required checks, and the per-job names shift with the matrix, while
-  # this one is fixed. It also reports on pull_request -- where the gated work is
-  # skipped -- so PRs can still enqueue.
+  # Gate job. Reports a single status check that passes only if every job in
+  # `needs:` passed. Branch protection requires this check's name, so the merge
+  # queue blocks on all of those jobs at once.
   validation-gate:
     name: stable-diffusion.cpp validation
     needs: [discover-release, build, validate, verify-cuda-assets]
@@ -695,12 +694,8 @@ jobs:
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
-          # $NEEDS is {"job-id": {"result": "success|failure|skipped|cancelled", ...}, ...}
-          # for every job listed in `needs:` above. Two separate failures to catch:
-          #   failure/cancelled          -> a gated job ran and broke
-          #   anything but success, in a -> the job never ran at all (empty matrix, or
-          #   merge_group run               an `if:` that stopped matching). Without this
-          #                                 the gate would go green having checked nothing.
+          # $NEEDS: {"job-id": {"result": "success|failure|skipped|cancelled"}, ...}
+          # Fail if any job broke. In the merge queue, also fail if any never ran.
           echo "$NEEDS"
           broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
           if [ -n "$broke" ]; then

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -357,10 +357,9 @@ jobs:
             --base main \
             --head "$BRANCH"
 
-  # Required status check standing in for the jobs above: the merge queue gates
-  # only on required checks, and the per-job names shift with the matrix, while
-  # this one is fixed. It also reports on pull_request -- where the gated work is
-  # skipped -- so PRs can still enqueue.
+  # Gate job. Reports a single status check that passes only if every job in
+  # `needs:` passed. Branch protection requires this check's name, so the merge
+  # queue blocks on all of those jobs at once.
   validation-gate:
     name: vLLM validation
     needs: [build, validate]
@@ -371,12 +370,8 @@ jobs:
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
-          # $NEEDS is {"job-id": {"result": "success|failure|skipped|cancelled", ...}, ...}
-          # for every job listed in `needs:` above. Two separate failures to catch:
-          #   failure/cancelled          -> a gated job ran and broke
-          #   anything but success, in a -> the job never ran at all (empty matrix, or
-          #   merge_group run               an `if:` that stopped matching). Without this
-          #                                 the gate would go green having checked nothing.
+          # $NEEDS: {"job-id": {"result": "success|failure|skipped|cancelled"}, ...}
+          # Fail if any job broke. In the merge queue, also fail if any never ran.
           echo "$NEEDS"
           broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
           if [ -n "$broke" ]; then

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -8,25 +8,7 @@ on:
         type: boolean
         default: false
   pull_request:
-    paths:
-      - ".github/workflows/validate_vllm.yml"
-      - ".github/actions/setup-venv/**"
-      - "test/validate_vllm.py"
-      - "test/utils/**"
-      - "test/requirements.txt"
-      - "setup.sh"
-      - "src/cpp/resources/backend_versions.json"
-      - "src/cpp/resources/server_models.json"
-      - "src/cpp/resources/vllm_model_config.json"
-      - "src/cpp/server/backends/vllm/**"
-      - "src/cpp/server/backends/backend_*.cpp"
-      - "src/cpp/server/backend_manager.cpp"
-      - "src/cpp/server/runtime_config.cpp"
-      - "src/cpp/server/system_info.cpp"
-      - "src/cpp/include/lemon/backends/vllm/**"
-      - "src/cpp/include/lemon/backends/backend_*.h"
-      - "src/cpp/include/lemon/backend_manager.h"
-      - "src/cpp/include/lemon/backend_version_policy.h"
+  merge_group:
   schedule:
     # Sunday at 6:00 PM UTC
     - cron: "0 18 * * 0"
@@ -71,7 +53,7 @@ jobs:
   build:
     name: Build (Linux)
     needs: get-latest-releases
-    if: always() && !failure() && !cancelled()
+    if: github.event_name != 'pull_request' && always() && !failure() && !cancelled()
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
@@ -374,3 +356,31 @@ jobs:
             --body-file pr_body.md \
             --base main \
             --head "$BRANCH"
+
+  # Required status check standing in for the jobs above: the merge queue gates
+  # only on required checks, and the per-job names shift with the matrix, while
+  # this one is fixed. It also has to report on pull_request — where the work is
+  # skipped — so PRs can still enqueue.
+  validation-gate:
+    name: vLLM validation
+    needs: [build, validate]
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      RESULTS: build=${{ needs.build.result }} validate=${{ needs.validate.result }}
+    steps:
+      - name: Fail if any validation job did not succeed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "$RESULTS"
+            exit 1
+          fi
+
+      - name: Require the validation to have run in the merge queue
+        if: github.event_name == 'merge_group'
+        run: |
+          if [ "${{ needs.build.result }}" != "success" ] \
+            || [ "${{ needs.validate.result }}" != "success" ]; then
+            echo "$RESULTS"
+            exit 1
+          fi

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -8,6 +8,25 @@ on:
         type: boolean
         default: false
   pull_request:
+    paths:
+      - ".github/workflows/validate_vllm.yml"
+      - ".github/actions/setup-venv/**"
+      - "test/validate_vllm.py"
+      - "test/utils/**"
+      - "test/requirements.txt"
+      - "setup.sh"
+      - "src/cpp/resources/backend_versions.json"
+      - "src/cpp/resources/server_models.json"
+      - "src/cpp/resources/vllm_model_config.json"
+      - "src/cpp/server/backends/vllm/**"
+      - "src/cpp/server/backends/backend_*.cpp"
+      - "src/cpp/server/backend_manager.cpp"
+      - "src/cpp/server/runtime_config.cpp"
+      - "src/cpp/server/system_info.cpp"
+      - "src/cpp/include/lemon/backends/vllm/**"
+      - "src/cpp/include/lemon/backends/backend_*.h"
+      - "src/cpp/include/lemon/backend_manager.h"
+      - "src/cpp/include/lemon/backend_version_policy.h"
   schedule:
     # Sunday at 6:00 PM UTC
     - cron: "0 18 * * 0"

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -357,9 +357,9 @@ jobs:
             --base main \
             --head "$BRANCH"
 
-  # Gate job. Reports a single status check that passes only if every job in
-  # `needs:` passed. Branch protection requires this check's name, so the merge
-  # queue blocks on all of those jobs at once.
+  # Gate job that ensures: 1. in the merge queue, all jobs in `needs:` ran
+  # successfully (otherwise the merge is blocked), and 2. these jobs do not need
+  # to run on ordinary pull request pushes.
   validation-gate:
     name: vLLM validation
     needs: [build, validate]

--- a/.github/workflows/validate_vllm.yml
+++ b/.github/workflows/validate_vllm.yml
@@ -359,28 +359,34 @@ jobs:
 
   # Required status check standing in for the jobs above: the merge queue gates
   # only on required checks, and the per-job names shift with the matrix, while
-  # this one is fixed. It also has to report on pull_request — where the work is
-  # skipped — so PRs can still enqueue.
+  # this one is fixed. It also reports on pull_request -- where the gated work is
+  # skipped -- so PRs can still enqueue.
   validation-gate:
     name: vLLM validation
     needs: [build, validate]
     if: always()
     runs-on: ubuntu-latest
-    env:
-      RESULTS: build=${{ needs.build.result }} validate=${{ needs.validate.result }}
     steps:
-      - name: Fail if any validation job did not succeed
+      - name: Check gated jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
         run: |
-          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
-            echo "$RESULTS"
+          # $NEEDS is {"job-id": {"result": "success|failure|skipped|cancelled", ...}, ...}
+          # for every job listed in `needs:` above. Two separate failures to catch:
+          #   failure/cancelled          -> a gated job ran and broke
+          #   anything but success, in a -> the job never ran at all (empty matrix, or
+          #   merge_group run               an `if:` that stopped matching). Without this
+          #                                 the gate would go green having checked nothing.
+          echo "$NEEDS"
+          broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
+          if [ -n "$broke" ]; then
+            echo "FAILED: $broke"
             exit 1
           fi
-
-      - name: Require the validation to have run in the merge queue
-        if: github.event_name == 'merge_group'
-        run: |
-          if [ "${{ needs.build.result }}" != "success" ] \
-            || [ "${{ needs.validate.result }}" != "success" ]; then
-            echo "$RESULTS"
-            exit 1
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            absent=$(jq -r 'to_entries[]|select(.value.result!="success")|.key' <<<"$NEEDS")
+            if [ -n "$absent" ]; then
+              echo "DID NOT RUN IN MERGE QUEUE: $absent"
+              exit 1
+            fi
           fi


### PR DESCRIPTION
- **Why** — `validate_llamacpp`, `validate_vllm` and `validate_sdcpp` fire on every PR push: 5 GitHub-hosted jobs (~48 min, 36 of it on windows-latest) plus 7 self-hosted rig legs. Their only PR-time job is catching a PR that breaks the weekly cron.
- **What** — Moves the work to `merge_group` behind required aggregate gates (**`llama.cpp validation`**, **`vLLM validation`**, **`stable-diffusion.cpp validation`**) and deletes the `paths:` filters. Over the last 30 days the repo saw 973 `pull_request` runs against 164 merge groups, so this is ~83% fewer runs with no path lists to maintain. The queue gates *only* on required checks — see #2867, which merged despite a red merge-group run — and the per-job names shift with the matrix, so they can't be required directly.
- **Rollout** — Merge this **first**, then add the three gate names to `main`'s required status checks. Flipping the setting first blocks every open PR on contexts that don't exist yet; until it's flipped the gates are advisory.

Related: #2902, #2909 and #2910 apply the same gate pattern to the packaging, Launchpad PPA and Linux distro workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
