### PR TITLE
GUI3 fix: backend hide technical details

### DIFF
--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -1111,32 +1111,36 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
                 </div>
 
                 <div className="backend-card__variant-meta">
-                  {version && (installedReleaseUrl ? (
-                    <a
-                      className="backend-card__version"
-                      href={installedReleaseUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      title={`Open installed ${engineName} ${version} release page`}
-                    >
-                      {version}
-                      <Icon name="external-link" size={11} aria-hidden="true" />
-                    </a>
-                  ) : (
-                    <span className="backend-card__version">{version}</span>
-                  ))}
-                  {isUpdate && targetReleaseUrl && targetVersion && targetVersion !== version && (
-                    <a
-                      className="backend-card__version"
-                      href={targetReleaseUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      title={`Open ${engineName} ${targetVersion} update release page`}
-                    >
-                      <Icon name="chevron-right" size={11} aria-hidden="true" />
-                      {targetVersion}
-                      <Icon name="external-link" size={11} aria-hidden="true" />
-                    </a>
+                  {showTech && (
+                    <>
+                      {version && (installedReleaseUrl ? (
+                        <a
+                          className="backend-card__version"
+                          href={installedReleaseUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title={`Open installed ${engineName} ${version} release page`}
+                        >
+                          {version}
+                          <Icon name="external-link" size={11} aria-hidden="true" />
+                        </a>
+                      ) : (
+                        <span className="backend-card__version">{version}</span>
+                      ))}
+                      {isUpdate && targetReleaseUrl && targetVersion && targetVersion !== version && (
+                        <a
+                          className="backend-card__version"
+                          href={targetReleaseUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title={`Open ${engineName} ${targetVersion} update release page`}
+                        >
+                          <Icon name="chevron-right" size={11} aria-hidden="true" />
+                          {targetVersion}
+                          <Icon name="external-link" size={11} aria-hidden="true" />
+                        </a>
+                      )}
+                    </>
                   )}
                   {tuning && (
                     <span className={`cell__args-state cell__args-state--${tuning.source}`} data-cell-backend-args={tuning.source}>
@@ -1229,7 +1233,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
                 )}
                 {backendDownload?.status === 'error' && backendDownload.error ? (
                   <p className="backend-card__note backend-card__note--error">{backendDownload.error}</p>
-                ) : ((showTech || info.state === 'update_available' || info.state === 'update_required') && info.message && (
+                ) : (showTech && info.message && (
                   <p className="backend-card__note">{info.message}</p>
                 ))}
               </div>

--- a/src/app/tests/features.spec.ts
+++ b/src/app/tests/features.spec.ts
@@ -676,6 +676,53 @@ test.describe('Lemonade UI — Feature Parity', () => {
   });
 
 
+  test('Backend technical details stay hidden until enabled', async ({ page }) => {
+    await page.route('**/api/v1/health**', route => route.fulfill({
+      json: { status: 'ok', version: 'test', all_models_loaded: [] },
+    }));
+    await page.route('**/api/v1/system-info**', route => route.fulfill({
+      json: {
+        devices: { cpu: { name: 'Test CPU', available: true } },
+        recipes: {
+          llamacpp: {
+            default_backend: 'cpu',
+            backends: {
+              cpu: {
+                state: 'update_available',
+                version: '1.0.0',
+                message: 'Version 2.0.0 is available.',
+                action: '',
+                release_url: 'https://github.com/lemonade-sdk/lemonade/releases/tag/2.0.0',
+              },
+            },
+          },
+        },
+      },
+    }));
+    await page.route('**/api/v1/models**', route => route.fulfill({ json: { data: [] } }));
+
+    await page.goto('/#/backends');
+    await page.waitForSelector('[data-view="backends"]');
+
+    const backend = page.locator('[data-cell="llamacpp:cpu"]');
+    await expect(backend).toBeVisible();
+    await expect(backend.getByText('Update available', { exact: true })).toBeVisible();
+    await expect(backend.getByRole('button', { name: 'Update llama.cpp · cpu' })).toBeVisible();
+
+    // Version metadata and the server-provided update detail are technical
+    // information and must not leak while the toggle is off.
+    await expect(backend.locator('.backend-card__version')).toHaveCount(0);
+    await expect(backend.locator('.backend-card__note')).toHaveCount(0);
+
+    await page.getByRole('checkbox', { name: 'Show technical details' }).check();
+
+    await expect(backend.locator('.backend-card__version')).toHaveCount(2);
+    await expect(backend.locator('.backend-card__version').nth(0)).toContainText('1.0.0');
+    await expect(backend.locator('.backend-card__version').nth(1)).toContainText('2.0.0');
+    await expect(backend.locator('.backend-card__note')).toHaveText('Version 2.0.0 is available.');
+  });
+
+
   test('14 — Backends view shows matrix and device info', async ({ page }) => {
     await page.goto('/');
     await page.waitForSelector('.titlebar__nav');


### PR DESCRIPTION
currently show technical details is useless, if applied:
<img width="984" height="438" alt="image" src="https://github.com/user-attachments/assets/73a08f64-fd2c-4676-ae2b-f406e6aeb89a" />
If not no meaningfull difference:
<img width="983" height="431" alt="image" src="https://github.com/user-attachments/assets/87bb14cc-1cba-4f53-a33f-a9dcafa1f002" />

With this change the user is now protected from detail he might not want to know:
<img width="1539" height="831" alt="image" src="https://github.com/user-attachments/assets/a6a9fbfe-58cc-4afc-8098-154727710699" />
Or he can opt it to know more:
<img width="1510" height="942" alt="image" src="https://github.com/user-attachments/assets/3b7d9b98-bf2c-43ac-b67b-502bd79369ef" />
