### PR TITLE
ci: isolate llama.cpp validation cleanup on self-hosted runners

### DIFF
--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -422,6 +422,178 @@ jobs:
           # - backend: cuda
           #   runner: [self-hosted, Windows, 128gb, cuda]
     steps:
+      - name: Capture Vulkan runner configuration
+        if: matrix.backend == 'vulkan'
+        shell: PowerShell
+        run: |
+          $ErrorActionPreference = "Continue"
+
+          $outDir = Join-Path $env:RUNNER_TEMP "vulkan-runner-config"
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+          # General system / Windows / BIOS information
+          $os = Get-CimInstance Win32_OperatingSystem
+          $computer = Get-CimInstance Win32_ComputerSystem
+          $bios = Get-CimInstance Win32_BIOS
+
+          [pscustomobject]@{
+            CapturedUtc        = (Get-Date).ToUniversalTime()
+            RunnerName         = $env:RUNNER_NAME
+            Manufacturer       = $computer.Manufacturer
+            Model              = $computer.Model
+            PhysicalMemoryGiB  = [math]::Round(
+              $computer.TotalPhysicalMemory / 1GB,
+              2
+            )
+            WindowsCaption     = $os.Caption
+            WindowsVersion     = $os.Version
+            WindowsBuild       = $os.BuildNumber
+            OSArchitecture     = $os.OSArchitecture
+            LastBootUpTime     = $os.LastBootUpTime
+            UptimeHours        = [math]::Round(
+              ((Get-Date) - $os.LastBootUpTime).TotalHours,
+              2
+            )
+            BIOSManufacturer   = $bios.Manufacturer
+            BIOSVersion        = $bios.SMBIOSBIOSVersion
+            BIOSReleaseDate    = $bios.ReleaseDate
+          } |
+            Format-List |
+            Out-File (Join-Path $outDir "system.txt") -Encoding utf8
+
+          # GPU model, PCI device ID and Windows display-driver information
+          Get-CimInstance Win32_VideoController |
+            Select-Object `
+              Name,
+              VideoProcessor,
+              PNPDeviceID,
+              DriverVersion,
+              DriverDate,
+              Status |
+            Format-List |
+            Out-File (Join-Path $outDir "gpu.txt") -Encoding utf8
+
+          Get-CimInstance Win32_PnPSignedDriver |
+            Where-Object { $_.DeviceClass -eq "DISPLAY" } |
+            Select-Object `
+              DeviceName,
+              Manufacturer,
+              DriverProviderName,
+              DriverVersion,
+              DriverDate,
+              InfName,
+              DeviceID |
+            Format-List |
+            Out-File (Join-Path $outDir "display-drivers.txt") -Encoding utf8
+
+          # Current Windows power scheme
+          powercfg /getactivescheme 2>&1 |
+            Out-File (Join-Path $outDir "power.txt") -Encoding utf8
+
+          # Reboot-frequency proxy plus exact current boot time above
+          $bootEvents = @(
+            Get-WinEvent -FilterHashtable @{
+              LogName   = "System"
+              Id        = 6005
+              StartTime = (Get-Date).AddDays(-30)
+            } -ErrorAction SilentlyContinue
+          )
+
+          "Event Log service starts in last 30 days: $($bootEvents.Count)" |
+            Out-File (Join-Path $outDir "reboots.txt") -Encoding utf8
+
+          # Relevant workloads present before validation cleanup
+          $processes = @(
+            Get-Process -Name @(
+              "lemond",
+              "llama-server",
+              "lemonade",
+              "LemonadeServer",
+              "flm",
+              "ort-server",
+              "moonshine-server"
+            ) -ErrorAction SilentlyContinue
+          )
+
+          if ($processes.Count -gt 0) {
+            $processes |
+              Select-Object ProcessName, Id, StartTime, CPU, WorkingSet64 |
+              Format-Table -AutoSize |
+              Out-File (Join-Path $outDir "processes-before-cleanup.txt") `
+                -Encoding utf8
+          } else {
+            "No known inference processes detected." |
+              Out-File (Join-Path $outDir "processes-before-cleanup.txt") `
+                -Encoding utf8
+          }
+
+          # Best-effort AMD cache-directory state.
+          # This does not modify or clear any cache.
+          $amdRoot = if ($env:LOCALAPPDATA) {
+            Join-Path $env:LOCALAPPDATA "AMD"
+          } else {
+            $null
+          }
+
+          if ($amdRoot -and (Test-Path $amdRoot)) {
+            Get-ChildItem $amdRoot -Directory -ErrorAction SilentlyContinue |
+              Where-Object { $_.Name -match "cache" } |
+              Select-Object Name, CreationTimeUtc, LastWriteTimeUtc |
+              Format-Table -AutoSize |
+              Out-File (Join-Path $outDir "amd-cache-state.txt") `
+                -Encoding utf8
+          } else {
+            "AMD local cache directory not found." |
+              Out-File (Join-Path $outDir "amd-cache-state.txt") `
+                -Encoding utf8
+          }
+
+          # Vulkan device, driver, memory heaps and capabilities
+          $vulkaninfo = Get-Command vulkaninfo -ErrorAction SilentlyContinue
+
+          if ($vulkaninfo) {
+            & $vulkaninfo.Source --summary *>&1 |
+              Out-File (Join-Path $outDir "vulkaninfo-summary.txt") `
+                -Encoding utf8
+            $summaryExitCode = $LASTEXITCODE
+
+            & $vulkaninfo.Source *>&1 |
+              Out-File (Join-Path $outDir "vulkaninfo.txt") `
+                -Encoding utf8
+            $fullExitCode = $LASTEXITCODE
+
+            Write-Host "=== vulkaninfo --summary ==="
+            Get-Content (Join-Path $outDir "vulkaninfo-summary.txt")
+
+            Write-Host "vulkaninfo summary exit code: $summaryExitCode"
+            Write-Host "vulkaninfo full exit code: $fullExitCode"
+          } else {
+            "vulkaninfo was not found in PATH." |
+              Out-File (Join-Path $outDir "vulkaninfo-unavailable.txt") `
+                -Encoding utf8
+            Write-Warning "vulkaninfo was not found in PATH."
+          }
+
+          Write-Host "=== Runner configuration ==="
+          Get-Content (Join-Path $outDir "system.txt")
+          Get-Content (Join-Path $outDir "gpu.txt")
+          Get-Content (Join-Path $outDir "display-drivers.txt")
+          Get-Content (Join-Path $outDir "power.txt")
+          Get-Content (Join-Path $outDir "reboots.txt")
+          Get-Content (Join-Path $outDir "processes-before-cleanup.txt")
+
+          # Environment collection should never make validation fail.
+          exit 0
+
+      - name: Upload Vulkan runner configuration
+        if: always() && matrix.backend == 'vulkan'
+        uses: actions/upload-artifact@v7
+        with:
+          name: vulkan-runner-config
+          path: ${{ runner.temp }}/vulkan-runner-config/
+          retention-days: 30
+          if-no-files-found: warn
+
       - name: Cleanup prior validation processes
         if: runner.os == 'Windows'
         shell: PowerShell

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -454,7 +454,7 @@ jobs:
           foreach ($process in $staleProcesses) {
             Write-Host "Stopping stale $($process.Name) PID $($process.ProcessId)." `
               -ForegroundColor Yellow
-            & taskkill.exe /PID $process.ProcessId /T /F 2>$null | Out-Null
+            Stop-Process -Id $process.ProcessId -Force -ErrorAction SilentlyContinue
           }
           if ($staleProcesses.Count -gt 0) {
             Start-Sleep -Seconds 1
@@ -601,14 +601,14 @@ jobs:
               }
   
               if (-not $proc.HasExited) {
-                & taskkill.exe /PID $proc.Id /T /F 2>$null | Out-Null
+                Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
                 $null = $proc.WaitForExit(5000)
               }
   
               # Catch a llama-server orphan even if its lemond parent exited first.
               $orphans = @(Get-ValidationLlamaServers)
               foreach ($orphan in $orphans) {
-                & taskkill.exe /PID $orphan.ProcessId /T /F 2>$null | Out-Null
+                Stop-Process -Id $orphan.ProcessId -Force -ErrorAction SilentlyContinue
               }
               if ($orphans.Count -gt 0) { Start-Sleep -Seconds 1 }
   

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -422,19 +422,49 @@ jobs:
           # - backend: cuda
           #   runner: [self-hosted, Windows, 128gb, cuda]
     steps:
