### PR TITLE
fix(server): report backend errors on the Anthropic messages bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2793,7 +2793,7 @@ if(EXISTS "${_CLOUD_DISCOVERY_POLICY_TEST_SRC}")
 endif()
 
 set(_ANTHROPIC_ERROR_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_anthropic_error.cpp")
-if(EXISTS "${_ANTHROPIC_ERROR_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_ANTHROPIC_ERROR_TEST_SRC}")
     add_executable(test_anthropic_error test/cpp/test_anthropic_error.cpp)
     target_link_libraries(test_anthropic_error PRIVATE lemonade-server-core)
     add_cpp_ci_test(AnthropicErrorTest CI ON COMMAND test_anthropic_error)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2792,6 +2792,13 @@ if(EXISTS "${_CLOUD_DISCOVERY_POLICY_TEST_SRC}")
     add_cpp_ci_test(CloudDiscoveryPolicyTest CI OFF COMMAND test_cloud_discovery_policy)
 endif()
 
+set(_ANTHROPIC_ERROR_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_anthropic_error.cpp")
+if(EXISTS "${_ANTHROPIC_ERROR_TEST_SRC}")
+    add_executable(test_anthropic_error test/cpp/test_anthropic_error.cpp)
+    target_link_libraries(test_anthropic_error PRIVATE lemonade-server-core)
+    add_cpp_ci_test(AnthropicErrorTest CI ON COMMAND test_anthropic_error)
+endif()
+
 set(_ORIGIN_UTILS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_origin_utils.cpp")
 if(EXISTS "${_ORIGIN_UTILS_TEST_SRC}")
     add_executable(test_origin_utils test/cpp/test_origin_utils.cpp)

--- a/src/cpp/include/lemon/anthropic_error.h
+++ b/src/cpp/include/lemon/anthropic_error.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <string>
+
+#include "lemon/error_types.h"
+
+namespace lemon {
+namespace anthropic {
+
+// Lemonade and the streaming proxy report an upstream HTTP status as
+// "status_code"; llama.cpp's own error bodies carry a numeric "code" instead.
+inline int backend_error_http_status(const nlohmann::json& error) {
+    if (!error.is_object()) {
+        return 500;
+    }
+
+    const auto read_status = [](const nlohmann::json& object) {
+        for (const char* key : {"status_code", "code"}) {
+            if (object.contains(key) && object[key].is_number_integer()) {
+                const int status = object[key].get<int>();
+                if (status >= 400 && status <= 599) {
+                    return status;
+                }
+            }
+        }
+        return 0;
+    };
+
+    if (const int status = read_status(error); status != 0) {
+        return status;
+    }
+    if (error.contains("details") && error["details"].is_object()) {
+        if (const int status = read_status(error["details"]); status != 0) {
+            return status;
+        }
+    }
+
+    const std::string type = error.value("type", "");
+    if (type == ErrorType::INVALID_REQUEST || type == "invalid_request_error" ||
+        type == ErrorType::UNSUPPORTED_OPERATION) {
+        return 400;
+    }
+    if (type == ErrorType::MODEL_NOT_LOADED) {
+        return 404;
+    }
+
+    return 500;
+}
+
+inline nlohmann::json build_anthropic_error(const nlohmann::json& error, int status) {
+    const char* type = "api_error";
+    switch (status) {
+        case 400: type = "invalid_request_error"; break;
+        case 401: type = "authentication_error"; break;
+        case 403: type = "permission_error"; break;
+        case 404: type = "not_found_error"; break;
+        case 413: type = "request_too_large"; break;
+        case 429: type = "rate_limit_error"; break;
+        case 529: type = "overloaded_error"; break;
+        default:
+            // Anthropic names no type for the remaining 4xx, and every one of
+            // them means the caller can fix the request.
+            if (status >= 400 && status < 500) {
+                type = "invalid_request_error";
+            }
+            break;
+    }
+
+    const std::string message = error.is_object()
+        ? error.value("message", "backend error")
+        : error.dump();
+
+    return nlohmann::json{
+        {"type", "error"},
+        {"error", {
+            {"type", type},
+            {"message", message},
+        }},
+    };
+}
+
+}  // namespace anthropic
+}  // namespace lemon

--- a/src/cpp/include/lemon/anthropic_error.h
+++ b/src/cpp/include/lemon/anthropic_error.h
@@ -53,10 +53,13 @@ inline nlohmann::json build_anthropic_error(const nlohmann::json& error, int sta
     switch (status) {
         case 400: type = "invalid_request_error"; break;
         case 401: type = "authentication_error"; break;
+        case 402: type = "billing_error"; break;
         case 403: type = "permission_error"; break;
         case 404: type = "not_found_error"; break;
+        case 409: type = "conflict_error"; break;
         case 413: type = "request_too_large"; break;
         case 429: type = "rate_limit_error"; break;
+        case 504: type = "timeout_error"; break;
         case 529: type = "overloaded_error"; break;
         default:
             // Anthropic names no type for the remaining 4xx, and every one of

--- a/src/cpp/server/anthropic_api.cpp
+++ b/src/cpp/server/anthropic_api.cpp
@@ -1,5 +1,6 @@
-#include "lemon/ollama_api.h"
+#include "lemon/anthropic_error.h"
 #include "lemon/error_types.h"
+#include "lemon/ollama_api.h"
 #include <iostream>
 #include <sstream>
 #include <chrono>
@@ -148,55 +149,6 @@ static json parse_openai_tool_arguments(const json& tool_call, std::vector<std::
     return json::object();
 }
 
-static int backend_error_http_status(const json& error) {
-    if (!error.is_object()) {
-        return 500;
-    }
-
-    for (const char* key : {"status_code", "code"}) {
-        if (error.contains(key) && error[key].is_number_integer()) {
-            const int status = error[key].get<int>();
-            if (status >= 400 && status <= 599) {
-                return status;
-            }
-        }
-    }
-
-    const std::string type = error.value("type", "");
-    if (type == ErrorType::INVALID_REQUEST || type == "invalid_request_error" ||
-        type == ErrorType::UNSUPPORTED_OPERATION) {
-        return 400;
-    }
-    if (type == ErrorType::MODEL_NOT_LOADED) {
-        return 404;
-    }
-
-    return 500;
-}
-
-static json build_anthropic_error(const json& error, int status) {
-    const char* type = "api_error";
-    if (status == 400) {
-        type = "invalid_request_error";
-    } else if (status == 404) {
-        type = "not_found_error";
-    } else if (status == 429) {
-        type = "rate_limit_error";
-    }
-
-    const std::string message = error.is_object()
-        ? error.value("message", "backend error")
-        : error.dump();
-
-    return json{
-        {"type", "error"},
-        {"error", {
-            {"type", type},
-            {"message", message},
-        }},
-    };
-}
-
 static bool set_anthropic_backend_error_response(const json& response, httplib::Response& res) {
     if (!response.contains("error")) {
         return false;
@@ -205,9 +157,9 @@ static bool set_anthropic_backend_error_response(const json& response, httplib::
     const auto& error = response["error"];
     std::cerr << "[OllamaApi] Backend returned error: " << error.dump() << std::endl;
 
-    const int status = backend_error_http_status(error);
+    const int status = anthropic::backend_error_http_status(error);
     res.status = status;
-    res.set_content(build_anthropic_error(error, status).dump(), "application/json");
+    res.set_content(anthropic::build_anthropic_error(error, status).dump(), "application/json");
     return true;
 }
 
@@ -698,7 +650,8 @@ void OllamaApi::stream_openai_sse_to_anthropic_sse(const std::string& openai_bod
                               << error.dump() << std::endl;
                     sent_error = true;
                     write_sse_event(client_sink, "error",
-                                    build_anthropic_error(error, backend_error_http_status(error)));
+                                    anthropic::build_anthropic_error(
+                                        error, anthropic::backend_error_http_status(error)));
                     return false;
                 }
 

--- a/src/cpp/server/anthropic_api.cpp
+++ b/src/cpp/server/anthropic_api.cpp
@@ -148,6 +148,69 @@ static json parse_openai_tool_arguments(const json& tool_call, std::vector<std::
     return json::object();
 }
 
+static int backend_error_http_status(const json& error) {
+    if (!error.is_object()) {
+        return 500;
+    }
+
+    for (const char* key : {"status_code", "code"}) {
+        if (error.contains(key) && error[key].is_number_integer()) {
+            const int status = error[key].get<int>();
+            if (status >= 400 && status <= 599) {
+                return status;
+            }
+        }
+    }
+
+    const std::string type = error.value("type", "");
+    if (type == ErrorType::INVALID_REQUEST || type == "invalid_request_error" ||
+        type == ErrorType::UNSUPPORTED_OPERATION) {
+        return 400;
+    }
+    if (type == ErrorType::MODEL_NOT_LOADED) {
+        return 404;
+    }
+
+    return 500;
+}
+
+static json build_anthropic_error(const json& error, int status) {
+    const char* type = "api_error";
+    if (status == 400) {
+        type = "invalid_request_error";
+    } else if (status == 404) {
+        type = "not_found_error";
+    } else if (status == 429) {
+        type = "rate_limit_error";
+    }
+
+    const std::string message = error.is_object()
+        ? error.value("message", "backend error")
+        : error.dump();
+
+    return json{
+        {"type", "error"},
+        {"error", {
+            {"type", type},
+            {"message", message},
+        }},
+    };
+}
+
+static bool set_anthropic_backend_error_response(const json& response, httplib::Response& res) {
+    if (!response.contains("error")) {
+        return false;
+    }
+
+    const auto& error = response["error"];
+    std::cerr << "[OllamaApi] Backend returned error: " << error.dump() << std::endl;
+
+    const int status = backend_error_http_status(error);
+    res.status = status;
+    res.set_content(build_anthropic_error(error, status).dump(), "application/json");
+    return true;
+}
+
 static void set_anthropic_residency_conflict_response(
     const RouterResidencyConflictException& error,
     httplib::Response& res) {
@@ -579,6 +642,7 @@ void OllamaApi::stream_openai_sse_to_anthropic_sse(const std::string& openai_bod
     bool sent_message_start = false;
     bool sent_text_content_start = false;
     bool sent_text_content_stop = false;
+    bool sent_error = false;
     std::vector<bool> started_tool_blocks;
     std::vector<bool> stopped_tool_blocks;
     std::vector<std::string> tool_ids;
@@ -595,6 +659,7 @@ void OllamaApi::stream_openai_sse_to_anthropic_sse(const std::string& openai_bod
                           &sent_message_start,
                           &sent_text_content_start,
                           &sent_text_content_stop,
+                          &sent_error,
                           &started_tool_blocks,
                           &stopped_tool_blocks,
                           &tool_ids,
@@ -626,6 +691,16 @@ void OllamaApi::stream_openai_sse_to_anthropic_sse(const std::string& openai_bod
 
             try {
                 auto openai_chunk = json::parse(json_str);
+
+                if (openai_chunk.contains("error")) {
+                    const auto& error = openai_chunk["error"];
+                    std::cerr << "[OllamaApi] Backend error in Anthropic stream: "
+                              << error.dump() << std::endl;
+                    sent_error = true;
+                    write_sse_event(client_sink, "error",
+                                    build_anthropic_error(error, backend_error_http_status(error)));
+                    return false;
+                }
 
                 if (!sent_message_start) {
                     if (openai_chunk.contains("id") && openai_chunk["id"].is_string()) {
@@ -781,12 +856,21 @@ void OllamaApi::stream_openai_sse_to_anthropic_sse(const std::string& openai_bod
                          &sent_message_start,
                          &sent_text_content_start,
                          &sent_text_content_stop,
+                         &sent_error,
                          &started_tool_blocks,
                          &stopped_tool_blocks,
                          &stop_reason,
                          &input_tokens,
                          &output_tokens,
                          &warnings]() {
+        // The error event terminates the stream. Emitting the closing frames
+        // here would let a client read the failure as a turn that produced no
+        // content, which is the state this path exists to avoid.
+        if (sent_error) {
+            client_sink.done();
+            return;
+        }
+
         if (!sent_message_start) {
             json message_start = {
                 {"type", "message_start"},
@@ -959,6 +1043,10 @@ void OllamaApi::handle_anthropic_messages(const httplib::Request& req, httplib::
 
         openai_req["stream"] = false;
         auto openai_response = router_->chat_completion(openai_req);
+        if (set_anthropic_backend_error_response(openai_response, res)) {
+            return;
+        }
+
         auto anthropic_response = convert_openai_chat_to_anthropic(openai_response, model, warnings);
         res.set_content(anthropic_response.dump(), "application/json");
 

--- a/src/cpp/server/backends/trellis/trellis_server.cpp
+++ b/src/cpp/server/backends/trellis/trellis_server.cpp
@@ -184,7 +184,7 @@ void TrellisServer::model_3d_generations(const json& request, httplib::DataSink&
         const std::string payload = json{{"error", {
             {"message", "unsupported image format: expected PNG, JPEG, BMP, or GIF"},
             {"type", "invalid_request_error"},
-            {"status", 400}}}}.dump();
+            {"status_code", 400}}}}.dump();
         sink.write(payload.data(), payload.size());
         return;
     }

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -4154,14 +4154,7 @@ void Server::serve_media_or_error(httplib::Response& res, const std::string& mim
         return;
     }
     if (auto error_payload = extract_error_payload(buf); !error_payload.is_null()) {
-        res.status = 500;
-        const auto& err = error_payload["error"];
-        if (err.is_object() && err.contains("status") && err["status"].is_number_integer()) {
-            const int status = err["status"].get<int>();
-            if (status >= 400 && status <= 599) {
-                res.status = status;
-            }
-        }
+        res.status = get_error_status_code(error_payload, 500);
         res.set_content(error_payload.dump(), "application/json");
         return;
     }

--- a/src/cpp/server/streaming_proxy.cpp
+++ b/src/cpp/server/streaming_proxy.cpp
@@ -194,7 +194,11 @@ void StreamingProxy::forward_sse_stream(
                 : error_body;
             payload = json{{"error", {{"message", message},
                                       {"type", "backend_error"},
-                                      {"status", status}}}};
+                                      {"status_code", status}}}};
+        } else if (payload["error"].is_object() && !payload["error"].contains("status_code")) {
+            // A backend's own error object carries no transport status, so
+            // adapters downstream would have to guess one.
+            payload["error"]["status_code"] = status;
         }
         const std::string event = "data: " + payload.dump() + "\n\n";
         sink.write(event.data(), event.size());
@@ -325,7 +329,9 @@ void StreamingProxy::forward_byte_stream(
                 : error_body;
             payload = json{{"error", {{"message", message},
                                       {"type", "backend_error"},
-                                      {"status", status}}}};
+                                      {"status_code", status}}}};
+        } else if (payload["error"].is_object() && !payload["error"].contains("status_code")) {
+            payload["error"]["status_code"] = status;
         }
         const std::string out = payload.dump();
         sink.write(out.data(), out.size());

--- a/test/cpp/test_anthropic_error.cpp
+++ b/test/cpp/test_anthropic_error.cpp
@@ -58,15 +58,17 @@ static void test_error_type_mapping(TestResult& r) {
     const Case cases[] = {
         {400, "invalid_request_error"},
         {401, "authentication_error"},
+        {402, "billing_error"},
         {403, "permission_error"},
         {404, "not_found_error"},
+        {409, "conflict_error"},
         {413, "request_too_large"},
         {422, "invalid_request_error"},
         {429, "rate_limit_error"},
         {499, "invalid_request_error"},
         {500, "api_error"},
         {502, "api_error"},
-        {504, "api_error"},
+        {504, "timeout_error"},
         {529, "overloaded_error"},
     };
 

--- a/test/cpp/test_anthropic_error.cpp
+++ b/test/cpp/test_anthropic_error.cpp
@@ -1,0 +1,104 @@
+#include "lemon/anthropic_error.h"
+
+#include <cstdio>
+#include <nlohmann/json.hpp>
+#include <string>
+
+using json = nlohmann::json;
+using lemon::anthropic::backend_error_http_status;
+using lemon::anthropic::build_anthropic_error;
+
+struct TestResult {
+    int passed = 0;
+    int failed = 0;
+
+    void check(bool condition, const std::string& name) {
+        printf("[%s] %s\n", condition ? "PASS" : "FAIL", name.c_str());
+        if (condition) {
+            ++passed;
+        } else {
+            ++failed;
+        }
+    }
+};
+
+static void test_status_extraction(TestResult& r) {
+    r.check(backend_error_http_status(json{{"status_code", 429}}) == 429,
+            "status_code wins");
+    r.check(backend_error_http_status(json{{"code", 413}}) == 413,
+            "llama.cpp numeric code");
+    r.check(backend_error_http_status(json{{"details", {{"status_code", 504}}}}) == 504,
+            "nested details.status_code");
+    r.check(backend_error_http_status(json{{"status_code", 200}}) == 500,
+            "non-error status_code ignored");
+    r.check(backend_error_http_status(json{{"status_code", "429"}}) == 500,
+            "non-integer status_code ignored");
+    r.check(backend_error_http_status(json{{"type", "invalid_request_error"}}) == 400,
+            "type invalid_request_error");
+    r.check(backend_error_http_status(json{{"type", "unsupported_operation"}}) == 400,
+            "type unsupported_operation");
+    r.check(backend_error_http_status(json{{"type", "model_not_loaded"}}) == 404,
+            "type model_not_loaded");
+    r.check(backend_error_http_status(json{{"type", "backend_error"}}) == 500,
+            "unmapped type falls back to 500");
+    r.check(backend_error_http_status(json("not an object")) == 500,
+            "non-object error falls back to 500");
+}
+
+static std::string error_type_for(int status) {
+    return build_anthropic_error(json{{"message", "boom"}}, status)["error"]["type"]
+        .get<std::string>();
+}
+
+static void test_error_type_mapping(TestResult& r) {
+    struct Case {
+        int status;
+        const char* type;
+    };
+    const Case cases[] = {
+        {400, "invalid_request_error"},
+        {401, "authentication_error"},
+        {403, "permission_error"},
+        {404, "not_found_error"},
+        {413, "request_too_large"},
+        {422, "invalid_request_error"},
+        {429, "rate_limit_error"},
+        {499, "invalid_request_error"},
+        {500, "api_error"},
+        {502, "api_error"},
+        {504, "api_error"},
+        {529, "overloaded_error"},
+    };
+
+    for (const auto& c : cases) {
+        r.check(error_type_for(c.status) == c.type,
+                std::to_string(c.status) + " -> " + c.type);
+    }
+}
+
+static void test_envelope(TestResult& r) {
+    const json wrapped = build_anthropic_error(json{{"message", "context overflow"}}, 400);
+    r.check(wrapped.value("type", "") == "error", "envelope type is error");
+    r.check(wrapped["error"].value("message", "") == "context overflow",
+            "backend message survives");
+
+    const json without_message = build_anthropic_error(json::object(), 500);
+    r.check(without_message["error"].value("message", "") == "backend error",
+            "missing message falls back");
+
+    const json non_object = build_anthropic_error(json("raw failure"), 500);
+    r.check(non_object["error"].value("message", "") == "\"raw failure\"",
+            "non-object error is dumped into the message");
+}
+
+int main() {
+    TestResult r;
+    printf("=== Anthropic Error Mapping Unit Tests ===\n\n");
+
+    test_status_extraction(r);
+    test_error_type_mapping(r);
+    test_envelope(r);
+
+    printf("\n%d/%d tests passed\n", r.passed, r.passed + r.failed);
+    return r.failed == 0 ? 0 : 1;
+}

--- a/test/test_ollama.py
+++ b/test/test_ollama.py
@@ -935,6 +935,74 @@ class OllamaTests(ServerTestBase):
             except Exception as exc:  # noqa: BLE001 - best-effort cleanup
                 print(f"Warning: cleanup unload_all_models failed: {exc}")
 
+    def _anthropic_overflow_payload(self, stream):
+        """Build a /v1/messages payload whose prompt exceeds the model context."""
+        # ~6 000 tokens, well above the 4096-token context of Tiny-Test-Model-GGUF,
+        # so llama.cpp rejects the request with a 400 the bridge has to relay.
+        overflow_prompt = "The quick brown fox jumps over the lazy dog. " * 600
+
+        return {
+            "model": ENDPOINT_TEST_MODEL,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": overflow_prompt}],
+                }
+            ],
+            "max_tokens": 16,
+            "stream": stream,
+        }
+
+    def test_027_anthropic_messages_backend_error(self):
+        """Test Anthropic-compatible backend errors are reported, not returned empty."""
+        self.ensure_model_pulled()
+
+        response = requests.post(
+            f"{OLLAMA_BASE_URL}/v1/messages?beta=true",
+            json=self._anthropic_overflow_payload(stream=False),
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(response.status_code, 400, response.text[:500])
+
+        data = response.json()
+        self.assertEqual(data.get("type"), "error")
+        self.assertEqual(data.get("error", {}).get("type"), "invalid_request_error")
+        self.assertIn("context", data.get("error", {}).get("message", ""))
+
+    def test_028_anthropic_messages_streaming_backend_error(self):
+        """Test Anthropic-compatible streaming backend errors are framed as an error event."""
+        self.ensure_model_pulled()
+
+        response = requests.post(
+            f"{OLLAMA_BASE_URL}/v1/messages?beta=true",
+            json=self._anthropic_overflow_payload(stream=True),
+            timeout=TIMEOUT_MODEL_OPERATION,
+            stream=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        event_types = []
+        error_payloads = []
+        for raw_line in response.iter_lines():
+            if not raw_line:
+                continue
+
+            line = raw_line.decode("utf-8")
+            if line.startswith("event: "):
+                event_types.append(line[len("event: ") :])
+            elif line.startswith("data: "):
+                payload_json = json.loads(line[len("data: ") :])
+                if payload_json.get("type") == "error":
+                    error_payloads.append(payload_json)
+
+        self.assertIn("error", event_types)
+        self.assertNotIn("message_stop", event_types)
+        self.assertEqual(len(error_payloads), 1)
+        self.assertEqual(
+            error_payloads[0].get("error", {}).get("type"), "invalid_request_error"
+        )
+        self.assertIn("context", error_payloads[0].get("error", {}).get("message", ""))
+
 
 if __name__ == "__main__":
     run_server_tests(OllamaTests, "OLLAMA API TESTS")


### PR DESCRIPTION
`POST /v1/messages` answered HTTP 200 with an empty text block whenever the backend failed, on
both the non-streaming and the streaming path. A caller — Claude Code, say — sees "the model had
nothing to say" instead of the error.

- **Non-streaming:** the router response went straight into `convert_openai_chat_to_anthropic()`,
  which has no `error` branch and falls into its empty-content path. Every Ollama handler in the
  same class guards this with `send_backend_error()`; the OpenAI path uses `set_error_response()`.
- **Streaming:** since #2975 the OpenAI stream carries a backend failure as a framed
  `data: {"error": ...}` event. The Anthropic adapter inspects only `id`, `usage` and
  `choices[0]`, so it dropped that event and closed the stream with `stop_reason: "end_turn"`.
  It now emits an Anthropic `event: error` frame and stops there, with no closing message frames.

Verified against `llamacpp:vulkan` + `Tiny-Test-Model-GGUF` with a context-overflow prompt:

```
before: 200 {"content":[{"text":"","type":"text"}],...,"stop_reason":"end_turn"}
after:  400 {"type":"error","error":{"type":"invalid_request_error","message":"request (6009 tokens) exceeds the available context size (4096 tokens), try increasing it"}}
```

Both new tests in `test_ollama.py` fail against a build of `main` and pass with this change;
`test_024`/`test_025` and `server_streaming_errors.py` still pass.

One open question: `backend_error_http_status()` covers the same ground as
`get_error_status_code()` in `server.cpp`, which is file-local. I kept a local helper rather than
widening that file's API surface, but I'm happy to export it in a header and call it from here
instead — just say which you prefer.
