### PR TITLE
feat(gui3): refine apps navigation, backend identity UX and design details

### DIFF
--- a/src/app/DESIGN.md
+++ b/src/app/DESIGN.md
@@ -163,11 +163,19 @@ The labels below are normative boundaries, not backlog states. **Justified speci
 
 **Logs — justified specialization:** monospace virtualized output, severity markers, and compact fixed-height rows. The filter panel, search control, header, and actions are standard workspace UI.
 
+### Apps
+
+**Layout:** two panels: an App types `.workspace-rail` and a full-width `.workspace-pane` directory. Marketplace categories live in the rail; search remains a pane-level action. The directory is not centered or embedded in Settings.
+
+**Justified specialization:** marketplace logos, category metadata, and external Visit, Guide, and Video actions.
+
+**Prohibited variation:** horizontal category chip bars, centered fixed-width page shells, duplicate Settings navigation entries, or app-specific rail/mobile behavior. Apps uses the shared workspace rail, pane header, resource rows, actions, and mobile context panel.
+
 ### Connect
 
-**Layout:** two panels: Settings `.workspace-rail` and a `.workspace-pane` for the selected Server, Storage, Cloud, MCP, Apps, Support, or Account section.
+**Layout:** two panels: Settings `.workspace-rail` and a `.workspace-pane` for the selected Server, Storage, Cloud, MCP, Support, or Account section.
 
-**Justified specialization:** provider brand marks, endpoint examples, and marketplace metadata. Forms use a bounded reading width.
+**Justified specialization:** provider brand marks and endpoint examples. Forms use a bounded reading width.
 
 **Prohibited variation:** card-heavy pages, independent headings inside an already titled pane, custom input heights, or unique help-link styling. Sections use the pane header, standard forms/actions, and restrained row/card grouping.
 
@@ -178,10 +186,11 @@ The implementation was audited against every boundary above on 2026-07-20. The c
 | Area | Implemented boundary |
 | --- | --- |
 | App chrome | One centered rounded primary selector; one contextual mobile menu position; compact utilities live under the settings control; the decorative lemon icon is not rendered. |
-| Rails and mobile context | Chat, Models, Backends, Monitor, and Settings use `WorkspaceRailHeader` and `WorkspaceMobileMenuButton`. Mobile panels share the same dialog, backdrop, focus-return, Escape, and toggle behavior. |
+| Rails and mobile context | Chat, Models, Backends, Apps, Monitor, and Settings use `WorkspaceRailHeader` and `WorkspaceMobileMenuButton`. Mobile panels share the same dialog, backdrop, focus-return, Escape, and toggle behavior. |
 | Backends | The filter rail, pane header, status actions, and buttons use workspace components. Only the device × capability matrix and compact backend identity marks remain specialized. |
+| Apps | Category navigation lives in a dedicated rail; the directory uses the full content pane with shared search, resource rows, actions, and responsive context-panel behavior. |
 | Monitor | Performance retains charts and gauges without ornamental glow. Telemetry and Logs retain diagnostic artifacts while their navigation, filters, forms, and actions use the workspace grammar. |
-| Connect | Settings navigation, pane headers, fields, actions, provider/help/app rows, and bounded content use shared components and control sizing. |
+| Connect | Settings navigation, pane headers, fields, actions, provider/help rows, and bounded content use shared components and control sizing. |
 | CSS integrity | Component colors resolve through tokens, `styles.css` contains no literal product colors, and the audit contains no exact duplicate rule blocks in the same cascade context. Remaining `!important` declarations are limited to third-party SVG theming, reduced-motion enforcement, mobile browser input behavior, and measured/virtualized layout overrides. |
 
 “Prohibited variation” entries remain in this specification after conformance because they are regression guards, not unresolved work.

--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef, Component, ErrorInfo, ReactNode } from 'react';
-import api, { LoadedModel, ModelInfo } from './api';
+import api, { friendlyErrorMessage, LoadedModel, ModelInfo } from './api';
 import { canSelectInComposer, capabilityFromModelInfo, selectPreferredLoadedModel } from './modelCapabilities';
 import { customModelToModelInfo, loadCustomModels } from './features/customModels/customModelStore';
 import { findModelInfoByName, isCollectionFullyLoaded, isCollectionModel, withVirtualLoadedCollections } from './features/collections/collectionModels';
 import ChatView from './components/ChatView';
 import ModelManager from './components/ModelManager';
 import ConnectView from './components/ConnectView';
-import AppsView from './components/AppsView';
+import AppsView, { MARKETPLACE_URL, type MarketplaceApp } from './components/AppsView';
 import BackendManager from './components/BackendManager';
 import DownloadManager from './components/DownloadManager';
 import MonitorView from './components/MonitorView';
@@ -206,9 +206,24 @@ function routeFromHash(): AppRoute | null {
   return routeFromHashValue(window.location.hash || '');
 }
 
