### PR TITLE
Debian packaging improvements

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -1,5 +1,5 @@
 Source: lemonade
-Standards-Version: 4.7.3
+Standards-Version: 4.7.4
 Maintainer: Mario Limonciello <superm1@debian.org>
 Section: utils
 Testsuite: autopkgtest-pkg-python

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -1,7 +1,8 @@
 Source: lemonade
-Section: utils
-Priority: optional
+Standards-Version: 4.7.3
 Maintainer: Mario Limonciello <superm1@debian.org>
+Section: utils
+Testsuite: autopkgtest-pkg-python
 Build-Depends:
  cmake,
  debhelper-compat (= 13),
@@ -38,16 +39,20 @@ Build-Depends:
  node-webpack-cli,
  nodejs,
  pkgconf,
-Testsuite: autopkgtest-pkg-python
-Standards-Version: 4.7.3
-Homepage: https://lemonade-server.ai/
 Vcs-Browser: https://salsa.debian.org/debian/lemonade
 Vcs-Git: https://salsa.debian.org/debian/lemonade.git
+Homepage: https://lemonade-server.ai/
 
 Package: lemonade-server
 Architecture: linux-any
 Multi-Arch: foreign
-Depends: ${shlibs:Depends}, ${misc:Depends}, fonts-katex, unzip, libatomic1, libgomp1
+Depends:
+ ${shlibs:Depends},
+ ${misc:Depends},
+ fonts-katex,
+ unzip,
+ libatomic1,
+ libgomp1,
 Description: Local LLM serving with GPU and NPU acceleration server
  Lemonade helps users run local LLMs with the highest performance by
  configuring state-of-the-art inference engines for their NPUs and GPUs.
@@ -58,8 +63,14 @@ Description: Local LLM serving with GPU and NPU acceleration server
 Package: lemonade-desktop
 Architecture: all
 Multi-Arch: foreign
-Depends: ${shlibs:Depends}, ${misc:Depends}, jq, lemonade-server, xdg-utils
-Recommends: chromium | www-browser
+Depends:
+ ${shlibs:Depends},
+ ${misc:Depends},
+ jq,
+ lemonade-server,
+ xdg-utils,
+Recommends:
+ chromium | www-browser,
 Description: Local LLM serving with GPU and NPU acceleration web application
  Lemonade helps users run local LLMs with the highest performance by
  configuring state-of-the-art inference engines for their NPUs and GPUs.

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -38,7 +38,6 @@ Build-Depends:
  node-webpack-cli,
  nodejs,
  pkgconf,
- quilt,
 Testsuite: autopkgtest-pkg-python
 Standards-Version: 4.7.3
 Homepage: https://lemonade-server.ai/

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -1,13 +1,14 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Source: https://github.com/lemonade-sdk/lemonade
 Upstream-Name: lemonade
-Upstream-Contact: lemonade@amd.com
+Upstream-Contact:
+ lemonade@amd.com,
 
 Files: *
 Copyright: 2024-2025 Advanced Micro Devices, Inc. (AMD)
-           2023 Groq Inc.
-Comment: Portions derived from TurnkeyML/MLAgility
+            2023 Groq Inc.
 License: Apache-2.0
+Comment: Portions derived from TurnkeyML/MLAgility
 
 Files: .devcontainer/reinstall-cmake.sh
 Copyright: Microsoft Corporation
@@ -102,56 +103,6 @@ License: Expat
  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-License: ISC
- Permission to use, copy, modify, and/or distribute this software for any
- purpose with or without fee is hereby granted, provided that the above
- copyright notice and this permission notice appear in all copies.
- .
- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-License: GPL-2.0
- This package is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; version 2 of the License.
- .
- This package is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
- .
- You should have received a copy of the GNU General Public License
- along with this program. If not, see <http://www.gnu.org/licenses/>
- .
- On Debian systems, the complete text of the GNU General
- Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
-
-License: BSD-2-clause
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
- .
- 1. Redistributions of source code must retain the above copyright notice, this
-    list of conditions and the following disclaimer.
- 2. Redistributions in binary form must reproduce the above copyright notice,
-    this list of conditions and the following disclaimer in the documentation
-    and/or other materials provided with the distribution.
- .
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 License: GPL-2+
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -168,37 +119,6 @@ License: GPL-2+
  .
  On Debian systems, the full text of the GNU General Public License
  version 2 can be found in the file '/usr/share/common-licenses/GPL-2'.
-
-License: BSD-3-clause
- Copyright (c) 2018 Machine Zone, Inc. All rights reserved.
- .
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are
- met:
- .
- 1. Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
- .
- 2. Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the
-    distribution.
- .
- 3. Neither the name of the copyright holder nor the names of its
-    contributors may be used to endorse or promote products derived
-    from this software without specific prior written permission.
- .
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 License: GPL-2.0-with-linux-syscall-note
  This package is free software; you can redistribute it and/or modify
@@ -228,3 +148,16 @@ License: GPL-2.0-with-linux-syscall-note
  v2.2 or v3.x or whatever), unless explicitly otherwise stated.
  .
  Linus Torvalds
+
+License: ISC
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
## Summary
Debian packaging updates for lemonade.

- Drop quilt from build-depends (Closes: #1143219)
- Reformat d/control using cme
- Remove unnecessary licenses flagged by cme from d/copyright
- Bump standards version