### PR TITLE
docs: add new engine logos to homepage engine ticker

### DIFF
--- a/docs/assets/website-styles.css
+++ b/docs/assets/website-styles.css
@@ -4668,13 +4668,21 @@ body.install-options {
   mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent);
 }
 
+/* The track must size to its content (it holds two copies of the logo set) so the
+   -50% keyframe lands exactly on the second copy's start. Spacing lives on the
+   chips rather than flex gap — a track-level gap would offset that midpoint by
+   half a gap and cause a visible jump each loop. */
 .hp-logo-ticker-track {
   display: flex;
   align-items: center;
-  gap: 2.5rem;
+  width: max-content;
   white-space: nowrap;
   will-change: transform;
-  animation: ticker-scroll 30s linear infinite;
+  animation: ticker-scroll 45s linear infinite;
+}
+
+.hp-logo-ticker-track .hp-logo-chip {
+  margin-right: 2.5rem;
 }
 
 .hp-logo-ticker:hover .hp-logo-ticker-track {

--- a/docs/guide/configuration/moonshine.md
+++ b/docs/guide/configuration/moonshine.md
@@ -1,6 +1,6 @@
 # Moonshine Backend Options
 
-Lemonade integrates [Moonshine](https://github.com/usefulsensors/moonshine) as a CPU-only **streaming speech-to-text** backend, using the [`moonshine-voice`](https://pypi.org/project/moonshine-voice/) streaming API. It complements the existing Whisper backend:
+Lemonade integrates [Moonshine](https://github.com/moonshine-ai/moonshine) as a CPU-only **streaming speech-to-text** backend, using the [`moonshine-voice`](https://pypi.org/project/moonshine-voice/) streaming API. It complements the existing Whisper backend:
 
 1. **True streaming.** Moonshine transcribes audio incrementally while you speak — interim results stream over the WebSocket Realtime API (`conversation.item.input_audio_transcription.delta`), with finals on segment completion. Whisper, by contrast, transcribes buffered VAD segments.
 2. **Small and fast on CPU.** The streaming models range from ~30 MB (tiny) to ~250 MB (medium) and run in real-time on a laptop CPU — no GPU or NPU required.

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Lemonade: Local AI for Text, Images, and Speech</title>
   <link rel="icon" href="./favicon.ico">
-  <link rel="stylesheet" href="assets/website-styles.css?v=responsive-polish-3">
+  <link rel="stylesheet" href="assets/website-styles.css?v=ticker-loop-fix">
   <link rel="stylesheet" href="assets/persona-demo.css?v=responsive-polish-3">
   <link rel="stylesheet" href="assets/flowchart.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/docs/index.html
+++ b/docs/index.html
@@ -735,7 +735,12 @@
           { href: 'https://www.vulkan.org/', img: 'vulkan.png', alt: 'Vulkan' },
           { href: 'https://github.com/ggml-org/whisper.cpp', img: 'whisper_cpp.png', alt: 'whisper.cpp' },
           { href: 'https://github.com/leejet/stable-diffusion.cpp', img: 'stable_diffusion_cpp.png', alt: 'stable-diffusion.cpp' },
-          { href: 'https://github.com/lucasjinreal/Kokoros', img: 'kokoros.png', alt: 'Kokoros' }
+          { href: 'https://github.com/lucasjinreal/Kokoros', img: 'kokoros.png', alt: 'Kokoros' },
+          { href: 'https://github.com/vllm-project/vllm', img: 'vllm.png', alt: 'vLLM' },
+          { href: 'https://github.com/moonshine-ai/moonshine', img: 'moonshine.png', alt: 'Moonshine' },
+          { href: 'https://github.com/OpenMOSS/MOSS-TTSD', img: 'openmoss.png', alt: 'OpenMOSS' },
+          { href: 'https://github.com/microsoft/TRELLIS', img: 'trellis.png', alt: 'TRELLIS' },
+          { href: 'https://github.com/ace-step/ACE-Step', img: 'ace_step.png', alt: 'ACE-Step' }
         ];
         var html = logos.map(function(l) {
           return '<a href="' + l.href + '" title="' + l.alt + '" target="_blank" rel="noopener" class="hp-logo-chip">' +


### PR DESCRIPTION
The [lemonade-sdk/assets](https://github.com/lemonade-sdk/assets) repo added logos for vLLM, Moonshine, OpenMOSS, TRELLIS, and ACE-Step. This adds those five to the engine logo ticker on the homepage, linking each to its upstream project.

Also fixes the ticker's loop: the track was a block-level flex container, so its width was clamped to the container and `translateX(-50%)` only scrolled 560px of a ~2160px logo strip before visibly snapping back — the trailing logos were never reached at all. The track now sizes to `max-content`, with chip spacing moved from flex `gap` to margins so the `-50%` keyframe lands exactly on the duplicated copy's start (a track-level gap offsets that midpoint by half a gap).

Verified with Playwright: the seam aligns with the loop point to within 0.5px, position sampling across multiple loop wraps shows no visual jump, and all 15 logos scroll through the viewport.

New logos in the ticker (followed by the seamless wrap back to llama.cpp):

![Engine ticker showing the new vLLM, Moonshine, OpenMOSS, TRELLIS, and ACE-Step logos](https://github.com/lemonade-sdk/lemonade/raw/pr-2920-assets/ticker_new_logos.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
