### PR TITLE
ci: run watchdog lifecycle tests in backend CI

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1397,6 +1397,78 @@ jobs:
         if: always()
         uses: ./.github/actions/cleanup-processes-linux
 
+  test-watchdog-lifecycle-linux:
+    name: Test watchdog lifecycle (ubuntu-latest)
+    runs-on: ubuntu-latest
+    needs: build-lemonade-deb
+    if: >-
+      !startsWith(github.ref, 'refs/tags/') &&
+      inputs.enable_signing != true &&
+      inputs.disable_macos_signing != true &&
+      (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:backends'))
+    timeout-minutes: 15
+    container:
+      image: ghcr.io/lemonade-sdk/lemonade/build-environment:ubuntu24.04
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    env:
+      LEMONADE_CI_MODE: "True"
+      HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
+      HF_HOME: ${{ github.workspace }}/hf-cache
+      PYTHONIOENCODING: utf-8
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      LEMONADE_VERSION: ${{ needs.build-lemonade-deb.outputs.version }}
+      # Must be present before install-lemonade-deb starts lemond.
+      LEMONADE_BACKEND_WATCHDOG_POLL_SECONDS: "1"
+      # Test-side health / reap assertions do not need 500ms polling.
+      LEMONADE_TEST_WATCHDOG_ASSERT_POLL_SECONDS: "0.1"
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory $(pwd)
+
+      - name: Install pip and test dependencies
+        shell: bash
+        run: |
+          set -e
+          if ! command -v pip3 &> /dev/null; then
+            apt-get update
+            apt-get install -y python3-pip python3-venv
+          fi
+          python3 -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r test/requirements.txt
+
+      - name: Prepare HF cache
+        shell: bash
+        run: |
+          set -e
+          mkdir -p "$HF_HOME"
+          echo "HF_HOME=$HF_HOME"
+
+      - name: Install Lemonade (.deb)
+        uses: ./.github/actions/install-lemonade-deb
+        with:
+          version: ${{ env.LEMONADE_VERSION }}
+          port: auto
+
+      - name: Test watchdog lifecycle
+        shell: bash
+        run: |
+          set -e
+          .venv/bin/python test/server_watchdog_lifecycle.py \
+            --wrapped-server llamacpp \
+            --backend cpu \
+            --cli-binary lemonade
+
+      - name: Capture and upload server logs
+        if: always()
+        uses: ./.github/actions/capture-server-logs
+        with:
+          artifact-name: server-logs-watchdog-lifecycle
+
   test-rpm-package:
     name: Test .rpm - Fedora ${{ matrix.fedora-version }}${{ matrix.job-suffix }}
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:distros')
@@ -1502,7 +1574,7 @@ jobs:
   # so renaming the job requires a matching branch-protection update.
   backends-gate:
     name: Inference backend tests
-    needs: [build-lemonade-server-installer, build-lemonade-deb, cpp-unit-tests, test-exe-inference, test-deb-inference]
+    needs: [build-lemonade-server-installer, build-lemonade-deb, cpp-unit-tests, test-exe-inference, test-deb-inference, test-watchdog-lifecycle-linux]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/test/server_watchdog_lifecycle.py
+++ b/test/server_watchdog_lifecycle.py
@@ -37,7 +37,7 @@ from utils.test_models import PORT, TIMEOUT_DEFAULT, TIMEOUT_MODEL_OPERATION
 
 WATCHDOG_WAIT_SECONDS = int(os.environ.get("LEMONADE_TEST_WATCHDOG_WAIT_SECONDS", "60"))
 POLL_SECONDS = float(
-    os.environ.get("LEMONADE_TEST_WATCHDOG_ASSERT_POLL_SECONDS", "0.5")
+    os.environ.get("LEMONADE_TEST_WATCHDOG_ASSERT_POLL_SECONDS", "0.1")
 )
 
 
@@ -67,18 +67,18 @@ class WatchdogLifecycleTests(ServerTestBase):
             )
         super().setUpClass()
 
-    def tearDown(self):
-        # Best-effort cleanup so a failed run does not leave a backend around.
+    @classmethod
+    def tearDownClass(cls):
         try:
             requests.post(
-                f"{self.base_url}/unload",
+                f"http://localhost:{PORT}/api/v1/unload",
                 json={},
                 headers=_headers(),
                 timeout=TIMEOUT_DEFAULT,
             )
         except Exception:
             pass
-        super().tearDown()
+        super().tearDownClass()
 
     def _test_model(self):
         return os.environ.get("LEMONADE_TEST_MODEL") or self.get_test_model("llm")
