### PR TITLE
Polish backends tab (GUI3)

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -32,7 +32,7 @@
     "test:storage": "node tests/storage.runtime.cjs",
     "test:configuration-consistency": "node tests/configuration-consistency.runtime.cjs",
     "test:model-list-backends": "node tests/model-list-backend-layout.runtime.cjs",
-    "test:ui-regressions": "node tests/ui-regression-contracts.runtime.cjs",
+    "test:ui-regressions": "node tests/ui-regression-contracts.runtime.cjs && node tests/backend-manager-lifecycle.runtime.cjs",
     "test:model-nav-filters": "node tests/model-nav-filter-layout.runtime.cjs",
     "test:model-state": "node tests/model-state-deduplication.runtime.cjs",
     "test:download-polling": "node tests/download-polling-lifecycle.runtime.cjs"

--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -1942,7 +1942,20 @@ class LemonadeAPI {
               : downloadPayloadErrorMessage(d);
             if (eventError) throw new Error(String(eventError));
             callbacks?.onProgress?.(d);
-            if (currentEventType === 'complete' || downloadPayloadCompleted(d)) sawTerminal = true;
+            const progressData = currentEventType === 'complete'
+              ? {
+                  ...d,
+                  status: 'completed',
+                  complete: true,
+                  running: false,
+                }
+              : d;
+
+            callbacks?.onProgress?.(progressData);
+
+            if (currentEventType === 'complete' || downloadPayloadCompleted(progressData)) {
+              sawTerminal = true;
+            }
           }
         }
 

--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -227,6 +227,96 @@ function backendProgressPercent(download: DownloadListItem): number {
   return Math.max(0, Math.min(100, Number.isFinite(download.percent) ? download.percent : 0));
 }
 
