### PR TITLE
ci: run Fedora RPM and Debian 13 packaging jobs only in the merge queue

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1589,10 +1589,9 @@ jobs:
               exit 1
           fi
 
-  # Required status check standing in for the jobs above: the merge queue gates
-  # only on required checks, and the per-job names shift with the matrix, while
-  # this one is fixed. It also reports on pull_request -- where the gated work is
-  # skipped -- so PRs can still enqueue.
+  # Gate job. Reports a single status check that passes only if every job in
+  # `needs:` passed. Branch protection requires this check's name, so the merge
+  # queue blocks on all of those jobs at once.
   packaging-gate:
     name: Packaging builds
     needs: [build-lemonade-debian13, test-lemonade-debian13-smoke, build-lemonade-rpm, test-rpm-package]
@@ -1603,12 +1602,8 @@ jobs:
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
-          # $NEEDS is {"job-id": {"result": "success|failure|skipped|cancelled", ...}, ...}
-          # for every job listed in `needs:` above. Two separate failures to catch:
-          #   failure/cancelled          -> a gated job ran and broke
-          #   anything but success, in a -> the job never ran at all (empty matrix, or
-          #   merge_group run               an `if:` that stopped matching). Without this
-          #                                 the gate would go green having checked nothing.
+          # $NEEDS: {"job-id": {"result": "success|failure|skipped|cancelled"}, ...}
+          # Fail if any job broke. In the merge queue, also fail if any never ran.
           echo "$NEEDS"
           broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
           if [ -n "$broke" ]; then

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1589,42 +1589,38 @@ jobs:
               exit 1
           fi
 
-  # Required status check standing in for the four packaging jobs above: the merge
-  # queue gates only on required checks, and their matrix-generated names change
-  # with the Fedora/arch matrix, while this one is fixed. It also has to report on
-  # pull_request — where the packaging jobs are skipped — so PRs can still enqueue.
+  # Required status check standing in for the jobs above: the merge queue gates
+  # only on required checks, and the per-job names shift with the matrix, while
+  # this one is fixed. It also reports on pull_request -- where the gated work is
+  # skipped -- so PRs can still enqueue.
   packaging-gate:
     name: Packaging builds
-    needs:
-      - build-lemonade-debian13
-      - test-lemonade-debian13-smoke
-      - build-lemonade-rpm
-      - test-rpm-package
+    needs: [build-lemonade-debian13, test-lemonade-debian13-smoke, build-lemonade-rpm, test-rpm-package]
     if: always()
     runs-on: ubuntu-latest
-    env:
-      RESULTS: >-
-        build-lemonade-debian13=${{ needs.build-lemonade-debian13.result }}
-        test-lemonade-debian13-smoke=${{ needs.test-lemonade-debian13-smoke.result }}
-        build-lemonade-rpm=${{ needs.build-lemonade-rpm.result }}
-        test-rpm-package=${{ needs.test-rpm-package.result }}
     steps:
-      - name: Fail if any packaging job did not succeed
+      - name: Check gated jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
         run: |
-          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
-            echo "$RESULTS"
+          # $NEEDS is {"job-id": {"result": "success|failure|skipped|cancelled", ...}, ...}
+          # for every job listed in `needs:` above. Two separate failures to catch:
+          #   failure/cancelled          -> a gated job ran and broke
+          #   anything but success, in a -> the job never ran at all (empty matrix, or
+          #   merge_group run               an `if:` that stopped matching). Without this
+          #                                 the gate would go green having checked nothing.
+          echo "$NEEDS"
+          broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
+          if [ -n "$broke" ]; then
+            echo "FAILED: $broke"
             exit 1
           fi
-
-      - name: Require the packaging jobs to have run in the merge queue
-        if: github.event_name == 'merge_group'
-        run: |
-          if [ "${{ needs.build-lemonade-debian13.result }}" != "success" ] \
-            || [ "${{ needs.test-lemonade-debian13-smoke.result }}" != "success" ] \
-            || [ "${{ needs.build-lemonade-rpm.result }}" != "success" ] \
-            || [ "${{ needs.test-rpm-package.result }}" != "success" ]; then
-            echo "$RESULTS"
-            exit 1
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            absent=$(jq -r 'to_entries[]|select(.value.result!="success")|.key' <<<"$NEEDS")
+            if [ -n "$absent" ]; then
+              echo "DID NOT RUN IN MERGE QUEUE: $absent"
+              exit 1
+            fi
           fi
 
   test-embeddable-posix:

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1589,9 +1589,9 @@ jobs:
               exit 1
           fi
 
