### PR TITLE
ci: run Launchpad PPA binary builds in the merge queue instead of every PR

### DIFF
--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -229,9 +229,9 @@ jobs:
       artifact: lemonade-${{ matrix.codename }}-source-package
     secrets: inherit
 
-  # Gate job. Reports a single status check that passes only if every job in
-  # `needs:` passed. Branch protection requires this check's name, so the merge
-  # queue blocks on all of those jobs at once.
+  # Gate job that ensures: 1. in the merge queue, all jobs in `needs:` ran
+  # successfully (otherwise the merge is blocked), and 2. these jobs do not need
+  # to run on ordinary pull request pushes.
   gate:
     name: Launchpad PPA builds
     needs: [prepare-matrix, package, package-arm64]

--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -9,14 +9,12 @@ on:
       - main
     tags:
       - '*'
-  pull_request:
-    branches:
-      - main
+  merge_group:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}
+  cancel-in-progress: false
 
 jobs:
   prepare-matrix:
@@ -98,7 +96,7 @@ jobs:
 
       - name: Build binary package
         id: build_binary
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'merge_group'
         uses: ./.github/actions/build-debian-package
         with:
           package-type: binary
@@ -106,14 +104,14 @@ jobs:
 
       - name: Build source package
         id: build_source
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'merge_group'
         uses: ./.github/actions/build-debian-package
         with:
           package-type: source
           deb-version: ${{ steps.get_version.outputs.version }}
 
       - name: Upload Debian package
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'merge_group'
         uses: actions/upload-artifact@v7
         with:
           name: lemonade-${{ matrix.codename }}-deb
@@ -121,7 +119,7 @@ jobs:
           retention-days: 30
 
       - name: Upload source package
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'merge_group'
         uses: actions/upload-artifact@v7
         with:
           name: lemonade-${{ matrix.codename }}-source-package
@@ -138,7 +136,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'merge_group'
     strategy:
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.package_matrix) }}
     container:
@@ -206,7 +204,7 @@ jobs:
     needs: [prepare-matrix, package]
     permissions:
       contents: read
-    if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'merge_group' }}
     uses: ./.github/workflows/upload.yml
     with:
       target: ppa:lemonade-team/stable
@@ -220,7 +218,7 @@ jobs:
     needs: [prepare-matrix, package]
     permissions:
       contents: read
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') && github.event_name != 'pull_request' }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') && github.event_name != 'merge_group' }}
     uses: ./.github/workflows/upload.yml
     with:
       target: ppa:lemonade-team/bleeding-edge

--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -9,12 +9,15 @@ on:
       - main
     tags:
       - '*'
+  pull_request:
+    branches:
+      - main
   merge_group:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && 'pr' || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   prepare-matrix:
@@ -61,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: github.event_name != 'pull_request'
     strategy:
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.package_matrix) }}
     container:
@@ -204,7 +208,7 @@ jobs:
     needs: [prepare-matrix, package]
     permissions:
       contents: read
-    if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'merge_group' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     uses: ./.github/workflows/upload.yml
     with:
       target: ppa:lemonade-team/stable
@@ -218,9 +222,30 @@ jobs:
     needs: [prepare-matrix, package]
     permissions:
       contents: read
