### PR TITLE
fix(cloud): restore public model name in provider responses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
-project(lemon_cpp VERSION 11.5.2)
+project(lemon_cpp VERSION 11.6.0)
 
 include(CTest)
 
@@ -45,6 +45,16 @@ endfunction()
 #               dependency of the cpp-ci-tests aggregate target.
 #   * CI OFF -> the test is created for local/other runs but excluded from CI.
 #
+# The enclosing if() MUST test BUILD_TESTING. Distro packaging configures with
+# BUILD_TESTING=OFF so it does not build ~40 test binaries it then discards, and
+# calling this helper in that configuration is a fatal error rather than a
+# silent return to the slow build:
+#
+#   if(BUILD_TESTING AND EXISTS "${_FOO_TEST_SRC}")
+#       add_executable(test_foo ...)
+#       add_cpp_ci_test(FooTest CI ON COMMAND test_foo)
+#   endif()
+#
 # Usage:
 #   add_cpp_ci_test(<TestName>
 #                   CI <ON|OFF>                 # required, explicit CI decision
@@ -72,6 +82,14 @@ function(add_cpp_ci_test test_name)
     if(NOT ACT_COMMAND)
         message(FATAL_ERROR
             "add_cpp_ci_test(${test_name}): required 'COMMAND <command>' argument is missing")
+    endif()
+    # Distro packaging configures with BUILD_TESTING=OFF and never runs or ships
+    # a test, so reaching here means the enclosing if() forgot to check it —
+    # which silently puts the whole test suite back into every package build.
+    if(NOT BUILD_TESTING)
+        message(FATAL_ERROR
+            "add_cpp_ci_test(${test_name}): declared with BUILD_TESTING=OFF. Add "
+            "BUILD_TESTING to the enclosing if() guard, as the other test blocks do.")
     endif()
 
     # _add_test is the built-in add_test preserved by the override below, so this
