### PR TITLE
fix(sdcpp): wildcard ROCm runtime in asset only for latest bin pins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2445,6 +2445,26 @@ if(BUILD_TESTING AND EXISTS "${_LATEST_FALLBACK_TEST_SRC}")
     add_cpp_ci_test(LatestVersionFallbackTest CI ON COMMAND test_latest_version_fallback)
 endif()
 
+# sd.cpp ROCm release-asset naming policy (lemon::backends::sdcpp::
+# sdcpp_rocm_asset_pattern). Header-only pure logic, so the test links nothing
+# beyond the standard library — coverage for #2988 (wildcard the runtime only
+# for an explicit "latest" bin pin; pinned installs name the TheRock runtime
+# exactly).
+set(_SDCPP_ROCM_ASSET_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_sdcpp_rocm_asset.cpp"
+)
+if(BUILD_TESTING AND EXISTS "${_SDCPP_ROCM_ASSET_TEST_SRC}")
+    add_executable(test_sdcpp_rocm_asset
+        test/cpp/test_sdcpp_rocm_asset.cpp
+    )
+    target_include_directories(test_sdcpp_rocm_asset PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+    )
+
+    include(CTest)
+    add_cpp_ci_test(SdcppRocmAssetTest CI ON COMMAND test_sdcpp_rocm_asset)
+endif()
+
 # Label-to-deployment-mode mapping (lemon::get_model_type_from_labels). Header-only,
 # so the test links nothing beyond the standard library.
 set(_MODEL_TYPE_CLASSIFIER_TEST_SRC

--- a/src/cpp/include/lemon/backends/sdcpp/sdcpp_asset.h
+++ b/src/cpp/include/lemon/backends/sdcpp/sdcpp_asset.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace lemon {
+namespace backends {
+namespace sdcpp {
+
+// Pinned installs must name the TheRock runtime exactly (it is what the
+// binary runs against); only an explicit "latest" bin pin wildcards it for
+// install-time resolution of upstream's newest build.
+inline std::string sdcpp_rocm_asset_pattern(const std::string& short_version,
+                                            bool wildcard_runtime,
+                                            const std::string& therock_version) {
+    const std::string runtime = wildcard_runtime ? "*" : therock_version;
+#ifdef _WIN32
+    return "sd-" + short_version + "-bin-win-rocm-" + runtime + "-x64.zip";
+#elif defined(__linux__)
+    return "sd-" + short_version + "-bin-Linux-Ubuntu-24.04-x86_64-rocm-" + runtime + ".zip";
+#else
+    throw std::runtime_error("ROCm sd.cpp only supported on Windows and Linux");
+#endif
+}
+
+}  // namespace sdcpp
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -166,9 +166,8 @@ namespace lemon::backends {
         return p == pattern.size();
     }
 
-    // Compare two release-asset version tokens numerically, segment by segment,
-    // so "7.10.0" beats "7.9.0" even though lexicographic order would say
-    // otherwise. Non-numeric segments are skipped; only digit runs count.
+    // Numeric segment-by-segment compare, so "7.10.0" beats "7.9.0" where
+    // lexicographic order would not.
     static bool version_greater(const std::string& a, const std::string& b) {
         std::vector<unsigned long> as, bs;
         const auto collect = [](const std::string& v, std::vector<unsigned long>& out) {
@@ -198,16 +197,11 @@ namespace lemon::backends {
         return false;
     }
 
-    // Resolve a '*' wildcard in a release asset filename to the concrete asset
-    // name published for `tag`. Some upstreams embed a component that changes
-    // on every build (e.g. the macOS runner version in sd-cpp's Darwin asset:
-    // sd-...-bin-Darwin-macOS-15.7.7-arm64.zip, or the ROCm runtime in
-    // sd-...-bin-win-rocm-7.13.0-x64.zip). Rather than hardcode and chase
-    // that value on every bump, the backend spec carries a '*' placeholder and
-    // we look up the real asset name here via the GitHub Releases API. When
-    // several assets match (sd-cpp publishes a per-ROCm-runtime build, e.g.
-    // -rocm-7.1.1 alongside -rocm-7.13.0), the numerically newest version wins.
-    // Returns the pattern unchanged when it contains no wildcard.
+    // Resolve a '*' wildcard in a release asset filename to the concrete
+    // asset published for `tag` via the GitHub Releases API, for upstream
+    // components that change between builds (e.g. the macOS runner version or
+    // sd.cpp's ROCm runtime). When several assets match, the numerically
+    // newest version wins.
     static std::string resolve_asset_wildcard(const std::string& repo,
                                               const std::string& tag,
                                               const std::string& pattern,

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -166,13 +166,48 @@ namespace lemon::backends {
         return p == pattern.size();
     }
 
+    // Compare two release-asset version tokens numerically, segment by segment,
+    // so "7.10.0" beats "7.9.0" even though lexicographic order would say
+    // otherwise. Non-numeric segments are skipped; only digit runs count.
+    static bool version_greater(const std::string& a, const std::string& b) {
+        std::vector<unsigned long> as, bs;
+        const auto collect = [](const std::string& v, std::vector<unsigned long>& out) {
+            std::string cur;
+            for (char ch : v) {
+                if (std::isdigit(static_cast<unsigned char>(ch))) {
+                    cur.push_back(ch);
+                } else if (!cur.empty()) {
+                    out.push_back(std::strtoul(cur.c_str(), nullptr, 10));
+                    cur.clear();
+                }
+            }
+            if (!cur.empty()) {
+                out.push_back(std::strtoul(cur.c_str(), nullptr, 10));
+            }
+        };
+        collect(a, as);
+        collect(b, bs);
+        const size_t n = std::max(as.size(), bs.size());
+        for (size_t i = 0; i < n; ++i) {
+            const unsigned long ai = i < as.size() ? as[i] : 0;
+            const unsigned long bi = i < bs.size() ? bs[i] : 0;
+            if (ai != bi) {
+                return ai > bi;
+            }
+        }
+        return false;
+    }
+
     // Resolve a '*' wildcard in a release asset filename to the concrete asset
     // name published for `tag`. Some upstreams embed a component that changes
     // on every build (e.g. the macOS runner version in sd-cpp's Darwin asset:
-    // sd-...-bin-Darwin-macOS-15.7.7-arm64.zip). Rather than hardcode and chase
+    // sd-...-bin-Darwin-macOS-15.7.7-arm64.zip, or the ROCm runtime in
+    // sd-...-bin-win-rocm-7.13.0-x64.zip). Rather than hardcode and chase
     // that value on every bump, the backend spec carries a '*' placeholder and
-    // we look up the real asset name here via the GitHub Releases API. Returns
-    // the pattern unchanged when it contains no wildcard.
+    // we look up the real asset name here via the GitHub Releases API. When
+    // several assets match (sd-cpp publishes a per-ROCm-runtime build, e.g.
+    // -rocm-7.1.1 alongside -rocm-7.13.0), the numerically newest version wins.
+    // Returns the pattern unchanged when it contains no wildcard.
     static std::string resolve_asset_wildcard(const std::string& repo,
                                               const std::string& tag,
                                               const std::string& pattern,
@@ -210,17 +245,44 @@ namespace lemon::backends {
                 tag + ": " + e.what());
         }
 
+        // A single-* pattern must match text beginning with the pattern's fixed
+        // prefix and ending with its fixed suffix, so the wildcard region is
+        // exactly the version token we use to break multi-match ties.
+        const size_t star = pattern.find('*');
+        const std::string prefix = pattern.substr(0, star);
+        const std::string suffix = pattern.substr(star + 1);
+
         if (body.contains("assets") && body["assets"].is_array()) {
+            std::string best_name;
+            std::string best_version;
             for (const auto& asset : body["assets"]) {
                 if (!asset.contains("name") || !asset["name"].is_string()) {
                     continue;
                 }
                 const std::string name = asset["name"].get<std::string>();
-                if (wildcard_match(pattern, name)) {
-                    LOG(INFO, spec.log_name()) << "Resolved asset wildcard '"
-                        << pattern << "' to '" << name << "'" << std::endl;
-                    return name;
+                if (!wildcard_match(pattern, name)) {
+                    continue;
                 }
+
+                std::string version;
+                if (name.size() >= prefix.size() + suffix.size() &&
+                    name.compare(0, prefix.size(), prefix) == 0 &&
+                    name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0) {
+                    version = name.substr(prefix.size(),
+                                          name.size() - prefix.size() - suffix.size());
+                }
+
+                if (best_name.empty() ||
+                    (!version.empty() && version_greater(version, best_version))) {
+                    best_name = name;
+                    best_version = version;
+                }
+            }
+
+            if (!best_name.empty()) {
+                LOG(INFO, spec.log_name()) << "Resolved asset wildcard '"
+                    << pattern << "' to '" << best_name << "'" << std::endl;
+                return best_name;
             }
         }
 

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -53,34 +53,6 @@ std::string resolve_sdcpp_backend(const std::string& backend) {
     return backend;
 }
 
-std::string trim_version_prefix(const std::string& version) {
-    if (!version.empty() && version[0] == 'v') {
-        return version.substr(1);
-    }
-    return version;
-}
-
-std::string trim_to_major_minor(const std::string& version) {
-    // Trim to MAJOR.MINOR format (e.g., "7.12.0" -> "7.12")
-    std::string trimmed = trim_version_prefix(version);
-    size_t second_dot = trimmed.find('.', trimmed.find('.') + 1);
-    if (second_dot != std::string::npos) {
-        return trimmed.substr(0, second_dot);
-    }
-    return trimmed;
-}
-
-std::string get_therock_version() {
-    auto config = JsonUtils::load_from_file(utils::get_resource_path("resources/backend_versions.json"));
-    if (!config.contains("therock") || !config["therock"].is_object() ||
-        !config["therock"].contains("version") || !config["therock"]["version"].is_string()) {
-        throw std::runtime_error("backend_versions.json is missing 'therock.version'");
-    }
-    // stable-diffusion.cpp release assets include full ROCm runtime version in filenames
-    // (for example: rocm-7.12.0), so keep the patch component.
-    return trim_version_prefix(config["therock"]["version"].get<std::string>());
-}
-
 int generate_random_seed() {
     return static_cast<int>(std::random_device{}() & 0x7fffffffU);
 }
@@ -127,11 +99,13 @@ InstallParams SDServer::get_install_params(const std::string& backend, const std
                 SystemInfo::get_unsupported_backend_error("sd-cpp", "rocm")
             );
         }
+        // sd.cpp embeds the ROCm runtime it was built with (e.g. rocm-7.14.0),
+        // which drifts independently of backend_versions.json's therock.version.
+        // Wildcard the runtime so install resolves the actual published asset.
 #ifdef _WIN32
-        params.filename = "sd-" + short_version + "-bin-win-rocm-" + get_therock_version() + "-x64.zip";
+        params.filename = "sd-" + short_version + "-bin-win-rocm-*-x64.zip";
 #elif defined(__linux__)
-        params.filename = "sd-" + short_version + "-bin-Linux-Ubuntu-24.04-x86_64-rocm-" +
-                  get_therock_version() + ".zip";
+        params.filename = "sd-" + short_version + "-bin-Linux-Ubuntu-24.04-x86_64-rocm-*.zip";
 #else
         throw std::runtime_error("ROCm sd.cpp only supported on Windows and Linux");
 #endif

--- a/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
+++ b/src/cpp/server/backends/sdcpp/sdcpp_server.cpp
@@ -1,5 +1,6 @@
 #include "lemon/backends/sdcpp/sdcpp_server.h"
 #include "lemon/backends/sdcpp/sdcpp.h"
+#include "lemon/backends/sdcpp/sdcpp_asset.h"
 #include "lemon/backends/backend_registry.h"
 #include "lemon/backends/backend_utils.h"
 #include "lemon/backend_manager.h"
@@ -53,6 +54,20 @@ std::string resolve_sdcpp_backend(const std::string& backend) {
     return backend;
 }
 
+std::string get_therock_version() {
+    auto config = JsonUtils::load_from_file(utils::get_resource_path("resources/backend_versions.json"));
+    if (!config.contains("therock") || !config["therock"].is_object() ||
+        !config["therock"].contains("version") || !config["therock"]["version"].is_string()) {
+        throw std::runtime_error("backend_versions.json is missing 'therock.version'");
+    }
+    // sd.cpp assets embed the full ROCm runtime version (e.g. rocm-7.13.0).
+    std::string version = config["therock"]["version"].get<std::string>();
+    if (!version.empty() && version[0] == 'v') {
+        return version.substr(1);
+    }
+    return version;
+}
+
 int generate_random_seed() {
     return static_cast<int>(std::random_device{}() & 0x7fffffffU);
 }
@@ -99,17 +114,14 @@ InstallParams SDServer::get_install_params(const std::string& backend, const std
                 SystemInfo::get_unsupported_backend_error("sd-cpp", "rocm")
             );
         }
-        // sd.cpp embeds the ROCm runtime it was built with (e.g. rocm-7.14.0),
-        // which drifts independently of backend_versions.json's therock.version.
-        // Wildcard the runtime so install resolves the actual published asset.
-#ifdef _WIN32
-        params.filename = "sd-" + short_version + "-bin-win-rocm-*-x64.zip";
-#elif defined(__linux__)
-        params.filename = "sd-" + short_version + "-bin-Linux-Ubuntu-24.04-x86_64-rocm-*.zip";
-#else
-        throw std::runtime_error("ROCm sd.cpp only supported on Windows and Linux");
-#endif
-        } else if (resolved_backend == "vulkan") {
+        // Only "latest" bin pins wildcard the ROCm runtime; pinned installs
+        // match the TheRock runtime exactly (see sdcpp_asset.h).
+        const bool wildcard_runtime =
+            BackendUtils::get_bin_config_value("sd-cpp", resolved_backend) == "latest";
+        params.filename = sdcpp::sdcpp_rocm_asset_pattern(
+            short_version, wildcard_runtime,
+            wildcard_runtime ? std::string() : get_therock_version());
+    } else if (resolved_backend == "vulkan") {
     #ifdef _WIN32
         params.filename = "sd-" + short_version + "-bin-win-vulkan-x64.zip";
     #elif defined(__linux__)

--- a/test/cpp/test_sdcpp_rocm_asset.cpp
+++ b/test/cpp/test_sdcpp_rocm_asset.cpp
@@ -1,0 +1,83 @@
+// Standalone unit tests for lemon::backends::sdcpp::sdcpp_rocm_asset_pattern() —
+// the pure decision of which ROCm runtime token goes into the sd.cpp release
+// asset name. sd.cpp publishes per-runtime builds (e.g. -rocm-7.13.0-x64.zip
+// alongside -rocm-7.14.0-x64.zip), but the runtime loaded at launch is the
+// TheRock pin from backend_versions.json, so a pinned install must name that
+// exact runtime. Only an explicit "latest" bin pin wildcards it, letting the
+// installer resolve whatever runtime upstream's newest release was built with
+// (lemonade-sdk/lemonade#2988).
+//
+// Checks use an explicit pass/fail counter (not assert()) so the test stays
+// effective under the Release build the CI `default` preset uses, where
+// -DNDEBUG would compile assert() to a no-op.
+//
+// Compile with:
+//   g++ -std=c++17 -I src/cpp/include \
+//       test/cpp/test_sdcpp_rocm_asset.cpp -o sdcpp_rocm_asset_test
+//
+// Run with:
+//   ./sdcpp_rocm_asset_test
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+#include <lemon/backends/sdcpp/sdcpp_asset.h>
+
+using lemon::backends::sdcpp::sdcpp_rocm_asset_pattern;
+
+struct TestResult {
+    int passed = 0;
+    int failed = 0;
+
+    void check(bool cond, const std::string& name) {
+        if (cond) {
+            printf("[PASS] %s\n", name.c_str());
+            ++passed;
+        } else {
+            printf("[FAIL] %s\n", name.c_str());
+            ++failed;
+        }
+    }
+};
+
+int main() {
+    TestResult r;
+
+    printf("=== sdcpp_rocm_asset_pattern() Unit Tests ===\n\n");
+
+#if defined(_WIN32) || defined(__linux__)
+    // Pinned install: exact TheRock runtime in the asset name, no wildcard.
+    const std::string pinned = sdcpp_rocm_asset_pattern("master-8caa3f9", false, "7.13.0");
+    // "latest" bin pin: runtime wildcarded for install-time resolution.
+    const std::string latest = sdcpp_rocm_asset_pattern("master-bfbef5b", true, "");
+
+    r.check(pinned.find("*") == std::string::npos,
+            "pinned: asset name has no wildcard");
+    r.check(latest.find("-rocm-*") != std::string::npos,
+            "latest: runtime component is wildcarded");
+
+#ifdef _WIN32
+    r.check(pinned == "sd-master-8caa3f9-bin-win-rocm-7.13.0-x64.zip",
+            "pinned: exact Windows asset name");
+    r.check(latest == "sd-master-bfbef5b-bin-win-rocm-*-x64.zip",
+            "latest: wildcard Windows asset name");
+#else
+    r.check(pinned == "sd-master-8caa3f9-bin-Linux-Ubuntu-24.04-x86_64-rocm-7.13.0.zip",
+            "pinned: exact Linux asset name");
+    r.check(latest == "sd-master-bfbef5b-bin-Linux-Ubuntu-24.04-x86_64-rocm-*.zip",
+            "latest: wildcard Linux asset name");
+#endif
+#else
+    bool threw = false;
+    try {
+        sdcpp_rocm_asset_pattern("master-8caa3f9", false, "7.13.0");
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    r.check(threw, "unsupported platform throws");
+#endif
+
+    printf("\n%d passed, %d failed\n", r.passed, r.failed);
+    return r.failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
sd.cpp ROCm release assets embed the ROCm runtime they were built against (e.g. `-rocm-7.14.0-`), which drifts independently of the `therock.version` pin that determines which runtime Lemonade installs and loads next to the binary. Under `sd-cpp.rocm_stable` pinned by Lemonade this is fine, but with an explicit `sdcpp.rocm_bin=latest` pin the newest upstream release no longer publishes an asset matching `therock.version` and the install fails with HTTP 404.

So the wildcard is now scoped to that opt-in: `sdcpp.rocm_bin == "latest"` names the runtime as `*` and `resolve_asset_wildcard()` picks the numerically newest matching asset via the GitHub Releases API. Anything else (builtin pins, explicit release tags) names `therock.version` exactly.

`resolve_asset_wildcard()` itself now collects all matches and prefers the numerically newest version (sd.cpp publishes per-runtime builds such as `-rocm-7.1.1` alongside `-rocm-7.13.0`); numeric comparison is also the tiebreak the multi-asset Darwin metal names already need.

Closes #2988
