### PR TITLE
GUI3 Fix: improve telemetry optimizer model selection and cancellation

### DIFF
--- a/src/app/src/components/inspect/ImproveTab.tsx
+++ b/src/app/src/components/inspect/ImproveTab.tsx
@@ -7,6 +7,13 @@ import MarkdownMessage from '../MarkdownMessage';
 import Modal from './Modal';
 import { useAutoScroll } from '../../hooks/useAutoScroll';
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+import { modelCapabilityTags } from '../../modelCapabilities';
+import {
+  LEMONADE_DEFAULT_CHAT_MODELS,
+  loadLastReadyModelName,
+  modelInfoName,
+  modelIsDownloaded,
+} from '../../features/chatDefaultModels';
 
 interface ImproveTabProps {
   selectedTrace: Trace;
@@ -35,6 +42,10 @@ interface OptimizedPromptData {
   key_improvements: string[];
 }
 
+const QUALITY_DEFAULT_MODEL = LEMONADE_DEFAULT_CHAT_MODELS.find(
+  (model) => model.tier === 'quality'
+)?.name || '';
+
 
 function truncateText(text: string, maxChars: number): string {
   if (!text || text.length <= maxChars) return text || '';
@@ -45,11 +56,28 @@ function truncateText(text: string, maxChars: number): string {
 export default function ImproveTab({ selectedTrace }: ImproveTabProps) {
   const availableModels = api.allModels;
   const optimizerModels = useMemo(
-    () => availableModels.filter((model) =>
-      (model.labels || []).some((label) => label.trim().toLowerCase() === 'reasoning')
+    () => availableModels.filter(
+      (model) => modelIsDownloaded(model) && modelCapabilityTags(model).includes('tool')
     ),
     [availableModels]
   );
+  const preferredImproveModel = useMemo(() => {
+    const recentModelName = loadLastReadyModelName()?.toLowerCase();
+
+    if (recentModelName) {
+      const recentModel = optimizerModels.find(
+        (model) => modelInfoName(model).toLowerCase() === recentModelName
+      );
+      if (recentModel) return modelInfoName(recentModel);
+    }
+
+    const hotModel = optimizerModels.find((model) =>
+      (model.labels || []).some((label) => label.trim().toLowerCase() === 'hot')
+    );
+    if (hotModel) return modelInfoName(hotModel);
+
+    return QUALITY_DEFAULT_MODEL;
+  }, [optimizerModels]);
   const [improveModel, setImproveModel] = useState('');
   const [improveCritique, setImproveCritique] = useState('The response was too verbose and failed to strictly answer in the requested format.');
   const [improveOutput, setImproveOutput] = useState('');
@@ -77,6 +105,7 @@ export default function ImproveTab({ selectedTrace }: ImproveTabProps) {
   const improveBodyRef = useRef<HTMLDivElement>(null);
   const improveOutputBoxRef = useRef<HTMLDivElement>(null);
   const testOutputBoxRef = useRef<HTMLDivElement>(null);
+  const improveAbortRef = useRef<AbortController | null>(null);
 
   const handleLeftScroll = () => {
     const left = leftBoxRef.current;
@@ -125,6 +154,11 @@ export default function ImproveTab({ selectedTrace }: ImproveTabProps) {
   // Auto-scroll improve stream modal body and output box when streaming updates
   useAutoScroll([improveBodyRef, improveOutputBoxRef], [improveStreamingText, improveStreamingReasoning], improveRunning);
   useAutoScroll([testOutputBoxRef], [testStreamingText, testStreamingReasoning], testRunning);
+
+  useEffect(() => () => {
+    improveAbortRef.current?.abort();
+    improveAbortRef.current = null;
+  }, [selectedTrace.id]);
 
   // Clear test validation error when a model is selected
   useEffect(() => {
@@ -203,14 +237,13 @@ export default function ImproveTab({ selectedTrace }: ImproveTabProps) {
   // Set default model when models load
   useEffect(() => {
     const selectedModelAvailable = optimizerModels.some(
-      (model) => (model.name || model.id || '') === improveModel
-    );
-    if (optimizerModels.length > 0 && !selectedModelAvailable) {
-      setImproveModel(optimizerModels[0].name || optimizerModels[0].id || '');
-    } else if (optimizerModels.length === 0 && improveModel) {
-      setImproveModel('');
+      (model) => modelInfoName(model) === improveModel
+    ) || improveModel === QUALITY_DEFAULT_MODEL;
+
+    if (!improveModel || !selectedModelAvailable) {
+      setImproveModel(preferredImproveModel);
     }
-  }, [optimizerModels, improveModel]);
+  }, [optimizerModels, improveModel, preferredImproveModel]);
 
   // Sync edits when prompt parsed data changes
   useEffect(() => {
@@ -618,9 +651,17 @@ ${truncatedOutput}
     };
   };
 
+  const handleCancelImprovement = () => {
+    improveAbortRef.current?.abort();
+    improveAbortRef.current = null;
+    setImproveRunning(false);
+  };
+
   // Runs optimization loop with retry logic
   const handleRunImprovement = async () => {
     if (!improveModel || improveRunning) return;
+    const controller = new AbortController();
+    improveAbortRef.current = controller;
     setImproveRunning(true);
     setImproveOutput('');
     setImproveParsedData(null);
@@ -630,6 +671,13 @@ ${truncatedOutput}
 
     const callApi = (tempOverride?: number, errorReason?: string): Promise<string> => {
       return new Promise<string>((resolve, reject) => {
+        const rejectAbort = () => reject(new DOMException('Prompt optimization cancelled.', 'AbortError'));
+        if (controller.signal.aborted) {
+          rejectAbort();
+          return;
+        }
+        controller.signal.addEventListener('abort', rejectAbort, { once: true });
+
         let systemMsg = generatedMetaSystem;
         let userMsg = generatedMetaUser;
         if (errorReason) {
@@ -656,38 +704,48 @@ ${truncatedOutput}
           { role: 'user', content: userMsg },
         ], {
           params,
+          signal: controller.signal,
           onToken: (tok) => {
+            if (controller.signal.aborted) return;
             accumulated += tok;
             setImproveStreamingText(accumulated);
           },
           onReasoning: (reas) => {
+            if (controller.signal.aborted) return;
             accumulatedReasoning += reas;
             setImproveStreamingReasoning(accumulatedReasoning);
           },
           onDone: () => {
+            controller.signal.removeEventListener('abort', rejectAbort);
+            if (controller.signal.aborted) {
+              rejectAbort();
+              return;
+            }
             resolve(accumulated);
           },
           onError: (err) => {
+            controller.signal.removeEventListener('abort', rejectAbort);
             reject(err);
           }
-        }).catch(reject);
+        }).catch((err) => {
+          controller.signal.removeEventListener('abort', rejectAbort);
+          reject(err);
+        });
       });
     };
 
     let response = '';
     let parsedJson: any = null;
     let sanitized: OptimizedPromptData | null = null;
-    let firstErrorMsg = '';
 
     try {
-
       try {
         response = await callApi();
         setImproveOutput(response);
         parsedJson = parseAndSanitizeResponse(response);
         sanitized = validateAndCoerceSchema(parsedJson, selectedTrace);
       } catch (err: any) {
-        firstErrorMsg = err.message;
+        if (controller.signal.aborted || err?.name === 'AbortError') throw err;
 
         // Skip retry if it failed due to context length / bad request, since it will just fail again
         if (err.message?.toLowerCase().includes('exceeds') || err.message?.toLowerCase().includes('context size') || err.message?.toLowerCase().includes('400')) {
@@ -730,6 +788,7 @@ ${truncatedOutput}
 
       inspectStore.showToast('Prompt analysis complete');
     } catch (e: any) {
+      if (controller.signal.aborted || e?.name === 'AbortError') return;
       console.error('Prompt optimizer execution failed:', e);
       if (response) {
         setImproveOutput(response);
@@ -742,6 +801,9 @@ ${truncatedOutput}
       setImproveParsedData(null);
       setWhatChangedModalOpen(true);
     } finally {
+      if (improveAbortRef.current === controller) {
+        improveAbortRef.current = null;
+      }
       setImproveRunning(false);
     }
   };
@@ -876,9 +938,10 @@ ${truncatedOutput}
           value={improveModel}
           onChange={setImproveModel}
           availableModels={optimizerModels}
+          showAllOnFocus
         />
 
-        <div className="flex-col gap-6">
+        <div className="flex-col gap-4">
           <label className="input-label" htmlFor="improve-critique-input">Critique / Desired Behavior</label>
           <input
             id="improve-critique-input"
@@ -942,7 +1005,7 @@ ${truncatedOutput}
       {/* Progress Modal */}
       <Modal
         isOpen={improveRunning}
-        onClose={() => {}}
+        onClose={handleCancelImprovement}
         title="Analyzing & Optimizing Prompt"
         ariaLabelledBy="unified-modal-title"
         maxWidth="640px"

--- a/src/app/src/components/inspect/ModelSearchSelector.tsx
+++ b/src/app/src/components/inspect/ModelSearchSelector.tsx
@@ -8,6 +8,7 @@ interface ModelSearchSelectorProps {
   onChange: (val: string) => void;
   availableModels: ModelInfo[];
   className?: string;
+  showAllOnFocus?: boolean;
 }
 
 export default function ModelSearchSelector({
@@ -16,7 +17,8 @@ export default function ModelSearchSelector({
   value,
   onChange,
   availableModels,
-  className = 'critique-input-control'
+  className = 'critique-input-control',
+  showAllOnFocus = false
 }: ModelSearchSelectorProps) {
   const [search, setSearch] = useState('');
   const [isOpen, setIsOpen] = useState(false);
@@ -125,11 +127,13 @@ export default function ModelSearchSelector({
           if (!isOpen) setIsOpen(true);
         }}
         onFocus={() => {
-          setSearch(value || '');
+          setSearch(showAllOnFocus ? '' : (value || ''));
           setIsOpen(true);
-          setTimeout(() => {
-            inputRef.current?.select();
-          }, 0);
+          if (!showAllOnFocus) {
+            setTimeout(() => {
+              inputRef.current?.select();
+            }, 0);
+          }
         }}
         onKeyDown={handleKeyDown}
         className={className}

--- a/src/app/src/components/inspect/TraceList.tsx
+++ b/src/app/src/components/inspect/TraceList.tsx
@@ -21,11 +21,11 @@ interface TraceListProps {
 }
 
 const TRACE_FILTERS = [
-  ['All', 'All', 'layers'],
-  ['LLM', 'LLM', 'chat'],
-  ['EMBEDDING', 'Embed', 'embedding'],
-  ['RERANKER', 'Rerank', 'reranking'],
-  ['Errors', 'Errors', 'alert'],
+  ['All', 'All', 'globe', 'var(--text-tertiary)'],
+  ['LLM', 'LLM', 'chat', 'var(--cap-chat)'],
+  ['EMBEDDING', 'Embed', 'embedding', 'var(--cap-embedding)'],
+  ['RERANKER', 'Rerank', 'reranking', 'var(--cap-reranking)'],
+  ['Errors', 'Errors', 'alert', 'var(--danger)'],
 ] as const;
 
 export function getRelativeTimeAgo(startTimeMs: number): string {
@@ -180,19 +180,31 @@ export default function TraceList({
           />
         </div>
 
-        <nav className="workspace-filter-list" aria-label="Request filters">
-          {TRACE_FILTERS.map(([kind, label, icon]) => (
-            <button
-              key={kind}
-              type="button"
-              aria-pressed={filterKind === kind}
-              className={`workspace-filter-list__item${filterKind === kind ? ' is-active' : ''}`}
-              onClick={() => inspectStore.setFilterKind(kind)}
-            >
-              <Icon className="workspace-filter-list__icon" name={icon} size={14} />
-              <span className="workspace-filter-list__label">{label}</span>
-            </button>
-          ))}
+        <nav
+          className="model-nav-rail__chip-list"
+          aria-label="Request filters"
+        >
+          {TRACE_FILTERS.map(([kind, label, icon, color]) => {
+            const active = filterKind === kind;
+
+            return (
+              <button
+                key={kind}
+                type="button"
+                aria-pressed={active}
+                className={`model-nav-rail__filter-chip model-nav-rail__task-chip${active ? ' is-active' : ''}`}
+                style={{ '--filter-chip-color': color } as React.CSSProperties}
+                onClick={() => inspectStore.setFilterKind(kind)}
+              >
+                <Icon
+                  name={icon}
+                  size={13}
+                  className="model-nav-rail__task-icon"
+                />
+                <span>{label}</span>
+              </button>
+            );
+          })}
         </nav>
       </div>
 

--- a/src/app/tests/inspect-interactions.spec.ts
+++ b/src/app/tests/inspect-interactions.spec.ts
@@ -59,7 +59,29 @@ test.beforeEach(async ({ page }) => {
             id: 'mock-reasoning-model',
             name: 'mock-reasoning-model',
             model_name: 'mock-reasoning-model',
-            labels: ['reasoning']
+            labels: ['reasoning'],
+            downloaded: true
+          },
+          {
+            id: 'mock-tool-hot',
+            name: 'mock-tool-hot',
+            model_name: 'mock-tool-hot',
+            labels: ['tool-calling', 'hot'],
+            downloaded: true
+          },
+          {
+            id: 'mock-tool-downloaded',
+            name: 'mock-tool-downloaded',
+            model_name: 'mock-tool-downloaded',
+            labels: ['tool-calling'],
+            downloaded: true
+          },
+          {
+            id: 'mock-tool-remote',
+            name: 'mock-tool-remote',
+            model_name: 'mock-tool-remote',
+            labels: ['tool-calling'],
+            downloaded: false
           },
           {
             id: 'ACE-Step-music',
@@ -92,7 +114,10 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('Session Inspector - Recent Improvements', () => {
-  test('Improve optimizer model selector only lists reasoning models', async ({ page }) => {
+  test('Improve optimizer model selector lists downloaded tool-calling models', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('lemonade:chat_last_ready_model', 'mock-tool-downloaded');
+    });
     await page.goto('/#/dashboard/telemetry');
     await expect(page.locator('.inspect-rail')).toBeVisible();
 
@@ -130,20 +155,82 @@ test.describe('Session Inspector - Recent Improvements', () => {
 
     await page.getByRole('tab', { name: 'Improve' }).click();
     const optimizerSelector = page.getByRole('combobox', { name: 'Select LLM Optimizer' });
+    await expect(optimizerSelector).toHaveValue('mock-tool-downloaded');
     await optimizerSelector.click();
-    await optimizerSelector.press('Control+A');
-    await optimizerSelector.press('Backspace');
 
-    await expect(page.getByRole('option', { name: 'mock-reasoning-model', exact: true })).toBeVisible();
+    // Opening the optimizer picker must immediately expose every downloaded
+    // tool-calling model, without requiring the user to clear the current value.
+    await expect(page.getByRole('option', { name: 'mock-tool-hot', exact: true })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'mock-tool-downloaded', exact: true })).toBeVisible();
+    await expect(page.getByRole('option', { name: 'mock-tool-remote', exact: true })).toHaveCount(0);
+    await expect(page.getByRole('option', { name: 'mock-reasoning-model', exact: true })).toHaveCount(0);
     await expect(page.getByRole('option', { name: 'ACE-Step-music', exact: true })).toHaveCount(0);
 
-    await optimizerSelector.press('Escape');
+    await page.getByRole('option', { name: 'mock-tool-hot', exact: true }).click();
+    await expect(optimizerSelector).toHaveValue('mock-tool-hot');
+
     await page.getByRole('button', { name: 'Test', exact: true }).click();
     const testModelSelector = page.getByRole('combobox', { name: 'Select Test Model' });
     await testModelSelector.click();
     await testModelSelector.press('Control+A');
     await testModelSelector.press('Backspace');
     await expect(page.getByRole('option', { name: 'ACE-Step-music', exact: true })).toBeVisible();
+  });
+
+  test('Closing optimization progress aborts the request and releases the GUI', async ({ page }) => {
+    await page.goto('/#/dashboard/telemetry');
+    await expect(page.locator('.inspect-rail')).toBeVisible();
+
+    await page.evaluate(() => {
+      const originalFetch = window.fetch.bind(window);
+      (window as any).__optimizerAborted = false;
+      window.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+        if (url.includes('/api/v1/chat/completions')) {
+          return new Promise<Response>((_resolve, reject) => {
+            const abort = () => {
+              (window as any).__optimizerAborted = true;
+              reject(new DOMException('Aborted', 'AbortError'));
+            };
+            if (init?.signal?.aborted) {
+              abort();
+              return;
+            }
+            init?.signal?.addEventListener('abort', abort, { once: true });
+          });
+        }
+        return originalFetch(input, init);
+      }) as typeof window.fetch;
+
+      (window as any).inspectStore.setState({
+        traces: [{
+          id: 'mock-cancel-trace',
+          traceId: 'trace-cancel',
+          spanId: 'span-cancel',
+          kind: 'LLM',
+          operation: 'chat.completions',
+          status: 'ok',
+          model: 'mock-tool-hot',
+          timestamp: '12:00:00 PM',
+          startTimeMs: Date.now(),
+          dur: 1500,
+          messages: [{ role: 'user', content: 'Summarize this report.' }],
+          output: 'A response that needs improvement.'
+        }],
+        selectedTraceId: 'mock-cancel-trace'
+      });
+    });
+
+    await page.getByRole('tab', { name: 'Improve' }).click();
+    await page.getByRole('button', { name: 'Analyze and Optimize Prompt' }).click();
+
+    const progressDialog = page.getByRole('dialog', { name: 'Analyzing & Optimizing Prompt' });
+    await expect(progressDialog).toBeVisible();
+    await progressDialog.getByRole('button', { name: 'Close modal' }).click();
+
+    await expect(progressDialog).toHaveCount(0);
+    await expect.poll(() => page.evaluate(() => (window as any).__optimizerAborted)).toBe(true);
+    await expect(page.getByRole('dialog', { name: 'Prompt Optimization Failed' })).toHaveCount(0);
   });
 
   test('Improve optimizer rejects an echoed worked-example response', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes two issues in **Monitor → Telemetry → Improve**:

* Selects optimizer models from downloaded tool-calling models instead of arbitrary reasoning models (was an old Qwen3 fixed)
* Prefers the recent used downloaded tool model, then a downloaded **hot** tool model, and falls back to Lemonade's quality default.
* Allows users to override the automatic choice with any downloaded tool-calling model.
* Makes the optimization progress dialog cancellable. Closing it now aborts the active request and immediately releases the UI (long or looping request blocked the UI, breaking)

Modified `ModelSearchSelector` keeps its existing behavior by default; the new show-all-on-focus behavior is opt-in and only used by the optimizer.

## Testing

* Local function test
* Updated Playwright coverage for tool-model selection and request cancellation.
* Existing model navigation and model-state runtime checks pass.
