### PR TITLE
GUI3 fix: gui2 hugging face search parity

### DIFF
--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -2418,7 +2418,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
   const filterRemoteResults = useCallback((provider: ModelRegistryProvider, results: HFModelResult[]) => {
     if (!providerEnabled[provider] || searchQuery.trim().length < 2 || primaryFilter !== 'all') return [];
     return results.filter(result => {
-      if (localRegistryRefs.has(result.id.toLowerCase())) return false;
+      if (provider !== 'huggingface' && localRegistryRefs.has(result.id.toLowerCase())) return false;
       const key = providerKey(provider, result.id);
       const variants = remoteVariants[key];
       if (provider === 'huggingface'


### PR DESCRIPTION
**Tiny fix:** GUI2 keeps Hugging Face rows visible even when the checkpoint is already registered locally.

<img width="655" height="838" alt="image" src="https://github.com/user-attachments/assets/f7881a31-4ffd-4044-97b8-2c4e3711055c" />

Follow-up on #2967 
Fixes #2948 