### PR TITLE
Minor refactor of new gate code 

### DIFF
--- a/.github/actions/check-gated-jobs/action.yml
+++ b/.github/actions/check-gated-jobs/action.yml
@@ -1,0 +1,34 @@
+name: Check gated jobs
+description: >-
+  Fail if any needed job broke; in the merge queue, also fail if any never ran.
+inputs:
+  needs:
+    description: 'toJSON(needs) from the calling job'
+    required: true
+  event-name:
+    description: 'github.event_name from the calling workflow'
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Check gated jobs
+      shell: bash
+      env:
+        NEEDS: ${{ inputs.needs }}
+        EVENT_NAME: ${{ inputs.event-name }}
+      run: |
+        # $NEEDS: {"job-id": {"result": "success|failure|skipped|cancelled"}, ...}
+        # Fail if any job broke. In the merge queue, also fail if any never ran.
+        echo "$NEEDS"
+        broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
+        if [ -n "$broke" ]; then
+          echo "FAILED: $broke"
+          exit 1
+        fi
+        if [ "$EVENT_NAME" = "merge_group" ]; then
+          absent=$(jq -r 'to_entries[]|select(.value.result!="success")|.key' <<<"$NEEDS")
+          if [ -n "$absent" ]; then
+            echo "DID NOT RUN IN MERGE QUEUE: $absent"
+            exit 1
+          fi
+        fi

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1490,25 +1490,11 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check gated jobs
-        env:
-          NEEDS: ${{ toJSON(needs) }}
-        run: |
-          # $NEEDS: {"job-id": {"result": "success|failure|skipped|cancelled"}, ...}
-          # Fail if any job broke. In the merge queue, also fail if any never ran.
-          echo "$NEEDS"
-          broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
-          if [ -n "$broke" ]; then
-            echo "FAILED: $broke"
-            exit 1
-          fi
-          if [ "${{ github.event_name }}" = "merge_group" ]; then
-            absent=$(jq -r 'to_entries[]|select(.value.result!="success")|.key' <<<"$NEEDS")
-            if [ -n "$absent" ]; then
-              echo "DID NOT RUN IN MERGE QUEUE: $absent"
-              exit 1
-            fi
-          fi
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/check-gated-jobs
+        with:
+          needs: ${{ toJSON(needs) }}
+          event-name: ${{ github.event_name }}
 
   # Same gate pattern as packaging-gate, for the self-hosted inference rigs
   # that PR pushes skip. The job name below belongs in main's required status
@@ -1520,25 +1506,11 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check gated jobs
-        env:
-          NEEDS: ${{ toJSON(needs) }}
-        run: |
-          # $NEEDS: {"job-id": {"result": "success|failure|skipped|cancelled"}, ...}
-          # Fail if any job broke. In the merge queue, also fail if any never ran.
-          echo "$NEEDS"
-          broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
-          if [ -n "$broke" ]; then
-            echo "FAILED: $broke"
-            exit 1
-          fi
-          if [ "${{ github.event_name }}" = "merge_group" ]; then
-            absent=$(jq -r 'to_entries[]|select(.value.result!="success")|.key' <<<"$NEEDS")
-            if [ -n "$absent" ]; then
-              echo "DID NOT RUN IN MERGE QUEUE: $absent"
-              exit 1
-            fi
-          fi
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/check-gated-jobs
+        with:
+          needs: ${{ toJSON(needs) }}
+          event-name: ${{ github.event_name }}
 
   # Same gate pattern as packaging-gate, for the macOS jobs that PR pushes skip.
   macos-gate:
@@ -1547,25 +1519,11 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check gated jobs
-        env:
-          NEEDS: ${{ toJSON(needs) }}
-        run: |
-          # $NEEDS: {"job-id": {"result": "success|failure|skipped|cancelled"}, ...}
-          # Fail if any job broke. In the merge queue, also fail if any never ran.
-          echo "$NEEDS"
-          broke=$(jq -r 'to_entries[]|select(.value.result=="failure" or .value.result=="cancelled")|.key' <<<"$NEEDS")
-          if [ -n "$broke" ]; then
-            echo "FAILED: $broke"
-            exit 1
-          fi
-          if [ "${{ github.event_name }}" = "merge_group" ]; then
-            absent=$(jq -r 'to_entries[]|select(.value.result!="success")|.key' <<<"$NEEDS")
-            if [ -n "$absent" ]; then
-              echo "DID NOT RUN IN MERGE QUEUE: $absent"
-              exit 1
-            fi
-          fi
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/check-gated-jobs
+        with:
+          needs: ${{ toJSON(needs) }}
+          event-name: ${{ github.event_name }}
 
   test-embeddable-posix:
     name: Test Embeddable (${{ matrix.label }})


### PR DESCRIPTION
The three gate jobs from https://github.com/lemonade-sdk/lemonade/pull/2950 now share one composite action.

**New file:** action.yml — the jq logic lives here once, taking `needs` (JSON) and `event-name` as inputs.

**Refactored:** `packaging-gate`, `backends-gate`, `macos-gate` in cpp_server_build_test_release.yml each shrank from ~19 lines of inline shell to a two-step `checkout` + `uses: ./.github/actions/check-gated-jobs`. Net removal of the triplicated script; a future fix to the gate logic now lands in one place.

Two behavior-preserving notes:
- Each gate now runs `actions/checkout@v5` first — required because a local composite action must exist on disk before it can be used. Job names (`Packaging builds`, `Inference backend tests`, `macOS builds`) are unchanged, so required-status-check registration is unaffected.
- `github.event_name` is now passed through the `event-name` input (surfaced as `$EVENT_NAME` env inside the action) instead of being interpolated inline — same value, no functional change.