### PR TITLE
Use the selected GPU for context auto-tuning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2975,6 +2975,7 @@ if(BUILD_TESTING AND EXISTS "${_GPU_MEMORY_SELECTION_TEST_SRC}")
     target_include_directories(test_gpu_memory_selection PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
     )
+    target_link_libraries(test_gpu_memory_selection PRIVATE nlohmann_json::nlohmann_json)
     include(CTest)
     add_cpp_ci_test(GpuMemorySelectionTest CI ON COMMAND test_gpu_memory_selection)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2967,6 +2967,18 @@ if(BUILD_TESTING AND EXISTS "${_AUTO_TUNE_TEST_SRC}")
     add_cpp_ci_test(AutoTuneTest CI OFF COMMAND test_auto_tune)
 endif()
 
+set(_GPU_MEMORY_SELECTION_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_gpu_memory_selection.cpp"
+)
+if(EXISTS "${_GPU_MEMORY_SELECTION_TEST_SRC}")
+    add_executable(test_gpu_memory_selection test/cpp/test_gpu_memory_selection.cpp)
+    target_include_directories(test_gpu_memory_selection PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+    )
+    include(CTest)
+    add_cpp_ci_test(GpuMemorySelectionTest CI ON COMMAND test_gpu_memory_selection)
+endif()
+
 set(_TELEMETRY_HELPERS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_telemetry_helpers.cpp")
 if(BUILD_TESTING AND EXISTS "${_TELEMETRY_HELPERS_TEST_SRC}")
     add_executable(test_telemetry_helpers test/cpp/test_telemetry_helpers.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2896,6 +2896,18 @@ if(BUILD_TESTING AND EXISTS "${_AUTO_TUNE_TEST_SRC}")
     add_cpp_ci_test(AutoTuneTest CI OFF COMMAND test_auto_tune)
 endif()
 
+set(_GPU_MEMORY_SELECTION_TEST_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_gpu_memory_selection.cpp"
+)
+if(EXISTS "${_GPU_MEMORY_SELECTION_TEST_SRC}")
+    add_executable(test_gpu_memory_selection test/cpp/test_gpu_memory_selection.cpp)
+    target_include_directories(test_gpu_memory_selection PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include
+    )
+    include(CTest)
+    add_cpp_ci_test(GpuMemorySelectionTest CI ON COMMAND test_gpu_memory_selection)
+endif()
+
 set(_TELEMETRY_HELPERS_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_telemetry_helpers.cpp")
 if(BUILD_TESTING AND EXISTS "${_TELEMETRY_HELPERS_TEST_SRC}")
     add_executable(test_telemetry_helpers test/cpp/test_telemetry_helpers.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2899,7 +2899,7 @@ endif()
 set(_GPU_MEMORY_SELECTION_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_gpu_memory_selection.cpp"
 )
-if(EXISTS "${_GPU_MEMORY_SELECTION_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_GPU_MEMORY_SELECTION_TEST_SRC}")
     add_executable(test_gpu_memory_selection test/cpp/test_gpu_memory_selection.cpp)
     target_include_directories(test_gpu_memory_selection PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2970,7 +2970,7 @@ endif()
 set(_GPU_MEMORY_SELECTION_TEST_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_gpu_memory_selection.cpp"
 )
-if(EXISTS "${_GPU_MEMORY_SELECTION_TEST_SRC}")
+if(BUILD_TESTING AND EXISTS "${_GPU_MEMORY_SELECTION_TEST_SRC}")
     add_executable(test_gpu_memory_selection test/cpp/test_gpu_memory_selection.cpp)
     target_include_directories(test_gpu_memory_selection PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/include

--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <iomanip>
+#include <optional>
 #include <lemon/gpu_memory_selection.h>
 #include <lemon/model_manager.h>
 #include <lemon/system_info.h>
@@ -101,14 +102,18 @@ inline double get_available_memory_gb(DeviceType device_type,
         auto amd_dgpus = si->get_amd_dgpu_devices();
         auto nvidia_gpus = si->get_nvidia_gpu_devices();
         auto apple_gpu = si->get_apple_silicon_device();
-        const char* cuda_visible_devices = std::getenv("CUDA_VISIBLE_DEVICES");
+        const char* cuda_visible_devices_env = std::getenv("CUDA_VISIBLE_DEVICES");
+        const std::optional<std::string> cuda_visible_devices =
+            cuda_visible_devices_env
+                ? std::optional<std::string>(cuda_visible_devices_env)
+                : std::nullopt;
         auto pool = select_gpu_memory_pool(gpu_vendor,
                                            amd_igpu, amd_dgpus, nvidia_gpus, apple_gpu,
                                            gpu_device,
-                                           cuda_visible_devices ? cuda_visible_devices : "");
+                                           cuda_visible_devices);
         if (pool.total_gb > 0) {
             if (pool.used_gb >= 0.0) used_gb = pool.used_gb;
-            double available = pool.label == "Metal"
+            double available = pool.vendor == GpuMemoryVendor::Metal
                 ? (std::min)(pool.total_gb, (std::max)(0.0, apple_gpu.virtual_gb - used_gb))
                 : (std::max)(0.0, pool.total_gb - used_gb);
             LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (" << pool.label
@@ -290,12 +295,11 @@ inline int64_t resolve_auto_ctx_size(const RecipeOptions& effective_options,
     bool is_embedding = (model_info.type == ModelType::EMBEDDING);
     std::string backend;
     std::string device;
-    if (effective_options.get_recipe() == "llamacpp") {
-        const json backend_json = effective_options.get_option("llamacpp_backend");
-        const json device_json = effective_options.get_option("llamacpp_device");
-        if (backend_json.is_string()) backend = backend_json.get<std::string>();
-        if (device_json.is_string()) device = device_json.get<std::string>();
-    }
+    const std::string recipe = effective_options.get_recipe();
+    const json backend_json = effective_options.get_option(recipe + "_backend");
+    const json device_json = effective_options.get_option(recipe + "_device");
+    if (backend_json.is_string()) backend = backend_json.get<std::string>();
+    if (device_json.is_string()) device = device_json.get<std::string>();
     double available_gb = get_available_memory_gb(
         model_info.device, gpu_memory_vendor_for_target(backend, device), device);
 

--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -288,8 +288,10 @@ inline int64_t resolve_auto_ctx_size(const RecipeOptions& effective_options,
     std::string backend;
     std::string device;
     if (effective_options.get_recipe() == "llamacpp") {
-        backend = effective_options.get_option("llamacpp_backend").get<std::string>();
-        device = effective_options.get_option("llamacpp_device").get<std::string>();
+        const json backend_json = effective_options.get_option("llamacpp_backend");
+        const json device_json = effective_options.get_option("llamacpp_device");
+        if (backend_json.is_string()) backend = backend_json.get<std::string>();
+        if (device_json.is_string()) device = device_json.get<std::string>();
     }
     double available_gb = get_available_memory_gb(
         model_info.device, gpu_memory_vendor_for_target(backend, device), device);

--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -87,7 +87,8 @@ static double get_used_memory_gb(DeviceType device_type) {
 /// CPU  → system RAM minus currently-used RAM
 /// NPU  → system RAM minus currently-used RAM
 inline double get_available_memory_gb(DeviceType device_type,
-                                      GpuMemoryVendor gpu_vendor = GpuMemoryVendor::Any) {
+                                      GpuMemoryVendor gpu_vendor = GpuMemoryVendor::Any,
+                                      const std::string& gpu_device = "") {
     auto si = create_system_info();
 
     // Subtract currently-used memory
@@ -100,8 +101,10 @@ inline double get_available_memory_gb(DeviceType device_type,
         auto nvidia_gpus = si->get_nvidia_gpu_devices();
         auto apple_gpu = si->get_apple_silicon_device();
         auto pool = select_gpu_memory_pool(gpu_vendor,
-                                           amd_igpu, amd_dgpus, nvidia_gpus, apple_gpu);
+                                           amd_igpu, amd_dgpus, nvidia_gpus, apple_gpu,
+                                           gpu_device);
         if (pool.total_gb > 0) {
+            if (pool.used_gb >= 0.0) used_gb = pool.used_gb;
             double available = pool.label == "Metal"
                 ? (std::min)(pool.total_gb, (std::max)(0.0, apple_gpu.virtual_gb - used_gb))
                 : (std::max)(0.0, pool.total_gb - used_gb);
@@ -289,7 +292,7 @@ inline int64_t resolve_auto_ctx_size(const RecipeOptions& effective_options,
         device = effective_options.get_option("llamacpp_device").get<std::string>();
     }
     double available_gb = get_available_memory_gb(
-        model_info.device, gpu_memory_vendor_for_target(backend, device));
+        model_info.device, gpu_memory_vendor_for_target(backend, device), device);
 
     if (available_gb <= 0) {
         int64_t fallback = is_embedding ? EMBEDDING_CTX_SIZE : AUTO_CTX_FALLBACK;

--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <iomanip>
 #include <lemon/gpu_memory_selection.h>
 #include <lemon/model_manager.h>
@@ -100,9 +101,11 @@ inline double get_available_memory_gb(DeviceType device_type,
         auto amd_dgpus = si->get_amd_dgpu_devices();
         auto nvidia_gpus = si->get_nvidia_gpu_devices();
         auto apple_gpu = si->get_apple_silicon_device();
+        const char* cuda_visible_devices = std::getenv("CUDA_VISIBLE_DEVICES");
         auto pool = select_gpu_memory_pool(gpu_vendor,
                                            amd_igpu, amd_dgpus, nvidia_gpus, apple_gpu,
-                                           gpu_device);
+                                           gpu_device,
+                                           cuda_visible_devices ? cuda_visible_devices : "");
         if (pool.total_gb > 0) {
             if (pool.used_gb >= 0.0) used_gb = pool.used_gb;
             double available = pool.label == "Metal"

--- a/src/cpp/include/lemon/auto_tune.h
+++ b/src/cpp/include/lemon/auto_tune.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstdint>
 #include <iomanip>
+#include <lemon/gpu_memory_selection.h>
 #include <lemon/model_manager.h>
 #include <lemon/system_info.h>
 #include <lemon/system_metrics_platform.h>
@@ -85,7 +86,8 @@ static double get_used_memory_gb(DeviceType device_type) {
 /// GPU  → VRAM (+ GTT for iGPU) minus currently-used VRAM
 /// CPU  → system RAM minus currently-used RAM
 /// NPU  → system RAM minus currently-used RAM
-inline double get_available_memory_gb(DeviceType device_type) {
+inline double get_available_memory_gb(DeviceType device_type,
+                                      GpuMemoryVendor gpu_vendor = GpuMemoryVendor::Any) {
     auto si = create_system_info();
 
     // Subtract currently-used memory
@@ -93,62 +95,28 @@ inline double get_available_memory_gb(DeviceType device_type) {
 
     // GPU recipes: use VRAM
     if (device_type & DEVICE_GPU) {
-        // AMD iGPU (APU — uses dedicated VRAM + GTT from system RAM)
         auto amd_igpu = si->get_amd_igpu_device();
-        if (amd_igpu.available && amd_igpu.vram_gb > 0) {
-            // iGPU total = dedicated VRAM + GTT (system memory pool accessible by GPU)
-            double total_gb = amd_igpu.vram_gb + amd_igpu.virtual_gb;
-            double available = (std::max)(0.0, total_gb - used_gb);
-            LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (AMD iGPU) total="
-                                   << std::fixed << std::setprecision(2) << total_gb
-                                   << " GB (vram=" << amd_igpu.vram_gb
-                                   << " + gtt=" << amd_igpu.virtual_gb << "), used=" << used_gb
-                                   << " GB → " << available << " GB available"  << " ";
-            return available;
-        }
-
-        // AMD dGPU
         auto amd_dgpus = si->get_amd_dgpu_devices();
-        for (const auto& gpu : amd_dgpus) {
-            if (gpu.available && gpu.vram_gb > 0) {
-                double available = (std::max)(0.0, gpu.vram_gb - used_gb);
-                LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (AMD dGPU) total="
-                                       << std::fixed << std::setprecision(2) << gpu.vram_gb
-                                       << " GB, used=" << used_gb
-                                       << " GB → " << available << " GB available"  << " ";
-                return available;
-            }
-        }
-
-        // NVIDIA
         auto nvidia_gpus = si->get_nvidia_gpu_devices();
-        for (const auto& gpu : nvidia_gpus) {
-            if (gpu.available && gpu.vram_gb > 0) {
-                double available = (std::max)(0.0, gpu.vram_gb - used_gb);
-                LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (NVIDIA) total="
-                                       << std::fixed << std::setprecision(2) << gpu.vram_gb
-                                       << " GB, used=" << used_gb
-                                       << " GB → " << available << " GB available"  << " ";
-                return available;
-            }
-        }
-
-        // Metal (macOS — Apple Silicon unified memory). CPU and GPU share one pool:
-        //   vram_gb    = Metal's recommended GPU working-set budget (a soft ceiling)
-        //   virtual_gb = total unified RAM
-        // Available to the GPU = the free unified RAM (total − used), capped at the
-        // working-set budget so we don't push the system into swap.
-        auto apple = si->get_apple_silicon_device();
-        if (apple.available && apple.vram_gb > 0) {
-            double free_unified = (std::max)(0.0, apple.virtual_gb - used_gb);
-            double available = (std::min)(apple.vram_gb, free_unified);
-            LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (Metal) budget="
-                                   << std::fixed << std::setprecision(2) << apple.vram_gb
-                                   << " GB, unified=" << apple.virtual_gb
-                                   << " GB, used=" << used_gb
-                                   << " GB → " << available << " GB available"  << " ";
+        auto apple_gpu = si->get_apple_silicon_device();
+        auto pool = select_gpu_memory_pool(gpu_vendor,
+                                           amd_igpu, amd_dgpus, nvidia_gpus, apple_gpu);
+        if (pool.total_gb > 0) {
+            double available = pool.label == "Metal"
+                ? (std::min)(pool.total_gb, (std::max)(0.0, apple_gpu.virtual_gb - used_gb))
+                : (std::max)(0.0, pool.total_gb - used_gb);
+            LOG(DEBUG, "AutoTune") << "get_available_memory_gb: GPU (" << pool.label
+                                   << ") total=" << std::fixed << std::setprecision(2)
+                                   << pool.total_gb << " GB, used=" << used_gb
+                                   << " GB → " << available << " GB available" << " ";
             return available;
         }
+
+        if (gpu_vendor != GpuMemoryVendor::Any) {
+            LOG(DEBUG, "AutoTune") << "get_available_memory_gb: selected GPU vendor unavailable";
+            return 0.0;
+        }
+
     }
 
     // CPU / NPU: use system RAM
@@ -314,7 +282,14 @@ inline int64_t resolve_auto_ctx_size(const RecipeOptions& effective_options,
     }
 
     bool is_embedding = (model_info.type == ModelType::EMBEDDING);
-    double available_gb = get_available_memory_gb(model_info.device);
+    std::string backend;
+    std::string device;
+    if (effective_options.get_recipe() == "llamacpp") {
+        backend = effective_options.get_option("llamacpp_backend").get<std::string>();
+        device = effective_options.get_option("llamacpp_device").get<std::string>();
+    }
+    double available_gb = get_available_memory_gb(
+        model_info.device, gpu_memory_vendor_for_target(backend, device));
 
     if (available_gb <= 0) {
         int64_t fallback = is_embedding ? EMBEDDING_CTX_SIZE : AUTO_CTX_FALLBACK;

--- a/src/cpp/include/lemon/gpu_memory_selection.h
+++ b/src/cpp/include/lemon/gpu_memory_selection.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -16,6 +17,7 @@ struct GpuMemoryPool {
     double total_gb = 0.0;
     double used_gb = -1.0;
     std::string label;
+    GpuMemoryVendor vendor = GpuMemoryVendor::Any;
 };
 
 struct GpuTargetIndices {
@@ -86,8 +88,10 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
                                              const std::vector<GPUInfo>& nvidia_gpus,
                                              const GPUInfo& apple,
                                              const std::string& device = "",
-                                             const std::string& cuda_visible_devices = "") {
-    auto pool_for = [](const GPUInfo& gpu, const std::string& label, bool unified = false) {
+                                             const std::optional<std::string>& cuda_visible_devices =
+                                                 std::nullopt) {
+    auto pool_for = [](const GPUInfo& gpu, const std::string& label,
+                       GpuMemoryVendor vendor, bool unified = false) {
         double used_gb = gpu.vram_used_gb;
         if (unified) {
             used_gb = gpu.vram_used_gb >= 0.0 && gpu.virtual_used_gb >= 0.0
@@ -95,16 +99,18 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
                 : -1.0;
         }
         return GpuMemoryPool{gpu.vram_gb + (unified ? gpu.virtual_gb : 0.0),
-                             used_gb,
-                             label};
+                             used_gb, label, vendor};
     };
     auto most_constrained = [](const std::vector<GpuMemoryPool>& pools) {
         GpuMemoryPool result;
         for (const auto& pool : pools) {
             if (pool.total_gb <= 0) continue;
-            const double available = pool.total_gb - (std::max)(0.0, pool.used_gb);
-            const double result_available =
-                result.total_gb - (std::max)(0.0, result.used_gb);
+            const double available = pool.used_gb < 0.0
+                ? 0.0
+                : pool.total_gb - pool.used_gb;
+            const double result_available = result.used_gb < 0.0
+                ? 0.0
+                : result.total_gb - result.used_gb;
             if (result.total_gb <= 0 || available < result_available)
                 result = pool;
         }
@@ -126,28 +132,30 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
                 if (index >= static_cast<int>(devices.size())) continue;
                 const auto& gpu = *devices[index];
                 pools.push_back(pool_for(gpu, "AMD ROCm" + std::to_string(index),
+                                         GpuMemoryVendor::Amd,
                                          &gpu == &amd_igpu));
             }
             return most_constrained(pools);
         }
         if (amd_igpu.available && amd_igpu.vram_gb > 0) {
-            return pool_for(amd_igpu, "AMD iGPU", true);
+            return pool_for(amd_igpu, "AMD iGPU", GpuMemoryVendor::Amd, true);
         }
         for (const auto& gpu : amd_dgpus) {
-            if (gpu.available && gpu.vram_gb > 0) return pool_for(gpu, "AMD dGPU");
+            if (gpu.available && gpu.vram_gb > 0)
+                return pool_for(gpu, "AMD dGPU", GpuMemoryVendor::Amd);
         }
         return {};
     };
-    auto select_nvidia = [&]() -> GpuMemoryPool {
+    auto select_nvidia = [&](bool apply_visibility) -> GpuMemoryPool {
         auto target = gpu_indices_for_target(device, "CUDA");
         if (target.targets_vendor && !target.valid) return {};
         std::vector<const GPUInfo*> visible_gpus;
-        if (cuda_visible_devices.empty()) {
+        if (!apply_visibility || !cuda_visible_devices.has_value()) {
             for (const auto& gpu : nvidia_gpus) {
                 if (gpu.available && gpu.vram_gb > 0) visible_gpus.push_back(&gpu);
             }
         } else {
-            std::istringstream stream(cuda_visible_devices);
+            std::istringstream stream(*cuda_visible_devices);
             std::string token;
             while (std::getline(stream, token, ',')) {
                 const GPUInfo* match = nullptr;
@@ -189,25 +197,28 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
             for (int index : target.indices) {
                 if (index >= static_cast<int>(visible_gpus.size())) continue;
                 pools.push_back(pool_for(*visible_gpus[index],
-                                         "NVIDIA CUDA" + std::to_string(index)));
+                                         "NVIDIA CUDA" + std::to_string(index),
+                                         GpuMemoryVendor::Nvidia));
             }
             return most_constrained(pools);
         }
-        if (!visible_gpus.empty()) return pool_for(*visible_gpus.front(), "NVIDIA");
+        if (!visible_gpus.empty())
+            return pool_for(*visible_gpus.front(), "NVIDIA", GpuMemoryVendor::Nvidia);
         return {};
     };
     auto select_metal = [&]() -> GpuMemoryPool {
-        if (apple.available && apple.vram_gb > 0) return pool_for(apple, "Metal");
+        if (apple.available && apple.vram_gb > 0)
+            return pool_for(apple, "Metal", GpuMemoryVendor::Metal);
         return {};
     };
 
     if (vendor == GpuMemoryVendor::Amd) return select_amd();
-    if (vendor == GpuMemoryVendor::Nvidia) return select_nvidia();
+    if (vendor == GpuMemoryVendor::Nvidia) return select_nvidia(true);
     if (vendor == GpuMemoryVendor::Metal) return select_metal();
 
     auto pool = select_amd();
     if (pool.total_gb > 0) return pool;
-    pool = select_nvidia();
+    pool = select_nvidia(false);
     if (pool.total_gb > 0) return pool;
     return select_metal();
 }

--- a/src/cpp/include/lemon/gpu_memory_selection.h
+++ b/src/cpp/include/lemon/gpu_memory_selection.h
@@ -3,6 +3,7 @@
 #include <lemon/system_info.h>
 
 #include <algorithm>
+#include <cctype>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -17,30 +18,65 @@ struct GpuMemoryPool {
     std::string label;
 };
 
-inline std::vector<int> gpu_indices_for_target(const std::string& device,
-                                                const std::string& prefix) {
+struct GpuTargetIndices {
+    bool targets_vendor = false;
+    bool valid = true;
     std::vector<int> indices;
-    std::istringstream stream(device);
+};
+
+inline std::string gpu_memory_ascii_lower(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+inline GpuTargetIndices gpu_indices_for_target(const std::string& device,
+                                                const std::string& prefix) {
+    GpuTargetIndices result;
+    const std::string lower_device = gpu_memory_ascii_lower(device);
+    const std::string lower_prefix = gpu_memory_ascii_lower(prefix);
+    if (lower_device.rfind(lower_prefix, 0) != 0) return result;
+
+    result.targets_vendor = true;
+    if (lower_device == lower_prefix) return result;
+
+    std::istringstream stream(lower_device);
     std::string token;
     while (std::getline(stream, token, ',')) {
-        if (token.rfind(prefix, 0) != 0 || token.size() == prefix.size()) return {};
+        if (token.rfind(lower_prefix, 0) != 0 || token.size() == lower_prefix.size()) {
+            result.valid = false;
+            result.indices.clear();
+            return result;
+        }
         try {
             size_t consumed = 0;
-            int index = std::stoi(token.substr(prefix.size()), &consumed);
-            if (consumed != token.size() - prefix.size() || index < 0) return {};
-            indices.push_back(index);
+            int index = std::stoi(token.substr(lower_prefix.size()), &consumed);
+            if (consumed != token.size() - lower_prefix.size() || index < 0) {
+                result.valid = false;
+                result.indices.clear();
+                return result;
+            }
+            result.indices.push_back(index);
         } catch (...) {
-            return {};
+            result.valid = false;
+            result.indices.clear();
+            return result;
         }
     }
-    return indices;
+    return result;
 }
 
 inline GpuMemoryVendor gpu_memory_vendor_for_target(const std::string& backend,
                                                      const std::string& device) {
-    if (backend == "cuda" || device.rfind("CUDA", 0) == 0) return GpuMemoryVendor::Nvidia;
-    if (backend.rfind("rocm", 0) == 0 || device.rfind("ROCm", 0) == 0) return GpuMemoryVendor::Amd;
-    if (backend == "metal" || device.rfind("Metal", 0) == 0) return GpuMemoryVendor::Metal;
+    const std::string lower_backend = gpu_memory_ascii_lower(backend);
+    const std::string lower_device = gpu_memory_ascii_lower(device);
+    if (lower_backend == "cuda" || lower_device.rfind("cuda", 0) == 0)
+        return GpuMemoryVendor::Nvidia;
+    if (lower_backend.rfind("rocm", 0) == 0 || lower_device.rfind("rocm", 0) == 0)
+        return GpuMemoryVendor::Amd;
+    if (lower_backend == "metal" || lower_device.rfind("metal", 0) == 0)
+        return GpuMemoryVendor::Metal;
     return GpuMemoryVendor::Any;
 }
 
@@ -49,7 +85,8 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
                                              const std::vector<GPUInfo>& amd_dgpus,
                                              const std::vector<GPUInfo>& nvidia_gpus,
                                              const GPUInfo& apple,
-                                             const std::string& device = "") {
+                                             const std::string& device = "",
+                                             const std::string& cuda_visible_devices = "") {
     auto pool_for = [](const GPUInfo& gpu, const std::string& label, bool unified = false) {
         double used_gb = gpu.vram_used_gb;
         if (unified) {
@@ -78,11 +115,14 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
         if (amd_igpu.available && amd_igpu.vram_gb > 0) devices.push_back(&amd_igpu);
         for (const auto& gpu : amd_dgpus)
             if (gpu.available && gpu.vram_gb > 0) devices.push_back(&gpu);
-        auto indices = gpu_indices_for_target(device, "ROCm");
-        if (device.rfind("ROCm", 0) == 0 && indices.empty()) return {};
-        if (!indices.empty()) {
+        auto target = gpu_indices_for_target(device, "ROCm");
+        if (target.targets_vendor && !target.valid) return {};
+        if (!target.indices.empty()) {
             std::vector<GpuMemoryPool> pools;
-            for (int index : indices) {
+            // llama.cpp numbers ROCm devices by HSA-agent order. SystemInfo currently
+            // exposes the iGPU followed by dGPUs, which is the order used here until it
+            // carries a runtime ordinal for each AMD device.
+            for (int index : target.indices) {
                 if (index >= static_cast<int>(devices.size())) continue;
                 const auto& gpu = *devices[index];
                 pools.push_back(pool_for(gpu, "AMD ROCm" + std::to_string(index),
@@ -99,23 +139,61 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
         return {};
     };
     auto select_nvidia = [&]() -> GpuMemoryPool {
-        auto indices = gpu_indices_for_target(device, "CUDA");
-        if (device.rfind("CUDA", 0) == 0 && indices.empty()) return {};
-        if (!indices.empty()) {
-            std::vector<GpuMemoryPool> pools;
-            for (int index : indices) {
-                for (size_t position = 0; position < nvidia_gpus.size(); ++position) {
-                    const auto& gpu = nvidia_gpus[position];
-                    if (!gpu.available || gpu.vram_gb <= 0) continue;
-                    if ((gpu.index >= 0 ? gpu.index : static_cast<int>(position)) == index)
-                        pools.push_back(pool_for(gpu, "NVIDIA CUDA" + std::to_string(index)));
+        auto target = gpu_indices_for_target(device, "CUDA");
+        if (target.targets_vendor && !target.valid) return {};
+        std::vector<const GPUInfo*> visible_gpus;
+        if (cuda_visible_devices.empty()) {
+            for (const auto& gpu : nvidia_gpus) {
+                if (gpu.available && gpu.vram_gb > 0) visible_gpus.push_back(&gpu);
+            }
+        } else {
+            std::istringstream stream(cuda_visible_devices);
+            std::string token;
+            while (std::getline(stream, token, ',')) {
+                const GPUInfo* match = nullptr;
+                try {
+                    size_t consumed = 0;
+                    int physical_index = std::stoi(token, &consumed);
+                    if (consumed == token.size() && physical_index >= 0) {
+                        for (const auto& gpu : nvidia_gpus) {
+                            if (gpu.available && gpu.vram_gb > 0 &&
+                                gpu.index == physical_index) {
+                                match = &gpu;
+                                break;
+                            }
+                        }
+                    }
+                } catch (...) {
                 }
+                if (!match && token.rfind("GPU-", 0) == 0) {
+                    for (const auto& gpu : nvidia_gpus) {
+                        if (gpu.available && gpu.vram_gb > 0 &&
+                            gpu.uuid.rfind(token, 0) == 0) {
+                            if (match) {
+                                match = nullptr;  // Ambiguous UUID prefix.
+                                break;
+                            }
+                            match = &gpu;
+                        }
+                    }
+                }
+                // CUDA stops exposing devices at the first invalid entry (for example,
+                // CUDA_VISIBLE_DEVICES=2,-1,3 exposes only physical GPU 2).
+                if (!match) break;
+                visible_gpus.push_back(match);
+            }
+        }
+
+        if (!target.indices.empty()) {
+            std::vector<GpuMemoryPool> pools;
+            for (int index : target.indices) {
+                if (index >= static_cast<int>(visible_gpus.size())) continue;
+                pools.push_back(pool_for(*visible_gpus[index],
+                                         "NVIDIA CUDA" + std::to_string(index)));
             }
             return most_constrained(pools);
         }
-        for (const auto& gpu : nvidia_gpus) {
-            if (gpu.available && gpu.vram_gb > 0) return pool_for(gpu, "NVIDIA");
-        }
+        if (!visible_gpus.empty()) return pool_for(*visible_gpus.front(), "NVIDIA");
         return {};
     };
     auto select_metal = [&]() -> GpuMemoryPool {

--- a/src/cpp/include/lemon/gpu_memory_selection.h
+++ b/src/cpp/include/lemon/gpu_memory_selection.h
@@ -23,12 +23,15 @@ inline std::vector<int> gpu_indices_for_target(const std::string& device,
     std::istringstream stream(device);
     std::string token;
     while (std::getline(stream, token, ',')) {
-        if (token.rfind(prefix, 0) != 0 || token.size() == prefix.size()) continue;
+        if (token.rfind(prefix, 0) != 0 || token.size() == prefix.size()) return {};
         try {
             size_t consumed = 0;
             int index = std::stoi(token.substr(prefix.size()), &consumed);
-            if (consumed == token.size() - prefix.size() && index >= 0) indices.push_back(index);
-        } catch (...) {}
+            if (consumed != token.size() - prefix.size() || index < 0) return {};
+            indices.push_back(index);
+        } catch (...) {
+            return {};
+        }
     }
     return indices;
 }
@@ -49,8 +52,10 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
                                              const std::string& device = "") {
     auto pool_for = [](const GPUInfo& gpu, const std::string& label, bool unified = false) {
         double used_gb = gpu.vram_used_gb;
-        if (unified && gpu.virtual_used_gb >= 0.0) {
-            used_gb = (std::max)(0.0, used_gb) + gpu.virtual_used_gb;
+        if (unified) {
+            used_gb = gpu.vram_used_gb >= 0.0 && gpu.virtual_used_gb >= 0.0
+                ? gpu.vram_used_gb + gpu.virtual_used_gb
+                : -1.0;
         }
         return GpuMemoryPool{gpu.vram_gb + (unified ? gpu.virtual_gb : 0.0),
                              used_gb,
@@ -74,6 +79,7 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
         for (const auto& gpu : amd_dgpus)
             if (gpu.available && gpu.vram_gb > 0) devices.push_back(&gpu);
         auto indices = gpu_indices_for_target(device, "ROCm");
+        if (device.rfind("ROCm", 0) == 0 && indices.empty()) return {};
         if (!indices.empty()) {
             std::vector<GpuMemoryPool> pools;
             for (int index : indices) {
@@ -94,6 +100,7 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
     };
     auto select_nvidia = [&]() -> GpuMemoryPool {
         auto indices = gpu_indices_for_target(device, "CUDA");
+        if (device.rfind("CUDA", 0) == 0 && indices.empty()) return {};
         if (!indices.empty()) {
             std::vector<GpuMemoryPool> pools;
             for (int index : indices) {

--- a/src/cpp/include/lemon/gpu_memory_selection.h
+++ b/src/cpp/include/lemon/gpu_memory_selection.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <lemon/system_info.h>
+
+#include <string>
+#include <vector>
+
+namespace lemon {
+
+enum class GpuMemoryVendor { Any, Amd, Nvidia, Metal };
+
+struct GpuMemoryPool {
+    double total_gb = 0.0;
+    std::string label;
+};
+
+inline GpuMemoryVendor gpu_memory_vendor_for_target(const std::string& backend,
+                                                     const std::string& device) {
+    if (backend == "cuda" || device.rfind("CUDA", 0) == 0) return GpuMemoryVendor::Nvidia;
+    if (backend.rfind("rocm", 0) == 0 || device.rfind("ROCm", 0) == 0) return GpuMemoryVendor::Amd;
+    if (backend == "metal" || device.rfind("Metal", 0) == 0) return GpuMemoryVendor::Metal;
+    return GpuMemoryVendor::Any;
+}
+
+inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
+                                             const GPUInfo& amd_igpu,
+                                             const std::vector<GPUInfo>& amd_dgpus,
+                                             const std::vector<GPUInfo>& nvidia_gpus,
+                                             const GPUInfo& apple) {
+    auto select_amd = [&]() -> GpuMemoryPool {
+        if (amd_igpu.available && amd_igpu.vram_gb > 0) {
+            return {amd_igpu.vram_gb + amd_igpu.virtual_gb, "AMD iGPU"};
+        }
+        for (const auto& gpu : amd_dgpus) {
+            if (gpu.available && gpu.vram_gb > 0) return {gpu.vram_gb, "AMD dGPU"};
+        }
+        return {};
+    };
+    auto select_nvidia = [&]() -> GpuMemoryPool {
+        for (const auto& gpu : nvidia_gpus) {
+            if (gpu.available && gpu.vram_gb > 0) return {gpu.vram_gb, "NVIDIA"};
+        }
+        return {};
+    };
+    auto select_metal = [&]() -> GpuMemoryPool {
+        if (apple.available && apple.vram_gb > 0) return {apple.vram_gb, "Metal"};
+        return {};
+    };
+
+    if (vendor == GpuMemoryVendor::Amd) return select_amd();
+    if (vendor == GpuMemoryVendor::Nvidia) return select_nvidia();
+    if (vendor == GpuMemoryVendor::Metal) return select_metal();
+
+    auto pool = select_amd();
+    if (pool.total_gb > 0) return pool;
+    pool = select_nvidia();
+    if (pool.total_gb > 0) return pool;
+    return select_metal();
+}
+
+} // namespace lemon

--- a/src/cpp/include/lemon/gpu_memory_selection.h
+++ b/src/cpp/include/lemon/gpu_memory_selection.h
@@ -2,6 +2,8 @@
 
 #include <lemon/system_info.h>
 
+#include <algorithm>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -11,8 +13,25 @@ enum class GpuMemoryVendor { Any, Amd, Nvidia, Metal };
 
 struct GpuMemoryPool {
     double total_gb = 0.0;
+    double used_gb = -1.0;
     std::string label;
 };
+
+inline std::vector<int> gpu_indices_for_target(const std::string& device,
+                                                const std::string& prefix) {
+    std::vector<int> indices;
+    std::istringstream stream(device);
+    std::string token;
+    while (std::getline(stream, token, ',')) {
+        if (token.rfind(prefix, 0) != 0 || token.size() == prefix.size()) continue;
+        try {
+            size_t consumed = 0;
+            int index = std::stoi(token.substr(prefix.size()), &consumed);
+            if (consumed == token.size() - prefix.size() && index >= 0) indices.push_back(index);
+        } catch (...) {}
+    }
+    return indices;
+}
 
 inline GpuMemoryVendor gpu_memory_vendor_for_target(const std::string& backend,
                                                      const std::string& device) {
@@ -26,24 +45,74 @@ inline GpuMemoryPool select_gpu_memory_pool(GpuMemoryVendor vendor,
                                              const GPUInfo& amd_igpu,
                                              const std::vector<GPUInfo>& amd_dgpus,
                                              const std::vector<GPUInfo>& nvidia_gpus,
-                                             const GPUInfo& apple) {
+                                             const GPUInfo& apple,
+                                             const std::string& device = "") {
+    auto pool_for = [](const GPUInfo& gpu, const std::string& label, bool unified = false) {
+        double used_gb = gpu.vram_used_gb;
+        if (unified && gpu.virtual_used_gb >= 0.0) {
+            used_gb = (std::max)(0.0, used_gb) + gpu.virtual_used_gb;
+        }
+        return GpuMemoryPool{gpu.vram_gb + (unified ? gpu.virtual_gb : 0.0),
+                             used_gb,
+                             label};
+    };
+    auto most_constrained = [](const std::vector<GpuMemoryPool>& pools) {
+        GpuMemoryPool result;
+        for (const auto& pool : pools) {
+            if (pool.total_gb <= 0) continue;
+            const double available = pool.total_gb - (std::max)(0.0, pool.used_gb);
+            const double result_available =
+                result.total_gb - (std::max)(0.0, result.used_gb);
+            if (result.total_gb <= 0 || available < result_available)
+                result = pool;
+        }
+        return result;
+    };
     auto select_amd = [&]() -> GpuMemoryPool {
+        std::vector<const GPUInfo*> devices;
+        if (amd_igpu.available && amd_igpu.vram_gb > 0) devices.push_back(&amd_igpu);
+        for (const auto& gpu : amd_dgpus)
+            if (gpu.available && gpu.vram_gb > 0) devices.push_back(&gpu);
+        auto indices = gpu_indices_for_target(device, "ROCm");
+        if (!indices.empty()) {
+            std::vector<GpuMemoryPool> pools;
+            for (int index : indices) {
+                if (index >= static_cast<int>(devices.size())) continue;
+                const auto& gpu = *devices[index];
+                pools.push_back(pool_for(gpu, "AMD ROCm" + std::to_string(index),
+                                         &gpu == &amd_igpu));
+            }
+            return most_constrained(pools);
+        }
         if (amd_igpu.available && amd_igpu.vram_gb > 0) {
-            return {amd_igpu.vram_gb + amd_igpu.virtual_gb, "AMD iGPU"};
+            return pool_for(amd_igpu, "AMD iGPU", true);
         }
         for (const auto& gpu : amd_dgpus) {
-            if (gpu.available && gpu.vram_gb > 0) return {gpu.vram_gb, "AMD dGPU"};
+            if (gpu.available && gpu.vram_gb > 0) return pool_for(gpu, "AMD dGPU");
         }
         return {};
     };
     auto select_nvidia = [&]() -> GpuMemoryPool {
+        auto indices = gpu_indices_for_target(device, "CUDA");
+        if (!indices.empty()) {
+            std::vector<GpuMemoryPool> pools;
+            for (int index : indices) {
+                for (size_t position = 0; position < nvidia_gpus.size(); ++position) {
+                    const auto& gpu = nvidia_gpus[position];
+                    if (!gpu.available || gpu.vram_gb <= 0) continue;
+                    if ((gpu.index >= 0 ? gpu.index : static_cast<int>(position)) == index)
+                        pools.push_back(pool_for(gpu, "NVIDIA CUDA" + std::to_string(index)));
+                }
+            }
+            return most_constrained(pools);
+        }
         for (const auto& gpu : nvidia_gpus) {
-            if (gpu.available && gpu.vram_gb > 0) return {gpu.vram_gb, "NVIDIA"};
+            if (gpu.available && gpu.vram_gb > 0) return pool_for(gpu, "NVIDIA");
         }
         return {};
     };
     auto select_metal = [&]() -> GpuMemoryPool {
-        if (apple.available && apple.vram_gb > 0) return {apple.vram_gb, "Metal"};
+        if (apple.available && apple.vram_gb > 0) return pool_for(apple, "Metal");
         return {};
     };
 

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -26,12 +26,14 @@ struct CPUInfo : DeviceInfo {
 };
 
 struct GPUInfo : DeviceInfo {
-    int index = -1;  // NVIDIA only: physical device index from nvidia-smi, when available
+    int index = -1;  // Physical device index, when available
     std::string uuid;  // NVIDIA only: stable GPU UUID from nvidia-smi (preferred for CUDA_VISIBLE_DEVICES)
     std::string driver_version;
     std::string compute_capability;  // NVIDIA only: "MAJOR.MINOR" from nvidia-smi (e.g. "8.6")
     double vram_gb = 0.0;
+    double vram_used_gb = -1.0;  // -1 when per-device usage is unavailable
     double virtual_gb = 0.0;
+    double virtual_used_gb = -1.0;
 };
 
 struct NPUInfo : DeviceInfo {

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -242,7 +242,8 @@ private:
     bool get_amd_is_igpu(const std::string& drm_render_minor);
 
 private:
-    double parse_memory_sysfs(const std::string& drm_render_minor, const std::string& fname);
+    double parse_memory_sysfs(const std::string& drm_render_minor, const std::string& fname,
+                              bool* success = nullptr);
 };
 
 // macOS implementation

--- a/src/cpp/include/lemon/system_info.h
+++ b/src/cpp/include/lemon/system_info.h
@@ -25,12 +25,14 @@ struct CPUInfo : DeviceInfo {
 };
 
 struct GPUInfo : DeviceInfo {
-    int index = -1;  // NVIDIA only: physical device index from nvidia-smi, when available
+    int index = -1;  // Physical device index, when available
     std::string uuid;  // NVIDIA only: stable GPU UUID from nvidia-smi (preferred for CUDA_VISIBLE_DEVICES)
     std::string driver_version;
     std::string compute_capability;  // NVIDIA only: "MAJOR.MINOR" from nvidia-smi (e.g. "8.6")
     double vram_gb = 0.0;
+    double vram_used_gb = -1.0;  // -1 when per-device usage is unavailable
     double virtual_gb = 0.0;
+    double virtual_used_gb = -1.0;
 };
 
 struct NPUInfo : DeviceInfo {

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -2376,11 +2376,12 @@ struct NvidiaSmiGpuInfo {
     std::string compute_cap;   // e.g. "8.6"
     std::string driver_version;
     double vram_gb = 0.0;
+    double vram_used_gb = 0.0;
 };
 
 // Query nvidia-smi for all GPUs. Returns one entry per GPU or an empty vector
 // if nvidia-smi is not available (e.g. drivers not installed).
-// Uses: nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total
+// Uses: nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total,memory.used
 //                  --format=csv,noheader,nounits
 static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
     std::vector<NvidiaSmiGpuInfo> result;
@@ -2388,13 +2389,13 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
 
 #ifdef _WIN32
     int rc = lemon::utils::ProcessManager::run_command(
-        "nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total "
+        "nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total,memory.used "
         "--format=csv,noheader,nounits 2>NUL",
         output, 10);
     if (rc != 0 || output.empty()) return result;
 #else
     static const char* smi_query =
-        " --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total"
+        " --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total,memory.used"
         " --format=csv,noheader,nounits 2>/dev/null";
     for (const char* smi : {"nvidia-smi", "/usr/bin/nvidia-smi"}) {
         std::string cmd = std::string(smi) + smi_query;
@@ -2424,17 +2425,17 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
         line = trim(line);
         if (line.empty()) continue;
 
-        // Fields: index, uuid, name, compute_cap, driver_version, memory_mb.
+        // Fields: index, uuid, name, compute_cap, driver_version, total_mb, used_mb.
         // Split the right side first so names with commas are handled.
         std::string remaining = line;
         std::vector<std::string> tail;
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < 4; i++) {
             size_t pos = remaining.rfind(", ");
             if (pos == std::string::npos) break;
             tail.insert(tail.begin(), trim(remaining.substr(pos + 2)));
             remaining = remaining.substr(0, pos);
         }
-        if (tail.size() != 3) continue;
+        if (tail.size() != 4) continue;
 
         NvidiaSmiGpuInfo info;
         size_t first_comma = remaining.find(", ");
@@ -2466,6 +2467,10 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
         try {
             double mem_mb = std::stod(tail[2]);
             info.vram_gb = mem_mb / 1024.0;
+        } catch (...) {}
+        try {
+            double used_mb = std::stod(tail[3]);
+            info.vram_used_gb = used_mb / 1024.0;
         } catch (...) {}
         result.push_back(info);
     }
@@ -2564,8 +2569,10 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_nvml() {
 
             if (nvmlGetMem) {
                 NvmlMemory mem{};
-                if (nvmlGetMem(dev, &mem) == NVML_SUCCESS)
+                if (nvmlGetMem(dev, &mem) == NVML_SUCCESS) {
                     info.vram_gb = static_cast<double>(mem.total) / (1024.0 * 1024.0 * 1024.0);
+                    info.vram_used_gb = static_cast<double>(mem.used) / (1024.0 * 1024.0 * 1024.0);
+                }
             }
 
             result.push_back(info);
@@ -2673,6 +2680,7 @@ std::vector<GPUInfo> WindowsSystemInfo::get_nvidia_gpu_devices() {
             gpu.compute_capability = smi.compute_cap;
             gpu.driver_version     = smi.driver_version;
             gpu.vram_gb            = smi.vram_gb;
+            gpu.vram_used_gb       = smi.vram_used_gb;
             gpus.push_back(gpu);
         }
         return gpus;
@@ -3153,6 +3161,7 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
             gpu.compute_capability = smi.compute_cap;
             gpu.driver_version     = smi.driver_version;
             gpu.vram_gb            = smi.vram_gb;
+            gpu.vram_used_gb       = smi.vram_used_gb;
             gpus.push_back(gpu);
         }
         return gpus;
@@ -3177,6 +3186,7 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
                     ? get_nvidia_driver_version() : nvml.driver_version;
                 if (gpu.driver_version.empty()) gpu.driver_version = "Unknown";
                 gpu.vram_gb            = nvml.vram_gb;
+                gpu.vram_used_gb       = nvml.vram_used_gb;
                 gpus.push_back(gpu);
             }
             return gpus;
@@ -3493,7 +3503,9 @@ std::vector<GPUInfo> LinuxSystemInfo::detect_amd_gpus(const std::string& gpu_typ
 
         // Get VRAM and GTT for GPUs
         gpu.vram_gb = get_amd_vram(drm_render_minor);
+        gpu.vram_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_vram_used");
         gpu.virtual_gb = get_amd_gtt(drm_render_minor);
+        gpu.virtual_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_gtt_used");
 
         gpus.push_back(gpu);
     }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -3504,14 +3504,14 @@ std::vector<GPUInfo> LinuxSystemInfo::detect_amd_gpus(const std::string& gpu_typ
         // Get VRAM and GTT for GPUs
         gpu.vram_gb = get_amd_vram(drm_render_minor);
         gpu.virtual_gb = get_amd_gtt(drm_render_minor);
-        const fs::path memory_path =
-            fs::path("/sys/class/drm/renderD" + drm_render_minor) / "device";
-        if (fs::exists(memory_path / "mem_info_vram_used")) {
-            gpu.vram_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_vram_used");
-        }
-        if (fs::exists(memory_path / "mem_info_gtt_used")) {
-            gpu.virtual_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_gtt_used");
-        }
+        bool read_used = false;
+        const double vram_used_gb =
+            parse_memory_sysfs(drm_render_minor, "mem_info_vram_used", &read_used);
+        if (read_used) gpu.vram_used_gb = vram_used_gb;
+
+        const double virtual_used_gb =
+            parse_memory_sysfs(drm_render_minor, "mem_info_gtt_used", &read_used);
+        if (read_used) gpu.virtual_used_gb = virtual_used_gb;
 
         gpus.push_back(gpu);
     }
@@ -3635,7 +3635,11 @@ bool LinuxSystemInfo::get_amd_is_igpu(const std::string& drm_render_minor) {
     return !(fs::exists(board_info_path) && fs::is_regular_file(board_info_path));
 }
 
-double LinuxSystemInfo::parse_memory_sysfs(const std::string& drm_render_minor, const std::string& fname){
+double LinuxSystemInfo::parse_memory_sysfs(const std::string& drm_render_minor,
+                                           const std::string& fname,
+                                           bool* success) {
+    if (success) *success = false;
+
     // Try device-specific path first
     std::string sysfs_path = "/sys/class/drm/renderD" + drm_render_minor + "/device/" + fname;
 
@@ -3649,6 +3653,7 @@ double LinuxSystemInfo::parse_memory_sysfs(const std::string& drm_render_minor, 
 
     try {
         uint64_t memory_bytes = std::stoull(memory_str);
+        if (success) *success = true;
         return std::round(memory_bytes / (1024.0 * 1024.0 * 1024.0) * 10.0) / 10.0;
     } catch (...) {
         return 0.0;

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -2376,7 +2376,7 @@ struct NvidiaSmiGpuInfo {
     std::string compute_cap;   // e.g. "8.6"
     std::string driver_version;
     double vram_gb = 0.0;
-    double vram_used_gb = 0.0;
+    double vram_used_gb = -1.0;
 };
 
 // Query nvidia-smi for all GPUs. Returns one entry per GPU or an empty vector
@@ -2425,8 +2425,8 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
         line = trim(line);
         if (line.empty()) continue;
 
-        // Fields: index, uuid, name, compute_cap, driver_version, total_mb, used_mb.
-        // Split the right side first so names with commas are handled.
+        // The four fields after name cannot contain commas, while GPU names can.
+        // Splitting those fields from the right preserves names containing commas.
         std::string remaining = line;
         std::vector<std::string> tail;
         for (int i = 0; i < 4; i++) {
@@ -3503,9 +3503,15 @@ std::vector<GPUInfo> LinuxSystemInfo::detect_amd_gpus(const std::string& gpu_typ
 
         // Get VRAM and GTT for GPUs
         gpu.vram_gb = get_amd_vram(drm_render_minor);
-        gpu.vram_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_vram_used");
         gpu.virtual_gb = get_amd_gtt(drm_render_minor);
-        gpu.virtual_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_gtt_used");
+        const fs::path memory_path =
+            fs::path("/sys/class/drm/renderD" + drm_render_minor) / "device";
+        if (fs::exists(memory_path / "mem_info_vram_used")) {
+            gpu.vram_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_vram_used");
+        }
+        if (fs::exists(memory_path / "mem_info_gtt_used")) {
+            gpu.virtual_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_gtt_used");
+        }
 
         gpus.push_back(gpu);
     }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -2384,11 +2384,12 @@ struct NvidiaSmiGpuInfo {
     std::string compute_cap;   // e.g. "8.6"
     std::string driver_version;
     double vram_gb = 0.0;
+    double vram_used_gb = 0.0;
 };
 
 // Query nvidia-smi for all GPUs. Returns one entry per GPU or an empty vector
 // if nvidia-smi is not available (e.g. drivers not installed).
-// Uses: nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total
+// Uses: nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total,memory.used
 //                  --format=csv,noheader,nounits
 static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
     std::vector<NvidiaSmiGpuInfo> result;
@@ -2396,13 +2397,13 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
 
 #ifdef _WIN32
     int rc = lemon::utils::ProcessManager::run_command(
-        "nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total "
+        "nvidia-smi --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total,memory.used "
         "--format=csv,noheader,nounits 2>NUL",
         output, 10);
     if (rc != 0 || output.empty()) return result;
 #else
     static const char* smi_query =
-        " --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total"
+        " --query-gpu=index,uuid,name,compute_cap,driver_version,memory.total,memory.used"
         " --format=csv,noheader,nounits 2>/dev/null";
     for (const char* smi : {"nvidia-smi", "/usr/bin/nvidia-smi"}) {
         std::string cmd = std::string(smi) + smi_query;
@@ -2432,17 +2433,17 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
         line = trim(line);
         if (line.empty()) continue;
 
-        // Fields: index, uuid, name, compute_cap, driver_version, memory_mb.
+        // Fields: index, uuid, name, compute_cap, driver_version, total_mb, used_mb.
         // Split the right side first so names with commas are handled.
         std::string remaining = line;
         std::vector<std::string> tail;
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < 4; i++) {
             size_t pos = remaining.rfind(", ");
             if (pos == std::string::npos) break;
             tail.insert(tail.begin(), trim(remaining.substr(pos + 2)));
             remaining = remaining.substr(0, pos);
         }
-        if (tail.size() != 3) continue;
+        if (tail.size() != 4) continue;
 
         NvidiaSmiGpuInfo info;
         size_t first_comma = remaining.find(", ");
@@ -2474,6 +2475,10 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
         try {
             double mem_mb = std::stod(tail[2]);
             info.vram_gb = mem_mb / 1024.0;
+        } catch (...) {}
+        try {
+            double used_mb = std::stod(tail[3]);
+            info.vram_used_gb = used_mb / 1024.0;
         } catch (...) {}
         result.push_back(info);
     }
@@ -2572,8 +2577,10 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_nvml() {
 
             if (nvmlGetMem) {
                 NvmlMemory mem{};
-                if (nvmlGetMem(dev, &mem) == NVML_SUCCESS)
+                if (nvmlGetMem(dev, &mem) == NVML_SUCCESS) {
                     info.vram_gb = static_cast<double>(mem.total) / (1024.0 * 1024.0 * 1024.0);
+                    info.vram_used_gb = static_cast<double>(mem.used) / (1024.0 * 1024.0 * 1024.0);
+                }
             }
 
             result.push_back(info);
@@ -2681,6 +2688,7 @@ std::vector<GPUInfo> WindowsSystemInfo::get_nvidia_gpu_devices() {
             gpu.compute_capability = smi.compute_cap;
             gpu.driver_version     = smi.driver_version;
             gpu.vram_gb            = smi.vram_gb;
+            gpu.vram_used_gb       = smi.vram_used_gb;
             gpus.push_back(gpu);
         }
         return gpus;
@@ -3161,6 +3169,7 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
             gpu.compute_capability = smi.compute_cap;
             gpu.driver_version     = smi.driver_version;
             gpu.vram_gb            = smi.vram_gb;
+            gpu.vram_used_gb       = smi.vram_used_gb;
             gpus.push_back(gpu);
         }
         return gpus;
@@ -3185,6 +3194,7 @@ std::vector<GPUInfo> LinuxSystemInfo::get_nvidia_gpu_devices() {
                     ? get_nvidia_driver_version() : nvml.driver_version;
                 if (gpu.driver_version.empty()) gpu.driver_version = "Unknown";
                 gpu.vram_gb            = nvml.vram_gb;
+                gpu.vram_used_gb       = nvml.vram_used_gb;
                 gpus.push_back(gpu);
             }
             return gpus;
@@ -3501,7 +3511,9 @@ std::vector<GPUInfo> LinuxSystemInfo::detect_amd_gpus(const std::string& gpu_typ
 
         // Get VRAM and GTT for GPUs
         gpu.vram_gb = get_amd_vram(drm_render_minor);
+        gpu.vram_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_vram_used");
         gpu.virtual_gb = get_amd_gtt(drm_render_minor);
+        gpu.virtual_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_gtt_used");
 
         gpus.push_back(gpu);
     }

--- a/src/cpp/server/system_info.cpp
+++ b/src/cpp/server/system_info.cpp
@@ -2384,7 +2384,7 @@ struct NvidiaSmiGpuInfo {
     std::string compute_cap;   // e.g. "8.6"
     std::string driver_version;
     double vram_gb = 0.0;
-    double vram_used_gb = 0.0;
+    double vram_used_gb = -1.0;
 };
 
 // Query nvidia-smi for all GPUs. Returns one entry per GPU or an empty vector
@@ -2433,8 +2433,8 @@ static std::vector<NvidiaSmiGpuInfo> query_nvidia_smi() {
         line = trim(line);
         if (line.empty()) continue;
 
-        // Fields: index, uuid, name, compute_cap, driver_version, total_mb, used_mb.
-        // Split the right side first so names with commas are handled.
+        // The four fields after name cannot contain commas, while GPU names can.
+        // Splitting those fields from the right preserves names containing commas.
         std::string remaining = line;
         std::vector<std::string> tail;
         for (int i = 0; i < 4; i++) {
@@ -3511,9 +3511,15 @@ std::vector<GPUInfo> LinuxSystemInfo::detect_amd_gpus(const std::string& gpu_typ
 
         // Get VRAM and GTT for GPUs
         gpu.vram_gb = get_amd_vram(drm_render_minor);
-        gpu.vram_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_vram_used");
         gpu.virtual_gb = get_amd_gtt(drm_render_minor);
-        gpu.virtual_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_gtt_used");
+        const fs::path memory_path =
+            fs::path("/sys/class/drm/renderD" + drm_render_minor) / "device";
+        if (fs::exists(memory_path / "mem_info_vram_used")) {
+            gpu.vram_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_vram_used");
+        }
+        if (fs::exists(memory_path / "mem_info_gtt_used")) {
+            gpu.virtual_used_gb = parse_memory_sysfs(drm_render_minor, "mem_info_gtt_used");
+        }
 
         gpus.push_back(gpu);
     }

--- a/test/cpp/test_gpu_memory_selection.cpp
+++ b/test/cpp/test_gpu_memory_selection.cpp
@@ -113,6 +113,18 @@ int main() {
     check(hidden_cuda.total_gb == 0.0,
           "CUDA_VISIBLE_DEVICES=-1 leaves no NVIDIA memory pool");
 
+    auto explicitly_empty_cuda = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("cuda", ""), unavailable, amd,
+        filtered_nvidia, unavailable, "", std::string{});
+    check(explicitly_empty_cuda.total_gb == 0.0,
+          "empty CUDA_VISIBLE_DEVICES leaves no NVIDIA memory pool");
+
+    auto generic_ignores_cuda_visibility = select_gpu_memory_pool(
+        GpuMemoryVendor::Any, unavailable, {}, filtered_nvidia, unavailable,
+        "", std::string{});
+    check(generic_ignores_cuda_visibility.total_gb == 8.0,
+          "generic GPU selection ignores CUDA visibility filtering");
+
     auto bare_rocm = select_gpu_memory_pool(
         gpu_memory_vendor_for_target("system", "ROCm"), amd_igpu, two_amd, nvidia,
         unavailable, "ROCm");
@@ -130,6 +142,20 @@ int main() {
         GpuMemoryVendor::Amd, amd_igpu_unknown_usage, two_amd, nvidia, unavailable);
     check(unknown_usage.used_gb < 0.0,
           "incomplete unified-memory usage remains unknown");
+
+    std::vector<GPUInfo> mixed_usage_nvidia{
+        gpu(24.0, -1.0, 0), gpu(8.0, 1.0, 1)};
+    auto unknown_constrained = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("cuda", "CUDA0,CUDA1"), unavailable, amd,
+        mixed_usage_nvidia, unavailable, "CUDA0,CUDA1");
+    check(unknown_constrained.label == "NVIDIA CUDA0" && unknown_constrained.used_gb < 0.0,
+          "unknown usage is the most constrained selected GPU");
+
+    GPUInfo apple = gpu(16.0, 2.0);
+    auto metal = select_gpu_memory_pool(
+        GpuMemoryVendor::Metal, unavailable, amd, nvidia, apple);
+    check(metal.vendor == GpuMemoryVendor::Metal,
+          "Metal pool carries typed vendor identity");
 
     auto automatic = select_gpu_memory_pool(
         GpuMemoryVendor::Any, unavailable, amd, nvidia, unavailable);

--- a/test/cpp/test_gpu_memory_selection.cpp
+++ b/test/cpp/test_gpu_memory_selection.cpp
@@ -1,0 +1,42 @@
+#include <lemon/gpu_memory_selection.h>
+
+#include <cstdio>
+
+using namespace lemon;
+
+static GPUInfo gpu(double vram_gb) {
+    GPUInfo info;
+    info.available = true;
+    info.vram_gb = vram_gb;
+    return info;
+}
+
+int main() {
+    int failures = 0;
+    auto check = [&](bool condition, const char* name) {
+        std::printf("[%s] %s\n", condition ? "PASS" : "FAIL", name);
+        if (!condition) ++failures;
+    };
+
+    GPUInfo unavailable;
+    std::vector<GPUInfo> amd{gpu(4.0)};
+    std::vector<GPUInfo> nvidia{gpu(11.0)};
+
+    auto cuda = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("cuda", ""), unavailable, amd, nvidia, unavailable);
+    check(cuda.total_gb == 11.0 && cuda.label == "NVIDIA", "CUDA selects NVIDIA memory");
+
+    auto rocm = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("rocm-stable", ""), unavailable, amd, nvidia, unavailable);
+    check(rocm.total_gb == 4.0 && rocm.label == "AMD dGPU", "ROCm selects AMD memory");
+
+    auto system_cuda = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA0"), unavailable, amd, nvidia, unavailable);
+    check(system_cuda.total_gb == 11.0, "explicit CUDA device selects NVIDIA memory");
+
+    auto automatic = select_gpu_memory_pool(
+        GpuMemoryVendor::Any, unavailable, amd, nvidia, unavailable);
+    check(automatic.total_gb == 4.0, "ambiguous target preserves fallback order");
+
+    return failures == 0 ? 0 : 1;
+}

--- a/test/cpp/test_gpu_memory_selection.cpp
+++ b/test/cpp/test_gpu_memory_selection.cpp
@@ -67,6 +67,25 @@ int main() {
         unavailable, "CUDA2");
     check(missing_cuda.total_gb == 0.0, "unknown explicit CUDA device does not use another GPU");
 
+    auto malformed_cuda = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA0+1"), unavailable, amd, two_nvidia,
+        unavailable, "CUDA0+1");
+    check(malformed_cuda.total_gb == 0.0,
+          "malformed CUDA device does not silently select another GPU");
+
+    auto partly_malformed_cuda = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA0,CUDA1+2"), unavailable, amd,
+        two_nvidia, unavailable, "CUDA0,CUDA1+2");
+    check(partly_malformed_cuda.total_gb == 0.0,
+          "malformed CUDA device list is not partially accepted");
+
+    GPUInfo amd_igpu_unknown_usage = gpu(2.0, 0.5);
+    amd_igpu_unknown_usage.virtual_gb = 6.0;
+    auto unknown_usage = select_gpu_memory_pool(
+        GpuMemoryVendor::Amd, amd_igpu_unknown_usage, two_amd, nvidia, unavailable);
+    check(unknown_usage.used_gb < 0.0,
+          "incomplete unified-memory usage remains unknown");
+
     auto automatic = select_gpu_memory_pool(
         GpuMemoryVendor::Any, unavailable, amd, nvidia, unavailable);
     check(automatic.total_gb == 4.0, "ambiguous target preserves fallback order");

--- a/test/cpp/test_gpu_memory_selection.cpp
+++ b/test/cpp/test_gpu_memory_selection.cpp
@@ -4,10 +4,12 @@
 
 using namespace lemon;
 
-static GPUInfo gpu(double vram_gb) {
+static GPUInfo gpu(double vram_gb, double used_gb = 0.0, int index = -1) {
     GPUInfo info;
     info.available = true;
     info.vram_gb = vram_gb;
+    info.vram_used_gb = used_gb;
+    info.index = index;
     return info;
 }
 
@@ -19,20 +21,51 @@ int main() {
     };
 
     GPUInfo unavailable;
-    std::vector<GPUInfo> amd{gpu(4.0)};
-    std::vector<GPUInfo> nvidia{gpu(11.0)};
+    std::vector<GPUInfo> amd{gpu(4.0, 1.0)};
+    std::vector<GPUInfo> nvidia{gpu(11.0, 2.0, 0)};
 
     auto cuda = select_gpu_memory_pool(
         gpu_memory_vendor_for_target("cuda", ""), unavailable, amd, nvidia, unavailable);
-    check(cuda.total_gb == 11.0 && cuda.label == "NVIDIA", "CUDA selects NVIDIA memory");
+    check(cuda.total_gb == 11.0 && cuda.used_gb == 2.0 && cuda.label == "NVIDIA",
+          "CUDA selects NVIDIA total and used memory");
 
     auto rocm = select_gpu_memory_pool(
         gpu_memory_vendor_for_target("rocm-stable", ""), unavailable, amd, nvidia, unavailable);
-    check(rocm.total_gb == 4.0 && rocm.label == "AMD dGPU", "ROCm selects AMD memory");
+    check(rocm.total_gb == 4.0 && rocm.used_gb == 1.0 && rocm.label == "AMD dGPU",
+          "ROCm selects AMD total and used memory");
 
     auto system_cuda = select_gpu_memory_pool(
-        gpu_memory_vendor_for_target("system", "CUDA0"), unavailable, amd, nvidia, unavailable);
+        gpu_memory_vendor_for_target("system", "CUDA0"), unavailable, amd, nvidia, unavailable,
+        "CUDA0");
     check(system_cuda.total_gb == 11.0, "explicit CUDA device selects NVIDIA memory");
+
+    std::vector<GPUInfo> two_nvidia{gpu(8.0, 1.0, 0), gpu(24.0, 4.0, 1)};
+    auto cuda1 = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA1"), unavailable, amd, two_nvidia,
+        unavailable, "CUDA1");
+    check(cuda1.total_gb == 24.0 && cuda1.used_gb == 4.0 && cuda1.label == "NVIDIA CUDA1",
+          "CUDA1 selects NVIDIA device 1");
+
+    GPUInfo amd_igpu = gpu(2.0, 0.5);
+    amd_igpu.virtual_gb = 6.0;
+    amd_igpu.virtual_used_gb = 1.5;
+    std::vector<GPUInfo> two_amd{gpu(16.0, 3.0)};
+    auto rocm1 = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "ROCm1"), amd_igpu, two_amd, nvidia,
+        unavailable, "ROCm1");
+    check(rocm1.total_gb == 16.0 && rocm1.used_gb == 3.0 && rocm1.label == "AMD ROCm1",
+          "ROCm1 selects AMD device 1");
+
+    auto cuda_list = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA0,CUDA1"), unavailable, amd, two_nvidia,
+        unavailable, "CUDA0,CUDA1");
+    check(cuda_list.label == "NVIDIA CUDA0" && cuda_list.total_gb - cuda_list.used_gb == 7.0,
+          "CUDA device list uses the most constrained selected GPU");
+
+    auto missing_cuda = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA2"), unavailable, amd, two_nvidia,
+        unavailable, "CUDA2");
+    check(missing_cuda.total_gb == 0.0, "unknown explicit CUDA device does not use another GPU");
 
     auto automatic = select_gpu_memory_pool(
         GpuMemoryVendor::Any, unavailable, amd, nvidia, unavailable);

--- a/test/cpp/test_gpu_memory_selection.cpp
+++ b/test/cpp/test_gpu_memory_selection.cpp
@@ -4,12 +4,14 @@
 
 using namespace lemon;
 
-static GPUInfo gpu(double vram_gb, double used_gb = 0.0, int index = -1) {
+static GPUInfo gpu(double vram_gb, double used_gb = 0.0, int index = -1,
+                   const std::string& uuid = "") {
     GPUInfo info;
     info.available = true;
     info.vram_gb = vram_gb;
     info.vram_used_gb = used_gb;
     info.index = index;
+    info.uuid = uuid;
     return info;
 }
 
@@ -46,6 +48,21 @@ int main() {
     check(cuda1.total_gb == 24.0 && cuda1.used_gb == 4.0 && cuda1.label == "NVIDIA CUDA1",
           "CUDA1 selects NVIDIA device 1");
 
+    std::vector<GPUInfo> filtered_nvidia{
+        gpu(8.0, 1.0, 0, "GPU-aaaa"), gpu(12.0, 2.0, 1, "GPU-bbbb"),
+        gpu(16.0, 3.0, 2, "GPU-cccc"), gpu(24.0, 4.0, 3, "GPU-dddd")};
+    auto filtered_cuda1 = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA1"), unavailable, amd,
+        filtered_nvidia, unavailable, "CUDA1", "2,3");
+    check(filtered_cuda1.total_gb == 24.0 && filtered_cuda1.used_gb == 4.0,
+          "CUDA1 follows CUDA_VISIBLE_DEVICES ordinal mapping");
+
+    auto uuid_filtered_cuda0 = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA0"), unavailable, amd,
+        filtered_nvidia, unavailable, "CUDA0", "GPU-dddd,GPU-cccc");
+    check(uuid_filtered_cuda0.total_gb == 24.0 && uuid_filtered_cuda0.used_gb == 4.0,
+          "CUDA0 follows UUID CUDA_VISIBLE_DEVICES ordering");
+
     GPUInfo amd_igpu = gpu(2.0, 0.5);
     amd_igpu.virtual_gb = 6.0;
     amd_igpu.virtual_used_gb = 1.5;
@@ -78,6 +95,34 @@ int main() {
         two_nvidia, unavailable, "CUDA0,CUDA1+2");
     check(partly_malformed_cuda.total_gb == 0.0,
           "malformed CUDA device list is not partially accepted");
+
+    auto bare_cuda = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA"), unavailable, amd, two_nvidia,
+        unavailable, "CUDA");
+    check(bare_cuda.total_gb == 8.0, "bare CUDA selects the first NVIDIA pool");
+
+    auto filtered_bare_cuda = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA"), unavailable, amd,
+        filtered_nvidia, unavailable, "CUDA", "2,3");
+    check(filtered_bare_cuda.total_gb == 16.0,
+          "bare CUDA selects the first visible NVIDIA pool");
+
+    auto hidden_cuda = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "CUDA0"), unavailable, amd,
+        filtered_nvidia, unavailable, "CUDA0", "-1");
+    check(hidden_cuda.total_gb == 0.0,
+          "CUDA_VISIBLE_DEVICES=-1 leaves no NVIDIA memory pool");
+
+    auto bare_rocm = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("system", "ROCm"), amd_igpu, two_amd, nvidia,
+        unavailable, "ROCm");
+    check(bare_rocm.total_gb == 8.0, "bare ROCm selects the first AMD pool");
+
+    auto lowercase_cuda = select_gpu_memory_pool(
+        gpu_memory_vendor_for_target("SYSTEM", "cuda1"), unavailable, amd, two_nvidia,
+        unavailable, "cuda1");
+    check(lowercase_cuda.total_gb == 24.0,
+          "CUDA vendor and device matching is case-insensitive");
 
     GPUInfo amd_igpu_unknown_usage = gpu(2.0, 0.5);
     amd_igpu_unknown_usage.virtual_gb = 6.0;


### PR DESCRIPTION
Fixes #3017.

Use the llama.cpp backend or explicit device to choose the GPU memory pool for context auto-tuning. Previously, mixed AMD/NVIDIA systems could use the AMD GPU's memory when running the CUDA backend.

Added tests for CUDA, ROCm, explicit CUDA device selection, and the existing fallback order. Verified on an AMD/NVIDIA Linux host: CUDA auto-tuning now uses the RTX 2080 Ti and resolves the test model's context to 40,960 instead of 34,068.
