### PR TITLE
fix(tts): stop dropping response_format on the streaming path

### DIFF
--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -913,11 +913,11 @@ A typical workflow is to generate an image first, then upscale it:
 ## `POST /v1/audio/speech`
 <sub>![Status](https://img.shields.io/badge/status-fully_available-green)</sub>
 
-Speech Generation API. You provide a text input and receive an audio file. This API uses [Kokoros](https://github.com/lucasjinreal/Kokoros) as the backend.
+Speech Generation API. You provide a text input and receive an audio file. Which engine serves the request depends on the model.
 
 > **Note:** Supported models are `kokoro-v1` (fixed voices, [Kokoros](https://github.com/lucasjinreal/Kokoros) backend) and the OpenMOSS family — `OpenMOSS-TTS` (voice cloning from a reference WAV) and `MOSS-VoiceGen` (voice design from a text description).
 >
-> **Limitations:** `kokoro-v1` supports `mp3`, `wav`, `opus`, and `pcm`; OpenMOSS models natively produce `wav` only, and other formats are rejected with `400 Bad Request`. Streaming is supported in `audio` (`pcm`) mode on `kokoro-v1`.
+> **Limitations:** Which `response_format` values are accepted depends on the model's backend: `kokoro-v1` encodes `mp3`, `wav`, `opus`, and `pcm`, while OpenMOSS models natively produce `wav` only. A format the backend cannot encode is rejected with `400 Bad Request` listing the ones it does support. Streaming works for any TTS backend, but a backend's streamable set can be narrower than its buffered set — `kokoro-v1` streams `pcm` only, so an explicit `response_format` of `mp3` alongside `stream_format` is rejected rather than silently answered with PCM.
 
 ### Parameters
 
@@ -929,8 +929,8 @@ Speech Generation API. You provide a text input and receive an audio file. This 
 | `voice` | No | The voice to use. All OpenAI-defined voices can be used (`alloy`, `ash`, ...), as well as those defined by the kokoro model (`af_sky`, `am_echo`, ...). Default: `shimmer` | <sub>![Status](https://img.shields.io/badge/partial-yellow)</sub> |
 | `voice` (OpenMOSS) | No | For OpenMOSS models the field is a free-text voice/style instruction instead of a fixed voice name (e.g. `a calm, deep male narrator voice`). | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
 | `reference_wav_b64` | No | Lemonade extension (OpenMOSS voice cloning): base64-encoded WAV sample of the voice to clone. | <sub>![Status](https://img.shields.io/badge/available-green)</sub> |
-| `response_format` | No | Format of the response. `mp3`, `wav`, `opus`, and `pcm` are supported. Default: `mp3`| <sub>![Status](https://img.shields.io/badge/partial-yellow)</sub> |
-| `stream_format` | No | If set, the response will be streamed. Only `audio` is supported, which will output `pcm` audio. Default: not set| <sub>![Status](https://img.shields.io/badge/partial-yellow)</sub> |
+| `response_format` | No | Container for the returned audio. Which values are accepted depends on the model's backend (see Limitations above). Default: `mp3` when buffered and `pcm` when streaming, falling back to the backend's first supported format when it cannot encode that default. | <sub>![Status](https://img.shields.io/badge/partial-yellow)</sub> |
+| `stream_format` | No | If set, the response is streamed. Only `audio` is supported. This selects the transport only — the container still comes from `response_format`, and an explicit one is honored on both transports. Default: not set| <sub>![Status](https://img.shields.io/badge/partial-yellow)</sub> |
 
 ### Example request
 

--- a/src/cpp/include/lemon/backends/kokoro/kokoro_server.h
+++ b/src/cpp/include/lemon/backends/kokoro/kokoro_server.h
@@ -36,6 +36,17 @@ public:
 
     // ITextToSpeechServer implementation
     void audio_speech(const json& request, httplib::DataSink& sink) override;
+    // Kokoros deserializes all six OpenAI formats but only implements four; aac and
+    // flac silently fall back to MP3 bytes, so they are not advertised.
+    std::vector<std::string> supported_audio_formats() const override {
+        return {"mp3", "wav", "opus", "pcm"};
+    }
+    // Its streaming path returns headerless s16le regardless of response_format
+    // ("Force PCM for optimal streaming performance"), so anything else would be
+    // served under a Content-Type the bytes don't match.
+    std::vector<std::string> supported_streaming_audio_formats() const override {
+        return {"pcm"};
+    }
 };
 
 namespace kokoro {

--- a/src/cpp/include/lemon/router.h
+++ b/src/cpp/include/lemon/router.h
@@ -222,6 +222,7 @@ public:
     json audio_transcriptions(const json& request);
     void audio_speech(const json& request, httplib::DataSink& sink);
     std::vector<std::string> audio_speech_supported_formats(const std::string& model_name);
+    std::vector<std::string> audio_speech_supported_streaming_formats(const std::string& model_name);
 
     json image_generations(const json& request);
     json image_edits(const json& request);

--- a/src/cpp/include/lemon/server_capabilities.h
+++ b/src/cpp/include/lemon/server_capabilities.h
@@ -55,6 +55,10 @@ public:
     virtual ~ITextToSpeechServer() = default;
     virtual void audio_speech(const json& request, httplib::DataSink& sink) = 0;
     virtual std::vector<std::string> supported_audio_formats() const { return {}; }
+    // What the backend can emit while streaming, which is often narrower than the
+    // buffered set — Kokoros hands back raw PCM on its streaming path whatever the
+    // request asked for. Empty means the buffered list applies to both transports.
+    virtual std::vector<std::string> supported_streaming_audio_formats() const { return {}; }
 };
 
 // Text-classification capability (encoder classifiers: PII, prompt-safety,

--- a/src/cpp/server/router.cpp
+++ b/src/cpp/server/router.cpp
@@ -2089,6 +2089,13 @@ std::vector<std::string> Router::audio_speech_supported_formats(const std::strin
     return tts_server ? tts_server->supported_audio_formats() : std::vector<std::string>{};
 }
 
+std::vector<std::string> Router::audio_speech_supported_streaming_formats(const std::string& model_name) {
+    std::lock_guard<std::mutex> lock(load_mutex_);
+    auto tts_server = dynamic_cast<ITextToSpeechServer*>(
+        find_server_by_model_name(resolve_model_name(model_name)));
+    return tts_server ? tts_server->supported_streaming_audio_formats() : std::vector<std::string>{};
+}
+
 json Router::image_generations(const json& request) {
     return execute_inference(request, [&](WrappedServer* server) {
         auto image_server = dynamic_cast<IImageServer*>(server);

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -4086,6 +4086,10 @@ void Server::handle_audio_speech(const httplib::Request& req, httplib::Response&
             return;
         }
         std::string mime_type = MIME_TYPES[response_format];
+        // The backend has to encode what the Content-Type above promises. Without
+        // this it would receive whatever the client sent -- nothing, when the
+        // format came from a default -- and fall back to its own choice.
+        request_json["response_format"] = response_format;
 
         // Log the HTTP request
         LOG(INFO, "Server") << "POST /api/v1/audio/speech" << std::endl;

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -4023,7 +4023,7 @@ void Server::handle_audio_speech(const httplib::Request& req, httplib::Response&
             if (request_json["stream_format"] != "audio") {
                 res.status = 400;
                 nlohmann::json error = {{"error", {
-                    {"message", "Only pcm audio streaming format is supported"},
+                    {"message", "Only 'audio' is supported for stream_format"},
                     {"type", "invalid_request_error"}
                 }}};
                 res.set_content(error.dump(), "application/json");
@@ -4031,15 +4031,32 @@ void Server::handle_audio_speech(const httplib::Request& req, httplib::Response&
             }
         }
 
-        const auto supported_formats =
-            router_->audio_speech_supported_formats(request_json["model"].get<std::string>());
-        std::string response_format = "mp3";
+        const std::string speech_model = request_json["model"].get<std::string>();
+        // A backend's streaming encoder is often narrower than its buffered one, so
+        // which constraint applies depends on the transport in play.
+        auto supported_formats = router_->audio_speech_supported_formats(speech_model);
         if (is_streaming) {
-            response_format = "pcm";
-        } else if (request_json.contains("response_format") && request_json["response_format"].is_string()) {
+            auto streaming_formats = router_->audio_speech_supported_streaming_formats(speech_model);
+            if (!streaming_formats.empty()) {
+                supported_formats = std::move(streaming_formats);
+            }
+        }
+        // Streaming and encoding are orthogonal: stream_format picks the transport,
+        // response_format the container. An explicit response_format therefore wins
+        // even when streaming, and is rejected below rather than silently swapped if
+        // the backend can't emit it. Only the implicit default differs by transport,
+        // and it yields to whatever the backend declares.
+        std::string response_format;
+        if (request_json.contains("response_format") && request_json["response_format"].is_string()) {
             response_format = request_json["response_format"].get<std::string>();
-        } else if (!supported_formats.empty()) {
-            response_format = supported_formats.front();
+        } else {
+            response_format = is_streaming ? "pcm" : "mp3";
+            const bool default_supported = supported_formats.empty() ||
+                std::find(supported_formats.begin(), supported_formats.end(),
+                          response_format) != supported_formats.end();
+            if (!default_supported) {
+                response_format = supported_formats.front();
+            }
         }
         if (!MIME_TYPES.contains(response_format)) {
             res.status = 400;

--- a/test/server_tts.py
+++ b/test/server_tts.py
@@ -153,6 +153,24 @@ class TextToSpeechTests(ServerTestBase):
             f"Speech generation failed with status {response.status_code}: {response.text}",
         )
 
+        content_type = response.headers.get("Content-Type", "")
+        self.assertTrue(
+            content_type.startswith("audio/l16"),
+            f"Streamed audio should be declared as raw PCM, got '{content_type}'",
+        )
+
+        # Kokoros streams headerless s16le. A container magic here would mean the
+        # bytes and the Content-Type disagree.
+        for magic, kind in ((b"RIFF", "WAV"), (b"ID3", "MP3"), (b"OggS", "Ogg")):
+            self.assertFalse(
+                response.content.startswith(magic),
+                f"Streamed body declared as PCM but starts with {kind} magic",
+            )
+
+        self.assertGreater(
+            len(response.content), 1000, "Streamed clip should be substantial"
+        )
+
         print(f"[OK] Speech generation successful")
 
     def test_006_tts_speed(self):
@@ -185,6 +203,36 @@ class TextToSpeechTests(ServerTestBase):
         )
 
         print(f"[OK] Speech generation successful")
+
+    def test_007_tts_stream_rejects_unstreamable_format(self):
+        """A format the backend can only emit buffered must not be streamed."""
+        payload = {
+            "model": TTS_MODEL,
+            "input": "Lemonade can speak",
+            "stream_format": "audio",
+            "response_format": "mp3",
+        }
+
+        print(f"[INFO] Requesting streamed mp3 from {TTS_MODEL} (expected to fail)")
+
+        response = requests.post(
+            f"{self.base_url}/audio/speech",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        # Kokoros forces raw PCM on its streaming path whatever the request asks
+        # for, so serving this as mp3 would hand back undecodable bytes under a
+        # Content-Type that does not match them.
+        self.assertEqual(
+            response.status_code,
+            400,
+            "Streaming a format the backend cannot encode should be rejected, "
+            f"got {response.status_code} with Content-Type "
+            f"'{response.headers.get('Content-Type', '')}'",
+        )
+
+        print(f"[OK] Unstreamable format rejected")
 
 
 if __name__ == "__main__":

--- a/test/server_tts_openmoss.py
+++ b/test/server_tts_openmoss.py
@@ -264,6 +264,48 @@ class OpenMossTTSTests(ServerTestBase):
         self._assert_wav_response(response, "Voice design")
         print(f"[OK] Voice design produced a clip ({len(response.content)} bytes)")
 
+    def test_011_streaming_wav(self):
+        """A wav-only backend streams its own container instead of being rejected."""
+        model = get_test_model("tts")
+        payload = {
+            "model": model,
+            "input": "Lemonade can stream speech from a wav-only backend.",
+            "stream_format": "audio",
+        }
+
+        print(f"[INFO] Requesting streamed speech from {model}")
+
+        # Headers and body are read off the live response before any assertion:
+        # unittest evaluates a failure message eagerly, so touching response.text
+        # here would consume the stream and leave iter_content replaying a cache.
+        with requests.post(
+            f"{self.base_url}/audio/speech",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+            stream=True,
+        ) as response:
+            status = response.status_code
+            content_type = response.headers.get("Content-Type", "")
+            body = b"".join(response.iter_content(chunk_size=8192))
+
+        self.assertEqual(
+            status,
+            200,
+            f"Streamed speech failed with status {status}: {body[:1000]!r}",
+        )
+        self.assertIn(
+            "audio/wav",
+            content_type,
+            f"Streamed speech should keep the backend's WAV container, got '{content_type}'",
+        )
+        self.assertTrue(
+            body[:4] == b"RIFF",
+            "Streamed body should be a valid WAV (RIFF) file",
+        )
+        self.assertGreater(len(body), 1000, "Streamed clip should be substantial")
+
+        print(f"[OK] Streamed WAV received ({len(body)} bytes)")
+
 
 if __name__ == "__main__":
     run_server_tests(


### PR DESCRIPTION
## Summary

`/audio/speech` hardcoded `response_format = "pcm"` for any streaming request and never read the value the client sent. That silently dropped an explicit `response_format`, and it locked wav-only TTS backends out of streaming entirely — the forced `pcm` isn't in their supported set, so the request was rejected outright.

## What changes

- **`ITextToSpeechServer::supported_streaming_audio_formats()`** — a backend's streaming encoder is often narrower than its buffered one. Empty (the default) means the buffered list covers both transports.

- **Kokoro declares `{pcm}` for streaming.** Kokoros forces headerless s16le on that path whatever `response_format` asked for, so honoring anything else there would serve bytes the Content-Type doesn't match. Its buffered set is also narrowed to the four formats it actually implements — `aac` and `flac` deserialize fine but silently fall back to MP3 bytes.

- **Transport and container are now orthogonal in the gateway.** `stream_format` picks the transport, `response_format` the container. An explicit `response_format` wins on both paths and is rejected with 400 if the backend can't encode it, rather than silently swapped. Only the implicit default still varies by transport (`pcm` streaming, `mp3` buffered), and it yields to whatever the backend declares.

⚠️ **Behavior change:** `stream_format=audio` with `response_format=mp3` against Kokoro now returns 400 (`supported: pcm`) instead of silently returning PCM.

## Testing

`test/server_tts.py` gains a Content-Type and container-magic assertion on the streaming test, plus a new `test_007_tts_stream_rejects_unstreamable_format`. Both run against `kokoro-v1` in the existing TTS CI job — no new backend or runner needed.
