### PR TITLE
fix: honor custom backend binary environment variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2716,7 +2716,7 @@ set(_GPU_ENV_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_backend_utils_g
 if(EXISTS "${_GPU_ENV_TEST_SRC}")
     add_executable(test_backend_utils_gpu_env test/cpp/test_backend_utils_gpu_env.cpp)
     target_link_libraries(test_backend_utils_gpu_env PRIVATE lemonade-server-core)
-    add_cpp_ci_test(BackendUtilsGpuEnvTest CI OFF COMMAND test_backend_utils_gpu_env)
+    add_cpp_ci_test(BackendUtilsGpuEnvTest CI ON COMMAND test_backend_utils_gpu_env)
 endif()
 
 set(_NETWORK_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_network_utils.cpp")

--- a/src/cpp/include/lemon/backends/backend_utils.h
+++ b/src/cpp/include/lemon/backends/backend_utils.h
@@ -169,9 +169,10 @@ namespace lemon::backends {
         static std::string find_external_backend_binary(const std::string& recipe, const std::string& backend);
 
         /**
-         * Returns the raw user-supplied *_bin config value for this (recipe, backend),
+         * Returns the raw user-supplied *_bin value for this (recipe, backend),
          * e.g. "builtin" / "latest" / "b8664" / "/path/to/bin" / "". Empty string when
-         * RuntimeConfig is unavailable or the key is unset. Does not validate or resolve.
+         * the environment override and config key are both unset. Environment takes
+         * precedence over RuntimeConfig. Does not validate or resolve.
          */
         static std::string get_bin_config_value(const std::string& recipe, const std::string& backend);
 

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -434,9 +434,7 @@ std::string BackendManager::resolve_user_version(const std::string& recipe,
     auto* cfg = RuntimeConfig::global();
     if (!cfg) return pinned_version;
 
-    std::string section, bin_key;
-    backends::BackendUtils::build_bin_config_key(recipe, resolved_backend, section, bin_key);
-    std::string raw = cfg->backend_string(section, bin_key);
+    std::string raw = backends::BackendUtils::get_bin_config_value(recipe, resolved_backend);
 
     // "" / "builtin" → use lemonade's pinned version.
     if (raw.empty() || raw == "builtin") return pinned_version;

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -323,12 +323,19 @@ namespace lemon::backends {
     }
 
     std::string BackendUtils::find_external_backend_binary(const std::string& recipe, const std::string& backend) {
-        auto* cfg = lemon::RuntimeConfig::global();
-        if (!cfg) return "";
-
         std::string section, bin_key;
         build_bin_config_key(recipe, backend, section, bin_key);
-        std::string bin_value = cfg->backend_string(section, bin_key);
+
+        std::string env_name = "LEMONADE_" + section + "_" + bin_key;
+        std::transform(env_name.begin(), env_name.end(), env_name.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+
+        std::string bin_value = utils::get_environment_variable_utf8(env_name);
+        if (bin_value.empty()) {
+            auto* cfg = lemon::RuntimeConfig::global();
+            if (!cfg) return "";
+            bin_value = cfg->backend_string(section, bin_key);
+        }
 
         // Reserved keywords and bare version tags are handled by the install flow.
         if (bin_value.empty() || bin_value == "builtin" || bin_value == "latest") {

--- a/src/cpp/server/backends/backend_utils.cpp
+++ b/src/cpp/server/backends/backend_utils.cpp
@@ -325,17 +325,7 @@ namespace lemon::backends {
     std::string BackendUtils::find_external_backend_binary(const std::string& recipe, const std::string& backend) {
         std::string section, bin_key;
         build_bin_config_key(recipe, backend, section, bin_key);
-
-        std::string env_name = "LEMONADE_" + section + "_" + bin_key;
-        std::transform(env_name.begin(), env_name.end(), env_name.begin(),
-                       [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
-
-        std::string bin_value = utils::get_environment_variable_utf8(env_name);
-        if (bin_value.empty()) {
-            auto* cfg = lemon::RuntimeConfig::global();
-            if (!cfg) return "";
-            bin_value = cfg->backend_string(section, bin_key);
-        }
+        std::string bin_value = get_bin_config_value(recipe, backend);
 
         // Reserved keywords and bare version tags are handled by the install flow.
         if (bin_value.empty() || bin_value == "builtin" || bin_value == "latest") {
@@ -350,10 +340,18 @@ namespace lemon::backends {
     }
 
     std::string BackendUtils::get_bin_config_value(const std::string& recipe, const std::string& backend) {
-        auto* cfg = lemon::RuntimeConfig::global();
-        if (!cfg) return "";
         std::string section, bin_key;
         build_bin_config_key(recipe, backend, section, bin_key);
+
+        std::string env_name = "LEMONADE_" + section + "_" + bin_key;
+        std::transform(env_name.begin(), env_name.end(), env_name.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+
+        std::string bin_value = utils::get_environment_variable_utf8(env_name);
+        if (!bin_value.empty()) return bin_value;
+
+        auto* cfg = lemon::RuntimeConfig::global();
+        if (!cfg) return "";
         return cfg->backend_string(section, bin_key);
     }
 

--- a/test/cpp/test_backend_utils_gpu_env.cpp
+++ b/test/cpp/test_backend_utils_gpu_env.cpp
@@ -5,12 +5,14 @@
 // selection validation deterministically without requiring physical GPU hardware.
 
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include <lemon/backends/backend_utils.h>
+#include <lemon/runtime_config.h>
 
 #ifdef _WIN32
 #include <process.h>
@@ -111,6 +113,27 @@ int main() {
         }
         check(no_throw_matching,
               "validate_device_backend_match accepts matching pairs and system/auto backends gracefully");
+    }
+
+    // Test 3: a custom backend binary environment variable takes precedence
+    // over config.json. ROCm channel names collapse to the public ROCm override
+    // documented for users, while config remains the fallback.
+    {
+        const std::string override_path = std::filesystem::current_path().string();
+        const std::string config_path = std::filesystem::temp_directory_path().string();
+        lemon::RuntimeConfig config({{"llamacpp", {{"rocm_bin", config_path}}}});
+        lemon::RuntimeConfig::set_global(&config);
+        set_env_var("LEMONADE_LLAMACPP_ROCM_BIN", override_path);
+
+        check(BackendUtils::find_external_backend_binary("llamacpp", "rocm-stable") == override_path,
+              "ROCm stable resolves LEMONADE_LLAMACPP_ROCM_BIN");
+        check(BackendUtils::find_external_backend_binary("llamacpp", "rocm-nightly") == override_path,
+              "ROCm nightly resolves LEMONADE_LLAMACPP_ROCM_BIN");
+
+        clear_env_var("LEMONADE_LLAMACPP_ROCM_BIN");
+        check(BackendUtils::find_external_backend_binary("llamacpp", "rocm-stable") == config_path,
+              "ROCm stable falls back to configured llamacpp.rocm_bin");
+        lemon::RuntimeConfig::set_global(nullptr);
     }
 
     if (g_failures > 0) {

--- a/test/cpp/test_backend_utils_gpu_env.cpp
+++ b/test/cpp/test_backend_utils_gpu_env.cpp
@@ -121,7 +121,7 @@ int main() {
     {
         const std::string override_path = std::filesystem::current_path().string();
         const std::string config_path = std::filesystem::temp_directory_path().string();
-        lemon::RuntimeConfig config({{"llamacpp", {{"rocm_bin", config_path}}}});
+        lemon::RuntimeConfig config(lemon::json{{"llamacpp", {{"rocm_bin", config_path}}}});
         lemon::RuntimeConfig::set_global(&config);
         set_env_var("LEMONADE_LLAMACPP_ROCM_BIN", override_path);
 
@@ -143,7 +143,7 @@ int main() {
     // restores the configured value and disables the external-binary path.
     {
         const std::string override_path = std::filesystem::current_path().string();
-        lemon::RuntimeConfig config({{"llamacpp", {{"rocm_bin", "builtin"}}}});
+        lemon::RuntimeConfig config(lemon::json{{"llamacpp", {{"rocm_bin", "builtin"}}}});
         lemon::RuntimeConfig::set_global(&config);
         set_env_var("LEMONADE_LLAMACPP_ROCM_BIN", override_path);
 

--- a/test/cpp/test_backend_utils_gpu_env.cpp
+++ b/test/cpp/test_backend_utils_gpu_env.cpp
@@ -129,10 +129,34 @@ int main() {
               "ROCm stable resolves LEMONADE_LLAMACPP_ROCM_BIN");
         check(BackendUtils::find_external_backend_binary("llamacpp", "rocm-nightly") == override_path,
               "ROCm nightly resolves LEMONADE_LLAMACPP_ROCM_BIN");
+        check(BackendUtils::get_bin_config_value("llamacpp", "rocm-stable") == override_path,
+              "raw bin resolution gives the environment override precedence over config");
 
         clear_env_var("LEMONADE_LLAMACPP_ROCM_BIN");
         check(BackendUtils::find_external_backend_binary("llamacpp", "rocm-stable") == config_path,
               "ROCm stable falls back to configured llamacpp.rocm_bin");
+        lemon::RuntimeConfig::set_global(nullptr);
+    }
+
+    // Test 4: an environment path also overrides the reserved "builtin" config
+    // value used by status and version resolution. Clearing the environment
+    // restores the configured value and disables the external-binary path.
+    {
+        const std::string override_path = std::filesystem::current_path().string();
+        lemon::RuntimeConfig config({{"llamacpp", {{"rocm_bin", "builtin"}}}});
+        lemon::RuntimeConfig::set_global(&config);
+        set_env_var("LEMONADE_LLAMACPP_ROCM_BIN", override_path);
+
+        check(BackendUtils::get_bin_config_value("llamacpp", "rocm-stable") == override_path,
+              "environment path overrides builtin for status and version resolution");
+        check(BackendUtils::find_external_backend_binary("llamacpp", "rocm-stable") == override_path,
+              "environment path overrides builtin for runtime binary resolution");
+
+        clear_env_var("LEMONADE_LLAMACPP_ROCM_BIN");
+        check(BackendUtils::get_bin_config_value("llamacpp", "rocm-stable") == "builtin",
+              "raw bin resolution falls back to builtin after clearing the environment");
+        check(BackendUtils::find_external_backend_binary("llamacpp", "rocm-stable").empty(),
+              "builtin remains reserved after clearing the environment");
         lemon::RuntimeConfig::set_global(nullptr);
     }
 


### PR DESCRIPTION
## Summary
- resolve documented `LEMONADE_<SECTION>_<BIN_KEY>` overrides before `config.json`
- preserve `config.json` as the fallback
- cover both ROCm channels, which share `LEMONADE_LLAMACPP_ROCM_BIN`

This addresses the env-override failure reported in #2089 without adding fork-specific integration.

## Validation
- `cmake --build build --target test_backend_utils_gpu_env -j4`
- `./build/test_backend_utils_gpu_env`
- `git diff --check`