### PR TITLE
fix(gui): move model tab settings towards setting tab

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1280,9 +1280,17 @@ const App: React.FC = () => {
                 <ConnectView
                   status={status}
                   isActive={view === 'connect'}
-                  activeSection={route.view === 'connect' ? route.section : lastWorkspaceSectionsRef.current.connect}
-                  onSectionChange={section => navigateToRoute({ view: 'connect', section })}
+                  activeSection={
+                    route.view === 'connect'
+                      ? route.section
+                      : lastWorkspaceSectionsRef.current.connect
+                  }
+                  onSectionChange={section =>
+                    navigateToRoute({ view: 'connect', section })
+                  }
                   onLocalDataReset={handleLocalDataReset}
+                  models={loadedModelViewState.knownInfos}
+                  loadedModels={loadedModels}
                 />
               </Suspense>
             </ViewErrorBoundary>

--- a/src/app/src/components/ConnectView.tsx
+++ b/src/app/src/components/ConnectView.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import api, { CloudProviderRow, ConnectionStatus, DirectorySettings, friendlyErrorMessage, normalizeBaseUrl } from '../api';
+import api, { CloudProviderRow, ConnectionStatus, DirectorySettings, friendlyErrorMessage, normalizeBaseUrl, type LoadedModel, type ModelInfo } from '../api';
 import { clearClientStorage } from '../storage';
-import { loadChatHistoryPreference, saveChatHistoryPreference } from '../features/chatHistory/historySettings';
 import { Icon, IconName } from './Icon';
+import GlobalModelSettingsPanel from './GlobalModelSettingsPanel';
 import McpPanel from './McpPanel';
 import WorkspaceSectionRail from './WorkspaceSectionRail';
 import { WORKSPACE_NAVIGATION, type ConnectSection } from '../features/navigation/workspaceNavigation';
@@ -20,6 +20,8 @@ interface ConnectViewProps {
   activeSection: ConnectSection;
   onSectionChange: (section: ConnectSection) => void;
   onLocalDataReset: () => void;
+  models: ModelInfo[];
+  loadedModels: LoadedModel[];
 }
 
 const HELP_LINKS: { label: string; href: string; icon: IconName; description: string }[] = [
@@ -38,7 +40,7 @@ const CLOUD_QUICK_FILL = [
 
 const emptyDirectorySettings: DirectorySettings = { modelsDir: '', extraModelsDir: '', canPersist: false };
 
-const ConnectView: React.FC<ConnectViewProps> = ({ status, isActive, activeSection, onSectionChange, onLocalDataReset }) => {
+const ConnectView: React.FC<ConnectViewProps> = ({ status, isActive, activeSection, onSectionChange, onLocalDataReset, models, loadedModels }) => {
   const [railCollapsed, setRailCollapsed] = useState(false);
   const [host, setHost] = useState(api.baseUrl);
   const [apiKey, setApiKey] = useState(api.apiKey);
@@ -47,8 +49,6 @@ const ConnectView: React.FC<ConnectViewProps> = ({ status, isActive, activeSecti
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState<string | null>(api.lastConnectionError);
   const [notice, setNotice] = useState<string | null>(null);
-  const [persistHistory, setPersistHistory] = useState(() => loadChatHistoryPreference());
-
   const [providers, setProviders] = useState<CloudProviderRow[]>([]);
   const [providerName, setProviderName] = useState('');
   const [providerBaseUrl, setProviderBaseUrl] = useState('');
@@ -383,21 +383,18 @@ const ConnectView: React.FC<ConnectViewProps> = ({ status, isActive, activeSecti
               </WorkspaceActionButton>
             </WorkspaceActionGroup>
           </form>
-          <div className="connect__section">
-            <label className="connect__checkbox">
-              <input
-                type="checkbox"
-                checked={persistHistory}
-                onChange={event => {
-                  const persist = event.target.checked;
-                  setPersistHistory(persist);
-                  saveChatHistoryPreference(persist);
-                }}
-              />
-              <span>Save chat history in this browser</span>
-            </label>
-            <p className="connect__hint">Chat media is never persisted.</p>
-          </div>
+        </section>
+        )}
+
+        {activeSection === 'chat' && (
+        <section className="connect__section global-model-settings">
+          <GlobalModelSettingsPanel section="chat" models={models} loadedModels={loadedModels} />
+        </section>
+        )}
+
+        {activeSection === 'memory' && (
+        <section className="connect__section global-model-settings">
+          <GlobalModelSettingsPanel section="memory" models={models} loadedModels={loadedModels} />
         </section>
         )}
 
@@ -436,6 +433,7 @@ const ConnectView: React.FC<ConnectViewProps> = ({ status, isActive, activeSecti
           </WorkspaceActionGroup>
           {directoryNotice && <div className="connect__notice">{directoryNotice}</div>}
           {directoryError && <div className="connect__error">{directoryError}</div>}
+          <GlobalModelSettingsPanel section="updates" models={models} loadedModels={loadedModels} />
         </section>
         )}
 

--- a/src/app/src/components/GlobalModelSettingsPanel.tsx
+++ b/src/app/src/components/GlobalModelSettingsPanel.tsx
@@ -1,13 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import type { LoadedModel, ModelInfo } from '../api';
 import { capabilityFromModelInfo } from '../modelCapabilities';
-import { Icon } from './Icon';
-import {
-  WorkspaceActionButton,
-  WorkspaceActionGroup,
-  WorkspaceDetailPanel,
-  WorkspaceMetadataChip,
-} from './WorkspacePanels';
+import { loadChatHistoryPreference, saveChatHistoryPreference } from '../features/chatHistory/historySettings';
 import {
   DEFAULT_GLOBAL_MODEL_SETTINGS,
   estimatedLoadedSizeGb,
@@ -25,20 +19,15 @@ import {
   ttsReadModeFromSettings,
   type TtsReadMode,
 } from '../features/audio/ttsSettings';
+import { Icon } from './Icon';
+import { WorkspaceActionButton, WorkspaceActionGroup } from './WorkspacePanels';
 
-export interface UpdateAllModelsResult {
-  started: number;
-  skipped: number;
-  errors: string[];
-}
+export type GlobalSettingsSection = 'chat' | 'memory' | 'updates';
 
 interface GlobalModelSettingsPanelProps {
+  section: GlobalSettingsSection;
   models: ModelInfo[];
   loadedModels: LoadedModel[];
-  pinnedModels: string[];
-  onTogglePin: (modelName: string) => void;
-  onUpdateAllModels: () => Promise<UpdateAllModelsResult>;
-  onClose: () => void;
 }
 
 function modelName(model: ModelInfo): string {
@@ -64,41 +53,25 @@ const READ_MODES: Array<{ value: TtsReadMode; title: string; description: string
   { value: 'agent-and-user', title: 'Read agent and user', description: 'Read assistant responses and submitted user text.' },
 ];
 
-const GlobalModelSettingsPanel: React.FC<GlobalModelSettingsPanelProps> = ({
-  models,
-  loadedModels,
-  pinnedModels,
-  onTogglePin,
-  onUpdateAllModels,
-  onClose,
-}) => {
+const GlobalModelSettingsPanel: React.FC<GlobalModelSettingsPanelProps> = ({ section, models, loadedModels }) => {
   const [draft, setDraft] = useState<GlobalModelSettings>(() => loadGlobalModelSettings());
+  const [persistHistory, setPersistHistory] = useState(() => loadChatHistoryPreference());
   const [ttsModel, setTtsModel] = useState<string | null>(() => loadTtsPlaybackSettings().modelName);
   const [ttsReadMode, setTtsReadMode] = useState<TtsReadMode>(() => ttsReadModeFromSettings(loadTtsPlaybackSettings()));
-  const [pinCandidate, setPinCandidate] = useState('');
   const [saved, setSaved] = useState(false);
-  const [updating, setUpdating] = useState(false);
-  const [updateNotice, setUpdateNotice] = useState<string | null>(null);
 
   useEffect(() => {
     setDraft(loadGlobalModelSettings());
+    setPersistHistory(loadChatHistoryPreference());
     const speech = loadTtsPlaybackSettings();
     setTtsModel(speech.modelName);
     setTtsReadMode(ttsReadModeFromSettings(speech));
     setSaved(false);
-    setUpdateNotice(null);
-  }, []);
+  }, [section]);
 
-  const pinnedSet = useMemo(() => new Set(pinnedModels.map(name => name.toLowerCase())), [pinnedModels]);
   const sortedModels = useMemo(() => [...models]
     .filter(model => modelName(model))
     .sort((a, b) => modelDisplayName(a).localeCompare(modelDisplayName(b))), [models]);
-  const pinOptions = useMemo(() => sortedModels.filter(model => !pinnedSet.has(modelName(model).toLowerCase())), [sortedModels, pinnedSet]);
-  const pinnedRows = useMemo(() => pinnedModels.map(name => {
-    const info = models.find(model => modelName(model).toLowerCase() === name.toLowerCase()) || null;
-    return { name, label: info ? modelDisplayName(info) : name, size: info ? Number((info as any).size || 0) : 0 };
-  }), [models, pinnedModels]);
-
   const ttsModels = useMemo(() => sortedModels.filter(model => capabilityFromModelInfo(model) === 'tts'), [sortedModels]);
   const kokoroModels = ttsModels.filter(model => modelRecipe(model).includes('kokoro'));
   const openMossModels = ttsModels.filter(model => modelRecipe(model).includes('openmoss') && !/voicegen/i.test(modelName(model)));
@@ -111,206 +84,200 @@ const GlobalModelSettingsPanel: React.FC<GlobalModelSettingsPanelProps> = ({
   };
 
   const handleSave = () => {
-    saveGlobalModelSettings(draft);
-    saveActiveTtsModel(ttsModel);
-    saveTtsReadMode(ttsReadMode);
+    const current = loadGlobalModelSettings();
+    const next = section === 'memory'
+      ? {
+          ...current,
+          resourceBudgetMode: draft.resourceBudgetMode,
+          resourceBudgetGb: draft.resourceBudgetGb,
+          autoEvictOnPressure: draft.autoEvictOnPressure,
+          loadingPolicy: draft.loadingPolicy,
+          evictionPolicy: draft.evictionPolicy,
+          protectPinnedModels: draft.protectPinnedModels,
+        }
+      : section === 'chat'
+        ? { ...current, collapseThinkingByDefault: draft.collapseThinkingByDefault }
+        : {
+            ...current,
+            automaticModelUpdates: draft.automaticModelUpdates,
+            lastAutomaticUpdateAt: draft.lastAutomaticUpdateAt,
+          };
+
+    const savedSettings = saveGlobalModelSettings(next);
+    setDraft(savedSettings);
+    if (section === 'chat') {
+      saveChatHistoryPreference(persistHistory);
+      saveActiveTtsModel(ttsModel);
+      saveTtsReadMode(ttsReadMode);
+    }
     setSaved(true);
     window.setTimeout(() => setSaved(false), 1600);
   };
 
   const handleReset = () => {
-    setDraft({ ...DEFAULT_GLOBAL_MODEL_SETTINGS });
-    setTtsModel(null);
-    setTtsReadMode('on-demand');
+    if (section === 'memory') {
+      setDraft(current => ({
+        ...current,
+        resourceBudgetMode: DEFAULT_GLOBAL_MODEL_SETTINGS.resourceBudgetMode,
+        resourceBudgetGb: DEFAULT_GLOBAL_MODEL_SETTINGS.resourceBudgetGb,
+        autoEvictOnPressure: DEFAULT_GLOBAL_MODEL_SETTINGS.autoEvictOnPressure,
+        loadingPolicy: DEFAULT_GLOBAL_MODEL_SETTINGS.loadingPolicy,
+        evictionPolicy: DEFAULT_GLOBAL_MODEL_SETTINGS.evictionPolicy,
+        protectPinnedModels: DEFAULT_GLOBAL_MODEL_SETTINGS.protectPinnedModels,
+      }));
+    } else if (section === 'chat') {
+      setDraft(current => ({ ...current, collapseThinkingByDefault: DEFAULT_GLOBAL_MODEL_SETTINGS.collapseThinkingByDefault }));
+      setPersistHistory(false);
+      setTtsModel(null);
+      setTtsReadMode('on-demand');
+    } else {
+      setDraft(current => ({
+        ...current,
+        automaticModelUpdates: DEFAULT_GLOBAL_MODEL_SETTINGS.automaticModelUpdates,
+        lastAutomaticUpdateAt: DEFAULT_GLOBAL_MODEL_SETTINGS.lastAutomaticUpdateAt,
+      }));
+    }
     setSaved(false);
   };
 
-  const handleAddPin = () => {
-    if (!pinCandidate) return;
-    onTogglePin(pinCandidate);
-    setPinCandidate('');
-  };
-
-  const handleUpdateAll = async () => {
-    if (updating) return;
-    setUpdating(true);
-    setUpdateNotice(null);
-    try {
-      const result = await onUpdateAllModels();
-      const parts = [`Started ${result.started} model update${result.started === 1 ? '' : 's'}.`];
-      if (result.skipped) parts.push(`${result.skipped} skipped.`);
-      if (result.errors.length) parts.push(`${result.errors.length} failed to start.`);
-      setUpdateNotice(parts.join(' '));
-    } catch (error) {
-      setUpdateNotice(error instanceof Error ? error.message : String(error));
-    } finally {
-      setUpdating(false);
-    }
-  };
-
   return (
-    <WorkspaceDetailPanel
-      className="global-model-settings"
-      ariaLabel="Global model settings"
-      leading={<Icon name="settings" size={20} aria-hidden="true" />}
-      title={<h2 className="workspace-detail-panel__title">Global model settings</h2>}
-      metadata={<WorkspaceMetadataChip emphasis="high" tone="accent">Defaults</WorkspaceMetadataChip>}
-      description={<p>Defaults for model memory, loading, chat reasoning, speech, and updates.</p>}
-      actions={(
-        <WorkspaceActionGroup label="Global model settings actions">
-          <WorkspaceActionButton appearance="primary" icon="check" onClick={handleSave}>
-            {saved ? 'Saved' : 'Save settings'}
-          </WorkspaceActionButton>
-          <WorkspaceActionButton appearance="quiet" icon="rotate-ccw" onClick={handleReset}>Reset defaults</WorkspaceActionButton>
-          <span className="workspace-action-group__spacer" />
-          <WorkspaceActionButton appearance="secondary" icon="x" onClick={onClose}>Cancel</WorkspaceActionButton>
-        </WorkspaceActionGroup>
-      )}
-      onClose={onClose}
-      closeLabel="Close global model settings"
-    >
+    <div className="global-model-settings__body">
+      {section === 'chat' && (
+        <>
+          <section className="global-settings-card">
+            <div className="global-settings-card__head"><div><Icon name="chat" size={18} /><h3>Chat history</h3></div></div>
+            <label className="global-settings-toggle">
+              <input type="checkbox" checked={persistHistory} onChange={event => { setPersistHistory(event.target.checked); setSaved(false); }} />
+              <span><strong>Save chat history in this browser</strong><small>Chat media is never persisted.</small></span>
+            </label>
+          </section>
 
-      <div className="global-model-settings__body">
-        <section className="global-settings-card">
-          <div className="global-settings-card__head">
-            <div><Icon name="gauge" size={18} /><h3>Memory budget</h3></div>
-            <span>{loadedModels.length} loaded · {formatGb(loadedEstimate)} estimated</span>
-          </div>
-          <p className="global-settings-card__description">The client uses known model sizes to pre-evict before loading. Server-managed mode leaves memory decisions entirely to Lemonade.</p>
-          <div className="global-settings-grid global-settings-grid--two">
+          <section className="global-settings-card">
+            <div className="global-settings-card__head"><div><Icon name="brain" size={18} /><h3>Chat behavior</h3></div></div>
+            <label className="global-settings-toggle">
+              <input type="checkbox" checked={draft.collapseThinkingByDefault} onChange={event => patchDraft('collapseThinkingByDefault', event.target.checked)} />
+              <span><strong>Collapse thinking by default</strong><small>Reasoning remains available in an expandable section on every assistant message.</small></span>
+            </label>
+          </section>
+
+          <section className="global-settings-card">
+            <div className="global-settings-card__head"><div><Icon name="tts" size={18} /><h3>Chat speech</h3></div></div>
             <label className="global-settings-field">
-              <span>Budget source</span>
-              <select className="select" value={draft.resourceBudgetMode} onChange={event => patchDraft('resourceBudgetMode', event.target.value as ResourceBudgetMode)}>
-                <option value="server">Automatic / server managed</option>
-                <option value="vram">Custom VRAM budget</option>
-                <option value="memory">Custom system memory budget</option>
+              <span>Default TTS model</span>
+              <select className="select" value={ttsModel || ''} onChange={event => { setTtsModel(event.target.value || null); setSaved(false); }}>
+                <option value="">No default speech model</option>
+                <optgroup label="Kokoro · English">
+                  {kokoroModels.length
+                    ? kokoroModels.map(model => <option key={modelName(model)} value={modelName(model)}>{modelDisplayName(model)}</option>)
+                    : <option disabled value="__kokoro_missing">Kokoro English · install kokoro-v1</option>}
+                </optgroup>
+                <optgroup label="OpenMOSS · Multilingual">
+                  {openMossModels.length
+                    ? openMossModels.map(model => <option key={modelName(model)} value={modelName(model)}>{modelDisplayName(model)}</option>)
+                    : <option disabled value="__openmoss_missing">OpenMOSS multilingual · install OpenMOSS-TTS</option>}
+                </optgroup>
+                {otherTtsModels.length > 0 && <optgroup label="Other TTS models">
+                  {otherTtsModels.map(model => <option key={modelName(model)} value={modelName(model)}>{modelDisplayName(model)}</option>)}
+                </optgroup>}
               </select>
             </label>
-            <label className="global-settings-field">
-              <span>Budget</span>
-              <div className="global-settings-number">
-                <input
-                  className="input"
-                  type="number"
-                  min={1}
-                  max={1024}
-                  step={0.5}
-                  disabled={draft.resourceBudgetMode === 'server'}
-                  value={draft.resourceBudgetGb}
-                  onChange={event => patchDraft('resourceBudgetGb', Number(event.target.value))}
-                />
-                <strong>GB</strong>
-              </div>
-            </label>
-          </div>
-          <label className="global-settings-toggle">
-            <input type="checkbox" checked={draft.autoEvictOnPressure} disabled={draft.evictionPolicy === 'manual'} onChange={event => patchDraft('autoEvictOnPressure', event.target.checked)} />
-            <span><strong>Auto-evict on memory or VRAM pressure</strong><small>On an OOM-style load failure, evict eligible models and retry once.</small></span>
-          </label>
-        </section>
-
-        <section className="global-settings-card">
-          <div className="global-settings-card__head"><div><Icon name="layers" size={18} /><h3>Loading and eviction</h3></div></div>
-          <div className="global-settings-grid global-settings-grid--two">
-            <label className="global-settings-field">
-              <span>Loading policy</span>
-              <select className="select" value={draft.loadingPolicy} onChange={event => patchDraft('loadingPolicy', event.target.value as ModelLoadingPolicy)}>
-                <option value="keep-loaded">Keep loaded models</option>
-                <option value="single-active">Single active model</option>
-                <option value="budget-aware">Stay within budget</option>
-              </select>
-            </label>
-            <label className="global-settings-field">
-              <span>Eviction order</span>
-              <select className="select" value={draft.evictionPolicy} onChange={event => patchDraft('evictionPolicy', event.target.value as ModelEvictionPolicy)}>
-                <option value="lru">Least recently used</option>
-                <option value="largest">Largest first</option>
-                <option value="oldest-process">Oldest process first</option>
-                <option value="manual">Manual only</option>
-              </select>
-            </label>
-          </div>
-          <label className="global-settings-toggle">
-            <input type="checkbox" checked={draft.protectPinnedModels} onChange={event => patchDraft('protectPinnedModels', event.target.checked)} />
-            <span><strong>Protect pinned models from automatic eviction</strong><small>Pinned models can still be unloaded manually.</small></span>
-          </label>
-        </section>
-
-        <section className="global-settings-card">
-          <div className="global-settings-card__head"><div><Icon name="pin" size={18} /><h3>Pinned models</h3></div><span>{pinnedRows.length} pinned</span></div>
-          <div className="global-settings-pin-add">
-            <select className="select" value={pinCandidate} onChange={event => setPinCandidate(event.target.value)}>
-              <option value="">Select a model to pin…</option>
-              {pinOptions.map(model => <option key={modelName(model)} value={modelName(model)}>{modelDisplayName(model)}</option>)}
-            </select>
-            <WorkspaceActionButton icon="pin" disabled={!pinCandidate} onClick={handleAddPin}>Pin model</WorkspaceActionButton>
-          </div>
-          {pinnedRows.length ? (
-            <div className="global-settings-pinned-list">
-              {pinnedRows.map(row => (
-                <div key={row.name} className="global-settings-pinned-row">
-                  <Icon name="pin" size={14} />
-                  <span><strong>{row.label}</strong><small>{row.name}{row.size > 0 ? ` · ${formatGb(row.size)}` : ''}</small></span>
-                  <WorkspaceActionButton appearance="quiet" size="small" icon="x" iconOnly onClick={() => onTogglePin(row.name)} aria-label={`Unpin ${row.label}`} title={`Unpin ${row.label}`} />
-                </div>
+            <div className="global-settings-read-modes" role="radiogroup" aria-label="Global TTS playback mode">
+              {READ_MODES.map(mode => (
+                <button key={mode.value} type="button" role="radio" aria-checked={ttsReadMode === mode.value} className={ttsReadMode === mode.value ? 'is-active' : ''} onClick={() => { setTtsReadMode(mode.value); setSaved(false); }}>
+                  <strong>{mode.title}</strong><small>{mode.description}</small>
+                </button>
               ))}
             </div>
-          ) : <p className="global-settings-empty">No pinned models. Pinning keeps important models at the top and can protect them from eviction.</p>}
-        </section>
+          </section>
+        </>
+      )}
 
-        <section className="global-settings-card">
-          <div className="global-settings-card__head"><div><Icon name="brain" size={18} /><h3>Chat behavior</h3></div></div>
-          <label className="global-settings-toggle">
-            <input type="checkbox" checked={draft.collapseThinkingByDefault} onChange={event => patchDraft('collapseThinkingByDefault', event.target.checked)} />
-            <span><strong>Collapse thinking by default</strong><small>Reasoning remains available in an expandable section on every assistant message.</small></span>
-          </label>
-        </section>
+      {section === 'memory' && (
+        <>
+          <section className="global-settings-card">
+            <div className="global-settings-card__head">
+              <div><Icon name="gauge" size={18} /><h3>Memory budget</h3></div>
+              <span>{loadedModels.length} loaded · {formatGb(loadedEstimate)} estimated</span>
+            </div>
+            <p className="global-settings-card__description">The client uses known model sizes to pre-evict before loading. Server-managed mode leaves memory decisions entirely to Lemonade.</p>
+            <div className="global-settings-grid global-settings-grid--two">
+              <label className="global-settings-field">
+                <span>Budget source</span>
+                <select className="select" value={draft.resourceBudgetMode} onChange={event => patchDraft('resourceBudgetMode', event.target.value as ResourceBudgetMode)}>
+                  <option value="server">Automatic / server managed</option>
+                  <option value="vram">Custom VRAM budget</option>
+                  <option value="memory">Custom system memory budget</option>
+                </select>
+              </label>
+              <label className="global-settings-field">
+                <span>Budget</span>
+                <div className="global-settings-number">
+                  <input
+                    className="input"
+                    type="number"
+                    min={1}
+                    max={1024}
+                    step={0.5}
+                    disabled={draft.resourceBudgetMode === 'server'}
+                    value={draft.resourceBudgetGb}
+                    onChange={event => patchDraft('resourceBudgetGb', Number(event.target.value))}
+                  />
+                  <strong>GB</strong>
+                </div>
+              </label>
+            </div>
+            <label className="global-settings-toggle">
+              <input type="checkbox" checked={draft.autoEvictOnPressure} disabled={draft.evictionPolicy === 'manual'} onChange={event => patchDraft('autoEvictOnPressure', event.target.checked)} />
+              <span><strong>Auto-evict on memory or VRAM pressure</strong><small>On an OOM-style load failure, evict eligible models and retry once.</small></span>
+            </label>
+          </section>
 
-        <section className="global-settings-card">
-          <div className="global-settings-card__head"><div><Icon name="tts" size={18} /><h3>Chat speech</h3></div></div>
-          <label className="global-settings-field">
-            <span>Default TTS model</span>
-            <select className="select" value={ttsModel || ''} onChange={event => setTtsModel(event.target.value || null)}>
-              <option value="">No default speech model</option>
-              <optgroup label="Kokoro · English">
-                {kokoroModels.length
-                  ? kokoroModels.map(model => <option key={modelName(model)} value={modelName(model)}>{modelDisplayName(model)}</option>)
-                  : <option disabled value="__kokoro_missing">Kokoro English · install kokoro-v1</option>}
-              </optgroup>
-              <optgroup label="OpenMOSS · Multilingual">
-                {openMossModels.length
-                  ? openMossModels.map(model => <option key={modelName(model)} value={modelName(model)}>{modelDisplayName(model)}</option>)
-                  : <option disabled value="__openmoss_missing">OpenMOSS multilingual · install OpenMOSS-TTS</option>}
-              </optgroup>
-              {otherTtsModels.length > 0 && <optgroup label="Other TTS models">
-                {otherTtsModels.map(model => <option key={modelName(model)} value={modelName(model)}>{modelDisplayName(model)}</option>)}
-              </optgroup>}
-            </select>
-          </label>
-          <div className="global-settings-read-modes" role="radiogroup" aria-label="Global TTS playback mode">
-            {READ_MODES.map(mode => (
-              <button key={mode.value} type="button" role="radio" aria-checked={ttsReadMode === mode.value} className={ttsReadMode === mode.value ? 'is-active' : ''} onClick={() => setTtsReadMode(mode.value)}>
-                <strong>{mode.title}</strong><small>{mode.description}</small>
-              </button>
-            ))}
-          </div>
-        </section>
+          <section className="global-settings-card">
+            <div className="global-settings-card__head"><div><Icon name="layers" size={18} /><h3>Loading and eviction</h3></div></div>
+            <div className="global-settings-grid global-settings-grid--two">
+              <label className="global-settings-field">
+                <span>Loading policy</span>
+                <select className="select" value={draft.loadingPolicy} onChange={event => patchDraft('loadingPolicy', event.target.value as ModelLoadingPolicy)}>
+                  <option value="keep-loaded">Keep loaded models</option>
+                  <option value="single-active">Single active model</option>
+                  <option value="budget-aware">Stay within budget</option>
+                </select>
+              </label>
+              <label className="global-settings-field">
+                <span>Eviction order</span>
+                <select className="select" value={draft.evictionPolicy} onChange={event => patchDraft('evictionPolicy', event.target.value as ModelEvictionPolicy)}>
+                  <option value="lru">Least recently used</option>
+                  <option value="largest">Largest first</option>
+                  <option value="oldest-process">Oldest process first</option>
+                  <option value="manual">Manual only</option>
+                </select>
+              </label>
+            </div>
+            <label className="global-settings-toggle">
+              <input type="checkbox" checked={draft.protectPinnedModels} onChange={event => patchDraft('protectPinnedModels', event.target.checked)} />
+              <span><strong>Protect pinned models from automatic eviction</strong><small>Pinned models can still be unloaded manually.</small></span>
+            </label>
+          </section>
+        </>
+      )}
 
+      {section === 'updates' && (
         <section className="global-settings-card">
           <div className="global-settings-card__head"><div><Icon name="rotate-ccw" size={18} /><h3>Model updates</h3></div></div>
           <label className="global-settings-toggle">
             <input type="checkbox" checked={draft.automaticModelUpdates} onChange={event => patchDraft('automaticModelUpdates', event.target.checked)} />
             <span><strong>Automatic model updates</strong><small>Off by default. When enabled, GUI3 checks downloaded models at most once per day.</small></span>
           </label>
-          <div className="global-settings-update-action">
-            <div><strong>Update all models now</strong><small>Starts a pull/update for every downloaded or currently loaded model.</small></div>
-            <WorkspaceActionButton icon="rotate-ccw" disabled={updating} onClick={handleUpdateAll}>{updating ? 'Starting…' : 'Update all'}</WorkspaceActionButton>
-          </div>
-          {updateNotice && <p className="global-settings-notice" role="status">{updateNotice}</p>}
         </section>
-      </div>
+      )}
 
-    </WorkspaceDetailPanel>
+      <WorkspaceActionGroup label={`${section} settings actions`}>
+        <WorkspaceActionButton appearance="primary" icon="check" onClick={handleSave}>
+          {saved ? 'Saved' : 'Save settings'}
+        </WorkspaceActionButton>
+        <WorkspaceActionButton appearance="quiet" icon="rotate-ccw" onClick={handleReset}>Reset defaults</WorkspaceActionButton>
+      </WorkspaceActionGroup>
+    </div>
   );
 };
 

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -424,7 +424,7 @@ export interface ModelListPanelProps {
   searchInputRef?: React.RefObject<HTMLInputElement | null>;
   onOpenCustomModels?: () => void;
   onOpenRouter?: () => void;
-  onOpenGlobalSettings?: () => void;
+  onUpdateAllModels?: () => void;
   /** Lowercased set of pinned model names. Pinned rows float to the top. Client-local. */
   pinnedNames?: Set<string>;
   /** Toggle a model's pinned state. Receives the model name. */
@@ -460,7 +460,7 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
   searchInputRef,
   onOpenCustomModels,
   onOpenRouter,
-  onOpenGlobalSettings,
+  onUpdateAllModels,
   pinnedNames,
   onTogglePin,
   favoriteNames,
@@ -616,14 +616,14 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
               title="Create or edit a model router"
             />
           )}
-          {onOpenGlobalSettings && (
+          {onUpdateAllModels && (
             <WorkspaceActionButton
               size="toolbar"
-              icon="settings"
+              icon="rotate-ccw"
               iconOnly
-              onClick={onOpenGlobalSettings}
-              aria-label="Open global model settings"
-              title="Global model settings"
+              onClick={onUpdateAllModels}
+              aria-label="Update all models"
+              title="Update all downloaded models"
             />
           )}
         </WorkspaceActionGroup>

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -21,7 +21,6 @@ import { useWorkspaceMobileRail } from '../hooks/useWorkspaceMobileRail';
 import { useWorkspacePanelResize } from '../hooks/useWorkspacePanelResize';
 import { DEFAULT_OMNI_SYSTEM_PROMPT_TEMPLATE } from '../tools/omniTools';
 import { remoteResultAsModelInfo } from '../remoteModelCapabilities';
-import type { UpdateAllModelsResult } from './GlobalModelSettingsPanel';
 import { WorkspaceActionButton, WorkspaceActionGroup, WorkspaceDetailPanel, WorkspaceMetadataChip, WorkspacePanelResizer } from './WorkspacePanels';
 import { ROUTER_RECIPE, type RouterPullRequest } from '../features/router/routerTypes';
 import { deleteRouterRecord, loadRouterRecords, routerRecordToModelInfo } from '../features/router/routerStore';
@@ -40,7 +39,6 @@ import { useServerModelState } from '../features/models/modelState';
 import {
   ModelDetailPanelPreloaded as ModelDetailPanel,
   RouterEditorPanelPreloaded as RouterEditorPanel,
-  GlobalModelSettingsPanelPreloaded as GlobalModelSettingsPanel,
   preloadModelManagerSecondarySurfaces,
 } from '../interactionPreload';
 
@@ -1143,7 +1141,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const [routerModels, setRouterModels] = useState<ModelInfo[]>(() => loadRouterRecords().map(routerRecordToModelInfo));
   const [showRouterEditor, setShowRouterEditor] = useState(false);
   const [routerEditorModel, setRouterEditorModel] = useState<ModelInfo | null>(null);
-  const [showGlobalSettings, setShowGlobalSettings] = useState(false);
   const [showCustomForm, setShowCustomForm] = useState(false);
   const [editingCustomModelName, setEditingCustomModelName] = useState<string | null>(null);
   const [customError, setCustomError] = useState<string | null>(null);
@@ -1955,7 +1952,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
 
   const openCustomForm = (mode: CustomFormMode = 'model') => {
     setShowRouterEditor(false);
-    setShowGlobalSettings(false);
     setRouterEditorModel(null);
     setEditingCustomModelName(null);
     setCustomDraft(createEmptyCustomDraft(mode));
@@ -1967,7 +1963,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
 
   const openCustomCollectionEditor = (model: ModelInfo) => {
     setShowRouterEditor(false);
-    setShowGlobalSettings(false);
     setRouterEditorModel(null);
     const name = modelName(model);
     setSelectedDetailModelId(name);
@@ -1987,7 +1982,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
 
   const openRouterEditor = (model?: ModelInfo | null) => {
     closeCustomForm();
-    setShowGlobalSettings(false);
     const routerModel = model && String((model as any).recipe || '').toLowerCase() === ROUTER_RECIPE ? model : null;
     setRouterEditorModel(routerModel);
     setShowRouterEditor(true);
@@ -1997,17 +1991,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const closeRouterEditor = () => {
     setShowRouterEditor(false);
     setRouterEditorModel(null);
-  };
-
-  const openGlobalSettings = () => {
-    closeCustomForm();
-    closeRouterEditor();
-    setShowGlobalSettings(true);
-    setMobileDetailOpen(true);
-  };
-
-  const closeGlobalSettings = () => {
-    setShowGlobalSettings(false);
   };
 
   const pullRegistrationOrThrow = async (
@@ -2418,7 +2401,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const pinnedNameSet = useMemo(() => new Set(pinnedModels.map(name => name.toLowerCase())), [pinnedModels]);
   const favoriteNameSet = useMemo(() => new Set(favoriteModels.map(name => name.toLowerCase())), [favoriteModels]);
 
-  const handleUpdateAllModels = useCallback(async (): Promise<UpdateAllModelsResult> => {
+  const handleUpdateAllModels = useCallback(async (): Promise<void> => {
     const candidates = allModels.filter(model => {
       const name = modelName(model);
       if (!name || String((model as any).recipe || '').toLowerCase() === ROUTER_RECIPE) return false;
@@ -2426,24 +2409,15 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         || (isCollectionModel(model) ? isCollectionFullyDownloaded(model, allModels) : Boolean((model as any).downloaded));
     });
 
-    let started = 0;
-    let skipped = 0;
-    const errors: string[] = [];
     for (const model of candidates) {
       const name = modelName(model);
       if (pulling[name] !== undefined || activeDownloadForModel(downloadItems, name)) {
-        skipped += 1;
         continue;
       }
-      started += 1;
-      // Queue all pulls without holding the settings panel open for potentially
-      // multi-gigabyte downloads. Progress and terminal failures stay visible in
-      // the normal download manager and model rows.
       void handlePull(model).catch(error => {
         console.error(`Could not start update for ${name}:`, error);
       });
     }
-    return { started, skipped, errors };
   }, [allModels, downloadItems, loadedNames, pulling]);
 
   useEffect(() => {
@@ -2532,7 +2506,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     setTagFilters(new Set());
     if (showCustomForm) closeCustomForm();
     if (showRouterEditor) closeRouterEditor();
-    if (showGlobalSettings) closeGlobalSettings();
   }, [allModels, openModelRequest?.modelName, openModelRequest?.nonce]);
 
   const handlePrimaryFilterChange = (next: PrimaryFilter) => {
@@ -2889,7 +2862,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
           setMobileDetailOpen(true);
           if (showCustomForm) closeCustomForm();
           if (showRouterEditor) closeRouterEditor();
-          if (showGlobalSettings) closeGlobalSettings();
         }}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
@@ -2900,7 +2872,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
         tagFilters={tagFilters}
         searchInputRef={searchRef}
         onOpenRouter={() => openRouterEditor(selectedDetailModel)}
-        onOpenGlobalSettings={openGlobalSettings}
+        onUpdateAllModels={() => { void handleUpdateAllModels(); }}
         onOpenCustomModels={() => openCustomForm('model')}
         pinnedNames={pinnedNameSet}
         onTogglePin={togglePinnedModel}
@@ -2913,31 +2885,24 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
 
       <WorkspacePanelResizer label="Resize model list panel" {...panelResize.resizerProps} />
 
-      {/* Right panel: global settings, router editor, custom form, or model detail */}
-      {showGlobalSettings ? (
-        <div className="manager__detail-form-panel manager__detail-form-panel--global-settings">
-          <Suspense fallback={<div className="view-loading" role="status"><span className="spinner" aria-hidden="true" /></div>}>
-          <GlobalModelSettingsPanel
-            models={allModels}
-            loadedModels={loadedModels}
-            pinnedModels={pinnedModels}
-            onTogglePin={togglePinnedModel}
-            onUpdateAllModels={handleUpdateAllModels}
-            onClose={closeGlobalSettings}
-          />
-          </Suspense>
-        </div>
-      ) : showRouterEditor ? (
+      {/* Right panel: router editor, custom form, or model detail */}
+      {showRouterEditor ? (
         <div className="manager__detail-form-panel manager__detail-form-panel--router">
-          <Suspense fallback={<div className="view-loading" role="status"><span className="spinner" aria-hidden="true" /></div>}>
-          <RouterEditorPanel
-            models={allModels}
-            initialModel={routerEditorModel}
-            onRegister={handleRegisterRouter}
-            onSaved={handleRouterSaved}
-            onDeleted={handleDeleteRouterDefinition}
-            onClose={closeRouterEditor}
-          />
+          <Suspense
+            fallback={
+              <div className="view-loading" role="status">
+                <span className="spinner" aria-hidden="true" />
+              </div>
+            }
+          >
+            <RouterEditorPanel
+              models={allModels}
+              initialModel={routerEditorModel}
+              onRegister={handleRegisterRouter}
+              onSaved={handleRouterSaved}
+              onDeleted={handleDeleteRouterDefinition}
+              onClose={closeRouterEditor}
+            />
           </Suspense>
         </div>
       ) : showCustomEditor ? (

--- a/src/app/src/features/navigation/workspaceNavigation.ts
+++ b/src/app/src/features/navigation/workspaceNavigation.ts
@@ -52,6 +52,8 @@ export const WORKSPACE_NAVIGATION = {
   ] as const, 'Monitor'),
   connect: defineWorkspace('connect', [
     defineSection('server', 'Endpoint and authentication', 'plug'),
+    defineSection('chat', 'History, reasoning, and speech', 'chat'),
+    defineSection('memory', 'Budget, Loading and eviction', 'gauge'),
     defineSection('model-storage', 'Cache and custom directories', 'hard-drive'),
     defineSection('cloud-providers', 'OpenAI-compatible services', 'cloud'),
     defineSection('mcp-gateway', 'Tools and external servers', 'tools'),

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -13436,6 +13436,7 @@ a.backend-card__version:focus-visible {
   scrollbar-gutter: stable;
 }
 .connect__section > .global-model-settings__body {
+  width: min(var(--content-form-width), 100%);
   padding: 0;
   overflow: visible;
 }

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -13422,7 +13422,6 @@ a.backend-card__version:focus-visible {
 .router-node__wrap-actions button:hover { border-color: color-mix(in srgb, var(--accent-fg) 40%, var(--border-subtle)); color: var(--accent-fg); }
 
 /* ── Global model settings ─────────────────────────────────── */
-.manager__detail-form-panel--global-settings { overflow: hidden; }
 .global-model-settings {
   width: 100%;
   color: var(--text-primary);
@@ -13435,6 +13434,13 @@ a.backend-card__version:focus-visible {
   gap: var(--space-4);
   padding: var(--space-5);
   scrollbar-gutter: stable;
+}
+.connect__section > .global-model-settings__body {
+  padding: 0;
+  overflow: visible;
+}
+.connect__section--directories > .global-model-settings__body {
+  margin-top: var(--space-5);
 }
 .global-settings-card {
   display: grid;

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -89,6 +89,8 @@ test.describe('Lemonade UI — Feature Parity', () => {
 
     const expectedConnectRoutes = [
       ['Server', 'server'],
+      ['Chat', 'chat'],
+      ['Memory', 'memory'],
       ['Model storage', 'model-storage'],
       ['Cloud providers', 'cloud-providers'],
       ['MCP gateway', 'mcp-gateway'],

--- a/src/app/tests/global-model-settings.runtime.cjs
+++ b/src/app/tests/global-model-settings.runtime.cjs
@@ -114,17 +114,27 @@ assert.equal(settings.estimatedModelFootprintGb(collectionModels[3], collectionM
 const listSource = fs.readFileSync(path.join(root, 'src/components/ModelListPanel.tsx'), 'utf8');
 const managerSource = fs.readFileSync(path.join(root, 'src/components/ModelManager.tsx'), 'utf8');
 const panelSource = fs.readFileSync(path.join(root, 'src/components/GlobalModelSettingsPanel.tsx'), 'utf8');
+const connectSource = fs.readFileSync(path.join(root, 'src/components/ConnectView.tsx'), 'utf8');
+const navigationSource = fs.readFileSync(path.join(root, 'src/features/navigation/workspaceNavigation.ts'), 'utf8');
 const chatSource = fs.readFileSync(path.join(root, 'src/components/ChatView.tsx'), 'utf8');
 
-assert.match(listSource, /onOpenRouter && \([\s\S]*?icon="router"[\s\S]*?onOpenGlobalSettings && \([\s\S]*?icon="settings"/, 'settings must sit beside the router action');
-assert.match(managerSource, /showGlobalSettings \?[\s\S]*<GlobalModelSettingsPanel/);
+assert.doesNotMatch(listSource, /onOpenGlobalSettings|Open global model settings|Global model settings/);
+assert.match(listSource, /onUpdateAllModels && \([\s\S]*?icon="rotate-ccw"[\s\S]*?Update all downloaded models/);
+assert.doesNotMatch(managerSource, /showGlobalSettings|<GlobalModelSettingsPanel/);
 assert.match(managerSource, /loadWithGlobalModelPolicy/);
 assert.match(managerSource, /handleUpdateAllModels/);
-for (const label of ['Memory budget', 'Loading and eviction', 'Pinned models', 'Collapse thinking by default', 'Default TTS model', 'Automatic model updates', 'Update all models now']) {
-  assert.ok(panelSource.includes(label), `global settings panel is missing ${label}`);
+for (const label of ['Chat history', 'Memory budget', 'Loading and eviction', 'Collapse thinking by default', 'Default TTS model', 'Automatic model updates']) {
+  assert.ok(panelSource.includes(label), `settings panel is missing ${label}`);
 }
 assert.match(panelSource, /Kokoro · English/);
 assert.match(panelSource, /OpenMOSS · Multilingual/);
+assert.match(panelSource, /section === 'chat'/);
+assert.match(panelSource, /section === 'memory'/);
+assert.match(panelSource, /section === 'updates'/);
+assert.match(connectSource, /activeSection === 'chat'[\s\S]*?<GlobalModelSettingsPanel section="chat"/);
+assert.match(connectSource, /activeSection === 'memory'[\s\S]*?<GlobalModelSettingsPanel section="memory"/);
+assert.match(connectSource, /activeSection === 'model-storage'[\s\S]*?<GlobalModelSettingsPanel section="updates"/);
+assert.match(navigationSource, /defineSection\('chat',[\s\S]*?defineSection\('memory'/);
 assert.match(chatSource, /defaultThinkingOpen=\{!globalModelSettings\.collapseThinkingByDefault\}/);
 assert.match(chatSource, /GLOBAL_MODEL_SETTINGS_EVENT/);
 assert.match(chatSource, /loadModelWithPolicy/);

--- a/src/app/tests/global-model-settings.runtime.cjs
+++ b/src/app/tests/global-model-settings.runtime.cjs
@@ -116,6 +116,7 @@ const managerSource = fs.readFileSync(path.join(root, 'src/components/ModelManag
 const panelSource = fs.readFileSync(path.join(root, 'src/components/GlobalModelSettingsPanel.tsx'), 'utf8');
 const connectSource = fs.readFileSync(path.join(root, 'src/components/ConnectView.tsx'), 'utf8');
 const navigationSource = fs.readFileSync(path.join(root, 'src/features/navigation/workspaceNavigation.ts'), 'utf8');
+const stylesSource = fs.readFileSync(path.join(root, 'src/styles/styles.css'), 'utf8');
 const chatSource = fs.readFileSync(path.join(root, 'src/components/ChatView.tsx'), 'utf8');
 
 assert.doesNotMatch(listSource, /onOpenGlobalSettings|Open global model settings|Global model settings/);
@@ -135,6 +136,7 @@ assert.match(connectSource, /activeSection === 'chat'[\s\S]*?<GlobalModelSetting
 assert.match(connectSource, /activeSection === 'memory'[\s\S]*?<GlobalModelSettingsPanel section="memory"/);
 assert.match(connectSource, /activeSection === 'model-storage'[\s\S]*?<GlobalModelSettingsPanel section="updates"/);
 assert.match(navigationSource, /defineSection\('chat',[\s\S]*?defineSection\('memory'/);
+assert.match(stylesSource, /\.connect__section > \.global-model-settings__body\s*\{[\s\S]*?width:\s*min\(var\(--content-form-width\), 100%\);/);
 assert.match(chatSource, /defaultThinkingOpen=\{!globalModelSettings\.collapseThinkingByDefault\}/);
 assert.match(chatSource, /GLOBAL_MODEL_SETTINGS_EVENT/);
 assert.match(chatSource, /loadModelWithPolicy/);


### PR DESCRIPTION
## Summary

* Add dedicated **Chat** and **Memory** sub-tabs under Settings
* Move chat/TTS settings into Chat
* Move memory budget, loading, and eviction settings into Memory
* Remove the settings view from the Models tab
* Keep model update settings under Model storage with on icon

## Testing

* Updated feature and regression tests
* Verified Settings search and routing behavior

Closes #2929

# Visuals
<img width="357" height="113" alt="image" src="https://github.com/user-attachments/assets/12092766-16af-4d21-b865-27978b960f0a" />

<img width="1818" height="902" alt="image" src="https://github.com/user-attachments/assets/488478a2-e324-435e-9725-f6ac9bbf6539" />
<img width="1794" height="787" alt="image" src="https://github.com/user-attachments/assets/ed1735ea-db5d-431b-9c70-072a4d3d34f4" />