+function isLegacyAppDirectoryHash(hash: string): boolean {
+  return /^#\/?connect\/app-directory(?:[/?]|$)/i.test(hash);
+}
+
+function canonicalizeLegacyHash(route: AppRoute | null): void {
+  if (!route || !isLegacyAppDirectoryHash(window.location.hash || '')) return;
+  const canonicalHash = hashForRoute(route);
+  if (window.location.hash !== canonicalHash) {
+    window.history.replaceState(null, '', canonicalHash);
+  }
+}
+
 function loadSavedRoute(): AppRoute {
   const fromLocation = routeFromCurrentLocation();
-  if (fromLocation) return fromLocation;
+  if (fromLocation) {
+    canonicalizeLegacyHash(fromLocation);
+    return fromLocation;
+  }
   try {
     const saved = localStorage.getItem('lemonade_current_view');
     const savedRoute = routeFromValue(saved);
@@ -244,6 +259,9 @@ const App: React.FC = () => {
   const [clientDataResetNonce, setClientDataResetNonce] = useState(0);
   const [downloadManagerOpen, setDownloadManagerOpen] = useState(false);
   const [modelDetailsRequest, setModelDetailsRequest] = useState<{ modelName: string; nonce: number } | null>(null);
+  const [marketplaceApps, setMarketplaceApps] = useState<MarketplaceApp[]>([]);
+  const [marketplaceError, setMarketplaceError] = useState<string | null>(null);
+  const [marketplaceLoading, setMarketplaceLoading] = useState(true);
   const [utilityMenuOpen, setUtilityMenuOpen] = useState(false);
   const [navigationSearch, setNavigationSearch] = useState('');
   const [navigationSearchOpen, setNavigationSearchOpen] = useState(false);
@@ -253,6 +271,28 @@ const App: React.FC = () => {
   const navigationSearchRef = useRef<HTMLInputElement>(null);
   const [isDesktop, setIsDesktop] = useState(false);
   const navigationSearchShortcut = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent) ? '⌘ K' : 'Ctrl K';
+
+  useEffect(() => {
+    let cancelled = false;
+    setMarketplaceLoading(true);
+    fetch(MARKETPLACE_URL)
+      .then(response => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.json();
+      })
+      .then(data => {
+        if (cancelled) return;
+        setMarketplaceApps(Array.isArray(data?.apps) ? data.apps as MarketplaceApp[] : []);
+        setMarketplaceError(null);
+      })
+      .catch(error => {
+        if (!cancelled) setMarketplaceError(friendlyErrorMessage(error));
+      })
+      .finally(() => {
+        if (!cancelled) setMarketplaceLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     import('./tauriShim').then(({ tauriReady }) => {
@@ -403,6 +443,8 @@ const App: React.FC = () => {
     const normalizedQuery = searchKey(query);
     const matches = (value: string) =>
       !query || value.toLowerCase().includes(query) || searchKey(value).includes(normalizedQuery);
+    if (!query) return [];
+
     const pages = NAVIGATION_DESTINATIONS
       .filter(destination => matches(`${destination.label} ${destination.keywords}`))
       .map(destination => ({
@@ -412,19 +454,27 @@ const App: React.FC = () => {
         icon: destination.icon,
         view: destination.id,
       }));
-    if (!query) return [];
 
-    const settings = Object.entries(WORKSPACE_NAVIGATION).flatMap(([workspace, definition]) =>
-      definition.sections
-        .filter(section => matches(`${section.label} ${section.description}`))
-        .map(section => ({
-          id: `settings:${workspace}:${section.id}`,
-          label: section.label,
-          description: `${definition.label} - ${section.description}`,
-          icon: section.icon,
-          route: { view: workspace as 'dashboard' | 'connect', section: section.id } as AppRoute,
-        })),
-    );
+    const monitorDefinition = WORKSPACE_NAVIGATION.dashboard;
+    const monitor = monitorDefinition.sections
+      .filter(section => matches(`${section.label} ${section.description}`))
+      .map(section => ({
+        id: `workspace:dashboard:${section.id}`,
+        label: section.label,
+        description: `${monitorDefinition.label} - ${section.description}`,
+        icon: section.icon,
+        route: { view: 'dashboard', section: section.id } as AppRoute,
+      }));
+    const settingsDefinition = WORKSPACE_NAVIGATION.connect;
+    const settings = settingsDefinition.sections
+      .filter(section => matches(`${section.label} ${section.description}`))
+      .map(section => ({
+        id: `workspace:connect:${section.id}`,
+        label: section.label,
+        description: `${settingsDefinition.label} - ${section.description}`,
+        icon: section.icon,
+        route: { view: 'connect', section: section.id } as AppRoute,
+      }));
     const models = searchableServerModels
       .map(model => {
         const name = modelSearchName(model as unknown as Record<string, unknown>);
@@ -451,8 +501,37 @@ const App: React.FC = () => {
         icon: 'box' as Parameters<typeof Icon>[0]['name'],
         view: 'backends' as View,
       }));
-    return [...models, ...backends, ...settings, ...pages];
-  }, [navigationSearch, searchableServerModels]);
+    const apps = marketplaceApps
+      .filter(marketplaceApp => matches(`${marketplaceApp.name} ${marketplaceApp.description || ''} ${(marketplaceApp.category || []).join(' ')}`))
+      .slice(0, 8)
+      .map(marketplaceApp => ({
+        id: `app:${marketplaceApp.id || marketplaceApp.name}`,
+        label: marketplaceApp.name,
+        description: marketplaceApp.category?.length ? `App - ${marketplaceApp.category.join(', ')}` : 'App',
+        icon: 'layers' as Parameters<typeof Icon>[0]['name'],
+        view: 'apps' as View,
+      }));
+
+    type SearchGroup = 'models' | 'backends' | 'apps' | 'settings' | 'monitor' | 'pages';
+    const groups: Record<SearchGroup, GlobalSearchResult[]> = {
+      models,
+      backends,
+      apps,
+      settings,
+      monitor,
+      pages,
+    };
+    const defaultOrder: SearchGroup[] = ['pages', 'models', 'backends', 'apps', 'settings', 'monitor'];
+    const preferredGroup: SearchGroup = view === 'apps'
+      ? 'apps'
+      : view === 'backends'
+        ? 'backends'
+        : view === 'connect'
+          ? 'settings'
+          : 'models';
+    const groupOrder = [preferredGroup, ...defaultOrder.filter(group => group !== preferredGroup)];
+    return groupOrder.flatMap(group => groups[group]);
+  }, [marketplaceApps, navigationSearch, searchableServerModels, view]);
 
   const selectNavigationDestination = useCallback((destination: GlobalSearchResult) => {
     if (destination.modelName) {
@@ -525,6 +604,7 @@ const App: React.FC = () => {
     const onHashChange = () => {
       const nextRoute = routeFromHash();
       if (nextRoute) {
+        canonicalizeLegacyHash(nextRoute);
         if (nextRoute.view === 'dashboard') lastWorkspaceSectionsRef.current.dashboard = nextRoute.section;
         if (nextRoute.view === 'connect') lastWorkspaceSectionsRef.current.connect = nextRoute.section;
         setRouteState(nextRoute);
@@ -631,7 +711,7 @@ const App: React.FC = () => {
             </button>
             <div id="titlebar-utility-menu" className="titlebar__utility-menu" aria-label="App controls">
               <div
-                className={`titlebar__search${navigationSearchOpen ? ' is-open' : ''}`}
+                className={`titlebar__search${navigationSearchOpen ? ' is-open' : ''}${view === 'apps' ? ' is-context-visible' : ''}`}
                 onBlur={event => {
                   if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
                     setNavigationSearchOpen(false);
@@ -660,7 +740,7 @@ const App: React.FC = () => {
                       type="search"
                       value={navigationSearch}
                       placeholder="Search"
-                      aria-label="Search Lemonade"
+                      aria-label={view === 'apps' ? 'Search apps' : 'Search Lemonade'}
                       aria-autocomplete="list"
                       aria-expanded={navigationSearchOpen}
                       aria-controls="titlebar-search-results"
@@ -821,7 +901,11 @@ const App: React.FC = () => {
         </div>
         <div className="view-slot" hidden={view !== 'apps'}>
           <ViewErrorBoundary view="apps">
-            <AppsView isActive={view === 'apps'} />
+            <AppsView
+              apps={marketplaceApps}
+              loading={marketplaceLoading}
+              error={marketplaceError}
+            />
           </ViewErrorBoundary>
         </div>
         <div className="view-slot" hidden={view !== 'dashboard'}>

--- a/src/app/src/components/AppsView.tsx
+++ b/src/app/src/components/AppsView.tsx
@@ -1,16 +1,15 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { friendlyErrorMessage } from '../api';
-import { Icon } from './Icon';
+import type { IconName } from './Icon';
+import WorkspaceSectionRail, { type WorkspaceSectionDefinition } from './WorkspaceSectionRail';
 import {
   WorkspaceActionButton,
   WorkspaceActionGroup,
-  WorkspaceMetadataChip,
   WorkspacePaneHeader,
   WorkspaceResourceList,
   WorkspaceResourceRow,
 } from './WorkspacePanels';
 
-type MarketplaceApp = {
+export type MarketplaceApp = {
   id: string;
   name: string;
   description?: string;
@@ -20,54 +19,106 @@ type MarketplaceApp = {
   links?: { app?: string; guide?: string; video?: string };
 };
 
-const MARKETPLACE_URL = 'https://raw.githubusercontent.com/lemonade-sdk/marketplace/main/apps.json';
+export const MARKETPLACE_URL = 'https://raw.githubusercontent.com/lemonade-sdk/marketplace/main/apps.json';
+const ALL_APPS_SECTION = 'all-apps';
 
-const AppsView: React.FC<{ isActive: boolean; embedded?: boolean }> = ({ isActive, embedded = false }) => {
-  const [marketplaceApps, setMarketplaceApps] = useState<MarketplaceApp[]>([]);
-  const [marketplaceSearch, setMarketplaceSearch] = useState('');
+function categorySectionId(category: string): string {
+  const safeCategory = encodeURIComponent(category.trim().toLowerCase())
+    .replace(/%/g, '')
+    .replace(/[^a-z0-9_-]+/g, '-');
+  return `category-${safeCategory || 'other'}`;
+}
+
+function categoryIcon(category: string): IconName {
+  const normalized = category.toLowerCase();
+  if (/chat|assistant|conversation|bot/.test(normalized)) return 'chat';
+  if (/image|photo|design|creative|art/.test(normalized)) return 'image';
+  if (/audio|music|speech|voice/.test(normalized)) return 'audio';
+  if (/code|developer|development|ide/.test(normalized)) return 'code';
+  if (/search|research|knowledge|rag/.test(normalized)) return 'search';
+  if (/automation|workflow|tool|productivity/.test(normalized)) return 'tools';
+  if (/3d|model/.test(normalized)) return 'box';
+  return 'layers';
+}
+
+function appCountLabel(count: number): string {
+  return `${count} compatible ${count === 1 ? 'app' : 'apps'}`;
+}
+
+function categoryLabel(category: string): string {
+  return category.trim().replace(/(^|[\s/&-])(\p{Ll})/gu, (_match, separator: string, letter: string) =>
+    `${separator}${letter.toLocaleUpperCase()}`);
+}
+
+function normalizedCategory(category: string): string {
+  return category.trim().toLocaleLowerCase();
+}
+
+function appHasCategory(app: MarketplaceApp, category: string): boolean {
+  const normalizedFilter = normalizedCategory(category);
+  return (app.category || []).some(item => normalizedCategory(item) === normalizedFilter);
+}
+
+type AppsViewProps = {
+  apps: MarketplaceApp[];
+  loading: boolean;
+  error: string | null;
+};
+
+const AppsView: React.FC<AppsViewProps> = ({
+  apps: marketplaceApps,
+  loading: marketplaceLoading,
+  error: marketplaceError,
+}) => {
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
-  const [marketplaceError, setMarketplaceError] = useState<string | null>(null);
-  const [marketplaceLoading, setMarketplaceLoading] = useState(false);
+  const [railCollapsed, setRailCollapsed] = useState(false);
+
+  const categories = useMemo(() => {
+    const categoryByKey = new Map<string, string>();
+    marketplaceApps.flatMap(app => app.category || []).forEach(rawCategory => {
+      const category = rawCategory.trim();
+      const key = normalizedCategory(category);
+      if (key && !categoryByKey.has(key)) categoryByKey.set(key, category);
+    });
+    return Array.from(categoryByKey.values()).sort((left, right) => left.localeCompare(right));
+  }, [marketplaceApps]);
 
   useEffect(() => {
-    if (!isActive || marketplaceApps.length > 0) return;
-    let cancelled = false;
-    setMarketplaceLoading(true);
-    fetch(MARKETPLACE_URL)
-      .then(response => {
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        return response.json();
-      })
-      .then(data => {
-        if (cancelled) return;
-        const apps = Array.isArray(data?.apps) ? data.apps as MarketplaceApp[] : [];
-        setMarketplaceApps(apps);
-        setMarketplaceError(null);
-      })
-      .catch(err => { if (!cancelled) setMarketplaceError(friendlyErrorMessage(err)); })
-      .finally(() => { if (!cancelled) setMarketplaceLoading(false); });
-    return () => { cancelled = true; };
-  }, [isActive, marketplaceApps.length]);
+    if (categoryFilter && !categories.includes(categoryFilter)) setCategoryFilter(null);
+  }, [categories, categoryFilter]);
 
-  const categories = useMemo(() => Array.from(new Set(
-    marketplaceApps.flatMap(app => app.category || [])
-      .map(category => category.trim())
-      .filter(Boolean),
-  )).sort((left, right) => left.localeCompare(right)), [marketplaceApps]);
+  const categorySections = useMemo<WorkspaceSectionDefinition<string>[]>(() => [
+    {
+      id: ALL_APPS_SECTION,
+      label: 'All Apps',
+      description: marketplaceLoading
+        ? 'Loading directory'
+        : marketplaceError
+          ? 'Directory unavailable'
+          : appCountLabel(marketplaceApps.length),
+      icon: 'globe',
+    },
+    ...categories.map(category => {
+      const count = marketplaceApps.filter(app => appHasCategory(app, category)).length;
+      return {
+        id: categorySectionId(category),
+        label: categoryLabel(category),
+        description: appCountLabel(count),
+        icon: categoryIcon(category),
+      };
+    }),
+  ], [categories, marketplaceApps, marketplaceError, marketplaceLoading]);
 
-  const filteredMarketplaceApps = useMemo(() => {
-    const query = marketplaceSearch.trim().toLowerCase();
-    return marketplaceApps
-      .filter(app => {
-        const categories = app.category || [];
-        const matchesCategory = !categoryFilter || categories.some(category => category.toLowerCase() === categoryFilter.toLowerCase());
-        const matchesQuery = !query || app.name.toLowerCase().includes(query)
-          || (app.description || '').toLowerCase().includes(query)
-          || categories.join(' ').toLowerCase().includes(query);
-        return matchesCategory && matchesQuery;
-      })
-      .sort((a, b) => Number(Boolean(b.pinned)) - Number(Boolean(a.pinned)) || a.name.localeCompare(b.name));
-  }, [categoryFilter, marketplaceApps, marketplaceSearch]);
+  const categoryBySection = useMemo(() => new Map(
+    categories.map(category => [categorySectionId(category), category]),
+  ), [categories]);
+
+  const activeCategorySection = categoryFilter ? categorySectionId(categoryFilter) : ALL_APPS_SECTION;
+
+  const filteredMarketplaceApps = useMemo(() => marketplaceApps
+    .filter(app => !categoryFilter || appHasCategory(app, categoryFilter))
+    .sort((a, b) => Number(Boolean(b.pinned)) - Number(Boolean(a.pinned)) || a.name.localeCompare(b.name)),
+  [categoryFilter, marketplaceApps]);
 
   const openExternal = (url?: string) => {
     if (!url) return;
@@ -79,72 +130,75 @@ const AppsView: React.FC<{ isActive: boolean; embedded?: boolean }> = ({ isActiv
     window.open(url, '_blank', 'noopener,noreferrer');
   };
 
-  const directoryContent = (
-    <section className="connect__section connect__section--marketplace">
-          <div className="connect__section-head connect__section-head--search">
-            <input
-              className="input connect__marketplace-search"
-              value={marketplaceSearch}
-              onChange={e => setMarketplaceSearch(e.target.value)}
-              placeholder="Search apps..."
-              aria-label="Search apps"
-            />
-          </div>
-          {categories.length > 0 && (
-            <div className="apps__category-filters" role="group" aria-label="Filter apps by category">
-              <WorkspaceMetadataChip
-                emphasis={categoryFilter === null ? 'medium' : 'low'}
-                tone={categoryFilter === null ? 'accent' : 'neutral'}
-                buttonProps={{ onClick: () => setCategoryFilter(null), 'aria-pressed': categoryFilter === null }}
-              >
-                All
-              </WorkspaceMetadataChip>
-              {categories.map(category => (
-                <WorkspaceMetadataChip
-                  key={category}
-                  emphasis={categoryFilter === category ? 'medium' : 'low'}
-                  tone={categoryFilter === category ? 'accent' : 'neutral'}
-                  buttonProps={{ onClick: () => setCategoryFilter(category), 'aria-pressed': categoryFilter === category }}
-                >
-                  {category}
-                </WorkspaceMetadataChip>
-              ))}
-            </div>
-          )}
-          {marketplaceLoading ? <div className="connect__empty">Loading apps...</div> : marketplaceError ? <div className="connect__error">Apps unavailable: {marketplaceError}</div> : (
-            <WorkspaceResourceList label="Compatible apps">
-              {filteredMarketplaceApps.map(app => (
-                <WorkspaceResourceRow
-                  key={app.id || app.name}
-                  title={app.name}
-                  description={app.description || 'No description available.'}
-                  metadata={app.category?.[0]}
-                  leading={app.logo ? <img className="connect__app-logo" src={app.logo} alt="" /> : <span className="connect__app-logo connect__app-logo--fallback">{app.name.slice(0, 1).toUpperCase()}</span>}
-                  actions={<WorkspaceActionGroup className="connect__marketplace-actions" label={`Links for ${app.name}`}>
-                    {app.links?.app && <WorkspaceActionButton appearance="secondary" size="small" icon="globe" onClick={() => openExternal(app.links?.app)}>Visit</WorkspaceActionButton>}
-                    {app.links?.guide && <WorkspaceActionButton appearance="quiet" size="small" onClick={() => openExternal(app.links?.guide)}>Guide</WorkspaceActionButton>}
-                    {app.links?.video && <WorkspaceActionButton appearance="quiet" size="small" onClick={() => openExternal(app.links?.video)}>Video</WorkspaceActionButton>}
-                  </WorkspaceActionGroup>}
-                />
-              ))}
-              {filteredMarketplaceApps.length === 0 && <div className="connect__empty">No apps match your search.</div>}
-            </WorkspaceResourceList>
-          )}
-    </section>
-  );
-
-  if (embedded) return directoryContent;
+  const visibleCount = filteredMarketplaceApps.length;
+  const paneTitle = categoryFilter ? categoryLabel(categoryFilter) : 'All Apps';
+  const paneSubtitle = categoryFilter
+    ? `${appCountLabel(visibleCount)} in ${categoryLabel(categoryFilter)}.`
+    : 'Compatible clients and tools for Lemonade.';
 
   return (
-    <section className="workspace-pane connect__main apps__main" aria-labelledby="apps-pane-title" data-view="apps">
-      <WorkspacePaneHeader
-        title="Apps"
-        subtitle="Compatible clients and tools for Lemonade."
-        titleId="apps-pane-title"
+    <section
+      className={`apps-workspace${railCollapsed ? ' workspace--rail-collapsed' : ''}`}
+      data-view="apps"
+    >
+      <WorkspaceSectionRail
+        sections={categorySections}
+        activeSection={activeCategorySection}
+        onSectionChange={section => setCategoryFilter(categoryBySection.get(section) ?? null)}
+        collapsed={railCollapsed}
+        onCollapsedChange={setRailCollapsed}
+        panelId="apps-types-panel"
+        railLabel="App type navigation"
+        navigationLabel="App categories"
+        railClassName="apps__rail"
+        navClassName="apps__nav"
+        headerTitle="App Types"
+        sidebarLabel="app types"
+        headerIcon="layers"
+        mobileMenuLabel="Open app types"
       />
-      <div className="connect__layout workspace-pane__scroll">
-        {directoryContent}
-      </div>
+
+      <section className="workspace-pane apps__main" aria-labelledby="apps-pane-title">
+        <WorkspacePaneHeader
+          title={paneTitle}
+          subtitle={paneSubtitle}
+          titleId="apps-pane-title"
+        />
+
+        <div className="apps__content workspace-pane__scroll">
+          <section className="apps__directory" aria-label={paneTitle}>
+            {marketplaceLoading ? (
+              <div className="apps__empty" role="status">Loading apps...</div>
+            ) : marketplaceError ? (
+              <div className="apps__error" role="alert">Apps unavailable: {marketplaceError}</div>
+            ) : (
+              <WorkspaceResourceList label={`${paneTitle} directory`} className="apps__resource-list">
+                {filteredMarketplaceApps.map(app => (
+                  <WorkspaceResourceRow
+                    key={app.id || app.name}
+                    title={app.name}
+                    description={app.description || 'No description available.'}
+                    metadata={app.category?.join(' · ')}
+                    leading={app.logo
+                      ? <img className="apps__app-logo" src={app.logo} alt="" />
+                      : <span className="apps__app-logo apps__app-logo--fallback">{app.name.slice(0, 1).toUpperCase()}</span>}
+                    actions={<WorkspaceActionGroup className="apps__marketplace-actions" label={`Links for ${app.name}`}>
+                      {app.links?.app && <WorkspaceActionButton appearance="secondary" size="small" icon="globe" onClick={() => openExternal(app.links?.app)}>Visit</WorkspaceActionButton>}
+                      {app.links?.guide && <WorkspaceActionButton appearance="quiet" size="small" onClick={() => openExternal(app.links?.guide)}>Guide</WorkspaceActionButton>}
+                      {app.links?.video && <WorkspaceActionButton appearance="quiet" size="small" onClick={() => openExternal(app.links?.video)}>Video</WorkspaceActionButton>}
+                    </WorkspaceActionGroup>}
+                  />
+                ))}
+                {filteredMarketplaceApps.length === 0 && (
+                  <div className="apps__empty">
+                    No apps are available for this type.
+                  </div>
+                )}
+              </WorkspaceResourceList>
+            )}
+          </section>
+        </div>
+      </section>
     </section>
   );
 };

--- a/src/app/src/components/ConnectView.tsx
+++ b/src/app/src/components/ConnectView.tsx
@@ -4,7 +4,6 @@ import { clearClientStorage } from '../storage';
 import { loadChatHistoryPreference, saveChatHistoryPreference } from '../features/chatHistory/historySettings';
 import { Icon, IconName } from './Icon';
 import McpPanel from './McpPanel';
-import AppsView from './AppsView';
 import WorkspaceSectionRail from './WorkspaceSectionRail';
 import { WORKSPACE_NAVIGATION, type ConnectSection } from '../features/navigation/workspaceNavigation';
 import {
@@ -501,10 +500,6 @@ const ConnectView: React.FC<ConnectViewProps> = ({ status, isActive, activeSecti
         <div hidden={activeSection !== 'mcp-gateway'}>
           <McpPanel connectionStatus={status} isActive={isActive && activeSection === 'mcp-gateway'} />
         </div>
-
-        {activeSection === 'app-directory' && (
-          <AppsView isActive={isActive} embedded />
-        )}
 
       </div>
       </section>

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -1135,9 +1135,9 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                 </span>
               </span>
 
-              {/* The backend identity now lives on the lower guide line instead
-                  of in a separate badge. The line terminates in the compact
-                  readiness ring; the pin sits directly above it. */}
+              {/* The backend identity lives on the lower guide line. A hollow
+                  marker means remote/available; every concrete readiness state
+                  replaces that ring with one solid status point. */}
               <span className="model-list-item__footer" aria-hidden="true">
                 <span className="model-list-item__footer-info">
                   {status === 'downloading' && downloadPct != null && (
@@ -1156,11 +1156,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
                   className={`model-list-item__status model-list-item__status--${statusTone}`}
                   title={readinessLabel}
                   data-backend-state={backendReadiness?.state || statusTone}
-                >
-                  {status !== 'available' && (
-                    <span className={`model-list-item__dot model-list-item__dot--${statusTone}`} />
-                  )}
-                </span>
+                />
               </span>
 
               {/* Pointer users click the compact pin above the status terminus;

--- a/src/app/src/components/ModelNavRail.tsx
+++ b/src/app/src/components/ModelNavRail.tsx
@@ -26,6 +26,13 @@ import { backendColor } from '../modelPresentation';
 import type { IconName } from './Icon';
 import WorkspaceRailHeader from './WorkspaceRailHeader';
 import {
+  DEFAULT_VISIBLE_BACKEND_COUNT,
+  hideBackendShortcut,
+  resolveBackendRailVisibility,
+  revealNextBackend,
+  type BackendRailVisibilityState,
+} from '../features/models/backendRailVisibility';
+import {
   listModelName,
   listRecipeBadgeText,
   modelHasFilterableBackend,
@@ -166,6 +173,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
   const [tasksOpen, setTasksOpen] = useState(true);
   const [backendsOpen, setBackendsOpen] = useState(true);
   const [tagsOpen, setTagsOpen] = useState(true);
+  const [backendVisibility, setBackendVisibility] = useState<BackendRailVisibilityState | null>(null);
   const [customTags, setCustomTags] = useState<string[]>(loadCustomFilterTags);
   const [customTagDraft, setCustomTagDraft] = useState('');
 
@@ -207,6 +215,22 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
       .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
   }, [allModels]);
 
+  const resolvedBackendVisibility = useMemo(
+    () => resolveBackendRailVisibility(backends.map(backend => backend.value), backendVisibility),
+    [backends, backendVisibility],
+  );
+
+  const visibleBackends = useMemo(() => {
+    const byValue = new Map(backends.map(backend => [backend.value, backend]));
+    return resolvedBackendVisibility.order
+      .slice(0, resolvedBackendVisibility.visibleCount)
+      .map(value => byValue.get(value))
+      .filter((backend): backend is { value: string; label: string; count: number } => Boolean(backend));
+  }, [backends, resolvedBackendVisibility]);
+
+  const hiddenBackendCount = Math.max(0, backends.length - visibleBackends.length);
+  const backendShortcutsRemovable = visibleBackends.length > DEFAULT_VISIBLE_BACKEND_COUNT;
+
   const allTagChips = useMemo(
     () => [...TAG_CHIPS, ...customTags.filter(tag => !TAG_CHIPS.some(builtIn => builtIn.toLowerCase() === tag.toLowerCase()))],
     [customTags],
@@ -239,6 +263,18 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
   const toggleBackend = (backend: string) => {
     const next = new Set(backendFilters);
     if (next.has(backend)) next.delete(backend); else next.add(backend);
+    onBackendFiltersChange(next);
+  };
+
+  const showNextBackend = () => {
+    setBackendVisibility(revealNextBackend(resolvedBackendVisibility));
+  };
+
+  const removeBackendShortcut = (backend: string) => {
+    setBackendVisibility(hideBackendShortcut(resolvedBackendVisibility, backend));
+    if (!backendFilters.has(backend)) return;
+    const next = new Set(backendFilters);
+    next.delete(backend);
     onBackendFiltersChange(next);
   };
 
@@ -440,23 +476,48 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
         </h2>
         {backendsOpen && (
           <div className="model-nav-rail__chip-list model-nav-rail__backend-list" id="nav-backends" role="group" aria-label="Filter by backend">
-            {backends.map(backend => {
+            {visibleBackends.map(backend => {
               const active = backendFilters.has(backend.value);
               return (
-                <button
+                <span
                   key={backend.value}
-                  type="button"
-                  className={`model-nav-rail__filter-chip model-nav-rail__backend-chip${active ? ' is-active' : ''}`}
-                  style={{ '--filter-chip-color': backendColor(backend.value) } as React.CSSProperties}
-                  aria-pressed={active}
-                  onClick={() => toggleBackend(backend.value)}
+                  className={`model-nav-rail__backend-wrap${backendShortcutsRemovable ? ' is-removable' : ''}`}
                 >
-                  <span>{backend.label}</span>
-                  <span className="model-nav-rail__chip-count" aria-hidden="true">{backend.count}</span>
-                  <span className="sr-only">{`, ${backend.count} models`}</span>
-                </button>
+                  <button
+                    type="button"
+                    className={`model-nav-rail__filter-chip model-nav-rail__backend-chip${active ? ' is-active' : ''}`}
+                    style={{ '--filter-chip-color': backendColor(backend.value) } as React.CSSProperties}
+                    aria-pressed={active}
+                    onClick={() => toggleBackend(backend.value)}
+                  >
+                    <span>{backend.label}</span>
+                    <span className="model-nav-rail__chip-count" aria-hidden="true">{backend.count}</span>
+                    <span className="sr-only">{`, ${backend.count} models`}</span>
+                  </button>
+                  {backendShortcutsRemovable && (
+                    <button
+                      type="button"
+                      className="model-nav-rail__backend-remove"
+                      onClick={() => removeBackendShortcut(backend.value)}
+                      aria-label={`Hide ${backend.label} backend shortcut`}
+                    >
+                      <Icon name="x" size={10} aria-hidden="true" />
+                    </button>
+                  )}
+                </span>
               );
             })}
+            {hiddenBackendCount > 0 && (
+              <button
+                type="button"
+                className="model-nav-rail__filter-chip model-nav-rail__backend-more"
+                onClick={showNextBackend}
+                aria-label={`Show one more backend, ${hiddenBackendCount} hidden`}
+              >
+                <Icon name="plus" size={11} aria-hidden="true" />
+                <span>{hiddenBackendCount}</span>
+              </button>
+            )}
           </div>
         )}
       </section>

--- a/src/app/src/features/models/backendRailVisibility.ts
+++ b/src/app/src/features/models/backendRailVisibility.ts
@@ -1,0 +1,58 @@
+export const DEFAULT_VISIBLE_BACKEND_COUNT = 6;
+
+export interface BackendRailVisibilityState {
+  order: string[];
+  visibleCount: number;
+}
+
+/** Keep the user's rail ordering while reconciling backends that appeared or disappeared. */
+export function resolveBackendRailVisibility(
+  availableValues: readonly string[],
+  state: BackendRailVisibilityState | null,
+): BackendRailVisibilityState {
+  const available = new Set(availableValues);
+  const seen = new Set<string>();
+  const order: string[] = [];
+
+  const append = (value: string) => {
+    if (!available.has(value) || seen.has(value)) return;
+    seen.add(value);
+    order.push(value);
+  };
+
+  for (const value of state?.order || []) append(value);
+  for (const value of availableValues) append(value);
+
+  const minimumVisible = Math.min(DEFAULT_VISIBLE_BACKEND_COUNT, order.length);
+  const requestedVisible = state?.visibleCount ?? minimumVisible;
+
+  return {
+    order,
+    visibleCount: Math.min(order.length, Math.max(minimumVisible, requestedVisible)),
+  };
+}
+
+export function revealNextBackend(state: BackendRailVisibilityState): BackendRailVisibilityState {
+  return {
+    ...state,
+    visibleCount: Math.min(state.order.length, state.visibleCount + 1),
+  };
+}
+
+/** Move a visible backend behind the remaining choices so the next reveal advances. */
+export function hideBackendShortcut(
+  state: BackendRailVisibilityState,
+  backend: string,
+): BackendRailVisibilityState {
+  if (
+    state.visibleCount <= DEFAULT_VISIBLE_BACKEND_COUNT
+    || !state.order.slice(0, state.visibleCount).includes(backend)
+  ) {
+    return state;
+  }
+
+  return {
+    order: [...state.order.filter(value => value !== backend), backend],
+    visibleCount: state.visibleCount - 1,
+  };
+}

--- a/src/app/src/features/navigation/workspaceNavigation.ts
+++ b/src/app/src/features/navigation/workspaceNavigation.ts
@@ -55,7 +55,6 @@ export const WORKSPACE_NAVIGATION = {
     defineSection('model-storage', 'Cache and custom directories', 'hard-drive'),
     defineSection('cloud-providers', 'OpenAI-compatible services', 'cloud'),
     defineSection('mcp-gateway', 'Tools and external servers', 'tools'),
-    defineSection('app-directory', 'Compatible clients and integrations', 'layers'),
     defineSection('help-and-support', 'Docs, releases and community', 'book-open'),
   ] as const, 'Settings'),
 } as const;

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -7744,8 +7744,10 @@ optgroup {
   font-variant-numeric: tabular-nums;
 }
 
-/* The ring is the physical end of the lower rule. Its inner light reports the
-   joined model/backend readiness state; a hollow ring means remote/available. */
+/* The status marker is the physical end of the lower rule. Remote/available
+   stays a small hollow circle. Every concrete state is one larger solid point,
+   replacing the ring instead of being centered inside it. Keeping a single
+   painted shape avoids fractional-zoom drift between two nested circles. */
 .model-list-item__status {
   position: absolute;
   z-index: 3;
@@ -7753,54 +7755,57 @@ optgroup {
   inset-inline-end: 0;
   width: 11px;
   height: 11px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--model-list-line);
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  pointer-events: none;
+}
+
+.model-list-item__status::before {
+  content: '';
+  box-sizing: border-box;
   border-radius: 50%;
-  background: var(--model-list-row-bg);
   box-shadow: 0 0 0 2px var(--model-list-row-bg);
 }
 
-.model-list-item__dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
+.model-list-item__status--available::before {
+  width: 9px;
+  height: 9px;
+  border: 1px solid var(--model-list-line);
+  background: var(--model-list-row-bg);
 }
 
-.model-list-item__dot--ready,
-.model-list-item__dot--running {
+.model-list-item__status--ready::before,
+.model-list-item__status--running::before,
+.model-list-item__status--attention::before,
+.model-list-item__status--unknown::before,
+.model-list-item__status--downloading::before {
+  width: 7px;
+  height: 7px;
+  border: 0;
+}
+
+.model-list-item__status--ready::before,
+.model-list-item__status--running::before {
   background: var(--status-ok);
 }
 
-.model-list-item__dot--running {
+.model-list-item__status--running::before {
   animation: dotPulse 2s ease-in-out infinite;
 }
 
-.model-list-item__dot--attention {
+.model-list-item__status--attention::before {
   background: var(--status-warning);
 }
 
-.model-list-item__dot--unknown {
+.model-list-item__status--unknown::before {
   background: var(--text-disabled);
 }
 
-.model-list-item__dot--downloading {
+.model-list-item__status--downloading::before {
   background: var(--accent-fg);
   animation: dotPulse 1.4s ease-in-out infinite;
-}
-
-.model-list-item__status--attention {
-  border-color: color-mix(in srgb, var(--status-warning) 48%, var(--model-list-line));
-}
-
-.model-list-item__status--running,
-.model-list-item__status--ready {
-  border-color: color-mix(in srgb, var(--status-ok) 42%, var(--model-list-line));
-}
-
-.model-list-item__status--downloading {
-  border-color: color-mix(in srgb, var(--accent-fg) 48%, var(--model-list-line));
 }
 
 /* Pin / favorite: a single compact icon above the status terminus, without a

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -11676,6 +11676,7 @@ optgroup {
 }
 
 .connect--workspace.workspace--rail-collapsed,
+.apps-workspace.workspace--rail-collapsed,
 .logs-workspace.workspace--rail-collapsed,
 .backends--workspace.workspace--rail-collapsed {
   grid-template-columns: var(--rail-collapsed) minmax(0, 1fr);
@@ -11690,20 +11691,6 @@ optgroup {
 
 .connect__layout {
   padding: var(--space-5);
-}
-
-.apps__main > .workspace-pane__header {
-  width: min(880px, calc(100% - (var(--space-5) * 2)));
-  margin-inline: auto;
-  padding-inline: 0;
-}
-
-.apps__main { height: 100%; }
-
-.apps__main .connect__layout {
-  display: flex;
-  justify-content: center;
-  min-height: 0;
 }
 
 .connect__section,
@@ -11767,26 +11754,65 @@ optgroup {
 }
 
 .connect__provider-list { margin-top: var(--space-4); }
-.connect__provider-actions,
-.connect__marketplace-actions { width: auto; justify-content: flex-end; }
+.connect__provider-actions { width: auto; justify-content: flex-end; }
 .connect__provider-actions .input { width: min(220px, 34vw); }
 
-.connect__marketplace-search { width: min(360px, 100%); }
-
-.apps__category-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  margin-top: var(--space-3);
+.connect__empty {
+  padding: var(--space-4) 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
 }
 
-.connect__app-logo {
+/* Apps */
+.apps-workspace {
+  display: grid;
+  grid-template-columns: var(--workspace-rail) minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.apps__main {
+  height: 100%;
+  display: grid;
+  grid-template-rows: var(--workspace-header) minmax(0, 1fr);
+}
+
+.apps__main .workspace-pane__heading h2 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.apps__nav {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.apps__content {
+  min-height: 0;
+  padding: var(--space-5);
+}
+
+.apps__directory {
+  width: min(100%, var(--max-content-width));
+  min-width: 0;
+  margin-inline: auto;
+}
+
+.apps__marketplace-actions {
+  width: auto;
+  justify-content: flex-end;
+}
+
+.apps__app-logo {
   width: 28px;
   height: 28px;
   object-fit: contain;
 }
 
-.connect__app-logo--fallback {
+.apps__app-logo--fallback {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -11794,11 +11820,14 @@ optgroup {
   font-weight: var(--weight-semibold);
 }
 
-.connect__empty {
+.apps__empty,
+.apps__error {
   padding: var(--space-4) 0;
-  color: var(--text-tertiary);
   font-size: var(--text-sm);
 }
+
+.apps__empty { color: var(--text-tertiary); }
+.apps__error { color: var(--danger); }
 
 @media (max-width: 900px) {
   .connect__directory-grid,
@@ -12456,6 +12485,47 @@ optgroup {
     margin-top: var(--space-1);
     overflow-y: auto;
   }
+
+  /* Apps uses the shared titlebar search as its primary pane search. Keep the
+     actual field visible at the standard Playwright/desktop width instead of
+     collapsing it behind the search icon. */
+  .titlebar__search.is-context-visible,
+  .titlebar__search.is-context-visible:focus-within {
+    width: 176px;
+    flex-basis: 176px;
+  }
+
+  .titlebar__search.is-context-visible .titlebar__search-leading-icon {
+    display: block;
+  }
+
+  .titlebar__search.is-context-visible .titlebar__search-toggle {
+    display: none;
+  }
+
+  .titlebar__search.is-context-visible .titlebar__search-popover,
+  .titlebar__search.is-context-visible.is-open .titlebar__search-popover {
+    position: relative;
+    inset: auto;
+    width: auto;
+    display: flex;
+    flex: 1;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .titlebar__search.is-context-visible.is-open .titlebar__search-results {
+    position: absolute;
+    top: calc(100% + var(--space-2));
+    left: 0;
+    width: 100%;
+    max-height: min(420px, calc(100vh - var(--titlebar-height) - 80px));
+    margin-top: 0;
+    overflow-y: auto;
+  }
 }
 
 @media (max-width: 768px) {
@@ -12681,17 +12751,22 @@ optgroup {
   }
 
   .connect--workspace,
+  .apps-workspace,
   .monitor-workspace,
   .backends--workspace {
     position: relative;
   }
 
   .connect--workspace,
+  .apps-workspace,
   .monitor-workspace,
   .backends--workspace {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: minmax(0, 1fr);
   }
+
+
+  .apps__content { padding: var(--space-4); }
 
 
 

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -7029,6 +7029,24 @@ optgroup {
   color: var(--filter-chip-color);
 }
 
+.model-nav-rail__backend-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.model-nav-rail__backend-wrap.is-removable .model-nav-rail__backend-chip {
+  padding-inline-end: 19px;
+}
+
+.model-nav-rail__backend-more {
+  --filter-chip-color: var(--accent-fg);
+  color: var(--text-tertiary);
+}
+
+.model-nav-rail__backend-more svg {
+  color: var(--accent-fg);
+}
+
 .model-nav-rail__chip-count {
   color: var(--text-tertiary);
   font-size: var(--type-overline-size);
@@ -7048,6 +7066,7 @@ optgroup {
   padding-inline-end: 19px;
 }
 
+.model-nav-rail__backend-remove,
 .model-nav-rail__custom-tag-remove {
   position: absolute;
   inset-inline-end: 3px;
@@ -7066,6 +7085,7 @@ optgroup {
   cursor: pointer;
 }
 
+.model-nav-rail__backend-remove:hover,
 .model-nav-rail__custom-tag-remove:hover {
   background: var(--danger-soft);
   color: var(--danger);
@@ -7110,6 +7130,7 @@ optgroup {
 }
 
 .model-nav-rail__filter-chip:focus-visible,
+.model-nav-rail__backend-remove:focus-visible,
 .model-nav-rail__custom-tag-remove:focus-visible,
 .model-nav-rail__custom-tag-entry input:focus-visible,
 .model-nav-rail__custom-tag-entry button:focus-visible {

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -35,6 +35,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await expect(nav.getByText('Chat')).toBeVisible();
     await expect(nav.getByText('Models')).toBeVisible();
     await expect(nav.getByText('Backends')).toBeVisible();
+    await expect(nav.getByText('Apps')).toBeVisible();
     await expect(nav.getByText('Monitor')).toBeVisible();
     await expect(nav.getByText('Settings')).toBeVisible();
 
@@ -91,7 +92,6 @@ test.describe('Lemonade UI — Feature Parity', () => {
       ['Model storage', 'model-storage'],
       ['Cloud providers', 'cloud-providers'],
       ['MCP gateway', 'mcp-gateway'],
-      ['App directory', 'app-directory'],
       ['Help & support', 'help-and-support'],
     ] as const;
 
@@ -111,6 +111,93 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.goBack();
     await expect(page).toHaveURL(/#\/dashboard\/telemetry$/);
     await expect(dashboardSections.getByRole('button', { name: 'Telemetry', exact: true })).toHaveAttribute('aria-current', 'page');
+  });
+
+  test('01c — Apps is a standalone workspace with category rail navigation', async ({ page }) => {
+    await page.route('**/api/v1/health**', route => route.fulfill({
+      json: { status: 'ok', version: 'test', all_models_loaded: [] },
+    }));
+    await page.route('**/api/v1/models**', route => route.fulfill({
+      json: {
+        data: [{
+          id: 'llama-search-model',
+          name: 'Llama Search Model',
+          type: 'llm',
+          labels: ['llm'],
+          recipe: 'llamacpp',
+          suggested: true,
+        }],
+      },
+    }));
+    await page.route('**/apps.json', route => route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        apps: [
+          { id: 'chat-client', name: 'Chat Client', description: 'A conversational client.', category: ['Chat'] },
+          { id: 'creative-studio', name: 'Creative Studio', description: 'Image workflows.', category: ['creative tools'] },
+          { id: 'llama-app', name: 'Llama App', description: 'A llama.cpp companion.', category: ['tools'] },
+        ],
+      }),
+    }));
+
+    await page.goto('/#/apps');
+    await page.waitForSelector('[data-view="apps"]');
+
+    const appCategories = page.getByRole('navigation', { name: 'App categories' });
+    await expect(appCategories.getByRole('button', { name: 'All Apps', exact: true })).toHaveAttribute('aria-current', 'page');
+    await expect(appCategories.getByRole('button', { name: 'Chat', exact: true })).toBeVisible();
+    await expect(appCategories.getByRole('button', { name: 'Creative Tools', exact: true })).toBeVisible();
+    await expect(page.locator('#apps-pane-title')).toHaveText('All Apps');
+    await expect(page.getByText('Chat Client', { exact: true })).toBeVisible();
+    await expect(page.getByText('Creative Studio', { exact: true })).toBeVisible();
+    await expect(page.getByText('Llama App', { exact: true })).toBeVisible();
+    await expect(page.getByRole('searchbox', { name: 'Search apps' })).toBeVisible();
+
+    const globalResults = page.locator('#titlebar-search-results [role="option"]');
+    const searchFromView = async (viewName: 'Chat' | 'Backends' | 'Apps' | 'Monitor' | 'Settings', query: string) => {
+      await page.locator('.titlebar__nav').getByRole('button', { name: viewName, exact: true }).click();
+      await page.keyboard.press('Control+K');
+      const accessibleName = viewName === 'Apps' ? 'Search apps' : 'Search Lemonade';
+      await page.getByRole('searchbox', { name: accessibleName }).fill(query);
+    };
+
+    await searchFromView('Apps', 'llama');
+    await expect(globalResults.first()).toContainText('Llama App');
+    await page.keyboard.press('Escape');
+
+    await searchFromView('Backends', 'llama');
+    await expect(globalResults.first()).toContainText('llama.cpp');
+    await page.keyboard.press('Escape');
+
+    await searchFromView('Chat', 'llama');
+    await expect(globalResults.first()).toContainText('Llama Search Model');
+    await page.keyboard.press('Escape');
+
+    await searchFromView('Monitor', 'llama');
+    await expect(globalResults.first()).toContainText('Llama Search Model');
+    await page.keyboard.press('Escape');
+
+    await searchFromView('Settings', 'model');
+    await expect(globalResults.first()).toContainText('Model storage');
+    await page.keyboard.press('Escape');
+
+    await page.locator('.titlebar__nav').getByRole('button', { name: 'Apps', exact: true }).click();
+    await expect(page.locator('.apps__category-filters')).toHaveCount(0);
+
+    await appCategories.getByRole('button', { name: 'Chat', exact: true }).click();
+    await expect(page.locator('#apps-pane-title')).toHaveText('Chat');
+    await expect(page.getByText('Chat Client', { exact: true })).toBeVisible();
+    await expect(page.getByText('Creative Studio', { exact: true })).toHaveCount(0);
+    await expect(page).toHaveURL(/#\/apps$/);
+
+    await page.locator('.titlebar__nav').getByRole('button', { name: 'Settings', exact: true }).click();
+    await expect(page.getByRole('navigation', { name: 'Connect sections' })
+      .getByRole('button', { name: 'App directory', exact: true })).toHaveCount(0);
+
+    await page.goto('/#/connect/app-directory');
+    await expect(page).toHaveURL(/#\/apps$/);
+    await expect(page.locator('[data-view="apps"]')).toBeVisible();
   });
 
   test('02 — Chat view renders with composer', async ({ page }) => {
@@ -508,6 +595,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
         visibleControls: ['All Models', 'Downloaded', 'My Models', 'Favorites'],
       },
       { tab: 'Backends', trigger: 'Open backend filters', dialog: 'Backend filters' },
+      { tab: 'Apps', trigger: 'Open app types', dialog: 'App type navigation', visibleControls: ['All Apps'] },
       { tab: 'Monitor', trigger: 'Open monitor views', dialog: 'Monitor navigation' },
       { tab: 'Settings', trigger: 'Open connection settings', dialog: 'Connection settings' },
     ];

--- a/src/app/tests/model-list-backend-layout.runtime.cjs
+++ b/src/app/tests/model-list-backend-layout.runtime.cjs
@@ -51,7 +51,8 @@ assert.match(component, /className="model-list-item__footer"/);
 assert.match(component, /const neutralCollectionGuide = modelIsOmni\(model\) \|\| modelIsRouter\(model\);/);
 assert.match(component, /className="model-list-item__footer-info"[\s\S]*recipe && !neutralCollectionGuide[\s\S]*className="model-list-item__backend"[\s\S]*\{displayedBackend\}/);
 assert.match(component, /model-list-item__status model-list-item__status--\$\{statusTone\}/);
-assert.match(component, /model-list-item__dot model-list-item__dot--\$\{statusTone\}/);
+assert.doesNotMatch(component, /model-list-item__dot/,
+  'active readiness must replace the hollow ring instead of nesting a dot inside it');
 assert.match(component, /data-backend-state=\{backendReadiness\?\.state \|\| statusTone\}/);
 assert.match(component, /aria-label=\{`\$\{displayName\}[\s\S]*\$\{readinessLabel \? `, \$\{readinessLabel\}` : ''\}`\}/);
 assert.match(component, /model-list-item__pin row__pin[\s\S]*?<Icon name="pin" size=\{12\}/);
@@ -78,8 +79,12 @@ assert.doesNotMatch(styles, /\.model-list-item__footer::after/,
   'backend and neutral guide colors must share one one-pixel paint layer');
 assert.match(styles, /\.model-list-item__footer-info\s*\{[^}]*inset-inline-end:\s*16px;[^}]*display:\s*inline-flex;[^}]*font-weight:\s*var\(--weight-regular\);/s);
 assert.match(styles, /\.model-list-item__backend\s*\{[^}]*text-transform:\s*none;/s);
-assert.match(styles, /\.model-list-item__status\s*\{[^}]*inset-inline-end:\s*0;[^}]*width:\s*11px;[^}]*border-radius:\s*50%;/s);
-assert.match(styles, /\.model-list-item__dot--attention\s*\{[^}]*background:\s*var\(--status-warning\);/s);
+assert.match(styles, /\.model-list-item__status\s*\{[^}]*inset-inline-end:\s*0;[^}]*width:\s*11px;[^}]*display:\s*grid;[^}]*place-items:\s*center;/s);
+assert.match(styles, /\.model-list-item__status--available::before\s*\{[^}]*width:\s*9px;[^}]*height:\s*9px;[^}]*border:\s*1px solid var\(--model-list-line\);/s);
+assert.match(styles, /\.model-list-item__status--ready::before,[\s\S]*\.model-list-item__status--downloading::before\s*\{[^}]*width:\s*7px;[^}]*height:\s*7px;[^}]*border:\s*0;/s);
+assert.match(styles, /\.model-list-item__status--attention::before\s*\{[^}]*background:\s*var\(--status-warning\);/s);
+assert.doesNotMatch(styles, /\.model-list-item__dot/,
+  'the status marker must use one painted shape at every state');
 assert.match(styles, /\.model-list-item__pin\s*\{[^}]*position:\s*absolute;[^}]*inset-block-start:\s*6px;[^}]*inset-inline-end:\s*6px;[^}]*border:\s*0;/s);
 assert.doesNotMatch(styles, /model-list-item__backend-cluster/,
   'the previous custom backend badge/cluster design must be removed');

--- a/src/app/tests/model-nav-filter-layout.runtime.cjs
+++ b/src/app/tests/model-nav-filter-layout.runtime.cjs
@@ -7,14 +7,16 @@ const root = path.resolve(__dirname, '..');
 const navPath = path.join(root, 'src/components/ModelNavRail.tsx');
 const listPath = path.join(root, 'src/components/ModelListPanel.tsx');
 const managerPath = path.join(root, 'src/components/ModelManager.tsx');
+const backendVisibilityPath = path.join(root, 'src/features/models/backendRailVisibility.ts');
 const stylesPath = path.join(root, 'src/styles/styles.css');
 
 const nav = fs.readFileSync(navPath, 'utf8');
 const list = fs.readFileSync(listPath, 'utf8');
 const manager = fs.readFileSync(managerPath, 'utf8');
+const backendVisibility = fs.readFileSync(backendVisibilityPath, 'utf8');
 const styles = fs.readFileSync(stylesPath, 'utf8');
 
-for (const [fileName, source] of [[navPath, nav], [listPath, list], [managerPath, manager]]) {
+for (const [fileName, source] of [[navPath, nav], [listPath, list], [managerPath, manager], [backendVisibilityPath, backendVisibility]]) {
   const compiled = ts.transpileModule(source, {
     compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext, jsx: ts.JsxEmit.ReactJSX },
     fileName,
@@ -29,6 +31,11 @@ assert.match(nav, /key: 'llm', label: 'Chat'/);
 assert.match(nav, /key: 'router', label: 'Router'/);
 assert.match(nav, /model-nav-rail__task-chip/);
 assert.match(nav, /model-nav-rail__backend-chip/);
+assert.match(nav, /visibleBackends\.map/);
+assert.match(nav, /model-nav-rail__backend-more/);
+assert.match(nav, /hiddenBackendCount > 0/);
+assert.match(nav, /backendShortcutsRemovable/);
+assert.match(nav, /model-nav-rail__backend-remove/);
 assert.match(nav, /model-nav-rail__tag-chip/);
 assert.match(nav, /aria-pressed=\{active\}/);
 assert.match(nav, /onTaskFiltersChange\(next\)/);
@@ -59,6 +66,51 @@ assert.match(manager, /modelMatchesTags\(info, tagFilters\)/);
 assert.match(styles, /\.model-nav-rail__chip-list\s*\{[^}]*flex-wrap:\s*wrap;/s);
 assert.match(styles, /\.model-nav-rail__task-icon\s*\{[^}]*color:\s*var\(--filter-chip-color\);/s);
 assert.match(styles, /\.model-nav-rail__backend-chip\s*\{[^}]*color:\s*var\(--filter-chip-color\);/s);
+assert.doesNotMatch(styles, /\.model-nav-rail__backend-chip::before\s*\{/,
+  'reverting the backend color concept must restore the colored label instead of a separate dot');
+assert.match(styles, /\.model-nav-rail__backend-wrap\.is-removable \.model-nav-rail__backend-chip\s*\{[^}]*padding-inline-end:\s*19px;/s);
+assert.match(styles, /\.model-nav-rail__backend-remove,/);
+
+const visibilityCompiled = ts.transpileModule(backendVisibility, {
+  compilerOptions: { target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.CommonJS },
+  fileName: backendVisibilityPath,
+});
+const visibilityModule = { exports: {} };
+Function('exports', 'require', 'module', visibilityCompiled.outputText)(
+  visibilityModule.exports,
+  require,
+  visibilityModule,
+);
+
+const {
+  DEFAULT_VISIBLE_BACKEND_COUNT,
+  resolveBackendRailVisibility,
+  revealNextBackend,
+  hideBackendShortcut,
+} = visibilityModule.exports;
+
+const backendValues = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+const initialVisibility = resolveBackendRailVisibility(backendValues, null);
+assert.equal(DEFAULT_VISIBLE_BACKEND_COUNT, 6);
+assert.deepEqual(initialVisibility, { order: backendValues, visibleCount: 6 });
+
+const sevenVisible = revealNextBackend(initialVisibility);
+assert.equal(sevenVisible.visibleCount, 7, 'the plus pill reveals exactly one backend');
+
+const curatedVisibility = hideBackendShortcut(sevenVisible, 'a');
+assert.equal(curatedVisibility.visibleCount, 6);
+assert.deepEqual(curatedVisibility.order, ['b', 'c', 'd', 'e', 'f', 'g', 'h', 'a']);
+assert.deepEqual(
+  revealNextBackend(curatedVisibility).order.slice(0, 7),
+  ['b', 'c', 'd', 'e', 'f', 'g', 'h'],
+  'removing a top backend must advance to the next hidden backend instead of immediately restoring it',
+);
+
+assert.deepEqual(
+  hideBackendShortcut(initialVisibility, 'a'),
+  initialVisibility,
+  'backend shortcuts cannot be removed while only the default six are visible',
+);
 
 console.log('Model nav Task/Backend/Tag multi-select contract checks passed.');
 

--- a/src/app/tests/ui-regression-contracts.runtime.cjs
+++ b/src/app/tests/ui-regression-contracts.runtime.cjs
@@ -42,9 +42,11 @@ assert.match(sources.chat, /const openMcpPicker = useCallback\(\(\) => \{[\s\S]*
 assert.match(sources.chat, /role="tab"[\s\S]*?>[\s\S]*?Lemonade tools[\s\S]*?<\/button>/);
 assert.match(sources.chat, /role="tab"[\s\S]*?>[\s\S]*?External MCP servers[\s\S]*?<\/button>/);
 
-assert.match(sources.navigation, /defineSection\('app-directory', 'Compatible clients and integrations', 'layers'\)/);
-assert.match(sources.connect, /activeSection === 'app-directory'[\s\S]*?<AppsView isActive=\{isActive\} embedded \/>/);
-assert.match(sources.apps, /embedded\?: boolean/);
+assert.doesNotMatch(sources.navigation, /defineSection\('app-directory'/);
+assert.doesNotMatch(sources.connect, /AppsView|app-directory/);
+assert.match(sources.apps, /<WorkspaceSectionRail[\s\S]*?navigationLabel="App categories"/);
+assert.match(sources.apps, /className={`apps-workspace\$\{railCollapsed \? ' workspace--rail-collapsed' : ''\}`}/);
+assert.doesNotMatch(sources.apps, /embedded\?: boolean|apps__category-filters|WorkspaceMetadataChip/);
 
 assert.match(sources.mcpPanel, /transport: 'streamable-http'/);
 assert.match(sources.mcpPanel, />HTTP endpoint</);


### PR DESCRIPTION
## Summary

This PR improves GUI3 navigation and backend presentation across the Apps and Models workspaces.

Apps is now treated as a standalone workspace instead of a Settings section, while backend colors, rail behavior, and status markers have been made more stable, distinguishable, and consistent across Light and Dark Mode.

## Changes

### Apps workspace

* remove Apps from the Settings navigation
* integrate the existing Apps view into the standard GUI3 workspace layout
* replace the centered layout and top category navigation with a left-side category rail
* align responsive rail behavior with the Monitor and Settings workspaces
* preserve the legacy `#/connect/app-directory` route and canonicalize it to `#/apps`

### Backend color identity

* introduce a centralized backend identity registry with stable color slots
* use the same backend colors in Light and Dark Mode
* enforce a global minimum OKLab color distance of `0.14`
* improve the visual separation between `llama.cpp` and `TRELLIS.2`
* preserve existing assignments when new backends are added
* support aliases without generating new backend identities
* reserve removed backend color slots instead of reusing them
* keep fallback and override handling centralized and maintainable

### Models view styling

* shorten the colored section of the backend accent line
* ensure all accent lines use a consistent single-pixel thickness
* remove overlapping styles that could render lines at double width
* improve contrast against both light and dark surfaces

### Backend rail behavior

* limit the backend rail to six visible backends by default
* add a `+N` pill showing the number of hidden backends
* reveal one additional backend per pill click
* hide the pill once no hidden backends remain
* show remove controls when more than six backends are visible
* move removed backends to the end of the hidden selection
* clear the active backend filter when its backend is removed

### Backend status markers

* replace nested status rings with stable single-state markers
* use a smaller hollow circle for available backends
* use a larger solid dot for active states
* avoid zoom-related alignment issues caused by nested markers
* preserve running and download pulse animations

## UX impact

The updated layout provides a clearer separation between global workspaces and Settings, while the backend rail remains compact by default and can be expanded incrementally.

Backend identities are now consistent across themes and sessions, status markers remain aligned at different zoom levels, and backend accent colors are easier to distinguish without introducing additional theme-specific styling.

The color "pressure" is reduced, here some examples

<img width="1124" height="936" alt="image" src="https://github.com/user-attachments/assets/9f2514bd-0019-45d9-acd3-e8c8fb93751d" />
<img width="1129" height="930" alt="image" src="https://github.com/user-attachments/assets/a4f1386c-ec7d-426a-97bd-f38fbc0797d8" />