-  # Gate job. Reports a single status check that passes only if every job in
-  # `needs:` passed. Branch protection requires this check's name, so the merge
-  # queue blocks on all of those jobs at once.
+  # Gate job that ensures: 1. in the merge queue, all jobs in `needs:` ran
+  # successfully (otherwise the merge is blocked), and 2. these jobs do not need
+  # to run on ordinary pull request pushes.
   packaging-gate:
     name: Packaging builds
     needs: [build-lemonade-debian13, test-lemonade-debian13-smoke, build-lemonade-rpm, test-rpm-package]

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1589,6 +1589,44 @@ jobs:
               exit 1
           fi
 
+  # Required status check standing in for the four packaging jobs above: the merge
+  # queue gates only on required checks, and their matrix-generated names change
+  # with the Fedora/arch matrix, while this one is fixed. It also has to report on
+  # pull_request — where the packaging jobs are skipped — so PRs can still enqueue.
+  packaging-gate:
+    name: Packaging builds
+    needs:
+      - build-lemonade-debian13
+      - test-lemonade-debian13-smoke
+      - build-lemonade-rpm
+      - test-rpm-package
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      RESULTS: >-
+        build-lemonade-debian13=${{ needs.build-lemonade-debian13.result }}
+        test-lemonade-debian13-smoke=${{ needs.test-lemonade-debian13-smoke.result }}
+        build-lemonade-rpm=${{ needs.build-lemonade-rpm.result }}
+        test-rpm-package=${{ needs.test-rpm-package.result }}
+    steps:
+      - name: Fail if any packaging job did not succeed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "$RESULTS"
+            exit 1
+          fi
+
+      - name: Require the packaging jobs to have run in the merge queue
+        if: github.event_name == 'merge_group'
+        run: |
+          if [ "${{ needs.build-lemonade-debian13.result }}" != "success" ] \
+            || [ "${{ needs.test-lemonade-debian13-smoke.result }}" != "success" ] \
+            || [ "${{ needs.build-lemonade-rpm.result }}" != "success" ] \
+            || [ "${{ needs.test-rpm-package.result }}" != "success" ]; then
+            echo "$RESULTS"
+            exit 1
+          fi
+
   test-embeddable-posix:
     name: Test Embeddable (${{ matrix.label }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -303,6 +303,9 @@ jobs:
 
   build-lemonade-debian13:
     name: Build Lemonade .deb Package (Debian 13)${{ matrix.job-suffix }}
+    # Packaging-only variant: the merge queue gates every merge, so PR pushes
+    # skip it. Any Debian 13 build break still blocks at merge-queue time.
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.runs-on }}
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -385,6 +388,7 @@ jobs:
 
   test-lemonade-debian13-smoke:
     name: Smoke test .deb (Debian 13)${{ matrix.job-suffix }}
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.runs-on }}
     needs: build-lemonade-debian13
     container:
@@ -459,6 +463,9 @@ jobs:
 
   build-lemonade-rpm:
     name: Build Lemonade .rpm - Fedora ${{ matrix.fedora-version }}${{ matrix.job-suffix }}
+    # Packaging-only variant: the merge queue gates every merge, so PR pushes
+    # skip it. Any Fedora build break still blocks at merge-queue time.
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.runs-on }}
     container:
       image: fedora:${{ matrix.fedora-version }}
@@ -1500,6 +1507,7 @@ jobs:
 
   test-rpm-package:
     name: Test .rpm - Fedora ${{ matrix.fedora-version }}${{ matrix.job-suffix }}
+    if: github.event_name != 'pull_request'
     runs-on: ${{ matrix.runs-on }}
     needs: build-lemonade-rpm
     container:


### PR DESCRIPTION
- **Why** — The Fedora 43/44 × x86/ARM RPM builds+tests and Debian 13 builds+smokes are 12 hosted jobs on every PR push (org cap: 20 concurrent). Over 24 days only 4 PR runs failed *solely* in these legs, all single-leg flakes.
- **What** — Skips them on `pull_request` and gates them in the merge queue behind a new required **`Packaging builds`** aggregate job. The queue gates *only* on required checks — see #2867, which merged despite a red merge-group run — and the matrix-generated job names shift on every Fedora bump, so they can't be required directly.
- **Rollout** — Merge this **first**, then add `Packaging builds` to `main`'s required status checks. Flipping the setting first blocks every open PR on a context that doesn't exist yet; until it's flipped the gate is advisory.

Related: #2909 and #2910 apply the same gate pattern to the Launchpad PPA and Linux distro workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
