### PR TITLE
ci: swap oversized models out of the test suites

### DIFF
--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -207,7 +207,7 @@ the generator instead. Prose outside the markers is preserved. -->
 |-------|-----------|--------|
 | `kokoro-v1` | 0.354 | tts |
 
-#### `llamacpp` — Llama.cpp GPU (87 models)
+#### `llamacpp` — Llama.cpp GPU (88 models)
 
 | Model | Size (GB) | Labels |
 |-------|-----------|--------|
@@ -288,6 +288,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `Qwen3.6-35B-A3B-GGUF` | 23.3 | vision, tool-calling, hot |
 | `Qwen3.6-35B-A3B-MTP-GGUF` | 23.8 | vision, tool-calling, mtp |
 | `SmolLM3-3B-GGUF` | 1.94 | — |
+| `Tiny-Test-Model-2-GGUF` | 0.153 | — |
 | `Tiny-Test-Model-GGUF` | 0.18 | — |
 | `bge-reranker-v2-m3-GGUF` | 0.636 | reranking |
 | `gpt-oss-120b-GGUF` | 62.8 | reasoning, tool-calling |

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -654,6 +654,12 @@
         "suggested": false,
         "size": 0.18
     },
+    "Tiny-Test-Model-2-GGUF": {
+        "checkpoint": "LiquidAI/LFM2.5-230M-GGUF:LFM2.5-230M-Q4_K_M.gguf",
+        "recipe": "llamacpp",
+        "suggested": false,
+        "size": 0.153
+    },
     "Qwen3-1.7B-GGUF": {
         "checkpoint": "unsloth/Qwen3-1.7B-GGUF:Q4_0",
         "recipe": "llamacpp",

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -39,7 +39,7 @@ from utils.test_models import (
 )
 
 OLLAMA_BASE_URL = f"http://localhost:{PORT}"
-TOOL_CALLING_LLAMA_ARGS = "--reasoning-format none"
+TOOL_CALLING_LLAMA_ARGS = "--reasoning-format none --reasoning off"
 
 
 class OllamaTests(ServerTestBase):

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -191,20 +191,21 @@ SAMPLE_TOOL = {
 ENDPOINT_TEST_MODEL = "Tiny-Test-Model-GGUF"
 
 # Model for tool-calling tests (must have native tool-calling support in its chat template)
-TOOL_CALLING_MODEL = "Qwen3-4B-Instruct-2507-GGUF"
+# Kept equal to VISION_MODEL so the bundled CI job downloads the checkpoint once.
+TOOL_CALLING_MODEL = "Qwen3.5-0.8B-GGUF"
 
 # Secondary model for multi-model testing (small, fast to load)
 MULTI_MODEL_SECONDARY = "Tiny-Test-Model-GGUF"
 
-# Secondary model for eviction testing
-SECOND_TEST_MODEL_EVICTION = "Phi-4-mini-instruct-GGUF"
+# Secondary model for eviction testing (that suite fakes VRAM pressure, so size is moot)
+SECOND_TEST_MODEL_EVICTION = "Tiny-Test-Model-2-GGUF"
 
 # Tertiary model for LRU eviction testing
 MULTI_MODEL_TERTIARY = "Qwen3-0.6B-GGUF"
 
 # A further small LLM, distinct from every model above, for tests that need one
-# more resident model. Kept small: runners without a model cache re-download it.
-MULTI_MODEL_QUATERNARY = "Llama-3.2-1B-Instruct-GGUF"
+# more resident model. Kept equal to VISION_MODEL so it is downloaded once, not twice.
+MULTI_MODEL_QUATERNARY = "Qwen3.5-0.8B-GGUF"
 
 # Whisper test configuration
 WHISPER_MODEL = "Whisper-Tiny"

--- a/test/utils/test_models.py
+++ b/test/utils/test_models.py
@@ -191,20 +191,19 @@ SAMPLE_TOOL = {
 ENDPOINT_TEST_MODEL = "Tiny-Test-Model-GGUF"
 
 # Model for tool-calling tests (must have native tool-calling support in its chat template)
-# Kept equal to VISION_MODEL so the bundled CI job downloads the checkpoint once.
 TOOL_CALLING_MODEL = "Qwen3.5-0.8B-GGUF"
 
 # Secondary model for multi-model testing (small, fast to load)
 MULTI_MODEL_SECONDARY = "Tiny-Test-Model-GGUF"
 
-# Secondary model for eviction testing (that suite fakes VRAM pressure, so size is moot)
+# Secondary model for eviction testing (must differ from ENDPOINT_TEST_MODEL)
 SECOND_TEST_MODEL_EVICTION = "Tiny-Test-Model-2-GGUF"
 
 # Tertiary model for LRU eviction testing
 MULTI_MODEL_TERTIARY = "Qwen3-0.6B-GGUF"
 
-# A further small LLM, distinct from every model above, for tests that need one
-# more resident model. Kept equal to VISION_MODEL so it is downloaded once, not twice.
+# A further small LLM for tests that need one more resident model; must differ
+# from ENDPOINT_TEST_MODEL and MULTI_MODEL_TERTIARY.
 MULTI_MODEL_QUATERNARY = "Qwen3.5-0.8B-GGUF"
 
 # Whisper test configuration


### PR DESCRIPTION
| Constant | Was | Now | Time saved |
|---|---|---|---|
| `TOOL_CALLING_MODEL` | `Qwen3-4B-Instruct-2507-GGUF` (2.5 GB) | `Qwen3.5-0.8B-GGUF` (0.76 GB, already pulled as `VISION_MODEL`) | **~41s** (30.7s download + ~11s load/inference) |
| `MULTI_MODEL_QUATERNARY` | `Llama-3.2-1B-Instruct-GGUF` (0.83 GB) | `Qwen3.5-0.8B-GGUF` (same checkpoint) | **~14s** (download) |
| `SECOND_TEST_MODEL_EVICTION` | `Phi-4-mini-instruct-GGUF` (2.5 GB) | `Tiny-Test-Model-2-GGUF` (0.153 GB) | **0s** |

~55s and 3.3 GB less per `Test CLI/Endpoints` run, measured against main run 31316827197. The eviction row saves no runner time until #3010 puts `server_eviction.py` in CI.