@@ -143,6 +161,7 @@ set(LEMON_BACKENDS
     "flm|fastflowlm"
     "ryzenai-llm|ryzenai"
     "vllm|vllm"
+    "thenoise|thenoise"
     "cloud|cloud"
     "thinksound|thinksound"
     "acestep|acestep"
@@ -724,6 +743,16 @@ if(WIN32)
         add_compile_options(/guard:cf)
         # Buffer Security Check - stack buffer overflow detection
         add_compile_options(/GS)
+        # MSBuild parallelizes across projects, but within one project cl.exe
+        # compiles a single file at a time, which leaves most cores idle.
+        # Ninja already schedules per file, so /MP would oversubscribe there.
+        # Applies to this project's targets only — the FetchContent
+        # dependencies above were already configured by this point.
+        # Do not pass --parallel to `cmake --build` with a Visual Studio
+        # generator: CMake then sets CL_MPCount=1, which disables this.
+        if(CMAKE_GENERATOR MATCHES "Visual Studio")
+            add_compile_options(/MP)
+        endif()
     endif()
 endif()
 
@@ -785,10 +814,35 @@ if(WIN32)
         file(TO_NATIVE_PATH "${WIX_TAURI_FRAGMENT}" WIX_TAURI_FRAGMENT_NATIVE)
 
 
-        # Web app fragment paths
+        # Request the extension matching the CLI that was actually found, so
+        # `wix build` cannot resolve a newer major from NuGet that this CLI then
+        # refuses to load. Derived rather than hardcoded: the project supports
+        # WiX 5.0+, so pinning a literal would break a newer supported CLI.
+        # Falls back to unversioned if the banner is not parseable.
+        string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" WIX_EXT_VERSION "${WIX_VERSION_OUTPUT}")
+        if(WIX_EXT_VERSION)
+            set(WIX_UI_EXTENSION "WixToolset.UI.wixext/${WIX_EXT_VERSION}")
+        else()
+            set(WIX_UI_EXTENSION "WixToolset.UI.wixext")
+        endif()
+        message(STATUS "WiX UI extension: ${WIX_UI_EXTENSION}")
+
+        # Web app fragment paths. The minimal and full installers each get
+        # their own file: both regenerate it and then feed it to wix build, so
+        # a shared path makes the two targets race whenever a build runs them
+        # in parallel (`cmake --build --target wix_installers -- /m`).
+        # Their wix intermediate folders are separated below for the same
+        # reason — both compile Product.wxs, so a shared obj/ would collide on
+        # Product.wixobj with different -d IncludeTauriApp values.
+        set(WIX_INTERMEDIATE_MINIMAL "${CMAKE_CURRENT_BINARY_DIR}/installer/obj-minimal")
+        file(TO_NATIVE_PATH "${WIX_INTERMEDIATE_MINIMAL}" WIX_INTERMEDIATE_MINIMAL_NATIVE)
+        set(WIX_INTERMEDIATE_FULL "${CMAKE_CURRENT_BINARY_DIR}/installer/obj-full")
+        file(TO_NATIVE_PATH "${WIX_INTERMEDIATE_FULL}" WIX_INTERMEDIATE_FULL_NATIVE)
         file(TO_NATIVE_PATH "${WEB_APP_BUILD_DIR}" WIX_WEBAPP_SOURCE_NATIVE)
-        set(WIX_WEBAPP_FRAGMENT "${CMAKE_CURRENT_BINARY_DIR}/installer/WebAppFragment.wxs")
-        file(TO_NATIVE_PATH "${WIX_WEBAPP_FRAGMENT}" WIX_WEBAPP_FRAGMENT_NATIVE)
+        set(WIX_WEBAPP_FRAGMENT_MINIMAL "${CMAKE_CURRENT_BINARY_DIR}/installer/WebAppFragment.minimal.wxs")
+        file(TO_NATIVE_PATH "${WIX_WEBAPP_FRAGMENT_MINIMAL}" WIX_WEBAPP_FRAGMENT_MINIMAL_NATIVE)
+        set(WIX_WEBAPP_FRAGMENT_FULL "${CMAKE_CURRENT_BINARY_DIR}/installer/WebAppFragment.full.wxs")
+        file(TO_NATIVE_PATH "${WIX_WEBAPP_FRAGMENT_FULL}" WIX_WEBAPP_FRAGMENT_FULL_NATIVE)
 
         # Both installers require Python3 for fragment generation and always include the web app
         if(NOT Python3_FOUND)
@@ -801,13 +855,14 @@ if(WIN32)
             # Generate web-app fragment
             COMMAND ${Python3_EXECUTABLE} ${WIX_FRAGMENT_SCRIPT}
                 --source "${WEB_APP_BUILD_DIR}"
-                --output "${WIX_WEBAPP_FRAGMENT}"
+                --output "${WIX_WEBAPP_FRAGMENT_MINIMAL}"
                 --component-group "WebAppComponents"
                 --root-id "WebAppDir"
                 --path-variable "WebAppSourceDir"
             COMMAND ${WIX_EXECUTABLE} build
                 -arch x64
-                -ext WixToolset.UI.wixext
+                -intermediateFolder "${WIX_INTERMEDIATE_MINIMAL_NATIVE}"
+                -ext ${WIX_UI_EXTENSION}
                 -d SourceDir="${WIX_SOURCE_DIR_NATIVE}"
                 -d CppSourceDir="${WIX_CPP_SOURCE_DIR_NATIVE}"
                 -d BuildDir="${WIX_BUILD_DIR_NATIVE}"
@@ -816,7 +871,7 @@ if(WIN32)
                 -d WebAppSourceDir="${WIX_WEBAPP_SOURCE_NATIVE}"
                 -out "${WIX_MINIMAL_OUTPUT_NATIVE}"
                 "${WIX_PRODUCT_WXS_NATIVE}"
-                "${WIX_WEBAPP_FRAGMENT_NATIVE}"
+                "${WIX_WEBAPP_FRAGMENT_MINIMAL_NATIVE}"
             COMMAND ${CMAKE_COMMAND} -E echo "MSI installer created: lemonade-server-minimal.msi"
             DEPENDS ${EXECUTABLE_NAME}
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -831,7 +886,7 @@ if(WIN32)
             # Generate web-app fragment
             COMMAND ${Python3_EXECUTABLE} ${WIX_FRAGMENT_SCRIPT}
                 --source "${WEB_APP_BUILD_DIR}"
-                --output "${WIX_WEBAPP_FRAGMENT}"
+                --output "${WIX_WEBAPP_FRAGMENT_FULL}"
                 --component-group "WebAppComponents"
                 --root-id "WebAppDir"
                 --path-variable "WebAppSourceDir"
@@ -844,7 +899,8 @@ if(WIN32)
                 --path-variable "TauriSourceDir"
             COMMAND ${WIX_EXECUTABLE} build
                 -arch x64
-                -ext WixToolset.UI.wixext
+                -intermediateFolder "${WIX_INTERMEDIATE_FULL_NATIVE}"
+                -ext ${WIX_UI_EXTENSION}
                 -d SourceDir="${WIX_SOURCE_DIR_NATIVE}"
                 -d CppSourceDir="${WIX_CPP_SOURCE_DIR_NATIVE}"
                 -d BuildDir="${WIX_BUILD_DIR_NATIVE}"
@@ -855,7 +911,7 @@ if(WIN32)
                 -out "${WIX_FULL_OUTPUT_NATIVE}"
                 "${WIX_PRODUCT_WXS_NATIVE}"
                 "${WIX_TAURI_FRAGMENT_NATIVE}"
-                "${WIX_WEBAPP_FRAGMENT_NATIVE}"
+                "${WIX_WEBAPP_FRAGMENT_FULL_NATIVE}"
             COMMAND ${CMAKE_COMMAND} -E echo "MSI installer created: lemonade.msi"
             DEPENDS ${EXECUTABLE_NAME}
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -899,6 +955,7 @@ set(SOURCES_CORE
     src/cpp/server/cloud_provider_registry.cpp
     src/cpp/server/config_file.cpp
     src/cpp/server/directory_watcher.cpp
+    src/cpp/server/alias_manager.cpp
     src/cpp/server/model_manager.cpp
     src/cpp/server/model_registry.cpp
     src/cpp/server/hf_variants.cpp
@@ -2183,7 +2240,7 @@ set(_FLM_ARG_RESOLVER_TEST_SRC
 set(_FLM_ARG_RESOLVER_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/backends/fastflowlm/flm_arg_resolver.cpp"
 )
-if(EXISTS "${_FLM_ARG_RESOLVER_TEST_SRC}" AND EXISTS "${_FLM_ARG_RESOLVER_SRC}")
+if(BUILD_TESTING AND EXISTS "${_FLM_ARG_RESOLVER_TEST_SRC}" AND EXISTS "${_FLM_ARG_RESOLVER_SRC}")
     add_executable(test_flm_arg_resolver
         test/cpp/test_flm_arg_resolver.cpp
         src/cpp/server/backends/fastflowlm/flm_arg_resolver.cpp
@@ -2214,7 +2271,7 @@ set(_DIR_WATCHER_TEST_SRC
 set(_DIR_WATCHER_LIB_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/server/directory_watcher.cpp"
 )
-if(EXISTS "${_DIR_WATCHER_TEST_SRC}" AND EXISTS "${_DIR_WATCHER_LIB_SRC}")
+if(BUILD_TESTING AND EXISTS "${_DIR_WATCHER_TEST_SRC}" AND EXISTS "${_DIR_WATCHER_LIB_SRC}")
     add_executable(test_directory_watcher
         test/cpp/test_directory_watcher.cpp
         src/cpp/server/directory_watcher.cpp
@@ -2238,7 +2295,7 @@ endif()
 set(_GGUF_CAPS_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_gguf_capabilities.cpp"
 )
-if(EXISTS "${_GGUF_CAPS_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_GGUF_CAPS_TEST_SRC}")
     add_executable(test_gguf_capabilities
         test/cpp/test_gguf_capabilities.cpp
     )
@@ -2252,11 +2309,29 @@ if(EXISTS "${_GGUF_CAPS_TEST_SRC}")
     add_cpp_ci_test(GgufCapabilitiesTest CI OFF COMMAND test_gguf_capabilities)
 endif()
 
+set(_GGUF_SHARD_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_gguf_shard_utils.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_GGUF_SHARD_TEST_SRC}")
+    add_executable(test_gguf_shard_utils
+        test/cpp/test_gguf_shard_utils.cpp
+    )
+    target_include_directories(test_gguf_shard_utils PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+    target_link_libraries(test_gguf_shard_utils PRIVATE lemonade-server-core)
+    add_dependencies(test_gguf_shard_utils copy_resources)
+
+    include(CTest)
+    add_cpp_ci_test(GgufShardUtilsTest CI ON COMMAND test_gguf_shard_utils)
+endif()
+
 # Model residency role/pool contract for router dependencies
 set(_MODEL_RESIDENCY_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_model_residency.cpp"
 )
-if(EXISTS "${_MODEL_RESIDENCY_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_MODEL_RESIDENCY_TEST_SRC}")
     add_executable(test_model_residency
         test/cpp/test_model_residency.cpp
     )
@@ -2276,7 +2351,7 @@ endif()
 set(_LATEST_FALLBACK_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_latest_version_fallback.cpp"
 )
-if(EXISTS "${_LATEST_FALLBACK_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_LATEST_FALLBACK_TEST_SRC}")
     add_executable(test_latest_version_fallback
         test/cpp/test_latest_version_fallback.cpp
     )
@@ -2289,11 +2364,29 @@ if(EXISTS "${_LATEST_FALLBACK_TEST_SRC}")
     add_cpp_ci_test(LatestVersionFallbackTest CI ON COMMAND test_latest_version_fallback)
 endif()
 
+# Label-to-deployment-mode mapping (lemon::get_model_type_from_labels). Header-only,
+# so the test links nothing beyond the standard library.
+set(_MODEL_TYPE_CLASSIFIER_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_model_type_classifier.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_MODEL_TYPE_CLASSIFIER_TEST_SRC}")
+    add_executable(test_model_type_classifier
+        test/cpp/test_model_type_classifier.cpp
+    )
+    target_include_directories(test_model_type_classifier PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
+    )
+
+    include(CTest)
+    add_cpp_ci_test(ModelTypeClassifierTest CI ON COMMAND test_model_type_classifier)
+endif()
+
 # Job engine pure core: the `when`/`branch` expression evaluator + reference
 # resolution, and step-graph validation (forward-only ⇒ no loops). Header-only,
 # so these link only nlohmann/json.
 set(_JOB_EXPR_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_job_expr.cpp")
-if(EXISTS "${_JOB_EXPR_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_JOB_EXPR_TEST_SRC}")
     add_executable(test_job_expr test/cpp/test_job_expr.cpp)
     target_include_directories(test_job_expr PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
@@ -2305,7 +2398,7 @@ if(EXISTS "${_JOB_EXPR_TEST_SRC}")
 endif()
 
 set(_JOB_GRAPH_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_job_graph.cpp")
-if(EXISTS "${_JOB_GRAPH_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_JOB_GRAPH_TEST_SRC}")
     add_executable(test_job_graph test/cpp/test_job_graph.cpp)
     target_include_directories(test_job_graph PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
@@ -2321,7 +2414,7 @@ endif()
 set(_INSTALL_ATOMICITY_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_install_atomicity.cpp"
 )
-if(EXISTS "${_INSTALL_ATOMICITY_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_INSTALL_ATOMICITY_TEST_SRC}")
     add_executable(test_install_atomicity
         test/cpp/test_install_atomicity.cpp
     )
@@ -2341,7 +2434,7 @@ endif()
 set(_ROUTING_CONTRACT_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_contract.cpp"
 )
-if(EXISTS "${_ROUTING_CONTRACT_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_CONTRACT_TEST_SRC}")
     add_executable(test_routing_policy_contract
         test/cpp/test_routing_policy_contract.cpp
         src/cpp/server/routing_policy.cpp
@@ -2365,7 +2458,7 @@ endif()
 set(_ROUTING_EVALUATOR_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_evaluator.cpp"
 )
-if(EXISTS "${_ROUTING_EVALUATOR_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_EVALUATOR_TEST_SRC}")
     add_executable(test_routing_policy_evaluator
         test/cpp/test_routing_policy_evaluator.cpp
         src/cpp/server/routing_policy.cpp
@@ -2385,7 +2478,7 @@ endif()
 set(_ROUTING_REGISTRY_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_registry.cpp"
 )
-if(EXISTS "${_ROUTING_REGISTRY_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_REGISTRY_TEST_SRC}")
     add_executable(test_routing_policy_registry
         test/cpp/test_routing_policy_registry.cpp
         src/cpp/server/routing_policy.cpp
@@ -2407,7 +2500,7 @@ endif()
 set(_ROUTING_SEMANTIC_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_semantic.cpp"
 )
-if(EXISTS "${_ROUTING_SEMANTIC_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_SEMANTIC_TEST_SRC}")
     add_executable(test_routing_policy_semantic
         test/cpp/test_routing_policy_semantic.cpp
         src/cpp/server/routing_policy.cpp
@@ -2428,7 +2521,7 @@ endif()
 set(_ROUTING_LLM_ROUTER_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_llm_router.cpp"
 )
-if(EXISTS "${_ROUTING_LLM_ROUTER_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_LLM_ROUTER_TEST_SRC}")
     add_executable(test_routing_policy_llm_router
         test/cpp/test_routing_policy_llm_router.cpp
         src/cpp/server/routing_policy.cpp
@@ -2450,7 +2543,7 @@ endif()
 set(_ROUTING_DETERMINISTIC_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_deterministic.cpp"
 )
-if(EXISTS "${_ROUTING_DETERMINISTIC_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_DETERMINISTIC_TEST_SRC}")
     add_executable(test_routing_policy_deterministic
         test/cpp/test_routing_policy_deterministic.cpp
         src/cpp/server/routing_policy.cpp
@@ -2472,7 +2565,7 @@ endif()
 set(_ROUTING_ENGINE_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_engine.cpp"
 )
-if(EXISTS "${_ROUTING_ENGINE_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_ENGINE_TEST_SRC}")
     add_executable(test_routing_policy_engine
         test/cpp/test_routing_policy_engine.cpp
         src/cpp/server/routing_policy.cpp
@@ -2495,7 +2588,7 @@ endif()
 set(_ROUTING_PARSER_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_parser.cpp"
 )
-if(EXISTS "${_ROUTING_PARSER_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_PARSER_TEST_SRC}")
     add_executable(test_routing_policy_parser
         test/cpp/test_routing_policy_parser.cpp
         src/cpp/server/routing_policy.cpp
@@ -2522,7 +2615,7 @@ endif()
 set(_ROUTING_STORE_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_policy_store.cpp"
 )
-if(EXISTS "${_ROUTING_STORE_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_STORE_TEST_SRC}")
     add_executable(test_routing_policy_store
         test/cpp/test_routing_policy_store.cpp
         src/cpp/server/routing_policy.cpp
@@ -2549,7 +2642,7 @@ endif()
 set(_ROUTE_DECISION_RESPONSE_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_route_decision_response.cpp"
 )
-if(EXISTS "${_ROUTE_DECISION_RESPONSE_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTE_DECISION_RESPONSE_TEST_SRC}")
     add_executable(test_route_decision_response
         test/cpp/test_route_decision_response.cpp
         src/cpp/server/route_decision_response.cpp
@@ -2575,7 +2668,7 @@ endif()
 set(_ROUTING_CONFORMANCE_CORPUS_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_conformance_corpus.cpp"
 )
-if(EXISTS "${_ROUTING_CONFORMANCE_CORPUS_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_CONFORMANCE_CORPUS_TEST_SRC}")
     add_executable(test_routing_conformance_corpus
         test/cpp/test_routing_conformance_corpus.cpp
         src/cpp/server/route_decision_response.cpp
@@ -2608,7 +2701,7 @@ endif()
 set(_MODEL_MANAGER_COLLECTION_VALIDATION_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_model_manager_collection_validation.cpp"
 )
-if(EXISTS "${_MODEL_MANAGER_COLLECTION_VALIDATION_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_MODEL_MANAGER_COLLECTION_VALIDATION_TEST_SRC}")
     add_executable(test_model_manager_collection_validation
         test/cpp/test_model_manager_collection_validation.cpp
     )
@@ -2633,12 +2726,24 @@ if(BUILD_TESTING AND EXISTS "${_MODEL_REGISTRY_TEST_SRC}")
     add_cpp_ci_test(ModelRegistryTest CI OFF COMMAND test_model_registry)
 endif()
 
+set(_MODEL_ALIAS_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_model_alias.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_MODEL_ALIAS_TEST_SRC}")
+    add_executable(test_model_alias test/cpp/test_model_alias.cpp)
+    target_link_libraries(test_model_alias PRIVATE lemonade-server-core)
+    add_dependencies(test_model_alias copy_resources)
+
+    include(CTest)
+    add_cpp_ci_test(ModelAliasTest CI ON COMMAND test_model_alias)
+endif()
+
 # Router-backed ClassifierServices wiring (issue #2384): binds the pure engine's
 # embed/run_classifier/chat lambdas to Router-style JSON calls.
 set(_ROUTING_CLASSIFIER_SERVICES_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_classifier_services.cpp"
 )
-if(EXISTS "${_ROUTING_CLASSIFIER_SERVICES_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_CLASSIFIER_SERVICES_TEST_SRC}")
     add_executable(test_routing_classifier_services
         test/cpp/test_routing_classifier_services.cpp
         src/cpp/server/routing_classifier_services.cpp
@@ -2661,7 +2766,7 @@ endif()
 set(_AUTO_TUNE_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_auto_tune.cpp"
 )
-if(EXISTS "${_AUTO_TUNE_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_AUTO_TUNE_TEST_SRC}")
     add_executable(test_auto_tune
         test/cpp/test_auto_tune.cpp
     )
@@ -2675,62 +2780,83 @@ if(EXISTS "${_AUTO_TUNE_TEST_SRC}")
 endif()
 
 set(_TELEMETRY_HELPERS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_telemetry_helpers.cpp")
-if(EXISTS "${_TELEMETRY_HELPERS_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_TELEMETRY_HELPERS_TEST_SRC}")
     add_executable(test_telemetry_helpers test/cpp/test_telemetry_helpers.cpp)
     target_link_libraries(test_telemetry_helpers PRIVATE lemonade-server-core)
     add_cpp_ci_test(TelemetryHelpersTest CI OFF COMMAND test_telemetry_helpers)
 endif()
 
 set(_SUSPEND_INHIBITOR_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_suspend_inhibitor.cpp")
-if(EXISTS "${_SUSPEND_INHIBITOR_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_SUSPEND_INHIBITOR_TEST_SRC}")
     add_executable(test_suspend_inhibitor test/cpp/test_suspend_inhibitor.cpp)
     target_link_libraries(test_suspend_inhibitor PRIVATE lemonade-server-core)
     add_cpp_ci_test(SuspendInhibitorTest CI OFF COMMAND test_suspend_inhibitor)
 endif()
 
 set(_CONFIG_MIGRATION_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_migration.cpp")
-if(EXISTS "${_CONFIG_MIGRATION_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_CONFIG_MIGRATION_TEST_SRC}")
     add_executable(test_config_migration test/cpp/test_config_migration.cpp)
     target_link_libraries(test_config_migration PRIVATE lemonade-server-core)
     add_cpp_ci_test(ConfigMigrationTest CI OFF COMMAND test_config_migration)
 endif()
 
 set(_CONFIG_TELEMETRY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_telemetry.cpp")
-if(EXISTS "${_CONFIG_TELEMETRY_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_CONFIG_TELEMETRY_TEST_SRC}")
     add_executable(test_config_telemetry test/cpp/test_config_telemetry.cpp)
     target_link_libraries(test_config_telemetry PRIVATE lemonade-server-core)
     add_cpp_ci_test(ConfigTelemetryTest CI OFF COMMAND test_config_telemetry)
 endif()
 
+set(_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_runtime_config_backend_validation.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC}")
+    add_executable(test_runtime_config_backend_validation
+        test/cpp/test_runtime_config_backend_validation.cpp
+    )
+    target_link_libraries(test_runtime_config_backend_validation PRIVATE lemonade-server-core)
+    add_cpp_ci_test(RuntimeConfigBackendValidationTest CI ON
+        COMMAND test_runtime_config_backend_validation
+    )
+endif()
+
+set(_CONFIG_DEFAULT_SOURCE_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_default_source.cpp")
+if(BUILD_TESTING AND EXISTS "${_CONFIG_DEFAULT_SOURCE_TEST_SRC}")
+    add_executable(test_config_default_source test/cpp/test_config_default_source.cpp)
+    target_link_libraries(test_config_default_source PRIVATE lemonade-server-core)
+    add_cpp_ci_test(ConfigDefaultSourceTest CI ON COMMAND test_config_default_source)
+endif()
+
 # ROCm root resolution (ROCM_PATH / rocm-sdk / /opt/rocm priority): covers the
 # external-ROCm detection that lets Lemonade skip the bundled TheRock download.
 set(_ROCM_ROOT_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_rocm_root_resolution.cpp")
-if(EXISTS "${_ROCM_ROOT_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ROCM_ROOT_TEST_SRC}")
     add_executable(test_rocm_root_resolution test/cpp/test_rocm_root_resolution.cpp)
     target_link_libraries(test_rocm_root_resolution PRIVATE lemonade-server-core)
     add_cpp_ci_test(RocmRootResolutionTest CI OFF COMMAND test_rocm_root_resolution)
 endif()
 
 set(_GPU_ENV_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_backend_utils_gpu_env.cpp")
-if(EXISTS "${_GPU_ENV_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_GPU_ENV_TEST_SRC}")
     add_executable(test_backend_utils_gpu_env test/cpp/test_backend_utils_gpu_env.cpp)
     target_link_libraries(test_backend_utils_gpu_env PRIVATE lemonade-server-core)
-    add_cpp_ci_test(BackendUtilsGpuEnvTest CI OFF COMMAND test_backend_utils_gpu_env)
+    add_cpp_ci_test(BackendUtilsGpuEnvTest CI ON COMMAND test_backend_utils_gpu_env)
 endif()
 
 set(_NETWORK_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_network_utils.cpp")
-if(EXISTS "${_NETWORK_UTILS_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_NETWORK_UTILS_TEST_SRC}")
     add_executable(test_network_utils test/cpp/test_network_utils.cpp)
     target_link_libraries(test_network_utils PRIVATE lemonade-server-core)
     add_cpp_ci_test(NetworkUtilsTest CI ON COMMAND test_network_utils)
 endif()
 
 set(_URL_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_url_utils.cpp")
-if(EXISTS "${_URL_UTILS_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_URL_UTILS_TEST_SRC}")
     add_executable(test_url_utils test/cpp/test_url_utils.cpp)
     target_link_libraries(test_url_utils PRIVATE lemonade-server-core)
     add_cpp_ci_test(UrlUtilsTest CI OFF COMMAND test_url_utils)
 endif()
+
 
 set(_PROCESS_SSE_LINES_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_process_sse_lines.cpp")
 if(EXISTS "${_PROCESS_SSE_LINES_TEST_SRC}")
@@ -2739,10 +2865,26 @@ if(EXISTS "${_PROCESS_SSE_LINES_TEST_SRC}")
     add_cpp_ci_test(ProcessSseLinesTest CI ON COMMAND test_process_sse_lines)
 endif()
 
+
+set(_GITHUB_API_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_github_api.cpp")
+if(BUILD_TESTING AND EXISTS "${_GITHUB_API_TEST_SRC}")
+    add_executable(test_github_api test/cpp/test_github_api.cpp)
+    target_link_libraries(test_github_api PRIVATE lemonade-server-core)
+    add_cpp_ci_test(GithubApiTest CI ON COMMAND test_github_api)
+endif()
+
+# GGUF variant enumeration: grouping, name disambiguation, and quant ordering.
+set(_HF_VARIANTS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_hf_variants.cpp")
+if(BUILD_TESTING AND EXISTS "${_HF_VARIANTS_TEST_SRC}")
+    add_executable(test_hf_variants test/cpp/test_hf_variants.cpp)
+    target_link_libraries(test_hf_variants PRIVATE lemonade-server-core)
+    add_cpp_ci_test(HfVariantsTest CI ON COMMAND test_hf_variants)
+endif()
+
 # vLLM CDNA gating: the vllm descriptor support row + asset-family resolution for
 # AMD Instinct (gfx942), alongside the existing RDNA families.
 set(_VLLM_CDNA_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_vllm_cdna_gating.cpp")
-if(EXISTS "${_VLLM_CDNA_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_VLLM_CDNA_TEST_SRC}")
     add_executable(test_vllm_cdna_gating test/cpp/test_vllm_cdna_gating.cpp)
     target_link_libraries(test_vllm_cdna_gating PRIVATE lemonade-server-core)
     add_cpp_ci_test(VllmCdnaGatingTest CI OFF COMMAND test_vllm_cdna_gating)
@@ -2752,28 +2894,35 @@ endif()
 # published, so the shared Windows/Linux support row must not advertise Windows
 # or nightly installs for gfx950.
 set(_LLAMACPP_GFX950_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_llamacpp_gfx950_gating.cpp")
-if(EXISTS "${_LLAMACPP_GFX950_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_LLAMACPP_GFX950_TEST_SRC}")
     add_executable(test_llamacpp_gfx950_gating test/cpp/test_llamacpp_gfx950_gating.cpp)
     target_link_libraries(test_llamacpp_gfx950_gating PRIVATE lemonade-server-core)
     add_cpp_ci_test(LlamacppGfx950GatingTest CI OFF COMMAND test_llamacpp_gfx950_gating)
 endif()
 
 set(_HTTP_CLIENT_SECURITY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_http_client_security.cpp")
-if(EXISTS "${_HTTP_CLIENT_SECURITY_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_HTTP_CLIENT_SECURITY_TEST_SRC}")
     add_executable(test_http_client_security test/cpp/test_http_client_security.cpp)
     target_link_libraries(test_http_client_security PRIVATE lemonade-server-core)
     add_cpp_ci_test(HttpClientSecurityTest CI OFF COMMAND test_http_client_security)
 endif()
 
 set(_CLOUD_DISCOVERY_POLICY_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_cloud_discovery_policy.cpp")
-if(EXISTS "${_CLOUD_DISCOVERY_POLICY_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_CLOUD_DISCOVERY_POLICY_TEST_SRC}")
     add_executable(test_cloud_discovery_policy test/cpp/test_cloud_discovery_policy.cpp)
     target_link_libraries(test_cloud_discovery_policy PRIVATE lemonade-server-core)
     add_cpp_ci_test(CloudDiscoveryPolicyTest CI OFF COMMAND test_cloud_discovery_policy)
 endif()
 
+set(_ANTHROPIC_ERROR_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_anthropic_error.cpp")
+if(BUILD_TESTING AND EXISTS "${_ANTHROPIC_ERROR_TEST_SRC}")
+    add_executable(test_anthropic_error test/cpp/test_anthropic_error.cpp)
+    target_link_libraries(test_anthropic_error PRIVATE lemonade-server-core)
+    add_cpp_ci_test(AnthropicErrorTest CI ON COMMAND test_anthropic_error)
+endif()
+
 set(_ORIGIN_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_origin_utils.cpp")
-if(EXISTS "${_ORIGIN_UTILS_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ORIGIN_UTILS_TEST_SRC}")
     add_executable(test_origin_utils test/cpp/test_origin_utils.cpp)
     target_link_libraries(test_origin_utils PRIVATE lemonade-server-core)
     add_cpp_ci_test(OriginUtilsTest CI ON COMMAND test_origin_utils)
@@ -2794,4 +2943,13 @@ if(BUILD_TESTING)
     add_cpp_ci_test(HttplibDetection_polluted_target_fatal CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_polluted_target_fatal -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=polluted_target_fatal -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
     set_tests_properties(HttplibDetection_polluted_target_fatal PROPERTIES WILL_FAIL TRUE)
     add_cpp_ci_test(HttplibDetection_wolfssl_target CI OFF COMMAND ${CMAKE_COMMAND} -B ${CMAKE_CURRENT_BINARY_DIR}/test_httplib_wolfssl_target -S ${CMAKE_CURRENT_SOURCE_DIR}/test/cmake -DTEST_CASE=wolfssl_target -DDETECTION_MACRO_PATH=${CMAKE_SOURCE_DIR}/cmake/DetectSystemHttplib.cmake)
+endif()
+
+# Routing-helper reconciliation: durable needed-set + non-blocking prune that
+# skips busy/pinned helpers, plus a policy-update-vs-busy concurrency race.
+set(_ROUTING_HELPER_RECONCILE_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_routing_helper_reconcile.cpp")
+if(BUILD_TESTING AND EXISTS "${_ROUTING_HELPER_RECONCILE_TEST_SRC}")
+    add_executable(test_routing_helper_reconcile test/cpp/test_routing_helper_reconcile.cpp)
+    target_link_libraries(test_routing_helper_reconcile PRIVATE lemonade-server-core)
+    add_cpp_ci_test(RoutingHelperReconcileTest CI ON COMMAND test_routing_helper_reconcile)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2732,6 +2732,13 @@ if(EXISTS "${_URL_UTILS_TEST_SRC}")
     add_cpp_ci_test(UrlUtilsTest CI OFF COMMAND test_url_utils)
 endif()
 
+set(_PROCESS_SSE_LINES_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_process_sse_lines.cpp")
+if(EXISTS "${_PROCESS_SSE_LINES_TEST_SRC}")
+    add_executable(test_process_sse_lines test/cpp/test_process_sse_lines.cpp)
+    target_link_libraries(test_process_sse_lines PRIVATE lemonade-server-core)
+    add_cpp_ci_test(ProcessSseLinesTest CI ON COMMAND test_process_sse_lines)
+endif()
+
 # vLLM CDNA gating: the vllm descriptor support row + asset-family resolution for
 # AMD Instinct (gfx942), alongside the existing RDNA families.
 set(_VLLM_CDNA_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_vllm_cdna_gating.cpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2859,10 +2859,17 @@ endif()
 
 
 set(_PROCESS_SSE_LINES_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_process_sse_lines.cpp")
-if(EXISTS "${_PROCESS_SSE_LINES_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_PROCESS_SSE_LINES_TEST_SRC}")
     add_executable(test_process_sse_lines test/cpp/test_process_sse_lines.cpp)
     target_link_libraries(test_process_sse_lines PRIVATE lemonade-server-core)
     add_cpp_ci_test(ProcessSseLinesTest CI ON COMMAND test_process_sse_lines)
+endif()
+
+set(_CLOUD_RESPONSE_MODEL_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_cloud_response_model.cpp")
+if(BUILD_TESTING AND EXISTS "${_CLOUD_RESPONSE_MODEL_TEST_SRC}")
+    add_executable(test_cloud_response_model test/cpp/test_cloud_response_model.cpp)
+    target_link_libraries(test_cloud_response_model PRIVATE lemonade-server-core)
+    add_cpp_ci_test(CloudResponseModelTest CI ON COMMAND test_cloud_response_model)
 endif()
 
 

--- a/src/cpp/include/lemon/backends/cloud/cloud_server.h
+++ b/src/cpp/include/lemon/backends/cloud/cloud_server.h
@@ -111,6 +111,12 @@ private:
     json post_with_auth(const std::string& path, const json& request,
                         const ResolvedCreds& creds, long timeout_seconds = 0);
     json rewrite_model_field(const json& request) const;
+    /// Restore the client-facing public model name after a provider call
+    /// rewrote `model` to the upstream id (mirrors LlamaCppServer).
+    json normalize_response_model(json response, const json& original_request) const;
+    /// Rewrite `"model"` inside one SSE `data:` JSON frame, if present.
+    static std::string rewrite_sse_model_line(const std::string& line,
+                                              const std::string& public_model);
     json missing_creds_error() const;
     std::string missing_creds_sse() const;
     json insecure_http_error() const;

--- a/src/cpp/include/lemon/backends/cloud/cloud_server.h
+++ b/src/cpp/include/lemon/backends/cloud/cloud_server.h
@@ -94,6 +94,13 @@ public:
     static utils::HttpSecurityPolicy discovery_policy(const std::string& base_url,
                                                       bool allow_insecure_http);
 
+    /// Restore the client-facing public model name on a non-streaming JSON body.
+    static json restore_public_model(json response, const std::string& public_model);
+
+    /// Rewrite `"model"` inside one SSE `data:` JSON frame, if present.
+    static std::string rewrite_sse_model_line(const std::string& line,
+                                              const std::string& public_model);
+
 private:
     struct ResolvedCreds {
         std::string api_key;
@@ -114,9 +121,6 @@ private:
     /// Restore the client-facing public model name after a provider call
     /// rewrote `model` to the upstream id (mirrors LlamaCppServer).
     json normalize_response_model(json response, const json& original_request) const;
-    /// Rewrite `"model"` inside one SSE `data:` JSON frame, if present.
-    static std::string rewrite_sse_model_line(const std::string& line,
-                                              const std::string& public_model);
     json missing_creds_error() const;
     std::string missing_creds_sse() const;
     json insecure_http_error() const;

--- a/src/cpp/include/lemon/streaming_proxy.h
+++ b/src/cpp/include/lemon/streaming_proxy.h
@@ -60,6 +60,12 @@ public:
 
     static void process_sse_lines(std::string& line_buffer, std::function<void(const std::string&)> line_callback);
 
+    /// Emit any trailing partial SSE line left in *line_buffer* (no final ``\\n``).
+    /// Providers sometimes omit the newline on the last ``data: [DONE]`` frame;
+    /// without this flush the line stays buffered and is never sent downstream.
+    static void flush_sse_line_buffer(std::string& line_buffer,
+                                      std::function<void(const std::string&)> line_callback);
+
     static TelemetryData parse_telemetry(const std::string& buffer);
 
     static void accumulate_responses_delta(const nlohmann::json& parsed, std::string& accumulated_text);

--- a/src/cpp/server/backends/cloud/cloud_server.cpp
+++ b/src/cpp/server/backends/cloud/cloud_server.cpp
@@ -423,11 +423,16 @@ json CloudServer::rewrite_model_field(const json& request) const {
     return modified;
 }
 
-json CloudServer::normalize_response_model(json response, const json& original_request) const {
-    if (response.is_object() && response.contains("model")) {
-        response["model"] = original_request.value("model", get_model_name());
+json CloudServer::restore_public_model(json response, const std::string& public_model) {
+    if (!public_model.empty() && response.is_object() && response.contains("model")) {
+        response["model"] = public_model;
     }
     return response;
+}
+
+json CloudServer::normalize_response_model(json response, const json& original_request) const {
+    return restore_public_model(
+        std::move(response), original_request.value("model", get_model_name()));
 }
 
 std::string CloudServer::rewrite_sse_model_line(const std::string& line,
@@ -645,6 +650,15 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
                 }
             };
 
+            // Detect [DONE] only on reassembled SSE lines. A raw chunk search
+            // misses markers split across reads (e.g. "data: [DO" + "NE]\n")
+            // and would emit a second synthetic [DONE] after the real one.
+            auto note_done_marker = [&](const std::string& line) {
+                if (line.rfind("data: ", 0) == 0 && line.substr(6) == "[DONE]") {
+                    has_done_marker = true;
+                }
+            };
+
             auto result = utils::HttpClient::post_stream(
                 url,
                 forwarded_body,
@@ -659,15 +673,12 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
                         }
                     }
                     if (streaming_mode) {
-                        if (std::string_view(data, length).find("[DONE]") != std::string_view::npos) {
-                            has_done_marker = true;
-                        }
-
                         // Parse SSE lines; rewrite echoed upstream model ids
                         // back to the public name before flushing to the client.
                         sse_line_buffer.append(data, length);
                         bool ok = true;
                         StreamingProxy::process_sse_lines(sse_line_buffer, [&](const std::string& line) {
+                            note_done_marker(line);
                             process_cloud_line(line);
                             std::string out = rewrite_sse_model_line(line, public_model);
                             out.push_back('\n');
@@ -731,6 +742,7 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
             // flush the buffer now so the client at least sees the payload.
             if (streaming_mode) {
                 StreamingProxy::flush_sse_line_buffer(sse_line_buffer, [&](const std::string& line) {
+                    note_done_marker(line);
                     process_cloud_line(line);
                     std::string out = rewrite_sse_model_line(line, public_model);
                     out.push_back('\n');

--- a/src/cpp/server/backends/cloud/cloud_server.cpp
+++ b/src/cpp/server/backends/cloud/cloud_server.cpp
@@ -423,6 +423,34 @@ json CloudServer::rewrite_model_field(const json& request) const {
     return modified;
 }
 
+json CloudServer::normalize_response_model(json response, const json& original_request) const {
+    if (response.is_object() && response.contains("model")) {
+        response["model"] = original_request.value("model", get_model_name());
+    }
+    return response;
+}
+
+std::string CloudServer::rewrite_sse_model_line(const std::string& line,
+                                                const std::string& public_model) {
+    if (public_model.empty() || line.rfind("data: ", 0) != 0) {
+        return line;
+    }
+    const std::string payload = line.substr(6);
+    if (payload.empty() || payload == "[DONE]") {
+        return line;
+    }
+    try {
+        json chunk = json::parse(payload);
+        if (chunk.is_object() && chunk.contains("model")) {
+            chunk["model"] = public_model;
+            return "data: " + chunk.dump();
+        }
+    } catch (const json::exception&) {
+        // Best-effort: leave the frame alone if it is not JSON.
+    }
+    return line;
+}
+
 json CloudServer::post_with_auth(const std::string& path, const json& request,
                                   const ResolvedCreds& creds, long timeout_seconds) {
     if (!loaded_) {
@@ -473,12 +501,16 @@ json CloudServer::post_with_auth(const std::string& path, const json& request,
 
 json CloudServer::chat_completion(const json& request) {
     json modified = rewrite_model_field(request);
-    return post_with_auth("/chat/completions", modified, resolve_creds());
+    return normalize_response_model(
+        post_with_auth("/chat/completions", modified, resolve_creds()),
+        request);
 }
 
 json CloudServer::completion(const json& request) {
     json modified = rewrite_model_field(request);
-    return post_with_auth("/completions", modified, resolve_creds());
+    return normalize_response_model(
+        post_with_auth("/completions", modified, resolve_creds()),
+        request);
 }
 
 json CloudServer::responses(const json& /*request*/) {
@@ -530,14 +562,19 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
     // fails the body forwards verbatim — most providers will then 400 with
     // a body the client can interpret, which is more informative than
     // refusing locally.
+    // Keep the client-facing public name so SSE frames can be normalized
+    // on the way back (providers echo the upstream id).
     std::string forwarded_body = request_body;
+    std::string public_model;
     try {
         json req = json::parse(request_body);
+        public_model = req.value("model", get_model_name());
         req["model"] = upstream_model_;
         utils::JsonUtils::add_legacy_max_tokens_alias(req);
         forwarded_body = req.dump();
     } catch (const json::exception&) {
         // Best-effort: forward whatever we got.
+        public_model = get_model_name();
     }
 
     ResolvedCreds creds = resolve_creds();
@@ -626,9 +663,18 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
                             has_done_marker = true;
                         }
 
-                        // Parse SSE lines
+                        // Parse SSE lines; rewrite echoed upstream model ids
+                        // back to the public name before flushing to the client.
                         sse_line_buffer.append(data, length);
-                        StreamingProxy::process_sse_lines(sse_line_buffer, process_cloud_line);
+                        bool ok = true;
+                        StreamingProxy::process_sse_lines(sse_line_buffer, [&](const std::string& line) {
+                            process_cloud_line(line);
+                            std::string out = rewrite_sse_model_line(line, public_model);
+                            out.push_back('\n');
+                            if (!sink.write(out.data(), out.size())) {
+                                ok = false;
+                            }
+                        });
 
                         if (!has_first_token && std::string_view(data, length).find("data: ") != std::string_view::npos) {
                             has_first_token = true;
@@ -636,7 +682,7 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
                                 std::chrono::steady_clock::now() - start_time).count();
                         }
 
-                        return sink.write(data, length);
+                        return ok;
                     }
                     body_buffer.append(data, length);
                     return true;

--- a/src/cpp/server/backends/cloud/cloud_server.cpp
+++ b/src/cpp/server/backends/cloud/cloud_server.cpp
@@ -723,9 +723,20 @@ void CloudServer::forward_streaming_request(const std::string& endpoint,
                 return;
             }
 
-            // 200 OK: if streaming_mode is true we've already flushed everything.
+            // 200 OK: if streaming_mode is true we've already flushed complete
+            // lines. Still flush any trailing partial SSE line (providers may
+            // omit the final newline, including on `data: [DONE]`), then emit a
+            // synthetic DONE only if the marker never appeared.
             // If we somehow buffered on a 200 (provider sent non-SSE success),
             // flush the buffer now so the client at least sees the payload.
+            if (streaming_mode) {
+                StreamingProxy::flush_sse_line_buffer(sse_line_buffer, [&](const std::string& line) {
+                    process_cloud_line(line);
+                    std::string out = rewrite_sse_model_line(line, public_model);
+                    out.push_back('\n');
+                    sink.write(out.data(), out.size());
+                });
+            }
             if (!body_buffer.empty()) {
                 sink.write(body_buffer.data(), body_buffer.size());
             }

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -86,6 +86,10 @@ void StreamingProxy::forward_sse_stream(
     double time_to_first_token = 0.0;
     const auto start_time = std::chrono::steady_clock::now();
 
+    int backend_status = 200;
+    std::string error_body;
+    static constexpr size_t max_error_body = 64 * 1024;
+
     auto process_line = [&telemetry](const std::string& line) {
         std::string json_str;
         if (line.find("data: ") == 0) {
@@ -104,10 +108,17 @@ void StreamingProxy::forward_sse_stream(
     utils::HttpResponse result = utils::HttpClient::post_stream(
         backend_url,
         request_body,
-        [&sink, &line_buffer, &has_done_marker, &has_first_token,
-         &time_to_first_token, &start_time, &on_chunk, &process_line](const char* data, size_t length) {
+        [&sink, &line_buffer, &has_done_marker, &has_first_token, &time_to_first_token,
+         &start_time, &on_chunk, &process_line, &backend_status, &error_body](const char* data, size_t length) {
             if (on_chunk) {
                 on_chunk();
+            }
+
+            if (backend_status != 200) {
+                if (error_body.size() < max_error_body) {
+                    error_body.append(data, std::min(length, max_error_body - error_body.size()));
+                }
+                return true;
             }
 
             line_buffer.append(data, length);
@@ -132,7 +143,7 @@ void StreamingProxy::forward_sse_stream(
         },
         {},
         timeout_seconds,
-        nullptr,
+        [&backend_status](int status) { backend_status = status; },
         utils::HttpSecurityPolicy::TrustedLoopback
     );
 
@@ -161,10 +172,36 @@ void StreamingProxy::forward_sse_stream(
         }
     }
 
-    if (result.status_code != 200) {
+    if (result.status_code != 200 || backend_status != 200) {
         stream_error = true;
-        LOG(ERROR, "StreamingProxy") << "Backend returned error: " << result.status_code << std::endl;
-        telemetry.error_message = "Backend returned error status code: " + std::to_string(result.status_code);
+        const int status = backend_status != 200 ? backend_status : result.status_code;
+        LOG(ERROR, "StreamingProxy") << "Backend returned error: " << status
+                                     << (error_body.empty() ? "" : ": " + error_body) << std::endl;
+        telemetry.error_message = "Backend returned error status code: " + std::to_string(status);
+
+        // The response is already committed as 200 text/event-stream, so an
+        // unframed error body is dropped by every spec-compliant client parser.
+        // No [DONE] follows, matching OpenAI's behavior for in-stream errors.
+        json payload;
+        try {
+            payload = json::parse(error_body);
+        } catch (...) {
+            payload = nullptr;
+        }
+        if (!payload.is_object() || !payload.contains("error")) {
+            std::string message = error_body.empty()
+                ? "backend returned HTTP " + std::to_string(status)
+                : error_body;
+            payload = json{{"error", {{"message", message},
+                                      {"type", "backend_error"},
+                                      {"status_code", status}}}};
+        } else if (payload["error"].is_object() && !payload["error"].contains("status_code")) {
+            // A backend's own error object carries no transport status, so
+            // adapters downstream would have to guess one.
+            payload["error"]["status_code"] = status;
+        }
+        const std::string event = "data: " + payload.dump() + "\n\n";
+        sink.write(event.data(), event.size());
     }
 
     if (!stream_error) {
@@ -292,7 +329,9 @@ void StreamingProxy::forward_byte_stream(
                 : error_body;
             payload = json{{"error", {{"message", message},
                                       {"type", "backend_error"},
-                                      {"status", status}}}};
+                                      {"status_code", status}}}};
+        } else if (payload["error"].is_object() && !payload["error"].contains("status_code")) {
+            payload["error"]["status_code"] = status;
         }
         const std::string out = payload.dump();
         sink.write(out.data(), out.size());

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -356,6 +356,21 @@ void StreamingProxy::process_sse_lines(std::string& line_buffer, std::function<v
     }
 }
 
+void StreamingProxy::flush_sse_line_buffer(std::string& line_buffer,
+                                           std::function<void(const std::string&)> line_callback) {
+    if (line_buffer.empty()) {
+        return;
+    }
+    std::string line = std::move(line_buffer);
+    line_buffer.clear();
+    if (!line.empty() && line.back() == '\r') {
+        line.pop_back();
+    }
+    if (!line.empty()) {
+        line_callback(line);
+    }
+}
+
 void StreamingProxy::accumulate_responses_delta(const nlohmann::json& parsed, std::string& accumulated_text) {
     if (parsed.contains("choices") && parsed["choices"].is_array() && !parsed["choices"].empty()) {
         auto choice = parsed["choices"][0];

--- a/test/cpp/test_cloud_response_model.cpp
+++ b/test/cpp/test_cloud_response_model.cpp
@@ -1,0 +1,75 @@
+// Regression tests for CloudServer public-model restoration on JSON and SSE
+// frames (lemonade-sdk/lemonade#2964 / PR #2980).
+//
+// Uses an explicit pass/fail counter (not assert()) so the test stays
+// effective under Release builds where -DNDEBUG would compile assert away.
+
+#include <cstdio>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <lemon/backends/cloud/cloud_server.h>
+
+using json = nlohmann::json;
+using lemon::backends::CloudServer;
+
+struct TestResult {
+    int passed = 0;
+    int failed = 0;
+
+    void check(bool cond, const std::string& name) {
+        if (cond) {
+            printf("[PASS] %s\n", name.c_str());
+            ++passed;
+        } else {
+            printf("[FAIL] %s\n", name.c_str());
+            ++failed;
+        }
+    }
+};
+
+int main() {
+    TestResult r;
+    printf("=== CloudServer response model Unit Tests ===\n\n");
+
+    const std::string public_model = "my-public-alias";
+
+    // Non-streaming: provider echoes upstream id -> restore public name.
+    {
+        json response = {{"id", "chatcmpl-1"},
+                         {"model", "accounts/fireworks/models/upstream-id"},
+                         {"choices", json::array()}};
+        json restored = CloudServer::restore_public_model(response, public_model);
+        r.check(restored.value("model", "") == public_model,
+                "non-streaming model == public_model");
+    }
+
+    // Streaming SSE data frame: rewrite model field.
+    {
+        std::string line =
+            "data: {\"model\":\"accounts/fireworks/models/upstream-id\",\"choices\":[]}";
+        std::string out = CloudServer::rewrite_sse_model_line(line, public_model);
+        r.check(out.rfind("data: ", 0) == 0, "streaming rewrite keeps data: prefix");
+        try {
+            json chunk = json::parse(out.substr(6));
+            r.check(chunk.value("model", "") == public_model,
+                    "streaming model == public_model");
+        } catch (const json::exception&) {
+            r.check(false, "streaming model == public_model");
+        }
+    }
+
+    // [DONE] and non-JSON frames are left alone.
+    {
+        r.check(CloudServer::rewrite_sse_model_line("data: [DONE]", public_model) ==
+                    "data: [DONE]",
+                "rewrite leaves [DONE] unchanged");
+        r.check(CloudServer::rewrite_sse_model_line(": keepalive", public_model) ==
+                    ": keepalive",
+                "rewrite leaves non-data frames unchanged");
+    }
+
+    printf("\n=== %d passed, %d failed ===\n", r.passed, r.failed);
+    return r.failed == 0 ? 0 : 1;
+}

--- a/test/cpp/test_process_sse_lines.cpp
+++ b/test/cpp/test_process_sse_lines.cpp
@@ -1,0 +1,85 @@
+#include <lemon/streaming_proxy.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+struct TestResult {
+    int passed = 0;
+    int failed = 0;
+
+    void ok(const std::string& name) {
+        printf("[PASS] %s\n", name.c_str());
+        ++passed;
+    }
+
+    void fail(const std::string& name) {
+        printf("[FAIL] %s\n", name.c_str());
+        ++failed;
+    }
+};
+
+int main() {
+    TestResult result;
+
+    // Chunks split across reads: reassembled into complete SSE lines.
+    {
+        std::string buffer;
+        std::vector<std::string> lines;
+        auto collect = [&](const std::string& line) { lines.push_back(line); };
+
+        buffer.append("data: {\"model\":\"upstream\"}");
+        lemon::StreamingProxy::process_sse_lines(buffer, collect);
+        buffer.append("\ndata: [DO");
+        lemon::StreamingProxy::process_sse_lines(buffer, collect);
+        buffer.append("NE]\n");
+        lemon::StreamingProxy::process_sse_lines(buffer, collect);
+
+        if (lines.size() == 2 && lines[0] == "data: {\"model\":\"upstream\"}" &&
+            lines[1] == "data: [DONE]" && buffer.empty()) {
+            result.ok("split chunks across reads");
+        } else {
+            result.fail("split chunks across reads");
+        }
+    }
+
+    // Final frame without trailing newline stays buffered until flush.
+    {
+        std::string buffer;
+        std::vector<std::string> lines;
+        auto collect = [&](const std::string& line) { lines.push_back(line); };
+
+        buffer.append("data: {\"choices\":[]}\n");
+        lemon::StreamingProxy::process_sse_lines(buffer, collect);
+        buffer.append("data: [DONE]");  // no trailing '\n'
+        lemon::StreamingProxy::process_sse_lines(buffer, collect);
+
+        if (lines.size() == 1 && lines[0] == "data: {\"choices\":[]}" &&
+            buffer == "data: [DONE]") {
+            // Flush remaining partial line (cloud streaming path).
+            lemon::StreamingProxy::flush_sse_line_buffer(buffer, collect);
+            if (lines.size() == 2 && lines[1] == "data: [DONE]" && buffer.empty()) {
+                result.ok("flush final frame without trailing newline");
+            } else {
+                result.fail("flush final frame without trailing newline");
+            }
+        } else {
+            result.fail("flush final frame without trailing newline");
+        }
+    }
+
+    // Empty flush is a no-op.
+    {
+        std::string buffer;
+        int calls = 0;
+        lemon::StreamingProxy::flush_sse_line_buffer(buffer, [&](const std::string&) { ++calls; });
+        if (calls == 0 && buffer.empty()) {
+            result.ok("empty flush is no-op");
+        } else {
+            result.fail("empty flush is no-op");
+        }
+    }
+
+    printf("\n%d passed, %d failed\n", result.passed, result.failed);
+    return result.failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
Cloud backend responses echoed the **upstream provider model id** in `model` after `rewrite_model_field` rewrote the outbound request. Clients that key state on `response.model` saw a different name than they sent (and mixed naming in router conversations).

The llamacpp backend already restores the request model via `normalize_response_model`; cloud had no equivalent.

## Changes
- Add `CloudServer::normalize_response_model` (same idea as llamacpp) and apply it to non-streaming `chat_completion` / `completion`.
- On the SSE path, rewrite `"model"` inside each `data:` JSON frame back to the public name from the original request.

## Test plan
- [ ] Non-streaming chat/completions: `response.model` equals the requested public name (e.g. `fireworks.kimi-k2p6`), not the upstream id
- [ ] Streaming: intermediate and final chunks keep the public `model` field
- [ ] Existing cloud auth / insecure-http error paths unchanged

Fixes #2964
