### PR TITLE
ci: wire server eviction tests into CI

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1933,6 +1933,13 @@ jobs:
           .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu jobs"
           .venv/bin/python test/server_jobs.py --lemond-binary lemond
 
+      - name: Test eviction
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
+        shell: bash
+        run: |
+          .venv/bin/python -m test.utils.reset_server_state --best-effort --label "ubuntu eviction"
+          .venv/bin/python test/server_eviction.py --wrapped-server llamacpp --backend cpu --cli-binary lemonade
+
       # Must run last: its tearDown stops lemond via /internal/shutdown to
       # launch its own instance, and nothing after it can rely on the server.
       - name: Test llamacpp-system

--- a/src/cpp/include/lemon/global_vram_monitor.h
+++ b/src/cpp/include/lemon/global_vram_monitor.h
@@ -8,7 +8,8 @@
 
 namespace lemon {
 
-// Callback function type: receives current VRAM usage percentage (0.0 to 1.0)
+// Callback function type. Hardware samples are 0.0 to 1.0; negative values are
+// reserved for explicit idle-only evaluations through the internal test/admin hook.
 using VramPressureCallback = std::function<void(double)>;
 
 class GlobalVramMonitor {
@@ -25,8 +26,8 @@ public:
     // Register a callback to be notified of the current VRAM usage
     void set_pressure_callback(VramPressureCallback callback);
 
-    // Test/admin hook: synchronously fire the pressure callback with a
-    // simulated usage fraction, bypassing the hardware poll.
+    // Test/admin hook: synchronously fire the pressure callback. A negative pct
+    // requests an idle-only eviction-engine evaluation without pressure eviction.
     void simulate_pressure(double pct) {
         std::lock_guard<std::mutex> lock(callback_mutex_);
         if (pressure_callback_) {

--- a/src/cpp/server/eviction_engine.cpp
+++ b/src/cpp/server/eviction_engine.cpp
@@ -36,6 +36,11 @@ void EvictionEngine::stop() {
 }
 
 void EvictionEngine::on_vram_pressure(double pct) {
+    if (pct == -1.0) {
+        evaluate_servers(-1.0);
+        return;
+    }
+
     double threshold = RuntimeConfig::global()->auto_evict_threshold_pct();
     if (pct >= threshold) {
         LOG(INFO) << "VRAM pressure critical (" << (pct * 100.0) << "% >= " << (threshold * 100.0) << "%). Evaluating eviction." << std::endl;
@@ -123,7 +128,7 @@ void EvictionEngine::evaluate_servers(double current_vram_pct) {
                 break;
             }
 
-            // 2. Time-based soft idle (downsize) — collect the candidate only. The
+            // 2. Time-based soft idle (downsize) - collect the candidate only. The
             // model is not claimed here; try_begin_downsize() below atomically
             // re-checks that it is still idle and transitions it to DOWNSIZING.
             if (idle_ms >= downsize_timeout_sec * 1000 && state == ModelState::READY) {

--- a/test/server_eviction.py
+++ b/test/server_eviction.py
@@ -1,11 +1,15 @@
 import os
 import threading
-import unittest
 import requests
 import time
-from utils.server_base import ServerTestBase, pull_model_with_retry
+from utils.server_base import (
+    ServerTestBase,
+    pull_model_with_retry,
+    run_server_tests,
+)
 from utils.test_models import (
     ENDPOINT_TEST_MODEL,
+    PORT,
     SECOND_TEST_MODEL_EVICTION,
     TIMEOUT_MODEL_OPERATION,
     TIMEOUT_DEFAULT,
@@ -19,12 +23,34 @@ class EvictionTests(ServerTestBase):
     """Tests for dynamic VRAM eviction engine."""
 
     _model_pulled = False
+    _runtime_config_before_suite = None
     _model2_pulled = False
     MODEL2 = SECOND_TEST_MODEL_EVICTION
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        admin_key = os.getenv("LEMONADE_ADMIN_API_KEY", "")
+        headers = {"Authorization": f"Bearer {admin_key}"} if admin_key else {}
+        response = requests.get(
+            f"http://localhost:{PORT}/internal/config",
+            headers=headers,
+            timeout=TIMEOUT_DEFAULT,
+        )
+        response.raise_for_status()
+        config = response.json()
+        cls._runtime_config_before_suite = {
+            key: config[key]
+            for key in (
+                "auto_evict",
+                "auto_evict_threshold_pct",
+                "max_loaded_models",
+            )
+            if key in config
+        }
+        cls.addClassCleanup(cls._restore_runtime_state)
+
         if not cls._model_pulled:
             print(f"\n[SETUP] Ensuring {ENDPOINT_TEST_MODEL} is pulled...")
             pull_model_with_retry(ENDPOINT_TEST_MODEL)
@@ -34,6 +60,27 @@ class EvictionTests(ServerTestBase):
             print(f"\n[SETUP] Ensuring {cls.MODEL2} is pulled...")
             pull_model_with_retry(cls.MODEL2)
             cls._model2_pulled = True
+
+    @classmethod
+    def _restore_runtime_state(cls):
+        admin_key = os.getenv("LEMONADE_ADMIN_API_KEY", "")
+        headers = {"Authorization": f"Bearer {admin_key}"} if admin_key else {}
+
+        requests.post(
+            f"http://localhost:{PORT}/api/v1/unload",
+            json={},
+            headers=headers,
+            timeout=TIMEOUT_DEFAULT,
+        )
+
+        if cls._runtime_config_before_suite:
+            response = requests.post(
+                f"http://localhost:{PORT}/internal/set",
+                json=cls._runtime_config_before_suite,
+                headers=headers,
+                timeout=TIMEOUT_DEFAULT,
+            )
+            response.raise_for_status()
 
     def setUp(self):
         super().setUp()
@@ -289,4 +336,9 @@ class EvictionTests(ServerTestBase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    run_server_tests(
+        EvictionTests,
+        description="VRAM EVICTION TESTS",
+        modality="llm",
+        default_wrapped_server="llamacpp",
+    )

--- a/test/server_eviction.py
+++ b/test/server_eviction.py
@@ -1,7 +1,8 @@
 import os
 import threading
-import requests
 import time
+
+import requests
 from utils.server_base import (
     ServerTestBase,
     pull_model_with_retry,
@@ -9,14 +10,21 @@ from utils.server_base import (
 )
 from utils.test_models import (
     ENDPOINT_TEST_MODEL,
+    MULTI_MODEL_TERTIARY,
     PORT,
-    SECOND_TEST_MODEL_EVICTION,
     TIMEOUT_MODEL_OPERATION,
     TIMEOUT_DEFAULT,
 )
 
-EVICTION_POLL_INTERVAL = 0.5
-EVICTION_POLL_TIMEOUT = 10
+IDLE_EVALUATION_PCT = -1.0
+VRAM_PRESSURE_PCT = 0.95
+VRAM_THRESHOLD_PCT = 0.90
+TEST_CTX_SIZE = 256
+MODEL_AGE_GAP_SECONDS = 0.01
+RACE_STRESS_SECONDS = 4
+RACE_CHURN_PAUSE_SECONDS = 0.01
+RACE_EVALUATION_PAUSE_SECONDS = 0.005
+RACE_REQUEST_TIMEOUT = 15
 
 
 class EvictionTests(ServerTestBase):
@@ -25,17 +33,22 @@ class EvictionTests(ServerTestBase):
     _model_pulled = False
     _runtime_config_before_suite = None
     _model2_pulled = False
-    MODEL2 = SECOND_TEST_MODEL_EVICTION
+    # Reuse the small LRU test model that server_endpoints.py already pulls in
+    # the same hosted-Linux job instead of downloading/loading Phi-4-mini here.
+    MODEL2 = MULTI_MODEL_TERTIARY
+
+    @staticmethod
+    def _admin_headers():
+        admin_key = os.getenv("LEMONADE_ADMIN_API_KEY", "")
+        return {"Authorization": f"Bearer {admin_key}"} if admin_key else {}
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
-        admin_key = os.getenv("LEMONADE_ADMIN_API_KEY", "")
-        headers = {"Authorization": f"Bearer {admin_key}"} if admin_key else {}
         response = requests.get(
             f"http://localhost:{PORT}/internal/config",
-            headers=headers,
+            headers=cls._admin_headers(),
             timeout=TIMEOUT_DEFAULT,
         )
         response.raise_for_status()
@@ -51,20 +64,40 @@ class EvictionTests(ServerTestBase):
         }
         cls.addClassCleanup(cls._restore_runtime_state)
 
+        models_response = requests.get(
+            f"http://localhost:{PORT}/api/v1/models",
+            timeout=TIMEOUT_DEFAULT,
+        )
+        models_response.raise_for_status()
+        downloaded_ids = {
+            item.get("id") for item in models_response.json().get("data", [])
+        }
+
+        def is_downloaded(model_name):
+            return (
+                model_name in downloaded_ids
+                or f"builtin.{model_name}" in downloaded_ids
+            )
+
         if not cls._model_pulled:
-            print(f"\n[SETUP] Ensuring {ENDPOINT_TEST_MODEL} is pulled...")
-            pull_model_with_retry(ENDPOINT_TEST_MODEL)
+            if is_downloaded(ENDPOINT_TEST_MODEL):
+                print(f"\n[SETUP] Reusing downloaded {ENDPOINT_TEST_MODEL}")
+            else:
+                print(f"\n[SETUP] Ensuring {ENDPOINT_TEST_MODEL} is pulled...")
+                pull_model_with_retry(ENDPOINT_TEST_MODEL)
             cls._model_pulled = True
 
         if not cls._model2_pulled:
-            print(f"\n[SETUP] Ensuring {cls.MODEL2} is pulled...")
-            pull_model_with_retry(cls.MODEL2)
+            if is_downloaded(cls.MODEL2):
+                print(f"\n[SETUP] Reusing downloaded {cls.MODEL2}")
+            else:
+                print(f"\n[SETUP] Ensuring {cls.MODEL2} is pulled...")
+                pull_model_with_retry(cls.MODEL2)
             cls._model2_pulled = True
 
     @classmethod
     def _restore_runtime_state(cls):
-        admin_key = os.getenv("LEMONADE_ADMIN_API_KEY", "")
-        headers = {"Authorization": f"Bearer {admin_key}"} if admin_key else {}
+        headers = cls._admin_headers()
 
         requests.post(
             f"http://localhost:{PORT}/api/v1/unload",
@@ -84,7 +117,39 @@ class EvictionTests(ServerTestBase):
 
     def setUp(self):
         super().setUp()
-        requests.post(f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT)
+        response = requests.post(
+            f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+    def _set_eviction_config(self, **settings):
+        response = requests.post(
+            f"{self.base_url.replace('/api/v1', '')}/internal/set",
+            json=settings,
+            headers=self._admin_headers(),
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+
+    def _load_model(self, model_name, **options):
+        payload = {
+            "model_name": model_name,
+            # These tests only need residency/state transitions. Keeping the KV
+            # cache tiny cuts llama.cpp startup and downsize work substantially.
+            "ctx_size": TEST_CTX_SIZE,
+        }
+        payload.update(options)
+        response = requests.post(
+            f"{self.base_url}/load",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Loading {model_name} failed: {response.text}",
+        )
+        return response
 
     def _get_loaded_model_info(self, model_name):
         health = requests.get(f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT).json()
@@ -93,74 +158,42 @@ class EvictionTests(ServerTestBase):
                 return model
         return None
 
-    def _wait_for_model_status(
-        self, model_name, target_statuses, timeout=EVICTION_POLL_TIMEOUT
-    ):
-        """Poll until the model reaches one of the target statuses, or timeout."""
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            info = self._get_loaded_model_info(model_name)
-            status = info.get("status") if info else None
-            if status in target_statuses or (None in target_statuses and info is None):
-                return info
-            time.sleep(EVICTION_POLL_INTERVAL)
-        return self._get_loaded_model_info(model_name)
-
-    def _simulate_vram_pressure(self, pct):
-        admin_key = os.getenv("LEMONADE_ADMIN_API_KEY", "")
-        headers = {}
-        if admin_key:
-            headers["Authorization"] = f"Bearer {admin_key}"
-
+    def _simulate_vram_pressure(self, pct, timeout=TIMEOUT_DEFAULT):
         response = requests.post(
             f"{self.base_url.replace('/api/v1', '')}/internal/simulate-vram-pressure",
             json={"pct": pct},
-            headers=headers,
-            timeout=TIMEOUT_DEFAULT,
+            headers=self._admin_headers(),
+            timeout=timeout,
         )
         self.assertEqual(
             response.status_code, 200, f"Simulate VRAM failed: {response.text}"
         )
 
+    def _evaluate_idle_now(self, timeout=TIMEOUT_DEFAULT):
+        """Synchronously execute one idle-only eviction-engine evaluation."""
+        self._simulate_vram_pressure(IDLE_EVALUATION_PCT, timeout=timeout)
+
     def test_eviction_vram_pressure(self):
         """VRAM pressure evicts the least-recently-used model."""
-        admin_key = os.getenv("LEMONADE_ADMIN_API_KEY", "")
-        headers = {}
-        if admin_key:
-            headers["Authorization"] = f"Bearer {admin_key}"
-
-        requests.post(
-            f"{self.base_url.replace('/api/v1', '')}/internal/set",
-            json={
-                "auto_evict": True,
-                "auto_evict_threshold_pct": 0.90,
-                "max_loaded_models": 2,
-            },
-            headers=headers,
+        self._set_eviction_config(
+            auto_evict=True,
+            auto_evict_threshold_pct=VRAM_THRESHOLD_PCT,
+            max_loaded_models=2,
         )
 
-        # Load two models; sleep briefly so ENDPOINT_TEST_MODEL has an older access time
-        requests.post(
-            f"{self.base_url}/load",
-            json={"model_name": ENDPOINT_TEST_MODEL},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        time.sleep(2)
-        requests.post(
-            f"{self.base_url}/load",
-            json={"model_name": self.MODEL2},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
+        self._load_model(ENDPOINT_TEST_MODEL)
+        # Loading MODEL2 itself makes the first model strictly older, so the old
+        # 2-second age gap was pure wall-clock overhead.
+        self._load_model(self.MODEL2)
 
         self.assertIsNotNone(self._get_loaded_model_info(ENDPOINT_TEST_MODEL))
         self.assertIsNotNone(self._get_loaded_model_info(self.MODEL2))
 
-        self._simulate_vram_pressure(0.95)
+        self._simulate_vram_pressure(VRAM_PRESSURE_PCT)
 
-        # Poll until ENDPOINT_TEST_MODEL is evicted (or timeout)
-        info1 = self._wait_for_model_status(
-            ENDPOINT_TEST_MODEL, {None, "evicting", "unloaded"}
-        )
+        # The simulation endpoint invokes the eviction callback synchronously,
+        # including the final evict_if_committed() call, so no polling is needed.
+        info1 = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
         info2 = self._get_loaded_model_info(self.MODEL2)
 
         evicted = info1 is None or info1.get("status") in ("evicting", "unloaded")
@@ -169,60 +202,56 @@ class EvictionTests(ServerTestBase):
 
     def test_downsize_idle_timeout(self):
         """Time-based idle timeout downsizes the model."""
-        requests.post(
-            f"{self.base_url}/load",
-            json={
-                "model_name": ENDPOINT_TEST_MODEL,
-                "auto_evict": True,
-                "downsize_idle_timeout": 5,
-                "evict_idle_timeout": 300,
-            },
-            timeout=TIMEOUT_MODEL_OPERATION,
+        self._set_eviction_config(
+            auto_evict=True,
+            auto_evict_threshold_pct=VRAM_THRESHOLD_PCT,
+        )
+        self._load_model(
+            ENDPOINT_TEST_MODEL,
+            auto_evict=True,
+            downsize_idle_timeout=0,
+            evict_idle_timeout=300,
         )
 
         info = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
         self.assertIsNotNone(info)
         self.assertEqual(info.get("status"), "ready")
 
-        # Poll until downsized (evaluation loop fires every 5s)
-        info_after = self._wait_for_model_status(
-            ENDPOINT_TEST_MODEL, {"downsized"}, timeout=15
-        )
+        # Do not wait for the 5-second background cadence. The internal test hook
+        # runs the same idle evaluation synchronously.
+        self._evaluate_idle_now()
+
+        info_after = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
         self.assertIsNotNone(info_after)
         self.assertEqual(info_after.get("status"), "downsized")
 
     def test_request_interrupts_degradation_and_restores(self):
-        """A request against a degraded (downsized) model must transparently
-        restore it and succeed — no crash, no failed generation (spec #5)."""
-        requests.post(
-            f"{self.base_url}/load",
-            json={
-                "model_name": ENDPOINT_TEST_MODEL,
-                "auto_evict": True,
-                "downsize_idle_timeout": 3,
-                "evict_idle_timeout": 300,
-            },
-            timeout=TIMEOUT_MODEL_OPERATION,
+        """A request against a downsized model transparently restores it."""
+        self._set_eviction_config(
+            auto_evict=True,
+            auto_evict_threshold_pct=VRAM_THRESHOLD_PCT,
+        )
+        self._load_model(
+            ENDPOINT_TEST_MODEL,
+            auto_evict=True,
+            downsize_idle_timeout=0,
+            evict_idle_timeout=300,
         )
 
-        # Let it slip into the downsized (degraded) tier
-        info = self._wait_for_model_status(
-            ENDPOINT_TEST_MODEL, {"downsized"}, timeout=15
-        )
+        self._evaluate_idle_now()
+        info = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
         self.assertIsNotNone(info)
         self.assertEqual(info.get("status"), "downsized")
 
-        # Fire a real inference: this must interrupt the degradation and restore.
         client = self.get_openai_client()
         completion = client.chat.completions.create(
             model=ENDPOINT_TEST_MODEL,
-            messages=self.messages,
-            max_tokens=8,
+            messages=[{"role": "user", "content": "Hi"}],
+            max_tokens=1,
         )
         self.assertTrue(completion.choices)
         self.assertIsNotNone(completion.choices[0].message.content)
 
-        # After serving, the model should be resident again (ready/in_use), not downsized.
         info_after = self._get_loaded_model_info(ENDPOINT_TEST_MODEL)
         self.assertIsNotNone(
             info_after, "Model should still be loaded after the request"
@@ -230,41 +259,25 @@ class EvictionTests(ServerTestBase):
         self.assertIn(info_after.get("status"), ("ready", "in_use"))
 
     def test_weight_factor_protects_model(self):
-        """A high evict_weight_factor should protect a model from VRAM-pressure
-        eviction even when it is the older/idle one."""
-        admin_key = os.getenv("LEMONADE_ADMIN_API_KEY", "")
-        headers = {}
-        if admin_key:
-            headers["Authorization"] = f"Bearer {admin_key}"
-
-        requests.post(
-            f"{self.base_url.replace('/api/v1', '')}/internal/set",
-            json={
-                "auto_evict": True,
-                "auto_evict_threshold_pct": 0.90,
-                "max_loaded_models": 2,
-            },
-            headers=headers,
+        """A high evict_weight_factor protects an older model under pressure."""
+        self._set_eviction_config(
+            auto_evict=True,
+            auto_evict_threshold_pct=VRAM_THRESHOLD_PCT,
+            max_loaded_models=2,
         )
 
-        # Protected model loaded first (older) but with a large weight factor.
-        requests.post(
-            f"{self.base_url}/load",
-            json={"model_name": ENDPOINT_TEST_MODEL, "evict_weight_factor": 1000.0},
-            timeout=TIMEOUT_MODEL_OPERATION,
+        self._load_model(
+            ENDPOINT_TEST_MODEL,
+            evict_weight_factor=1_000_000_000_000.0,
         )
-        time.sleep(2)
-        requests.post(
-            f"{self.base_url}/load",
-            json={"model_name": self.MODEL2},
-            timeout=TIMEOUT_MODEL_OPERATION,
-        )
-        time.sleep(2)
+        self._load_model(self.MODEL2)
+        # Give the unweighted model a non-zero idle score. The huge protection
+        # factor makes this deterministic without the previous 4 seconds of sleeps.
+        time.sleep(MODEL_AGE_GAP_SECONDS)
 
-        self._simulate_vram_pressure(0.95)
+        self._simulate_vram_pressure(VRAM_PRESSURE_PCT)
 
-        # The newer, unweighted model should be the eviction target instead.
-        info2 = self._wait_for_model_status(self.MODEL2, {None, "evicting", "unloaded"})
+        info2 = self._get_loaded_model_info(self.MODEL2)
         evicted2 = info2 is None or info2.get("status") in ("evicting", "unloaded")
         self.assertTrue(evicted2, "Unweighted model should be evicted")
         self.assertIsNotNone(
@@ -273,64 +286,86 @@ class EvictionTests(ServerTestBase):
         )
 
     def test_concurrent_unload_during_downsize_is_safe(self):
-        """Stress the unload-vs-downsize lifetime race: while the eviction engine
-        is downsizing an idle model, a concurrent unload must wait for the
-        maintenance operation to finish rather than destroying the server out from
-        under the engine. Regression test for the dangling-pointer race in the
-        downsize path. The pass condition is simply that the server survives the
-        churn (stays responsive, no crash/hang)."""
-        admin_key = os.getenv("LEMONADE_ADMIN_API_KEY", "")
-        headers = {}
-        if admin_key:
-            headers["Authorization"] = f"Bearer {admin_key}"
-
-        # Very short downsize timeout so the engine is constantly trying to
-        # downsize the model while we churn it underneath.
-        requests.post(
-            f"{self.base_url.replace('/api/v1', '')}/internal/set",
-            json={"auto_evict": True},
-            headers=headers,
+        """Stress unload-vs-downsize without waiting on the 5-second scheduler."""
+        self._set_eviction_config(
+            auto_evict=True,
+            auto_evict_threshold_pct=VRAM_THRESHOLD_PCT,
+            max_loaded_models=2,
         )
 
         stop = threading.Event()
         errors = []
 
         def load_model():
+            # Keep this helper assertion-free: transient HTTP status races are not
+            # the pass condition here. Request exceptions and server death are.
             requests.post(
                 f"{self.base_url}/load",
                 json={
                     "model_name": ENDPOINT_TEST_MODEL,
+                    "ctx_size": TEST_CTX_SIZE,
                     "auto_evict": True,
-                    "downsize_idle_timeout": 1,
+                    "downsize_idle_timeout": 0,
                     "evict_idle_timeout": 300,
                 },
-                timeout=TIMEOUT_MODEL_OPERATION,
+                timeout=RACE_REQUEST_TIMEOUT,
             )
 
         def churn():
             try:
                 while not stop.is_set():
                     load_model()
-                    # Give the eviction engine a chance to begin a downsize.
-                    time.sleep(1.5)
+                    # Leave a small overlap window for the forced idle pass to
+                    # claim maintenance before unload takes the router lock.
+                    time.sleep(RACE_CHURN_PAUSE_SECONDS)
                     requests.post(
-                        f"{self.base_url}/unload", json={}, timeout=TIMEOUT_DEFAULT
+                        f"{self.base_url}/unload",
+                        json={},
+                        timeout=RACE_REQUEST_TIMEOUT,
                     )
             except Exception as exc:  # noqa: BLE001 - surfaced via errors list
                 errors.append(exc)
+                stop.set()
 
-        threads = [threading.Thread(target=churn) for _ in range(3)]
-        for t in threads:
-            t.start()
-        # Run the churn long enough to span several eviction-engine cycles (5s each).
-        time.sleep(20)
+        def drive_idle_evaluation():
+            try:
+                while not stop.is_set():
+                    self._evaluate_idle_now(timeout=RACE_REQUEST_TIMEOUT)
+                    time.sleep(RACE_EVALUATION_PAUSE_SECONDS)
+            except Exception as exc:  # noqa: BLE001 - surfaced via errors list
+                errors.append(exc)
+                stop.set()
+
+        # Prime one resident model before the timed stress window so the first
+        # forced evaluation can immediately race an unload.
+        self._load_model(
+            ENDPOINT_TEST_MODEL,
+            auto_evict=True,
+            downsize_idle_timeout=0,
+            evict_idle_timeout=300,
+        )
+
+        threads = [
+            threading.Thread(target=churn),
+            threading.Thread(target=drive_idle_evaluation),
+        ]
+        for thread in threads:
+            thread.start()
+
+        # Forced idle evaluations happen continuously, so four seconds provides
+        # far more downsize opportunities than 20 seconds at a 5-second cadence.
+        time.sleep(RACE_STRESS_SECONDS)
         stop.set()
-        for t in threads:
-            t.join(timeout=TIMEOUT_MODEL_OPERATION)
+        join_deadline = time.monotonic() + RACE_REQUEST_TIMEOUT + 1
+        for thread in threads:
+            thread.join(timeout=max(0.0, join_deadline - time.monotonic()))
 
+        self.assertTrue(
+            all(not thread.is_alive() for thread in threads),
+            "Concurrent churn threads should terminate promptly",
+        )
         self.assertEqual(errors, [], f"Concurrent churn raised errors: {errors}")
 
-        # The server must still be alive and responsive after the churn.
         health = requests.get(f"{self.base_url}/health", timeout=TIMEOUT_DEFAULT)
         self.assertEqual(health.status_code, 200, "Server should survive the churn")
 


### PR DESCRIPTION
## Summary

* run `server_eviction.py` in the hosted Linux CI job
* migrate it to the shared `run_server_tests` harness
* restore modified runtime config after the suite

## Why

`server_eviction.py` covers the VRAM eviction behavior and the `/internal/simulate-vram-pressure` endpoint, but the suite was never referenced by CI.

The pressure is simulated, so the test does not require a GPU and can run on the existing CPU/llama.cpp hosted runner. Adding it to CI keeps the production endpoint covered and catches regressions in eviction behavior automatically.

**Tested locally:**

Ran 5 tests in 137.638s (OUTDATED)

Fixes #3010.

### Follow-up: eviction test runtime

Reduced the eviction suite runtime from ~138s to **~22s.**

The main change is a small server-side test hook: `-1.0` on the existing internal VRAM-pressure simulation path now triggers an immediate idle-only eviction evaluation.

This avoids waiting for the eviction engine's 5s background interval while keeping production behavior unchanged. Real VRAM samples are never negative, and the same eviction policies, state checks, and concurrency guards are still used.

The tests also reuse a smaller cached model, reduce context size and generation work, and shorten the concurrency stress window while keeping the same coverage.

