### PR TITLE
fix(gui3): model detail panel refinement

### DIFF
--- a/src/app/src/components/ModelDetailPanel.tsx
+++ b/src/app/src/components/ModelDetailPanel.tsx
@@ -1001,17 +1001,14 @@ const ModelConfigurationTab: React.FC<{
   loadedModel: LoadedModel | null;
   isActive: boolean;
   serverDefaultCtxSize: number;
-  isDownloaded?: boolean;
   isLoadingThis?: boolean;
   onReloadModel?: (model: LoadedModel, recipeOptions?: Record<string, unknown>) => Promise<void>;
-  onLoadWithOptions?: (recipeOptions: RecipeOptions) => Promise<void>;
   onDirtyChange?: (dirty: boolean) => void;
-}> = ({ model, loadedModel, isActive, serverDefaultCtxSize, isDownloaded, isLoadingThis, onReloadModel, onLoadWithOptions, onDirtyChange }) => {
+}> = ({ model, loadedModel, isActive, serverDefaultCtxSize, isLoadingThis, onReloadModel, onDirtyChange }) => {
   const name = mdName(model);
-  const imageOnly = isImageOnlyModel(model);
+  const supportsContextSize = capabilityFromModelInfo(model) === 'chat';
   const [notice, setNotice] = useState<string | null>(null);
   const [isReloading, setIsReloading] = useState(false);
-  const [isLoadingViaPanel, setIsLoadingViaPanel] = useState(false);
   const [systemInfo, setSystemInfo] = useState<Record<string, unknown> | null>(() => api.systemInfoData);
 
 
@@ -1034,7 +1031,10 @@ const ModelConfigurationTab: React.FC<{
   const knownVoiceOptions = useMemo(() => knownVoiceOptionsForModel(model), [model]);
   const knownVoiceIds = useMemo(() => new Set(knownVoiceOptions.map(option => option.id.toLowerCase())), [knownVoiceOptions]);
 
-  const [ctxSizeDraft, setCtxSizeDraft] = useState('');
+  const [ctxSizeDraft, setCtxSizeDraft] = useState(() => {
+    const ctxRaw = loadModelTuning(name)?.recipe_options?.ctx_size;
+    return ctxRaw != null ? String(ctxRaw) : '-1';
+  });
   const [recipeDraft, setRecipeDraft] = useState<Record<string, string>>({});
   const [customVoiceMode, setCustomVoiceMode] = useState(false);
 
@@ -1046,7 +1046,7 @@ const ModelConfigurationTab: React.FC<{
     }
     const ctxRaw = userTuning?.recipe_options?.ctx_size;
     return {
-      ctxSize: ctxRaw != null ? String(ctxRaw) : '',
+      ctxSize: ctxRaw != null ? String(ctxRaw) : '-1',
       recipe: nextRecipe,
     };
   }, [name]);
@@ -1117,7 +1117,7 @@ const ModelConfigurationTab: React.FC<{
       }
     }
     const ctxNum = parseNumberOrUndefined(ctxSizeDraft);
-    if (ctxNum !== undefined) (raw as Record<string, unknown>).ctx_size = ctxNum;
+    if (supportsContextSize && ctxNum !== undefined) (raw as Record<string, unknown>).ctx_size = ctxNum;
     return sanitizeRecipeOptions(raw);
   };
 
@@ -1142,7 +1142,7 @@ const ModelConfigurationTab: React.FC<{
     } else {
       resetModelTuning(name);
     }
-    setCtxSizeDraft('');
+    setCtxSizeDraft('-1');
     setRecipeDraft({});
     setCustomVoiceMode(false);
     setNotice('Load settings reset to built-in defaults.');