+type PendingBackendAction = {
+  isUpdate: boolean;
+  initialVersion: string;
+};
+
+type BackendSyncResult = {
+  state?: BackendInfo['state'];
+  version: string;
+  settled: boolean;
+  hadResponse: boolean;
+};
+
+const BACKEND_STATUS_RETRY_DELAYS_MS = [0, 250, 500, 1000, 2000, 4000, 8000] as const;
+
+class BackendDownloadMissingError extends Error {
+  constructor() {
+    super('Backend download disappeared before reaching a terminal state');
+    this.name = 'BackendDownloadMissingError';
+  }
+}
+
+function backendActionIsReflected(
+  info: BackendInfo | undefined,
+  action: PendingBackendAction | undefined,
+): boolean {
+  if (!info) return false;
+  if (info.state === 'installed') return true;
+  if (info.state !== 'update_available' || !action) return false;
+
+  if (!action.isUpdate) return true;
+  const currentVersion = cleanString(info.version);
+  return Boolean(currentVersion && currentVersion !== cleanString(action.initialVersion));
+}
+
+function waitForBackendDownloadTerminal(
+  recipe: string,
+  backend: string,
+  signal: AbortSignal,
+): Promise<DownloadListItem> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let sawDownload = false;
+    let unsubscribe: (() => void) | null = null;
+    let unsubscribeWhenReady = false;
+
+    const cleanup = () => {
+      signal.removeEventListener('abort', onAbort);
+      if (unsubscribe) unsubscribe();
+      else unsubscribeWhenReady = true;
+    };
+
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+
+    const onAbort = () => finish(() => {
+      const reason = signal.reason;
+      reject(reason instanceof Error ? reason : new Error('Backend download wait cancelled'));
+    });
+
+    const inspect = (items: DownloadListItem[]) => {
+      const item = items.find(download => backendDownloadMatches(download, recipe, backend));
+      if (!item) {
+        if (sawDownload) {
+          finish(() => reject(new BackendDownloadMissingError()));
+        }
+        return;
+      }
+      sawDownload = true;
+      if (isDownloadActive(item) || item.running === true) return;
+      if (item.status !== 'completed'
+        && item.status !== 'error'
+        && item.status !== 'cancelled'
+        && item.status !== 'paused') return;
+      finish(() => resolve(item));
+    };
+
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+    unsubscribe = downloadStore.subscribe(inspect);
+    if (unsubscribeWhenReady) unsubscribe();
+  });
+}
+
 function buildBackendCatalog(cells: Map<string, CellEntry[]>): BackendCatalogSection[] {
   const byCapability = new Map<CapabilityCol, Map<string, BackendCatalogEntry>>();
 
@@ -379,6 +469,36 @@ function releaseLink(info: BackendInfo): string {
   return url;
 }
 
+function releaseVersion(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    const marker = '/releases/tag/';
+    const markerIndex = pathname.indexOf(marker);
+    if (markerIndex < 0) return '';
+    return decodeURIComponent(
+      pathname.slice(markerIndex + marker.length).replace(/\/$/, ''),
+    );
+  } catch {
+    return '';
+  }
+}
+
+function releaseLinkForVersion(url: string, version: string): string {
+  if (!url || !version) return '';
+  try {
+    const releaseUrl = new URL(url);
+    const marker = '/releases/tag/';
+    const markerIndex = releaseUrl.pathname.indexOf(marker);
+    if (markerIndex < 0) return '';
+    releaseUrl.pathname = `${releaseUrl.pathname.slice(0, markerIndex + marker.length)}${encodeURIComponent(version)}`;
+    releaseUrl.search = '';
+    releaseUrl.hash = '';
+    return releaseUrl.toString();
+  } catch {
+    return '';
+  }
+}
+
 interface BackendArgsDialogProps {
   backendKeyValue: string | null;
   tuning: BackendTuning | null;
@@ -508,6 +628,10 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
   const [argsEditorKey, setArgsEditorKey] = useState<string | null>(null);
   const [downloadItems, setDownloadItems] = useState<DownloadListItem[]>(() => downloadStore.snapshot());
   const terminalBackendRefreshRef = useRef<Set<string>>(new Set());
+  const systemInfoRequestRef = useRef(0);
+  const pendingBackendActionsRef = useRef<Map<string, PendingBackendAction>>(new Map());
+  const backendSyncPromisesRef = useRef<Map<string, Promise<BackendSyncResult>>>(new Map());
+  const toastTimerRef = useRef<number | null>(null);
   const sysInfoRef = useRef<SystemInfoData | null>(null);
   const argsTriggerRef = useRef<HTMLButtonElement | null>(null);
 
@@ -527,27 +651,86 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
 
   /* ── Fetch system-info ────────────────────────────────── */
 
+  const loadSystemInfo = useCallback(async (): Promise<SystemInfoData> => {
+    const requestId = ++systemInfoRequestRef.current;
+    let data: SystemInfoData;
+    try {
+      data = await api.systemInfo() as unknown as SystemInfoData;
+    } catch (err) {
+      // A superseded request must not replace a newer successful snapshot with
+      // an error banner merely because its slower network call failed later.
+      if (requestId !== systemInfoRequestRef.current && sysInfoRef.current) {
+        return sysInfoRef.current;
+      }
+      throw err;
+    }
+    if (requestId === systemInfoRequestRef.current) {
+      sysInfoRef.current = data;
+      setSysInfo(data);
+    }
+    return data;
+  }, []);
+
   const fetchInfo = useCallback(async (showSpinner = true) => {
     try {
       if (showSpinner) setLoading(true);
       setError(null);
       if (!api.healthData) await api.health().catch(() => null);
-      const data = await api.systemInfo() as unknown as SystemInfoData;
-      setSysInfo(data);
+      await loadSystemInfo();
     } catch (err) {
       setError(friendlyErrorMessage(err));
     } finally {
       if (showSpinner) setLoading(false);
     }
-  }, []);
+  }, [loadSystemInfo]);
+
+  const syncBackendStatus = useCallback((recipe: string, backend: string): Promise<BackendSyncResult> => {
+    const key = backendKey(recipe, backend);
+    const existing = backendSyncPromisesRef.current.get(key);
+    if (existing) return existing;
+
+    const task = (async (): Promise<BackendSyncResult> => {
+      const action = pendingBackendActionsRef.current.get(key);
+      let state: BackendInfo['state'] | undefined;
+      let version = '';
+      let hadResponse = false;
+
+      for (const delay of BACKEND_STATUS_RETRY_DELAYS_MS) {
+        if (delay > 0) {
+          await new Promise(resolve => window.setTimeout(resolve, delay));
+        }
+
+        try {
+          const freshInfo = await loadSystemInfo();
+          hadResponse = true;
+          const backendInfo = freshInfo.recipes?.[recipe]?.backends?.[backend];
+          state = backendInfo?.state;
+          version = cleanString(backendInfo?.version);
+          if (backendActionIsReflected(backendInfo, action)) {
+            return { state, version, settled: true, hadResponse };
+          }
+        } catch {
+          // The download is already terminal. Keep retrying transient system-info
+          // failures so the user does not need to clear the completed row manually.
+        }
+      }
+
+      return { state, version, settled: false, hadResponse };
+    })().finally(() => {
+      backendSyncPromisesRef.current.delete(key);
+    });
+
+    backendSyncPromisesRef.current.set(key, task);
+    return task;
+  }, [loadSystemInfo]);
 
   useEffect(() => {
-    if (!isActive) return;
+    if (!isActive || pendingBackendActionsRef.current.size > 0) return;
     void fetchInfo(!sysInfoRef.current);
   }, [fetchInfo, isActive]);
 
   useEffect(() => api.onModelsChanged(() => {
-    if (isActive) void fetchInfo(false);
+    if (isActive && pendingBackendActionsRef.current.size === 0) void fetchInfo(false);
   }), [fetchInfo, isActive]);
 
   useEffect(() => downloadStore.subscribe((items) => {
@@ -556,67 +739,87 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
       if (item.downloadType !== 'backend') continue;
       if (isDownloadActive(item)) continue;
       if (item.status !== 'completed' && item.status !== 'error' && item.status !== 'cancelled') continue;
+      if (!isActive) continue;
+
+      const name = item.modelName || item.id.replace(/^backend:/, '');
+      const separator = name.indexOf(':');
+      const key = separator > 0 ? backendKey(name.slice(0, separator), name.slice(separator + 1)) : '';
+      if (key && pendingBackendActionsRef.current.has(key)) continue;
+
       const refreshKey = `${item.id}:${item.status}:${item.terminalAt || item.updatedAt}`;
       if (terminalBackendRefreshRef.current.has(refreshKey)) continue;
       terminalBackendRefreshRef.current.add(refreshKey);
-      if (isActive) void fetchInfo(false);
+      void fetchInfo(false);
     }
   }), [fetchInfo, isActive]);
 
   /* ── Actions ──────────────────────────────────────────── */
 
   const toast = useCallback((msg: string) => {
+    if (toastTimerRef.current != null) window.clearTimeout(toastTimerRef.current);
     setToastMsg(msg);
-    window.setTimeout(() => setToastMsg(null), 3500);
+    toastTimerRef.current = window.setTimeout(() => {
+      toastTimerRef.current = null;
+      setToastMsg(null);
+    }, 3500);
+  }, []);
+
+  useEffect(() => () => {
+    if (toastTimerRef.current != null) window.clearTimeout(toastTimerRef.current);
   }, []);
 
   const handleInstall = useCallback(async (recipe: string, backend: string, isUpdate = false) => {
     const key = backendKey(recipe, backend);
+    const engineName = RECIPE_LABELS[recipe] || recipe;
     const actionLabel = isUpdate ? 'Updating' : 'Installing';
     const doneLabel = isUpdate ? 'updated' : 'installed';
-    setInstalling(key);
-    toast(`${actionLabel} ${RECIPE_LABELS[recipe] || recipe} · ${backend}…`);
+    const initialInfo = sysInfoRef.current?.recipes?.[recipe]?.backends?.[backend];
     const downloadName = backendDownloadName(recipe, backend);
+    const waitController = new AbortController();
+    let actionUrl = '';
+
+    pendingBackendActionsRef.current.set(key, {
+      isUpdate,
+      initialVersion: cleanString(initialInfo?.version),
+    });
+    setInstalling(key);
+    toast(`${actionLabel} ${engineName} · ${backend}…`);
     downloadStore.markLocal(downloadName, 'downloading', 'backend');
+    const terminalDownloadPromise = waitForBackendDownloadTerminal(recipe, backend, waitController.signal);
+    // Observe rejection immediately; the original promise is still awaited below,
+    // but this prevents an unhandled rejection if the API call itself fails first.
+    void terminalDownloadPromise.catch(() => undefined);
+
     try {
       await api.installBackend(recipe, backend, {
         onProgress: (d) => {
+          const rawStatus = typeof d.status === 'string' ? d.status : '';
+          const normalizedStatus = rawStatus.toLowerCase();
+          const completed = d.complete === true
+            || normalizedStatus === 'completed'
+            || normalizedStatus === 'complete'
+            || normalizedStatus === 'success'
+            || normalizedStatus === 'done';
           const percent = typeof d.percent === 'number' ? d.percent : undefined;
+          if (typeof d.action === 'string' && d.action.trim()) actionUrl = d.action.trim();
+
           downloadStore.upsertFromPull(downloadName, {
             ...d,
             id: backendDownloadId(recipe, backend),
             type: 'backend',
             name: downloadName,
-            status: 'downloading',
-            percent: percent ?? d.percent,
+            status: completed ? 'completed' : (rawStatus || 'downloading'),
+            complete: completed ? true : d.complete,
+            running: completed && typeof d.running !== 'boolean' ? false : d.running,
+            percent: completed ? 100 : (percent ?? d.percent),
           }, 'backend');
-          if (d.percent != null) {
-            setToastMsg(`${actionLabel} ${RECIPE_LABELS[recipe] || recipe} · ${backend}… ${d.percent}%`);
+
+          if (!completed && percent != null) {
+            toast(`${actionLabel} ${engineName} · ${backend}… ${percent}%`);
           }
         },
-        onComplete: async () => {
-          downloadStore.upsertFromPull(downloadName, {
-            id: backendDownloadId(recipe, backend),
-            type: 'backend',
-            name: downloadName,
-            status: 'completed',
-            complete: true,
-            percent: 100,
-          }, 'backend');
-          toast(`${RECIPE_LABELS[recipe] || recipe} · ${backend} ${doneLabel}`);
-          setInstalling(null);
-          try {
-            const fresh = await api.systemInfo() as unknown as SystemInfoData;
-            setSysInfo(fresh);
-            if (isUpdate && fresh?.recipes?.[recipe]?.backends?.[backend]) {
-              const newState = fresh.recipes[recipe].backends[backend].state;
-              if (newState === 'update_required' || newState === 'update_available') {
-                toast(`${RECIPE_LABELS[recipe] || recipe} · ${backend} still needs update — the existing binary may need to be removed manually`);
-              }
-            }
-          } catch {
-            void fetchInfo(false);
-          }
+        onComplete: () => {
+          void downloadStore.refresh();
         },
         onError: (err) => {
           downloadStore.upsertFromPull(downloadName, {
@@ -624,27 +827,73 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
             type: 'backend',
             name: downloadName,
             status: 'error',
+            running: false,
             error: friendlyErrorMessage(err),
           }, 'backend');
-          toast(`${actionLabel} failed: ${friendlyErrorMessage(err)}`);
-          setInstalling(null);
         },
       });
-      await fetchInfo(false);
+
+      if (actionUrl) {
+        waitController.abort();
+        await terminalDownloadPromise.catch(() => undefined);
+        downloadStore.remove(backendDownloadId(recipe, backend));
+        window.open(actionUrl, '_blank', 'noopener,noreferrer');
+        toast(`${engineName} · ${backend} requires manual setup`);
+        return;
+      }
+
+      const terminalDownload = await terminalDownloadPromise;
+      if (terminalDownload.status === 'paused') {
+        toast(`${engineName} · ${backend} installation paused`);
+        return;
+      }
+      if (terminalDownload.status === 'cancelled') {
+        toast(`${engineName} · ${backend} installation cancelled`);
+        return;
+      }
+      if (terminalDownload.status === 'error') {
+        throw new Error(terminalDownload.error || 'Unknown backend install error');
+      }
+
+      const synced = await syncBackendStatus(recipe, backend);
+      if (synced.settled) {
+        toast(`${engineName} · ${backend} ${doneLabel}`);
+      } else if (synced.hadResponse) {
+        toast(`${engineName} · ${backend} download completed, but Lemonade still reports the previous backend status`);
+      } else {
+        toast(`${engineName} · ${backend} download completed, but the backend status could not be refreshed`);
+      }
     } catch (err) {
+      if (err instanceof BackendDownloadMissingError) {
+        const synced = await syncBackendStatus(recipe, backend);
+        if (synced.settled) {
+          toast(`${engineName} · ${backend} ${doneLabel}`);
+          return;
+        }
+      }
+
       const message = friendlyErrorMessage(err);
-      downloadStore.upsertFromPull(downloadName, {
-        id: backendDownloadId(recipe, backend),
-        type: 'backend',
-        name: downloadName,
-        status: 'error',
-        error: message,
-      }, 'backend');
+      const current = downloadStore.snapshot()
+        .find(download => backendDownloadMatches(download, recipe, backend));
+      if (current?.status !== 'error' && current?.status !== 'cancelled' && current?.status !== 'paused') {
+        downloadStore.upsertFromPull(downloadName, {
+          id: backendDownloadId(recipe, backend),
+          type: 'backend',
+          name: downloadName,
+          status: 'error',
+          running: false,
+          error: message,
+        }, 'backend');
+      }
       toast(`${actionLabel} failed: ${message}`);
-      setInstalling(null);
       void fetchInfo(false);
+    } finally {
+      waitController.abort();
+      pendingBackendActionsRef.current.delete(key);
+      setInstalling(current => current === key ? null : current);
+      void downloadStore.refresh();
     }
-  }, [fetchInfo, toast]);
+  }, [fetchInfo, syncBackendStatus, toast]);
 
   const handleUninstall = useCallback(async (recipe: string, backend: string) => {
     try {
@@ -782,10 +1031,13 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
             const tuning = backendTunings[cellKey] || null;
             const name = `${engineName} · ${backend}`;
             const version = cleanString(info.version);
-            const releaseUrl =
-              info.state === 'update_required' || info.state === 'update_available'
-                ? ''
-                : releaseLink(info);
+            const isUpdate =
+              info.state === 'update_required' || info.state === 'update_available';
+            const targetReleaseUrl = releaseLink(info);
+            const targetVersion = isUpdate ? releaseVersion(targetReleaseUrl) : '';
+            const installedReleaseUrl = isUpdate
+              ? releaseLinkForVersion(targetReleaseUrl, version)
+              : targetReleaseUrl;
             const variantLabel = BACKEND_LABELS[backend] || backend;
 
             return (
@@ -807,13 +1059,13 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
                 </div>
 
                 <div className="backend-card__variant-meta">
-                  {version && (releaseUrl ? (
+                  {version && (installedReleaseUrl ? (
                     <a
                       className="backend-card__version"
-                      href={releaseUrl}
+                      href={installedReleaseUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      title={`Open ${engineName} ${version} release page`}
+                      title={`Open installed ${engineName} ${version} release page`}
                     >
                       {version}
                       <Icon name="external-link" size={11} aria-hidden="true" />
@@ -821,6 +1073,19 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
                   ) : (
                     <span className="backend-card__version">{version}</span>
                   ))}
+                  {isUpdate && targetReleaseUrl && targetVersion && targetVersion !== version && (
+                    <a
+                      className="backend-card__version"
+                      href={targetReleaseUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={`Open ${engineName} ${targetVersion} update release page`}
+                    >
+                      <Icon name="chevron-right" size={11} aria-hidden="true" />
+                      {targetVersion}
+                      <Icon name="external-link" size={11} aria-hidden="true" />
+                    </a>
+                  )}
                   {tuning && (
                     <span className={`cell__args-state cell__args-state--${tuning.source}`} data-cell-backend-args={tuning.source}>
                       <Icon name="terminal-square" size={12} aria-hidden="true" />

--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -782,7 +782,10 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
             const tuning = backendTunings[cellKey] || null;
             const name = `${engineName} · ${backend}`;
             const version = cleanString(info.version);
-            const releaseUrl = releaseLink(info);
+            const releaseUrl =
+              info.state === 'update_required' || info.state === 'update_available'
+                ? ''
+                : releaseLink(info);
             const variantLabel = BACKEND_LABELS[backend] || backend;
 
             return (

--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -72,6 +72,7 @@ interface SystemInfoData {
 /** User-facing labels for recipes */
 const RECIPE_LABELS: Record<string, string> = {
   llamacpp:       'llama.cpp',
+  onnxruntime:    'ONNX Runtime',
   whispercpp:     'whisper.cpp',
   moonshine:      'Moonshine',
   'sd-cpp':       'stable-diffusion.cpp',
@@ -83,6 +84,19 @@ const RECIPE_LABELS: Record<string, string> = {
   thinksound:      'ThinkSound',
   openmoss:        'OpenMOSS TTS',
   trellis:         'TRELLIS.2',
+};
+
+/** User-facing labels for backend variants */
+const BACKEND_LABELS: Record<string, string> = {
+  cpu:      'CPU',
+  system:   'System',
+  vulkan:   'Vulkan',
+  rocm:     'ROCm',
+  cuda:     'CUDA',
+  metal:    'Metal',
+  npu:      'NPU',
+  directml: 'DirectML',
+  dml:      'DirectML',
 };
 
 /** Recipe → capability column for the matrix */
@@ -131,17 +145,6 @@ function isExperimentalBackend(recipe: string, recipeInfo: RecipeInfo, backendIn
 /** Device display order */
 const DEVICE_ORDER = ['cpu', 'nvidia_gpu', 'amd_gpu', 'metal', 'amd_npu', 'gpu', 'accelerator', 'unknown'] as const;
 type DeviceKey = typeof DEVICE_ORDER[number];
-
-const DEVICE_LABELS: Record<DeviceKey, string> = {
-  cpu:         'CPU',
-  amd_gpu:     'GPU (AMD)',
-  nvidia_gpu:  'GPU (NVIDIA / CUDA)',
-  metal:       'GPU (Metal)',
-  amd_npu:     'NPU',
-  gpu:         'GPU',
-  accelerator: 'Accelerator',
-  unknown:     'Other device',
-};
 
 /** Backend → fallback row when the server does not expose BackendInfo.devices */
 const BACKEND_DEVICE: Record<string, DeviceKey> = {
@@ -261,11 +264,14 @@ function buildBackendCatalog(cells: Map<string, CellEntry[]>): BackendCatalogSec
     unsupported: 5,
   };
 
+  const experimentalRank = (entry: BackendCatalogEntry): number =>
+    entry.variants.every(variant => variant.info.experimental) ? 1 : 0;
+
   return CAPABILITY_COLS.map(capability => ({
     capability,
     entries: [...(byCapability.get(capability)?.values() || [])].sort((a, b) => (
-      Math.min(...a.variants.map(variant => stateRank[variant.info.state]))
-        - Math.min(...b.variants.map(variant => stateRank[variant.info.state]))
+      experimentalRank(a) - experimentalRank(b)
+      || b.variants.length - a.variants.length
       || (RECIPE_LABELS[a.recipe] || a.recipe).localeCompare(RECIPE_LABELS[b.recipe] || b.recipe)
     )).map(entry => ({
       ...entry,
@@ -363,6 +369,14 @@ function canShowUninstall(info: BackendInfo): boolean {
   return info.state === 'installed'
     || info.state === 'update_required'
     || info.state === 'update_available';
+}
+
+function releaseLink(info: BackendInfo): string {
+  const url = (info.release_url || '').trim();
+  if (!/^https?:\/\//.test(url)) return '';
+  const path = url.replace(/^https?:\/\//, '');
+  if (path.includes('//') || url.endsWith('/tag/')) return '';
+  return url;
 }
 
 interface BackendArgsDialogProps {
@@ -698,8 +712,8 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
           experimental: isExperimentalBackend(recipe, recipeInfo, backendInfo),
         };
         // Match GUI2: unsupported backends are not useful actions/statuses for
-        // the current system and should not take matrix space (#2568).
-        if (effectiveInfo.state === 'unsupported') continue;
+        // the current system and are hidden unless explicitly requested (#2568).
+        if (!showUnsupported && effectiveInfo.state === 'unsupported') continue;
         for (const device of devicesForBackend(recipe, backend, effectiveInfo)) {
           const key = `${device}:${cap}`;
           if (!cells.has(key)) cells.set(key, []);
@@ -708,42 +722,9 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
       }
     }
     return cells;
-  }, [sysInfo]);
-
-  const unsupportedMatrixCells = useMemo(() => {
-    if (!sysInfo?.recipes) return new Map<string, CellEntry[]>();
-    const cells = new Map<string, CellEntry[]>();
-
-    for (const [recipe, recipeInfo] of Object.entries(sysInfo.recipes)) {
-      const cap = (RECIPE_CAPABILITY[recipe] || 'LLM') as CapabilityCol;
-      for (const [backend, backendInfo] of Object.entries(recipeInfo.backends)) {
-        const effectiveInfo: BackendInfo = {
-          ...backendInfo,
-          experimental: isExperimentalBackend(recipe, recipeInfo, backendInfo),
-        };
-        // Keep unsupported backends out of the primary matrix (#2568), but retain
-        // a collapsed same-shape matrix for debugging and technical-detail reasons.
-        if (effectiveInfo.state !== 'unsupported') continue;
-        for (const device of devicesForBackend(recipe, backend, effectiveInfo)) {
-          const key = `${device}:${cap}`;
-          if (!cells.has(key)) cells.set(key, []);
-          cells.get(key)!.push({ recipe, backend, info: effectiveInfo });
-        }
-      }
-    }
-    return cells;
-  }, [sysInfo]);
+  }, [showUnsupported, sysInfo]);
 
   const backendCatalog = useMemo(() => buildBackendCatalog(matrixCells), [matrixCells]);
-  const unsupportedBackendCatalog = useMemo(() => buildBackendCatalog(unsupportedMatrixCells), [unsupportedMatrixCells]);
-
-  const unsupportedBackendCount = useMemo(() => {
-    const keys = new Set<string>();
-    for (const entries of unsupportedMatrixCells.values()) {
-      for (const { recipe, backend } of entries) keys.add(backendKey(recipe, backend));
-    }
-    return keys.size;
-  }, [unsupportedMatrixCells]);
 
   const updatesAvailable = useMemo(() => {
     if (!sysInfo?.recipes) return 0;
@@ -761,7 +742,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     if (!sysInfo?.recipes) return counts;
     for (const [recipe, recipeInfo] of Object.entries(sysInfo.recipes)) {
       for (const backendInfo of Object.values(recipeInfo.backends)) {
-        if (backendInfo.state === 'unsupported') continue;
+        if (backendInfo.state === 'unsupported' && !showUnsupported) continue;
         counts.all++;
         if (backendInfo.state === 'installed') counts.installed++;
         if (backendInfo.state === 'installable') counts.available++;
@@ -770,7 +751,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
       }
     }
     return counts;
-  }, [sysInfo]);
+  }, [showUnsupported, sysInfo]);
 
   const backendMatchesView = useCallback((entry: CellEntry) => {
     if (viewFilter === 'all') return true;
@@ -781,30 +762,18 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     return recipeInfo ? isExperimentalBackend(entry.recipe, recipeInfo, entry.info) : Boolean(entry.info.experimental);
   }, [sysInfo, viewFilter]);
 
-  const renderBackendCard = useCallback(({ recipe, variants, devices }: BackendCatalogEntry) => {
+  const renderBackendCard = useCallback(({ recipe, variants }: BackendCatalogEntry) => {
     const engineName = RECIPE_LABELS[recipe] || recipe;
     const supportsArgs = backendSupportsArgs(recipe);
-    const hasExperimentalVariant = variants.some(variant => variant.info.experimental);
 
     return (
       <article className="backend-card" key={recipe} data-recipe={recipe}>
         <div className="backend-card__head">
-          <div>
-            <h3 className={hasExperimentalVariant ? 'backend-card__name is-experimental' : 'backend-card__name'}>
-              {engineName}
-              {hasExperimentalVariant && <Icon name="flask-conical" size={14} aria-label="Experimental variant available" />}
-            </h3>
-            <div className="backend-card__devices">
-              {devices.map(device => <span key={device}>{DEVICE_LABELS[device]}</span>)}
-            </div>
-          </div>
-          <span className="backend-card__variant-count">
-            {variants.length} variant{variants.length === 1 ? '' : 's'}
-          </span>
+          <h3 className="backend-card__name">{engineName}</h3>
         </div>
 
         <div className="backend-card__variants">
-          {variants.map(({ backend, info, devices: variantDevices }) => {
+          {variants.map(({ backend, info }) => {
             const badge = stateBadge(info.state);
             const cellKey = backendKey(recipe, backend);
             const isInstalling = installing === cellKey;
@@ -812,40 +781,57 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
             const showBackendProgress = Boolean(backendDownload && (isDownloadActive(backendDownload) || backendDownload.status === 'paused'));
             const tuning = backendTunings[cellKey] || null;
             const name = `${engineName} · ${backend}`;
+            const version = cleanString(info.version);
+            const releaseUrl = releaseLink(info);
+            const variantLabel = BACKEND_LABELS[backend] || backend;
 
             return (
-              <div className="backend-card__variant" key={cellKey} data-cell={cellKey}>
+              <div
+                className={`backend-card__variant${info.state === 'unsupported' ? ' backend-card__variant--unsupported' : ''}`}
+                key={cellKey}
+                data-cell={cellKey}
+              >
                 <div className="backend-card__variant-head">
-                  <div>
-                    <h4 className={info.experimental ? 'backend-card__variant-name is-experimental' : 'backend-card__variant-name'}>
-                      {backend}
-                      {info.experimental && (
-                        <span className="cell__experimental-icon" role="img" aria-label="experimental" title="experimental">
-                          <Icon name="flask-conical" size={13} aria-hidden="true" />
-                        </span>
-                      )}
-                    </h4>
-                    <div className="backend-card__devices">
-                      {variantDevices.map(device => <span key={device}>{DEVICE_LABELS[device]}</span>)}
-                    </div>
-                  </div>
-                  <span className={`cell__badge ${badge.cls}`}>{badge.label}</span>
+                  <h4 className="backend-card__variant-name">
+                    {variantLabel}
+                    {info.experimental && (
+                      <span className="cell__experimental-icon" role="img" aria-label="experimental" title="experimental">
+                        <Icon name="flask-conical" size={13} aria-hidden="true" />
+                      </span>
+                    )}
+                  </h4>
+                  {info.state !== 'installable' && <span className={`cell__badge ${badge.cls}`}>{badge.label}</span>}
                 </div>
 
-                {showTech && info.version && <span className="backend-card__version">{info.version}</span>}
-                {tuning && (
-                  <span className={`cell__args-state cell__args-state--${tuning.source}`} data-cell-backend-args={tuning.source}>
-                    <Icon name="terminal-square" size={12} aria-hidden="true" />
-                    Args · {tuning.source === 'optimized' ? 'Optimized' : 'Manual'}
-                  </span>
-                )}
+                <div className="backend-card__variant-meta">
+                  {version && (releaseUrl ? (
+                    <a
+                      className="backend-card__version"
+                      href={releaseUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={`Open ${engineName} ${version} release page`}
+                    >
+                      {version}
+                      <Icon name="external-link" size={11} aria-hidden="true" />
+                    </a>
+                  ) : (
+                    <span className="backend-card__version">{version}</span>
+                  ))}
+                  {tuning && (
+                    <span className={`cell__args-state cell__args-state--${tuning.source}`} data-cell-backend-args={tuning.source}>
+                      <Icon name="terminal-square" size={12} aria-hidden="true" />
+                      Args · {tuning.source === 'optimized' ? 'Optimized' : 'Manual'}
+                    </span>
+                  )}
+                </div>
 
                 <div className="backend-card__footer">
                   <div className="backend-card__actions">
                     {info.state === 'installable' && (
                       <WorkspaceActionButton
                         size="small"
-                        appearance="primary"
+                        appearance="secondary"
                         icon="download"
                         className="cell__swap"
                         aria-label={`Install ${name}`}
@@ -893,24 +879,24 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
                         {isInstalling ? 'Working…' : 'Uninstall'}
                       </WorkspaceActionButton>
                     )}
+                    {supportsArgs && info.state !== 'unsupported' && (
+                      <WorkspaceActionButton
+                        type="button"
+                        size="toolbar"
+                        appearance="quiet"
+                        icon="terminal-square"
+                        iconOnly
+                        className={`cell__args-button${tuning ? ' is-active' : ''}`}
+                        data-backend-args-button={cellKey}
+                        onClick={event => {
+                          argsTriggerRef.current = event.currentTarget;
+                          setArgsEditorKey(cellKey);
+                        }}
+                        title={tuning ? 'Edit backend arguments' : 'Add backend arguments'}
+                        aria-label={`${tuning ? 'Edit' : 'Add'} backend arguments for ${engineName} (${backend})`}
+                      />
+                    )}
                   </div>
-                  {supportsArgs && (
-                    <WorkspaceActionButton
-                      type="button"
-                      size="toolbar"
-                      appearance="quiet"
-                      icon="terminal-square"
-                      iconOnly
-                      className={`cell__args-button${tuning ? ' is-active' : ''}`}
-                      data-backend-args-button={cellKey}
-                      onClick={event => {
-                        argsTriggerRef.current = event.currentTarget;
-                        setArgsEditorKey(cellKey);
-                      }}
-                      title={tuning ? 'Edit backend arguments' : 'Add backend arguments'}
-                      aria-label={`${tuning ? 'Edit' : 'Add'} backend arguments for ${engineName} (${backend})`}
-                    />
-                  )}
                 </div>
 
                 {showBackendProgress && backendDownload && (
@@ -921,12 +907,11 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
                     <span className="cell__download-progress-text">{backendProgressPercent(backendDownload).toFixed(0)}%</span>
                   </div>
                 )}
-                {(showTech && info.message || backendDownload?.status === 'error' && backendDownload.error) && (
-                  <details className="backend-card__details">
-                    <summary>View technical details</summary>
-                    <span>{backendDownload?.status === 'error' && backendDownload.error ? backendDownload.error : info.message}</span>
-                  </details>
-                )}
+                {backendDownload?.status === 'error' && backendDownload.error ? (
+                  <p className="backend-card__note backend-card__note--error">{backendDownload.error}</p>
+                ) : ((showTech || info.state === 'update_available' || info.state === 'update_required') && info.message && (
+                  <p className="backend-card__note">{info.message}</p>
+                ))}
               </div>
             );
           })}
@@ -941,9 +926,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
   if (loading && !sysInfo) {
     return (
       <section className="backends" data-view="backends">
-        <div className="backends__head">
-          <div className="backends__title"><h1>Backends</h1></div>
-        </div>
+        <WorkspacePaneHeader className="backends__pane-header" headingLevel={1} title="Backends" />
         <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--space-8)' }}>
           <div className="hf-zone__spinner" />
         </div>
@@ -988,6 +971,15 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
             />
             <span>Show technical details</span>
           </label>
+          <label className="backends__toggle">
+            <input
+              type="checkbox"
+              checked={showUnsupported}
+              onChange={e => setShowUnsupported(e.target.checked)}
+              data-backends-unsupported-toggle
+            />
+            <span>Show unsupported backends</span>
+          </label>
           {sysInfo && (
             <div className="backends__runtime-meta">
               <strong>Lemonade {lemonadeVersion(sysInfo)}</strong>
@@ -1008,8 +1000,9 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
       <div className="backends__main workspace-pane">
       <WorkspacePaneHeader
         className="backends__pane-header"
-        title="Compatibility matrix"
-        subtitle="Runtime availability by device and model capability."
+        headingLevel={1}
+        title="Backends"
+        subtitle="Install and update the inference engines available on this machine."
         actions={updatesAvailable > 0 ? (
           <div className="backends__header-update" data-backends-banner>
             <span className="sr-only" data-backends-banner-text>{updatesAvailable} backend update{updatesAvailable > 1 ? 's' : ''} available</span>
@@ -1045,21 +1038,6 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
         )}
 
         <div className="backends__content">
-          <section className="backend-overview" aria-label="Backend setup summary">
-            <button type="button" className="backend-overview__item" onClick={() => setViewFilter('installed')}>
-              <strong>{backendStateCounts.installed}</strong>
-              <span>Ready to use</span>
-            </button>
-            <button type="button" className="backend-overview__item" onClick={() => setViewFilter('available')}>
-              <strong>{backendStateCounts.available}</strong>
-              <span>Ready to install</span>
-            </button>
-            <button type="button" className="backend-overview__item" onClick={() => setViewFilter('updates')}>
-              <strong>{backendStateCounts.updates}</strong>
-              <span>Need attention</span>
-            </button>
-          </section>
-
           <div className="backend-catalog" data-backends-matrix>
             {backendCatalog.map(({ capability, entries }) => {
               const visibleEntries = entries
@@ -1080,7 +1058,6 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
                       <h2>{CAPABILITY_LABELS[capability]}</h2>
                       <p>{CAPABILITY_DESCRIPTIONS[capability]}</p>
                     </div>
-                    <span>{visibleEntries.length} engine{visibleEntries.length === 1 ? '' : 's'}</span>
                   </header>
                   <div className="backend-catalog__grid">
                     {visibleEntries.map(renderBackendCard)}
@@ -1089,41 +1066,8 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
               );
             })}
           </div>
+
         </div>
-
-        {unsupportedBackendCount > 0 && (
-            <section className="backends__unsupported" data-backends-unsupported>
-            <button
-              type="button"
-              className="backends__unsupported-toggle"
-              aria-expanded={showUnsupported}
-              aria-controls="backends-unsupported-matrix"
-              onClick={() => setShowUnsupported(open => !open)}>
-              <span className="backends__unsupported-title">
-                <Icon name={showUnsupported ? 'chevron-down' : 'chevron-right'} size={14} aria-hidden="true" />
-                Unsupported backends
-              </span>
-              <span className="backends__unsupported-meta">
-                {unsupportedBackendCount} hidden from the main table
-              </span>
-            </button>
-
-            {showUnsupported && (
-              <div className="backend-catalog backend-catalog--unsupported" id="backends-unsupported-matrix" data-backends-unsupported-matrix>
-                {unsupportedBackendCatalog.map(({ capability, entries }) => (
-                  <section className="backend-catalog__section" key={capability}>
-                    <header className="backend-catalog__heading">
-                      <div><h2>{CAPABILITY_LABELS[capability]}</h2></div>
-                    </header>
-                    <div className="backend-catalog__grid">
-                      {entries.map(renderBackendCard)}
-                    </div>
-                  </section>
-                ))}
-              </div>
-            )}
-          </section>
-        )}
 
       <BackendArgsDialog
         backendKeyValue={argsEditorKey}

--- a/src/app/src/components/Icon.tsx
+++ b/src/app/src/components/Icon.tsx
@@ -20,7 +20,7 @@ export type IconName =
   | 'speech' | 'book-open' | 'newspaper' | 'github' | 'discord' | 'funnel' | 'info'
   | 'thermometer' | 'gem' | 'gauge' | 'timer' | 'hard-drive' | 'library' | 'scan-eye' | 'minimize-2'
   | 'panel-left-close' | 'panel-left-open' | 'maximize-2' | 'brain-off' | 'brain-cog' | 'brain-circuit' | 'wrench-off' | 'terminal-square' | 'settings' | 'layers'
-  | 'menu' | 'flask-conical';
+  | 'menu' | 'flask-conical' | 'external-link';
 
 interface IconProps {
   name: IconName;

--- a/src/app/src/components/localIcons.tsx
+++ b/src/app/src/components/localIcons.tsx
@@ -24,6 +24,10 @@ export const LOCAL_ICON_DEFINITIONS: Record<string, LocalIconDefinition> = {
     "viewBox": "0 0 24 24",
     "body": "<path d=\"m5 12 7-7 7 7\"></path><path d=\"M5 19h14\"></path>"
   },
+  "external-link": {
+    "viewBox": "0 0 24 24",
+    "body": "<path d=\"M15 3h6v6\"></path><path d=\"M10 14 21 3\"></path><path d=\"M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6\"></path>"
+  },
   "audio": {
     "viewBox": "0 0 24 24",
     "body": "<path d=\"M2 10v3\"></path><path d=\"M6 6v11\"></path><path d=\"M10 3v18\"></path><path d=\"M14 8v7\"></path><path d=\"M18 5v13\"></path><path d=\"M22 10v3\"></path>"

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -12025,7 +12025,7 @@ a.backend-card__version:focus-visible {
 }
 
 @media (max-width: 680px) {
-  .backends__content { padding: var(--space-3); }
+  .backends__content { padding: var(--space-2) var(--space-4) var(--space-5); }
   .backend-catalog__grid { grid-template-columns: 1fr; }
   .backend-catalog__heading { align-items: flex-start; flex-direction: column; gap: var(--space-1); }
   .backend-card__variant-head { gap: var(--space-2); }
@@ -12171,6 +12171,7 @@ a.backend-card__version:focus-visible {
   .workspace-nav__copy small { display: none; }
   .workspace-nav button { min-height: 44px; }
   .workspace-pane__header { padding-inline: var(--space-4); }
+  .backends__content, .backends--workspace .backends__head { padding-inline: var(--space-4); }
   .inspect-layout--embedded { grid-template-columns: 280px minmax(0, 1fr); grid-template-rows: minmax(0, 1fr); }
   .logs-workspace--embedded { grid-template-columns: 240px minmax(0, 1fr); grid-template-rows: minmax(0, 1fr); }
 }

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -3149,21 +3149,6 @@ optgroup {
 
 .backends__head {
   padding: var(--space-6) var(--space-8) var(--space-4);
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-.backends__title {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: var(--space-4);
-}
-
-.backends__title h1 {
-  font-size: var(--text-2xl);
-  font-weight: var(--weight-semibold);
-  letter-spacing: var(--tracking-tight);
-  margin: 0;
 }
 
 .backends__toggle {
@@ -3286,64 +3271,6 @@ optgroup {
   color: var(--text-disabled);
   font-style: italic;
   font-size: var(--text-xs);
-}
-
-.backends__unsupported {
-  margin: 0 var(--space-8) var(--space-5);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-lg);
-  background: var(--surface-1);
-  overflow: hidden;
-}
-
-.backends__unsupported-toggle {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
-  background: var(--surface-base);
-  color: var(--text-secondary);
-  border: 0;
-  cursor: pointer;
-  text-align: left;
-  transition: background var(--duration-fast) var(--ease-out),
-              color var(--duration-fast) var(--ease-out);
-}
-
-.backends__unsupported-toggle:hover,
-.backends__unsupported-toggle:focus-visible {
-  background: var(--surface-2);
-  color: var(--text-primary);
-}
-
-.backends__unsupported-toggle:focus-visible {
-  outline: 2px solid var(--accent-focus);
-  outline-offset: -2px;
-}
-
-.backends__unsupported-title {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-size: var(--text-sm);
-  font-weight: var(--weight-semibold);
-}
-
-.backends__unsupported-meta {
-  color: var(--text-tertiary);
-  font-size: var(--text-xs);
-}
-
-.matrix--unsupported {
-  margin: 0;
-  border: 0;
-  border-top: 1px solid var(--border-subtle);
-  border-radius: 0;
-  flex: none;
-  max-width: none;
-  max-height: min(42vh, 460px);
 }
 
 /* Cell within matrix */
@@ -3701,11 +3628,7 @@ optgroup {
   .active-models { grid-template-columns: 1fr; }
   .applied-row { grid-template-columns: 1fr; gap: var(--space-2); }
   .backends__head { padding: var(--space-5) var(--space-4) var(--space-3); }
-  .backends__title { flex-direction: column; gap: var(--space-2); }
   .matrix { margin: var(--space-3) var(--space-4); }
-  .backends__unsupported { margin: 0 var(--space-4) var(--space-3); }
-  .matrix--unsupported { margin: 0; }
-  .backends__unsupported-toggle { align-items: flex-start; flex-direction: column; }
   .matrix th, .matrix td { padding: var(--space-3); }
 }
 
@@ -11078,13 +11001,6 @@ optgroup {
   word-break: break-all;
 }
 
-/* Keep the optional unsupported backend matrix aligned with the main backend matrix. */
-.matrix.matrix--unsupported {
-  width: 100%;
-  max-width: 100%;
-  margin: 0;
-}
-
 /* ---------- Generated audio + 3D modalities ---------- */
 .cap-badge--audio-gen { background: color-mix(in srgb, var(--cap-audio-generation) 16%, transparent); color: var(--cap-audio-generation); }
 .cap-badge--model3d { background: color-mix(in srgb, var(--cap-model3d) 17%, transparent); color: var(--cap-model3d); }
@@ -11858,7 +11774,7 @@ optgroup {
   grid-template-rows: var(--workspace-header) auto minmax(0, 1fr) auto;
 }
 
-.backends--workspace .backends__head { padding: 0 var(--space-4); }
+.backends--workspace .backends__head { padding: 0 var(--panel-padding-inline); }
 .backends__rail-footer { display: grid; gap: var(--space-3); }
 .backends__rail-footer .backends__toggle { justify-content: flex-start; }
 .backends__runtime-meta { display: flex; flex-direction: column; gap: var(--space-0-5); }
@@ -11888,53 +11804,12 @@ optgroup {
 .backends--workspace .matrix th,
 .backends--workspace .matrix td { padding: var(--space-3); }
 .backends--workspace .cell { gap: var(--space-2); }
-.backends--workspace .backends__unsupported { margin: 0 var(--space-4) var(--space-4); }
 
 .backends__content {
   min-height: 0;
   overflow: auto;
-  padding: var(--space-4);
+  padding: var(--space-2) var(--panel-padding-inline) var(--space-6);
 }
-
-.backend-overview {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-3);
-  margin-bottom: var(--space-5);
-}
-
-.backend-overview__item {
-  display: grid;
-  gap: var(--space-1);
-  padding: var(--space-4);
-  color: var(--text-secondary);
-  text-align: left;
-  background: var(--surface-1);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-}
-
-.backend-overview__item:hover,
-.backend-overview__item:focus-visible {
-  color: var(--text-primary);
-  background: var(--surface-2);
-  border-color: var(--border-strong);
-}
-
-.backend-overview__item:focus-visible {
-  outline: 2px solid var(--accent-focus);
-  outline-offset: 2px;
-}
-
-.backend-overview__item strong {
-  color: var(--text-primary);
-  font-size: var(--text-2xl);
-  font-weight: var(--weight-semibold);
-  line-height: 1;
-}
-
-.backend-overview__item span { font-size: var(--text-sm); }
 
 .backend-catalog {
   display: grid;
@@ -11974,14 +11849,14 @@ optgroup {
 
 .backend-catalog__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: var(--space-3);
+  align-items: start;
 }
 
 .backend-card {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
   min-width: 0;
   padding: var(--space-4);
   background: var(--surface-1);
@@ -11991,59 +11866,51 @@ optgroup {
 
 .backend-card__head,
 .backend-card__footer,
-.backend-card__actions,
-.backend-card__devices {
+.backend-card__actions {
   display: flex;
   align-items: center;
 }
 
 .backend-card__head {
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-3);
-}
-
-.backend-card__variant-count {
-  flex: 0 0 auto;
-  color: var(--text-tertiary);
-  font-size: var(--text-xs);
-  white-space: nowrap;
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .backend-card__name {
   display: flex;
   align-items: center;
-  gap: var(--space-1);
+  gap: var(--space-2);
   margin: 0;
   color: var(--text-primary);
   font-size: var(--text-base);
   font-weight: var(--weight-semibold);
   line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-tight);
 }
-
-.backend-card__name.is-experimental { color: var(--warn); }
 
 .backend-card__variants {
   display: grid;
-  gap: var(--space-3);
 }
 
 .backend-card__variant {
   display: grid;
-  gap: var(--space-2);
+  gap: var(--space-1-5, 6px);
   min-width: 0;
-  padding-top: var(--space-3);
+  padding: var(--space-3) 0;
   border-top: 1px solid var(--border-subtle);
 }
 
 .backend-card__variant:first-child {
-  padding-top: 0;
   border-top: 0;
+}
+
+.backend-card__variant:last-child {
+  padding-bottom: 0;
 }
 
 .backend-card__variant-head {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
 }
@@ -12051,75 +11918,114 @@ optgroup {
 .backend-card__variant-name {
   display: flex;
   align-items: center;
-  gap: var(--space-1);
+  gap: var(--space-1-5, 6px);
   margin: 0;
   color: var(--text-primary);
   font-size: var(--text-sm);
-  font-weight: var(--weight-semibold);
+  font-weight: var(--weight-medium);
   line-height: var(--leading-snug);
 }
 
-.backend-card__variant-name.is-experimental { color: var(--warn); }
+.backend-card .cell__experimental-icon { color: var(--text-tertiary); }
 
-.backend-card__devices {
-  flex-wrap: wrap;
-  gap: var(--space-1);
-  margin-top: var(--space-2);
+.backend-card .cell__badge {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--space-1-5, 6px);
+  padding: 0;
+  background: none;
+  border-radius: 0;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: normal;
+  text-transform: none;
 }
 
-.backend-card__devices span {
-  padding: 2px 6px;
+.backend-card .cell__badge::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.backend-card__variant-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1) var(--space-3);
   color: var(--text-tertiary);
-  background: var(--surface-2);
-  border-radius: var(--radius-pill);
-  font-size: var(--type-overline-size);
-  line-height: 1.2;
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
 }
 
 .backend-card__version {
-  color: var(--text-disabled);
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
-  font-size: var(--type-overline-size);
+  font-size: var(--text-xs);
+}
+
+/* Optically center the icon on the digits: flex centering uses the full line
+   box, whose descender space the mono digits never occupy. */
+.backend-card__version .app-icon { transform: translateY(-1.5px); }
+
+a.backend-card__version {
+  text-decoration: none;
+}
+
+a.backend-card__version:hover,
+a.backend-card__version:focus-visible {
+  color: var(--text-primary);
+  text-decoration: underline;
 }
 
 .backend-card__footer {
-  justify-content: space-between;
   gap: var(--space-2);
-  margin-top: auto;
+  margin-top: var(--space-1);
+}
+
+/* Uninstall repeats on every installed row; keep it neutral at rest so the
+   danger color only signals on intent, not across the whole catalog. */
+.backend-card .btn--danger:not(:hover):not(:focus-visible) {
+  border-color: var(--border-subtle);
+  background: none;
+  color: var(--text-tertiary);
+}
+
+.backend-card__footer:empty {
+  display: none;
 }
 
 .backend-card__actions { gap: var(--space-2); }
 
-.backend-card__details {
-  display: grid;
-  gap: var(--space-2);
-  padding-top: var(--space-2);
+.backend-card__note {
+  margin: 0;
   color: var(--text-tertiary);
-  border-top: 1px solid var(--border-subtle);
   font-size: var(--text-xs);
-}
-
-.backend-card__details summary {
-  color: var(--text-secondary);
-  cursor: pointer;
-}
-
-.backend-card__details span {
+  line-height: var(--leading-snug);
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
 
-.backend-catalog--unsupported {
-  padding: var(--space-4);
-  border-top: 1px solid var(--border-subtle);
+.backend-card__note--error { color: var(--danger); }
+
+.backend-card__variant--unsupported .backend-card__variant-name,
+.backend-card__variant--unsupported .backend-card__variant-meta,
+.backend-card__variant--unsupported .backend-card__version {
+  color: var(--text-disabled);
+}
+
+.backend-card__variant--unsupported a.backend-card__version:hover,
+.backend-card__variant--unsupported a.backend-card__version:focus-visible {
+  color: var(--text-secondary);
 }
 
 @media (max-width: 680px) {
   .backends__content { padding: var(--space-3); }
-  .backend-overview { gap: var(--space-2); margin-bottom: var(--space-4); }
-  .backend-overview__item { padding: var(--space-3); }
-  .backend-overview__item strong { font-size: var(--text-xl); }
-  .backend-overview__item span { font-size: var(--text-xs); }
   .backend-catalog__grid { grid-template-columns: 1fr; }
   .backend-catalog__heading { align-items: flex-start; flex-direction: column; gap: var(--space-1); }
   .backend-card__variant-head { gap: var(--space-2); }

--- a/src/app/tests/backend-manager-lifecycle.runtime.cjs
+++ b/src/app/tests/backend-manager-lifecycle.runtime.cjs
@@ -1,0 +1,203 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const ts = require('typescript');
+
+const filename = path.resolve(__dirname, '../src/components/BackendManager.tsx');
+const source = fs.readFileSync(filename, 'utf8');
+const compiled = ts.transpileModule(source, {
+  compilerOptions: {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    jsx: ts.JsxEmit.ReactJSX,
+  },
+  fileName: filename,
+  reportDiagnostics: true,
+});
+const errors = (compiled.diagnostics || []).filter(d => d.category === ts.DiagnosticCategory.Error);
+assert.equal(errors.length, 0, errors.map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n'));
+
+const installBlock = source.match(
+  /const handleInstall = useCallback[\s\S]*?\n  const handleUninstall = useCallback/,
+)?.[0];
+assert.ok(installBlock, 'BackendManager handleInstall block not found');
+
+// Job acceptance is not completion. Completion must come from the download store.
+assert.match(
+  installBlock,
+  /const terminalDownloadPromise = waitForBackendDownloadTerminal[\s\S]*?await api\.installBackend\([\s\S]*?const terminalDownload = await terminalDownloadPromise/,
+);
+assert.match(installBlock, /void terminalDownloadPromise\.catch\(\(\) => undefined\)/);
+assert.match(installBlock, /onComplete: \(\) => \{[\s\S]*?downloadStore\.refresh\(\)/);
+const onCompleteBlock = installBlock.match(
+  /onComplete: \(\) => \{[\s\S]*?\n\s*\},\n\s*onError:/,
+)?.[0] || '';
+assert.doesNotMatch(onCompleteBlock, /status: 'completed'|still needs update/);
+
+// An API error must become a truly terminal error and can never fall through to success.
+assert.match(installBlock, /onError: \(err\) => \{[\s\S]*?status: 'error',[\s\S]*?running: false/);
+assert.match(installBlock, /terminalDownload\.status === 'error'[\s\S]*?throw new Error/);
+
+// Both install and update use the same post-terminal status synchronization.
+assert.match(installBlock, /const synced = await syncBackendStatus\(recipe, backend\)/);
+assert.match(source, /BACKEND_STATUS_RETRY_DELAYS_MS/);
+assert.match(source, /backendActionIsReflected/);
+
+// Concurrent refreshes may not overwrite the newest system-info snapshot.
+assert.match(source, /const requestId = \+\+systemInfoRequestRef\.current/);
+assert.match(source, /requestId === systemInfoRequestRef\.current/);
+
+// Regression: never tell the user to remove a binary based on a stale snapshot.
+assert.doesNotMatch(source, /existing binary may need to be removed manually/);
+
+function declarationText(name, kind) {
+  const sourceFile = ts.createSourceFile(filename, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  let match;
+  const visit = node => {
+    const kindMatches = kind === 'function' ? ts.isFunctionDeclaration(node) : ts.isClassDeclaration(node);
+    if (kindMatches && node.name?.text === name) match = node.getText(sourceFile);
+    if (!match) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  assert.ok(match, `${kind} ${name} not found`);
+  return match;
+}
+
+function buildRuntimeHelpers(downloadStore) {
+  const helperSource = [
+    declarationText('BackendDownloadMissingError', 'class'),
+    declarationText('backendActionIsReflected', 'function'),
+    declarationText('waitForBackendDownloadTerminal', 'function'),
+    'module.exports = { backendActionIsReflected, waitForBackendDownloadTerminal };',
+  ].join('\n\n');
+  const output = ts.transpileModule(helperSource, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.CommonJS,
+    },
+    reportDiagnostics: true,
+  });
+  const helperErrors = (output.diagnostics || []).filter(d => d.category === ts.DiagnosticCategory.Error);
+  assert.equal(helperErrors.length, 0, helperErrors.map(d => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n'));
+
+  const module = { exports: {} };
+  const context = {
+    module,
+    exports: module.exports,
+    AbortController,
+    Error,
+    downloadStore,
+    cleanString: value => {
+      const text = String(value || '').trim();
+      return text && text.toLowerCase() !== 'unknown' ? text : '';
+    },
+    backendDownloadMatches: (download, recipe, backend) => (
+      download.downloadType === 'backend'
+      && (download.id === `backend:${recipe}:${backend}` || download.modelName === `${recipe}:${backend}`)
+    ),
+    isDownloadActive: download => download.running === true || download.status === 'downloading',
+  };
+  vm.runInNewContext(output.outputText, context, { filename: 'backend-manager-lifecycle-helpers.cjs' });
+  return module.exports;
+}
+
+function createDownloadStore(initialItems) {
+  let items = initialItems;
+  const listeners = new Set();
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(items);
+      return () => listeners.delete(listener);
+    },
+    set(nextItems) {
+      items = nextItems;
+      for (const listener of listeners) listener(items);
+    },
+  };
+}
+
+function backendItem(status, running) {
+  return {
+    id: 'backend:llamacpp:cpu',
+    downloadType: 'backend',
+    modelName: 'llamacpp:cpu',
+    status,
+    running,
+  };
+}
+
+async function runBehaviorChecks() {
+  {
+    const store = createDownloadStore([backendItem('downloading', true)]);
+    const { waitForBackendDownloadTerminal } = buildRuntimeHelpers(store);
+    const controller = new AbortController();
+    const terminal = waitForBackendDownloadTerminal('llamacpp', 'cpu', controller.signal);
+    store.set([backendItem('completed', false)]);
+    assert.equal((await terminal).status, 'completed');
+  }
+
+  {
+    const store = createDownloadStore([backendItem('downloading', true)]);
+    const { waitForBackendDownloadTerminal } = buildRuntimeHelpers(store);
+    const controller = new AbortController();
+    const terminal = waitForBackendDownloadTerminal('llamacpp', 'cpu', controller.signal);
+    store.set([backendItem('error', false)]);
+    assert.equal((await terminal).status, 'error');
+  }
+
+  {
+    const store = createDownloadStore([backendItem('downloading', true)]);
+    const { waitForBackendDownloadTerminal } = buildRuntimeHelpers(store);
+    const controller = new AbortController();
+    const terminal = waitForBackendDownloadTerminal('llamacpp', 'cpu', controller.signal);
+    store.set([]);
+    await assert.rejects(terminal, error => error?.name === 'BackendDownloadMissingError');
+  }
+
+  {
+    const store = createDownloadStore([backendItem('downloading', true)]);
+    const { waitForBackendDownloadTerminal } = buildRuntimeHelpers(store);
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled by test'));
+    await assert.rejects(
+      waitForBackendDownloadTerminal('llamacpp', 'cpu', controller.signal),
+      /cancelled by test/,
+    );
+  }
+
+  {
+    const store = createDownloadStore([]);
+    const { backendActionIsReflected } = buildRuntimeHelpers(store);
+    assert.equal(backendActionIsReflected({ state: 'installed', version: '1.0' }, undefined), true);
+    assert.equal(
+      backendActionIsReflected(
+        { state: 'update_available', version: '1.0' },
+        { isUpdate: false, initialVersion: '' },
+      ),
+      true,
+    );
+    assert.equal(
+      backendActionIsReflected(
+        { state: 'update_available', version: '1.0' },
+        { isUpdate: true, initialVersion: '1.0' },
+      ),
+      false,
+    );
+    assert.equal(
+      backendActionIsReflected(
+        { state: 'update_available', version: '1.1' },
+        { isUpdate: true, initialVersion: '1.0' },
+      ),
+      true,
+    );
+  }
+}
+
+runBehaviorChecks()
+  .then(() => console.log('Backend manager lifecycle regression checks passed.'))
+  .catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
Visual polish pass on the Backends tab (GUI3).

**Desktop**

![Backends tab, desktop](https://raw.githubusercontent.com/lemonade-sdk/lemonade/eafcb759d258abd841d9570894affdc96f3332c5/pr1_desktop.png)

**Desktop, scrolled down**

![Backends tab scrolled to TTS and 3D sections](https://raw.githubusercontent.com/lemonade-sdk/lemonade/eafcb759d258abd841d9570894affdc96f3332c5/pr2_scrolled.png)

**"Show technical details" checked**

![Backends tab with technical details shown inline](https://raw.githubusercontent.com/lemonade-sdk/lemonade/eafcb759d258abd841d9570894affdc96f3332c5/pr3_tech_details.png)

**"Show unsupported backends" checked**

![Backends tab with unsupported backends shown grayed out](https://raw.githubusercontent.com/lemonade-sdk/lemonade/eafcb759d258abd841d9570894affdc96f3332c5/pr4_unsupported.png)

**Mobile**

![Backends tab in a mobile viewport](https://raw.githubusercontent.com/lemonade-sdk/lemonade/eafcb759d258abd841d9570894affdc96f3332c5/pr5_mobile.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
