### PR TITLE
GUI3 fix: avoid strange 0 when there is no online model search

### DIFF
--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -2744,6 +2744,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         onTagFiltersChange={setTagFilters}
         providerEnabled={providerEnabled}
         providerCounts={providerCounts}
+        searchActive={searchActive}
         onToggleProvider={toggleProvider}
         storageInfo={storageInfo}
         collapsed={navRailCollapsed}

--- a/src/app/src/components/ModelNavRail.tsx
+++ b/src/app/src/components/ModelNavRail.tsx
@@ -130,6 +130,7 @@ export interface ModelNavRailProps {
   onTagFiltersChange: (next: Set<string>) => void;
   providerEnabled: Record<ModelRegistryProvider, boolean>;
   providerCounts: Record<ModelRegistryProvider, number>;
+  searchActive: boolean;
   onToggleProvider: (provider: ModelRegistryProvider) => void;
   /** Real disk usage of the model-storage drive, when available (else null →
       derived fallback). Sourced from api.getStorageInfo(). */
@@ -160,6 +161,7 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
   onTagFiltersChange,
   providerEnabled,
   providerCounts,
+  searchActive,
   onToggleProvider,
   storageInfo,
   id = 'model-nav-rail',
@@ -171,15 +173,11 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
 }) => {
   const [tasksOpen, setTasksOpen] = useState(true);
   const [backendsOpen, setBackendsOpen] = useState(true);
+  const [catalogsOpen, setCatalogsOpen] = useState(true);
   const [tagsOpen, setTagsOpen] = useState(true);
   const [backendVisibility, setBackendVisibility] = useState<BackendRailVisibilityState | null>(null);
   const [customTags, setCustomTags] = useState<string[]>(loadCustomFilterTags);
   const [customTagDraft, setCustomTagDraft] = useState('');
-
-  const hasEnabledProvider = providerEnabled.huggingface || providerEnabled.modelscope;
-  const providerResultCount =
-    (providerEnabled.huggingface ? providerCounts.huggingface : 0) +
-    (providerEnabled.modelscope ? providerCounts.modelscope : 0);
 
   // ── Client-side derived counts ──────────────────────────────
   const primaryCounts = useMemo<Record<PrimaryFilter, number>>(() => {
@@ -376,40 +374,8 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
           );
         })}
 
-        <li className="model-nav-rail__catalogs">
-          <div
-            className="workspace-filter-list__item model-nav-rail__catalog-heading"
-            id="nav-online-catalogs-heading"
-          >
-            <Icon name="cloud" size={14} aria-hidden="true" className="workspace-filter-list__icon model-nav-rail__nav-icon" />
-            <span className="workspace-filter-list__label model-nav-rail__nav-label">Online Catalogs</span>
-            {hasEnabledProvider && (
-              <>
-                <span className="workspace-filter-list__count model-nav-rail__nav-count" aria-hidden="true">{providerResultCount}</span>
-                <span className="sr-only">{`, ${providerResultCount} online catalog results`}</span>
-              </>
-            )}
-          </div>
-          <ul className="model-nav-rail__provider-list" role="list" aria-labelledby="nav-online-catalogs-heading">
-            {MODEL_PROVIDERS.map(provider => {
-              const enabled = providerEnabled[provider.key];
-              const title = `${provider.label} ${enabled ? 'will be searched' : 'will not be searched'} during online model search`;
-              return (
-                <li key={provider.key}>
-                  <label className="model-nav-rail__provider-option" title={title}>
-                    <input
-                      type="checkbox"
-                      checked={enabled}
-                      onChange={() => onToggleProvider(provider.key)}
-                    />
-                    <span>{provider.label}</span>
-                  </label>
-                </li>
-              );
-            })}
-          </ul>
-        </li>
       </ul>
+
 
       <section className="model-nav-rail__section model-nav-rail__section--tasks">
         <h2 className="model-nav-rail__section-head">
@@ -506,6 +472,49 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
               </button>
             )}
           </div>
