### PR TITLE
fix(server): frame backend errors as SSE events on the streaming path

### DIFF
--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -86,9 +86,6 @@ void StreamingProxy::forward_sse_stream(
     double time_to_first_token = 0.0;
     const auto start_time = std::chrono::steady_clock::now();
 
-    // On a non-200 the backend body is an error description, not SSE payload:
-    // divert it here instead of the client sink, so it can be reframed as an
-    // SSE event below rather than reaching the client as unparsable bytes.
     int backend_status = 200;
     std::string error_body;
     static constexpr size_t max_error_body = 64 * 1024;
@@ -182,11 +179,9 @@ void StreamingProxy::forward_sse_stream(
                                      << (error_body.empty() ? "" : ": " + error_body) << std::endl;
         telemetry.error_message = "Backend returned error status code: " + std::to_string(status);
 
-        // The response is already committed as 200 text/event-stream, so the only
-        // way to surface the failure is as an SSE event: an unframed body is
-        // dropped by every spec-compliant client parser. Same payload shape as
-        // forward_byte_stream(). No [DONE] follows, matching OpenAI's behavior
-        // for in-stream errors.
+        // The response is already committed as 200 text/event-stream, so an
+        // unframed error body is dropped by every spec-compliant client parser.
+        // No [DONE] follows, matching OpenAI's behavior for in-stream errors.
         json payload;
         try {
             payload = json::parse(error_body);

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -86,6 +86,13 @@ void StreamingProxy::forward_sse_stream(
     double time_to_first_token = 0.0;
     const auto start_time = std::chrono::steady_clock::now();
 
+    // On a non-200 the backend body is an error description, not SSE payload:
+    // divert it here instead of the client sink, so it can be reframed as an
+    // SSE event below rather than reaching the client as unparsable bytes.
+    int backend_status = 200;
+    std::string error_body;
+    static constexpr size_t max_error_body = 64 * 1024;
+
     auto process_line = [&telemetry](const std::string& line) {
         std::string json_str;
         if (line.find("data: ") == 0) {
@@ -104,10 +111,17 @@ void StreamingProxy::forward_sse_stream(
     utils::HttpResponse result = utils::HttpClient::post_stream(
         backend_url,
         request_body,
-        [&sink, &line_buffer, &has_done_marker, &has_first_token,
-         &time_to_first_token, &start_time, &on_chunk, &process_line](const char* data, size_t length) {
+        [&sink, &line_buffer, &has_done_marker, &has_first_token, &time_to_first_token,
+         &start_time, &on_chunk, &process_line, &backend_status, &error_body](const char* data, size_t length) {
             if (on_chunk) {
                 on_chunk();
+            }
+
+            if (backend_status != 200) {
+                if (error_body.size() < max_error_body) {
+                    error_body.append(data, std::min(length, max_error_body - error_body.size()));
+                }
+                return true;
             }
 
             line_buffer.append(data, length);
@@ -132,7 +146,7 @@ void StreamingProxy::forward_sse_stream(
         },
         {},
         timeout_seconds,
-        nullptr,
+        [&backend_status](int status) { backend_status = status; },
         utils::HttpSecurityPolicy::TrustedLoopback
     );
 
@@ -161,10 +175,34 @@ void StreamingProxy::forward_sse_stream(
         }
     }
 
-    if (result.status_code != 200) {
+    if (result.status_code != 200 || backend_status != 200) {
         stream_error = true;
-        LOG(ERROR, "StreamingProxy") << "Backend returned error: " << result.status_code << std::endl;
-        telemetry.error_message = "Backend returned error status code: " + std::to_string(result.status_code);
+        const int status = backend_status != 200 ? backend_status : result.status_code;
+        LOG(ERROR, "StreamingProxy") << "Backend returned error: " << status
+                                     << (error_body.empty() ? "" : ": " + error_body) << std::endl;
+        telemetry.error_message = "Backend returned error status code: " + std::to_string(status);
+
+        // The response is already committed as 200 text/event-stream, so the only
+        // way to surface the failure is as an SSE event: an unframed body is
+        // dropped by every spec-compliant client parser. Same payload shape as
+        // forward_byte_stream(). No [DONE] follows, matching OpenAI's behavior
+        // for in-stream errors.
+        json payload;
+        try {
+            payload = json::parse(error_body);
+        } catch (...) {
+            payload = nullptr;
+        }
+        if (!payload.is_object() || !payload.contains("error")) {
+            std::string message = error_body.empty()
+                ? "backend returned HTTP " + std::to_string(status)
+                : error_body;
+            payload = json{{"error", {{"message", message},
+                                      {"type", "backend_error"},
+                                      {"status", status}}}};
+        }
+        const std::string event = "data: " + payload.dump() + "\n\n";
+        sink.write(event.data(), event.size());
     }
 
     if (!stream_error) {

--- a/test/server_streaming_errors.py
+++ b/test/server_streaming_errors.py
@@ -248,7 +248,11 @@ class StreamingErrorTests(ServerTestBase):
                 errors.append(parsed["error"])
 
         self.assertTrue(errors, f"No error event in stream. Lines: {lines[:10]}")
-        self.assertTrue(errors[0].get("message"), errors[0])
+
+        # A generic message would still be a framed error event, so assert the
+        # backend's own description survived rather than the router's fallback.
+        self.assertNotEqual(errors[0].get("type"), "backend_error", errors[0])
+        self.assertIn("context", errors[0].get("message", "").lower(), errors[0])
         print(
             f"[OK] Context overflow: error event framed ({errors[0]['message'][:80]})"
         )

--- a/test/server_streaming_errors.py
+++ b/test/server_streaming_errors.py
@@ -213,10 +213,9 @@ class StreamingErrorTests(ServerTestBase):
     def test_004a_context_overflow_error_is_sse_framed(self):
         """Backend non-200 during a stream reaches the client as an SSE event.
 
-        test_004 sends the same request and only checks that the stream
-        terminates. An SSE parser drops any line that is not a recognized
-        field, so an error body written without framing is invisible to every
-        OpenAI-style client even though its bytes are on the wire.
+        An SSE parser drops any line that is not a recognized field, so an
+        error body written without framing is invisible to every OpenAI-style
+        client even though its bytes are on the wire.
         """
         self._ensure_test_model_loaded()
 
@@ -249,8 +248,6 @@ class StreamingErrorTests(ServerTestBase):
 
         self.assertTrue(errors, f"No error event in stream. Lines: {lines[:10]}")
 
-        # A generic message would still be a framed error event, so assert the
-        # backend's own description survived rather than the router's fallback.
         self.assertNotEqual(errors[0].get("type"), "backend_error", errors[0])
         self.assertIn("context", errors[0].get("message", "").lower(), errors[0])
         print(

--- a/test/server_streaming_errors.py
+++ b/test/server_streaming_errors.py
@@ -9,6 +9,7 @@ Usage:
     python server_streaming_errors.py --cli-binary /path/to/lemonade
 """
 
+import json
 import time
 
 import requests
@@ -208,6 +209,49 @@ class StreamingErrorTests(ServerTestBase):
         )
         lines = self._consume_stream(response)
         print(f"[OK] Context overflow: stream closed cleanly ({len(lines)} line(s))")
+
+    def test_004a_context_overflow_error_is_sse_framed(self):
+        """Backend non-200 during a stream reaches the client as an SSE event.
+
+        test_004 sends the same request and only checks that the stream
+        terminates. An SSE parser drops any line that is not a recognized
+        field, so an error body written without framing is invisible to every
+        OpenAI-style client even though its bytes are on the wire.
+        """
+        self._ensure_test_model_loaded()
+
+        overflow_prompt = "The quick brown fox jumps over the lazy dog. " * 600
+
+        response = self._post_streaming(
+            ENDPOINT_TEST_MODEL,
+            messages=[{"role": "user", "content": overflow_prompt}],
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        lines = self._consume_stream(response)
+
+        sse_fields = ("data:", "event:", "id:", "retry:", ":")
+        unframed = [line for line in lines if not line.startswith(sse_fields)]
+        self.assertEqual(unframed, [], f"Lines no SSE parser will read: {unframed[:5]}")
+
+        errors = []
+        for line in lines:
+            if not line.startswith("data:"):
+                continue
+            payload = line.split(":", 1)[1].strip()
+            if payload == "[DONE]":
+                continue
+            try:
+                parsed = json.loads(payload)
+            except ValueError:
+                continue
+            if isinstance(parsed, dict) and isinstance(parsed.get("error"), dict):
+                errors.append(parsed["error"])
+
+        self.assertTrue(errors, f"No error event in stream. Lines: {lines[:10]}")
+        self.assertTrue(errors[0].get("message"), errors[0])
+        print(
+            f"[OK] Context overflow: error event framed ({errors[0]['message'][:80]})"
+        )
 
     def test_005_streaming_with_many_tools_terminates_cleanly(self):
         """Streaming with 15 tools terminates cleanly (original bug report scenario)."""


### PR DESCRIPTION
Fixes #2826.

`forward_sse_stream()` writes the backend's error body straight to the client sink. The response is already committed as `200 OK` / `text/event-stream`, so the body arrives without a `data:` prefix, and every spec-compliant SSE parser drops it. The client sees an empty stream that just ends, with no hint of what went wrong.

## Root cause

`post_stream()` documents its `on_status` hook for exactly this case:

> on_status fires once, before the first chunk is delivered, so callers can divert an error body instead of forwarding it as payload bytes.

`forward_byte_stream()` in the same file uses it: it diverts the non-200 body into a capped buffer and reshapes it into `{"error": {message, type, status}}` before writing. `forward_sse_stream()` passes `nullptr`, so every byte reaches the sink including the error body.

Captured on `main` — the whole of what a client receives for a context overflow:

```
{"error":{"code":400,"message":"request (6009 tokens) exceeds the available context size (4096 tokens),
 try increasing it","type":"exceed_context_size_error","n_prompt_tokens":6009,"n_ctx":4096}}
```

The diagnosis is already useful; only the framing is missing.

## Fix

Apply the byte-stream pattern to the SSE path: register the status callback, buffer the non-200 body instead of forwarding it, and emit it as one framed `data:` event before the stream closes. The payload shape is the one `forward_byte_stream()` already produces, so both streaming paths report failures identically.

The issue asked whether `[DONE]` should follow the error event. It does not here: OpenAI does not send `[DONE]` after an in-stream error, and `sink.done()` still terminates the response cleanly, so clients that iterate to end-of-stream are unaffected. Easy to change if you would rather always terminate with `[DONE]`.

The `[DONE]` synthesis on the clean-transport path and the interrupted-transport `throw` are untouched.

## Testing

Windows, llamacpp/vulkan, `Tiny-Test-Model-GGUF`.

- Added `test/server_streaming_errors.py::test_004a_context_overflow_error_is_sse_framed`. It reuses the request from `test_004`, which reaches the same backend 400 but only asserts the stream terminates, and additionally asserts every non-empty line is a recognised SSE field and that a `data:` event carries an `error` object. Verified it fails on `main` — the failure output is the unframed line quoted above — and passes with this change.
- Full suite green: `python test/server_streaming_errors.py` — 7/7, including `test_006`, which asserts `[DONE]` on the success path.
- This suite runs in `test-cli-endpoints-linux`, so the new case is covered on every PR.
- Not run on Linux or macOS; the change is platform-independent.

The diagnosis in #2826 is @ekenberg's — the issue identifies `forward_byte_stream()` as the reference implementation and offered a PR twelve days ago. This follows that plan.
