### PR TITLE
GUI3: make Lemonade shockingly fast to load

### DIFF
--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1,19 +1,22 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef, Component, ErrorInfo, ReactNode } from 'react';
-import api, { friendlyErrorMessage, LoadedModel, ModelInfo } from './api';
-import { canSelectInComposer, capabilityFromModelInfo, selectPreferredLoadedModel } from './modelCapabilities';
-import { customModelToModelInfo, loadCustomModels } from './features/customModels/customModelStore';
-import { findModelInfoByName, isCollectionFullyLoaded, isCollectionModel, withVirtualLoadedCollections } from './features/collections/collectionModels';
-import ChatView from './components/ChatView';
-import ModelManager from './components/ModelManager';
-import ConnectView from './components/ConnectView';
-import AppsView, { MARKETPLACE_URL, type MarketplaceApp, type MarketplaceCategory } from './components/AppsView';
-import BackendManager from './components/BackendManager';
-import DownloadManager from './components/DownloadManager';
-import MonitorView from './components/MonitorView';
+import React, { lazy, Suspense, useState, useEffect, useCallback, useMemo, useRef, Component, ErrorInfo, ReactNode } from 'react';
+import type { LoadedModel, ModelInfo } from './api';
 import { Icon } from './components/Icon';
-import { WorkspaceActionButton } from './components/WorkspacePanels';
-import { downloadStore, isDownloadActive } from './features/downloadManager/downloadStore';
-import { useServerModelState } from './features/models/modelState';
+import ChatView from './components/ChatView';
+import { scheduleIdleWork } from './startupScheduler';
+import { attachServerModelState, useServerModelState } from './features/models/modelState';
+import { preloadInteractionSurfaces } from './interactionPreload';
+const MARKETPLACE_URL = 'https://raw.githubusercontent.com/lemonade-sdk/marketplace/main/apps.json';
+type MarketplaceApp = {
+  id: string;
+  name: string;
+  description?: string;
+  category?: string[];
+  logo?: string;
+  pinned?: boolean;
+  links?: { app?: string; guide?: string; video?: string };
+};
+type MarketplaceCategory = { id: string; label: string };
+
 import {
   WORKSPACE_NAVIGATION,
   type ConnectSection,
@@ -23,8 +26,107 @@ import {
   workspaceRouteFromPath,
 } from './features/navigation/workspaceNavigation';
 
+// Chat is the default route and stays in the initial renderer chunk to avoid an
+// immediate request waterfall. Non-default workspaces stay out of the cold path,
+// then their code is warmed immediately after the first usable frame so the
+// first tab switch does not pay the lazy-chunk latency.
+type ViewModule<P extends object> = { default: React.ComponentType<P> };
+
+let backendDataWarmStarted = false;
+
+function warmBackendData(): void {
+  if (backendDataWarmStarted) return;
+  backendDataWarmStarted = true;
+
+  void import(/* webpackChunkName: "api-client" */ './api')
+    .then(({ default: api }) => {
+      const warm = () => {
+        if (api.systemInfoData) return;
+        void api.systemInfo().catch(error => {
+          // This is speculative warming only. BackendManager still owns the
+          // user-visible error/retry path when the workspace is actually open.
+          console.debug('Backend system-info prewarm skipped:', error);
+        });
+      };
+
+      if (api.status === 'connected' || api.healthData) {
+        warm();
+        return;
+      }
+
+      const unsubscribe = api.onStatusChange(status => {
+        if (status !== 'connected') return;
+        unsubscribe();
+        warm();
+      });
+    })
+    .catch(error => console.debug('Backend data prewarm unavailable:', error));
+}
+
+function createPreloadableView<P extends object>(loader: () => Promise<ViewModule<P>>) {
+  let resolved: React.ComponentType<P> | null = null;
+  let modulePromise: Promise<ViewModule<P>> | null = null;
+
+  const load = () => {
+    if (!modulePromise) {
+      modulePromise = loader().then(module => {
+        resolved = module.default;
+        return module;
+      });
+    }
+    return modulePromise;
+  };
+
+  const LazyView = lazy(load);
+  const View = (props: P) => resolved
+    ? React.createElement(resolved, props)
+    : React.createElement(LazyView, props);
+
+  return { View, preload: () => load().then(() => undefined) };
+}
+
+const loadModelManagerView = () => import(/* webpackChunkName: "view-models" */ './components/ModelManager');
+const loadMonitorView = () => import(/* webpackChunkName: "view-monitor" */ './components/MonitorView');
+
+
+const modelManagerView = createPreloadableView(loadModelManagerView);
+const backendManagerView = createPreloadableView(() => {
+  // Start expensive backend discovery as soon as navigation intent/code preload
+  // is known, but never wait for it before resolving the workspace module.
+  warmBackendData();
+  return import(/* webpackChunkName: "view-backends" */ './components/BackendManager');
+});
+const appsWorkspaceView = createPreloadableView(() => import(/* webpackChunkName: "view-apps" */ './components/AppsView'));
+const monitorWorkspaceView = createPreloadableView(loadMonitorView);
+const connectWorkspaceView = createPreloadableView(() => import(/* webpackChunkName: "view-settings" */ './components/ConnectView'));
+const downloadManagerView = createPreloadableView(() => import(/* webpackChunkName: "download-manager" */ './components/DownloadManager'));
+
+const ModelManager = modelManagerView.View;
+const BackendManager = backendManagerView.View;
+const AppsView = appsWorkspaceView.View;
+const MonitorView = monitorWorkspaceView.View;
+const ConnectView = connectWorkspaceView.View;
+const DownloadManager = downloadManagerView.View;
+
 type View = 'chat' | 'models' | 'backends' | 'apps' | 'dashboard' | 'connect';
 type SimpleView = Exclude<View, 'dashboard' | 'connect'>;
+type LazyWorkspace = Exclude<View, 'chat'>;
+
+const WORKSPACE_PRELOADERS: Record<LazyWorkspace, () => Promise<void>> = {
+  models: async () => {
+    await modelManagerView.preload();
+    const module = await loadModelManagerView();
+    await module.preloadModelManagerSecondary();
+  },
+  backends: backendManagerView.preload,
+  apps: appsWorkspaceView.preload,
+  dashboard: async () => {
+    await monitorWorkspaceView.preload();
+    const module = await loadMonitorView();
+    await module.preloadMonitorSections();
+  },
+  connect: connectWorkspaceView.preload,
+};
 type AppRoute =
   | { view: SimpleView }
   | { view: 'dashboard'; section: DashboardSection }
@@ -101,12 +203,13 @@ class ViewErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState
           <pre>
             {this.state.error.message}
           </pre>
-          <WorkspaceActionButton
-            appearance="primary"
+          <button
+            type="button"
+            className="btn btn--primary btn--medium workspace-action-button workspace-action-button--primary workspace-action-button--medium"
             onClick={() => this.setState({ error: null })}
           >
-            Try again
-          </WorkspaceActionButton>
+            <span className="workspace-action-button__label">Try again</span>
+          </button>
         </div>
       );
     }
@@ -115,6 +218,12 @@ class ViewErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState
 }
 
 const SIMPLE_VIEWS: SimpleView[] = ['chat', 'models', 'backends', 'apps'];
