### PR TITLE
ci: cut the longest test jobs via parameter tuning

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1786,6 +1786,10 @@ jobs:
       - name: Test ollama
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         shell: bash
+        env:
+          # Hosted runners have no persistent HF cache; the 2 GB GGUF beats
+          # the 5.2 GB safetensors pull. Self-hosted SD jobs keep the default.
+          LEMONADE_TEST_SD_MODEL: SD-Turbo-GGUF
         run: |
           .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu ollama"
           .venv/bin/python test/test_ollama.py --cli-binary lemonade
@@ -2000,6 +2004,10 @@ jobs:
       - name: Test ollama
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         shell: bash
+        env:
+          # Hosted runners have no persistent HF cache; the 2 GB GGUF beats
+          # the 5.2 GB safetensors pull. Self-hosted SD jobs keep the default.
+          LEMONADE_TEST_SD_MODEL: SD-Turbo-GGUF
         run: |
           $VENV_PYTHON -m test.utils.reset_server_state --best-effort --label "windows-latest ollama"
           $VENV_PYTHON test/test_ollama.py --cli-binary "$CLI_BINARY"

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1787,8 +1787,7 @@ jobs:
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         shell: bash
         env:
-          # Hosted runners have no persistent HF cache; the 2 GB GGUF beats
-          # the 5.2 GB safetensors pull. Self-hosted SD jobs keep the default.
+          # No persistent HF cache here, so prefer the 2 GB GGUF build.
           LEMONADE_TEST_SD_MODEL: SD-Turbo-GGUF
         run: |
           .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu ollama"
@@ -2005,8 +2004,7 @@ jobs:
         if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         shell: bash
         env:
-          # Hosted runners have no persistent HF cache; the 2 GB GGUF beats
-          # the 5.2 GB safetensors pull. Self-hosted SD jobs keep the default.
+          # No persistent HF cache here, so prefer the 2 GB GGUF build.
           LEMONADE_TEST_SD_MODEL: SD-Turbo-GGUF
         run: |
           $VENV_PYTHON -m test.utils.reset_server_state --best-effort --label "windows-latest ollama"

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -144,6 +144,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | Option | CLI flag | Type | Default | Description |
 |--------|----------|------|---------|-------------|
 | `trellis_backend` | `--trellis` | BACKEND | "" | Trellis backend to use |
