### PR TITLE
fix(server): return the router error status on rerank, slots and tokenize

### DIFF
--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -3530,6 +3530,11 @@ void Server::handle_reranking(const httplib::Request& req, httplib::Response& re
 
         // Call router's reranking method
         auto response = router_->reranking(request_json);
+        if (response.contains("error")) {
+            set_error_response(response, res);
+            return;
+        }
+
         res.set_content(response.dump(), "application/json");
 
     } catch (const std::exception& e) {
@@ -3698,6 +3703,11 @@ void Server::handle_slots(const httplib::Request& req, httplib::Response& res) {
 
         // Call router's get_slots method
         auto response = router_->get_slots();
+        if (response.contains("error")) {
+            set_error_response(response, res);
+            return;
+        }
+
         res.set_content(response.dump(), "application/json");
 
     } catch (const std::exception& e) {
@@ -3765,6 +3775,11 @@ void Server::handle_slots_by_id(const httplib::Request& req, httplib::Response& 
 
         // Call router's slots_action method with slot ID, action, and request body
         auto response = router_->slots_action(slot_id, action_param, request_body);
+        if (response.contains("error")) {
+            set_error_response(response, res);
+            return;
+        }
+
         res.set_content(response.dump(), "application/json");
 
     } catch (const std::exception& e) {
@@ -3812,6 +3827,11 @@ void Server::handle_tokenize(const httplib::Request& req, httplib::Response& res
 
         // Forward request to router
         auto response = router_->tokenize(request_body);
+        if (response.contains("error")) {
+            set_error_response(response, res);
+            return;
+        }
+
         res.set_content(response.dump(), "application/json");
 
     } catch (const std::exception& e) {

--- a/test/server_llm.py
+++ b/test/server_llm.py
@@ -1007,17 +1007,19 @@ class LLMTests(ServerTestBase):
                     print(f"Slots erase response: {erase_data}")
                     if "id_slot" in erase_data:
                         self.assertEqual(erase_data["id_slot"], slot_id_to_erase)
-                    elif "error" in erase_data:
-                        # Received an error response from the erase endpoint, this may be because the server
-                        # was not started with the --slot-save-path argument
-                        print(
-                            f"Slots erase backend error response: {erase_data['error']}"
-                        )
-                        pass
                     else:
                         self.fail(
                             f"Unexpected response from slots erase endpoint: {erase_data}"
                         )
+                elif erase_response.status_code == 501:
+                    error_data = erase_response.json()
+                    print(f"Slots erase backend error response: {error_data}")
+                    self.assertIn("error", error_data)
+                    self.assertEqual(error_data["error"].get("type"), "not_supported_error")
+                    self.assertIn(
+                        "--slot-save-path",
+                        error_data["error"].get("message", ""),
+                    )
                 else:
                     error_data = erase_response.json()
                     print(f"Slots erase error response: {error_data}")
@@ -1025,7 +1027,6 @@ class LLMTests(ServerTestBase):
                         f"Failed to erase slot with id {slot_id_to_erase}, "
                         f"status code: {erase_response.status_code}"
                     )
-
             else:
                 self.fail("No slot id found to erase in /api/v1/slots response")
         else:

--- a/test/server_llm.py
+++ b/test/server_llm.py
@@ -1015,7 +1015,9 @@ class LLMTests(ServerTestBase):
                     error_data = erase_response.json()
                     print(f"Slots erase backend error response: {error_data}")
                     self.assertIn("error", error_data)
-                    self.assertEqual(error_data["error"].get("type"), "not_supported_error")
+                    self.assertEqual(
+                        error_data["error"].get("type"), "not_supported_error"
+                    )
                     self.assertIn(
                         "--slot-save-path",
                         error_data["error"].get("message", ""),

--- a/test/server_llm.py
+++ b/test/server_llm.py
@@ -772,6 +772,30 @@ class LLMTests(ServerTestBase):
             f"Expected food-related documents {expected_top_3} in top 3, got {actual_top_3}",
         )
 
+    @skip_if_unsupported("reranking")
+    def test_018d_reranking_error_is_not_reported_as_success(self):
+        """Test reranking a model that cannot rerank returns an error status."""
+        model = self.get_test_model("llm")
+
+        payload = {
+            "query": "A man is eating pasta.",
+            "documents": ["A man is eating food.", "A man is riding a horse."],
+            "model": model,
+        }
+
+        response = requests.post(
+            f"{self.base_url}/rerank", json=payload, timeout=TIMEOUT_MODEL_OPERATION
+        )
+
+        print(
+            f"/rerank with {model}: HTTP {response.status_code} {response.text[:200]}"
+        )
+        self.assertGreaterEqual(response.status_code, 400, response.text)
+
+        error = response.json().get("error")
+        self.assertIsInstance(error, dict, response.text)
+        self.assertTrue(error.get("message"), response.text)
+
     # =========================================================================
     # MULTI-MODEL TESTS
     # =========================================================================


### PR DESCRIPTION
`Router::reranking`, `get_slots`, `slots_action` and `tokenize` return an error payload instead of throwing when the loaded backend cannot serve the request. Their handlers write that payload out with HTTP 200, so a client reads a failure as a success.

#2061 added the `set_error_response()` check to `handle_embeddings`. This applies the same check to the four handlers that call the router the same way.

## Root cause

`handle_reranking` is otherwise a structural copy of `handle_embeddings`, but it never inspects the response:

```cpp
auto response = router_->reranking(request_json);
res.set_content(response.dump(), "application/json");   // 200, even when response is {"error": ...}
```

`get_error_status_code()` already knows how to map these payloads — it honours an embedded `status_code` and maps `unsupported_operation` to 400 and `model_not_loaded` to 404. It just was not reached from these four paths.

Measured on `main`, with a chat model loaded and `POST /api/v1/rerank`:

```
POST /api/v1/rerank    -> HTTP 200
POST /api/v1/reranking -> HTTP 200
POST /api/v1/reranker  -> HTTP 200
{"error":{"code":501,"message":"This server does not support reranking. Start it with `--reranking`",
          "type":"not_supported_error","status_code":501, ...}}
```

An OpenAI- or LiteLLM-style client treats 200 as success and then fails on the missing `results` key. The same request shape against `/embeddings` has returned a correct status since #2061.

With this change all three paths return 501 and the body is unchanged.

## Fix

The same five-line check in `handle_reranking`, `handle_slots`, `handle_slots_by_id` and `handle_tokenize`. No new helper, no new status mapping, no change on the success path. The `/reranking` and `/reranker` aliases share the handler, so they are covered too.

## Testing

Windows, llamacpp/vulkan, `LFM2-1.2B-GGUF` and `jina-reranker-v1-tiny-en-GGUF`.

- Added `test/server_llm.py::test_018d_reranking_error_is_not_reported_as_success`. Verified it fails on `main` — `AssertionError: 200 not greater than or equal to 400` — and passes with this change.
- `test_018`, `test_018b`, `test_018c` (the existing reranking tests) still pass, so the success path is unaffected.
- `ctest -L cpp-ci`: 22/22, unchanged from the pre-change baseline.
- `/slots` and `/tokenize` are served by llamacpp, so I could not reach their error path locally; the edit is identical to the reranking one. Happy to add tests for them if you would rather have the coverage.
- Not run on Linux or macOS; the change is platform-independent.