+
+const ViewLoadingFallback: React.FC<{ label?: string }> = ({ label = 'Loading view' }) => (
+  <div className="view-loading" role="status" aria-label={label} aria-live="polite">
+    <span className="spinner" aria-hidden="true" />
+  </div>
+);
 
 
 type HostNavigationPayload = string | URL | {
@@ -232,10 +341,23 @@ function loadSavedRoute(): AppRoute {
   return { view: 'chat' };
 }
 
+type ModelHelpers = Pick<typeof import('./modelCapabilities'), 'canSelectInComposer' | 'capabilityFromModelInfo' | 'selectPreferredLoadedModel'>
+  & Pick<typeof import('./features/collections/collectionModels'), 'findModelInfoByName' | 'isCollectionFullyLoaded' | 'isCollectionModel' | 'withVirtualLoadedCollections'>;
+type AppApiClient = (typeof import('./api'))['default'];
+
 type Theme = 'dark' | 'light';
 const THEME_KEY = 'lemonade_theme';
 const EMPTY_MODELS: ModelInfo[] = [];
 const EMPTY_LOADED_MODELS: LoadedModel[] = [];
+
+function friendlyErrorMessage(error: unknown): string {
+  if (error && typeof error === 'object') {
+    const value = error as { userMessage?: unknown; message?: unknown };
+    if (typeof value.userMessage === 'string' && value.userMessage) return value.userMessage;
+    if (typeof value.message === 'string' && value.message) return value.message;
+  }
+  return String(error || 'Unknown error');
+}
 
 function loadTheme(): Theme {
   try {
@@ -248,8 +370,14 @@ function loadTheme(): Theme {
 const App: React.FC = () => {
   const [route, setRouteState] = useState<AppRoute>(loadSavedRoute);
   const view = route.view;
+  // Mount only the active workspace on cold start. Once a workspace has been
+  // visited it stays mounted (hidden when inactive) so navigation still
+  // preserves its local UI state without paying for every view up front.
+  const mountedViewsRef = useRef<Set<View>>(new Set());
+  mountedViewsRef.current.add(view);
   const routeRef = useRef(route);
   routeRef.current = route;
+  const apiClientRef = useRef<AppApiClient | null>(null);
   const serverModelState = useServerModelState();
   const status = serverModelState.status;
   const serverModels = serverModelState.models?.data ?? EMPTY_MODELS;
@@ -257,12 +385,17 @@ const App: React.FC = () => {
   const [currentModel, setCurrentModel] = useState<string | null>(null);
   const [theme, setTheme] = useState<Theme>(loadTheme);
   const [clientDataResetNonce, setClientDataResetNonce] = useState(0);
+  const [customModelInfos, setCustomModelInfos] = useState<ModelInfo[]>(EMPTY_MODELS);
+  const [modelHelpers, setModelHelpers] = useState<ModelHelpers | null>(null);
   const [downloadManagerOpen, setDownloadManagerOpen] = useState(false);
+  const downloadManagerMountedRef = useRef(false);
+  if (downloadManagerOpen) downloadManagerMountedRef.current = true;
   const [modelDetailsRequest, setModelDetailsRequest] = useState<{ modelName: string; nonce: number } | null>(null);
   const [marketplaceApps, setMarketplaceApps] = useState<MarketplaceApp[]>([]);
   const [marketplaceCategories, setMarketplaceCategories] = useState<MarketplaceCategory[]>([]);
   const [marketplaceError, setMarketplaceError] = useState<string | null>(null);
   const [marketplaceLoading, setMarketplaceLoading] = useState(true);
+  const marketplaceRequestedRef = useRef(false);
   const [utilityMenuOpen, setUtilityMenuOpen] = useState(false);
   const [navigationSearch, setNavigationSearch] = useState('');
   const [navigationSearchOpen, setNavigationSearchOpen] = useState(false);
@@ -273,8 +406,9 @@ const App: React.FC = () => {
   const [isDesktop, setIsDesktop] = useState(false);
   const navigationSearchShortcut = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent) ? '⌘ K' : 'Ctrl+K';
 
-  useEffect(() => {
-    let cancelled = false;
+  const requestMarketplace = useCallback(() => {
+    if (marketplaceRequestedRef.current) return;
+    marketplaceRequestedRef.current = true;
     setMarketplaceLoading(true);
     fetch(MARKETPLACE_URL)
       .then(response => {
@@ -282,48 +416,195 @@ const App: React.FC = () => {
         return response.json();
       })
       .then(data => {
-        if (cancelled) return;
         setMarketplaceApps(Array.isArray(data?.apps) ? data.apps as MarketplaceApp[] : []);
         setMarketplaceCategories(Array.isArray(data?.categories) ? data.categories as MarketplaceCategory[] : []);
         setMarketplaceError(null);
       })
       .catch(error => {
-        if (!cancelled) setMarketplaceError(friendlyErrorMessage(error));
+        setMarketplaceError(friendlyErrorMessage(error));
       })
       .finally(() => {
-        if (!cancelled) setMarketplaceLoading(false);
+        setMarketplaceLoading(false);
       });
-    return () => { cancelled = true; };
   }, []);
 
   useEffect(() => {
-    import('./tauriShim').then(({ tauriReady }) => {
-      tauriReady.then(() => {
-        if (window.api && window.api.isWebApp !== true) {
-          setIsDesktop(true);
-        }
+    // Still load on demand if the user reaches Apps before background warming
+    // has run (for example via a deep link or an immediate keyboard action).
+    if (view === 'apps' || navigationSearchOpen) requestMarketplace();
+  }, [navigationSearchOpen, requestMarketplace, view]);
+
+  useEffect(() => {
+    // Keep the cold path minimal, but do not move that latency to navigation.
+    // Once the first usable frame is visible, evaluate every workspace module
+    // plus the heavy secondary surfaces that used to load on click (Monitor
+    // Telemetry/Logs and Models details/editors). They are cached but not mounted,
+    // so effects and polling still do not run until the user opens the surface.
+    let cancelled = false;
+
+    const warmRemainingWorkspaces = () => {
+      // Inspector state is a public runtime contract (window.inspectStore) and
+      // also owns capture/session-header wiring. Initialize it immediately after
+      // the first usable frame instead of waiting for the Telemetry tab to mount.
+      void import(/* webpackChunkName: "inspect-store" */ './inspectStore').catch(error => {
+        console.debug('Inspector state prewarm unavailable:', error);
       });
+
+      if (cancelled) return;
+
+      // First warm only the two interactions users can notice immediately:
+      // Models -> Details and Monitor -> Telemetry. This starts after reveal,
+      // so it cannot regress first paint. The remaining interaction surfaces
+      // are scheduled by preloadInteractionSurfaces() in the background.
+      void preloadInteractionSurfaces().finally(() => {
+        if (cancelled) return;
+        const preloaders = (Object.keys(WORKSPACE_PRELOADERS) as LazyWorkspace[])
+          .map(target => WORKSPACE_PRELOADERS[target]);
+
+        void Promise.allSettled(preloaders.map(preload => preload()))
+          .then(results => {
+            if (cancelled) return;
+            const failed = results.filter(result => result.status === 'rejected');
+            if (failed.length) {
+              console.warn(`Failed to preload ${failed.length} workspace chunk(s)`);
+              return;
+            }
+            if (window.__LEMONADE_STARTUP_METRICS__) {
+              window.__LEMONADE_STARTUP_METRICS__.workspacePreloadReadyMs = performance.now();
+            }
+          });
+
+        requestMarketplace();
+      });
+    };
+
+    if (window.__LEMONADE_STARTUP_METRICS__?.firstUsableFrameMs !== undefined) {
+      warmRemainingWorkspaces();
+    } else {
+      window.addEventListener('lemonade:first-usable', warmRemainingWorkspaces, { once: true });
+    }
+
+    return () => {
+      cancelled = true;
+      window.removeEventListener('lemonade:first-usable', warmRemainingWorkspaces);
+    };
+  }, [requestMarketplace]);
+
+  useEffect(() => {
+    // Paint the application shell before loading the native bridge and before
+    // starting server I/O. Native settings are loaded explicitly here so we no
+    // longer depend on the hidden Settings screen mounting at startup.
+    let cancelled = false;
+    let frame = 0;
+    let timer = 0;
+
+    const bootstrapHost = async () => {
+      if (window.__LEMONADE_STARTUP_METRICS__) {
+        window.__LEMONADE_STARTUP_METRICS__.hostBootstrapStartMs = performance.now();
+      }
+      try {
+        // Pure-web launches already have their host bridge injected by the
+        // server. Do not request/evaluate the Tauri shim there. Desktop still
+        // loads it in parallel with the API client.
+        const tauriReadyPromise = '__TAURI_INTERNALS__' in window
+          ? import(/* webpackChunkName: "tauri-shim" */ './tauriShim').then(module => module.tauriReady)
+          : Promise.resolve();
+        const { default: api } = await import(/* webpackChunkName: "api-client" */ './api');
+        apiClientRef.current = api;
+        attachServerModelState(api);
+        await tauriReadyPromise;
+        if (window.__LEMONADE_STARTUP_METRICS__) {
+          window.__LEMONADE_STARTUP_METRICS__.hostBridgeReadyMs = performance.now();
+        }
+        if (cancelled) return;
+        if (window.api && window.api.isWebApp !== true) setIsDesktop(true);
+        try {
+          await api.loadConnectionSettings();
+          if (window.__LEMONADE_STARTUP_METRICS__) {
+            window.__LEMONADE_STARTUP_METRICS__.connectionSettingsReadyMs = performance.now();
+          }
+        } catch (error) {
+          console.warn('Failed to load host connection settings:', error);
+        }
+        if (!cancelled) {
+          void api.connect();
+          if (routeRef.current.view === 'dashboard') api.stopPolling();
+          else api.startPolling(15000);
+        }
+      } catch (error) {
+        console.warn('Host bootstrap failed:', error);
+        if (!cancelled) {
+          void import(/* webpackChunkName: "api-client" */ './api')
+            .then(async ({ default: api }) => {
+              apiClientRef.current = api;
+              attachServerModelState(api);
+              void api.connect();
+              if (routeRef.current.view === 'dashboard') api.stopPolling();
+              else api.startPolling(15000);
+            })
+            .catch(apiError => console.warn('API bootstrap failed:', apiError));
+        }
+      }
+    };
+
+    frame = window.requestAnimationFrame(() => {
+      timer = window.setTimeout(() => { void bootstrapHost(); }, 0);
     });
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(timer);
+      apiClientRef.current?.stopPolling();
+    };
   }, []);
-  const [activeDownloadCount, setActiveDownloadCount] = useState(
-    () => downloadStore.snapshot().filter(isDownloadActive).length,
-  );
-  const activeDownloadCountRef = useRef(activeDownloadCount);
+  // Download persistence/polling is sizeable and not needed for the first
+  // paint. Hydrate the badge after the shell is visible instead of importing
+  // the whole download manager into the entry bundle.
+  const [activeDownloadCount, setActiveDownloadCount] = useState(0);
+  const activeDownloadCountRef = useRef(0);
   const lastWorkspaceSectionsRef = useRef({
     dashboard: route.view === 'dashboard' ? route.section : WORKSPACE_NAVIGATION.dashboard.defaultSection,
     connect: route.view === 'connect' ? route.section : WORKSPACE_NAVIGATION.connect.defaultSection,
   });
-  useEffect(() => downloadStore.subscribe(items => {
-    const nextCount = items.filter(isDownloadActive).length;
-    if (nextCount === activeDownloadCountRef.current) return;
-    activeDownloadCountRef.current = nextCount;
-    setActiveDownloadCount(nextCount);
-  }), []);
+  useEffect(() => {
+    let cancelled = false;
+    let unsubscribe: (() => void) | undefined;
+    const cancelSchedule = scheduleIdleWork(() => {
+      void import(/* webpackChunkName: "download-store" */ './features/downloadManager/downloadStore')
+        .then(({ downloadStore, isDownloadActive }) => {
+          if (cancelled) return;
+          const update = (items: ReturnType<typeof downloadStore.snapshot>) => {
+            const nextCount = items.filter(isDownloadActive).length;
+            if (nextCount === activeDownloadCountRef.current) return;
+            activeDownloadCountRef.current = nextCount;
+            setActiveDownloadCount(nextCount);
+          };
+          update(downloadStore.snapshot());
+          unsubscribe = downloadStore.subscribe(update);
+        })
+        .catch(error => console.warn('Failed to hydrate download activity:', error));
+    }, 900);
+    return () => {
+      cancelled = true;
+      cancelSchedule();
+      unsubscribe?.();
+    };
+  }, []);
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
     try { localStorage.setItem(THEME_KEY, theme); } catch { /* ignore */ }
   }, [theme]);
+
+  useEffect(() => {
+    if (status !== 'connected') return;
+    const metrics = window.__LEMONADE_STARTUP_METRICS__;
+    if (metrics && metrics.serverConnectedMs === undefined) {
+      metrics.serverConnectedMs = performance.now();
+      console.info('[startup] Lemonade server connected', { ...metrics });
+    }
+  }, [status]);
 
   const toggleTheme = useCallback(() => {
     setTheme(t => t === 'dark' ? 'light' : 'dark');
@@ -355,13 +636,49 @@ const App: React.FC = () => {
     setUtilityMenuOpen(false);
   }, [view]);
 
+  useEffect(() => {
+    if (modelHelpers || (serverModels.length === 0 && rawLoadedModels.length === 0 && customModelInfos.length === 0)) return;
+    let cancelled = false;
+    void Promise.all([
+      import(/* webpackChunkName: "model-capabilities" */ './modelCapabilities'),
+      import(/* webpackChunkName: "collection-models" */ './features/collections/collectionModels'),
+    ]).then(([capabilities, collections]) => {
+      if (!cancelled) setModelHelpers({
+        canSelectInComposer: capabilities.canSelectInComposer,
+        capabilityFromModelInfo: capabilities.capabilityFromModelInfo,
+        selectPreferredLoadedModel: capabilities.selectPreferredLoadedModel,
+        findModelInfoByName: collections.findModelInfoByName,
+        isCollectionFullyLoaded: collections.isCollectionFullyLoaded,
+        isCollectionModel: collections.isCollectionModel,
+        withVirtualLoadedCollections: collections.withVirtualLoadedCollections,
+      });
+    }).catch(error => console.warn('Failed to hydrate model helpers:', error));
+    return () => { cancelled = true; };
+  }, [customModelInfos.length, modelHelpers, rawLoadedModels.length, serverModels.length]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const cancelSchedule = scheduleIdleWork(() => {
+      void import(/* webpackChunkName: "custom-model-store" */ './features/customModels/customModelStore')
+        .then(({ loadCustomModels, customModelToModelInfo }) => {
+          if (!cancelled) setCustomModelInfos(loadCustomModels().map(customModelToModelInfo));
+        })
+        .catch(error => console.warn('Failed to hydrate custom models:', error));
+    }, 700);
+    return () => {
+      cancelled = true;
+      cancelSchedule();
+    };
+  }, [clientDataResetNonce]);
+
   const loadedModelViewState = useMemo(() => {
-    const customInfos = loadCustomModels().map(customModelToModelInfo);
+    const customInfos = customModelInfos;
     const knownInfos = [...customInfos, ...serverModels];
-    const models = withVirtualLoadedCollections(rawLoadedModels, knownInfos).map(model => {
-      const info = findModelInfoByName(knownInfos, model.model_name);
+    if (!modelHelpers) return { models: rawLoadedModels, customInfos, knownInfos };
+    const models = modelHelpers.withVirtualLoadedCollections(rawLoadedModels, knownInfos).map(model => {
+      const info = modelHelpers.findModelInfoByName(knownInfos, model.model_name);
       if (!info) return model;
-      const cap = capabilityFromModelInfo(info);
+      const cap = modelHelpers.capabilityFromModelInfo(info);
       return {
         ...model,
         type: cap === 'unknown' ? model.type : cap,
@@ -370,40 +687,41 @@ const App: React.FC = () => {
       };
     });
     return { models, customInfos, knownInfos };
-  }, [clientDataResetNonce, rawLoadedModels, serverModels]);
+  }, [customModelInfos, modelHelpers, rawLoadedModels, serverModels]);
 
   const loadedModels = loadedModelViewState.models;
 
   useEffect(() => {
+    if (!modelHelpers) return;
     const { customInfos, knownInfos } = loadedModelViewState;
     const customSelectable = (name: string) => {
-      const info = findModelInfoByName(customInfos, name);
+      const info = modelHelpers.findModelInfoByName(customInfos, name);
       if (!info) return false;
-      const cap = capabilityFromModelInfo(info);
+      const cap = modelHelpers.capabilityFromModelInfo(info);
       return cap === 'chat' || cap === 'omni' || cap === 'image' || cap === 'audio' || cap === 'audio-generation' || cap === 'tts' || cap === 'model3d';
     };
     const infoSelectable = (name: string) => {
-      const info = findModelInfoByName(knownInfos, name);
+      const info = modelHelpers.findModelInfoByName(knownInfos, name);
       if (!info) return false;
-      const cap = capabilityFromModelInfo(info);
+      const cap = modelHelpers.capabilityFromModelInfo(info);
       return cap === 'chat' || cap === 'omni' || cap === 'image' || cap === 'audio' || cap === 'audio-generation' || cap === 'tts' || cap === 'model3d';
     };
     setCurrentModel(current => {
-      if (current && loadedModels.some(m => m.model_name === current && (canSelectInComposer(m) || customSelectable(m.model_name) || infoSelectable(m.model_name)))) return current;
+      if (current && loadedModels.some(m => m.model_name === current && (modelHelpers.canSelectInComposer(m) || customSelectable(m.model_name) || infoSelectable(m.model_name)))) return current;
       if (current) {
-        const info = findModelInfoByName(knownInfos, current);
-        if (info && isCollectionModel(info) && isCollectionFullyLoaded(info, rawLoadedModels)) return current;
+        const info = modelHelpers.findModelInfoByName(knownInfos, current);
+        if (info && modelHelpers.isCollectionModel(info) && modelHelpers.isCollectionFullyLoaded(info, rawLoadedModels)) return current;
       }
       const virtualOmni = loadedModels.find(model => {
-        const info = findModelInfoByName(knownInfos, model.model_name);
-        return info && isCollectionModel(info);
+        const info = modelHelpers.findModelInfoByName(knownInfos, model.model_name);
+        return info && modelHelpers.isCollectionModel(info);
       });
       return virtualOmni?.model_name
-        || selectPreferredLoadedModel(loadedModels)?.model_name
+        || modelHelpers.selectPreferredLoadedModel(loadedModels)?.model_name
         || loadedModels.find(m => customSelectable(m.model_name) || infoSelectable(m.model_name))?.model_name
         || null;
     });
-  }, [loadedModelViewState, loadedModels, rawLoadedModels]);
+  }, [loadedModelViewState, loadedModels, modelHelpers, rawLoadedModels]);
 
   const navigateToRoute = useCallback((nextRoute: AppRoute) => {
     if (nextRoute.view === 'dashboard') lastWorkspaceSectionsRef.current.dashboard = nextRoute.section;
@@ -635,21 +953,18 @@ const App: React.FC = () => {
     return () => window.removeEventListener('lemonade:navigate', onAppNavigate as EventListener);
   }, [navigateToRoute]);
 
+  // The host bootstrap owns the API import and starts polling after its
+  // first connection attempt. Route changes only toggle that already-loaded
+  // client, avoiding a second API import request during the first React commit.
   useEffect(() => {
-    void api.connect();
-  }, []);
-
-  // App-level health polling: skip when Monitor is active (it polls every 2s)
-  useEffect(() => {
-    if (view === 'dashboard') {
-      api.stopPolling();
-    } else {
-      api.startPolling(15000);
-    }
-    return () => { api.stopPolling(); };
+    const api = apiClientRef.current;
+    if (!api) return;
+    if (view === 'dashboard') api.stopPolling();
+    else api.startPolling(15000);
   }, [view]);
 
   const handleRefreshModels = useCallback(async () => {
+    const { default: api } = await import(/* webpackChunkName: "api-client" */ './api');
     await api.refresh();
   }, []);
 
@@ -683,6 +998,15 @@ const App: React.FC = () => {
             <button
               key={id}
               className={view === id ? 'is-active' : ''}
+              onPointerEnter={() => {
+                if (id !== 'chat') void WORKSPACE_PRELOADERS[id as LazyWorkspace]().catch(() => undefined);
+              }}
+              onFocus={() => {
+                if (id !== 'chat') void WORKSPACE_PRELOADERS[id as LazyWorkspace]().catch(() => undefined);
+              }}
+              onPointerDown={() => {
+                if (id !== 'chat') void WORKSPACE_PRELOADERS[id as LazyWorkspace]().catch(() => undefined);
+              }}
               onClick={() => setView(id)}
               title={label}
               aria-label={label}
@@ -877,66 +1201,94 @@ const App: React.FC = () => {
         </div>
       </header>
 
-      <DownloadManager isVisible={downloadManagerOpen} onClose={() => setDownloadManagerOpen(false)} />
+      {downloadManagerMountedRef.current && (
+        <Suspense fallback={downloadManagerOpen ? <ViewLoadingFallback label="Loading downloads" /> : null}>
+          <DownloadManager isVisible={downloadManagerOpen} onClose={() => setDownloadManagerOpen(false)} />
+        </Suspense>
+      )}
 
       <main id="main-content" tabIndex={-1} className="view-container">
-        <div className="view-slot" hidden={view !== 'chat'}>
-          <ViewErrorBoundary view="chat">
-            <ChatView
-              key={clientDataResetNonce}
-              currentModel={currentModel}
-              loadedModels={loadedModels}
-              onModelSelect={handleModelSelect}
-              onOpenModelDetails={openModelDetails}
-              onRefresh={handleRefreshModels}
-            />
-          </ViewErrorBoundary>
-        </div>
-        <div className="view-slot" hidden={view !== 'models'}>
-          <ViewErrorBoundary view="models">
-            <ModelManager
-              key={clientDataResetNonce}
-              onModelSelect={handleModelSelect}
-              openModelRequest={modelDetailsRequest}
-            />
-          </ViewErrorBoundary>
-        </div>
-        <div className="view-slot" hidden={view !== 'backends'}>
-          <ViewErrorBoundary view="backends">
-            <BackendManager isActive={view === 'backends'} />
-          </ViewErrorBoundary>
-        </div>
-        <div className="view-slot" hidden={view !== 'apps'}>
-          <ViewErrorBoundary view="apps">
-            <AppsView
-              apps={marketplaceApps}
-              categories={marketplaceCategories}
-              loading={marketplaceLoading}
-              error={marketplaceError}
-            />
-          </ViewErrorBoundary>
-        </div>
-        <div className="view-slot" hidden={view !== 'dashboard'}>
-          <ViewErrorBoundary view="dashboard">
-            <MonitorView
-              activeSection={route.view === 'dashboard' ? route.section : lastWorkspaceSectionsRef.current.dashboard}
-              isActive={view === 'dashboard'}
-              onSectionChange={section => navigateToRoute({ view: 'dashboard', section })}
-            />
-          </ViewErrorBoundary>
-        </div>
-        <div className="view-slot" hidden={view !== 'connect'}>
-          <ViewErrorBoundary view="connect">
-            <ConnectView
-              status={status}
-              isActive={view === 'connect'}
-              activeSection={route.view === 'connect' ? route.section : lastWorkspaceSectionsRef.current.connect}
-              onSectionChange={section => navigateToRoute({ view: 'connect', section })}
-              onLocalDataReset={handleLocalDataReset}
-            />
-          </ViewErrorBoundary>
-        </div>
-        </main>
+        {mountedViewsRef.current.has('chat') && (
+          <div className="view-slot" hidden={view !== 'chat'}>
+            <ViewErrorBoundary view="chat">
+              <ChatView
+                key={clientDataResetNonce}
+                currentModel={currentModel}
+                loadedModels={loadedModels}
+                serverModels={serverModels}
+                connectionStatus={status}
+                onModelSelect={handleModelSelect}
+                onOpenModelDetails={openModelDetails}
+                onRefresh={handleRefreshModels}
+              />
+            </ViewErrorBoundary>
+          </div>
+        )}
+        {mountedViewsRef.current.has('models') && (
+          <div className="view-slot" hidden={view !== 'models'}>
+            <ViewErrorBoundary view="models">
+              <Suspense fallback={<ViewLoadingFallback label="Loading models" />}>
+                <ModelManager
+                  key={clientDataResetNonce}
+                  onModelSelect={handleModelSelect}
+                  openModelRequest={modelDetailsRequest}
+                />
+              </Suspense>
+            </ViewErrorBoundary>
+          </div>
+        )}
+        {mountedViewsRef.current.has('backends') && (
+          <div className="view-slot" hidden={view !== 'backends'}>
+            <ViewErrorBoundary view="backends">
+              <Suspense fallback={<ViewLoadingFallback label="Loading backends" />}>
+                <BackendManager isActive={view === 'backends'} />
+              </Suspense>
+            </ViewErrorBoundary>
+          </div>
+        )}
+        {mountedViewsRef.current.has('apps') && (
+          <div className="view-slot" hidden={view !== 'apps'}>
+            <ViewErrorBoundary view="apps">
+              <Suspense fallback={<ViewLoadingFallback label="Loading apps" />}>
+                <AppsView
+                  apps={marketplaceApps}
+                  categories={marketplaceCategories}
+                  loading={marketplaceLoading}
+                  error={marketplaceError}
+                />
+              </Suspense>
+            </ViewErrorBoundary>
+          </div>
+        )}
+        {mountedViewsRef.current.has('dashboard') && (
+          <div className="view-slot" hidden={view !== 'dashboard'}>
+            <ViewErrorBoundary view="dashboard">
+              <Suspense fallback={<ViewLoadingFallback label="Loading monitor" />}>
+                <MonitorView
+                  activeSection={route.view === 'dashboard' ? route.section : lastWorkspaceSectionsRef.current.dashboard}
+                  isActive={view === 'dashboard'}
+                  onSectionChange={section => navigateToRoute({ view: 'dashboard', section })}
+                />
+              </Suspense>
+            </ViewErrorBoundary>
+          </div>
+        )}
+        {mountedViewsRef.current.has('connect') && (
+          <div className="view-slot" hidden={view !== 'connect'}>
+            <ViewErrorBoundary view="connect">
+              <Suspense fallback={<ViewLoadingFallback label="Loading settings" />}>
+                <ConnectView
+                  status={status}
+                  isActive={view === 'connect'}
+                  activeSection={route.view === 'connect' ? route.section : lastWorkspaceSectionsRef.current.connect}
+                  onSectionChange={section => navigateToRoute({ view: 'connect', section })}
+                  onLocalDataReset={handleLocalDataReset}
+                />
+              </Suspense>
+            </ViewErrorBoundary>
+          </div>
+        )}
+      </main>
       </div>
     </>
   );

--- a/src/app/src/api.ts
+++ b/src/app/src/api.ts
@@ -4,9 +4,8 @@
  * and model downloads, and health polling.
  */
 
-import { recipeOptionsForModel, samplingForModel, type RecipeOptions } from './modelConfiguration';
+import type { RecipeOptions } from './modelConfiguration';
 import { COLLECTION_IMAGE_SIZE } from './features/collections/collectionImageConfig';
-import { filterHuggingFaceSearchResults, HUGGING_FACE_SEARCH_LIMIT } from './features/models/huggingFaceSearch';
 
 function detectDefaultBaseUrl(): string {
   if (typeof window !== 'undefined' && window.location) {
@@ -758,6 +757,7 @@ class LemonadeAPI {
   private _modelsDataSignature = '';
   private _modelsFetchRevision = 0;
   private _systemInfoData: Record<string, unknown> | null = null;
+  private _systemInfoInFlight: Promise<Record<string, unknown>> | null = null;
   private _modelStateSnapshot: ModelStateSnapshot = {
     status: 'disconnected',
     health: null,
@@ -1389,6 +1389,9 @@ class LemonadeAPI {
     await this._assertModelNotDownloading(modelName);
     const target = modelName.trim().toLowerCase();
     const cachedModelInfo = modelInfo || this.allModels.find(model => modelInfoKey(model).toLowerCase() === target) || null;
+    const { recipeOptionsForModel } = await import(
+      /* webpackChunkName: "model-configuration" */ './modelConfiguration'
+    );
     const stagedOptions = recipeOptionsForModel(modelName, cachedModelInfo, recipeOptions as RecipeOptions | undefined, this._systemInfoData);
     const body: Record<string, unknown> = {
       model_name: modelName,
@@ -1404,6 +1407,9 @@ class LemonadeAPI {
   async effectiveLoadCommand(modelName: string, recipeOptions?: Record<string, unknown>, modelInfo?: ModelInfo | null): Promise<EffectiveLoadCommand> {
     const target = modelName.trim().toLowerCase();
     const cachedModelInfo = modelInfo || this.allModels.find(model => modelInfoKey(model).toLowerCase() === target) || null;
+    const { recipeOptionsForModel } = await import(
+      /* webpackChunkName: "model-configuration" */ './modelConfiguration'
+    );
     const stagedOptions = recipeOptionsForModel(modelName, cachedModelInfo, recipeOptions as RecipeOptions | undefined, this._systemInfoData);
     const body: Record<string, unknown> = { model_name: modelName, ...(stagedOptions || {}), ...recipeOptions };
     return this._json<EffectiveLoadCommand>('/api/v1/load/command', { method: 'POST', body });
@@ -1449,12 +1455,23 @@ class LemonadeAPI {
   }
 
   async systemInfo(): Promise<Record<string, unknown>> {
-    const data = await this._json<Record<string, unknown>>(
+    // Several views use the same expensive system-info endpoint. A workspace
+    // preload and the view's first effect can overlap, so share the in-flight
+    // request instead of making the server do the same discovery twice.
+    if (this._systemInfoInFlight) return this._systemInfoInFlight;
+
+    const request = this._json<Record<string, unknown>>(
       '/api/v1/system-info',
       { cache: 'no-store' } as LemonadeRequestInit,
-    );
-    this._systemInfoData = data;
-    return data;
+    ).then(data => {
+      this._systemInfoData = data;
+      return data;
+    }).finally(() => {
+      if (this._systemInfoInFlight === request) this._systemInfoInFlight = null;
+    });
+
+    this._systemInfoInFlight = request;
+    return request;
   }
 
   /**
@@ -2384,6 +2401,9 @@ class LemonadeAPI {
     const statsInterval = onStats ? setInterval(emitStats, 200) : undefined;
 
     try {
+      const { samplingForModel } = await import(
+        /* webpackChunkName: "model-configuration" */ './modelConfiguration'
+      );
       const requestModelInfo = this.allModels.find(candidate => modelInfoKey(candidate).toLowerCase() === model.trim().toLowerCase()) || null;
       const body: Record<string, unknown> = { model, messages, stream: true, ...samplingForModel(model, requestModelInfo), ...(params || {}) };
       if (tools && tools.length > 0) body.tools = tools;
@@ -2495,6 +2515,9 @@ class LemonadeAPI {
     messages: ChatMessage[],
     params: Record<string, unknown> = {},
   ): Promise<string> {
+    const { samplingForModel } = await import(
+      /* webpackChunkName: "model-configuration" */ './modelConfiguration'
+    );
     const data = await this._json<Record<string, any>>('/api/v1/chat/completions', {
       method: 'POST',
       body: { model, messages, stream: false, ...samplingForModel(model, this.allModels.find(candidate => modelInfoKey(candidate).toLowerCase() === model.trim().toLowerCase()) || null), ...params },
@@ -2689,6 +2712,9 @@ export async function searchHuggingFace(
   query: string,
   signal?: AbortSignal,
 ): Promise<HFModelResult[]> {
+  const { filterHuggingFaceSearchResults, HUGGING_FACE_SEARCH_LIMIT } = await import(
+    /* webpackChunkName: "huggingface-search-utils" */ './features/models/huggingFaceSearch'
+  );
   if (typeof navigator !== 'undefined' && navigator.onLine === false) {
     throw new Error('Browser is offline; HuggingFace search is unavailable.');
   }

--- a/src/app/src/components/BackendManager.tsx
+++ b/src/app/src/components/BackendManager.tsx
@@ -634,8 +634,10 @@ interface BackendManagerProps {
 }
 
 const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
-  const [sysInfo, setSysInfo] = useState<SystemInfoData | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [sysInfo, setSysInfo] = useState<SystemInfoData | null>(() =>
+    api.systemInfoData as unknown as SystemInfoData | null
+  );
+  const [loading, setLoading] = useState(() => !api.systemInfoData);
   const [error, setError] = useState<string | null>(null);
   const [showTech, setShowTech] = useState(false);
   const [showUnsupported, setShowUnsupported] = useState(false);
@@ -651,7 +653,7 @@ const BackendManager: React.FC<BackendManagerProps> = ({ isActive = true }) => {
   const pendingBackendActionsRef = useRef<Map<string, PendingBackendAction>>(new Map());
   const backendSyncPromisesRef = useRef<Map<string, Promise<BackendSyncResult>>>(new Map());
   const toastTimerRef = useRef<number | null>(null);
-  const sysInfoRef = useRef<SystemInfoData | null>(null);
+  const sysInfoRef = useRef<SystemInfoData | null>(sysInfo);
   const argsTriggerRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {

--- a/src/app/src/components/ChatView.tsx
+++ b/src/app/src/components/ChatView.tsx
@@ -1,15 +1,21 @@
 import React, { Suspense, lazy, useState, useRef, useCallback, useEffect, useMemo } from 'react';
-import api, { ChatMessage, ChatCompletionStats, LoadedModel, ModelInfo, RealtimeTranscriptionHandle, friendlyErrorMessage } from '../api';
+import type { ChatMessage, ChatCompletionStats, ConnectionStatus, LoadedModel, ModelInfo, RealtimeTranscriptionHandle } from '../api';
 import { copyTextToClipboard } from '../clipboard';
-import MarkdownMessage from './MarkdownMessage';
-import LogViewer from './LogViewer';
 import { Icon, CapabilityIcon } from './Icon';
-import EffectiveSettingsModal from './EffectiveSettingsModal';
+
 import WorkspaceMobileMenuButton from './WorkspaceMobileMenuButton';
 import WorkspaceRailHeader from './WorkspaceRailHeader';
-import { WorkspaceActionButton } from './WorkspacePanels';
+import { scheduleIdleWork } from '../startupScheduler';
 
-const Model3DResult = lazy(() => import('./Model3DResult'));
+const Model3DResult = lazy(() => import(/* webpackChunkName: "chat-model3d" */ './Model3DResult'));
+const LogViewer = lazy(() => import(/* webpackChunkName: "chat-logs" */ './LogViewer'));
+const EffectiveSettingsModal = lazy(() => import(/* webpackChunkName: "chat-effective-settings" */ './EffectiveSettingsModal'));
+const LazyMarkdownMessage = lazy(() => import(/* webpackChunkName: "markdown-renderer" */ './MarkdownMessage'));
+const MarkdownMessage: React.FC<React.ComponentProps<typeof LazyMarkdownMessage>> = props => (
+  <Suspense fallback={<div className="message__content message__content--loading" aria-busy="true" />}>
+    <LazyMarkdownMessage {...props} />
+  </Suspense>
+);
 import { useChatStreaming, ToolCallEntry, ChatToolRuntime, ToolArtifact } from '../hooks/useChatStreaming';
 import { useAudioCapture } from '../hooks/useAudioCapture';
 import { useFocusTrap } from '../hooks/useFocusTrap';
@@ -32,12 +38,10 @@ import {
 } from '../modelCapabilities';
 import { storageKey } from '../storage';
 import { CHAT_HISTORY_PREFERENCE_EVENT, loadChatHistoryPreference } from '../features/chatHistory/historySettings';
-import { customModelToModelInfo, loadCustomModels } from '../features/customModels/customModelStore';
-import { activeDownloadForModel, downloadsForModel, downloadStore, isDownloadTerminal, type DownloadListItem } from '../features/downloadManager/downloadStore';
+import type { DownloadListItem } from '../features/downloadManager/downloadStore';
 import { findModelInfoByName, getAudioTranscriptionComponent, getPrimaryChatComponent, getVisionChatComponent, isCollectionModel } from '../features/collections/collectionModels';
-import { buildOmniToolRuntime } from '../tools/omniTools';
-import { LEMONADE_MCP_SERVER_ID, LEMONADE_MCP_TOOLS, MAX_MCP_SERVER_SELECTION, buildSelectedMcpRuntime, composeMcpRuntimes, listMcpServerToolOptions, type McpServerToolOption } from '../tools/mcpRuntime';
-import { DEFAULT_CONTEXT_SIZE, loadModelTuning } from '../modelConfiguration';
+import { LEMONADE_MCP_SERVER_ID, LEMONADE_MCP_TOOL_COUNT, MAX_MCP_SERVER_SELECTION, type McpServerToolOption } from '../tools/mcpMetadata';
+import type { ModelTuning } from '../modelConfiguration';
 import { TTS_SETTINGS_EVENT, loadTtsPlaybackSettings, ttsVoiceFromRecipeOptions } from '../features/audio/ttsSettings';
 import {
   LEMONADE_DEFAULT_CHAT_MODELS,
@@ -86,6 +90,27 @@ interface Conversation {
 const STORAGE_KEY = 'conversations';
 const ACTIVE_KEY = 'active_conversation';
 const STORAGE_VERSION = 3;
+
+// Keep aligned with modelConfiguration.ts without pulling that feature module into the cold chat chunk.
+const DEFAULT_CONTEXT_SIZE = 4096;
+
+let apiClientPromise: Promise<(typeof import('../api'))['default']> | null = null;
+function getApiClient(): Promise<(typeof import('../api'))['default']> {
+  if (!apiClientPromise) {
+    apiClientPromise = import(/* webpackChunkName: "api-client" */ '../api').then(module => module.default);
+  }
+  return apiClientPromise;
+}
+
+let downloadStoreModulePromise: Promise<typeof import('../features/downloadManager/downloadStore')> | null = null;
+function getDownloadStoreModule(): Promise<typeof import('../features/downloadManager/downloadStore')> {
+  if (!downloadStoreModulePromise) {
+    downloadStoreModulePromise = import(
+      /* webpackChunkName: "download-store" */ '../features/downloadManager/downloadStore'
+    );
+  }
+  return downloadStoreModulePromise;
+}
 
 const CHAT_LOGS_WIDTH_KEY = 'chat_logs_panel_width';
 const CHAT_LOGS_DEFAULT_WIDTH = 520;
@@ -253,6 +278,28 @@ function saveActiveId(id: string | null, persist: boolean) {
  * download. Progress/speed updates arrive every second and must not rerender
  * completed message markup while a user is selecting text to copy.
  */
+function isDownloadTerminal(download: Pick<DownloadListItem, 'status' | 'running'>): boolean {
+  return download.running !== true && (
+    download.status === 'completed'
+    || download.status === 'error'
+    || download.status === 'cancelled'
+  );
+}
+
+function downloadsForModel(downloads: DownloadListItem[], modelName: string): DownloadListItem[] {
+  const target = modelName.trim().toLowerCase();
+  return downloads.filter(download => {
+    if (download.downloadType !== 'model') return false;
+    const name = download.modelName.trim().toLowerCase();
+    const id = download.id.trim().toLowerCase();
+    return name === target || id === `model:${target}` || id.endsWith(`:${target}`);
+  });
+}
+
+function activeDownloadForModel(downloads: DownloadListItem[], modelName: string): DownloadListItem | undefined {
+  return downloadsForModel(downloads, modelName).find(download => !isDownloadTerminal(download));
+}
+
 function chatBlockingDownloads(downloads: DownloadListItem[]): DownloadListItem[] {
   return downloads.filter(download => !isDownloadTerminal(download));
 }
@@ -358,6 +405,8 @@ function timeAgo(ts: number): string {
 interface ChatViewProps {
   currentModel: string | null;
   loadedModels: LoadedModel[];
+  serverModels: ModelInfo[];
+  connectionStatus: ConnectionStatus;
   onModelSelect: (model: string) => void;
   onOpenModelDetails: (model: string) => void;
   onRefresh: () => void | Promise<void>;
@@ -722,20 +771,33 @@ const CopyInlineButton: React.FC<{ text: string; title?: string; className?: str
   );
 };
 
+function friendlyErrorMessage(error: unknown): string {
+  if (error && typeof error === 'object') {
+    const value = error as { userMessage?: unknown; message?: unknown };
+    if (typeof value.userMessage === 'string' && value.userMessage) return value.userMessage;
+    if (typeof value.message === 'string' && value.message) return value.message;
+  }
+  return String(error || 'Unknown error');
+}
+
 function friendlyChatError(message: string): string {
   const cleaned = message.replace(/^Error:\s*/i, '').trim();
   if (!cleaned) return "I couldn't complete that request. Please check the server logs for details.";
   return `I couldn't complete that request.\n\n${cleaned}`;
 }
 
-const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loadedModels, onModelSelect, onOpenModelDetails, onRefresh }) => {
+const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loadedModels, serverModels, connectionStatus, onModelSelect, onOpenModelDetails, onRefresh }) => {
   const [fallbackModelOverride, setFallbackModelOverride] = useState<string | null>(null);
   const [preferredDefaultModelName, setPreferredDefaultModelName] = useState(() => loadPreferredDefaultModelName());
   const [lastReadyModelName, setLastReadyModelName] = useState<string | null>(() => loadLastReadyModelName());
   const [modelPreparations, setModelPreparations] = useState<Record<string, ModelPreparationState>>({});
   const [persistHistory, setPersistHistory] = useState(() => loadPersistencePreference());
-  const [conversations, setConversations] = useState<Conversation[]>(() => loadConversations(loadPersistencePreference()));
-  const [activeId, setActiveId] = useState<string | null>(() => loadActiveId(loadPersistencePreference()));
+  // Large persisted conversations are not required to draw the first usable
+  // frame.  Hydrate them after paint instead of JSON-parsing the full history
+  // synchronously inside the initial React render.
+  const [historyHydrated, setHistoryHydrated] = useState(() => !loadPersistencePreference());
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
   const [inputValue, setInputValue] = useState('');
   const [imageMode, setImageMode] = useState<ImageMode>('generate');
   const [imageSettings, setImageSettings] = useState<ImageGenerationSettings>(DEFAULT_IMAGE_SETTINGS);
@@ -785,11 +847,12 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   const [modelPickerLoading, setModelPickerLoading] = useState<string | null>(null);
   const [modelPickerError, setModelPickerError] = useState<string | null>(null);
   const [modelPickerUnloading, setModelPickerUnloading] = useState<string | null>(null);
-  const [downloadItems, setDownloadItems] = useState<DownloadListItem[]>(() => chatBlockingDownloads(downloadStore.snapshot()));
+  const [downloadItems, setDownloadItems] = useState<DownloadListItem[]>([]);
   const downloadAvailabilityKeyRef = useRef(chatBlockingDownloadsKey(downloadItems));
   const [unloadAnnouncement, setUnloadAnnouncement] = useState('');
   const [effectiveSettingsOpen, setEffectiveSettingsOpen] = useState(false);
   const [serverDefaultCtxSize, setServerDefaultCtxSize] = useState(DEFAULT_CONTEXT_SIZE);
+  const [currentModelTuning, setCurrentModelTuning] = useState<ModelTuning | null>(null);
   const threadRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -826,26 +889,41 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
-    const refreshDefaultContextSize = async () => {
-      try {
-        const value = await api.getDefaultContextSize();
-        if (!cancelled) setServerDefaultCtxSize(typeof value === 'number' ? value : DEFAULT_CONTEXT_SIZE);
-      } catch {
-        if (!cancelled) setServerDefaultCtxSize(DEFAULT_CONTEXT_SIZE);
-      }
-    };
+    if (historyHydrated) return;
+    if (!persistHistory) {
+      setHistoryHydrated(true);
+      return;
+    }
+    const cancelSchedule = scheduleIdleWork(() => {
+      const storedConversations = loadConversations(true);
+      const storedActiveId = loadActiveId(true);
+      setConversations(current => {
+        if (current.length === 0) return storedConversations;
+        const existing = new Set(current.map(conversation => conversation.id));
+        return [...current, ...storedConversations.filter(conversation => !existing.has(conversation.id))];
+      });
+      setActiveId(current => current || storedActiveId);
+      setHistoryHydrated(true);
+    }, 500);
+    return cancelSchedule;
+  }, [historyHydrated, persistHistory]);
 
-    void refreshDefaultContextSize();
-    const unsubscribe = api.onStatusChange(status => {
-      if (status === 'connected') void refreshDefaultContextSize();
-      else if (!cancelled) setServerDefaultCtxSize(DEFAULT_CONTEXT_SIZE);
-    });
-    return () => {
-      cancelled = true;
-      unsubscribe();
-    };
-  }, []);
+  useEffect(() => {
+    let cancelled = false;
+    if (connectionStatus !== 'connected') {
+      setServerDefaultCtxSize(DEFAULT_CONTEXT_SIZE);
+      return () => { cancelled = true; };
+    }
+    void getApiClient()
+      .then(api => api.getDefaultContextSize())
+      .then(value => {
+        if (!cancelled) setServerDefaultCtxSize(typeof value === 'number' ? value : DEFAULT_CONTEXT_SIZE);
+      })
+      .catch(() => {
+        if (!cancelled) setServerDefaultCtxSize(DEFAULT_CONTEXT_SIZE);
+      });
+    return () => { cancelled = true; };
+  }, [connectionStatus]);
 
   useEffect(() => {
     try {
@@ -906,16 +984,27 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     }
   }, [railExpanded]);
 
-  const customModelInfos = useMemo(
-    () => loadCustomModels().map(customModelToModelInfo),
-    [],
-  );
+  const [customModelInfos, setCustomModelInfos] = useState<ModelInfo[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    const cancelSchedule = scheduleIdleWork(() => {
+      void import(/* webpackChunkName: "custom-model-store" */ '../features/customModels/customModelStore')
+        .then(({ loadCustomModels, customModelToModelInfo }) => {
+          if (!cancelled) setCustomModelInfos(loadCustomModels().map(customModelToModelInfo));
+        })
+        .catch(error => console.warn('Failed to hydrate chat custom models:', error));
+    }, 650);
+    return () => {
+      cancelled = true;
+      cancelSchedule();
+    };
+  }, []);
   const knownModelInfos = useMemo(
     () => {
       const seen = new Set<string>();
       const infos: ModelInfo[] = [];
       const defaultInfos = LEMONADE_DEFAULT_CHAT_MODELS.map(lemonadeDefaultModelInfo);
-      [...customModelInfos, ...api.allModels, ...defaultInfos].forEach(info => {
+      [...customModelInfos, ...serverModels, ...defaultInfos].forEach(info => {
         const rawName = String((info as any).model_name || info.name || info.id || '').trim();
         const name = rawName.toLowerCase();
         if (!name || seen.has(name)) return;
@@ -934,7 +1023,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
       });
       return infos;
     },
-    [customModelInfos, loadedModels],
+    [customModelInfos, loadedModels, serverModels],
   );
   const lastReadyModelInfo = useMemo(
     () => resolveLastReadyChatModel(knownModelInfos, lastReadyModelName),
@@ -1050,31 +1139,78 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
         : (imageGenerationModels[0] || ''),
     }));
   }, [currentCapability, imageGenerationModels]);
-  useEffect(() => downloadStore.subscribe(items => {
-    const blocking = chatBlockingDownloads(items);
-    const nextKey = chatBlockingDownloadsKey(blocking);
-    if (nextKey === downloadAvailabilityKeyRef.current) return;
-    downloadAvailabilityKeyRef.current = nextKey;
-    setDownloadItems(blocking);
-  }), []);
+  useEffect(() => {
+    const specialCapability = !['chat', 'omni', 'unknown'].includes(currentCapability);
+    if (!modelPickerOpen && !specialCapability) return;
+
+    let cancelled = false;
+    let unsubscribe: (() => void) | undefined;
+    const hydrate = () => {
+      void getDownloadStoreModule().then(({ downloadStore }) => {
+        if (cancelled) return;
+        const update = (items: DownloadListItem[]) => {
+          const blocking = chatBlockingDownloads(items);
+          const nextKey = chatBlockingDownloadsKey(blocking);
+          if (nextKey === downloadAvailabilityKeyRef.current) return;
+          downloadAvailabilityKeyRef.current = nextKey;
+          setDownloadItems(blocking);
+        };
+        update(downloadStore.snapshot());
+        unsubscribe = downloadStore.subscribe(update);
+      }).catch(error => console.warn('Failed to hydrate chat download state:', error));
+    };
+
+    // Opening the picker is an explicit interaction, so hydrate immediately.
+    // Capability-specific background state can still wait for idle time.
+    const cancelSchedule = modelPickerOpen
+      ? (hydrate(), () => {})
+      : scheduleIdleWork(hydrate, 650);
+    return () => {
+      cancelled = true;
+      cancelSchedule();
+      unsubscribe?.();
+    };
+  }, [currentCapability, modelPickerOpen]);
 
   useEffect(() => {
+    // Initial state already read these settings in useState.  Do not perform the
+    // same synchronous localStorage/JSON work again immediately after mount.
     const reloadTtsSettings = () => setTtsPlaybackSettings(loadTtsPlaybackSettings());
-    reloadTtsSettings();
     window.addEventListener(TTS_SETTINGS_EVENT, reloadTtsSettings);
     return () => window.removeEventListener(TTS_SETTINGS_EVENT, reloadTtsSettings);
   }, []);
 
   useEffect(() => {
     const reloadGlobalModelSettings = () => setGlobalModelSettings(loadGlobalModelSettings());
-    reloadGlobalModelSettings();
     window.addEventListener(GLOBAL_MODEL_SETTINGS_EVENT, reloadGlobalModelSettings);
     return () => window.removeEventListener(GLOBAL_MODEL_SETTINGS_EVENT, reloadGlobalModelSettings);
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
+    const needsTuning = !!currentModel && (
+      currentCapability === 'image'
+      || currentCapability === 'audio-generation'
+      || currentCapability === 'tts'
+      || isOpenMossTts
+    );
+    if (!needsTuning) {
+      setCurrentModelTuning(null);
+      return () => { cancelled = true; };
+    }
+    void import(/* webpackChunkName: "model-configuration" */ '../modelConfiguration')
+      .then(({ loadModelTuning }) => {
+        if (!cancelled) setCurrentModelTuning(loadModelTuning(currentModel || ''));
+      })
+      .catch(() => {
+        if (!cancelled) setCurrentModelTuning(null);
+      });
+    return () => { cancelled = true; };
+  }, [currentCapability, currentModel, isOpenMossTts]);
+
+  useEffect(() => {
     if (currentCapability !== 'audio-generation') return;
-    const recipeOptions = loadModelTuning(currentModel || '')?.recipe_options || {};
+    const recipeOptions = currentModelTuning?.recipe_options || {};
     setAudioGenerationSettings(prev => ({
       ...prev,
       duration: isAceStepAudio ? 150 : 10,
@@ -1082,16 +1218,16 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
       cfg: typeof recipeOptions.cfg_scale === 'number' ? recipeOptions.cfg_scale : 4.5,
       lyrics: '',
     }));
-  }, [currentModel, currentCapability, isAceStepAudio]);
+  }, [currentModel, currentCapability, currentModelTuning, isAceStepAudio]);
 
   useEffect(() => {
     if (!isOpenMossTts) return;
     setOpenMossSettings({
       mode: 'plain',
-      voiceDescription: String(loadModelTuning(currentModel || '')?.recipe_options?.voice || ''),
+      voiceDescription: String(currentModelTuning?.recipe_options?.voice || ''),
     });
     setPendingAudioFiles([]);
-  }, [currentModel, isOpenMossTts]);
+  }, [currentModel, currentModelTuning, isOpenMossTts]);
 
   useEffect(() => {
     const keepsAudioAttachments = currentCapability === 'audio'
@@ -1133,10 +1269,10 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
       currentLoadedModel,
       currentKnownModelInfo,
       currentCapability === 'image'
-        ? (loadModelTuning(currentModel || '')?.recipe_options as Record<string, unknown> | undefined)
+        ? (currentModelTuning?.recipe_options as Record<string, unknown> | undefined)
         : undefined,
     ),
-    [currentLoadedModel, currentKnownModelInfo, currentModel, currentCapability],
+    [currentLoadedModel, currentKnownModelInfo, currentModel, currentCapability, currentModelTuning],
   );
   const defaultImageSettingsKey = useMemo(() => JSON.stringify(defaultImageSettings), [defaultImageSettings]);
 
@@ -1241,7 +1377,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
       addOption({
         name,
         capability,
-        recipe: info.recipe,
+        recipe: typeof info.recipe === 'string' ? info.recipe : undefined,
         loaded: false,
         audioInput: modelSupportsChatAudioInput(info, null),
         info,
@@ -1298,7 +1434,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     if (selectedMcpToolNames !== null) return selectedMcpToolNames.length;
     const visibleToolCount = mcpToolNamesForServers(mcpOptions, selectedMcpServerIds).length;
     if (visibleToolCount > 0) return visibleToolCount;
-    return selectedMcpServerIds.includes(LEMONADE_MCP_SERVER_ID) ? LEMONADE_MCP_TOOLS.length : 0;
+    return selectedMcpServerIds.includes(LEMONADE_MCP_SERVER_ID) ? LEMONADE_MCP_TOOL_COUNT : 0;
   }, [mcpOptions, selectedMcpServerIds, selectedMcpToolNames]);
   const visibleMcpOptions = useMemo(
     () => mcpOptions.filter(server => mcpPickerTab === 'lemonade' ? server.transport === 'builtin' : server.transport !== 'builtin'),
@@ -1309,6 +1445,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     setMcpPickerLoading(true);
     setMcpPickerError('');
     try {
+      const { listMcpServerToolOptions } = await import(/* webpackChunkName: "mcp-runtime" */ '../tools/mcpRuntime');
       setMcpOptions(await listMcpServerToolOptions());
     } catch (error) {
       setMcpPickerError(friendlyErrorMessage(error));
@@ -1466,6 +1603,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     info: ModelInfo | null,
     recipeOptions?: Record<string, unknown>,
   ) => {
+    const api = await getApiClient();
     let currentLoaded = loadedModels;
     try {
       currentLoaded = (await api.health()).all_models_loaded || loadedModels;
@@ -1486,6 +1624,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
   }, [globalModelSettings, knownModelInfos, loadedModels]);
 
   const waitForExistingModelDownload = useCallback(async (modelName: string, convoId: string): Promise<boolean> => {
+    const [{ downloadStore }, api] = await Promise.all([getDownloadStoreModule(), getApiClient()]);
     let sawDownload = false;
     const startedAt = Date.now();
 
@@ -1539,6 +1678,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
     initialInfo: ModelInfo | null,
     convoId: string,
   ): Promise<ModelSnapshot> => {
+    const [{ downloadStore }, api] = await Promise.all([getDownloadStoreModule(), getApiClient()]);
     const loadedFrom = (models: LoadedModel[]) => models.find(
       model => model.model_name.toLowerCase() === modelName.toLowerCase(),
     ) || null;
@@ -1628,6 +1768,7 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
       if (source === 'user' && !ttsPlaybackSettings.speakUserText) return;
     }
     try {
+      const api = await getApiClient();
       const isLoaded = loadedModels.some(model => model.model_name.toLowerCase() === modelName.toLowerCase());
       if (!isLoaded) {
         await loadModelWithPolicy(modelName, findModelInfoByName(knownModelInfos, modelName) || null);
@@ -1637,6 +1778,9 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
         (modelInfo as any)?.recipe
         || ((Array.isArray(modelInfo?.recipes) && modelInfo?.recipes?.[0]) ? (modelInfo.recipes[0] as any).recipe : ''),
       ).toLowerCase();
+      const { loadModelTuning } = await import(
+        /* webpackChunkName: "model-configuration" */ '../modelConfiguration'
+      );
       const directOptions = loadModelTuning(modelName)?.recipe_options || {};
       const voice = modelRecipe.includes('openmoss')
         ? String(directOptions.voice || '')
@@ -1781,14 +1925,17 @@ const ChatView: React.FC<ChatViewProps> = ({ currentModel: selectedModel, loaded
 
   // Persist conversations to localStorage only when the user explicitly opted in.
   useEffect(() => {
+    if (!historyHydrated) return;
     saveConversations(conversations, persistHistory);
     try { localStorage.setItem(storageKey('persist_conversations'), String(persistHistory)); } catch { /* ignore */ }
-  }, [conversations, persistHistory]);
+  }, [conversations, historyHydrated, persistHistory]);
 
-  // Persist active conversation id
+  // Persist active conversation id only after the initial stored value has been
+  // hydrated, otherwise an empty cold-start state could overwrite it.
   useEffect(() => {
+    if (!historyHydrated) return;
     saveActiveId(activeId, persistHistory);
-  }, [activeId, persistHistory]);
+  }, [activeId, historyHydrated, persistHistory]);
 
   // Active ID can point at stale/missing data after manual localStorage edits or migrations.
   useEffect(() => {
@@ -2056,6 +2203,7 @@ ${finalText}`
     setLiveTranscript('');
     liveTranscriptRef.current = '';
     try {
+      const api = await getApiClient();
       const handle = await api.connectRealtimeTranscription(currentModel, {
         onConnected: () => setIsLiveConnected(true),
         onDisconnected: () => setIsLiveConnected(false),
@@ -2122,6 +2270,7 @@ ${finalText}`
   ) => {
     setCapabilityBusyConvoIds(prev => new Set(prev).add(convoId));
     try {
+      const api = await getApiClient();
       if (model.capability === 'image') {
         if (!text) throw new Error('Image mode needs a text prompt.');
         imageSettingsCommittedRef.current = true;
@@ -2214,6 +2363,9 @@ ${finalText}`
       } else if (model.capability === 'tts') {
         if (!text) throw new Error('TTS mode needs text to speak.');
         let targetModel = model.name;
+        const { loadModelTuning } = await import(
+          /* webpackChunkName: "model-configuration" */ '../modelConfiguration'
+        );
         let voice = ttsVoiceFromRecipeOptions(loadModelTuning(model.name)?.recipe_options || {});
         let speechOptions: Record<string, unknown> = {};
         let content = 'Generated speech audio from your text.';
@@ -2317,6 +2469,7 @@ ${finalText}`
     audioFiles: File[],
     appendUserToConversation: boolean,
   ) => {
+    const api = await getApiClient();
     const text = userMessage.content.trim();
     const images = userMessage.images?.length ? [...userMessage.images] : undefined;
     const hasImages = !!images?.length;
@@ -2362,13 +2515,17 @@ ${finalText}`
     let requestImages = images;
     let includeDirectAudioParts = canUseAudioInput && modeSupportsChatCompletions && audioFiles.length > 0;
 
-    const omniRuntime = collectionInfo
-      ? buildOmniToolRuntime(collectionInfo, knownModelInfos, {
-          attachedImages: images || [],
-          attachedAudioFiles: audioFiles,
-          previousImages: collectConversationImages(priorMessages),
-        })
-      : null;
+    let omniRuntime: ChatToolRuntime | null = null;
+    if (collectionInfo) {
+      const { buildOmniToolRuntime } = await import(
+        /* webpackChunkName: "omni-tools" */ '../tools/omniTools'
+      );
+      omniRuntime = buildOmniToolRuntime(collectionInfo, knownModelInfos, {
+        attachedImages: images || [],
+        attachedAudioFiles: audioFiles,
+        previousImages: collectConversationImages(priorMessages),
+      });
+    }
 
     if (collectionInfo) {
       const primaryChatComponent = getPrimaryChatComponent(collectionInfo, knownModelInfos);
@@ -2415,6 +2572,9 @@ ${finalText}`
     let selectedMcpRuntime: ChatToolRuntime | null = null;
     if (useMcp && modeSupportsMcp) {
       try {
+        const { buildSelectedMcpRuntime } = await import(
+          /* webpackChunkName: "mcp-runtime" */ '../tools/mcpRuntime'
+        );
         selectedMcpRuntime = await buildSelectedMcpRuntime(
           selectedMcpServerIds,
           {
@@ -2439,7 +2599,16 @@ ${finalText}`
       }
     }
 
-    const toolRuntime = composeMcpRuntimes([omniRuntime, selectedMcpRuntime]);
+    const activeToolRuntimes = [omniRuntime, selectedMcpRuntime].filter(
+      (runtime): runtime is ChatToolRuntime => !!runtime && runtime.tools.length > 0,
+    );
+    let toolRuntime: ChatToolRuntime | null = activeToolRuntimes[0] || null;
+    if (activeToolRuntimes.length > 1) {
+      const { composeMcpRuntimes } = await import(
+        /* webpackChunkName: "mcp-runtime" */ '../tools/mcpRuntime'
+      );
+      toolRuntime = composeMcpRuntimes(activeToolRuntimes);
+    }
 
     // Build chat history from the conversation's messages before this user prompt.
     // Do not feed prior friendly UI error messages or generated media artifacts back as assistant context.
@@ -2567,7 +2736,7 @@ ${finalText}`
     setPendingAudioFiles([]);
     void speakWithPinnedTts(text, 'user');
 
-    if (!api.isConnected) {
+    if (connectionStatus !== 'connected') {
       appendAssistantMessage(convoId, {
         content: friendlyChatError('Lemonade Server is not connected. Reconnect the server, then retry this message.'),
         model: initialSnapshot,
@@ -2612,7 +2781,7 @@ ${finalText}`
 
   const handleRetryAssistant = useCallback(async (messageIndex: number) => {
     if (!activeId || isBusy) return;
-    if (!api.isConnected || !currentModel || !currentModelSnapshot) return;
+    if (connectionStatus !== 'connected' || !currentModel || !currentModelSnapshot) return;
     const convo = conversations.find(c => c.id === activeId);
     if (!convo || convo.messages[messageIndex]?.role !== 'assistant') return;
 
@@ -2645,7 +2814,7 @@ ${finalText}`
       [],
       false,
     );
-  }, [activeId, appendAssistantMessage, conversations, currentModel, currentModelSnapshot, isBusy, startAssistantResponse]);
+  }, [activeId, appendAssistantMessage, connectionStatus, conversations, currentModel, currentModelSnapshot, isBusy, startAssistantResponse]);
 
   const handleSpeakAssistantMessage = useCallback((text: string) => {
     void speakWithPinnedTts(text, 'assistant', true);
@@ -2656,7 +2825,7 @@ ${finalText}`
   const handleEditUserMessage = useCallback(async (messageIndex: number, revisedContent: string) => {
     const text = revisedContent.trim();
     if (!text || !activeId || isBusy) return;
-    if (!api.isConnected || !currentModel || !currentModelSnapshot) return;
+    if (connectionStatus !== 'connected' || !currentModel || !currentModelSnapshot) return;
     const convo = conversations.find(c => c.id === activeId);
     if (!convo || convo.messages[messageIndex]?.role !== 'user') return;
 
@@ -2677,7 +2846,7 @@ ${finalText}`
     } : c));
 
     await startAssistantResponse(activeId, currentModelSnapshot, editedUserMessage, priorMessages, [], false);
-  }, [activeId, conversations, currentModel, currentModelSnapshot, isBusy, startAssistantResponse]);
+  }, [activeId, connectionStatus, conversations, currentModel, currentModelSnapshot, isBusy, startAssistantResponse]);
 
   // Keep option-button callbacks stable across unrelated Chat state updates. This
   // lets memoized completed Markdown messages retain their DOM and selection.
@@ -2807,6 +2976,7 @@ ${finalText}`
     if (modelPickerUnloading) return;
     setModelPickerUnloading(modelName);
     try {
+      const api = await getApiClient();
       await api.unloadModel(modelName);
       await Promise.resolve(onRefresh());
       setUnloadAnnouncement(`${modelName} unloaded`);
@@ -2820,6 +2990,7 @@ ${finalText}`
     setModelPickerUnloading(modelName);
     void (async () => {
       try {
+        const api = await getApiClient();
         await api.unloadModel(modelName);
         await Promise.resolve(onRefresh());
         setUnloadAnnouncement(`${modelName} unloaded`);
@@ -2852,7 +3023,8 @@ ${finalText}`
       return;
     }
 
-    if (!api.isConnected || modelPickerLoading) return;
+    if (connectionStatus !== 'connected' || modelPickerLoading) return;
+    const { downloadStore } = await getDownloadStoreModule();
     if (activeDownloadForModel(downloadStore.snapshot(), option.name)) {
       setModelPickerError(`${option.name} is still downloading. Wait for the download to finish before loading it.`);
       return;
@@ -2876,7 +3048,7 @@ ${finalText}`
     } finally {
       setModelPickerLoading(null);
     }
-  }, [currentModel, loadModelWithPolicy, modelPickerLoading, onModelSelect, onRefresh]);
+  }, [connectionStatus, currentModel, loadModelWithPolicy, modelPickerLoading, onModelSelect, onRefresh]);
 
   // ── Option select from assistant messages ───────────────────
 
@@ -2976,6 +3148,7 @@ ${finalText}`
       <div
         className={`chat ${railExpanded ? 'rail-expanded' : ''}${showInlineLogs ? ' chat--with-logs' : ''}`}
         style={showInlineLogs ? chatLayoutStyle : undefined}
+        data-startup-ready="chat"
       >
       {/* Conversation rail */}
       <aside className={`rail workspace-rail${railExpanded ? '' : ' is-collapsed'}`}>
@@ -2988,7 +3161,10 @@ ${finalText}`
         />
 
         <div className="rail__new-wrap">
-          <WorkspaceActionButton className="rail__new" appearance="primary" icon="compose" onClick={handleNewChat} aria-label="New chat">New chat</WorkspaceActionButton>
+          <button type="button" className="btn btn--primary btn--medium workspace-action-button workspace-action-button--primary workspace-action-button--medium rail__new" onClick={handleNewChat} aria-label="New chat">
+            <Icon name="compose" size={14} aria-hidden="true" />
+            <span className="workspace-action-button__label">New chat</span>
+          </button>
         </div>
 
         <ul className="rail__list" role="listbox" aria-label="Conversations" onKeyDown={handleRailKeyDown}>
@@ -3054,9 +3230,14 @@ ${finalText}`
         </div>
         <div className="bottom-sheet__header">
           <strong>Conversations</strong>
-          <WorkspaceActionButton size="toolbar" appearance="quiet" icon="x" iconOnly onClick={closeMobileSheet} aria-label="Close conversation history" title="Close panel" />
+          <button type="button" className="btn btn--quiet btn--toolbar btn--icon-only workspace-action-button workspace-action-button--quiet workspace-action-button--toolbar workspace-action-button--icon-only" onClick={closeMobileSheet} aria-label="Close conversation history" title="Close panel">
+            <Icon name="x" size={16} aria-hidden="true" />
+          </button>
         </div>
-        <WorkspaceActionButton className="bottom-sheet__new" appearance="primary" icon="compose" onClick={() => { handleNewChat(); closeMobileSheet(); }}>New chat</WorkspaceActionButton>
+        <button type="button" className="btn btn--primary btn--medium workspace-action-button workspace-action-button--primary workspace-action-button--medium bottom-sheet__new" onClick={() => { handleNewChat(); closeMobileSheet(); }}>
+          <Icon name="compose" size={14} aria-hidden="true" />
+          <span className="workspace-action-button__label">New chat</span>
+        </button>
         <ul className="bottom-sheet__list rail__list" role="listbox" aria-label="Conversations" onKeyDown={handleSheetKeyDown}>
           {conversations.map((c, idx) => {
             const badge = modelModeBadge(c.model?.capability || 'chat', c.model?.recipe);
@@ -3232,7 +3413,9 @@ ${finalText}`
             onPointerDown={handleChatLogsResizeStart}
             onKeyDown={handleChatLogsResizeKeyDown}
           />
-          <LogViewer />
+          <Suspense fallback={<div className="view-loading view-loading--compact"><span className="spinner" aria-hidden="true" /></div>}>
+            <LogViewer />
+          </Suspense>
         </aside>
       )}
 
@@ -3360,8 +3543,9 @@ ${finalText}`
             <Icon name="logs" size={13} /> Logs
           </button>
         </div>
-        {currentModel && (
-          <EffectiveSettingsModal
+        {currentModel && effectiveSettingsOpen && (
+          <Suspense fallback={null}>
+            <EffectiveSettingsModal
             open={effectiveSettingsOpen}
             onClose={() => setEffectiveSettingsOpen(false)}
             modelName={currentModel}
@@ -3373,14 +3557,17 @@ ${finalText}`
             loadedModel={currentLoadedModel}
             isModelLoaded={!!currentLoadedModel}
             onReload={async () => {
+              const api = await getApiClient();
               await api.reloadModel(currentModel, undefined, currentKnownModelInfo || currentCustomModelInfo || null);
               await Promise.resolve(onRefresh());
             }}
             onLoad={async () => {
+              const api = await getApiClient();
               await api.loadModel(currentModel, undefined, currentKnownModelInfo || currentCustomModelInfo || null);
               await Promise.resolve(onRefresh());
             }}
-          />
+            />
+          </Suspense>
         )}
         {streamingToolStatus && (
           <div className="composer__tool-status">

--- a/src/app/src/components/Dashboard.tsx
+++ b/src/app/src/components/Dashboard.tsx
@@ -1,5 +1,4 @@
-import React, { useMemo } from 'react';
-import { AreaChart as RechartArea, Area, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import React, { lazy, Suspense, useMemo } from 'react';
 import { LoadedModel } from '../api';
 import { useDashboardData } from '../hooks/useDashboardData';
 import { dashboardMemoryTopology } from '../features/dashboard/memoryTopology';
@@ -132,15 +131,14 @@ const RingGauge = React.memo<{
   );
 });
 
-/* ── Smooth Recharts wrapper ────────────────────────────────── */
+/* ── Smooth chart wrapper ───────────────────────────────────── */
 
-const CHART_TOOLTIP_STYLE: React.CSSProperties = {
-  background: '#1d1b16',
-  border: '1px solid rgba(255,245,220,0.1)',
-  borderRadius: 8,
-  fontSize: 12,
-  padding: '6px 10px',
-};
+// Recharts is by far the heaviest dependency of the default Monitor section.
+// Render the dashboard shell immediately and hydrate charts in a nested async
+// chunk so opening/reloading Monitor never waits for the charting library.
+const LazyDashboardChart = lazy(() =>
+  import(/* webpackChunkName: "monitor-charts" */ './DashboardChart')
+);
 
 const SmoothChart = React.memo<{
   data: Record<string, number>[];
@@ -148,39 +146,9 @@ const SmoothChart = React.memo<{
   height?: number;
   unit?: string;
 }>(({ data, series, height = 80, unit = '' }) => (
-  <ResponsiveContainer width="100%" height={height}>
-    <RechartArea data={data} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
-      <defs>
-        {series.map(s => (
-          <linearGradient key={s.key} id={`grad-${s.key}`} x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor={s.color} stopOpacity={0.3} />
-            <stop offset="100%" stopColor={s.color} stopOpacity={0} />
-          </linearGradient>
-        ))}
-      </defs>
-      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,245,220,0.04)" vertical={false} />
-      <YAxis hide domain={[0, 'auto']} />
-      <Tooltip
-        contentStyle={CHART_TOOLTIP_STYLE}
-        labelStyle={{ display: 'none' }}
-        formatter={(value) => [`${Number(value ?? 0).toFixed(1)}${unit}`, '']}
-        isAnimationActive={false}
-      />
-      {series.map(s => (
-        <Area
-          key={s.key}
-          type="monotone"
-          dataKey={s.key}
-          stroke={s.color}
-          fill={`url(#grad-${s.key})`}
-          strokeWidth={2}
-          dot={false}
-          isAnimationActive={false}
-          name={s.name || s.key}
-        />
-      ))}
-    </RechartArea>
-  </ResponsiveContainer>
+  <Suspense fallback={<div aria-hidden="true" style={{ height }} />}>
+    <LazyDashboardChart data={data} series={series} height={height} unit={unit} />
+  </Suspense>
 ));
 
 /* ── Model row ─────────────────────────────────────────────── */

--- a/src/app/src/components/DashboardChart.tsx
+++ b/src/app/src/components/DashboardChart.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import {
+  AreaChart as RechartArea,
+  Area,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+const CHART_TOOLTIP_STYLE: React.CSSProperties = {
+  background: '#1d1b16',
+  border: '1px solid rgba(255,245,220,0.1)',
+  borderRadius: 8,
+  fontSize: 12,
+  padding: '6px 10px',
+};
+
+export interface DashboardChartProps {
+  data: Record<string, number>[];
+  series: { key: string; color: string; name?: string }[];
+  height?: number;
+  unit?: string;
+}
+
+const DashboardChart: React.FC<DashboardChartProps> = ({
+  data,
+  series,
+  height = 80,
+  unit = '',
+}) => (
+  <ResponsiveContainer width="100%" height={height}>
+    <RechartArea data={data} margin={{ top: 4, right: 0, bottom: 0, left: 0 }}>
+      <defs>
+        {series.map(s => (
+          <linearGradient key={s.key} id={`grad-${s.key}`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={s.color} stopOpacity={0.3} />
+            <stop offset="100%" stopColor={s.color} stopOpacity={0} />
+          </linearGradient>
+        ))}
+      </defs>
+      <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,245,220,0.04)" vertical={false} />
+      <YAxis hide domain={[0, 'auto']} />
+      <Tooltip
+        contentStyle={CHART_TOOLTIP_STYLE}
+        labelStyle={{ display: 'none' }}
+        formatter={(value) => [`${Number(value ?? 0).toFixed(1)}${unit}`, '']}
+        isAnimationActive={false}
+      />
+      {series.map(s => (
+        <Area
+          key={s.key}
+          type="monotone"
+          dataKey={s.key}
+          stroke={s.color}
+          fill={`url(#grad-${s.key})`}
+          strokeWidth={2}
+          dot={false}
+          isAnimationActive={false}
+          name={s.name || s.key}
+        />
+      ))}
+    </RechartArea>
+  </ResponsiveContainer>
+);
+
+export default React.memo(DashboardChart);

--- a/src/app/src/components/InspectView.tsx
+++ b/src/app/src/components/InspectView.tsx
@@ -14,6 +14,7 @@ import CreateModal from './inspect/CreateModal';
 import CurlModal from './inspect/CurlModal';
 import { WorkspaceActionButton, WorkspaceDetailEmpty } from './WorkspacePanels';
 import { isMobileLayout } from '../styles/breakpoints';
+import { useServerModelState } from '../features/models/modelState';
 
 interface InspectViewProps {
   embedded?: boolean;
@@ -38,7 +39,8 @@ export default function InspectView({ embedded = false }: InspectViewProps) {
   const tablistRef = useRef<HTMLDivElement>(null);
   const mobileBackRef = useRef<HTMLButtonElement>(null);
 
-  const availableModels = api.allModels;
+  const serverModelState = useServerModelState();
+  const availableModels = serverModelState.models?.data ?? api.allModels;
 
   const selectedTrace = useMemo(() => {
     return traces.find((t) => t.id === selectedTraceId) || null;

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { Suspense, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import api, { ModelInfo, LoadedModel, PullCallbacks, PullVariantsResult, HFModelResult, ModelRegistryProvider, searchHuggingFace, searchModelScope, friendlyErrorMessage } from '../api';
 import { copyTextToClipboard } from '../clipboard';
 import { capabilityFromModelInfo } from '../modelCapabilities';
@@ -16,14 +16,12 @@ import { DownloadListItem, activeDownloadForModel, downloadStore } from '../feat
 import { ModelListPanel, modelIsCustom, modelMatchesBackends, modelMatchesTags, modelMatchesTasks } from './ModelListPanel';
 import type { FilterTab, PrimaryFilter } from './ModelListPanel';
 import { ModelNavRail } from './ModelNavRail';
-import { ModelDetailPanel } from './ModelDetailPanel';
 import WorkspaceMobileMenuButton from './WorkspaceMobileMenuButton';
 import { useWorkspaceMobileRail } from '../hooks/useWorkspaceMobileRail';
 import { useWorkspacePanelResize } from '../hooks/useWorkspacePanelResize';
 import { DEFAULT_OMNI_SYSTEM_PROMPT_TEMPLATE } from '../tools/omniTools';
 import { remoteResultAsModelInfo } from '../remoteModelCapabilities';
-import RouterEditorPanel from './RouterEditorPanel';
-import GlobalModelSettingsPanel, { type UpdateAllModelsResult } from './GlobalModelSettingsPanel';
+import type { UpdateAllModelsResult } from './GlobalModelSettingsPanel';
 import { WorkspaceActionButton, WorkspaceActionGroup, WorkspaceDetailPanel, WorkspaceMetadataChip, WorkspacePanelResizer } from './WorkspacePanels';
 import { ROUTER_RECIPE, type RouterPullRequest } from '../features/router/routerTypes';
 import { deleteRouterRecord, loadRouterRecords, routerRecordToModelInfo } from '../features/router/routerStore';
@@ -39,6 +37,16 @@ import {
 } from '../features/modelSettings/globalModelSettings';
 import { backendLabel } from '../modelPresentation';
 import { useServerModelState } from '../features/models/modelState';
+import {
+  ModelDetailPanelPreloaded as ModelDetailPanel,
+  RouterEditorPanelPreloaded as RouterEditorPanel,
+  GlobalModelSettingsPanelPreloaded as GlobalModelSettingsPanel,
+  preloadModelManagerSecondarySurfaces,
+} from '../interactionPreload';
+
+export async function preloadModelManagerSecondary(): Promise<void> {
+  await preloadModelManagerSecondarySurfaces();
+}
 
 /* ── Helpers ─────────────────────────────────────────────────── */
 
@@ -936,8 +944,18 @@ const OmniComponentPicker: React.FC<OmniComponentPickerProps> = ({ role, value, 
     return filtered.slice(0, 40);
   }, [options, queryText]);
 
-  // Reset active index when the option list changes
-  useEffect(() => { setActiveIndex(-1); }, [visibleOptions]);
+  // Keep keyboard focus stable while the progressive model catalog updates.
+  // Resetting to -1 here races ArrowDown: an async model snapshot can arrive
+  // immediately after the key press and erase aria-activedescendant. Query
+  // edits/close paths already reset explicitly; catalog updates only need to
+  // clamp an existing index to the new list bounds.
+  useEffect(() => {
+    setActiveIndex(previous => {
+      if (previous < 0) return -1;
+      if (visibleOptions.length === 0) return -1;
+      return Math.min(previous, visibleOptions.length - 1);
+    });
+  }, [visibleOptions.length]);
 
   const groups: Array<{ source: OmniComponentOptionSource; label: string; options: OmniComponentOption[] }> = [
     { source: 'custom' as OmniComponentOptionSource, label: 'Custom models', options: visibleOptions.filter(option => option.source === 'custom') },
@@ -1056,11 +1074,19 @@ interface ModelManagerProps {
 }
 
 const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelRequest }) => {
+  useEffect(() => {
+    // Direct/deep-linked Models loads must also warm the details/editor modules
+    // automatically. Never make selecting a model the event that starts them.
+    void preloadModelManagerSecondarySurfaces().catch(() => undefined);
+  }, []);
   const serverModelState = useServerModelState();
   const models = serverModelState.models?.data ?? EMPTY_MODELS;
+  const fullModelStateReady = serverModelState.models !== null;
+  const [fastLocalModels, setFastLocalModels] = useState<ModelInfo[]>(EMPTY_MODELS);
+  const visibleServerModels = fullModelStateReady ? models : fastLocalModels;
   const loadedModels = serverModelState.health?.all_models_loaded ?? EMPTY_LOADED_MODELS;
   const connectionStatus = serverModelState.status;
-  const modelsLoading = serverModelState.refreshing && models.length === 0;
+  const modelsLoading = serverModelState.refreshing && !fullModelStateReady && fastLocalModels.length === 0;
   const [loadingModel, setLoadingModel] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<{ modelName: string; message: string } | null>(null);
   const [pulling, setPulling] = useState<Record<string, number>>({});  // model -> percent
@@ -1129,6 +1155,27 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
 
   useEffect(() => downloadStore.subscribe(setDownloadItems), []);
 
+  // The full catalog uses /models?show_all=true and can take noticeably longer
+  // than the optimized downloaded-only endpoint.  On a cold Models mount, show
+  // the user's local models as soon as the server is connected while the global
+  // model-state refresh continues loading the complete catalog in the background.
+  useEffect(() => {
+    if (fullModelStateReady || connectionStatus !== 'connected') return;
+    let cancelled = false;
+    void api.models(false)
+      .then(data => {
+        if (!cancelled && !fullModelStateReady && Array.isArray(data.data)) {
+          setFastLocalModels(data.data);
+        }
+      })
+      .catch(() => undefined);
+    return () => { cancelled = true; };
+  }, [connectionStatus, fullModelStateReady]);
+
+  useEffect(() => {
+    if (fullModelStateReady && fastLocalModels.length > 0) setFastLocalModels(EMPTY_MODELS);
+  }, [fastLocalModels.length, fullModelStateReady]);
+
   const reloadCustomModels = useCallback(() => {
     setCustomModels(loadCustomModels().map(customModelToModelInfo));
   }, []);
@@ -1156,7 +1203,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       .then(info => { if (!cancelled) setStorageInfo(info); })
       .catch(() => { if (!cancelled) setStorageInfo(null); });
     return () => { cancelled = true; };
-  }, [models.length]);
+  }, [visibleServerModels.length]);
 
   useEffect(() => {
     const reloadGlobalSettings = () => setGlobalModelSettings(loadGlobalModelSettings());
@@ -2223,7 +2270,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       merged.push(m);
     }
     const loadedNames = new Set(loadedModels.map(lm => lm.model_name.toLowerCase()));
-    for (const m of models) {
+    for (const m of visibleServerModels) {
       const name = modelName(m).toLowerCase();
       if (!name || seen.has(name)) continue;
       // Hide models explicitly marked as not suggested, unless they are downloaded or loaded
@@ -2232,7 +2279,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       merged.push(m);
     }
     return merged;
-  }, [routerModels, customModels, models, loadedModels]);
+  }, [routerModels, customModels, visibleServerModels, loadedModels]);
 
   const omniComponentOptions = useMemo(() => {
     const roles: Record<OmniComponentRole, OmniComponentOption[]> = {
@@ -2860,6 +2907,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
       {/* Right panel: global settings, router editor, custom form, or model detail */}
       {showGlobalSettings ? (
         <div className="manager__detail-form-panel manager__detail-form-panel--global-settings">
+          <Suspense fallback={<div className="view-loading" role="status"><span className="spinner" aria-hidden="true" /></div>}>
           <GlobalModelSettingsPanel
             models={allModels}
             loadedModels={loadedModels}
@@ -2868,9 +2916,11 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
             onUpdateAllModels={handleUpdateAllModels}
             onClose={closeGlobalSettings}
           />
+          </Suspense>
         </div>
       ) : showRouterEditor ? (
         <div className="manager__detail-form-panel manager__detail-form-panel--router">
+          <Suspense fallback={<div className="view-loading" role="status"><span className="spinner" aria-hidden="true" /></div>}>
           <RouterEditorPanel
             models={allModels}
             initialModel={routerEditorModel}
@@ -2879,6 +2929,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
             onDeleted={handleDeleteRouterDefinition}
             onClose={closeRouterEditor}
           />
+          </Suspense>
         </div>
       ) : showCustomEditor ? (
         <div className="manager__detail-form-panel">
@@ -3197,7 +3248,20 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
           {customJsonNotice && <div className="manager__inline-notice">{customJsonNotice}</div>}
           </WorkspaceDetailPanel>
         </div>
+      ) : (!selectedDetailModel && !selectedRemoteModel) ? (
+        <div className="model-detail-panel workspace-detail-panel workspace-detail-panel--empty model-detail-panel--empty" aria-label="Model detail">
+          <div className="model-detail-panel__placeholder">
+            <Icon name="model" size={40} aria-hidden="true" />
+            <p>{allModels.length === 0 ? 'Loading model catalog…' : 'No model selected'}</p>
+            <p className="model-detail-panel__placeholder-sub">
+              {allModels.length === 0
+                ? 'Downloaded models appear first while the full Lemonade catalog finishes loading.'
+                : 'Select a model from the list to view its details.'}
+            </p>
+          </div>
+        </div>
       ) : (
+        <Suspense fallback={<div className="view-loading" role="status"><span className="spinner" aria-hidden="true" /></div>}>
         <ModelDetailPanel
           model={selectedDetailModel}
           models={allModels}
@@ -3250,6 +3314,7 @@ const ModelManager: React.FC<ModelManagerProps> = ({ onModelSelect, openModelReq
           }}
           onClose={() => { setSelectedDetailModelId(null); setSelectedRemoteModel(null); }}
         />
+        </Suspense>
       )}
     </div>
   );

--- a/src/app/src/components/ModelManager.tsx
+++ b/src/app/src/components/ModelManager.tsx
@@ -965,13 +965,22 @@ const OmniComponentPicker: React.FC<OmniComponentPickerProps> = ({ role, value, 
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     const count = visibleOptions.length;
+
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      if (!open) { setOpen(true); setActiveIndex(count > 0 ? 0 : -1); return; }
-      setActiveIndex(prev => count > 0 ? (prev + 1) % count : -1);
+      if (!open) {
+        setOpen(true);
+        setActiveIndex(0);
+        return;
+      }
+      setActiveIndex(prev => count > 0 ? (prev + 1) % count : 0);
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      if (!open) { setOpen(true); setActiveIndex(count > 0 ? count - 1 : -1); return; }
+      if (!open) {
+        setOpen(true);
+        setActiveIndex(count > 0 ? count - 1 : -1);
+        return;
+      }
       setActiveIndex(prev => count > 0 ? (prev <= 0 ? count - 1 : prev - 1) : -1);
     } else if (e.key === 'Enter') {
       e.preventDefault();

--- a/src/app/src/components/MonitorView.tsx
+++ b/src/app/src/components/MonitorView.tsx
@@ -1,9 +1,12 @@
-import React, { useState } from 'react';
+import React, { Suspense, useEffect, useRef, useState } from 'react';
 import Dashboard from './Dashboard';
-import InspectView from './InspectView';
-import LogViewer from './LogViewer';
 import WorkspaceSectionRail from './WorkspaceSectionRail';
 import { WORKSPACE_NAVIGATION, type DashboardSection } from '../features/navigation/workspaceNavigation';
+import {
+  InspectViewPreloaded as InspectView,
+  LogViewerPreloaded as LogViewer,
+  preloadMonitorSecondarySurfaces,
+} from '../interactionPreload';
 
 interface MonitorViewProps {
   activeSection: DashboardSection;
@@ -11,12 +14,32 @@ interface MonitorViewProps {
   onSectionChange: (section: DashboardSection) => void;
 }
 
+export async function preloadMonitorSections(): Promise<void> {
+  await preloadMonitorSecondarySurfaces();
+}
+
+const MonitorSectionFallback = () => (
+  <div className="view-loading" role="status" aria-label="Loading monitor section" aria-live="polite">
+    <span className="spinner" aria-hidden="true" />
+  </div>
+);
+
 export default function MonitorView({
   activeSection,
   isActive,
   onSectionChange,
 }: MonitorViewProps) {
   const [railCollapsed, setRailCollapsed] = useState(false);
+  const mountedSectionsRef = useRef<Set<DashboardSection>>(new Set([activeSection]));
+  mountedSectionsRef.current.add(activeSection);
+
+  useEffect(() => {
+    if (!isActive) return;
+    // Do not wait for a click on Telemetry/Logs. As soon as Monitor itself is
+    // active, warm those modules without mounting them. Shared preload promises
+    // make this a no-op when the global post-start warm-up already finished.
+    void preloadMonitorSections().catch(() => undefined);
+  }, [isActive]);
 
   return (
     <section
@@ -40,15 +63,25 @@ export default function MonitorView({
       />
 
       <div className="monitor-content">
-        <div className="monitor-section" hidden={activeSection !== 'performance'}>
-          <Dashboard isActive={isActive && activeSection === 'performance'} />
-        </div>
-        <div className="monitor-section" hidden={activeSection !== 'telemetry'}>
-          <InspectView embedded />
-        </div>
-        <div className="monitor-section" hidden={activeSection !== 'logs'}>
-          <LogViewer embedded />
-        </div>
+        {mountedSectionsRef.current.has('performance') && (
+          <div className="monitor-section" hidden={activeSection !== 'performance'}>
+            <Dashboard isActive={isActive && activeSection === 'performance'} />
+          </div>
+        )}
+        {mountedSectionsRef.current.has('telemetry') && (
+          <div className="monitor-section" hidden={activeSection !== 'telemetry'}>
+            <Suspense fallback={<MonitorSectionFallback />}>
+              <InspectView embedded />
+            </Suspense>
+          </div>
+        )}
+        {mountedSectionsRef.current.has('logs') && (
+          <div className="monitor-section" hidden={activeSection !== 'logs'}>
+            <Suspense fallback={<MonitorSectionFallback />}>
+              <LogViewer embedded />
+            </Suspense>
+          </div>
+        )}
       </div>
     </section>
   );

--- a/src/app/src/components/inspect/ImproveTab.tsx
+++ b/src/app/src/components/inspect/ImproveTab.tsx
@@ -14,6 +14,7 @@ import {
   modelInfoName,
   modelIsDownloaded,
 } from '../../features/chatDefaultModels';
+import { useServerModelState } from '../../features/models/modelState';
 
 interface ImproveTabProps {
   selectedTrace: Trace;
@@ -54,7 +55,9 @@ function truncateText(text: string, maxChars: number): string {
 }
 
 export default function ImproveTab({ selectedTrace }: ImproveTabProps) {
-  const availableModels = api.allModels;
+  const serverModelState = useServerModelState();
+  const availableModels = serverModelState.models?.data ?? api.allModels;
+  const modelCatalogReady = serverModelState.models !== null || api.allModels.length > 0;
   const optimizerModels = useMemo(
     () => availableModels.filter(
       (model) => modelIsDownloaded(model) && modelCapabilityTags(model).includes('tool')
@@ -236,14 +239,19 @@ export default function ImproveTab({ selectedTrace }: ImproveTabProps) {
 
   // Set default model when models load
   useEffect(() => {
+    // Do not lock in the static quality fallback while the shared model catalog
+    // is still loading. Once the catalog arrives, prefer the user's last-ready
+    // downloaded tool model (or the hot model) immediately.
+    if (!modelCatalogReady) return;
+
     const selectedModelAvailable = optimizerModels.some(
       (model) => modelInfoName(model) === improveModel
-    ) || improveModel === QUALITY_DEFAULT_MODEL;
+    ) || (optimizerModels.length === 0 && improveModel === QUALITY_DEFAULT_MODEL);
 
     if (!improveModel || !selectedModelAvailable) {
       setImproveModel(preferredImproveModel);
     }
-  }, [optimizerModels, improveModel, preferredImproveModel]);
+  }, [optimizerModels, improveModel, preferredImproveModel, modelCatalogReady]);
 
   // Sync edits when prompt parsed data changes
   useEffect(() => {

--- a/src/app/src/css.d.ts
+++ b/src/app/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/src/app/src/features/models/modelState.ts
+++ b/src/app/src/features/models/modelState.ts
@@ -1,16 +1,60 @@
 import { useSyncExternalStore } from 'react';
-import api, { type ModelStateSnapshot } from '../../api';
+import type { ModelStateSnapshot } from '../../api';
 
-const subscribe = (listener: () => void): (() => void) => api.onModelStateChange(listener);
-const getSnapshot = (): ModelStateSnapshot => api.modelStateSnapshot;
+const EMPTY_MODEL_STATE: ModelStateSnapshot = {
+  status: 'disconnected',
+  health: null,
+  models: null,
+  refreshing: false,
+  error: null,
+};
+
+type ModelStateApi = {
+  readonly modelStateSnapshot: ModelStateSnapshot;
+  onModelStateChange(listener: () => void): () => void;
+};
+
+let snapshot = EMPTY_MODEL_STATE;
+let attachedApi: ModelStateApi | null = null;
+let detachApi: (() => void) | null = null;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): ModelStateSnapshot {
+  return snapshot;
+}
 
 /**
- * Shared server model state for the renderer.
+ * Attach the already-loaded API singleton to the tiny renderer store.
  *
- * The API singleton owns the canonical registry/health snapshot and coalesces
- * refreshes. Views subscribe here instead of fetching `/api/v1/models` into
- * independent local state.
+ * This is deliberately explicit.  The old hook imported the 100 KB+ API
+ * module from a useEffect on every cold start, which raced the default Chat
+ * render and defeated App's post-paint host bootstrap.  App now loads the API
+ * once on the post-paint path and hands the same singleton to this bridge.
  */
+export function attachServerModelState(api: ModelStateApi): void {
+  if (attachedApi === api) return;
+  detachApi?.();
+  attachedApi = api;
+  snapshot = api.modelStateSnapshot;
+  emit();
+  detachApi = api.onModelStateChange(() => {
+    const next = api.modelStateSnapshot;
+    if (next === snapshot) return;
+    snapshot = next;
+    emit();
+  });
+}
+
+/** Shared server model state for the renderer. */
 export function useServerModelState(): ModelStateSnapshot {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/src/app/src/hooks/useChatStreaming.ts
+++ b/src/app/src/hooks/useChatStreaming.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import api, { ChatMessage, LiveStreamStats, ChatCompletionStats } from '../api';
-import { LEMONADE_TOOLS, executeTool, ToolCall, ToolResult } from '../tools/lemonadeTools';
+import type { ChatMessage, LiveStreamStats, ChatCompletionStats } from '../api';
+import type { ToolCall, ToolResult } from '../tools/lemonadeTools';
 
 export type { ToolCall } from '../tools/lemonadeTools';
 
@@ -30,11 +30,6 @@ export interface ChatToolRuntime {
   execute: (call: ToolCall) => Promise<ToolExecutionPayload>;
   systemPrompt?: string;
 }
-
-const DEFAULT_TOOL_RUNTIME: ChatToolRuntime = {
-  tools: LEMONADE_TOOLS as unknown as Record<string, unknown>[],
-  execute: executeTool as unknown as (call: ToolCall) => Promise<ToolExecutionPayload>,
-};
 
 /** Produce a short human-readable summary of a tool result */
 function summarizeResult(toolName: string, data: Record<string, unknown>): string {
@@ -119,25 +114,34 @@ export function useChatStreaming(
 
   const controllersRef = useRef<Map<string, AbortController>>(new Map());
   const tokenBufferRef = useRef<Record<string, StreamState>>({});
+  const flushTimerRef = useRef<number | null>(null);
 
-  // Flush token buffer → state (50ms interval)
-  useEffect(() => {
-    const flush = setInterval(() => {
-      const buf = tokenBufferRef.current;
-      const keys = Object.keys(buf);
-      if (keys.length === 0) return;
-      setActiveStreams(prev => {
-        let next = prev;
-        for (const id of keys) {
-          if (!prev[id]) continue;
-          if (next === prev) next = { ...prev };
-          next[id] = { ...next[id], ...buf[id] };
-        }
-        return next;
-      });
-      tokenBufferRef.current = {};
-    }, 50);
-    return () => clearInterval(flush);
+  // Do not keep a 50ms interval alive for the entire lifetime of the Chat view.
+  // Schedule a flush only when a streaming token actually arrives.
+  const flushTokenBuffer = useCallback(() => {
+    flushTimerRef.current = null;
+    const buf = tokenBufferRef.current;
+    const keys = Object.keys(buf);
+    if (keys.length === 0) return;
+    setActiveStreams(prev => {
+      let next = prev;
+      for (const id of keys) {
+        if (!prev[id]) continue;
+        if (next === prev) next = { ...prev };
+        next[id] = { ...next[id], ...buf[id] };
+      }
+      return next;
+    });
+    tokenBufferRef.current = {};
+  }, []);
+
+  const scheduleTokenFlush = useCallback(() => {
+    if (flushTimerRef.current !== null) return;
+    flushTimerRef.current = window.setTimeout(flushTokenBuffer, 50);
+  }, [flushTokenBuffer]);
+
+  useEffect(() => () => {
+    if (flushTimerRef.current !== null) window.clearTimeout(flushTimerRef.current);
   }, []);
 
   const getStream = useCallback(
@@ -151,9 +155,16 @@ export function useChatStreaming(
   );
 
   const send = useCallback(async (convoId: string, model: string, messages: ChatMessage[], tools: boolean | ChatToolRuntime | null = false) => {
-    const runtime: ChatToolRuntime | null = tools === true
-      ? DEFAULT_TOOL_RUNTIME
-      : (tools && typeof tools === 'object' ? tools : null);
+    let runtime: ChatToolRuntime | null = tools && typeof tools === 'object' ? tools : null;
+    if (tools === true) {
+      const { LEMONADE_TOOLS, executeTool } = await import(
+        /* webpackChunkName: "lemonade-tools" */ '../tools/lemonadeTools'
+      );
+      runtime = {
+        tools: LEMONADE_TOOLS as unknown as Record<string, unknown>[],
+        execute: executeTool as unknown as (call: ToolCall) => Promise<ToolExecutionPayload>,
+      };
+    }
     setActiveStreams(prev => ({ ...prev, [convoId]: { content: '', thinking: '', toolCalls: [] } }));
     setThinkingExpanded(false);
 
@@ -166,6 +177,7 @@ export function useChatStreaming(
     const allToolCalls: ToolCallEntry[] = [];
 
     const runCompletion = async (): Promise<void> => {
+      const { default: api } = await import(/* webpackChunkName: "api-client" */ '../api');
       return new Promise<void>((resolve, reject) => {
         api.chatCompletion(model, fullMessages, {
           tools: runtime?.tools?.length ? runtime.tools : undefined,
@@ -173,12 +185,14 @@ export function useChatStreaming(
             const buf = tokenBufferRef.current;
             if (!buf[convoId]) buf[convoId] = { content: '', thinking: '', toolCalls: [] };
             buf[convoId].thinking = fullReasoning;
+            scheduleTokenFlush();
             if (!thinkingExpanded) setThinkingExpanded(true);
           },
           onToken: (_token, full) => {
             const buf = tokenBufferRef.current;
             if (!buf[convoId]) buf[convoId] = { content: '', thinking: '', toolCalls: [] };
             buf[convoId].content = full;
+            scheduleTokenFlush();
           },
           onStats: (stats) => {
             setLiveStats(prev => ({ ...prev, [convoId]: stats }));
@@ -315,7 +329,7 @@ export function useChatStreaming(
     };
 
     await runCompletion();
-  }, [onDone, onError]);
+  }, [onDone, onError, scheduleTokenFlush]);
 
   const stop = useCallback((convoId: string): { content: string; thinking?: string } | null => {
     const controller = controllersRef.current.get(convoId);

--- a/src/app/src/index.html
+++ b/src/app/src/index.html
@@ -5,9 +5,26 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="color-scheme" content="dark light" />
   <title>lemonade — UI redesign prototype</title>
-  <script>try{var t=localStorage.getItem('lemonade_theme');if(t==='light')document.documentElement.setAttribute('data-theme','light')}catch(e){}</script>
+  <script>
+    window.__LEMONADE_DOCUMENT_START_MS__ = performance.now();
+    try {
+      var t = localStorage.getItem('lemonade_theme');
+      if (t === 'light') document.documentElement.setAttribute('data-theme', 'light');
+    } catch (e) {}
+  </script>
+  <style id="lemonade-boot-guard">
+    html,body{margin:0;min-width:100%;min-height:100%;background:#fff}
+    #root{visibility:hidden}
+    #lemonade-startup-cover{position:fixed;inset:0;z-index:2147483647;background:#fff;pointer-events:none}
+    html.lemonade-startup-revealed #root{visibility:visible}
+    html.lemonade-startup-revealed #lemonade-startup-cover{display:none}
+  </style>
+  <style id="lemonade-critical-css">/*__LEMONADE_CRITICAL_CSS__*/</style>
+  <link id="lemonade-app-css" rel="preload" as="style" href="app.css" onload="this.onload=null;this.rel='stylesheet'" />
+  <noscript><link rel="stylesheet" href="app.css" /></noscript>
 </head>
 <body>
+  <div id="lemonade-startup-cover" aria-hidden="true"></div>
   <div id="root"></div>
 </body>
 </html>

--- a/src/app/src/index.tsx
+++ b/src/app/src/index.tsx
@@ -1,17 +1,204 @@
-import './tauriShim';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import './styles/tokens.css';
-import './styles/styles.css';
-import './styles/hljs-styles.css';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
-);
+type StartupMetrics = {
+  documentStartMs?: number;
+  entryMs: number;
+  criticalCssReadyMs?: number;
+  fullCssReadyMs?: number;
+  cssSource?: 'inline-critical' | 'missing-critical' | 'linked-full' | 'fallback-full' | 'missing';
+  uiCommitMs?: number;
+  coverRemovedMs?: number;
+  firstUsableFrameMs?: number;
+  firstPaintMs?: number;
+  firstContentfulPaintMs?: number;
+  loadMs?: number;
+  hostBootstrapStartMs?: number;
+  hostBridgeReadyMs?: number;
+  connectionSettingsReadyMs?: number;
+  serverConnectedMs?: number;
+  workspacePreloadReadyMs?: number;
+};
 
-root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+declare global {
+  interface Window {
+    __LEMONADE_DOCUMENT_START_MS__?: number;
+    __LEMONADE_STARTUP_METRICS__?: StartupMetrics;
+  }
+}
+
+const startup: StartupMetrics = {
+  documentStartMs: window.__LEMONADE_DOCUMENT_START_MS__,
+  entryMs: performance.now(),
+};
+window.__LEMONADE_STARTUP_METRICS__ = startup;
+
+function collectPaintEntries(): void {
+  for (const entry of performance.getEntriesByType('paint')) {
+    if (entry.name === 'first-paint') startup.firstPaintMs = entry.startTime;
+    if (entry.name === 'first-contentful-paint') startup.firstContentfulPaintMs = entry.startTime;
+  }
+}
+
+if (typeof PerformanceObserver !== 'undefined') {
+  try {
+    const observer = new PerformanceObserver(() => collectPaintEntries());
+    observer.observe({ type: 'paint', buffered: true });
+  } catch {
+    // Older embedded webviews may not expose buffered paint observations.
+  }
+}
+
+window.addEventListener('load', () => {
+  startup.loadMs = performance.now();
+  collectPaintEntries();
+}, { once: true });
+
+function cssVariable(name: string): string {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+// The source HTML contains a tiny white boot guard on purpose. Some Lemonade
+// web hosts serve the template directly instead of webpack's generated HTML.
+// That guard prevents a flash of raw, unstyled controls in both cases.
+const criticalStyle = document.getElementById('lemonade-critical-css') as HTMLStyleElement | null;
+const hasInlineCriticalCss = (criticalStyle?.textContent?.length || 0) > 256;
+if (hasInlineCriticalCss) {
+  startup.criticalCssReadyMs = performance.now();
+  startup.cssSource = 'inline-critical';
+} else {
+  startup.cssSource = 'missing-critical';
+}
+
+let fullStyleFallbackPromise: Promise<boolean> | null = null;
+function fullStylesApplied(): boolean {
+  return cssVariable('--lemonade-full-styles-loaded') === '1';
+}
+
+function markLinkedStylesReady(): boolean {
+  if (!fullStylesApplied()) return false;
+  startup.fullCssReadyMs ??= performance.now();
+  startup.cssSource = 'linked-full';
+  return true;
+}
+
+function loadFullStyleFallback(): Promise<boolean> {
+  if (markLinkedStylesReady()) return Promise.resolve(true);
+  if (fullStyleFallbackPromise) return fullStyleFallbackPromise;
+
+  fullStyleFallbackPromise = Promise.all([
+    import(/* webpackChunkName: "app-styles-fallback" */ './styles/tokens.css'),
+    import(/* webpackChunkName: "app-styles-fallback" */ './styles/styles.css'),
+  ]).then(() => {
+    // style-loader injects these rules while the chunk evaluates. The raw CSS
+    // fallback has no emitted app.css sentinel, so reaching this point is the
+    // readiness signal for the direct-template host path.
+    startup.fullCssReadyMs = performance.now();
+    startup.cssSource = 'fallback-full';
+    return true;
+  }).catch((error) => {
+    startup.cssSource = 'missing';
+    console.error('Failed to load Lemonade full application styles', error);
+    return false;
+  });
+
+  return fullStyleFallbackPromise;
+}
+
+let fullStyleLinkFailed = false;
+const fullStyleLink = document.getElementById('lemonade-app-css') as HTMLLinkElement | null;
+if (fullStyleLink) {
+  fullStyleLink.addEventListener('load', () => {
+    requestAnimationFrame(() => { markLinkedStylesReady(); });
+  });
+  fullStyleLink.addEventListener('error', () => {
+    fullStyleLinkFailed = true;
+    // If the host served the raw source template there is no embedded critical
+    // CSS and app.css may also be absent. Start recovery immediately while the
+    // white cover is still hiding the React tree.
+    if (!hasInlineCriticalCss) void loadFullStyleFallback();
+  }, { once: true });
+}
+
+// On the raw-template host path, do not wait for React to expose the missing CSS
+// problem. Fetch/inject full styles in parallel with the initial React render.
+const stylesReadyForFirstReveal: Promise<boolean> = hasInlineCriticalCss
+  ? Promise.resolve(true)
+  : loadFullStyleFallback();
+
+function revealApplication(): void {
+  if (document.documentElement.classList.contains('lemonade-startup-revealed')) return;
+  document.documentElement.classList.add('lemonade-startup-revealed');
+  startup.coverRemovedMs = performance.now();
+}
+
+function watchFirstUsableFrame(rootElement: HTMLElement): void {
+  let frame1 = 0;
+  let frame2 = 0;
+  let recoveryTimer = 0;
+  let scheduled = false;
+  let finished = false;
+
+  const finish = () => {
+    if (finished || scheduled) return;
+    const explicitReady = rootElement.querySelector<HTMLElement>('[data-startup-ready]');
+    const activeSlot = rootElement.querySelector<HTMLElement>('.view-slot:not([hidden])');
+    const lazyViewReady = activeSlot && !activeSlot.querySelector('.view-loading');
+    if (!explicitReady && !lazyViewReady) return;
+
+    scheduled = true;
+    startup.uiCommitMs = performance.now();
+
+    void stylesReadyForFirstReveal.then((stylesReady) => {
+      // Never expose raw browser-default controls. If both app.css and the JS
+      // fallback fail, keep the neutral white cover and surface the error only
+      // in the console instead of flashing a broken-looking application.
+      if (!stylesReady) {
+        console.error('Lemonade UI kept behind startup cover because styles are unavailable.');
+        return;
+      }
+
+      frame1 = requestAnimationFrame(() => {
+        revealApplication();
+        frame2 = requestAnimationFrame(() => {
+          finished = true;
+          startup.firstUsableFrameMs = performance.now();
+          collectPaintEntries();
+          observer.disconnect();
+          console.info('[startup] Lemonade first usable frame', { ...startup });
+          window.dispatchEvent(new Event('lemonade:first-usable'));
+
+          // Critical CSS is enough for the default screen, but the rest of the
+          // application still needs full styles before the user visits another
+          // workspace. Recover after reveal without blocking the first frame.
+          if (hasInlineCriticalCss) {
+            recoveryTimer = window.setTimeout(() => {
+              if (!markLinkedStylesReady()) void loadFullStyleFallback();
+            }, fullStyleLinkFailed ? 0 : 120);
+          }
+        });
+      });
+    });
+  };
+
+  const observer = new MutationObserver(finish);
+  observer.observe(rootElement, { childList: true, subtree: true });
+  finish();
+
+  window.addEventListener('pagehide', () => {
+    observer.disconnect();
+    if (frame1) cancelAnimationFrame(frame1);
+    if (frame2) cancelAnimationFrame(frame2);
+    if (recoveryTimer) window.clearTimeout(recoveryTimer);
+  }, { once: true });
+}
+
+const rootElement = document.getElementById('root') as HTMLElement;
+const root = ReactDOM.createRoot(rootElement);
+watchFirstUsableFrame(rootElement);
+
+// React can render behind the white cover while CSS and JS finish their critical
+// work. The cover is removed only after both the active view and usable styles
+// are ready, eliminating FOUC without serializing React behind CSS loading.
+root.render(<App />);

--- a/src/app/src/interactionPreload.tsx
+++ b/src/app/src/interactionPreload.tsx
@@ -1,0 +1,126 @@
+import React, { lazy } from 'react';
+
+type PreloadableComponent<P extends object> = {
+  Component: React.ComponentType<P>;
+  preload: () => Promise<void>;
+};
+
+function createPreloadableComponent<P extends object, M>(
+  loader: () => Promise<M>,
+  select: (module: M) => React.ComponentType<P>,
+): PreloadableComponent<P> {
+  let resolved: React.ComponentType<P> | null = null;
+  let modulePromise: Promise<{ default: React.ComponentType<P> }> | null = null;
+
+  const load = () => {
+    if (!modulePromise) {
+      modulePromise = loader().then(module => {
+        resolved = select(module);
+        return { default: resolved };
+      });
+    }
+    return modulePromise;
+  };
+
+  const LazyComponent = lazy(load);
+  const Component: React.FC<P> = props => resolved
+    ? React.createElement(resolved, props)
+    : React.createElement(LazyComponent, props);
+
+  return {
+    Component,
+    preload: () => load().then(() => undefined),
+  };
+}
+
+type ModelDetailProps = React.ComponentProps<typeof import('./components/ModelDetailPanel')['ModelDetailPanel']>;
+type RouterEditorProps = React.ComponentProps<typeof import('./components/RouterEditorPanel')['default']>;
+type GlobalModelSettingsProps = React.ComponentProps<typeof import('./components/GlobalModelSettingsPanel')['default']>;
+type InspectViewProps = React.ComponentProps<typeof import('./components/InspectView')['default']>;
+type LogViewerProps = React.ComponentProps<typeof import('./components/LogViewer')['default']>;
+
+const modelDetail = createPreloadableComponent<ModelDetailProps, typeof import('./components/ModelDetailPanel')>(
+  () => import(/* webpackChunkName: "models-detail" */ './components/ModelDetailPanel'),
+  module => module.ModelDetailPanel,
+);
+const routerEditor = createPreloadableComponent<RouterEditorProps, typeof import('./components/RouterEditorPanel')>(
+  () => import(/* webpackChunkName: "models-router-editor" */ './components/RouterEditorPanel'),
+  module => module.default,
+);
+const globalModelSettings = createPreloadableComponent<GlobalModelSettingsProps, typeof import('./components/GlobalModelSettingsPanel')>(
+  () => import(/* webpackChunkName: "models-global-settings" */ './components/GlobalModelSettingsPanel'),
+  module => module.default,
+);
+const inspectView = createPreloadableComponent<InspectViewProps, typeof import('./components/InspectView')>(
+  () => import(/* webpackChunkName: "monitor-telemetry" */ './components/InspectView'),
+  module => module.default,
+);
+const logViewer = createPreloadableComponent<LogViewerProps, typeof import('./components/LogViewer')>(
+  () => import(/* webpackChunkName: "monitor-logs" */ './components/LogViewer'),
+  module => module.default,
+);
+
+export const ModelDetailPanelPreloaded = modelDetail.Component;
+export const RouterEditorPanelPreloaded = routerEditor.Component;
+export const GlobalModelSettingsPanelPreloaded = globalModelSettings.Component;
+export const InspectViewPreloaded = inspectView.Component;
+export const LogViewerPreloaded = logViewer.Component;
+
+export async function preloadModelManagerSecondarySurfaces(): Promise<void> {
+  // Details is the first action inside Models; give it the request/evaluation
+  // slot before lower-frequency editors.
+  await modelDetail.preload();
+  await Promise.all([routerEditor.preload(), globalModelSettings.preload()]);
+}
+
+export async function preloadMonitorSecondarySurfaces(): Promise<void> {
+  // Telemetry is the common first action inside Monitor; Logs follows.
+  await inspectView.preload();
+  await logViewer.preload();
+}
+
+let primaryInteractionPreloadPromise: Promise<void> | null = null;
+let deferredInteractionPreloadPromise: Promise<void> | null = null;
+
+function reportPreloadFailures(label: string, results: PromiseSettledResult<void>[]): void {
+  const failed = results.filter(result => result.status === 'rejected');
+  if (failed.length) console.debug(`Failed to warm ${failed.length} ${label} surface(s)`);
+}
+
+/**
+ * Warm the two surfaces that were still noticeable on a first interaction.
+ * This is deliberately started only after the first usable frame by App.tsx,
+ * so it can never hold the startup cover or compete with critical JS.
+ */
+export function preloadPrimaryInteractionSurfaces(): Promise<void> {
+  if (!primaryInteractionPreloadPromise) {
+    primaryInteractionPreloadPromise = Promise.allSettled([
+      modelDetail.preload(),
+      inspectView.preload(),
+    ]).then(results => reportPreloadFailures('primary interaction', results));
+  }
+  return primaryInteractionPreloadPromise;
+}
+
+/** Warm lower-frequency secondary surfaces after the two primary ones. */
+export function preloadDeferredInteractionSurfaces(): Promise<void> {
+  if (!deferredInteractionPreloadPromise) {
+    deferredInteractionPreloadPromise = Promise.allSettled([
+      routerEditor.preload(),
+      globalModelSettings.preload(),
+      logViewer.preload(),
+    ]).then(results => reportPreloadFailures('deferred interaction', results));
+  }
+  return deferredInteractionPreloadPromise;
+}
+
+/**
+ * Start interaction warming in UX priority order. The returned promise covers
+ * only Model Details + Monitor Telemetry; lower-frequency surfaces continue in
+ * the background and never delay broad workspace warming.
+ */
+export function preloadInteractionSurfaces(): Promise<void> {
+  const primary = preloadPrimaryInteractionSurfaces();
+  void primary.finally(() => { void preloadDeferredInteractionSurfaces(); });
+  return primary;
+}

--- a/src/app/src/startupScheduler.ts
+++ b/src/app/src/startupScheduler.ts
@@ -1,0 +1,38 @@
+/**
+ * Run non-critical renderer work only after the browser has had a chance to
+ * paint the startup UI.  requestIdleCallback keeps parsing/hydration work out
+ * of the first-input window; the timeout guarantees progress on busy pages and
+ * on engines that throttle idle callbacks.
+ */
+export function scheduleIdleWork(task: () => void, timeout = 1000): () => void {
+  let cancelled = false;
+  let rafId = 0;
+  let timerId = 0;
+  let idleId: number | null = null;
+
+  const run = () => {
+    if (!cancelled) task();
+  };
+
+  rafId = window.requestAnimationFrame(() => {
+    const requestIdle = (window as typeof window & {
+      requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number;
+    }).requestIdleCallback;
+
+    if (typeof requestIdle === 'function') {
+      idleId = requestIdle.call(window, run, { timeout });
+    } else {
+      timerId = window.setTimeout(run, Math.min(timeout, 250));
+    }
+  });
+
+  return () => {
+    cancelled = true;
+    if (rafId) window.cancelAnimationFrame(rafId);
+    if (timerId) window.clearTimeout(timerId);
+    if (idleId !== null) {
+      const cancelIdle = (window as typeof window & { cancelIdleCallback?: (id: number) => void }).cancelIdleCallback;
+      if (cancelIdle) cancelIdle.call(window, idleId);
+    }
+  };
+}

--- a/src/app/src/styles/critical.generated.css
+++ b/src/app/src/styles/critical.generated.css
@@ -1,0 +1,3435 @@
+/* Lemonade GUI design tokens. DESIGN.md defines the roles and usage rules. */
+
+:root {
+  /* ---------- Color roles (dark / Midnight Palette) ---------- */
+  --surface-base:   #0E0E0B;
+  --surface-1:      #1A1813;
+  --surface-2:      #1F1D17;
+  --surface-3:      #25221B;
+  --surface-raised: #2D2922;
+  --surface-glass:  rgba(45, 41, 33, 0.72);
+  --surface-overlay: rgba(14, 14, 11, 0.72);
+  --surface-titlebar: var(--surface-1);
+  --surface-alpha-1: rgba(255, 255, 255, 0.10);
+  --surface-alpha-05: rgba(255, 255, 255, 0.05);
+  --surface-alpha-02: rgba(255, 255, 255, 0.02);
+
+  --text-primary:   #F2EFE5;
+  --text-secondary: #C7C2B5;
+  --text-tertiary:  #A8A39A;
+  --text-disabled:  #7A776E;
+  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23A8A39A' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+
+  --accent:         #FCD846;
+  --accent-hover:   #FAF972;
+  --accent-deep:    #5C4B00;
+  --accent-fg:      var(--accent);
+  --accent-soft:    rgba(252, 216, 70, 0.14);
+  --accent-strong:  rgba(252, 216, 70, 0.24);
+  --accent-surface: var(--accent-soft);
+  --accent-border:  color-mix(in srgb, var(--accent) 28%, transparent);
+  --accent-on:      #000000;
+  --accent-focus:   var(--accent);
+
+  --success:        #78A86B;
+  --success-soft:   rgba(120, 168, 107, 0.15);
+  --warn:           #F2B94F;
+  --warn-soft:      rgba(242, 185, 79, 0.15);
+  --danger:         #EF8D7F;
+  --danger-soft:    rgba(239, 141, 127, 0.15);
+  --danger-on:      #FFFFFF;
+  --info:           #88BDE9;
+  --info-soft:      rgba(136, 189, 233, 0.15);
+
+  --status-ok:      var(--success);
+  --status-success: var(--success);
+  --status-warning: var(--warn);
+  --status-error:   var(--danger);
+
+  --border:         rgba(255, 255, 255, 0.10);
+  --border-subtle:  rgba(255, 255, 255, 0.07);
+  --border-strong:  rgba(252, 216, 70, 0.18);
+
+  /* ---------- Checkbox ---------- */
+  --checkbox-fill:   var(--surface-3);
+  --checkbox-border: color-mix(in srgb, var(--text-tertiary) 55%, transparent);
+  --checkbox-check:  var(--accent-fg);
+
+  --bg-primary: var(--surface-base);
+  --bg-secondary: var(--surface-1);
+  --surface-0: var(--surface-base);
+  --text-muted: var(--text-tertiary);
+  --error: var(--danger);
+  --primary-yellow: var(--accent);
+  --on-primary: var(--accent-on);
+
+  --warning: var(--warn);
+  --warning-soft: var(--warn-soft);
+
+  /* ---------- Capability, provider, backend, and monitoring identity ---------- */
+  /* Task colors are intentionally theme-invariant across dark and light. */
+  --cap-chat:       #A77C00;
+  --cap-omni:       #8064D8;
+  --cap-router:     #3289D1;
+  --cap-vision:     #B58CFF;
+  --cap-code:       #6AD0A3;
+  --cap-embedding: #665F59;
+  --cap-reranking:  #FF9D6A;
+  --cap-image:      #D8752B;
+  --cap-image-edit: #D8752B;
+  --cap-audio:      #1693A5;
+  --cap-audio-generation: #1693A5;
+  --cap-tts:        #B35A9F;
+  --cap-model3d:   #65758A;
+
+  --provider-hugging-face:    #FF9D00;
+  --provider-hugging-face-fg: #FFB84D;
+  --provider-modelscope:      #4C8DFF;
+  --provider-modelscope-fg:   #7BA9FF;
+
+  --chart-series-1: #E8C66B;
+  --chart-series-2: #7BAED4;
+  --chart-series-3: #7FB38A;
+  --chart-series-4: #B07DF0;
+  --chart-series-5: #E07B7B;
+  --chart-series-6: #7BC8C8;
+  --chart-cache:    #D9A35B;
+
+  /* ---------- Typography ---------- */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI Variable",
+               "Segoe UI", system-ui, "Inter", "Helvetica Neue", sans-serif;
+  --font-mono: "SF Mono", "JetBrains Mono", Menlo, Consolas,
+               "Liberation Mono", monospace;
+
+  --text-xs:   11px;
+  --text-sm:   12.5px;
+  --text-md:   13.5px;
+  --text-base: 14px;
+  --text-lg:   15px;
+  --text-xl:   18px;
+  --text-2xl:  24px;
+  --text-3xl:  32px;
+
+  --type-detail-title-size: clamp(22px, 2vw, 28px);
+  --type-pane-title-size:   20px;
+  --type-panel-title-size:  var(--text-base);
+  --type-body-size:         var(--text-base);
+  --type-supporting-size:   var(--text-xs);
+  --type-caption-size:      var(--text-xs);
+  --type-overline-size:     10px;
+
+  --weight-regular:  400;
+  --weight-normal:   400;
+  --weight-medium:   500;
+  --weight-semibold: 600;
+  --weight-bold:     700;
+
+  --leading-tight:   1.2;
+  --leading-snug:    1.35;
+  --leading-normal:  1.5;
+  --leading-relaxed: 1.65;
+
+  --tracking-tight:  -0.01em;
+  --tracking-caps:   0.08em;
+
+  /* ---------- Space (4px grid) ---------- */
+  --space-0:  0;
+  --space-0-5: 2px;
+  --space-1:  4px;
+  --space-1-5: 6px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  24px;
+  --space-6:  32px;
+  --space-8:  48px;
+  --space-10: 64px;
+  --space-12: 80px;
+
+  /* ---------- Radii ---------- */
+  --radius-sm:   6px;
+  --radius-md:   10px;
+  --radius-lg:   14px;
+  --radius-xl:   20px;
+  --radius-pill: 9999px;
+  --control-radius: var(--radius-md);
+
+  /* ---------- Shadows ---------- */
+  --shadow-sm:
+    0 1px 2px rgba(0, 0, 0, 0.18),
+    0 1px 1px rgba(0, 0, 0, 0.12);
+  --shadow-md:
+    0 4px 12px rgba(0, 0, 0, 0.22),
+    0 2px 4px rgba(0, 0, 0, 0.14);
+  --shadow-soft: var(--shadow-md);
+  --shadow-lg:
+    0 18px 48px rgba(0, 0, 0, 0.42),
+    0 8px 16px rgba(0, 0, 0, 0.20);
+  --shadow-top: 0 -8px 24px rgba(0, 0, 0, 0.24);
+
+  /* ---------- Motion ---------- */
+  --ease-out:    cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+
+  --duration-fast:  150ms;
+  --duration-base:  220ms;
+  --duration-normal: 220ms;
+  --duration-slow:  380ms;
+
+  /* ---------- Layout constants ---------- */
+  --titlebar-height:    52px;
+  --rail-collapsed:     56px;
+  --rail-expanded:      248px;
+  --workspace-rail:     248px;
+  --workspace-list:     304px;
+  --workspace-header:   72px;
+  --rail-toolbar:       48px;
+  --control-height-xs:  28px;
+  --control-height-sm:  32px;
+  --control-height-md:  36px;
+  --control-height-lg:  44px;
+  --control-height:     var(--control-height-md);
+  --icon-button-size:   34px;
+  --composer-min:       96px;
+  --max-content-width:  860px;
+  --content-form-width: 680px;
+  --slide-over-width:   420px;
+  --panel-padding-inline: var(--space-5);
+  --panel-padding-block:  var(--space-4);
+
+  /* ---------- Responsive breakpoints ----------
+   * Note: CSS custom properties cannot be used inside @media queries.
+   * These values are documented here for reference; use the raw px
+   * values in media query expressions.
+   *   @media (max-width: 480px)  → phone
+   *   @media (max-width: 768px)  → tablet (already used throughout)
+   *   @media (max-width: 1024px) → desktop narrow
+   */
+  --breakpoint-mobile:  480px;
+  --breakpoint-tablet:  768px;
+  --breakpoint-desktop: 1024px;
+}
+
+/* ---------- Light theme overrides ---------- */
+[data-theme="light"] {
+  --surface-base:   #fdfbf6;
+  --surface-1:      #fdfbf6;
+  --surface-2:      #f5f2ec;
+  --surface-3:      #fdfbf6;
+  --surface-raised: #fdfbf6;
+  --surface-glass:  #fdfbf6;
+  --surface-overlay: rgba(45, 47, 47, 0.32);
+  --surface-titlebar: #efebe1;
+
+  --surface-alpha-1: rgba(0, 0, 0, 0.1);
+  --surface-alpha-05: rgba(0, 0, 0, 0.05);
+  --surface-alpha-02: rgba(0, 0, 0, 0.02);
+
+  --text-primary:   #000000;
+  --text-secondary: #2D2F2F;
+  --text-tertiary:  #52525B;
+  --text-disabled:  #767676;
+  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2352525B' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+
+  --accent:         rgba(252, 216, 70, 0.58);
+  --accent-hover:   rgba(252, 216, 70, 0.58);
+  --accent-deep:    #5C4B00;
+  --accent-fg:      var(--accent-deep);
+  --accent-soft:    rgba(252, 216, 70, 0.18);
+  --accent-strong:  rgba(252, 216, 70, 0.58);
+  --accent-on:      #000000;
+
+  --success:        #4CAF50;
+  --success-soft:   rgba(60, 101, 49, 0.10);
+  --warn:           #ffb74d;
+  --warn-soft:      rgba(252, 216, 70, 0.20);
+  --danger:         #f44336;
+  --danger-soft:    rgba(185, 74, 61, 0.10);
+  --info:           #2196F3;
+  --info-soft:      rgba(48, 110, 168, 0.10);
+
+  --border:         rgba(0, 0, 0, 0.16);
+  --border-subtle:  rgba(92, 75, 0, 0.18);
+  --border-strong:  rgba(92, 75, 0, 0.18);
+
+  --checkbox-fill: color-mix(in srgb, #FCD846 12%, transparent);
+  --checkbox-check: #A98700;
+  /* The dark --accent is opaque; the light one is already 58% alpha, so
+     mixing it again would leave the border barely visible. */
+  --accent-border:  rgba(92, 75, 0, 0.32);
+
+  /* ---------- Non-task identity and monitoring colors, darkened for the light canvas ----------
+   * The dark-theme values are tuned against #16140F and land between 1.5:1 and
+   * 2.9:1 on #fdfbf6. These preserve each hue while clearing the 3:1 floor WCAG
+   * 1.4.11 sets for non-text UI components (glyphs, marks, chart series). */
+  --cap-vision:     #A16DFF;
+  --cap-code:       #2C9E6C;
+  --cap-reranking:  #F95500;
+  --cap-image-edit: #CE752B;
+
+  --provider-hugging-face-fg: #C77800;
+  --provider-modelscope-fg:   #4888FF;
+
+  --backend-llamacpp:          #A98700;
+  --backend-vllm:              #308BFC;
+  --backend-flm:               #1E9D6E;
+  --backend-ryzenai:           #E96103;
+  --backend-sd-cpp:            #B164FD;
+  --backend-whispercpp:        #0093D4;
+  --backend-moonshine:         #089BB1;
+  --backend-kokoro:            #F44AA3;
+  --backend-acestep:           #FD4661;
+  --backend-thinksound:        #C47D04;
+  --backend-trellis:           #727EF8;
+  --backend-collection-omni:   #9876FA;
+  --backend-collection-router: #089BB1;
+  --backend-collection:        #7B8EA8;
+
+  --chart-series-1: #B28612;
+  --chart-series-2: #4A92C8;
+  --chart-series-3: #5A9B68;
+  --chart-series-4: #A86FEF;
+  --chart-series-5: #DD6A6A;
+  --chart-series-6: #3A9999;
+  --chart-cache:    #C07F27;
+
+  --shadow-sm:
+    0 1px 2px rgba(0, 0, 0, 0.06),
+    0 1px 1px rgba(0, 0, 0, 0.04);
+  --shadow-md:
+    0 4px 12px rgba(0, 0, 0, 0.08),
+    0 2px 4px rgba(0, 0, 0, 0.05);
+  --shadow-soft: var(--shadow-md);
+  --shadow-lg:
+    0 18px 48px rgba(0, 0, 0, 0.12),
+    0 8px 16px rgba(0, 0, 0, 0.06);
+  --shadow-top: 0 -8px 24px rgba(0, 0, 0, 0.10);
+}
+
+*, *::before, *::after { box-sizing: border-box; }html, body, #root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  background: var(--surface-base);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}button {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  
+  outline: 0;
+}input, textarea {
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: 0;
+}input[type="checkbox"] {
+  -webkit-appearance: none;
+  appearance: none;
+  display: inline-grid;
+  place-content: center;
+  width: 16px;
+  height: 16px;
+  min-width: 16px;
+  flex: 0 0 16px;
+  margin: 0;
+  border: 1px solid var(--checkbox-border);
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  transition:
+    background-color var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out);
+}input[type="checkbox"]::after {
+  content: "";
+  width: 4px;
+  height: 8px;
+  border: solid var(--checkbox-check);
+  border-width: 0 2px 2px 0;
+  transform: translateY(-1px) rotate(45deg) scale(0);
+  transform-origin: center;
+  transition: transform var(--duration-fast) var(--ease-out);
+}input[type="checkbox"]:checked {
+  background: var(--checkbox-fill);
+}[data-theme="light"] input[type="checkbox"]:checked {
+  border-color: #A98700;
+}input[type="checkbox"]:checked::after {
+  transform: translateY(-1px) rotate(45deg) scale(1);
+}input[type="checkbox"]:not(:disabled):hover {
+  border-color: var(--text-tertiary);
+}input[type="checkbox"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: 2px;
+}.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}::-webkit-scrollbar { width: 10px; height: 10px; }::-webkit-scrollbar-track { background: transparent; }::-webkit-scrollbar-thumb {
+  background: var(--surface-3);
+  border-radius: var(--radius-pill);
+  border: 2px solid var(--surface-base);
+}::-webkit-scrollbar-thumb:hover { background: var(--text-tertiary); }.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--accent);
+  color: var(--accent-on);
+  padding: var(--space-2) var(--space-4);
+  z-index: 9999;
+  border-radius: var(--radius-sm);
+  font-weight: var(--weight-semibold);
+  font-size: var(--text-sm);
+  text-decoration: none;
+}.skip-link:focus { top: var(--space-2); }.app {
+  display: grid;
+  grid-template-rows: var(--titlebar-height) 1fr;
+  height: 100vh;
+  width: 100%;
+  max-width: 100vw;
+  overflow: hidden;
+  background: var(--surface-base);
+}.view-slot { display: contents; }.view-slot[hidden] { display: none; }.view-error {
+  padding: var(--space-6);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+}.view-error h2 {
+  margin: 0 0 var(--space-4);
+  color: var(--danger);
+  font-family: var(--font-sans);
+  font-size: var(--type-pane-title-size);
+}.view-error pre {
+  color: var(--text-secondary);
+  font-size: var(--text-md);
+  white-space: pre-wrap;
+}.view-error .workspace-action-button { margin-top: var(--space-4); }.titlebar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  column-gap: var(--space-2);
+  padding: 0 var(--space-3);
+  background: var(--surface-1);
+  border-bottom: 1px solid var(--border-subtle);
+  position: relative;
+  z-index: 10;
+}.titlebar__brand {
+  grid-column: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}.titlebar__brand-name {
+  text-transform: capitalize;
+}.titlebar__brand-logo {
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  flex: 0 0 auto;
+  color: #F2EFE5;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  text-transform: none;
+}.titlebar__brand-icon {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  background: url("../../assets/logo.svg") center / contain no-repeat;
+}[data-theme="light"] .titlebar__brand-logo {
+  color: #18181B;
+}.titlebar__search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 176px;
+  height: 32px;
+  padding: 0;
+  color: var(--text-tertiary);
+  transition: width var(--duration-base) var(--ease-out),
+              color var(--duration-fast) var(--ease-out);
+}.titlebar__search:focus-within {
+  width: 208px;
+  color: var(--text-secondary);
+}.titlebar__search-leading-icon {
+  flex: 0 0 auto;
+}.titlebar__search-toggle {
+  width: 32px;
+  height: 32px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}.titlebar__search-toggle:hover {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.titlebar__search-popover {
+  min-width: 0;
+  display: flex;
+  position: relative;
+  flex: 1;
+}.titlebar__search-entry {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  gap: var(--space-1);
+  height: 28px;
+  border-bottom: 1px solid color-mix(in srgb, var(--text-tertiary) 36%, transparent);
+  transition: border-color var(--duration-fast) var(--ease-out),
+              box-shadow var(--duration-fast) var(--ease-out);
+}.titlebar__search:focus-within .titlebar__search-entry {
+  border-bottom-color: color-mix(in srgb, var(--text-tertiary) 36%, transparent);
+  box-shadow: none;
+}.titlebar__search input {
+  min-width: 0;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: var(--text-sm);
+}.titlebar__search input::placeholder {
+  color: var(--text-tertiary);
+}.titlebar__search kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 2px;
+  border: 0;
+  color: var(--text-tertiary);
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: var(--weight-medium);
+  white-space: nowrap;
+}.titlebar__search-results {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + var(--space-2));
+  left: 0;
+  width: 100%;
+  overflow: hidden;
+  padding: var(--space-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-lg);
+}.titlebar__search-results button {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: var(--text-sm);
+  text-align: left;
+  cursor: pointer;
+}.titlebar__search-results button > span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}.titlebar__search-results button strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: var(--weight-semibold);
+}.titlebar__search-results button small {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}.titlebar__search-results button:hover,
+.titlebar__search-results button.is-active {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.titlebar__search-results p {
+  margin: 0;
+  padding: var(--space-2);
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+}.titlebar__nav {
+  grid-column: 2;
+  min-width: 0;
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  gap: var(--space-0-5);
+  padding: 3px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--surface-2);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--text-primary) 4%, transparent);
+}.titlebar__nav button {
+  min-width: 72px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  padding: 0 10px;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  border-radius: var(--radius-pill);
+  transition: background var(--duration-fast) var(--ease-out),
+              box-shadow var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out);
+}.titlebar__nav button:hover {
+  background: color-mix(in srgb, var(--surface-3) 68%, transparent);
+  color: var(--text-primary);
+}.titlebar__nav button.is-active {
+  background: var(--surface-3);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 6%, transparent),
+              var(--shadow-sm);
+}.titlebar__right {
+  grid-column: 3;
+  min-width: 0;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}.titlebar__utilities {
+  position: relative;
+}.titlebar__utilities,
+.titlebar__utility-menu {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}.titlebar__utility-menu > .titlebar__search,
+.titlebar__utility-menu > .titlebar__theme-toggle,
+.titlebar__utility-menu > .titlebar__download-toggle {
+  flex: 0 0 auto;
+}.titlebar__utilities-toggle {
+  width: 32px;
+  height: 32px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--surface-1);
+  color: var(--text-secondary);
+}.titlebar__utilities-toggle:hover,
+.titlebar__utilities-toggle[aria-expanded="true"] {
+  border-color: var(--border-strong);
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.titlebar__utility-label { display: none; }.titlebar__utility-status,
+.titlebar__utility-value { display: none; }.titlebar__theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: var(--text-base);
+  transition: background var(--duration-fast) var(--ease-out);
+  line-height: 1;
+}.titlebar__theme-toggle:hover { background: var(--surface-2); }.titlebar__window-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--icon-button-size);
+  height: var(--icon-button-size);
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: background var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out);
+}.titlebar__window-btn:hover {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.titlebar__window-btn--close:hover {
+  background: var(--danger);
+  color: var(--danger-on);
+}.titlebar__status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-disabled);
+  transition: background var(--duration-fast);
+  flex-shrink: 0;
+}.titlebar__status-dot--connected {
+  background: var(--success);
+  box-shadow: 0 0 6px var(--success);
+}.titlebar__status-dot--connecting {
+  background: var(--warn);
+  animation: pulse 1.2s ease-in-out infinite;
+}@keyframes pulse { 50% { opacity: 0.4; } }.view-container {
+  position: relative;
+  overflow: hidden;
+}.chat {
+  display: grid;
+  grid-template-columns: var(--rail-collapsed) 1fr;
+  grid-template-rows: 1fr auto;
+  grid-template-areas:
+    "rail main"
+    "rail composer";
+  height: 100%;
+  transition: grid-template-columns var(--duration-base) var(--ease-out);
+}.chat.rail-expanded {
+  grid-template-columns: var(--rail-expanded) 1fr;
+}.rail {
+  grid-area: rail / rail / composer / rail;
+  background: var(--surface-1);
+  border-right: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}.chat.rail-expanded .rail__title { opacity: 1; }.rail__new-wrap {
+  padding: var(--space-2) var(--space-3) var(--space-1);
+}.rail__new {
+  width: 100%;
+}.chat:not(.rail-expanded) .rail__new {
+  width: var(--icon-button-size);
+}.chat:not(.rail-expanded) .rail__new .workspace-action-button__label { display: none; }.rail__list {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-2);
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-0-5);
+  opacity: 0;
+  transition: opacity var(--duration-base) var(--ease-out);
+}.chat.rail-expanded .rail__list { opacity: 1; }.rail__item {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-0-5);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out);
+}.rail__item:hover { background: var(--surface-2); }.rail__item.is-active {
+  background: var(--accent-soft);
+}.rail__item.is-active::before {
+  content: "";
+  position: absolute;
+  left: -2px;
+  top: 6px;
+  bottom: 6px;
+  width: 3px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+}.rail__item-title {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}.rail__item-meta {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}.rail__model-badge {
+  font-size: var(--type-overline-size);
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-3);
+  color: var(--text-secondary);
+}.rail__streaming-badge {
+  font-size: var(--type-overline-size);
+  letter-spacing: var(--tracking-caps);
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  color: var(--accent-fg);
+  animation: rail-pulse 1.5s ease-in-out infinite;
+}@keyframes rail-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}.rail__item-delete {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: var(--text-base);
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-out), background var(--duration-fast) var(--ease-out);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}.rail__item:hover .rail__item-delete { opacity: 1; }.rail__item:focus-within .rail__item-delete { opacity: 1; }.rail__item-delete:hover { background: var(--surface-3); color: var(--danger); }.rail__empty {
+  padding: var(--space-4) var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-align: center;
+}.chat__main {
+  grid-area: main;
+  overflow-y: auto;
+  position: relative;
+}.chat__inner {
+  max-width: var(--max-content-width);
+  margin: 0 auto;
+  padding: var(--space-8) var(--space-6);
+}.hero {
+  padding: var(--space-12) 0 var(--space-8);
+  text-align: center;
+}.hero__title {
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+  margin: 0 0 var(--space-3);
+  color: var(--text-primary);
+}.hero__subtitle {
+  font-size: var(--text-lg);
+  color: var(--text-tertiary);
+  margin: 0 auto;
+  max-width: 520px;
+}.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: center;
+  margin-top: var(--space-6);
+}.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 10px var(--space-4);
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out),
+              transform var(--duration-fast) var(--ease-out);
+}.chip:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}.chip:active { transform: scale(0.97); }.chip__icon { font-size: var(--text-base); line-height: 1; }.section-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-10) 0 var(--space-3);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}.section-label__rule {
+  flex: 1;
+  height: 1px;
+  background: var(--border-subtle);
+}.active-models {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--space-3);
+}.active-card {
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 190px;
+  transition: border-color var(--duration-fast) var(--ease-out),
+              box-shadow var(--duration-fast) var(--ease-out),
+              transform var(--duration-fast) var(--ease-out);
+}.active-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: 0 10px 30px color-mix(in srgb, #000 24%, transparent);
+  transform: translateY(-1px);
+}.active-card__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+}.active-card__head > div:first-child {
+  min-width: 0;
+}.active-card__name {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+  line-height: 1.35;
+  text-align: left;
+  overflow-wrap: anywhere;
+  cursor: pointer;
+}.active-card__name:hover,
+.active-card__name:focus-visible {
+  color: var(--accent-fg);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}.active-card__meta {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  line-height: 1.35;
+  margin-top: var(--space-1);
+  overflow-wrap: anywhere;
+}.active-card__device {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  font-size: var(--type-overline-size);
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-3);
+  color: var(--text-secondary);
+}.active-card__badges {
+  display: flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}.active-card__actions {
+  display: flex;
+  align-items: center;
+  min-height: 28px;
+}.active-card__action {
+  align-self: flex-start;
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--accent-fg);
+  padding: 6px var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--accent-fg) 25%, transparent);
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  transition: background var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out),
+              transform var(--duration-fast) var(--ease-out);
+}.active-card__action:hover {
+  background: var(--accent-strong);
+  border-color: color-mix(in srgb, var(--accent-fg) 45%, transparent);
+  transform: translateY(-1px);
+}.active-card__details {
+  padding: 5px var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--surface-1);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out);
+}.active-card__details:hover,
+.active-card__details:focus-visible {
+  color: var(--accent-fg);
+  border-color: color-mix(in srgb, var(--accent-fg) 35%, var(--border-subtle));
+  background: color-mix(in srgb, var(--accent) 8%, var(--surface-1));
+}.active-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-top: auto;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}.active-card__eject {
+  padding: 5px var(--space-2);
+  border: 1px solid color-mix(in srgb, var(--danger) 24%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--danger) 7%, transparent);
+  color: var(--danger);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out);
+}.active-card__eject:hover,
+.active-card__eject:focus-visible {
+  border-color: color-mix(in srgb, var(--danger) 42%, transparent);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+}.active-card__eject:disabled {
+  cursor: progress;
+  opacity: 0.7;
+  text-decoration: none;
+}.active-card__status {
+  align-self: flex-start;
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--success);
+  padding: 6px var(--space-3);
+  border-radius: var(--radius-pill);
+  background: var(--success-soft);
+}.cap-badge {
+  font-size: var(--type-overline-size);
+  letter-spacing: 0.04em;
+  font-weight: var(--weight-semibold);
+  padding: 2px 7px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-3);
+  color: var(--text-secondary);
+  text-transform: none;
+}.cap-badge--chat   { background: color-mix(in srgb, var(--cap-chat) 18%, transparent); color: var(--cap-chat); }.cap-badge--router { background: color-mix(in srgb, var(--cap-router) 18%, transparent); color: var(--cap-router); }.cap-badge--vision { background: color-mix(in srgb, var(--cap-vision) 18%, transparent); color: var(--cap-vision); }.cap-badge--code   { background: color-mix(in srgb, var(--cap-code) 18%, transparent); color: var(--cap-code); }.cap-badge--embed  { background: color-mix(in srgb, var(--cap-embedding) 18%, transparent); color: var(--cap-embedding); }.cap-badge--rerank { background: color-mix(in srgb, var(--cap-reranking) 18%, transparent); color: var(--cap-reranking); }.cap-badge--audio  { background: color-mix(in srgb, var(--cap-audio) 18%, transparent); color: var(--cap-audio); }.cap-badge--tts    { background: color-mix(in srgb, var(--cap-tts) 18%, transparent); color: var(--cap-tts); }.cap-badge--image  { background: color-mix(in srgb, var(--cap-image) 18%, transparent); color: var(--cap-image); }.thread {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding: var(--space-6) 0;
+}.message {
+  display: flex;
+  gap: var(--space-3);
+  animation: msgIn var(--duration-slow) var(--ease-out);
+}@keyframes msgIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}.message__avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-caps);
+}.message--user .message__avatar {
+  background: var(--surface-3);
+  color: var(--text-secondary);
+}.message--assistant .message__avatar {
+  background: var(--accent-soft);
+  color: var(--accent-fg);
+}.message__body { flex: 1; min-width: 0; }.message__author {
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  font-weight: var(--weight-semibold);
+  color: var(--text-tertiary);
+  margin-bottom: var(--space-2);
+}.message__content {
+  font-size: var(--text-lg);
+  line-height: var(--leading-relaxed);
+  color: var(--text-primary);
+}.message__content p { margin: 0 0 var(--space-3); }.message__content p:last-child { margin-bottom: 0; }.message__content pre {
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}.message__content pre code {
+  font-family: var(--font-mono);
+  background: none;
+  padding: 0;
+  border-radius: 0;
+}.message__content code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  padding: 0.15em 0.4em;
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+}.message__content ul, .message__content ol {
+  margin: var(--space-2) 0;
+  padding-left: var(--space-5);
+}.message__content li { margin-bottom: var(--space-1); }.message__content blockquote {
+  margin: var(--space-3) 0;
+  padding: var(--space-2) var(--space-4);
+  border-left: 3px solid var(--accent);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}.message__content table {
+  border-collapse: collapse;
+  margin: var(--space-3) 0;
+  font-size: var(--text-sm);
+  max-width: 100%;
+  display: block;
+  overflow-x: auto;
+}.message__content th, .message__content td {
+  border: 1px solid var(--border);
+  padding: var(--space-2) var(--space-3);
+}.message__content th {
+  background: var(--surface-raised);
+  font-weight: var(--weight-semibold);
+}.message__content a {
+  color: var(--accent-fg);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}.message__metrics {
+  margin-top: var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+  display: flex;
+  gap: var(--space-3);
+}.message__live-stats {
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--accent-fg);
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+  display: flex;
+  gap: var(--space-3);
+  opacity: 0.8;
+}.message__thinking {
+  margin-bottom: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  font-size: var(--text-sm);
+}.message__thinking summary {
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  background: var(--surface-raised);
+  user-select: none;
+}.message__thinking summary::marker { color: var(--text-tertiary); }.message__thinking[open] summary { border-bottom: 1px solid var(--border); }.message__thinking-content {
+  padding: var(--space-2) var(--space-3);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: 1.35;
+  max-height: 240px;
+  overflow-y: auto;
+  white-space: normal;
+  background: var(--surface-raised);
+  opacity: 0.9;
+}.message__thinking-content .message__content {
+  font-size: inherit;
+  line-height: 1.35;
+  color: inherit;
+}.message__thinking-content .message__content p { margin: 0 0 6px; }.message__thinking-content .message__content p:last-child { margin-bottom: 0; }.message__thinking-content .message__content ul,
+.message__thinking-content .message__content ol {
+  margin: 4px 0;
+  padding-left: 18px;
+}.message__thinking-content .message__content li { margin: 0 0 4px; }.message__thinking-content .message__content li:last-child { margin-bottom: 0; }.message__thinking-content .message__content li > p { margin: 0 0 4px; }.message__thinking-content .message__content li > p:last-child { margin-bottom: 0; }.message__thinking-content .message__content pre,
+.message__thinking-content .code-block {
+  margin: 6px 0;
+}.message__thinking-content .message__content blockquote {
+  margin: 6px 0;
+  padding: 6px 10px;
+}.message__tool-calls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-2);
+}.message__tool-call {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+  font-size: var(--text-xs);
+  overflow: hidden;
+}.message__tool-call summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 6px var(--space-3);
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+  color: var(--text-secondary);
+  transition: background var(--duration-fast) var(--ease-out);
+}.message__tool-call summary::-webkit-details-marker { display: none; }.message__tool-call summary::marker { display: none; content: ""; }.message__tool-call summary:hover {
+  background: var(--surface-2);
+}.message__tool-call--running summary {
+  color: var(--accent-fg);
+}.message__tool-call--error summary {
+  color: var(--status-error);
+}.message__tool-call-icon {
+  font-size: 12px;
+  flex-shrink: 0;
+}.message__tool-call-name {
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}.message__tool-call-args {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}.message__tool-call-result {
+  padding: 6px var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--surface-raised);
+}.code-block__copy.copied { color: var(--success); }.streaming-cursor {
+  vertical-align: text-bottom;
+  display: inline-block;
+  width: 8px;
+  height: 15px;
+  background: var(--accent);
+  margin-left: 2px;
+  animation: blink-cursor 0.8s infinite;
+}.composer {
+  grid-area: composer;
+  padding: var(--space-3) var(--space-6) var(--space-4);
+  background: var(--surface-base);
+  position: relative;
+}.composer__model-picker {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}.composer__toolbar {
+  max-width: var(--max-content-width);
+  margin: 0 auto var(--space-2);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}.composer__tools-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  gap: 5px;
+  min-height: 30px;
+  font-size: var(--text-xs);
+  font-family: var(--font-sans);
+  font-weight: var(--weight-medium);
+  line-height: 1;
+  color: var(--text-tertiary);
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  padding: 4px var(--space-3);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+  white-space: nowrap;
+}.composer__tools-toggle:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}.composer__tools-toggle--active {
+  color: var(--accent-fg);
+  border-color: var(--accent-fg);
+  background: color-mix(in srgb, var(--accent) 10%, var(--surface-1));
+}.composer__mcp-menu {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + var(--space-2));
+  z-index: var(--z-dropdown);
+  width: min(420px, calc(100vw - 32px));
+  max-height: min(520px, calc(100vh - 180px));
+  overflow: auto;
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-lg);
+}.composer__mcp-modal {
+  position: fixed;
+  z-index: 1000;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: var(--space-4);
+  background: color-mix(in srgb, #000 54%, transparent);
+}.composer__mcp-menu--modal {
+  position: relative;
+  left: auto;
+  bottom: auto;
+  width: min(620px, 100%);
+  max-height: min(720px, calc(100vh - 2 * var(--space-4)));
+  box-shadow: var(--shadow-lg);
+}.composer__mcp-back {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin: 0 0 var(--space-2);
+  padding: 4px var(--space-1);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: var(--text-sm);
+  cursor: pointer;
+}.composer__mcp-back:hover {
+  color: var(--text-primary);
+  background: var(--surface-2);
+}.composer__mcp-header,
+.composer__mcp-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}.composer__mcp-tabs {
+  display: flex;
+  gap: var(--space-1);
+  margin-top: var(--space-3);
+  padding: var(--space-1);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+}.composer__mcp-tab {
+  flex: 1;
+  padding: var(--space-2);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+}.composer__mcp-tab:hover {
+  color: var(--text-primary);
+}.composer__mcp-tab.is-active {
+  background: var(--surface-raised);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
+}.composer__mcp-tab:focus-visible {
+  outline: 2px solid var(--accent-fg);
+  outline-offset: 1px;
+}.composer__mcp-footer {
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}.composer__mcp-master,
+.composer__mcp-server-row,
+.composer__mcp-tool {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+}.composer__mcp-master {
+  flex: 1;
+}.composer__mcp-master span,
+.composer__mcp-server-text,
+.composer__mcp-tool span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}.composer__mcp-master strong,
+.composer__mcp-server-text strong,
+.composer__mcp-tool strong {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}.composer__mcp-master small,
+.composer__mcp-server-text small,
+.composer__mcp-tool small {
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}.composer__mcp-servers {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}.composer__mcp-server {
+  padding: var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+}.composer__mcp-server.is-selected {
+  border-color: color-mix(in srgb, var(--accent-fg) 45%, var(--border-subtle));
+}.composer__mcp-status {
+  width: 8px;
+  height: 8px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex: 0 0 auto;
+}.composer__mcp-status.is-connected {
+  background: var(--success);
+}.composer__mcp-tools {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  padding-left: 24px;
+}.composer__mcp-tool {
+  min-width: 0;
+  padding: 6px var(--space-2);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+}.composer__mcp-tool strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}.composer__mcp-empty,
+.composer__mcp-error {
+  margin: var(--space-3) 0 0;
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}.composer__mcp-error {
+  color: var(--danger);
+}.composer__tool-status {
+  max-width: var(--max-content-width);
+  margin: 0 auto var(--space-2);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--accent-fg);
+  font-weight: var(--weight-medium);
+  animation: fadeIn var(--duration-normal) var(--ease-out);
+}.composer__tool-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: pulse 1s ease-in-out infinite;
+}@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }.composer__model-label {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: var(--weight-medium);
+}.composer__bar {
+  max-width: var(--max-content-width);
+  margin: 0 auto;
+  display: flex;
+  gap: var(--space-2);
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  padding: var(--space-2) var(--space-2) var(--space-2) var(--space-3);
+  transition: border-color var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out);
+  align-items: center;
+}[data-theme="light"] .composer__bar {
+  background: var(--surface-raised);
+}.composer__bar:focus-within {
+  border-color: var(--accent-fg);
+  background: var(--surface-2);
+}[data-theme="light"] .composer__bar:focus-within {
+  background: var(--surface-raised);
+}.composer__input {
+  flex: 1;
+  resize: none;
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  padding: 8px var(--space-2);
+  min-height: 40px;
+  max-height: 200px;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  border: none;
+  outline: none;
+}.composer__input:focus,
+.composer__input:focus-visible {
+  
+  outline-style: none;
+  outline-width: 0;
+  outline-offset: 0;
+  box-shadow: none;
+}.composer__input::placeholder { color: var(--text-tertiary); }.composer__send {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  background: var(--accent);
+  color: var(--accent-on);
+  font-weight: var(--weight-bold);
+  font-size: var(--text-lg);
+  transition: background var(--duration-fast) var(--ease-out),
+              opacity var(--duration-fast);
+  flex-shrink: 0;
+}.composer__send:hover { background: var(--accent-hover); }[data-theme="light"] .composer__send:hover { filter: brightness(0.85) saturate(1.5); }.composer__send:disabled { opacity: 0.3; cursor: default; }.composer__stop {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  background: var(--danger);
+  color: var(--danger-on);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  flex-shrink: 0;
+  transition: opacity var(--duration-fast);
+}.composer__stop:hover { opacity: 0.85; }.composer__hint {
+  text-align: center;
+  margin-top: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}.manager {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+  overflow: hidden;
+}@keyframes dotPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}@keyframes hfSpin {
+  to { transform: rotate(360deg); }
+}.row {
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  transition: background var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out),
+              box-shadow var(--duration-fast) var(--ease-out);
+  overflow: hidden;
+}.row:hover {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}@keyframes detailSlide {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}.btn {
+  min-width: 0;
+  height: var(--control-height-sm);
+  padding: 0 11px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1-5);
+  flex: 0 0 auto;
+  border: 1px solid transparent;
+  border-radius: var(--control-radius);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out);
+}.btn--primary {
+  border-color: color-mix(in srgb, var(--accent) 72%, transparent);
+  background: var(--accent);
+  color: var(--accent-on);
+}.btn--primary:hover:not(:disabled) { background: var(--accent-hover); }.btn--primary:focus-visible { background: var(--accent); color: var(--accent-on); }.btn--secondary,
+.btn--ghost {
+  border-color: var(--border-subtle);
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.btn--secondary:hover:not(:disabled),
+.btn--ghost:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--surface-3);
+}.btn--quiet {
+  background: transparent;
+  color: var(--text-secondary);
+}.btn--quiet:hover:not(:disabled) {
+  border-color: var(--border-subtle);
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.btn--danger {
+  border-color: color-mix(in srgb, var(--danger) 30%, transparent);
+  background: color-mix(in srgb, var(--danger) 9%, transparent);
+  color: var(--danger);
+}.btn--danger:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--danger) 52%, transparent);
+  background: color-mix(in srgb, var(--danger) 15%, transparent);
+}.btn--small,
+.btn--sm,
+.btn--tiny { height: var(--control-height-xs); padding-inline: 9px; }.btn--toolbar,
+.btn--icon-only { width: var(--icon-button-size); padding: 0; }.btn--toolbar { height: var(--icon-button-size); }.btn:disabled { opacity: 0.42; cursor: default; }.scrim.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}.slideover.is-open { transform: translateX(0); }.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+  margin-top: var(--space-3);
+}.field:first-child { margin-top: 0; }.field__row .select { flex: 1; }.select,
+.input,
+.textarea {
+  background: var(--surface-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  transition: border-color var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out);
+}.select,
+.input {
+  display: inline-flex;
+  align-items: center;
+  height: var(--control-height-sm);
+  padding: 0 var(--space-3);
+}.textarea {
+  display: block;
+  width: 100%;
+  min-height: calc(2 * var(--control-height-lg));
+  padding: var(--space-3);
+  resize: vertical;
+  line-height: var(--leading-normal);
+}select,
+.select {
+  appearance: none;
+  -webkit-appearance: none;
+  background-color: var(--surface-1);
+  background-image: var(--select-chevron);
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: var(--space-6);
+  cursor: pointer;
+}select:hover,
+.select:hover,
+.input:hover,
+.textarea:hover {
+  border-color: var(--border-strong);
+  background-color: var(--surface-2);
+}select:focus-visible,
+select:focus,
+.select:focus-visible,
+.select:focus,
+.input:focus-visible,
+.textarea:focus-visible {
+  border-color: var(--accent-fg);
+  outline: none;
+  background-color: var(--surface-2);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}select:disabled,
+.select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}option, select option, optgroup option {
+  background-color: var(--surface-2);
+  color: var(--text-primary);
+  padding: 8px 12px;
+  font-size: var(--text-sm);
+  font-family: var(--font-sans);
+  min-height: 32px;
+}option:hover,
+option:focus,
+option:active,
+option:checked {
+  background-color: var(--surface-3);
+  color: var(--text-primary);
+}optgroup {
+  background-color: var(--surface-1);
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 6px 10px 4px;
+}.custom-select__trigger:focus-visible,
+.custom-select.is-open .custom-select__trigger {
+  outline: none;
+  border-color: var(--accent-fg);
+  background-color: var(--surface-2);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}.custom-select.is-open .custom-select__chevron {
+  transform: rotate(180deg);
+  color: var(--accent-fg);
+}.custom-select__option.is-selected {
+  background-color: color-mix(in srgb, var(--accent-fg) 16%, var(--surface-2));
+  color: var(--text-primary);
+  font-weight: var(--weight-semibold);
+}.select:disabled, .input:disabled, .textarea:disabled {
+  opacity: .52;
+  cursor: not-allowed;
+}.backends {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}@keyframes toast-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}.context-rail.is-collapsed .context-rail__title-wrap,
+.context-rail.is-collapsed .context-rail__body {
+  display: none;
+}.context-rail.is-collapsed .context-rail__head {
+  justify-content: center;
+  padding-inline: var(--space-2);
+}.auto-run-card.is-active,
+.cell.is-selected {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border-strong));
+  background: var(--accent-soft);
+}@keyframes card-flash {
+  0% {
+    border-color: var(--accent-fg);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 40%, transparent);
+  }
+  100% {
+    border-color: var(--border-subtle);
+    box-shadow: none;
+  }
+}@media (max-width: 768px) {.chat {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "main"
+      "composer";
+  }.rail { display: none; }.chat__inner { padding: var(--space-5) var(--space-4); overflow-x: hidden; }.composer { padding: var(--space-3) var(--space-4); }.manager__custom-actions .btn { flex: 1; justify-content: center; }.hero { padding: var(--space-8) 0 var(--space-6); }.hero__title { font-size: var(--text-2xl); }.hero__subtitle { font-size: var(--text-base); }.chips { gap: var(--space-1); }.chip { padding: 8px var(--space-3); font-size: var(--text-xs); }.active-models { grid-template-columns: 1fr; }}@media (max-width: 480px) {.composer__send,
+  .composer__stop {
+    width: 44px;
+    height: 44px;
+    flex-shrink: 0;
+  }.composer__toolbar {
+    flex-wrap: wrap;
+    gap: var(--space-2); max-width: 100%;
+  }.composer {
+    padding: var(--space-2) var(--space-3) calc(var(--space-3) + env(safe-area-inset-bottom, 0px));
+  }.composer__bar { max-width: 100%; }.composer__model-button {
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 50vw;
+  }.composer__model-search input,
+
+  .composer__input,
+  input, textarea, select {
+    font-size: 16px !important;
+  }.connect { padding: 0 var(--space-4); }.hero { padding: var(--space-3) 0 var(--space-2); }.chat,
+  .chat.rail-expanded {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "main"
+      "composer";
+  }.rail { display: none; }.chat__inner { padding: var(--space-4) var(--space-3); }.active-card { padding: var(--space-3); gap: var(--space-2); }.active-card__name { font-size: var(--text-sm); }.hero__title { font-size: var(--text-xl); }.hero__subtitle { font-size: var(--text-sm); }.section-label { font-size: var(--type-overline-size); margin-bottom: var(--space-2); }.composer__toolbar .btn,
+  .composer__toolbar .chip,
+  .composer__toolbar button {
+    font-size: var(--text-xs);
+    padding: 4px var(--space-2);
+  }.titlebar__right { gap: var(--space-1); }}.mermaid-block__diagram .label,
+.mermaid-block__diagram .nodeLabel,
+.mermaid-block__diagram .edgeLabel,
+.mermaid-block__diagram .label-container {
+  color: var(--text-primary) !important;
+  fill: var(--text-primary) !important;
+}.mermaid-block__diagram .edgePath .path,
+.mermaid-block__diagram .flowchart-link {
+  stroke: var(--text-tertiary) !important;
+}.mermaid-block__diagram .note {
+  fill: var(--accent-soft) !important;
+  stroke: var(--accent-deep) !important;
+}.options-block {
+  margin: var(--space-3) 0;
+  padding: var(--space-3);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}.options-block__question {
+  font-weight: var(--weight-semibold);
+  margin-bottom: var(--space-2);
+  color: var(--text-primary);
+}.options-block__choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}.options-block__btn {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: var(--space-1) var(--space-3);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}.options-block__btn:hover {
+  background: var(--accent);
+  color: var(--bg-primary);
+  border-color: var(--accent-fg);
+}.options-block__btn:active {
+  transform: scale(0.97);
+}.options-block__btn--selected {
+  background: var(--accent);
+  color: var(--bg-primary);
+  border-color: var(--accent-fg);
+  cursor: default;
+}.options-block__btn--selected:hover {
+  background: var(--accent);
+  color: var(--bg-primary);
+  border-color: var(--accent-fg);
+}.options-block__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}.options-block__confirmation {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: var(--space-1);
+}.options-block__custom {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}.options-block__input {
+  flex: 1;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  font-size: 0.85rem;
+  outline: none;
+}.options-block__input:focus {
+  border-color: var(--accent-fg);
+}.options-block__submit {
+  background: var(--accent);
+  color: var(--bg-primary);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-3);
+  font-size: 0.85rem;
+  cursor: pointer;
+  font-weight: var(--weight-medium);
+}.options-block__submit:hover {
+  opacity: 0.9;
+}.composer__images {
+  display: flex;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  overflow-x: auto;
+}.composer__image-thumb {
+  position: relative;
+  flex-shrink: 0;
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}.composer__image-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}.composer__image-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 18px;
+  height: 18px;
+  background: var(--surface-overlay);
+  color: var(--danger-on);
+  border: none;
+  border-radius: 50%;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s;
+}.composer__image-thumb:hover .composer__image-remove {
+  opacity: 1;
+}.composer__attach {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: var(--space-1);
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}.composer__attach:hover {
+  color: var(--text-primary);
+}.composer__attach:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}.composer__add {
+  position: relative;
+  flex: 0 0 auto;
+}.composer__add-trigger {
+  width: 32px;
+  height: 32px;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+}.composer__add-menu {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + var(--space-2));
+  z-index: var(--z-dropdown);
+  width: min(460px, calc(100vw - 32px));
+  max-height: min(620px, calc(100vh - 150px));
+  overflow-y: auto;
+  padding: var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-lg);
+}.composer__add-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2);
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}.composer__add-row:hover:not(:disabled),
+.composer__add-row.is-active {
+  background: var(--surface-2);
+}.composer__add-row:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}.composer__add-icon {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+}.composer__add-text {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}.composer__add-text strong {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}.composer__add-text small {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}.message__images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}.message__image {
+  max-width: 200px;
+  max-height: 200px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  object-fit: contain;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}.message__image:hover {
+  opacity: 0.85;
+}.composer__files {
+  max-width: var(--max-content-width);
+  margin: 0 auto var(--space-2);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}.composer__file-chip,
+.message__file-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 100%;
+  padding: 5px var(--space-3);
+  border-radius: var(--radius-pill);
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}.composer__file-chip button {
+  color: var(--text-tertiary);
+  font-weight: var(--weight-bold);
+}.composer__file-chip button:hover { color: var(--danger); }.message--error .message__avatar {
+  background: var(--danger-soft);
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 28%, transparent);
+}.message--error .message__body {
+  border-color: color-mix(in srgb, var(--danger) 22%, transparent);
+}.message--error .markdown-body,
+.message--error .message__content {
+  color: var(--text-primary);
+}.message__audio {
+  margin-top: var(--space-3);
+}.message__audio audio {
+  width: min(100%, 420px);
+}.message__images--generated {
+  margin-top: var(--space-3);
+  margin-bottom: 0;
+}.message__image--generated {
+  max-width: min(100%, 512px);
+  max-height: 512px;
+}.active-card__status--muted {
+  background: var(--surface-3);
+  color: var(--text-tertiary);
+}.composer__mode-badge--omni, .cap-badge--omni, .cap-chip--omni, .rail__model-badge--omni { color: var(--cap-omni); background: color-mix(in srgb, var(--cap-omni) 18%, transparent); }.rail__model-badge--router { color: var(--cap-router); background: color-mix(in srgb, var(--cap-router) 18%, transparent); }.custom-model-form__grid .input, .custom-model-form__grid .select { width: 100%; }.custom-model-form__grid .textarea { min-height: 192px; font-family: var(--font-mono); font-size: var(--text-xs); line-height: var(--leading-relaxed); }.chat:not(.rail-expanded) .rail__list,
+.chat:not(.rail-expanded) .rail__privacy {
+  display: none;
+}.chat:not(.rail-expanded) .rail__head,
+.chat:not(.rail-expanded) .rail__new-wrap {
+  justify-content: center;
+  padding-left: 0;
+  padding-right: 0;
+}.chat:not(.rail-expanded) .rail__new-wrap {
+  display: flex;
+}.message__author-row,
+.active-card__name-row,
+.row__name-wrap,
+.applied-row__model-name-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  min-width: 0;
+  max-width: 100%;
+}.row__name-wrap .row__name,
+.active-card__name-row .active-card__name,
+.applied-row__model-name-wrap .applied-row__model-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}.active-card__name-row .active-card__name {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}.copy-inline {
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-1);
+  color: var(--text-tertiary);
+  font-size: 12px;
+  line-height: 1;
+  transition: background var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out);
+}.copy-inline:hover:not(:disabled) {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}.copy-inline:disabled {
+  opacity: 0.35;
+  cursor: default;
+}.copy-inline--copied {
+  color: var(--success);
+  border-color: color-mix(in srgb, var(--success) 45%, transparent);
+  background: var(--success-soft);
+}.copy-inline--author {
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  font-size: var(--text-xs);
+  transform: translateY(-1px);
+}.message__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}.message__action {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 4px var(--space-2);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-1);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  transition: background var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out);
+}.message__action:hover:not(:disabled) {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}.message__action:disabled {
+  opacity: 0.35;
+  cursor: default;
+}.chat:not(.rail-expanded) .rail__head {
+  display: flex;
+  visibility: visible;
+  flex: 0 0 auto;
+  min-height: 56px;
+}.chat:not(.rail-expanded) .rail__toggle {
+  display: flex;
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  color: var(--text-primary);
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  position: relative;
+  z-index: 2;
+}.chat:not(.rail-expanded) .rail__toggle:hover {
+  background: var(--surface-3);
+  border-color: var(--border-strong);
+}.chat:not(.rail-expanded) .rail__title {
+  display: none;
+}.composer__image-settings {
+  max-width: var(--max-content-width);
+  margin: 0 auto var(--space-2);
+  display: grid;
+  grid-template-columns: minmax(112px, 1.1fr) repeat(5, minmax(82px, 0.8fr)) minmax(112px, 1.1fr);
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: color-mix(in srgb, var(--surface-1) 92%, transparent);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-soft);
+}.composer__image-setting {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+  position: relative;
+}.composer__image-setting span {
+  font-size: var(--type-overline-size);
+  line-height: 1;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: var(--weight-semibold);
+}.composer__image-setting input,
+.composer__image-setting select {
+  width: 100%;
+  min-height: 36px;
+  color: var(--text-primary);
+  background: var(--surface-0);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 0 var(--space-3);
+  font: inherit;
+  font-size: var(--text-sm);
+  outline: none;
+  transition: border-color var(--duration-fast) var(--ease-out),
+              background var(--duration-fast) var(--ease-out),
+              opacity var(--duration-fast) var(--ease-out);
+}.composer__image-setting select {
+  -webkit-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23807a6c'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+}.composer__image-setting input:focus,
+.composer__image-setting select:focus {
+  border-color: var(--accent-fg);
+  background: var(--surface-2);
+}.composer__image-setting input[type=number] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}.composer__image-setting input[type=number]::-webkit-outer-spin-button,
+.composer__image-setting input[type=number]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}.composer__image-setting input:disabled,
+.composer__image-setting select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}@media (max-width: 1100px) {.composer__image-settings {
+    grid-template-columns: repeat(4, minmax(96px, 1fr));
+  }}@media (max-width: 720px) {.composer__image-settings {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }}.composer__mic {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  transition: background var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out),
+              opacity var(--duration-fast);
+}.composer__mic:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-color: var(--accent-fg);
+}.composer__mic:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}.composer__mic--recording {
+  background: var(--danger-soft);
+  border-color: color-mix(in srgb, var(--danger) 42%, transparent);
+  color: var(--danger);
+}.composer__live {
+  max-width: var(--max-content-width);
+  margin: 0 auto var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-1);
+  color: var(--text-secondary);
+}.composer__live--error {
+  border-color: color-mix(in srgb, var(--danger) 28%, transparent);
+  background: var(--danger-soft);
+  color: var(--text-primary);
+}.composer__live-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  color: var(--text-secondary);
+}.composer__live-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+  flex-shrink: 0;
+}.composer__live-dot--speaking {
+  background: var(--danger);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--danger) 16%, transparent);
+}.composer__live-meter {
+  width: 72px;
+  height: 5px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-3);
+  overflow: hidden;
+}.composer__live-meter span {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  transition: width 80ms linear;
+}.composer__live-text {
+  margin-top: var(--space-1);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  white-space: pre-wrap;
+}.input[type="number"] {
+  color-scheme: dark;
+  appearance: auto;
+  -moz-appearance: auto;
+}.input[type="number"]::-webkit-outer-spin-button,
+.input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: auto;
+  opacity: 1;
+  margin: 0;
+}[data-theme="light"] .app {
+  background: var(--surface-base);
+}[data-theme="dark"] .app,
+:root:not([data-theme="light"]) .app {
+  background: var(--surface-base);
+}[data-theme="light"] .titlebar,
+[data-theme="light"] .titlebar__nav {
+  background: var(--surface-titlebar);
+}[data-theme="light"] .titlebar__nav button.is-active {
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}.capability-icon-pair {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-0-5);
+  flex: 0 0 auto;
+  line-height: 1;
+}.capability-icon-pair > svg + svg {
+  opacity: 0.92;
+}.icon-inline,
+.composer__tools-toggle svg,
+.composer__model-button svg,
+.composer__mode-badge svg,
+.message__action svg,
+.chip__icon svg,
+.cap-badge svg,
+.message__file-chip svg {
+  flex: 0 0 auto;
+}.chat--with-logs {
+  grid-template-columns: var(--rail-collapsed) minmax(320px, 1fr) minmax(340px, var(--chat-logs-width, 34vw));
+  grid-template-areas:
+    "rail main logs"
+    "rail composer logs";
+}.chat--with-logs.rail-expanded {
+  grid-template-columns: var(--rail-expanded) minmax(320px, 1fr) minmax(360px, var(--chat-logs-width, 34vw));
+}.chat__logs {
+  grid-area: logs;
+  position: relative;
+  min-width: 0;
+  border-left: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface-1) 90%, transparent);
+  overflow: hidden;
+}.chat__logs-resizer {
+  position: absolute;
+  left: -5px;
+  top: 0;
+  bottom: 0;
+  width: 10px;
+  cursor: col-resize;
+  z-index: 5;
+  touch-action: none;
+}.chat__logs-resizer::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: var(--space-3);
+  bottom: var(--space-3);
+  width: 2px;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  transition: background var(--duration-fast) var(--ease-out);
+}.chat__logs-resizer:hover::after,
+.chat__logs-resizer:focus-visible::after,
+.is-resizing-chat-logs .chat__logs-resizer::after {
+  background: var(--accent-fg);
+}.chat__logs-resizer:focus-visible {
+  outline: 2px solid var(--accent-focus);
+  outline-offset: -2px;
+}.is-resizing-chat-logs {
+  cursor: col-resize;
+  user-select: none;
+}.chat__logs .logs-view {
+  height: 100%;
+  min-height: 0;
+}.chat__logs .logs-view__panel {
+  height: calc(100% - 132px);
+}.composer__model-picker {
+
+  position: relative;
+}.composer__model-button {
+  min-width: 220px;
+  max-width: min(420px, 46vw);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 5px var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--surface-1);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+}.composer__model-button:hover,
+.composer__model-button[aria-expanded="true"] {
+  background: var(--surface-2);
+  border-color: var(--border-strong);
+}.composer__model-button-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}.composer__model-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: 0 0 auto;
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  line-height: 1;
+  white-space: nowrap;
+}.composer__model-mode--chat { color: var(--cap-chat); }.composer__model-mode--image { color: var(--cap-image); }.composer__model-mode--audio { color: var(--cap-audio); }.composer__model-mode--tts { color: var(--cap-tts); }.composer__model-mode--omni { color: var(--cap-omni); }.composer__model-mode--router { color: var(--cap-router); }.composer__model-mode--audio-gen { color: var(--cap-audio-generation); }.composer__model-mode--model3d { color: color-mix(in srgb, var(--cap-model3d) 75%, var(--text-primary)); }.composer__model-mode--embed { color: var(--cap-embedding); }.composer__model-mode--rank { color: var(--cap-reranking); }.composer__model-mode--model { color: var(--text-tertiary); }.composer__model-mode svg {
+  color: currentColor;
+}.cap-badge .app-icon,
+.composer__model-mode .app-icon {
+  stroke-width: 2;
+}.cap-badge--model3d .app-icon,
+.composer__model-mode--model3d .app-icon {
+  color: var(--cap-model3d);
+}.composer__model-button-caret {
+  margin-left: auto;
+  color: var(--text-tertiary);
+}.composer__model-menu {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + var(--space-2));
+  width: min(520px, 90vw);
+  z-index: 40;
+  padding: var(--space-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--surface-raised) 92%, transparent);
+  box-shadow: var(--shadow-lg);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  backdrop-filter: blur(24px) saturate(160%);
+}.composer__model-search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+  color: var(--text-tertiary);
+}.composer__model-search input {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-primary);
+}.composer__model-results {
+  margin-top: var(--space-2);
+  max-height: 320px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-0-5);
+}.composer__model-option {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  text-align: left;
+}.composer__model-option:hover,
+.composer__model-option.is-active {
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}.composer__model-option:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}.composer__model-option-text {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}.composer__model-option-text strong,
+.composer__model-option-text span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}.composer__model-option-text span,
+.composer__model-empty,
+.composer__model-option-loading,
+.composer__model-error {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+}.composer__model-option-loading {
+  margin-left: auto;
+}.composer__model-loading-bar {
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--accent-fg) 30%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--accent) 10%, var(--surface-1));
+  color: var(--accent-fg);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+}.composer__model-button-badge {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  font-weight: var(--weight-regular);
+  flex-shrink: 0;
+}.composer__model-option-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  border-radius: var(--radius-md);
+}.composer__model-option-row:hover,
+.composer__model-option-row.is-active {
+  background: var(--accent-soft);
+  color: var(--text-primary);
+}.composer__model-option-row .composer__model-option {
+  flex: 1;
+  min-width: 0;
+  border-radius: 0;
+}.composer__model-option-row .composer__model-option:hover,
+.composer__model-option-row .composer__model-option.is-active {
+  background: transparent;
+}.composer__model-option-row.is-unloading .composer__model-option {
+  opacity: 0.6;
+  cursor: wait;
+}.composer__model-option-unload {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-base);
+  line-height: 1;
+  color: var(--text-tertiary);
+  opacity: 1;
+  transition: color 0.12s, background 0.12s;
+  margin-right: var(--space-1);
+}.composer__model-option-unload:hover {
+  color: var(--danger);
+  background: var(--danger-soft);
+}.composer__model-option-row.is-unloading .composer__model-option-unload {
+  opacity: 1;
+  color: var(--text-tertiary);
+  cursor: wait;
+}.composer__model-error {
+  margin-top: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  color: var(--danger);
+  background: var(--danger-soft);
+}.composer__mode-badge--interactive:hover,
+.composer__mode-badge--interactive:focus-visible,
+
+
+
+.composer__tools-toggle:hover,
+.composer__tools-toggle:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-fg) 18%, transparent);
+}.composer__tools-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+  box-shadow: none;
+}.composer__attach,
+.composer__mic,
+.composer__send,
+.composer__stop {
+  align-self: center;
+}.composer__file-chip span,
+.message__file-chip,
+.cap-badge,
+.manager__filter-icon,
+.hf-zone__empty,
+.custom-model-form__error,
+.banner__icon {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}.message__edit {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}.message__edit-input {
+  width: 100%;
+  min-width: min(520px, 100%);
+  resize: vertical;
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+  color: var(--text-primary);
+  line-height: var(--leading-normal);
+}.message__edit-input:focus {
+  border-color: var(--accent-fg);
+  background: var(--surface-2);
+}.message__edit-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}@media (max-width: 980px) {.chat--with-logs,
+  .chat--with-logs.rail-expanded {
+    grid-template-columns: var(--rail-collapsed) 1fr;
+    grid-template-areas:
+      "rail main"
+      "rail logs"
+      "rail composer";
+  }.chat__logs {
+    min-height: 280px;
+    border-left: 0;
+    border-top: 1px solid var(--border-subtle);
+  }.chat__logs-resizer {
+    display: none;
+  }.composer__model-button {
+
+  }}@media (max-width: 480px) {.chat--with-logs,
+  .chat--with-logs.rail-expanded {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "main"
+      "logs"
+      "composer";
+  }}.bottom-sheet-backdrop {
+  display: none;
+}.bottom-sheet {
+  display: none;
+}@media (max-width: 768px) {.bottom-sheet-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: var(--surface-overlay);
+    z-index: 900;
+    animation: fadeIn 200ms ease-out;
+  }@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }.bottom-sheet {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    max-height: 80vh;
+    background: var(--surface-1);
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    z-index: 901;
+    transform: translateY(100%);
+    transition: transform 280ms ease-out;
+    box-shadow: var(--shadow-top);
+    overflow: hidden;
+  }.bottom-sheet--open {
+    transform: translateY(0);
+  }.bottom-sheet__handle {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 12px 0 8px;
+    cursor: grab;
+    touch-action: none;
+  }.bottom-sheet__handle-pill {
+    width: 40px;
+    height: 4px;
+    border-radius: 2px;
+    background: var(--text-tertiary);
+    opacity: 0.5;
+  }.bottom-sheet__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: 0 var(--space-3) var(--space-3);
+  }.bottom-sheet__header strong {
+    color: var(--text-primary);
+    font-size: var(--text-base);
+    font-weight: var(--weight-semibold);
+  }.bottom-sheet__new {
+    align-self: stretch;
+    margin: 0 var(--space-3) var(--space-2);
+  }.bottom-sheet__list {
+    flex: 1;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 0 var(--space-2) var(--space-4);
+    margin: 0;
+    list-style: none;
+  }}@media (prefers-reduced-motion: reduce) {*, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }.bottom-sheet {
+    transform: none !important;
+  }}.app-icon {
+  display: block;
+  flex: 0 0 auto;
+  overflow: visible;
+  vertical-align: middle;
+}.titlebar__status-dot--brand {
+  margin-left: var(--space-1);
+}.titlebar__download-toggle {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  border: 0;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out),
+              border-color var(--duration-fast) var(--ease-out),
+              box-shadow var(--duration-fast) var(--ease-out);
+}.titlebar__download-toggle:hover,
+.titlebar__download-toggle.is-active {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.titlebar__download-toggle.has-active-downloads {
+  color: var(--accent-fg);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 8%, transparent);
+}.titlebar__download-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  color: var(--accent-on);
+  border: 1px solid var(--surface-0, var(--surface-base));
+  font-size: var(--type-overline-size);
+  font-weight: var(--weight-semibold);
+  line-height: 14px;
+  font-variant-numeric: tabular-nums;
+}.download-manager {
+  position: fixed;
+  inset: var(--titlebar-height) 0 0 0;
+  z-index: 80;
+  pointer-events: auto;
+}@media (max-width: 768px) {.download-manager { inset: var(--titlebar-height) 0 0 0; }}@keyframes mcp-pulse {
+  from { opacity: 1; }
+  to   { opacity: 0.35; }
+}.model-nav-rail__filter-chip .app-icon {
+  stroke-width: 2;
+}.model-nav-rail__filter-chip.is-active {
+  border-color: color-mix(in srgb, var(--filter-chip-color) 68%, var(--border-subtle));
+  background: color-mix(in srgb, var(--filter-chip-color) 12%, var(--surface-2));
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--filter-chip-color) 12%, transparent);
+}.model-nav-rail__backend-chip.is-active {
+  color: var(--text-primary);
+}.model-nav-rail__filter-chip.is-active .model-nav-rail__chip-count {
+  color: color-mix(in srgb, var(--filter-chip-color) 70%, var(--text-primary));
+}@media (max-width: 768px) {.manager--detail.manager--nav-open .model-nav-rail.is-collapsed > .model-nav-rail__scroll {
+    display: flex;
+  }}.model-detail-panel__fav-btn--on .app-icon[data-icon="star"] path { fill: currentColor; }.detail-tuning__intent-card.is-active {
+  border-color: var(--accent-fg);
+  box-shadow: 0 0 0 1px var(--accent-soft);
+}.detail-tuning__actions .btn[aria-busy="true"] {
+  cursor: progress;
+  opacity: 0.85;
+}.input.detail-configuration__context-input[type="number"] {
+  -moz-appearance: textfield !important;
+  -webkit-appearance: textfield !important;
+  appearance: textfield !important;
+}.input.detail-configuration__context-input[type="number"]::-webkit-outer-spin-button,
+.input.detail-configuration__context-input[type="number"]::-webkit-inner-spin-button {
+  display: none !important;
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  margin: 0 !important;
+}.input.detail-configuration__number-input[type="number"] {
+  -moz-appearance: textfield !important;
+  -webkit-appearance: textfield !important;
+  appearance: textfield !important;
+}.input.detail-configuration__number-input[type="number"]::-webkit-outer-spin-button,
+.input.detail-configuration__number-input[type="number"]::-webkit-inner-spin-button {
+  display: none !important;
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  margin: 0 !important;
+}.detail-configuration__selector-grid .input {
+  min-height: 36px;
+}@keyframes lm-pulse {
+  0% { transform: scale(0.85); opacity: 0.5; }
+  50% { transform: scale(1.15); opacity: 1; }
+  100% { transform: scale(0.85); opacity: 0.5; }
+}.capture-badge.paused {
+  color: var(--text-tertiary);
+  background: var(--surface-1);
+}.capture-badge.connecting {
+  color: var(--info);
+  background: var(--info-soft);
+  border-color: color-mix(in srgb, var(--info) 20%, transparent);
+}.connecting .capture-badge__dot {
+  animation: lm-pulse 1.2s infinite ease-in-out;
+}.switch-control.active {
+  background: var(--accent);
+}.switch-control.active .switch-control__thumb {
+  transform: translateX(14px);
+}.filter-chip.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-on);
+  font-weight: var(--weight-bold);
+}.trace-row.selected {
+  background: var(--surface-3);
+  border-left: 3px solid var(--accent);
+  padding-left: calc(var(--space-4) - 3px);
+}.trace-row__kind.llm { color: var(--info); background: var(--info-soft); }.trace-row__kind.embedding { color: var(--success); background: var(--success-soft); }.trace-row__kind.reranker { color: var(--warn); background: var(--warn-soft); }.trace-row__status-dot.ok { background: var(--success); }.trace-row__status-dot.error { background: var(--danger); }.inspect-rail__footer .workspace-action-button { flex: 1 1 0; }.detail-kind-badge.llm { color: var(--info); background: var(--info-soft); }.detail-kind-badge.embedding { color: var(--success); background: var(--success-soft); }.detail-kind-badge.reranker { color: var(--warn); background: var(--warn-soft); }.detail-tab.active {
+  color: var(--accent-fg);
+  border-bottom-color: var(--accent);
+}@keyframes inspectFadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}.health-banner.ok {
+  background: var(--success-soft);
+  border-color: color-mix(in srgb, var(--success) 28%, transparent);
+}.health-banner.ok .health-banner__icon { color: var(--success); font-weight: bold; }.health-banner.warn {
+  background: var(--warn-soft);
+  border-color: color-mix(in srgb, var(--warn) 30%, transparent);
+}.health-banner.warn .health-banner__icon { color: var(--warn); font-weight: bold; }.attribute-card__val.mono {
+  font-family: var(--font-mono, monospace);
+  word-break: break-all;
+}.toolbar-segmented button.active {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.message-card.collapsed .message-card__header {
+  border-bottom: none;
+}.message-card__role.system { color: var(--warn); background: var(--warn-soft); }.message-card__role.user { color: var(--info); background: var(--info-soft); }.message-card__role.assistant { color: var(--success); background: var(--success-soft); }.reasoning-block__chevron.is-collapsed { transform: rotate(-90deg); }.comparison-output-box.replay {
+  background: var(--surface-base);
+  border-color: var(--border-strong);
+}.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spinner-rot 0.8s linear infinite;
+}@keyframes spinner-rot {
+  to { transform: rotate(360deg); }
+}.replay-btn.primary {
+  background: var(--accent);
+  color: var(--accent-on);
+}.replay-btn.primary:disabled {
+  background: var(--border-subtle);
+  color: var(--text-disabled);
+  cursor: not-allowed;
+}.protocol-selector-segmented button.active {
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.critique-severity-pill.high {
+  background: var(--danger-soft);
+  color: var(--danger);
+  border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
+}.critique-severity-pill.low {
+  background: var(--success-soft);
+  color: var(--success);
+  border: 1px solid color-mix(in srgb, var(--success) 30%, transparent);
+}.critique-rationale.high {
+  border-left-color: var(--danger);
+}.critique-rationale.low {
+  border-left-color: var(--success);
+}@keyframes inspectToastFade {
+  from { opacity: 0; transform: translate(-50%, 8px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}.trace-row.selected .trace-row__time,
+.trace-row.selected .trace-row__metrics,
+.trace-row.selected .trace-row__status-label {
+  color: var(--text-secondary);
+}@media (prefers-reduced-motion: reduce) {.spinner {
+    animation: none !important;
+    border-top-color: transparent !important;
+    border-style: double !important;
+  }}@keyframes inspectModalSlideUp {
+  from { transform: translateY(16px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}@keyframes blink-cursor {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}.message-card__caret.collapsed {
+  transform: rotate(-90deg);
+}.comparison-output-box.streaming {
+  min-height: 150px;
+  max-height: 300px;
+  background: var(--surface-base);
+  border-color: var(--border-strong);
+}.dropdown-menu button.selected {
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-weight: var(--weight-bold);
+}.cap-badge--audio-gen { background: color-mix(in srgb, var(--cap-audio-generation) 16%, transparent); color: var(--cap-audio-generation); }.cap-badge--model3d { background: color-mix(in srgb, var(--cap-model3d) 17%, transparent); color: color-mix(in srgb, var(--cap-model3d) 75%, var(--text-primary)); }.composer__capability-settings {
+  max-width: var(--max-content-width);
+  margin: 0 auto var(--space-2);
+  display: grid;
+  grid-template-columns: repeat(5, minmax(92px, 1fr));
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: color-mix(in srgb, var(--surface-1) 92%, transparent);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-soft);
+}.composer__audio-generation-settings {
+  grid-template-columns: repeat(4, minmax(92px, 0.75fr)) minmax(130px, 1fr);
+}.composer__model3d-settings {
+  grid-template-columns: minmax(150px, 1.1fr) minmax(180px, 1.5fr) repeat(3, minmax(112px, 0.8fr));
+}.composer__openmoss-settings {
+  grid-template-columns: minmax(150px, 0.8fr) minmax(260px, 2fr);
+}.composer__openmoss-description {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+  min-width: 0;
+}.composer__openmoss-description > span {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-1-5);
+  font-size: var(--type-overline-size);
+  line-height: 1;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: var(--weight-semibold);
+}.composer__openmoss-description > span small {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: var(--weight-normal);
+}.composer__openmoss-description input {
+  width: 100%;
+  min-width: 0;
+  height: 36px;
+  padding: 0 var(--space-3);
+  color: var(--text-primary);
+  background: var(--surface-0);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font: inherit;
+  font-size: var(--text-sm);
+  outline: none;
+}.composer__openmoss-description input:focus {
+  border-color: var(--accent-fg);
+  background: var(--surface-2);
+}.composer__openmoss-description input:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}.composer__openmoss-status {
+  grid-column: 1 / -1;
+  min-height: 18px;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}.composer__openmoss-status--error { color: var(--danger); }.composer__image-setting small {
+  position: absolute;
+  align-self: flex-end;
+  margin: 28px 8px 0 0;
+  color: var(--text-tertiary);
+  pointer-events: none;
+}.composer__audio-lyrics {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+}.composer__audio-lyrics > span {
+  font-size: var(--type-overline-size);
+  line-height: 1;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: var(--weight-semibold);
+}.composer__audio-lyrics > span small {
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: var(--weight-normal);
+}.composer__audio-lyrics textarea {
+  width: 100%;
+  min-height: 82px;
+  resize: vertical;
+  padding: var(--space-3);
+  color: var(--text-primary);
+  background: var(--surface-0);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  font: inherit;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  outline: none;
+}.composer__audio-lyrics textarea:focus { border-color: var(--accent-fg); background: var(--surface-2); }.composer__audio-lyrics textarea:disabled { opacity: 0.55; cursor: not-allowed; }.model3d-viewer {
+  display: block;
+  position: relative;
+  width: 100%;
+  height: 420px;
+  min-height: 420px;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  background: var(--surface-0);
+}.model3d-viewer canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 420px;
+  cursor: grab;
+}.model3d-viewer canvas:active { cursor: grabbing; }.model3d-viewer--loading,
+.model3d-viewer--error {
+  display: grid;
+  place-items: center;
+  padding: var(--space-6);
+  color: var(--text-secondary);
+  text-align: center;
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+}.model3d-viewer--error { color: var(--danger); }.message__model3d-actions .message__action {
+  text-decoration: none;
+}@media (max-width: 1100px) {.composer__capability-settings,
+  .composer__audio-generation-settings,
+  .composer__openmoss-settings,
+  .composer__model3d-settings {
+    grid-template-columns: repeat(3, minmax(110px, 1fr));
+  }}@media (max-width: 720px) {.composer__capability-settings,
+  .composer__audio-generation-settings,
+  .composer__openmoss-settings,
+  .composer__model3d-settings {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }.composer__image-setting--model,
+  .composer__openmoss-description,
+  .composer__audio-lyrics { grid-column: 1 / -1; }.model3d-viewer { height: 320px; min-height: 320px; }.model3d-viewer canvas { min-height: 320px; }}.message__audio-download {
+  align-self: flex-start;
+  margin-top: var(--space-2);
+  text-decoration: none;
+}.workspace-rail {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--surface-1);
+  border-right: 1px solid var(--border-subtle);
+}.workspace-rail__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: var(--rail-toolbar);
+  padding: 0 var(--space-2);
+}.workspace-rail__context {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  overflow: hidden;
+  color: var(--text-tertiary);
+}.workspace-rail__title {
+  overflow: hidden;
+  font-size: var(--type-overline-size);
+  font-weight: var(--weight-semibold);
+  line-height: 1.2;
+  letter-spacing: var(--tracking-caps);
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}.workspace-rail__toggle {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-left: auto;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-tertiary);
+}.workspace-rail__toggle:hover,
+.workspace-rail__toggle:focus-visible {
+  border-color: var(--border-subtle);
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.workspace-rail__mobile-close,
+.workspace-mobile-menu-button,
+.workspace-mobile-rail-backdrop {
+  display: none;
+}.workspace-rail.is-collapsed > :not(.workspace-rail__header) { display: none; }.workspace-rail.is-collapsed .workspace-rail__header {
+  justify-content: center;
+  padding-inline: var(--space-2);
+}.workspace-rail.is-collapsed .workspace-rail__context { display: none; }.workspace-rail.is-collapsed .workspace-rail__toggle {
+  margin-left: 0;
+  border-color: var(--border-subtle);
+  background: var(--surface-2);
+  color: var(--text-primary);
+}.workspace-nav button.is-active {
+  background: var(--accent-soft);
+  border-color: color-mix(in srgb, var(--accent-fg) 32%, var(--border-subtle));
+  color: var(--text-primary);
+}.workspace-nav button.is-active .workspace-nav__icon {
+  background: color-mix(in srgb, var(--accent-fg) 16%, var(--surface-2));
+  color: var(--accent-fg);
+}.workspace-filter-list__item.is-active {
+  border-color: color-mix(in srgb, var(--accent-fg) 30%, transparent);
+  background: var(--accent-soft);
+  color: var(--accent-fg);
+}.workspace-filter-list__item.is-active .workspace-filter-list__icon { color: var(--accent-fg); }.workspace-filter-list__item.is-active .workspace-filter-list__count { color: var(--accent-fg); }.connect__provider-actions .input { width: min(220px, 34vw); }.workspace-action-button.logs-filter-toggle,
+.workspace-action-button.logs-rail__mobile-close { display: none; }.backend-card__version .app-icon { transform: translateY(-1.5px); }.backend-card .btn--danger:not(:hover):not(:focus-visible) {
+  border-color: var(--border-subtle);
+  background: none;
+  color: var(--text-tertiary);
+}.chat > .rail,
+.model-nav-rail,
+.model-list-panel,
+.inspect-rail,
+.context-rail { background: var(--surface-1); }@media (max-width: 1100px) {:root { --workspace-list: 286px; }.titlebar__nav button { min-width: 42px; padding-inline: var(--space-2); }.titlebar__nav .nav-label { display: none; }.titlebar__brand-name { display: none; }}@media (max-width: 768px) {.connect--workspace .workspace-rail,
+  .logs-workspace .workspace-rail,
+  .workspace-catalog-layout .workspace-rail {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }.connect--workspace .workspace-rail__header,
+  .logs-workspace .workspace-rail__header,
+  .workspace-catalog-layout .workspace-rail__header,
+  .connect--workspace .workspace-rail__footer,
+  .logs-workspace .workspace-rail__footer,
+  .workspace-catalog-layout .workspace-rail__footer,
+  .logs-workspace .workspace-rail__body { display: none; }.connect--workspace .workspace-rail.is-collapsed > .workspace-nav,
+  .workspace-catalog-layout .workspace-rail.is-collapsed > .workspace-filter-list {
+    display: flex;
+  }.monitor-workspace > .workspace-rail {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }.monitor-workspace .workspace-rail__header { display: none; }.monitor-workspace .monitor-nav,
+  .monitor-workspace .workspace-rail.is-collapsed > .monitor-nav {
+    display: flex;
+    flex-direction: row;
+    gap: var(--space-1);
+    overflow-x: auto;
+    padding: var(--space-2);
+  }.inspect-layout--embedded .inspect-detail__mobile-back .app-icon { transform: rotate(180deg); }.logs-workspace--embedded .workspace-action-button.logs-filter-toggle,
+  .logs-workspace--embedded .workspace-action-button.logs-rail__mobile-close { display: inline-flex; }}@media (max-width: 768px) {.chat.rail-expanded,
+  .chat:not(.rail-expanded) {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "main"
+      "composer";
+  }.chat .rail.workspace-rail { display: none; }}@media (min-width: 769px) and (max-width: 1320px) {.titlebar__search,
+  .titlebar__search:focus-within {
+    width: 32px;
+    flex-basis: 32px;
+  }.titlebar__search-leading-icon { display: none; }.titlebar__search-toggle { display: inline-flex; }.titlebar__search-popover { display: none; }.titlebar__search.is-open .titlebar__search-popover {
+    width: min(320px, calc(100vw - 24px));
+    display: block;
+    position: absolute;
+    top: calc(100% + var(--space-2));
+    right: 0;
+    z-index: 80;
+    padding: var(--space-2);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-lg);
+    background: var(--surface-raised);
+    box-shadow: var(--shadow-lg);
+  }.titlebar__search.is-open .titlebar__search-entry { width: 100%; }.titlebar__search.is-open .titlebar__search-results {
+    position: static;
+    width: 100%;
+    max-height: min(420px, calc(100vh - var(--titlebar-height) - 80px));
+    margin-top: var(--space-1);
+    overflow-y: auto;
+  }.titlebar__search.is-context-visible,
+  .titlebar__search.is-context-visible:focus-within {
+    width: 176px;
+    flex-basis: 176px;
+  }.titlebar__search.is-context-visible .titlebar__search-leading-icon {
+    display: block;
+  }.titlebar__search.is-context-visible .titlebar__search-toggle {
+    display: none;
+  }.titlebar__search.is-context-visible .titlebar__search-popover,
+  .titlebar__search.is-context-visible.is-open .titlebar__search-popover {
+    position: relative;
+    inset: auto;
+    width: auto;
+    display: flex;
+    flex: 1;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }.titlebar__search.is-context-visible.is-open .titlebar__search-results {
+    position: absolute;
+    top: calc(100% + var(--space-2));
+    left: 0;
+    width: 100%;
+    max-height: min(420px, calc(100vh - var(--titlebar-height) - 80px));
+    margin-top: 0;
+    overflow-y: auto;
+  }}@media (max-width: 768px) {.titlebar__brand { display: none; }.titlebar__right { justify-self: end; }.titlebar__status-dot--brand { display: none; }.titlebar__utilities-toggle { display: inline-flex; }.titlebar__utility-menu {
+    width: min(320px, calc(100vw - 24px));
+    display: none;
+    position: fixed;
+    top: calc(var(--titlebar-height) + var(--space-2));
+    right: var(--space-3);
+    z-index: 80;
+    align-items: stretch;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    padding: var(--space-2);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-lg);
+    background: var(--surface-raised);
+    box-shadow: var(--shadow-lg);
+  }.titlebar__utilities.is-open .titlebar__utility-menu { display: flex; }.titlebar__utility-menu .titlebar__search,
+  .titlebar__utility-menu .titlebar__search:focus-within {
+    width: 100%;
+    height: 44px;
+    padding: 0 var(--space-3);
+  }.titlebar__utility-menu .titlebar__search-results {
+    top: calc(100% + var(--space-1));
+  }.titlebar__utility-menu .titlebar__theme-toggle,
+  .titlebar__utility-menu .titlebar__download-toggle {
+    width: 100%;
+    height: 44px;
+    justify-content: flex-start;
+    gap: var(--space-3);
+    padding: 0 var(--space-3);
+    border-color: transparent;
+    border-radius: var(--radius-md);
+    background: transparent;
+    color: var(--text-secondary);
+  }.titlebar__utility-menu .titlebar__theme-toggle:hover,
+  .titlebar__utility-menu .titlebar__download-toggle:hover {
+    border-color: transparent;
+    background: var(--surface-2);
+    color: var(--text-primary);
+  }.titlebar__utility-status {
+    width: 100%;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 0 var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+    color: var(--text-secondary);
+  }.titlebar__utility-status .titlebar__status-dot {
+    margin-inline: 8px 4px;
+  }.titlebar__utility-label,
+  .titlebar__utility-value { display: inline; }.titlebar__utility-value {
+    margin-left: auto;
+    color: var(--text-tertiary);
+    font-size: var(--text-xs);
+  }.titlebar__utility-menu .titlebar__download-badge {
+    position: static;
+    margin-left: auto;
+    border-color: transparent;
+  }}@media (max-width: 768px) {.workspace-mobile-menu-button {
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    position: fixed;
+    top: 10px;
+    left: var(--space-3);
+    z-index: 40;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-pill);
+    background: var(--surface-1);
+    color: var(--text-secondary);
+    box-shadow: var(--shadow-sm);
+  }.workspace-mobile-menu-button:hover,
+  .workspace-mobile-menu-button:focus-visible,
+  .workspace-mobile-menu-button[aria-expanded="true"] {
+    border-color: var(--border-strong);
+    background: var(--surface-3);
+    color: var(--text-primary);
+  }.workspace-mobile-menu-button[aria-expanded="true"] { z-index: 902; }.workspace-rail.mobile-context-panel {
+    display: none;
+  }.workspace-rail.mobile-context-panel.is-mobile-open {
+    width: auto;
+    max-height: calc(100% - var(--space-4));
+    display: flex;
+    position: absolute;
+    inset: auto var(--space-2) var(--space-2);
+    z-index: 61;
+    overflow: hidden;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-lg);
+    background: var(--surface-1);
+    box-shadow: var(--shadow-lg);
+  }.workspace-rail.mobile-context-panel.is-mobile-open .workspace-rail__header {
+    display: flex;
+    flex-shrink: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }.workspace-rail.mobile-context-panel > .workspace-nav,
+  .workspace-rail.mobile-context-panel > .workspace-filter-list {
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: var(--space-3);
+  }.workspace-rail.mobile-context-panel .workspace-nav button,
+  .workspace-rail.mobile-context-panel .workspace-filter-list__item {
+    width: 100%;
+  }.workspace-rail.mobile-context-panel .workspace-nav button {
+    min-height: 52px;
+    grid-template-columns: 28px minmax(0, 1fr) auto;
+  }.workspace-rail.mobile-context-panel .workspace-filter-list__item {
+    min-height: 36px;
+    grid-template-columns: 18px minmax(0, 1fr) auto;
+  }.workspace-rail.mobile-context-panel .workspace-nav__copy,
+  .workspace-rail.mobile-context-panel .workspace-nav__chevron,
+  .workspace-rail.mobile-context-panel .workspace-filter-list__label,
+  .workspace-rail.mobile-context-panel .workspace-filter-list__count,
+  .workspace-rail.mobile-context-panel .workspace-rail__footer {
+    display: flex;
+  }.workspace-rail.mobile-context-panel .workspace-nav__copy small {
+    display: block;
+  }.workspace-rail.mobile-context-panel .workspace-rail__footer {
+    flex-direction: column;
+  }.workspace-rail.mobile-context-panel .backends__rail-footer {
+    display: grid;
+  }.workspace-rail.mobile-context-panel .workspace-rail__toggle {
+    display: none;
+  }.manager--detail.manager--detail-mobile-open > .workspace-mobile-menu-button {
+    display: none;
+  }.manager--detail.manager--nav-open .model-nav-rail .workspace-rail__header {
+    display: flex;
+  }}@media (max-width: 480px) {.titlebar {
+    grid-template-columns: minmax(44px, 1fr) auto minmax(32px, 1fr);
+    column-gap: var(--space-1);
+    padding-inline: var(--space-1);
+  }.titlebar__nav {
+    gap: 2px;
+    padding: 3px;
+  }.titlebar__nav button {
+    width: 32px;
+    min-width: 32px;
+    height: 30px;
+    gap: 0;
+    padding: 0;
+  }}@media (max-width: 300px) {.titlebar__nav button {
+    width: 28px;
+    min-width: 28px;
+  }}.custom-model-form__mode-switch button.is-active {
+  background: var(--surface-raised);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
+}.custom-collection-settings__intro .btn {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  box-sizing: border-box;
+  min-height: 28px;
+  line-height: 1;
+  white-space: nowrap;
+}@media (max-width: 720px) {.custom-model-form__mode-switch button,
+  .custom-model-form__io-actions .btn {
+    flex: 1;
+  }}.detail-tuning__intent-card--selectable.is-selected {
+  border-color: var(--accent-fg);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}.cell__args-button.is-active {
+  border-color: var(--accent-fg);
+  background: var(--accent-soft);
+  color: var(--accent-fg);
+}.mcp-panel__status-dot.is-connected { background: var(--success); }.mcp-transport-option.is-selected { border-color: color-mix(in srgb, var(--brand) 65%, var(--border-subtle)); background: color-mix(in srgb, var(--brand) 7%, var(--surface-1)); }.router-editor__tabs button.is-active { color: var(--text-primary); border-bottom-color: var(--accent-fg); }.router-editor__strategy-option.is-active { border-color: color-mix(in srgb, var(--accent-fg) 70%, var(--border-subtle)); background: color-mix(in srgb, var(--accent-fg) 7%, var(--surface-1)); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-fg) 18%, transparent); color: var(--text-primary); }.router-editor__strategy-option > .app-icon { margin-top: 1px; color: var(--accent-fg); }.router-editor .input,
+.router-editor .select {
+  min-width: 0;
+}.router-editor .textarea {
+  min-height: 90px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--leading-relaxed);
+}.router-editor .input[readonly] { color: var(--text-tertiary); background: var(--surface-2); }.router-editor__candidate.is-selected { background: color-mix(in srgb, var(--accent-fg) 6%, var(--surface-1)); }.router-editor__card-head > .workspace-action-button { margin-left: auto; }.global-settings-field > .select,
+.global-settings-field .input,
+.global-settings-pin-add > .select {
+  width: 100%;
+  min-width: 0;
+}.global-settings-number .input { padding-right: 44px; }.global-settings-read-modes button.is-active {
+  border-color: var(--accent-fg);
+  background: var(--accent-soft);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-fg) 24%, transparent);
+}.workspace-list-panel__actions .workspace-action-button {
+  width: var(--icon-button-size);
+  height: var(--icon-button-size);
+  padding: 0;
+  border-color: transparent;
+  background: transparent;
+  color: var(--text-tertiary);
+}.workspace-list-panel__actions .workspace-action-button:hover:not(:disabled),
+.workspace-list-panel__actions .workspace-action-button:focus-visible {
+  border-color: var(--border-subtle);
+  background: var(--surface-2);
+  color: var(--accent-fg);
+}.workspace-detail-panel__action-bar .workspace-action-button:not(.workspace-action-button--icon-only) {
+  height: var(--detail-gutter);
+  padding-inline: var(--detail-title-row-gap);
+  gap: var(--detail-title-metadata-gap);
+  font-size: var(--detail-type-action);
+}.workspace-action-button__label {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}.model-list-panel__count.sr-only { padding: 0; }.model-detail-panel__actions .workspace-action-button,
+.model-detail-panel__actions .model-detail-panel__fav-btn,
+.model-detail-panel__actions .workspace-action-button--danger {
+  width: auto;
+  padding-inline: var(--detail-title-row-gap);
+}.recipes > .slideover--recipe {
+  position: relative;
+  inset: auto;
+  grid-column: 3;
+  grid-row: 1;
+  width: auto;
+  max-width: none;
+  height: 100%;
+  transform: none;
+  z-index: auto;
+  border-left: 0;
+  background: var(--surface-base);
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}.recipes > .scrim { display: none; }@media (max-width: 768px) {.recipes > .slideover--recipe {
+    position: fixed;
+    top: 0;
+    right: 0;
+    grid-column: auto;
+    grid-row: auto;
+    width: min(100%, var(--slide-over-width));
+    max-width: 100vw;
+    height: 100vh;
+    transform: translateX(100%);
+    z-index: 51;
+    border-left: 1px solid var(--border-strong);
+    box-shadow: var(--shadow-lg);
+  }.recipes > .slideover--recipe.is-open { transform: translateX(0); }.recipes > .scrim { display: block; }.workspace-list-panel__actions .btn { padding-inline: var(--space-2); }}.composer__effective-settings {
+  padding: 4px;
+  width: 30px;
+  gap: 0;
+}.effective-settings__sampling-field .input {
+  width: 100%;
+  font-family: var(--font-mono);
+}.composer__model-default-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: var(--accent);
+}.composer__model-option-row .composer__model-default-icon {
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+}.router-editor__connection-endpoint > .workspace-action-button {
+  justify-self: start;
+  margin-top: var(--space-1);
+}.router-editor__endpoint-editor .input {
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}.router-collection-settings__endpoint > .workspace-action-button {
+  justify-self: start;
+  margin-top: var(--space-1);
+}@media (max-width: 620px) {.router-editor__endpoint-editor .input {
+    grid-column: 1 / -1;
+  }}.router-editor__endpoint-editor .input,
+.router-editor__insecure-opt-in {
+  grid-column: 1 / -1;
+}.view-loading {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  min-height: 8rem;
+}.view-loading--compact {
+  min-height: 3rem;
+}.message__content--loading {
+  min-height: 1em;
+}