+        )}
+      </section>
+
+      <section className="model-nav-rail__section model-nav-rail__section--providers">
+        <h2 className="model-nav-rail__section-head">
+          <button
+            type="button"
+            className="model-nav-rail__section-toggle"
+            aria-expanded={catalogsOpen}
+            aria-controls="nav-online-catalogs"
+            onClick={() => setCatalogsOpen(value => !value)}
+          >
+            <Icon name={catalogsOpen ? 'chevron-down' : 'chevron-right'} size={13} aria-hidden="true" />
+            <span>Online Catalogs</span>
+          </button>
+        </h2>
+        {catalogsOpen && (
+          <ul className="model-nav-rail__provider-list" id="nav-online-catalogs" role="list">
+            {MODEL_PROVIDERS.map(provider => {
+              const enabled = providerEnabled[provider.key];
+              const count = providerCounts[provider.key];
+              const showCount = searchActive && primaryFilter === 'all' && enabled;
+              const title = `${provider.label} ${enabled ? 'will be searched' : 'will not be searched'} during online model search`;
+              return (
+                <li key={provider.key}>
+                  <label className="backends__toggle model-nav-rail__provider-option" title={title}>
+                    <input
+                      type="checkbox"
+                      checked={enabled}
+                      onChange={() => onToggleProvider(provider.key)}
+                    />
+                    <span className="model-nav-rail__provider-label">{provider.label}</span>
+                    {showCount && (
+                      <>
+                        <span className="model-nav-rail__nav-count" aria-hidden="true">{count}</span>
+                        <span className="sr-only">{`, ${count} search results`}</span>
+                      </>
+                    )}
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
         )}
       </section>
 

--- a/src/app/src/components/ModelNavRail.tsx
+++ b/src/app/src/components/ModelNavRail.tsx
@@ -169,13 +169,17 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
   onMobileClose,
   railRef,
 }) => {
-  const [providersOpen, setProvidersOpen] = useState(true);
   const [tasksOpen, setTasksOpen] = useState(true);
   const [backendsOpen, setBackendsOpen] = useState(true);
   const [tagsOpen, setTagsOpen] = useState(true);
   const [backendVisibility, setBackendVisibility] = useState<BackendRailVisibilityState | null>(null);
   const [customTags, setCustomTags] = useState<string[]>(loadCustomFilterTags);
   const [customTagDraft, setCustomTagDraft] = useState('');
+
+  const hasEnabledProvider = providerEnabled.huggingface || providerEnabled.modelscope;
+  const providerResultCount =
+    (providerEnabled.huggingface ? providerCounts.huggingface : 0) +
+    (providerEnabled.modelscope ? providerCounts.modelscope : 0);
 
   // ── Client-side derived counts ──────────────────────────────
   const primaryCounts = useMemo<Record<PrimaryFilter, number>>(() => {
@@ -372,57 +376,40 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
           );
         })}
 
-      </ul>
-
-      <section className="model-nav-rail__section model-nav-rail__section--providers">
-        <h2 className="model-nav-rail__section-head">
-          <button
-            type="button"
-            className="model-nav-rail__section-toggle"
-            aria-expanded={providersOpen}
-            aria-controls="nav-model-providers"
-            onClick={() => setProvidersOpen(v => !v)}
+        <li className="model-nav-rail__catalogs">
+          <div
+            className="workspace-filter-list__item model-nav-rail__catalog-heading"
+            id="nav-online-catalogs-heading"
           >
-            <Icon name={providersOpen ? 'chevron-down' : 'chevron-right'} size={13} aria-hidden="true" />
-            <span>Model-Provider</span>
-            {!providersOpen && (
-              <span className="model-nav-rail__section-count" aria-label={`${providerCounts.huggingface + providerCounts.modelscope} provider search results`}>
-                {providerCounts.huggingface + providerCounts.modelscope}
-              </span>
+            <Icon name="cloud" size={14} aria-hidden="true" className="workspace-filter-list__icon model-nav-rail__nav-icon" />
+            <span className="workspace-filter-list__label model-nav-rail__nav-label">Online Catalogs</span>
+            {hasEnabledProvider && (
+              <>
+                <span className="workspace-filter-list__count model-nav-rail__nav-count" aria-hidden="true">{providerResultCount}</span>
+                <span className="sr-only">{`, ${providerResultCount} online catalog results`}</span>
+              </>
             )}
-          </button>
-        </h2>
-        {providersOpen && (
-          <ul className="model-nav-rail__provider-list" id="nav-model-providers" role="list">
+          </div>
+          <ul className="model-nav-rail__provider-list" role="list" aria-labelledby="nav-online-catalogs-heading">
             {MODEL_PROVIDERS.map(provider => {
               const enabled = providerEnabled[provider.key];
-              const count = enabled ? providerCounts[provider.key] : 0;
-              const title = `${provider.label} search ${enabled ? 'enabled — click to disable' : 'disabled — click to enable'}`;
+              const title = `${provider.label} ${enabled ? 'will be searched' : 'will not be searched'} during online model search`;
               return (
                 <li key={provider.key}>
-                  <button
-                    type="button"
-                    className={`model-nav-rail__provider-item${enabled ? ' model-nav-rail__provider-item--enabled' : ' model-nav-rail__provider-item--disabled'}`}
-                    aria-pressed={enabled}
-                    title={title}
-                    onClick={() => onToggleProvider(provider.key)}
-                  >
-                    <span className="model-nav-rail__provider-label">{provider.label}</span>
-                    <span className="model-nav-rail__nav-count" aria-hidden="true">{count}</span>
-                    <Icon
-                      name={enabled ? 'cloud' : 'cloud-off'}
-                      size={14}
-                      aria-hidden="true"
-                      className="model-nav-rail__provider-status"
+                  <label className="model-nav-rail__provider-option" title={title}>
+                    <input
+                      type="checkbox"
+                      checked={enabled}
+                      onChange={() => onToggleProvider(provider.key)}
                     />
-                    <span className="sr-only">{`, ${count} results, search ${enabled ? 'enabled' : 'disabled'}`}</span>
-                  </button>
+                    <span>{provider.label}</span>
+                  </label>
                 </li>
               );
             })}
           </ul>
-        )}
-      </section>
+        </li>
+      </ul>
 
       <section className="model-nav-rail__section model-nav-rail__section--tasks">
         <h2 className="model-nav-rail__section-head">

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -12896,78 +12896,47 @@ a.backend-card__version:focus-visible {
 }
 
 /* ── Remote model providers (GUI3) ─────────────────────────── */
-.model-nav-rail__catalogs {
-  list-style: none;
-}
-
-.model-nav-rail__catalog-heading {
-  cursor: default;
-}
-
-.model-nav-rail__catalog-heading:hover {
-  background: transparent;
-  color: var(--text-secondary);
+.model-nav-rail__section-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  width: 100%;
+  box-sizing: border-box;
+  padding: var(--space-1) var(--space-2);
+  color: var(--text-tertiary);
+  font-size: var(--type-overline-size);
+  font-weight: var(--weight-semibold);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .model-nav-rail__provider-list {
   list-style: none;
   margin: 0;
-  padding: 0 var(--space-2) 0 calc(var(--space-2) + 18px + var(--space-2));
+  padding: 2px var(--space-2) 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-0-5);
 }
 
 .model-nav-rail__provider-option {
-  font-size: var(--text-sm);
-  color: var(--text-tertiary);
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  min-height: 28px;
-  cursor: pointer;
+  width: 100%;
+  min-height: 25px;
+  box-sizing: border-box;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
 }
 
 .model-nav-rail__provider-option:hover {
-  color: var(--text-secondary);
+  color: var(--text-primary);
 }
 
-.model-nav-rail__provider-option input {
-  appearance: none;
-  display: grid;
-  place-content: center;
-  flex: 0 0 auto;
-  width: 16px;
-  height: 16px;
-  margin: 0;
-  background: var(--surface-base);
-  border: 1px solid var(--border-strong);
-  border-radius: 3px;
-  cursor: pointer;
-}
-
-.model-nav-rail__provider-option input::after {
-  width: 5px;
-  height: 8px;
-  content: '';
-  border: solid var(--accent-on);
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg) scale(0);
-  transition: transform var(--duration-fast) var(--ease-out);
-}
-
-.model-nav-rail__provider-option input:checked {
-  background: var(--accent);
-  border-color: var(--accent);
-}
-
-.model-nav-rail__provider-option input:checked::after {
-  transform: rotate(45deg) scale(1);
-}
-
-.model-nav-rail__provider-option input:focus-visible {
-  outline: 2px solid var(--accent-focus);
-  outline-offset: 2px;
+.model-nav-rail__provider-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .registry-zones {

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -12896,76 +12896,78 @@ a.backend-card__version:focus-visible {
 }
 
 /* ── Remote model providers (GUI3) ─────────────────────────── */
-.model-nav-rail__section--providers {
-  border-top: 1px solid var(--border-subtle);
-  padding-top: var(--space-2);
+.model-nav-rail__catalogs {
+  list-style: none;
 }
 
-.model-nav-rail__section-count {
-  margin-left: auto;
-  font-size: var(--type-overline-size);
-  font-variant-numeric: tabular-nums;
-  color: var(--text-tertiary);
+.model-nav-rail__catalog-heading {
+  cursor: default;
+}
+
+.model-nav-rail__catalog-heading:hover {
+  background: transparent;
+  color: var(--text-secondary);
 }
 
 .model-nav-rail__provider-list {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 var(--space-2) 0 calc(var(--space-2) + 18px + var(--space-2));
   display: flex;
   flex-direction: column;
   gap: var(--space-0-5);
 }
 
-.model-nav-rail__provider-item {
-  display: flex;
+.model-nav-rail__provider-option {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  width: 100%;
-  box-sizing: border-box;
-  padding: var(--space-2);
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
+  min-height: 28px;
   cursor: pointer;
-  text-align: left;
 }
 
-.model-nav-rail__provider-item:hover {
-  background: var(--surface-2);
-  color: var(--text-primary);
+.model-nav-rail__provider-option:hover {
+  color: var(--text-secondary);
 }
 
-.model-nav-rail__provider-item:focus-visible {
+.model-nav-rail__provider-option input {
+  appearance: none;
+  display: grid;
+  place-content: center;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  background: var(--surface-base);
+  border: 1px solid var(--border-strong);
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.model-nav-rail__provider-option input::after {
+  width: 5px;
+  height: 8px;
+  content: '';
+  border: solid var(--accent-on);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) scale(0);
+  transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.model-nav-rail__provider-option input:checked {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.model-nav-rail__provider-option input:checked::after {
+  transform: rotate(45deg) scale(1);
+}
+
+.model-nav-rail__provider-option input:focus-visible {
   outline: 2px solid var(--accent-focus);
-  outline-offset: 0;
-}
-
-.model-nav-rail__provider-item--enabled {
-  background: color-mix(in srgb, var(--accent-soft) 55%, transparent);
-}
-
-.model-nav-rail__provider-item--disabled {
-  color: var(--text-disabled);
-}
-
-.model-nav-rail__provider-label {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.model-nav-rail__provider-status {
-  flex-shrink: 0;
-  color: var(--accent-fg);
-}
-
-.model-nav-rail__provider-item--disabled .model-nav-rail__provider-status {
-  color: var(--text-disabled);
+  outline-offset: 2px;
 }
 
 .registry-zones {

--- a/src/app/tests/model-provider-search.runtime.cjs
+++ b/src/app/tests/model-provider-search.runtime.cjs
@@ -96,28 +96,33 @@ assert.match(listPanelSource, /if \(filter === 'llm'\) return cap === 'chat' && 
 assert.match(listPanelSource, /if \(filter === 'omni'\) return modelIsOmni\(m\);/,
   'Omni models must match the dedicated Omni task filter');
 
-assert.match(nav, />Online Catalogs</,
-  'remote provider controls must use the Online Catalogs label');
-assert.match(nav, /<Icon name="cloud" size=\{14\}/,
-  'Online Catalogs must be prefixed by the cloud icon');
-assert.match(nav, /providerEnabled\.huggingface \? providerCounts\.huggingface : 0/,
-  'the aggregate count must include enabled Hugging Face results');
-assert.match(nav, /providerEnabled\.modelscope \? providerCounts\.modelscope : 0/,
-  'the aggregate count must include enabled ModelScope results');
-assert.match(nav, /\{hasEnabledProvider && \([\s\S]*\{providerResultCount\}/,
-  'the aggregate result count must remain visible, including zero, while at least one catalog is enabled');
+assert.match(nav, /const \[catalogsOpen, setCatalogsOpen\] = useState\(true\)/, 'Online Catalogs must be independently collapsible');
+assert.match(nav, /aria-expanded=\{catalogsOpen\}[\s\S]*aria-controls="nav-online-catalogs"[\s\S]*setCatalogsOpen/, 'Online Catalogs must use the standard collapsible section header');
+assert.match(nav, /\{catalogsOpen && \([\s\S]*id="nav-online-catalogs"/, 'catalog checkboxes must hide when collapsed');
+assert.match(nav, /className="model-nav-rail__section-toggle"[\s\S]*aria-expanded=\{catalogsOpen\}[\s\S]*>\s*<Icon name=\{catalogsOpen \? 'chevron-down' : 'chevron-right'\}[\s\S]*<span>Online Catalogs<\/span>/,
+  'Online Catalogs must use the same collapsible heading treatment as the other filter sections');
+assert.match(nav, /className="backends__toggle model-nav-rail__provider-option"/,
+  'online catalogs must reuse the Backends checkbox treatment');
 assert.match(nav, /type="checkbox"[\s\S]*checked=\{enabled\}[\s\S]*onChange=\{\(\) => onToggleProvider\(provider\.key\)\}/,
-  'remote catalogs must use native checkboxes for enabled state');
-assert.ok(nav.indexOf('Online Catalogs') < nav.indexOf('model-nav-rail__section--tasks'),
-  'Online Catalogs must sit directly below the primary model navigation');
-assert.doesNotMatch(nav, /model-nav-rail__section--providers/,
-  'Online Catalogs must not be separated from Favorites by its own filter section');
-assert.doesNotMatch(nav, /model-nav-rail__provider-item/,
-  'remote catalogs must not use the old button/highlight treatment');
-assert.match(styles, /\.model-nav-rail__provider-option input \{[\s\S]*appearance: none;[\s\S]*width: 16px;[\s\S]*height: 16px;[\s\S]*border-radius: 3px;/,
-  'catalog checkboxes must match the custom checkbox geometry used in the Backends tab');
-assert.match(styles, /\.model-nav-rail__provider-option input:checked \{[\s\S]*background: var\(--accent\);[\s\S]*border-color: var\(--accent\);/,
-  'catalog checkboxes must match the Backends checked state');
+  'online catalogs must use explicit checkbox toggles');
+assert.match(nav, /const showCount = searchActive && primaryFilter === 'all' && enabled;/,
+  'provider counts must only render while that provider is actually participating in an online search');
+assert.match(nav, /\{showCount && \([\s\S]*model-nav-rail__nav-count[\s\S]*\{count\}/,
+  'each provider must show its own result count, including zero during an active search');
+assert.doesNotMatch(nav, /providerCounts\.huggingface \+ providerCounts\.modelscope/,
+  'provider counts must not be aggregated on the Online Catalogs heading');
+assert.ok(nav.indexOf('model-nav-rail__section--backends') < nav.indexOf('Online Catalogs'),
+  'Online Catalogs must be below Backends');
+assert.ok(nav.indexOf('Online Catalogs') < nav.indexOf('aria-controls="nav-tags"'),
+  'Online Catalogs must remain directly before Tags');
+assert.doesNotMatch(styles, /model-nav-rail__section--providers\s*\{[\s\S]*border-top:/,
+  'Online Catalogs must not add a divider below Backends');
+assert.match(styles, /\.model-nav-rail__provider-list \{[\s\S]*padding: 2px var\(--space-2\) 0;/,
+  'catalog checkboxes must align horizontally with the task/backend controls');
+assert.match(styles, /\.backends__toggle input \{[\s\S]*width: 16px;[\s\S]*height: 16px;[\s\S]*border-radius: 3px;/,
+  'catalog checkboxes must inherit the exact Backends checkbox geometry');
+assert.match(manager, /providerCounts=\{providerCounts\}[\s\S]*searchActive=\{searchActive\}/,
+  'ModelManager must pass the existing search activity signal to the nav rail');
 
 const { remoteCapabilityEvidence } = loadTypeScriptModule(path.join(root, 'src/remoteModelCapabilities.ts'));
 const { capabilityFromModelInfo, modelCapabilityTags } = loadTypeScriptModule(path.join(root, 'src/modelCapabilities.ts'));

--- a/src/app/tests/model-provider-search.runtime.cjs
+++ b/src/app/tests/model-provider-search.runtime.cjs
@@ -10,6 +10,7 @@ const api = fs.readFileSync(path.join(root, 'src/api.ts'), 'utf8');
 const capabilitiesSource = fs.readFileSync(path.join(root, 'src/modelCapabilities.ts'), 'utf8');
 const remoteCapabilitiesSource = fs.readFileSync(path.join(root, 'src/remoteModelCapabilities.ts'), 'utf8');
 const listPanelSource = fs.readFileSync(path.join(root, 'src/components/ModelListPanel.tsx'), 'utf8');
+const styles = fs.readFileSync(path.join(root, 'src/styles/styles.css'), 'utf8');
 
 function loadTypeScriptModule(filename) {
   const source = fs.readFileSync(filename, 'utf8');
@@ -95,11 +96,28 @@ assert.match(listPanelSource, /if \(filter === 'llm'\) return cap === 'chat' && 
 assert.match(listPanelSource, /if \(filter === 'omni'\) return modelIsOmni\(m\);/,
   'Omni models must match the dedicated Omni task filter');
 
-assert.match(nav, />Model-Provider</);
-assert.match(nav, /name=\{enabled \? 'cloud' : 'cloud-off'\}/);
-assert.match(nav, /providerCounts\.huggingface \+ providerCounts\.modelscope/,
-  'collapsed provider section must show the combined result count');
-assert.match(nav, /aria-pressed=\{enabled\}/);
+assert.match(nav, />Online Catalogs</,
+  'remote provider controls must use the Online Catalogs label');
+assert.match(nav, /<Icon name="cloud" size=\{14\}/,
+  'Online Catalogs must be prefixed by the cloud icon');
+assert.match(nav, /providerEnabled\.huggingface \? providerCounts\.huggingface : 0/,
+  'the aggregate count must include enabled Hugging Face results');
+assert.match(nav, /providerEnabled\.modelscope \? providerCounts\.modelscope : 0/,
+  'the aggregate count must include enabled ModelScope results');
+assert.match(nav, /\{hasEnabledProvider && \([\s\S]*\{providerResultCount\}/,
+  'the aggregate result count must remain visible, including zero, while at least one catalog is enabled');
+assert.match(nav, /type="checkbox"[\s\S]*checked=\{enabled\}[\s\S]*onChange=\{\(\) => onToggleProvider\(provider\.key\)\}/,
+  'remote catalogs must use native checkboxes for enabled state');
+assert.ok(nav.indexOf('Online Catalogs') < nav.indexOf('model-nav-rail__section--tasks'),
+  'Online Catalogs must sit directly below the primary model navigation');
+assert.doesNotMatch(nav, /model-nav-rail__section--providers/,
+  'Online Catalogs must not be separated from Favorites by its own filter section');
+assert.doesNotMatch(nav, /model-nav-rail__provider-item/,
+  'remote catalogs must not use the old button/highlight treatment');
+assert.match(styles, /\.model-nav-rail__provider-option input \{[\s\S]*appearance: none;[\s\S]*width: 16px;[\s\S]*height: 16px;[\s\S]*border-radius: 3px;/,
+  'catalog checkboxes must match the custom checkbox geometry used in the Backends tab');
+assert.match(styles, /\.model-nav-rail__provider-option input:checked \{[\s\S]*background: var\(--accent\);[\s\S]*border-color: var\(--accent\);/,
+  'catalog checkboxes must match the Backends checked state');
 
 const { remoteCapabilityEvidence } = loadTypeScriptModule(path.join(root, 'src/remoteModelCapabilities.ts'));
 const { capabilityFromModelInfo, modelCapabilityTags } = loadTypeScriptModule(path.join(root, 'src/modelCapabilities.ts'));


### PR DESCRIPTION
## Summary

* Hide provider result counts when they are **0**
* Keep positive remote search result counts visible
* Avoid showing misleading zero-result text to screen readers

Fixes #2939.

<img width="277" height="129" alt="image" src="https://github.com/user-attachments/assets/c86f3e43-2ec9-40ab-b4d0-83cb9d2785d3" />
<img width="276" height="128" alt="image" src="https://github.com/user-attachments/assets/9e7cfe84-3c14-48a2-8922-0d81a47b367d" />
<img width="276" height="128" alt="image" src="https://github.com/user-attachments/assets/d14d207f-7c8d-4311-870a-9ee8fd436e44" />
