### PR TITLE
Allow explicit system llama.cpp backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2779,7 +2779,7 @@ endif()
 set(_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_runtime_config_backend_validation.cpp"
 )
-if(EXISTS "${_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC}")
     add_executable(test_runtime_config_backend_validation
         test/cpp/test_runtime_config_backend_validation.cpp
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2776,6 +2776,19 @@ if(BUILD_TESTING AND EXISTS "${_CONFIG_TELEMETRY_TEST_SRC}")
     add_cpp_ci_test(ConfigTelemetryTest CI OFF COMMAND test_config_telemetry)
 endif()
 
+set(_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_runtime_config_backend_validation.cpp"
+)
+if(EXISTS "${_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC}")
+    add_executable(test_runtime_config_backend_validation
+        test/cpp/test_runtime_config_backend_validation.cpp
+    )
+    target_link_libraries(test_runtime_config_backend_validation PRIVATE lemonade-server-core)
+    add_cpp_ci_test(RuntimeConfigBackendValidationTest CI ON
+        COMMAND test_runtime_config_backend_validation
+    )
+endif()
+
 # ROCm root resolution (ROCM_PATH / rocm-sdk / /opt/rocm priority): covers the
 # external-ROCm detection that lets Lemonade skip the bundled TheRock download.
 set(_ROCM_ROOT_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_rocm_root_resolution.cpp")

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -8,6 +8,9 @@ namespace lemon {
 
 using json = nlohmann::json;
 
+// Lowercase OS identifier used by backend descriptors.
+std::string get_current_os();
+
 // Device information structures
 struct DeviceInfo {
     std::string name;

--- a/src/cpp/server/backend_manager.cpp
+++ b/src/cpp/server/backend_manager.cpp
@@ -25,18 +25,6 @@ namespace lemon {
 
 namespace {
 
-std::string get_current_os() {
-#ifdef _WIN32
-    return "windows";
-#elif defined(__APPLE__)
-    return "macos";
-#elif defined(__linux__)
-    return "linux";
-#else
-    return "unknown";
-#endif
-}
-
 std::string normalize_backend_name(const std::string& recipe, const std::string& backend) {
     if (backends::recipe_has_rocm_channels(recipe) && backend == "rocm") {
         // Map "rocm" to the appropriate channel based on config

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -140,13 +140,7 @@ void RuntimeConfig::validate_backend_choice(const std::string& config_section,
 
     if (value == "system") {
         const auto* desc = lemon::backends::descriptor_for(recipe);
-#ifdef _WIN32
-        const std::string current_os = "windows";
-#elif defined(__APPLE__)
-        const std::string current_os = "macos";
-#else
-        const std::string current_os = "linux";
-#endif
+        const std::string current_os = get_current_os();
         if (desc) {
             auto supported = std::find_if(
                 desc->support.begin(), desc->support.end(),

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -137,6 +137,26 @@ void RuntimeConfig::validate_backend_choice(const std::string& config_section,
     }
 
     std::string recipe = config_section_to_recipe(config_section);
+
+    if (value == "system") {
+        const auto* desc = lemon::backends::descriptor_for(recipe);
+#ifdef _WIN32
+        const std::string current_os = "windows";
+#elif defined(__APPLE__)
+        const std::string current_os = "macos";
+#else
+        const std::string current_os = "linux";
+#endif
+        if (desc) {
+            auto supported = std::find_if(
+                desc->support.begin(), desc->support.end(),
+                [&](const BackendSupport& row) {
+                    return row.backend == value && row.supported_os.count(current_os) > 0;
+                });
+            if (supported != desc->support.end()) return;
+        }
+    }
+
     auto result = SystemInfo::get_supported_backends(recipe);
 
     if (std::find(result.backends.begin(), result.backends.end(), value)

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -591,7 +591,7 @@ struct DetectedDevice {
 };
 
 // Get current OS identifier
-static std::string get_current_os() {
+std::string get_current_os() {
     #ifdef _WIN32
     return "windows";
     #elif defined(__APPLE__)

--- a/test/cpp/test_runtime_config_backend_validation.cpp
+++ b/test/cpp/test_runtime_config_backend_validation.cpp
@@ -1,0 +1,30 @@
+#include <lemon/runtime_config.h>
+
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+using lemon::RuntimeConfig;
+
+int main() {
+    int failures = 0;
+
+    try {
+        RuntimeConfig::validate_backend_choice("llamacpp", "system");
+#ifdef __linux__
+        std::puts("[PASS] llamacpp system backend is accepted on Linux");
+#else
+        std::puts("[FAIL] llamacpp system backend was accepted on an unsupported platform");
+        ++failures;
+#endif
+    } catch (const std::invalid_argument& error) {
+#ifdef __linux__
+        std::printf("[FAIL] llamacpp system backend was rejected on Linux: %s\n", error.what());
+        ++failures;
+#else
+        std::puts("[PASS] llamacpp system backend is rejected on unsupported platforms");
+#endif
+    }
+
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #2536.

Allow `llamacpp_backend=system` when the llama.cpp descriptor declares it for the current platform. Hardware detection can omit a user-managed llama-server, which caused Lemonade to reject it before trying to start it.

Tested on Linux with a system llama-server and `--device CUDA0`. Added a `cpp-ci` regression test for the platform check.
