### PR TITLE
fix(server): sum sibling shards when computing on-disk GGUF size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2309,6 +2309,24 @@ if(BUILD_TESTING AND EXISTS "${_GGUF_CAPS_TEST_SRC}")
     add_cpp_ci_test(GgufCapabilitiesTest CI OFF COMMAND test_gguf_capabilities)
 endif()
 
+set(_GGUF_SHARD_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_gguf_shard_utils.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_GGUF_SHARD_TEST_SRC}")
+    add_executable(test_gguf_shard_utils
+        test/cpp/test_gguf_shard_utils.cpp
+    )
+    target_include_directories(test_gguf_shard_utils PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_gguf_shard_utils PRIVATE lemonade-server-core)
+    add_dependencies(test_gguf_shard_utils copy_resources)
+
+    include(CTest)
+    add_cpp_ci_test(GgufShardUtilsTest CI ON COMMAND test_gguf_shard_utils)
+endif()
+
 # Model residency role/pool contract for router dependencies
 set(_MODEL_RESIDENCY_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_model_residency.cpp"

--- a/src/cpp/include/lemon/gguf_shard_utils.h
+++ b/src/cpp/include/lemon/gguf_shard_utils.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <regex>
+#include <string>
+
+namespace lemon {
+
+// Separators mirror hf_variants.cpp and visible_extra_variant_name(), which
+// both accept `-`, `.` and `_` before the shard index.
+inline bool is_gguf_shard_filename(const std::string& filename, std::string* base,
+                                   int* total = nullptr, int* index = nullptr) {
+    static const std::regex shard_pattern(R"([-._](\d+)-of-(\d+)\.gguf$)", std::regex::icase);
+    std::smatch match;
+    if (!std::regex_search(filename, match, shard_pattern)) {
+        return false;
+    }
+
+    int parsed_index = 0;
+    int parsed_total = 0;
+    try {
+        parsed_index = std::stoi(match[1].str());
+        parsed_total = std::stoi(match[2].str());
+    } catch (...) {
+        return false;
+    }
+    if (parsed_index <= 0 || parsed_total <= 0 || parsed_index > parsed_total) {
+        return false;
+    }
+
+    if (base) {
+        *base = filename.substr(0, match.position(0));
+    }
+    if (total) {
+        *total = parsed_total;
+    }
+    if (index) {
+        *index = parsed_index;
+    }
+    return true;
+}
+
+inline bool same_shard_family(const std::string& filename, const std::string& base, int total) {
+    std::string candidate_base;
+    int candidate_total = 0;
+    if (!is_gguf_shard_filename(filename, &candidate_base, &candidate_total)) {
+        return false;
+    }
+    return candidate_base == base && candidate_total == total;
+}
+
+// Total on-disk size of every sibling shard sharing `shard_path`'s family.
+// Returns 0 when `shard_path` is not a shard. Defined in model_manager.cpp,
+// which owns the Windows-safe filesystem helpers.
+std::uintmax_t sharded_gguf_size_bytes(const std::filesystem::path& shard_path);
+
+} // namespace lemon

--- a/src/cpp/server/model_manager.cpp
+++ b/src/cpp/server/model_manager.cpp
@@ -14,6 +14,7 @@
 #include <lemon/backends/cloud/cloud_server.h>
 #include <lemon/backends/fastflowlm/fastflowlm_models.h>
 #include <lemon/cloud_provider_registry.h>
+#include <lemon/gguf_shard_utils.h>
 #include <filesystem>
 #include <iostream>
 #include <fstream>
@@ -549,9 +550,10 @@ static void cleanup_empty_parents(const fs::path& file_path, const fs::path& sto
     }
 }
 