@@ -1152,18 +1152,6 @@ const ModelConfigurationTab: React.FC<{
     loadFromStore();
     onDirtyChange?.(false);
     setNotice('Unsaved load setting changes discarded.');
-  };
-
-  const loadViaPanel = async () => {
-    if (!onLoadWithOptions) return;
-    saveConfig(false);
-    setIsLoadingViaPanel(true);
-    try {
-      await onLoadWithOptions(buildConfigOptions());
-      setNotice('Model loaded with current settings.');
-    } finally {
-      setIsLoadingViaPanel(false);
-    }
   };
 
   const reloadViaPanel = async () => {
@@ -1377,43 +1365,44 @@ const ModelConfigurationTab: React.FC<{
         </div>
 
         <div className="detail-configuration__load-controls">
-          {!imageOnly && (
+          {supportsContextSize && (
             <div className="detail-configuration__context-card">
               <div className="detail-configuration__control-head">
                 <label htmlFor={ctxSliderId}>Context size</label>
-                <div className="detail-configuration__context-number">
-                  <input
-                    id={ctxSizeId}
-                    className="input detail-configuration__context-input"
-                    type="number"
-                    min={ctxMin}
-                    max={ctxMax}
-                    step={ctxStep}
-                    value={ctxSizeDraft}
-                    placeholder={String(baseCtxSize)}
-                    onChange={e => setCtxSizeDraft(e.target.value)}
-                    aria-label="Context size tokens"
-                    disabled={isAutoTuning}
-                  />
-                  <span className="detail-configuration__context-stepper">
-                    <button
-                      type="button"
-                      onClick={() => stepContextSize(1)}
-                      disabled={isAutoTuning || currentCtxSize >= ctxMax}
-                      aria-label={`Increase context size by ${ctxStep} tokens`}
-                    >
-                      <Icon name="chevron-up" size={11} aria-hidden="true" />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => stepContextSize(-1)}
-                      disabled={isAutoTuning || currentCtxSize <= ctxMin}
-                      aria-label={`Decrease context size by ${ctxStep} tokens`}
-                    >
-                      <Icon name="chevron-down" size={11} aria-hidden="true" />
-                    </button>
-                  </span>
-                </div>
+                {!isAutoTuning && (
+                  <div className="detail-configuration__context-number">
+                    <input
+                      id={ctxSizeId}
+                      className="input detail-configuration__context-input"
+                      type="number"
+                      min={ctxMin}
+                      max={ctxMax}
+                      step={ctxStep}
+                      value={ctxSizeDraft}
+                      placeholder={String(baseCtxSize)}
+                      onChange={e => setCtxSizeDraft(e.target.value)}
+                      aria-label="Context size tokens"
+                    />
+                    <span className="detail-configuration__context-stepper">
+                      <button
+                        type="button"
+                        onClick={() => stepContextSize(1)}
+                        disabled={currentCtxSize >= ctxMax}
+                        aria-label={`Increase context size by ${ctxStep} tokens`}
+                      >
+                        <Icon name="chevron-up" size={11} aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => stepContextSize(-1)}
+                        disabled={currentCtxSize <= ctxMin}
+                        aria-label={`Decrease context size by ${ctxStep} tokens`}
+                      >
+                        <Icon name="chevron-down" size={11} aria-hidden="true" />
+                      </button>
+                    </span>
+                  </div>
+                )}
               </div>
               <label
                 className="detail-configuration__autotune"
@@ -1422,7 +1411,7 @@ const ModelConfigurationTab: React.FC<{
                 <input
                   type="checkbox"
                   checked={isAutoTuning}
-                  onChange={e => setCtxSizeDraft(e.target.checked ? '-1' : '')}
+                  onChange={e => setCtxSizeDraft(e.target.checked ? '-1' : String(currentCtxSize))}
                   aria-describedby={`${ctxSizeId}-autotune-help`}
                 />
                 <span>Auto tune context size</span>
@@ -1431,21 +1420,22 @@ const ModelConfigurationTab: React.FC<{
               <small id={`${ctxSizeId}-autotune-help`} className="detail-configuration__autotune-help">
                 Estimates a safe context size from available memory when the model loads. Turn it off to choose a fixed value.
               </small>
-              <div className="detail-configuration__slider-row">
-                <span>{formatContextSize(ctxMin)}</span>
-                <input
-                  id={ctxSliderId}
-                  className="slider detail-configuration__context-slider"
-                  type="range"
-                  min={ctxMin}
-                  max={ctxMax}
-                  step={ctxStep}
-                  value={currentCtxSize}
-                  onChange={e => setCtxSizeDraft(e.target.value)}
-                  disabled={isAutoTuning}
-                />
-                <span>{formatContextSize(ctxMax)}</span>
-              </div>
+              {!isAutoTuning && (
+                <div className="detail-configuration__slider-row">
+                  <span>{formatContextSize(ctxMin)}</span>
+                  <input
+                    id={ctxSliderId}
+                    className="slider detail-configuration__context-slider"
+                    type="range"
+                    min={ctxMin}
+                    max={ctxMax}
+                    step={ctxStep}
+                    value={currentCtxSize}
+                    onChange={e => setCtxSizeDraft(e.target.value)}
+                  />
+                  <span>{formatContextSize(ctxMax)}</span>
+                </div>
+              )}
               <small>{isAutoTuning ? 'Estimated at load time' : `${currentCtxSize.toLocaleString()} tokens`}</small>
             </div>
           )}
@@ -1470,17 +1460,6 @@ const ModelConfigurationTab: React.FC<{
         </div>
 
         <div className="detail-tuning__actions detail-configuration__actions">
-          {!loadedModel && isDownloaded && onLoadWithOptions && (
-            <button
-              type="button"
-              className="btn btn--primary btn--sm"
-              onClick={loadViaPanel}
-              disabled={isLoadingViaPanel || isLoadingThis}
-              aria-busy={isLoadingViaPanel}
-            >
-              <Icon name="play" size={13} aria-hidden="true" /> {isLoadingViaPanel ? 'Loading\u2026' : 'Load model'}
-            </button>
-          )}
           {loadedModel && onReloadModel && (
             <button
               type="button"
@@ -1492,7 +1471,7 @@ const ModelConfigurationTab: React.FC<{
               <Icon name="rotate-ccw" size={13} aria-hidden="true" /> {isReloading ? 'Reloading\u2026' : 'Reload model'}
             </button>
           )}
-          <button type="button" className="btn btn--ghost btn--sm" onClick={() => saveConfig()}>Save defaults</button>
+          <button type="button" className={`btn ${hasLoadSettingChanges ? 'btn--primary' : 'btn--ghost'} btn--sm`} onClick={() => saveConfig()}>Save defaults</button>
           {hasLoadSettingChanges && (
             <button type="button" className="btn btn--ghost btn--sm" onClick={discardConfig}>Discard changes</button>
           )}
@@ -1917,9 +1896,13 @@ export interface ModelDetailPanelProps {
   onDelete: (model: ModelInfo) => void;
   onCancelPull: (name: string) => void;
   serverDefaultCtxSize: number;
-  /** Whether this model is currently marked a favorite (client-local pin store). */
+  /** Whether this model is currently pinned in the client-local model list. */
+  isPinned?: boolean;
+  /** Toggle this model's pinned state. Receives the model name. */
+  onTogglePin?: (name: string) => void;
+  /** Whether this model is currently marked as a favorite. */
   isFavorite?: boolean;
-  /** Toggle this model's favorite/pin state. Receives the model name. */
+  /** Toggle this model's favorite state. Receives the model name. */
   onToggleFavorite?: (name: string) => void;
   /** Open the persistent settings editor for a saved custom Omni collection. */
   onEditCustomCollection?: (model: ModelInfo) => void;
@@ -1944,8 +1927,6 @@ export interface ModelDetailPanelProps {
   pullingHf?: Record<string, number>;
   /** Cancel an in-progress HF download. */
   onCancelHfPull?: (hfId: string) => void;
-  /** Load a model with explicit recipe options. */
-  onLoadWithOptions?: (model: ModelInfo, recipeOptions: Record<string, unknown>) => Promise<void>;
 }
 
 type DetailTab = 'settings' | 'readme' | 'config' | 'files';
@@ -1978,6 +1959,8 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   onDelete,
   onCancelPull,
   serverDefaultCtxSize,
+  isPinned = false,
+  onTogglePin,
   isFavorite = false,
   onToggleFavorite,
   onEditCustomCollection,
@@ -1991,7 +1974,6 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
   onHfPull,
   pullingHf,
   onCancelHfPull,
-  onLoadWithOptions,
 }) => {
   const [activeTab, setActiveTab] = useState<DetailTab>('config');
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -2152,25 +2134,15 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
           </WorkspaceActionButton>
         </>
       ) : isDownloaded ? (
-        <>
-          <WorkspaceActionButton
-            appearance="quiet"
-            icon="sliders-horizontal"
-            onClick={() => setActiveTab('config')}
-            title="Configure runtime options before loading"
-          >
-            Configure…
-          </WorkspaceActionButton>
-          <WorkspaceActionButton
-            appearance="primary"
-            icon="play"
-            onClick={() => onLoad(model)}
-            disabled={isLoadingThis}
-            aria-label={isLoadingThis ? `Loading ${name}…` : `Load ${name}`}
-          >
-            {isLoadingThis ? 'Loading…' : 'Load'}
-          </WorkspaceActionButton>
-        </>
+        <WorkspaceActionButton
+          appearance="primary"
+          icon="play"
+          onClick={() => onLoad(model)}
+          disabled={isLoadingThis}
+          aria-label={isLoadingThis ? `Loading ${name}…` : `Load ${name}`}
+        >
+          {isLoadingThis ? 'Loading…' : 'Load'}
+        </WorkspaceActionButton>
       ) : (
         <>
           <WorkspaceActionButton appearance="primary" icon="download" onClick={() => onPullAndLoad(model)} aria-label={`Get and load ${name}`}>
@@ -2180,6 +2152,19 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
             Download
           </WorkspaceActionButton>
         </>
+      )}
+      {onTogglePin && (
+        <WorkspaceActionButton
+          className={`model-detail-panel__fav-btn${isPinned ? ' model-detail-panel__fav-btn--on' : ''}`}
+          appearance="quiet"
+          icon="pin"
+          onClick={() => onTogglePin(name)}
+          aria-pressed={isPinned}
+          aria-label={isPinned ? `Unpin ${name}` : `Pin ${name}`}
+          title={isPinned ? 'Unpin model' : 'Pin model'}
+        >
+          {isPinned ? 'Pinned' : 'Pin'}
+        </WorkspaceActionButton>
       )}
       {onToggleFavorite && (
         <WorkspaceActionButton
@@ -2196,7 +2181,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
       )}
       {(isDownloaded || isLoaded) && (
         <WorkspaceActionButton
-          appearance="danger"
+          appearance="secondary"
           icon="trash"
           onClick={() => onDelete(model)}
           disabled={isLoadingThis}
@@ -2285,10 +2270,8 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
                         loadedModel={loadedModel}
                         isActive={activeTab === 'config'}
                         serverDefaultCtxSize={serverDefaultCtxSize}
-                        isDownloaded={isDownloaded}
                         isLoadingThis={isLoadingThis}
                         onReloadModel={onReloadModel}
-                        onLoadWithOptions={onLoadWithOptions ? (opts) => onLoadWithOptions(model, opts as Record<string, unknown>) : undefined}
                         onDirtyChange={setConfigHasUnsavedChanges}
                       />
                     )}

--- a/src/app/src/components/ModelDetailPanel.tsx
+++ b/src/app/src/components/ModelDetailPanel.tsx
@@ -12,7 +12,7 @@ import api from '../api';
 import { capabilityFromModelInfo, capabilityLabel } from '../modelCapabilities';
 import {
   modelBaseTuningForModel, loadModelTuning, saveModelTuning, resetModelTuning,
-  sanitizeRecipeOptions,
+  modelSupportsContextSize, sanitizeRecipeOptions,
   type RecipeOptions,
 } from '../modelConfiguration';
 import { Icon, CapabilityIcon } from './Icon';
@@ -1006,7 +1006,6 @@ const ModelConfigurationTab: React.FC<{
   onDirtyChange?: (dirty: boolean) => void;
 }> = ({ model, loadedModel, isActive, serverDefaultCtxSize, isLoadingThis, onReloadModel, onDirtyChange }) => {
   const name = mdName(model);
-  const supportsContextSize = capabilityFromModelInfo(model) === 'chat';
   const [notice, setNotice] = useState<string | null>(null);
   const [isReloading, setIsReloading] = useState(false);
   const [systemInfo, setSystemInfo] = useState<Record<string, unknown> | null>(() => api.systemInfoData);
@@ -1027,6 +1026,7 @@ const ModelConfigurationTab: React.FC<{
     () => modelBaseTuningForModel(model, serverDefaultCtxSize),
     [model, serverDefaultCtxSize],
   );
+  const supportsContextSize = modelSupportsContextSize(model);
   const recipeKeys = useMemo(() => tuningKeysForModel(model), [model]);
   const knownVoiceOptions = useMemo(() => knownVoiceOptionsForModel(model), [model]);
   const knownVoiceIds = useMemo(() => new Set(knownVoiceOptions.map(option => option.id.toLowerCase())), [knownVoiceOptions]);
@@ -1070,6 +1070,10 @@ const ModelConfigurationTab: React.FC<{
     onDirtyChange?.(hasLoadSettingChanges);
   }, [hasLoadSettingChanges, onDirtyChange]);
 
+  useEffect(() => {
+    if (hasLoadSettingChanges && notice === 'Saved for future loads') setNotice(null);
+  }, [hasLoadSettingChanges, notice]);
+
   const ctxSizeId = `config-${name}-ctx_size`.replace(/[^a-zA-Z0-9_-]/g, '-');
   const ctxSliderId = `${ctxSizeId}-slider`;
   const info = systemInfo || {};
@@ -1086,6 +1090,9 @@ const ModelConfigurationTab: React.FC<{
     ?? 4096;
   const isAutoTuning = ctxSizeDraft === '-1';
   const currentCtxSize = positiveCtxValue(ctxSizeDraft) ?? baseCtxSize;
+  const autoTuneTooltip = isAutoTuning
+    ? 'Lemonade estimates the context size from available memory when the model loads. Uncheck to use a fixed value.'
+    : `Context size is fixed at ${currentCtxSize.toLocaleString()} tokens. Check Auto tune context size to let Lemonade estimate it from available memory at load time.`;
   const ctxMax = Math.max(
     ctxMin,
     currentCtxSize,
@@ -1128,7 +1135,7 @@ const ModelConfigurationTab: React.FC<{
       recipe_options: buildConfigOptions(),
       sampling: existingTuning?.sampling || {},
     });
-    if (showNotice) setNotice('Defaults saved for future loads.');
+    if (showNotice) setNotice('Saved for future loads');
   };
 
   const resetConfig = () => {
@@ -1359,9 +1366,9 @@ const ModelConfigurationTab: React.FC<{
               Settings used when this model loads or reloads.
             </p>
           </div>
-          <span className={`detail-configuration__status ${loadedModel ? 'is-loaded' : ''}`}>
-            {loadedModel ? 'Loaded now' : 'Saved defaults'}
-          </span>
+          {loadedModel && (
+            <span className="detail-configuration__status is-loaded">Loaded now</span>
+          )}
         </div>
 
         <div className="detail-configuration__load-controls">
@@ -1406,20 +1413,16 @@ const ModelConfigurationTab: React.FC<{
               </div>
               <label
                 className="detail-configuration__autotune"
-                title="Lemonade estimates a context size from available memory at load time. The result can differ if other models are loaded or memory use changes."
+                title={autoTuneTooltip}
               >
                 <input
                   type="checkbox"
                   checked={isAutoTuning}
                   onChange={e => setCtxSizeDraft(e.target.checked ? '-1' : String(currentCtxSize))}
-                  aria-describedby={`${ctxSizeId}-autotune-help`}
                 />
                 <span>Auto tune context size</span>
                 <Icon name="info" size={14} aria-hidden="true" />
               </label>
-              <small id={`${ctxSizeId}-autotune-help`} className="detail-configuration__autotune-help">
-                Estimates a safe context size from available memory when the model loads. Turn it off to choose a fixed value.
-              </small>
               {!isAutoTuning && (
                 <div className="detail-configuration__slider-row">
                   <span>{formatContextSize(ctxMin)}</span>
@@ -1436,7 +1439,6 @@ const ModelConfigurationTab: React.FC<{
                   <span>{formatContextSize(ctxMax)}</span>
                 </div>
               )}
-              <small>{isAutoTuning ? 'Estimated at load time' : `${currentCtxSize.toLocaleString()} tokens`}</small>
             </div>
           )}
 
@@ -1471,7 +1473,7 @@ const ModelConfigurationTab: React.FC<{
               <Icon name="rotate-ccw" size={13} aria-hidden="true" /> {isReloading ? 'Reloading\u2026' : 'Reload model'}
             </button>
           )}
-          <button type="button" className={`btn ${hasLoadSettingChanges ? 'btn--primary' : 'btn--ghost'} btn--sm`} onClick={() => saveConfig()}>Save defaults</button>
+          <button type="button" className={`btn ${hasLoadSettingChanges ? 'btn--primary' : 'btn--ghost'} btn--sm`} onClick={() => saveConfig()}>Save</button>
           {hasLoadSettingChanges && (
             <button type="button" className="btn btn--ghost btn--sm" onClick={discardConfig}>Discard changes</button>
           )}

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -1688,29 +1688,6 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
     await refresh();
   };
 
-  const handleLoadWithOptions = async (model: ModelInfo, recipeOptions: Record<string, unknown>): Promise<void> => {
-    if (loadingModel) return;
-    const name = modelName(model);
-    if (activeDownloadForModel(downloadStore.snapshot(), name)) {
-      setLoadError({ modelName: name, message: `${name} is still downloading. Wait for the download to finish before loading it.` });
-      window.setTimeout(() => setLoadError(prev => prev?.modelName === name ? null : prev), 6000);
-      return;
-    }
-    setLoadError(null);
-    setLoadingModel(name);
-    try {
-      await loadWithGlobalPolicy(model, recipeOptions);
-      await refresh();
-      onModelSelect(name);
-    } catch (err) {
-      console.error('Load with options failed:', err);
-      const message = friendlyErrorMessage(err);
-      setLoadError({ modelName: name, message });
-      window.setTimeout(() => setLoadError(prev => prev?.modelName === name ? null : prev), 6000);
-    }
-    setLoadingModel(null);
-  };
-
   const handleDeleteRouterDefinition = async (name: string): Promise<void> => {
     if (api.isConnected) await api.deleteModel(name);
     deleteRouterRecord(name);
@@ -3248,12 +3225,13 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
           onLoad={handleLoad}
           onUnload={handleUnload}
           onReloadModel={handleReloadModel}
-          onLoadWithOptions={handleLoadWithOptions}
           onPull={handlePull}
           onPullAndLoad={handlePullAndLoad}
           onDelete={handleDelete}
           onCancelPull={handleCancelPull}
           serverDefaultCtxSize={serverDefaultCtxSize}
+          isPinned={selectedDetailModelId ? pinnedNameSet.has(selectedDetailModelId.toLowerCase()) : false}
+          onTogglePin={togglePinnedModel}
           isFavorite={selectedDetailModelId ? favoriteNameSet.has(selectedDetailModelId.toLowerCase()) : false}
           onToggleFavorite={toggleFavoriteModel}
           onEditCustomCollection={(model) => {

--- a/src/app/src/modelConfiguration.ts
+++ b/src/app/src/modelConfiguration.ts
@@ -927,6 +927,9 @@ export function recipeOptionsForModel(
   const modelOptions = model
     ? recipeOptionsForCapability(directTuning?.recipe_options || {}, capability!)
     : (directTuning?.recipe_options || {});
+  if (model && capability === 'chat' && modelOptions.ctx_size === undefined) {
+    modelOptions.ctx_size = -1;
+  }
 
   const backendTuning = activeBackendTuningForModel(model, {
     explicitOptions,

--- a/src/app/src/modelConfiguration.ts
+++ b/src/app/src/modelConfiguration.ts
@@ -574,6 +574,16 @@ function activeRecipeName(model: ModelInfo | null | undefined): string {
   return recipeName(recipesForModel(model)[0]);
 }
 
+const CONTEXT_SIZE_RECIPES = new Set(['llamacpp', 'flm', 'ryzenai-llm', 'vllm']);
+
+export function modelSupportsContextSize(model: ModelInfo | null | undefined): boolean {
+  if (!model) return false;
+  const capability = capabilityFromModelInfo(model);
+  if (capability === 'chat') return true;
+  if (capability !== 'unknown') return false;
+  return CONTEXT_SIZE_RECIPES.has(activeRecipeName(model));
+}
+
 function readNumberFromActiveRecipe(model: ModelInfo | null | undefined, paths: string[][]): number | undefined {
   const recipes = recipesForModel(model);
   const active = activeRecipeName(model);
@@ -927,7 +937,7 @@ export function recipeOptionsForModel(
   const modelOptions = model
     ? recipeOptionsForCapability(directTuning?.recipe_options || {}, capability!)
     : (directTuning?.recipe_options || {});
-  if (model && capability === 'chat' && modelOptions.ctx_size === undefined) {
+  if (modelSupportsContextSize(model) && modelOptions.ctx_size === undefined) {
     modelOptions.ctx_size = -1;
   }
 

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -8598,6 +8598,7 @@ optgroup {
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--space-3);
+  translate: 0 6px;
 }
 
 .detail-configuration__slider-row span,

--- a/src/app/tests/a11y.spec.ts
+++ b/src/app/tests/a11y.spec.ts
@@ -2548,7 +2548,7 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     await goToModelsRefined(page);
     await page.locator('.model-list-item').first().click();
     await page.waitForTimeout(200);
-    const star = page.locator('.model-detail-panel__fav-btn');
+    const star = page.locator('.model-detail-panel').getByRole('button', { name: /favorites/i });
     await expect(star).toBeVisible();
     await expect(star).toHaveRole('button');
     // Off state: not pressed, label invites adding to favorites and names the model.
@@ -2567,7 +2567,7 @@ test.describe('Accessibility — model view refinements (#2424)', () => {
     await goToModelsRefined(page);
     await page.locator('.model-list-item').first().click();
     await page.waitForTimeout(150);
-    await page.locator('.model-detail-panel__fav-btn').click();
+    await page.locator('.model-detail-panel').getByRole('button', { name: /favorites/i }).click();
     await page.waitForTimeout(150);
 
     // Favorites primary-nav entry now reports one model (via its sr-only phrase).

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -670,6 +670,14 @@ test.describe('Lemonade UI — Feature Parity', () => {
           labels: ['transcription'],
           recipe: 'whispercpp',
           downloaded: true,
+        }, {
+          id: 'unknown-context-model',
+          name: 'unknown-context-model',
+          display_name: 'Unknown Context Model',
+          registry_source: 'huggingface',
+          recipe: 'llamacpp',
+          downloaded: true,
+          max_context_window: 32768,
         }],
       }),
     }));
@@ -683,8 +691,16 @@ test.describe('Lemonade UI — Feature Parity', () => {
     const panel = page.locator('#detail-panel-config');
     await expect(panel).toBeVisible();
     await expect(panel.getByRole('heading', { name: 'Load settings' })).toBeVisible();
+    await expect(panel.getByText('Saved defaults', { exact: true })).toHaveCount(0);
     const autoTune = panel.getByRole('checkbox', { name: 'Auto tune context size' });
+    const autoTuneControl = panel.locator('.detail-configuration__autotune');
     await expect(autoTune).toBeChecked();
+    await expect(autoTuneControl).toHaveAttribute(
+      'title',
+      'Lemonade estimates the context size from available memory when the model loads. Uncheck to use a fixed value.',
+    );
+    await expect(panel.getByText('Estimated at load time', { exact: true })).toHaveCount(0);
+    await expect(panel.getByText(/Estimates a safe context size from available memory/)).toHaveCount(0);
     await expect(panel.getByLabel('Context size tokens')).toHaveCount(0);
     await expect(panel.locator('.detail-configuration__slider-row')).toHaveCount(0);
     await expect(panel.getByRole('button', { name: 'Load model' })).toHaveCount(0);
@@ -692,16 +708,23 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await expect(loadButton).toBeVisible();
     await expect(page.getByText('Configure…', { exact: true })).toHaveCount(0);
 
-    const saveDefaults = panel.getByRole('button', { name: 'Save defaults' });
-    await expect(saveDefaults).toHaveClass(/btn--ghost/);
+    const save = panel.getByRole('button', { name: 'Save', exact: true });
+    await expect(save).toHaveClass(/btn--ghost/);
     await autoTune.uncheck();
     await expect(panel.getByLabel('Context size tokens')).toBeVisible();
     await expect(panel.locator('.detail-configuration__slider-row')).toBeVisible();
-    await expect(saveDefaults).toHaveClass(/btn--primary/);
+    await expect(autoTuneControl).toHaveAttribute('title', /Context size is fixed at .* tokens.*Check Auto tune context size/);
+    await expect(save).toHaveClass(/btn--primary/);
+    await save.click();
+    await expect(save).toHaveClass(/btn--ghost/);
+    await expect(panel.locator('.detail-tuning__notice')).toHaveText('Saved for future loads');
     await autoTune.check();
+    await expect(panel.locator('.detail-tuning__notice')).toHaveCount(0);
     await expect(panel.getByLabel('Context size tokens')).toHaveCount(0);
     await expect(panel.locator('.detail-configuration__slider-row')).toHaveCount(0);
-    await expect(saveDefaults).toHaveClass(/btn--ghost/);
+    await expect(save).toHaveClass(/btn--primary/);
+    await save.click();
+    await expect(save).toHaveClass(/btn--ghost/);
     await expect(panel.locator('[id$="llamacpp_backend"]')).toBeVisible();
     await expect(panel.getByRole('button', { name: 'Reset' })).toBeVisible();
 
@@ -719,8 +742,18 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await expect(speechPanel.getByRole('checkbox', { name: 'Auto tune context size' })).toHaveCount(0);
     await expect(speechPanel.getByLabel('Context size tokens')).toHaveCount(0);
 
-    await page.locator('.model-list-item').filter({ hasText: 'Config Beta Model' }).click();
-    await page.getByRole('button', { name: 'Load config-beta-model' }).click();
+    await page.locator('.model-list-item').filter({ hasText: 'Unknown Context Model' }).click();
+    await page.getByRole('tab', { name: 'Configuration' }).click();
+    const unknownPanel = page.locator('#detail-panel-config');
+    const unknownAutoTune = unknownPanel.getByRole('checkbox', { name: 'Auto tune context size' });
+    await expect(unknownAutoTune).toBeChecked();
+    await unknownAutoTune.uncheck();
+    await expect(unknownPanel.getByLabel('Context size tokens')).toBeVisible();
+    await expect(unknownPanel.locator('.detail-configuration__slider-row')).toBeVisible();
+    await unknownAutoTune.check();
+
+    await page.getByRole('button', { name: 'Load unknown-context-model' }).click();
+    await expect.poll(() => loadRequestBody?.model_name).toBe('unknown-context-model');
     await expect.poll(() => loadRequestBody?.ctx_size).toBe(-1);
   });
 
@@ -1373,7 +1406,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await expect(page.locator('[id$="llamacpp_backend"]')).toBeVisible();
 
     await page.getByLabel('Context size tokens').fill('16384');
-    await page.getByRole('button', { name: 'Save defaults' }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
 
     const saved = await page.evaluate(({ model }) => {
       for (const key of Object.keys(localStorage)) {
@@ -1425,9 +1458,9 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await expect(panel).toBeVisible();
 
     // Save — notice must appear and stay visible
-    await panel.getByRole('button', { name: 'Save defaults' }).click();
+    await panel.getByRole('button', { name: 'Save' }).click();
     await expect(panel.locator('.detail-tuning__notice')).toBeVisible();
-    await expect(panel.locator('.detail-tuning__notice')).toContainText('Defaults saved for future loads.');
+    await expect(panel.locator('.detail-tuning__notice')).toContainText('Saved for future loads');
 
     // Switch to model B — stale notice must be gone
     await page.locator('.model-list-item').filter({ hasText: modelB }).click();

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -628,6 +628,7 @@ test.describe('Lemonade UI — Feature Parity', () => {
   });
 
   test('13c — Configuration tab shows runtime controls for a downloaded model', async ({ page }) => {
+    let loadRequestBody: Record<string, unknown> | null = null;
     await page.addInitScript(() => {
       for (const key of Object.keys(localStorage)) {
         if (key.includes('model_tunings')) localStorage.removeItem(key);
@@ -646,6 +647,10 @@ test.describe('Lemonade UI — Feature Parity', () => {
         },
       },
     }));
+    await page.route('**/api/v1/load', route => {
+      loadRequestBody = route.request().postDataJSON() as Record<string, unknown>;
+      return route.fulfill({ json: { status: 'ok' } });
+    });
     await page.route('**/api/v1/models**', route => route.fulfill({
       contentType: 'application/json',
       body: JSON.stringify({
@@ -658,6 +663,13 @@ test.describe('Lemonade UI — Feature Parity', () => {
           downloaded: true,
           max_context_window: 65536,
           recipe_options: { ctx_size: 8192 },
+        }, {
+          id: 'speech-beta-model',
+          name: 'speech-beta-model',
+          display_name: 'Speech Beta Model',
+          labels: ['transcription'],
+          recipe: 'whispercpp',
+          downloaded: true,
         }],
       }),
     }));
@@ -671,10 +683,45 @@ test.describe('Lemonade UI — Feature Parity', () => {
     const panel = page.locator('#detail-panel-config');
     await expect(panel).toBeVisible();
     await expect(panel.getByRole('heading', { name: 'Load settings' })).toBeVisible();
+    const autoTune = panel.getByRole('checkbox', { name: 'Auto tune context size' });
+    await expect(autoTune).toBeChecked();
+    await expect(panel.getByLabel('Context size tokens')).toHaveCount(0);
+    await expect(panel.locator('.detail-configuration__slider-row')).toHaveCount(0);
+    await expect(panel.getByRole('button', { name: 'Load model' })).toHaveCount(0);
+    const loadButton = page.getByRole('button', { name: 'Load config-beta-model' });
+    await expect(loadButton).toBeVisible();
+    await expect(page.getByText('Configure…', { exact: true })).toHaveCount(0);
+
+    const saveDefaults = panel.getByRole('button', { name: 'Save defaults' });
+    await expect(saveDefaults).toHaveClass(/btn--ghost/);
+    await autoTune.uncheck();
     await expect(panel.getByLabel('Context size tokens')).toBeVisible();
+    await expect(panel.locator('.detail-configuration__slider-row')).toBeVisible();
+    await expect(saveDefaults).toHaveClass(/btn--primary/);
+    await autoTune.check();
+    await expect(panel.getByLabel('Context size tokens')).toHaveCount(0);
+    await expect(panel.locator('.detail-configuration__slider-row')).toHaveCount(0);
+    await expect(saveDefaults).toHaveClass(/btn--ghost/);
     await expect(panel.locator('[id$="llamacpp_backend"]')).toBeVisible();
-    await expect(panel.getByRole('button', { name: 'Save defaults' })).toBeVisible();
     await expect(panel.getByRole('button', { name: 'Reset' })).toBeVisible();
+
+    const pin = page.getByRole('button', { name: 'Pin config-beta-model' });
+    await expect(pin).toBeVisible();
+    await pin.click();
+    await expect(page.getByRole('button', { name: 'Unpin config-beta-model' }))
+      .toHaveClass(/model-detail-panel__fav-btn--on/);
+    await expect(page.getByRole('button', { name: 'Delete downloaded files for config-beta-model' }))
+      .toHaveClass(/workspace-action-button--secondary/);
+
+    await page.locator('.model-list-item').filter({ hasText: 'Speech Beta Model' }).click();
+    await page.getByRole('tab', { name: 'Configuration' }).click();
+    const speechPanel = page.locator('#detail-panel-config');
+    await expect(speechPanel.getByRole('checkbox', { name: 'Auto tune context size' })).toHaveCount(0);
+    await expect(speechPanel.getByLabel('Context size tokens')).toHaveCount(0);
+
+    await page.locator('.model-list-item').filter({ hasText: 'Config Beta Model' }).click();
+    await page.getByRole('button', { name: 'Load config-beta-model' }).click();
+    await expect.poll(() => loadRequestBody?.ctx_size).toBe(-1);
   });
 
 
@@ -1317,6 +1364,11 @@ test.describe('Lemonade UI — Feature Parity', () => {
     await page.locator('.model-list-item').first().click();
     await page.locator('#detail-tab-config').click();
 
+    const autoTune = page.getByRole('checkbox', { name: 'Auto tune context size' });
+    await expect(autoTune).toBeChecked();
+    await expect(page.getByLabel('Context size tokens')).toHaveCount(0);
+    await expect(page.locator('.detail-configuration__slider-row')).toHaveCount(0);
+    await autoTune.uncheck();
     await expect(page.getByLabel('Context size tokens')).toBeVisible();
     await expect(page.locator('[id$="llamacpp_backend"]')).toBeVisible();
 


### PR DESCRIPTION
<img width="1092" height="877" alt="image" src="https://github.com/user-attachments/assets/4db5f4fb-458f-48df-968b-7d3d6fa1c53f" />

1. Non-LLM models have no ctx size control
2. Removed configure button
3. Made the delete button quieter
4. Add a Pin button with the same desgin as favorites but not filled upon acivation
5. Removed the duplicate Load button (bottom)
6. Default "auto tune context size"  hides ctz settings



<img width="1092" height="790" alt="image" src="https://github.com/user-attachments/assets/a3437cbe-738a-4edd-9ada-32702e443913" />
7. Save button becomes primary action once configuration is modified.
<img width="749" height="322" alt="image" src="https://github.com/user-attachments/assets/3925ee4a-6f1f-4bd5-8c08-59ecfb4ac627" />
