### PR TITLE
update sdcpp backend versions to 727 to support older CPUs

### DIFF
--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -61,11 +61,11 @@
     "metal": "v1.8.4"
   },
   "sd-cpp": {
-    "cpu": "master-721-8caa3f9",
-    "rocm-stable": "master-721-8caa3f9",
-    "vulkan": "master-721-8caa3f9",
-    "cuda": "master-726-db48014",
-    "metal": "master-721-8caa3f9"
+    "cpu": "master-727-f54e45e",
+    "rocm-stable": "master-727-f54e45e",
+    "vulkan": "master-727-f54e45e",
+    "cuda": "master-727-f54e45e",
+    "metal": "master-727-f54e45e"
   },
   "therock": {
     "version": "7.13.0",


### PR DESCRIPTION
Current version of sdcpp backend uses instructions which are not supported by older CPUs (e.g. AMD FX-6100) and crash with illegal instruction.

Support of older CPUs was introduced with [#1704 on leejet/stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp/pull/1704). Update to master-727-f54e45e of sdcpp backend will include support of older CPUs into lemonade sdcpp.

Solves #2912 
 