-// Return the on-disk size of a resolved model path. Some recipes (for
-// example Moonshine streaming) resolve to a directory of artifacts rather than
-// to a single model file. std::filesystem::file_size() fails on directories
+// Size of one resolved path. Deliberately per-path: list_model_files() reports
+// this as an individual file's size, so shard aggregation must not happen here.
+// Directories (e.g. Moonshine artifacts) are summed recursively because
+// std::filesystem::file_size() fails on them.
 static uintmax_t resolved_path_size_bytes(const fs::path& path) {
     std::error_code ec;
     if (!safe_exists(path)) {
@@ -585,14 +587,52 @@ static uintmax_t resolved_path_size_bytes(const fs::path& path) {
 }
 
 
+std::uintmax_t sharded_gguf_size_bytes(const fs::path& shard_path) {
+    std::string base;
+    int total = 0;
+    if (!is_gguf_shard_filename(shard_path.filename().string(), &base, &total)) {
+        return 0;
+    }
+
+    const fs::path dir = shard_path.parent_path();
+    if (!safe_is_directory(dir)) {
+        return 0;
+    }
+
+    uintmax_t sum = 0;
+    std::error_code ec;
+    for (const auto& entry : fs::directory_iterator(dir, safe_dir_options, ec)) {
+        if (!entry.is_regular_file(ec)) {
+            if (ec) ec.clear();
+            continue;
+        }
+        if (!same_shard_family(entry.path().filename().string(), base, total)) {
+            continue;
+        }
+
+        auto size = fs::file_size(entry.path(), ec);
+        if (!ec) {
+            sum += size;
+        } else {
+            ec.clear();
+        }
+    }
+    return sum;
+}
+
+
 // Replace the static registry size with the aggregate on-disk size once the
 // files exist, so directory-checkpoint models (whose repos can carry more than
-// the registry estimate) report what was actually downloaded.
+// the registry estimate) report what was actually downloaded. A sharded GGUF
+// resolves to a single shard, which for unsloth-style layouts is a small stub,
+// so the whole family is summed instead.
 static void refresh_on_disk_size(ModelInfo& info) {
     uintmax_t total_size = 0;
     for (auto& [type, path] : info.resolved_paths) {
         (void)type;
-        total_size += resolved_path_size_bytes(path_from_utf8(path));
+        fs::path resolved = path_from_utf8(path);
+        uintmax_t shard_total = sharded_gguf_size_bytes(resolved);
+        total_size += (shard_total > 0) ? shard_total : resolved_path_size_bytes(resolved);
     }
     if (total_size == 0) {
         return;

--- a/test/cpp/test_gguf_shard_utils.cpp
+++ b/test/cpp/test_gguf_shard_utils.cpp
@@ -1,0 +1,163 @@
+#include "lemon/gguf_shard_utils.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static int g_failures = 0;
+
+static void check(const char* name, bool ok) {
+    std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (!ok) ++g_failures;
+}
+
+static fs::path make_file(const fs::path& dir, const std::string& name, std::uintmax_t bytes) {
+    fs::path p = dir / name;
+    { std::ofstream(p, std::ios::out | std::ios::trunc); }
+    std::error_code ec;
+    fs::resize_file(p, bytes, ec);
+    if (ec) {
+        std::printf("resize_file('%s') failed: %s\n", p.string().c_str(), ec.message().c_str());
+    }
+    return p;
+}
+
+static fs::path make_temp_test_dir() {
+    const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+    return fs::temp_directory_path() / ("lemonade_gguf_shard_test_" + std::to_string(tick));
+}
+
+int main() {
+    fs::path base_dir = make_temp_test_dir();
+    std::error_code ec;
+    fs::remove_all(base_dir, ec);
+    fs::create_directories(base_dir, ec);
+
+    {
+        std::string b;
+        bool ok = lemon::is_gguf_shard_filename("Laguna-S-2.1-UD-Q4_K_XL-00001-of-00003.gguf", &b);
+        check("detects folder-sharded filename", ok);
+        check("extracts correct shard base", b == "Laguna-S-2.1-UD-Q4_K_XL");
+    }
+    {
+        std::string b;
+        int t = 0;
+        int i = 0;
+        check("extracts total shard count",
+              lemon::is_gguf_shard_filename("model-00001-of-00005.gguf", &b, &t, &i) && t == 5 && i == 1);
+    }
+    {
+        std::string b;
+        check("dot-separated shard is detected",
+              lemon::is_gguf_shard_filename("model.00001-of-00003.gguf", &b) && b == "model");
+    }
+    {
+        std::string b;
+        check("underscore-separated shard is detected",
+              lemon::is_gguf_shard_filename("model_00001-of-00003.gguf", &b) && b == "model");
+    }
+    {
+        std::string b;
+        check("bare numbered file is not a shard (no -of-)",
+              !lemon::is_gguf_shard_filename("model-7.gguf", &b));
+    }
+    {
+        std::string b;
+        check("shard index without a separator is not a shard",
+              !lemon::is_gguf_shard_filename("model00001-of-00003.gguf", &b));
+    }
+    {
+        std::string b;
+        check("plain model.gguf is not a shard", !lemon::is_gguf_shard_filename("model.gguf", &b));
+    }
+    {
+        std::string b;
+        check("interrupted .gguf.partial is not a shard",
+              !lemon::is_gguf_shard_filename("model-00001-of-00003.gguf.partial", &b));
+    }
+    {
+        std::string b;
+        check("zero total is not a shard",
+              !lemon::is_gguf_shard_filename("model-00001-of-00000.gguf", &b));
+    }
+    {
+        std::string b;
+        check("zero index is not a shard",
+              !lemon::is_gguf_shard_filename("model-00000-of-00003.gguf", &b));
+    }
+    {
+        std::string b;
+        check("index greater than total is not a shard",
+              !lemon::is_gguf_shard_filename("model-00004-of-00003.gguf", &b));
+    }
+
+    {
+        check("matching base and total are the same family",
+              lemon::same_shard_family("model-00002-of-00003.gguf", "model", 3));
+        check("same base, different total is a different family",
+              !lemon::same_shard_family("model-00001-of-00005.gguf", "model", 3));
+        check("different base is a different family",
+              !lemon::same_shard_family("other-00001-of-00003.gguf", "model", 3));
+        check("non-shard filename is not a family member",
+              !lemon::same_shard_family("model.gguf", "model", 3));
+        check("out-of-range index is not a family member",
+              !lemon::same_shard_family("model-00004-of-00003.gguf", "model", 3));
+    }
+
+    {
+        fs::path sub = base_dir / "same_dir";
+        fs::create_directories(sub, ec);
+        make_file(sub, "same-00001-of-00003.gguf", 10);
+        make_file(sub, "same-00002-of-00003.gguf", 20);
+        make_file(sub, "same-00003-of-00003.gguf", 30);
+        make_file(sub, "same-00001-of-00005.gguf", 500);
+        make_file(sub, "other-00001-of-00002.gguf", 1000);
+        make_file(sub, "model.gguf", 9000);
+        make_file(sub, "model-7.gguf", 8000);
+
+        check("of-3 family sums only its own shards",
+              lemon::sharded_gguf_size_bytes(sub / "same-00001-of-00003.gguf") == 10 + 20 + 30);
+        check("of-5 family does not absorb the of-3 family",
+              lemon::sharded_gguf_size_bytes(sub / "same-00001-of-00005.gguf") == 500);
+        check("different-base family sums independently",
+              lemon::sharded_gguf_size_bytes(sub / "other-00001-of-00002.gguf") == 1000);
+        check("non-shard path aggregates nothing",
+              lemon::sharded_gguf_size_bytes(sub / "model.gguf") == 0);
+    }
+
+    {
+        fs::path sub = base_dir / "widths";
+        fs::create_directories(sub, ec);
+        make_file(sub, "Q4_K_M-1-of-2.gguf", 50);
+        make_file(sub, "Q4_K_M-2-of-2.gguf", 60);
+        check("varying index widths are the same family",
+              lemon::sharded_gguf_size_bytes(sub / "Q4_K_M-1-of-2.gguf") == 50 + 60);
+    }
+
+    {
+        fs::path sub = base_dir / "separators";
+        fs::create_directories(sub, ec);
+        make_file(sub, "model.00001-of-00002.gguf", 70);
+        make_file(sub, "model.00002-of-00002.gguf", 80);
+        make_file(sub, "other_00001-of-00002.gguf", 90);
+        make_file(sub, "other_00002-of-00002.gguf", 100);
+        check("dot-separated shards are summed",
+              lemon::sharded_gguf_size_bytes(sub / "model.00001-of-00002.gguf") == 70 + 80);
+        check("underscore-separated shards are summed",
+              lemon::sharded_gguf_size_bytes(sub / "other_00001-of-00002.gguf") == 90 + 100);
+    }
+
+    fs::remove_all(base_dir, ec);
+
+    if (g_failures == 0) {
+        std::printf("\nAll gguf_shard tests passed\n");
+        return 0;
+    }
+    std::printf("\n%d gguf_shard test(s) FAILED\n", g_failures);
+    return 1;
+}

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -5726,6 +5726,64 @@ class EndpointTests(ServerTestBase):
             self._set_extra_models_dir(prior_dir)
             shutil.rmtree(extra_dir, ignore_errors=True)
 
+    def test_021ub_extra_subdir_sharded_size_sums_shards_but_files_stay_per_file(self):
+        """Issue #2972: a sharded model reports the whole family's size, while
+        /models/{id}/files keeps reporting each file's own size."""
+        extra_dir = tempfile.mkdtemp(prefix="lemon_extra_shard_size_")
+        folder_name = "Sharded-Size-GGUF"
+        model_dir = os.path.join(extra_dir, folder_name)
+        shard1 = os.path.join(model_dir, "Sharded-Size-00001-of-00002.gguf")
+        shard2 = os.path.join(model_dir, "Sharded-Size-00002-of-00002.gguf")
+        self._write_stub_gguf_file(shard1)
+        self._write_stub_gguf_file(shard2)
+
+        # The resolved path is the first shard, which in unsloth-style layouts
+        # is a small stub; the bulk of the weights live in the later shards.
+        shard2_bytes = 200 * 1024 * 1024
+        with open(shard2, "r+b") as f:
+            f.truncate(shard2_bytes)
+        shard1_bytes = os.path.getsize(shard1)
+        expected_gb = (shard1_bytes + shard2_bytes) / (1024**3)
+        shard1_only_gb = shard1_bytes / (1024**3)
+
+        prior_dir = self._set_extra_models_dir(extra_dir)
+        try:
+            models_response = requests.get(
+                f"{self.base_url}/models?show_all=true", timeout=TIMEOUT_DEFAULT
+            )
+            self.assertEqual(models_response.status_code, 200)
+            models_by_id = {
+                model["id"]: model for model in models_response.json()["data"]
+            }
+            self.assertIn(folder_name, models_by_id)
+            self.assertAlmostEqual(
+                models_by_id[folder_name]["size"],
+                expected_gb,
+                places=2,
+                msg="model size must cover every shard, not just the resolved one",
+            )
+            self.assertGreater(models_by_id[folder_name]["size"], shard1_only_gb)
+
+            files_response = requests.get(
+                f"{self.base_url}/models/{folder_name}/files",
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(files_response.status_code, 200)
+            files = files_response.json()["files"]
+            main_files = [f for f in files if f["role"] == "main"]
+            self.assertEqual(len(main_files), 1)
+            self.assertEqual(main_files[0]["name"], os.path.basename(shard1))
+            self.assertEqual(
+                main_files[0]["size_bytes"],
+                shard1_bytes,
+                "/files must report the individual file size, not the shard total",
+            )
+
+            print("[OK] sharded size sums shards while /files stays per-file")
+        finally:
+            self._set_extra_models_dir(prior_dir)
+            shutil.rmtree(extra_dir, ignore_errors=True)
+
     def test_021v_extra_subdir_multiple_sharded_quantizations_split_by_variant(self):
         """A folder with multiple sharded variants lists one model per variant."""
         extra_dir = tempfile.mkdtemp(prefix="lemon_extra_sharded_variants_")


### PR DESCRIPTION
Fixes #2972

Folder-sharded GGUF variants (unsloth-style repos, e.g. `Laguna-S-2.1-GGUF:UD-Q4_K_XL`) showed only the first shard's size (~3 MB) in the model list instead of the total (~68 GB).

`resolve_gguf_path()` resolves such quants to a single shard file, which in these layouts is a small stub. `refresh_on_disk_size()` now sums the whole shard family via `sharded_gguf_size_bytes()`, so the model list reports the real on-disk total. `resolved_path_size_bytes()` deliberately stays per-file so `/v1/models/{id}/files` keeps reporting each file's own size.

Shard filenames are matched on `-NNNNN-of-NNNNN.gguf` with `-`, `.` or `_` as the separator, matching the conventions already recognized in `hf_variants.cpp`. Siblings are grouped on both the base name and the `-of-N` count, and `index > total` is rejected.

Covered by `test_gguf_shard_utils` (exercises the production aggregation directly) and an endpoint test asserting the model size / `/files` split.