--- a/src/app/src/styles/styles.css
+++ b/src/app/src/styles/styles.css
@@ -1900,7 +1900,7 @@ input[type="checkbox"]:disabled {
 
 .zone__count {
   font-size: var(--text-xs);
-  color: var(--text-disabled);
+  color: var(--text-tertiary);
   font-family: var(--font-mono);
 }
 

--- a/src/app/src/tools/mcpMetadata.ts
+++ b/src/app/src/tools/mcpMetadata.ts
@@ -1,0 +1,24 @@
+export const LEMONADE_MCP_SERVER_ID = 'lemonade';
+export const MAX_MCP_SERVER_SELECTION = 4;
+export const LEMONADE_MCP_TOOL_COUNT = 6;
+
+export interface McpServerOption {
+  id: string;
+  name: string;
+  transport: 'builtin' | 'streamable-http' | 'stdio';
+  connected: boolean;
+  status: string;
+  tools: number;
+  lastError?: string;
+}
+
+export interface McpToolOption {
+  name: string;
+  runtimeName: string;
+  title?: string;
+  description?: string;
+}
+
+export interface McpServerToolOption extends McpServerOption {
+  toolOptions: McpToolOption[];
+}

--- a/src/web-app/webpack.config.js
+++ b/src/web-app/webpack.config.js
@@ -1,169 +1,303 @@
+const fs = require('fs');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const webpack = require('webpack');
 
+function firstExisting(paths) {
+  return paths.find(candidate => fs.existsSync(candidate)) || null;
+}
+
+class EmitAppCssPlugin {
+  constructor(rendererRoot, appRoot) {
+    this.rendererRoot = rendererRoot;
+    this.appRoot = appRoot;
+  }
+
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap('EmitAppCssPlugin', compilation => {
+      const cssFiles = [
+        path.resolve(this.rendererRoot, 'styles/tokens.css'),
+        path.resolve(this.rendererRoot, 'styles/styles.css'),
+      ].filter(file => fs.existsSync(file));
+      const logoFile = firstExisting([
+        path.resolve(this.appRoot, 'assets/logo.svg'),
+        path.resolve(this.rendererRoot, '../assets/logo.svg'),
+      ]);
+
+      for (const file of cssFiles) compilation.fileDependencies.add(file);
+      if (logoFile) compilation.fileDependencies.add(logoFile);
+
+      compilation.hooks.processAssets.tap(
+        {
+          name: 'EmitAppCssPlugin',
+          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+        },
+        () => {
+          if (cssFiles.length) {
+            const css = cssFiles
+              .map(file => fs.readFileSync(file, 'utf8'))
+              .join('\n')
+              .replaceAll('../../assets/logo.svg', 'logo.svg')
+              + '\n:root{--lemonade-full-styles-loaded:1;}\n';
+            compilation.emitAsset('app.css', new webpack.sources.RawSource(css));
+          }
+          if (logoFile) {
+            compilation.emitAsset('logo.svg', new webpack.sources.RawSource(fs.readFileSync(logoFile)));
+          }
+        },
+      );
+    });
+  }
+}
+
 module.exports = (env, argv) => {
-  const useSystemPackages = process.env.USE_SYSTEM_NODEJS_MODULES === 'true' || process.env.USE_SYSTEM_NODEJS_MODULES === '1';
+  // The CMake web build stages app/ and web-app/ next to each other. GUI3 used
+  // both a flattened app/src/index.tsx layout and the newer app/src/renderer/
+  // layout during development; support either so this config is drop-in safe.
+  const appRoot = path.resolve(__dirname, '../app');
+  const rendererRoot = firstExisting([
+    path.resolve(appRoot, 'src/index.tsx'),
+    path.resolve(appRoot, 'src/renderer/index.tsx'),
+  ]);
+  if (!rendererRoot) {
+    throw new Error('Cannot find shared Lemonade renderer entry under ../app/src');
+  }
+  const sourceRoot = path.dirname(rendererRoot);
+  const entryFile = rendererRoot;
+  const templateFile = path.resolve(sourceRoot, 'index.html');
+  const isProduction = (argv.mode || 'production') === 'production';
+  const useSystemPackages = process.env.USE_SYSTEM_NODEJS_MODULES === 'true'
+    || process.env.USE_SYSTEM_NODEJS_MODULES === '1';
 
-  const fs = require('fs');
-
-  // When using system packages, check if overlay exists before using it
   let katexAlias = {};
   let useSystemKatexCss = false;
   if (useSystemPackages) {
     const overlayPath = path.resolve(__dirname, 'katex-overlay/katex/index.js');
     const overlayCssPath = path.resolve(__dirname, 'katex-overlay/katex/dist/katex.min.css');
     const systemKatexFontsPath = '/usr/share/fonts/truetype/katex';
-    // Only use overlay if both the shim AND the CSS file exist
     if (fs.existsSync(overlayPath) && fs.existsSync(overlayCssPath)) {
       katexAlias = {
         'katex$': overlayPath,
         'katex/dist/katex.min.css': overlayCssPath,
       };
-
-      // Only disable URL rewriting when system fonts are also present
-      if (fs.existsSync(systemKatexFontsPath)) {
-        useSystemKatexCss = true;
-      }
+      if (fs.existsSync(systemKatexFontsPath)) useSystemKatexCss = true;
     }
   }
 
   const systemPackageAliases = useSystemPackages ? {
-    // These GUI3 libraries remain real npm dependencies for the Tauri/app
-    // build. The distro web-app build uses system Node modules and maps
-    // unavailable packages to conservative local fallbacks.
     'dompurify$': path.resolve(__dirname, 'system-stubs/dompurify.ts'),
     'mermaid$': path.resolve(__dirname, 'system-stubs/mermaid.ts'),
     'recharts$': path.resolve(__dirname, 'system-stubs/recharts.tsx'),
-
-    // Debian/Ubuntu/Fedora system highlight.js packages can provide the JS
-    // module without the npm package's bundled style files. Keep the GUI3
-    // import graph unchanged and provide a small local stylesheet only for
-    // the system-node web-app build.
     'highlight.js/styles/github-dark.css$': path.resolve(__dirname, 'system-stubs/highlight-github-dark.css'),
   } : {};
 
-  // Resolve polyfills conditionally - try to resolve them, but fall back to false if not available
   let bufferPolyfill = false;
   let processPolyfill = false;
-  try {
-    bufferPolyfill = require.resolve('buffer/');
-  } catch (e) {
-    // buffer package not installed locally
-  }
-  try {
-    processPolyfill = require.resolve('process/browser');
-  } catch (e) {
-    // process package not installed locally
-  }
+  try { bufferPolyfill = require.resolve('buffer/'); } catch {}
+  try { processPolyfill = require.resolve('process/browser'); } catch {}
 
-  // The staged GUI app source lives in ../app/src (sibling tree). The
-  // web-app build resolves it directly via these relative paths instead of
-  // checking in OS-level symlinks (which break Windows checkouts unless
-  // core.symlinks=true and developer mode are both enabled). The CMake
-  // staging step (BuildWebApp.cmake) preserves this layout by copying both
-  // src/app and src/web-app into the build directory side by side.
+  const tauriStub = path.resolve(__dirname, 'tauri-stub.js');
+  const normalize = value => value.replace(/\\/g, '/');
+  const sourceRootNormalized = `${normalize(sourceRoot)}/`;
+  const shellPatterns = [
+    /\/App\.tsx$/,
+    /\/components\/ShellIcon\.tsx$/,
+    /\/startupScheduler\.ts$/,
+    /\/features\/navigation\//,
+    /\/features\/models\/modelState\.ts$/,
+    /\/features\/apps\/marketplace\.ts$/,
+  ];
+
+  const isReactSource = module => {
+    const resource = module && module.resource ? normalize(module.resource) : '';
+    return /(?:^|\/)(?:node_modules|usr\/share\/nodejs|usr\/lib\/nodejs)\/(react|react-dom|scheduler)(?:\/|$)/.test(resource);
+  };
+
+  const isRendererSource = module => {
+    const resource = module && module.resource ? normalize(module.resource) : '';
+    return resource.startsWith(sourceRootNormalized);
+  };
+  const isShellSource = module => {
+    if (!isRendererSource(module)) return false;
+    const resource = normalize(module.resource);
+    return shellPatterns.some(pattern => pattern.test(resource));
+  };
+  const isStartupAppSource = module => {
+    if (!isRendererSource(module)) return false;
+    const resource = normalize(module.resource);
+    if (resource === normalize(entryFile)) return false;
+    return !isShellSource(module);
+  };
+
   const config = {
-    mode: argv.mode || 'development',
-    entry: '../app/src/index.tsx',
-    target: 'web',  // Changed from 'electron-renderer' to 'web' for browser
-    devtool: argv.mode === 'production' ? false : 'source-map',
+    // Production is the safe default for the server-delivered UI. Developers
+    // can still request --mode development explicitly.
+    mode: argv.mode || 'production',
+    entry: {
+      renderer: entryFile,
+    },
+    target: 'web',
+    devtool: isProduction ? false : 'source-map',
+
     module: {
       rules: [
         {
           test: /\.tsx?$/,
           use: {
             loader: 'ts-loader',
-            options: {
-              transpileOnly: true,  // Skip type checking for faster builds
-              configFile: path.resolve(__dirname, 'tsconfig.json'),
-              context: __dirname,
-              onlyCompileBundledFiles: true,
-            }
+            options: { transpileOnly: true },
           },
           exclude: /node_modules/,
         },
         {
           test: /\.css$/,
           use: ['style-loader', 'css-loader'],
-          exclude: useSystemKatexCss ? /katex\.min\.css$/ : undefined,
+          exclude: useSystemPackages ? /katex\.min\.css$/ : undefined,
         },
-        {
-          test: /\.svg$/,
-          type: 'asset/resource',
-        },
+        { test: /\.svg$/, type: 'asset/resource' },
         {
           test: /\.(png|jpg|jpeg|gif|ico|woff|woff2|ttf|eot)$/,
           type: 'asset/resource',
-          generator: {
-            filename: '[name][ext]'
-          }
+          generator: { filename: '[name][ext]' },
         },
-        {
-          test: /\.json$/,
-          type: 'json',
-        },
+        { test: /\.json$/, type: 'json' },
       ],
     },
+
     resolve: {
       extensions: ['.tsx', '.ts', '.js', '.jsx'],
-      modules: useSystemPackages ? [
-        path.resolve(__dirname, 'node_modules'),  // Local node_modules for build tools
-        '/usr/share/nodejs',  // System packages for runtime dependencies
-        '/usr/lib/nodejs',
-        '/usr/share/javascript',
-        'node_modules'  // fallback to standard resolution
-      ] : [
-        path.resolve(__dirname, 'node_modules'),
-        'node_modules'
-      ],
+      modules: useSystemPackages
+        ? [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(appRoot, 'node_modules'),
+            '/usr/share/nodejs',
+            '/usr/lib/nodejs',
+            '/usr/share/javascript',
+            'node_modules',
+          ]
+        : [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(appRoot, 'node_modules'),
+            'node_modules',
+          ],
       alias: {
         ...katexAlias,
         ...systemPackageAliases,
-        // The staged GUI app imports @tauri-apps/*
-        // modules in tauriShim.ts. The web-app intentionally excludes those
-        // packages; alias each specifier to a no-op stub. The shim never calls
-        // into them at runtime in pure-web mode (isTauri() is always false).
-        '@tauri-apps/api/core$': path.resolve(__dirname, 'tauri-stub.js'),
-        '@tauri-apps/api/event$': path.resolve(__dirname, 'tauri-stub.js'),
-        '@tauri-apps/api/window$': path.resolve(__dirname, 'tauri-stub.js'),
-        '@tauri-apps/plugin-opener$': path.resolve(__dirname, 'tauri-stub.js'),
-        '@tauri-apps/plugin-clipboard-manager$': path.resolve(__dirname, 'tauri-stub.js'),
+        '@tauri-apps/api/core$': tauriStub,
+        '@tauri-apps/api/event$': tauriStub,
+        '@tauri-apps/api/window$': tauriStub,
+        '@tauri-apps/plugin-opener$': tauriStub,
+        '@tauri-apps/plugin-clipboard-manager$': tauriStub,
       },
       fallback: {
-        "path": false,
-        "fs": false,
-        "url": false,
-        "util": false,
-        "stream": false,
-        "http": false,
-        "https": false,
-        "buffer": bufferPolyfill,
-        "process": processPolyfill,
+        path: false,
+        fs: false,
+        url: false,
+        util: false,
+        stream: false,
+        http: false,
+        https: false,
+        buffer: bufferPolyfill,
+        process: processPolyfill,
       },
     },
+
     output: {
-      filename: 'renderer.bundle.js',
+      filename: '[name].bundle.js',
+      chunkFilename: isProduction ? '[name].[contenthash:8].chunk.js' : '[name].chunk.js',
       path: process.env.WEBPACK_OUTPUT_PATH || path.resolve(__dirname, 'dist/renderer'),
+      publicPath: 'auto',
+      clean: true,
     },
+
     optimization: {
-      // GUI3's full web entry includes large markdown/diagram/chart code.
-      // Keep packaging builds unminified so CI does not stall in Terser.
-      minimize: false,
+      minimize: isProduction,
+      usedExports: true,
+      sideEffects: true,
+      concatenateModules: isProduction,
+      moduleIds: isProduction ? 'deterministic' : 'named',
+      chunkIds: isProduction ? 'deterministic' : 'named',
+
+      // lemond currently serves a large response much more slowly than the
+      // browser can parse/evaluate it. Keep the bootstrap tiny and turn the
+      // default Chat path into a handful of *initial* chunks. HtmlWebpackPlugin
+      // inserts every initial script into HTML, so the browser fetches these in
+      // parallel rather than waiting for React.lazy() to discover the next one.
+      runtimeChunk: 'single',
+      splitChunks: {
+        chunks: 'all',
+        maxInitialRequests: 6,
+        maxAsyncRequests: 20,
+        cacheGroups: {
+          react: {
+            test: isReactSource,
+            name: 'react-core',
+            chunks: 'all',
+            priority: 100,
+            enforce: true,
+          },
+          startupShell: {
+            test: isShellSource,
+            name: 'startup-shell',
+            chunks: 'initial',
+            priority: 80,
+            enforce: true,
+          },
+          startupApp: {
+            test: isStartupAppSource,
+            name: 'startup-chat',
+            chunks: 'initial',
+            priority: 70,
+            enforce: true,
+          },
+          mermaid: {
+            test: /[\\/]node_modules[\\/](mermaid|@mermaid-js|cytoscape|dagre-d3-es)[\\/]/,
+            name: 'mermaid',
+            chunks: 'async',
+            priority: 60,
+            enforce: true,
+          },
+          charts: {
+            test: /[\\/]node_modules[\\/](recharts|victory-vendor|d3|d3-.*)[\\/]/,
+            name: 'charts',
+            chunks: 'async',
+            priority: 55,
+            enforce: true,
+          },
+          markdown: {
+            test: /[\\/]node_modules[\\/](highlight\.js|markdown-it|katex|markdown-it-texmath|dompurify)[\\/]/,
+            name: 'markdown',
+            chunks: 'async',
+            priority: 55,
+            enforce: true,
+          },
+          asyncVendors: {
+            test: /[\\/]node_modules[\\/]/,
+            chunks: 'async',
+            name: false,
+            priority: 0,
+            reuseExistingChunk: true,
+          },
+          default: false,
+          defaultVendors: false,
+        },
+      },
     },
-    // @google/model-viewer contains one optional expression-based import.
-    // It is valid in the browser; suppress only that known parser warning.
-    ignoreWarnings: [
-      warning => /Critical dependency: the request of a dependency is an expression/.test(warning.message || '')
-        && /model-viewer\.min\.js/.test(warning.module?.resource || warning.moduleName || ''),
-    ],
+
     plugins: [
-      new HtmlWebpackPlugin({
-        template: '../app/src/index.html',
-        filename: 'index.html',
-      }),
+      new EmitAppCssPlugin(sourceRoot, appRoot),
       new webpack.DefinePlugin({
         'process.env.LEMONADE_BASE_URL': JSON.stringify(process.env.LEMONADE_BASE_URL || ''),
+      }),
+      new HtmlWebpackPlugin({
+        filename: 'index.html',
+        scriptLoading: 'defer',
+        templateContent: () => {
+          const template = fs.readFileSync(templateFile, 'utf8');
+          const criticalCssFile = path.resolve(sourceRoot, 'styles/critical.generated.css');
+          const criticalCss = fs.existsSync(criticalCssFile) ? fs.readFileSync(criticalCssFile, 'utf8') : '';
+          return template.replace('/*__LEMONADE_CRITICAL_CSS__*/', criticalCss);
+        },
       }),
       ...(bufferPolyfill && processPolyfill ? [
         new webpack.ProvidePlugin({
@@ -172,14 +306,11 @@ module.exports = (env, argv) => {
         }),
       ] : []),
     ],
-    performance: {
-      hints: false,
-    },
+
+    performance: { hints: false },
   };
 
-  // Special handling for system packages (Debian)
   if (useSystemKatexCss) {
-    // Handle KaTeX CSS without URL resolution (fonts are provided by the system/overlay)
     config.module.rules.unshift({
       test: /katex\.min\.css$/,
       use: ['style-loader', { loader: 'css-loader', options: { url: false } }],


### PR DESCRIPTION
## Summary

This PR significantly speeds up Lemonade GUI startup by keeping only the active workspace on the critical path and moving everything else into ordered background prewarming.

On my setup, the browser UI now reaches the **first usable frame in ~350 ms median**.

## What changed

* Production-optimized and split web renderer bundles
* Only the active workspace blocks initial rendering
* Remaining workspaces and interaction-critical modules are automatically prewarmed after the first frame
* Heavy Monitor views and charts no longer block opening the Monitor tab
* Models use a fast initial model snapshot while the full catalog loads in the background
* Model Details, Telemetry, Logs, Router Editor and Settings are prepared automatically instead of loading on first interaction
* Hidden workspaces are not mounted, avoiding unnecessary effects and polling
* Startup remains covered until styles are ready, preventing unstyled flashes
* Preserves async model-state and accessibility behavior

The result is a fast initial render without simply moving the delay to the first tab or panel interaction.

Tauri uses the same renderer-side startup changes, but I’d benchmark desktop startup separately before putting a number on that improvement.

Closes #3035
