### PR TITLE
ci: fail fast in merge queue matrices

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -323,7 +323,7 @@ jobs:
     container:
       image: debian:trixie
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - arch-name: X86_64
@@ -405,7 +405,7 @@ jobs:
     container:
       image: debian:trixie
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - arch-name: X86_64
@@ -483,7 +483,7 @@ jobs:
       image: fedora:${{ matrix.fedora-version }}
 
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         fedora-version: ["43", "44"]
         runs-on: ["ubuntu-latest", "ubuntu-24.04-arm"]
@@ -643,7 +643,7 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - arch-name: X86_64
@@ -877,7 +877,7 @@ jobs:
       inputs.disable_macos_signing != true &&
       (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:backends'))
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - name: llamacpp
@@ -1145,7 +1145,7 @@ jobs:
       inputs.disable_macos_signing != true &&
       (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:backends'))
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - name: llamacpp
@@ -1285,7 +1285,7 @@ jobs:
       image: fedora:${{ matrix.fedora-version }}
 
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         fedora-version: ["43", "44"]
         runs-on: ["ubuntu-latest", "ubuntu-24.04-arm"]
@@ -1451,7 +1451,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: build-lemonade-embeddable-linux
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - label: Linux
@@ -1874,7 +1874,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: build-lemonade-linux-arm64
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         # llamacpp-system and env-vars omitted: no system llama-server or .deb on
         # GitHub-hosted ARM64 runners; Vulkan tests omitted: no GPU available.

--- a/.github/workflows/linux_distro_builds.yml
+++ b/.github/workflows/linux_distro_builds.yml
@@ -35,7 +35,7 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
 
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - distro: Arch

--- a/.github/workflows/validate_llamacpp.yml
+++ b/.github/workflows/validate_llamacpp.yml
@@ -410,7 +410,7 @@ jobs:
     if: always() && needs.build.result == 'success'
     runs-on: ${{ matrix.runner }}
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - backend: vulkan

--- a/.github/workflows/validate_sdcpp.yml
+++ b/.github/workflows/validate_sdcpp.yml
@@ -267,7 +267,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 420
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix:
         include:
           - label: cpu


### PR DESCRIPTION
Enable matrix fail-fast behavior for merge queue runs while keeping the existing behavior for PRs and scheduled workflows.

If one matrix job already fails in the merge queue, the remaining matrix jobs can be cancelled instead of continuing to consume runner capacity for a merge that can no longer succeed.

This is especially useful for flaky failures where the PR will be re-queued anyway.
