### PR TITLE
fix: add GITHUB_TOKEN / GH_TOKEN support to GitHub API requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2810,7 +2810,7 @@ set(_GITHUB_API_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_github_api.c
 if(BUILD_TESTING AND EXISTS "${_GITHUB_API_TEST_SRC}")
     add_executable(test_github_api test/cpp/test_github_api.cpp)
     target_link_libraries(test_github_api PRIVATE lemonade-server-core)
-    add_cpp_ci_test(GithubApiTest CI OFF COMMAND test_github_api)
+    add_cpp_ci_test(GithubApiTest CI ON COMMAND test_github_api)
 endif()
 
 # GGUF variant enumeration: grouping, name disambiguation, and quant ordering.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2806,6 +2806,13 @@ if(BUILD_TESTING AND EXISTS "${_URL_UTILS_TEST_SRC}")
     add_cpp_ci_test(UrlUtilsTest CI OFF COMMAND test_url_utils)
 endif()
 
+set(_GITHUB_API_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_github_api.cpp")
+if(BUILD_TESTING AND EXISTS "${_GITHUB_API_TEST_SRC}")
+    add_executable(test_github_api test/cpp/test_github_api.cpp)
+    target_link_libraries(test_github_api PRIVATE lemonade-server-core)
+    add_cpp_ci_test(GithubApiTest CI OFF COMMAND test_github_api)
+endif()
+
 # GGUF variant enumeration: grouping, name disambiguation, and quant ordering.
 set(_HF_VARIANTS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_hf_variants.cpp")
 if(BUILD_TESTING AND EXISTS "${_HF_VARIANTS_TEST_SRC}")

--- a/src/cpp/cli/recipe_import.cpp
+++ b/src/cpp/cli/recipe_import.cpp
@@ -2,6 +2,7 @@
 
 #include "lemon/model_manager.h"
 #include "lemon/model_registry.h"
+#include "lemon/utils/github_api.h"
 #include "lemon/utils/http_client.h"
 #include "lemon/utils/path_utils.h"
 
@@ -64,14 +65,12 @@ bool fetch_github_recipe_contents(const std::string& subpath,
     }
 
     std::map<std::string, std::string> headers = {
-        {"Accept", "application/vnd.github+json"},
-        {"X-GitHub-Api-Version", "2022-11-28"},
-        {"User-Agent", "lemonade-cli"}
+        {"X-GitHub-Api-Version", "2022-11-28"}
     };
 
     lemon::utils::HttpResponse res;
     try {
-        res = lemon::utils::HttpClient::get("https://api.github.com" + api_path, headers);
+        res = lemon::utils::github_api::get("https://api.github.com" + api_path, headers);
     } catch (const std::exception& e) {
         error_out = "GitHub API request failed: " + std::string(e.what());
         return false;

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <string>
-#include <functional>
 #include <filesystem>
+#include <functional>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 #include "lemon/backends/backend_descriptor.h"

--- a/src/cpp/include/lemon/utils/github_api.h
+++ b/src/cpp/include/lemon/utils/github_api.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdlib>
+#include <map>
+#include <string>
+#include "lemon/utils/http_client.h"
+
+namespace lemon::utils::github_api {
+
+// Return HTTP headers for GitHub API requests. Includes an Authorization
+// header when GITHUB_TOKEN or GH_TOKEN is set in the environment, raising the
+// rate limit from the unauthenticated 60 requests/hour.
+inline std::map<std::string, std::string> headers() {
+    std::map<std::string, std::string> h = {
+        {"User-Agent", "lemonade"},
+        {"Accept", "application/vnd.github+json"},
+    };
+    const char* token = std::getenv("GITHUB_TOKEN");
+    if (!token || token[0] == '\0') token = std::getenv("GH_TOKEN");
+    if (token && token[0] != '\0') {
+        h["Authorization"] = std::string("Bearer ") + token;
+    }
+    return h;
+}
+
+// GET for api.github.com with headers(). When an auth token was included and
+// the response is 403 (e.g. a scoped GitHub Actions token rejected by an
+// unrelated repo), retries once without the Authorization header.
+inline HttpResponse get(
+    const std::string& url,
+    const std::map<std::string, std::string>& extra_headers = {}) {
+    auto h = headers();
+    for (const auto& [k, v] : extra_headers) {
+        h[k] = v;
+    }
+    auto resp = HttpClient::get(url, h);
+    if (h.count("Authorization") && resp.status_code == 403) {
+        h.erase("Authorization");
+        resp = HttpClient::get(url, h);
+    }
+    return resp;
+}
+
+} // namespace lemon::utils::github_api

--- a/src/cpp/include/lemon/utils/github_api.h
+++ b/src/cpp/include/lemon/utils/github_api.h
@@ -24,8 +24,9 @@ inline std::map<std::string, std::string> headers() {
 }
 
 // GET for api.github.com with headers(). When an auth token was included and
-// the response is 403 (e.g. a scoped GitHub Actions token rejected by an
-// unrelated repo), retries once without the Authorization header.
+// the response is 401/403/404 (e.g. a scoped GitHub Actions token rejected by
+// an unrelated repo, which GitHub surfaces as any of these statuses), retries
+// once without the Authorization header.
 inline HttpResponse get(
     const std::string& url,
     const std::map<std::string, std::string>& extra_headers = {}) {
@@ -34,7 +35,10 @@ inline HttpResponse get(
         h[k] = v;
     }
     auto resp = HttpClient::get(url, h);
-    if (h.count("Authorization") && resp.status_code == 403) {
+    if (h.count("Authorization") &&
+        (resp.status_code == 401 ||
+         resp.status_code == 403 ||
+         resp.status_code == 404)) {
         h.erase("Authorization");
         resp = HttpClient::get(url, h);
     }

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -4,6 +4,7 @@
 #include "lemon/backends/backend_utils.h"
 #include "lemon/runtime_config.h"
 #include "lemon/system_info.h"
+#include "lemon/utils/github_api.h"
 #include "lemon/utils/http_client.h"
 #include "lemon/utils/json_utils.h"
 #include "lemon/utils/path_utils.h"
@@ -377,15 +378,11 @@ std::string BackendManager::fetch_latest_github_tag(const std::string& repo,
     }
 
     const std::string url = "https://api.github.com/repos/" + repo + "/releases/latest";
-    std::map<std::string, std::string> headers = {
-        {"User-Agent", "lemonade"},
-        {"Accept", "application/vnd.github+json"},
-    };
 
     LOG(DEBUG, "BackendManager") << "Resolving 'latest' for " << repo << " via " << url << std::endl;
     utils::HttpResponse resp;
     try {
-        resp = utils::HttpClient::get(url, headers);
+        resp = utils::github_api::get(url);
     } catch (const std::exception& e) {
         if (throw_on_failure) {
             throw std::runtime_error(

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -5,6 +5,7 @@
 #include "lemon/backends/backend_registry.h"  // spec_for() — descriptor->install spec, no server includes
 #include "lemon/model_manager.h"  // For DownloadProgress, DownloadProgressCallback
 
+#include "lemon/utils/github_api.h"
 #include "lemon/utils/path_utils.h"
 #include "lemon/utils/json_utils.h"
 #include "lemon/utils/http_client.h"
@@ -179,17 +180,13 @@ namespace lemon::backends {
 
         const std::string url = "https://api.github.com/repos/" + repo +
                                 "/releases/tags/" + tag;
-        const std::map<std::string, std::string> headers = {
-            {"User-Agent", "lemonade"},
-            {"Accept", "application/vnd.github+json"},
-        };
 
         LOG(DEBUG, spec.log_name()) << "Resolving asset wildcard '" << pattern
             << "' for " << repo << "@" << tag << " via " << url << std::endl;
 
         utils::HttpResponse resp;
         try {
-            resp = utils::HttpClient::get(url, headers);
+            resp = utils::github_api::get(url);
         } catch (const std::exception& e) {
             throw std::runtime_error(
                 "Failed to query GitHub for release '" + tag + "' of " + repo +

--- a/test/cpp/test_github_api.cpp
+++ b/test/cpp/test_github_api.cpp
@@ -9,12 +9,8 @@
     #define set_env(k, v) _putenv_s(k, v)
     #define unset_env(k)  _putenv_s(k, "")
 #else
-    #include <cstring>
     static void set_env(const char* k, const char* v) {
-        if (v && v[0])
-            setenv(k, v, 1);
-        else
-            unsetenv(k);
+        setenv(k, v ? v : "", 1);
     }
     #define unset_env(k) unsetenv(k)
 #endif
@@ -89,7 +85,7 @@ int main() {
 
     // 4. GITHUB_TOKEN empty, GH_TOKEN set — falls back to GH_TOKEN.
     {
-        unset_env("GITHUB_TOKEN");        // empty string
+        set_env("GITHUB_TOKEN", "");  // present but empty
         set_env("GH_TOKEN", "tok-gh");
         auto h = lemon::utils::github_api::headers();
         if (h.count(kAuth) == 1 &&

--- a/test/cpp/test_github_api.cpp
+++ b/test/cpp/test_github_api.cpp
@@ -1,0 +1,142 @@
+#include <lemon/utils/github_api.h>
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+#ifdef _WIN32
+    #define set_env(k, v) _putenv_s(k, v)
+    #define unset_env(k)  _putenv_s(k, "")
+#else
+    #include <cstring>
+    static void set_env(const char* k, const char* v) {
+        if (v && v[0])
+            setenv(k, v, 1);
+        else
+            unsetenv(k);
+    }
+    #define unset_env(k) unsetenv(k)
+#endif
+
+struct TestResult {
+    int passed = 0;
+    int failed = 0;
+
+    void ok(const std::string& name) {
+        printf("[PASS] %s\n", name.c_str());
+        ++passed;
+    }
+
+    void fail(const std::string& name) {
+        printf("[FAIL] %s\n", name.c_str());
+        ++failed;
+    }
+};
+
+int main() {
+    TestResult result;
+
+    const std::string kUserAgent{"User-Agent"};
+    const std::string kAccept{"Accept"};
+    const std::string kAuth{"Authorization"};
+
+    // Save and clear both env vars so tests start from a known state.
+    const char* saved_github = std::getenv("GITHUB_TOKEN");
+    const char* saved_gh     = std::getenv("GH_TOKEN");
+    const std::string orig_github = saved_github ? saved_github : "";
+    const std::string orig_gh     = saved_gh     ? saved_gh     : "";
+
+    // 1. Neither GITHUB_TOKEN nor GH_TOKEN set — no Authorization header.
+    {
+        unset_env("GITHUB_TOKEN");
+        unset_env("GH_TOKEN");
+        auto h = lemon::utils::github_api::headers();
+        if (h.count(kAuth) == 0 &&
+            h.at(kUserAgent) == "lemonade" &&
+            h.count(kAccept) > 0) {
+            result.ok("no token env vars");
+        } else {
+            result.fail("no token env vars");
+        }
+    }
+
+    // 2. GITHUB_TOKEN set — Authorization uses it.
+    {
+        set_env("GITHUB_TOKEN", "tok-ghub");
+        unset_env("GH_TOKEN");
+        auto h = lemon::utils::github_api::headers();
+        if (h.count(kAuth) == 1 &&
+            h.at(kAuth) == "Bearer tok-ghub") {
+            result.ok("GITHUB_TOKEN set");
+        } else {
+            result.fail("GITHUB_TOKEN set");
+        }
+    }
+
+    // 3. Only GH_TOKEN set — Authorization uses it.
+    {
+        unset_env("GITHUB_TOKEN");
+        set_env("GH_TOKEN", "tok-gh");
+        auto h = lemon::utils::github_api::headers();
+        if (h.count(kAuth) == 1 &&
+            h.at(kAuth) == "Bearer tok-gh") {
+            result.ok("only GH_TOKEN set");
+        } else {
+            result.fail("only GH_TOKEN set");
+        }
+    }
+
+    // 4. GITHUB_TOKEN empty, GH_TOKEN set — falls back to GH_TOKEN.
+    {
+        unset_env("GITHUB_TOKEN");        // empty string
+        set_env("GH_TOKEN", "tok-gh");
+        auto h = lemon::utils::github_api::headers();
+        if (h.count(kAuth) == 1 &&
+            h.at(kAuth) == "Bearer tok-gh") {
+            result.ok("empty GITHUB_TOKEN falls back to GH_TOKEN");
+        } else {
+            result.fail("empty GITHUB_TOKEN falls back to GH_TOKEN");
+        }
+    }
+
+    // 5. Both set — GITHUB_TOKEN takes priority.
+    {
+        set_env("GITHUB_TOKEN", "tok-ghub");
+        set_env("GH_TOKEN", "tok-gh");
+        auto h = lemon::utils::github_api::headers();
+        if (h.count(kAuth) == 1 &&
+            h.at(kAuth) == "Bearer tok-ghub") {
+            result.ok("both set, GITHUB_TOKEN wins");
+        } else {
+            result.fail("both set, GITHUB_TOKEN wins");
+        }
+    }
+
+    // 6. Baseline headers are always present (no tokens).
+    {
+        unset_env("GITHUB_TOKEN");
+        unset_env("GH_TOKEN");
+        auto h = lemon::utils::github_api::headers();
+        if (h.count(kUserAgent) == 1 && h.at(kUserAgent) == "lemonade" &&
+            h.count(kAccept) == 1    && h.at(kAccept) == "application/vnd.github+json") {
+            result.ok("baseline headers present");
+        } else {
+            result.fail("baseline headers present");
+        }
+    }
+
+    // Restore original environment.
+    if (orig_github.empty())
+        unset_env("GITHUB_TOKEN");
+    else
+        set_env("GITHUB_TOKEN", orig_github.c_str());
+
+    if (orig_gh.empty())
+        unset_env("GH_TOKEN");
+    else
+        set_env("GH_TOKEN", orig_gh.c_str());
+
+    printf("\n%d passed, %d failed\n", result.passed, result.failed);
+    return result.failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Unauthenticated GitHub API calls are capped at 60 req/h. BackendManager scans multiple repos on startup, `resolve_asset_wildcard` queries per-install, and `recipe_import` hits the API — sometimes exhausting the limit under normal use, causing 403s.

Add `lemon/utils/github_api.h` with `github_api::headers()` (reads `GITHUB_TOKEN`, falling back to `GH_TOKEN`, and injects `Authorization: Bearer …` when set) and `github_api::get()`, a thin wrapper that retries once without auth on `401`,`403` or `404` to handle scoped GitHub Actions tokens rejected by unrelated repos. Applied in `fetch_latest_github_tag()`, `resolve_asset_wildcard()`, and `recipe_import.cpp` — the three code paths that issue HTTP GET to `api.github.com`.

Adds `test/cpp/test_github_api.cpp` covering the token-priority / fallback / empty-value cases.

Closes #2993