-      - name: Prepare Windows runner for long paths and stale workspace caches
+      - name: Cleanup prior validation processes
         if: runner.os == 'Windows'
         shell: PowerShell
         run: |
-          $ErrorActionPreference = "Continue"
-
-          # 1. Kill any running/orphaned processes to release file locks
-          $patterns = @("lemonade", "lemond", "llama-server", "llama", "flm", "ort-server", "moonshine-server", "wscript", "LemonadeServer")
-          foreach ($p in $patterns) {
-              Get-Process | Where-Object { $_.ProcessName -like "*$p*" } | Stop-Process -Force -ErrorAction SilentlyContinue
+          $ErrorActionPreference = "Stop"
+          $workspaceRoot = [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
+          $lemondPath = [IO.Path]::GetFullPath(
+            (Join-Path $workspaceRoot "build\Release\lemond.exe")
+          )
+          $cachePrefix = [IO.Path]::GetFullPath(
+            (Join-Path $workspaceRoot "ci-cache-")
+          )
+          $staleProcesses = @(
+            Get-CimInstance Win32_Process `
+              -Filter "Name = 'lemond.exe' OR Name = 'llama-server.exe'" `
+              -ErrorAction SilentlyContinue | Where-Object {
+                $_.ExecutablePath -and (
+                  ($_.Name -eq "lemond.exe" -and $_.ExecutablePath.Equals(
+                    $lemondPath,
+                    [StringComparison]::OrdinalIgnoreCase
+                  )) -or
+                  ($_.Name -eq "llama-server.exe" -and $_.ExecutablePath.StartsWith(
+                    $cachePrefix,
+                    [StringComparison]::OrdinalIgnoreCase
+                  ))
+                )
+              }
+          )
+  
+          foreach ($process in $staleProcesses) {
+            Write-Host "Stopping stale $($process.Name) PID $($process.ProcessId)." `
+              -ForegroundColor Yellow
+            & taskkill.exe /PID $process.ProcessId /T /F 2>$null | Out-Null
           }
-
-
+          if ($staleProcesses.Count -gt 0) {
+            Start-Sleep -Seconds 1
+            foreach ($process in $staleProcesses) {
+              if (Get-Process -Id $process.ProcessId -ErrorAction SilentlyContinue) {
+                throw "Failed to stop workspace process PID $($process.ProcessId)."
+              }
+            }
+          }
+  
       - uses: actions/checkout@v5
         with:
           clean: true
@@ -458,6 +488,7 @@ jobs:
               exit 1
           }
           & $lemondExe --version
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           Write-Host "Binaries verified!" -ForegroundColor Green
 
       - name: Setup Python and virtual environment
@@ -471,34 +502,78 @@ jobs:
         shell: PowerShell
         run: |
           $ErrorActionPreference = "Stop"
+          $port = 13305
           $lemondExe = (Resolve-Path "build\Release\lemond.exe").Path
           $backend = "${{ matrix.backend }}"
           $channel = "${{ matrix.channel }}"
           $label = if ($channel) { "$backend-$channel" } else { $backend }
           $logsDir = "server-logs-$label"
           $cacheDir = Join-Path $PWD "ci-cache-$label"
+          $cachePrefix = [IO.Path]::GetFullPath($cacheDir)
+          $separator = [string][IO.Path]::DirectorySeparatorChar
+          if (-not $cachePrefix.EndsWith($separator)) { $cachePrefix += $separator }
           $venvPython = ".\.venv\Scripts\python.exe"
-
+          $tempRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { $PWD }
+          $pidFile = Join-Path $tempRoot "lemond-validate-llamacpp.pid"
+  
+          function Get-ValidationLlamaServers {
+            Get-CimInstance Win32_Process `
+              -Filter "Name = 'llama-server.exe'" `
+              -ErrorAction SilentlyContinue | Where-Object {
+                $_.ExecutablePath -and $_.ExecutablePath.StartsWith(
+                  $cachePrefix,
+                  [StringComparison]::OrdinalIgnoreCase
+                )
+              }
+          }
+  
           New-Item -ItemType Directory -Force -Path $logsDir | Out-Null
           New-Item -ItemType Directory -Force -Path $cacheDir | Out-Null
 
           $stdoutLog = Join-Path $PWD "$logsDir\lemond.stdout.log"
           $stderrLog = Join-Path $PWD "$logsDir\lemond.stderr.log"
-
-          # Start lemond (Python script handles readiness polling)
-          $proc = Start-Process `
-            -FilePath $lemondExe `
-            -ArgumentList @($cacheDir, "--port", "13305", "--host", "127.0.0.1") `
-            -RedirectStandardOutput $stdoutLog `
-            -RedirectStandardError $stderrLog `
-            -PassThru
-
-          Write-Host "Started lemond PID $($proc.Id)" -ForegroundColor Cyan
-
+  
+          # Do not benchmark while another known inference process is active.
+          $conflicts = @(
+            Get-Process -Name @(
+              "lemond", "llama-server", "lemonade", "LemonadeServer",
+              "flm", "ort-server", "moonshine-server"
+            ) -ErrorAction SilentlyContinue
+          )
+          if ($conflicts.Count -gt 0) {
+            $details = ($conflicts | ForEach-Object {
+              "$($_.ProcessName):$($_.Id)"
+            }) -join ", "
+            throw "Runner is not idle: $details"
+          }
+          if (Get-NetTCPConnection -State Listen -LocalPort $port -ErrorAction SilentlyContinue) {
+            throw "Port $port is already in use."
+          }
+  
+          $proc = $null
+          $validationExitCode = 0
+          $cleanupFailed = $false
+  
           try {
+            $proc = Start-Process `
+              -FilePath $lemondExe `
+              -ArgumentList @($cacheDir, "--port", $port, "--host", "127.0.0.1") `
+              -RedirectStandardOutput $stdoutLog `
+              -RedirectStandardError $stderrLog `
+              -PassThru
+  
+            # Same-job fallback for the existing final cleanup action.
+            Set-Content -Path $pidFile -Value $proc.Id -Encoding ASCII
+            Write-Host "Started lemond PID $($proc.Id)" -ForegroundColor Cyan
+  
+            if ($proc.WaitForExit(500)) {
+              throw "lemond exited before validation started. See $stderrLog."
+            }
+  
             $validationArgs = @(
               "test/validate_llamacpp.py",
               "--backend", $backend,
+              "--port", $port,
               "--output", "llamacpp_validation_$label.json",
               "--logs-dir", $logsDir
             )
@@ -511,17 +586,48 @@ jobs:
             }
 
             & $venvPython @validationArgs
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            $validationExitCode = $LASTEXITCODE
           } finally {
-            try {
-              Invoke-WebRequest -Uri "http://127.0.0.1:13305/internal/shutdown" `
-                -Method POST -TimeoutSec 10 | Out-Null
-              Start-Sleep -Seconds 2
-            } catch {
-              Write-Host "lemond shutdown not reachable; relying on cleanup step." -ForegroundColor Yellow
+            if ($null -ne $proc) {
+              try {
+                if (-not $proc.HasExited) {
+                  Invoke-WebRequest -Uri "http://127.0.0.1:$port/internal/shutdown" `
+                    -Method POST -TimeoutSec 10 -UseBasicParsing | Out-Null
+                  $null = $proc.WaitForExit(10000)
+                }
+              } catch {
+                Write-Host "Graceful shutdown failed; forcing targeted cleanup." `
+                  -ForegroundColor Yellow
+              }
+  
+              if (-not $proc.HasExited) {
+                & taskkill.exe /PID $proc.Id /T /F 2>$null | Out-Null
+                $null = $proc.WaitForExit(5000)
+              }
+  
+              # Catch a llama-server orphan even if its lemond parent exited first.
+              $orphans = @(Get-ValidationLlamaServers)
+              foreach ($orphan in $orphans) {
+                & taskkill.exe /PID $orphan.ProcessId /T /F 2>$null | Out-Null
+              }
+              if ($orphans.Count -gt 0) { Start-Sleep -Seconds 1 }
+  
+              $remainingOrphans = @(Get-ValidationLlamaServers)
+              if ($proc.HasExited -and $remainingOrphans.Count -eq 0) {
+                Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+              } else {
+                $cleanupFailed = $true
+                Write-Host "Validation process cleanup did not complete." `
+                  -ForegroundColor Yellow
+              }
             }
           }
-
+  
+          if ($validationExitCode -ne 0) { exit $validationExitCode }
+          if ($cleanupFailed) {
+            throw "Validation completed, but its processes could not be stopped."
+          }
+  
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
##  Summary

Make the llama.cpp validation job safer and more reproducible on persistent Windows self-hosted runners.

This change replaces broad process-name termination with cleanup scoped to processes owned by the current repository workspace or validation cache.

## Why

The validation runners are persistent machines. A failed or cancelled run can leave lemond or llama-server processes behind, which may hold file locks, consume memory, or affect later performance measurements.

The previous cleanup also matched processes by broad name patterns. On a shared runner, that could terminate processes belonging to another job or a manually running Lemonade instance.

The goal of this change is to start each validation from a known process state without changing the benchmark itself.

## Changes

* remove the broad process-name kill from the self-hosted validation job
* clean up stale lemond processes only when their executable belongs to the current workspace
* clean up stale llama-server processes only when they belong to a validation cache in the current workspace
* fail early when unrelated inference processes are already running
* fail early when the validation port is already occupied
* record the lemond PID for the existing cleanup action
* prefer the server's graceful shutdown endpoint
* use targeted process-tree termination only as a fallback
* check separately for orphaned llama-server processes after shutdown
* preserve the validation exit code across cleanup commands
* verify the native exit code from lemond --version

* capture a read-only Vulkan runner configuration snapshot before cleanup/setup
* upload GPU, driver, Windows, BIOS, power, uptime, process state, and full
  `vulkaninfo` output as a per-run artifact

## Measurement scope

This PR intentionally does not change:

* test/validate_llamacpp.py
* model order
* prompts or token limits
* the number of inference requests
* backend installation behavior
* model or driver caches
* power plans or process priorities
* the validation result format
* runner metadata collection is read-only and does not modify driver caches,
  power settings, drivers, BIOS, or firmware

The workflow lifecycle is isolated from the benchmark logic so existing TTFT results remain comparable.

This change reduces interference from stale or unrelated processes. It does not attempt to make cold TTFT fully deterministic, since later models can still inherit memory, driver, and cache state from earlier models in the same validation run.