### PR TITLE
docs: add winget and Homebrew install to homepage quickstart

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -314,14 +314,20 @@
         switch (gsPlatform) {
           case 'windows':
             html = '<a class="gs-download-link" href="https://github.com/lemonade-sdk/lemonade/releases/latest/download/lemonade.msi">' +
-              '<span class="material-symbols-outlined">desktop_windows</span> Download for Windows (.msi)</a>';
+              '<span class="material-symbols-outlined">desktop_windows</span> Download for Windows (.msi)</a>' +
+              '<div class="gs-install-block">' +
+                gsConsoleHtml(['winget install --id AMD.LemonadeServer -e']) +
+              '</div>';
             break;
           case 'apple':
-            html = v
+            html = (v
               ? '<a class="gs-download-link" href="https://github.com/lemonade-sdk/lemonade/releases/latest/download/Lemonade-' + v + '-Darwin.pkg">' +
                 '<span class="material-symbols-outlined">laptop_mac</span> Download for macOS (.pkg)</a>'
               : '<a class="gs-download-link" href="https://github.com/lemonade-sdk/lemonade/releases/latest">' +
-                '<span class="material-symbols-outlined">laptop_mac</span> Download for macOS (.pkg)</a>';
+                '<span class="material-symbols-outlined">laptop_mac</span> Download for macOS (.pkg)</a>') +
+              '<div class="gs-install-block">' +
+                gsConsoleHtml(['brew install --cask lemonade-server']) +
+              '</div>';
             break;
           case 'docker':
             html = gsConsoleHtml([


### PR DESCRIPTION
## Summary
- Add `winget install --id AMD.LemonadeServer -e` to the Windows quickstart on the homepage.
- Add `brew install --cask lemonade-server` for macOS, using the same copyable console block as other platforms.
- Keep the direct `.msi` / `.pkg` download links so users can install via package manager or installer.

## Test plan
- [x] Open the homepage, select Windows → confirm the `.msi` link and winget command block appear (copy works).
- [x] Select macOS → confirm the `.pkg` link and brew command block appear (copy works).
<img width="952" height="505" alt="image" src="https://github.com/user-attachments/assets/81cf1077-5c42-469d-ab91-2866fc855315" />
<img width="952" height="505" alt="image" src="https://github.com/user-attachments/assets/2ff5fb99-ae4c-4ba9-9e66-89984864be75" />
