### PR TITLE
GUI3: Apps Marketplace, shared catalog layout, and engine logos

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -6,7 +6,7 @@ import { findModelInfoByName, isCollectionFullyLoaded, isCollectionModel, withVi
 import ChatView from './components/ChatView';
 import ModelManager from './components/ModelManager';
 import ConnectView from './components/ConnectView';
-import AppsView, { MARKETPLACE_URL, type MarketplaceApp } from './components/AppsView';
+import AppsView, { MARKETPLACE_URL, type MarketplaceApp, type MarketplaceCategory } from './components/AppsView';
 import BackendManager from './components/BackendManager';
 import DownloadManager from './components/DownloadManager';
 import MonitorView from './components/MonitorView';
@@ -260,6 +260,7 @@ const App: React.FC = () => {
   const [downloadManagerOpen, setDownloadManagerOpen] = useState(false);
   const [modelDetailsRequest, setModelDetailsRequest] = useState<{ modelName: string; nonce: number } | null>(null);
   const [marketplaceApps, setMarketplaceApps] = useState<MarketplaceApp[]>([]);
+  const [marketplaceCategories, setMarketplaceCategories] = useState<MarketplaceCategory[]>([]);
   const [marketplaceError, setMarketplaceError] = useState<string | null>(null);
   const [marketplaceLoading, setMarketplaceLoading] = useState(true);
   const [utilityMenuOpen, setUtilityMenuOpen] = useState(false);
@@ -283,6 +284,7 @@ const App: React.FC = () => {
       .then(data => {
         if (cancelled) return;
         setMarketplaceApps(Array.isArray(data?.apps) ? data.apps as MarketplaceApp[] : []);
+        setMarketplaceCategories(Array.isArray(data?.categories) ? data.categories as MarketplaceCategory[] : []);
         setMarketplaceError(null);
       })
       .catch(error => {
@@ -903,6 +905,7 @@ const App: React.FC = () => {
           <ViewErrorBoundary view="apps">
             <AppsView
               apps={marketplaceApps}
+              categories={marketplaceCategories}
               loading={marketplaceLoading}
               error={marketplaceError}
             />

--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -742,10 +742,14 @@ const App: React.FC = () => {
                       type="search"
                       value={navigationSearch}
                       placeholder="Search"
+                      role="combobox"
                       aria-label={view === 'apps' ? 'Search apps' : 'Search Lemonade'}
                       aria-autocomplete="list"
                       aria-expanded={navigationSearchOpen}
                       aria-controls="titlebar-search-results"
+                      aria-activedescendant={navigationSearchOpen && navigationSearchResults[navigationSearchIndex]
+                        ? `titlebar-search-option-${navigationSearchIndex}`
+                        : undefined}
                       onFocus={() => setNavigationSearchOpen(true)}
                       onChange={event => {
                         setNavigationSearch(event.target.value);
@@ -784,6 +788,7 @@ const App: React.FC = () => {
                       {navigationSearchResults.length > 0 ? navigationSearchResults.map((destination, index) => (
                         <button
                           key={destination.id}
+                          id={`titlebar-search-option-${index}`}
                           type="button"
                           role="option"
                           aria-selected={index === navigationSearchIndex}

--- a/src/app/src/components/AppsView.tsx
+++ b/src/app/src/components/AppsView.tsx
@@ -68,6 +68,70 @@ type CategoryGroup = {
   apps: MarketplaceApp[];
 };
 
+/* Dark artwork over a transparent field disappears on the dark theme, so
+ * those logos get a white tile behind them; opaque or bright logos render
+ * bare. Sampled through a canvas, which requires CORS-enabled logo hosts. */
+const logoTileCache = new Map<string, boolean>();
+
+function logoNeedsTile(src: string): Promise<boolean> {
+  return new Promise(resolve => {
+    const probe = new Image();
+    probe.crossOrigin = 'anonymous';
+    probe.onload = () => {
+      try {
+        const size = 24;
+        const canvas = document.createElement('canvas');
+        canvas.width = size;
+        canvas.height = size;
+        const context = canvas.getContext('2d');
+        if (!context) {
+          resolve(false);
+          return;
+        }
+        context.drawImage(probe, 0, 0, size, size);
+        const { data } = context.getImageData(0, 0, size, size);
+        let transparent = 0;
+        let opaque = 0;
+        let luminanceSum = 0;
+        for (let i = 0; i < data.length; i += 4) {
+          if (data[i + 3] < 26) {
+            transparent += 1;
+            continue;
+          }
+          opaque += 1;
+          luminanceSum += (0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2]) / 255;
+        }
+        const transparentShare = transparent / (transparent + opaque || 1);
+        const meanLuminance = opaque ? luminanceSum / opaque : 1;
+        resolve(transparentShare > 0.05 && meanLuminance < 0.45);
+      } catch {
+        resolve(false);
+      }
+    };
+    probe.onerror = () => resolve(false);
+    probe.src = src;
+  });
+}
+
+const AppLogo: React.FC<{ src: string }> = ({ src }) => {
+  const [tiled, setTiled] = useState(() => logoTileCache.get(src) ?? false);
+
+  useEffect(() => {
+    if (logoTileCache.has(src)) {
+      setTiled(logoTileCache.get(src)!);
+      return undefined;
+    }
+    let cancelled = false;
+    logoNeedsTile(src).then(needsTile => {
+      logoTileCache.set(src, needsTile);
+      if (!cancelled) setTiled(needsTile);
+    });
+    return () => { cancelled = true; };
+  }, [src]);
+
+  return <img className={`app-card__logo${tiled ? ' app-card__logo--tile' : ''}`} src={src} alt="" />;
+};
+
 type AppsViewProps = {
   apps: MarketplaceApp[];
   categories: MarketplaceCategory[];
@@ -182,8 +246,8 @@ const AppsView: React.FC<AppsViewProps> = ({
     <article key={app.id || app.name} className="workspace-card app-card">
       <header className="workspace-card__head">
         {app.logo
-          ? <img className="app-card__logo" src={app.logo} alt="" />
-          : <span className="app-card__logo app-card__logo--fallback" aria-hidden="true">{app.name.slice(0, 1).toUpperCase()}</span>}
+          ? <AppLogo src={app.logo} />
+          : <span className="app-card__logo app-card__logo--tile app-card__logo--fallback" aria-hidden="true">{app.name.slice(0, 1).toUpperCase()}</span>}
         <span className="app-card__identity">
           <h3 className="workspace-card__name app-card__name">{app.name}</h3>
           {app.category && app.category.length > 0 && (

--- a/src/app/src/components/AppsView.tsx
+++ b/src/app/src/components/AppsView.tsx
@@ -21,6 +21,11 @@ export type MarketplaceApp = {
   links?: { app?: string; guide?: string; video?: string };
 };
 
+export type MarketplaceCategory = {
+  id: string;
+  label: string;
+};
+
 export const MARKETPLACE_URL = 'https://raw.githubusercontent.com/lemonade-sdk/marketplace/main/apps.json';
 const ALL_APPS_SECTION = 'all-apps';
 const FEATURED_APP_LIMIT = 4;
@@ -65,12 +70,14 @@ type CategoryGroup = {
 
 type AppsViewProps = {
   apps: MarketplaceApp[];
+  categories: MarketplaceCategory[];
   loading: boolean;
   error: string | null;
 };
 
 const AppsView: React.FC<AppsViewProps> = ({
   apps: marketplaceApps,
+  categories: marketplaceCategories,
   loading: marketplaceLoading,
   error: marketplaceError,
 }) => {
@@ -81,6 +88,13 @@ const AppsView: React.FC<AppsViewProps> = ({
     [marketplaceApps],
   );
 
+  const labelByCategory = useMemo(() => new Map(
+    marketplaceCategories.map(category => [normalizedCategory(category.id), category.label]),
+  ), [marketplaceCategories]);
+
+  const displayLabel = (rawCategory: string): string =>
+    labelByCategory.get(normalizedCategory(rawCategory)) ?? categoryLabel(rawCategory);
+
   const categoryGroups = useMemo<CategoryGroup[]>(() => {
     const groups = new Map<string, CategoryGroup>();
     marketplaceApps.forEach(app => {
@@ -88,15 +102,26 @@ const AppsView: React.FC<AppsViewProps> = ({
       const key = primary ? normalizedCategory(primary) : 'other';
       let group = groups.get(key);
       if (!group) {
-        group = { key, label: primary ? categoryLabel(primary) : 'Other', apps: [] };
+        const label = primary
+          ? labelByCategory.get(key) ?? categoryLabel(primary)
+          : 'Other';
+        group = { key, label, apps: [] };
         groups.set(key, group);
       }
       group.apps.push(app);
     });
+    const feedOrder = new Map(marketplaceCategories.map((category, index) => [normalizedCategory(category.id), index]));
     return Array.from(groups.values())
       .map(group => ({ ...group, apps: [...group.apps].sort((a, b) => a.name.localeCompare(b.name)) }))
-      .sort((left, right) => left.label.localeCompare(right.label));
-  }, [marketplaceApps]);
+      .sort((left, right) => {
+        const leftOrder = feedOrder.get(left.key);
+        const rightOrder = feedOrder.get(right.key);
+        if (leftOrder !== undefined && rightOrder !== undefined) return leftOrder - rightOrder;
+        if (leftOrder !== undefined) return -1;
+        if (rightOrder !== undefined) return 1;
+        return left.label.localeCompare(right.label);
+      });
+  }, [labelByCategory, marketplaceApps, marketplaceCategories]);
 
   useEffect(() => {
     if (categoryFilter && !categoryGroups.some(group => group.key === categoryFilter)) setCategoryFilter(null);
@@ -156,7 +181,7 @@ const AppsView: React.FC<AppsViewProps> = ({
         <span className="app-card__identity">
           <h3 className="workspace-card__name app-card__name">{app.name}</h3>
           {app.category && app.category.length > 0 && (
-            <span className="app-card__category">{app.category.map(categoryLabel).join(' · ')}</span>
+            <span className="app-card__category">{app.category.map(displayLabel).join(' · ')}</span>
           )}
         </span>
       </header>

--- a/src/app/src/components/AppsView.tsx
+++ b/src/app/src/components/AppsView.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import type { IconName } from './Icon';
-import WorkspaceSectionRail, { type WorkspaceSectionDefinition } from './WorkspaceSectionRail';
+import {
+  WorkspaceCatalogLayout,
+  WorkspaceCatalogSection,
+  type CatalogFilterDefinition,
+} from './WorkspaceCatalogLayout';
 import {
   WorkspaceActionButton,
   WorkspaceActionGroup,
   WorkspacePaneHeader,
-  WorkspaceResourceList,
-  WorkspaceResourceRow,
 } from './WorkspacePanels';
 
 export type MarketplaceApp = {
@@ -21,9 +23,10 @@ export type MarketplaceApp = {
 
 export const MARKETPLACE_URL = 'https://raw.githubusercontent.com/lemonade-sdk/marketplace/main/apps.json';
 const ALL_APPS_SECTION = 'all-apps';
+const FEATURED_APP_LIMIT = 4;
 
-function categorySectionId(category: string): string {
-  const safeCategory = encodeURIComponent(category.trim().toLowerCase())
+function categorySectionId(categoryKey: string): string {
+  const safeCategory = encodeURIComponent(categoryKey)
     .replace(/%/g, '')
     .replace(/[^a-z0-9_-]+/g, '-');
   return `category-${safeCategory || 'other'}`;
@@ -54,10 +57,11 @@ function normalizedCategory(category: string): string {
   return category.trim().toLocaleLowerCase();
 }
 
-function appHasCategory(app: MarketplaceApp, category: string): boolean {
-  const normalizedFilter = normalizedCategory(category);
-  return (app.category || []).some(item => normalizedCategory(item) === normalizedFilter);
-}
+type CategoryGroup = {
+  key: string;
+  label: string;
+  apps: MarketplaceApp[];
+};
 
 type AppsViewProps = {
   apps: MarketplaceApp[];
@@ -71,54 +75,62 @@ const AppsView: React.FC<AppsViewProps> = ({
   error: marketplaceError,
 }) => {
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
-  const [railCollapsed, setRailCollapsed] = useState(false);
 
-  const categories = useMemo(() => {
-    const categoryByKey = new Map<string, string>();
-    marketplaceApps.flatMap(app => app.category || []).forEach(rawCategory => {
-      const category = rawCategory.trim();
-      const key = normalizedCategory(category);
-      if (key && !categoryByKey.has(key)) categoryByKey.set(key, category);
+  const featuredApps = useMemo(
+    () => marketplaceApps.filter(app => app.pinned).slice(0, FEATURED_APP_LIMIT),
+    [marketplaceApps],
+  );
+
+  const categoryGroups = useMemo<CategoryGroup[]>(() => {
+    const groups = new Map<string, CategoryGroup>();
+    marketplaceApps.forEach(app => {
+      const primary = app.category?.[0]?.trim();
+      const key = primary ? normalizedCategory(primary) : 'other';
+      let group = groups.get(key);
+      if (!group) {
+        group = { key, label: primary ? categoryLabel(primary) : 'Other', apps: [] };
+        groups.set(key, group);
+      }
+      group.apps.push(app);
     });
-    return Array.from(categoryByKey.values()).sort((left, right) => left.localeCompare(right));
+    return Array.from(groups.values())
+      .map(group => ({ ...group, apps: [...group.apps].sort((a, b) => a.name.localeCompare(b.name)) }))
+      .sort((left, right) => left.label.localeCompare(right.label));
   }, [marketplaceApps]);
 
   useEffect(() => {
-    if (categoryFilter && !categories.includes(categoryFilter)) setCategoryFilter(null);
-  }, [categories, categoryFilter]);
+    if (categoryFilter && !categoryGroups.some(group => group.key === categoryFilter)) setCategoryFilter(null);
+  }, [categoryGroups, categoryFilter]);
 
-  const categorySections = useMemo<WorkspaceSectionDefinition<string>[]>(() => [
+  const categoryFilters = useMemo<CatalogFilterDefinition<string>[]>(() => [
     {
       id: ALL_APPS_SECTION,
-      label: 'All Apps',
+      label: 'All apps',
       description: marketplaceLoading
         ? 'Loading directory'
         : marketplaceError
           ? 'Directory unavailable'
-          : appCountLabel(marketplaceApps.length),
+          : 'Compatible clients and tools',
       icon: 'globe',
+      count: marketplaceLoading || marketplaceError ? undefined : marketplaceApps.length,
     },
-    ...categories.map(category => {
-      const count = marketplaceApps.filter(app => appHasCategory(app, category)).length;
-      return {
-        id: categorySectionId(category),
-        label: categoryLabel(category),
-        description: appCountLabel(count),
-        icon: categoryIcon(category),
-      };
-    }),
-  ], [categories, marketplaceApps, marketplaceError, marketplaceLoading]);
+    ...categoryGroups.map(group => ({
+      id: categorySectionId(group.key),
+      label: group.label,
+      description: appCountLabel(group.apps.length),
+      icon: categoryIcon(group.key),
+      count: group.apps.length,
+    })),
+  ], [categoryGroups, marketplaceApps.length, marketplaceError, marketplaceLoading]);
 
   const categoryBySection = useMemo(() => new Map(
-    categories.map(category => [categorySectionId(category), category]),
-  ), [categories]);
+    categoryGroups.map(group => [categorySectionId(group.key), group.key]),
+  ), [categoryGroups]);
 
   const activeCategorySection = categoryFilter ? categorySectionId(categoryFilter) : ALL_APPS_SECTION;
-
-  const filteredMarketplaceApps = useMemo(() => marketplaceApps
-    .filter(app => !categoryFilter || appHasCategory(app, categoryFilter))
-    .sort((a, b) => Number(Boolean(b.pinned)) - Number(Boolean(a.pinned)) || a.name.localeCompare(b.name)),
-  [categoryFilter, marketplaceApps]);
+  const activeGroup = categoryFilter
+    ? categoryGroups.find(group => group.key === categoryFilter) ?? null
+    : null;
 
   const openExternal = (url?: string) => {
     if (!url) return;
@@ -130,76 +142,91 @@ const AppsView: React.FC<AppsViewProps> = ({
     window.open(url, '_blank', 'noopener,noreferrer');
   };
 
-  const visibleCount = filteredMarketplaceApps.length;
-  const paneTitle = categoryFilter ? categoryLabel(categoryFilter) : 'All Apps';
-  const paneSubtitle = categoryFilter
-    ? `${appCountLabel(visibleCount)} in ${categoryLabel(categoryFilter)}.`
-    : 'Compatible clients and tools for Lemonade.';
+  const paneTitle = activeGroup ? activeGroup.label : 'Apps Marketplace';
+  const paneSubtitle = activeGroup
+    ? `${appCountLabel(activeGroup.apps.length)} in ${activeGroup.label}.`
+    : 'Lemonade works best as the inference server for applications. Try out this curated list of apps!';
+
+  const renderAppCard = (app: MarketplaceApp) => (
+    <article key={app.id || app.name} className="workspace-card app-card">
+      <header className="workspace-card__head">
+        {app.logo
+          ? <img className="app-card__logo" src={app.logo} alt="" />
+          : <span className="app-card__logo app-card__logo--fallback" aria-hidden="true">{app.name.slice(0, 1).toUpperCase()}</span>}
+        <span className="app-card__identity">
+          <h3 className="workspace-card__name app-card__name">{app.name}</h3>
+          {app.category && app.category.length > 0 && (
+            <span className="app-card__category">{app.category.map(categoryLabel).join(' · ')}</span>
+          )}
+        </span>
+      </header>
+      <p className="app-card__description">{app.description || 'No description available.'}</p>
+      <footer className="app-card__footer">
+        <WorkspaceActionGroup className="app-card__actions" label={`Links for ${app.name}`}>
+          {app.links?.app && <WorkspaceActionButton appearance="secondary" size="small" icon="globe" onClick={() => openExternal(app.links?.app)}>Visit</WorkspaceActionButton>}
+          {app.links?.guide && <WorkspaceActionButton appearance="quiet" size="small" onClick={() => openExternal(app.links?.guide)}>Guide</WorkspaceActionButton>}
+          {app.links?.video && <WorkspaceActionButton appearance="quiet" size="small" onClick={() => openExternal(app.links?.video)}>Video</WorkspaceActionButton>}
+        </WorkspaceActionGroup>
+      </footer>
+    </article>
+  );
 
   return (
-    <section
-      className={`apps-workspace${railCollapsed ? ' workspace--rail-collapsed' : ''}`}
-      data-view="apps"
-    >
-      <WorkspaceSectionRail
-        sections={categorySections}
-        activeSection={activeCategorySection}
-        onSectionChange={section => setCategoryFilter(categoryBySection.get(section) ?? null)}
-        collapsed={railCollapsed}
-        onCollapsedChange={setRailCollapsed}
-        panelId="apps-types-panel"
-        railLabel="App type navigation"
-        navigationLabel="App categories"
-        railClassName="apps__rail"
-        navClassName="apps__nav"
-        headerTitle="App Types"
-        sidebarLabel="app types"
-        headerIcon="layers"
-        mobileMenuLabel="Open app types"
-      />
-
-      <section className="workspace-pane apps__main" aria-labelledby="apps-pane-title">
+    <WorkspaceCatalogLayout
+      view="apps"
+      className="apps-workspace"
+      panelId="apps-types-panel"
+      railTitle="Filters"
+      railLabel="App categories"
+      sidebarLabel="app categories"
+      mobileMenuLabel="Open app categories"
+      filters={categoryFilters}
+      activeFilter={activeCategorySection}
+      onFilterChange={section => setCategoryFilter(categoryBySection.get(section) ?? null)}
+      header={
         <WorkspacePaneHeader
+          headingLevel={1}
           title={paneTitle}
           subtitle={paneSubtitle}
           titleId="apps-pane-title"
         />
-
-        <div className="apps__content workspace-pane__scroll">
-          <section className="apps__directory" aria-label={paneTitle}>
-            {marketplaceLoading ? (
-              <div className="apps__empty" role="status">Loading apps...</div>
-            ) : marketplaceError ? (
-              <div className="apps__error" role="alert">Apps unavailable: {marketplaceError}</div>
-            ) : (
-              <WorkspaceResourceList label={`${paneTitle} directory`} className="apps__resource-list">
-                {filteredMarketplaceApps.map(app => (
-                  <WorkspaceResourceRow
-                    key={app.id || app.name}
-                    title={app.name}
-                    description={app.description || 'No description available.'}
-                    metadata={app.category?.join(' · ')}
-                    leading={app.logo
-                      ? <img className="apps__app-logo" src={app.logo} alt="" />
-                      : <span className="apps__app-logo apps__app-logo--fallback">{app.name.slice(0, 1).toUpperCase()}</span>}
-                    actions={<WorkspaceActionGroup className="apps__marketplace-actions" label={`Links for ${app.name}`}>
-                      {app.links?.app && <WorkspaceActionButton appearance="secondary" size="small" icon="globe" onClick={() => openExternal(app.links?.app)}>Visit</WorkspaceActionButton>}
-                      {app.links?.guide && <WorkspaceActionButton appearance="quiet" size="small" onClick={() => openExternal(app.links?.guide)}>Guide</WorkspaceActionButton>}
-                      {app.links?.video && <WorkspaceActionButton appearance="quiet" size="small" onClick={() => openExternal(app.links?.video)}>Video</WorkspaceActionButton>}
-                    </WorkspaceActionGroup>}
-                  />
-                ))}
-                {filteredMarketplaceApps.length === 0 && (
-                  <div className="apps__empty">
-                    No apps are available for this type.
-                  </div>
-                )}
-              </WorkspaceResourceList>
-            )}
-          </section>
+      }
+    >
+      {marketplaceLoading ? (
+        <div className="apps__empty" role="status">Loading apps...</div>
+      ) : marketplaceError ? (
+        <div className="apps__error" role="alert">Apps unavailable: {marketplaceError}</div>
+      ) : (
+        <div className="workspace-catalog" aria-label={`${paneTitle} directory`}>
+          {activeGroup ? (
+            <WorkspaceCatalogSection>
+              {activeGroup.apps.map(renderAppCard)}
+            </WorkspaceCatalogSection>
+          ) : (
+            <>
+              {featuredApps.length > 0 && (
+                <WorkspaceCatalogSection
+                  title="Featured"
+                  description="Picks from the Lemonade team."
+                >
+                  {featuredApps.map(renderAppCard)}
+                </WorkspaceCatalogSection>
+              )}
+              {categoryGroups.map(group => (
+                <WorkspaceCatalogSection key={group.key} title={group.label}>
+                  {group.apps.map(renderAppCard)}
+                </WorkspaceCatalogSection>
+              ))}
+            </>
+          )}
+          {marketplaceApps.length === 0 && (
+            <div className="apps__empty">
+              No apps are available yet.
+            </div>
+          )}
         </div>
-      </section>
-    </section>
+      )}
+    </WorkspaceCatalogLayout>
   );
 };
 

--- a/src/app/src/components/AppsView.tsx
+++ b/src/app/src/components/AppsView.tsx
@@ -68,6 +68,40 @@ type CategoryGroup = {
   apps: MarketplaceApp[];
 };
 
+function collectCategoryGroups(
+  apps: MarketplaceApp[],
+  categoriesOf: (app: MarketplaceApp) => string[],
+  labelByCategory: Map<string, string>,
+  feedOrder: Map<string, number>,
+): CategoryGroup[] {
+  const groups = new Map<string, CategoryGroup>();
+  apps.forEach(app => {
+    const rawCategories = categoriesOf(app).map(category => category.trim());
+    const seenKeys = new Set<string>();
+    (rawCategories.length ? rawCategories : ['']).forEach(raw => {
+      const key = raw ? normalizedCategory(raw) : 'other';
+      if (seenKeys.has(key)) return;
+      seenKeys.add(key);
+      let group = groups.get(key);
+      if (!group) {
+        group = { key, label: raw ? labelByCategory.get(key) ?? categoryLabel(raw) : 'Other', apps: [] };
+        groups.set(key, group);
+      }
+      group.apps.push(app);
+    });
+  });
+  return Array.from(groups.values())
+    .map(group => ({ ...group, apps: [...group.apps].sort((a, b) => a.name.localeCompare(b.name)) }))
+    .sort((left, right) => {
+      const leftOrder = feedOrder.get(left.key);
+      const rightOrder = feedOrder.get(right.key);
+      if (leftOrder !== undefined && rightOrder !== undefined) return leftOrder - rightOrder;
+      if (leftOrder !== undefined) return -1;
+      if (rightOrder !== undefined) return 1;
+      return left.label.localeCompare(right.label);
+    });
+}
+
 /* Dark artwork over a transparent field disappears on the dark theme, so
  * those logos get a white tile behind them; opaque or bright logos render
  * bare. Sampled through a canvas, which requires CORS-enabled logo hosts. */
@@ -159,37 +193,26 @@ const AppsView: React.FC<AppsViewProps> = ({
   const displayLabel = (rawCategory: string): string =>
     labelByCategory.get(normalizedCategory(rawCategory)) ?? categoryLabel(rawCategory);
 
-  const categoryGroups = useMemo<CategoryGroup[]>(() => {
-    const groups = new Map<string, CategoryGroup>();
-    marketplaceApps.forEach(app => {
-      const primary = app.category?.[0]?.trim();
-      const key = primary ? normalizedCategory(primary) : 'other';
-      let group = groups.get(key);
-      if (!group) {
-        const label = primary
-          ? labelByCategory.get(key) ?? categoryLabel(primary)
-          : 'Other';
-        group = { key, label, apps: [] };
-        groups.set(key, group);
-      }
-      group.apps.push(app);
-    });
-    const feedOrder = new Map(marketplaceCategories.map((category, index) => [normalizedCategory(category.id), index]));
-    return Array.from(groups.values())
-      .map(group => ({ ...group, apps: [...group.apps].sort((a, b) => a.name.localeCompare(b.name)) }))
-      .sort((left, right) => {
-        const leftOrder = feedOrder.get(left.key);
-        const rightOrder = feedOrder.get(right.key);
-        if (leftOrder !== undefined && rightOrder !== undefined) return leftOrder - rightOrder;
-        if (leftOrder !== undefined) return -1;
-        if (rightOrder !== undefined) return 1;
-        return left.label.localeCompare(right.label);
-      });
-  }, [labelByCategory, marketplaceApps, marketplaceCategories]);
+  const feedOrder = useMemo(() => new Map(
+    marketplaceCategories.map((category, index) => [normalizedCategory(category.id), index]),
+  ), [marketplaceCategories]);
+
+  /* Sections group each app under its primary category; the sidebar filters
+   * match every assigned category, so a multi-category app is reachable from
+   * all of them. */
+  const categoryGroups = useMemo(
+    () => collectCategoryGroups(marketplaceApps, app => app.category?.slice(0, 1) ?? [], labelByCategory, feedOrder),
+    [feedOrder, labelByCategory, marketplaceApps],
+  );
+
+  const categoryOptions = useMemo(
+    () => collectCategoryGroups(marketplaceApps, app => app.category ?? [], labelByCategory, feedOrder),
+    [feedOrder, labelByCategory, marketplaceApps],
+  );
 
   useEffect(() => {
-    if (categoryFilter && !categoryGroups.some(group => group.key === categoryFilter)) setCategoryFilter(null);
-  }, [categoryGroups, categoryFilter]);
+    if (categoryFilter && !categoryOptions.some(group => group.key === categoryFilter)) setCategoryFilter(null);
+  }, [categoryOptions, categoryFilter]);
 
   const categoryFilters = useMemo<CatalogFilterDefinition<string>[]>(() => [
     {
@@ -203,22 +226,22 @@ const AppsView: React.FC<AppsViewProps> = ({
       icon: 'globe',
       count: marketplaceLoading || marketplaceError ? undefined : marketplaceApps.length,
     },
-    ...categoryGroups.map(group => ({
+    ...categoryOptions.map(group => ({
       id: categorySectionId(group.key),
       label: group.label,
       description: appCountLabel(group.apps.length),
       icon: categoryIcon(group.key),
       count: group.apps.length,
     })),
-  ], [categoryGroups, marketplaceApps.length, marketplaceError, marketplaceLoading]);
+  ], [categoryOptions, marketplaceApps.length, marketplaceError, marketplaceLoading]);
 
   const categoryBySection = useMemo(() => new Map(
-    categoryGroups.map(group => [categorySectionId(group.key), group.key]),
-  ), [categoryGroups]);
+    categoryOptions.map(group => [categorySectionId(group.key), group.key]),
+  ), [categoryOptions]);
 
   const activeCategorySection = categoryFilter ? categorySectionId(categoryFilter) : ALL_APPS_SECTION;
   const activeGroup = categoryFilter
-    ? categoryGroups.find(group => group.key === categoryFilter) ?? null
+    ? categoryOptions.find(group => group.key === categoryFilter) ?? null
     : null;
 
   const openExternal = (url?: string) => {

--- a/src/app/src/components/AppsView.tsx
+++ b/src/app/src/components/AppsView.tsx
@@ -167,10 +167,16 @@ const AppsView: React.FC<AppsViewProps> = ({
     window.open(url, '_blank', 'noopener,noreferrer');
   };
 
-  const paneTitle = activeGroup ? activeGroup.label : 'Apps Marketplace';
-  const paneSubtitle = activeGroup
-    ? `${appCountLabel(activeGroup.apps.length)} in ${activeGroup.label}.`
-    : 'Lemonade works best as the inference server for applications. Try out this curated list of apps!';
+  const paneTitle = 'Apps Marketplace';
+  const paneSubtitle = 'Lemonade works best as the inference server for applications. Try out this curated list of apps!';
+
+  const showFeatured = !activeGroup && featuredApps.length > 0;
+  const visibleGroups = (activeGroup ? [activeGroup] : categoryGroups)
+    .map(group => ({
+      ...group,
+      apps: showFeatured ? group.apps.filter(app => !featuredApps.includes(app)) : group.apps,
+    }))
+    .filter(group => group.apps.length > 0);
 
   const renderAppCard = (app: MarketplaceApp) => (
     <article key={app.id || app.name} className="workspace-card app-card">
@@ -223,27 +229,19 @@ const AppsView: React.FC<AppsViewProps> = ({
         <div className="apps__error" role="alert">Apps unavailable: {marketplaceError}</div>
       ) : (
         <div className="workspace-catalog" aria-label={`${paneTitle} directory`}>
-          {activeGroup ? (
-            <WorkspaceCatalogSection>
-              {activeGroup.apps.map(renderAppCard)}
+          {showFeatured && (
+            <WorkspaceCatalogSection
+              title="Featured"
+              description="Picks from the Lemonade team."
+            >
+              {featuredApps.map(renderAppCard)}
             </WorkspaceCatalogSection>
-          ) : (
-            <>
-              {featuredApps.length > 0 && (
-                <WorkspaceCatalogSection
-                  title="Featured"
-                  description="Picks from the Lemonade team."
-                >
-                  {featuredApps.map(renderAppCard)}
-                </WorkspaceCatalogSection>
-              )}
-              {categoryGroups.map(group => (
-                <WorkspaceCatalogSection key={group.key} title={group.label}>
-                  {group.apps.map(renderAppCard)}
-                </WorkspaceCatalogSection>
-              ))}
-            </>
           )}
+          {visibleGroups.map(group => (
+            <WorkspaceCatalogSection key={group.key} title={group.label}>
+              {group.apps.map(renderAppCard)}
+            </WorkspaceCatalogSection>
+          ))}
           {marketplaceApps.length === 0 && (
             <div className="apps__empty">
               No apps are available yet.

--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -88,8 +88,9 @@ const ENGINE_LOGO_BASE = 'https://raw.githubusercontent.com/lemonade-sdk/assets/
 
 /* plate 'dark' matches logos with a baked-in dark background fill; showName
  * accompanies icon-only logos that don't spell out the engine name.
- * stable_diffusion_cpp.png is intentionally unmapped: it's a near-square
- * collage that reads badly at banner height. */
+ * stable_diffusion_cpp.png (near-square collage) and ryzen_ai_sw.png
+ * (gradient badge) are intentionally unmapped: they read badly at banner
+ * height, so those engines get the text plate instead. */
 type EngineLogo = { file: string; plate?: 'dark'; showName?: boolean };
 
 const ENGINE_LOGOS: Record<string, EngineLogo> = {
@@ -99,7 +100,6 @@ const ENGINE_LOGOS: Record<string, EngineLogo> = {
   moonshine:      { file: 'moonshine.png', showName: true },
   kokoro:         { file: 'kokoros.png' },
   flm:            { file: 'fastflowlm.png' },
-  'ryzenai-llm':  { file: 'ryzen_ai_sw.png', plate: 'dark' },
   vllm:           { file: 'vllm.png' },
   acestep:        { file: 'ace_step.png', plate: 'dark' },
   openmoss:       { file: 'openmoss.png' },

--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -84,6 +84,28 @@ const RECIPE_LABELS: Record<string, string> = {
   trellis:         'TRELLIS.2',
 };
 
+const ENGINE_LOGO_BASE = 'https://raw.githubusercontent.com/lemonade-sdk/assets/main/engines/';
+
+/* plate 'dark' matches logos with a baked-in dark background fill; showName
+ * accompanies icon-only logos that don't spell out the engine name.
+ * stable_diffusion_cpp.png is intentionally unmapped: it's a near-square
+ * collage that reads badly at banner height. */
+type EngineLogo = { file: string; plate?: 'dark'; showName?: boolean };
+
+const ENGINE_LOGOS: Record<string, EngineLogo> = {
+  llamacpp:       { file: 'llama_cpp.png' },
+  onnxruntime:    { file: 'onnx_runtime.png' },
+  whispercpp:     { file: 'whisper_cpp.png', plate: 'dark' },
+  moonshine:      { file: 'moonshine.png', showName: true },
+  kokoro:         { file: 'kokoros.png' },
+  flm:            { file: 'fastflowlm.png' },
+  'ryzenai-llm':  { file: 'ryzen_ai_sw.png', plate: 'dark' },
+  vllm:           { file: 'vllm.png' },
+  acestep:        { file: 'ace_step.png', plate: 'dark' },
+  openmoss:       { file: 'openmoss.png' },
+  trellis:        { file: 'trellis.png' },
+};
+
 /** User-facing labels for backend variants */
 const BACKEND_LABELS: Record<string, string> = {
   cpu:      'CPU',
@@ -1010,11 +1032,29 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
   const renderBackendCard = useCallback(({ recipe, variants }: BackendCatalogEntry) => {
     const engineName = RECIPE_LABELS[recipe] || recipe;
     const supportsArgs = backendSupportsArgs(recipe);
+    const logo = ENGINE_LOGOS[recipe];
 
     return (
       <article className="workspace-card backend-card" key={recipe} data-recipe={recipe}>
         <div className="workspace-card__head">
-          <h3 className="workspace-card__name">{engineName}</h3>
+          <h3 className="sr-only">{engineName}</h3>
+          <div
+            className={`backend-card__logo${logo?.plate === 'dark' ? ' backend-card__logo--dark' : ''}${logo && !logo.showName ? ' backend-card__logo--image-only' : ''}`}
+            aria-hidden="true"
+          >
+            {logo && (
+              <img
+                src={`${ENGINE_LOGO_BASE}${logo.file}`}
+                alt=""
+                loading="lazy"
+                onError={event => {
+                  event.currentTarget.style.display = 'none';
+                  event.currentTarget.parentElement!.className = 'backend-card__logo';
+                }}
+              />
+            )}
+            <span className="backend-card__logo-name">{engineName}</span>
+          </div>
         </div>
 
         <div className="backend-card__variants">

--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -9,10 +9,8 @@ import {
   saveBackendTuning,
 } from '../modelConfiguration';
 import { Icon, type IconName } from './Icon';
-import WorkspaceMobileMenuButton from './WorkspaceMobileMenuButton';
-import WorkspaceRailHeader from './WorkspaceRailHeader';
+import { WorkspaceCatalogLayout, WorkspaceCatalogSection } from './WorkspaceCatalogLayout';
 import { useFocusTrap } from '../hooks/useFocusTrap';
-import { useWorkspaceMobileRail } from '../hooks/useWorkspaceMobileRail';
 import { DownloadListItem, downloadStore, isDownloadActive } from '../features/downloadManager/downloadStore';
 import { WorkspaceActionButton, WorkspaceActionGroup, WorkspacePaneHeader } from './WorkspacePanels';
 
@@ -620,8 +618,6 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
   const [showTech, setShowTech] = useState(false);
   const [showUnsupported, setShowUnsupported] = useState(false);
   const [viewFilter, setViewFilter] = useState<BackendViewFilter>('all');
-  const [railCollapsed, setRailCollapsed] = useState(false);
-  const mobileRail = useWorkspaceMobileRail();
   const [installing, setInstalling] = useState<string | null>(null); // "recipe:backend"
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const [backendTunings, setBackendTunings] = useState<Record<string, BackendTuning>>(loadBackendTunings);
@@ -1016,9 +1012,9 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     const supportsArgs = backendSupportsArgs(recipe);
 
     return (
-      <article className="backend-card" key={recipe} data-recipe={recipe}>
-        <div className="backend-card__head">
-          <h3 className="backend-card__name">{engineName}</h3>
+      <article className="workspace-card backend-card" key={recipe} data-recipe={recipe}>
+        <div className="workspace-card__head">
+          <h3 className="workspace-card__name">{engineName}</h3>
         </div>
 
         <div className="backend-card__variants">
@@ -1194,7 +1190,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
   if (loading && !sysInfo) {
     return (
       <section className="backends" data-view="backends">
-        <WorkspacePaneHeader className="backends__pane-header" headingLevel={1} title="Backends" />
+        <WorkspacePaneHeader className="backends__pane-header" headingLevel={1} title="Inference Backends" />
         <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--space-8)' }}>
           <div className="hf-zone__spinner" />
         </div>
@@ -1203,34 +1199,25 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
   }
 
   return (
-    <section className={`backends backends--workspace${railCollapsed ? ' workspace--rail-collapsed' : ''}${showTech ? ' show-tech' : ''}`} data-view="backends">
-      {mobileRail.isOpen && <div className="workspace-mobile-rail-backdrop" onClick={mobileRail.close} aria-hidden="true" />}
-      <aside
-        ref={mobileRail.panelRef}
-        id="backend-filters-panel"
-        className={`workspace-rail mobile-context-panel backends__rail${railCollapsed && !mobileRail.isOpen ? ' is-collapsed' : ''}${mobileRail.isOpen ? ' is-mobile-open' : ''}`}
-        aria-label="Backend filters"
-        role={mobileRail.isOpen ? 'dialog' : undefined}
-        aria-modal={mobileRail.isOpen ? true : undefined}
-      >
-        <WorkspaceRailHeader
-          title="Filters"
-          sidebarLabel="backend filters"
-          purpose="filter"
-          collapsed={railCollapsed && !mobileRail.isOpen}
-          onToggle={() => setRailCollapsed(value => !value)}
-          onMobileClose={mobileRail.isOpen ? mobileRail.close : undefined}
-        />
-        <nav className="workspace-filter-list" aria-label="Backend filters">
-          {BACKEND_VIEW_FILTERS.map(([id, label, description, icon]) => (
-            <button key={id} type="button" className={`workspace-filter-list__item${viewFilter === id ? ' is-active' : ''}`} aria-current={viewFilter === id ? 'true' : undefined} aria-label={label} title={`${label} — ${description}`} onClick={() => { setViewFilter(id); mobileRail.close(); }}>
-              <Icon className="workspace-filter-list__icon" name={icon} size={14} />
-              <span className="workspace-filter-list__label">{label}</span>
-              <span className="workspace-filter-list__count">{backendStateCounts[id]}</span>
-            </button>
-          ))}
-        </nav>
-        <div className="workspace-rail__footer backends__rail-footer">
+    <WorkspaceCatalogLayout
+      view="backends"
+      className={`backends backends--workspace${showTech ? ' show-tech' : ''}`}
+      panelId="backend-filters-panel"
+      railTitle="Filters"
+      railLabel="Backend filters"
+      sidebarLabel="backend filters"
+      mobileMenuLabel="Open backend filters"
+      filters={BACKEND_VIEW_FILTERS.map(([id, label, description, icon]) => ({
+        id,
+        label,
+        description,
+        icon,
+        count: backendStateCounts[id],
+      }))}
+      activeFilter={viewFilter}
+      onFilterChange={setViewFilter}
+      railFooter={
+        <div className="backends__rail-footer">
           <label className="backends__toggle">
             <input
               type="checkbox"
@@ -1255,103 +1242,84 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
             </div>
           )}
         </div>
-      </aside>
-
-      <WorkspaceMobileMenuButton
-        menuLabel="Open backend filters"
-        panelId="backend-filters-panel"
-        expanded={mobileRail.isOpen}
-        onClick={mobileRail.toggle}
-        triggerRef={mobileRail.triggerRef}
-      />
-
-      <div className="backends__main workspace-pane">
-      <WorkspacePaneHeader
-        className="backends__pane-header"
-        headingLevel={1}
-        title="Backends"
-        subtitle="Install and update the inference engines available on this machine."
-        actions={updatesAvailable > 0 ? (
-          <div className="backends__header-update" data-backends-banner>
-            <span className="sr-only" data-backends-banner-text>{updatesAvailable} backend update{updatesAvailable > 1 ? 's' : ''} available</span>
-            <WorkspaceActionButton appearance="primary" icon="rotate-ccw" data-backends-banner-action onClick={handleUpdateAll} disabled={installing !== null}>
-              {installing ? 'Updating…' : `Update all (${updatesAvailable})`}
-            </WorkspaceActionButton>
-          </div>
-        ) : undefined}
-      />
-
-      <div className="backends__head">
-
-        {error && (
-          <div className="banner banner--error" data-backends-error>
-            <span className="banner__icon" aria-hidden="true"><Icon name="alert" size={16} /></span>
-            <span className="banner__text">Could not load backend system info: {error}</span>
-            <WorkspaceActionButton size="small" icon="rotate-ccw" onClick={() => void fetchInfo()} disabled={loading}>Retry</WorkspaceActionButton>
-          </div>
-        )}
-
-      </div>
-
-      {backendCatalog.length === 0 && (
-        <p className="sr-only" data-backends-matrix-empty>No backend data is available for this Lemonade server yet.</p>
-      )}
-
-      {backendStateCounts[viewFilter] === 0 && (
-        <div className="backends__filter-empty">
-          <Icon name={viewFilter === 'updates' ? 'check' : 'box'} size={24} />
-          <strong>No {viewFilter} backends</strong>
-          <span>{viewFilter === 'updates' ? 'Every installed backend is current.' : 'No runtimes match this filter on the connected machine.'}</span>
-          </div>
-        )}
-
-        <div className="backends__content">
-          <div className="backend-catalog" data-backends-matrix>
-            {backendCatalog.map(({ capability, entries }) => {
-              const visibleEntries = entries
-                .map(entry => {
-                  const variants = entry.variants.filter(backendMatchesView);
-                  return {
-                    ...entry,
-                    variants,
-                    devices: uniq(variants.flatMap(variant => variant.devices)),
-                  };
-                })
-                .filter(entry => entry.variants.length > 0);
-              if (visibleEntries.length === 0) return null;
-              return (
-                <section className="backend-catalog__section" key={capability}>
-                  <header className="backend-catalog__heading">
-                    <div>
-                      <h2>{CAPABILITY_LABELS[capability]}</h2>
-                      <p>{CAPABILITY_DESCRIPTIONS[capability]}</p>
-                    </div>
-                  </header>
-                  <div className="backend-catalog__grid">
-                    {visibleEntries.map(renderBackendCard)}
-                  </div>
-                </section>
-              );
-            })}
-          </div>
-
+      }
+      header={
+        <WorkspacePaneHeader
+          className="backends__pane-header"
+          headingLevel={1}
+          title="Inference Backends"
+          subtitle="Install and update the inference engines available on this machine."
+          actions={updatesAvailable > 0 ? (
+            <div className="backends__header-update" data-backends-banner>
+              <span className="sr-only" data-backends-banner-text>{updatesAvailable} backend update{updatesAvailable > 1 ? 's' : ''} available</span>
+              <WorkspaceActionButton appearance="primary" icon="rotate-ccw" data-backends-banner-action onClick={handleUpdateAll} disabled={installing !== null}>
+                {installing ? 'Updating…' : `Update all (${updatesAvailable})`}
+              </WorkspaceActionButton>
+            </div>
+          ) : undefined}
+        />
+      }
+      preContent={<>
+        <div className="backends__head">
+          {error && (
+            <div className="banner banner--error" data-backends-error>
+              <span className="banner__icon" aria-hidden="true"><Icon name="alert" size={16} /></span>
+              <span className="banner__text">Could not load backend system info: {error}</span>
+              <WorkspaceActionButton size="small" icon="rotate-ccw" onClick={() => void fetchInfo()} disabled={loading}>Retry</WorkspaceActionButton>
+            </div>
+          )}
         </div>
-
-      <BackendArgsDialog
-        backendKeyValue={argsEditorKey}
-        tuning={argsEditorKey ? backendTunings[argsEditorKey] || null : null}
-        onSave={handleSaveBackendArgs}
-        onClear={handleClearBackendArgs}
-        onClose={closeArgsEditor}
-      />
-
-      {/* #2351: always-present polite live region so NVDA announces toast messages */}
-      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only" data-backends-toast-live>
-        {toastMsg || ''}
+        {backendCatalog.length === 0 && (
+          <p className="sr-only" data-backends-matrix-empty>No backend data is available for this Lemonade server yet.</p>
+        )}
+        {backendStateCounts[viewFilter] === 0 && (
+          <div className="backends__filter-empty">
+            <Icon name={viewFilter === 'updates' ? 'check' : 'box'} size={24} />
+            <strong>No {viewFilter} backends</strong>
+            <span>{viewFilter === 'updates' ? 'Every installed backend is current.' : 'No runtimes match this filter on the connected machine.'}</span>
+          </div>
+        )}
+      </>}
+      overlay={<>
+        <BackendArgsDialog
+          backendKeyValue={argsEditorKey}
+          tuning={argsEditorKey ? backendTunings[argsEditorKey] || null : null}
+          onSave={handleSaveBackendArgs}
+          onClear={handleClearBackendArgs}
+          onClose={closeArgsEditor}
+        />
+        {/* #2351: always-present polite live region so NVDA announces toast messages */}
+        <div role="status" aria-live="polite" aria-atomic="true" className="sr-only" data-backends-toast-live>
+          {toastMsg || ''}
+        </div>
+        {toastMsg && <div className="backends__toast" data-backends-toast>{toastMsg}</div>}
+      </>}
+    >
+      <div className="workspace-catalog" data-backends-matrix>
+        {backendCatalog.map(({ capability, entries }) => {
+          const visibleEntries = entries
+            .map(entry => {
+              const variants = entry.variants.filter(backendMatchesView);
+              return {
+                ...entry,
+                variants,
+                devices: uniq(variants.flatMap(variant => variant.devices)),
+              };
+            })
+            .filter(entry => entry.variants.length > 0);
+          if (visibleEntries.length === 0) return null;
+          return (
+            <WorkspaceCatalogSection
+              key={capability}
+              title={CAPABILITY_LABELS[capability]}
+              description={CAPABILITY_DESCRIPTIONS[capability]}
+            >
+              {visibleEntries.map(renderBackendCard)}
+            </WorkspaceCatalogSection>
+          );
+        })}
       </div>
-      {toastMsg && <div className="backends__toast" data-backends-toast>{toastMsg}</div>}
-      </div>
-    </section>
+    </WorkspaceCatalogLayout>
   );
 };
 

--- a/src/app/src/components/WorkspaceCatalogLayout.tsx
+++ b/src/app/src/components/WorkspaceCatalogLayout.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import { Icon, type IconName } from './Icon';
+import WorkspaceMobileMenuButton from './WorkspaceMobileMenuButton';
+import WorkspaceRailHeader from './WorkspaceRailHeader';
+import { useWorkspaceMobileRail } from '../hooks/useWorkspaceMobileRail';
+
+export type CatalogFilterDefinition<Id extends string> = {
+  id: Id;
+  label: string;
+  description?: string;
+  icon: IconName;
+  count?: number;
+};
+
+interface WorkspaceCatalogLayoutProps<Id extends string> {
+  view: string;
+  className?: string;
+  panelId: string;
+  railTitle: string;
+  railLabel: string;
+  sidebarLabel: string;
+  mobileMenuLabel: string;
+  filters: readonly CatalogFilterDefinition<Id>[];
+  activeFilter: Id;
+  onFilterChange: (id: Id) => void;
+  railFooter?: React.ReactNode;
+  header: React.ReactNode;
+  preContent?: React.ReactNode;
+  overlay?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export function WorkspaceCatalogLayout<Id extends string>({
+  view,
+  className = '',
+  panelId,
+  railTitle,
+  railLabel,
+  sidebarLabel,
+  mobileMenuLabel,
+  filters,
+  activeFilter,
+  onFilterChange,
+  railFooter,
+  header,
+  preContent,
+  overlay,
+  children,
+}: WorkspaceCatalogLayoutProps<Id>) {
+  const mobileRail = useWorkspaceMobileRail();
+  const [railCollapsed, setRailCollapsed] = useState(false);
+
+  return (
+    <section
+      className={`workspace-catalog-layout${railCollapsed ? ' workspace--rail-collapsed' : ''}${className ? ` ${className}` : ''}`}
+      data-view={view}
+    >
+      {mobileRail.isOpen && <div className="workspace-mobile-rail-backdrop" onClick={mobileRail.close} aria-hidden="true" />}
+      <aside
+        ref={mobileRail.panelRef}
+        id={panelId}
+        className={`workspace-rail mobile-context-panel${railCollapsed && !mobileRail.isOpen ? ' is-collapsed' : ''}${mobileRail.isOpen ? ' is-mobile-open' : ''}`}
+        aria-label={railLabel}
+        role={mobileRail.isOpen ? 'dialog' : undefined}
+        aria-modal={mobileRail.isOpen ? true : undefined}
+      >
+        <WorkspaceRailHeader
+          title={railTitle}
+          sidebarLabel={sidebarLabel}
+          purpose="filter"
+          collapsed={railCollapsed && !mobileRail.isOpen}
+          onToggle={() => setRailCollapsed(value => !value)}
+          onMobileClose={mobileRail.isOpen ? mobileRail.close : undefined}
+        />
+        <nav className="workspace-filter-list" aria-label={railLabel}>
+          {filters.map(filter => (
+            <button
+              key={filter.id}
+              type="button"
+              className={`workspace-filter-list__item${activeFilter === filter.id ? ' is-active' : ''}`}
+              aria-current={activeFilter === filter.id ? 'true' : undefined}
+              aria-label={filter.label}
+              title={filter.description ? `${filter.label} — ${filter.description}` : filter.label}
+              onClick={() => { onFilterChange(filter.id); mobileRail.close(); }}
+            >
+              <Icon className="workspace-filter-list__icon" name={filter.icon} size={14} />
+              <span className="workspace-filter-list__label">{filter.label}</span>
+              {filter.count !== undefined && <span className="workspace-filter-list__count">{filter.count}</span>}
+            </button>
+          ))}
+        </nav>
+        {railFooter && <div className="workspace-rail__footer">{railFooter}</div>}
+      </aside>
+
+      <WorkspaceMobileMenuButton
+        menuLabel={mobileMenuLabel}
+        panelId={panelId}
+        expanded={mobileRail.isOpen}
+        onClick={mobileRail.toggle}
+        triggerRef={mobileRail.triggerRef}
+      />
+
+      <div className="workspace-pane workspace-catalog-layout__main">
+        {header}
+        {preContent}
+        <div className="workspace-catalog-layout__content">
+          {children}
+        </div>
+        {overlay}
+      </div>
+    </section>
+  );
+}
+
+interface WorkspaceCatalogSectionProps {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  aside?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const WorkspaceCatalogSection: React.FC<WorkspaceCatalogSectionProps> = ({ title, description, aside, children }) => (
+  <section className="workspace-catalog__section">
+    {title && (
+      <header className="workspace-catalog__heading">
+        <div>
+          <h2>{title}</h2>
+          {description && <p>{description}</p>}
+        </div>
+        {aside && <span>{aside}</span>}
+      </header>
+    )}
+    <div className="workspace-catalog__grid">{children}</div>
+  </section>
+);
+
+export default WorkspaceCatalogLayout;

--- a/src/app/src/components/WorkspaceCatalogLayout.tsx
+++ b/src/app/src/components/WorkspaceCatalogLayout.tsx
@@ -80,12 +80,16 @@ export function WorkspaceCatalogLayout<Id extends string>({
               className={`workspace-filter-list__item${activeFilter === filter.id ? ' is-active' : ''}`}
               aria-current={activeFilter === filter.id ? 'true' : undefined}
               aria-label={filter.label}
+              aria-describedby={filter.description ? `${panelId}-${filter.id}-description` : undefined}
               title={filter.description ? `${filter.label} — ${filter.description}` : filter.label}
               onClick={() => { onFilterChange(filter.id); mobileRail.close(); }}
             >
               <Icon className="workspace-filter-list__icon" name={filter.icon} size={14} />
               <span className="workspace-filter-list__label">{filter.label}</span>
               {filter.count !== undefined && <span className="workspace-filter-list__count">{filter.count}</span>}
+              {filter.description && (
+                <span id={`${panelId}-${filter.id}-description`} className="sr-only">{filter.description}</span>
+              )}
             </button>
           ))}
         </nav>

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -3438,22 +3438,13 @@ optgroup {
   grid-template-columns: 56px minmax(0, 1fr);
 }
 
-.manager__main,
-.backends__main {
+.manager__main {
   min-width: 0;
   min-height: 0;
   height: 100%;
   overflow: hidden;
-}
-
-.manager__main {
   display: grid;
   grid-template-rows: auto 1fr;
-}
-
-.backends__main {
-  display: flex;
-  flex-direction: column;
 }
 
 .context-rail {
@@ -3613,7 +3604,7 @@ optgroup {
   .rail { display: none; }
   .manager--with-rail, .backends--with-rail { grid-template-columns: 1fr; }
   .context-rail { display: none; }
-  .manager__main, .backends__main { height: 100%; }
+  .manager__main { height: 100%; }
   .chat__inner { padding: var(--space-5) var(--space-4); overflow-x: hidden; }
   .composer { padding: var(--space-3) var(--space-4); }
   .manager__custom-actions .btn { flex: 1; justify-content: center; }
@@ -11618,9 +11609,8 @@ optgroup {
 }
 
 .connect--workspace.workspace--rail-collapsed,
-.apps-workspace.workspace--rail-collapsed,
 .logs-workspace.workspace--rail-collapsed,
-.backends--workspace.workspace--rail-collapsed {
+.workspace-catalog-layout.workspace--rail-collapsed {
   grid-template-columns: var(--rail-collapsed) minmax(0, 1fr);
 }
 
@@ -11706,60 +11696,67 @@ optgroup {
 }
 
 /* Apps */
-.apps-workspace {
-  display: grid;
-  grid-template-columns: var(--workspace-rail) minmax(0, 1fr);
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
+.apps-workspace .workspace-catalog__grid { align-items: stretch; }
+
+.app-card__logo {
+  flex: none;
+  width: 36px;
+  height: 36px;
+  object-fit: contain;
+  border-radius: var(--radius-sm);
 }
 
-.apps__main {
-  height: 100%;
-  display: grid;
-  grid-template-rows: var(--workspace-header) minmax(0, 1fr);
+.app-card__logo--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
 }
 
-.apps__main .workspace-pane__heading h2 {
+.app-card__identity {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-0-5);
+}
+
+.app-card__name {
+  display: block;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.apps__nav {
+.app-card__description {
   flex: 1;
-  min-height: 0;
-  overflow-y: auto;
+  margin: var(--space-3) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
 }
 
-.apps__content {
-  min-height: 0;
-  padding: var(--space-5);
-}
-
-.apps__directory {
-  width: min(100%, var(--max-content-width));
-  min-width: 0;
-  margin-inline: auto;
-}
-
-.apps__marketplace-actions {
-  width: auto;
-  justify-content: flex-end;
-}
-
-.apps__app-logo {
-  width: 28px;
-  height: 28px;
-  object-fit: contain;
-}
-
-.apps__app-logo--fallback {
-  display: inline-flex;
+.app-card__footer {
+  display: flex;
   align-items: center;
-  justify-content: center;
-  color: var(--text-primary);
-  font-weight: var(--weight-semibold);
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.app-card__actions {
+  width: auto;
+}
+
+.app-card__category {
+  overflow: hidden;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .apps__empty,
@@ -11815,20 +11812,34 @@ optgroup {
 .workspace-action-button.logs-rail__mobile-close { display: none; }
 .monitor-subpanel__title-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
 .monitor-subpanel__title-row > div { min-width: 0; }
-/* Backends */
-.backends--workspace {
+/* Catalog layout — shared contract for tabs with a filter rail and card grid
+   (Backends, Apps) */
+.workspace-catalog-layout {
   display: grid;
   grid-template-columns: var(--workspace-rail) minmax(0, 1fr);
+  width: 100%;
   height: 100%;
   padding: 0;
   overflow: hidden;
 }
 
-.backends--workspace .backends__main {
-  display: grid;
-  grid-template-rows: var(--workspace-header) auto minmax(0, 1fr) auto;
+.workspace-catalog-layout__main {
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
+.workspace-catalog-layout__content {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-2) var(--panel-padding-inline) var(--space-6);
+}
+
+/* Backends */
 .backends--workspace .backends__head { padding: 0 var(--panel-padding-inline); }
 .backends__rail-footer { display: grid; gap: var(--space-3); }
 .backends__rail-footer .backends__toggle { justify-content: flex-start; }
@@ -11854,62 +11865,57 @@ optgroup {
 }
 .backends__filter-empty strong { color: var(--text-primary); font-size: var(--text-sm); }
 .backends__filter-empty span { max-width: 320px; font-size: var(--text-xs); }
-.backends__filter-empty + .backends__content { display: none; }
+.backends__filter-empty + .workspace-catalog-layout__content { display: none; }
 
 .backends--workspace .matrix th,
 .backends--workspace .matrix td { padding: var(--space-3); }
 .backends--workspace .cell { gap: var(--space-2); }
 
-.backends__content {
-  min-height: 0;
-  overflow: auto;
-  padding: var(--space-2) var(--panel-padding-inline) var(--space-6);
-}
-
-.backend-catalog {
+/* Shared catalog: sectioned card grid */
+.workspace-catalog {
   display: grid;
   gap: var(--space-6);
 }
 
-.backend-catalog__section {
+.workspace-catalog__section {
   display: grid;
   gap: var(--space-3);
 }
 
-.backend-catalog__heading {
+.workspace-catalog__heading {
   display: flex;
   align-items: end;
   justify-content: space-between;
   gap: var(--space-3);
 }
 
-.backend-catalog__heading h2 {
+.workspace-catalog__heading h2 {
   margin: 0;
   color: var(--text-primary);
   font-size: var(--text-lg);
   font-weight: var(--weight-semibold);
 }
 
-.backend-catalog__heading p {
+.workspace-catalog__heading p {
   margin: var(--space-1) 0 0;
   color: var(--text-tertiary);
   font-size: var(--text-sm);
 }
 
-.backend-catalog__heading > span {
+.workspace-catalog__heading > span {
   color: var(--text-tertiary);
   font-size: var(--text-xs);
   white-space: nowrap;
 }
 
-.backend-catalog__grid {
+.workspace-catalog__grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   gap: var(--space-3);
   align-items: start;
 }
 
-.backend-card {
+.workspace-card {
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -11919,19 +11925,15 @@ optgroup {
   border-radius: var(--radius-md);
 }
 
-.backend-card__head,
-.backend-card__footer,
-.backend-card__actions {
+.workspace-card__head {
   display: flex;
   align-items: center;
-}
-
-.backend-card__head {
+  gap: var(--space-3);
   padding-bottom: var(--space-3);
   border-bottom: 1px solid var(--border-subtle);
 }
 
-.backend-card__name {
+.workspace-card__name {
   display: flex;
   align-items: center;
   gap: var(--space-2);
@@ -11941,6 +11943,12 @@ optgroup {
   font-weight: var(--weight-semibold);
   line-height: var(--leading-snug);
   letter-spacing: var(--tracking-tight);
+}
+
+.backend-card__footer,
+.backend-card__actions {
+  display: flex;
+  align-items: center;
 }
 
 .backend-card__variants {
@@ -12080,9 +12088,9 @@ a.backend-card__version:focus-visible {
 }
 
 @media (max-width: 680px) {
-  .backends__content { padding: var(--space-2) var(--space-4) var(--space-5); }
-  .backend-catalog__grid { grid-template-columns: 1fr; }
-  .backend-catalog__heading { align-items: flex-start; flex-direction: column; gap: var(--space-1); }
+  .workspace-catalog-layout__content { padding: var(--space-2) var(--space-4) var(--space-5); }
+  .workspace-catalog__grid { grid-template-columns: 1fr; }
+  .workspace-catalog__heading { align-items: flex-start; flex-direction: column; gap: var(--space-1); }
   .backend-card__variant-head { gap: var(--space-2); }
   .backend-card__footer { align-items: flex-start; flex-direction: column; }
   .backend-card__actions { flex-wrap: wrap; }
@@ -12226,7 +12234,7 @@ a.backend-card__version:focus-visible {
   .workspace-nav__copy small { display: none; }
   .workspace-nav button { min-height: 44px; }
   .workspace-pane__header { padding-inline: var(--space-4); }
-  .backends__content, .backends--workspace .backends__head { padding-inline: var(--space-4); }
+  .workspace-catalog-layout__content, .backends--workspace .backends__head { padding-inline: var(--space-4); }
   .inspect-layout--embedded { grid-template-columns: 280px minmax(0, 1fr); grid-template-rows: minmax(0, 1fr); }
   .logs-workspace--embedded { grid-template-columns: 240px minmax(0, 1fr); grid-template-rows: minmax(0, 1fr); }
 }
@@ -12234,51 +12242,51 @@ a.backend-card__version:focus-visible {
 @media (max-width: 768px) {
   .connect--workspace,
   .logs-workspace,
-  .backends--workspace {
+  .workspace-catalog-layout {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto minmax(0, 1fr);
   }
 
   .connect--workspace.workspace--rail-collapsed,
   .logs-workspace.workspace--rail-collapsed,
-  .backends--workspace.workspace--rail-collapsed {
+  .workspace-catalog-layout.workspace--rail-collapsed {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto minmax(0, 1fr);
   }
 
   .connect--workspace .workspace-rail,
   .logs-workspace .workspace-rail,
-  .backends--workspace .workspace-rail {
+  .workspace-catalog-layout .workspace-rail {
     border-right: 0;
     border-bottom: 1px solid var(--border-subtle);
   }
 
   .connect--workspace .workspace-rail__header,
   .logs-workspace .workspace-rail__header,
-  .backends--workspace .workspace-rail__header,
+  .workspace-catalog-layout .workspace-rail__header,
   .connect--workspace .workspace-rail__footer,
   .logs-workspace .workspace-rail__footer,
-  .backends--workspace .workspace-rail__footer,
+  .workspace-catalog-layout .workspace-rail__footer,
   .logs-workspace .workspace-rail__body { display: none; }
 
   .connect--workspace .workspace-nav,
-  .backends--workspace .workspace-filter-list {
+  .workspace-catalog-layout .workspace-filter-list {
     flex-direction: row;
     overflow-x: auto;
     padding: var(--space-2);
   }
 
   .connect--workspace .workspace-rail.is-collapsed > .workspace-nav,
-  .backends--workspace .workspace-rail.is-collapsed > .workspace-filter-list {
+  .workspace-catalog-layout .workspace-rail.is-collapsed > .workspace-filter-list {
     display: flex;
   }
 
   .connect--workspace .workspace-nav button,
-  .backends--workspace .workspace-filter-list__item { width: auto; min-width: 44px; grid-template-columns: 18px; }
+  .workspace-catalog-layout .workspace-filter-list__item { width: auto; min-width: 44px; grid-template-columns: 18px; }
   .connect--workspace .workspace-nav__copy,
   .connect--workspace .workspace-nav__chevron,
-  .backends--workspace .workspace-filter-list__label,
-  .backends--workspace .workspace-filter-list__count { display: none; }
+  .workspace-catalog-layout .workspace-filter-list__label,
+  .workspace-catalog-layout .workspace-filter-list__count { display: none; }
   .workspace-pane__header p { display: none; }
   .monitor-workspace,
   .monitor-workspace.workspace--rail-collapsed {
@@ -12312,10 +12320,14 @@ a.backend-card__version:focus-visible {
   .monitor-workspace .monitor-nav .workspace-nav__copy,
   .monitor-workspace .monitor-nav .workspace-nav__chevron { display: none; }
 
-  .backends--workspace .backends__main {
-    grid-template-rows: var(--workspace-header) auto auto auto;
-    align-content: start;
+  .workspace-catalog-layout__main {
     overflow-y: auto;
+  }
+
+  .workspace-catalog-layout__content {
+    flex: none;
+    min-height: auto;
+    overflow: visible;
   }
 
   .backends--workspace .matrix {
@@ -12684,23 +12696,17 @@ a.backend-card__version:focus-visible {
   }
 
   .connect--workspace,
-  .apps-workspace,
   .monitor-workspace,
-  .backends--workspace {
+  .workspace-catalog-layout {
     position: relative;
   }
 
   .connect--workspace,
-  .apps-workspace,
   .monitor-workspace,
-  .backends--workspace {
+  .workspace-catalog-layout {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: minmax(0, 1fr);
   }
-
-
-  .apps__content { padding: var(--space-4); }
-
 
 
   .model-nav-rail .model-nav-rail__scroll {

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -11945,6 +11945,43 @@ optgroup {
   letter-spacing: var(--tracking-tight);
 }
 
+.backend-card__logo {
+  flex: 1;
+  height: 48px;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: #fff;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.backend-card__logo--dark {
+  background: #000;
+}
+
+.backend-card__logo img {
+  max-width: 100%;
+  max-height: 30px;
+  object-fit: contain;
+}
+
+.backend-card__logo-name {
+  overflow: hidden;
+  color: #1c1c1c;
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-tight);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.backend-card__logo--dark .backend-card__logo-name { color: #fff; }
+.backend-card__logo--image-only .backend-card__logo-name { display: none; }
+
 .backend-card__footer,
 .backend-card__actions {
   display: flex;

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -11706,14 +11706,16 @@ optgroup {
   border-radius: var(--radius-sm);
 }
 
+.app-card__logo--tile {
+  background: #fff;
+  border-radius: var(--radius-md);
+}
+
 .app-card__logo--fallback {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--surface-2);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  color: var(--text-primary);
+  color: #1c1c1c;
   font-size: var(--text-sm);
   font-weight: var(--weight-semibold);
 }

--- a/src/app/tests/ui-regression-contracts.runtime.cjs
+++ b/src/app/tests/ui-regression-contracts.runtime.cjs
@@ -9,6 +9,7 @@ const files = {
   chat: path.join(root, 'src/components/ChatView.tsx'),
   connect: path.join(root, 'src/components/ConnectView.tsx'),
   apps: path.join(root, 'src/components/AppsView.tsx'),
+  catalogLayout: path.join(root, 'src/components/WorkspaceCatalogLayout.tsx'),
   mcpPanel: path.join(root, 'src/components/McpPanel.tsx'),
   api: path.join(root, 'src/api.ts'),
   mcpRuntime: path.join(root, 'src/tools/mcpRuntime.ts'),
@@ -44,9 +45,11 @@ assert.match(sources.chat, /role="tab"[\s\S]*?>[\s\S]*?External MCP servers[\s\S
 
 assert.doesNotMatch(sources.navigation, /defineSection\('app-directory'/);
 assert.doesNotMatch(sources.connect, /AppsView|app-directory/);
-assert.match(sources.apps, /<WorkspaceSectionRail[\s\S]*?navigationLabel="App categories"/);
-assert.match(sources.apps, /className={`apps-workspace\$\{railCollapsed \? ' workspace--rail-collapsed' : ''\}`}/);
+assert.match(sources.apps, /<WorkspaceCatalogLayout[\s\S]*?railLabel="App categories"/);
+assert.match(sources.apps, /className="apps-workspace"/);
 assert.doesNotMatch(sources.apps, /embedded\?: boolean|apps__category-filters|WorkspaceMetadataChip/);
+assert.match(sources.catalogLayout, /workspace-catalog-layout\$\{railCollapsed \? ' workspace--rail-collapsed' : ''\}/);
+assert.match(sources.catalogLayout, /className="workspace-filter-list"/);
 
 assert.match(sources.mcpPanel, /transport: 'streamable-http'/);
 assert.match(sources.mcpPanel, />HTTP endpoint</);


### PR DESCRIPTION
**Apps Marketplace — Featured row + curated category sections**
![Apps Marketplace overview](https://raw.githubusercontent.com/lemonade-sdk/lemonade/jfowers/gui3-apps-screenshots/pr1_apps_marketplace.png)

**Category sections keyed by each app's primary label**
![Category sections](https://raw.githubusercontent.com/lemonade-sdk/lemonade/jfowers/gui3-apps-screenshots/pr2_apps_categories.png)

**Sidebar filter view (labels from marketplace category metadata)**
![Filtered category view](https://raw.githubusercontent.com/lemonade-sdk/lemonade/jfowers/gui3-apps-screenshots/pr3_apps_filtered.png)

**Light theme**
![Apps light theme](https://raw.githubusercontent.com/lemonade-sdk/lemonade/jfowers/gui3-apps-screenshots/pr4_apps_light.png)

**Backends — engine logo plates**
![Backends with engine logos](https://raw.githubusercontent.com/lemonade-sdk/lemonade/jfowers/gui3-apps-screenshots/pr5_backends_logos.png)

**Dark plates for dark-fill logos, text plates when no logo exists, icon+name lockup for Moonshine**
![Backends audio section](https://raw.githubusercontent.com/lemonade-sdk/lemonade/jfowers/gui3-apps-screenshots/pr6_backends_audio.png)

**More logo plates (TTS / 3D sections)**
![Backends TTS section](https://raw.githubusercontent.com/lemonade-sdk/lemonade/jfowers/gui3-apps-screenshots/pr7_backends_tts.png)

**Responsive layout (shared with Backends via the new catalog layout contract)**
![Apps mobile](https://raw.githubusercontent.com/lemonade-sdk/lemonade/jfowers/gui3-apps-screenshots/pr8_apps_mobile.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)