### PR TITLE
Add support for a default model source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2820,6 +2820,13 @@ if(BUILD_TESTING AND EXISTS "${_RUNTIME_CONFIG_BACKEND_VALIDATION_TEST_SRC}")
     )
 endif()
 
+set(_CONFIG_DEFAULT_SOURCE_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_config_default_source.cpp")
+if(BUILD_TESTING AND EXISTS "${_CONFIG_DEFAULT_SOURCE_TEST_SRC}")
+    add_executable(test_config_default_source test/cpp/test_config_default_source.cpp)
+    target_link_libraries(test_config_default_source PRIVATE lemonade-server-core)
+    add_cpp_ci_test(ConfigDefaultSourceTest CI ON COMMAND test_config_default_source)
+endif()
+
 # ROCm root resolution (ROCM_PATH / rocm-sdk / /opt/rocm priority): covers the
 # external-ROCm detection that lets Lemonade skip the bundled TheRock download.
 set(_ROCM_ROOT_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_rocm_root_resolution.cpp")

--- a/docs/dev/model-registries.md
+++ b/docs/dev/model-registries.md
@@ -12,6 +12,10 @@ Remote provenance is stored separately from local origin:
 
 Hugging Face is the default for backward compatibility. A model and all of its checkpoints have one registry source. Collection components inherit the collection source unless an inline component definition explicitly declares another source.
 
+## Default source policy
+
+When a pull request names no registry — no `--source`, no `source`/`registry_source` field, and no provider URL — lemond falls back to the `default_model_source` config key (`huggingface` or `modelscope`, default `huggingface`). Resolution is server-side and authoritative so every client (CLI, desktop, web, Ollama-compatible endpoints) inherits the same policy, per the many-clients-one-server contract. The resolution happens once, up front in the `/pull` handler, so the chosen registry is persisted with the model and stays consistent across download, cache layout, and later refresh. A bare `pull <registered-name>` refresh carries no checkpoint and keeps its recorded provenance rather than re-applying the default. `GET /pull/variants` echoes the resolved `source` so the CLI's interactive flow records the same registry the weights came from.
+
 ## Registry interface
 
 `ModelRegistry` normalizes provider behavior into:

--- a/docs/dev/model-registries.md
+++ b/docs/dev/model-registries.md
@@ -16,6 +16,8 @@ Hugging Face is the shipped default for backward compatibility, but the effectiv
 
 When a pull request names no registry — no `--source`, no `source`/`registry_source` field, and no provider URL — lemond falls back to the `default_model_source` config key (`huggingface` or `modelscope`, default `huggingface`). Resolution is server-side and authoritative so every client (CLI, desktop, web, Ollama-compatible endpoints) inherits the same policy, per the many-clients-one-server contract. The resolution happens once, up front in the `/pull` handler, so the chosen registry is persisted with the model and stays consistent across download, cache layout, and later refresh. A bare `pull <registered-name>` refresh carries no checkpoint and keeps its recorded provenance rather than re-applying the default. `GET /pull/variants` echoes the resolved `source` so the CLI's interactive flow records the same registry the weights came from.
 
+Provider URL detection is shared code (`detect_registry_url`) applied server-side in `apply_default_pull_source`, not only in the CLI. A provider URL is authoritative for its registry: every registry-backed checkpoint in the body (primary and secondary entries such as `mmproj`, `vae`, or `text_encoder`) is normalized to `owner/repo`, and the whole model must resolve to a single registry. The primary checkpoint follows the same precedence as model registration — `checkpoints.main` when a `checkpoints` object is present, otherwise `checkpoint`. A `source`/`registry_source` that conflicts with a checkpoint's provider URL, or checkpoints that disagree on the registry, are rejected with `400`, matching the CLI.
+
 ## Registry interface
 
 `ModelRegistry` normalizes provider behavior into:

--- a/docs/dev/model-registries.md
+++ b/docs/dev/model-registries.md
@@ -10,7 +10,7 @@ Remote provenance is stored separately from local origin:
 - `ModelInfo::registry_source` identifies the remote registry: `huggingface` or `modelscope`.
 - The public registration field is `source`. For a remote model it is canonicalized and persisted as the registry name. `registry_source` is also accepted in exported/internal records.
 
-Hugging Face is the default for backward compatibility. A model and all of its checkpoints have one registry source. Collection components inherit the collection source unless an inline component definition explicitly declares another source.
+Hugging Face is the shipped default for backward compatibility, but the effective default for source-less pulls is the `default_model_source` config key (see [Default source policy](#default-source-policy) below). A model and all of its checkpoints have one registry source. Collection components inherit the collection source unless an inline component definition explicitly declares another source.
 
 ## Default source policy
 

--- a/docs/embeddable/models.md
+++ b/docs/embeddable/models.md
@@ -205,7 +205,7 @@ For example, if you wanted to add [OmniCoder-9B](https://huggingface.co/Tesslate
 
 You can learn more in the [Custom Models](../guide/configuration/custom-models.md) guide, including how to enable your users to register their own custom models at runtime.
 
-Set `"source": "modelscope"` for curated entries hosted on ModelScope. Lemonade preserves that field in its model metadata and uses it for every subsequent download and update check. The default is `huggingface`, so existing registry files require no migration.
+Set `"source": "modelscope"` for curated entries hosted on ModelScope. Lemonade preserves that field in its model metadata and uses it for every subsequent download and update check. When `source` is omitted the shipped default is `huggingface`, so existing registry files require no migration.
 
 ### Per-Model Load Options
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -195,7 +195,7 @@ lemonade pull user.MyModel --checkpoint main org/model:Q4_0 --recipe llamacpp --
 | Option | Description | Required |
 |--------|-------------|----------|
 | `MODEL_OR_CHECKPOINT` | Registered model name, or `owner/repo[:variant]` Hugging Face/ModelScope checkpoint | Yes |
-| `--source` | Remote registry for checkpoint pulls: `huggingface` (default) or `modelscope`; direct hub URLs are auto-detected | No |
+| `--source` | Remote registry for checkpoint pulls: `huggingface` or `modelscope`; when omitted, the server's configured `default_model_source` applies. Direct hub URLs are auto-detected | No |
 | `--alias ALIAS` | Add an alias for the model being registered or pulled. | No |
 | `--checkpoint TYPE CHECKPOINT` | Manual registration: add a checkpoint entry. Repeat for multi-component models such as `main` + `mmproj` or `main` + `vae`. | No |
 | `--recipe RECIPE` | Manual registration: recipe to associate with the new `user.*` model (`llamacpp`, `flm`, `ryzenai-llm`, `vllm`, `whispercpp`, `sd-cpp`, `kokoro`, `collection.omni`) | No |

--- a/docs/guide/configuration/README.md
+++ b/docs/guide/configuration/README.md
@@ -45,6 +45,7 @@ Values set in the user's `config.json` always take precedence over these seeded 
   "cloud_providers": [],
   "config_version": 2,
   "ctx_size": -1,
+  "default_model_source": "huggingface",
   "disable_model_filtering": false,
   "enable_dgpu_gtt": false,
   "extra_models_dir": "",
@@ -181,6 +182,7 @@ Values set in the user's `config.json` always take precedence over these seeded 
 | `extra_models_dir` | string | "" | Secondary directory to scan for GGUF model files |
 | `models_dir` | string | "auto" | Directory for cached model files. "auto" follows HF_HUB_CACHE / HF_HOME / platform default |
 | `ctx_size` | int | -1 | Default context size for LLM models. Use `-1` for auto-resolution: the server computes the largest context that fits in available device memory using GGUF architecture metadata. Use a positive integer to set an explicit size. |
+| `default_model_source` | string | "huggingface" | Remote registry used to pull checkpoints when a request does not name one (`huggingface` or `modelscope`). Explicit `--source`, a `source`/`registry_source` field, or a provider URL always overrides it. |
 | `offline` | bool | false | Skip model downloads |
 | `auto_check_model_updates` | bool | true | Check downloaded Hugging Face-backed models for updates during server startup. Set to `false` to check only with `lemonade check-updates` or `POST /v1/models/check-updates`. Manual downloads and updates remain enabled. |
 | `no_fetch_executables` | bool | false | Prevent downloading backend executable artifacts; backends must already be installed or use the system backend |

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -6,7 +6,7 @@ This guide explains every supported way to add a custom model to Lemonade Server
 
 ### Pull from Hugging Face or ModelScope
 
-Hugging Face remains the default registry, so existing commands keep working unchanged:
+A source-less pull uses the server's configured `default_model_source` (shipped default: Hugging Face), so existing commands keep working unchanged:
 
 ```bash
 lemonade pull org/repo
@@ -32,7 +32,7 @@ For supported repository layouts, Lemonade lists GGUF quantizations and sharded 
 Examples:
 
 ```bash
-# Hugging Face (default)
+# Hugging Face (shipped default source)
 lemonade pull unsloth/Qwen3-8B-GGUF:Q4_K_M
 
 # ModelScope
@@ -195,7 +195,7 @@ Example collection file:
 
 ### Register via API
 
-The `/v1/pull` endpoint accepts the same model registration fields as the CLI. Set `source` to `huggingface` (the default) or `modelscope`; the server canonicalizes and persists it for later update checks. Use this when integrating Lemonade into another app or script:
+The `/v1/pull` endpoint accepts the same model registration fields as the CLI. Set `source` to `huggingface` or `modelscope`; when omitted, the server's configured `default_model_source` applies. The server canonicalizes and persists the resolved value for later update checks. Use this when integrating Lemonade into another app or script:
 
 ```bash
 curl -X POST http://localhost:13305/v1/pull \
@@ -378,7 +378,7 @@ This file contains a JSON object where each key is a model name and each value d
 
 | Field | Required | Type | Description |
 |-------|----------|------|-------------|
-| `source` | No | String | Remote registry: `huggingface` (default) or `modelscope`. Persisted and used for variants, downloads, cache paths, links, and update checks. |
+| `source` | No | String | Remote registry: `huggingface` or `modelscope`. When omitted, the server's configured `default_model_source` applies. Persisted and used for variants, downloads, cache paths, links, and update checks. A `source`/`registry_source` that conflicts with a provider URL in the checkpoint is rejected with 400. |
 | `checkpoint` | Yes* | String | Registry checkpoint in `org/repo` or `org/repo:variant` format. Use `org/repo:filename.gguf` for GGUF models. |
 | `checkpoints` | Yes* | Object | Alternative to `checkpoint` for models with multiple files. See [Multi-file models](#multi-file-models). |
 | `recipe` | Yes | String | Backend engine to use. One of: `llamacpp`, `whispercpp`, `moonshine`, `sd-cpp`, `kokoro`, `ryzenai-llm`, `flm`, `collection.omni`. |

--- a/docs/guide/configuration/custom-models.md
+++ b/docs/guide/configuration/custom-models.md
@@ -85,7 +85,7 @@ Supported registration flags:
 
 | Flag | Description |
 |------|-------------|
-| `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` (default) or `modelscope`. |
+| `--source SOURCE` | Remote registry for every checkpoint in this model: `huggingface` or `modelscope`. When omitted, the server's configured `default_model_source` applies. |
 | `--checkpoint TYPE CHECKPOINT` | Add a checkpoint entry. Repeat for multi-file models such as `main` + `mmproj` or `main` + `vae`. |
 | `--recipe RECIPE` | Recipe to associate with the new `user.*` model. Common values: <!-- BEGIN GENERATED: recipe-values -->`llamacpp`, `whispercpp`, `moonshine`, `kokoro`, `sd-cpp`, `flm`, `ryzenai-llm`, `vllm`, `thenoise`, `thinksound`, `acestep`, `onnxruntime`, `trellis`, `openmoss`, `collection.omni`<!-- END GENERATED: recipe-values -->. |
 | `--label LABEL` | Add a label to the new model. Repeatable. Valid labels include `coding`, `embeddings`, `hot`, `mtp`, `reasoning`, `reranking`, `tool-calling`, `vision`. |

--- a/src/app/src/renderer/AddModelPanel.tsx
+++ b/src/app/src/renderer/AddModelPanel.tsx
@@ -21,7 +21,9 @@ export interface ModelInstallData {
   name: string;
   checkpoint: string;
   recipe: string;
-  source: ModelRegistrySource;
+  // Omitted when the user leaves the source on "Automatic" so the server can
+  // apply its configured default_model_source.
+  source?: ModelRegistrySource;
   checkpoints?: Record<string, string>;
   mmproj?: string;
   labels?: string[];
@@ -92,7 +94,8 @@ type AddModelFormState = {
   name: string;
   checkpoint: string;
   recipe: string;
-  source: ModelRegistrySource;
+  // '' means "Automatic": defer to the server's configured default_model_source.
+  source: ModelRegistrySource | '';
   textEncoderCheckpoint: string;
   vaeCheckpoint: string;
   mmproj: string;
@@ -106,7 +109,7 @@ const createEmptyForm = (initial?: AddModelInitialValues): AddModelFormState => 
   name: initial?.name ?? '',
   checkpoint: initial?.checkpoint ?? initial?.checkpoints?.main ?? '',
   recipe: initial?.recipe ?? 'llamacpp',
-  source: initial?.source ?? 'huggingface',
+  source: initial?.source ?? '',
   textEncoderCheckpoint: initial?.checkpoints?.text_encoder ?? '',
   vaeCheckpoint: initial?.checkpoints?.vae ?? '',
   mmproj: '',
@@ -204,7 +207,9 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
     onInstall({
       name,
       checkpoint,
-      source,
+      // Only pin a registry when the user picked one; "Automatic" lets the
+      // server apply its configured default_model_source.
+      ...(source ? { source } : {}),
       checkpoints: recipe === 'sd-cpp' && hasSdComponents
         ? { main: checkpoint, text_encoder: textEncoderCheckpoint, vae: vaeCheckpoint }
         : undefined,
@@ -292,13 +297,15 @@ const AddModelPanel: React.FC<AddModelPanelProps> = ({ onClose, onInstall, initi
           <select
             className="form-input form-select"
             value={form.source}
-            onChange={(e) => handleChange('source', e.target.value as ModelRegistrySource)}
+            onChange={(e) => handleChange('source', e.target.value as ModelRegistrySource | '')}
           >
+            <option value="">Automatic (server default)</option>
             <option value="huggingface">Hugging Face</option>
             <option value="modelscope">ModelScope</option>
           </select>
           <span className="settings-description">
-            Lemonade stores this source with the model so future updates use the same registry.
+            Automatic uses the server's configured default registry. Choosing one stores it with the
+            model so future updates use the same registry.
           </span>
         </div>
 

--- a/src/app/src/renderer/ChatWindow.tsx
+++ b/src/app/src/renderer/ChatWindow.tsx
@@ -227,7 +227,8 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ isVisible, width }) => {
           checkpoint: data.checkpoint,
           checkpoints: data.checkpoints,
           recipe: data.recipe,
-          source: data.source,
+          // Omitted on "Automatic" so lemond applies its default_model_source.
+          ...(data.source ? { source: data.source } : {}),
           mmproj: data.mmproj,
           labels: data.labels,
           reasoning: data.reasoning,

--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -10,6 +10,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include <lemon/model_registry.h>
+
 namespace lemon_cli {
 
 namespace {
@@ -153,30 +155,13 @@ std::string strip_query_fragment(std::string value) {
     return value;
 }
 
-std::string first_repo_segments(const std::string& path) {
-    const size_t slash = path.find('/');
-    if (slash == std::string::npos) return path;
-    const size_t second = path.find('/', slash + 1);
-    return second == std::string::npos ? path : path.substr(0, second);
-}
-
 std::string normalize_registry_url(const std::string& arg,
                                    std::string& source) {
-    static const std::vector<std::pair<std::string, std::string>> prefixes = {
-        {"https://huggingface.co/", "huggingface"},
-        {"http://huggingface.co/", "huggingface"},
-        {"https://modelscope.cn/models/", "modelscope"},
-        {"https://www.modelscope.cn/models/", "modelscope"},
-        {"http://modelscope.cn/models/", "modelscope"},
-        {"http://www.modelscope.cn/models/", "modelscope"},
-        {"https://modelscope.ai/models/", "modelscope"},
-        {"https://www.modelscope.ai/models/", "modelscope"},
-    };
-    for (const auto& [prefix, detected] : prefixes) {
-        if (arg.rfind(prefix, 0) != 0) continue;
-        source = detected;
-        std::string path = strip_query_fragment(arg.substr(prefix.size()));
-        return first_repo_segments(path);
+    lemon::RemoteRegistrySource detected;
+    std::string repo_id;
+    if (lemon::detect_registry_url(arg, detected, repo_id)) {
+        source = lemon::remote_registry_source_name(detected);
+        return repo_id;
     }
     return strip_query_fragment(arg);
 }

--- a/src/cpp/cli/hf_pull.cpp
+++ b/src/cpp/cli/hf_pull.cpp
@@ -209,7 +209,10 @@ std::string format_variant_label(const json& v) {
 std::string normalize_registry_checkpoint_arg(const std::string& arg,
                                               const std::string& source_hint,
                                               std::string* detected_source) {
-    std::string source = normalize_source(source_hint);
+    // An empty hint stays empty unless the argument is a provider URL: it means
+    // "no explicit registry", letting the server apply its configured default.
+    std::string source = source_hint.empty() ? std::string()
+                                             : normalize_source(source_hint);
     std::string checkpoint = normalize_registry_url(arg, source);
     if (detected_source) *detected_source = source;
     return checkpoint;
@@ -237,9 +240,13 @@ int registry_pull_flow(lemonade::LemonadeClient& client,
         return 1;
     }
 
-    // Fetch variants from the local server.
-    std::string path = "/api/v1/pull/variants?checkpoint=" + url_encode(checkpoint) +
-                       "&source=" + url_encode(source);
+    // Fetch variants from the local server. When no registry was specified the
+    // source param is omitted so lemond resolves its configured default, which
+    // it echoes back in the response for the follow-up pull.
+    std::string path = "/api/v1/pull/variants?checkpoint=" + url_encode(checkpoint);
+    if (!source.empty()) {
+        path += "&source=" + url_encode(source);
+    }
     json variants_response;
     try {
         std::string body = client.make_request(path, "GET");
@@ -247,7 +254,9 @@ int registry_pull_flow(lemonade::LemonadeClient& client,
     } catch (const lemonade::HttpError& e) {
         if (e.status_code() == 404) {
             std::cerr << "Checkpoint '" << checkpoint << "' not found on "
-                      << (source == "modelscope" ? "ModelScope" : "Hugging Face")
+                      << (source == "modelscope" ? "ModelScope"
+                          : source.empty()        ? "the configured registry"
+                                                  : "Hugging Face")
                       << "." << std::endl;
             return 1;
         }
@@ -256,6 +265,12 @@ int registry_pull_flow(lemonade::LemonadeClient& client,
     } catch (const std::exception& e) {
         std::cerr << "Error fetching variants: " << e.what() << std::endl;
         return 1;
+    }
+
+    // Adopt the registry lemond resolved so every pull body below records the
+    // same provenance the weights were fetched from.
+    if (source.empty()) {
+        source = variants_response.value("source", std::string("huggingface"));
     }
 
     // Omni collection repos: /pull/variants only inspected the repo and told us

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -7,6 +7,7 @@
 #include <lemon_cli/agent_config_file.h>
 #include <lemon/model_types.h>
 #include <lemon/recipe_options.h>
+#include <lemon/model_registry.h>
 #include <lemon/version.h>
 #include <lemon_cli/agent_launcher.h>
 #include <lemon_cli/opencode_profile.h>
@@ -335,23 +336,6 @@ static int handle_import_command(lemonade::LemonadeClient& client, const CliConf
                                            config.skip_prompt, config.yes, nullptr, true);
 }
 
-static std::optional<std::string> explicit_registry_source_from_url(const std::string& value) {
-    if (value.rfind("https://huggingface.co/", 0) == 0 ||
-        value.rfind("http://huggingface.co/", 0) == 0) {
-        return "huggingface";
-    }
-    for (const char* prefix : {
-             "https://modelscope.cn/models/",
-             "https://www.modelscope.cn/models/",
-             "http://modelscope.cn/models/",
-             "http://www.modelscope.cn/models/",
-             "https://modelscope.ai/models/",
-             "https://www.modelscope.ai/models/"}) {
-        if (value.rfind(prefix, 0) == 0) return "modelscope";
-    }
-    return std::nullopt;
-}
-
 static int handle_manual_pull_command(lemonade::LemonadeClient& client, const CliConfig& config) {
     nlohmann::json model_data;
 
@@ -366,23 +350,24 @@ static int handle_manual_pull_command(lemonade::LemonadeClient& client, const Cl
             std::string detected_source;
             checkpoints[type] = lemon_cli::normalize_registry_checkpoint_arg(
                 checkpoint, config.model_source, &detected_source);
-
-            if (auto source_from_url = explicit_registry_source_from_url(checkpoint)) {
+            lemon::RemoteRegistrySource detected;
+            std::string repo_id;
+            if (lemon::detect_registry_url(checkpoint, detected, repo_id)) {
+                std::string url_source = lemon::remote_registry_source_name(detected);
                 if (config.model_source_explicit &&
-                    config.model_source != *source_from_url) {
+                    config.model_source != url_source) {
                     std::cerr
-                        << "Error: checkpoint URL uses " << *source_from_url
+                        << "Error: checkpoint URL uses " << url_source
                         << " but --source was set to " << config.model_source
                         << "." << std::endl;
                     return 1;
                 }
-
-                if (explicit_source && *explicit_source != *source_from_url) {
+                if (explicit_source && *explicit_source != url_source) {
                     std::cerr << "Error: all checkpoints in one model must use the same "
                                  "remote registry." << std::endl;
                     return 1;
                 }
-                explicit_source = *source_from_url;
+                explicit_source = url_source;
             }
         }
         model_data["checkpoints"] = std::move(checkpoints);
@@ -439,7 +424,22 @@ static int handle_pull_command(lemonade::LemonadeClient& client, const CliConfig
         return handle_manual_pull_command(client, config);
     }
 
+    // Detect the URL source before normalization so we can reject mismatches
+    // with --source before normalize_registry_checkpoint_arg silently converts
+    // the user's value or lets the URL win.
+    lemon::RemoteRegistrySource detected;
+    std::string url_repo_id;
     std::string detected_source;
+    if (lemon::detect_registry_url(config.model, detected, url_repo_id)) {
+        std::string url_source = lemon::remote_registry_source_name(detected);
+        if (config.model_source_explicit && config.model_source != url_source) {
+            std::cerr << "Error: model URL uses " << url_source
+                      << " but --source was set to " << config.model_source << "."
+                      << std::endl;
+            return 1;
+        }
+        detected_source = url_source;
+    }
     std::string normalized_model = lemon_cli::normalize_registry_checkpoint_arg(
         config.model, config.model_source, &detected_source);
 

--- a/src/cpp/cli/main.cpp
+++ b/src/cpp/cli/main.cpp
@@ -150,7 +150,7 @@ struct CliConfig {
     std::string list_filter;
     std::map<std::string, std::string> checkpoints;
     std::string recipe;
-    std::string model_source = "huggingface";
+    std::string model_source;  // empty means defer to lemond's default_model_source
     bool model_source_explicit = false;
     std::vector<std::string> labels;
     std::vector<std::string> components;
@@ -388,7 +388,14 @@ static int handle_manual_pull_command(lemonade::LemonadeClient& client, const Cl
         model_data["checkpoints"] = std::move(checkpoints);
     }
 
-    model_data["source"] = explicit_source.value_or(config.model_source);
+    // Only pin a registry when one was actually chosen (a checkpoint URL or
+    // --source). Otherwise leave it unset so lemond applies its configured
+    // default_model_source and persists that provenance.
+    if (explicit_source) {
+        model_data["source"] = *explicit_source;
+    } else if (config.model_source_explicit) {
+        model_data["source"] = config.model_source;
+    }
 
     if (!config.components.empty()) {
         model_data["components"] = config.components;
@@ -1330,7 +1337,8 @@ int main(int argc, char* argv[]) {
         ->type_name("MODEL_OR_CHECKPOINT");
     CLI::Option* pull_source_opt =
         pull_cmd->add_option("--source", config.model_source,
-            "Remote registry for checkpoint pulls: huggingface or modelscope")
+            "Remote registry for checkpoint pulls: huggingface or modelscope "
+            "(default: the server's configured default_model_source)")
             ->type_name("SOURCE")
             ->check(CLI::IsMember({"huggingface", "modelscope"}));
     pull_cmd->add_option("--checkpoint", config.checkpoints,

--- a/src/cpp/include/lemon/model_registry.h
+++ b/src/cpp/include/lemon/model_registry.h
@@ -73,6 +73,30 @@ std::string remote_registry_source_name(RemoteRegistrySource source);
 std::string remote_registry_display_name(RemoteRegistrySource source);
 bool is_remote_registry_source(const std::string& source);
 
+// Detects a Hugging Face or ModelScope model URL. On a match returns true, sets
+// `out_source` to the registry and `out_repo_id` to the `owner/repo` the URL
+// points at (query string, fragment and any deeper path are dropped). Non-URL
+// inputs return false and leave the outputs untouched. Shared by the CLI and
+// the server so both resolve provider URLs the same way.
+bool detect_registry_url(const std::string& value,
+                         RemoteRegistrySource& out_source,
+                         std::string& out_repo_id);
+
+// True when a checkpoint is an `owner/repo` registry id (optionally with a
+// `:variant` suffix). Self-managed backend identifiers such as FLM tags
+// (`gemma3:4b`) have no owner segment and return false.
+bool checkpoint_looks_like_repo_id(const std::string& checkpoint);
+
+// Applies the default-source policy to a /pull request body in place:
+//   * A provider URL in the checkpoint is normalized to `owner/repo` and its
+//     registry recorded as `source` (unless the caller already named one).
+//   * An unqualified, registry-backed checkpoint inherits `default_source`.
+// Explicit `source`/`registry_source`, local imports, self-managed recipes
+// (`flm`, `cloud`), and non-registry checkpoints are left untouched, so a
+// registry source is only ever persisted for genuinely registry-backed pulls.
+void apply_default_pull_source(nlohmann::json& request_json,
+                               const std::string& default_source);
+
 // Normalize one provider-specific model-list entry into Lemonade's registry contract.
 // Exposed so fixture tests and future clients share the same field mapping.
 RegistrySearchResult normalize_registry_search_result(

--- a/src/cpp/include/lemon/model_registry.h
+++ b/src/cpp/include/lemon/model_registry.h
@@ -87,13 +87,19 @@ bool detect_registry_url(const std::string& value,
 // (`gemma3:4b`) have no owner segment and return false.
 bool checkpoint_looks_like_repo_id(const std::string& checkpoint);
 
-// Applies the default-source policy to a /pull request body in place:
-//   * A provider URL in the checkpoint is normalized to `owner/repo` and its
-//     registry recorded as `source` (unless the caller already named one).
-//   * An unqualified, registry-backed checkpoint inherits `default_source`.
+// Applies the default-source policy to a /pull request body in place. The
+// primary checkpoint follows the ModelManager precedence (`checkpoints.main`
+// when a `checkpoints` object is present, otherwise `checkpoint`):
+//   * A provider URL in any checkpoint is normalized to `owner/repo` and its
+//     registry recorded as `source` (unless the caller already named one). Every
+//     registry-backed checkpoint is normalized and must resolve to one registry.
+//   * An unqualified, registry-backed primary checkpoint inherits
+//     `default_source`.
 // Explicit `source`/`registry_source`, local imports, self-managed recipes
 // (`flm`, `cloud`), and non-registry checkpoints are left untouched, so a
 // registry source is only ever persisted for genuinely registry-backed pulls.
+// Throws std::invalid_argument when a provider URL conflicts with an explicit
+// source or when checkpoints disagree on the registry (callers map this to 400).
 void apply_default_pull_source(nlohmann::json& request_json,
                                const std::string& default_source);
 

--- a/src/cpp/include/lemon/runtime_config.h
+++ b/src/cpp/include/lemon/runtime_config.h
@@ -60,6 +60,7 @@ public:
     bool no_fetch_executables() const;
     bool disable_model_filtering() const;
     bool enable_dgpu_gtt() const;
+    std::string default_model_source() const;
     std::string rocm_channel() const;
     std::string rocm_channel_for_recipe(const std::string& recipe) const;
 

--- a/src/cpp/resources/defaults.json
+++ b/src/cpp/resources/defaults.json
@@ -10,6 +10,7 @@
   "cloud_providers": [],
   "config_version": 2,
   "ctx_size": -1,
+  "default_model_source": "huggingface",
   "disable_model_filtering": false,
   "enable_dgpu_gtt": false,
   "extra_models_dir": "",

--- a/src/cpp/server/model_registry.cpp
+++ b/src/cpp/server/model_registry.cpp
@@ -828,6 +828,20 @@ std::optional<RemoteRegistrySource> explicit_registry_source(const json& request
 void apply_default_pull_source(json& request_json, const std::string& default_source) {
     if (request_json.value("local_import", false)) return;
 
+    // Explicit source fields must be strings when present; reject non-string
+    // values (e.g. `source: 123`) up front so a provider URL cannot later hide
+    // them by overwriting with the URL's registry. A JSON null is treated as
+    // absent so it falls back to the configured default like an omitted field.
+    for (const char* field : {"source", "registry_source"}) {
+        if (!request_json.contains(field)) continue;
+        if (request_json[field].is_null()) {
+            request_json.erase(field);
+        } else if (!request_json[field].is_string()) {
+            throw std::invalid_argument(std::string("'") + field +
+                                        "' must be a string");
+        }
+    }
+
     // Validate explicit registry source values before any URL normalization
     // so that invalid values (like "nexus" with an HF URL) are rejected up
     // front rather than silently overwritten by a provider URL.

--- a/src/cpp/server/model_registry.cpp
+++ b/src/cpp/server/model_registry.cpp
@@ -828,6 +828,25 @@ std::optional<RemoteRegistrySource> explicit_registry_source(const json& request
 void apply_default_pull_source(json& request_json, const std::string& default_source) {
     if (request_json.value("local_import", false)) return;
 
+    // Validate explicit registry source values before any URL normalization
+    // so that invalid values (like "nexus" with an HF URL) are rejected up
+    // front rather than silently overwritten by a provider URL.
+    if (request_json.contains("registry_source") &&
+        request_json["registry_source"].is_string()) {
+        (void)parse_remote_registry_source(
+            request_json["registry_source"].get<std::string>());
+    }
+    if (request_json.contains("source") && request_json["source"].is_string()) {
+        const auto& src = request_json["source"].get<std::string>();
+        if (!is_remote_registry_source(src) &&
+            src != "local_upload" && src != "local_path" &&
+            src != "extra_models_dir") {
+            throw std::invalid_argument(
+                "Unsupported model source '" + src +
+                "' (expected remote registry or local import type)");
+        }
+    }
+
     // Follow the ModelManager precedence: multi-component bodies carry every
     // checkpoint under `checkpoints` (primary in `main`); single-checkpoint
     // bodies use `checkpoint`. When `checkpoints` is present it is authoritative,
@@ -871,6 +890,29 @@ void apply_default_pull_source(json& request_json, const std::string& default_so
                 "checkpoint URL uses " + remote_registry_source_name(detected) +
                 " but source was set to " +
                 remote_registry_source_name(*explicit_source));
+        }
+    }
+
+    if (url_source && explicit_source && *explicit_source != *url_source) {
+        throw std::invalid_argument(
+            "checkpoint URL uses " + remote_registry_source_name(*url_source) +
+            " but source was set to " +
+            remote_registry_source_name(*explicit_source));
+    }
+
+    // If registry_source is set (and source is empty), validate against the
+    // URL as well.
+    if (url_source && !explicit_source &&
+        request_json.contains("registry_source") &&
+        request_json["registry_source"].is_string()) {
+        RemoteRegistrySource registry_parsed =
+            parse_remote_registry_source(
+                request_json["registry_source"].get<std::string>());
+        if (*url_source != registry_parsed) {
+            throw std::invalid_argument(
+                "checkpoint URL uses " + remote_registry_source_name(*url_source) +
+                " but registry_source was set to " +
+                remote_registry_source_name(registry_parsed));
         }
     }
 

--- a/src/cpp/server/model_registry.cpp
+++ b/src/cpp/server/model_registry.cpp
@@ -5,7 +5,9 @@
 #include <cstdlib>
 #include <iomanip>
 #include <initializer_list>
+#include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <utility>
 
 #include "lemon/utils/http_client.h"
@@ -801,45 +803,95 @@ bool checkpoint_looks_like_repo_id(const std::string& checkpoint) {
     return repo.find('/') != std::string::npos;
 }
 
+namespace {
+
+// Returns the caller's explicitly named remote registry, if any. Non-registry
+// `source` values (local_upload/local_path/…) are ignored so only genuine
+// registry provenance participates in provider-URL conflict checks.
+std::optional<RemoteRegistrySource> explicit_registry_source(const json& request_json) {
+    if (request_json.contains("registry_source") &&
+        request_json["registry_source"].is_string()) {
+        return parse_remote_registry_source(
+            request_json["registry_source"].get<std::string>());
+    }
+    if (request_json.contains("source") && request_json["source"].is_string()) {
+        const std::string source = request_json["source"].get<std::string>();
+        if (is_remote_registry_source(source)) {
+            return parse_remote_registry_source(source);
+        }
+    }
+    return std::nullopt;
+}
+
+}  // namespace
+
 void apply_default_pull_source(json& request_json, const std::string& default_source) {
     if (request_json.value("local_import", false)) return;
 
-    // Locate the primary checkpoint. Multi-component bodies (e.g. sd-cpp) carry
-    // it under checkpoints.main; single-checkpoint bodies under checkpoint.
-    std::string* checkpoint_slot = nullptr;
-    if (request_json.contains("checkpoint") && request_json["checkpoint"].is_string()) {
-        checkpoint_slot = request_json["checkpoint"].get_ptr<std::string*>();
-    } else if (request_json.contains("checkpoints") &&
-               request_json["checkpoints"].is_object() &&
-               request_json["checkpoints"].contains("main") &&
-               request_json["checkpoints"]["main"].is_string()) {
-        checkpoint_slot = request_json["checkpoints"]["main"].get_ptr<std::string*>();
+    // Follow the ModelManager precedence: multi-component bodies carry every
+    // checkpoint under `checkpoints` (primary in `main`); single-checkpoint
+    // bodies use `checkpoint`. When `checkpoints` is present it is authoritative,
+    // even if a stray top-level `checkpoint` also exists.
+    std::vector<std::string*> checkpoint_slots;
+    std::string* primary_slot = nullptr;
+    if (request_json.contains("checkpoints") &&
+        request_json["checkpoints"].is_object()) {
+        for (auto& [role, value] : request_json["checkpoints"].items()) {
+            if (!value.is_string()) continue;
+            std::string* slot = value.get_ptr<std::string*>();
+            checkpoint_slots.push_back(slot);
+            if (role == "main") primary_slot = slot;
+        }
+    } else if (request_json.contains("checkpoint") &&
+               request_json["checkpoint"].is_string()) {
+        primary_slot = request_json["checkpoint"].get_ptr<std::string*>();
+        checkpoint_slots.push_back(primary_slot);
     }
-    if (checkpoint_slot == nullptr || checkpoint_slot->empty()) return;
+    if (primary_slot == nullptr || primary_slot->empty()) return;
 
-    const bool has_explicit_source =
-        request_json.contains("source") || request_json.contains("registry_source");
+    std::optional<RemoteRegistrySource> explicit_source =
+        explicit_registry_source(request_json);
 
-    // A provider URL is authoritative: normalize it to owner/repo and adopt the
-    // URL's registry unless the caller already named one.
-    RemoteRegistrySource url_source;
-    std::string repo_id;
-    if (detect_registry_url(*checkpoint_slot, url_source, repo_id)) {
-        *checkpoint_slot = repo_id;
-        if (!has_explicit_source) {
-            request_json["source"] = remote_registry_source_name(url_source);
+    // A provider URL is authoritative for its registry. Normalize every
+    // registry-backed checkpoint to owner/repo, enforce a single registry across
+    // the whole model, and reject a URL that contradicts an explicit source.
+    std::optional<RemoteRegistrySource> url_source;
+    for (std::string* slot : checkpoint_slots) {
+        RemoteRegistrySource detected;
+        std::string repo_id;
+        if (!detect_registry_url(*slot, detected, repo_id)) continue;
+        *slot = repo_id;
+        if (url_source && *url_source != detected) {
+            throw std::invalid_argument(
+                "All checkpoints in one model must use the same remote registry");
+        }
+        url_source = detected;
+        if (explicit_source && *explicit_source != detected) {
+            throw std::invalid_argument(
+                "checkpoint URL uses " + remote_registry_source_name(detected) +
+                " but source was set to " +
+                remote_registry_source_name(*explicit_source));
+        }
+    }
+
+    if (url_source) {
+        if (!explicit_source) {
+            request_json["source"] = remote_registry_source_name(*url_source);
         }
         return;
     }
 
-    if (has_explicit_source) return;
+    if (explicit_source ||
+        request_json.contains("source") || request_json.contains("registry_source")) {
+        return;
+    }
 
     // Self-managed backends own their checkpoints; those are not registry ids
     // even when they happen to contain a '/' (e.g. cloud model identifiers).
     const std::string recipe = request_json.value("recipe", "");
     if (recipe == "flm" || recipe == "cloud") return;
 
-    if (!checkpoint_looks_like_repo_id(*checkpoint_slot)) return;
+    if (!checkpoint_looks_like_repo_id(*primary_slot)) return;
 
     request_json["source"] = default_source;
 }

--- a/src/cpp/server/model_registry.cpp
+++ b/src/cpp/server/model_registry.cpp
@@ -24,6 +24,20 @@ std::string lower_copy(std::string value) {
     return value;
 }
 
+std::string strip_query_fragment(std::string value) {
+    const size_t pos = value.find_first_of("?#");
+    if (pos != std::string::npos) value.resize(pos);
+    while (!value.empty() && value.back() == '/') value.pop_back();
+    return value;
+}
+
+std::string first_two_path_segments(const std::string& path) {
+    const size_t slash = path.find('/');
+    if (slash == std::string::npos) return path;
+    const size_t second = path.find('/', slash + 1);
+    return second == std::string::npos ? path : path.substr(0, second);
+}
+
 bool is_unreserved(unsigned char c) {
     return std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~';
 }
@@ -752,6 +766,82 @@ bool is_remote_registry_source(const std::string& source) {
     const std::string normalized = lower_copy(source);
     return normalized == "huggingface" || normalized == "hf" ||
            normalized == "modelscope" || normalized == "ms";
+}
+
+bool detect_registry_url(const std::string& value,
+                         RemoteRegistrySource& out_source,
+                         std::string& out_repo_id) {
+    static const std::initializer_list<std::pair<const char*, RemoteRegistrySource>> prefixes = {
+        {"https://huggingface.co/", RemoteRegistrySource::HuggingFace},
+        {"http://huggingface.co/", RemoteRegistrySource::HuggingFace},
+        {"https://modelscope.cn/models/", RemoteRegistrySource::ModelScope},
+        {"https://www.modelscope.cn/models/", RemoteRegistrySource::ModelScope},
+        {"http://modelscope.cn/models/", RemoteRegistrySource::ModelScope},
+        {"http://www.modelscope.cn/models/", RemoteRegistrySource::ModelScope},
+        {"https://modelscope.ai/models/", RemoteRegistrySource::ModelScope},
+        {"https://www.modelscope.ai/models/", RemoteRegistrySource::ModelScope},
+    };
+    for (const auto& [prefix, source] : prefixes) {
+        const std::string prefix_str(prefix);
+        if (value.rfind(prefix_str, 0) != 0) continue;
+        out_source = source;
+        out_repo_id = first_two_path_segments(
+            strip_query_fragment(value.substr(prefix_str.size())));
+        return true;
+    }
+    return false;
+}
+
+bool checkpoint_looks_like_repo_id(const std::string& checkpoint) {
+    // Registry repo ids never contain ':', so the portion before the first ':'
+    // is the repo. An owner/repo id carries a '/'; FLM tags (`gemma3:4b`) do not.
+    const size_t colon = checkpoint.find(':');
+    const std::string repo =
+        colon == std::string::npos ? checkpoint : checkpoint.substr(0, colon);
+    return repo.find('/') != std::string::npos;
+}
+
+void apply_default_pull_source(json& request_json, const std::string& default_source) {
+    if (request_json.value("local_import", false)) return;
+
+    // Locate the primary checkpoint. Multi-component bodies (e.g. sd-cpp) carry
+    // it under checkpoints.main; single-checkpoint bodies under checkpoint.
+    std::string* checkpoint_slot = nullptr;
+    if (request_json.contains("checkpoint") && request_json["checkpoint"].is_string()) {
+        checkpoint_slot = request_json["checkpoint"].get_ptr<std::string*>();
+    } else if (request_json.contains("checkpoints") &&
+               request_json["checkpoints"].is_object() &&
+               request_json["checkpoints"].contains("main") &&
+               request_json["checkpoints"]["main"].is_string()) {
+        checkpoint_slot = request_json["checkpoints"]["main"].get_ptr<std::string*>();
+    }
+    if (checkpoint_slot == nullptr || checkpoint_slot->empty()) return;
+
+    const bool has_explicit_source =
+        request_json.contains("source") || request_json.contains("registry_source");
+
+    // A provider URL is authoritative: normalize it to owner/repo and adopt the
+    // URL's registry unless the caller already named one.
+    RemoteRegistrySource url_source;
+    std::string repo_id;
+    if (detect_registry_url(*checkpoint_slot, url_source, repo_id)) {
+        *checkpoint_slot = repo_id;
+        if (!has_explicit_source) {
+            request_json["source"] = remote_registry_source_name(url_source);
+        }
+        return;
+    }
+
+    if (has_explicit_source) return;
+
+    // Self-managed backends own their checkpoints; those are not registry ids
+    // even when they happen to contain a '/' (e.g. cloud model identifiers).
+    const std::string recipe = request_json.value("recipe", "");
+    if (recipe == "flm" || recipe == "cloud") return;
+
+    if (!checkpoint_looks_like_repo_id(*checkpoint_slot)) return;
+
+    request_json["source"] = default_source;
 }
 
 std::string registry_tree_snapshot_id(RemoteRegistrySource source,

--- a/src/cpp/server/runtime_config.cpp
+++ b/src/cpp/server/runtime_config.cpp
@@ -316,6 +316,11 @@ bool RuntimeConfig::enable_dgpu_gtt() const {
     return config_["enable_dgpu_gtt"].get<bool>();
 }
 
+std::string RuntimeConfig::default_model_source() const {
+    std::shared_lock lock(mutex_);
+    return config_.value("default_model_source", std::string("huggingface"));
+}
+
 std::string RuntimeConfig::rocm_channel() const {
     std::shared_lock lock(mutex_);
     return config_["rocm_channel"].get<std::string>();
@@ -560,6 +565,15 @@ void RuntimeConfig::validate(const std::string& key, const json& value) const {
     } else if (key == "extra_models_dir" || key == "models_dir") {
         if (!value.is_string()) {
             throw std::invalid_argument("'" + key + "' must be a string");
+        }
+    } else if (key == "default_model_source") {
+        if (!value.is_string()) {
+            throw std::invalid_argument("'default_model_source' must be a string");
+        }
+        const std::string source = value.get<std::string>();
+        if (source != "huggingface" && source != "modelscope") {
+            throw std::invalid_argument(
+                "'default_model_source' must be either 'huggingface', or 'modelscope'");
         }
     } else if (key == "no_broadcast" || key == "offline" ||
                key == "auto_check_model_updates" ||

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5366,6 +5366,11 @@ void Server::handle_registry_search(const httplib::Request& req, httplib::Respon
 }
 
 void Server::handle_pull_variants(const httplib::Request& req, httplib::Response& res) {
+    auto bad_request = [&res](const std::string& message) {
+        res.status = 400;
+        nlohmann::json error = {{"error", message}};
+        res.set_content(error.dump(), "application/json");
+    };
     try {
         std::string checkpoint = req.get_param_value("checkpoint");
         if (checkpoint.empty()) {
@@ -5374,14 +5379,37 @@ void Server::handle_pull_variants(const httplib::Request& req, httplib::Response
             res.set_content(error.dump(), "application/json");
             return;
         }
+        // Detect the URL provider upfront so we can reject mismatches with
+        // an explicit `--source` param (just like /pull and the CLI do).
+        lemon::RemoteRegistrySource url_source;
+        std::string url_repo_id;
+        bool has_url = lemon::detect_registry_url(checkpoint, url_source, url_repo_id);
+
+        // Explicit `--source` was provided (or not).  Capture the raw param
+        // now while checkpoint still holds the URL for error messages.
+        std::string raw_source;
+        if (req.has_param("source")) {
+            raw_source = req.get_param_value("source");
+        }
+
+        // Reject mismatches between explicit source and detected URL source.
+        if (has_url && !raw_source.empty()) {
+            if (remote_registry_source_name(url_source) != raw_source) {
+                bad_request(
+                    "checkpoint URL uses " + remote_registry_source_name(url_source) +
+                    " but source was set to '" + raw_source + "'");
+                return;
+            }
+        }
+
         // A provider URL is authoritative: normalize it to owner/repo and adopt
         // its registry. Otherwise honor an explicit source param, falling back
         // to the server's configured default when none is given.
-        lemon::RemoteRegistrySource url_source;
-        std::string url_repo_id;
-        std::string source;
-        if (lemon::detect_registry_url(checkpoint, url_source, url_repo_id)) {
+        if (has_url) {
             checkpoint = url_repo_id;
+        }
+        std::string source;
+        if (has_url) {
             source = remote_registry_source_name(url_source);
         } else {
             source = req.has_param("source")

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5077,7 +5077,12 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
         // provider URL is normalized to owner/repo and its registry adopted.
         // Self-managed backends (flm/cloud), non-registry checkpoints, explicit
         // sources, and bare `pull <registered-name>` refreshes are left as-is.
-        lemon::apply_default_pull_source(request_json, config_->default_model_source());
+        try {
+            lemon::apply_default_pull_source(request_json, config_->default_model_source());
+        } catch (const std::invalid_argument& e) {
+            bad_request(e.what());
+            return;
+        }
         // The helper may have rewritten a provider URL into an owner/repo id.
         checkpoint = request_json.value("checkpoint", "");
 

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5393,8 +5393,10 @@ void Server::handle_pull_variants(const httplib::Request& req, httplib::Response
         }
 
         // Reject mismatches between explicit source and detected URL source.
+        // Canonicalize the raw param first so accepted aliases (e.g. `hf`) are
+        // not rejected against the URL's canonical registry name.
         if (has_url && !raw_source.empty()) {
-            if (remote_registry_source_name(url_source) != raw_source) {
+            if (parse_remote_registry_source(raw_source) != url_source) {
                 bad_request(
                     "checkpoint URL uses " + remote_registry_source_name(url_source) +
                     " but source was set to '" + raw_source + "'");

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5071,6 +5071,23 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
         bool subscribe = request_json.value("subscribe", true);
         bool local_import = request_json.value("local_import", false);
 
+        // A remote checkpoint pull that names no registry inherits the server's
+        // configured default so the resolved provenance is persisted once, up
+        // front, keeping download, cache layout, and later refresh consistent.
+        // Bare `pull <registered-name>` refreshes carry no checkpoint and keep
+        // their recorded provenance instead.
+        const bool has_remote_checkpoint =
+            (request_json.contains("checkpoint") &&
+             !request_json["checkpoint"].get<std::string>().empty()) ||
+            (request_json.contains("checkpoints") &&
+             request_json["checkpoints"].is_object() &&
+             !request_json["checkpoints"].empty());
+        if (has_remote_checkpoint && !local_import &&
+            !request_json.contains("source") &&
+            !request_json.contains("registry_source")) {
+            request_json["source"] = config_->default_model_source();
+        }
+
         // Validate and canonicalize remote-registry provenance before anything is
         // persisted. `source` remains backward-compatible with local origins, while
         // remote registrations store a canonical huggingface/modelscope value.
@@ -5367,7 +5384,7 @@ void Server::handle_pull_variants(const httplib::Request& req, httplib::Response
             return;
         }
         const std::string source = req.has_param("source")
-            ? req.get_param_value("source") : "huggingface";
+            ? req.get_param_value("source") : config_->default_model_source();
         const auto parsed_source = parse_remote_registry_source(source);
         if (config_->offline()) {
             res.status = 400;
@@ -5376,14 +5393,18 @@ void Server::handle_pull_variants(const httplib::Request& req, httplib::Response
             return;
         }
         bool not_found = false;
+        const std::string resolved_source = remote_registry_source_name(parsed_source);
         nlohmann::json body = lemon::fetch_pull_variants(
-            checkpoint, remote_registry_source_name(parsed_source), not_found);
+            checkpoint, resolved_source, not_found);
         if (not_found) {
             res.status = 404;
             nlohmann::json error = {{"error", "Checkpoint '" + checkpoint + "' not found on " +
                 remote_registry_display_name(parsed_source)}};
             res.set_content(error.dump(), "application/json");
             return;
+        }
+        if (body.is_object()) {
+            body["source"] = resolved_source;
         }
         res.set_content(body.dump(), "application/json");
     } catch (const std::invalid_argument& e) {

--- a/src/cpp/server/server.cpp
+++ b/src/cpp/server/server.cpp
@@ -5071,22 +5071,15 @@ void Server::handle_pull(const httplib::Request& req, httplib::Response& res) {
         bool subscribe = request_json.value("subscribe", true);
         bool local_import = request_json.value("local_import", false);
 
-        // A remote checkpoint pull that names no registry inherits the server's
-        // configured default so the resolved provenance is persisted once, up
-        // front, keeping download, cache layout, and later refresh consistent.
-        // Bare `pull <registered-name>` refreshes carry no checkpoint and keep
-        // their recorded provenance instead.
-        const bool has_remote_checkpoint =
-            (request_json.contains("checkpoint") &&
-             !request_json["checkpoint"].get<std::string>().empty()) ||
-            (request_json.contains("checkpoints") &&
-             request_json["checkpoints"].is_object() &&
-             !request_json["checkpoints"].empty());
-        if (has_remote_checkpoint && !local_import &&
-            !request_json.contains("source") &&
-            !request_json.contains("registry_source")) {
-            request_json["source"] = config_->default_model_source();
-        }
+        // Resolve the pull's registry provenance once, up front, so download,
+        // cache layout, and later refresh stay consistent. A registry-backed
+        // checkpoint that names no source inherits the configured default; a
+        // provider URL is normalized to owner/repo and its registry adopted.
+        // Self-managed backends (flm/cloud), non-registry checkpoints, explicit
+        // sources, and bare `pull <registered-name>` refreshes are left as-is.
+        lemon::apply_default_pull_source(request_json, config_->default_model_source());
+        // The helper may have rewritten a provider URL into an owner/repo id.
+        checkpoint = request_json.value("checkpoint", "");
 
         // Validate and canonicalize remote-registry provenance before anything is
         // persisted. `source` remains backward-compatible with local origins, while
@@ -5376,6 +5369,19 @@ void Server::handle_pull_variants(const httplib::Request& req, httplib::Response
             res.set_content(error.dump(), "application/json");
             return;
         }
+        // A provider URL is authoritative: normalize it to owner/repo and adopt
+        // its registry. Otherwise honor an explicit source param, falling back
+        // to the server's configured default when none is given.
+        lemon::RemoteRegistrySource url_source;
+        std::string url_repo_id;
+        std::string source;
+        if (lemon::detect_registry_url(checkpoint, url_source, url_repo_id)) {
+            checkpoint = url_repo_id;
+            source = remote_registry_source_name(url_source);
+        } else {
+            source = req.has_param("source")
+                ? req.get_param_value("source") : config_->default_model_source();
+        }
         if (checkpoint.find('/') == std::string::npos) {
             res.status = 400;
             nlohmann::json error = {{"error",
@@ -5383,8 +5389,6 @@ void Server::handle_pull_variants(const httplib::Request& req, httplib::Response
             res.set_content(error.dump(), "application/json");
             return;
         }
-        const std::string source = req.has_param("source")
-            ? req.get_param_value("source") : config_->default_model_source();
         const auto parsed_source = parse_remote_registry_source(source);
         if (config_->offline()) {
             res.status = 400;

--- a/test/cpp/test_config_default_source.cpp
+++ b/test/cpp/test_config_default_source.cpp
@@ -2,10 +2,12 @@
 #include <stdexcept>
 #include <string>
 #include <nlohmann/json.hpp>
+#include <lemon/model_registry.h>
 #include <lemon/runtime_config.h>
 
 using json = nlohmann::json;
 using lemon::RuntimeConfig;
+using lemon::apply_default_pull_source;
 
 static int passed = 0;
 static int failures = 0;
@@ -69,6 +71,118 @@ int main() {
             threw = true;
         }
         check(threw, "rejects non-string default_model_source value");
+    }
+
+    // ---- /pull source-resolution policy (apply_default_pull_source) ----
+    // These mirror the persistence decision the /pull handler makes before a
+    // model definition is written, using a non-huggingface default so a bug
+    // that hardcodes Hugging Face cannot pass.
+
+    // A source-less registry checkpoint inherits the configured default.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "owner/repo:Q4_K_M"}};
+        apply_default_pull_source(req, "modelscope");
+        check(req.value("source", "") == "modelscope",
+              "source-less registry checkpoint inherits the default");
+        check(req["checkpoint"] == "owner/repo:Q4_K_M",
+              "registry checkpoint is left untouched");
+    }
+
+    // An explicit source is never overridden by the default.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "owner/repo"}, {"source", "huggingface"}};
+        apply_default_pull_source(req, "modelscope");
+        check(req["source"] == "huggingface",
+              "explicit source overrides the configured default");
+    }
+
+    // An explicit registry_source alone suppresses default injection.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "owner/repo"}, {"registry_source", "modelscope"}};
+        apply_default_pull_source(req, "huggingface");
+        check(!req.contains("source"),
+              "registry_source suppresses default source injection");
+    }
+
+    // A Hugging Face URL is normalized to owner/repo and adopts its registry
+    // even when the configured default is ModelScope.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "https://huggingface.co/owner/repo/tree/main"}};
+        apply_default_pull_source(req, "modelscope");
+        check(req["checkpoint"] == "owner/repo",
+              "hugging face URL is normalized to owner/repo");
+        check(req.value("source", "") == "huggingface",
+              "hugging face URL adopts its own registry over the default");
+    }
+
+    // A ModelScope URL is detected regardless of the configured default.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "https://modelscope.cn/models/owner/repo"}};
+        apply_default_pull_source(req, "huggingface");
+        check(req["checkpoint"] == "owner/repo",
+              "modelscope URL is normalized to owner/repo");
+        check(req.value("source", "") == "modelscope",
+              "modelscope URL adopts its own registry");
+    }
+
+    // Self-managed FLM tags are not registry ids: no source is persisted.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "flm"},
+                    {"checkpoint", "gemma3:4b"}};
+        apply_default_pull_source(req, "modelscope");
+        check(!req.contains("source"),
+              "self-managed flm checkpoint gets no registry source");
+        check(req["checkpoint"] == "gemma3:4b",
+              "flm checkpoint is left untouched");
+    }
+
+    // Cloud identifiers can look like repo ids but are still self-managed.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "cloud"},
+                    {"checkpoint", "openai/gpt-4o"}};
+        apply_default_pull_source(req, "modelscope");
+        check(!req.contains("source"),
+              "self-managed cloud checkpoint gets no registry source");
+    }
+
+    // A bare, ownerless checkpoint is not registry-backed.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "just-a-name"}};
+        apply_default_pull_source(req, "modelscope");
+        check(!req.contains("source"),
+              "ownerless checkpoint gets no registry source");
+    }
+
+    // Multi-component bodies resolve off checkpoints.main.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "sd-cpp"},
+                    {"checkpoints", {{"main", "owner/repo:model.safetensors"}}}};
+        apply_default_pull_source(req, "modelscope");
+        check(req.value("source", "") == "modelscope",
+              "checkpoints.main drives default source resolution");
+    }
+
+    // Local imports never receive a remote registry source.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "owner/repo"}, {"local_import", true}};
+        apply_default_pull_source(req, "modelscope");
+        check(!req.contains("source"),
+              "local import gets no remote registry source");
+    }
+
+    // A bare refresh with no checkpoint keeps its recorded provenance.
+    {
+        json req = {{"model_name", "user.M"}};
+        apply_default_pull_source(req, "modelscope");
+        check(!req.contains("source"),
+              "checkpoint-less refresh gets no injected source");
     }
 
     std::printf("================================================\n");

--- a/test/cpp/test_config_default_source.cpp
+++ b/test/cpp/test_config_default_source.cpp
@@ -185,6 +185,91 @@ int main() {
               "checkpoint-less refresh gets no injected source");
     }
 
+    // When both fields are present, `checkpoints` is authoritative and its
+    // `main` entry drives resolution — matching the ModelManager precedence.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "flm"},
+                    {"checkpoint", "owner/repo"},
+                    {"checkpoints", {{"main", "gemma3:4b"}}}};
+        apply_default_pull_source(req, "modelscope");
+        check(!req.contains("source"),
+              "checkpoints.main takes precedence over a stray top-level checkpoint");
+        check(req["checkpoint"] == "owner/repo",
+              "the ignored top-level checkpoint is left untouched");
+    }
+
+    // A provider URL that contradicts an explicit source is a 400 (throws).
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "https://huggingface.co/owner/repo"},
+                    {"source", "modelscope"}};
+        bool threw = false;
+        try {
+            apply_default_pull_source(req, "huggingface");
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        check(threw, "provider URL conflicting with explicit source throws");
+    }
+
+    // registry_source is honored the same way for conflict detection.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "https://modelscope.cn/models/owner/repo"},
+                    {"registry_source", "huggingface"}};
+        bool threw = false;
+        try {
+            apply_default_pull_source(req, "huggingface");
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        check(threw, "provider URL conflicting with registry_source throws");
+    }
+
+    // A provider URL that agrees with the explicit source is accepted and
+    // normalized without re-injecting the source.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "https://modelscope.cn/models/owner/repo"},
+                    {"source", "modelscope"}};
+        apply_default_pull_source(req, "huggingface");
+        check(req["checkpoint"] == "owner/repo",
+              "agreeing provider URL is still normalized to owner/repo");
+        check(req["source"] == "modelscope",
+              "agreeing explicit source is preserved");
+    }
+
+    // Secondary checkpoints carrying provider URLs are normalized too, not just
+    // main, and the whole model adopts the shared registry.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "sd-cpp"},
+                    {"checkpoints",
+                     {{"main", "https://modelscope.cn/models/owner/repo"},
+                      {"vae", "https://modelscope.cn/models/owner/vae"}}}};
+        apply_default_pull_source(req, "huggingface");
+        check(req["checkpoints"]["main"] == "owner/repo",
+              "main checkpoint URL is normalized");
+        check(req["checkpoints"]["vae"] == "owner/vae",
+              "secondary checkpoint URL is normalized");
+        check(req.value("source", "") == "modelscope",
+              "multi-checkpoint model adopts the URL registry");
+    }
+
+    // Checkpoints disagreeing on the registry are rejected.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "sd-cpp"},
+                    {"checkpoints",
+                     {{"main", "https://huggingface.co/owner/repo"},
+                      {"vae", "https://modelscope.cn/models/owner/vae"}}}};
+        bool threw = false;
+        try {
+            apply_default_pull_source(req, "huggingface");
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        check(threw, "checkpoints from different registries are rejected");
+    }
+
     std::printf("================================================\n");
     if (failures > 0) {
         std::printf("Tests finished: %d FAILURE(S)\n", failures);

--- a/test/cpp/test_config_default_source.cpp
+++ b/test/cpp/test_config_default_source.cpp
@@ -270,6 +270,45 @@ int main() {
         check(threw, "checkpoints from different registries are rejected");
     }
 
+    // A non-string `source` must be rejected before URL normalization, so a
+    // provider URL cannot silently overwrite it with the URL's registry.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "https://huggingface.co/owner/repo"},
+                    {"source", 123}};
+        bool threw = false;
+        try {
+            apply_default_pull_source(req, "huggingface");
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        check(threw, "non-string source with a provider URL is rejected");
+    }
+
+    // The same guard applies to `registry_source`.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "owner/repo"},
+                    {"registry_source", true}};
+        bool threw = false;
+        try {
+            apply_default_pull_source(req, "huggingface");
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        check(threw, "non-string registry_source is rejected");
+    }
+
+    // A JSON null is treated as absent, not as an invalid value.
+    {
+        json req = {{"model_name", "user.M"}, {"recipe", "llamacpp"},
+                    {"checkpoint", "owner/repo"},
+                    {"source", nullptr}};
+        apply_default_pull_source(req, "modelscope");
+        check(req.value("source", "") == "modelscope",
+              "null source falls back to the configured default");
+    }
+
     std::printf("================================================\n");
     if (failures > 0) {
         std::printf("Tests finished: %d FAILURE(S)\n", failures);

--- a/test/cpp/test_config_default_source.cpp
+++ b/test/cpp/test_config_default_source.cpp
@@ -1,0 +1,81 @@
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <nlohmann/json.hpp>
+#include <lemon/runtime_config.h>
+
+using json = nlohmann::json;
+using lemon::RuntimeConfig;
+
+static int passed = 0;
+static int failures = 0;
+
+static void check(bool cond, const char* desc) {
+    if (cond) {
+        std::printf("[PASS] %s\n", desc);
+        ++passed;
+    } else {
+        std::printf("[FAIL] %s\n", desc);
+        ++failures;
+    }
+}
+
+int main() {
+    // Absent key falls back to Hugging Face for backward compatibility.
+    {
+        RuntimeConfig config(json::object());
+        check(config.default_model_source() == "huggingface",
+              "missing default_model_source falls back to huggingface");
+    }
+
+    // Explicit huggingface round-trips.
+    {
+        RuntimeConfig config(json{{"default_model_source", "huggingface"}});
+        check(config.default_model_source() == "huggingface",
+              "explicit huggingface preserved");
+    }
+
+    // Switching the policy to modelscope is accepted and observable.
+    {
+        RuntimeConfig config(json{{"default_model_source", "huggingface"}});
+        config.set(json{{"default_model_source", "modelscope"}});
+        check(config.default_model_source() == "modelscope",
+              "default_model_source set to modelscope");
+        check(config.snapshot()["default_model_source"] == "modelscope",
+              "modelscope reflected in snapshot");
+    }
+
+    // Unknown registry names are rejected.
+    {
+        RuntimeConfig config(json{{"default_model_source", "huggingface"}});
+        bool threw = false;
+        try {
+            config.set(json{{"default_model_source", "nexus"}});
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        check(threw, "rejects unsupported default_model_source value");
+        check(config.default_model_source() == "huggingface",
+              "rejected value leaves prior policy intact");
+    }
+
+    // Non-string values are rejected.
+    {
+        RuntimeConfig config(json{{"default_model_source", "huggingface"}});
+        bool threw = false;
+        try {
+            config.set(json{{"default_model_source", 42}});
+        } catch (const std::invalid_argument&) {
+            threw = true;
+        }
+        check(threw, "rejects non-string default_model_source value");
+    }
+
+    std::printf("================================================\n");
+    if (failures > 0) {
+        std::printf("Tests finished: %d FAILURE(S)\n", failures);
+        return 1;
+    }
+    std::printf("All default_model_source tests PASSED (%d passed).\n", passed);
+    return 0;
+}

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -6934,6 +6934,74 @@ class EndpointTests(ServerTestBase):
             except Exception:
                 pass
 
+    def test_054_pull_variants_url_source_conflict_returns_400(self):
+        """GET /pull/variants with a --source param that contradicts the
+        detected URL registry is rejected with 400 (matching /pull and CLI)."""
+        # HF URL with --source modelscope should be rejected
+        resp = requests.get(
+            f"{self.base_url}/pull/variants",
+            params={
+                "checkpoint": "https://huggingface.co/fredmagg/Phi-4-mini-instruct-GGUF",
+                "source": "modelscope",
+            },
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(resp.status_code, 400, resp.text)
+        self.assertIn("checkpoint URL uses", resp.json()["error"])
+        self.assertIn("but source was set to", resp.json()["error"])
+
+        # MS URL with --source huggingface should also be rejected
+        resp2 = requests.get(
+            f"{self.base_url}/pull/variants",
+            params={
+                "checkpoint": "https://modelscope.cn/models/owner/repo",
+                "source": "huggingface",
+            },
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(resp2.status_code, 400, resp2.text)
+
+        # An invalid source with a URL should also be rejected
+        resp3 = requests.get(
+            f"{self.base_url}/pull/variants",
+            params={
+                "checkpoint": "https://huggingface.co/owner/repo",
+                "source": "nexus",
+            },
+            timeout=TIMEOUT_DEFAULT,
+        )
+        self.assertEqual(resp3.status_code, 400, resp3.text)
+        print("[OK] /pull/variants rejects URL vs --source mismatches")
+
+    def test_055_pull_invalid_source_rejected(self):
+        """Invalid source values (not huggingface/modelscope/local_*) are
+        rejected before URL normalization, not silently overwritten."""
+        name = f"user.InvalidSrc-{uuid.uuid4().hex[:8]}"
+        try:
+            resp = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": name,
+                    "checkpoint": "https://huggingface.co/owner/repo",
+                    "recipe": "llamacpp",
+                    "source": "nexus",
+                    "stream": False,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 400, resp.text)
+            self.assertIn("Unsupported model source", resp.json()["error"])
+            print("[OK] invalid source rejected before URL normalization")
+        finally:
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": name},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+
     def test_037_model_update_check_lifecycle(self):
         """A successful re-pull clears a staged per-model update marker.
 

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -6893,6 +6893,47 @@ class EndpointTests(ServerTestBase):
                 timeout=TIMEOUT_DEFAULT,
             )
 
+    def test_053_pull_source_url_conflict_returns_400(self):
+        """A provider URL that contradicts an explicit source/registry_source is
+        rejected up front with 400, matching the CLI, before any download."""
+        name = f"user.Conflict-{uuid.uuid4().hex[:8]}"
+        try:
+            resp = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": name,
+                    "checkpoint": "https://huggingface.co/owner/repo",
+                    "recipe": "llamacpp",
+                    "source": "modelscope",
+                    "stream": False,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp.status_code, 400, resp.text)
+
+            resp2 = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": name,
+                    "checkpoint": "https://modelscope.cn/models/owner/repo",
+                    "recipe": "llamacpp",
+                    "registry_source": "huggingface",
+                    "stream": False,
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(resp2.status_code, 400, resp2.text)
+            print("[OK] conflicting /pull source vs provider URL returns 400")
+        finally:
+            try:
+                requests.post(
+                    f"{self.base_url}/delete",
+                    json={"model_name": name},
+                    timeout=TIMEOUT_DEFAULT,
+                )
+            except Exception:
+                pass
+
     def test_037_model_update_check_lifecycle(self):
         """A successful re-pull clears a staged per-model update marker.
 

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -6736,6 +6736,73 @@ class EndpointTests(ServerTestBase):
                 timeout=TIMEOUT_DEFAULT,
             )
 
+    def test_051_default_model_source_policy(self):
+        """default_model_source validates and drives source-less variant lookups."""
+        config_url = f"http://localhost:{PORT}/internal/config"
+        set_url = f"http://localhost:{PORT}/internal/set"
+
+        prior = (
+            requests.get(config_url, timeout=TIMEOUT_DEFAULT)
+            .json()
+            .get("default_model_source", "huggingface")
+        )
+        try:
+            # Ships defaulting to Hugging Face.
+            self.assertIn(prior, ("huggingface", "modelscope"))
+
+            # An unsupported registry name is rejected by config validation.
+            bad = requests.post(
+                set_url,
+                json={"default_model_source": "nexus"},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(bad.status_code, 400, bad.text)
+
+            # Switching the policy round-trips.
+            resp = requests.post(
+                set_url,
+                json={"default_model_source": "modelscope"},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(
+                resp.status_code, 200, f"/internal/set failed: {resp.text}"
+            )
+            read_back = (
+                requests.get(config_url, timeout=TIMEOUT_DEFAULT)
+                .json()
+                .get("default_model_source")
+            )
+            self.assertEqual(read_back, "modelscope")
+
+            # A source-less variant lookup now resolves to ModelScope: the 404
+            # message names the registry the server actually contacted, proving
+            # the policy drove the choice without a per-request source.
+            variants = requests.get(
+                f"{self.base_url}/pull/variants",
+                params={"checkpoint": "lemonade/definitely-not-a-real-repo"},
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(variants.status_code, 404, variants.text)
+            self.assertIn("ModelScope", variants.text)
+
+            # An explicit source always overrides the configured default.
+            override = requests.get(
+                f"{self.base_url}/pull/variants",
+                params={
+                    "checkpoint": "lemonade/definitely-not-a-real-repo",
+                    "source": "huggingface",
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(override.status_code, 404, override.text)
+            self.assertIn("Hugging Face", override.text)
+        finally:
+            requests.post(
+                set_url,
+                json={"default_model_source": prior},
+                timeout=TIMEOUT_DEFAULT,
+            )
+
     def test_037_model_update_check_lifecycle(self):
         """A successful re-pull clears a staged per-model update marker.
 

--- a/test/server_endpoints.py
+++ b/test/server_endpoints.py
@@ -6796,7 +6796,97 @@ class EndpointTests(ServerTestBase):
             )
             self.assertEqual(override.status_code, 404, override.text)
             self.assertIn("Hugging Face", override.text)
+
+            # A provider URL is detected server-side and beats the configured
+            # policy: even with the default set to ModelScope, a Hugging Face URL
+            # is normalized and contacts Hugging Face.
+            url_lookup = requests.get(
+                f"{self.base_url}/pull/variants",
+                params={
+                    "checkpoint": (
+                        "https://huggingface.co/lemonade/definitely-not-a-real-repo"
+                    )
+                },
+                timeout=TIMEOUT_DEFAULT,
+            )
+            self.assertEqual(url_lookup.status_code, 404, url_lookup.text)
+            self.assertIn("Hugging Face", url_lookup.text)
         finally:
+            requests.post(
+                set_url,
+                json={"default_model_source": prior},
+                timeout=TIMEOUT_DEFAULT,
+            )
+
+    def test_052_default_source_pull_persistence(self):
+        """A source-less /pull persists the configured default as the model's
+        registry provenance; an explicit source is recorded verbatim."""
+        config_url = f"http://localhost:{PORT}/internal/config"
+        set_url = f"http://localhost:{PORT}/internal/set"
+
+        prior = (
+            requests.get(config_url, timeout=TIMEOUT_DEFAULT)
+            .json()
+            .get("default_model_source", "huggingface")
+        )
+        default_name = f"user.DefaultSource-{uuid.uuid4().hex[:8]}"
+        explicit_name = f"user.ExplicitSource-{uuid.uuid4().hex[:8]}"
+
+        def persisted_source(model_name):
+            info = requests.get(
+                f"{self.base_url}/models/{model_name}", timeout=TIMEOUT_DEFAULT
+            ).json()
+            return info.get("registry_source") or info.get("source")
+
+        try:
+            # Force the shipped default so the source-less pull resolves to a
+            # registry that actually hosts the tiny test checkpoint.
+            requests.post(
+                set_url,
+                json={"default_model_source": "huggingface"},
+                timeout=TIMEOUT_DEFAULT,
+            )
+
+            # Source-less pull: persisted provenance is the configured default.
+            resp = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": default_name,
+                    "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
+                    "recipe": "llamacpp",
+                    "stream": False,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(persisted_source(default_name), "huggingface")
+
+            # Explicit source is recorded even when it matches the default.
+            resp2 = requests.post(
+                f"{self.base_url}/pull",
+                json={
+                    "model_name": explicit_name,
+                    "checkpoint": USER_MODEL_MAIN_CHECKPOINT,
+                    "recipe": "llamacpp",
+                    "source": "huggingface",
+                    "stream": False,
+                },
+                timeout=TIMEOUT_MODEL_OPERATION,
+            )
+            self.assertEqual(resp2.status_code, 200, resp2.text)
+            self.assertEqual(persisted_source(explicit_name), "huggingface")
+
+            print("[OK] source-less /pull persists default_model_source provenance")
+        finally:
+            for name in (default_name, explicit_name):
+                try:
+                    requests.post(
+                        f"{self.base_url}/delete",
+                        json={"model_name": name},
+                        timeout=TIMEOUT_DEFAULT,
+                    )
+                except Exception:
+                    pass
             requests.post(
                 set_url,
                 json={"default_model_source": prior},


### PR DESCRIPTION
The default will be HuggingFace.

If a user is in China they can set the default model source to Modelscope they can change the configuration option.