-    if: ${{ !startsWith(github.ref, 'refs/tags/v') && github.event_name != 'merge_group' }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     uses: ./.github/workflows/upload.yml
     with:
       target: ppa:lemonade-team/bleeding-edge
       artifact: lemonade-${{ matrix.codename }}-source-package
     secrets: inherit
+
+  gate:
+    name: Launchpad PPA builds
+    needs: [prepare-matrix, package, package-arm64]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any build job did not succeed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "prepare-matrix=${{ needs.prepare-matrix.result }} package=${{ needs.package.result }} package-arm64=${{ needs['package-arm64'].result }}"
+            exit 1
+          fi
+
+      - name: Require the binary builds to have run in the merge queue
+        if: github.event_name == 'merge_group'
+        run: |
+          if [ "${{ needs.package.result }}" != "success" ] || [ "${{ needs['package-arm64'].result }}" != "success" ]; then
+            echo "package=${{ needs.package.result }} package-arm64=${{ needs['package-arm64'].result }}"
+            exit 1
+          fi

--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -229,10 +229,9 @@ jobs:
       artifact: lemonade-${{ matrix.codename }}-source-package
     secrets: inherit
 
-  # Required status check standing in for the jobs above: the merge queue gates
-  # only on required checks, and the per-job names shift with the matrix, while
-  # this one is fixed. It also reports on pull_request -- where the gated work is
-  # skipped -- so PRs can still enqueue.
+  # Gate job. Reports a single status check that passes only if every job in
+  # `needs:` passed. Branch protection requires this check's name, so the merge
+  # queue blocks on all of those jobs at once.
   gate:
     name: Launchpad PPA builds
     needs: [prepare-matrix, package, package-arm64]
@@ -243,12 +242,8 @@ jobs:
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
-          # $NEEDS is {"job-id": {"result": "success|failure|skipped|cancelled", ...}, ...}
-          # for every job listed in `needs:` above. Two separate failures to catch:
-          #   failure/cancelled          -> a gated job ran and broke
-          #   anything but success, in a -> the job never ran at all (empty matrix, or
-          #   merge_group run               an `if:` that stopped matching). Without this
-          #                                 the gate would go green having checked nothing.
+          # $NEEDS: {"job-id": {"result": "success|failure|skipped|cancelled"}, ...}
+          # Fail if any job broke. In the merge queue, also fail if any never ran.
           echo "$NEEDS"
           broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
           if [ -n "$broke" ]; then

--- a/.github/workflows/launchpad-ppa.yml
+++ b/.github/workflows/launchpad-ppa.yml
@@ -229,23 +229,36 @@ jobs:
       artifact: lemonade-${{ matrix.codename }}-source-package
     secrets: inherit
 
+  # Required status check standing in for the jobs above: the merge queue gates
+  # only on required checks, and the per-job names shift with the matrix, while
+  # this one is fixed. It also reports on pull_request -- where the gated work is
+  # skipped -- so PRs can still enqueue.
   gate:
     name: Launchpad PPA builds
     needs: [prepare-matrix, package, package-arm64]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if any build job did not succeed
+      - name: Check gated jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
         run: |
-          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
-            echo "prepare-matrix=${{ needs.prepare-matrix.result }} package=${{ needs.package.result }} package-arm64=${{ needs['package-arm64'].result }}"
+          # $NEEDS is {"job-id": {"result": "success|failure|skipped|cancelled", ...}, ...}
+          # for every job listed in `needs:` above. Two separate failures to catch:
+          #   failure/cancelled          -> a gated job ran and broke
+          #   anything but success, in a -> the job never ran at all (empty matrix, or
+          #   merge_group run               an `if:` that stopped matching). Without this
+          #                                 the gate would go green having checked nothing.
+          echo "$NEEDS"
+          broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
+          if [ -n "$broke" ]; then
+            echo "FAILED: $broke"
             exit 1
           fi
-
-      - name: Require the binary builds to have run in the merge queue
-        if: github.event_name == 'merge_group'
-        run: |
-          if [ "${{ needs.package.result }}" != "success" ] || [ "${{ needs['package-arm64'].result }}" != "success" ]; then
-            echo "package=${{ needs.package.result }} package-arm64=${{ needs['package-arm64'].result }}"
-            exit 1
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            absent=$(jq -r 'to_entries[]|select(.value.result!="success")|.key' <<<"$NEEDS")
+            if [ -n "$absent" ]; then
+              echo "DID NOT RUN IN MERGE QUEUE: $absent"
+              exit 1
+            fi
           fi


### PR DESCRIPTION
- **Why** — `launchpad-ppa` built binary .debs for every supported Ubuntu codename on every PR push: 7 jobs, ~68 min of runner time (org cap: 20 concurrent). Of its 37 PR-run failures between 04 Jul and 05 Aug, only 2 were the sole red signal.
- **What** — The binary-build matrix moves from `pull_request` to `merge_group`, gated by a new required **`Launchpad PPA builds`** aggregate job; the upload jobs now key off `push`/`workflow_dispatch` so a PR event can't reach the PPA. The queue gates *only* on required checks — see #2867, which merged despite a red merge-group run — and the build names embed the codename and PPA URL, so they can't be required directly.
- **Rollout** — Merge this **first**, then add `Launchpad PPA builds` to `main`'s required status checks. Flipping the setting first blocks every open PR on a context that doesn't exist yet; until it's flipped the gate is advisory. (`release-v*` has no required checks configured, so nothing to do there.)

Related: #2902 and #2910 apply the same gate pattern to the packaging and Linux distro workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
