### PR TITLE
GUI3 fix: use eject icon for model detail unload action

### DIFF
--- a/src/app/src/components/ModelDetailPanel.tsx
+++ b/src/app/src/components/ModelDetailPanel.tsx
@@ -2143,7 +2143,7 @@ export const ModelDetailPanel: React.FC<ModelDetailPanelProps> = ({
         <>
           <WorkspaceActionButton
             appearance="primary"
-            icon="stop"
+            icon="eject"
             onClick={() => onUnload(loadedModel!)}
             disabled={isLoadingThis}
             aria-label={isLoadingThis ? `Working on ${name}…` : `Unload ${name}`}

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -6231,6 +6231,10 @@ optgroup {
   vertical-align: middle;
 }
 
+.app-icon[data-icon='eject'] {
+  stroke-width: 2;
+}
+
 /* Fix model action icon vertical alignment and bind capability icons to labels. */
 
 .row__action svg {


### PR DESCRIPTION
<img width="306" height="145" alt="image" src="https://github.com/user-attachments/assets/4bfe3fe0-1ac1-4d9f-b255-9e40c338324f" />
<img width="322" height="140" alt="image" src="https://github.com/user-attachments/assets/083577f4-6ea0-4e1c-a665-d81a41a0fbc3" />

<img width="668" height="195" alt="image" src="https://github.com/user-attachments/assets/920e8090-1ed3-48f4-9a3c-d05606bc3d6b" />

Used the eject icon since stop in the chat can be confused with stopping the response.
Opted for double stroke width so the icon is clearly visible.

Closes #3034 