### PR TITLE
GUI3: Fix status indicators and Apps test, add optional backend logos

### DIFF
--- a/src/app/src/components/AppsView.tsx
+++ b/src/app/src/components/AppsView.tsx
@@ -217,7 +217,7 @@ const AppsView: React.FC<AppsViewProps> = ({
   const categoryFilters = useMemo<CatalogFilterDefinition<string>[]>(() => [
     {
       id: ALL_APPS_SECTION,
-      label: 'All apps',
+      label: 'All Apps',
       description: marketplaceLoading
         ? 'Loading directory'
         : marketplaceError

--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -639,6 +639,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
   const [error, setError] = useState<string | null>(null);
   const [showTech, setShowTech] = useState(false);
   const [showUnsupported, setShowUnsupported] = useState(false);
+  const [showLogos, setShowLogos] = useState(true);
   const [viewFilter, setViewFilter] = useState<BackendViewFilter>('all');
   const [installing, setInstalling] = useState<string | null>(null); // "recipe:backend"
   const [toastMsg, setToastMsg] = useState<string | null>(null);
@@ -1037,24 +1038,31 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
     return (
       <article className="workspace-card backend-card" key={recipe} data-recipe={recipe}>
         <div className="workspace-card__head">
-          <h3 className="sr-only">{engineName}</h3>
-          <div
-            className={`backend-card__logo${logo?.plate === 'dark' ? ' backend-card__logo--dark' : ''}${logo && !logo.showName ? ' backend-card__logo--image-only' : ''}`}
-            aria-hidden="true"
-          >
-            {logo && (
-              <img
-                src={`${ENGINE_LOGO_BASE}${logo.file}`}
-                alt=""
-                loading="lazy"
-                onError={event => {
-                  event.currentTarget.style.display = 'none';
-                  event.currentTarget.parentElement!.className = 'backend-card__logo';
-                }}
-              />
-            )}
-            <span className="backend-card__logo-name">{engineName}</span>
-          </div>
+          {showLogos ? (
+            <>
+              <h3 className="sr-only">{engineName}</h3>
+              <div
+                className={`backend-card__logo${logo?.plate === 'dark' ? ' backend-card__logo--dark' : ''}${logo && !logo.showName ? ' backend-card__logo--image-only' : ''}`}
+                aria-hidden="true"
+                data-backend-logo
+              >
+                {logo && (
+                  <img
+                    src={`${ENGINE_LOGO_BASE}${logo.file}`}
+                    alt=""
+                    loading="lazy"
+                    onError={event => {
+                      event.currentTarget.style.display = 'none';
+                      event.currentTarget.parentElement!.className = 'backend-card__logo';
+                    }}
+                  />
+                )}
+                <span className="backend-card__logo-name">{engineName}</span>
+              </div>
+            </>
+          ) : (
+            <h3 className="workspace-card__name backend-card__name">{engineName}</h3>
+          )}
         </div>
 
         <div className="backend-card__variants">
@@ -1222,7 +1230,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
         </div>
       </article>
     );
-  }, [backendTunings, downloadItems, handleAction, handleInstall, handleUninstall, installing, showTech]);
+  }, [backendTunings, downloadItems, handleAction, handleInstall, handleUninstall, installing, showLogos, showTech]);
 
 
   /* ── Render ───────────────────────────────────────────── */
@@ -1274,6 +1282,15 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
               data-backends-unsupported-toggle
             />
             <span>Show unsupported backends</span>
+          </label>
+          <label className="backends__toggle">
+            <input
+              type="checkbox"
+              checked={showLogos}
+              onChange={e => setShowLogos(e.target.checked)}
+              data-backends-logo-toggle
+            />
+            <span>Show logos</span>
           </label>
           {sysInfo && (
             <div className="backends__runtime-meta">

--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -218,7 +218,7 @@ const CAPABILITY_DESCRIPTIONS: Record<CapabilityCol, string> = {
 };
 
 const BACKEND_VIEW_FILTERS: Array<[BackendViewFilter, string, string, IconName]> = [
-  ['all', 'All backends', 'Complete compatibility matrix', 'layers'],
+  ['all', 'All Backends', 'Complete compatibility matrix', 'layers'],
   ['installed', 'Installed', 'Ready on this machine', 'check'],
   ['available', 'Available', 'Ready to install', 'download'],
   ['updates', 'Updates', 'Newer runtime available', 'rotate-ccw'],

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -475,7 +475,7 @@ input, textarea {
 
 .titlebar__status-dot--connected {
   background: var(--success);
-  box-shadow: 0 0 0 3px var(--success-soft);
+  box-shadow: 0 0 6px var(--success);
 }
 
 .titlebar__status-dot--connecting {
@@ -2414,7 +2414,7 @@ input, textarea {
   background: var(--text-disabled);
 }
 
-.connect__status-dot--connected { background: var(--success); box-shadow: 0 0 0 3px var(--success-soft); }
+.connect__status-dot--connected { background: var(--success); box-shadow: 0 0 6px var(--success); }
 .connect__status-dot--connecting { background: var(--warn); animation: pulse 1.2s ease-in-out infinite; }
 
 /* ---------- Buttons ---------- */

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -145,21 +145,21 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.waitForSelector('[data-view="apps"]');
 
     const appCategories = page.getByRole('navigation', { name: 'App categories' });
-    await expect(appCategories.getByRole('button', { name: 'All Apps', exact: true })).toHaveAttribute('aria-current', 'page');
+    await expect(appCategories.getByRole('button', { name: 'All Apps', exact: true })).toHaveAttribute('aria-current', 'true');
     await expect(appCategories.getByRole('button', { name: 'Chat', exact: true })).toBeVisible();
     await expect(appCategories.getByRole('button', { name: 'Creative Tools', exact: true })).toBeVisible();
-    await expect(page.locator('#apps-pane-title')).toHaveText('All Apps');
+    await expect(page.locator('#apps-pane-title')).toHaveText('Apps Marketplace');
     await expect(page.getByText('Chat Client', { exact: true })).toBeVisible();
     await expect(page.getByText('Creative Studio', { exact: true })).toBeVisible();
     await expect(page.getByText('Llama App', { exact: true })).toBeVisible();
-    await expect(page.getByRole('searchbox', { name: 'Search apps' })).toBeVisible();
+    await expect(page.getByRole('combobox', { name: 'Search apps' })).toBeVisible();
 
     const globalResults = page.locator('#titlebar-search-results [role="option"]');
     const searchFromView = async (viewName: 'Chat' | 'Backends' | 'Apps' | 'Monitor' | 'Settings', query: string) => {
       await page.locator('.titlebar__nav').getByRole('button', { name: viewName, exact: true }).click();
       await page.keyboard.press('Control+K');
       const accessibleName = viewName === 'Apps' ? 'Search apps' : 'Search Lemonade';
-      await page.getByRole('searchbox', { name: accessibleName }).fill(query);
+      await page.getByRole('combobox', { name: accessibleName }).fill(query);
     };
 
     await searchFromView('Apps', 'llama');
@@ -185,8 +185,11 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.locator('.titlebar__nav').getByRole('button', { name: 'Apps', exact: true }).click();
     await expect(page.locator('.apps__category-filters')).toHaveCount(0);
 
-    await appCategories.getByRole('button', { name: 'Chat', exact: true }).click();
-    await expect(page.locator('#apps-pane-title')).toHaveText('Chat');
+    const chatCategory = appCategories.getByRole('button', { name: 'Chat', exact: true });
+    await chatCategory.click();
+    await expect(chatCategory).toHaveAttribute('aria-current', 'true');
+    await expect(page.locator('#apps-pane-title')).toHaveText('Apps Marketplace');
+    await expect(page.getByRole('heading', { name: 'Chat', exact: true, level: 2 })).toBeVisible();
     await expect(page.getByText('Chat Client', { exact: true })).toBeVisible();
     await expect(page.getByText('Creative Studio', { exact: true })).toHaveCount(0);
     await expect(page).toHaveURL(/#\/apps$/);
@@ -595,7 +598,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
         visibleControls: ['All Models', 'Downloaded', 'My Models', 'Favorites'],
       },
       { tab: 'Backends', trigger: 'Open backend filters', dialog: 'Backend filters' },
-      { tab: 'Apps', trigger: 'Open app types', dialog: 'App type navigation', visibleControls: ['All Apps'] },
+      { tab: 'Apps', trigger: 'Open app categories', dialog: 'App categories', visibleControls: ['All Apps'] },
       { tab: 'Monitor', trigger: 'Open monitor views', dialog: 'Monitor navigation' },
       { tab: 'Settings', trigger: 'Open connection settings', dialog: 'Connection settings' },
     ];

--- a/src/app/tests/ui-regression-contracts.runtime.cjs
+++ b/src/app/tests/ui-regression-contracts.runtime.cjs
@@ -9,6 +9,7 @@ const files = {
   chat: path.join(root, 'src/components/ChatView.tsx'),
   connect: path.join(root, 'src/components/ConnectView.tsx'),
   apps: path.join(root, 'src/components/AppsView.tsx'),
+  backendManager: path.join(root, 'src/components/BackendManager.tsx'),
   catalogLayout: path.join(root, 'src/components/WorkspaceCatalogLayout.tsx'),
   mcpPanel: path.join(root, 'src/components/McpPanel.tsx'),
   api: path.join(root, 'src/api.ts'),
@@ -50,6 +51,11 @@ assert.match(sources.apps, /className="apps-workspace"/);
 assert.doesNotMatch(sources.apps, /embedded\?: boolean|apps__category-filters|WorkspaceMetadataChip/);
 assert.match(sources.catalogLayout, /workspace-catalog-layout\$\{railCollapsed \? ' workspace--rail-collapsed' : ''\}/);
 assert.match(sources.catalogLayout, /className="workspace-filter-list"/);
+
+assert.match(sources.backendManager, /const \[showLogos, setShowLogos\] = useState\(true\)/);
+assert.match(sources.backendManager, /data-backends-unsupported-toggle[\s\S]*?data-backends-logo-toggle/);
+assert.match(sources.backendManager, /checked=\{showLogos\}[\s\S]*?<span>Show logos<\/span>/);
+assert.match(sources.backendManager, /showLogos \? \([\s\S]*?data-backend-logo[\s\S]*?: \([\s\S]*?workspace-card__name backend-card__name/);
 
 assert.match(sources.mcpPanel, /transport: 'streamable-http'/);
 assert.match(sources.mcpPanel, />HTTP endpoint</);


### PR DESCRIPTION
## What changed

* Fixed the Lemonade connection indicator so the top bar and Settings rail use the same green glow as the Monitor live-status dot.
* Updated the Apps feature test to use the input’s actual combobox role, fixing the failing Playwright test.
* Capitalized the navigation label to **All Apps**.
* Backend tab: Added a **Show logos** checkbox below **Show unsupported backends**.

  * Enabled by default to preserve the current design.
  * When disabled, backend cards return to the previous text-only presentation.

## Why

Backend logos help many users recognize engines quickly, but their different colors, shapes, and background plates can also add visual noise or make the list harder to scan. This keeps logos as the default while giving sensitive users the choice to restore the simpler presentation used before PR #2921.

With logos:

<img width="1825" height="930" alt="image" src="https://github.com/user-attachments/assets/16f76eb9-a38a-43ca-9b6d-1edc5e69e28c" />

Without as before:

<img width="1823" height="946" alt="image" src="https://github.com/user-attachments/assets/8c288563-1d2a-4cc1-b99f-a7023f342c63" />
