### PR TITLE
GUI3 feat/fix: new design line concept and no backend colors

### DIFF
--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -279,11 +279,24 @@ function mcpToolNamesForServers(servers: McpServerToolOption[], serverIds: strin
     .flatMap(server => server.toolOptions.map(tool => tool.runtimeName));
 }
 
+function isRouterRecipe(recipe?: string | null): boolean {
+  const normalized = String(recipe || '').trim().toLowerCase();
+  return normalized === 'collection.router' || normalized.startsWith('collection.router.');
+}
+
+function modelModeBadge(capability: ModelCapability, recipe?: string | null): string {
+  return isRouterRecipe(recipe) ? 'router' : capabilityBadge(capability);
+}
+
 const ModelModeIcons: React.FC<{
   capability: ModelCapability;
+  recipe?: string | null;
   audioInput?: boolean;
   size?: number;
-}> = ({ capability, audioInput = false, size = 14 }) => {
+}> = ({ capability, recipe, audioInput = false, size = 14 }) => {
+  if (isRouterRecipe(recipe)) {
+    return <Icon name="router" size={size} aria-hidden="true" />;
+  }
   const showAudio = audioInput && capability === 'chat';
   return (
     <span className="capability-icon-pair" aria-hidden="true">
@@ -297,6 +310,10 @@ function modelModeLabel(capability: ModelCapability, audioInput = false): string
   return audioInput && capability === 'chat'
     ? 'Chat + Audio'
     : capabilityLabel(capability);
+}
+
+function modelModeDisplayLabel(capability: ModelCapability, audioInput = false, recipe?: string | null): string {
+  return isRouterRecipe(recipe) ? 'Router' : modelModeLabel(capability, audioInput);
 }
 
 function deriveTitle(messages: Message[]): string {
@@ -1179,6 +1196,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   type ModelPickerOption = {
     name: string;
     capability: ModelCapability;
+    recipe?: string;
     loaded: boolean;
     audioInput: boolean;
     info?: ModelInfo;
@@ -1209,6 +1227,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     selectableModels.forEach(model => addOption({
       name: model.model_name,
       capability: capabilityForLoaded(model),
+      recipe: model.recipe,
       loaded: true,
       audioInput: audioInputForLoaded(model),
       detail: `Loaded · ${model.recipe || 'runtime'}${model.device ? ` · ${model.device}` : ''}`,
@@ -1222,6 +1241,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
       addOption({
         name,
         capability,
+        recipe: info.recipe,
         loaded: false,
         audioInput: modelSupportsChatAudioInput(info, null),
         info,
@@ -1242,7 +1262,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
 
     const q = modelPickerQuery.trim().toLowerCase();
     const filtered = q
-      ? options.filter(option => `${option.name} ${option.defaultLabel || ''} ${modelModeLabel(option.capability, option.audioInput)} ${option.detail}`.toLowerCase().includes(q))
+      ? options.filter(option => `${option.name} ${option.defaultLabel || ''} ${modelModeDisplayLabel(option.capability, option.audioInput, option.recipe)} ${option.detail}`.toLowerCase().includes(q))
       : options;
     return filtered.slice(0, 80);
   }, [audioInputForLoaded, capabilityForLoaded, downloadItems, knownModelInfos, modelPickerQuery, selectableModels]);
@@ -2973,7 +2993,7 @@ ${finalText}`
 
         <ul className="rail__list" role="listbox" aria-label="Conversations" onKeyDown={handleRailKeyDown}>
           {conversations.map((c, idx) => {
-            const badge = capabilityBadge(c.model?.capability || 'chat');
+            const badge = modelModeBadge(c.model?.capability || 'chat', c.model?.recipe);
             const isSelected = c.id === activeId;
             const isTabTarget = isSelected || (idx === 0 && !activeId);
             const convTitle = c.title || deriveTitle(c.messages);
@@ -3039,7 +3059,7 @@ ${finalText}`
         <WorkspaceActionButton className="bottom-sheet__new" appearance="primary" icon="compose" onClick={() => { handleNewChat(); closeMobileSheet(); }}>New chat</WorkspaceActionButton>
         <ul className="bottom-sheet__list rail__list" role="listbox" aria-label="Conversations" onKeyDown={handleSheetKeyDown}>
           {conversations.map((c, idx) => {
-            const badge = capabilityBadge(c.model?.capability || 'chat');
+            const badge = modelModeBadge(c.model?.capability || 'chat', c.model?.recipe);
             const isSelected = c.id === activeId;
             const isTabTarget = isSelected || (idx === 0 && !activeId);
             const convTitle = c.title || deriveTitle(c.messages);
@@ -3231,12 +3251,19 @@ ${finalText}`
                 aria-expanded={modelPickerOpen}
               >
                 {currentLoadedModel ? (
-                  <span className={`composer__model-mode composer__model-mode--${capabilityBadge(currentCapability)}`}>
-                    <ModelModeIcons capability={currentCapability} audioInput={supportsChatAudioInput} size={14} />
-                    <span>{modelModeLabel(currentCapability, supportsChatAudioInput)}</span>
-                  </span>
+                  isRouterRecipe(currentRecipe) ? (
+                    <span className="composer__model-mode composer__model-mode--router">
+                      <Icon name="router" size={14} aria-hidden="true" />
+                      <span>Router</span>
+                    </span>
+                  ) : (
+                    <span className={`composer__model-mode composer__model-mode--${capabilityBadge(currentCapability)}`}>
+                      <ModelModeIcons capability={currentCapability} audioInput={supportsChatAudioInput} size={14} />
+                      <span>{modelModeLabel(currentCapability, supportsChatAudioInput)}</span>
+                    </span>
+                  )
                 ) : (
-                  <ModelModeIcons capability={currentCapability} audioInput={supportsChatAudioInput} size={14} />
+                  <ModelModeIcons capability={currentCapability} recipe={currentRecipe} audioInput={supportsChatAudioInput} size={14} />
                 )}
                 {!currentLoadedModel && currentDefaultModel && (
                   <span className="composer__model-default-icon" title={currentDefaultModel.label} aria-label={currentDefaultModel.label}>
@@ -3279,7 +3306,7 @@ ${finalText}`
                           role="option"
                           aria-selected={option.name === currentModel}
                         >
-                          <ModelModeIcons capability={option.capability} audioInput={option.audioInput} size={15} />
+                          <ModelModeIcons capability={option.capability} recipe={option.recipe} audioInput={option.audioInput} size={15} />
                           {option.defaultIcon && option.defaultLabel && (
                             <span className="composer__model-default-icon" title={option.defaultLabel} aria-label={option.defaultLabel}>
                               <Icon name={option.defaultIcon} size={14} />
@@ -3287,7 +3314,7 @@ ${finalText}`
                           )}
                           <span className="composer__model-option-text">
                             <strong>{option.name}</strong>
-                            <span>{modelModeLabel(option.capability, option.audioInput)} · {option.detail}</span>
+                            <span>{modelModeDisplayLabel(option.capability, option.audioInput, option.recipe)} · {option.detail}</span>
                           </span>
                           {modelPickerLoading === option.name && <span className="composer__model-option-loading">Loading…</span>}
                         </button>
@@ -3987,7 +4014,8 @@ const EmptyState: React.FC<EmptyStateProps> = ({ loadedModels, currentModel, onM
             const customInfo = customModelInfos.find(cm => (cm.name || cm.id) === m.model_name);
             const cap = customInfo ? capabilityFromModelInfo(customInfo) : capabilityFromLoaded(m);
             const audioInput = modelSupportsChatAudioInput(customInfo || null, m);
-            const modeLabel = modelModeLabel(cap, audioInput);
+            const modeLabel = modelModeDisplayLabel(cap, audioInput, m.recipe);
+            const modeBadge = modelModeBadge(cap, m.recipe);
             const selectable = canSelectInComposer(m) || ['chat', 'omni', 'image', 'audio', 'audio-generation', 'tts', 'model3d'].includes(cap);
             const isActive = currentModel === m.model_name;
             return (
@@ -4010,7 +4038,7 @@ const EmptyState: React.FC<EmptyStateProps> = ({ loadedModels, currentModel, onM
                   <span className="active-card__device">{m.device || 'device unknown'}</span>
                 </div>
                 <div className="active-card__badges">
-                  <span className={`cap-badge cap-badge--${capabilityBadge(cap)}`}><ModelModeIcons capability={cap} audioInput={audioInput} size={13} /> {modeLabel}</span>
+                  <span className={`cap-badge cap-badge--${modeBadge}`}><ModelModeIcons capability={cap} recipe={m.recipe} audioInput={audioInput} size={13} /> {modeLabel}</span>
                 </div>
                 <div className="active-card__actions">
                   {isActive ? (

--- a/src/app/src/components/ModelListPanel.tsx
+++ b/src/app/src/components/ModelListPanel.tsx
@@ -17,7 +17,7 @@ import type { IconName } from './Icon';
 import type { CapabilityIconTarget } from './Icon';
 import { activeDownloadForModel, type DownloadListItem } from '../features/downloadManager/downloadStore';
 import { WorkspaceActionButton, WorkspaceActionGroup, WorkspaceListPanel } from './WorkspacePanels';
-import { backendColor, backendCompactLabel, backendLabel } from '../modelPresentation';
+import { backendCompactLabel, backendLabel } from '../modelPresentation';
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
@@ -702,9 +702,6 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
           const displayedBackend = recipe && !neutralCollectionGuide ? modelListBackendLabel(recipe) : '';
           const isSelected = mId === selectedModelId;
           const capTags = modelCapabilityTags(model);
-          const backendStyle = recipe && !neutralCollectionGuide
-            ? ({ '--list-backend-color': backendColor(recipe) } as React.CSSProperties)
-            : undefined;
           const backendReadiness = status === 'downloaded'
             ? modelBackendReadiness(model, systemInfo)
             : null;
@@ -730,7 +727,6 @@ export const ModelListPanel: React.FC<ModelListPanelProps> = ({
               tabIndex={isSelected ? 0 : -1}
               aria-selected={isSelected}
               data-model-id={mId}
-              style={backendStyle}
               aria-keyshortcuts={onTogglePin ? 'P' : undefined}
               className={`model-list-item${isSelected ? ' model-list-item--selected' : ''}${pinned ? ' model-list-item--pinned' : ''}${neutralCollectionGuide ? ' model-list-item--neutral-guide' : ''} model-list-item--${status}`}
               onClick={() => onSelectModel(mId)}

--- a/src/app/src/components/ModelNavRail.tsx
+++ b/src/app/src/components/ModelNavRail.tsx
@@ -57,8 +57,8 @@ const PRIMARY_ITEMS: Array<{ key: PrimaryFilter; label: string; iconName: IconNa
 const TASK_ITEMS: Array<{ key: FilterTab; label: string; iconName: IconName; color: string }> = [
   { key: 'all', label: 'All', iconName: 'globe', color: 'var(--text-tertiary)' },
   { key: 'llm', label: 'Chat', iconName: 'chat', color: 'var(--cap-chat)' },
-  { key: 'omni', label: 'Omni', iconName: 'omni', color: 'var(--accent-fg)' },
-  { key: 'router', label: 'Router', iconName: 'router', color: 'var(--cap-tool, var(--accent-fg))' },
+  { key: 'omni', label: 'Omni', iconName: 'omni', color: 'var(--cap-omni)' },
+  { key: 'router', label: 'Router', iconName: 'router', color: 'var(--cap-router)' },
   { key: 'image', label: 'Image', iconName: 'image', color: 'var(--cap-image)' },
   { key: 'audio', label: 'Audio', iconName: 'audio', color: 'var(--cap-audio)' },
   { key: 'audio-generation', label: 'Music & SFX', iconName: 'audio', color: 'var(--cap-audio-generation)' },

--- a/src/app/src/components/ModelNavRail.tsx
+++ b/src/app/src/components/ModelNavRail.tsx
@@ -22,7 +22,6 @@ import React, { useMemo, useState } from 'react';
 import { storageKey } from '../storage';
 import type { ModelInfo, ModelRegistryProvider, StorageInfo } from '../api';
 import { Icon } from './Icon';
-import { backendColor } from '../modelPresentation';
 import type { IconName } from './Icon';
 import WorkspaceRailHeader from './WorkspaceRailHeader';
 import {
@@ -439,7 +438,6 @@ export const ModelNavRail: React.FC<ModelNavRailProps> = ({
                   <button
                     type="button"
                     className={`model-nav-rail__filter-chip model-nav-rail__backend-chip${active ? ' is-active' : ''}`}
-                    style={{ '--filter-chip-color': backendColor(backend.value) } as React.CSSProperties}
                     aria-pressed={active}
                     onClick={() => toggleBackend(backend.value)}
                   >

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -1024,6 +1024,7 @@ input[type="checkbox"]:disabled {
 }
 
 .cap-badge--chat   { background: color-mix(in srgb, var(--cap-chat) 18%, transparent); color: var(--cap-chat); }
+.cap-badge--router { background: color-mix(in srgb, var(--cap-router) 18%, transparent); color: var(--cap-router); }
 .cap-badge--vision { background: color-mix(in srgb, var(--cap-vision) 18%, transparent); color: var(--cap-vision); }
 .cap-badge--code   { background: color-mix(in srgb, var(--cap-code) 18%, transparent); color: var(--cap-code); }
 .cap-badge--embed  { background: color-mix(in srgb, var(--cap-embedding) 18%, transparent); color: var(--cap-embedding); }
@@ -5159,7 +5160,8 @@ optgroup {
   border-top: 1px solid color-mix(in srgb, var(--danger) 24%, transparent);
 }
 
-.composer__mode-badge--omni, .cap-badge--omni, .cap-chip--omni, .rail__model-badge--omni { color: var(--accent-fg); background: var(--accent-soft); }
+.composer__mode-badge--omni, .cap-badge--omni, .cap-chip--omni, .rail__model-badge--omni { color: var(--cap-omni); background: color-mix(in srgb, var(--cap-omni) 18%, transparent); }
+.rail__model-badge--router { color: var(--cap-router); background: color-mix(in srgb, var(--cap-router) 18%, transparent); }
 
 .manager__detail-form-panel {
   height: 100%;
@@ -5755,7 +5757,8 @@ optgroup {
 .composer__model-mode--image { color: var(--cap-image); }
 .composer__model-mode--audio { color: var(--cap-audio); }
 .composer__model-mode--tts { color: var(--cap-tts); }
-.composer__model-mode--omni { color: var(--accent-fg); }
+.composer__model-mode--omni { color: var(--cap-omni); }
+.composer__model-mode--router { color: var(--cap-router); }
 .composer__model-mode--audio-gen { color: var(--cap-audio-generation); }
 .composer__model-mode--model3d { color: var(--cap-model3d); }
 .composer__model-mode--embed { color: var(--cap-embedding); }

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -5760,13 +5760,25 @@ optgroup {
 .composer__model-mode--omni { color: var(--cap-omni); }
 .composer__model-mode--router { color: var(--cap-router); }
 .composer__model-mode--audio-gen { color: var(--cap-audio-generation); }
-.composer__model-mode--model3d { color: var(--cap-model3d); }
+.composer__model-mode--model3d { color: color-mix(in srgb, var(--cap-model3d) 75%, var(--text-primary)); }
 .composer__model-mode--embed { color: var(--cap-embedding); }
 .composer__model-mode--rank { color: var(--cap-reranking); }
 .composer__model-mode--model { color: var(--text-tertiary); }
 
 .composer__model-mode svg {
   color: currentColor;
+}
+
+/* Small task icons need more visual weight than the default 1px glyph stroke.
+   Keep task identity on the icon even when small task text is contrast-adjusted. */
+.cap-badge .app-icon,
+.composer__model-mode .app-icon {
+  stroke-width: 2;
+}
+
+.cap-badge--model3d .app-icon,
+.composer__model-mode--model3d .app-icon {
+  color: var(--cap-model3d);
 }
 
 .composer__model-button-caret {
@@ -6890,6 +6902,10 @@ optgroup {
   white-space: nowrap;
 }
 
+.model-nav-rail__filter-chip .app-icon {
+  stroke-width: 2;
+}
+
 .model-nav-rail__filter-chip:hover {
   border-color: color-mix(in srgb, var(--filter-chip-color) 48%, var(--border-strong));
   color: var(--text-primary);
@@ -6908,11 +6924,12 @@ optgroup {
 }
 
 .model-nav-rail__backend-chip {
-  color: var(--filter-chip-color);
+  --filter-chip-color: var(--text-tertiary);
+  color: var(--text-secondary);
 }
 
 .model-nav-rail__backend-chip.is-active {
-  color: var(--filter-chip-color);
+  color: var(--text-primary);
 }
 
 .model-nav-rail__backend-wrap {
@@ -7261,9 +7278,9 @@ optgroup {
   --model-list-row-bg: var(--surface-base);
   --model-list-line: color-mix(in srgb, var(--border-strong) 72%, transparent);
   position: relative;
-  min-height: 58px;
+  min-height: 54px;
   display: block;
-  padding: var(--space-2) calc(var(--space-2) + 22px) 19px var(--space-2);
+  padding: var(--space-2) calc(var(--space-2) + 22px) 15px var(--space-2);
   border-radius: var(--radius-md);
   cursor: pointer;
   border: 1px solid transparent;
@@ -7315,8 +7332,8 @@ optgroup {
   color: var(--text-tertiary);
 }
 
-/* Lower guide: a restrained backend-color lead-in merges into the standard
-   one-pixel rule. The label sits on that rule and the status ring terminates it. */
+/* Lower guide: one neutral rule fades in toward the status terminus.
+   The backend label sits on the rule without carrying backend identity color. */
 .model-list-item__footer {
   position: absolute;
   z-index: 1;
@@ -7336,17 +7353,11 @@ optgroup {
 
   background: linear-gradient(
     90deg,
-    var(--list-backend-color, var(--model-list-line)) 0%,
-    var(--list-backend-color, var(--model-list-line)) 26%,
-    color-mix(in srgb, var(--list-backend-color, var(--model-list-line)) 48%, var(--model-list-line)) 44%,
-    var(--model-list-line) 58%,
+    transparent 0%,
+    color-mix(in srgb, var(--model-list-line) 42%, transparent) 42%,
     var(--model-list-line) 100%
   );
   opacity: 0.78;
-}
-
-.model-list-item--neutral-guide .model-list-item__footer::before {
-  background: var(--model-list-line);
 }
 
 .model-list-item__footer-info {
@@ -7390,7 +7401,7 @@ optgroup {
   display: grid;
   place-items: center;
   border: 0;
-  background: transparent;
+  background: var(--model-list-row-bg);
   pointer-events: none;
 }
 
@@ -10738,7 +10749,7 @@ optgroup {
 
 /* ---------- Generated audio + 3D modalities ---------- */
 .cap-badge--audio-gen { background: color-mix(in srgb, var(--cap-audio-generation) 16%, transparent); color: var(--cap-audio-generation); }
-.cap-badge--model3d { background: color-mix(in srgb, var(--cap-model3d) 17%, transparent); color: var(--cap-model3d); }
+.cap-badge--model3d { background: color-mix(in srgb, var(--cap-model3d) 17%, transparent); color: color-mix(in srgb, var(--cap-model3d) 75%, var(--text-primary)); }
 .composer__mode-badge--audio-gen { color: var(--cap-audio-generation); background: color-mix(in srgb, var(--cap-audio-generation) 12%, transparent); }
 .composer__mode-badge--model3d { color: var(--cap-model3d); background: color-mix(in srgb, var(--cap-model3d) 12%, transparent); }
 

--- a/src/app/src/styles/tokens.css
+++ b/src/app/src/styles/tokens.css
@@ -73,36 +73,19 @@
   --cap-router:     #3289D1;
   --cap-vision:     #B58CFF;
   --cap-code:       #6AD0A3;
-  --cap-embedding:  #65758A;
+  --cap-embedding: #665F59;
   --cap-reranking:  #FF9D6A;
   --cap-image:      #D8752B;
-  --cap-image-edit: #D99358;
+  --cap-image-edit: #D8752B;
   --cap-audio:      #1693A5;
   --cap-audio-generation: #1693A5;
   --cap-tts:        #B35A9F;
-  --cap-model3d:    #92744C;
+  --cap-model3d:   #65758A;
 
   --provider-hugging-face:    #FF9D00;
   --provider-hugging-face-fg: #FFB84D;
   --provider-modelscope:      #4C8DFF;
   --provider-modelscope-fg:   #7BA9FF;
-
-  --backend-llamacpp:          #FACC15;
-  --backend-vllm:              #60A5FA;
-  --backend-flm:               #34D399;
-  --backend-ryzenai:           #F97316;
-  --backend-sd-cpp:            #C084FC;
-  --backend-whispercpp:        #38BDF8;
-  --backend-moonshine:         #22D3EE;
-  --backend-kokoro:            #F472B6;
-  --backend-acestep:           #FB7185;
-  --backend-thinksound:        #F59E0B;
-  --backend-openmoss:          #EC4899;
-  --backend-trellis:           #818CF8;
-  --backend-collection-omni:   #A78BFA;
-  --backend-collection-router: #22D3EE;
-  --backend-collection:        #94A3B8;
-  --backend-other:             var(--text-tertiary);
 
   --chart-series-1: #E8C66B;
   --chart-series-2: #7BAED4;

--- a/src/app/src/styles/tokens.css
+++ b/src/app/src/styles/tokens.css
@@ -67,17 +67,20 @@
   --warning-soft: var(--warn-soft);
 
   /* ---------- Capability, provider, backend, and monitoring identity ---------- */
-  --cap-chat:       var(--accent-fg);
+  /* Task colors are intentionally theme-invariant across dark and light. */
+  --cap-chat:       #A77C00;
+  --cap-omni:       #8064D8;
+  --cap-router:     #3289D1;
   --cap-vision:     #B58CFF;
   --cap-code:       #6AD0A3;
-  --cap-embedding:  #6ABFFF;
+  --cap-embedding:  #65758A;
   --cap-reranking:  #FF9D6A;
-  --cap-image:      #F0B04C;
+  --cap-image:      #D8752B;
   --cap-image-edit: #D99358;
-  --cap-audio:      #6ACCCF;
-  --cap-audio-generation: #2DD4BF;
-  --cap-tts:        #FF7AB6;
-  --cap-model3d:    #818CF8;
+  --cap-audio:      #1693A5;
+  --cap-audio-generation: #1693A5;
+  --cap-tts:        #B35A9F;
+  --cap-model3d:    #92744C;
 
   --provider-hugging-face:    #FF9D00;
   --provider-hugging-face-fg: #FFB84D;
@@ -272,20 +275,14 @@
      mixing it again would leave the border barely visible. */
   --accent-border:  rgba(92, 75, 0, 0.32);
 
-  /* ---------- Identity and monitoring colors, darkened for the light canvas ----------
+  /* ---------- Non-task identity and monitoring colors, darkened for the light canvas ----------
    * The dark-theme values are tuned against #16140F and land between 1.5:1 and
    * 2.9:1 on #fdfbf6. These preserve each hue while clearing the 3:1 floor WCAG
    * 1.4.11 sets for non-text UI components (glyphs, marks, chart series). */
   --cap-vision:     #A16DFF;
   --cap-code:       #2C9E6C;
-  --cap-embedding:  #008EF9;
   --cap-reranking:  #F95500;
-  --cap-image:      #C47A08;
   --cap-image-edit: #CE752B;
-  --cap-audio:      #2C999C;
-  --cap-audio-generation: #1C9D8D;
-  --cap-tts:        #FF3D94;
-  --cap-model3d:    #727EF8;
 
   --provider-hugging-face-fg: #C77800;
   --provider-modelscope-fg:   #4888FF;

--- a/src/app/tests/model-list-backend-layout.runtime.cjs
+++ b/src/app/tests/model-list-backend-layout.runtime.cjs
@@ -38,7 +38,9 @@ for (const [fileName, source] of [
   );
 }
 
-assert.match(component, /import \{ backendColor, backendCompactLabel, backendLabel \}/);
+assert.match(component, /import \{ backendCompactLabel, backendLabel \}/);
+assert.doesNotMatch(component, /backendColor|--list-backend-color/,
+  'model rows must not carry backend identity colors');
 assert.match(component, /function modelListBackendLabel\(recipe: string\): string \{[\s\S]*return backendCompactLabel\(recipe\);/);
 assert.doesNotMatch(component, /backendCompactLabel\(recipe\)\.toUpperCase\(\)/,
   'backend labels must preserve product casing such as llama.cpp and vLLM');
@@ -71,12 +73,13 @@ for (const expected of ['llama.cpp', 'vLLM', 'FLM', 'SD.cpp', 'Moonshine', 'Open
   assert.ok(presentation.includes(`compact: '${expected}'`), `missing complete compact backend label: ${expected}`);
 }
 
-assert.match(styles, /\.model-list-item\s*\{[^}]*position:\s*relative;[^}]*display:\s*block;[^}]*padding:[^;]*19px/s);
+assert.match(styles, /\.model-list-item\s*\{[^}]*position:\s*relative;[^}]*min-height:\s*54px;[^}]*display:\s*block;[^}]*padding:[^;]*15px/s);
 assert.match(styles, /\.model-list-item__footer\s*\{[^}]*position:\s*absolute;[^}]*inset-block-end:\s*5px;/s);
-assert.match(styles, /\.model-list-item__footer::before\s*\{[^}]*inset-inline:\s*0 5px;[^}]*height:\s*1px;[^}]*linear-gradient\([^}]*var\(--list-backend-color[^}]*var\(--model-list-line\) 100%/s);
-assert.match(styles, /\.model-list-item--neutral-guide \.model-list-item__footer::before\s*\{[^}]*background:\s*var\(--model-list-line\);/s);
+assert.match(styles, /\.model-list-item__footer::before\s*\{[^}]*inset-inline:\s*0 5px;[^}]*height:\s*1px;[^}]*linear-gradient\([^}]*transparent 0%[^}]*var\(--model-list-line\) 100%/s);
+assert.doesNotMatch(styles, /--list-backend-color|\.model-list-item--neutral-guide \.model-list-item__footer::before/,
+  'the lower guide must be one neutral right-to-left fade for every model row');
 assert.doesNotMatch(styles, /\.model-list-item__footer::after/,
-  'backend and neutral guide colors must share one one-pixel paint layer');
+  'the neutral guide must remain a single one-pixel paint layer');
 assert.match(styles, /\.model-list-item__footer-info\s*\{[^}]*inset-inline-end:\s*16px;[^}]*display:\s*inline-flex;[^}]*font-weight:\s*var\(--weight-regular\);/s);
 assert.match(styles, /\.model-list-item__backend\s*\{[^}]*text-transform:\s*none;/s);
 assert.match(styles, /\.model-list-item__status\s*\{[^}]*inset-inline-end:\s*0;[^}]*width:\s*11px;[^}]*display:\s*grid;[^}]*place-items:\s*center;/s);

--- a/src/app/tests/model-nav-filter-layout.runtime.cjs
+++ b/src/app/tests/model-nav-filter-layout.runtime.cjs
@@ -75,9 +75,11 @@ assert.doesNotMatch(manager, /capabilityFilter/, 'ModelManager must not retain h
 
 assert.match(styles, /\.model-nav-rail__chip-list\s*\{[^}]*flex-wrap:\s*wrap;/s);
 assert.match(styles, /\.model-nav-rail__task-icon\s*\{[^}]*color:\s*var\(--filter-chip-color\);/s);
-assert.match(styles, /\.model-nav-rail__backend-chip\s*\{[^}]*color:\s*var\(--filter-chip-color\);/s);
+assert.doesNotMatch(nav, /backendColor/, 'backend filters must not receive per-backend identity colors');
+assert.match(styles, /\.model-nav-rail__backend-chip\s*\{[^}]*--filter-chip-color:\s*var\(--text-tertiary\);[^}]*color:\s*var\(--text-secondary\);/s);
+assert.match(styles, /\.model-nav-rail__backend-chip\.is-active\s*\{[^}]*color:\s*var\(--text-primary\);/s);
 assert.doesNotMatch(styles, /\.model-nav-rail__backend-chip::before\s*\{/,
-  'reverting the backend color concept must restore the colored label instead of a separate dot');
+  'backend filters must stay neutral without introducing a colored identity marker');
 assert.match(styles, /\.model-nav-rail__backend-wrap\.is-removable \.model-nav-rail__backend-chip\s*\{[^}]*padding-inline-end:\s*19px;/s);
 assert.match(styles, /\.model-nav-rail__backend-remove,/);
 assert.doesNotMatch(styles, /\.model-list-panel__filter-(?:btn|popover|option|clear)/, 'removed middle filter styles must not remain');


### PR DESCRIPTION
Colors are now only for TASK.
We already have more backend the Tasks and I suspect then trend to go on.
So dropping color for backend reduces maintainer headache.
Saved 4px per model element by moving design line a bit higher.

Overall - I think we have a significant improvement here.

<img width="758" height="972" alt="image" src="https://github.com/user-attachments/assets/e0639c87-3155-4a38-a372-f788fa100a08" />

<img width="788" height="942" alt="image" src="https://github.com/user-attachments/assets/ce7780fa-05ec-45d8-ad53-c856b16ee564" />

on light mode same TASK colors used, maybe needs thicker icon line with 

Router mode is added.