### PR TITLE
feat: add VoxCPM2 text-to-speech backend

### DIFF
--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1079,7 +1079,7 @@ jobs:
           - name: tts-voxcpm2
             script: server_tts_voxcpm2.py
             extra_args: "--wrapped-server voxcpm2"
-            backends: "vulkan"
+            backends: "vulkan cpu"
             runner: [Windows, rocm, vulkan, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"
@@ -1337,7 +1337,7 @@ jobs:
           - name: tts-voxcpm2
             script: server_tts_voxcpm2.py
             extra_args: "--wrapped-server voxcpm2"
-            backends: "vulkan"
+            backends: "vulkan cpu"
             runner: [Linux, vulkan, rocm, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"

--- a/.github/workflows/cpp_server_build_test_release.yml
+++ b/.github/workflows/cpp_server_build_test_release.yml
@@ -1076,6 +1076,11 @@ jobs:
             extra_args: "--wrapped-server openmoss"
             backends: "vulkan rocm"
             runner: [Windows, rocm, vulkan, lemon-prod]
+          - name: tts-voxcpm2
+            script: server_tts_voxcpm2.py
+            extra_args: "--wrapped-server voxcpm2"
+            backends: "vulkan"
+            runner: [Windows, rocm, vulkan, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"
       HF_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}
@@ -1328,6 +1333,11 @@ jobs:
             script: server_tts_openmoss.py
             extra_args: "--wrapped-server openmoss"
             backends: "vulkan rocm"
+            runner: [Linux, vulkan, rocm, lemon-prod]
+          - name: tts-voxcpm2
+            script: server_tts_voxcpm2.py
+            extra_args: "--wrapped-server voxcpm2"
+            backends: "vulkan"
             runner: [Linux, vulkan, rocm, lemon-prod]
     env:
       LEMONADE_CI_MODE: "True"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ set(LEMON_BACKENDS
     "onnxruntime|onnxruntime"
     "trellis|trellis"
     "openmoss|openmoss"
+    "voxcpm2|voxcpm2"
 )
 
 # ============================================================

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
       <td>Windows, Linux, macOS</td>
     </tr>
     <tr>
-      <td rowspan="5"><strong>Text-to-speech</strong></td>
+      <td rowspan="9"><strong>Text-to-speech</strong></td>
       <td rowspan="2"><code>kokoro</code></td>
       <td><code>metal</code></td>
       <td>Apple Silicon GPU</td>
@@ -255,6 +255,27 @@ Lemonade supports multiple inference engines for LLM, speech, TTS, and image gen
     <tr>
       <td><code>rocm</code></td>
       <td>AMD GPUs (ROCm via TheRock)</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td rowspan="4"><code>voxcpm2</code> (experimental)</td>
+      <td><code>metal</code></td>
+      <td>Apple Silicon GPU</td>
+      <td>macOS</td>
+    </tr>
+    <tr>
+      <td><code>cuda</code></td>
+      <td>NVIDIA GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>vulkan</code></td>
+      <td>Vulkan-capable GPUs</td>
+      <td>Windows, Linux</td>
+    </tr>
+    <tr>
+      <td><code>cpu</code></td>
+      <td><code>x86_64</code> CPU</td>
       <td>Windows, Linux</td>
     </tr>
     <tr>

--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -915,7 +915,7 @@ A typical workflow is to generate an image first, then upscale it:
 
 Speech Generation API. You provide a text input and receive an audio file. Which engine serves the request depends on the model.
 
-> **Note:** Supported models are `kokoro-v1` (fixed voices, [Kokoros](https://github.com/lucasjinreal/Kokoros) backend), the OpenMOSS family — `OpenMOSS-TTS` (voice cloning from a reference WAV) and `MOSS-VoiceGen` (voice design from a text description) — and `VoxCPM2` (voice design from a parenthetical description at the start of the input, 48 kHz output).
+> **Note:** Supported models are `kokoro-v1` (fixed voices, [Kokoros](https://github.com/lucasjinreal/Kokoros) backend), the OpenMOSS family — `OpenMOSS-TTS` (voice cloning from a reference WAV) and `MOSS-VoiceGen` (voice design from a text description) — and `VoxCPM2` (voice design from a parenthetical description at the start of the input, 48 kHz output). `VoxCPM2-ModelScope` serves the same weights from ModelScope for networks where Hugging Face is unreachable.
 >
 > **Limitations:** Which `response_format` values are accepted depends on the model's backend: `kokoro-v1` encodes `mp3`, `wav`, `opus`, and `pcm`, while OpenMOSS and VoxCPM2 models natively produce `wav` only. A format the backend cannot encode is rejected with `400 Bad Request` listing the ones it does support. Streaming works for any TTS backend, but a backend's streamable set can be narrower than its buffered set — `kokoro-v1` streams `pcm` only, so an explicit `response_format` of `mp3` alongside `stream_format` is rejected rather than silently answered with PCM.
 

--- a/docs/api/openai.md
+++ b/docs/api/openai.md
@@ -915,9 +915,9 @@ A typical workflow is to generate an image first, then upscale it:
 
 Speech Generation API. You provide a text input and receive an audio file. Which engine serves the request depends on the model.
 
-> **Note:** Supported models are `kokoro-v1` (fixed voices, [Kokoros](https://github.com/lucasjinreal/Kokoros) backend) and the OpenMOSS family — `OpenMOSS-TTS` (voice cloning from a reference WAV) and `MOSS-VoiceGen` (voice design from a text description).
+> **Note:** Supported models are `kokoro-v1` (fixed voices, [Kokoros](https://github.com/lucasjinreal/Kokoros) backend), the OpenMOSS family — `OpenMOSS-TTS` (voice cloning from a reference WAV) and `MOSS-VoiceGen` (voice design from a text description) — and `VoxCPM2` (voice design from a parenthetical description at the start of the input, 48 kHz output).
 >
-> **Limitations:** Which `response_format` values are accepted depends on the model's backend: `kokoro-v1` encodes `mp3`, `wav`, `opus`, and `pcm`, while OpenMOSS models natively produce `wav` only. A format the backend cannot encode is rejected with `400 Bad Request` listing the ones it does support. Streaming works for any TTS backend, but a backend's streamable set can be narrower than its buffered set — `kokoro-v1` streams `pcm` only, so an explicit `response_format` of `mp3` alongside `stream_format` is rejected rather than silently answered with PCM.
+> **Limitations:** Which `response_format` values are accepted depends on the model's backend: `kokoro-v1` encodes `mp3`, `wav`, `opus`, and `pcm`, while OpenMOSS and VoxCPM2 models natively produce `wav` only. A format the backend cannot encode is rejected with `400 Bad Request` listing the ones it does support. Streaming works for any TTS backend, but a backend's streamable set can be narrower than its buffered set — `kokoro-v1` streams `pcm` only, so an explicit `response_format` of `mp3` alongside `stream_format` is rejected rather than silently answered with PCM.
 
 ### Parameters
 

--- a/docs/assets/models.js
+++ b/docs/assets/models.js
@@ -17,6 +17,7 @@ const RECIPE_PRIORITY = [
   'thinksound',
   'trellis',
   'vllm',
+  'voxcpm2',
   'whispercpp'
 ];
 
@@ -32,7 +33,8 @@ const RECIPE_DISPLAY_NAMES = {
   acestep: 'ACE-Step',
   onnxruntime: 'ONNX Runtime',
   trellis: 'TRELLIS.2',
-  openmoss: 'OpenMOSS TTS'
+  openmoss: 'OpenMOSS TTS',
+  voxcpm2: 'VoxCPM2'
 };
 /* END GENERATED: models-js-recipes */
 

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -470,12 +470,13 @@ the generator instead. Prose outside the markers is preserved. -->
 | `Qwen3.6-35B-A3B-FP8-vLLM-highconc` | 36.0 | reasoning, tool-calling, vision, mtp |
 | `Qwen3.6-35B-A3B-FP8-vLLM-lowconc` | 36.0 | reasoning, tool-calling, vision, mtp |
 
-#### `voxcpm2` — VoxCPM2 (2 models)
+#### `voxcpm2` — VoxCPM2 (3 models)
 
 | Model | Size (GB) | Labels |
 |-------|-----------|--------|
 | `VoxCPM2` | 3.31 | tts, voice-design |
 | `VoxCPM2-F16` | 4.72 | tts, voice-design |
+| `VoxCPM2-ModelScope` | 3.56 | tts, voice-design |
 
 #### `whispercpp` — Whisper.cpp (6 models)
 

--- a/docs/dev/backends-reference.md
+++ b/docs/dev/backends-reference.md
@@ -22,6 +22,7 @@ the generator instead. Prose outside the markers is preserved. -->
 | `thinksound` | ThinkSound | yes | no | cuda, rocm, vulkan |
 | `trellis` | TRELLIS.2 | yes | no | cuda, rocm, vulkan |
 | `vllm` | vLLM ROCm (experimental) | yes | yes | rocm |
+| `voxcpm2` | VoxCPM2 | yes | no | cpu, cuda, metal, vulkan |
 | `whispercpp` | Whisper.cpp | yes | no | cpu, metal, npu, rocm, vulkan |
 <!-- END GENERATED: backends-overview -->
 
@@ -65,6 +66,10 @@ the generator instead. Prose outside the markers is preserved. -->
 | `trellis` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
 | `trellis` | rocm | linux, windows | amd_gpu (gfx103X, gfx110X, gfx1150, gfx1151, gfx1152, gfx120X) |
 | `vllm` | rocm | linux | amd_gpu (gfx110X, gfx1150, gfx1151, gfx120X) |
+| `voxcpm2` | metal | macos | metal |
+| `voxcpm2` | cuda | linux, windows | nvidia_gpu |
+| `voxcpm2` | vulkan | linux, windows | amd_gpu; cpu (x86_64); nvidia_gpu |
+| `voxcpm2` | cpu | linux, windows | cpu (x86_64) |
 | `whispercpp` | npu | windows | amd_npu (XDNA2) |
 | `whispercpp` | metal | macos | metal |
 | `whispercpp` | vulkan | linux, windows | amd_gpu; cpu (x86_64) |
@@ -173,6 +178,12 @@ the generator instead. Prose outside the markers is preserved. -->
 | `ctx_size` | `--ctx-size` | SIZE | -1 | Context size for the model |
 | `vllm_backend` | `--vllm` | BACKEND | "" | vLLM backend to use |
 | `vllm_args` | `--vllm-args` | ARGS | "" | Custom arguments to pass to vllm-server |
+
+#### `voxcpm2` — VoxCPM2
+
+| Option | CLI flag | Type | Default | Description |
+|--------|----------|------|---------|-------------|
+| `voxcpm2_backend` | `--voxcpm2` | BACKEND | "" | VoxCPM2 backend to use |
 
 #### `whispercpp` — Whisper.cpp
 
@@ -458,6 +469,13 @@ the generator instead. Prose outside the markers is preserved. -->
 | `Qwen3.6-35B-A3B-FP16-vLLM` | 71.93 | reasoning, tool-calling, vision |
 | `Qwen3.6-35B-A3B-FP8-vLLM-highconc` | 36.0 | reasoning, tool-calling, vision, mtp |
 | `Qwen3.6-35B-A3B-FP8-vLLM-lowconc` | 36.0 | reasoning, tool-calling, vision, mtp |
+
+#### `voxcpm2` — VoxCPM2 (2 models)
+
+| Model | Size (GB) | Labels |
+|-------|-----------|--------|
+| `VoxCPM2` | 3.31 | tts, voice-design |
+| `VoxCPM2-F16` | 4.72 | tts, voice-design |
 
 #### `whispercpp` — Whisper.cpp (6 models)
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -457,6 +457,12 @@ The following options are available depending on the recipe being used:
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--openmoss BACKEND` | OpenMOSS TTS backend to use | Auto-detected |
+
+#### VoxCPM2 (`voxcpm2` recipe)
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--voxcpm2 BACKEND` | VoxCPM2 backend to use | Auto-detected |
 <!-- END GENERATED: cli-recipe-options -->
 **Notes:**
 - Unspecified options will use the backend's default values

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -156,6 +156,12 @@ Values set in the user's `config.json` always take precedence over these seeded 
     "args": "",
     "backend": "auto"
   },
+  "voxcpm2": {
+    "backend": "auto",
+    "cpu_bin": "builtin",
+    "cuda_bin": "builtin",
+    "vulkan_bin": "builtin"
+  },
   "websocket_port": "auto",
   "whispercpp": {
     "args": "",

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -87,7 +87,7 @@ Supported registration flags:
 |------|-------------|
 | `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` or `modelscope`. When omitted, the server's configured `default_model_source` applies. |
 | `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
-| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
+| `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `voxcpm2`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `coding`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. |
 | `--components MODEL [MODEL ...]` | Components for an omni collection (see below). Use with `--recipe collection.omni`. |
 

--- a/src/cpp/include/lemon/backends/voxcpm2/voxcpm2.h
+++ b/src/cpp/include/lemon/backends/voxcpm2/voxcpm2.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "lemon/backends/backend_descriptor.h"
+
+namespace lemon {
+namespace backends {
+namespace voxcpm2 {
+
+// VoxCPM2 text-to-speech (OpenBMB), wrapped via llama.cpp-omni's resident
+// llama-tts-server subprocess. Serves the /audio/speech capability.
+inline const BackendDescriptor descriptor = {
+    /*recipe*/          "voxcpm2",
+    /*display_name*/    "VoxCPM2",
+#ifdef _WIN32
+    /*binary*/          "llama-tts-server.exe",
+#else
+    /*binary*/          "llama-tts-server",
+#endif
+    /*config_section*/  "",  // defaults to recipe
+    /*default_device*/  DEVICE_GPU,
+    /*slot_policy*/     SlotPolicy::Standard,
+    /*selectable_backend*/ true,
+    /*uses_ctx_size*/   false,
+    /*dynamic_models*/  false,
+    /*options*/ {
+        {"voxcpm2_backend", "--voxcpm2", "", "BACKEND",
+         "VoxCPM2 backend to use", "Text-to-Speech Options"},
+    },
+    /*support*/ {
+        {"metal", {"macos"}, {{"metal", {}}}, "Apple Silicon GPU"},
+        {"cuda", {"linux", "windows"}, {{"nvidia_gpu", {}}}, "NVIDIA GPUs"},
+        {"vulkan", {"linux", "windows"}, {{"cpu", {"x86_64"}}, {"amd_gpu", {}}, {"nvidia_gpu", {}}}, "Vulkan-capable GPUs"},
+        {"cpu", {"linux", "windows"}, {{"cpu", {"x86_64"}}}, "x86_64 CPU"},
+    },
+    /*default_labels*/  {"tts"},
+    /*required_checkpoints*/ {"main", "acoustic"},  // BaseLM + Acoustic GGUF, both always needed
+    /*modality*/        "Text-to-speech",
+    /*experimental*/    true,
+    /*web_display_name*/ "",
+    /*rocm_channels*/   {},
+    /*exposes_prometheus_metrics*/ false,
+    /*rocm_requires_cwsr_fix*/ false,
+    /*version_policy*/  VersionPolicy::Exact,
+    /*self_manages_downloads*/ false,
+    /*takes_args*/      false,
+    /*arg_variants*/    {},
+    /*bin_variants*/    {"vulkan", "cuda", "cpu"},
+    /*config_extra*/    nlohmann::json::object(),
+};
+
+}  // namespace voxcpm2
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/include/lemon/backends/voxcpm2/voxcpm2_server.h
+++ b/src/cpp/include/lemon/backends/voxcpm2/voxcpm2_server.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "lemon/backends/backend_registry.h"
+
+#include "lemon/wrapped_server.h"
+#include "lemon/server_capabilities.h"
+#include "lemon/backends/backend_utils.h"
+#include <string>
+
+namespace lemon {
+namespace backends {
+
+class VoxCPM2Server : public WrappedServer, public ITextToSpeechServer {
+public:
+    static InstallParams get_install_params(const std::string& backend, const std::string& version);
+
+    VoxCPM2Server(const std::string& log_level,
+                  ModelManager* model_manager,
+                  BackendManager* backend_manager);
+    ~VoxCPM2Server() override;
+
+    void load(const std::string& model_name,
+              const ModelInfo& model_info,
+              const RecipeOptions& options,
+              bool do_not_upgrade) override;
+    void unload() override;
+
+    void audio_speech(const json& request, httplib::DataSink& sink) override;
+    std::vector<std::string> supported_audio_formats() const override { return {"wav"}; }
+
+private:
+    std::string resolve_binary_path(const std::string& backend);
+};
+
+namespace voxcpm2 {
+std::unique_ptr<WrappedServer> create(const BackendContext& ctx);
+const BackendSpec* spec();
+const BackendOps* ops();
+}  // namespace voxcpm2
+
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/include/lemon/backends/voxcpm2/voxcpm2_server.h
+++ b/src/cpp/include/lemon/backends/voxcpm2/voxcpm2_server.h
@@ -28,7 +28,15 @@ public:
     void audio_speech(const json& request, httplib::DataSink& sink) override;
     std::vector<std::string> supported_audio_formats() const override { return {"wav"}; }
 
+    // The cpu variant runs entirely on the CPU, so the router must not account
+    // for it against a GPU slot the way the descriptor's default_device implies.
+    DeviceType effective_device(const RecipeOptions& options) const override;
+
 private:
+    // Resolves the backend variant the way load() will, or "" if this system
+    // supports none. Kept in one place so the device reported before the load
+    // cannot disagree with the variant the load actually picks.
+    std::string resolve_backend(const RecipeOptions& options) const;
     std::string resolve_binary_path(const std::string& backend);
 };
 

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -42,6 +42,17 @@
           "trellis-cuda-linux-x64.tar.gz": "sha256:454c161b2179551db5e80786bba16ae81eaf28ab8fdb685d371b30d58769fbaa",
           "trellis-cuda-windows-x64.zip": "sha256:47b87271f8b644a8e50767f6d58d5baf597e1aa6bb46b809a5e5d5b0ac741b29"
         }
+      },
+      "ZMXJJ/llama.cpp-omni": {
+        "tts-v0.1.2": {
+          "llama-tts-server-cpu-linux-x64.tar.gz": "sha256:96f9c9617d1feb0a3b581d3b61eca16bedf66cd32376009ed2ddf5fa66ad3e3e",
+          "llama-tts-server-cpu-windows-x64.zip": "sha256:932ba915b83e236fdad30c89a40c679db2824d4e451d78a8a5595b948b8af593",
+          "llama-tts-server-cuda-linux-x64.tar.gz": "sha256:f157486f4fb19dfdf18f42819b3e47db3bf63f2ee80e1beca6dc3165cf5ead77",
+          "llama-tts-server-cuda-windows-x64.zip": "sha256:7caa63e82af114c698f23e86cfac670c39e4f86f5c6353c0990ca1d689b6d65a",
+          "llama-tts-server-metal-macos-arm64.tar.gz": "sha256:4df3b5e1a7d9c6db6b3d7857ef56db11e1152c73a25fff972b58b2d5f6da34b4",
+          "llama-tts-server-vulkan-linux-x64.tar.gz": "sha256:986bf8078db75bc8591d1af60d7e6d1855d82acc640975f5e701d37898a41d89",
+          "llama-tts-server-vulkan-windows-x64.zip": "sha256:25d527dfde3296f73b7e7188839c5bdc42f6f6b4d7f37e9da54e0a30edfb79da"
+        }
       }
     }
   },
@@ -192,10 +203,10 @@
   },
   "voxcpm2": {
     "comment": "Tags come from the fork that builds the per-variant llama-tts-server archives; upstream llama.cpp-omni releases only the Comni desktop installers. The tts- prefix keeps these clear of upstream's v1.0.x Comni tags.",
-    "metal": "tts-v0.1.0",
-    "vulkan": "tts-v0.1.0",
-    "cuda": "tts-v0.1.0",
-    "cpu": "tts-v0.1.0"
+    "metal": "tts-v0.1.2",
+    "vulkan": "tts-v0.1.2",
+    "cuda": "tts-v0.1.2",
+    "cpu": "tts-v0.1.2"
   },
   "clear_bin_if_lemonade_below": "9.4.0"
 }

--- a/src/cpp/resources/backend_versions.json
+++ b/src/cpp/resources/backend_versions.json
@@ -190,5 +190,12 @@
     "rocm-stable": "v0.1.3",
     "cuda": "v0.1.3"
   },
+  "voxcpm2": {
+    "comment": "Tags come from the fork that builds the per-variant llama-tts-server archives; upstream llama.cpp-omni releases only the Comni desktop installers. The tts- prefix keeps these clear of upstream's v1.0.x Comni tags.",
+    "metal": "tts-v0.1.0",
+    "vulkan": "tts-v0.1.0",
+    "cuda": "tts-v0.1.0",
+    "cpu": "tts-v0.1.0"
+  },
   "clear_bin_if_lemonade_below": "9.4.0"
 }

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -121,6 +121,12 @@
     "args": "",
     "backend": "auto"
   },
+  "voxcpm2": {
+    "backend": "auto",
+    "cpu_bin": "builtin",
+    "cuda_bin": "builtin",
+    "vulkan_bin": "builtin"
+  },
   "websocket_port": "auto",
   "whispercpp": {
     "args": "",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1854,6 +1854,32 @@
             "height": 1024
         }
     },
+    "VoxCPM2": {
+        "checkpoints": {
+            "main": "DennisHuang648/VoxCPM2-GGUF:VoxCPM2-BaseLM-Q8_0.gguf",
+            "acoustic": "DennisHuang648/VoxCPM2-GGUF:VoxCPM2-Acoustic-F16.gguf"
+        },
+        "recipe": "voxcpm2",
+        "suggested": true,
+        "labels": [
+            "tts",
+            "voice-design"
+        ],
+        "size": 3.31
+    },
+    "VoxCPM2-F16": {
+        "checkpoints": {
+            "main": "DennisHuang648/VoxCPM2-GGUF:VoxCPM2-BaseLM-F16.gguf",
+            "acoustic": "DennisHuang648/VoxCPM2-GGUF:VoxCPM2-Acoustic-F16.gguf"
+        },
+        "recipe": "voxcpm2",
+        "suggested": false,
+        "labels": [
+            "tts",
+            "voice-design"
+        ],
+        "size": 4.72
+    },
     "RealESRGAN-x4plus": {
         "checkpoint": "amd/realesrgan-x4plus:RealESRGAN_x4plus.pth",
         "recipe": "sd-cpp",

--- a/src/cpp/resources/server_models.json
+++ b/src/cpp/resources/server_models.json
@@ -1880,6 +1880,20 @@
         ],
         "size": 4.72
     },
+    "VoxCPM2-ModelScope": {
+        "checkpoints": {
+            "main": "DennisHuang/VoxCPM2-GGUF:VoxCPM2-BaseLM-Q8_0.gguf",
+            "acoustic": "DennisHuang/VoxCPM2-GGUF:VoxCPM2-Acoustic-F16.gguf"
+        },
+        "registry_source": "modelscope",
+        "recipe": "voxcpm2",
+        "suggested": false,
+        "labels": [
+            "tts",
+            "voice-design"
+        ],
+        "size": 3.56
+    },
     "RealESRGAN-x4plus": {
         "checkpoint": "amd/realesrgan-x4plus:RealESRGAN_x4plus.pth",
         "recipe": "sd-cpp",

--- a/src/cpp/server/backends/voxcpm2/voxcpm2_server.cpp
+++ b/src/cpp/server/backends/voxcpm2/voxcpm2_server.cpp
@@ -55,6 +55,23 @@ std::string VoxCPM2Server::resolve_binary_path(const std::string& backend) {
     return BackendUtils::get_backend_binary_path(*spec, backend);
 }
 
+std::string VoxCPM2Server::resolve_backend(const RecipeOptions& options) const {
+    std::string backend = options.get_option("voxcpm2_backend");
+    if (!backend.empty()) {
+        return backend;
+    }
+    auto supported = SystemInfo::get_supported_backends("voxcpm2");
+    return supported.backends.empty() ? std::string() : supported.backends[0];
+}
+
+DeviceType VoxCPM2Server::effective_device(const RecipeOptions& options) const {
+    const std::string backend = resolve_backend(options);
+    if (backend.empty()) {
+        return WrappedServer::effective_device(options);
+    }
+    return backend == "cpu" ? DEVICE_CPU : DEVICE_GPU;
+}
+
 void VoxCPM2Server::load(const std::string& model_name,
                          const ModelInfo& model_info,
                          const RecipeOptions& options,
@@ -71,14 +88,10 @@ void VoxCPM2Server::load(const std::string& model_name,
         throw std::runtime_error("Acoustic path not found for checkpoint: " + model_info.checkpoint("acoustic"));
     }
 
-    std::string backend = options.get_option("voxcpm2_backend");
+    const std::string backend = resolve_backend(options);
     if (backend.empty()) {
-        auto supported = SystemInfo::get_supported_backends("voxcpm2");
-        if (supported.backends.empty()) {
-            throw UnsupportedOperationException(
-                "VoxCPM2", "this system: no supported backend (Metal, Vulkan, ROCm, CUDA, or CPU) detected");
-        }
-        backend = supported.backends[0];
+        throw UnsupportedOperationException(
+            "VoxCPM2", "this system: no supported backend (Metal, Vulkan, CUDA, or CPU) detected");
     }
     RuntimeConfig::validate_backend_choice("voxcpm2", backend);
     const std::string exe_path = resolve_binary_path(backend);

--- a/src/cpp/server/backends/voxcpm2/voxcpm2_server.cpp
+++ b/src/cpp/server/backends/voxcpm2/voxcpm2_server.cpp
@@ -1,0 +1,166 @@
+#include "lemon/backends/voxcpm2/voxcpm2_server.h"
+#include "lemon/backends/voxcpm2/voxcpm2.h"
+#include "lemon/backends/backend_registry.h"
+#include "lemon/backends/backend_ops.h"
+#include "lemon/backends/backend_utils.h"
+#include "lemon/backend_manager.h"
+#include "lemon/error_types.h"
+#include "lemon/model_manager.h"
+#include "lemon/runtime_config.h"
+#include "lemon/system_info.h"
+#include "lemon/utils/process_manager.h"
+#include <lemon/utils/aixlog.hpp>
+#include <cstdlib>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace lemon {
+namespace backends {
+
+InstallParams VoxCPM2Server::get_install_params(const std::string& backend, const std::string& version) {
+    (void)version;
+    InstallParams params;
+    // Upstream llama.cpp-omni publishes only the Comni desktop installers, so the
+    // per-variant llama-tts-server archives are built and released from a fork.
+    params.repo = "ZMXJJ/llama.cpp-omni";
+#ifdef _WIN32
+    params.filename = "llama-tts-server-" + backend + "-windows-x64.zip";
+#elif defined(__APPLE__)
+    params.filename = "llama-tts-server-" + backend + "-macos-arm64.tar.gz";
+#else
+    params.filename = "llama-tts-server-" + backend + "-linux-x64.tar.gz";
+#endif
+    return params;
+}
+
+VoxCPM2Server::VoxCPM2Server(const std::string& log_level,
+                             ModelManager* model_manager,
+                             BackendManager* backend_manager)
+    : WrappedServer("voxcpm2-server", log_level, model_manager, backend_manager) {}
+
+VoxCPM2Server::~VoxCPM2Server() {
+    unload();
+}
+
+std::string VoxCPM2Server::resolve_binary_path(const std::string& backend) {
+    const BackendSpec* spec = voxcpm2::spec();
+    std::string external = BackendUtils::find_external_backend_binary(spec->recipe, backend);
+    if (!external.empty() && std::filesystem::exists(external)) {
+        return external;
+    }
+    backend_manager_->install_backend(spec->recipe, backend);
+    return BackendUtils::get_backend_binary_path(*spec, backend);
+}
+
+void VoxCPM2Server::load(const std::string& model_name,
+                         const ModelInfo& model_info,
+                         const RecipeOptions& options,
+                         bool /*do_not_upgrade*/) {
+    LOG(INFO, "voxcpm2-server") << "Loading model: " << model_name << std::endl;
+
+    const std::string base_lm_path = model_info.resolved_path("main");
+    if (base_lm_path.empty() || !std::filesystem::exists(base_lm_path)) {
+        throw std::runtime_error("BaseLM path not found for checkpoint: " + model_info.checkpoint("main"));
+    }
+
+    const std::string acoustic_path = model_info.resolved_path("acoustic");
+    if (acoustic_path.empty() || !std::filesystem::exists(acoustic_path)) {
+        throw std::runtime_error("Acoustic path not found for checkpoint: " + model_info.checkpoint("acoustic"));
+    }
+
+    std::string backend = options.get_option("voxcpm2_backend");
+    if (backend.empty()) {
+        auto supported = SystemInfo::get_supported_backends("voxcpm2");
+        if (supported.backends.empty()) {
+            throw UnsupportedOperationException(
+                "VoxCPM2", "this system: no supported backend (Metal, Vulkan, ROCm, CUDA, or CPU) detected");
+        }
+        backend = supported.backends[0];
+    }
+    RuntimeConfig::validate_backend_choice("voxcpm2", backend);
+    const std::string exe_path = resolve_binary_path(backend);
+
+    port_ = choose_port();
+    if (port_ == 0) {
+        throw std::runtime_error("Failed to find an available port");
+    }
+
+    std::vector<std::string> args = {
+        "--voxcpm2-base-lm", base_lm_path,
+        "--voxcpm2-acoustic", acoustic_path,
+        "--host", "127.0.0.1",
+        "--port", std::to_string(port_),
+    };
+
+    std::vector<std::pair<std::string, std::string>> env_vars;
+    if (backend == "cuda") {
+        const std::string exe_dir = std::filesystem::path(exe_path).parent_path().string();
+#ifdef _WIN32
+        std::string path = exe_dir;
+        if (const char* p = std::getenv("PATH")) path += std::string(";") + p;
+        env_vars.push_back({"PATH", path});
+#else
+        std::string ld = exe_dir;
+        if (const char* p = std::getenv("LD_LIBRARY_PATH")) ld += std::string(":") + p;
+        env_vars.push_back({"LD_LIBRARY_PATH", ld});
+#endif
+        BackendUtils::apply_cuda_env_vars(env_vars, "voxcpm2-server");
+    }
+
+    LOG(INFO, "voxcpm2-server") << "Starting " << exe_path << " on port " << port_ << std::endl;
+    ProcessHandle started_handle = utils::ProcessManager::start_process(
+        exe_path, args, "", is_debug(), false, env_vars);
+    set_process_handle(started_handle);
+    if (!has_process_handle(started_handle)) {
+        throw std::runtime_error("Failed to start llama-tts-server process");
+    }
+    LOG(INFO, "voxcpm2-server") << "Process started with PID: " << started_handle.pid << std::endl;
+
+    if (!wait_for_ready("/health")) {
+        unload();
+        throw std::runtime_error("llama-tts-server failed to start or become ready");
+    }
+}
+
+void VoxCPM2Server::unload() {
+    stop_backend_watchdog();
+    const ProcessHandle handle = consume_process_handle_for_cleanup();
+    if (has_process_handle(handle)) {
+        LOG(INFO, "voxcpm2-server") << "Stopping server (PID: " << handle.pid << ")" << std::endl;
+        utils::ProcessManager::stop_process(handle);
+    }
+}
+
+void VoxCPM2Server::audio_speech(const json& request, httplib::DataSink& sink) {
+    json forwarded = request;
+    // llama-tts-server validates "model" against its own engine name and rejects
+    // anything else, so the catalog name Lemonade routed on cannot be passed through.
+    forwarded["model"] = "voxcpm2";
+
+    // Streaming requests deliberately go to the buffered endpoint. llama-tts-server
+    // also exposes /v1/audio/speech/stream, but its first decode step feeds a
+    // single 4-frame latent patch into the AudioVAE, whose causal convolutions need
+    // more left padding than that — GGML_ASSERT(lp0 <= x->ne[0]) in
+    // voxcpm2_audiovae.cpp aborts the subprocess on every such request. Switch the
+    // endpoint here once that is fixed upstream.
+    forward_streaming_request("/v1/audio/speech", forwarded.dump(), sink, /*sse=*/false, /*timeout_seconds=*/600);
+}
+
+}  // namespace backends
+
+namespace backends {
+namespace voxcpm2 {
+
+std::unique_ptr<WrappedServer> create(const BackendContext& ctx) {
+    return make_server<VoxCPM2Server>(ctx);
+}
+
+const BackendSpec* spec() { return make_spec<VoxCPM2Server>(descriptor); }
+const BackendOps* ops() { return default_backend_ops(); }
+
+}  // namespace voxcpm2
+}  // namespace backends
+}  // namespace lemon

--- a/src/cpp/server/backends/voxcpm2/voxcpm2_server.cpp
+++ b/src/cpp/server/backends/voxcpm2/voxcpm2_server.cpp
@@ -140,12 +140,11 @@ void VoxCPM2Server::audio_speech(const json& request, httplib::DataSink& sink) {
     // anything else, so the catalog name Lemonade routed on cannot be passed through.
     forwarded["model"] = "voxcpm2";
 
-    // Streaming requests deliberately go to the buffered endpoint. llama-tts-server
-    // also exposes /v1/audio/speech/stream, but its first decode step feeds a
-    // single 4-frame latent patch into the AudioVAE, whose causal convolutions need
-    // more left padding than that — GGML_ASSERT(lp0 <= x->ne[0]) in
-    // voxcpm2_audiovae.cpp aborts the subprocess on every such request. Switch the
-    // endpoint here once that is fixed upstream.
+    // Streaming requests deliberately go to the buffered endpoint.
+    // /v1/audio/speech/stream re-decodes a context window of latents on every
+    // step, which costs more than one buffered decode of the whole utterance,
+    // so the extra wall-clock outweighs starting playback earlier. Switch once
+    // that gap closes.
     forward_streaming_request("/v1/audio/speech", forwarded.dump(), sink, /*sse=*/false, /*timeout_seconds=*/600);
 }
 

--- a/test/server_tts_voxcpm2.py
+++ b/test/server_tts_voxcpm2.py
@@ -102,14 +102,36 @@ class VoxCPM2TTSTests(ServerTestBase):
             "stream_format": "audio",
         }
 
-        response = requests.post(
+        # Headers and body are read off the live response before any assertion:
+        # unittest evaluates a failure message eagerly, so touching response.text
+        # here would consume the stream and leave iter_content replaying a cache.
+        with requests.post(
             f"{self.base_url}/audio/speech",
             json=payload,
             timeout=TIMEOUT_MODEL_OPERATION,
-        )
+            stream=True,
+        ) as response:
+            status = response.status_code
+            content_type = response.headers.get("Content-Type", "")
+            body = b"".join(response.iter_content(chunk_size=8192))
 
-        self._assert_wav_response(response, "Streamed speech")
-        print(f"[OK] Streamed speech produced a clip ({len(response.content)} bytes)")
+        self.assertEqual(
+            status,
+            200,
+            f"Streamed speech failed with status {status}: {body[:1000]!r}",
+        )
+        self.assertIn(
+            "audio/wav",
+            content_type,
+            f"Streamed speech should keep the backend's WAV container, got '{content_type}'",
+        )
+        self.assertTrue(
+            body[:4] == b"RIFF",
+            "Streamed body should be a valid WAV (RIFF) file",
+        )
+        self.assertGreater(len(body), 1000, "Streamed clip should be substantial")
+
+        print(f"[OK] Streamed speech produced a clip ({len(body)} bytes)")
 
     def test_004_rejects_unsupported_format(self):
         """An explicitly requested format the backend cannot encode is rejected."""

--- a/test/server_tts_voxcpm2.py
+++ b/test/server_tts_voxcpm2.py
@@ -1,0 +1,160 @@
+"""
+VoxCPM2 TTS tests for Lemonade Server.
+
+Tests the /audio/speech endpoint with the VoxCPM2 backend: plain synthesis,
+voice design from a parenthetical description, streaming, and format rejection.
+
+Usage:
+    python server_tts_voxcpm2.py --wrapped-server voxcpm2 --backend metal
+    python server_tts_voxcpm2.py --wrapped-server voxcpm2 --backend vulkan
+"""
+
+import requests
+
+from utils.server_base import (
+    ServerTestBase,
+    run_server_tests,
+    pull_model_with_retry,
+)
+from utils.capabilities import get_test_model
+from utils.test_models import (
+    TIMEOUT_MODEL_OPERATION,
+)
+
+
+class VoxCPM2TTSTests(ServerTestBase):
+    """Tests for VoxCPM2 text-to-speech."""
+
+    _model_pulled = False
+
+    @classmethod
+    def setUpClass(cls):
+        """Verify server, apply runtime config, and pre-pull the TTS model."""
+        super().setUpClass()
+        cls._ensure_model_pulled()
+
+    @classmethod
+    def _ensure_model_pulled(cls):
+        if cls._model_pulled:
+            return
+        model = get_test_model("tts")
+        print(f"\n[SETUP] Ensuring {model} is pulled...")
+        pull_model_with_retry(model)
+        print(f"[SETUP] {model} is ready")
+        cls._model_pulled = True
+
+    def _assert_wav_response(self, response, context):
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"{context} failed with status {response.status_code}: {response.text[:1000]}",
+        )
+        self.assertIn(
+            "audio/wav",
+            response.headers.get("Content-Type", ""),
+            f"{context}: response should have audio/wav content type",
+        )
+        self.assertTrue(
+            response.content[:4] == b"RIFF",
+            f"{context}: response body should be a valid WAV (RIFF) file",
+        )
+        self.assertGreater(
+            len(response.content), 1000, f"{context}: clip should be substantial"
+        )
+
+    def test_001_basic_speech(self):
+        """Test basic speech synthesis defaults to the backend's WAV output."""
+        payload = {
+            "model": get_test_model("tts"),
+            "input": "Lemonade can speak with VoxCPM2.",
+        }
+
+        response = requests.post(
+            f"{self.base_url}/audio/speech",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self._assert_wav_response(response, "Basic speech")
+        print(f"[OK] Basic speech produced a clip ({len(response.content)} bytes)")
+
+    def test_002_voice_design(self):
+        """VoxCPM2 designs a voice from a parenthetical prefix in the input."""
+        payload = {
+            "model": get_test_model("tts"),
+            "input": "(A calm, deep male narrator voice) Lemonade can speak.",
+        }
+
+        response = requests.post(
+            f"{self.base_url}/audio/speech",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self._assert_wav_response(response, "Voice design")
+        print(f"[OK] Voice design produced a clip ({len(response.content)} bytes)")
+
+    def test_003_streaming(self):
+        """Streaming falls back to the backend's WAV output, since it has no PCM."""
+        payload = {
+            "model": get_test_model("tts"),
+            "input": "Lemonade can stream speech with VoxCPM2.",
+            "stream_format": "audio",
+        }
+
+        response = requests.post(
+            f"{self.base_url}/audio/speech",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self._assert_wav_response(response, "Streamed speech")
+        print(f"[OK] Streamed speech produced a clip ({len(response.content)} bytes)")
+
+    def test_004_rejects_unsupported_format(self):
+        """An explicitly requested format the backend cannot encode is rejected."""
+        payload = {
+            "model": get_test_model("tts"),
+            "input": "Lemonade can speak.",
+            "response_format": "mp3",
+        }
+
+        response = requests.post(
+            f"{self.base_url}/audio/speech",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self.assertEqual(
+            response.status_code,
+            400,
+            "Requesting mp3 from a wav-only backend should be rejected, "
+            f"got {response.status_code}",
+        )
+        print(f"[OK] Unsupported format rejected")
+
+    def test_005_missing_input_error(self):
+        """Test error handling when input is missing."""
+        payload = {"model": get_test_model("tts")}
+
+        response = requests.post(
+            f"{self.base_url}/audio/speech",
+            json=payload,
+            timeout=TIMEOUT_MODEL_OPERATION,
+        )
+
+        self.assertEqual(
+            response.status_code,
+            400,
+            f"Missing input should be rejected, got {response.status_code}",
+        )
+        print(f"[OK] Missing input rejected")
+
+
+if __name__ == "__main__":
+    run_server_tests(
+        VoxCPM2TTSTests,
+        "VOXCPM2 TTS TESTS",
+        modality="tts",
+        default_wrapped_server="voxcpm2",
+    )

--- a/test/utils/capabilities.py
+++ b/test/utils/capabilities.py
@@ -249,6 +249,19 @@ CAPABILITIES = {
                 "tts_design": "MOSS-VoiceGen",
             },
         },
+        "voxcpm2": {
+            "backends": ["metal", "vulkan", "cuda", "cpu"],
+            "supports": {
+                "tts": True,
+                # The engine clones from reference audio, but Lemonade does not
+                # expose a request field for it yet.
+                "voice_cloning": False,
+                "voice_design": True,
+            },
+            "test_models": {
+                "tts": "VoxCPM2",
+            },
+        },
     },
     "omni": {
         # Omni "collection" models run a server-side tool-calling loop. The


### PR DESCRIPTION
## Summary

Adds VoxCPM2 (OpenBMB) as an experimental text-to-speech backend, wrapping llama.cpp-omni's `llama-tts-server` subprocess to serve `/audio/speech`. Ships three catalog entries: a suggested Q8 default, an F16 variant, and a ModelScope-hosted mirror.

Depends on #3029 — VoxCPM2 emits wav only, which the streaming path rejects without it.

## Notes for review

- **Two GGUF files per model** (BaseLM + Acoustic), resolved through the `checkpoints` map the way sd-cpp handles flux.

- **Streaming forwards to the buffered `/v1/audio/speech` on purpose.** `llama-tts-server` also exposes `/v1/audio/speech/stream`, but it re-decodes a context window of latents every step, costing more than one buffered decode of the whole utterance. The comment at the call site says so, so nobody flips it and lands a slower path.

- **Backend binaries come from a fork** (`ZMXJJ/llama.cpp-omni`) that builds the per-variant `llama-tts-server` archives; upstream llama.cpp-omni only releases the Comni desktop installers. SHA-256 digests for all seven archives are pinned in `backend_versions.json`, per #2710. The `tts-` tag prefix keeps these clear of upstream's `v1.0.x` Comni tags.

- **The ModelScope entry is `suggested: false`** so default listings stay on Hugging Face. It exists because HF is unreachable in parts of the world VoxCPM2 targets. Note the owner differs per registry: `DennisHuang648` on HF, `DennisHuang` on ModelScope.

## Testing

New `test/server_tts_voxcpm2.py`, plus a `voxcpm2` entry in `test/utils/capabilities.py`. Wired into CI as the `tts-voxcpm2` job on vulkan, for both Windows and Linux.