@@ -99,6 +99,13 @@ class WatchdogLifecycleTests(ServerTestBase):
         return None
 
     def _load_model(self, model_name):
+        # Reuse a healthy backend recovered by the previous case instead of
+        # paying another unload/load cycle. The idle-crash case removes its
+        # dead backend from /health, so it naturally falls through to load.
+        existing = self._loaded_model_entry(model_name)
+        if existing and existing.get("loaded", True) and existing.get("pid", 0) > 0:
+            return existing
+
         response = requests.post(
             f"{self.base_url}/load",
             json={"model_name": model_name},
@@ -174,7 +181,7 @@ class WatchdogLifecycleTests(ServerTestBase):
         # this, reap the child, remove stale model state, and allow reload.
         os.kill(pid, signal.SIGKILL)
 
-    def _non_streaming_chat_completion(self, model_name):
+    def _non_streaming_chat_completion(self, model_name, max_tokens=8):
         response = requests.post(
             f"{self.base_url}/chat/completions",
             json={
@@ -182,13 +189,10 @@ class WatchdogLifecycleTests(ServerTestBase):
                 "messages": [
                     {
                         "role": "user",
-                        "content": (
-                            "Write five short numbered facts about reliable software. "
-                            "Keep each fact under one sentence."
-                        ),
+                        "content": "Say OK.",
                     }
                 ],
-                "max_tokens": 128,
+                "max_tokens": max_tokens,
                 "stream": False,
             },
             headers=_headers(),
@@ -331,7 +335,9 @@ class WatchdogLifecycleTests(ServerTestBase):
 
         def run_request():
             try:
-                result["payload"] = self._non_streaming_chat_completion(model_name)
+                result["payload"] = self._non_streaming_chat_completion(
+                    model_name, max_tokens=32
+                )
             except (
                 Exception
             ) as exc:  # noqa: BLE001 - preserve assertion details across thread boundary
@@ -363,9 +369,6 @@ class WatchdogLifecycleTests(ServerTestBase):
         self._wait_for_pid_reaped(old_pid)
         new_pid = self._assert_fresh_backend_pid(model_name, old_pid)
 
-        # Prove the reloaded model is not merely visible in /health but actually
-        # usable for another completion after the recovered in-flight request.
-        self._non_streaming_chat_completion(model_name)
         print(
             f"[OK] Active non-streaming request reloaded {model_name}: pid {old_pid} -> {new_pid}"
         )
@@ -394,9 +397,6 @@ class WatchdogLifecycleTests(ServerTestBase):
         self._wait_for_pid_reaped(old_pid)
         new_pid = self._assert_fresh_backend_pid(model_name, old_pid)
 
-        # A second call verifies the replacement backend remains reachable after
-        # the transparent replay completed.
-        self._non_streaming_chat_completion(model_name)
         print(
             f"[OK] Non-streaming downtime request reloaded {model_name}: pid {old_pid} -> {new_pid}"
         )
@@ -422,9 +422,12 @@ class WatchdogLifecycleTests(ServerTestBase):
         )
 
         results = [{}, {}]
+        first_request_started = threading.Event()
 
         def run_request(index):
             try:
+                if index == 0:
+                    first_request_started.set()
                 results[index]["payload"] = self._non_streaming_chat_completion(
                     model_name
                 )
@@ -439,12 +442,9 @@ class WatchdogLifecycleTests(ServerTestBase):
         ]
 
         workers[0].start()
-        time.sleep(
-            float(
-                os.environ.get(
-                    "LEMONADE_TEST_WATCHDOG_CONCURRENT_REQUEST_GAP_SECONDS", "0.05"
-                )
-            )
+        self.assertTrue(
+            first_request_started.wait(timeout=1.0),
+            "First concurrent request thread did not reach the request boundary",
         )
         workers[1].start()
 


### PR DESCRIPTION
## Summary

* run `server_watchdog_lifecycle.py` in the backend CI path
* keep it behind the existing `ci:backends` / merge queue gate
* add it to the existing `Inference backend tests` status gate
* reduce unnecessary work in the watchdog suite while keeping all five recovery scenarios

## Why

`server_watchdog_lifecycle.py` covers backend crash, reap, reload, and request recovery behavior, but was not exercised by CI.

The suite is now fast enough to include without adding much overhead to the backend pipeline. It runs on the CPU llama.cpp backend and stays out of the normal PR path.

## Tested

* `server_watchdog_lifecycle.py`
* llama.cpp CPU
* 5/5 tests passing
* 11.8s locally

Related to #3019
