### PR TITLE
fix(gui): dedup online catalog results and improve UX

### DIFF
--- a/src/app/src/components/ModelDetailPanel.tsx
+++ b/src/app/src/components/ModelDetailPanel.tsx
@@ -756,51 +756,72 @@ const HfOverviewTab: React.FC<{
   isPulling: boolean;
   isActive: boolean;
 }> = ({ hfModel, hfVariants, onHfPull, isPulling, isActive }) => {
+  const [selectedVariantName, setSelectedVariantName] = useState('');
+  const selectedVariant = hfVariants?.variants.find(v => v.name === selectedVariantName)
+    ?? hfVariants?.variants[0];
+
   if (!isActive) return null;
   return (
     <div className="detail-tab-content hf-detail__overview">
       {hfVariants ? (
         <>
-          {hfVariants.suggested_labels.length > 0 && (
+          {hfVariants.mmproj_files.length > 0 && (
             <div className="hf-detail__overview-section">
-              <span className="hf-detail__overview-label">Capabilities</span>
-              <div className="hf-detail__overview-value">{hfVariants.suggested_labels.join(', ')}</div>
+              <span className="hf-detail__overview-label">Included components</span>
+              <div className="hf-detail__overview-value">Vision projector (MMProj)</div>
             </div>
           )}
           {hfVariants.variants.length > 0 ? (
             <div className="hf-detail__overview-section">
-              <span className="hf-detail__overview-label">Variants — pick one to download</span>
-              <div className="hf-detail__gguf-list">
-                {hfVariants.variants.map(v => (
-                  <button
-                    key={v.name}
-                    className="hf-detail__gguf-btn"
-                    aria-label={`Download ${v.name} from ${hfModel.id}`}
+              <span className="hf-detail__overview-label">Variants — select one</span>
+              {selectedVariant && (
+                <div className="hf-detail__gguf-primary-action">
+                  <WorkspaceActionButton
+                    appearance="primary"
+                    icon="download"
                     disabled={isPulling}
-                    onClick={() => onHfPull?.(hfModel.id, v.name, hfVariants.recipe)}
+                    onClick={() => onHfPull?.(hfModel.id, selectedVariant.name, hfVariants.recipe)}
+                    aria-label={`Download ${selectedVariant.name} from ${hfModel.id}`}
                   >
-                    <span className="hf-detail__gguf-name">
-                      {v.name}{v.sharded ? ' (sharded)' : ''}
-                    </span>
-                    <span className="hf-detail__gguf-size">{fmtBytes(v.size_bytes)}</span>
-                    <span className="hf-detail__gguf-action">Download</span>
-                  </button>
-                ))}
+                    Download {selectedVariant.name}
+                  </WorkspaceActionButton>
+                </div>
+              )}
+              <div className="hf-detail__gguf-list" role="radiogroup" aria-label={`Variants for ${hfModel.id}`}>
+                {hfVariants.variants.map(v => {
+                  const isSelected = selectedVariant?.name === v.name;
+                  return (
+                    <button
+                      key={v.name}
+                      type="button"
+                      role="radio"
+                      aria-checked={isSelected}
+                      className={`hf-detail__gguf-btn${isSelected ? ' hf-detail__gguf-btn--selected' : ''}`}
+                      disabled={isPulling}
+                      onClick={() => setSelectedVariantName(v.name)}
+                    >
+                      <span className="hf-detail__gguf-name">
+                        {v.name}{v.sharded ? ' (sharded)' : ''}
+                      </span>
+                      <span className="hf-detail__gguf-size">{fmtBytes(v.size_bytes)}</span>
+                    </button>
+                  );
+                })}
               </div>
             </div>
           ) : hfVariants.recipe !== 'llamacpp' ? (
             <div className="hf-detail__overview-section">
               <span className="hf-detail__overview-label">Repository download</span>
-              <div className="hf-detail__gguf-list">
-                <button
-                  className="hf-detail__gguf-btn"
-                  aria-label={`Download ${hfModel.id}`}
+              <div className="hf-detail__gguf-primary-action">
+                <WorkspaceActionButton
+                  appearance="primary"
+                  icon="download"
                   disabled={isPulling}
                   onClick={() => onHfPull?.(hfModel.id, '', hfVariants.recipe)}
+                  aria-label={`Download ${hfModel.id}`}
                 >
-                  <span className="hf-detail__gguf-name">{hfModel.id}</span>
-                  <span className="hf-detail__gguf-action">Download</span>
-                </button>
+                  Download model
+                </WorkspaceActionButton>
               </div>
             </div>
           ) : (

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -122,13 +122,6 @@ function formatDownloads(n: number): string {
   return String(n);
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(1)} GB`;
-  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(0)} MB`;
-  if (bytes >= 1_024) return `${(bytes / 1_024).toFixed(0)} KB`;
-  return `${bytes} B`;
-}
-
 
 
 function safeFileName(value: string): string {
@@ -1095,7 +1088,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const [modelScopeResults, setModelScopeResults] = useState<HFModelResult[]>([]);
   const [modelScopeLoading, setModelScopeLoading] = useState(false);
   const [modelScopeError, setModelScopeError] = useState<string | null>(null);
-  const [expandedRemoteModel, setExpandedRemoteModel] = useState<string | null>(null);
   const [selectedRemoteModel, setSelectedRemoteModel] = useState<HFModelResult | null>(null);
   const [selectedRemoteProvider, setSelectedRemoteProvider] = useState<ModelRegistryProvider>('huggingface');
   const [pullingRemote, setPullingRemote] = useState<Record<string, { percent: number; modelName: string; checkpoint: string }>>({});
@@ -1419,7 +1411,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   }, [hfResults, providerEnabled.huggingface]);
 
   useEffect(() => {
-    setExpandedRemoteModel(null);
     setSelectedRemoteModel(null);
   }, [searchQuery]);
 
@@ -1428,7 +1419,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     const key = providerKey('huggingface', selectedRemoteModel.id);
     if (!Object.prototype.hasOwnProperty.call(hfDetectedRecipes, key)
       || isCompatibleHuggingFaceRecipe(hfDetectedRecipes[key])) return;
-    setExpandedRemoteModel(null);
     setSelectedRemoteModel(null);
     setMobileDetailOpen(false);
   }, [hfDetectedRecipes, selectedRemoteModel, selectedRemoteProvider]);
@@ -2493,8 +2483,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
 
   const renderRemoteRow = (provider: ModelRegistryProvider, result: HFModelResult) => {
     const key = providerKey(provider, result.id);
-    const providerMeta = PROVIDER_META[provider];
-    const isExpanded = expandedRemoteModel === key;
     const pipelineTag = result.pipeline_tag || '';
     const variants = remoteVariants[key];
     const displayTags = Array.from(new Set([
@@ -2506,13 +2494,10 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     const remotePull = activeRemotePull(provider, result.id, variants);
     const pullPercent = remotePull?.percent;
     const isPulling = pullPercent !== undefined;
-    const isLoadingVariants = remoteVariantsLoading[key] || false;
     const recipeBadge = variants ? (RECIPE_BADGES[variants.recipe] || variants.recipe) : '';
+    const isSelected = selectedRemoteModel?.id === result.id && selectedRemoteProvider === provider;
 
-    const handleExpand = () => {
-      const next = isExpanded ? null : key;
-      setExpandedRemoteModel(next);
-      if (next) void fetchRemoteVariants(provider, result.id);
+    const handleSelect = () => {
       setSelectedRemoteModel(result);
       setSelectedRemoteProvider(provider);
       setSelectedDetailModelId(null);
@@ -2520,9 +2505,9 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     };
 
     return (
-      <div className={`row row--remote row--${provider} row--${provider === 'huggingface' ? 'hf' : 'modelscope'}${isExpanded ? ' row--expanded' : ''}`} key={key}>
+      <div className={`row row--remote row--${provider} row--${provider === 'huggingface' ? 'hf' : 'modelscope'}${isSelected ? ' row--active' : ''}`} key={key}>
         <div className="row__summary">
-          <button type="button" className="row__content" onClick={handleExpand} aria-expanded={isExpanded}>
+          <button type="button" className="row__content" onClick={handleSelect}>
             <div className="row__main">
               <div className={`row__icon row__icon--${provider}`}><Icon name="cloud" size={18} /></div>
               <div className="row__text">
@@ -2540,11 +2525,10 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
                 )}
               </div>
             </div>
-            <span className="row__expand">{isExpanded ? '▾' : '▸'}</span>
           </button>
           <div className="row__right">
             <CopyInlineButton text={result.id} title={`Copy repository name: ${result.id}`} />
-            {isPulling ? (
+            {isPulling && (
               <div className="row__progress">
                 <div className="row__progress-bar">
                   <div className="row__progress-fill" style={{ width: `${pullPercent}%` }} />
@@ -2557,116 +2541,12 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
                   aria-label={`Cancel download of ${result.id}`}
                 ><Icon name="x" size={13} /></button>
               </div>
-            ) : (
-              <button
-                className="row__action row__action--download"
-                aria-label={`Download ${result.id}`}
-                onClick={(event) => { event.stopPropagation(); handleExpand(); }}
-                title={variants?.variants.length === 0 && variants.recipe !== 'llamacpp'
-                  ? 'Expand to download repository'
-                  : 'Expand to pick a variant to download'}
-              >
-                <Icon name="download" size={13} /> Download
-              </button>
             )}
-            <a
-              className="row__action row__action--hf-link"
-              href={providerMeta.url(result.id)}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={event => event.stopPropagation()}
-            >
-              View
-            </a>
           </div>
         </div>
-
-        {isExpanded && (
-          <div className={`row__detail row__detail--remote row__detail--${provider}`}>
-            <div className="detail__grid">
-              <div className="detail__meta">
-                <div className="detail__field">
-                  <span className="detail__label">Provider</span>
-                  <span className="detail__value">{providerMeta.label}</span>
-                </div>
-                <div className="detail__field">
-                  <span className="detail__label">Repository</span>
-                  <span className="detail__value detail__value--mono">{result.id}</span>
-                </div>
-                {pipelineTag && (
-                  <div className="detail__field">
-                    <span className="detail__label">Pipeline</span>
-                    <span className="detail__value">{pipelineTag}</span>
-                  </div>
-                )}
-                {variants && (
-                  <>
-                    <div className="detail__field">
-                      <span className="detail__label">Backend</span>
-                      <span className="detail__value">{RECIPE_BADGES[variants.recipe] || variants.recipe}</span>
-                    </div>
-                    {variants.suggested_labels.length > 0 && (
-                      <div className="detail__field">
-                        <span className="detail__label">Capabilities</span>
-                        <span className="detail__value">{variants.suggested_labels.join(', ')}</span>
-                      </div>
-                    )}
-                  </>
-                )}
-              </div>
-              <div className="detail__source">
-                {isLoadingVariants && (
-                  <div className="detail__field"><span className="detail__label">Loading variants…</span></div>
-                )}
-                {variants && variants.variants.length > 0 && (
-                  <div className="detail__field">
-                    <span className="detail__label">Variants — pick one to download</span>
-                    <div className="hf-detail__gguf-list">
-                      {variants.variants.map(variant => (
-                        <button
-                          key={variant.name}
-                          className="hf-detail__gguf-btn"
-                          aria-label={`Download ${variant.name} from ${result.id}`}
-                          disabled={isPulling}
-                          onClick={() => void handleRemotePull(provider, result.id, variant.name, variants.recipe)}
-                        >
-                          <span className="hf-detail__gguf-name">
-                            {variant.name}{variant.sharded ? ' (sharded)' : ''}
-                          </span>
-                          <span className="hf-detail__gguf-size">{formatBytes(variant.size_bytes)}</span>
-                          <span className="hf-detail__gguf-action">Download</span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {variants && variants.variants.length === 0 && variants.recipe !== 'llamacpp' && (
-                  <div className="detail__field">
-                    <span className="detail__label">Repository download</span>
-                    <div className="hf-detail__gguf-list">
-                      <button
-                        className="hf-detail__gguf-btn"
-                        aria-label={`Download ${result.id}`}
-                        disabled={isPulling}
-                        onClick={() => void handleRemotePull(provider, result.id, '', variants.recipe)}
-                      >
-                        <span className="hf-detail__gguf-name">{result.id}</span>
-                        <span className="hf-detail__gguf-action">Download</span>
-                      </button>
-                    </div>
-                  </div>
-                )}
-                <a className="detail__hf-link" href={providerMeta.url(result.id)} target="_blank" rel="noopener noreferrer">
-                  View on {providerMeta.label}
-                </a>
-              </div>
-            </div>
-          </div>
-        )}
       </div>
     );
   };
-
 
   /* ── Stats ───────────────────────────────────────────────── */
   const searchActive = searchQuery.trim().length >= 2;
@@ -2727,7 +2607,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     setProviderEnabled(prev => ({ ...prev, [provider]: !prev[provider] }));
     if (selectedRemoteModel && selectedRemoteProvider === provider) {
       setSelectedRemoteModel(null);
-      setExpandedRemoteModel(null);
       setMobileDetailOpen(false);
     }
   };

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -1984,9 +1984,11 @@ input, textarea {
 .hf-detail__gguf-btn {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: var(--space-2);
+  width: 100%;
   padding: 6px 10px;
+  text-align: left;
   background: var(--surface-0);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
@@ -1994,9 +1996,29 @@ input, textarea {
   transition: background var(--duration-fast), border-color var(--duration-fast);
 }
 
+.hf-detail__gguf-btn::before {
+  content: '';
+  width: 12px;
+  height: 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
 .hf-detail__gguf-btn:hover {
   background: var(--surface-2);
   border-color: var(--accent-fg);
+}
+
+.hf-detail__gguf-btn--selected {
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface-0));
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border-subtle));
+}
+
+.hf-detail__gguf-btn--selected::before {
+  background: var(--accent-fg);
+  border-color: var(--accent-fg);
+  box-shadow: inset 0 0 0 3px var(--surface-0);
 }
 
 .hf-detail__gguf-btn:disabled {
@@ -2005,6 +2027,7 @@ input, textarea {
 }
 
 .hf-detail__gguf-name {
+  flex: 1 1 auto;
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   color: var(--text-secondary);
@@ -2014,18 +2037,17 @@ input, textarea {
   min-width: 0;
 }
 
-.hf-detail__gguf-action {
-  font-size: var(--text-xs);
-  color: var(--accent-fg);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
 .hf-detail__gguf-size {
   font-size: var(--text-xs);
   color: var(--text-muted);
   white-space: nowrap;
   flex-shrink: 0;
+}
+
+.hf-detail__gguf-primary-action {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: var(--space-2);
 }
 
 /* ── Model Row ────────────────────────────────────────────── */
@@ -12958,12 +12980,12 @@ a.backend-card__version:focus-visible {
 }
 
 .row--remote.row--huggingface:hover,
-.row--remote.row--huggingface.row--expanded {
+.row--remote.row--huggingface.row--active {
   border-left-color: var(--provider-hugging-face);
 }
 
 .row--remote.row--modelscope:hover,
-.row--remote.row--modelscope.row--expanded {
+.row--remote.row--modelscope.row--active {
   border-left-color: var(--provider-modelscope);
 }
 
@@ -12999,12 +13021,19 @@ a.backend-card__version:focus-visible {
 }
 
 .model-list-panel__scroll-area .row--remote .row__summary {
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--space-2);
 }
 
 .model-list-panel__scroll-area .row--remote .row__content {
   width: 100%;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+}
+
+.model-list-panel__scroll-area .row--remote .row__right {
+  justify-content: flex-end;
+  padding: 0;
 }
 
 .model-detail-panel--modelscope .hf-detail__source-label {

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -2777,7 +2777,7 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     await expect(hfZone).toContainText('Mistral-FLM');
     const flmRow = hfZone.locator('.row--hf').filter({ hasText: 'Mistral-FLM' });
     await flmRow.locator('.row__content').click();
-    await expect(flmRow.locator('.row__detail').getByRole('button', { name: 'Download FastFlowLM/Mistral-FLM' })).toBeVisible();
+    await expect(page.locator('.model-detail-panel--hf').getByRole('button', { name: 'Download FastFlowLM/Mistral-FLM' })).toBeVisible();
 
     // Clearing the search removes the HF zone entirely.
     await search.fill('');

--- a/src/app/tests/model-provider-search.runtime.cjs
+++ b/src/app/tests/model-provider-search.runtime.cjs
@@ -10,6 +10,7 @@ const api = fs.readFileSync(path.join(root, 'src/api.ts'), 'utf8');
 const capabilitiesSource = fs.readFileSync(path.join(root, 'src/modelCapabilities.ts'), 'utf8');
 const remoteCapabilitiesSource = fs.readFileSync(path.join(root, 'src/remoteModelCapabilities.ts'), 'utf8');
 const listPanelSource = fs.readFileSync(path.join(root, 'src/components/ModelListPanel.tsx'), 'utf8');
+const detailPanelSource = fs.readFileSync(path.join(root, 'src/components/ModelDetailPanel.tsx'), 'utf8');
 const styles = fs.readFileSync(path.join(root, 'src/styles/styles.css'), 'utf8');
 const huggingFaceSearchPath = path.join(root, 'src/features/models/huggingFaceSearch.ts');
 
@@ -89,6 +90,24 @@ assert.doesNotMatch(remoteCapabilitiesSource, /pipeline\.includes\(/,
   'remote capability matching must not be broad substring guessing');
 assert.ok(manager.indexOf("renderProviderZone('huggingface')") < manager.indexOf("renderProviderZone('modelscope')"),
   'ModelScope results must be rendered below Hugging Face');
+assert.doesNotMatch(manager, /expandedRemoteModel|row__detail row__detail--remote|row__expand/,
+  'remote registry rows must select the detail pane instead of expanding duplicate inline details');
+assert.doesNotMatch(manager, /row__action--download|row__action--hf-link/,
+  'remote registry rows must not duplicate download or provider-link actions from the detail pane');
+assert.match(styles, /\.hf-detail__gguf-list \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;/,
+  'remote variants must remain one vertical list at every detail-pane width');
+assert.match(detailPanelSource, /role="radiogroup"[\s\S]*?onClick=\{\(\) => setSelectedVariantName\(v\.name\)\}/,
+  'variant rows must select a quantization instead of starting a download');
+assert.match(detailPanelSource, /appearance="primary"[\s\S]*?onClick=\{\(\) => onHfPull\?\.\(hfModel\.id, selectedVariant\.name, hfVariants\.recipe\)\}/,
+  'the selected quantization must have one explicit primary download action');
+assert.ok(detailPanelSource.indexOf('hf-detail__gguf-primary-action') < detailPanelSource.indexOf('role="radiogroup"'),
+  'the primary download action must stay above the variant list so long lists cannot hide it');
+assert.match(detailPanelSource, /hfVariants\.mmproj_files\.length > 0[\s\S]*?Included components[\s\S]*?Vision projector \(MMProj\)/,
+  'remote details must describe a detected mmproj as an included component');
+assert.doesNotMatch(detailPanelSource, /hfVariants\.suggested_labels\.length > 0[\s\S]*?>Capabilities<\/span>/,
+  'provider capability labels must not create a duplicate Capabilities block in remote details');
+assert.doesNotMatch(detailPanelSource, /hf-detail__gguf-action/,
+  'variant rows must not repeat a Download action for every quantization');
 
 assert.doesNotMatch(capabilitiesSource, /found\.size === 0\) found\.add\('chat'\)/,
   'unknown capability must not silently become Chat');


### PR DESCRIPTION
Dedup realized via removing the card drop down.
UX is clear -> click on card opens details.

In the details card avoid 15+ primary action download button in favor for this improved concept:

<img width="1596" height="903" alt="image" src="https://github.com/user-attachments/assets/82fe3f9d-01fa-4075-8ef2-e203eeadd594" />



Additionally observed a misleading Vision capability disclaimer and opted for not removing the technical detail, make it clearer:

New:

<img width="1406" height="788" alt="image" src="https://github.com/user-attachments/assets/f392e97b-47bc-4b60-9179-116fd4a4b228" />

Old:
<img width="1464" height="686" alt="image" src="https://github.com/user-attachments/assets/6cfdcc7d-cf51-4013-a9e1-5c8c1e686cf9" />

Closes #2928 