+| `trellis_args` | `--trellis-args` | ARGS | "" | Custom arguments to pass to trellis-server |
 
 #### `vllm` — vLLM ROCm (experimental)
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -402,6 +402,7 @@ The following options are available depending on the recipe being used:
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--trellis BACKEND` | Trellis backend to use | Auto-detected |
+| `--trellis-args ARGS` | Custom arguments to pass to trellis-server | `""` |
 
 #### OpenMOSS TTS (`openmoss` recipe)
 

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -141,6 +141,7 @@ Values set in the user's `config.json` always take precedence over these seeded 
     "vulkan_bin": "builtin"
   },
   "trellis": {
+    "args": "",
     "backend": "auto",
     "cuda_bin": "builtin",
     "rocm_bin": "builtin",

--- a/src/cpp/include/lemon/backends/trellis/trellis.h
+++ b/src/cpp/include/lemon/backends/trellis/trellis.h
@@ -19,6 +19,8 @@ inline const BackendDescriptor descriptor = {
     /*options*/ {
         {"trellis_backend", "--trellis", "", "BACKEND",
          "Trellis backend to use", "3D Generation Options"},
+        {"trellis_args", "--trellis-args", "", "ARGS",
+         "Custom arguments to pass to trellis-server", "3D Generation Options"},
     },
     /*support*/ {
         {"cuda", {"linux", "windows"}, {{"nvidia_gpu", {}}}, "NVIDIA GPUs"},
@@ -35,7 +37,7 @@ inline const BackendDescriptor descriptor = {
     /*rocm_requires_cwsr_fix*/ false,
     /*version_policy*/  VersionPolicy::Exact,
     /*self_manages_downloads*/ false,
-    /*takes_args*/      false,
+    /*takes_args*/      true,
     /*arg_variants*/    {},
     /*bin_variants*/    {"vulkan", "rocm", "cuda"},
     /*config_extra*/    nlohmann::json::object(),

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -106,6 +106,7 @@
     "vulkan_bin": "builtin"
   },
   "trellis": {
+    "args": "",
     "backend": "auto",
     "cuda_bin": "builtin",
     "rocm_bin": "builtin",

--- a/src/cpp/server/backends/trellis/trellis_server.cpp
+++ b/src/cpp/server/backends/trellis/trellis_server.cpp
@@ -70,6 +70,18 @@ void TrellisServer::load(const std::string& model_name,
         throw std::runtime_error("Model path not found for checkpoint: " + model_info.checkpoint());
     }
 
+    // Validate before resolve_binary_path(), which can download a backend archive.
+    const std::string trellis_args = options.get_option("trellis_args");
+    if (!trellis_args.empty()) {
+        const std::set<std::string> reserved_flags = {"--models", "--host", "--port", "--res"};
+        const std::string validation_error =
+            utils::validate_custom_args(trellis_args, reserved_flags);
+        if (!validation_error.empty()) {
+            throw std::invalid_argument(
+                "Invalid custom trellis-server arguments:\n" + validation_error);
+        }
+    }
+
     std::string backend = options.get_option("trellis_backend");
     if (backend.empty()) {
         auto supported = SystemInfo::get_supported_backends("trellis");
@@ -94,15 +106,7 @@ void TrellisServer::load(const std::string& model_name,
         "--res", "512",
     };
 
-    const std::string trellis_args = options.get_option("trellis_args");
     if (!trellis_args.empty()) {
-        const std::set<std::string> reserved_flags = {"--models", "--host", "--port"};
-        const std::string validation_error =
-            utils::validate_custom_args(trellis_args, reserved_flags);
-        if (!validation_error.empty()) {
-            throw std::invalid_argument(
-                "Invalid custom trellis-server arguments:\n" + validation_error);
-        }
         LOG(DEBUG, "trellis-server") << "Adding custom arguments: " << trellis_args << std::endl;
         const std::vector<std::string> custom_args_vec = utils::parse_custom_args(trellis_args);
         args.insert(args.end(), custom_args_vec.begin(), custom_args_vec.end());

--- a/src/cpp/server/backends/trellis/trellis_server.cpp
+++ b/src/cpp/server/backends/trellis/trellis_server.cpp
@@ -73,7 +73,7 @@ void TrellisServer::load(const std::string& model_name,
     // Validate before resolve_binary_path(), which can download a backend archive.
     const std::string trellis_args = options.get_option("trellis_args");
     if (!trellis_args.empty()) {
-        const std::set<std::string> reserved_flags = {"--models", "--host", "--port", "--res"};
+        const std::set<std::string> reserved_flags = {"-m", "--models", "--host", "--port", "--res"};
         const std::string validation_error =
             utils::validate_custom_args(trellis_args, reserved_flags);
         if (!validation_error.empty()) {

--- a/src/cpp/server/backends/trellis/trellis_server.cpp
+++ b/src/cpp/server/backends/trellis/trellis_server.cpp
@@ -9,6 +9,7 @@
 #include "lemon/model_manager.h"
 #include "lemon/runtime_config.h"
 #include "lemon/system_info.h"
+#include "lemon/utils/custom_args.h"
 #include "lemon/utils/http_client.h"
 #include "lemon/utils/image_sniff.h"
 #include "lemon/utils/json_utils.h"
@@ -17,6 +18,7 @@
 #include <lemon/utils/aixlog.hpp>
 #include <cstdlib>
 #include <filesystem>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -91,6 +93,20 @@ void TrellisServer::load(const std::string& model_name,
         "--port", std::to_string(port_),
         "--res", "512",
     };
+
+    const std::string trellis_args = options.get_option("trellis_args");
+    if (!trellis_args.empty()) {
+        const std::set<std::string> reserved_flags = {"--models", "--host", "--port"};
+        const std::string validation_error =
+            utils::validate_custom_args(trellis_args, reserved_flags);
+        if (!validation_error.empty()) {
+            throw std::invalid_argument(
+                "Invalid custom trellis-server arguments:\n" + validation_error);
+        }
+        LOG(DEBUG, "trellis-server") << "Adding custom arguments: " << trellis_args << std::endl;
+        const std::vector<std::string> custom_args_vec = utils::parse_custom_args(trellis_args);
+        args.insert(args.end(), custom_args_vec.begin(), custom_args_vec.end());
+    }
 
     std::vector<std::pair<std::string, std::string>> env_vars;
     const std::string exe_dir = std::filesystem::path(exe_path).parent_path().string();

--- a/test/server_3d.py
+++ b/test/server_3d.py
@@ -8,9 +8,10 @@ Usage:
     python server_3d.py --wrapped-server trellis --backend vulkan
     python server_3d.py --wrapped-server trellis --backend rocm
 
-Note: 3D reconstruction is slow (minutes per mesh even at the 512 cascade).
-The negative tests run first and never pull the model; only the generation
-test downloads it.
+Note: 3D reconstruction is slow, so the generation test runs at the 512
+cascade with classifier-free guidance disabled (see setUpClass). The negative
+tests run first and never pull the model; only the generation test downloads
+it.
 """
 
 import base64
@@ -23,6 +24,7 @@ from utils.server_base import (
     ServerTestBase,
     run_server_tests,
     pull_model_with_retry,
+    set_server_config,
 )
 from utils.capabilities import get_test_model
 from utils.test_models import (
@@ -65,6 +67,15 @@ class Model3DTests(ServerTestBase):
     """Tests for the /3d/generations endpoint."""
 
     _model_pulled = False
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Disabling classifier-free guidance (gss/gsh 1) runs every pipeline
+        # stage with one forward pass per flow step instead of two and a
+        # sparser structure, cutting generation from ~99s to ~34s on a Strix
+        # Halo iGPU. CI validates the pipeline end-to-end, not output quality.
+        set_server_config({"trellis": {"args": "--gss 1 --gsh 1"}})
 
     @classmethod
     def _ensure_model_pulled(cls):
@@ -165,7 +176,7 @@ class Model3DTests(ServerTestBase):
         self._ensure_model_pulled()
         payload = self._generation_payload()
         print(f"[INFO] Sending 3D generation request with model {payload['model']}")
-        print(f"[INFO] Using the 512 cascade for CI speed; this still takes minutes")
+        print(f"[INFO] Using the 512 cascade with guidance disabled for CI speed")
 
         response = requests.post(
             f"{self.base_url}/3d/generations",

--- a/test/server_3d.py
+++ b/test/server_3d.py
@@ -192,11 +192,14 @@ class Model3DTests(ServerTestBase):
 
         # Load up front so the args apply to this run only; /load without
         # save_options persists nothing, and the generation below reuses this
-        # process instead of auto-loading.
+        # process instead of auto-loading. merge_args=False keeps trellis args
+        # already configured on the machine out of this load, so the timing the
+        # suite is tuned for does not depend on the host.
         load = load_model(
             payload["model"],
             timeout=TIMEOUT_3D_LOAD,
             trellis_args=FAST_GENERATION_ARGS,
+            merge_args=False,
         )
         self.assertEqual(
             load.status_code,
@@ -216,11 +219,9 @@ class Model3DTests(ServerTestBase):
             ),
             {},
         )
-        # Compare tokens, not the string: merging with a server that already
-        # carries trellis args rewrites the value in alphabetical order.
         self.assertEqual(
-            sorted(str(applied.get("trellis_args", "")).split()),
-            sorted(FAST_GENERATION_ARGS.split()),
+            applied.get("trellis_args", ""),
+            FAST_GENERATION_ARGS,
             f"trellis_args never reached the backend; applied options: {applied}",
         )
         print(f"[INFO] Sending 3D generation request with model {payload['model']}")

--- a/test/server_3d.py
+++ b/test/server_3d.py
@@ -8,10 +8,9 @@ Usage:
     python server_3d.py --wrapped-server trellis --backend vulkan
     python server_3d.py --wrapped-server trellis --backend rocm
 
-Note: 3D reconstruction is slow, so the generation test runs at the 512
-cascade with classifier-free guidance disabled (see setUpClass). The negative
-tests run first and never pull the model; only the generation test downloads
-it.
+Note: 3D reconstruction is slow, so the generation test loads the backend at
+the 512 cascade with classifier-free guidance disabled. The negative tests run
+first and never pull the model; only the generation test downloads it.
 """
 
 import base64
@@ -24,15 +23,20 @@ from utils.server_base import (
     ServerTestBase,
     run_server_tests,
     pull_model_with_retry,
-    get_server_config,
-    set_server_config,
+    unload_all_models,
 )
 from utils.capabilities import get_test_model
 from utils.test_models import (
     TIMEOUT_DEFAULT,
+    TIMEOUT_MODEL_OPERATION,
 )
 
 TIMEOUT_3D_GENERATION = 1800
+
+# Guidance strengths of 1 disable classifier-free guidance, so each flow step
+# costs one forward pass instead of two. These tests cover that the pipeline
+# returns a valid mesh, not how good the mesh looks.
+FAST_GENERATION_ARGS = "--gss 1 --gsh 1"
 
 
 def make_input_png_b64(size=64):
@@ -68,31 +72,15 @@ class Model3DTests(ServerTestBase):
     """Tests for the /3d/generations endpoint."""
 
     _model_pulled = False
-    _saved_trellis_args = None
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        # Guidance strengths of 1 disable classifier-free guidance, so each flow
-        # step costs one forward pass instead of two. These tests cover that the
-        # pipeline returns a valid mesh, not how good the mesh looks.
-        try:
-            cls._saved_trellis_args = (
-                get_server_config().get("trellis", {}).get("args", "")
-            )
-            set_server_config({"trellis": {"args": "--gss 1 --gsh 1"}})
-        except Exception as e:
-            print(f"Warning: Failed to disable guidance for CI speed: {e}")
 
     @classmethod
     def tearDownClass(cls):
-        # /internal/set writes through to config.json, so a value left behind
-        # would degrade every later generation this server performs.
-        if cls._saved_trellis_args is not None:
-            try:
-                set_server_config({"trellis": {"args": cls._saved_trellis_args}})
-            except Exception as e:
-                print(f"Warning: Failed to restore trellis args: {e}")
+        # The fast-generation args live only in this process, so drop it rather
+        # than leave a guidance-free backend serving whatever comes next.
+        try:
+            unload_all_models()
+        except Exception as e:
+            print(f"Warning: Failed to unload the 3D backend: {e}")
         super().tearDownClass()
 
     @classmethod
@@ -193,8 +181,26 @@ class Model3DTests(ServerTestBase):
         """Test basic image-to-3D generation returns a GLB mesh."""
         self._ensure_model_pulled()
         payload = self._generation_payload()
+
+        # Load up front so the args apply to this request only; /load without
+        # save_options does not write them to the server's config.json, and the
+        # generation below reuses this process instead of auto-loading.
+        load = requests.post(
+            f"{self.base_url}/load",
+            json={
+                "model_name": payload["model"],
+                "trellis_args": FAST_GENERATION_ARGS,
+            },
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(
+            load.status_code,
+            200,
+            f"Loading {payload['model']} with {FAST_GENERATION_ARGS} failed: "
+            f"{load.text[:1000]}",
+        )
         print(f"[INFO] Sending 3D generation request with model {payload['model']}")
-        print(f"[INFO] Using the 512 cascade with guidance disabled for CI speed")
+        print("[INFO] Using the 512 cascade with guidance disabled for CI speed")
 
         response = requests.post(
             f"{self.base_url}/3d/generations",

--- a/test/server_3d.py
+++ b/test/server_3d.py
@@ -23,10 +23,10 @@ from utils.server_base import (
     ServerTestBase,
     run_server_tests,
     pull_model_with_retry,
+    unload_model,
 )
 from utils.capabilities import get_test_model
 from utils.test_models import (
-    PORT,
     TIMEOUT_DEFAULT,
 )
 
@@ -80,11 +80,12 @@ class Model3DTests(ServerTestBase):
         # The guidance-free args belong to the backend subprocess this suite
         # started, so retire it rather than let it serve later requests.
         try:
-            requests.post(
-                f"http://localhost:{PORT}/api/v1/unload",
-                json={"model_name": get_test_model("model3d")},
-                timeout=TIMEOUT_DEFAULT,
-            )
+            response = unload_model(get_test_model("model3d"))
+            if response.status_code not in (200, 404):
+                print(
+                    "Warning: Failed to unload the 3D backend: "
+                    f"{response.status_code} {response.text[:200]}"
+                )
         except Exception as e:
             print(f"Warning: Failed to unload the 3D backend: {e}")
         super().tearDownClass()
@@ -188,9 +189,9 @@ class Model3DTests(ServerTestBase):
         self._ensure_model_pulled()
         payload = self._generation_payload()
 
-        # Load up front so the args apply to this request only; /load without
-        # save_options does not write them to the server's config.json, and the
-        # generation below reuses this process instead of auto-loading.
+        # Load up front so the args apply to this run only; /load without
+        # save_options persists nothing, and the generation below reuses this
+        # process instead of auto-loading.
         load = requests.post(
             f"{self.base_url}/load",
             json={

--- a/test/server_3d.py
+++ b/test/server_3d.py
@@ -216,9 +216,11 @@ class Model3DTests(ServerTestBase):
             ),
             {},
         )
+        # Compare tokens, not the string: merging with a server that already
+        # carries trellis args rewrites the value in alphabetical order.
         self.assertEqual(
-            applied.get("trellis_args"),
-            FAST_GENERATION_ARGS,
+            sorted(str(applied.get("trellis_args", "")).split()),
+            sorted(FAST_GENERATION_ARGS.split()),
             f"trellis_args never reached the backend; applied options: {applied}",
         )
         print(f"[INFO] Sending 3D generation request with model {payload['model']}")

--- a/test/server_3d.py
+++ b/test/server_3d.py
@@ -24,6 +24,7 @@ from utils.server_base import (
     ServerTestBase,
     run_server_tests,
     pull_model_with_retry,
+    get_server_config,
     set_server_config,
 )
 from utils.capabilities import get_test_model
@@ -67,15 +68,32 @@ class Model3DTests(ServerTestBase):
     """Tests for the /3d/generations endpoint."""
 
     _model_pulled = False
+    _saved_trellis_args = None
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # Disabling classifier-free guidance (gss/gsh 1) runs every pipeline
-        # stage with one forward pass per flow step instead of two and a
-        # sparser structure, cutting generation from ~99s to ~34s on a Strix
-        # Halo iGPU. CI validates the pipeline end-to-end, not output quality.
-        set_server_config({"trellis": {"args": "--gss 1 --gsh 1"}})
+        # Guidance strengths of 1 disable classifier-free guidance, so each flow
+        # step costs one forward pass instead of two. These tests cover that the
+        # pipeline returns a valid mesh, not how good the mesh looks.
+        try:
+            cls._saved_trellis_args = (
+                get_server_config().get("trellis", {}).get("args", "")
+            )
+            set_server_config({"trellis": {"args": "--gss 1 --gsh 1"}})
+        except Exception as e:
+            print(f"Warning: Failed to disable guidance for CI speed: {e}")
+
+    @classmethod
+    def tearDownClass(cls):
+        # /internal/set writes through to config.json, so a value left behind
+        # would degrade every later generation this server performs.
+        if cls._saved_trellis_args is not None:
+            try:
+                set_server_config({"trellis": {"args": cls._saved_trellis_args}})
+            except Exception as e:
+                print(f"Warning: Failed to restore trellis args: {e}")
+        super().tearDownClass()
 
     @classmethod
     def _ensure_model_pulled(cls):

--- a/test/server_3d.py
+++ b/test/server_3d.py
@@ -23,15 +23,17 @@ from utils.server_base import (
     ServerTestBase,
     run_server_tests,
     pull_model_with_retry,
-    unload_all_models,
 )
 from utils.capabilities import get_test_model
 from utils.test_models import (
+    PORT,
     TIMEOUT_DEFAULT,
-    TIMEOUT_MODEL_OPERATION,
 )
 
 TIMEOUT_3D_GENERATION = 1800
+
+# Loading can install the backend, which downloads and extracts an archive.
+TIMEOUT_3D_LOAD = 1800
 
 # Guidance strengths of 1 disable classifier-free guidance, so each flow step
 # costs one forward pass instead of two. These tests cover that the pipeline
@@ -75,10 +77,14 @@ class Model3DTests(ServerTestBase):
 
     @classmethod
     def tearDownClass(cls):
-        # The fast-generation args live only in this process, so drop it rather
-        # than leave a guidance-free backend serving whatever comes next.
+        # The guidance-free args belong to the backend subprocess this suite
+        # started, so retire it rather than let it serve later requests.
         try:
-            unload_all_models()
+            requests.post(
+                f"http://localhost:{PORT}/api/v1/unload",
+                json={"model_name": get_test_model("model3d")},
+                timeout=TIMEOUT_DEFAULT,
+            )
         except Exception as e:
             print(f"Warning: Failed to unload the 3D backend: {e}")
         super().tearDownClass()
@@ -191,7 +197,7 @@ class Model3DTests(ServerTestBase):
                 "model_name": payload["model"],
                 "trellis_args": FAST_GENERATION_ARGS,
             },
-            timeout=TIMEOUT_MODEL_OPERATION,
+            timeout=TIMEOUT_3D_LOAD,
         )
         self.assertEqual(
             load.status_code,

--- a/test/server_3d.py
+++ b/test/server_3d.py
@@ -23,6 +23,7 @@ from utils.server_base import (
     ServerTestBase,
     run_server_tests,
     pull_model_with_retry,
+    load_model,
     unload_model,
 )
 from utils.capabilities import get_test_model
@@ -192,13 +193,10 @@ class Model3DTests(ServerTestBase):
         # Load up front so the args apply to this run only; /load without
         # save_options persists nothing, and the generation below reuses this
         # process instead of auto-loading.
-        load = requests.post(
-            f"{self.base_url}/load",
-            json={
-                "model_name": payload["model"],
-                "trellis_args": FAST_GENERATION_ARGS,
-            },
+        load = load_model(
+            payload["model"],
             timeout=TIMEOUT_3D_LOAD,
+            trellis_args=FAST_GENERATION_ARGS,
         )
         self.assertEqual(
             load.status_code,

--- a/test/server_3d.py
+++ b/test/server_3d.py
@@ -204,6 +204,23 @@ class Model3DTests(ServerTestBase):
             f"Loading {payload['model']} with {FAST_GENERATION_ARGS} failed: "
             f"{load.text[:1000]}",
         )
+
+        # An option the server does not recognize is dropped silently, which
+        # would put the slow full-guidance path back without failing anything.
+        health = requests.get(f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT).json()
+        applied = next(
+            (
+                model.get("recipe_options", {})
+                for model in health.get("all_models_loaded", [])
+                if model.get("model_name") == payload["model"]
+            ),
+            {},
+        )
+        self.assertEqual(
+            applied.get("trellis_args"),
+            FAST_GENERATION_ARGS,
+            f"trellis_args never reached the backend; applied options: {applied}",
+        )
         print(f"[INFO] Sending 3D generation request with model {payload['model']}")
         print("[INFO] Using the 512 cascade with guidance disabled for CI speed")
 

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -43,7 +43,7 @@ from utils.server_base import (
 from utils.test_models import (
     PORT,
     ENDPOINT_TEST_MODEL,
-    SECOND_TEST_MODEL_EVICTION,
+    MULTI_MODEL_QUATERNARY,
     MULTI_MODEL_TERTIARY,
     get_default_lemond_binary,
     SHARED_REPO_MODEL_A_NAME,
@@ -4199,7 +4199,7 @@ class EndpointTests(ServerTestBase):
         """
         router_model = MULTI_MODEL_TERTIARY
         candidate_model = ENDPOINT_TEST_MODEL
-        third_model = SECOND_TEST_MODEL_EVICTION
+        third_model = MULTI_MODEL_QUATERNARY
         for model in (router_model, candidate_model, third_model):
             pull_model_with_retry(model)
 

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -185,6 +185,18 @@ def unload_all_models(port=PORT):
     return response
 
 
+def unload_model(model_name, port=PORT):
+    """POST /api/v1/unload for one model, leaving anything else resident."""
+    response = requests.post(
+        f"http://localhost:{port}/api/v1/unload",
+        json={"model_name": model_name},
+        headers=_auth_headers(),
+        timeout=30,
+    )
+    # 200 = unloaded, 404 = not loaded — both OK
+    return response
+
+
 def _is_transient_pull_status(status_code):
     return status_code in {408, 409, 429, 500, 502, 503, 504}
 
@@ -580,6 +592,7 @@ __all__ = [
     "wait_for_server",
     "set_server_config",
     "unload_all_models",
+    "unload_model",
     "pull_model_with_retry",
     "run_server_tests",
     "OpenAI",

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -185,7 +185,7 @@ def unload_all_models(port=PORT):
     return response
 
 
-def load_model(model_name, port=PORT, timeout=30, **options):
+def load_model(model_name, port=PORT, timeout=TIMEOUT_MODEL_OPERATION, **options):
     """POST /api/v1/load for one model, forwarding any recipe options."""
     payload = {"model_name": model_name}
     payload.update(options)

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -185,6 +185,19 @@ def unload_all_models(port=PORT):
     return response
 
 
+def load_model(model_name, port=PORT, timeout=30, **options):
+    """POST /api/v1/load for one model, forwarding any recipe options."""
+    payload = {"model_name": model_name}
+    payload.update(options)
+    response = requests.post(
+        f"http://localhost:{port}/api/v1/load",
+        json=payload,
+        headers=_auth_headers(),
+        timeout=timeout,
+    )
+    return response
+
+
 def unload_model(model_name, port=PORT):
     """POST /api/v1/unload for one model, leaving anything else resident."""
     response = requests.post(
@@ -592,6 +605,7 @@ __all__ = [
     "wait_for_server",
     "set_server_config",
     "unload_all_models",
+    "load_model",
     "unload_model",
     "pull_model_with_retry",
     "run_server_tests",

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -200,6 +200,9 @@ def load_model(model_name, port=PORT, timeout=30, **options):
 
 def unload_model(model_name, port=PORT):
     """POST /api/v1/unload for one model, leaving anything else resident."""
+    if not model_name:
+        # The server reads an empty name as "unload everything".
+        raise ValueError("unload_model needs a model name; use unload_all_models()")
     response = requests.post(
         f"http://localhost:{port}/api/v1/unload",
         json={"model_name": model_name},

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -161,6 +161,17 @@ def _auth_headers():
     return {}
 
 
+def get_server_config(port=PORT):
+    """GET /internal/config to read the current server config."""
+    response = requests.get(
+        f"http://localhost:{port}/internal/config",
+        headers=_auth_headers(),
+        timeout=10,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
 def set_server_config(config: dict, port=PORT):
     """POST /internal/set to update server config at runtime."""
     response = requests.post(
@@ -578,6 +589,7 @@ __all__ = [
     "get_config",
     "get_cli_binary",
     "wait_for_server",
+    "get_server_config",
     "set_server_config",
     "unload_all_models",
     "pull_model_with_retry",

--- a/test/utils/server_base.py
+++ b/test/utils/server_base.py
@@ -161,17 +161,6 @@ def _auth_headers():
     return {}
 
 
-def get_server_config(port=PORT):
-    """GET /internal/config to read the current server config."""
-    response = requests.get(
-        f"http://localhost:{port}/internal/config",
-        headers=_auth_headers(),
-        timeout=10,
-    )
-    response.raise_for_status()
-    return response.json()
-
-
 def set_server_config(config: dict, port=PORT):
     """POST /internal/set to update server config at runtime."""
     response = requests.post(
@@ -589,7 +578,6 @@ __all__ = [
     "get_config",
     "get_cli_binary",
     "wait_for_server",
-    "get_server_config",
     "set_server_config",
     "unload_all_models",
     "pull_model_with_retry",

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -202,8 +202,8 @@ SECOND_TEST_MODEL_EVICTION = "Phi-4-mini-instruct-GGUF"
 # Tertiary model for LRU eviction testing
 MULTI_MODEL_TERTIARY = "Qwen3-0.6B-GGUF"
 
-# A fourth model, distinct from the three above, for the router residency test.
-# Kept small because the hosted CLI/Endpoints jobs re-download it every run.
+# A further small LLM, distinct from every model above, for tests that need one
+# more resident model. Kept small: runners without a model cache re-download it.
 MULTI_MODEL_QUATERNARY = "Llama-3.2-1B-Instruct-GGUF"
 
 # Whisper test configuration
@@ -216,10 +216,8 @@ TEST_AUDIO_URL = (
 VISION_MODEL = "Qwen3.5-0.8B-GGUF"
 
 # Stable Diffusion test configuration
-# The ubuntu-latest and windows-latest ollama steps override this with
-# SD-Turbo-GGUF: those runners have no persistent Hugging Face cache and no GPU,
-# so the safetensors build costs a 5.2 GB download every run. Everything else,
-# including the self-hosted image jobs, keeps the safetensors default.
+# Runners without a persistent Hugging Face cache override this with the
+# SD-Turbo-GGUF build, which is a 2 GB download instead of 5.2 GB.
 SD_MODEL = os.environ.get("LEMONADE_TEST_SD_MODEL", "SD-Turbo")
 
 # ESRGAN upscale model test configuration

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -202,8 +202,8 @@ SECOND_TEST_MODEL_EVICTION = "Phi-4-mini-instruct-GGUF"
 # Tertiary model for LRU eviction testing
 MULTI_MODEL_TERTIARY = "Qwen3-0.6B-GGUF"
 
-# Third distinct standard LLM for router residency testing. Kept small because
-# the hosted CLI/Endpoints jobs re-download it on every run.
+# A fourth model, distinct from the three above, for the router residency test.
+# Kept small because the hosted CLI/Endpoints jobs re-download it every run.
 MULTI_MODEL_QUATERNARY = "Llama-3.2-1B-Instruct-GGUF"
 
 # Whisper test configuration
@@ -216,9 +216,10 @@ TEST_AUDIO_URL = (
 VISION_MODEL = "Qwen3.5-0.8B-GGUF"
 
 # Stable Diffusion test configuration
-# The GitHub-hosted CLI/Endpoints jobs override this with SD-Turbo-GGUF: they
-# have no persistent Hugging Face cache, so the safetensors build costs a
-# 5.2 GB download every run. Self-hosted jobs keep the safetensors default.
+# The ubuntu-latest and windows-latest ollama steps override this with
+# SD-Turbo-GGUF: those runners have no persistent Hugging Face cache and no GPU,
+# so the safetensors build costs a 5.2 GB download every run. Everything else,
+# including the self-hosted image jobs, keeps the safetensors default.
 SD_MODEL = os.environ.get("LEMONADE_TEST_SD_MODEL", "SD-Turbo")
 
 # ESRGAN upscale model test configuration

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -202,6 +202,9 @@ SECOND_TEST_MODEL_EVICTION = "Phi-4-mini-instruct-GGUF"
 # Tertiary model for LRU eviction testing
 MULTI_MODEL_TERTIARY = "Qwen3-0.6B-GGUF"
 
+# Quaternary model for multi-model testing (small, fast to pull and load)
+MULTI_MODEL_QUATERNARY = "Llama-3.2-1B-Instruct-GGUF"
+
 # Whisper test configuration
 WHISPER_MODEL = "Whisper-Tiny"
 TEST_AUDIO_URL = (

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -202,7 +202,8 @@ SECOND_TEST_MODEL_EVICTION = "Phi-4-mini-instruct-GGUF"
 # Tertiary model for LRU eviction testing
 MULTI_MODEL_TERTIARY = "Qwen3-0.6B-GGUF"
 
-# Quaternary model for multi-model testing (small, fast to pull and load)
+# Third distinct standard LLM for router residency testing. Kept small because
+# the hosted CLI/Endpoints jobs re-download it on every run.
 MULTI_MODEL_QUATERNARY = "Llama-3.2-1B-Instruct-GGUF"
 
 # Whisper test configuration
@@ -215,8 +216,9 @@ TEST_AUDIO_URL = (
 VISION_MODEL = "Qwen3.5-0.8B-GGUF"
 
 # Stable Diffusion test configuration
-# Allow CI to override with a smaller model (e.g. SD-Turbo-GGUF) on memory-
-# constrained runners like GitHub-hosted macos-latest.
+# The GitHub-hosted CLI/Endpoints jobs override this with SD-Turbo-GGUF: they
+# have no persistent Hugging Face cache, so the safetensors build costs a
+# 5.2 GB download every run. Self-hosted jobs keep the safetensors default.
 SD_MODEL = os.environ.get("LEMONADE_TEST_SD_MODEL", "SD-Turbo")
 
 # ESRGAN upscale model test configuration


### PR DESCRIPTION
Cuts **≈15 CI-minutes per full run** of `cpp_server_build_test_release.yml` without dropping a single test, endpoint, or backend from coverage.

| Where | Saved per run |
|---|---|
| Trellis 3D suites (self-hosted rigs) | **−10.7 min** |
| Model downloads on GitHub-hosted runners | **−4.2 min** |
| **Total** | **≈ −15 min** |

All figures below are measured: the baseline is the **median of 5 `main` runs**, the after-column is this PR's runs, and each comparison is checked against an unmodified control test in the same job so a fast or slow runner cannot be mistaken for a saving.

## 1. Trellis 3D — −10.7 min (the worst offender)

`Test .exe - 3d-trellis` was the longest test job in the workflow. Its cost is four image→mesh generations per run (2 OS × 2 backends), and ~75% of a generation is three 12-step diffusion flows in which classifier-free guidance runs **two** forward passes per step.

Launching `trellis-server` with `--gss 1 --gsh 1` disables guidance, halving the forward passes. Every pipeline stage still runs — background removal, DINOv3 conditioning, all three flows, both decodes, decimation and the xatlas UV bake — and still returns a valid ~5 MB textured GLB. These tests assert the pipeline works, not that the mesh looks good.

The test reads the applied options back from `/health` and asserts the flags actually landed, so a rename or a dropped option fails loudly instead of quietly restoring the slow path.

Those are launch flags, so this adds a `trellis_args` recipe option using the same descriptor-driven passthrough `llamacpp`, `sdcpp`, `whispercpp`, `moonshine` and `onnxruntime` already have. The test passes it on an explicit `POST /load`, which carries recipe options for that one load: without `save_options` nothing is persisted to disk, so the speed-up cannot outlive the suite. The generation then reuses that process, and `tearDownClass` unloads it.

Suite time per backend (`Ran 10 tests in …`):

| Job | backend | baseline median (n=5) | this PR | saved |
|---|---|---|---|---|
| `Test .exe - 3d-trellis` | vulkan | 480.6 s `[462–491]` | 225.8 s | −254.8 s |
| `Test .exe - 3d-trellis` | rocm | 447.2 s `[432–449]` | 213.7 s | −233.5 s |
| `Test .deb - 3d-trellis` | vulkan | 238.6 s `[227–254]` | 130.6 s | −108.0 s |
| `Test .deb - 3d-trellis` | rocm | 418.7 s `[369–456]` | 375.9 s | −42.8 s |

Three of the four sit far outside their baseline range. The `.deb` rocm row is the one noisy case — that job also installs the TheRock ROCm runtime, whose cost swings ±45 s — so the honest floor if you discount it entirely is still −10.0 min.

Locally on Strix Halo (gfx1151) a single generation goes 98.5 s → 31.8 s, and the suite passes on both rocm and vulkan.

## 2. Hosted runners — −4.2 min

GitHub-hosted runners have no persistent Hugging Face cache, so every run re-downloads these models from scratch.

- **`test_021zk` third model: Phi-4-mini (2.492 GB) → Llama-3.2-1B (0.834 GB).** The test asserts slot-pool promotion/demotion and eviction, which is size-independent; it only needs a third *distinct* standard LLM. Llama-3.2-1B also loads faster — 1.8 s vs 5.6 s for a warm CPU load-and-infer measured locally.
- **ollama image test: SD-Turbo safetensors (5.215 GB) → SD-Turbo-GGUF (2.024 GB)**, via the existing `LEMONADE_TEST_SD_MODEL` override, on the two hosted steps that actually run that test.

| Job | `test_021zk` | `test_022` (SD) | saved | control test in same job |
|---|---|---|---|---|
| `CLI/Endpoints (macos-latest)` | 209.7 s → 117.8 s | skipped on macOS | **−91.9 s** | 67.7 → 64.7 s (flat) |
| `CLI/Endpoints (windows-latest)` | 87.2 s → 56.3 s | 167.0 s → 74.4 s | **−123.5 s** | 19.6 → 19.6 s (flat) |
| `CLI/Endpoints (ubuntu-latest)` | 67.7 s → 60.4 s | 98.3 s → 72.9 s | **−32.7 s** | 64.0 → 90.9 s (slower ⇒ conservative) |
| `Test endpoints (ubuntu-24.04-arm)` | 69.0 s → 67.1 s | skipped on arm64 | −1.9 s | 12.7 → 12.7 s (flat) |

macOS and Windows carry 10× and 2× billing multipliers, so that column is worth ≈20 billed-minute-equivalents even though the wall-clock figure is 4.2 min.

## Coverage is unchanged

- The same hosted jobs still exercise a 2.5 GB model — `test_ollama.py` pulls and loads Qwen3-4B for tool calling — so dropping Phi-4-mini costs no large-model coverage.
- The safetensors load path is still covered: the self-hosted `stable-diffusion` jobs keep the default, and `SD-Turbo-GGUF` carries identical `image_defaults`, so `server_sd.py`'s assertions are unaffected.
- No test is skipped, shortened, or removed; every assertion is the same.

One deliberate trade: because the generation test now pre-loads, it no longer exercises lazy auto-load *for the 3D model type*. `auto_load_model_if_needed` is generic and every other modality's tests still cover it, so this buys the 11 minutes for a narrow loss.

## Not changed

The rest of the suite is already tuned — SD at 256×256/2 steps, audio at duration 3/steps 4, LLM tests at `max_tokens` 10–15, and trellis already pinned to the minimum 512 cascade with threshold background removal. What remains in those jobs is model loading and runner overhead, not parameters.

Two follow-ups worth separate issues, both out of scope here: `server_jobs.py` starts a fresh `lemond` per test (~10 s × 35 tests × 3 OS jobs), and `Test .deb - llamacpp` spends 6× longer on rocm than vulkan for environmental reasons.

## Validation

Full trellis suite run locally against a live server on both rocm and vulkan (10/10, valid GLB out), confirming the flags reach the backend process (`12 steps, 12 forwards`), that `trellis.args` in `config.json` stays empty before, during and after the run, and that no backend is left resident. Residency test run locally against a live server. `gen_backend_boilerplate.py --check` clean; Black clean; 23/23 `cpp-ci` unit tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
